### PR TITLE
Add Enable Banking integration

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -6,6 +6,7 @@ class AccountsController < ApplicationController
     @manual_accounts = family.accounts.manual.alphabetically
     @plaid_items = family.plaid_items.ordered
     @simplefin_items = family.simplefin_items.ordered
+    @enable_banking_items = family.enable_banking_items.ordered
 
     render layout: "settings"
   end

--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -1,0 +1,74 @@
+class EnableBankingItemsController < ApplicationController
+  before_action :set_enable_banking_item, only: %i[edit destroy sync]
+
+  def index
+    @enable_banking_items = Current.family.enable_banking_items.active.ordered
+    render layout: "settings"
+  end
+
+  def new
+    @enable_banking_item = Current.family.enable_banking_items.build
+    available_aspsps = enable_banking_provider.get_available_aspsps
+    @aspsps = available_aspsps.map do |aspsp|
+      [aspsp["name"], aspsp["name"]]
+    end
+  rescue => error
+    Sentry.capture_exception(error)
+    render json: { error: "#{error.message}" }, status: :bad_request
+  end
+
+  def edit
+  end
+
+  def destroy
+    @enable_banking_item.destroy_later
+    redirect_to enable_banking_items_path, notice: t(".success")
+  end
+
+  def authorization
+    aspsp_name = params[:aspsps_name]
+    auth_url = enable_banking_provider.generate_authorization_url(aspsp_name)
+    render json: { url: auth_url }
+  rescue => error
+    Sentry.capture_exception(error)
+    render json: { error: "#{error.message}" }, status: :bad_request
+  end
+
+  def auth_callback
+    code = params[:code]
+    if code.nil?
+      Rails.logger.error("Failed to retrieve code from authentication callback parameters")
+      redirect_to enable_banking_items_path, alert: "Authentication failed. Please try again."
+    else
+      session = enable_banking_provider.create_session(code)
+      @enable_banking_item = Current.family.create_enable_banking_item!(
+        session_id: session["session_id"],
+        valid_until: session["access"]["valid_until"],
+        item_name: session["aspsp"]["name"],
+        logo_url: "https://enablebanking.com/brands/#{session['aspsp']['country']}/#{session['aspsp']['name']}",
+        raw_payload: session.to_json
+      )
+      redirect_to enable_banking_items_path, notice: "Enable Banking connection added successfully! Your accounts will appear shortly as they sync in the background."
+    end
+  end
+
+  def sync
+    unless @enable_banking_item.syncing?
+      @enable_banking_item.sync_later
+    end
+
+    respond_to do |format|
+      format.html { redirect_back_or_to accounts_path }
+      format.json { head :ok }
+    end
+  end
+
+  private
+    def enable_banking_provider
+      @enable_banking_provider ||= Provider::Registry.get_provider(:enable_banking)
+    end
+    def set_enable_banking_item
+      @enable_banking_item = Current.family.enable_banking_items.find(params[:id])
+    end
+
+end

--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -34,7 +34,7 @@ class EnableBankingItemsController < ApplicationController
     auth_url = generate_authorization_url(aspsp_name)
     redirect_to auth_url, allow_other_host: true, status: :see_other
   rescue => error
-    @enable_banking_item.errors.add(:base, t(".authorization_error"))
+    redirect_to enable_banking_items_path, alert: t(".authorization_error")
   end
 
   def update_connection

--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -90,5 +90,4 @@ class EnableBankingItemsController < ApplicationController
     def generate_authorization_url(aspsp_name, country_code = nil, enable_banking_id = nil)
       enable_banking_provider.generate_authorization_url(aspsp_name, country_code, enable_banking_id)
     end
-
 end

--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -2,6 +2,7 @@ class EnableBankingItemsController < ApplicationController
   before_action :set_enable_banking_item, only: %i[edit destroy sync]
 
   def index
+    @breadcrumbs = [ [ "Home", root_path ], [ "Bank Sync", settings_bank_sync_path ], [ "Enable Banking", nil ] ]
     @enable_banking_items = Current.family.enable_banking_items.active.ordered
     render layout: "settings"
   end

--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -52,18 +52,12 @@ class EnableBankingItemsController < ApplicationController
       redirect_to enable_banking_items_path, alert: t(".auth_failed")
     else
       enable_banking_id = params[:state]
-      @enable_banking_item = Current.family.enable_banking_items.find_or_create_by(id: enable_banking_id)
-      session = enable_banking_provider.create_session(code)
-      @enable_banking_item.update!(
-        session_id: session["session_id"],
-        valid_until: session["access"]["valid_until"],
-        status: "good",
-        aspsp_name: session["aspsp"]["name"],
-        aspsp_country: session["aspsp"]["country"],
-        logo_url: "https://enablebanking.com/brands/#{session['aspsp']['country']}/#{session['aspsp']['name']}",
-        raw_payload: session.to_json
+      Current.family.create_enable_banking_item!(
+        enable_banking_id: enable_banking_id,
+        session_id: code
       )
-      redirect_to enable_banking_items_path, notice: t(".success")
+
+      redirect_to accounts_path, notice: t(".success")
     end
   end
 

--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -3,10 +3,10 @@ class EnableBankingItemsController < ApplicationController
 
   def index
     @enable_banking_items = Current.family.enable_banking_items.active.ordered
-    @breadcrumbs = [ 
-      [ "Home", root_path ], 
-      [ "Bank Sync", settings_bank_sync_path ], 
-      [ "Enable Banking", nil ] 
+    @breadcrumbs = [
+      [ "Home", root_path ],
+      [ "Bank Sync", settings_bank_sync_path ],
+      [ "Enable Banking", nil ]
     ]
     render layout: "settings"
   end
@@ -15,7 +15,7 @@ class EnableBankingItemsController < ApplicationController
     @enable_banking_item = Current.family.enable_banking_items.build
     available_aspsps = enable_banking_provider.get_available_aspsps
     @aspsps = available_aspsps.map do |aspsp|
-      [aspsp["name"], aspsp["name"]]
+      [ aspsp["name"], aspsp["name"] ]
     end
   rescue => error
     @enable_banking_item.errors.add(:base, t(".aspsp_error"))
@@ -82,7 +82,7 @@ class EnableBankingItemsController < ApplicationController
     def enable_banking_provider
       @enable_banking_provider ||= Provider::Registry.get_provider(:enable_banking)
     end
-    
+
     def set_enable_banking_item
       @enable_banking_item = Current.family.enable_banking_items.find(params[:id])
     end

--- a/app/controllers/settings/bank_sync_controller.rb
+++ b/app/controllers/settings/bank_sync_controller.rb
@@ -21,6 +21,11 @@ class Settings::BankSyncController < ApplicationController
         name: "SimpleFin",
         description: "US & Canada connections via SimpleFin protocol.",
         path: simplefin_items_path
+      },
+      {
+        name: "Enable Banking",
+        description: "Bank connections via Enable Banking APIs.",
+        path: enable_banking_items_path
       }
     ]
   end

--- a/app/controllers/settings/hostings_controller.rb
+++ b/app/controllers/settings/hostings_controller.rb
@@ -34,6 +34,18 @@ class Settings::HostingsController < ApplicationController
     if hosting_params.key?(:openai_access_token)
       Setting.openai_access_token = hosting_params[:openai_access_token]
     end
+
+    if hosting_params.key?(:enable_banking_country)
+      Setting.enable_banking_country = hosting_params[:enable_banking_country]
+    end
+
+    if hosting_params.key?(:enable_banking_application_id)
+      Setting.enable_banking_application_id = hosting_params[:enable_banking_application_id]
+    end
+
+    if hosting_params.key?(:enable_banking_certificate)
+      Setting.enable_banking_certificate = hosting_params[:enable_banking_certificate]
+    end
     if hosting_params.key?(:openai_access_token)
       token_param = hosting_params[:openai_access_token].to_s.strip
       # Ignore blanks and redaction placeholders to prevent accidental overwrite
@@ -55,7 +67,7 @@ class Settings::HostingsController < ApplicationController
 
   private
     def hosting_params
-      params.require(:setting).permit(:require_invite_for_signup, :require_email_confirmation, :brand_fetch_client_id, :twelve_data_api_key, :openai_access_token)
+      params.require(:setting).permit(:require_invite_for_signup, :require_email_confirmation, :brand_fetch_client_id, :twelve_data_api_key, :openai_access_token, :enable_banking_country, :enable_banking_application_id, :enable_banking_certificate)
     end
 
     def ensure_admin

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -9,6 +9,8 @@ module AccountsHelper
       sync_plaid_item_path(account.plaid_account.plaid_item)
     elsif account.simplefin_account_id.present?
       sync_simplefin_item_path(account.simplefin_account.simplefin_item)
+    elsif account.enable_banking_account_id.present?
+      sync_enable_banking_item_path(account.enable_banking_account.enable_banking_item)
     else
       sync_account_path(account)
     end

--- a/app/javascript/controllers/authorization_form_controller.js
+++ b/app/javascript/controllers/authorization_form_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    this.element.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const formData = new FormData(this.element);
+      try {
+        const response = await fetch(this.element.action, {
+          method: "POST",
+          headers: {
+            "Accept": "application/json",
+            "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
+          },
+          body: formData,
+        });
+        const data = await response.json();
+        if (data.url) {
+          window.location.assign(data.url);
+        } else {
+          alert("No authorization URL received.");
+        }
+      } catch (error) {
+        console.error("Authorization error:", error);
+        alert("Authorization error:", error);
+      }
+    });
+  }
+}

--- a/app/models/account/linkable.rb
+++ b/app/models/account/linkable.rb
@@ -4,11 +4,12 @@ module Account::Linkable
   included do
     belongs_to :plaid_account, optional: true
     belongs_to :simplefin_account, optional: true
+    belongs_to :enable_banking_account, optional: true
   end
 
-  # A "linked" account gets transaction and balance data from a third party like Plaid or SimpleFin
+  # A "linked" account gets transaction and balance data from a third party
   def linked?
-    plaid_account_id.present? || simplefin_account_id.present?
+    plaid_account_id.present? || simplefin_account_id.present? || enable_banking_account_id.present?
   end
 
   # An "offline" or "unlinked" account is one where the user tracks values and

--- a/app/models/data_enrichment.rb
+++ b/app/models/data_enrichment.rb
@@ -1,5 +1,5 @@
 class DataEnrichment < ApplicationRecord
   belongs_to :enrichable, polymorphic: true
 
-  enum :source, { rule: "rule", plaid: "plaid", synth: "synth", ai: "ai" }
+  enum :source, { rule: "rule", plaid: "plaid", synth: "synth", ai: "ai", enable_banking: "enable_banking" }
 end

--- a/app/models/enable_banking_account.rb
+++ b/app/models/enable_banking_account.rb
@@ -1,0 +1,34 @@
+class EnableBankingAccount < ApplicationRecord
+  belongs_to :enable_banking_item
+
+  has_one :account, dependent: :destroy
+
+  validates :name, :currency, presence: true
+  validate :has_balance
+
+  def upsert_enable_banking_snapshot!(account_snapshot)
+    assign_attributes(
+      account_id: account_snapshot["uid"],
+      current_balance: account_snapshot["balances"]["current"],
+      available_balance: account_snapshot["balances"]["available"],
+      currency: account_snapshot["currency"],
+      name: account_snapshot["name"],
+      account_type: account_snapshot["account_type"],
+      raw_payload: account_snapshot
+    )
+    save!
+  end
+
+  def upsert_enable_banking_transactions_snapshot!(transactions_snapshot)
+    assign_attributes(
+      raw_transactions_payload: transactions_snapshot
+    )
+    save!
+  end
+
+  private
+    def has_balance
+      return if current_balance.present? || available_balance.present?
+      errors.add(:base, "Enable Banking account must have either current or available balance")
+    end
+end

--- a/app/models/enable_banking_account/importer.rb
+++ b/app/models/enable_banking_account/importer.rb
@@ -1,5 +1,5 @@
 class EnableBankingAccount::Importer
-  
+
   def initialize(enable_banking_account, account_snapshot:)
     @enable_banking_account = enable_banking_account
     @account_snapshot = account_snapshot
@@ -20,5 +20,5 @@ class EnableBankingAccount::Importer
     def import_transactions
       enable_banking_account.upsert_enable_banking_transactions_snapshot!(account_snapshot["transactions_data"])
     end
-    
+
 end

--- a/app/models/enable_banking_account/importer.rb
+++ b/app/models/enable_banking_account/importer.rb
@@ -1,5 +1,4 @@
 class EnableBankingAccount::Importer
-
   def initialize(enable_banking_account, account_snapshot:)
     @enable_banking_account = enable_banking_account
     @account_snapshot = account_snapshot
@@ -20,5 +19,4 @@ class EnableBankingAccount::Importer
     def import_transactions
       enable_banking_account.upsert_enable_banking_transactions_snapshot!(account_snapshot["transactions_data"])
     end
-
 end

--- a/app/models/enable_banking_account/importer.rb
+++ b/app/models/enable_banking_account/importer.rb
@@ -1,0 +1,24 @@
+class EnableBankingAccount::Importer
+  
+  def initialize(enable_banking_account, account_snapshot:)
+    @enable_banking_account = enable_banking_account
+    @account_snapshot = account_snapshot
+  end
+
+  def import
+    import_account_info
+    import_transactions if account_snapshot["transactions_data"].present?
+  end
+
+  private
+    attr_reader :enable_banking_account, :account_snapshot
+
+    def import_account_info
+      enable_banking_account.upsert_enable_banking_snapshot!(account_snapshot)
+    end
+
+    def import_transactions
+      enable_banking_account.upsert_enable_banking_transactions_snapshot!(account_snapshot["transactions_data"])
+    end
+    
+end

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -1,0 +1,87 @@
+class EnableBankingAccount::Processor
+  include EnableBankingAccount::TypeMappable
+
+  attr_reader :enable_banking_account
+
+  def initialize(enable_banking_account)
+    @enable_banking_account = enable_banking_account
+  end
+
+  # Each step represents a different Enable Banking API endpoint
+  #
+  # Processing the account is the first step and if it fails, we halt the entire processor
+  # Each subsequent step can fail independently, but we continue processing the rest of the steps
+  def process
+    process_account!
+    process_transactions
+  end
+
+  private
+    def family
+      enable_banking_account.enable_banking_item.family
+    end
+
+    def process_account!
+      EnableBankingAccount.transaction do
+        account = family.accounts.find_or_initialize_by(
+          enable_banking_account_id: enable_banking_account.id
+        )
+
+        # Create or assign the accountable if needed
+        if account.accountable.nil?
+          accountable = map_accountable(enable_banking_account.account_type)
+          account.accountable = accountable
+        end
+
+        # Name and subtype are the attributes a user can override for Plaid accounts
+        # Use enrichable pattern to respect locked attributes
+        account.enrich_attributes(
+          {
+            name: enable_banking_account.name
+          },
+          source: "enable_banking"
+        )
+
+        account.assign_attributes(
+          balance: balance_calculator.balance,
+          currency: enable_banking_account.currency,
+          cash_balance: balance_calculator.cash_balance
+        )
+
+        account.save!
+
+        # Create or update the current balance anchor valuation for event-sourced ledger
+        account.set_current_balance(balance_calculator.balance)
+      end
+    end
+
+    def process_transactions
+      return unless enable_banking_account.raw_transactions_payload.present?
+
+      transactions_data = enable_banking_account.raw_transactions_payload
+      transactions_data&.each do |transaction|
+        EnableBankingEntry::Processor.new(
+          transaction,
+          enable_banking_account: enable_banking_account
+        ).process
+      end
+    rescue => e
+      report_exception(e)
+    end
+
+    def balance_calculator
+      balance = enable_banking_account.current_balance || enable_banking_account.available_balance || 0
+      # We don't currently distinguish "cash" vs. "non-cash" balances for non-investment accounts.
+      OpenStruct.new(
+          balance: balance,
+          cash_balance: balance
+      )
+    end
+
+    def report_exception(error)
+      Sentry.capture_exception(error) do |scope|
+        scope.set_tags(enable_banking_account_id: enable_banking_account.id)
+      end
+    end
+
+end

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -83,5 +83,4 @@ class EnableBankingAccount::Processor
         scope.set_tags(enable_banking_account_id: enable_banking_account.id)
       end
     end
-
 end

--- a/app/models/enable_banking_account/type_mappable.rb
+++ b/app/models/enable_banking_account/type_mappable.rb
@@ -1,0 +1,38 @@
+module EnableBankingAccount::TypeMappable
+  extend ActiveSupport::Concern
+
+  UnknownAccountTypeError = Class.new(StandardError)
+
+  def map_accountable(enable_banking_account_type)
+    accountable_class = TYPE_MAPPING.dig(
+      enable_banking_account_type.to_sym,
+      :accountable
+    )
+
+    unless accountable_class
+      raise UnknownAccountTypeError, "Unknown account type: #{enable_banking_account_type}"
+    end
+
+    accountable_class.new
+  end
+
+  # Enable Banking Types -> Accountable Types
+  # https://enablebanking.com/docs/api/reference/#cashaccounttype
+  TYPE_MAPPING = {
+    CACC: {
+      accountable: Depository
+    },
+    CASH: {
+      accountable: Depository
+    },
+    CARD: {
+      accountable: CreditCard
+    },
+    LOAN: {
+      accountable: Loan
+    },
+    OTHR: {
+      accountable: OtherAsset
+    }
+  }
+end

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -24,6 +24,14 @@ class EnableBankingEntry::Processor
         source: "enable_banking"
       )
 
+      if merchant
+        entry.transaction.enrich_attribute(
+          :merchant_id,
+          merchant.id,
+          source: "enable_banking"
+        )
+      end
+
     end
   end
 
@@ -63,5 +71,18 @@ class EnableBankingEntry::Processor
 
     def date
       enable_banking_transaction.dig("value_date")
+    end
+
+    def merchant
+      merchant_name = enable_banking_transaction.dig("creditor", "name")
+
+      return nil unless merchant_name.present?
+
+      ProviderMerchant.find_or_create_by!(
+        source: "enable_banking",
+        name: merchant_name,
+      ) do |m|
+        m.provider_merchant_id = merchant_name # There is no ID available in Enable Banking API, using name instead
+      end
     end
 end

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -7,7 +7,7 @@ class EnableBankingEntry::Processor
 
   def process
     EnableBankingAccount.transaction do
-      entry = account.entries.find_or_initialize_by(plaid_id: enable_banking_id) do |e| #TODO change plaid_id to enable_banking_id?
+      entry = account.entries.find_or_initialize_by(plaid_id: enable_banking_id) do |e|
         e.entryable = Transaction.new
       end
 

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -1,0 +1,55 @@
+class EnableBankingEntry::Processor
+  # enable_banking_transaction is the raw hash fetched from Enable Banking API and converted to JSONB
+  def initialize(enable_banking_transaction, enable_banking_account:)
+    @enable_banking_transaction = enable_banking_transaction
+    @enable_banking_account = enable_banking_account
+  end
+
+  def process
+    EnableBankingAccount.transaction do
+      entry = account.entries.find_or_initialize_by(plaid_id: enable_banking_id) do |e| #TODO change plaid_id to enable_banking_id?
+        e.entryable = Transaction.new
+      end
+
+      entry.assign_attributes(
+        amount: amount,
+        currency: currency,
+        date: date
+      )
+
+      entry.enrich_attribute(
+        :name,
+        name,
+        source: "enable_banking"
+      )
+
+    end
+  end
+
+  private
+    attr_reader :enable_banking_transaction, :enable_banking_account, :category_matcher
+
+    def account
+      enable_banking_account.account
+    end
+
+    def enable_banking_id
+      enable_banking_transaction["entry_reference"]
+    end
+
+    def name
+      enable_banking_transaction["remittance_information"].join(" ")
+    end
+
+    def amount
+      enable_banking_transaction["transaction_amount"]["amount"]
+    end
+
+    def currency
+      enable_banking_transaction["transaction_amount"]["currency"]
+    end
+
+    def date
+      enable_banking_transaction["booking_date"]
+    end
+end

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -31,7 +31,6 @@ class EnableBankingEntry::Processor
           source: "enable_banking"
         )
       end
-
     end
   end
 

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -39,7 +39,7 @@ class EnableBankingEntry::Processor
     end
 
     def name
-      enable_banking_transaction.dig("bank_transaction_code", "description")
+      enable_banking_transaction.dig("bank_transaction_code", "description") || enable_banking_transaction.dig("remittance_information")&.first
     end
 
     def notes

--- a/app/models/enable_banking_item.rb
+++ b/app/models/enable_banking_item.rb
@@ -51,5 +51,4 @@ class EnableBankingItem < ApplicationRecord
       )
     end
   end
-
 end

--- a/app/models/enable_banking_item.rb
+++ b/app/models/enable_banking_item.rb
@@ -1,0 +1,51 @@
+class EnableBankingItem < ApplicationRecord
+  include Syncable, Provided
+
+  enum :status, { good: "good", requires_update: "requires_update" }, default: :good
+
+  if Rails.application.credentials.active_record_encryption.present?
+    encrypts :session_id, deterministic: true
+  end
+
+  validates :name, :session_id, :valid_until, presence: true
+
+  belongs_to :family
+  has_one_attached :logo
+
+  has_many :enable_banking_accounts, dependent: :destroy
+  has_many :accounts, through: :enable_banking_accounts
+
+  scope :active, -> { where(scheduled_for_deletion: false) }
+  scope :ordered, -> { order(created_at: :desc) }
+  scope :needs_update, -> { where(status: :requires_update) }
+
+  def destroy_later
+    update!(scheduled_for_deletion: true)
+    DestroyJob.perform_later(self)
+  end
+
+  def import_latest_data
+    EnableBankingItem::Importer.new(self, enable_banking_provider: enable_banking_provider).import
+  end
+
+  # Reads the fetched data and updates internal domain objects
+  # Generally, this should only be called within a "sync", but can be called
+  # manually to "re-sync" the already fetched data
+  def process_accounts
+    enable_banking_accounts.each do |enable_banking_account|
+      EnableBankingAccount::Processor.new(enable_banking_account).process
+    end
+  end
+
+  # Once all the data is fetched, we can schedule account syncs to calculate historical balances
+  def schedule_account_syncs(parent_sync: nil, window_start_date: nil, window_end_date: nil)
+    accounts.each do |account|
+      account.sync_later(
+        parent_sync: parent_sync,
+        window_start_date: window_start_date,
+        window_end_date: window_end_date
+      )
+    end
+  end
+
+end

--- a/app/models/enable_banking_item.rb
+++ b/app/models/enable_banking_item.rb
@@ -7,7 +7,7 @@ class EnableBankingItem < ApplicationRecord
     encrypts :session_id, deterministic: true
   end
 
-  validates :name, :session_id, :valid_until, presence: true
+  validates :aspsp_name, :aspsp_country, :session_id, :valid_until, presence: true
 
   belongs_to :family
   has_one_attached :logo
@@ -22,6 +22,10 @@ class EnableBankingItem < ApplicationRecord
   def destroy_later
     update!(scheduled_for_deletion: true)
     DestroyJob.perform_later(self)
+  end
+
+  def is_session_valid?
+    valid_until > Time.current && !requires_update?
   end
 
   def import_latest_data

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -41,15 +41,14 @@ class EnableBankingItem::Importer
     end
 
     def extract_account_name(raw_account)
-      if raw_account["name"].present?
-        return raw_account["name"]
+      if raw_account["product"].present?
+        return raw_account["product"]
       end
       if raw_account.dig("account_id", "iban").present?
         return raw_account.dig("account_id", "iban")
       end
       identification = raw_account.dig("account_id", "other", "identification")
-      return identification if identification
-      nil
+      return identification
     end
 
 end

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -1,5 +1,4 @@
 class EnableBankingItem::Importer
-
   def initialize(enable_banking_item, enable_banking_provider:)
     @enable_banking_item = enable_banking_item
     @enable_banking_provider = enable_banking_provider
@@ -46,7 +45,7 @@ class EnableBankingItem::Importer
         raw_account["account_type"] = account_details["cash_account_type"]
         raw_account["balances"] = enable_banking_provider.get_current_available_balance(account_id)
         raw_account["transactions_data"] = transactions
-        
+
         EnableBankingAccount::Importer.new(
           enable_banking_account,
           account_snapshot: raw_account

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -61,7 +61,6 @@ class EnableBankingItem::Importer
         return raw_account.dig("account_id", "iban")
       end
       identification = raw_account.dig("account_id", "other", "identification")
-      return identification
+      identification
     end
-
 end

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -26,7 +26,7 @@ class EnableBankingItem::Importer
         )
 
         account_details = enable_banking_provider.get_account_details(account_id)
-        transactions = enable_banking_provider.get_transactions(account_id, 30.days.ago.to_date.iso8601) # TODO: use different date
+        transactions = enable_banking_provider.get_transactions(account_id, enable_banking_account.new_record?)
 
         raw_account["name"] = extract_account_name(account_details)
         raw_account["account_type"] = account_details["cash_account_type"]

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -1,0 +1,55 @@
+class EnableBankingItem::Importer
+  attr_reader :enable_banking_item, :enable_banking_provider
+
+  def initialize(enable_banking_item, enable_banking_provider:)
+    @enable_banking_item = enable_banking_item
+    @enable_banking_provider = enable_banking_provider
+  end
+
+  def import
+    fetch_and_import_accounts_data
+  end
+
+  private
+
+    def fetch_and_import_accounts_data
+      accounts = JSON.parse(enable_banking_item.raw_payload).dig("accounts")
+      unless accounts.is_a?(Array)
+        Rails.logger.warn("EnableBankingItem::Importer: 'accounts' is not an Array in payload for item ID #{enable_banking_item.id}")
+        return
+      end
+
+      accounts.each do |raw_account|
+        account_id = raw_account["uid"]
+        enable_banking_account = enable_banking_item.enable_banking_accounts.find_or_initialize_by(
+          account_id: account_id
+        )
+
+        account_details = enable_banking_provider.get_account_details(account_id)
+        transactions = enable_banking_provider.get_transactions(account_id, 30.days.ago.to_date.iso8601) # TODO: use different date
+
+        raw_account["name"] = extract_account_name(account_details)
+        raw_account["account_type"] = account_details["cash_account_type"]
+        raw_account["balances"] = enable_banking_provider.get_current_available_balance(account_id)
+        raw_account["transactions_data"] = transactions
+        
+        EnableBankingAccount::Importer.new(
+          enable_banking_account,
+          account_snapshot: raw_account
+        ).import
+      end
+    end
+
+    def extract_account_name(raw_account)
+      if raw_account["name"].present?
+        return raw_account["name"]
+      end
+      if raw_account.dig("account_id", "iban").present?
+        return raw_account.dig("account_id", "iban")
+      end
+      identification = raw_account.dig("account_id", "other", "identification")
+      return identification if identification
+      nil
+    end
+
+end

--- a/app/models/enable_banking_item/provided.rb
+++ b/app/models/enable_banking_item/provided.rb
@@ -1,0 +1,7 @@
+module EnableBankingItem::Provided
+  extend ActiveSupport::Concern
+
+  def enable_banking_provider
+    @enable_banking_provider ||= Provider::Registry.get_provider(:enable_banking)
+  end
+end

--- a/app/models/enable_banking_item/sync_complete_event.rb
+++ b/app/models/enable_banking_item/sync_complete_event.rb
@@ -1,0 +1,22 @@
+class EnableBankingItem::SyncCompleteEvent
+  attr_reader :enable_banking_item
+
+  def initialize(enable_banking_item)
+    @enable_banking_item = enable_banking_item
+  end
+
+  def broadcast
+    enable_banking_item.accounts.each do |account|
+      account.broadcast_sync_complete
+    end
+
+    enable_banking_item.broadcast_replace_to(
+      enable_banking_item.family,
+      target: "enable_banking_item_#{enable_banking_item.id}",
+      partial: "enable_banking_items/enable_banking_item",
+      locals: { enable_banking_item: enable_banking_item }
+    )
+
+    enable_banking_item.family.broadcast_sync_complete
+  end
+end

--- a/app/models/enable_banking_item/syncer.rb
+++ b/app/models/enable_banking_item/syncer.rb
@@ -1,0 +1,26 @@
+class EnableBankingItem::Syncer
+  attr_reader :enable_banking_item
+
+  def initialize(enable_banking_item)
+    @enable_banking_item = enable_banking_item
+  end
+
+  def perform_sync(sync)
+    # Loads item metadata, accounts, transactions, and other data to our DB
+    enable_banking_item.import_latest_data
+
+    # Processes the raw Enable Banking data and updates internal domain objects
+    enable_banking_item.process_accounts
+
+    # All data is synced, so we can now run an account sync to calculate historical balances and more
+    enable_banking_item.schedule_account_syncs(
+      parent_sync: sync,
+      window_start_date: sync.window_start_date,
+      window_end_date: sync.window_end_date
+    )
+  end
+
+  def perform_post_sync
+    # no-op
+  end
+end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -57,7 +57,7 @@ class Entry < ApplicationRecord
   end
 
   def linked?
-    plaid_id.present? || enable_banking_id.present?
+    plaid_id.present?
   end
 
   class << self

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -57,7 +57,7 @@ class Entry < ApplicationRecord
   end
 
   def linked?
-    plaid_id.present?
+    plaid_id.present? || enable_banking_id.present?
   end
 
   class << self

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1,5 +1,5 @@
 class Family < ApplicationRecord
-  include PlaidConnectable, SimplefinConnectable, Syncable, AutoTransferMatchable, Subscribeable
+  include PlaidConnectable, SimplefinConnectable, EnableBankingConnectable, Syncable, AutoTransferMatchable, Subscribeable
 
   DATE_FORMATS = [
     [ "MM-DD-YYYY", "%m-%d-%Y" ],

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -60,7 +60,7 @@ module Family::AutoTransferMatchable
         next if used_transaction_ids.include?(match.inflow_transaction_id) ||
                used_transaction_ids.include?(match.outflow_transaction_id)
 
-        Transfer.create!(
+        Transfer.find_or_create_by!(
           inflow_transaction_id: match.inflow_transaction_id,
           outflow_transaction_id: match.outflow_transaction_id,
         )

--- a/app/models/family/enable_banking_connectable.rb
+++ b/app/models/family/enable_banking_connectable.rb
@@ -5,11 +5,13 @@ module Family::EnableBankingConnectable
     has_many :enable_banking_items, dependent: :destroy
   end
 
-  def create_enable_banking_item!(session_id:, valid_until:, item_name: nil,logo_url: nil, raw_payload: {})
+  def create_enable_banking_item!(session_id:, valid_until:, aspsp_name:, aspsp_country:, logo_url: nil, raw_payload: {})
     enable_banking_item = enable_banking_items.create!(
       session_id: session_id,
       valid_until: valid_until,
-      name: item_name,
+      name: aspsp_name,
+      aspsp_name: aspsp_name,
+      aspsp_country: aspsp_country,
       logo_url: logo_url,
       raw_payload: raw_payload
     )

--- a/app/models/family/enable_banking_connectable.rb
+++ b/app/models/family/enable_banking_connectable.rb
@@ -5,19 +5,27 @@ module Family::EnableBankingConnectable
     has_many :enable_banking_items, dependent: :destroy
   end
 
-  def create_enable_banking_item!(session_id:, valid_until:, aspsp_name:, aspsp_country:, logo_url: nil, raw_payload: {})
-    enable_banking_item = enable_banking_items.create!(
-      session_id: session_id,
-      valid_until: valid_until,
-      name: aspsp_name,
-      aspsp_name: aspsp_name,
-      aspsp_country: aspsp_country,
-      logo_url: logo_url,
-      raw_payload: raw_payload
+  def create_enable_banking_item!(enable_banking_id:, session_id:)
+    session = enable_banking_provider.create_session(session_id)
+    enable_banking_item = Current.family.enable_banking_items.find_or_create_by(id: enable_banking_id)
+
+    enable_banking_item.update!(
+      session_id: session["session_id"],
+      valid_until: session["access"]["valid_until"],
+      status: "good",
+      aspsp_name: session["aspsp"]["name"],
+      aspsp_country: session["aspsp"]["country"],
+      logo_url: "https://enablebanking.com/brands/#{session['aspsp']['country']}/#{session['aspsp']['name']}",
+      raw_payload: session.to_json
     )
 
     enable_banking_item.sync_later
 
     enable_banking_item
   end
+
+  private
+    def enable_banking_provider
+      Provider::Registry.get_provider(:enable_banking)
+    end
 end

--- a/app/models/family/enable_banking_connectable.rb
+++ b/app/models/family/enable_banking_connectable.rb
@@ -1,0 +1,21 @@
+module Family::EnableBankingConnectable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :enable_banking_items, dependent: :destroy
+  end
+
+  def create_enable_banking_item!(session_id:, valid_until:, item_name: nil,logo_url: nil, raw_payload: {})
+    enable_banking_item = enable_banking_items.create!(
+      session_id: session_id,
+      valid_until: valid_until,
+      name: item_name,
+      logo_url: logo_url,
+      raw_payload: raw_payload
+    )
+
+    enable_banking_item.sync_later
+
+    enable_banking_item
+  end
+end

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -45,7 +45,7 @@ class Provider::EnableBanking < Provider
       body = {
         access: { valid_until: valid_until.utc.iso8601 },
         aspsp: { name: aspsp_name, country: country_code },
-        state: "random",
+        state: SecureRandom.uuid,
         redirect_url: redirect_urls[0]
       }
       response = client.post("#{base_url}/auth", body.to_json)

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -40,7 +40,7 @@ class Provider::EnableBanking < Provider
   def generate_authorization_url(aspsp_name, country_code, enable_banking_id)
     country_code ||= @country_code
     redirect_urls = get_redirect_urls
-    valid_until = Time.now + 15*7*24*60*60 # 90 days
+    valid_until = Time.now + 90*24*60*60 # 90 days
     result = with_provider_response do
       body = {
         access: { valid_until: valid_until.utc.iso8601 },

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -1,0 +1,180 @@
+class Provider::EnableBanking < Provider
+
+  # Subclass so errors caught in this provider are raised as Provider::EnableBanking::Error
+  Error = Class.new(Provider::Error)
+
+  def initialize(application_id:, certificate:, country_code:)
+    @application_id = application_id
+    @certificate = certificate
+    @country_code = country_code
+  end
+
+  def get_redirect_urls
+    result = with_provider_response do
+      response = client.get("#{base_url}/application")
+      JSON.parse(response.body).dig("redirect_urls")
+    end
+    if result.success?
+        result.data
+      else
+        Rails.logger.warn("Could not fetch redirect URLs. Provider error: #{result.error.message}")
+        Sentry.capture_exception(Error.new("Could not fetch redirect URLs"), level: :warning)
+      end
+  end
+
+  def get_available_aspsps(country_code: @country_code)
+    result = with_provider_response do
+      response = client.get("#{base_url}/aspsps") do |req|
+        req.params["country"] = country_code
+        req.params["psu_type"] = "personal" # Do not retrieve business accounts
+      end
+      JSON.parse(response.body).dig("aspsps")
+    end
+    if result.success?
+      result.data
+    else
+      Rails.logger.warn("Could not fetch available ASPSPS for country #{country_code}. Provider error: #{result.error.message}")
+      Sentry.capture_exception(Error.new("Could not fetch available ASPSPS"), level: :warning)
+    end
+  end
+
+  def generate_authorization_url(aspsp_name, country_code: @country_code)
+    redirect_urls = get_redirect_urls
+    valid_until = Time.now + 2*7*24*60*60 # 2 weeks
+    result = with_provider_response do
+      body = {
+        access: { valid_until: valid_until.utc.iso8601 },
+        aspsp: { name: aspsp_name, country: country_code },
+        state: "random",
+        redirect_url: redirect_urls[0]
+      }
+      response = client.post("#{base_url}/auth", body.to_json)
+      JSON.parse(response.body).dig("url")
+    end
+    if result.success?
+      result.data
+    else
+      Rails.logger.warn("Could not generate authorization URL. Provider error: #{result.error.message}")
+      Sentry.capture_exception(Error.new("Could not generate authorization URL"), level: :warning)
+    end
+  end
+
+  def create_session(auth_code)
+    result = with_provider_response do
+      body = { code: auth_code }
+      response = client.post("#{base_url}/sessions", body.to_json)
+      JSON.parse(response.body)
+    end
+    if result.success?
+      result.data
+    else
+      Rails.logger.warn("Could not create session. Provider error: #{result.error.message}")
+      Sentry.capture_exception(Error.new("Could not create session"), level: :warning)
+    end
+  end
+
+  def get_account_details(account_id)
+    result = with_provider_response do
+      response = client.get("#{base_url}/accounts/#{account_id}/details")
+      JSON.parse(response.body)
+    end
+    if result.success?
+        result.data
+      else
+        Rails.logger.warn("Could not fetch account details. Provider error: #{result.error.message}")
+        Sentry.capture_exception(Error.new("Could not fetch account details"), level: :warning)
+      end
+  end
+
+  def get_account_balances(account_id)
+    result = with_provider_response do
+      response = client.get("#{base_url}/accounts/#{account_id}/balances")
+      JSON.parse(response.body).dig("balances")
+    end
+    if result.success?
+      result.data
+    else
+      Rails.logger.warn("Could not fetch account balances. Provider error: #{result.error.message}")
+      Sentry.capture_exception(Error.new("Could not fetch account balances"), level: :warning)
+    end
+  end
+
+  def get_current_available_balance(account_id)
+    balances = get_account_balances(account_id)
+    balances = [] if balances.nil?
+    balances_by_type = balances.group_by { |balance| balance["balance_type"] }
+    available_balance = balances_by_type["ITAV"]&.first
+    current_balance = balances_by_type["ITBD"]&.first
+    {
+      "available" => available_balance&.dig("balance_amount", "amount") || 0,
+      "current" => current_balance&.dig("balance_amount", "amount") || 0
+    }
+  end
+
+  def get_account_transactions(account_id, date_from, continuation_key: nil)
+    result = with_provider_response do
+      response = client.get("#{base_url}/accounts/#{account_id}/transactions") do |req|
+        req.params["date_from"] = date_from
+        if continuation_key
+          req.params["continuation_key"] = continuation_key
+        end
+      end
+      JSON.parse(response.body)
+    end
+    if result.success?
+      result.data
+    else
+      Rails.logger.warn("Could not fetch account transactions. Provider error: #{result.error.message}")
+      Sentry.capture_exception(Error.new("Could not fetch account transactions"), level: :warning)
+    end
+  end
+
+  def get_transactions(account_id, date_from)
+    transactions = []
+    continuation_key = nil
+    loop do
+      transaction_data = get_account_transactions(account_id, date_from, continuation_key: continuation_key)
+      transactions += transaction_data.dig("transactions") || []
+      break unless transaction_data.has_key?("continuation_key") and transaction_data["continuation_key"]
+        continuation_key = transaction_data["continuation_key"]
+    end
+    transactions
+  end
+
+  private
+    attr_reader :application_id
+    attr_reader :certificate
+
+    def base_url
+      "https://api.enablebanking.com"
+    end
+
+    def generate_jwt
+      rsa_key = OpenSSL::PKey::RSA.new(certificate.gsub("\\n", "\n"))
+      iat = Time.now.to_i
+      jwt_header = { typ: "JWT", alg: "RS256", kid: application_id }
+      jwt_body = { iss: "enablebanking.com", aud: "api.enablebanking.com", iat: iat, exp: iat + 3600 }
+      JWT.encode(jwt_body, rsa_key, 'RS256', jwt_header)
+    end
+
+    def jwt
+      @jwt ||= generate_jwt
+    end
+
+    def client
+      @client ||= Faraday.new(url: base_url) do |faraday|
+        faraday.request(:retry, {
+          max: 2,
+          interval: 0.05,
+          interval_randomness: 0.5,
+          backoff_factor: 2
+        })
+
+        faraday.request :json
+        faraday.response :raise_error
+        faraday.headers["Content-Type"] = "application/json"
+        faraday.headers["Authorization"] = "Bearer #{jwt}"
+      end
+    end
+
+end

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -41,7 +41,7 @@ class Provider::EnableBanking < Provider
   def generate_authorization_url(aspsp_name, country_code, enable_banking_id)
     country_code ||= @country_code
     redirect_urls = get_redirect_urls
-    valid_until = Time.now + 2*7*24*60*60 # 2 weeks
+    valid_until = Time.now + 15*7*24*60*60 # 90 days
     result = with_provider_response do
       body = {
         access: { valid_until: valid_until.utc.iso8601 },

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -1,5 +1,4 @@
 class Provider::EnableBanking < Provider
-
   # Subclass so errors caught in this provider are raised as Provider::EnableBanking::Error
   Error = Class.new(Provider::Error)
 
@@ -15,11 +14,11 @@ class Provider::EnableBanking < Provider
       JSON.parse(response.body).dig("redirect_urls")
     end
     if result.success?
-        result.data
-      else
-        Rails.logger.warn("Could not fetch redirect URLs. Provider error: #{result.error.message}")
-        raise result.error
-      end
+      result.data
+    else
+      Rails.logger.warn("Could not fetch redirect URLs. Provider error: #{result.error.message}")
+      raise result.error
+    end
   end
 
   def get_available_aspsps(country_code: @country_code)
@@ -159,7 +158,7 @@ class Provider::EnableBanking < Provider
       iat = Time.now.to_i
       jwt_header = { typ: "JWT", alg: "RS256", kid: application_id }
       jwt_body = { iss: "enablebanking.com", aud: "api.enablebanking.com", iat: iat, exp: iat + 3600 }
-      JWT.encode(jwt_body, rsa_key, 'RS256', jwt_header)
+      JWT.encode(jwt_body, rsa_key, "RS256", jwt_header)
     end
 
     def jwt
@@ -181,5 +180,4 @@ class Provider::EnableBanking < Provider
         faraday.headers["Authorization"] = "Bearer #{jwt}"
       end
     end
-
 end

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -69,9 +69,9 @@ class Provider::Registry
       end
 
       def enable_banking
-        application_id = ENV["ENABLE_BANKING_APPLICATION_ID"]
-        certificate = ENV["ENABLE_BANKING_CERTIFICATE"]
-        country_code = ENV["ENABLE_BANKING_COUNTRY"]
+        application_id = ENV.fetch("ENABLE_BANKING_APPLICATION_ID", Setting.enable_banking_application_id)
+        country_code = ENV.fetch("ENABLE_BANKING_COUNTRY", Setting.enable_banking_country)
+        certificate = ENV.fetch("ENABLE_BANKING_CERTIFICATE", Setting.enable_banking_certificate)
         
         return nil unless application_id.present? && certificate.present? && country_code.present?
 

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -67,6 +67,16 @@ class Provider::Registry
 
         Provider::Openai.new(access_token)
       end
+
+      def enable_banking
+        application_id = ENV["ENABLE_BANKING_APPLICATION_ID"]
+        certificate = ENV["ENABLE_BANKING_CERTIFICATE"]
+        country_code = ENV["ENABLE_BANKING_COUNTRY"]
+        
+        return nil unless application_id.present? && certificate.present? && country_code.present?
+
+        Provider::EnableBanking.new(application_id:, certificate:, country_code:)
+      end
   end
 
   def initialize(concept)

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -72,7 +72,7 @@ class Provider::Registry
         application_id = ENV.fetch("ENABLE_BANKING_APPLICATION_ID", Setting.enable_banking_application_id)
         country_code = ENV.fetch("ENABLE_BANKING_COUNTRY", Setting.enable_banking_country)
         certificate = ENV.fetch("ENABLE_BANKING_CERTIFICATE", Setting.enable_banking_certificate)
-        
+
         return nil unless application_id.present? && certificate.present? && country_code.present?
 
         Provider::EnableBanking.new(application_id:, certificate:, country_code:)

--- a/app/models/provider_merchant.rb
+++ b/app/models/provider_merchant.rb
@@ -1,5 +1,5 @@
 class ProviderMerchant < Merchant
-  enum :source, { plaid: "plaid", synth: "synth", ai: "ai" }
+  enum :source, { plaid: "plaid", synth: "synth", ai: "ai", enable_banking: "enable_banking" }
 
   validates :name, uniqueness: { scope: [ :source ] }
   validates :source, presence: true

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -5,6 +5,9 @@ class Setting < RailsSettings::Base
   field :twelve_data_api_key, type: :string, default: ENV["TWELVE_DATA_API_KEY"]
   field :openai_access_token, type: :string, default: ENV["OPENAI_ACCESS_TOKEN"]
   field :brand_fetch_client_id, type: :string, default: ENV["BRAND_FETCH_CLIENT_ID"]
+  field :enable_banking_country, type: :string, default: ENV["ENABLE_BANKING_COUNTRY"]
+  field :enable_banking_application_id, type: :string, default: ENV["ENABLE_BANKING_APPLICATION_ID"]
+  field :enable_banking_certificate, type: :text, default: ENV["ENABLE_BANKING_CERTIFICATE"]
 
   field :require_invite_for_signup, type: :boolean, default: false
   field :require_email_confirmation, type: :boolean, default: ENV.fetch("REQUIRE_EMAIL_CONFIRMATION", "true") == "true"

--- a/app/models/transaction/transferable.rb
+++ b/app/models/transaction/transferable.rb
@@ -22,7 +22,7 @@ module Transaction::Transferable
     end
 
     candidates_scope.map do |match|
-      Transfer.new(
+      Transfer.find_or_create_by!(
         inflow_transaction_id: match.inflow_transaction_id,
         outflow_transaction_id: match.outflow_transaction_id,
       )

--- a/app/models/transaction/transferable.rb
+++ b/app/models/transaction/transferable.rb
@@ -22,7 +22,7 @@ module Transaction::Transferable
     end
 
     candidates_scope.map do |match|
-      Transfer.find_or_create_by!(
+      Transfer.new(
         inflow_transaction_id: match.inflow_transaction_id,
         outflow_transaction_id: match.outflow_transaction_id,
       )

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -1,0 +1,75 @@
+<%# locals: (enable_banking_item:) %>
+
+<%= tag.div id: dom_id(enable_banking_item) do %>
+  <details open class="group bg-container p-4 shadow-border-xs rounded-xl">
+    <summary class="flex items-center justify-between gap-2 focus-visible:outline-hidden">
+      <div class="flex items-center gap-4">
+
+        <% if enable_banking_item.logo_url? %>
+          <div class="flex items-center justify-center w-16 overflow-hidden">
+            <%= image_tag enable_banking_item.logo_url, class: "shrink-0", loading: "lazy" %>
+          </div>
+        <% else %>
+          <%= render DS::FilledIcon.new(
+            variant: :container,
+            text: enable_banking_item.name.first.upcase,
+            size: "md"
+          ) %>
+        <% end %>
+
+        <div class="pl-1 text-sm">
+          <div class="flex items-center gap-2">
+            <div>
+              <%= tag.p enable_banking_item.name, class: "font-medium text-primary" %>
+              <p class="text-secondary text-xs mb-1">Current session will expire on <%= I18n.l(enable_banking_item.valid_until, format: :long) %></p>
+            </div>
+            <% if enable_banking_item.scheduled_for_deletion? %>
+              <p class="text-destructive text-sm animate-pulse">(deletion in progress...)</p>
+            <% end %>
+          </div>
+          <% if enable_banking_item.syncing? %>
+            <div class="text-secondary flex items-center gap-1">
+              <%= icon "loader", size: "sm", class: "animate-pulse" %>
+              <%= tag.span "Syncing..." %>
+            </div>
+          <% elsif enable_banking_item.requires_update? %>
+            <div class="text-warning flex items-center gap-1">
+              <%= icon "alert-triangle", size: "sm", color: "warning" %>
+              <%= tag.span "Requires Update" %>
+            </div>
+          <% elsif enable_banking_item.sync_error.present? %>
+            <div class="text-secondary flex items-center gap-1">
+              <%= icon "alert-circle", size: "sm", color: "destructive" %>
+              <%= tag.span "Error", class: "text-destructive" %>
+            </div>
+          <% else %>
+            <p class="text-secondary">
+              <%= enable_banking_item.last_synced_at ? "Last synced #{time_ago_in_words(enable_banking_item.last_synced_at)} ago" : "Never synced" %>
+            </p>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <% if Rails.env.development? %>
+          <%= icon(
+            "refresh-cw",
+            as_button: true,
+            href: sync_enable_banking_item_path(enable_banking_item)
+          ) %>
+        <% end %>
+
+        <%= render DS::Menu.new do |menu| %>
+          <% menu.with_item(
+            variant: "button",
+            text: "Delete",
+            icon: "trash-2",
+            href: enable_banking_item_path(enable_banking_item),
+            method: :delete,
+            confirm: CustomConfirm.for_resource_deletion(t(".this_connection"), high_severity: true)
+          ) %>
+        <% end %>
+      </div>
+    </summary>
+  </details>
+<% end %>

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -61,12 +61,13 @@
             href: update_connection_enable_banking_item_path(enable_banking_item),
             method: :post
           ) %>
+        <% elsif Rails.env.development? %>
+          <%= icon(
+            "refresh-cw",
+            as_button: true,
+            href: sync_enable_banking_item_path(enable_banking_item)
+          ) %>
         <% end %>
-        <%= icon(
-          "refresh-cw",
-          as_button: true,
-          href: sync_enable_banking_item_path(enable_banking_item)
-        ) %>
 
         <%= render DS::Menu.new do |menu| %>
           <% menu.with_item(

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -21,7 +21,9 @@
           <div class="flex items-center gap-2">
             <div>
               <%= tag.p enable_banking_item.name, class: "font-medium text-primary" %>
-              <p class="text-secondary text-xs mb-1"><%= t(".session_expiration", timestamp: distance_of_time_in_words(Time.now, enable_banking_item.valid_until)) %></p>
+              <% if enable_banking_item.is_session_valid? %>
+                <p class="text-secondary text-xs mb-1"><%= t(".session_expiration", timestamp: distance_of_time_in_words(Time.now, enable_banking_item.valid_until)) %></p>
+              <% end %>
             </div>
             <% if enable_banking_item.scheduled_for_deletion? %>
               <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
@@ -32,7 +34,7 @@
               <%= icon "loader", size: "sm", class: "animate-spin" %>
               <%= tag.span t(".syncing") %>
             </div>
-          <% elsif enable_banking_item.requires_update? %>
+          <% elsif !enable_banking_item.is_session_valid? %>
             <div class="text-warning flex items-center gap-1">
               <%= icon "alert-triangle", size: "sm", color: "warning" %>
               <%= tag.span t(".requires_update") %>
@@ -51,7 +53,15 @@
       </div>
 
       <div class="flex items-center gap-2">
-        <% if Rails.env.development? %>
+        <% if enable_banking_item.requires_update? %>
+          <%= render DS::Button.new(
+            text: t(".update"),
+            icon: "refresh-cw",
+            variant: "secondary",
+            href: update_connection_enable_banking_item_path(enable_banking_item),
+            method: :post
+          ) %>
+        <% elsif Rails.env.development? %>
           <%= icon(
             "refresh-cw",
             as_button: true,

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (enable_banking_item:) %>
 
 <%= tag.div id: dom_id(enable_banking_item) do %>
-  <details open class="group bg-container p-4 shadow-border-xs rounded-xl">
+  <details open class="group bg-container p-4 shadow-border-xs">
     <summary class="flex items-center justify-between gap-2 focus-visible:outline-hidden">
       <div class="flex items-center gap-4">
 

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -66,7 +66,7 @@
             icon: "trash-2",
             href: enable_banking_item_path(enable_banking_item),
             method: :delete,
-            confirm: CustomConfirm.for_resource_deletion(t(".this_connection"), high_severity: true)
+            confirm: CustomConfirm.for_resource_deletion(t(".connection"), high_severity: true)
           ) %>
         <% end %>
       </div>

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -61,13 +61,12 @@
             href: update_connection_enable_banking_item_path(enable_banking_item),
             method: :post
           ) %>
-        <% elsif Rails.env.development? %>
-          <%= icon(
-            "refresh-cw",
-            as_button: true,
-            href: sync_enable_banking_item_path(enable_banking_item)
-          ) %>
         <% end %>
+        <%= icon(
+          "refresh-cw",
+          as_button: true,
+          href: sync_enable_banking_item_path(enable_banking_item)
+        ) %>
 
         <%= render DS::Menu.new do |menu| %>
           <% menu.with_item(

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -21,30 +21,30 @@
           <div class="flex items-center gap-2">
             <div>
               <%= tag.p enable_banking_item.name, class: "font-medium text-primary" %>
-              <p class="text-secondary text-xs mb-1">Current session will expire on <%= I18n.l(enable_banking_item.valid_until, format: :long) %></p>
+              <p class="text-secondary text-xs mb-1"><%= t(".session_expiration", timestamp: distance_of_time_in_words(Time.now, enable_banking_item.valid_until)) %></p>
             </div>
             <% if enable_banking_item.scheduled_for_deletion? %>
-              <p class="text-destructive text-sm animate-pulse">(deletion in progress...)</p>
+              <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
             <% end %>
           </div>
           <% if enable_banking_item.syncing? %>
             <div class="text-secondary flex items-center gap-1">
-              <%= icon "loader", size: "sm", class: "animate-pulse" %>
-              <%= tag.span "Syncing..." %>
+              <%= icon "loader", size: "sm", class: "animate-spin" %>
+              <%= tag.span t(".syncing") %>
             </div>
           <% elsif enable_banking_item.requires_update? %>
             <div class="text-warning flex items-center gap-1">
               <%= icon "alert-triangle", size: "sm", color: "warning" %>
-              <%= tag.span "Requires Update" %>
+              <%= tag.span t(".requires_update") %>
             </div>
           <% elsif enable_banking_item.sync_error.present? %>
             <div class="text-secondary flex items-center gap-1">
-              <%= icon "alert-circle", size: "sm", color: "destructive" %>
-              <%= tag.span "Error", class: "text-destructive" %>
+              <%= render DS::Tooltip.new(text: enable_banking_item.sync_error, icon: "alert-circle", size: "sm", color: "destructive") %>
+              <%= tag.span t(".error"), class: "text-destructive" %>
             </div>
           <% else %>
             <p class="text-secondary">
-              <%= enable_banking_item.last_synced_at ? "Last synced #{time_ago_in_words(enable_banking_item.last_synced_at)} ago" : "Never synced" %>
+              <%= enable_banking_item.last_synced_at ? t(".status", timestamp: time_ago_in_words(enable_banking_item.last_synced_at)) : t(".status_never") %>
             </p>
           <% end %>
         </div>
@@ -62,7 +62,7 @@
         <%= render DS::Menu.new do |menu| %>
           <% menu.with_item(
             variant: "button",
-            text: "Delete",
+            text: t(".delete"),
             icon: "trash-2",
             href: enable_banking_item_path(enable_banking_item),
             method: :delete,

--- a/app/views/enable_banking_items/_new_connection_form.html.erb
+++ b/app/views/enable_banking_items/_new_connection_form.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (enable_banking_item:) %>
 
 <div data-controller="enable-banking-connection">
-  <%= styled_form_with url: authorization_enable_banking_items_path, method: :post, local: false, id: "authorization-form", data: { controller: "authorization-form" }, class: "space-y-4" do |f| %>
+  <%= styled_form_with url: authorization_enable_banking_items_path, method: :post, local: false, class: "space-y-4" do |f| %>
     <section class="space-y-4">
       <% if enable_banking_item.errors.any? %>
         <%= render "shared/form_errors", model: enable_banking_item %>

--- a/app/views/enable_banking_items/_new_connection_form.html.erb
+++ b/app/views/enable_banking_items/_new_connection_form.html.erb
@@ -7,12 +7,12 @@
         <%= render "shared/form_errors", model: enable_banking_item %>
       <% end %>
       <div class="space-y-2">
-        <%= f.select :aspsps_name, @aspsps, include_blank: "Select ASPSPS" %>
+        <%= f.select :aspsps_name, @aspsps, include_blank: t(".select_aspsps") %>
       </div>
     </section>
 
     <section>
-      <%= f.submit("Link account") %>
+      <%= f.submit(t(".link_account")) %>
     </section>
   <% end %>
 </div>

--- a/app/views/enable_banking_items/_new_connection_form.html.erb
+++ b/app/views/enable_banking_items/_new_connection_form.html.erb
@@ -1,0 +1,18 @@
+<%# locals: (enable_banking_item:) %>
+
+<div data-controller="enable-banking-connection">
+  <%= styled_form_with url: authorization_enable_banking_items_path, method: :post, local: false, id: "authorization-form", data: { controller: "authorization-form" }, class: "space-y-4" do |f| %>
+    <section class="space-y-4">
+      <% if enable_banking_item.errors.any? %>
+        <%= render "shared/form_errors", model: enable_banking_item %>
+      <% end %>
+      <div class="space-y-2">
+        <%= f.select :aspsps_name, @aspsps, include_blank: "Select ASPSPS" %>
+      </div>
+    </section>
+
+    <section>
+      <%= f.submit("Link account") %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/enable_banking_items/_new_connection_form.html.erb
+++ b/app/views/enable_banking_items/_new_connection_form.html.erb
@@ -1,7 +1,9 @@
 <%# locals: (enable_banking_item:) %>
-
+<% if params[:redirect_uri] %>
+  <meta name="turbo-visit-control" content="reload">
+<% end %>
 <div data-controller="enable-banking-connection">
-  <%= styled_form_with url: authorization_enable_banking_items_path, method: :post, local: false, class: "space-y-4" do |f| %>
+  <%= styled_form_with url: authorization_enable_banking_items_path, method: :post, data: { turbo: false }, local: false, class: "space-y-4" do |f| %>
     <section class="space-y-4">
       <% if enable_banking_item.errors.any? %>
         <%= render "shared/form_errors", model: enable_banking_item %>

--- a/app/views/enable_banking_items/_new_connection_form.html.erb
+++ b/app/views/enable_banking_items/_new_connection_form.html.erb
@@ -5,11 +5,12 @@
     <section class="space-y-4">
       <% if enable_banking_item.errors.any? %>
         <%= render "shared/form_errors", model: enable_banking_item %>
+      <% else %>
+        <div class="space-y-2">
+          <%= f.select :aspsps_name, @aspsps, include_blank: t(".select_aspsps") %>
+        </div>
       <% end %>
-      <div class="space-y-2">
-        <%= f.select :aspsps_name, @aspsps, include_blank: t(".select_aspsps") %>
-      </div>
-    </section>
+    
 
     <section>
       <%= f.submit(t(".link_account")) %>

--- a/app/views/enable_banking_items/index.html.erb
+++ b/app/views/enable_banking_items/index.html.erb
@@ -1,0 +1,42 @@
+<header class="flex items-center justify-between">
+  <h1 class="text-primary text-xl font-medium">Enable Banking Connections</h1>
+
+  <%= render DS::Link.new(
+    text: "Add connection",
+    variant: "primary",
+    icon: "plus",
+    href: new_enable_banking_item_path,
+    frame: :modal
+  ) %>
+</header>
+
+<div class="bg-container rounded-xl shadow-border-xs p-4">
+  <% if @enable_banking_items.any? %>
+    <div class="rounded-xl bg-container-inset space-y-1 p-1">
+      <div class="flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-secondary uppercase">
+        <p><%= t(".title") %></p>
+        <span class="text-subdued">&middot;</span>
+        <p><%= @enable_banking_items.count %></p>
+      </div>
+
+      <div class="bg-container rounded-lg shadow-border-xs">
+        <div class="overflow-hidden rounded-lg">
+          <%= render partial: "enable_banking_items/enable_banking_item", collection: @enable_banking_items, spacer_template: "shared/ruler" %>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <div class="flex justify-center items-center py-20">
+      <div class="text-center flex flex-col items-center max-w-[300px]">
+        <p class="text-primary mb-1 font-medium text-sm"><%= t(".empty") %></p>
+        <p class="text-secondary mb-4 text-sm">Connect your bank accounts through Enable Banking to automatically sync transactions.</p>
+        <%= render DS::Link.new(
+          text: "Add your first connection",
+          variant: "primary",
+          href: new_enable_banking_item_path,
+          frame: :modal
+        ) %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/enable_banking_items/index.html.erb
+++ b/app/views/enable_banking_items/index.html.erb
@@ -1,8 +1,8 @@
 <header class="flex items-center justify-between">
-  <h1 class="text-primary text-xl font-medium">Enable Banking Connections</h1>
+  <h1 class="text-primary text-xl font-medium"><%= t(".enable_banking_page_title") %></h1>
 
   <%= render DS::Link.new(
-    text: "Add connection",
+    text: t(".add_new"),
     variant: "primary",
     icon: "plus",
     href: new_enable_banking_item_path,
@@ -29,9 +29,9 @@
     <div class="flex justify-center items-center py-20">
       <div class="text-center flex flex-col items-center max-w-[300px]">
         <p class="text-primary mb-1 font-medium text-sm"><%= t(".empty") %></p>
-        <p class="text-secondary mb-4 text-sm">Connect your bank accounts through Enable Banking to automatically sync transactions.</p>
+        <p class="text-secondary mb-4 text-sm"><%= t(".connect_accounts_description") %></p>
         <%= render DS::Link.new(
-          text: "Add your first connection",
+          text: t(".add_new"),
           variant: "primary",
           href: new_enable_banking_item_path,
           frame: :modal

--- a/app/views/enable_banking_items/new.html.erb
+++ b/app/views/enable_banking_items/new.html.erb
@@ -1,0 +1,9 @@
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_header(title: "New Enable Banking connection") %>
+  <% dialog.with_body do %>
+    <% if @error_message.present? %>
+      <%= render DS::Alert.new(message: @error_message, variant: :error) %>
+    <% end %>
+    <%= render "enable_banking_items/new_connection_form", enable_banking_item: @enable_banking_item %>
+  <% end %>
+<% end %>

--- a/app/views/enable_banking_items/new.html.erb
+++ b/app/views/enable_banking_items/new.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "New Enable Banking connection") %>
+  <% dialog.with_header(title: t(".new_connection")) %>
   <% dialog.with_body do %>
     <% if @error_message.present? %>
       <%= render DS::Alert.new(message: @error_message, variant: :error) %>

--- a/app/views/enable_banking_items/new.html.erb
+++ b/app/views/enable_banking_items/new.html.erb
@@ -1,9 +1,6 @@
 <%= render DS::Dialog.new do |dialog| %>
   <% dialog.with_header(title: t(".new_connection")) %>
   <% dialog.with_body do %>
-    <% if @error_message.present? %>
-      <%= render DS::Alert.new(message: @error_message, variant: :error) %>
-    <% end %>
-    <%= render "enable_banking_items/new_connection_form", enable_banking_item: @enable_banking_item %>
+    <%= render "new_connection_form", enable_banking_item: @enable_banking_item %>
   <% end %>
 <% end %>

--- a/app/views/settings/hostings/_enable_banking_settings.html.erb
+++ b/app/views/settings/hostings/_enable_banking_settings.html.erb
@@ -1,0 +1,53 @@
+<div class="space-y-4">
+  <h2 class="font-medium mb-1"><%= t(".title") %></h2>
+  <div>
+      <% if ENV["ENABLE_BANKING_COUNTRY"].present? %>
+        <p class="text-sm text-secondary">You have successfully configured your Enable Banking country through the ENABLE_BANKING_COUNTRY environment variable.</p>
+      <% else %>
+        <p class="text-secondary text-sm mb-4"><%= t(".country_description") %></p>
+      <% end %>
+    </div>
+  <%= styled_form_with model: Setting.new,
+                       class: "space-y-4",
+                       url: settings_hosting_path,
+                       method: :patch,
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+    <%= form.select :enable_banking_country,
+            country_options,
+            { label: t(".enable_banking_country"), selected: ENV.fetch("ENABLE_BANKING_COUNTRY", Setting.enable_banking_country) },
+            { 
+              disabled: ENV["ENABLE_BANKING_COUNTRY"].present?, 
+              data: { "auto-submit-form-target": "auto" } 
+            } %>
+    <div>
+      <% if ENV["ENABLE_BANKING_APPLICATION_ID"].present? %>
+        <p class="text-sm text-secondary">You have successfully configured your Enable Banking application ID through the ENABLE_BANKING_APPLICATION_ID environment variable.</p>
+      <% else %>
+        <p class="text-secondary text-sm mb-4"><%= t(".application_id_description") %></p>
+      <% end %>
+    </div>
+    <%= form.text_field :enable_banking_application_id,
+                        label: t(".enable_banking_application_id"),
+                        type: "password",
+                        placeholder: t(".placeholder_application_id"),
+                        value: ENV.fetch("ENABLE_BANKING_APPLICATION_ID", Setting.enable_banking_application_id),
+                        disabled: ENV["ENABLE_BANKING_APPLICATION_ID"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+    <div>
+      <% if ENV["ENABLE_BANKING_CERTIFICATE"].present? %>
+        <p class="text-sm text-secondary">You have successfully configured your Enable Banking certificate through the ENABLE_BANKING_CERTIFICATE environment variable.</p>
+      <% else %>
+        <p class="text-secondary text-sm mb-4"><%= t(".certificate_description") %></p>
+      <% end %>
+    </div>
+    <%= form.text_area :enable_banking_certificate,
+                       rows: 10,
+                       placeholder: t(".placeholder_certificate"),
+                       value: ENV.fetch("ENABLE_BANKING_CERTIFICATE", Setting.enable_banking_certificate),
+                       disabled: ENV["ENABLE_BANKING_CERTIFICATE"].present?,
+                       "data-auto-submit-form-target": "auto" %>
+  <% end %>
+</div>

--- a/app/views/settings/hostings/show.html.erb
+++ b/app/views/settings/hostings/show.html.erb
@@ -5,6 +5,7 @@
     <%= render "settings/hostings/openai_settings" %>
     <%= render "settings/hostings/brand_fetch_settings" %>
     <%= render "settings/hostings/twelve_data_settings" %>
+    <%= render "settings/hostings/enable_banking_settings" %>
   </div>
 <% end %>
 

--- a/config/locales/views/enable_banking_items/en.yml
+++ b/config/locales/views/enable_banking_items/en.yml
@@ -24,6 +24,8 @@ en:
       errors:
         update_failed: "Failed to update connection: %{message}"
         unexpected: An unexpected error occurred. Please try again or contact support.
+    update_connection:
+      authorization_error: "Failed to start authorization process. Please try again or contact support."
     enable_banking_item:
       confirm_accept: Delete connection
       confirm_body: This will permanently delete all the accounts in this group and all associated data.

--- a/config/locales/views/enable_banking_items/en.yml
+++ b/config/locales/views/enable_banking_items/en.yml
@@ -1,0 +1,40 @@
+---
+en:
+  enable_banking_items:
+    index:
+      enable_banking_page_title: Enable Banking Connections
+      add_new: Add new connection
+      empty: No accounts.
+      connect_accounts_description: Connect your bank accounts through Enable Banking to automatically sync transactions.
+    new:
+      new_connection: New Enable Banking connection
+    new_connection_form:
+      select_aspsps: Select your bank
+      link_account: Link account
+    create:
+      success: Enable Banking connection added successfully! Your accounts will appear shortly as they sync in the background.
+      errors:
+        unexpected: An unexpected error occurred. Please try again or contact support.
+    destroy:
+      success: Enable Banking connection will be removed
+    update:
+      success: Enable Banking connection updated successfully! Your accounts are being reconnected.
+      errors:
+        update_failed: "Failed to update connection: %{message}"
+        unexpected: An unexpected error occurred. Please try again or contact support.
+    enable_banking_item:
+      confirm_accept: Delete connection
+      confirm_body: This will permanently delete all the accounts in this group and all associated data.
+      confirm_title: Delete Enable Banking connection?
+      delete: Delete
+      deletion_in_progress: "(deletion in progress...)"
+      error: Error occurred while syncing data
+      no_accounts_description: This connection doesn't have any synchronized accounts yet.
+      no_accounts_title: No accounts found
+      requires_update: Requires re-authentication
+      setup_description: Choose account types for your newly imported Enable Banking accounts.
+      status: Last synced %{timestamp} ago
+      status_never: Never synced
+      session_expiration: Current session will expire in %{timestamp}.
+      syncing: Syncing...
+      update: Update connection

--- a/config/locales/views/enable_banking_items/en.yml
+++ b/config/locales/views/enable_banking_items/en.yml
@@ -29,6 +29,7 @@ en:
       confirm_body: This will permanently delete all the accounts in this group and all associated data.
       confirm_title: Delete Enable Banking connection?
       delete: Delete
+      connection: "connection"
       deletion_in_progress: "(deletion in progress...)"
       error: Error occurred while syncing data
       no_accounts_description: This connection doesn't have any synchronized accounts yet.

--- a/config/locales/views/enable_banking_items/en.yml
+++ b/config/locales/views/enable_banking_items/en.yml
@@ -12,6 +12,8 @@ en:
     new_connection_form:
       select_aspsps: Select your bank
       link_account: Link account
+    authorization:
+      authorization_error: "Failed to start authorization process. Please try again or contact support."
     auth_callback:
       success: Enable Banking connection added successfully! Your accounts will appear shortly as they sync in the background.
       errors:

--- a/config/locales/views/enable_banking_items/en.yml
+++ b/config/locales/views/enable_banking_items/en.yml
@@ -8,12 +8,14 @@ en:
       connect_accounts_description: Connect your bank accounts through Enable Banking to automatically sync transactions.
     new:
       new_connection: New Enable Banking connection
+      aspsp_error: Unable to fetch list of banks. Please try again later.
     new_connection_form:
       select_aspsps: Select your bank
       link_account: Link account
-    create:
+    auth_callback:
       success: Enable Banking connection added successfully! Your accounts will appear shortly as they sync in the background.
       errors:
+        aut_failed: Authentication failed. Please try again.
         unexpected: An unexpected error occurred. Please try again or contact support.
     destroy:
       success: Enable Banking connection will be removed

--- a/config/locales/views/settings/hostings/en.yml
+++ b/config/locales/views/settings/hostings/en.yml
@@ -40,6 +40,16 @@ en:
         placeholder: Enter your API key here
         plan: "%{plan} plan"
         title: Twelve Data
+      enable_banking_settings:
+        env_configured_message: Successfully configured through the ENABLE_BANKING_APPLICATION_ID environment variable.
+        enable_banking_country: Country
+        country_description: Select the country you whish to use to integrate Enable Banking.
+        enable_banking_application_id: Application ID
+        application_id_description: Enter the Application ID provided by Enable Banking
+        certificate_description: Paste the Enable Banking certificate content here.
+        placeholder_application_id: Enter your Application ID here
+        placeholder_certificate: Paste your Enable Banking certificate content here
+        title: Enable Banking
       update:
         failure: Invalid setting value
         success: Settings updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,16 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :enable_banking_items, only: %i[index new create show destroy] do
+    member do
+      post :sync
+    end
+
+    collection do 
+      post :authorization
+    end
+  end
+
   namespace :webhooks do
     post "plaid"
     post "plaid_eu"
@@ -282,6 +292,8 @@ Rails.application.routes.draw do
 
   get "privacy", to: redirect("https://maybefinance.com/privacy")
   get "terms", to: redirect("https://maybefinance.com/tos")
+
+  get 'enable_banking_auth_callback', to: 'enable_banking_items#auth_callback'
 
   # Defines the root path route ("/")
   root "pages#dashboard"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,7 +294,7 @@ Rails.application.routes.draw do
   get "privacy", to: redirect("https://maybefinance.com/privacy")
   get "terms", to: redirect("https://maybefinance.com/tos")
 
-  get 'enable_banking_auth_callback', to: 'enable_banking_items#auth_callback'
+  get "enable_banking_auth_callback", to: "enable_banking_items#auth_callback"
 
   # Defines the root path route ("/")
   root "pages#dashboard"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,9 +262,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :enable_banking_items, only: %i[index new create show destroy] do
+  resources :enable_banking_items, only: %i[index new create show edit update destroy] do
     member do
       post :sync
+      post :update_connection
     end
 
     collection do 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,7 +268,7 @@ Rails.application.routes.draw do
       post :update_connection
     end
 
-    collection do 
+    collection do
       post :authorization
     end
   end

--- a/db/migrate/20250825224717_add_enable_banking_domain.rb
+++ b/db/migrate/20250825224717_add_enable_banking_domain.rb
@@ -5,6 +5,8 @@ class AddEnableBankingDomain < ActiveRecord::Migration[7.2]
       t.string :session_id
       t.timestamp :valid_until
       t.string :name
+      t.string :aspsp_name
+      t.string :aspsp_country
       t.string :status, default: "good"
       t.string :logo_url
       t.boolean :scheduled_for_deletion, default: false

--- a/db/migrate/20250825224717_add_enable_banking_domain.rb
+++ b/db/migrate/20250825224717_add_enable_banking_domain.rb
@@ -31,6 +31,5 @@ class AddEnableBankingDomain < ActiveRecord::Migration[7.2]
     end
 
     add_reference :accounts, :enable_banking_account, null: true, foreign_key: true, type: :uuid
-
   end
 end

--- a/db/migrate/20250825224717_add_enable_banking_domain.rb
+++ b/db/migrate/20250825224717_add_enable_banking_domain.rb
@@ -3,7 +3,7 @@ class AddEnableBankingDomain < ActiveRecord::Migration[7.2]
     create_table :enable_banking_items, id: :uuid do |t|
       t.references :family, null: false, type: :uuid, foreign_key: true
       t.string :session_id
-      t.datetime :valid_until
+      t.timestamp :valid_until
       t.string :name
       t.string :status, default: "good"
       t.string :logo_url

--- a/db/migrate/20250825224717_add_enable_banking_domain.rb
+++ b/db/migrate/20250825224717_add_enable_banking_domain.rb
@@ -1,0 +1,34 @@
+class AddEnableBankingDomain < ActiveRecord::Migration[7.2]
+  def change
+    create_table :enable_banking_items, id: :uuid do |t|
+      t.references :family, null: false, type: :uuid, foreign_key: true
+      t.string :session_id
+      t.datetime :valid_until
+      t.string :name
+      t.string :status, default: "good"
+      t.string :logo_url
+      t.boolean :scheduled_for_deletion, default: false
+      t.jsonb :raw_payload
+
+      t.timestamps
+    end
+
+    create_table :enable_banking_accounts, id: :uuid do |t|
+      t.references :enable_banking_item, null: false, type: :uuid, foreign_key: true
+      t.string :account_id
+      t.string :account_type
+      t.decimal :current_balance, precision: 19, scale: 4
+      t.decimal :available_balance, precision: 19, scale: 4
+      t.string :currency
+      t.string :name
+      t.string :mask
+      t.jsonb :raw_payload
+      t.jsonb :raw_transactions_payload, default: {}
+
+      t.timestamps
+    end
+
+    add_reference :accounts, :enable_banking_account, null: true, foreign_key: true, type: :uuid
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -244,7 +244,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_25_224717) do
   create_table "enable_banking_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "family_id", null: false
     t.string "session_id"
-    t.datetime "valid_until"
+    t.datetime "valid_until", precision: nil
     t.string "name"
     t.string "status", default: "good"
     t.string "logo_url"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_08_143007) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_25_224717) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -29,16 +29,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_143007) do
     t.uuid "accountable_id"
     t.decimal "balance", precision: 19, scale: 4
     t.string "currency"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
     t.jsonb "locked_attributes", default: {}
     t.string "status", default: "active"
     t.uuid "simplefin_account_id"
+    t.uuid "enable_banking_account_id"
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"
+    t.index ["enable_banking_account_id"], name: "index_accounts_on_enable_banking_account_id"
     t.index ["family_id", "accountable_type"], name: "index_accounts_on_family_id_and_accountable_type"
     t.index ["family_id", "id"], name: "index_accounts_on_family_id_and_id"
     t.index ["family_id", "status"], name: "index_accounts_on_family_id_and_status"
@@ -221,6 +223,36 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_143007) do
     t.datetime "updated_at", null: false
     t.jsonb "locked_attributes", default: {}
     t.string "subtype"
+  end
+
+  create_table "enable_banking_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "enable_banking_item_id", null: false
+    t.string "account_id"
+    t.string "account_type"
+    t.decimal "current_balance", precision: 19, scale: 4
+    t.decimal "available_balance", precision: 19, scale: 4
+    t.string "currency"
+    t.string "name"
+    t.string "mask"
+    t.jsonb "raw_payload"
+    t.jsonb "raw_transactions_payload", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["enable_banking_item_id"], name: "index_enable_banking_accounts_on_enable_banking_item_id"
+  end
+
+  create_table "enable_banking_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "family_id", null: false
+    t.string "session_id"
+    t.datetime "valid_until"
+    t.string "name"
+    t.string "status", default: "good"
+    t.string "logo_url"
+    t.boolean "scheduled_for_deletion", default: false
+    t.jsonb "raw_payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_id"], name: "index_enable_banking_items_on_family_id"
   end
 
   create_table "entries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -876,6 +908,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_143007) do
     t.string "subtype"
   end
 
+  add_foreign_key "accounts", "enable_banking_accounts"
   add_foreign_key "accounts", "families"
   add_foreign_key "accounts", "imports"
   add_foreign_key "accounts", "plaid_accounts"
@@ -889,6 +922,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_143007) do
   add_foreign_key "budgets", "families"
   add_foreign_key "categories", "families"
   add_foreign_key "chats", "users"
+  add_foreign_key "enable_banking_accounts", "enable_banking_items"
+  add_foreign_key "enable_banking_items", "families"
   add_foreign_key "entries", "accounts"
   add_foreign_key "entries", "imports"
   add_foreign_key "family_exports", "families"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,6 +246,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_25_224717) do
     t.string "session_id"
     t.datetime "valid_until", precision: nil
     t.string "name"
+    t.string "aspsp_name"
+    t.string "aspsp_country"
     t.string "status", default: "good"
     t.string "logo_url"
     t.boolean "scheduled_for_deletion", default: false


### PR DESCRIPTION
## Description

This PR introduces an integration for **Enable Banking** in **Sure**.

As a European user, I found that Enable Banking is currently the only provider that allows the creation of a developer API key for use with personal accounts without requiring a paid subscription. For this reason, I wanted to try integrating it into Sure.

> **Disclaimer**: This is my first time working with Ruby on Rails, so there’s definitely room for improvement and optimizations. Please consider this as an initial iteration. 😄

## Prerequisites

To test this PR, you'll need to generate an API key. You can follow the [official guide](https://enablebanking.com/docs/api/quick-start/) to register your application and create a key for either the **sandbox** or **production** environment.

If you'd like to use real data, you'll need to link your personal accounts to your production application, as explained in [this guide](https://enablebanking.com/docs/api/linked-accounts/). This will allow you to use your personal accounts with Sure, without requiring a subscription.

> **Important**: When setting up your application, make sure to configure the following URL in the **Redirect URLs** field:  
> `https://<YOUR_DOMAIN>/enable_banking_auth_callback`  
> This is essential for completing the authentication process successfully, as it is the callback path expected by the application.

## Setup In Sure

This integration requires some configuration, which can be done from the **Settings > Self-Hosting** page in Sure.

You'll need to provide the following:

- **Country code**: Select your country from the dropdown list. This is used to display the available banks when adding a new connection.
- **Application ID**: This is the ID generated in your Enable Banking developer account.
- **Client certificate**: Paste the content of the certificate generated when you created your application. It must include both:

```
-----BEGIN PRIVATE KEY-----
...
-----END PRIVATE KEY-----
```

Once these parameters are saved, go to **Settings > Bank Sync > Enable Banking**, and click on **Add new connection**.

1. Choose your bank.
2. Click on **Link account**.
3. You'll be redirected to Enable Banking for authentication.
4. After completing the process, you'll be redirected back to Sure, and your connection will appear.

The system will begin syncing your data in the background. After a short while, you should see your accounts and transactions in Sure.

### Supported Features

- Configuration of Enable Banking integration parameters via the Sure settings UI.
- Authentication with Enable Banking APIs, including account linking and session information storage.
- Account synchronization (name, balance, currency, account type).
- Transaction synchronization (name, date, amount), including merchant data when available.
- Re-authentication flow for expired or compromised sessions.



