### PR TITLE
General bank provider framework with Mercury integration

### DIFF
--- a/app/services/bank_providers/base.rb
+++ b/app/services/bank_providers/base.rb
@@ -1,0 +1,15 @@
+module BankProviders
+  class Base
+    # Lists available accounts for the authenticated connection.
+    # Should return an array of hashes normalized for the application.
+    def list_accounts
+      raise NotImplementedError, "Subclasses must implement #list_accounts"
+    end
+
+    # Fetches transactions for a given account.
+    # Expected to return an array of normalized transaction hashes.
+    def fetch_transactions(account_id, from: nil, to: nil)
+      raise NotImplementedError, "Subclasses must implement #fetch_transactions"
+    end
+  end
+end

--- a/app/services/bank_providers/mercury.rb
+++ b/app/services/bank_providers/mercury.rb
@@ -1,0 +1,53 @@
+require "httparty"
+require "openssl"
+
+module BankProviders
+  class Mercury < Base
+    include HTTParty
+    base_uri "https://api.mercury.com/api/v1"
+
+    def initialize(api_key: ENV["MERCURY_API_KEY"], api_secret: ENV["MERCURY_API_SECRET"])
+      @api_key = api_key
+      @api_secret = api_secret
+    end
+
+    def list_accounts
+      request(:get, "/accounts")
+    end
+
+    def fetch_transactions(account_id, from: nil, to: nil)
+      params = {}
+      params[:start] = from if from
+      params[:end] = to if to
+      request(:get, "/accounts/#{account_id}/transactions", query: params)
+    end
+
+    private
+      attr_reader :api_key, :api_secret
+
+      def request(method, path, query: nil, body: nil)
+        headers = signed_headers(method.to_s.upcase, path, body)
+        options = { headers: headers }
+        options[:query] = query if query && !query.empty?
+        options[:body] = body.to_json if body
+
+        response = self.class.send(method, path, options)
+        JSON.parse(response.body)
+      end
+
+      def signed_headers(method, path, body)
+        timestamp = Time.now.utc.to_i.to_s
+        payload = "#{timestamp}#{method}#{path}#{body ? body.to_json : ""}"
+        signature = OpenSSL::HMAC.hexdigest("SHA256", api_secret, payload)
+
+        {
+          "X-Mercury-Api-Key" => api_key,
+          "X-Mercury-Timestamp" => timestamp,
+          "X-Mercury-Signature" => signature,
+          "Content-Type" => "application/json"
+        }
+      end
+  end
+end
+
+BankProviders::Registry.register(:mercury, BankProviders::Mercury)

--- a/app/services/bank_providers/registry.rb
+++ b/app/services/bank_providers/registry.rb
@@ -1,0 +1,19 @@
+module BankProviders
+  class Registry
+    class << self
+      def register(key, klass)
+        providers[key.to_sym] = klass
+      end
+
+      def for(key, **args)
+        klass = providers[key.to_sym]
+        raise ArgumentError, "Unknown bank provider: #{key}" unless klass
+        klass.new(**args)
+      end
+
+      def providers
+        @providers ||= {}
+      end
+    end
+  end
+end

--- a/app/services/bank_providers/wise.rb
+++ b/app/services/bank_providers/wise.rb
@@ -1,0 +1,41 @@
+require "httparty"
+
+module BankProviders
+  class Wise < Base
+    include HTTParty
+    base_uri "https://api.transferwise.com/v1"
+
+    def initialize(api_token: ENV["WISE_API_TOKEN"])
+      @api_token = api_token
+    end
+
+    def list_accounts
+      request(:get, "/profiles")
+    end
+
+    def fetch_transactions(account_id, from: nil, to: nil)
+      params = {}
+      params[:from] = from if from
+      params[:to] = to if to
+      request(:get, "/accounts/#{account_id}/statement", query: params)
+    end
+
+    private
+      attr_reader :api_token
+
+      def request(method, path, query: nil, body: nil)
+        headers = {
+          "Authorization" => "Bearer #{api_token}",
+          "Content-Type" => "application/json"
+        }
+        options = { headers: headers }
+        options[:query] = query if query && !query.empty?
+        options[:body] = body.to_json if body
+
+        response = self.class.send(method, path, options)
+        JSON.parse(response.body)
+      end
+  end
+end
+
+BankProviders::Registry.register(:wise, BankProviders::Wise)

--- a/docs/hosting/mercury.md
+++ b/docs/hosting/mercury.md
@@ -1,0 +1,17 @@
+# Mercury Bank Integration
+
+The application can connect directly to Mercury Bank using the public API.
+
+## Configuration
+
+Set the following environment variables with the credentials obtained from Mercury:
+
+```
+MERCURY_API_KEY=your_api_key
+MERCURY_API_SECRET=your_api_secret
+```
+
+## Usage
+
+The connection is implemented using a pluggable bank provider architecture.
+Mercury can be selected with the provider key `:mercury`.

--- a/docs/hosting/wise.md
+++ b/docs/hosting/wise.md
@@ -1,0 +1,16 @@
+# Wise Bank Integration
+
+The application can connect directly to Wise using the public API.
+
+## Configuration
+
+Set the following environment variable with your API token:
+
+```
+WISE_API_TOKEN=your_token
+```
+
+## Usage
+
+The connection is implemented using the pluggable bank provider architecture.
+Wise can be selected with the provider key `:wise`.

--- a/test/services/bank_providers/mercury_test.rb
+++ b/test/services/bank_providers/mercury_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class BankProvidersMercuryTest < ActiveSupport::TestCase
+  test "list_accounts signs request" do
+    provider = BankProviders::Mercury.new(api_key: "key", api_secret: "secret")
+
+    Time.stub :now, Time.at(1_700_000_000) do
+      path = "/accounts"
+      payload = "1700000000GET#{path}"
+      expected_signature = OpenSSL::HMAC.hexdigest("SHA256", "secret", payload)
+
+      stub_request(:get, "https://api.mercury.com/api/v1/accounts").with(
+        headers: {
+          "X-Mercury-Api-Key" => "key",
+          "X-Mercury-Timestamp" => "1700000000",
+          "X-Mercury-Signature" => expected_signature,
+          "Content-Type" => "application/json"
+        }
+      ).to_return(body: "{\"accounts\": []}", headers: { "Content-Type" => "application/json" })
+
+      assert_equal({"accounts" => []}, provider.list_accounts)
+    end
+  end
+end

--- a/test/services/bank_providers/wise_test.rb
+++ b/test/services/bank_providers/wise_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class BankProvidersWiseTest < ActiveSupport::TestCase
+  test "list_accounts sends bearer token" do
+    provider = BankProviders::Wise.new(api_token: "token")
+
+    stub_request(:get, "https://api.transferwise.com/v1/profiles").with(
+      headers: {
+        "Authorization" => "Bearer token",
+        "Content-Type" => "application/json"
+      }
+    ).to_return(body: "{\"profiles\": []}", headers: { "Content-Type" => "application/json" })
+
+    assert_equal({"profiles" => []}, provider.list_accounts)
+  end
+end


### PR DESCRIPTION
## Summary
- introduce generic bank provider base and registry
- implement Mercury provider with HMAC-signed requests
- add Wise provider using bearer token authentication
- document Mercury and Wise setup and add provider tests

## Testing
- `bundle exec rake test` *(fails: ActiveRecord::DatabaseConnectionError - There is an issue connecting with your hostname: 127.0.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0ca044888332a1f036d49a129432