### PR TITLE
FIX - Update recurring transactions status only for new records

### DIFF
--- a/app/models/recurring_transaction/identifier.rb
+++ b/app/models/recurring_transaction/identifier.rb
@@ -174,8 +174,7 @@ class RecurringTransaction
             expected_amount_avg: matching_amounts.sum / matching_amounts.size,
             occurrence_count: matching_amounts.size,
             last_occurrence_date: pattern[:last_occurrence_date],
-            next_expected_date: calculate_next_expected_date(pattern[:last_occurrence_date], recurring_transaction.expected_day_of_month),
-            status: "active"
+            next_expected_date: calculate_next_expected_date(pattern[:last_occurrence_date], recurring_transaction.expected_day_of_month)
           )
         end
       end


### PR DESCRIPTION
I was testing the new recurring transactions feature and noticed a problem.  Every time identification is performed either manually or during a sync, all identified transactions are created or updated to “active” status even if they were previously disabled manually.

This creates an issue because users must always re-disable recurring transactions potentially after each sync.

This PR addresses the issue by setting the status to “active” only for newly created recurring transactions while keeping existing records unchanged.  All other values are updated as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New recurring transactions are correctly marked "active" on creation.
  * Existing recurring transactions retain their current status when updated instead of being reset to "active".
  * Manual recurring updates no longer force a status change while still updating the next expected date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->