### PR TITLE
Include Redis to local development requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The instructions below are for developers to get started with contributing to th
 
 - See `.ruby-version` file for required Ruby version
 - PostgreSQL >9.3 (latest stable version recommended)
+- Redis > 5.4 (latest stable version recommended)
 
 ### Getting Started
 ```sh


### PR DESCRIPTION
This shows to a developer that Redis is needed for local development. The application will fail to run on `bin/dev` if Redis is not running and will give a proper error message, however we should include this to make it explicitly clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Local Development Setup Requirements to include Redis > 5.4 as a required dependency alongside the existing PostgreSQL requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->