### PR TITLE
fix: dark mode ui issue for transaction header

### DIFF
--- a/app/views/transactions/_header.html.erb
+++ b/app/views/transactions/_header.html.erb
@@ -3,7 +3,7 @@
 <%= tag.header class: "mb-4 space-y-1", id: dom_id(entry, :header) do %>
   <div class="flex items-center gap-4">
     <h3 class="font-medium">
-      <span class="text-2xl">
+      <span class="text-2xl text-primary">
         <%= format_money -entry.amount_money %>
       </span>
 


### PR DESCRIPTION
Minor UI issue with dark mode

Before:

<img width="708" height="258" alt="image" src="https://github.com/user-attachments/assets/ca53a06c-212e-4d9e-9b3d-7a6d77ff6a5a" />

After:

<img width="700" height="258" alt="image" src="https://github.com/user-attachments/assets/80581fdc-2f8f-470e-b6c0-e380df40aeac" />
