### PR TITLE
Add back button to password reset form

### DIFF
--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -8,4 +8,14 @@
 
     <%= form.submit t(".submit") %>
   <% end %>
+
+  <div class="mt-4">
+    <%= render DS::Link.new(
+      text: t(".back"),
+      href: new_session_path,
+      variant: :secondary,
+      full_width: true,
+      class: "bg-white hover:bg-gray-100"
+    ) %>
+  </div>
 <% end %>

--- a/config/locales/views/password_resets/en.yml
+++ b/config/locales/views/password_resets/en.yml
@@ -7,6 +7,7 @@ en:
       requested: Please check your email for a link to reset your password.
       submit: Reset password
       title: Reset password
+      back: Back
     update:
       invalid_token: Invalid token.
       success: Your password has been reset.

--- a/config/locales/views/password_resets/nb.yml
+++ b/config/locales/views/password_resets/nb.yml
@@ -7,6 +7,7 @@ nb:
       requested: Vennligst sjekk e-posten din for en lenke til å tilbakestille passordet ditt.
       submit: Tilbakestill passord
       title: Tilbakestill passord
+      back: Tilbake
     update:
       invalid_token: Ugyldig token.
       success: Passordet ditt er tilbakestilt.

--- a/config/locales/views/password_resets/tr.yml
+++ b/config/locales/views/password_resets/tr.yml
@@ -7,6 +7,7 @@ tr:
       requested: Lütfen şifrenizi sıfırlamak için e-postanızı kontrol edin.
       submit: Şifreyi sıfırla
       title: Şifreyi sıfırla
+      back: Geri
     update:
       invalid_token: Geçersiz token.
       success: Şifreniz başarıyla sıfırlandı.


### PR DESCRIPTION
## Summary
- add a full-width Back button under the Reset password action on the password reset form
- localize the new Back label for English, Norwegian Bokmål, and Turkish

## Testing
- bin/rails tailwindcss:build

------
https://chatgpt.com/codex/tasks/task_e_68e4ce3ece308332822cd4c0bacf5cbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a full-width secondary “Back” link button to the password reset page, shown after the email form when the step isn’t pending, directing users to the sign-in page.

- Localization
  - Introduced “Back” translations for the password reset view in English (Back), Norwegian Bokmål (Tilbake), and Turkish (Geri).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->