### PR TITLE
budget_category: Drop override of `subcategory?`

### DIFF
--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -140,8 +140,4 @@ class BudgetCategory < ApplicationRecord
       .joins(:category)
       .where(categories: { parent_id: category.id })
   end
-
-  def subcategory?
-    category.parent_id.present?
-  end
 end


### PR DESCRIPTION
`subcategory?` was defined twice in `budget_category`. Remove one of them (both methods did the same thing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a public method from the category system. Integrations or APIs depending on this method will require adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->