### PR TITLE
Highlight current month in trends insights table

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -287,6 +287,7 @@ class ReportsController < ApplicationController
 
         trends << {
           month: month_start.strftime("%b %Y"),
+          is_current_month: (month_start.month == Date.current.month && month_start.year == Date.current.year),
           income: income,
           expenses: expenses,
           net: income - expenses

--- a/app/views/reports/_trends_insights.html.erb
+++ b/app/views/reports/_trends_insights.html.erb
@@ -18,12 +18,11 @@
               </tr>
             </thead>
             <tbody>
-              <% trends_data.each_with_index do |trend, index| %>
-                <% is_current_month = trend[:month] == Date.current.strftime("%b %Y") %>
-                <tr class="border-b border-tertiary/50 <%= is_current_month ? "font-medium" : "" %>">
+              <% trends_data.each do |trend| %>
+                <tr class="border-b border-tertiary/50 <%= trend[:is_current_month] ? "font-medium" : "" %>">
                   <td class="py-3 pr-4 text-primary">
                     <%= trend[:month] %>
-                    <% if is_current_month %>
+                    <% if trend[:is_current_month] %>
                       <span class="ml-2 text-xs text-tertiary">(<%= t("reports.trends.current") %>)</span>
                     <% end %>
                   </td>


### PR DESCRIPTION
Refactored the logic to apply special styling and label to the row representing the current month, using a date comparison instead of relying on the last index. This ensures the current month is always highlighted, regardless of its position in the data.

before:
<img width="164" height="176" alt="Scherm­afbeelding 2025-12-12 om 21 23 06" src="https://github.com/user-attachments/assets/9f6f8e3c-a89d-4a43-ac7c-213ba20ad665" />

after:
<img width="146" height="180" alt="Scherm­afbeelding 2025-12-12 om 21 22 50" src="https://github.com/user-attachments/assets/0af03345-2342-4250-9863-fa6f4d867266" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection and display of the current month in trends and insights reports; current-month indicator and styling now consistently applied.
* **Refactor**
  * Simplified internal logic behind current-month highlighting to reduce positional dependence and improve maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->