### PR TITLE
Added instructions on where and how to obtain API key for Twelve Data

### DIFF
--- a/app/views/settings/hostings/_twelve_data_settings.html.erb
+++ b/app/views/settings/hostings/_twelve_data_settings.html.erb
@@ -7,9 +7,9 @@
       <p class="text-secondary text-sm mb-4"><%= t(".description") %></p>
         <ol class="text-sm text-secondary mb-4 list-decimal ml-6 space-y-2">
             <li>
-            Visit <a href="https://twelvedata.com/register" target="_blank">twelvedata.com</a> and create a free Twelve Data Developer account.
+            Visit <a href="https://twelvedata.com/register" target="_blank" rel="noopener noreferrer">twelvedata.com</a> and create a free Twelve Data Developer account.
           </li>
-          <li>Go to the <a href="https://twelvedata.com/account/api-keys" target="_blank">API Keys</a> page.</li>
+          <li>Go to the <a href="https://twelvedata.com/account/api-keys" target="_blank" rel="noopener noreferrer">API Keys</a> page.</li>
           <li>Reveal your <strong>Secret Key</strong> and paste it below.</li>
         </ol>
     <% end %>


### PR DESCRIPTION
Added detailed instructions on where and how to obtain key for Twelve Data in the Self-Hosting Settings page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for Twelve Data API integration. Users now see clear step-by-step guidance for registering, accessing API Keys, and entering the Secret Key in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->