### PR TITLE
Upgrade lucide-rails from 0.2.0 to 0.7.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "bootsnap", require: false
 gem "importmap-rails"
 gem "propshaft"
 gem "tailwindcss-rails"
-gem "lucide-rails", github: "maybe-finance/lucide-rails"
+gem "lucide-rails"
 
 # Hotwire + UI
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/maybe-finance/lucide-rails.git
-  revision: 272e5fb8418ea458da3995d6abe0ba0ceee9c9f0
-  specs:
-    lucide-rails (0.2.0)
-      railties (>= 4.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -341,6 +334,8 @@ GEM
       view_component (>= 2.0)
       yard (~> 0.9)
       zeitwerk (~> 2.5)
+    lucide-rails (0.7.3)
+      railties (>= 4.1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -788,7 +783,7 @@ DEPENDENCIES
   letter_opener
   logtail-rails
   lookbook (= 2.3.11)
-  lucide-rails!
+  lucide-rails
   mocha
   octokit
   omniauth (~> 2.1)


### PR DESCRIPTION
Can be considered as a fix for #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated lucide-rails gem to source from the standard repository instead of a custom GitHub reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->