### PR TITLE
PWA: Fix overflow issue with transaction edit/creation dialogue

### DIFF
--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -36,8 +36,7 @@
                     {
                       include_blank: t(".none"),
                       multiple: true,
-                      label:    t(".tags_label"),
-                      container_class: "h-40"
+                      label:    t(".tags_label")
                     },
                     { "data-controller": "multi-select" } %>
     <% end %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -81,8 +81,7 @@
                     {
                       include_blank: t(".none"),
                       multiple: true,
-                      label:    t(".tags_label"),
-                      container_class: "h-40"
+                      label:    t(".tags_label")
                     },
                     { "data-controller": "multi-select", "data-auto-submit-form-target": "auto" } %>
             <% end %>


### PR DESCRIPTION
Fix `New Transaction` and Transaction Edit dialogue tag multi-select overflows.

Now the selectors are all nicely contained.

With this PR:
| New Transaction | Edit Transaction |
|-|-|
| <img width="566" height="920" alt="image" src="https://github.com/user-attachments/assets/74cfdf45-0ab4-4220-bcf4-0931c1d487c8" /> | <img width="511" height="957" alt="image" src="https://github.com/user-attachments/assets/c7e59e7b-3e20-4b9f-be04-73cc67d0ebcf" /> |

Before this PR:
| New Transaction | Edit Transaction |
|-|-|
| <img width="566" height="920" alt="image" src="https://github.com/user-attachments/assets/6047df89-bab9-4e08-9400-ea633f9587dc" /> | <img width="531" height="962" alt="image" src="https://github.com/user-attachments/assets/a7f26966-0a4e-4b9c-9d14-0120b3833d57" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed fixed height constraints from tag selection dropdown fields in transaction forms. The fields now display with improved flexibility, adapting more naturally based on content and available space for better usability when managing multiple tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->