### PR TITLE
Filter language selector to show only supported locales

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -153,6 +153,15 @@ module LanguagesHelper
     "en-IND"
   ].freeze
 
+  # Locales with complete/extensive translations
+  SUPPORTED_LOCALES = [
+    "en",   # English - 61 translation files
+    "es",   # Spanish - 60 translation files
+    "tr",   # Turkish - 57 translation files
+    "nb",   # Norwegian Bokmål - 56 translation files
+    "ca"    # Catalan - 56 translation files
+  ].freeze
+
   COUNTRY_MAPPING = {
     AF: "🇦🇫 Afghanistan",
     AL: "🇦🇱 Albania",
@@ -356,7 +365,7 @@ module LanguagesHelper
 
   def language_options
     I18n.available_locales
-      .reject { |locale| EXCLUDED_LOCALES.include?(locale.to_s) }
+      .select { |locale| SUPPORTED_LOCALES.include?(locale.to_s) }
       .map do |locale|
         label = LANGUAGE_MAPPING[locale.to_sym] || locale.to_s.humanize
         [ "#{label} (#{locale})", locale ]


### PR DESCRIPTION
Updated the language selector in /settings/preferences to display only locales with extensive translations. Currently supported locales are:
- en (English) - 61 translation files
- es (Spanish) - 60 translation files
- tr (Turkish) - 57 translation files
- nb (Norwegian Bokmål) - 56 translation files
- ca (Catalan) - 56 translation files

Changes:
- Added SUPPORTED_LOCALES constant to LanguagesHelper
- Modified language_options method to filter using SUPPORTED_LOCALES instead of excluding specific locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Defined supported languages with complete translations. Language selection is now limited to: English, Spanish, Turkish, Norwegian Bokmål, and Catalan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->