### PR TITLE
Adjust color styles for checkboxes and text utilities

### DIFF
--- a/app/assets/tailwind/maybe-design-system.css
+++ b/app/assets/tailwind/maybe-design-system.css
@@ -394,7 +394,7 @@
 
   .checkbox--light {
     &[type='checkbox'] {
-      @apply border-alpha-black-200 checked:bg-gray-900 checked:ring-gray-900 focus:ring-gray-900 focus-visible:ring-gray-900 checked:hover:bg-gray-500;
+      @apply border-alpha-black-200 checked:bg-gray-900 checked:ring-gray-900 focus:ring-gray-900 focus-visible:ring-gray-900 checked:hover:bg-gray-300 hover:bg-gray-300;
     }
 
     &[type='checkbox']:disabled {
@@ -404,16 +404,16 @@
     @variant theme-dark {
       &[type='checkbox'] {
         @apply ring-gray-900 checked:text-white;
-        background-color: var(--color-gray-600);
+        background-color: var(--color-gray-100);
       }
   
       &[type='checkbox']:disabled {
-        @apply cursor-not-allowed opacity-80 ring-gray-600;
+        background-color: var(--color-gray-600);
       }
   
       &[type='checkbox']:checked {
-        background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
-        background-color: var(--color-gray-600);
+        background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='gray' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+        background-color: var(--color-gray-100);
       }
     }
   }

--- a/app/assets/tailwind/maybe-design-system/foreground-utils.css
+++ b/app/assets/tailwind/maybe-design-system/foreground-utils.css
@@ -42,7 +42,7 @@
   @apply text-gray-50;
 
   @variant theme-dark {
-    @apply text-gray-700;
+    @apply text-gray-400;
   }
 }
 
@@ -50,7 +50,7 @@
   @apply text-gray-100;
 
   @variant theme-dark {
-    @apply text-gray-600;
+    @apply text-gray-500;
   }
 }
 

--- a/app/assets/tailwind/maybe-design-system/text-utils.css
+++ b/app/assets/tailwind/maybe-design-system/text-utils.css
@@ -18,7 +18,7 @@
   @apply text-gray-500;
 
   @variant theme-dark {
-    @apply text-gray-400;
+    @apply text-gray-300;
   }
 }
 
@@ -26,7 +26,7 @@
   @apply text-gray-400;
 
   @variant theme-dark {
-    @apply text-gray-600;
+    @apply text-gray-500;
   }
 }
 


### PR DESCRIPTION
Updated checkbox hover and checked states for light and dark themes, including background and SVG fill colors. Modified text and foreground utility classes to use different gray shades in dark mode for improved contrast and consistency.
before:
<img width="238" height="207" alt="Scherm­afbeelding 2025-09-21 om 20 03 15" src="https://github.com/user-attachments/assets/f0f6bd02-0891-4548-898a-afc31b956e64" />
after:
<img width="238" height="207" alt="Scherm­afbeelding 2025-09-21 om 20 08 43" src="https://github.com/user-attachments/assets/6e8c66c3-18cd-4d70-b71a-936b87d2ff9f" />
NOTPROVIDED is a transfer between accounts and can not be selected from here.
before the change it looks like the FNV checkbox is disabled.