### PR TITLE
fix: Update budget percentage determination method

### DIFF
--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -70,9 +70,10 @@ class BudgetCategory < ApplicationRecord
   end
 
   def percent_of_budget_spent
-    return 0 unless budgeted_spending > 0
-
-    (actual_spending / budgeted_spending) * 100
+    return 0 if budgeted_spending == 0 && actual_spending == 0
+    return 0 if budgeted_spending > 0 && actual_spending == 0
+    return 100 if budgeted_spending == 0 && actual_spending > 0
+    (actual_spending.to_f / budgeted_spending) * 100 if budgeted_spending > 0 && actual_spending > 0
   end
 
   def bar_width_percent


### PR DESCRIPTION
I’ve made a small fix for a bug I noticed after the recent update to the “Budgets” section. This change allows the budget percentage to be calculated correctly based on the following criteria:

- If no budget is defined and no spending is recorded, the percentage will be 0.
- If no budget is defined but expenses are recorded, the percentage will be 100.
- If a budget is defined but no expenses are recorded, the percentage will be 0.
- If both budget and expenses are present, the percentage is calculated accordingly.

This fix resolves a UI issue where expenses were recorded but no budget was defined resulting in an empty progress bar.

| Before | After |
| ------------- | ------------- |
| <img width="918" height="253" alt="Screenshot 2025-12-10 alle 20 52 56" src="https://github.com/user-attachments/assets/88c5f2b2-11ee-4a22-90ac-25f215abb0f1" /> | <img width="924" height="255" alt="Screenshot 2025-12-10 alle 20 52 22" src="https://github.com/user-attachments/assets/997d4750-c471-4e1c-9075-214600ebc696" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved budget spending percentage calculations for scenarios involving zero budgets and zero spending amounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->