### PR TITLE
PWA: Scale theme picture evenly

### DIFF
--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -61,7 +61,7 @@
       ].each do |theme| %>
         <%= form.label :"theme_#{theme[:value]}", class: "group" do %>
           <div class="<%= theme_option_class %>">
-            <%= image_tag(theme[:image], alt: "#{theme[:value].titleize} Theme Preview", class: "h-44 mb-2") %>
+            <%= image_tag(theme[:image], alt: "#{theme[:value].titleize} Theme Preview", class: "max-h-44 mb-2") %>
             <div class="<%= theme[:value] == "system" ? "flex items-center gap-2 justify-center" : "text-sm font-medium text-primary" %>">
               <%= form.radio_button :theme, theme[:value], checked: @user.theme == theme[:value], class: "sr-only",
                 data: { auto_submit_form_target: "auto", autosubmit_trigger_event: "change", action: "theme#updateTheme" } %>


### PR DESCRIPTION
In the user preferences, scale the preview image for the theme preference. Don't just stretch it to a certain height.

| Before PR | After |
|-|-|
| <img width="936" height="891" alt="image" src="https://github.com/user-attachments/assets/15f753d8-98fa-4b52-9270-9d8e0bc2de78" /> | <img width="936" height="891" alt="image" src="https://github.com/user-attachments/assets/72935b0e-3d5c-4aa9-8ca6-32295960dda2" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted image preview sizing in theme preferences to use a maximum height constraint instead of fixed height, allowing images to display more responsively and naturally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->