### PR TITLE
Transfer Matching: Larger match date window for manual matching

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -1,5 +1,5 @@
 module Family::AutoTransferMatchable
-  def transfer_match_candidates
+  def transfer_match_candidates(date_window: 4)
     Entry.select([
       "inflow_candidates.entryable_id as inflow_transaction_id",
       "outflow_candidates.entryable_id as outflow_transaction_id",
@@ -10,7 +10,7 @@ module Family::AutoTransferMatchable
           inflow_candidates.amount < 0 AND
           outflow_candidates.amount > 0 AND
           inflow_candidates.account_id <> outflow_candidates.account_id AND
-          inflow_candidates.date BETWEEN outflow_candidates.date - 4 AND outflow_candidates.date + 4
+          inflow_candidates.date BETWEEN outflow_candidates.date - #{date_window.to_i} AND outflow_candidates.date + #{date_window.to_i}
         )
       ").joins("
         LEFT JOIN transfers existing_transfers ON (

--- a/app/models/transaction/transferable.rb
+++ b/app/models/transaction/transferable.rb
@@ -14,11 +14,11 @@ module Transaction::Transferable
     transfer_as_inflow || transfer_as_outflow
   end
 
-  def transfer_match_candidates
+  def transfer_match_candidates(date_window: 30)
     candidates_scope = if self.entry.amount.negative?
-      family_matches_scope.where("inflow_candidates.entryable_id = ?", self.id)
+      family_matches_scope(date_window: date_window).where("inflow_candidates.entryable_id = ?", self.id)
     else
-      family_matches_scope.where("outflow_candidates.entryable_id = ?", self.id)
+      family_matches_scope(date_window: date_window).where("outflow_candidates.entryable_id = ?", self.id)
     end
 
     candidates_scope.map do |match|
@@ -30,7 +30,7 @@ module Transaction::Transferable
   end
 
   private
-    def family_matches_scope
-      self.entry.account.family.transfer_match_candidates
+    def family_matches_scope(date_window:)
+      self.entry.account.family.transfer_match_candidates(date_window: date_window)
     end
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -133,6 +133,7 @@ class Transfer < ApplicationRecord
       return unless inflow_transaction&.entry && outflow_transaction&.entry
 
       date_diff = (inflow_transaction.entry.date - outflow_transaction.entry.date).abs
-      errors.add(:base, "Must be within 4 days") if date_diff > 4
+      max_days = status == "confirmed" ? 30 : 4
+      errors.add(:base, "Must be within #{max_days} days") if date_diff > max_days
     end
 end


### PR DESCRIPTION
Grow transfer matching window to 30 days for the manual matcher window.

Currently the matching requires that all matching transactions be within 4 days of each other. This makes sense for auto matching, but doesn't make sense for when the user manually attempts to match transactions. 

In the manual matcher window, show all transactions that match within a 30 day period, and allow the user to select the one that matches.

This does not change the auto-match window, only manual matching.

Example (in both of these examples, these transactions were imported automatically through simplefin to show that the auto-matching is unaffected):

| | Transaction List | Manual Matcher |
|-|-|-|
| Before | <img width="917" height="268" alt="Before - Tx list" src="https://github.com/user-attachments/assets/f107f4ae-7caa-4434-8020-78a115a188ae" /> | <img width="593" height="521" alt="Before - Matcher" src="https://github.com/user-attachments/assets/a981639b-65da-478a-a1e7-2c97be2e4bd8" /> |
| After | <img width="918" height="265" alt="After - Tx list" src="https://github.com/user-attachments/assets/333def17-d900-4d6d-be91-9dea7c4f1229" /> | <img width="576" height="548" alt="After - Matcher" src="https://github.com/user-attachments/assets/b435d20a-cb41-401a-bbdb-d30e6d4f20a0" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transfer matching now uses dynamic date windows based on transfer status: confirmed transfers match within 30 days, while pending transfers match within 4 days.
  * System now supports customizable date windows for enhanced control over transfer matching behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->