### PR TITLE
Add instructions on how to obtain Brand Logo Client ID API

### DIFF
--- a/app/views/settings/hostings/_brand_fetch_settings.html.erb
+++ b/app/views/settings/hostings/_brand_fetch_settings.html.erb
@@ -7,9 +7,9 @@
       <p class="text-secondary text-sm mb-4"><%= t(".description") %></p>
         <ol class="text-sm text-secondary mb-4 list-decimal ml-6 space-y-2">
             <li>
-              Visit <a href="https://brandfetch.com/developers" target="_blank">brandfetch.com</a> and create a free Brand Fetch Developer account.
+              Visit <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer">brandfetch.com</a> and create a free Brand Fetch Developer account.
             </li>
-            <li>Go to the <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank">Logo API</a> page.</li>
+            <li>Go to the <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer">Logo API</a> page.</li>
             <li>Tap the eye icon under the "Your Client ID" section to reveal your <strong>Client ID</strong> and paste it below.</li>
           </ol>
     <% end %>


### PR DESCRIPTION
Due to some confusion and complexity of multiple Brand API and what Client ID to use, adding instructions to the self-hosting settings page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline, ordered walkthrough in Brand Fetch settings (displayed when the Client ID isn't configured) that guides users to create a developer account, open the Logo API page, reveal the Client ID, and paste it into the settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->