### PR TITLE
Fix Enable Banking sync date determination

### DIFF
--- a/app/models/concerns/syncable.rb
+++ b/app/models/concerns/syncable.rb
@@ -56,7 +56,7 @@ module Syncable
   end
 
   def last_synced_at
-    latest_sync&.completed_at
+    latest_completed_sync&.completed_at
   end
 
   def last_sync_created_at
@@ -66,6 +66,10 @@ module Syncable
   private
     def latest_sync
       syncs.ordered.first
+    end
+
+    def latest_completed_sync
+      syncs.completed.ordered.first
     end
 
     def syncer

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -241,7 +241,7 @@ class EnableBankingItem::Importer
         if enable_banking_item.last_synced_at
           enable_banking_item.last_synced_at.to_date - 7.days
         else
-          user_start_date || 90.days.ago.to_date
+          30.days.ago.to_date
         end
       else
         # Initial sync: use user's configured date or default to 3 months


### PR DESCRIPTION
Following our discussion with @sokie on Discord, I’ve identified an issue in the sync date determination within the new Enable Banking integration.  After some debugging, I discovered that the `determine_sync_start_date` logic depends on the `completed_at` value of the **latest** sync. However, when the function is called, a new sync is still ongoing and its completion date is empty. Consequently, it always defaults to the user-defined start date or a default value.

To resolve this, I’ve slightly modified the `last_synced_at` to retrieve the completion date of the most recent completed sync. This change should eliminate the issue of an empty completion date. Additionally, I’ve removed the fallback to the user start date and retained it only for the first import. This prevents fetching too many transactions in that scenario.  Finally, I’ve reduced the default value from 90 to 30 days to avoid exceeding the API limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sync tracking to use completed sync records for accurate last sync timestamps.

* **Performance**
  * Reduced default transaction lookup window from 90 days to 30 days, enabling faster sync operations during initial data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->