### PR TITLE
Implement an outflows section

### DIFF
--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -7,13 +7,13 @@
   data-theme="<%= theme %>"
   data-controller="theme"
   data-theme-user-preference-value="<%= Current.user&.theme || "system" %>"
-  class="h-full text-primary overflow-hidden lg:overflow-auto font-sans <%= @os %>">
+  class="h-full text-primary overflow-hidden font-sans <%= @os %>">
   <head>
     <%= render "layouts/shared/head" %>
     <%= yield :head %>
   </head>
 
-  <body class="h-full overflow-hidden lg:overflow-auto antialiased">
+  <body class="h-full overflow-hidden antialiased">
     <% if Rails.env.development? %>
       <button hidden data-controller="hotkey" data-hotkey="t t /" data-action="theme#toggle"></button>
     <% end %>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -34,6 +34,17 @@
       </section>
     <% end %>
 
+    <% if @outflows_data[:categories].present? %>
+      <%= turbo_frame_tag "outflows_donut_section" do %>
+        <section class="bg-container py-4 rounded-xl shadow-border-xs mb-6">
+          <%= render partial: "pages/dashboard/outflows_donut", locals: {
+            outflows_data: @outflows_data,
+            period: @outflows_period
+          } %>
+        </section>
+      <% end %>
+    <% end %>
+
     <section class="bg-container py-4 rounded-xl shadow-border-xs">
       <%= render partial: "pages/dashboard/net_worth_chart", locals: {
         balance_sheet: @balance_sheet,

--- a/app/views/pages/dashboard/_outflows_donut.html.erb
+++ b/app/views/pages/dashboard/_outflows_donut.html.erb
@@ -1,0 +1,87 @@
+<%# locals: (outflows_data:, period:) %>
+<div id="outflows-donut-section">
+  <div class="flex justify-between items-center gap-4 px-4 mb-4">
+    <h2 class="text-lg font-medium inline-flex items-center gap-1.5">
+      Outflows
+    </h2>
+
+    <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "outflows_donut_section" } do |form| %>
+      <%= form.select :outflows_period,
+                Period.as_options,
+                { selected: period.key },
+                data: { "auto-submit-form-target": "auto" },
+                class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+    <% end %>
+  </div>
+
+  <div class="px-4">
+    <div class="flex flex-col lg:flex-row gap-8 items-center">
+      <!-- Donut Chart -->
+      <div class="w-full lg:w-1/3 max-w-[300px]">
+        <div class="h-[300px] relative"
+          data-controller="donut-chart"
+          data-donut-chart-segments-value="<%= outflows_data[:categories].to_json %>"
+          data-donut-chart-segment-height-value="5"
+          data-donut-chart-segment-opacity-value="0.9"
+          data-donut-chart-extended-hover-value="true"
+          data-donut-chart-hover-extension-value="3"
+          data-donut-chart-enable-click-value="true"
+          data-donut-chart-start-date-value="<%= period.date_range.first %>"
+          data-donut-chart-end-date-value="<%= period.date_range.last %>">
+          <div data-donut-chart-target="chartContainer" class="absolute inset-0 pointer-events-none"></div>
+
+          <div data-donut-chart-target="contentContainer" class="flex justify-center items-center h-full">
+            <div data-donut-chart-target="defaultContent" class="flex flex-col items-center">
+              <div class="text-secondary text-sm mb-2">
+                <span>Total Outflows</span>
+              </div>
+
+              <div class="text-3xl font-medium text-primary">
+                <%= outflows_data[:currency_symbol] %><%= number_with_delimiter(outflows_data[:total], delimiter: ',') %>
+              </div>
+            </div>
+
+            <% outflows_data[:categories].each do |category| %>
+              <div id="segment_<%= category[:id] %>" class="hidden">
+                <div class="flex flex-col gap-2 items-center">
+                  <p class="text-sm text-secondary"><%= category[:name] %></p>
+
+                  <p class="text-3xl font-medium text-primary">
+                    <%= outflows_data[:currency_symbol] %><%= number_with_delimiter(category[:amount], delimiter: ',') %>
+                  </p>
+
+                  <p class="text-sm text-secondary"><%= category[:percentage] %>%</p>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <!-- Category List -->
+      <div class="w-full lg:w-2/3">
+        <div class="space-y-2">
+          <% outflows_data[:categories].each do |category| %>
+            <%= link_to transactions_path(q: { categories: [category[:name]], start_date: period.date_range.first, end_date: period.date_range.last }),
+                class: "flex items-center justify-between p-3 rounded-lg hover:bg-container-inset transition-colors cursor-pointer group",
+                data: {
+                  turbo_frame: "_top",
+                  category_id: category[:id],
+                  action: "mouseenter->donut-chart#highlightSegment mouseleave->donut-chart#unhighlightSegment"
+                } do %>
+              <div class="flex items-center gap-3 flex-1 min-w-0">
+                <div class="w-3 h-3 rounded-full flex-shrink-0" style="background-color: <%= category[:color] %>"></div>
+                <%= icon(category[:icon], class: "w-4 h-4 text-primary flex-shrink-0") %>
+                <span class="text-sm font-medium text-primary truncate"><%= category[:name] %></span>
+              </div>
+              <div class="flex items-center gap-4 flex-shrink-0">
+                <span class="text-sm font-medium text-primary whitespace-nowrap"><%= outflows_data[:currency_symbol] %><%= number_with_delimiter(category[:amount], delimiter: ',') %></span>
+                <span class="text-sm text-secondary whitespace-nowrap"><%= category[:percentage] %>%</span>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Includes both a donut graph and a category list with amounts and percentages
- Has same date filters as other sections
- Can be clicked through and will redirect to transactions with filters applied
  - Includes a daterange filter also to make sure it shows the same transactions as in the main donut chart ( so 30D will filter accordingly )
<img width="858" height="671" alt="503215423-eaefc914-6788-45cb-bda2-df1507bfe3cd" src="https://github.com/user-attachments/assets/fab7704d-cdfe-4bc3-ad9a-90f343a4aa43" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new interactive outflows visualization displaying expense categories with flexible period-based filtering and percentages
  * Added enhanced chart interactions featuring extended hover behavior and clickable segment navigation to category transactions
  * Implemented robust cashflow and outflows period filtering with validation and automatic fallback handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->