### PR TITLE
Increasing trades.price decimal scale

### DIFF
--- a/app/views/shared/_money_field.html.erb
+++ b/app/views/shared/_money_field.html.erb
@@ -48,14 +48,14 @@
           inline: true,
           placeholder: "100",
           value: if options[:value]
-            sprintf("%.#{currency.default_precision}f", options[:value])
+            sprintf("%.#{options[:precision].presence || currency.default_precision }f", options[:value])
           elsif form.object && form.object.respond_to?(amount_method)
             val = form.object.public_send(amount_method)
-            sprintf("%.#{currency.default_precision}f", val) if val.present?
+            sprintf("%.#{options[:precision].presence || currency.default_precision }f", val) if val.present?
           end,
           min: options[:min] || -99999999999999,
           max: options[:max] || 99999999999999,
-          step: currency.step,
+          step: options[:step] || currency.step,
           disabled: options[:disabled],
           data: {
             "money-field-target": "amount",

--- a/app/views/shared/_money_field.html.erb
+++ b/app/views/shared/_money_field.html.erb
@@ -48,10 +48,10 @@
           inline: true,
           placeholder: "100",
           value: if options[:value]
-            sprintf("%.#{options[:precision].presence || currency.default_precision }f", options[:value])
+            sprintf("%.#{options[:precision].presence || currency.default_precision}f", options[:value])
           elsif form.object && form.object.respond_to?(amount_method)
             val = form.object.public_send(amount_method)
-            sprintf("%.#{options[:precision].presence || currency.default_precision }f", val) if val.present?
+            sprintf("%.#{options[:precision].presence || currency.default_precision}f", val) if val.present?
           end,
           min: options[:min] || -99999999999999,
           max: options[:max] || 99999999999999,

--- a/app/views/trades/_form.html.erb
+++ b/app/views/trades/_form.html.erb
@@ -50,7 +50,7 @@
 
       <% if %w[buy sell].include?(type) %>
         <%= form.number_field :qty, label: t(".qty"), placeholder: "10", min: 0.000000000000000001, step: "any", required: true %>
-        <%= form.money_field :price, label: t(".price"), required: true %>
+        <%= form.money_field :price, label: t(".price"), step: 'any', precision: 10, required: true %>
       <% end %>
     </div>
 

--- a/app/views/trades/show.html.erb
+++ b/app/views/trades/show.html.erb
@@ -40,6 +40,8 @@
                   disable_currency: true,
                   auto_submit: true,
                   min: 0,
+                  step: "any",
+                  precision: 10,
                   disabled: @entry.linked? %>
           <% end %>
         <% end %>

--- a/db/migrate/20250806155348_increase_trade_price_precision.rb
+++ b/db/migrate/20250806155348_increase_trade_price_precision.rb
@@ -1,0 +1,9 @@
+class IncreaseTradePricePrecision < ActiveRecord::Migration[7.2]
+  def up
+    change_column :trades, :price, :decimal, precision: 19, scale: 10
+  end
+
+  def down
+    change_column :trades, :price, :decimal, precision: 19, scale: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_24_115507) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_06_155348) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -741,7 +741,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_24_115507) do
   create_table "trades", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "security_id", null: false
     t.decimal "qty", precision: 19, scale: 4
-    t.decimal "price", precision: 19, scale: 4
+    t.decimal "price", precision: 19, scale: 10
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "currency"


### PR DESCRIPTION
 A scale of 4 causes for trades.price causes destructive rounding when calculating transaction cost. The UI was imposing a scale of 2, in any case.

e.g. 20000 shares bought for a total of 101,777.88 USD is 5.088894 USD per share (average cost). The UI forces that to be rounded to 5.08. The DB would only store 5.0888 anyway. So this causes the total transaction cost to be represented as 101,600 USD. There just isn't a way to track actual transaction cost accurately for some transactions.

This change:
* Widens trades.price decimal scale to 10 in the db. Enough for 1c / 100 million shares.
* Adds options[:precision] and options[:step] to the money_field partial with defaults that leave the markup unchanged for other money values call sites that use the partial
* Changes the call sites that use the money_field partial for Trade.price representation with appropriate precision and step values
* A test for storing Trades to ensure price is only rounded after 10 places