### PR TITLE
Have budget category reflect income and expenses

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -159,7 +159,10 @@ class Budget < ApplicationRecord
   end
 
   def budget_category_actual_spending(budget_category)
-    expense_totals.category_totals.find { |ct| ct.category.id == budget_category.category.id }&.total || 0
+    total_expenses = expense_totals.category_totals.find { |ct| ct.category.id == budget_category.category.id }&.total || 0
+    total_incomes = income_totals.category_totals.find { |ct| ct.category.id == budget_category.category.id }&.total || 0
+    total = total_incomes - total_expenses
+    total.negative? ? total.abs : 0
   end
 
   def category_median_monthly_expense(category)


### PR DESCRIPTION
Closes issue #314

Currently, budget categories will only check if your transaction expenses exceed the threshold and do not take into account the income (gross spending vs net spending). This change will allow the user to see how much they have spent, taking into account situations like healthcare reimbursements or product returns.

This might not be the best implementation of this, so I am happy to make changes for what works best for this calculation.

We resolve to a 0 value when the value is positive, as this means there is only an income.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-category spending now accounts for both incomes and expenses. Displayed actual spending reflects the net difference (incomes minus expenses); non-negative nets show as zero, negative nets show as the positive deficit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->