### PR TITLE
Avoid auto-categorizing without user categories

### DIFF
--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -54,6 +54,11 @@ class Provider::Openai < Provider
   def auto_categorize(transactions: [], user_categories: [], model: "", family: nil)
     with_provider_response do
       raise Error, "Too many transactions to auto-categorize. Max is 25 per request." if transactions.size > 25
+      if user_categories.blank?
+        family_id = family&.id || "unknown"
+        Rails.logger.error("Cannot auto-categorize transactions for family #{family_id}: no categories available")
+        raise Error, "No categories available for auto-categorization"
+      end
 
       effective_model = model.presence || @default_model
 


### PR DESCRIPTION
## Summary
- skip family auto-categorization when a family has no available categories
- prevent the OpenAI provider from making auto-categorization requests without categories and log an error

## Testing
- bin/rails test test/models/family/auto_categorizer_test.rb

------
https://chatgpt.com/codex/tasks/task_e_69033d0891ec833299a3eb936ae10a8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation in auto-categorization to prevent processing when category data is unavailable.
  * Enhanced error handling with improved logging for missing categories scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->