### PR TITLE
PWA: DS::Menu - Place below button and center

### DIFF
--- a/app/components/DS/menu_controller.js
+++ b/app/components/DS/menu_controller.js
@@ -102,6 +102,8 @@ export default class extends Controller {
   }
 
   update() {
+    if (!this.buttonTarget || !this.contentTarget) return;
+
     const isSmallScreen = !window.matchMedia("(min-width: 768px)").matches;
 
     computePosition(this.buttonTarget, this.contentTarget, {


### PR DESCRIPTION
On the `DS::Menu`s, this PR fixes a couple minor issues:
- The menu is not centered horizontally
- If the menu would extend past the bottom of the page, it is placed above the button. This leads to the menu overflowing past the top of the page (where the user is unable to scroll to).

## Examples of this PR
| Place | Before | After |
|-|-|-|
| Transaction Filter<br/>Centering issue | <img width="408" height="917" alt="image" src="https://github.com/user-attachments/assets/5a1f85ea-bce9-4941-aaa7-71263683e572" /> | <img width="408" height="917" alt="image" src="https://github.com/user-attachments/assets/94ed09f6-0855-4528-81ff-0bd619918baf" /> |
| Above Placement<br />Issue (Mobile) | <img width="408" height="697" alt="image" src="https://github.com/user-attachments/assets/f74a0c5d-262d-40d2-8254-49344ab31499" /> | <img width="408" height="697" alt="image" src="https://github.com/user-attachments/assets/05c92797-7a4b-4cc2-bf8a-5d7f1acebb0e" /> |
| Above Placement<br />Issue (Desktop) | <img width="1087" height="519" alt="image" src="https://github.com/user-attachments/assets/9908ee54-35bd-49b8-8f49-6ab9037fdd6e" /> | <img width="1087" height="519" alt="image" src="https://github.com/user-attachments/assets/6f8764e5-b204-4bab-a17d-15d8dbd17e7d" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Menu positioning now adapts responsively: on small screens it displays full-width at the bottom; on larger screens it preserves standard placement.
  * Improved stability when targets are missing to prevent layout errors.
  * Simplified positioning behavior for more consistent placement and better cross-screen reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->