### PR TITLE
feat(devcontainer): upgrade dev environment with better prompts, extensions, and configs

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+########
+# GitHub
+########
+
+function git_branch() {
+    local branch
+    branch="$(git symbolic-ref --short HEAD 2> /dev/null)"
+    if [[ -n "$branch" ]]; then
+        echo -n "$branch"
+        return 0
+    fi
+    return 1
+}
+
+function in_git_dir() {
+  git rev-parse --is-inside-work-tree > /dev/null 2>&1
+}
+
+function git_name() {
+  git config user.name 2> /dev/null
+}
+
+function git_has_diff() {
+  git diff --quiet HEAD 2> /dev/null
+}
+
+function git_status_marker() {
+  if in_git_dir; then
+    git_has_diff || echo -n ' *'
+  fi
+}
+
+########
+# PROMPT
+########
+
+export WHITE='\[\033[1;37m\]'
+export LIGHT_GREEN='\[\033[0;32m\]'
+export LIGHT_BLUE='\[\033[0;94m\]'
+export LIGHT_BLUE_BOLD='\[\033[1;94m\]'
+export RED_BOLD='\[\033[1;31m\]'
+export YELLOW_BOLD='\[\033[1;33m\]'
+export COLOUR_OFF='\[\033[0m\]'
+
+function prompt_command() {
+  local P=""
+  P="[\$?] "
+  P+="${LIGHT_GREEN}$(git_name || echo -n \$USER)"
+  P+="${WHITE} ➜ "
+  P+="${LIGHT_BLUE_BOLD}\w"
+
+  if in_git_dir; then
+    P+=" ${LIGHT_BLUE}("
+    P+="${RED_BOLD}\$(git_branch)"
+    P+="${YELLOW_BOLD}\$(git_status_marker)"
+    P+="${LIGHT_BLUE})"
+    P+="${COLOUR_OFF} "
+  else
+    P+="${COLOUR_OFF}"
+  fi
+
+  P+='\$ '
+  export PS1="$P"
+}
+
+export PROMPT_COMMAND='prompt_command'

--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ########
-# GitHub
+# Git
 ########
 
 function git_branch() {
@@ -22,7 +22,7 @@ function git_name() {
   git config user.name 2> /dev/null
 }
 
-function git_has_diff() {
+function git_has_no_diff() {
   git diff --quiet HEAD 2> /dev/null
 }
 
@@ -64,7 +64,7 @@ function git_status_marker() {
   fi
 
   # Dirty state: unstaged or staged changes
-  if ! git_has_diff; then
+  if ! git_has_no_diff; then
     echo -n " *"
     return 0
   fi
@@ -82,7 +82,7 @@ export LIGHT_BLUE='\[\033[0;94m\]'
 export LIGHT_BLUE_BOLD='\[\033[1;94m\]'
 export RED_BOLD='\[\033[1;31m\]'
 export YELLOW_BOLD='\[\033[1;33m\]'
-export COLOUR_OFF='\[\033[0m\]'
+export COLOR_OFF='\[\033[0m\]'
 
 function prompt_command() {
   local P=""
@@ -97,10 +97,20 @@ function prompt_command() {
     P+="${YELLOW_BOLD}\$(git_status_marker)"
     P+="${LIGHT_BLUE})"
   fi
-  P+="${COLOUR_OFF} "
+  P+="${COLOR_OFF} "
 
   P+='$ '
   export PS1="$P"
 }
 
 export PROMPT_COMMAND='prompt_command'
+
+########
+# Git autocompletion
+########
+
+if [[ -f /usr/share/bash-completion/completions/git ]]; then
+  . /usr/share/bash-completion/completions/git
+elif [[ -f /etc/bash_completion.d/git ]]; then
+  . /etc/bash_completion.d/git
+fi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,26 +1,28 @@
 ARG RUBY_VERSION=3.4.4
 FROM ruby:${RUBY_VERSION}-slim-bullseye
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -y install --no-install-recommends \
-  apt-utils \
-  build-essential \
-  curl \
-  git \
-  imagemagick \
-  iproute2 \
-  libpq-dev \
-  libyaml-dev \
-  libyaml-0-2 \
-  openssh-client \
-  postgresql-client \
-  vim
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN gem install bundler
-RUN gem install foreman
+RUN apt-get update -qq \
+  && apt-get -y install --no-install-recommends \
+    apt-utils \
+    build-essential \
+    curl \
+    git \
+    imagemagick \
+    iproute2 \
+    libpq-dev \
+    libyaml-dev \
+    libyaml-0-2 \
+    openssh-client \
+    postgresql-client \
+    vim \
+  && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+RUN gem install bundler foreman
 
 # Install Node.js 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-&& apt-get install -y nodejs
+  && apt-get install -y nodejs
 
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN gem install bundler foreman
 
 # Install Node.js 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-  && apt-get install -y nodejs
+  && apt-get install -y nodejs \
+  && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,10 @@
 {
-  "name": "Maybe",
+  "name": "Sure",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
   "containerEnv": {
+    "GIT_EDITOR": "code --wait",
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
     "GITHUB_USER": "${localEnv:GITHUB_USER}"
   },
@@ -15,8 +16,14 @@
     "vscode": {
       "extensions": [
         "biomejs.biome",
-        "EditorConfig.EditorConfig"
-      ]
+        "EditorConfig.EditorConfig",
+        "Shopify.ruby-extensions-pack"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.defaultProfile.osx": "zsh",
+        "terminal.integrated.defaultProfile.windows": "pwsh"
+      }
     }
   }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
 
     volumes:
+      - ./.bashrc:/root/.bashrc:ro,cached
       - ..:/workspace:cached
       - bundle_cache:/bundle
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,20 +16,15 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-
     volumes:
       - ./.bashrc:/root/.bashrc:ro,cached
       - ..:/workspace:cached
       - bundle_cache:/bundle
-
     ports:
       - "3000:3000"
-
     command: sleep infinity
-
     environment:
       <<: *rails_env
-
     depends_on:
       - db
       - redis
@@ -38,6 +33,9 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+      - bundle_cache:/bundle
     command: bundle exec sidekiq
     restart: unless-stopped
     environment:
@@ -47,20 +45,21 @@ services:
 
   redis:
     image: redis:latest
+    volumes:
+      - redis-data:/data
     ports:
       - "6379:6379"
     restart: unless-stopped
-    volumes:
-      - redis-data:/data
+  
   db:
     image: postgres:latest
-    restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
-    environment:
-      <<: *db_env
     ports:
       - "5432:5432"
+    restart: unless-stopped
+    environment:
+      <<: *db_env
 
 volumes:
   postgres-data:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,9 +5,6 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Backend
 
-  # Only needed for development in domain-cloaked GitHub devcontainer
-  skip_before_action :verify_authenticity_token if Rails.env.development?
-
   before_action :detect_os
   before_action :set_default_chat
   before_action :set_active_storage_url_options

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,9 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Backend
 
+  # Only needed for development in domain-cloaked GitHub devcontainer
+  skip_before_action :verify_authenticity_token if Rails.env.development?
+
   before_action :detect_os
   before_action :set_default_chat
   before_action :set_active_storage_url_options

--- a/config/initializers/codespaces.rb
+++ b/config/initializers/codespaces.rb
@@ -1,0 +1,25 @@
+# Dev-only adjustments for GitHub Codespaces
+if Rails.env.development? && ENV["CODESPACES"] == "true"
+  # Example: forwarded URLs like https://<repo>-<user>-<port>.app.github.dev
+  forwarding_domain = ENV["GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN"] # typically "app.github.dev"
+
+  # Append allowed hosts ONLY if Host Authorization is enabled (config.hosts is an Array).
+  # If it's nil, Host Authorization is disabled and we leave it alone.
+  if Rails.application.config.hosts.is_a?(Array)
+    if forwarding_domain.present?
+      Rails.application.config.hosts << /\A.*\.#{Regexp.escape(forwarding_domain)}\z/
+    end
+    # Older/alternative preview domain
+    Rails.application.config.hosts << /\A.*\.githubpreview\.dev\z/
+  end
+
+  # If you use the VS Code "Preview" (iframe), you need SameSite=None; Secure
+  # Codespaces serves over HTTPS, so secure: true is OK here.
+  Rails.application.config.session_store :cookie_store,
+    key: "_app_session",
+    same_site: :none,
+    secure: true
+
+  # Behind the proxy, Origin can differ; relax the origin check instead of disabling CSRF entirely.
+  Rails.application.config.action_controller.forgery_protection_origin_check = false
+end


### PR DESCRIPTION
I was appalled that devcontainers weren’t being used to their full potential - especially having seen entire dev teams request devcontainers - so I decided to make them genuinely usable.

### Changes
- **Added** `.devcontainer/.bashrc` with a Git-aware, colorized shell prompt that displays:
  - Current branch or commit hash
  - Git states (dirty, rebase, merge, bisect)
  - Exit status of last command
  - Current directory and username
- Refactored .devcontainer/Dockerfile to:
  - Set DEBIAN_FRONTEND=noninteractive as an environment variable.
  - Clean apt cache after package installation to reduce image size.
  - Combine gem install `bundler` and `foreman` into a single command.
- **Modified** `.devcontainer/devcontainer.json`:
  - Renamed container from `"Maybe"` to `"Sure"`
  - Added `GIT_EDITOR` environment variable for VSCode
  - Added `"Shopify.ruby-extensions-pack"` extension
  - Configured default terminal profiles for Linux, macOS, and Windows
- **Updated** `.devcontainer/docker-compose.yml` to mount `.bashrc` into `/root/.bashrc` as read-only
- [@jjmata] **Added** `config/initializers/codespaces.rb`:
  - Allowed GitHub Codespaces forwarding domains in `config.hosts`
  - Set secure, cross-site–compatible session cookies for Codespaces preview
  - Disabled strict origin check to prevent CSRF issues in proxied environments


---

Check it out and let me know how it goes! If you have any suggestions about `.bashrc`, feel free to comment!