### PR TITLE
Include transaction notes in LLM data for merchant/category determination

### DIFF
--- a/app/models/family/auto_categorizer.rb
+++ b/app/models/family/auto_categorizer.rb
@@ -76,7 +76,7 @@ class Family::AutoCategorizer
           id: transaction.id,
           amount: transaction.entry.amount.abs,
           classification: transaction.entry.classification,
-          description: transaction.entry.name,
+          description: [ transaction.entry.name, transaction.entry.notes ].compact.reject(&:empty?).join(" "),
           merchant: transaction.merchant&.name
         }
       end

--- a/app/models/family/auto_merchant_detector.rb
+++ b/app/models/family/auto_merchant_detector.rb
@@ -83,7 +83,7 @@ class Family::AutoMerchantDetector
           id: transaction.id,
           amount: transaction.entry.amount.abs,
           classification: transaction.entry.classification,
-          description: transaction.entry.name,
+          description: [ transaction.entry.name, transaction.entry.notes ].compact.reject(&:empty?).join(" "),
           merchant: transaction.merchant&.name
         }
       end


### PR DESCRIPTION
The new Enable Banking integration retrieves a lot of relevant information from remittance details stored in transaction notes. This PR includes these notes in the data sent to the LLM for merchant and category identification.

I’ve been testing it for a few months and it works well. Most of the time the category and merchant are correctly recognised which wouldn’t be possible without the transaction notes. For example, the transaction name returned from my bank lacks sufficient detail to accurately determine these data points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced transaction data handling to provide more complete information for automatic categorization and merchant detection processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->