### PR TITLE
Fix: make rolling update strategy configurable to prevent deadlock with topology constraints

### DIFF
--- a/charts/sure/templates/web-deployment.yaml
+++ b/charts/sure/templates/web-deployment.yaml
@@ -10,8 +10,13 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 25%
+      {{- if and .Values.web.strategy .Values.web.strategy.rollingUpdate }}
+      maxUnavailable: {{ .Values.web.strategy.rollingUpdate.maxUnavailable | default 1 }}
+      maxSurge: {{ .Values.web.strategy.rollingUpdate.maxSurge | default 0 }}
+      {{- else }}
+      maxUnavailable: 1
+      maxSurge: 0
+      {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: web

--- a/charts/sure/templates/worker-deployment.yaml
+++ b/charts/sure/templates/worker-deployment.yaml
@@ -6,7 +6,17 @@ metadata:
     {{- include "sure.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.worker.replicas }}
-  revisionHistoryLimit: 2
+  revisionHistoryLimit: {{ .Values.worker.revisionHistoryLimit | default 2 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      {{- if and .Values.worker.strategy .Values.worker.strategy.rollingUpdate }}
+      maxUnavailable: {{ .Values.worker.strategy.rollingUpdate.maxUnavailable | default 1 }}
+      maxSurge: {{ .Values.worker.strategy.rollingUpdate.maxSurge | default 0 }}
+      {{- else }}
+      maxUnavailable: 1
+      maxSurge: 0
+      {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: worker


### PR DESCRIPTION
## Problem

The hardcoded rolling update strategy (`maxUnavailable: 0, maxSurge: 25%`) causes
deployment deadlocks when `topologySpreadConstraints` with `DoNotSchedule` is configured.

With 3 replicas spread across 3 nodes:
  - `maxSurge: 25%` tries to create a 4th pod during rollout
  - `topologySpreadConstraints` blocks scheduling (would violate maxSkew)
  - `maxUnavailable: 0` prevents terminating existing pods
  - Result: rollout hangs indefinitely

## Solution

Change defaults to `maxUnavailable: 1, maxSurge: 0` and make configurable via values.

This tells Kubernetes to terminate one pod before starting its replacement, which
works correctly with topology constraints.

## Changes

  - `templates/web-deployment.yaml`: Make strategy configurable, default to maxUnavailable=1
  - `templates/worker-deployment.yaml`: Same change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Made deployment update strategies and revision history limits configurable through Helm values with sensible defaults, enabling customization without template modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->