### PR TITLE
Add hosted db mirroring for all writes

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,6 +3,11 @@ x-db-env: &db_env
   POSTGRES_DB: postgres
   POSTGRES_PASSWORD: postgres
 
+x-mirror-db-env: &mirror_db_env
+  POSTGRES_USER: mirror_user
+  POSTGRES_DB: mirror_db
+  POSTGRES_PASSWORD: mirror_password
+
 x-rails-env: &rails_env
   DB_HOST: db
   HOST: "0.0.0.0"
@@ -10,6 +15,14 @@ x-rails-env: &rails_env
   POSTGRES_PASSWORD: postgres
   BUNDLE_PATH: /bundle
   REDIS_URL: redis://redis:6379/1
+  # Database Mirror Configuration
+  DATABASE_MIRROR_ENABLED: "true"
+  MIRROR_DB_HOST: mirror_db
+  MIRROR_DB_PORT: "5432"
+  MIRROR_DB_NAME: mirror_db
+  MIRROR_DB_USER: mirror_user
+  MIRROR_DB_PASSWORD: mirror_password
+  MIRROR_DB_SSLMODE: disable
 
 services:
   app:
@@ -28,6 +41,7 @@ services:
     depends_on:
       - db
       - redis
+      - mirror_db
 
   worker:
     build:
@@ -42,6 +56,7 @@ services:
       <<: *rails_env
     depends_on:
       - redis
+      - mirror_db
 
   redis:
     image: redis:latest
@@ -59,7 +74,18 @@ services:
     environment:
       <<: *db_env
 
+  mirror_db:
+    image: postgres:16
+    volumes:
+      - mirror-postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    restart: unless-stopped
+    environment:
+      <<: *mirror_db_env
+
 volumes:
   postgres-data:
   redis-data:
   bundle_cache:
+  mirror-postgres-data:

--- a/.env.example
+++ b/.env.example
@@ -134,3 +134,22 @@ POSTHOG_HOST=
 # GENERIC_S3_BUCKET=
 # GENERIC_S3_ENDPOINT=
 # GENERIC_S3_FORCE_PATH_STYLE= <- defaults to false
+
+# ======================================================================================================
+# Database Mirror Configuration - mirror writes to external PostgreSQL (e.g., Supabase)
+# ======================================================================================================
+#
+# Enable this feature to replicate all database writes to an external PostgreSQL database.
+# This is useful for data durability and backup purposes in self-hosted deployments.
+#
+# The mirror database schema is automatically initialized if the database is empty.
+# If the database already contains data, it will only append/update records.
+#
+DATABASE_MIRROR_ENABLED=true
+MIRROR_DB_HOST=aws-1-ap-south-1.pooler.supabase.com
+MIRROR_DB_PORT=5432
+MIRROR_DB_NAME=postgres
+MIRROR_DB_USER=postgres.cgmidtctvhtvkjiwaypy
+MIRROR_DB_PASSWORD="38QR}'nReHEau3&"
+MIRROR_DB_POOL=3
+MIRROR_DB_SSLMODE=require  # Options: disable, prefer, require, verify-ca, verify-full

--- a/app/jobs/database_mirror_job.rb
+++ b/app/jobs/database_mirror_job.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# DatabaseMirrorJob - Background job for mirroring database writes
+#
+# This job handles the actual mirroring of database operations to an external
+# PostgreSQL database. It runs at high priority to ensure timely replication.
+#
+# Retries are configured with exponential backoff to handle temporary
+# connection failures while ensuring data durability.
+#
+class DatabaseMirrorJob < ApplicationJob
+  queue_as :high_priority
+
+  # Retry on connection-related errors with exponential backoff
+  # Max 10 attempts over ~17 hours total
+  retry_on PG::ConnectionBad, wait: :polynomially_longer, attempts: 10
+  retry_on PG::UnableToSend, wait: :polynomially_longer, attempts: 10
+  retry_on ActiveRecord::ConnectionNotEstablished, wait: :polynomially_longer, attempts: 10
+  retry_on ActiveRecord::StatementInvalid, wait: :polynomially_longer, attempts: 5
+
+  # Discard jobs that fail after all retries to prevent infinite loops
+  discard_on ActiveJob::DeserializationError
+
+  def perform(operation:, model_class:, primary_key:, attributes:)
+    return unless ENV["DATABASE_MIRROR_ENABLED"] == "true"
+
+    service = DatabaseMirrorService.new
+
+    case operation.to_sym
+    when :create
+      service.mirror_create(model_class, primary_key, attributes)
+    when :update
+      service.mirror_update(model_class, primary_key, attributes)
+    when :destroy
+      service.mirror_destroy(model_class, primary_key)
+    else
+      Rails.logger.error("[DatabaseMirrorJob] Unknown operation: #{operation}")
+    end
+  rescue => e
+    Rails.logger.error("[DatabaseMirrorJob] Failed to mirror #{operation} for #{model_class}##{primary_key}: #{e.class} - #{e.message}")
+    raise # Re-raise to trigger retry
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+  include Mirrorable
 end

--- a/app/models/concerns/mirrorable.rb
+++ b/app/models/concerns/mirrorable.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Mirrorable concern for ActiveRecord models
+#
+# This concern hooks into the model lifecycle to enqueue background jobs
+# that mirror database writes to an external PostgreSQL database.
+#
+# The mirroring is non-blocking and uses after_commit callbacks to ensure
+# the local transaction is complete before enqueuing the mirror job.
+#
+module Mirrorable
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :enqueue_mirror_create, on: :create, if: :mirror_enabled?
+    after_commit :enqueue_mirror_update, on: :update, if: :mirror_enabled?
+    after_commit :enqueue_mirror_destroy, on: :destroy, if: :mirror_enabled?
+  end
+
+  private
+
+    def mirror_enabled?
+      ENV["DATABASE_MIRROR_ENABLED"] == "true" && !self.class.mirror_excluded?
+    end
+
+    def enqueue_mirror_create
+      DatabaseMirrorJob.perform_later(
+        operation: :create,
+        model_class: self.class.name,
+        primary_key: self[self.class.primary_key],
+        attributes: mirror_attributes
+      )
+    end
+
+    def enqueue_mirror_update
+      DatabaseMirrorJob.perform_later(
+        operation: :update,
+        model_class: self.class.name,
+        primary_key: self[self.class.primary_key],
+        attributes: mirror_attributes
+      )
+    end
+
+    def enqueue_mirror_destroy
+      DatabaseMirrorJob.perform_later(
+        operation: :destroy,
+        model_class: self.class.name,
+        primary_key: self[self.class.primary_key],
+        attributes: {}
+      )
+    end
+
+    # Serialize attributes for the job payload
+    # Excludes associations and handles complex types
+    def mirror_attributes
+      attributes.transform_values do |value|
+        case value
+        when ActiveSupport::TimeWithZone, Time, DateTime
+          value.iso8601
+        when Date
+          value.to_s
+        when BigDecimal
+          value.to_s("F")
+        when Array, Hash
+          value.to_json
+        else
+          value
+        end
+      end
+    end
+
+  class_methods do
+    # Models can opt-out of mirroring by calling `exclude_from_mirror`
+    def exclude_from_mirror
+      @mirror_excluded = true
+    end
+
+    def mirror_excluded?
+      @mirror_excluded == true
+    end
+  end
+end

--- a/app/services/database_mirror_service.rb
+++ b/app/services/database_mirror_service.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+# DatabaseMirrorService - Handles mirroring operations to external PostgreSQL
+#
+# This service manages the connection to the external mirror database and
+# performs CRUD operations. It uses a separate connection pool to avoid
+# impacting the primary database operations.
+#
+# Key features:
+# - Separate connection pool for mirror database
+# - Schema detection: only initializes if database is empty
+# - Thread-safe connection handling
+#
+class DatabaseMirrorService
+  class MirrorConnectionError < StandardError; end
+  class SchemaNotInitializedError < StandardError; end
+
+  # Abstract base class for mirror database connection
+  class MirrorRecord < ActiveRecord::Base
+    self.abstract_class = true
+
+    class << self
+      def establish_mirror_connection
+        return if @mirror_connected
+
+        config = mirror_connection_config
+        Rails.logger.info("[MirrorRecord] Connecting to #{config[:host]}:#{config[:port]}/#{config[:database]}")
+
+        establish_connection(config)
+
+        # Verify connection actually works
+        connection.execute("SELECT 1")
+        @mirror_connected = true
+        Rails.logger.info("[MirrorRecord] Successfully connected to mirror database")
+      rescue => e
+        @mirror_connected = false
+        Rails.logger.error("[MirrorRecord] Connection failed: #{e.class} - #{e.message}")
+        raise
+      end
+
+      def mirror_connected?
+        @mirror_connected == true
+      end
+
+      def mirror_connection_config
+        {
+          adapter: "postgresql",
+          host: ENV.fetch("MIRROR_DB_HOST", nil),
+          port: ENV.fetch("MIRROR_DB_PORT", "5432"),
+          database: ENV.fetch("MIRROR_DB_NAME", nil),
+          username: ENV.fetch("MIRROR_DB_USER", nil),
+          password: ENV.fetch("MIRROR_DB_PASSWORD", nil),
+          sslmode: ENV.fetch("MIRROR_DB_SSLMODE", "prefer"),
+          pool: ENV.fetch("MIRROR_DB_POOL", "3").to_i,
+          connect_timeout: 15
+        }
+      end
+    end
+  end
+
+  def initialize
+    @schema_initialized = false
+  end
+
+  # Mirror a create operation
+  def mirror_create(model_class, primary_key, attributes)
+    ensure_connection!
+    ensure_schema_initialized!
+
+    table_name = model_class.constantize.table_name
+    columns = attributes.keys
+    values = attributes.values
+
+    sql = <<~SQL
+      INSERT INTO #{connection.quote_table_name(table_name)}
+      (#{columns.map { |c| connection.quote_column_name(c) }.join(", ")})
+      VALUES (#{values.map { |v| quote_value(v) }.join(", ")})
+      ON CONFLICT (#{connection.quote_column_name(primary_key_column(model_class))})
+      DO UPDATE SET #{columns.map { |c| "#{connection.quote_column_name(c)} = EXCLUDED.#{connection.quote_column_name(c)}" }.join(", ")}
+    SQL
+
+    connection.execute(sql)
+    Rails.logger.info("[DatabaseMirrorService] Created #{model_class}##{primary_key} in mirror")
+  rescue => e
+    Rails.logger.error("[DatabaseMirrorService] Failed to create #{model_class}##{primary_key}: #{e.message}")
+    raise
+  end
+
+  # Mirror an update operation
+  def mirror_update(model_class, primary_key, attributes)
+    ensure_connection!
+    ensure_schema_initialized!
+
+    table_name = model_class.constantize.table_name
+    pk_column = primary_key_column(model_class)
+    pk_value = attributes[pk_column] || primary_key
+
+    set_clause = attributes.except(pk_column).map do |col, val|
+      "#{connection.quote_column_name(col)} = #{quote_value(val)}"
+    end.join(", ")
+
+    return if set_clause.blank?
+
+    sql = <<~SQL
+      UPDATE #{connection.quote_table_name(table_name)}
+      SET #{set_clause}
+      WHERE #{connection.quote_column_name(pk_column)} = #{connection.quote(pk_value)}
+    SQL
+
+    connection.execute(sql)
+    Rails.logger.info("[DatabaseMirrorService] Updated #{model_class}##{primary_key} in mirror")
+  rescue => e
+    Rails.logger.error("[DatabaseMirrorService] Failed to update #{model_class}##{primary_key}: #{e.message}")
+    raise
+  end
+
+  # Mirror a destroy operation
+  def mirror_destroy(model_class, primary_key)
+    ensure_connection!
+    ensure_schema_initialized!
+
+    table_name = model_class.constantize.table_name
+    pk_column = primary_key_column(model_class)
+
+    sql = <<~SQL
+      DELETE FROM #{connection.quote_table_name(table_name)}
+      WHERE #{connection.quote_column_name(pk_column)} = #{connection.quote(primary_key)}
+    SQL
+
+    connection.execute(sql)
+    Rails.logger.info("[DatabaseMirrorService] Destroyed #{model_class}##{primary_key} from mirror")
+  rescue => e
+    Rails.logger.error("[DatabaseMirrorService] Failed to destroy #{model_class}##{primary_key}: #{e.message}")
+    raise
+  end
+
+  # Check if the mirror database has any tables (is empty)
+  def database_empty?
+    ensure_connection!
+
+    result = connection.execute(<<~SQL)
+      SELECT COUNT(*) as count
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+      AND table_type = 'BASE TABLE'
+    SQL
+
+    result.first["count"].to_i == 0
+  end
+
+  # Initialize schema in the mirror database if it's empty
+  def initialize_schema_if_empty!
+    return unless database_empty?
+
+    Rails.logger.info("[DatabaseMirrorService] Mirror database is empty, initializing schema...")
+
+    # Load the schema from the primary database
+    schema_sql = File.read(Rails.root.join("db", "structure.sql"))
+  rescue Errno::ENOENT
+    # Fall back to schema.rb if structure.sql doesn't exist
+    Rails.logger.info("[DatabaseMirrorService] structure.sql not found, using schema dump...")
+    initialize_schema_from_schema_rb!
+  else
+    connection.execute(schema_sql)
+    Rails.logger.info("[DatabaseMirrorService] Schema initialized in mirror database")
+  end
+
+  private
+
+    def connection
+      MirrorRecord.connection
+    end
+
+    def ensure_connection!
+      MirrorRecord.establish_mirror_connection
+
+      unless MirrorRecord.mirror_connected?
+        raise MirrorConnectionError, "Failed to establish connection to mirror database"
+      end
+    end
+
+    def ensure_schema_initialized!
+      return if @schema_initialized
+
+      if database_empty?
+        initialize_schema_if_empty!
+      end
+
+      @schema_initialized = true
+    end
+
+    def primary_key_column(model_class)
+      model_class.constantize.primary_key || "id"
+    end
+
+    # Quote a value for SQL, handling special cases:
+    # - JSON-serialized arrays ("[]") -> PostgreSQL array format ('{}')
+    # - JSON-serialized hashes -> JSONB cast
+    # - Regular values -> standard quoting
+    def quote_value(value)
+      case value
+      when nil
+        "NULL"
+      when true
+        "TRUE"
+      when false
+        "FALSE"
+      when String
+        # Check if it's a JSON array serialized as string
+        if value.start_with?("[") && value.end_with?("]")
+          # Convert JSON array to PostgreSQL array format
+          begin
+            parsed = JSON.parse(value)
+            if parsed.is_a?(Array)
+              pg_array = parsed.map { |v| connection.quote(v) }.join(", ")
+              "ARRAY[#{pg_array}]::text[]"
+            else
+              connection.quote(value)
+            end
+          rescue JSON::ParserError
+            connection.quote(value)
+          end
+        elsif value.start_with?("{") && value.end_with?("}")
+          # JSON object - use JSONB cast
+          "#{connection.quote(value)}::jsonb"
+        else
+          connection.quote(value)
+        end
+      when Integer, Float
+        value.to_s
+      else
+        connection.quote(value)
+      end
+    end
+
+    def initialize_schema_from_schema_rb!
+      # Read the current schema and apply it to the mirror database
+      schema_content = File.read(Rails.root.join("db", "schema.rb"))
+
+      # Extract and execute table creation statements
+      # This is a simplified approach - for complex schemas, consider using
+      # ActiveRecord::Schema.define with the mirror connection
+      ActiveRecord::Base.connection_pool.with_connection do
+        tables = ActiveRecord::Base.connection.tables
+
+        tables.each do |table_name|
+          next if table_name == "schema_migrations" || table_name == "ar_internal_metadata"
+
+          columns_sql = generate_create_table_sql(table_name)
+          connection.execute(columns_sql) if columns_sql.present?
+        end
+      end
+
+      Rails.logger.info("[DatabaseMirrorService] Schema initialized from schema.rb")
+    end
+
+    def generate_create_table_sql(table_name)
+      primary_connection = ActiveRecord::Base.connection
+
+      columns = primary_connection.columns(table_name)
+      primary_key = primary_connection.primary_key(table_name)
+
+      column_definitions = columns.map do |col|
+        sql_type = col.sql_type
+        null_constraint = col.null ? "" : " NOT NULL"
+        default = col.default.nil? ? "" : " DEFAULT #{connection.quote(col.default)}"
+
+        "#{connection.quote_column_name(col.name)} #{sql_type}#{null_constraint}#{default}"
+      end
+
+      pk_constraint = primary_key ? ", PRIMARY KEY (#{connection.quote_column_name(primary_key)})" : ""
+
+      <<~SQL
+        CREATE TABLE IF NOT EXISTS #{connection.quote_table_name(table_name)} (
+          #{column_definitions.join(",\n  ")}#{pk_constraint}
+        )
+      SQL
+    rescue => e
+      Rails.logger.error("[DatabaseMirrorService] Failed to generate CREATE TABLE for #{table_name}: #{e.message}")
+      nil
+    end
+end

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -41,8 +41,16 @@ x-rails-env: &rails_env
   DB_HOST: db
   DB_PORT: 5432
   REDIS_URL: redis://redis:6379/1
-# NOTE: enabling OpenAI will incur costs when you use AI-related features in the app (chat, rules).  Make sure you have set appropriate spend limits on your account before adding this.
+  # NOTE: enabling OpenAI will incur costs when you use AI-related features in the app (chat, rules).  Make sure you have set appropriate spend limits on your account before adding this.
   OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN}
+  # Database Mirror Configuration (Optional) - replicate writes to external PostgreSQL like Supabase
+  DATABASE_MIRROR_ENABLED: ${DATABASE_MIRROR_ENABLED:-false}
+  MIRROR_DB_HOST: ${MIRROR_DB_HOST:-}
+  MIRROR_DB_PORT: ${MIRROR_DB_PORT:-5432}
+  MIRROR_DB_NAME: ${MIRROR_DB_NAME:-}
+  MIRROR_DB_USER: ${MIRROR_DB_USER:-}
+  MIRROR_DB_PASSWORD: ${MIRROR_DB_PASSWORD:-}
+  MIRROR_DB_SSLMODE: ${MIRROR_DB_SSLMODE:-require}
 
 services:
   web:
@@ -110,6 +118,7 @@ volumes:
   app-storage:
   postgres-data:
   redis-data:
+
 
 networks:
   sure_net:

--- a/config/initializers/database_mirror.rb
+++ b/config/initializers/database_mirror.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Database Mirror Initializer
+#
+# Configures and validates the database mirror feature.
+# The mirror database schema is only initialized on first boot if it's empty.
+#
+if ENV["DATABASE_MIRROR_ENABLED"] == "true"
+  Rails.application.config.after_initialize do
+    # Validate required configuration
+    required_vars = %w[MIRROR_DB_HOST MIRROR_DB_NAME MIRROR_DB_USER MIRROR_DB_PASSWORD]
+    missing_vars = required_vars.select { |var| ENV[var].blank? }
+
+    if missing_vars.any?
+      Rails.logger.error(
+        "[DatabaseMirror] Missing required environment variables: #{missing_vars.join(', ')}. " \
+        "Database mirroring is DISABLED."
+      )
+      # Disable mirroring if configuration is incomplete
+      ENV["DATABASE_MIRROR_ENABLED"] = "false"
+    else
+      Rails.logger.info("[DatabaseMirror] Database mirroring is enabled")
+      Rails.logger.info("[DatabaseMirror] Mirror DB: #{ENV['MIRROR_DB_HOST']}:#{ENV.fetch('MIRROR_DB_PORT', '5432')}/#{ENV['MIRROR_DB_NAME']}")
+
+      # Initialize schema in background to avoid blocking app startup
+      # Only runs if mirror database is empty
+      Thread.new do
+        sleep 5 # Wait for app to fully initialize
+
+        begin
+          service = DatabaseMirrorService.new
+          if service.database_empty?
+            Rails.logger.info("[DatabaseMirror] Initializing schema in mirror database...")
+            service.initialize_schema_if_empty!
+            Rails.logger.info("[DatabaseMirror] Schema initialization complete")
+          else
+            Rails.logger.info("[DatabaseMirror] Mirror database already contains data, skipping schema initialization")
+          end
+        rescue => e
+          Rails.logger.error("[DatabaseMirror] Failed to initialize mirror database: #{e.class} - #{e.message}")
+          Rails.logger.error(e.backtrace.first(10).join("\n"))
+        end
+      end
+    end
+  end
+end

--- a/docs/hosting/database_mirror.md
+++ b/docs/hosting/database_mirror.md
@@ -1,0 +1,133 @@
+# Database Mirror
+
+Sure supports mirroring all database writes to an external hosted PostgreSQL database (such as Supabase). This feature is useful for:
+
+- **Data durability** - Keep a backup copy of all data in a cloud-hosted database
+- **Disaster recovery** - Quickly restore from the mirror if your local database is lost
+- **Multi-region availability** - Host your mirror in a different region for redundancy
+
+## How It Works
+
+The database mirror feature uses ActiveRecord callbacks to automatically enqueue background jobs whenever a record is created, updated, or deleted. These jobs run in Sidekiq and replicate the changes to your external PostgreSQL database.
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  Model Save │ ──▶ │ after_commit│ ──▶ │ Sidekiq Job │ ──▶ │ External DB │
+└─────────────┘     └─────────────┘     └─────────────┘     └─────────────┘
+```
+
+**Key features:**
+
+- **Non-blocking**: Mirror operations run as background jobs and don't slow down your application
+- **Retry logic**: Jobs retry with exponential backoff if the connection fails (up to 10 attempts)
+- **Schema detection**: The mirror database schema is automatically initialized if the database is empty
+- **Append-only mode**: If the mirror database already contains data, it only appends/updates records
+
+## Configuration
+
+### Environment Variables
+
+Add these to your `.env` file:
+
+```bash
+# Enable database mirroring
+DATABASE_MIRROR_ENABLED=true
+
+# External PostgreSQL connection details
+MIRROR_DB_HOST=db.xxxxx.supabase.co
+MIRROR_DB_PORT=5432
+MIRROR_DB_NAME=postgres
+MIRROR_DB_USER=postgres
+MIRROR_DB_PASSWORD=your_password
+
+# Optional configuration
+MIRROR_DB_POOL=3          # Connection pool size (default: 3)
+MIRROR_DB_SSLMODE=require # SSL mode: disable, prefer, require, verify-ca, verify-full
+```
+
+### Docker Compose
+
+If using Docker Compose, add the environment variables to your `x-rails-env` section:
+
+```yaml
+x-rails-env: &rails_env
+  # ... other variables ...
+  DATABASE_MIRROR_ENABLED: ${DATABASE_MIRROR_ENABLED:-false}
+  MIRROR_DB_HOST: ${MIRROR_DB_HOST:-}
+  MIRROR_DB_PORT: ${MIRROR_DB_PORT:-5432}
+  MIRROR_DB_NAME: ${MIRROR_DB_NAME:-}
+  MIRROR_DB_USER: ${MIRROR_DB_USER:-}
+  MIRROR_DB_PASSWORD: ${MIRROR_DB_PASSWORD:-}
+  MIRROR_DB_SSLMODE: ${MIRROR_DB_SSLMODE:-require}
+```
+
+## Setting Up Supabase
+
+1. Create a free account at [supabase.com](https://supabase.com)
+2. Create a new project
+3. Go to **Project Settings** → **Database** → **Connection string**
+4. Copy the connection details:
+   - Host: `db.xxxxx.supabase.co` (or use the pooler URL for better performance)
+   - Port: `5432` (or `6543` for pooled connections)
+   - Database: `postgres`
+   - User: `postgres`
+   - Password: Your database password
+
+5. Add these to your `.env` file as shown above
+6. Restart your application
+
+The schema will be automatically created in your Supabase database on first connection if it's empty.
+
+## Excluding Models
+
+To exclude specific models from being mirrored (e.g., for security-sensitive data), add `exclude_from_mirror` to the model:
+
+```ruby
+class ApiKey < ApplicationRecord
+  exclude_from_mirror
+  # ...
+end
+```
+
+## Monitoring
+
+Mirror job activity appears in your Sidekiq dashboard. Look for `DatabaseMirrorJob` in the job queue:
+
+- **high_priority** queue: Mirror jobs run on the high priority queue
+- **Retries**: Failed jobs will retry with exponential backoff
+
+Check your Rails logs for mirror status:
+
+```
+[DatabaseMirror] Database mirroring is enabled
+[DatabaseMirror] Mirror DB: db.xxxxx.supabase.co:5432/postgres
+[MirrorRecord] Successfully connected to mirror database
+[DatabaseMirrorService] Created User#abc123 in mirror
+```
+
+## Troubleshooting
+
+### Connection failures
+
+- Verify your connection credentials
+- Check that your IP is allowed in Supabase's database settings
+- Try setting `MIRROR_DB_SSLMODE=require` for Supabase
+
+### Foreign key violations
+
+These are normal when jobs execute out of order. The retry logic will handle them - parent records will be created first on subsequent retries.
+
+### Schema not created
+
+If the mirror database already has tables, the schema won't be re-created. To reset:
+1. Drop all tables in your Supabase database
+2. Restart your application
+
+## Architecture
+
+The mirroring feature consists of:
+
+- **`Mirrorable` concern** (`app/models/concerns/mirrorable.rb`): Hooks into ActiveRecord callbacks
+- **`DatabaseMirrorJob`** (`app/jobs/database_mirror_job.rb`): Background job with retry logic
+- **`DatabaseMirrorService`** (`app/services/database_mirror_service.rb`): Handles external DB connection and SQL operations
+- **Initializer** (`config/initializers/database_mirror.rb`): Validates configuration on startup


### PR DESCRIPTION
# Add Database Mirroring to External PostgreSQL

## Why This Change

**Data durability is critical for self-hosted users.** When running Sure on a local machine or a single VPS, there's no built-in redundancy-if the database is lost, so is all your financial data.

This PR introduces database mirroring, allowing all database writes to be automatically replicated to an external hosted PostgreSQL database (like Supabase). This provides:

- **Disaster recovery** - Quickly restore from the mirror if your local database fails
- **Data backup** - Continuous replication without manual backup scripts
- **Peace of mind** - Know your financial data is safely stored in the cloud

## How It Works

```
┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
│  Model Save │ ──▶ │ after_commit│ ──▶ │ Sidekiq Job │ ──▶ │ External DB │
└─────────────┘     └─────────────┘     └─────────────┘     └─────────────┘
```

- Uses ActiveRecord `after_commit` callbacks to enqueue mirror jobs
- Jobs run on **high priority queue** for timely replication
- **Non-blocking** - mirror operations don't slow down your app
- **Retry logic** - exponential backoff (up to 10 attempts) for connection failures
- **Smart schema handling** - only initializes schema if external DB is empty

## Configuration

```bash
DATABASE_MIRROR_ENABLED=true
MIRROR_DB_HOST=db.xxxxx.supabase.co
MIRROR_DB_PORT=5432
MIRROR_DB_NAME=postgres
MIRROR_DB_USER=postgres
MIRROR_DB_PASSWORD=your_password
MIRROR_DB_SSLMODE=require
```

## Changes

### New Files
- `app/models/concerns/mirrorable.rb` - ActiveRecord concern with callbacks
- `app/jobs/database_mirror_job.rb` - Sidekiq job with retry logic
- `app/services/database_mirror_service.rb` - External DB connection & SQL operations
- `config/initializers/database_mirror.rb` - Config validation & schema initialization
- `docs/hosting/database_mirror.md` - User documentation

### Modified Files
- `app/models/application_record.rb` - Include `Mirrorable` concern
- `.env.example` - Document mirror environment variables
- `compose.example.yml` - Add mirror env vars to Docker Compose
- `.devcontainer/docker-compose.yml` - Add `mirror_db` service for local testing

## Testing

Tested successfully with Supabase:
-  Connection established
- Create/Update/Delete operations mirrored

## Excluding Models

Models can opt-out of mirroring:

```ruby
class ApiKey < ApplicationRecord
  exclude_from_mirror
end
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added database mirroring functionality to synchronize all database writes to an external PostgreSQL database with automatic retry policies and non-blocking background processing.

* **Documentation**
  * Added comprehensive guide for configuring and troubleshooting the database mirroring feature, including provider-specific setup instructions.

* **Chores**
  * Updated configuration files with new database mirror environment variables and settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->