### PR TITLE
Update button styles in family export form

### DIFF
--- a/app/views/family_exports/new.html.erb
+++ b/app/views/family_exports/new.html.erb
@@ -34,7 +34,7 @@
       <%= form_with url: family_exports_path, method: :post, class: "space-y-4" do |form| %>
         <div class="flex gap-3">
           <%= link_to "Cancel", "#", class: "flex-1 text-center px-4 py-2 text-primary bg-surface border border-primary rounded-lg hover:bg-surface-hover", data: { action: "click->modal#close" } %>
-          <%= form.submit "Export data", class: "flex-1 text-inverse bg-inverse fg-inverse rounded-lg px-4 py-2 cursor-pointer hover:bg-inverse-hover" %>
+          <%= form.submit "Export data", class: "flex-1 bg-inverse fg-inverse rounded-lg px-4 py-2 cursor-pointer hover:bg-inverse-hover" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Enhanced the appearance of the 'Cancel' and 'Export data' buttons by adding text and background color classes, as well as hover effects, for improved UI consistency.
this fixes the issue in https://github.com/we-promise/sure/issues/548
<img width="569" height="499" alt="Scherm­afbeelding 2026-01-05 om 02 05 37" src="https://github.com/user-attachments/assets/398af6ac-05e5-43f3-9ef0-27d4d31e0d9f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling of export modal controls: refreshed Cancel link and Export Data button colors, added clearer background/border presentation and improved hover states while preserving existing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->