### PR TITLE
Fix screen flashing when dark mode is selected

### DIFF
--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -42,8 +42,10 @@ export default class extends Controller {
   // Sets or removes the data-theme attribute
   setTheme(isDark) {
     if (isDark) {
+      localStorage.theme = "dark";
       document.documentElement.setAttribute("data-theme", "dark");
     } else {
+      localStorage.theme = "light";
       document.documentElement.setAttribute("data-theme", "light");
     }
   }

--- a/app/views/layouts/_dark_mode_check.html.erb
+++ b/app/views/layouts/_dark_mode_check.html.erb
@@ -1,0 +1,5 @@
+<script>
+  if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    document.documentElement.setAttribute("data-theme", "dark");
+  }
+</script>

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -10,6 +10,7 @@
   <%= combobox_style_tag %>
 
   <%= javascript_importmap_tags %>
+  <%= render "layouts/dark_mode_check" %>
   <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
 
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">


### PR DESCRIPTION
Added a script to check user preferred theme in the HTML `head` element, to ensure the proper `theme` attribute is set before Stimulus is initialised. This avoids the flashing effect when page is reloaded.