### PR TITLE
update reports date picker

### DIFF
--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -54,7 +54,7 @@
                            value: @start_date.strftime("%Y-%m-%d"),
                            data: { auto_submit_form_target: "auto" },
                            autocomplete: "off",
-                           class: "px-3 py-1.5 border border-primary rounded-lg text-sm" %>
+                           class: "px-3 py-1.5 border border-primary rounded-lg text-sm bg-container-inset text-primary" %>
         </div>
         <span class="text-secondary">—</span>
         <div class="flex items-center gap-2">
@@ -63,7 +63,7 @@
                            value: @end_date.strftime("%Y-%m-%d"),
                            data: { auto_submit_form_target: "auto" },
                            autocomplete: "off",
-                           class: "px-3 py-1.5 border border-primary rounded-lg text-sm" %>
+                           class: "px-3 py-1.5 border border-primary rounded-lg text-sm bg-container-inset text-primary" %>
         </div>
       <% end %>
     <% end %>


### PR DESCRIPTION
the date picker on the reports page in dark mode is not useful.
this is the second time in a short period i see that the date picker is not formatted good in the code, is there something that can be done in the design system to check for this or something?
before:
<img width="942" height="262" alt="Scherm­afbeelding 2025-11-15 om 18 16 44" src="https://github.com/user-attachments/assets/9cc15356-c821-454c-be7f-31ca473ef37e" />

after:
<img width="942" height="262" alt="Scherm­afbeelding 2025-11-15 om 18 16 51" src="https://github.com/user-attachments/assets/a2a4ad70-33b6-4cde-9aaf-80dfab8ea1e1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of date range input fields in the reports interface for improved appearance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->