### PR TITLE
Chained Authentication Vulnerability Fix

### DIFF
--- a/app/controllers/oidc_accounts_controller.rb
+++ b/app/controllers/oidc_accounts_controller.rb
@@ -91,14 +91,15 @@ class OidcAccountsController < ApplicationController
       return
     end
 
-    # Create user with a secure random password since they're using SSO
-    secure_password = SecureRandom.base58(32)
+    # Create SSO-only user without local password.
+    # Security: JIT users should NOT have password_digest set to prevent
+    # chained authentication attacks where SSO users gain local login access
+    # via password reset.
     @user = User.new(
       email: email,
       first_name: @pending_auth["first_name"],
       last_name: @pending_auth["last_name"],
-      password: secure_password,
-      password_confirmation: secure_password
+      skip_password_validation: true
     )
 
     # Create new family for this user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
-  has_secure_password
+  # Allow nil password for SSO-only users (JIT provisioning).
+  # Custom validation ensures password is present for non-SSO registration.
+  has_secure_password validations: false
 
   belongs_to :family
   belongs_to :last_viewed_chat, class_name: "Chat", optional: true
@@ -17,6 +19,11 @@ class User < ApplicationRecord
   validate :ensure_valid_profile_image
   validates :default_period, inclusion: { in: Period::PERIODS.keys }
   validates :default_account_order, inclusion: { in: AccountOrder::ORDERS.keys }
+
+  # Password is required on create unless the user is being created via SSO JIT.
+  # SSO JIT users have password_digest = nil and authenticate via OIDC only.
+  validates :password, presence: true, on: :create, unless: :skip_password_validation?
+  validates :password, length: { minimum: 8 }, allow_nil: true
   normalizes :email, with: ->(email) { email.strip.downcase }
   normalizes :unconfirmed_email, with: ->(email) { email&.strip&.downcase }
 
@@ -103,6 +110,20 @@ class User < ApplicationRecord
   def ai_enabled?
     ai_enabled && ai_available?
   end
+
+  # SSO-only users have OIDC identities but no local password.
+  # They cannot use password reset or local login.
+  def sso_only?
+    password_digest.nil? && oidc_identities.exists?
+  end
+
+  # Check if user has a local password set (can authenticate locally)
+  def has_local_password?
+    password_digest.present?
+  end
+
+  # Attribute to skip password validation during SSO JIT provisioning
+  attr_accessor :skip_password_validation
 
   # Deactivation
   validate :can_deactivate, if: -> { active_changed? && !active }
@@ -258,6 +279,10 @@ class User < ApplicationRecord
   end
 
   private
+    def skip_password_validation?
+      skip_password_validation == true
+    end
+
     def default_dashboard_section_order
       %w[cashflow_sankey outflows_donut net_worth_chart balance_sheet]
     end

--- a/config/locales/views/password_resets/en.yml
+++ b/config/locales/views/password_resets/en.yml
@@ -2,6 +2,7 @@
 en:
   password_resets:
     disabled: Password reset via Sure is disabled. Please reset your password through your identity provider.
+    sso_only_user: Your account uses SSO for authentication. Please contact your administrator to manage your credentials.
     edit:
       title: Reset password
     new:

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -48,4 +48,43 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
     assert_equal "Password reset via Sure is disabled. Please reset your password through your identity provider.", flash[:alert]
   end
+
+  # Security: SSO-only users should not receive password reset emails
+  test "create does not send email for SSO-only user" do
+    sso_user = users(:sso_only)
+    assert sso_user.sso_only?, "Test user should be SSO-only"
+
+    assert_no_enqueued_emails do
+      post password_reset_path, params: { email: sso_user.email }
+    end
+
+    # Should still redirect to pending to prevent email enumeration
+    assert_redirected_to new_password_reset_url(step: "pending")
+  end
+
+  test "create sends email for user with local password" do
+    assert @user.has_local_password?, "Test user should have local password"
+
+    assert_enqueued_emails 1 do
+      post password_reset_path, params: { email: @user.email }
+    end
+
+    assert_redirected_to new_password_reset_url(step: "pending")
+  end
+
+  # Security: SSO-only users cannot set password via reset
+  test "update blocks password setting for SSO-only user" do
+    sso_user = users(:sso_only)
+    token = sso_user.generate_token_for(:password_reset)
+
+    patch password_reset_path(token: token),
+      params: { user: { password: "NewSecure1!", password_confirmation: "NewSecure1!" } }
+
+    assert_redirected_to new_session_path
+    assert_equal "Your account uses SSO for authentication. Please contact your administrator to manage your credentials.", flash[:alert]
+
+    # Verify password was not set
+    sso_user.reload
+    assert_nil sso_user.password_digest, "SSO-only user should still have nil password_digest"
+  end
 end

--- a/test/fixtures/oidc_identities.yml
+++ b/test/fixtures/oidc_identities.yml
@@ -19,3 +19,14 @@ jakob_google:
     first_name: Jakob
     last_name: Dylan
   last_authenticated_at: <%= 2.days.ago %>
+
+sso_only_identity:
+  user: sso_only
+  provider: openid_connect
+  uid: sso-only-uid-12345
+  info:
+    email: sso-user@example.com
+    name: SSO User
+    first_name: SSO
+    last_name: User
+  last_authenticated_at: <%= 1.day.ago %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -43,6 +43,17 @@ new_email:
   last_name: User
   email: user@example.com
   unconfirmed_email: new@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
   onboarded_at: <%= Time.current %>
+  ai_enabled: true
+
+# SSO-only user: created via JIT provisioning, no local password
+sso_only:
+  family: empty
+  first_name: SSO
+  last_name: User
+  email: sso-user@example.com
+  password_digest: ~
+  role: admin
+  onboarded_at: <%= 1.day.ago %>
   ai_enabled: true


### PR DESCRIPTION
Vulnerability: 

JIT-SSO users were created with a random password_digest, enabling a chained authentication attack:
  1. User authenticates via SSO → JIT creates account with random password hash
  2. User requests password reset (when local_login_enabled? is true)
  3. User sets known password via reset flow
  4. User can now bypass SSO and login directly with password
  
Changes Made:
  
1. app/models/user.rb:
  - Changed has_secure_password to has_secure_password validations: false
  - Added custom validation to require password on create unless skip_password_validation is set
  - Added sso_only? method - returns true if user has OIDC identity but no password
  - Added has_local_password? method
  - Added skip_password_validation attribute for JIT provisioning
  
2. app/controllers/oidc_accounts_controller.rb:
  - Removed random password generation for JIT users
  - JIT users are now created with password_digest = NULL
  - Uses skip_password_validation: true to bypass password requirement
  
3. app/controllers/password_resets_controller.rb:
  - create action now blocks password reset emails for SSO-only users
  - update action blocks password setting for SSO-only users (defense-in-depth)
  
4. config/locales/views/password_resets/en.yml:
  - Added sso_only_user translation message
  
5. Test fixtures:
  - Added sso_only user fixture with password_digest: ~
  - Added sso_only_identity OIDC identity fixture
  
6. Tests added:
  - test/models/user_test.rb: SSO-only user security tests
  - test/controllers/oidc_accounts_controller_test.rb: JIT user creation tests
  - test/controllers/password_resets_controller_test.rb: Password reset blocking tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Just-In-Time provisioning for SSO users now skips password requirements during account creation.
  * Password reset protection for SSO-only users: reset attempts are blocked with a message directing users to their administrator.

* **Tests**
  * Added comprehensive test coverage for SSO user provisioning, local authentication blocking, and password reset restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->