### PR TITLE
fix: allow optional OPENAI_ACCESS_TOKEN on self hosted instances

### DIFF
--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -16,7 +16,8 @@ class Provider::Openai < Provider
   end
 
   def initialize(access_token, uri_base: nil, model: nil)
-    client_options = { access_token: access_token }
+    client_options = {}
+    client_options[:access_token] = access_token if access_token.present?
     client_options[:uri_base] = uri_base if uri_base.present?
 
     @client = ::OpenAI::Client.new(**client_options)

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -64,10 +64,11 @@ class Provider::Registry
 
       def openai
         access_token = ENV["OPENAI_ACCESS_TOKEN"].presence || Setting.openai_access_token
-
-        return nil unless access_token.present?
-
         uri_base = ENV["OPENAI_URI_BASE"].presence || Setting.openai_uri_base
+
+        # Require access_token unless using a custom provider (custom URI base)
+        return nil unless access_token.present? || uri_base.present?
+
         model = ENV["OPENAI_MODEL"].presence || Setting.openai_model
 
         if uri_base.present? && model.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,7 +97,13 @@ class User < ApplicationRecord
   end
 
   def ai_available?
-    !Rails.application.config.app_mode.self_hosted? || ENV["OPENAI_ACCESS_TOKEN"].present? || Setting.openai_access_token.present?
+    return true unless Rails.application.config.app_mode.self_hosted?
+
+    # AI is available if access token is set OR if custom URI base is set (for self-hosted instances like Ollama)
+    access_token_present = ENV["OPENAI_ACCESS_TOKEN"].present? || Setting.openai_access_token.present?
+    custom_uri_base_present = ENV["OPENAI_URI_BASE"].present? || Setting.openai_uri_base.present?
+
+    access_token_present || custom_uri_base_present
   end
 
   def ai_enabled?

--- a/app/views/settings/hostings/_openai_settings.html.erb
+++ b/app/views/settings/hostings/_openai_settings.html.erb
@@ -15,8 +15,13 @@
                          controller: "auto-submit-form",
                          "auto-submit-form-trigger-event-value": "blur"
                        } do |form| %>
+  <% access_token_label = if self_hosted?
+                            "#{t('.access_token_label')} (optional)"
+                          else
+                            t(".access_token_label")
+                          end %>
   <%= form.password_field :openai_access_token,
-                          label: t(".access_token_label"),
+                          label: access_token_label,
                           placeholder: t(".access_token_placeholder"),
                           value: (Setting.openai_access_token.present? ? "********" : nil),
                           autocomplete: "off",

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -141,16 +141,23 @@ class UserTest < ActiveSupport::TestCase
 
   test "ai_available? returns true when openai access token set in settings" do
     Rails.application.config.app_mode.stubs(:self_hosted?).returns(true)
-    previous = Setting.openai_access_token
-    with_env_overrides OPENAI_ACCESS_TOKEN: nil do
+    previous_token = Setting.openai_access_token
+    previous_uri_base = Setting.openai_uri_base
+    with_env_overrides OPENAI_ACCESS_TOKEN: nil, OPENAI_URI_BASE: nil do
       Setting.openai_access_token = nil
+      Setting.openai_uri_base = nil
       assert_not @user.ai_available?
 
       Setting.openai_access_token = "token"
       assert @user.ai_available?
+
+      Setting.openai_access_token = nil
+      Setting.openai_uri_base = "http://localhost:11434/v1"
+      assert @user.ai_available?
     end
   ensure
-    Setting.openai_access_token = previous
+    Setting.openai_access_token = previous_token
+    Setting.openai_uri_base = previous_uri_base
   end
 
   test "update_dashboard_preferences handles concurrent updates atomically" do


### PR DESCRIPTION
I'm self hosting Sure and wanted to integrate a self-hosted LLM (Ollama), which has an OpenAI-compatible API, but requires no authentication locally. 

Not providing an `OPENAI_ACCESS_TOKEN` resulted in a disabled AI chat, which is something I would not expect.

One more note - specifying `OPENAI_ACCESS_TOKEN`  via settings UI and then removing the token leaves the chat enabled - missing validation?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for self-hosted AI deployments with custom URI endpoints (e.g., Ollama integration)
  * OpenAI access token is now optional when a custom URI base is configured

* **UX Improvements**
  * Access token field now labeled as optional in self-hosted OpenAI settings

* **Bug Fixes**
  * Improved credential handling during initialization to avoid passing null values

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->