### PR TITLE
Fix title overflow issue in chats

### DIFF
--- a/app/views/chats/_chat.html.erb
+++ b/app/views/chats/_chat.html.erb
@@ -2,7 +2,7 @@
 
 <%= tag.div class: "flex items-center justify-between px-4 py-3 bg-container shadow-border-xs rounded-lg" do %>
   <div class="grow truncate">
-    <%= turbo_frame_tag dom_id(chat, :title) do %>
+    <%= turbo_frame_tag dom_id(chat, :title), title: chat.title do %>
       <%= render "chats/chat_title", chat: chat, ctx: "list" %>
     <% end %>
 


### PR DESCRIPTION
A small change has been made to prevent overflow issues when the chat title is excessively long. This is particularly noticeable on mobile devices.

**Before:**

<img width="394" height="851" alt="Screenshot 2025-11-15 alle 00 44 34" src="https://github.com/user-attachments/assets/441a14cf-a30a-4c55-8546-f4f5693f1097" />


**After:**

<img width="390" height="845" alt="Screenshot 2025-11-15 alle 00 46 20" src="https://github.com/user-attachments/assets/cfbd0806-0123-4d4e-a3f1-07b9f2b22036" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Chat titles now truncate gracefully to prevent overflow and maintain clean layout.
* **User Experience**
  * Hovering a chat title reveals a tooltip with the full title for easier identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->