### PR TITLE
feat: split provider check and remove hardcoded synth check

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -69,10 +69,12 @@ class Family < ApplicationRecord
     country != "US" && country != "CA"
   end
 
-  def requires_data_provider?
+  def requires_securities_data_provider?
     # If family has any trades, they need a provider for historical prices
-    return true if trades.any?
+    trades.any?
+  end
 
+  def requires_exchange_rates_data_provider?
     # If family has any accounts not denominated in the family's currency, they need a provider for historical exchange rates
     return true if accounts.where.not(currency: self.currency).any?
 
@@ -85,7 +87,8 @@ class Family < ApplicationRecord
   end
 
   def missing_data_provider?
-    requires_data_provider? && Provider::Registry.get_provider(:synth).nil?
+    (requires_securities_data_provider? && Security.provider.nil?) ||
+    (requires_exchange_rates_data_provider? && ExchangeRate.provider.nil?)
   end
 
   def oldest_entry_date

--- a/app/views/accounts/_account_sidebar_tabs.html.erb
+++ b/app/views/accounts/_account_sidebar_tabs.html.erb
@@ -12,10 +12,10 @@
         <%= icon("chevron-down", color: "warning", class: "group-open:transform group-open:rotate-180") %>
       </summary>
       <div class="text-xs py-2 space-y-2">
-        <p>Maybe uses Synth API to fetch historical exchange rates, security prices, and more.  This data is required to calculate accurate historical account balances.</p>
+        <p>Sure uses third party providers to fetch historical exchange rates, security prices, and more.  This data is required to calculate accurate historical account balances.</p>
 
         <p>
-          <%= link_to "Add your Synth API key here.", settings_hosting_path, class: "text-yellow-600 underline" %>
+          <%= link_to "Configure your providers here.", settings_hosting_path, class: "text-yellow-600 underline" %>
         </p>
       </div>
     </details>


### PR DESCRIPTION
This PR does:

- splits the check for requiring providers to two so you either need a provider for exchange rates and/or securty prices
- removes the check for the hardcoded Synth provider, instead checks whatever provider is set for either separately
- removes references to Maybe and Synth in the copy:

Before:

<img width="324" height="136" alt="image" src="https://github.com/user-attachments/assets/932b970f-fad2-482d-b144-348c62e45ba2" />

After:
<img width="351" height="137" alt="image" src="https://github.com/user-attachments/assets/303dad8f-c494-4e9c-8297-d653ae5f3f03" />
