### PR TITLE
Fix SimpleFin missing transactions

### DIFF
--- a/lib/simplefin/date_utils.rb
+++ b/lib/simplefin/date_utils.rb
@@ -15,6 +15,7 @@ module Simplefin
       when Time, DateTime
         val.to_date
       when Integer, Float
+        return nil if val.to_i == 0
         Time.at(val).utc.to_date
       when String
         Date.parse(val)


### PR DESCRIPTION
**Issue Addressed:**  
Users reported missing transactions and inconsistent balances when compared to the accoumt provider after SimpleFin syncs. Root cause: SimpleFin may send pending versions (`posted: 0`, `pending: true`) first, then updated posted ones later. The importer's naive `uniq` merge kept the initial pending copy, hiding the finalized transaction and skewing balances (e.g., Sure at $33.07 vs. Citi's $55.69).

**Changes Made:**
- In `app/models/simplefin_item/importer.rb`: Replaced `uniq` with a smart reducer in `#import_account` that prioritizes duplicates by:
    - Matching on `id` > `fitid` > `[posted, amount, description]`.
    - Favoring real `posted` timestamps over `0`/nil.
    - Then non-pending over pending, and latest dates.  
      This ensures posted updates replace pending placeholders.
- In `lib/simplefin/date_utils.rb`: Updated `parse_provider_date` to return `nil` for epoch `0` (avoiding bogus 1970-01-01 dates that broke de-duping and filters).

**Impact:**
- Resolves missing posted transactions by upgrading pendings automatically.
- Balances now align closer to provider values (verified: post-fix, Sure matches Citi at $55.69).
- Plays nice with the existing pending transactions PR (no conflicts; reducer handles the flip to posted).
- Edge cases covered: Zero/missing dates, credit/debit signs (unchanged), large datasets (linear time), no regressions in error handling.

<img width="2345" height="1052" alt="image" src="https://github.com/user-attachments/assets/83901a76-fb8d-4092-9b9c-17ffc403c56a" />

<img width="1823" height="932" alt="image" src="https://github.com/user-attachments/assets/0230ecd9-abfa-4e58-80e5-eb0fc2a5fc55" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction consolidation to intelligently select the best version when duplicates exist, prioritizing date recency and transaction status
  * Updated date parsing to properly handle zero values instead of converting to epoch start date

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->