### PR TITLE
Fix Helm chart Redis URL port formatting for redisSimple mode

### DIFF
--- a/charts/sure/templates/_helpers.tpl
+++ b/charts/sure/templates/_helpers.tpl
@@ -69,7 +69,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- printf "redis://default:$(REDIS_PASSWORD)@%s:6379/0" $host -}}
   {{- else if .Values.redisSimple.enabled -}}
     {{- $host := printf "%s-redis.%s.svc.cluster.local" (include "sure.fullname" .) .Release.Namespace -}}
-    {{- printf "redis://default:$(REDIS_PASSWORD)@%s:%d/0" $host (.Values.redisSimple.service.port | default 6379) -}}
+    {{- printf "redis://default:$(REDIS_PASSWORD)@%s:%d/0" $host (int (.Values.redisSimple.service.port | default 6379)) -}}
   {{- else -}}
     {{- "" -}}
   {{- end -}}


### PR DESCRIPTION
Fixes a bug in the Helm chart where the Redis URL was malformed when using `redisSimple.enabled: true`.

**Problem:**
When `redisSimple.enabled` is set to `true`, the Redis URL template uses the `%d` format specifier for the port number. However, Helm/Go templates treat numeric values as `float64` by default, causing the URL to render incorrectly as:

**Solution:**
Added `int` conversion to the port value before passing it to the `printf` format specifier:
```go
{{- printf "redis://default:$(REDIS_PASSWORD)@%s:%d/0" $host (int (.Values.redisSimple.service.port | default 6379)) -}}



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Redis port configuration handling to ensure proper URL construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->