### PR TITLE
Reset account completeness

### DIFF
--- a/app/jobs/family_reset_job.rb
+++ b/app/jobs/family_reset_job.rb
@@ -9,6 +9,7 @@ class FamilyResetJob < ApplicationJob
       family.categories.destroy_all
       family.tags.destroy_all
       family.merchants.destroy_all
+      family.recurring_transactions.destroy_all
       family.plaid_items.destroy_all
       family.imports.destroy_all
       family.budgets.destroy_all

--- a/test/fixtures/recurring_transactions.yml
+++ b/test/fixtures/recurring_transactions.yml
@@ -19,3 +19,15 @@ inactive_subscription:
   next_expected_date: <%= 2.months.ago.to_date %>
   status: inactive
   occurrence_count: 2
+
+manual_subscription:
+  family: dylan_family
+  name: "Gym Membership"
+  amount: 45.00
+  currency: USD
+  expected_day_of_month: 10
+  last_occurrence_date: <%= 1.month.ago.to_date %>
+  next_expected_date: <%= 20.days.from_now.to_date %>
+  status: active
+  occurrence_count: 5
+  manual: true

--- a/test/jobs/family_reset_job_test.rb
+++ b/test/jobs/family_reset_job_test.rb
@@ -10,10 +10,12 @@ class FamilyResetJobTest < ActiveJob::TestCase
   test "resets family data successfully" do
     initial_account_count = @family.accounts.count
     initial_category_count = @family.categories.count
+    initial_recurring_count = @family.recurring_transactions.count
 
     # Family should have existing data
     assert initial_account_count > 0
     assert initial_category_count > 0
+    assert initial_recurring_count > 0
 
     # Don't expect Plaid removal calls since we're using fixtures without setup
     @plaid_provider.stubs(:remove_item)
@@ -23,6 +25,7 @@ class FamilyResetJobTest < ActiveJob::TestCase
     # All data should be removed
     assert_equal 0, @family.accounts.reload.count
     assert_equal 0, @family.categories.reload.count
+    assert_equal 0, @family.recurring_transactions.reload.count
   end
 
   test "resets family data even when Plaid credentials are invalid" do


### PR DESCRIPTION
## Summary
- ensure family reset clears recurring transactions along with other data
- add manual recurring fixture to cover non-merchant recurring data
- extend family reset job test to verify recurring transactions are removed

## TODO
- [ ] remove SimpleFIN connection and accounts
- [ ] remove Lunch Flow connection and accounts
- [ ] remove (all) merchants - `ProviderMerchant` is not cleared, should it?
- [ ] remove enrichments
- [ ] add more tests

## Testing
- bin/rails test test/jobs/family_reset_job_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3159c76083329276b8c4ea87bec1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recurring transactions are now properly removed when performing a family account reset, ensuring complete data cleanup during the reset process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->