### PR TITLE
Outlfows UI adjustments

### DIFF
--- a/app/views/pages/dashboard/_outflows_donut.html.erb
+++ b/app/views/pages/dashboard/_outflows_donut.html.erb
@@ -13,7 +13,7 @@
   <div class="px-4">
     <div class="flex flex-col lg:flex-row gap-8 items-center">
       <!-- Donut Chart -->
-      <div class="w-full lg:w-1/3 max-w-[300px]">
+      <div class="w-full lg:w-1/3 max-w-[300px] p-4">
         <div class="h-[300px] relative"
           data-controller="donut-chart"
           data-donut-chart-segments-value="<%= outflows_data[:categories].to_json %>"
@@ -78,19 +78,19 @@
                   action: "mouseenter->donut-chart#highlightSegment mouseleave->donut-chart#unhighlightSegment"
                 } do %>
               <div class="flex items-center gap-3 flex-1 min-w-0">
-                <div class="h-9 w-9 flex-shrink-0 group-hover:scale-105 transition-all duration-300 rounded-full flex justify-center items-center" 
+                <div class="h-6 w-6 flex-shrink-0 group-hover:scale-105 transition-all duration-300 rounded-full flex justify-center items-center" 
                   style="
                     background-color: color-mix(in oklab, <%= category[:color] %> 10%, transparent);
                     border-color: color-mix(in oklab, <%= category[:color] %> 10%, transparent);
                     color: <%= category[:color] %>;">
                   <% if category[:icon] %>
-                    <%= icon(category[:icon], color: "current") %>
+                    <%= icon(category[:icon], color: "current", size: "sm") %>
                   <% else %>
                     <%= render DS::FilledIcon.new(
                       variant: :text,
                       hex_color: category[:color],
                       text: category[:name],
-                      size: "md",
+                      size: "sm",
                       rounded: true
                     ) %>
                   <% end %>


### PR DESCRIPTION
Here are some small adjustments for the “Outflows” widget in the dashboard:

- Combine the colour and icon to save space on mobile.
- Reduce the donut size to match the one in the “Budgets” section for consistency.
- Make small adjustments to the spacing and width.

| Before  | After |
| ------------- | ------------- |
| <img width="962" height="708" alt="Screenshot 2025-12-11 alle 23 20 46" src="https://github.com/user-attachments/assets/a890077d-c97c-48da-82cd-f1bd1227316f" /> | <img width="960" height="754" alt="Screenshot 2025-12-11 alle 23 20 20" src="https://github.com/user-attachments/assets/f909bbee-3f5a-4ede-878e-d1611c505489" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dashboard outflows donut chart with improved spacing and layout refinements
  * Redesigned category icon display with new hover effects for improved visual feedback
  * Updated alignment and sizing of percentage values for better readability and consistency across devices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->