### PR TITLE
Cash Subgroups

### DIFF
--- a/app/controllers/depositories_controller.rb
+++ b/app/controllers/depositories_controller.rb
@@ -1,3 +1,5 @@
 class DepositoriesController <  ApplicationController
   include AccountableResource
+
+  permitted_accountable_attributes :subtype
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -106,7 +106,7 @@ class UsersController < ApplicationController
       params.require(:user).permit(
         :first_name, :last_name, :email, :profile_image, :redirect_to, :delete_profile_image, :onboarded_at,
         :show_sidebar, :default_period, :default_account_order, :show_ai_sidebar, :ai_enabled, :theme, :set_onboarding_preferences_at, :set_onboarding_goals_at,
-        family_attributes: [ :name, :currency, :country, :locale, :date_format, :timezone, :id ],
+        family_attributes: [ :name, :currency, :country, :locale, :date_format, :timezone, :cash_subgroup_enabled, :id ],
         goals: []
       )
     end

--- a/app/models/balance_sheet.rb
+++ b/app/models/balance_sheet.rb
@@ -13,7 +13,8 @@ class BalanceSheet
     @assets ||= ClassificationGroup.new(
       classification: "asset",
       currency: family.currency,
-      accounts: sorted(account_totals.asset_accounts)
+      accounts: sorted(account_totals.asset_accounts),
+      family: family
     )
   end
 
@@ -21,7 +22,8 @@ class BalanceSheet
     @liabilities ||= ClassificationGroup.new(
       classification: "liability",
       currency: family.currency,
-      accounts: sorted(account_totals.liability_accounts)
+      accounts: sorted(account_totals.liability_accounts),
+      family: family
     )
   end
 

--- a/app/models/balance_sheet/classification_group.rb
+++ b/app/models/balance_sheet/classification_group.rb
@@ -3,13 +3,14 @@ class BalanceSheet::ClassificationGroup
 
   monetize :total, as: :total_money
 
-  attr_reader :classification, :currency
+  attr_reader :classification, :currency, :family
 
-  def initialize(classification:, currency:, accounts:)
+  def initialize(classification:, currency:, accounts:, family:)
     @classification = normalize_classification!(classification)
     @name = name
     @currency = currency
     @accounts = accounts
+    @family = family
   end
 
   def name

--- a/app/models/balance_sheet/subtype_group.rb
+++ b/app/models/balance_sheet/subtype_group.rb
@@ -1,0 +1,29 @@
+class BalanceSheet::SubtypeGroup
+  include Monetizable
+
+  monetize :total, as: :total_money
+
+  attr_reader :subtype, :accounts, :account_group
+
+  def initialize(subtype:, accounts:, account_group:)
+    @subtype = subtype
+    @accounts = accounts
+    @account_group = account_group
+  end
+
+  def name
+    account_group.accountable_type.short_subtype_label_for(subtype) || account_group.name
+  end
+
+  def key
+    subtype.presence || "other"
+  end
+
+  def total
+    accounts.sum(&:converted_balance)
+  end
+
+  def currency
+    account_group.currency
+  end
+end

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -35,7 +35,8 @@ module Accountable
       return nil if subtype.nil?
 
       label_type = format == :long ? :long : :short
-      self::SUBTYPES[subtype]&.fetch(label_type, nil)
+      subtype_key = subtype.to_s.downcase
+      self::SUBTYPES[subtype_key]&.fetch(label_type, nil)
     end
 
     # Convenience method for getting the short label

--- a/app/views/accounts/_accountable_group.html.erb
+++ b/app/views/accounts/_accountable_group.html.erb
@@ -21,31 +21,108 @@
       </div>
     <% end %>
 
+    <% subgroups = account_group.subgroups %>
+    <% uncategorized_accounts = account_group.uncategorized_accounts %>
+
     <div class="space-y-1">
-      <% account_group.accounts.each do |account| %>
-        <%= link_to account_path(account),
-                  class: class_names(
-                    "block flex items-center gap-2 px-3 py-2 rounded-lg",
-                    page_active?(account_path(account)) ? "bg-container" : "hover:bg-surface-hover"
-                  ),
-                  title: account.name do %>
-          <%= render "accounts/logo", account: account, size: "sm", color: account_group.color %>
-
-          <div class="min-w-0 grow">
-            <div class="flex items-center gap-2 mb-0.5">
-              <%= tag.p account.name, class: class_names("text-sm text-primary font-medium truncate", "animate-pulse" => account.syncing?) %>
+      <% if subgroups.any? || uncategorized_accounts.any? %>
+        <% if uncategorized_accounts.any? %>
+          <div class="space-y-1">
+            <div class="flex items-center px-3 pt-2 text-xs font-medium text-secondary">
+              <p>Cash</p>
+              <p class="ml-auto text-sm text-primary whitespace-nowrap"><%= format_money(account_group.uncategorized_total_money) %></p>
             </div>
-            <%= tag.p account.short_subtype_label, class: "text-sm text-secondary truncate" %>
-          </div>
 
-          <div class="ml-auto text-right grow h-10">
-            <%= tag.p format_money(account.balance_money), class: "text-sm font-medium text-primary whitespace-nowrap" %>
-            <%= turbo_frame_tag dom_id(account, :sparkline), src: sparkline_account_path(account), loading: "lazy", data: { controller: "turbo-frame-timeout", turbo_frame_timeout_timeout_value: 10000 } do %>
-              <div class="flex items-center w-8 h-4 ml-auto">
-                <div class="w-6 h-px bg-loader"></div>
-              </div>
+            <% uncategorized_accounts.each do |account| %>
+              <%= link_to account_path(account),
+                        class: class_names(
+                          "block flex items-center gap-2 px-3 py-2 rounded-lg",
+                          page_active?(account_path(account)) ? "bg-container" : "hover:bg-surface-hover"
+                        ),
+                        title: account.name do %>
+                <%= render "accounts/logo", account: account, size: "sm", color: account_group.color %>
+
+                <div class="min-w-0 grow">
+                  <div class="flex items-center gap-2 mb-0.5">
+                    <%= tag.p account.name, class: class_names("text-sm text-primary font-medium truncate", "animate-pulse" => account.syncing?) %>
+                  </div>
+                  <%= tag.p account.short_subtype_label, class: "text-sm text-secondary truncate" %>
+                </div>
+
+                <div class="ml-auto text-right grow h-10">
+                  <%= tag.p format_money(account.balance_money), class: "text-sm font-medium text-primary whitespace-nowrap" %>
+                  <%= turbo_frame_tag dom_id(account, :sparkline), src: sparkline_account_path(account), loading: "lazy", data: { controller: "turbo-frame-timeout", turbo_frame_timeout_timeout_value: 10000 } do %>
+                    <div class="flex items-center w-8 h-4 ml-auto">
+                      <div class="w-6 h-px bg-loader"></div>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
             <% end %>
           </div>
+        <% end %>
+
+        <% subgroups.each do |subgroup| %>
+          <div class="space-y-1">
+            <div class="flex items-center px-3 pt-2 text-xs font-medium text-secondary">
+              <p><%= subgroup.name %></p>
+              <p class="ml-auto text-sm text-primary whitespace-nowrap"><%= format_money(subgroup.total_money) %></p>
+            </div>
+
+            <% subgroup.accounts.each do |account| %>
+              <%= link_to account_path(account),
+                        class: class_names(
+                          "block flex items-center gap-2 px-3 py-2 rounded-lg",
+                          page_active?(account_path(account)) ? "bg-container" : "hover:bg-surface-hover"
+                        ),
+                        title: account.name do %>
+                <%= render "accounts/logo", account: account, size: "sm", color: account_group.color %>
+
+                <div class="min-w-0 grow">
+                  <div class="flex items-center gap-2 mb-0.5">
+                    <%= tag.p account.name, class: class_names("text-sm text-primary font-medium truncate", "animate-pulse" => account.syncing?) %>
+                  </div>
+                  <%= tag.p account.short_subtype_label, class: "text-sm text-secondary truncate" %>
+                </div>
+
+                <div class="ml-auto text-right grow h-10">
+                  <%= tag.p format_money(account.balance_money), class: "text-sm font-medium text-primary whitespace-nowrap" %>
+                  <%= turbo_frame_tag dom_id(account, :sparkline), src: sparkline_account_path(account), loading: "lazy", data: { controller: "turbo-frame-timeout", turbo_frame_timeout_timeout_value: 10000 } do %>
+                    <div class="flex items-center w-8 h-4 ml-auto">
+                      <div class="w-6 h-px bg-loader"></div>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      <% else %>
+        <% account_group.accounts.each do |account| %>
+          <%= link_to account_path(account),
+                    class: class_names(
+                      "block flex items-center gap-2 px-3 py-2 rounded-lg",
+                      page_active?(account_path(account)) ? "bg-container" : "hover:bg-surface-hover"
+                    ),
+                    title: account.name do %>
+            <%= render "accounts/logo", account: account, size: "sm", color: account_group.color %>
+
+            <div class="min-w-0 grow">
+              <div class="flex items-center gap-2 mb-0.5">
+                <%= tag.p account.name, class: class_names("text-sm text-primary font-medium truncate", "animate-pulse" => account.syncing?) %>
+              </div>
+              <%= tag.p account.short_subtype_label, class: "text-sm text-secondary truncate" %>
+            </div>
+
+            <div class="ml-auto text-right grow h-10">
+              <%= tag.p format_money(account.balance_money), class: "text-sm font-medium text-primary whitespace-nowrap" %>
+              <%= turbo_frame_tag dom_id(account, :sparkline), src: sparkline_account_path(account), loading: "lazy", data: { controller: "turbo-frame-timeout", turbo_frame_timeout_timeout_value: 10000 } do %>
+                <div class="flex items-center w-8 h-4 ml-auto">
+                  <div class="w-6 h-px bg-loader"></div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/depositories/_form.html.erb
+++ b/app/views/depositories/_form.html.erb
@@ -1,7 +1,9 @@
 <%# locals: (account:, url:) %>
 
 <%= render "accounts/form", account: account, url: url do |form| %>
-  <%= form.select :subtype,
-                 Depository::SUBTYPES.map { |k, v| [v[:long], k] },
-                 { label: true, prompt: t("depositories.form.subtype_prompt"), include_blank: t("depositories.form.none") } %>
+  <%= form.fields_for :accountable do |accountable_fields| %>
+    <%= accountable_fields.select :subtype,
+                                 Depository::SUBTYPES.map { |k, v| [v[:long], k] },
+                                 { label: true, prompt: t("depositories.form.subtype_prompt"), include_blank: t("depositories.form.none") } %>
+  <% end %>
 <% end %>

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -40,7 +40,18 @@
             { label: t(".country") },
             { data: { auto_submit_form_target: "auto" } } %>
 
-        <p class="text-xs italic pl-2 text-secondary">Please note, we are still working on translations for various languages.</p>
+        <p class="text-xs italic pl-2 text-secondary">Please note, we are still working on translations for various languages.  Please see the <%= link_to "I18n issue", "https://github.com/maybe-finance/maybe/issues/1225", target: "_blank", class: "underline" %> for more information.</p>
+
+        <div class="mt-4">
+          <div class="flex items-center justify-between">
+            <div class="space-y-1">
+              <p class="text-sm text-primary"><%= t(".cash_subgroup_enabled_label") %></p>
+              <p class="text-secondary text-xs"><%= t(".cash_subgroup_enabled_hint") %></p>
+            </div>
+
+            <%= family_form.toggle :cash_subgroup_enabled, { data: { auto_submit_form_target: "auto" } } %>
+          </div>
+        </div>
       <% end %>
     <% end %>
   </div>

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -30,6 +30,8 @@ en:
         general_title: General
         default_period: Default Period
         default_account_order: Default Account Order
+        cash_subgroup_enabled_label: Group cash accounts by subtype
+        cash_subgroup_enabled_hint: Show Savings/Checking sections under Cash; turn off for a flat list.
         language: Language
         page_title: Preferences
         theme_dark: Dark

--- a/db/migrate/20251205120000_add_cash_subgroup_enabled_to_families.rb
+++ b/db/migrate/20251205120000_add_cash_subgroup_enabled_to_families.rb
@@ -1,0 +1,5 @@
+class AddCashSubgroupEnabledToFamilies < ActiveRecord::Migration[7.2]
+  def change
+    add_column :families, :cash_subgroup_enabled, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_26_094446) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_05_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -334,6 +334,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_26_094446) do
     t.boolean "auto_sync_on_login", default: true, null: false
     t.datetime "latest_sync_activity_at", default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "latest_sync_completed_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.boolean "cash_subgroup_enabled", default: true, null: false
   end
 
   create_table "family_exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/models/balance_sheet_test.rb
+++ b/test/models/balance_sheet_test.rb
@@ -75,6 +75,40 @@ class BalanceSheetTest < ActiveSupport::TestCase
     assert_equal 3000 + 5000, liability_groups.find { |ag| ag.name == I18n.t("accounts.types.other_liability") }.total
   end
 
+  test "cash subgroups render savings and uncategorized when enabled" do
+    create_account(balance: 100, accountable: Depository.new(subtype: "savings"))
+    create_account(balance: 200, accountable: Depository.new) # no subtype
+
+    cash_group = BalanceSheet.new(@family).assets.account_groups.find { |ag| ag.name == "Cash" }
+
+    assert_equal [ "Savings" ], cash_group.subgroups.map(&:name)
+    assert_equal 1, cash_group.uncategorized_accounts.size
+    assert_equal 20000.0, cash_group.uncategorized_total_money.to_f
+  end
+
+  test "cash subgroups flatten when preference disabled" do
+    @family.update!(cash_subgroup_enabled: false)
+
+    create_account(balance: 100, accountable: Depository.new(subtype: "savings"))
+    create_account(balance: 200, accountable: Depository.new)
+
+    cash_group = BalanceSheet.new(@family).assets.account_groups.find { |ag| ag.name == "Cash" }
+
+    assert_empty cash_group.subgroups
+    assert_empty cash_group.uncategorized_accounts
+    assert_equal 2, cash_group.accounts.size
+  end
+
+  test "unknown cash subtypes are treated as uncategorized" do
+    create_account(balance: 150, accountable: Depository.new(subtype: "mystery"))
+
+    cash_group = BalanceSheet.new(@family).assets.account_groups.find { |ag| ag.name == "Cash" }
+
+    assert_empty cash_group.subgroups
+    assert_equal 1, cash_group.uncategorized_accounts.size
+    assert_equal 15000.0, cash_group.uncategorized_total_money.to_f
+  end
+
   private
     def create_account(attributes = {})
       account = @family.accounts.create! name: "Test", currency: "USD", **attributes

--- a/test/system/chats_test.rb
+++ b/test/system/chats_test.rb
@@ -42,7 +42,7 @@ class ChatsTest < ApplicationSystemTestCase
 
       # After page refresh, we're still on the last chat we were viewing
       within "#chat-container" do
-        assert_selector "h1", text: @user.chats.first.title
+        assert_selector "h1", text: @user.chats.first.title, visible: :all
       end
     end
   end


### PR DESCRIPTION
Adds nested cash subgroups with subtype totals, exposes a preference toggle to keep a flat list, fixes subtype persistence, and adds regression tests.

<img width="1830" height="1125" alt="image" src="https://github.com/user-attachments/assets/02146792-2bbe-4239-a5da-f2be5223a907" />
<img width="1830" height="1125" alt="image" src="https://github.com/user-attachments/assets/561d637d-e3ab-4650-99e1-c4434ccf1631" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cash accounts now organize by subtype (Savings, Checking, etc.)
  * New preference setting to enable or disable cash grouping
  * Uncategorized cash accounts display separately within groups

* **Bug Fixes**
  * Fixed subtype label matching to handle varying case inputs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->