### PR TITLE
Merchants fixes

### DIFF
--- a/app/controllers/family_merchants_controller.rb
+++ b/app/controllers/family_merchants_controller.rb
@@ -4,7 +4,8 @@ class FamilyMerchantsController < ApplicationController
   def index
     @breadcrumbs = [ [ "Home", root_path ], [ "Merchants", nil ] ]
 
-    @family_merchants = Current.family.merchants.alphabetically
+    # Show all merchants assigned to transactions (both FamilyMerchant and ProviderMerchant)
+    @family_merchants = Current.family.assigned_merchants.alphabetically
 
     render layout: "settings"
   end


### PR DESCRIPTION
- Fix display issues on the settings -> merchants page. 
  - The controller was using Current.family.merchants which only returns FamilyMerchant records (user-created merchants)
  - ProviderMerchant records (auto-created from Lunchflow, Plaid, SimpleFin) were being created correctly but not displayed
  
- SimpleFin had its own MerchantDetector class that directly called ProviderMerchant.find_or_create_by!
  - This was inconsistent with Plaid and Lunchflow which use the centralized import_adapter.find_or_create_merchant method
  - Different unique keys: SimpleFin used source + name, others used source + provider_merchant_id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merchant list display to include all merchants assigned to transactions.
  * Enhanced SimpleFin merchant import with improved payee-based detection and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->