### PR TITLE
build: allow main branch publishing and add comprehensive OCI metadata for multi-arch images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
           flavor: latest=false
           tags: ${{ env.TAGS_SPEC }}
           labels: |
-            org.opencontainers.image.version=
+            org.opencontainers.image.version=${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
             org.opencontainers.image.created=${{ steps.date.outputs.date }}
             org.opencontainers.image.ref.name=${{ github.ref_name }}
             org.opencontainers.image.vendor=we-promise

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Get current date (RFC 3339 format)
         id: date
-        run: echo "::set-output name=date::$(date -Iseconds)"
+        run: echo "date=$(date -Iseconds)" >> $GITHUB_OUTPUT
 
       - name: Extract metadata for Docker
         id: meta

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,6 +84,7 @@ jobs:
           BASE_CONFIG="type=sha,format=long"
           if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
             BASE_CONFIG+=$'\n'"type=schedule,pattern=nightly"
+            BASE_CONFIG+=$'\n'"type=schedule,pattern=nightly-{{date 'ddd'}}"
           elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             BASE_CONFIG="type=semver,pattern={{version}}"
             BASE_CONFIG+=$'\n'"type=raw,value=stable"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,10 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
+      - name: Get current date (RFC 3339 format)
+        id: date
+        run: echo "::set-output name=date::$(date -Iseconds)"
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5.6.0
@@ -101,6 +105,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=false
           tags: ${{ env.TAGS_SPEC }}
+          labels: |
+            org.opencontainers.image.version=
+            org.opencontainers.image.created=${{ steps.date.outputs.date }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+            org.opencontainers.image.vendor=we-promise
+            org.opencontainers.image.title=Sure
+            org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app
 
       - name: Publish 'linux/${{ matrix.platform }}' image by digest
         uses: docker/build-push-action@v6.16.0
@@ -182,10 +193,29 @@ jobs:
             image_args+=("${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:$(<"${DIGESTS_DIR}/digest-${PLATFORM}")")
           done
 
+          annotations=(
+            "index:org.opencontainers.image.created=$(date -Iseconds)"
+            'index:org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}'
+            'index:org.opencontainers.image.revision=${{ github.sha }}'
+            'index:org.opencontainers.image.ref.name=${{ github.ref_name }}'
+            'index:org.opencontainers.image.vendor=we-promise'
+            'index:org.opencontainers.image.licenses=AGPL-3.0'
+            'index:org.opencontainers.image.title=Sure'
+            'index:org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app'
+          )
+          annotation_args=()
+          for annotation in "${annotations[@]}"; do
+            annotation_args+=("--annotation=${annotation}")
+          done
+          if [[ $GITHUB_REF_TYPE == "tag" ]]; then
+            annotation_args+=("--annotation='index:org.opencontainers.image.version=$GITHUB_REF_NAME'")
+          fi
+
           attempts=0
           until docker buildx imagetools create \
-            --annotation "index:org.opencontainers.image.description=A multi-arch Docker image for the Sure Rails app" \
-            "${tag_args[@]}" "${image_args[@]}" \
+            "${annotation_args[@]}" \
+            "${tag_args[@]}" \
+            "${image_args[@]}" \
           ; do
             attempts=$((attempts + 1))
             if [[ $attempts -ge 3 ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -210,7 +210,7 @@ jobs:
             annotation_args+=("--annotation=${annotation}")
           done
           if [[ $GITHUB_REF_TYPE == "tag" ]]; then
-            annotation_args+=("--annotation='index:org.opencontainers.image.version=$GITHUB_REF_NAME'")
+            annotation_args+=("--annotation=index:org.opencontainers.image.version=$GITHUB_REF_NAME")
           fi
 
           attempts=0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,13 @@
 # Reference: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
 
 # Conditions for pushing the image to GHCR:
+#   - Triggered by push to default branch (`main`)
 #   - Triggered by push to a version tag (`v*`)
 #   - Triggered by a scheduled run
 #   - Triggered manually via `workflow_dispatch` with `push: true`
 #
 # Conditional expression:
-#   startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push
+#   github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push
 
 name: Publish Docker image
 
@@ -131,7 +132,7 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},name-canonical=true,push-by-digest=true,oci-mediatypes=true
 
       - name: Export the Docker image digest
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
         run: |
           mkdir -p "${RUNNER_TEMP}"/digests
           echo "${DIGEST#sha256:}" > "${RUNNER_TEMP}/digests/digest-${PLATFORM}"
@@ -140,7 +141,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Upload the Docker image digest
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
         uses: actions/upload-artifact@v4.6.2
         with:
           name: digest-${{ matrix.platform }}
@@ -150,7 +151,7 @@ jobs:
 
   merge:
     name: Merge multi-arch manifest & push multi-arch tag
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event.inputs.push }}
     needs: [build]
 
     timeout-minutes: 60


### PR DESCRIPTION
- Updated conditional push logic to allow push of final image on push to `main` branch.
- Added new metadata labels for Docker images, including creation timestamp and vendor details.
- Introduced logic to annotate multi-arch manifests with comprehensive OCI labels.
- Adjusted conditional checks for digest export and artifact upload to match updated push logic.
- Added support for additional nightly build tag pattern (`nightly-{{date 'ddd'}}`).
  - This resolves the issue of having to cleanup images older than a week, since the tags will be cyclic.

---

<img width="1054" height="443" alt="image" src="https://github.com/user-attachments/assets/2d093505-f86c-4291-9ee9-6f94c7767896" />
