### PR TITLE
Add "Reset account" followed by sample data preload

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user
-  before_action :ensure_admin, only: :reset
+  before_action :ensure_admin, only: %i[reset reset_with_sample_data]
 
   def update
     @user = Current.user
@@ -37,6 +37,11 @@ class UsersController < ApplicationController
 
   def reset
     FamilyResetJob.perform_later(Current.family)
+    redirect_to settings_profile_path, notice: t(".success")
+  end
+
+  def reset_with_sample_data
+    FamilyResetJob.perform_later(Current.family, load_sample_data_for_email: @user.email)
     redirect_to settings_profile_path, notice: t(".success")
   end
 

--- a/app/jobs/family_reset_job.rb
+++ b/app/jobs/family_reset_job.rb
@@ -1,7 +1,7 @@
 class FamilyResetJob < ApplicationJob
   queue_as :low_priority
 
-  def perform(family)
+  def perform(family, load_sample_data_for_email: nil)
     # Delete all family data except users
     ActiveRecord::Base.transaction do
       # Delete accounts and related data
@@ -12,7 +12,11 @@ class FamilyResetJob < ApplicationJob
       family.plaid_items.destroy_all
       family.imports.destroy_all
       family.budgets.destroy_all
+    end
 
+    if load_sample_data_for_email.present?
+      Demo::Generator.new.generate_new_user_data_for!(family.reload, email: load_sample_data_for_email)
+    else
       family.sync_later
     end
   end

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -65,7 +65,6 @@ class Demo::Generator
     with_timing(__method__, max_seconds: 1000) do
       family = family.reload
       admin_user = ensure_admin_user!(family, email)
-      ensure_member_user!(family, admin_user)
 
       puts "📊 Creating sample financial data for #{family.name}..."
       ActiveRecord::Base.transaction do
@@ -145,19 +144,6 @@ class Demo::Generator
       return user if user&.admin? || user&.super_admin?
 
       raise ActiveRecord::RecordNotFound, "No admin user with email #{email} found in family ##{family.id}"
-    end
-
-    def ensure_member_user!(family, admin_user)
-      return if family.users.where.not(id: admin_user.id).exists?
-
-      family.users.create!(
-        email: partner_email_for(admin_user.email),
-        first_name: "Eve",
-        last_name: "Bogle",
-        role: :member,
-        password: SecureRandom.base58(24),
-        onboarded_at: Time.current
-      )
     end
 
     def partner_email_for(email)

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 class Demo::Generator
   # @param seed [Integer, String, nil] Seed value used to initialise the internal PRNG. If nil, the ENV variable DEMO_DATA_SEED will
   #   be honoured and default to a random seed when not present.
@@ -59,6 +61,26 @@ class Demo::Generator
     end
   end
 
+  def generate_new_user_data_for!(family, email:)
+    with_timing(__method__, max_seconds: 1000) do
+      family = family.reload
+      admin_user = ensure_admin_user!(family, email)
+      ensure_member_user!(family, admin_user)
+
+      puts "📊 Creating sample financial data for #{family.name}..."
+      ActiveRecord::Base.transaction do
+        create_realistic_categories!(family)
+        create_realistic_accounts!(family)
+        create_realistic_transactions!(family)
+        generate_budget_auto_fill!(family)
+      end
+
+      family.sync_later
+
+      puts "✅ Sample data loaded successfully!"
+    end
+  end
+
   # Generate comprehensive realistic demo data with multi-currency
   def generate_default_data!(skip_clear: false, email: "user@example.com")
     if skip_clear
@@ -116,6 +138,30 @@ class Demo::Generator
         raise "Too much data to clear efficiently (#{family_count} families). Run 'rails db:reset' instead."
       end
       Demo::DataCleaner.new.destroy_everything!
+    end
+
+    def ensure_admin_user!(family, email)
+      user = family.users.find_by(email: email)
+      return user if user&.admin? || user&.super_admin?
+
+      raise ActiveRecord::RecordNotFound, "No admin user with email #{email} found in family ##{family.id}"
+    end
+
+    def ensure_member_user!(family, admin_user)
+      return if family.users.where.not(id: admin_user.id).exists?
+
+      family.users.create!(
+        email: partner_email_for(admin_user.email),
+        first_name: "Eve",
+        last_name: "Bogle",
+        role: :member,
+        password: SecureRandom.base58(24),
+        onboarded_at: Time.current
+      )
+    end
+
+    def partner_email_for(email)
+      "partner_#{email}"
     end
 
     def create_family_and_users!(family_name, email, onboarded:, subscribed:)

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -137,9 +137,30 @@
           href: reset_user_path(@user),
           method: :delete,
           confirm: CustomConfirm.new(
-            title: "Reset account?",
-            body: "This will delete all data associated with your account. Your user profile will remain active.",
-            btn_text: "Reset account",
+            title: t(".confirm_reset.title"),
+            body: t(".confirm_reset.body"),
+            btn_text: t(".reset_account"),
+            destructive: true,
+            high_severity: true
+          )
+        ) %>
+      </div>
+
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div class="w-full md:w-2/3">
+          <h3 class="font-medium text-primary"><%= t(".reset_account_with_sample_data") %></h3>
+          <p class="text-secondary text-sm"><%= t(".reset_account_with_sample_data_warning") %></p>
+        </div>
+
+        <%= render DS::Button.new(
+          text: t(".reset_account_with_sample_data"),
+          variant: "destructive",
+          href: reset_with_sample_data_user_path(@user),
+          method: :delete,
+          confirm: CustomConfirm.new(
+            title: t(".confirm_reset_with_sample_data.title"),
+            body: t(".confirm_reset_with_sample_data.body"),
+            btn_text: t(".reset_account_with_sample_data"),
             destructive: true,
             high_severity: true
           )

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -66,8 +66,8 @@ en:
           your data and cannot be undone.
         reset_account: Reset account
         reset_account_warning: Resetting your account will delete all your accounts, categories, merchants, tags, and other data, but keep your user account intact.
-        reset_account_with_sample_data: Reset account and load sample data
-        reset_account_with_sample_data_warning: Resetting your account will delete all your existing data and then load fresh sample data so you can explore Sure with a pre-filled environment.
+        reset_account_with_sample_data: Reset and preload
+        reset_account_with_sample_data_warning: Delete all your existing data and then load fresh sample data so you can explore with a pre-filled environment.
         email: Email
         first_name: First Name
         household_form_input_placeholder: Enter household name

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -51,6 +51,9 @@ en:
         confirm_reset:
           body: Are you sure you want to reset your account? This will delete all your accounts, categories, merchants, tags, and other data. This action cannot be undone.
           title: Reset account?
+        confirm_reset_with_sample_data:
+          body: Are you sure you want to reset your account and load sample data? This will delete your existing data and replace it with demo data so you can explore Sure safely.
+          title: Reset account and load sample data?
         confirm_remove_invitation:
           body: Are you sure you want to remove the invitation for %{email}?
           title: Remove Invitation
@@ -63,6 +66,8 @@ en:
           your data and cannot be undone.
         reset_account: Reset account
         reset_account_warning: Resetting your account will delete all your accounts, categories, merchants, tags, and other data, but keep your user account intact.
+        reset_account_with_sample_data: Reset account and load sample data
+        reset_account_with_sample_data_warning: Resetting your account will delete all your existing data and then load fresh sample data so you can explore Sure with a pre-filled environment.
         email: Email
         first_name: First Name
         household_form_input_placeholder: Enter household name

--- a/config/locales/views/settings/nb.yml
+++ b/config/locales/views/settings/nb.yml
@@ -35,6 +35,9 @@ nb:
         confirm_reset:
           body: Er du sikker på at du vil tilbakestille kontoen din? Dette vil slette alle kontoene dine, kategorier, forhandlere, tagger og andre data. Denne handlingen kan ikke angres.
           title: Tilbakestill konto?
+        confirm_reset_with_sample_data:
+          body: Are you sure you want to reset your account and load sample data? This will delete your existing data and replace it with demo data so you can explore Sure safely.
+          title: Reset account and load sample data?
         confirm_remove_invitation:
           body: Er du sikker på at du vil fjerne invitasjonen for %{email}?
           title: Fjern invitasjon
@@ -47,6 +50,8 @@ nb:
           dataene dine og kan ikke angres.
         reset_account: Tilbakestill konto
         reset_account_warning: Tilbakestilling av kontoen din vil slette alle kontoene dine, kategorier, forhandlere, tagger og andre data, men beholde brukerkontoen din intakt.
+        reset_account_with_sample_data: Reset account and load sample data
+        reset_account_with_sample_data_warning: Resetting your account will delete all your existing data and then load fresh sample data so you can explore Sure with a pre-filled environment.
         email: E-post
         first_name: Fornavn
         household_form_input_placeholder: Angi husholdningsnavn

--- a/config/locales/views/settings/tr.yml
+++ b/config/locales/views/settings/tr.yml
@@ -35,6 +35,9 @@ tr:
         confirm_reset:
           body: Hesabınızı sıfırlamak istediğinizden emin misiniz? Bu işlem tüm hesaplarınızı, kategorilerinizi, satıcılarınızı, etiketlerinizi ve diğer verilerinizi silecektir. Bu işlem geri alınamaz.
           title: Hesap sıfırlansın mı?
+        confirm_reset_with_sample_data:
+          body: Are you sure you want to reset your account and load sample data? This will delete your existing data and replace it with demo data so you can explore Sure safely.
+          title: Reset account and load sample data?
         confirm_remove_invitation:
           body: "%{email} için daveti kaldırmak istediğinizden emin misiniz?"
           title: "Daveti Kaldır"
@@ -46,6 +49,8 @@ tr:
         delete_account_warning: Hesabınızı silmek tüm verilerinizi kalıcı olarak kaldırır ve geri alınamaz.
         reset_account: Hesabı sıfırla
         reset_account_warning: Hesabınızı sıfırlamak tüm hesaplarınızı, kategorilerinizi, satıcılarınızı, etiketlerinizi ve diğer verilerinizi silecek, ancak kullanıcı hesabınızı koruyacaktır.
+        reset_account_with_sample_data: Reset account and load sample data
+        reset_account_with_sample_data_warning: Resetting your account will delete all your existing data and then load fresh sample data so you can explore Sure with a pre-filled environment.
         email: E-posta
         first_name: Ad
         household_form_input_placeholder: Hane adı girin

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -11,3 +11,5 @@ en:
     reset:
       success: Your account has been reset. Data will be deleted in the background in some time.
       unauthorized: You are not authorized to perform this action
+    reset_with_sample_data:
+      success: Your account has been reset and sample data is being prepared. You’ll see demo data shortly.

--- a/config/locales/views/users/nb.yml
+++ b/config/locales/views/users/nb.yml
@@ -10,3 +10,6 @@ nb:
     reset:
       success: Kontoen din har blitt tilbakestilt. Data vil bli slettet i bakgrunnen om en stund.
       unauthorized: Du er ikke autorisert til å utføre denne handlingen.
+    reset_with_sample_data:
+      success: Kontoen din har blitt tilbakestilt og demodata forberedes. Du vil snart se eksempeldata.
+

--- a/config/locales/views/users/tr.yml
+++ b/config/locales/views/users/tr.yml
@@ -10,3 +10,6 @@ tr:
     reset:
       success: Hesabınız sıfırlandı. Verileriniz arka planda bir süre sonra silinecek.
       unauthorized: Bu işlemi gerçekleştirmeye yetkiniz yok.
+    reset_with_sample_data:
+      success: Hesabınız sıfırlandı ve örnek veriler hazırlanıyor. Kısa süre içinde demo verileri göreceksiniz.
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[update destroy] do
     delete :reset, on: :member
+    delete :reset_with_sample_data, on: :member
     patch :rule_prompt_settings, on: :member
   end
 


### PR DESCRIPTION
Visually:
<img width="819" height="313" alt="Screenshot 2025-09-25 at 11 36 47 AM" src="https://github.com/user-attachments/assets/98b7242d-22d2-4754-8e85-6b670118882f" />

Codex Prompt:
>  In the `/settings/profile` screen there is a "Danger Zone" section where we need to add another entry for "Reset account and load sample data" right below "Reset account" - it follows the exact same procedure but after reseting the account it calls a new function like `Demo::Generator.new.generate_new_user_data` but that allows passing of the email (since the account is already created) and can run in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Reset account with sample data” option in Settings → Profile (danger zone), with a dedicated confirmation and success notice.
- Localization
  - Replaced hard‑coded reset texts with i18n and added translations for English, Norwegian, and Turkish, including new sample-data reset messages.
- Permissions
  - Strengthened access control: both reset actions are restricted to admins.
- Tests
  - Added tests covering admin/non-admin access and the new sample-data reset flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->