### PR TITLE
fix: correct some dark mode ui issues

### DIFF
--- a/app/views/holdings/index.html.erb
+++ b/app/views/holdings/index.html.erb
@@ -5,7 +5,7 @@
       <%= link_to new_trade_path(account_id: @account.id),
                   id: dom_id(@account, "new_trade"),
                   data: { turbo_frame: :modal },
-                  class: "flex gap-1 font-medium items-center bg-gray-50 text-primary p-2 rounded-lg" do %>
+                  class: "flex gap-1 font-medium items-center bg-gray-50 theme-dark:bg-gray-700 hover:bg-gray-100 theme-dark:hover:bg-gray-600 text-primary p-2 rounded-lg" do %>
         <span class="text-primary">
           <%= icon("plus", color: "current") %>
         </span>

--- a/app/views/holdings/show.html.erb
+++ b/app/views/holdings/show.html.erb
@@ -61,7 +61,7 @@
                   <div>
                     <p class="text-secondary text-xs uppercase"><%= l(trade_entry.date, format: :long) %></p>
 
-                    <p><%= t(
+                    <p class="text-primary"><%= t(
                       ".trade_history_entry",
                       qty: trade_entry.trade.qty,
                       security: trade_entry.trade.security.ticker,


### PR DESCRIPTION
Fixes some minor dark mode UI issues I have noticed

Before:

<img width="1213" height="219" alt="image" src="https://github.com/user-attachments/assets/1eb1ae58-b778-4b33-921b-19406f57f7e8" />

After: 

<img width="1292" height="235" alt="image" src="https://github.com/user-attachments/assets/d8f08264-439e-4c88-b3d4-ec396fbb2549" />

Before:

<img width="714" height="748" alt="image" src="https://github.com/user-attachments/assets/7877a234-46f6-4e10-9fc8-88cf4addf7c8" />

After:

<img width="703" height="733" alt="image" src="https://github.com/user-attachments/assets/a4b007e8-28ee-4433-8484-97d3b1e3df8e" />

