### PR TITLE
Fix Reports transactions breakdown

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -304,11 +304,13 @@ class ReportsController < ApplicationController
 
     def build_transactions_breakdown
       # Base query: all transactions in the period
+      # Exclude transfers, one-time, and CC payments (matching income_statement logic)
       transactions = Transaction
         .joins(:entry)
         .joins(entry: :account)
         .where(accounts: { family_id: Current.family.id, status: [ "draft", "active" ] })
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
+        .where.not(kind: [ "funds_movement", "one_time", "cc_payment" ])
         .includes(entry: :account, category: [])
 
       # Apply filters
@@ -397,11 +399,13 @@ class ReportsController < ApplicationController
 
     def build_transactions_breakdown_for_export
       # Get flat transactions list (not grouped) for export
+      # Exclude transfers, one-time, and CC payments (matching income_statement logic)
       transactions = Transaction
         .joins(:entry)
         .joins(entry: :account)
         .where(accounts: { family_id: Current.family.id, status: [ "draft", "active" ] })
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
+        .where.not(kind: [ "funds_movement", "one_time", "cc_payment" ])
         .includes(entry: :account, category: [])
 
       transactions = apply_transaction_filters(transactions)
@@ -432,11 +436,13 @@ class ReportsController < ApplicationController
       end
 
       # Get all transactions in the period
+      # Exclude transfers, one-time, and CC payments (matching income_statement logic)
       transactions = Transaction
         .joins(:entry)
         .joins(entry: :account)
         .where(accounts: { family_id: Current.family.id, status: [ "draft", "active" ] })
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
+        .where.not(kind: [ "funds_movement", "one_time", "cc_payment" ])
         .includes(entry: :account, category: [])
 
       transactions = apply_transaction_filters(transactions)


### PR DESCRIPTION
The build_transactions_breakdown method was including ALL transaction types (including transfers, CC payments, and one-time transactions) when calculating the breakdown, while the "Period Comparison" and "Trends & Insights" sections correctly exclude these transaction types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Transaction reports now consistently filter out funds transfers, one-time transactions, and credit card payments across transaction breakdowns, monthly summaries, and data exports. This ensures alignment with income statement filtering methodology, improving accuracy and consistency in financial reporting across all report types and formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->