### PR TITLE
No CACHE_REDIS_URL used anywhere else

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,8 +69,8 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  if ENV["CACHE_REDIS_URL"].present?
-    config.cache_store = :redis_cache_store, { url: ENV["CACHE_REDIS_URL"] }
+  if ENV["REDIS_URL"].present?
+    config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"] }
   end
 
   config.action_mailer.perform_caching = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis cache configuration for production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->