### PR TITLE
QOL: Pre-fill rule suggestion with transaction name and category

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -29,6 +29,22 @@ class RulesController < ApplicationController
     @rule = Current.family.rules.build(
       resource_type: params[:resource_type] || "transaction",
     )
+
+    if params[:name].present?
+      @rule.name = params[:name]
+      @rule.conditions.build(
+        condition_type: "transaction_name",
+        operator: "like",
+        value: params[:name]
+      )
+    end
+
+    if params[:action_type].present? && params[:action_value].present?
+      @rule.actions.build(
+        action_type: params[:action_type],
+        value: params[:action_value]
+      )
+    end
   end
 
   def create

--- a/app/controllers/transaction_categories_controller.rb
+++ b/app/controllers/transaction_categories_controller.rb
@@ -11,7 +11,8 @@ class TransactionCategoriesController < ApplicationController
       flash[:cta] = {
         type: "category_rule",
         category_id: transaction.category_id,
-        category_name: transaction.category.name
+        category_name: transaction.category.name,
+        merchant_name: @entry.name
       }
     end
 

--- a/app/views/rules/_category_rule_cta.html.erb
+++ b/app/views/rules/_category_rule_cta.html.erb
@@ -14,7 +14,7 @@
 
     <%= tag.div class:"flex gap-2 justify-end" do %>
       <%= render DS::Button.new(text: "Dismiss", variant: "secondary") %>
-      <% rule_href = new_rule_path(resource_type: "transaction", action_type: "set_transaction_category", action_value: cta[:category_id]) %>
+      <% rule_href = new_rule_path(resource_type: "transaction", action_type: "set_transaction_category", action_value: cta[:category_id], name: cta[:merchant_name]) %>
       <%= render DS::Link.new(text: "Create rule", variant: "primary", href: rule_href, frame: :modal) %>
     <% end %>
   <% end %>

--- a/test/controllers/rules_controller_test.rb
+++ b/test/controllers/rules_controller_test.rb
@@ -10,6 +10,23 @@ class RulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should get new with pre-filled name and action" do
+    category = categories(:food_and_drink)
+    get new_rule_url(
+      resource_type: "transaction",
+      name: "Starbucks",
+      action_type: "set_transaction_category",
+      action_value: category.id
+    )
+    assert_response :success
+
+    assert_select "input[name='rule[name]'][value='Starbucks']"
+    assert_select "input[name*='[value]'][value='Starbucks']"
+    assert_select "select[name*='[condition_type]'] option[selected][value='transaction_name']"
+    assert_select "select[name*='[action_type]'] option[selected][value='set_transaction_category']"
+    assert_select "select[name*='[value]'] option[selected][value='#{category.id}']"
+  end
+
   test "should get edit" do
     get edit_rule_url(rules(:one))
     assert_response :success


### PR DESCRIPTION
  This PR improves the user experience when creating rules from transaction suggestions.
  Previously, clicking "Create rule" after categorizing a transaction would open a blank rule
  form. Now, the form is automatically pre-filled with:
   - Rule Name: The name of the transaction.
   - Conditions: A "Transaction Name" condition pre-populated with the transaction name
     (using the "contains/like" operator).
   - Actions: A "Set Transaction Category" action pre-selected with the category the user
     just assigned.

  Changes
   - `TransactionCategoriesController`: Now includes the transaction's name in the flash
     notification data.
   - `RulesController`: Updated the new action to handle name, action_type, and action_value
     parameters to bootstrap a new rule with default conditions and actions.
   - `_category_rule_cta.html.erb`: Updated the "Create rule" link to pass the transaction
     name to the rules form.
   - Tests: Added an integration test in RulesControllerTest to ensure the pre-filling logic
     works as expected.


 When Categorize a transaction that doesn't already have a rule, the rule modal should open with the name, condition, and category action already filled out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rule creation now supports pre-filled names and conditions for improved efficiency.
  * Merchant information is now passed through when creating rules from transaction category workflows.

* **Tests**
  * Added test coverage for pre-filled rule creation functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->