### PR TITLE
Retrieve only accounted transactions from Enable Banking API

### DIFF
--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -147,6 +147,7 @@ class Provider::EnableBanking
   def get_account_transactions(account_id:, date_from: nil, date_to: nil, continuation_key: nil)
     encoded_id = CGI.escape(account_id.to_s)
     query_params = {}
+    query_params[:transaction_status] = "BOOK" # Only accounted transactions
     query_params[:date_from] = date_from.to_date.iso8601 if date_from
     query_params[:date_to] = date_to.to_date.iso8601 if date_to
     query_params[:continuation_key] = continuation_key if continuation_key


### PR DESCRIPTION
As discussed in https://github.com/we-promise/sure/issues/395, this PR introduces a new parameter in the API requests for Enable Banking. This parameter allows retrieval of only accounted transactions, preventing duplicate records fetched during pending transactions and after booking.

Closes #395 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Optimized transaction filtering in the banking module to specifically retrieve accounted transactions, providing users with more accurate and precise transaction history and financial reporting data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->