### PR TITLE
Fix undefined variable in RuleJob error logging

### DIFF
--- a/app/jobs/rule_job.rb
+++ b/app/jobs/rule_job.rb
@@ -83,7 +83,7 @@ class RuleJob < ApplicationJob
             error_message: error_message
           )
         rescue => e
-          Rails.logger.error("RuleJob: Failed to create RuleRun for rule #{rule.id}: #{create_error.message}")
+          Rails.logger.error("RuleJob: Failed to create RuleRun for rule #{rule.id}: #{e.message}")
         end
       end
 


### PR DESCRIPTION
Fixed a NameError in RuleJob error handling. The rescue block referenced undefined variable 'create_error' instead of exception 'e', preventing proper error logging when RuleRun creation fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error logging in rule job execution to properly report exception details when rule creation fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->