### PR TITLE
doc: Add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 
 <img width="1190" alt="maybe_hero" src="https://github.com/user-attachments/assets/5ed08763-a9ee-42b2-a436-e05038fcf573" />
 
+<p align="center">
+  <!-- Keep these links. Translations will automatically update with the README. -->
+  <a href="https://readme-i18n.com/de/we-promise/sure">Deutsch</a> | 
+  <a href="https://readme-i18n.com/es/we-promise/sure">Español</a> | 
+  <a href="https://readme-i18n.com/fr/we-promise/sure">français</a> | 
+  <a href="https://readme-i18n.com/ja/we-promise/sure">日本語</a> | 
+  <a href="https://readme-i18n.com/ko/we-promise/sure">한국어</a> | 
+  <a href="https://readme-i18n.com/pt/we-promise/sure">Português</a> | 
+  <a href="https://readme-i18n.com/ru/we-promise/sure">Русский</a> | 
+  <a href="https://readme-i18n.com/zh/we-promise/sure">中文</a>
+</p>
+
 # ~Maybe~Sure: The personal finance app for everyone
 
 <b>Get


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated links can be previewed in my forked repository: https://github.com/dowithless/maybe/tree/patch-2