### PR TITLE
Allow disabling AI assistant

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,9 +21,11 @@ class UsersController < ApplicationController
       @user.update!(user_params.except(:redirect_to, :delete_profile_image))
       @user.profile_image.purge if should_purge_profile_image?
 
-      # Add a special notice if AI was just enabled
+      # Add a special notice if AI was just enabled or disabled
       notice = if !was_ai_enabled && @user.ai_enabled
         "AI Assistant has been enabled successfully."
+      elsif was_ai_enabled && !@user.ai_enabled
+        "AI Assistant has been disabled."
       else
         t(".success")
       end
@@ -67,6 +69,8 @@ class UsersController < ApplicationController
         redirect_to goals_onboarding_path
       when "trial"
         redirect_to trial_onboarding_path
+      when "ai_prompts"
+        redirect_to settings_ai_prompts_path, notice: notice
       else
         redirect_to settings_profile_path, notice: notice
       end

--- a/app/views/settings/ai_prompts/show.html.erb
+++ b/app/views/settings/ai_prompts/show.html.erb
@@ -1,5 +1,18 @@
 <%= content_for :page_title, t(".page_title") %>
 
+<% if Current.user.ai_enabled? %>
+  <div class="mb-4 flex justify-end">
+    <%= render DS::Button.new(
+      text: t(".disable_ai"),
+      href: user_path(Current.user),
+      method: :patch,
+      params: { user: { ai_enabled: false, redirect_to: "ai_prompts" } },
+      data: { turbo: false },
+      variant: :destructive
+    ) %>
+  </div>
+<% end %>
+
 <div class="bg-container rounded-xl shadow-border-xs p-4">
   <div class="rounded-xl bg-container-inset space-y-1 p-1">
     <div class="flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-secondary">

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -5,6 +5,7 @@ en:
       show:
         page_title: AI Prompts
         openai_label: OpenAI
+        disable_ai: Disable Maybe AI
         prompt_instructions: Prompt Instructions
         main_system_prompt:
           title: Main System Prompt

--- a/test/system/settings/ai_prompts_test.rb
+++ b/test/system/settings/ai_prompts_test.rb
@@ -1,0 +1,19 @@
+require "application_system_test_case"
+
+class Settings::AiPromptsTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:family_admin)
+    @user.update!(ai_enabled: true)
+    login_as @user
+  end
+
+  test "user can disable ai assistant" do
+    visit settings_ai_prompts_path
+
+    click_button "Disable Maybe AI"
+
+    assert_current_path settings_ai_prompts_path
+    @user.reload
+    assert_not @user.ai_enabled?
+  end
+end


### PR DESCRIPTION
## Summary
- add a destructive button on Settings > AI Prompts to turn off Maybe AI
- handle AI disable redirect and notice in UsersController
- test disabling the AI assistant from settings

## Testing
- `npm run lint`
- `npm run format`
- `bin/rubocop`
- `bin/rails test` *(fails: Please check your database configuration and ensure there is a valid connection to your database.)*

------
https://chatgpt.com/codex/tasks/task_e_68b11c384c348332b707a554b9d85880