### PR TITLE
Fix Yahoo Finance minor unit handling

### DIFF
--- a/test/models/provider/yahoo_finance_test.rb
+++ b/test/models/provider/yahoo_finance_test.rb
@@ -215,4 +215,34 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
       @provider.send(:validate_date_range!, Date.current - 5.years, Date.current)
     end
   end
+
+  # ================================
+  #   Currency Normalization Tests
+  # ================================
+
+  test "normalize_currency_and_price converts GBp to GBP" do
+    currency, price = @provider.send(:normalize_currency_and_price, "GBp", 1234.56)
+    assert_equal "GBP", currency
+    assert_equal 12.3456, price
+  end
+
+  test "normalize_currency_and_price converts ZAc to ZAR" do
+    currency, price = @provider.send(:normalize_currency_and_price, "ZAc", 5000.0)
+    assert_equal "ZAR", currency
+    assert_equal 50.0, price
+  end
+
+  test "normalize_currency_and_price leaves standard currencies unchanged" do
+    currency, price = @provider.send(:normalize_currency_and_price, "USD", 100.50)
+    assert_equal "USD", currency
+    assert_equal 100.50, price
+
+    currency, price = @provider.send(:normalize_currency_and_price, "GBP", 50.25)
+    assert_equal "GBP", currency
+    assert_equal 50.25, price
+
+    currency, price = @provider.send(:normalize_currency_and_price, "EUR", 75.75)
+    assert_equal "EUR", currency
+    assert_equal 75.75, price
+  end
 end


### PR DESCRIPTION
Some security prices get returned in [non-standard minor units](https://en.wikipedia.org/wiki/ISO_4217#Unofficial_codes_for_minor_units_of_currency) (eg. `GBp` for Great British Pence, instead of `GBP` for Great British Pounds), leading to incorrect handling of the returned price data, for example:
- GBp: https://finance.yahoo.com/quote/IITU.L
- ZAc: https://finance.yahoo.com/quote/JSE.JO

This PR adds conversion logic for theese currency codes (I was unable to find any examples of other minor units being used, like `USc`), so they get stored with the regular currency code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added currency normalization for Yahoo Finance data, including conversion of minor-unit currency codes with automatic price adjustments.

* **Tests**
  * Extended test coverage for currency normalization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->