### PR TITLE
Fix struct compatibility error in IncomeStatement::Totals

### DIFF
--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -127,7 +127,7 @@ class IncomeStatement
       sql_hash = Digest::MD5.hexdigest(transactions_scope.to_sql)
 
       Rails.cache.fetch([
-        "income_statement", "totals_query", family.id, sql_hash, family.entries_cache_version
+        "income_statement", "totals_query", "v2", family.id, sql_hash, family.entries_cache_version
       ]) { Totals.new(family, transactions_scope: transactions_scope, date_range: date_range).call }
     end
 


### PR DESCRIPTION
The TotalsRow struct was expanded from 5 to 6 fields in commit a4f70f4 (adding is_uncategorized_investment), but cached data from the old 5-field struct causes "struct size differs" errors when deserialized.

This adds a cache version ("v2") to the totals_query cache key to invalidate all old cached structs and force recalculation with the new 6-field definition.

Fixes: TypeError (struct IncomeStatement::Totals::TotalsRow not compatible (struct size differs))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cache versioning to improve data consistency and freshness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->