### PR TITLE
Hide settings navigation for intro users

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,10 @@ class PagesController < ApplicationController
   skip_authentication only: :redis_configuration_error
 
   def dashboard
+    if Current.user&.ui_layout_intro?
+      redirect_to chats_path and return
+    end
+
     @balance_sheet = Current.family.balance_sheet
     @accounts = Current.family.accounts.visible.with_attached_logo
 
@@ -43,6 +47,10 @@ class PagesController < ApplicationController
     @outflows_data = build_outflows_donut_data(outflows_expense_totals)
 
     @breadcrumbs = [ [ "Home", root_path ], [ "Dashboard", nil ] ]
+  end
+
+  def intro
+    @breadcrumbs = [ [ "Home", chats_path ], [ "Intro", nil ] ]
   end
 
   def changelog

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -1,5 +1,5 @@
 class Settings::ProfilesController < ApplicationController
-  layout "settings"
+  layout :layout_for_settings_profile
 
   def show
     @user = Current.user
@@ -36,4 +36,10 @@ class Settings::ProfilesController < ApplicationController
 
     redirect_to settings_profile_path
   end
+
+  private
+
+    def layout_for_settings_profile
+      Current.user&.ui_layout_intro? ? "application" : "settings"
+    end
 end

--- a/app/models/assistant/configurable.rb
+++ b/app/models/assistant/configurable.rb
@@ -6,13 +6,51 @@ module Assistant::Configurable
       preferred_currency = Money::Currency.new(chat.user.family.currency)
       preferred_date_format = chat.user.family.date_format
 
-      {
-        instructions: default_instructions(preferred_currency, preferred_date_format),
-        functions: default_functions
-      }
+      if chat.user.ui_layout_intro?
+        {
+          instructions: intro_instructions(preferred_currency, preferred_date_format),
+          functions: []
+        }
+      else
+        {
+          instructions: default_instructions(preferred_currency, preferred_date_format),
+          functions: default_functions
+        }
+      end
     end
 
     private
+      def intro_instructions(preferred_currency, preferred_date_format)
+        <<~PROMPT
+          ## Your identity
+
+          You are Sure, a warm and curious financial guide welcoming a new household to the Sure personal finance application.
+
+          ## Your purpose
+
+          Host an introductory conversation that helps you understand the user's stage of life, financial responsibilities, and near-term priorities so future guidance feels personal and relevant.
+
+          ## Conversation approach
+
+          - Ask one thoughtful question at a time and tailor follow-ups based on what the user shares.
+          - Reflect key details back to the user to confirm understanding.
+          - Keep responses concise, friendly, and free of filler phrases.
+          - If the user requests detailed analytics, let them know the dashboard experience will cover it soon and guide them back to sharing context.
+
+          ## Information to uncover
+
+          - Household composition and stage of life milestones (education, career, retirement, dependents, caregiving, etc.).
+          - Primary financial goals, concerns, and timelines.
+          - Notable upcoming events or obligations.
+
+          ## Formatting guidelines
+
+          - Use markdown for any lists or emphasis.
+          - When money or timeframes are discussed, format currency with #{preferred_currency.symbol} (#{preferred_currency.iso_code}) and dates using #{preferred_date_format}.
+          - Do not call external tools or functions.
+        PROMPT
+      end
+
       def default_functions
         [
           Assistant::Function::GetTransactions,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,18 @@
-<% mobile_nav_items = [
-  { name: "Home", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
-  { name: "Transactions", path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
-  { name: "Budgets", path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
-  { name: "Assistant", path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
-] %>
+<% intro_mode = Current.user&.ui_layout_intro? %>
+<% home_path = intro_mode ? chats_path : root_path %>
+<% mobile_nav_items = if intro_mode
+  [
+    { name: "Home", path: chats_path, icon: "home", icon_custom: false, active: page_active?(chats_path) },
+    { name: "Intro", path: intro_path, icon: "sparkles", icon_custom: false, active: page_active?(intro_path) }
+  ]
+else
+  [
+    { name: "Home", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
+    { name: "Transactions", path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
+    { name: "Budgets", path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
+    { name: "Assistant", path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
+  ]
+end %>
 
 <% desktop_nav_items = mobile_nav_items.reject { |item| item[:mobile_only] } %>
 <% expanded_sidebar_class = "w-full" %>
@@ -35,18 +44,18 @@
     <nav class="lg:hidden flex justify-between items-center p-3">
       <%= icon("panel-left", as_button: true, data: { action: "app-layout#openMobileSidebar"}) %>
 
-      <%= link_to root_path, class: "block" do %>
+      <%= link_to home_path, class: "block" do %>
         <%= image_tag "logomark-color.svg", class: "w-9 h-9 mx-auto" %>
       <% end %>
 
-      <%= render "users/user_menu", user: Current.user, placement: "bottom-end", offset: 12 %>
+      <%= render "users/user_menu", user: Current.user, placement: "bottom-end", offset: 12, intro_mode: intro_mode %>
     </nav>
 
     <%# DESKTOP - Left navbar %>
     <div class="hidden lg:block">
       <nav class="h-full flex flex-col shrink-0 w-[84px] py-4 mr-3">
         <div class="pl-2 mb-3">
-          <%= link_to root_path, class: "block" do %>
+          <%= link_to home_path, class: "block" do %>
             <%= image_tag "logomark-color.svg", class: "w-9 h-9 mx-auto" %>
           <% end %>
         </div>
@@ -67,7 +76,7 @@
             target: "_blank"
           ) %>
 
-          <%= render "users/user_menu", user: Current.user %>
+          <%= render "users/user_menu", user: Current.user, intro_mode: intro_mode %>
         </div>
       </nav>
     </div>

--- a/app/views/pages/intro.html.erb
+++ b/app/views/pages/intro.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_header do %>
+  <div class="space-y-2">
+    <h1 class="text-2xl font-semibold text-primary">Welcome to Sure</h1>
+    <p class="text-secondary">A guided introduction experience is on its way. Until then, share a bit about your household in chat so Sure can tailor future insights.</p>
+  </div>
+<% end %>
+
+<div class="mx-auto max-w-3xl">
+  <div class="bg-container shadow-border-xs rounded-2xl p-8 text-center space-y-4">
+    <div class="flex justify-center">
+      <%= image_tag "logomark-color.svg", class: "w-16 h-16" %>
+    </div>
+    <h2 class="text-xl font-semibold text-primary">Intro experience coming soon</h2>
+    <p class="text-secondary">
+      We're building a richer onboarding journey to learn about your goals, milestones, and day-to-day needs. For now, head over to the chat sidebar to start a conversation with Sure and let us know where you are in your financial journey.
+    </p>
+    <div>
+      <%= link_to "Start chatting", chats_path, class: "inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-white font-medium" %>
+    </div>
+  </div>
+</div>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -25,101 +25,103 @@
   <% end %>
 <% end %>
 
-<%= settings_section title: t(".household_title"), subtitle: t(".household_subtitle") do %>
-  <div class="space-y-4">
-    <%= styled_form_with model: Current.user, class: "space-y-4", data: { controller: "auto-submit-form" } do |form| %>
-      <%= form.fields_for :family do |family_fields| %>
-        <%= family_fields.text_field :name,
-              placeholder: t(".household_form_input_placeholder"),
-              label: t(".household_form_label"),
-              disabled: !Current.user.admin?,
-              "data-auto-submit-form-target": "auto" %>
+<% unless Current.user.ui_layout_intro? %>
+  <%= settings_section title: t(".household_title"), subtitle: t(".household_subtitle") do %>
+    <div class="space-y-4">
+      <%= styled_form_with model: Current.user, class: "space-y-4", data: { controller: "auto-submit-form" } do |form| %>
+        <%= form.fields_for :family do |family_fields| %>
+          <%= family_fields.text_field :name,
+                placeholder: t(".household_form_input_placeholder"),
+                label: t(".household_form_label"),
+                disabled: !Current.user.admin?,
+                "data-auto-submit-form-target": "auto" %>
+        <% end %>
       <% end %>
-    <% end %>
-    <div class="bg-container-inset rounded-xl p-1">
-      <div class="px-4 py-2">
-        <p class="uppercase text-xs text-secondary font-medium"><%= Current.family.name %> &middot; <%= Current.family.users.size %></p>
-      </div>
-      <% @users.each do |user| %>
-        <div class="flex gap-2 mt-2 items-center bg-container p-4 shadow-border-xs rounded-lg">
-          <div class="w-9 h-9 shrink-0">
-            <%= render "settings/user_avatar", avatar_url: user.profile_image&.variant(:small)&.url, initials: user.initials %>
-          </div>
-          <p class="text-primary font-medium text-sm"><%= user.display_name %></p>
-          <div class="rounded-md bg-surface px-1.5 py-0.5">
-            <p class="uppercase text-secondary font-medium text-xs"><%= user.role %></p>
-          </div>
-          <% if Current.user.admin? && user != Current.user %>
-            <div class="ml-auto">
-              <%= render DS::Button.new(
-                variant: "icon",
-                icon: "x",
-                href: settings_profile_path(user_id: user),
-                method: :delete,
-                confirm: CustomConfirm.for_resource_deletion(user.display_name, high_severity: true)
-              ) %>
-            </div>
-          <% end %>
+      <div class="bg-container-inset rounded-xl p-1">
+        <div class="px-4 py-2">
+          <p class="uppercase text-xs text-secondary font-medium"><%= Current.family.name %> &middot; <%= Current.family.users.size %></p>
         </div>
-      <% end %>
-      <% if @pending_invitations.any? %>
-        <% @pending_invitations.each do |invitation| %>
-          <div class="flex gap-2 items-center justify-between bg-container p-4 border border-alpha-black-25 rounded-lg">
-            <div class="flex gap-2 items-center">
-              <div class="w-9 h-9 shrink-0">
-                <div class="fg-inverse w-full h-full bg-surface-inset rounded-full flex items-center justify-center text-lg uppercase"><%= invitation.email[0] %></div>
-              </div>
-              <div class="flex">
-                <p class="text-primary font-medium text-sm"><%= invitation.email %></p>
-                <div class="rounded-md bg-surface px-1.5 py-0.5">
-                  <p class="uppercase text-secondary font-medium text-xs"><%= t(".pending") %></p>
-                </div>
-              </div>
+        <% @users.each do |user| %>
+          <div class="flex gap-2 mt-2 items-center bg-container p-4 shadow-border-xs rounded-lg">
+            <div class="w-9 h-9 shrink-0">
+              <%= render "settings/user_avatar", avatar_url: user.profile_image&.variant(:small)&.url, initials: user.initials %>
             </div>
-            <div class="flex items-center gap-4">
-              <% if self_hosted? %>
-                <div class="flex items-center gap-2" data-controller="clipboard">
-                  <p class="text-secondary text-sm"><%= t(".invitation_link") %></p>
-                  <span data-clipboard-target="source" class="hidden"><%= accept_invitation_url(invitation.token) %></span>
-                  <input type="text"
-                             readonly
-                             autocomplete="off"
-                             value="<%= accept_invitation_url(invitation.token) %>"
-                             class="text-sm bg-gray-50 px-2 py-1 rounded border border-secondary w-72">
-                  <button data-action="clipboard#copy" class="text-secondary hover:text-gray-700">
-                    <span data-clipboard-target="iconDefault">
-                      <%= icon "copy" %>
-                    </span>
-                    <span class="hidden" data-clipboard-target="iconSuccess">
-                      <%= icon "check" %>
-                    </span>
-                  </button>
-                </div>
-              <% end %>
-
-              <% if Current.user.admin? %>
+            <p class="text-primary font-medium text-sm"><%= user.display_name %></p>
+            <div class="rounded-md bg-surface px-1.5 py-0.5">
+              <p class="uppercase text-secondary font-medium text-xs"><%= user.role %></p>
+            </div>
+            <% if Current.user.admin? && user != Current.user %>
+              <div class="ml-auto">
                 <%= render DS::Button.new(
                   variant: "icon",
                   icon: "x",
-                  href: invitation_path(invitation),
+                  href: settings_profile_path(user_id: user),
                   method: :delete,
-                  confirm: CustomConfirm.for_resource_deletion(invitation.email, high_severity: true)
+                  confirm: CustomConfirm.for_resource_deletion(user.display_name, high_severity: true)
                 ) %>
-              <% end %>
-            </div>
+              </div>
+            <% end %>
           </div>
         <% end %>
-      <% end %>
-      <% if Current.user.admin? %>
-        <%= link_to new_invitation_path,
-                class: "bg-container-inset flex items-center justify-center gap-2 text-secondary mt-1 hover:bg-container-inset-hover rounded-lg px-4 py-2 w-full text-center",
-                data: { turbo_frame: :modal } do %>
-          <%= icon("plus") %>
-          <%= t(".invite_member") %>
+        <% if @pending_invitations.any? %>
+          <% @pending_invitations.each do |invitation| %>
+            <div class="flex gap-2 items-center justify-between bg-container p-4 border border-alpha-black-25 rounded-lg">
+              <div class="flex gap-2 items-center">
+                <div class="w-9 h-9 shrink-0">
+                  <div class="fg-inverse w-full h-full bg-surface-inset rounded-full flex items-center justify-center text-lg uppercase"><%= invitation.email[0] %></div>
+                </div>
+                <div class="flex">
+                  <p class="text-primary font-medium text-sm"><%= invitation.email %></p>
+                  <div class="rounded-md bg-surface px-1.5 py-0.5">
+                    <p class="uppercase text-secondary font-medium text-xs"><%= t(".pending") %></p>
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-4">
+                <% if self_hosted? %>
+                  <div class="flex items-center gap-2" data-controller="clipboard">
+                    <p class="text-secondary text-sm"><%= t(".invitation_link") %></p>
+                    <span data-clipboard-target="source" class="hidden"><%= accept_invitation_url(invitation.token) %></span>
+                    <input type="text"
+                               readonly
+                               autocomplete="off"
+                               value="<%= accept_invitation_url(invitation.token) %>"
+                               class="text-sm bg-gray-50 px-2 py-1 rounded border border-secondary w-72">
+                    <button data-action="clipboard#copy" class="text-secondary hover:text-gray-700">
+                      <span data-clipboard-target="iconDefault">
+                        <%= icon "copy" %>
+                      </span>
+                      <span class="hidden" data-clipboard-target="iconSuccess">
+                        <%= icon "check" %>
+                      </span>
+                    </button>
+                  </div>
+                <% end %>
+
+                <% if Current.user.admin? %>
+                  <%= render DS::Button.new(
+                    variant: "icon",
+                    icon: "x",
+                    href: invitation_path(invitation),
+                    method: :delete,
+                    confirm: CustomConfirm.for_resource_deletion(invitation.email, high_severity: true)
+                  ) %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         <% end %>
-      <% end %>
+        <% if Current.user.admin? %>
+          <%= link_to new_invitation_path,
+                  class: "bg-container-inset flex items-center justify-center gap-2 text-secondary mt-1 hover:bg-container-inset-hover rounded-lg px-4 py-2 w-full text-center",
+                  data: { turbo_frame: :modal } do %>
+            <%= icon("plus") %>
+            <%= t(".invite_member") %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>
 
 <%= settings_section title: t(".danger_zone_title") do %>

--- a/app/views/users/_user_menu.html.erb
+++ b/app/views/users/_user_menu.html.erb
@@ -1,7 +1,20 @@
-<%# locals: (user:, placement: "right-start", offset: 16) %>
+<%# locals: (user:, placement: "right-start", offset: 16, intro_mode: false) %>
+
+<% intro_mode = local_assigns.fetch(:intro_mode, false) %>
 
 <div data-testid="user-menu">
-  <%= render DS::Menu.new(variant: "avatar", avatar_url: user.profile_image&.variant(:small)&.url, initials: user.initials, placement: placement, offset: offset) do |menu| %>
+  <%= render DS::Menu.new(
+        variant: intro_mode ? "icon" : "avatar",
+        avatar_url: user.profile_image&.variant(:small)&.url,
+        initials: user.initials,
+        placement: placement,
+        offset: offset
+      ) do |menu| %>
+    <% if intro_mode %>
+      <% menu.with_button do %>
+        <%= render DS::Button.new(variant: "icon", icon: "settings", data: { DS__menu_target: "button" }) %>
+      <% end %>
+    <% end %>
     <%= menu.with_header do %>
       <div class="px-4 py-3 flex items-center gap-3">
         <div class="w-9 h-9 shrink-0">
@@ -30,10 +43,15 @@
       <% end %>
     <% end %>
 
-    <% menu.with_item(variant: "link", text: "Settings", icon: "settings", href: accounts_path(return_to: request.fullpath)) %>
+    <% menu.with_item(
+      variant: "link",
+      text: "Settings",
+      icon: "settings",
+      href: intro_mode ? settings_profile_path : accounts_path(return_to: request.fullpath)
+    ) %>
     <% menu.with_item(variant: "link", text: "Changelog", icon: "box", href: changelog_path) %>
 
-    <% if self_hosted? %>
+    <% if self_hosted? && !intro_mode %>
       <% menu.with_item(variant: "link", text: "Feedback", icon: "megaphone", href: feedback_path) %>
     <% end %>
     <% menu.with_item(variant: "link", text: "Contact", icon: "message-square-more", href: "https://discord.gg/36ZGBsxYEK") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,9 @@ module Sure
 
     # Enable Rack::Attack middleware for API rate limiting
     config.middleware.use Rack::Attack
+
+    config.x.ui = ActiveSupport::OrderedOptions.new
+    default_layout = ENV.fetch("DEFAULT_UI_LAYOUT", "dashboard")
+    config.x.ui.default_layout = default_layout.in?(%w[dashboard intro]) ? default_layout : "dashboard"
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -75,4 +75,6 @@ Rails.application.configure do
   config.autoload_paths += %w[test/support]
 
   config.action_mailer.default_url_options = { host: "example.com" }
+
+  config.assets.paths << Rails.root.join("test/support/assets")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,6 +304,7 @@ Rails.application.routes.draw do
 
   get "privacy", to: redirect("about:blank")
   get "terms", to: redirect("about:blank")
+  get "intro", to: "pages#intro"
 
   # Defines the root path route ("/")
   root "pages#dashboard"

--- a/db/migrate/20251030140000_add_ui_layout_to_users.rb
+++ b/db/migrate/20251030140000_add_ui_layout_to_users.rb
@@ -1,0 +1,17 @@
+class AddUiLayoutToUsers < ActiveRecord::Migration[7.2]
+  class MigrationUser < ApplicationRecord
+    self.table_name = "users"
+  end
+
+  def up
+    add_column :users, :ui_layout, :string
+
+    MigrationUser.reset_column_information
+    MigrationUser.where(ui_layout: [ nil, "" ]).update_all(ui_layout: "dashboard")
+  end
+
+  def down
+    remove_column :users, :ui_layout
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_29_204447) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_30_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -945,6 +945,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_204447) do
     t.datetime "set_onboarding_preferences_at"
     t.datetime "set_onboarding_goals_at"
     t.string "default_account_order", default: "name_asc"
+    t.string "ui_layout"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["family_id"], name: "index_users_on_family_id"
     t.index ["last_viewed_chat_id"], name: "index_users_on_last_viewed_chat_id"

--- a/test/controllers/settings/profiles_controller_test.rb
+++ b/test/controllers/settings/profiles_controller_test.rb
@@ -4,12 +4,22 @@ class Settings::ProfilesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @admin = users(:family_admin)
     @member = users(:family_member)
+    @intro_user = users(:intro_user)
   end
 
   test "should get show" do
     sign_in @admin
     get settings_profile_path
     assert_response :success
+  end
+
+  test "intro user sees profile without settings navigation" do
+    sign_in @intro_user
+    get settings_profile_path
+
+    assert_response :success
+    assert_select "#mobile-settings-nav", count: 0
+    assert_select "h2", text: I18n.t("settings.profiles.show.household_title"), count: 0
   end
 
   test "admin can remove a family member" do

--- a/test/fixtures/chats.yml
+++ b/test/fixtures/chats.yml
@@ -5,3 +5,7 @@ one:
 two:
   title: Second Chat
   user: family_member
+
+intro:
+  title: Intro Chat
+  user: intro_user

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,39 +3,51 @@ empty:
   first_name: User
   last_name: One
   email: user1@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
   onboarded_at: <%= 3.days.ago %>
   role: admin
   ai_enabled: true
+  show_sidebar: true
+  show_ai_sidebar: true
+  ui_layout: dashboard
 
 sure_support_staff:
   family: empty
   first_name: Support
   last_name: Admin
   email: support@sure.am
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
   role: super_admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
+  show_sidebar: true
+  show_ai_sidebar: true
+  ui_layout: dashboard
 
 family_admin:
   family: dylan_family
   first_name: Bob
   last_name: Dylan
   email: bob@bobdylan.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
   role: admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
+  show_sidebar: true
+  show_ai_sidebar: true
+  ui_layout: dashboard
 
 family_member:
   family: dylan_family
   first_name: Jakob
   last_name: Dylan
   email: jakobdylan@yahoo.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
+  show_sidebar: true
+  show_ai_sidebar: true
+  ui_layout: dashboard
 
 new_email:
   family: empty
@@ -43,6 +55,22 @@ new_email:
   last_name: User
   email: user@example.com
   unconfirmed_email: new@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
   onboarded_at: <%= Time.current %>
   ai_enabled: true
+  show_sidebar: true
+  show_ai_sidebar: true
+  ui_layout: dashboard
+
+intro_user:
+  family: empty
+  first_name: Intro
+  last_name: User
+  email: intro@example.com
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  onboarded_at: <%= 1.day.ago %>
+  role: member
+  ai_enabled: true
+  show_sidebar: false
+  show_ai_sidebar: false
+  ui_layout: intro

--- a/test/models/assistant/configurable_test.rb
+++ b/test/models/assistant/configurable_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class AssistantConfigurableTest < ActiveSupport::TestCase
+  test "returns dashboard configuration by default" do
+    chat = chats(:one)
+
+    config = Assistant.config_for(chat)
+
+    assert_not_empty config[:functions]
+    assert_includes config[:instructions], "You help users understand their financial data"
+  end
+
+  test "returns intro configuration without functions" do
+    chat = chats(:intro)
+
+    config = Assistant.config_for(chat)
+
+    assert_equal [], config[:functions]
+    assert_includes config[:instructions], "stage of life"
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -152,4 +152,20 @@ class UserTest < ActiveSupport::TestCase
   ensure
     Setting.openai_access_token = previous
   end
+
+  test "intro layout collapses sidebars and enables ai" do
+    user = User.new(
+      family: families(:empty),
+      email: "intro-new@example.com",
+      password: "Password1!",
+      password_confirmation: "Password1!",
+      ui_layout: :intro
+    )
+
+    assert user.save, user.errors.full_messages.to_sentence
+    assert user.ui_layout_intro?
+    assert_not user.show_sidebar?
+    assert_not user.show_ai_sidebar?
+    assert user.ai_enabled?
+  end
 end

--- a/test/support/assets/tailwind.css
+++ b/test/support/assets/tailwind.css
@@ -1,0 +1,1 @@
+/* Test placeholder for tailwind build */


### PR DESCRIPTION
## Summary
- render the settings profile within the standard application layout when intro mode is active so the broader settings navigation stays hidden
- skip the household management section for intro users to keep the profile page focused
- add a test asset path and controller coverage to ensure intro mode renders without the settings menu

## Testing
- bin/rails test test/controllers/settings/profiles_controller_test.rb

------
https://chatgpt.com/codex/tasks/task_e_69037a1a51e08332a62f1949ee747e59