### PR TITLE
Add DD/MM/YY format specifier

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -11,7 +11,7 @@ class Family < ApplicationRecord
     [ "MM/DD/YYYY", "%m/%d/%Y" ],
     [ "D/MM/YYYY", "%e/%m/%Y" ],
     [ "YYYY.MM.DD", "%Y.%m.%d" ],
-    [ "YYYYMMDD", "%Y%m%d" ]
+    [ "YYYYMMDD", "%Y%m%d" ],
     [ "DD/MM/YY", "%d/%m/%y" ]
   ].freeze
 


### PR DESCRIPTION
Added 'DD/MM/YY' to supported date formats in Family model. Looking at the list, I wonder if in the future it may be better to have the option to separately specify the separators? Otherwise it may have one for each "/", "-", ".", etc. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new date format option: DD/MM/YY.
  * This option is now available wherever date formats are selectable, giving another display choice without changing existing behavior.

* **Chores**
  * Minor formatting adjustment to internal date-format list (no functional changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->