### PR TITLE
Add Langfuse session and user metadata to OpenAI traces

### DIFF
--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -67,7 +67,9 @@ class Assistant::Responder
         functions: function_tool_caller.function_definitions,
         function_results: function_results,
         streamer: streamer,
-        previous_response_id: previous_response_id
+        previous_response_id: previous_response_id,
+        session_id: chat_session_id,
+        user_identifier: chat_user_identifier
       )
 
       unless response.success?
@@ -83,5 +85,19 @@ class Assistant::Responder
 
     def listeners
       @listeners ||= Hash.new { |h, k| h[k] = [] }
+    end
+
+    def chat_session_id
+      chat&.id&.to_s
+    end
+
+    def chat_user_identifier
+      return unless chat&.user_id
+
+      ::Digest::SHA256.hexdigest(chat.user_id.to_s)
+    end
+
+    def chat
+      @chat ||= message.chat
     end
 end

--- a/app/models/provider/llm_concept.rb
+++ b/app/models/provider/llm_concept.rb
@@ -18,7 +18,17 @@ module Provider::LlmConcept
   ChatResponse = Data.define(:id, :model, :messages, :function_requests)
   ChatFunctionRequest = Data.define(:id, :call_id, :function_name, :function_args)
 
-  def chat_response(prompt, model:, instructions: nil, functions: [], function_results: [], streamer: nil, previous_response_id: nil)
+  def chat_response(
+    prompt,
+    model:,
+    instructions: nil,
+    functions: [],
+    function_results: [],
+    streamer: nil,
+    previous_response_id: nil,
+    session_id: nil,
+    user_identifier: nil
+  )
     raise NotImplementedError, "Subclasses must implement #chat_response"
   end
 end


### PR DESCRIPTION
## Summary
- propagate chat session identifiers and anonymized user hashes into Langfuse logging for OpenAI calls
- derive session and user metadata from chat messages when requesting LLM responses
- extend assistant tests to assert the new metadata is passed through

## Testing
- bin/rails test test/models/assistant_test.rb
- bin/rails test test/models/provider/openai_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68daafd5d41c83328af563e99a785fd4