### PR TITLE
Fixes 'current can't be blank' and Missing content

### DIFF
--- a/app/controllers/simplefin_items_controller.rb
+++ b/app/controllers/simplefin_items_controller.rb
@@ -515,6 +515,17 @@ class SimplefinItemsController < ApplicationController
         @simplefin_item = Current.family.simplefin_items.build(setup_token: setup_token)
       end
       @error_message = message
-      render context, status: :unprocessable_entity
+
+      if turbo_frame_request?
+        # Re-render the SimpleFIN providers panel in place to avoid "Content missing"
+        @simplefin_items = Current.family.simplefin_items.ordered
+        render turbo_stream: turbo_stream.replace(
+          "simplefin-providers-panel",
+          partial: "settings/providers/simplefin_panel",
+          locals: { simplefin_items: @simplefin_items }
+        ), status: :unprocessable_entity
+      else
+        render context, status: :unprocessable_entity
+      end
     end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -57,6 +57,7 @@ class Series
   end
 
   def trend
+    return nil if values.blank?
     @trend ||= Trend.new(
       current: values.last&.value,
       previous: values.first&.value,

--- a/app/views/pages/dashboard/_net_worth_chart.html.erb
+++ b/app/views/pages/dashboard/_net_worth_chart.html.erb
@@ -9,14 +9,13 @@
           <h2 class="text-lg font-medium"><%= t(".title") %></h2>
         </div>
 
-        <p class="text-primary -space-x-0.5 text-3xl font-medium <%= "animate-pulse" if balance_sheet.syncing? %>">
-          <%= series.trend.current.format %>
-        </p>
-
-        <% if series.trend.nil? %>
-          <p class="text-sm text-secondary"><%= t(".data_not_available") %></p>
-        <% else %>
+        <% if series.trend.present? %>
+          <p class="text-primary -space-x-0.5 text-3xl font-medium <%= "animate-pulse" if balance_sheet.syncing? %>">
+            <%= series.trend.current.format %>
+          </p>
           <%= render partial: "shared/trend_change", locals: { trend: series.trend, comparison_label: period.comparison_label } %>
+        <% else %>
+          <p class="text-sm text-secondary"><%= t(".data_not_available") %></p>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Guard empty net‑worth series; make Series#trend nil‑safe; SimpleFIN panel 422 is frame-aware

- Net worth chart empty-state:
  - View: only render current value/change if `series.trend.present?`; otherwise show “No data available”.
  - Series: return `nil` from `Series#trend` when `values` are blank to avoid Trend validation on fresh datasets.

- SimpleFIN providers panel:
  - Frame-aware error path for invalid tokens: return Turbo Stream `replace` targeting `simplefin-providers-panel` on 422 to avoid “Content missing” when invalid token entered.
  - Notes: No behavior change for non-empty datasets; charts and streams behave as before. Improves UX on fresh installs and invalid-token flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the SimpleFIN providers panel with better dynamic updates and real-time panel refresh.
  * Enhanced net worth chart to gracefully handle missing trend data by displaying an appropriate message when trend information is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->