### PR TITLE
Lunch flow improvements

### DIFF
--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -27,6 +27,19 @@ class Account::ProviderImportAdapter
         e.entryable = Transaction.new
       end
 
+      # If this is a new entry, check for potential duplicates from manual/CSV imports
+      # This handles the case where a user manually created or CSV imported a transaction
+      # before linking their account to a provider
+      if entry.new_record?
+        duplicate = find_duplicate_transaction(date: date, amount: amount, currency: currency)
+        if duplicate
+          # "Claim" the duplicate by updating its external_id and source
+          # This prevents future duplicate checks from matching it again
+          entry = duplicate
+          entry.assign_attributes(external_id: external_id, source: source)
+        end
+      end
+
       # Validate entryable type matches to prevent external_id collisions
       if entry.persisted? && !entry.entryable.is_a?(Transaction)
         raise ArgumentError, "Entry with external_id '#{external_id}' already exists with different entryable type: #{entry.entryable_type}"
@@ -252,4 +265,34 @@ class Account::ProviderImportAdapter
     Rails.logger.error("Failed to update #{account.accountable_type} attributes from #{source}: #{e.message}")
     false
   end
+
+  private
+
+    # Finds a potential duplicate transaction from manual entry or CSV import
+    # Matches on date, amount, and currency
+    # Only matches transactions without external_id (manual/CSV imported)
+    #
+    # @param date [Date, String] Transaction date
+    # @param amount [BigDecimal, Numeric] Transaction amount
+    # @param currency [String] Currency code
+    # @return [Entry, nil] The duplicate entry or nil if not found
+    def find_duplicate_transaction(date:, amount:, currency:)
+      # Convert date to Date object if it's a string
+      date = Date.parse(date.to_s) unless date.is_a?(Date)
+
+      # Look for entries on the same account with:
+      # 1. Same date
+      # 2. Same amount (exact match)
+      # 3. Same currency
+      # 4. No external_id (manual/CSV imported transactions)
+      # 5. Entry type is Transaction (not Trade or Valuation)
+      account.entries
+             .where(entryable_type: "Transaction")
+             .where(date: date)
+             .where(amount: amount)
+             .where(currency: currency)
+             .where(external_id: nil)
+             .order(created_at: :asc)
+             .first
+    end
 end

--- a/app/views/accounts/_account.html.erb
+++ b/app/views/accounts/_account.html.erb
@@ -32,6 +32,15 @@
         <%= link_to edit_account_path(account, return_to: return_to), data: { turbo_frame: :modal }, class: "group-hover/account:flex hidden hover:opacity-80 items-center justify-center" do %>
           <%= icon("pencil-line", size: "sm") %>
         <% end %>
+
+        <% if !account.account_providers.exists? && (account.accountable_type == "Depository" || account.accountable_type == "CreditCard") %>
+          <%= link_to select_existing_account_lunchflow_items_path(account_id: account.id, return_to: return_to),
+                      data: { turbo_frame: :modal },
+                      class: "group-hover/account:flex hidden hover:opacity-80 items-center justify-center gap-1",
+                      title: t("accounts.account.link_lunchflow") do %>
+            <%= icon("link", size: "sm") %>
+          <% end %>
+        <% end %>
       <% end %>
     </div>
     <div class="flex items-center gap-8">

--- a/app/views/lunchflow_items/select_existing_account.html.erb
+++ b/app/views/lunchflow_items/select_existing_account.html.erb
@@ -1,0 +1,43 @@
+<%= turbo_frame_tag "modal" do %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t(".title", account_name: @account.name)) %>
+
+    <% dialog.with_body do %>
+      <div class="space-y-4">
+        <p class="text-sm text-secondary">
+          <%= t(".description") %>
+        </p>
+
+        <form action="<%= link_existing_account_lunchflow_items_path %>" method="post" class="space-y-4" data-turbo-frame="_top">
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= hidden_field_tag :account_id, @account.id %>
+          <%= hidden_field_tag :return_to, @return_to %>
+
+          <div class="space-y-2">
+            <% @available_accounts.each do |account| %>
+              <label class="flex items-start gap-3 p-3 border border-primary rounded-lg hover:bg-subtle cursor-pointer transition-colors">
+                <%= radio_button_tag "lunchflow_account_id", account[:id], false, class: "mt-1" %>
+                <div class="flex-1">
+                  <div class="font-medium text-sm text-primary">
+                    <%= account[:name] %>
+                  </div>
+                  <div class="text-xs text-secondary mt-1">
+                    <%= account[:institution_name] %> • <%= account[:currency] %> • <%= account[:status] %>
+                  </div>
+                </div>
+              </label>
+            <% end %>
+          </div>
+
+          <div class="flex gap-2 justify-end pt-4">
+            <%= link_to t(".cancel"), @return_to || accounts_path,
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
+                data: { turbo_frame: "_top" } %>
+            <%= submit_tag t(".link_account"),
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+          </div>
+        </form>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -2,6 +2,7 @@
 en:
   accounts:
     account:
+      link_lunchflow: Link with Lunch Flow
       troubleshoot: Troubleshoot
     chart:
       data_not_available: Data not available for the selected period

--- a/config/locales/views/lunchflow_items/en.yml
+++ b/config/locales/views/lunchflow_items/en.yml
@@ -39,6 +39,24 @@ en:
       no_accounts_found: No accounts found. Please check your API key configuration.
       no_api_key: Lunch Flow API key is not configured. Please configure it in Settings.
       title: Select Lunch Flow Accounts
+    select_existing_account:
+      account_already_linked: This account is already linked to a provider
+      all_accounts_already_linked: All Lunch Flow accounts are already linked
+      api_error: "API error: %{message}"
+      cancel: Cancel
+      description: Select a Lunch Flow account to link with this account. Transactions will be synced and deduplicated automatically.
+      link_account: Link account
+      no_account_specified: No account specified
+      no_accounts_found: No Lunch Flow accounts found. Please check your API key configuration.
+      no_api_key: Lunch Flow API key is not configured. Please configure it in Settings.
+      title: "Link %{account_name} with Lunch Flow"
+    link_existing_account:
+      account_already_linked: This account is already linked to a provider
+      api_error: "API error: %{message}"
+      lunchflow_account_already_linked: This Lunch Flow account is already linked to another account
+      lunchflow_account_not_found: Lunch Flow account not found
+      missing_parameters: Missing required parameters
+      success: "Successfully linked %{account_name} with Lunch Flow"
     sync:
       success: Sync started
     update:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,6 +277,8 @@ Rails.application.routes.draw do
     collection do
       get :select_accounts
       post :link_accounts
+      get :select_existing_account
+      post :link_existing_account
     end
 
     member do

--- a/test/jobs/family_reset_job_test.rb
+++ b/test/jobs/family_reset_job_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class FamilyResetJobTest < ActiveJob::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @plaid_provider = mock
+    Provider::Registry.stubs(:plaid_provider_for_region).returns(@plaid_provider)
+  end
+
+  test "resets family data successfully" do
+    initial_account_count = @family.accounts.count
+    initial_category_count = @family.categories.count
+
+    # Family should have existing data
+    assert initial_account_count > 0
+    assert initial_category_count > 0
+
+    # Don't expect Plaid removal calls since we're using fixtures without setup
+    @plaid_provider.stubs(:remove_item)
+
+    FamilyResetJob.perform_now(@family)
+
+    # All data should be removed
+    assert_equal 0, @family.accounts.reload.count
+    assert_equal 0, @family.categories.reload.count
+  end
+
+  test "resets family data even when Plaid credentials are invalid" do
+    # Use existing plaid item from fixtures
+    plaid_item = plaid_items(:one)
+    assert_equal @family, plaid_item.family
+
+    initial_plaid_count = @family.plaid_items.count
+    assert initial_plaid_count > 0
+
+    # Simulate invalid Plaid credentials error
+    error_response = {
+      "error_code" => "INVALID_API_KEYS",
+      "error_message" => "invalid client_id or secret provided"
+    }.to_json
+
+    plaid_error = Plaid::ApiError.new(code: 400, response_body: error_response)
+    @plaid_provider.expects(:remove_item).raises(plaid_error)
+
+    # Job should complete successfully despite the Plaid error
+    assert_nothing_raised do
+      FamilyResetJob.perform_now(@family)
+    end
+
+    # PlaidItem should be deleted
+    assert_equal 0, @family.plaid_items.reload.count
+  end
+end

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -16,4 +16,32 @@ class PlaidItemTest < ActiveSupport::TestCase
       @plaid_item.destroy
     end
   end
+
+  test "destroys item even when Plaid credentials are invalid" do
+    error_response = {
+      "error_code" => "INVALID_API_KEYS",
+      "error_message" => "invalid client_id or secret provided"
+    }.to_json
+
+    plaid_error = Plaid::ApiError.new(code: 400, response_body: error_response)
+    @plaid_provider.expects(:remove_item).raises(plaid_error)
+
+    assert_difference "PlaidItem.count", -1 do
+      @plaid_item.destroy
+    end
+  end
+
+  test "destroys item even when Plaid item not found" do
+    error_response = {
+      "error_code" => "ITEM_NOT_FOUND",
+      "error_message" => "item not found"
+    }.to_json
+
+    plaid_error = Plaid::ApiError.new(code: 400, response_body: error_response)
+    @plaid_provider.expects(:remove_item).raises(plaid_error)
+
+    assert_difference "PlaidItem.count", -1 do
+      @plaid_item.destroy
+    end
+  end
 end


### PR DESCRIPTION
- Add support to link existing account with lunch-flow The account will be promoted to a lunch flow connection now ( TBD if we want to allow un-linking? )
- Add support for proper de-dup at provider import level. This will handle de-dups for Lunch Flow, Plaid and SimpleFIN
- Fix plaid account removal on invalid credentials
<img width="335" height="279" alt="Screenshot 2025-10-31 at 10 07 54" src="https://github.com/user-attachments/assets/1ac7b685-c452-4f89-bdce-4f3647b8dbb8" />
<img width="587" height="524" alt="Screenshot 2025-10-31 at 10 07 59" src="https://github.com/user-attachments/assets/b69dfddf-8fef-4bfc-8954-9a0fe62ac91b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now select and link existing Lunchflow accounts to their current accounts with an improved workflow.
  * New UI interface for choosing and connecting Lunchflow accounts in account settings.

* **Bug Fixes**
  * Enhanced error handling for payment provider removals—operations now complete gracefully even with invalid credentials.
  * Improved duplicate transaction detection and claiming from provider data to prevent duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->