### PR TITLE
DS::Menu: Fix page jump when opened

### DIFF
--- a/app/components/DS/menu_controller.js
+++ b/app/components/DS/menu_controller.js
@@ -80,7 +80,7 @@ export default class extends Controller {
     const firstFocusableElement =
       this.contentTarget.querySelectorAll(focusableElements)[0];
     if (firstFocusableElement) {
-      firstFocusableElement.focus();
+      firstFocusableElement.focus({ preventScroll: true });
     }
   }
 


### PR DESCRIPTION
Under certain conditions, opening the DS::Menu on the bottom left of the home page can cause the page to jump, showing the white background of the main `<body>` element.

Example issue:
<img width="1067" height="905" alt="image" src="https://github.com/user-attachments/assets/4387c6c9-1ae3-4870-87b3-eb5cf8c9c2b4" />

By preventing scrolling when the DS::Menu is opened, we prevent the browser from auto scrolling past the content of the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended page scrolling when menu receives focus.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->