### PR TITLE
Revert "Fix GPU artifacts bug"

### DIFF
--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -13,7 +13,7 @@
     <%= yield :head %>
   </head>
 
-  <body class="h-full overflow-hidden antialiased transform-gpu">
+  <body class="h-full overflow-hidden antialiased">
     <% if Rails.env.development? %>
       <button hidden data-controller="hotkey" data-hotkey="t t /" data-action="theme#toggle"></button>
     <% end %>


### PR DESCRIPTION
Reverts we-promise/sure#498 due to the fact that starting with commit `7c524f2d74de17bfe428969d56ae85f1905201e3` the UI jumps when you click on the avatar/initials icon:
<img width="1030" height="1169" alt="image" src="https://github.com/user-attachments/assets/cd7e0570-8634-4bbe-9a26-b0e944902a8f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted CSS styling on the main page layout for improved rendering performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->