### PR TITLE
Fix api call for cloudflare API

### DIFF
--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -339,19 +339,23 @@ class Provider::Openai < Provider
       if function_results.any?
         # Build assistant message with tool_calls
         tool_calls = function_results.map do |fn_result|
+          # Convert arguments to JSON string if it's not already a string
+          arguments = fn_result[:arguments]
+          arguments_str = arguments.is_a?(String) ? arguments : arguments.to_json
+
           {
             id: fn_result[:call_id],
             type: "function",
             function: {
               name: fn_result[:name],
-              arguments: fn_result[:arguments]
+              arguments: arguments_str
             }
           }
         end
 
         messages << {
           role: "assistant",
-          content: nil,
+          content: "",  # Some OpenAI-compatible APIs require string, not null
           tool_calls: tool_calls
         }
 


### PR DESCRIPTION
(content field): The assistant message had content: null when it made tool calls, but Cloudflare's Workers AI API requires content to be a string (not null). Fixed by using content: "" instead.      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI API integration by properly serializing tool call arguments to JSON strings and standardizing assistant message formatting for better compatibility with OpenAI-compatible services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->