### PR TITLE
Restore login screen scrolling

### DIFF
--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -7,13 +7,13 @@
   data-theme="<%= theme %>"
   data-controller="theme"
   data-theme-user-preference-value="<%= Current.user&.theme || "system" %>"
-  class="h-full text-primary overflow-hidden font-sans <%= @os %>">
+  class="h-full text-primary overflow-hidden lg:overflow-auto font-sans <%= @os %>">
   <head>
     <%= render "layouts/shared/head" %>
     <%= yield :head %>
   </head>
 
-  <body class="h-full overflow-hidden antialiased">
+  <body class="h-full overflow-hidden lg:overflow-auto antialiased">
     <% if Rails.env.development? %>
       <button hidden data-controller="hotkey" data-hotkey="t t /" data-action="theme#toggle"></button>
     <% end %>


### PR DESCRIPTION
### Motivation
- Re-enable page scrolling on large viewports after a previous change removed the desktop overflow behavior. 
- The login (`auth`) layout uses the shared HTML wrapper which must allow overflow at `lg` breakpoints to scroll correctly. 
- Restoring `lg:overflow-auto` ensures auth pages like `/sessions/new` and other large-viewport layouts can scroll. 

### Description
- Updated `app/views/layouts/shared/_htmldoc.html.erb` to add `lg:overflow-auto` back to the `<html>` element. 
- Also added `lg:overflow-auto` back to the `<body>` element so desktop scrolling is restored. 
- No other structural or behavioral changes were made to the HTML wrapper. 
- The change targets only the shared layout wrapper used by `layout "auth"` and other layouts that render the partial. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490b0de2308332911a6856530f1108)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout handling for large screen displays with improved overflow management, ensuring better scrolling behavior and visual stability on desktop devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->