### PR TITLE
Scope Plaid Link script to Plaid flows

### DIFF
--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -6,9 +6,9 @@
 
   <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
 
-  <%= javascript_include_tag "https://cdn.plaid.com/link/v2/stable/link-initialize.js" %>
   <%= combobox_style_tag %>
 
+  <%= yield :plaid_link %>
   <%= javascript_importmap_tags %>
   <%= render "layouts/dark_mode_check" %>
   <%= turbo_refreshes_with method: :morph, scroll: :preserve %>

--- a/app/views/plaid_items/_auto_link_opener.html.erb
+++ b/app/views/plaid_items/_auto_link_opener.html.erb
@@ -1,5 +1,9 @@
 <%# locals: (link_token:, region:, item_id:, is_update: false) %>
 
+<% content_for :plaid_link, flush: true do %>
+  <%= javascript_include_tag "https://cdn.plaid.com/link/v2/stable/link-initialize.js" %>
+<% end %>
+
 <%= tag.div data: {
               controller: "plaid",
               plaid_link_token_value: link_token,


### PR DESCRIPTION
## Summary
- remove the global Plaid Link script include from the shared head
- load the Plaid Link JavaScript only when Plaid linking flows render

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951ccda69b883329a068da921e28992)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Plaid script loading: The integration now loads on-demand when needed, rather than being automatically loaded on every page, resulting in improved initial page performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->