### PR TITLE
fix: Apply right formatting for money values in outflows section

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,7 +14,7 @@ class PagesController < ApplicationController
     expense_totals = Current.family.income_statement.expense_totals(period: @period)
 
     @cashflow_sankey_data = build_cashflow_sankey_data(income_totals, expense_totals, family_currency)
-    @outflows_data = build_outflows_donut_data(expense_totals)
+    @outflows_data = build_outflows_donut_data(expense_totals, family_currency)
 
     @dashboard_sections = build_dashboard_sections
 
@@ -213,8 +213,7 @@ class PagesController < ApplicationController
       { nodes: nodes, links: links, currency_symbol: Money::Currency.new(currency_symbol).symbol }
     end
 
-    def build_outflows_donut_data(expense_totals)
-      currency_symbol = Money::Currency.new(expense_totals.currency).symbol
+    def build_outflows_donut_data(expense_totals, family_currency)
       total = expense_totals.total
 
       # Only include top-level categories with non-zero amounts
@@ -226,12 +225,13 @@ class PagesController < ApplicationController
             id: ct.category.id,
             name: ct.category.name,
             amount: ct.total.to_f.round(2),
+            currency: ct.currency,
             percentage: ct.weight.round(1),
             color: ct.category.color.presence || Category::UNCATEGORIZED_COLOR,
             icon: ct.category.lucide_icon
           }
         end
 
-      { categories: categories, total: total.to_f.round(2), currency_symbol: currency_symbol }
+      { categories: categories, total: total.to_f.round(2), currency: family_currency, currency_symbol: Money::Currency.new(family_currency).symbol }
     end
 end

--- a/app/views/pages/dashboard/_outflows_donut.html.erb
+++ b/app/views/pages/dashboard/_outflows_donut.html.erb
@@ -33,7 +33,7 @@
               </div>
 
               <div class="text-3xl font-medium text-primary">
-                <%= outflows_data[:currency_symbol] %><%= number_with_delimiter(outflows_data[:total], delimiter: ",") %>
+                <%= format_money Money.new(outflows_data[:total], outflows_data[:currency]) %>
               </div>
             </div>
 
@@ -84,7 +84,7 @@
                 <span class="text-sm font-medium text-primary truncate"><%= category[:name] %></span>
               </div>
               <div class="flex items-center gap-4 flex-shrink-0">
-                <span class="text-sm font-medium text-primary whitespace-nowrap"><%= outflows_data[:currency_symbol] %><%= number_with_delimiter(category[:amount], delimiter: ",") %></span>
+                <span class="text-sm font-medium text-primary whitespace-nowrap"><%= format_money Money.new(category[:amount], category[:currency]) %></span>
                 <span class="text-sm text-secondary whitespace-nowrap"><%= category[:percentage] %>%</span>
               </div>
             <% end %>


### PR DESCRIPTION
I’ve noticed the Outflow section doesn’t respect the user’s locale formatting. 
This PR addresses this by formatting the amounts displayed according to user preference.

| Before | After |
| ------------- | ------------- |
| <img width="966" height="707" alt="Screenshot 2025-12-06 alle 15 18 40" src="https://github.com/user-attachments/assets/a57fed21-fdc4-488d-a3bd-680c174a390c" /> | <img width="959" height="703" alt="Screenshot 2025-12-06 alle 15 19 59" src="https://github.com/user-attachments/assets/1a027b28-095d-4f44-9f04-1780b949e77f" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved currency context handling and propagation throughout outflows display.
  * Standardized monetary value formatting for consistent display of outflow totals and category amounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->