### PR TITLE
PWA: Update settings page next/previous array

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -12,11 +12,14 @@ module SettingsHelper
     { name: "Tags", path: :tags_path },
     { name: "Rules", path: :rules_path },
     { name: "Merchants", path: :family_merchants_path },
+    { name: "Recurring", path: :recurring_transactions_path },
     # Advanced section
     { name: "AI Prompts", path: :settings_ai_prompts_path },
+    { name: "LLM Usage", path: :settings_llm_usage_path },
     { name: "API Key", path: :settings_api_key_path },
     { name: "Self-Hosting", path: :settings_hosting_path, condition: :self_hosted? },
-    { name: "Imports", path: :imports_path },
+    { name: "Providers", path: :settings_providers_path },
+    { name: "Import/Export", path: :imports_path },
     { name: "SimpleFin", path: :simplefin_items_path },
     # More section
     { name: "Guides", path: :settings_guides_path },


### PR DESCRIPTION
Settings pages use the `SettingsHelper` -> `SETTINGS_ORDER` array to list all of the settings pages. This is used to create the next/previous settings page links at the bottom of any settings page.

Found that the array was out of sync with the current settings pages, so I updated the array to match the current state of the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Recurring" navigation option to manage recurring transactions within the Transactions section.
  * Added "LLM Usage" configuration option in the Advanced settings section.

* **UI/UX Improvements**
  * Restructured the Imports section into separate "Providers" and "Import/Export" navigation options for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->