### PR TITLE
Fix textarea display issue

### DIFF
--- a/app/assets/tailwind/maybe-design-system.css
+++ b/app/assets/tailwind/maybe-design-system.css
@@ -356,7 +356,6 @@
     @apply focus:opacity-100 focus:outline-hidden focus:ring-0;
     @apply placeholder-shown:opacity-50;
     @apply disabled:text-subdued;
-    @apply text-ellipsis overflow-hidden whitespace-nowrap;
     @apply transition-opacity duration-300;
     @apply placeholder:text-subdued;
 


### PR DESCRIPTION
I noticed that all the input fields have the `overflow` property set to hidden, and `white-space` set to `nowrap`.
This creates visibility issues in case of `textarea` elements, because the whole text is displayed on a single line and there is no scrollbar, so no way to easily move to a specific point of the text.

It is pretty noticeable, for instance, in the transaction notes:

<img width="544" height="507" alt="Screenshot 2025-09-29 alle 01 14 32" src="https://github.com/user-attachments/assets/30811ef4-0c6c-4dfa-a8dd-da4a839d8b3b" />

This is how it looks after removing the CSS properties:

<img width="537" height="501" alt="Screenshot 2025-09-29 alle 01 14 19" src="https://github.com/user-attachments/assets/b8d1c9cf-7c14-4a86-9a5f-9a3924bc68b2" />
