### PR TITLE
Add OpenAI token configuration to self-hosting settings

### DIFF
--- a/app/controllers/settings/hostings_controller.rb
+++ b/app/controllers/settings/hostings_controller.rb
@@ -31,6 +31,10 @@ class Settings::HostingsController < ApplicationController
       Setting.twelve_data_api_key = hosting_params[:twelve_data_api_key]
     end
 
+    if hosting_params.key?(:openai_access_token)
+      Setting.openai_access_token = hosting_params[:openai_access_token]
+    end
+
     redirect_to settings_hosting_path, notice: t(".success")
   rescue ActiveRecord::RecordInvalid => error
     flash.now[:alert] = t(".failure")
@@ -44,7 +48,7 @@ class Settings::HostingsController < ApplicationController
 
   private
     def hosting_params
-      params.require(:setting).permit(:require_invite_for_signup, :require_email_confirmation, :brand_fetch_client_id, :twelve_data_api_key)
+      params.require(:setting).permit(:require_invite_for_signup, :require_email_confirmation, :brand_fetch_client_id, :twelve_data_api_key, :openai_access_token)
     end
 
     def ensure_admin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,7 +88,7 @@ class User < ApplicationRecord
   end
 
   def ai_available?
-    !Rails.application.config.app_mode.self_hosted? || ENV["OPENAI_ACCESS_TOKEN"].present?
+    !Rails.application.config.app_mode.self_hosted? || ENV["OPENAI_ACCESS_TOKEN"].present? || Setting.openai_access_token.present?
   end
 
   def ai_enabled?

--- a/app/views/chats/_ai_consent.html.erb
+++ b/app/views/chats/_ai_consent.html.erb
@@ -10,7 +10,7 @@
       Maybe AI can answer financial questions and provide insights based on your data. To use this feature you'll need to explicitly enable it.
     <% else %>
       To use the AI assistant, you need to set the <code class="bg-surface-inset px-1 py-0.5 rounded font-mono text-xs">OPENAI_ACCESS_TOKEN</code>
-      environment variable in your self-hosted instance.
+      environment variable or configure it in the Self-Hosting settings of your instance.
     <% end %>
   </p>
 

--- a/app/views/settings/hostings/_openai_settings.html.erb
+++ b/app/views/settings/hostings/_openai_settings.html.erb
@@ -1,0 +1,26 @@
+<div class="space-y-4">
+  <div>
+    <h2 class="font-medium mb-1"><%= t(".title") %></h2>
+    <% if ENV["OPENAI_ACCESS_TOKEN"].present? %>
+      <p class="text-sm text-secondary">You have successfully configured your OpenAI access token through the OPENAI_ACCESS_TOKEN environment variable.</p>
+    <% else %>
+      <p class="text-secondary text-sm mb-4"><%= t(".description") %></p>
+    <% end %>
+  </div>
+
+  <%= styled_form_with model: Setting.new,
+                       url: settings_hosting_path,
+                       method: :patch,
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+    <%= form.text_field :openai_access_token,
+                        label: t(".label"),
+                        type: "password",
+                        placeholder: t(".placeholder"),
+                        value: ENV.fetch("OPENAI_ACCESS_TOKEN", Setting.openai_access_token),
+                        disabled: ENV["OPENAI_ACCESS_TOKEN"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+  <% end %>
+</div>

--- a/app/views/settings/hostings/show.html.erb
+++ b/app/views/settings/hostings/show.html.erb
@@ -1,8 +1,9 @@
 <%= content_for :page_title, t(".title") %>
 
 <%= settings_section title: t(".general") do %>
-  <div class="space-y-6">
+    <div class="space-y-6">
     <%= render "settings/hostings/brand_fetch_settings" %>
+    <%= render "settings/hostings/openai_settings" %>
     <%= render "settings/hostings/twelve_data_settings" %>
   </div>
 <% end %>

--- a/config/locales/views/settings/hostings/en.yml
+++ b/config/locales/views/settings/hostings/en.yml
@@ -26,6 +26,11 @@ en:
         label: Client ID
         placeholder: Enter your Client ID here
         title: Brand Fetch Settings
+      openai_settings:
+        description: Input the access token provided by OpenAI
+        label: Access Token
+        placeholder: Enter your access token here
+        title: OpenAI Settings
       twelve_data_settings:
         api_calls_used: "%{used} / %{limit} API daily calls used (%{percentage})"
         description: Input the API key provided by Twelve Data

--- a/test/controllers/settings/hostings_controller_test.rb
+++ b/test/controllers/settings/hostings_controller_test.rb
@@ -46,6 +46,14 @@ class Settings::HostingsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "can update openai access token when self hosting is enabled" do
+    with_self_hosting do
+      patch settings_hosting_url, params: { setting: { openai_access_token: "token" } }
+
+      assert_equal "token", Setting.openai_access_token
+    end
+  end
+
   test "can clear data cache when self hosting is enabled" do
     account = accounts(:investment)
     holding = account.holdings.first

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -138,4 +138,18 @@ class UserTest < ActiveSupport::TestCase
     assert_match %r{secret=#{user.otp_secret}}, user.provisioning_uri
     assert_match %r{issuer=Maybe}, user.provisioning_uri
   end
+
+  test "ai_available? returns true when openai access token set in settings" do
+    Rails.application.config.app_mode.stubs(:self_hosted?).returns(true)
+    previous = Setting.openai_access_token
+    with_env_overrides OPENAI_ACCESS_TOKEN: nil do
+      Setting.openai_access_token = nil
+      assert_not @user.ai_available?
+
+      Setting.openai_access_token = "token"
+      assert @user.ai_available?
+    end
+  ensure
+    Setting.openai_access_token = previous
+  end
 end


### PR DESCRIPTION
## Summary
- allow setting the OpenAI access token through Self-Hosting settings
- expose AI availability based on the configured token
- document configuration option in AI consent message

## Testing
- `bin/rails test` *(fails: There is an issue connecting with your hostname: 127.0.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f05b21208332b6990e509799a4e9