### PR TITLE
Rate exchange fix

### DIFF
--- a/app/models/exchange_rate/provided.rb
+++ b/app/models/exchange_rate/provided.rb
@@ -19,13 +19,23 @@ module ExchangeRate::Provided
       return nil unless response.success? # Provider error
 
       rate = response.data
-      ExchangeRate.create_or_find_by(
-        from_currency: rate.from,
-        to_currency: rate.to,
-        date: rate.date
-      ) do |exchange_rate|
-        exchange_rate.rate = rate.rate
-      end if cache
+      begin
+        ExchangeRate.find_or_create_by!(
+          from_currency: rate.from,
+          to_currency: rate.to,
+          date: rate.date
+        ) do |exchange_rate|
+          exchange_rate.rate = rate.rate
+        end if cache
+      rescue ActiveRecord::RecordNotUnique
+        # Race condition: another process inserted between our SELECT and INSERT
+        # Retry by finding the existing record
+        ExchangeRate.find_by!(
+          from_currency: rate.from,
+          to_currency: rate.to,
+          date: rate.date
+        ) if cache
+      end
       rate
     end
 


### PR DESCRIPTION
```
The find_or_create_by! at line 22 includes rate as a parameter, which means it tries to find a record matching all four fields. When a record exists with the same currencies and date but a slightly different rate, it won't find it and tries to create a duplicate, violating the unique constraint.

the database has a unique index on from_currency, to_currency, and date. The issue is that the find_or_create_by! call includes rate in the parameters, which causes it to not find existing records when the rate differs slightly.
```
also use `create_or_find_by` which is better for race conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved exchange-rate handling to ensure rates are set only on creation and to better handle concurrent insert races, reducing duplicate records and improving reliability. Public API remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->