### PR TITLE
Ensure disabled accounts remain visible for toggling

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -4,7 +4,7 @@ class AccountsController < ApplicationController
 
   def index
     @manual_accounts = family.accounts
-          .visible_manual
+          .listable_manual
           .order(:name)
     @plaid_items = family.plaid_items.ordered
     @simplefin_items = family.simplefin_items.ordered.includes(:syncs)
@@ -18,7 +18,7 @@ class AccountsController < ApplicationController
       latest_sync = item.syncs.ordered.first
       @simplefin_sync_stats_map[item.id] = (latest_sync&.sync_stats || {})
       @simplefin_has_unlinked_map[item.id] = item.family.accounts
-        .visible_manual
+        .listable_manual
         .exists?
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -32,6 +32,10 @@ class Account < ApplicationRecord
     visible.manual
   }
 
+  scope :listable_manual, -> {
+    manual.where.not(status: :pending_deletion)
+  }
+
   has_one_attached :logo
 
   delegated_type :accountable, types: Accountable::TYPES, dependent: :destroy

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -130,6 +130,28 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Depository account scheduled for deletion", flash[:notice]
   end
 
+  test "disabling an account keeps it visible on index" do
+    @account.disable!
+
+    get accounts_path
+
+    assert_response :success
+    assert_includes @response.body, @account.name
+    assert_includes @response.body, "account_#{@account.id}_active"
+  end
+
+  test "toggle_active disables and re-enables an account" do
+    patch toggle_active_account_url(@account)
+    assert_redirected_to accounts_path
+    @account.reload
+    assert @account.disabled?
+
+    patch toggle_active_account_url(@account)
+    assert_redirected_to accounts_path
+    @account.reload
+    assert @account.active?
+  end
+
   test "select_provider shows available providers" do
     get select_provider_account_url(@account)
     assert_response :success


### PR DESCRIPTION
## Summary
- include disabled manual accounts in the accounts index so they remain visible after toggling
- add a scope for listable manual accounts that excludes pending deletion
- cover the toggle visibility and reactivation flow with controller tests

## Testing
- bin/rails test test/controllers/accounts_controller_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f74ea87c08332a436710a5ba2632b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accounts pending deletion are now properly filtered and excluded from the accounts list, ensuring users only see relevant accounts.

* **Tests**
  * Added integration tests to verify disabled accounts remain visible in the accounts index and to validate account active state toggling between disabled and enabled states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->