### PR TITLE
docs: add missing redis url variable in example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,9 @@ DB_PORT=5432
 POSTGRES_PASSWORD=postgres
 POSTGRES_USER=postgres
 
+# Redis configuration
+REDIS_URL=redis://localhost:6379/1
+
 # App Domain
 # This is the domain that your Sure instance will be hosted at. It is used to generate links in emails and other places.
 APP_DOMAIN=


### PR DESCRIPTION
- Added `REDIS_URL` to example env file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Redis configuration option to environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->