### PR TITLE
Tag latest image on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,9 +86,16 @@ jobs:
           if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
             BASE_CONFIG+=$'\n'"type=schedule,pattern=nightly"
             BASE_CONFIG+=$'\n'"type=schedule,pattern=nightly-{{date 'ddd'}}"
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            BASE_CONFIG="type=semver,pattern={{version}}"
-            BASE_CONFIG+=$'\n'"type=raw,value=stable"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG_NAME="${GITHUB_REF#refs/tags/}"
+            if [[ "$TAG_NAME" == v* ]]; then
+              BASE_CONFIG="type=semver,pattern={{version}}"
+              if [[ "$TAG_NAME" =~ ^v.*-alpha([0-9]+)?$ ]]; then
+                BASE_CONFIG+=$'\n'"type=raw,value=latest"
+              else
+                BASE_CONFIG+=$'\n'"type=raw,value=stable"
+              fi
+            fi
           fi
           {
             echo 'TAGS_SPEC<<EOF'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
             TAG_NAME="${GITHUB_REF#refs/tags/}"
             if [[ "$TAG_NAME" == v* ]]; then
               BASE_CONFIG="type=semver,pattern={{version}}"
-              if [[ "$TAG_NAME" =~ ^v.*-alpha([0-9]+)?$ ]]; then
+              if [[ "$TAG_NAME" == v*-alpha* ]]; then
                 BASE_CONFIG+=$'\n'"type=raw,value=latest"
               else
                 BASE_CONFIG+=$'\n'"type=raw,value=stable"


### PR DESCRIPTION
## Summary
- scope the Docker tag configuration to only add the `stable` tag when the release tag itself begins with `v`
- retain the `latest` tag assignment strictly for `v*-alpha` release tags, keeping other refs on digest-only tags

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d320f0bba8833289d408ef155c1b43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated publishing workflow to recognize all tag refs but only publish when the tag name starts with "v".
  - Extracts the tag name and applies channel rules accordingly.
  - Publishes v*-alpha* prereleases to the "latest" channel.
  - Publishes other v* releases to the "stable" channel.
  - Non-"v" tags no longer alter release configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->