### PR TITLE
Simplefin liabilities recording fix

### DIFF
--- a/app/jobs/simplefin_item/balances_only_job.rb
+++ b/app/jobs/simplefin_item/balances_only_job.rb
@@ -19,12 +19,9 @@ class SimplefinItem::BalancesOnlyJob < ApplicationJob
       Rails.logger.warn("SimpleFin BalancesOnlyJob import failed: #{e.class} - #{e.message}")
     end
 
-    # Best-effort freshness update
-    begin
-      item.update!(last_synced_at: Time.current) if item.has_attribute?(:last_synced_at)
-    rescue => e
-      Rails.logger.warn("SimpleFin BalancesOnlyJob last_synced_at update failed: #{e.class} - #{e.message}")
-    end
+    # IMPORTANT: Do NOT update last_synced_at during balances-only discovery.
+    # Leaving last_synced_at nil ensures the next full sync uses the
+    # chunked-history path to fetch historical transactions.
 
     # Refresh the SimpleFin card on Providers/Accounts pages so badges and statuses update without a full reload
     begin

--- a/app/models/simplefin_account/processor.rb
+++ b/app/models/simplefin_account/processor.rb
@@ -41,15 +41,13 @@ class SimplefinAccount::Processor
       account = simplefin_account.current_account
       balance = simplefin_account.current_balance || simplefin_account.available_balance || 0
 
-      # Normalize balances for liabilities (SimpleFIN often reports them as negative)
-      # Our app convention is:
-      # - Liabilities: positive balance means you owe money; negative means provider owes you
-      # - Assets: pass-through
-      # Providers via SimpleFIN report liabilities as negative when you owe money,
-      # so we invert the sign for liability accounts.
+      # Normalize balances for liabilities (SimpleFIN typically uses opposite sign)
+      # App convention:
+      # - Liabilities: positive => you owe; negative => provider owes you (overpayment/credit)
+      # Since providers often send the opposite sign, ALWAYS invert for liabilities so
+      # that both debt and overpayment cases are represented correctly.
       if [ "CreditCard", "Loan" ].include?(account.accountable_type)
-        # Only invert when provider sends a negative value for debt owed
-        balance = -balance if balance < 0
+        balance = -balance
       end
 
       # Calculate cash balance correctly for investment accounts


### PR DESCRIPTION
Fixes an issue where SimpleFIN reports liability balances (e.g., for Chase credit cards and loans) as negative when money is owed, conflicting with our app's convention of positive values for liabilities. This led to incorrect net worth calculations and UI displays.

Changes:

- Updated SimplefinAccount::Processor#process_account! to normalize liability balances during SimpleFIN syncs:
For CreditCard and Loan accounts, invert negative provider balances to positive before saving.
Leave asset balances (e.g., Depository, Investment) unchanged.

- Added tests in test/models/simplefin_account_processor_test.rb to verify the normalization for liabilities and ensure assets remain unaltered.
Modified file: app/models/simplefin_account/processor.rb.

- Setup flow restored: first run does a quick balances‑only discovery so users can link accounts; after linking, the first full sync uses provider‑safe chunked history (60‑day chunks, up to ~3 years or sync_start_date).

- Robust first‑full‑sync guard: balances‑only runs no longer set last_synced_at, and if it was set previously, the importer detects “no transactions yet” and forces chunked history once.

Impact:

- Corrects liability signs for SimpleFIN-synced accounts, improving net worth accuracy and UI consistency.
Provider-specific fix that doesn't affect Plaid or other integrations.

- Corrects net worth and liability displays; restores expected history import after initial setup.

Fixes #406 

<img width="1783" height="955" alt="image" src="https://github.com/user-attachments/assets/29ce95e2-0aba-4ce6-b9e5-ced7d0902132" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected liability balance handling for credit cards and loans so balances display consistently; balances-only imports no longer update last-synced timestamp.

* **New Features**
  * Early "balances-only" discovery during initial sync and updated initial-import logic to prefer chunked history when appropriate (respecting user start dates and provider limits).

* **Tests**
  * Added unit tests verifying balance processing across account types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->