### PR TITLE
Tweaks to ES locale

### DIFF
--- a/config/locales/mailers/invitation_mailer/es.yml
+++ b/config/locales/mailers/invitation_mailer/es.yml
@@ -2,4 +2,4 @@
 es:
   invitation_mailer:
     invite_email:
-      subject: "¡%{inviter} te ha invitado a unirte a su hogar en %{product_name}!"
+      subject: "¡%{inviter} te ha invitado a unirte a su cuenta de %{product_name}!"

--- a/config/locales/views/onboardings/es.yml
+++ b/config/locales/views/onboardings/es.yml
@@ -15,7 +15,7 @@ es:
     profile:
       country: País
       first_name: Nombre
-      household_name: Nombre del hogar
+      household_name: Nombre del grupo familiar
       last_name: Apellidos
       profile_image: Imagen de perfil
       submit: Continuar

--- a/config/locales/views/settings/es.yml
+++ b/config/locales/views/settings/es.yml
@@ -69,10 +69,10 @@ es:
         reset_account_with_sample_data_warning: Elimina todos tus datos existentes y luego carga nuevos datos de ejemplo para que puedas explorar con un entorno prellenado.
         email: Correo electrónico
         first_name: Nombre
-        household_form_input_placeholder: Introduce el nombre del hogar
-        household_form_label: Nombre del hogar
-        household_subtitle: Invita a miembros de la familia, socios y otras personas. Los invitados pueden iniciar sesión en tu hogar y acceder a tus cuentas compartidas.
-        household_title: Hogar
+        household_form_input_placeholder: Introduce el nombre del grupo familiar
+        household_form_label: Nombre del grupo familiar
+        household_subtitle: Invita a miembros de la familia, socios y otras personas. Los invitados pueden entrar en la cuenta y acceder a las cuentas compartidas.
+        household_title: Grupo Familiar
         invitation_link: Enlace de invitación
         invite_member: Añadir miembro
         last_name: Apellido


### PR DESCRIPTION
Translation for "Home" in this context was weird as "Hogar" ... changed it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Spanish language translations across email templates, onboarding, and account settings for improved terminology consistency.
  * Refined account-related messaging and guest access descriptions for Spanish language users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->