### PR TITLE
feat: introduce multi-arch build matrix and OCI-compliant multi-arch images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,15 +51,15 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.10.0
 
       - name: Log in to the container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -84,14 +84,14 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=false
           tags: ${{ env.TAGS_SPEC }}
          
       - name: Build (and push) Docker image for ${{ matrix.platform }} by digest
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.16.0
         id: build
         with:
           context: .
@@ -134,7 +134,7 @@ jobs:
     
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.10.0
       
       - name: Download Docker image digests
         uses: actions/download-artifact@v4.3.0
@@ -144,7 +144,7 @@ jobs:
           merge-multiple: true
       
       - name: Log in to the container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
         type: string 
         default: 'main'
       push:
-        description: 'Whether to push the image to container registry'
+        description: 'Push the image to container registry'
         required: false
         type: boolean
         default: false
@@ -29,14 +29,21 @@ permissions:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
-
+  
   build:
-    name: Build docker image
+    name: Build Docker image
     needs: [ ci ]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [amd64, arm64]
+    
     timeout-minutes: 60
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
 
     permissions:
       contents: read
@@ -48,9 +55,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -60,6 +64,23 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Configure image tags
+        id: tag_config
+        shell: bash
+        run: |
+          BASE_CONFIG="type=sha,format=long"
+          if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
+            BASE_CONFIG+=$'\n'"type=schedule,pattern=nightly"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            BASE_CONFIG="type=semver,pattern={{version}}"
+            BASE_CONFIG+=$'\n'"type=raw,value=stable"
+          fi
+          {
+            echo 'TAGS_SPEC<<EOF'
+            echo "$BASE_CONFIG"
+            echo EOF
+          } >> $GITHUB_ENV
 
       - name: Extract metadata for Docker
         id: meta
@@ -67,24 +88,97 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=false
-          tags: |
-            type=sha,format=long
-            type=semver,pattern={{version}}
-            type=raw,value=nightly,enable=${{ github.event_name == 'schedule' }}
-            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Build and push Docker image
+          tags: ${{ env.TAGS_SPEC }}
+         
+      - name: Build (and push) Docker image for ${{ matrix.platform }} by digest
         uses: docker/build-push-action@v6
         id: build
         with:
           context: .
-          push: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
-          tags: ${{ steps.meta.outputs.tags }}
+          push: true
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: 'linux/amd64,linux/arm64'
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          platforms: 'linux/${{ matrix.platform }}'
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.platform }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.platform }},mode=max
           provenance: false
           # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},name-canonical=true,push-by-digest=true
           build-args: BUILD_COMMIT_SHA=${{ github.sha }}
+
+      - name: Export the Docker image digest
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}"/digests
+          echo "${DIGEST#sha256:}" > "${RUNNER_TEMP}/digests/digest-${PLATFORM}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Upload the Docker image digest
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: digest-${{ matrix.platform }}
+          path: ${{ runner.temp }}/digests/*
+  
+  merge:
+    name: Merge multi-arch manifest
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
+    needs: [build]
+
+    timeout-minutes: 60
+    runs-on: 'ubuntu-24.04'
+
+    permissions:
+      packages: write
+    
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Download Docker image digests
+        uses: actions/download-artifact@v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+      
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Merge and push Docker image
+        env:
+          TAGS: ${{ needs.build.outputs.tags }}
+          DIGESTS_DIR: ${{ runner.temp }}/digests
+        shell: bash -xeuo pipefail {0}
+        run: |
+          tag_args=()
+          while IFS=$'\n' read -r tag; do
+            [[ -n "${tag}" ]] || continue
+            tag_args+=("--tag=${tag}")
+          done <<< "${TAGS}"
+
+          image_args=()
+          for PLATFORM in amd64 arm64; do
+            image_args+=("${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:$(<"${DIGESTS_DIR}/digest-${PLATFORM}")")
+          done
+          
+          attempts=0
+          until docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app" \
+            "${tag_args[@]}" "${image_args[@]}" \
+          ; do
+            attempts=$((attempts + 1))
+            if [[ $attempts -ge 3 ]]; then
+              echo "[$(date -u)] ERROR: Failed after 3 attempts." >&2
+              exit 1
+            fi
+            delay=$((2 ** attempts))
+            if [[ $delay -gt 15 ]]; then delay=15; fi
+            echo "Push failed (attempt $attempts). Retrying in ${delay} seconds..."
+            sleep ${delay}
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,11 +61,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: latest=auto
+          flavor: latest=false
           tags: |
             type=sha,format=long
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=nightly,enable=${{ github.event_name == 'schedule' }}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,5 +81,5 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: false
           # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=A multi-arch Docker image for the Maybe Rails app
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app
           build-args: BUILD_COMMIT_SHA=${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: string 
         default: 'main'
+      push:
+        description: 'Whether to push the image to container registry'
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - 'v*'
@@ -73,7 +78,7 @@ jobs:
         id: build
         with:
           context: .
-          push: true
+          push: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: 'linux/amd64,linux/arm64'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,8 +82,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: 'linux/amd64,linux/arm64'
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           provenance: false
           # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.platform }},mode=max
           provenance: false
           # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},name-canonical=true,push-by-digest=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},name-canonical=true,push-by-digest=true,oci-mediatypes=true
           build-args: BUILD_COMMIT_SHA=${{ github.sha }}
 
       - name: Export the Docker image digest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,6 +120,8 @@ jobs:
         with:
           name: digest-${{ matrix.platform }}
           path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
   
   merge:
     name: Merge multi-arch manifest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ on:
       - 'v*'
     branches:
       - main
+  schedule:
+    - cron: '30 1 * * *'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,13 @@
+# Reference: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+
+# Conditions for pushing the image to GHCR:
+#   - Triggered by push to a version tag (`v*`)
+#   - Triggered by a scheduled run
+#   - Triggered manually via `workflow_dispatch` with `push: true`
+#
+# Conditional expression:
+#   startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push
+
 name: Publish Docker image
 
 on:
@@ -31,7 +41,7 @@ permissions:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
-  
+
   build:
     name: Build Docker image
     needs: [ ci ]
@@ -40,10 +50,10 @@ jobs:
       fail-fast: false
       matrix:
         platform: [amd64, arm64]
-    
+
     timeout-minutes: 60
     runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    
+
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
 
@@ -66,7 +76,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Configure image tags
         id: tag_config
         shell: bash
@@ -91,21 +101,22 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=false
           tags: ${{ env.TAGS_SPEC }}
-         
-      - name: Build (and push) Docker image for ${{ matrix.platform }} by digest
+
+      - name: Publish 'linux/${{ matrix.platform }}' image by digest
         uses: docker/build-push-action@v6.16.0
         id: build
         with:
           context: .
-          push: true
-          labels: ${{ steps.meta.outputs.labels }}
+          build-args: BUILD_COMMIT_SHA=${{ github.sha }}
           platforms: 'linux/${{ matrix.platform }}'
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.platform }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.platform }},mode=max
+          labels: ${{ steps.meta.outputs.labels }}
           provenance: false
-          # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
+          push: true
+          # DO NOT REMOVE `oci-mediatypes=true`, fixes annotation not showing up on job.merge.steps[-1]
+          # ref: https://github.com/docker/build-push-action/discussions/1022
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},name-canonical=true,push-by-digest=true,oci-mediatypes=true
-          build-args: BUILD_COMMIT_SHA=${{ github.sha }}
 
       - name: Export the Docker image digest
         if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
@@ -124,9 +135,9 @@ jobs:
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
-  
+
   merge:
-    name: Merge multi-arch manifest
+    name: Merge multi-arch manifest & push multi-arch tag
     if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
     needs: [build]
 
@@ -135,25 +146,25 @@ jobs:
 
     permissions:
       packages: write
-    
+
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0
-      
+
       - name: Download Docker image digests
         uses: actions/download-artifact@v4.3.0
         with:
           path: ${{ runner.temp }}/digests
           pattern: digest-*
           merge-multiple: true
-      
+
       - name: Log in to the container registry
         uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Merge and push Docker image
         env:
           TAGS: ${{ needs.build.outputs.tags }}
@@ -170,7 +181,7 @@ jobs:
           for PLATFORM in amd64 arm64; do
             image_args+=("${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:$(<"${DIGESTS_DIR}/digest-${PLATFORM}")")
           done
-          
+
           attempts=0
           until docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app" \


### PR DESCRIPTION
This PR refactors the `publish.yml` workflow to introduce a **multi-platform build matrix** (`amd64` + `arm64`) and **OCI-compliant manifest publishing**. It implements digest-based artifact handling, separates build/merge phases, and updates action versions for better reliability.

> [!NOTE]  
> Build times have dropped from [~35 minutes](https://github.com/we-promise/sure/actions/metrics/performance?tab=jobs&filters=job_name%3A%22Build+docker+image%22) to **6 minutes total** (~1-3.5 mins for `amd64`, ~1-5 mins for `arm64`, tested on fork with native runners).

### Changes
- Major workflow refactor to support matrix builds for `amd64` and `arm64` using native runners.
- Digest-based artifact workflow: build jobs export per-platform digests; merge job retrieves and combines them with `docker buildx imagetools create`.
- Conditional push logic for tags, scheduled runs, and `workflow_dispatch`.
- Upgraded actions (`checkout`, `setup-buildx`, `login-action`, `metadata-action`) to latest pinned versions.
- Added scheduled trigger and `push` parameter for manual runs.