### PR TITLE
Fix negative values in test data

### DIFF
--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -128,7 +128,7 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     entry = account.entries.create!(
       name: "Grocery shopping",
       date: weekday_date,
-      amount: -50.00,
+      amount: 50.00,
       currency: "USD",
       entryable: Transaction.new(
         category: expense_category,
@@ -142,7 +142,7 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     weekend_entry = account.entries.create!(
       name: "Weekend shopping",
       date: weekend_date,
-      amount: -75.00,
+      amount: 75.00,
       currency: "USD",
       entryable: Transaction.new(
         category: expense_category,


### PR DESCRIPTION
The issue was that the test was creating entries with negative amounts (-50.00 and -75.00), but the build_spending_patterns method in the
  controller filters for positive amounts (entries.amount > 0) since positive amounts represent expenses in this codebase's convention. I changed the test to use
  positive amounts (50.00 and 75.00) to match the expected expense transaction format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data values for expense transactions to improve test accuracy and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->