### PR TITLE
Add Gemini Code Assist config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: true
+code_review:
+  disable: true
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+ignore_patterns: []


### PR DESCRIPTION
Off by default, too many bots!

See:

- https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#default-configuration
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a Gemini Code Assist config file to set review and comment options. Code assist for reviews is disabled by default.

- **Configuration Changes**
 - Set comment severity threshold to MEDIUM.
 - Allow code review summaries when pull requests open.
 - Disabled help comments and limited max review comments.

<!-- End of auto-generated description by cubic. -->

