### PR TITLE
Enhanced Import Amount Type Selection

### DIFF
--- a/app/controllers/import/configurations_controller.rb
+++ b/app/controllers/import/configurations_controller.rb
@@ -38,6 +38,7 @@ class Import::ConfigurationsController < ApplicationController
         :number_format,
         :signage_convention,
         :amount_type_strategy,
+        :amount_type_identifier_value,
         :amount_type_inflow_value,
       )
     end

--- a/app/javascript/controllers/import_controller.js
+++ b/app/javascript/controllers/import_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     "signedAmountFieldset",
     "customColumnFieldset",
     "amountTypeValue",
+    "amountTypeInflowValue",
     "amountTypeStrategySelect",
   ];
 
@@ -20,6 +21,10 @@ export default class extends Controller {
       this.amountTypeColumnKeyValue
     ) {
       this.#showAmountTypeValueTargets(this.amountTypeColumnKeyValue);
+      const identifierValueSelect = this.amountTypeValueTarget.querySelector("select");
+      if (identifierValueSelect && identifierValueSelect.value) {
+        this.#showAmountTypeInflowValueTargets();
+      }
     }
   }
 
@@ -31,6 +36,10 @@ export default class extends Controller {
 
       if (this.amountTypeColumnKeyValue) {
         this.#showAmountTypeValueTargets(this.amountTypeColumnKeyValue);
+        const identifierValueSelect = this.amountTypeValueTarget.querySelector("select");
+        if (identifierValueSelect && identifierValueSelect.value) {
+          this.#showAmountTypeInflowValueTargets();
+        }
       }
     }
 
@@ -43,6 +52,10 @@ export default class extends Controller {
     const amountTypeColumnKey = event.target.value;
 
     this.#showAmountTypeValueTargets(amountTypeColumnKey);
+  }
+
+  handleAmountTypeIdentifierChange(event) {
+    this.#showAmountTypeInflowValueTargets();
   }
 
   #showAmountTypeValueTargets(amountTypeColumnKey) {
@@ -70,6 +83,29 @@ export default class extends Controller {
     });
 
     select.appendChild(fragment);
+  }
+
+  #showAmountTypeInflowValueTargets(amountTypeColumnKey) {
+    // This should be called when amount_type_identifier_value changes
+    // We need to update the displayed identifier value in the UI text
+    const identifierValueSelect = this.amountTypeValueTarget.querySelector("select");
+    const selectedValue = identifierValueSelect.value;
+    
+    if (!selectedValue) {
+      this.amountTypeInflowValueTarget.classList.add("hidden");
+      this.amountTypeInflowValueTarget.classList.remove("flex");
+      return;
+    }
+
+    // Show the inflow value dropdown
+    this.amountTypeInflowValueTarget.classList.remove("hidden");
+    this.amountTypeInflowValueTarget.classList.add("flex");
+
+    // Update the displayed identifier value in the text
+    const identifierSpan = this.amountTypeInflowValueTarget.querySelector("span.font-medium");
+    if (identifierSpan) {
+      identifierSpan.textContent = selectedValue;
+    }
   }
 
   #uniqueValuesForColumn(column) {
@@ -100,6 +136,12 @@ export default class extends Controller {
   #enableSignedAmountFieldset() {
     this.customColumnFieldsetTarget.classList.add("hidden");
     this.signedAmountFieldsetTarget.classList.remove("hidden");
+
+    // Hide the inflow value targets when using signed amount strategy
+    this.amountTypeValueTarget.classList.add("hidden");
+    this.amountTypeValueTarget.classList.remove("flex");
+    this.amountTypeInflowValueTarget.classList.add("hidden");
+    this.amountTypeInflowValueTarget.classList.remove("flex");
 
     // Remove required from custom column fields
     this.customColumnFieldsetTarget

--- a/app/models/import/row.rb
+++ b/app/models/import/row.rb
@@ -47,12 +47,13 @@ class Import::Row < ApplicationRecord
       if import.amount_type_strategy == "signed_amount"
         value * (import.signage_convention == "inflows_positive" ? -1 : 1)
       elsif import.amount_type_strategy == "custom_column"
-        inflow_value = import.amount_type_inflow_value
+        selected_identifier = import.amount_type_identifier_value
+        inflow_treatment = import.amount_type_inflow_value
 
-        if entity_type == inflow_value
-          value * -1
+        if entity_type == selected_identifier
+          value * (inflow_treatment == "inflows_positive" ? -1 : 1)
         else
-          value
+          value * (inflow_treatment == "inflows_positive" ? 1 : -1)
         end
       else
         raise "Unknown amount type strategy for import: #{import.amount_type_strategy}"

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -78,11 +78,21 @@
       <div class="items-center gap-2 text-sm <%= @import.entity_type_col_label.nil? ? "hidden" : "flex" %>" data-import-target="amountTypeValue">
         <span class="shrink-0 text-secondary">↪</span>
         <span class="text-secondary">Set</span>
-        <%= form.select :amount_type_inflow_value,
+        <%= form.select :amount_type_identifier_value,
                         @import.selectable_amount_type_values,
-                        { prompt: "Select column", container_class: "w-48 px-3 py-1.5 border border-secondary rounded-md" },
+                        { prompt: "Select value", container_class: "w-48 px-3 py-1.5 border border-secondary rounded-md" },
+                        required: @import.amount_type_strategy == "custom_column",
+                        data: { action: "import#handleAmountTypeIdentifierChange" } %>
+        <span class="text-secondary">as identifier value</span>
+      </div>
+
+      <div class="items-center gap-2 text-sm <%= @import.amount_type_identifier_value.nil? ? "hidden" : "flex" %>" data-import-target="amountTypeInflowValue">
+        <span class="shrink-0 text-secondary">↪</span>
+        <span class="text-secondary">Treat "<span class="font-medium"><%= @import.amount_type_identifier_value %></span>" as</span>
+        <%= form.select :amount_type_inflow_value,
+                        [["Income (inflow)", "inflows_positive"], ["Expense (outflow)", "inflows_negative"]],
+                        { prompt: "Select type", container_class: "w-48 px-3 py-1.5 border border-secondary rounded-md" },
                         required: @import.amount_type_strategy == "custom_column" %>
-        <span class="text-secondary">as "income" (inflow) value</span>
       </div>
     </div>
   <% end %>

--- a/db/migrate/20251002120000_add_amount_type_identifier_value_to_imports.rb
+++ b/db/migrate/20251002120000_add_amount_type_identifier_value_to_imports.rb
@@ -1,0 +1,5 @@
+class AddAmountTypeIdentifierValueToImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column :imports, :amount_type_identifier_value, :string
+  end
+end

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -84,7 +84,8 @@ class TransactionImportTest < ActiveSupport::TestCase
       date_format: "%m/%d/%Y",
       amount_col_label: "amount",
       entity_type_col_label: "amount_type",
-      amount_type_inflow_value: "debit",
+      amount_type_identifier_value: "debit",
+      amount_type_inflow_value: "inflows_positive",
       amount_type_strategy: "custom_column",
       signage_convention: nil # Explicitly set to nil to prove this is not needed
     )


### PR DESCRIPTION
Summary
Improved the import configuration flow to allow users to specify whether a selected CSV column value should be treated as income (inflow) or expense (outflow). This provides more flexibility when importing transaction data with custom amount type columns.

Problem
Previously, when using the "custom column" amount type strategy, users could only select which value from their CSV represented "inflow". This was limiting when:
- Import data only contained expense values (e.g., only "af"(expense) without "bij"(income))
- Users wanted to explicitly configure any value as either income or expense

before(csv only contains expense)
<img width="517" height="171" alt="Scherm­afbeelding 2025-10-02 om 00 49 20" src="https://github.com/user-attachments/assets/2d5a6e5d-74d9-40e4-9623-091d902e8d87" />


after
<img width="517" height="209" alt="Scherm­afbeelding 2025-10-02 om 00 50 00" src="https://github.com/user-attachments/assets/7018177d-e395-4ed5-9aa0-6ac55c90b511" />
