### PR TITLE
Fix cost basis handling for holdings without trade history

### DIFF
--- a/app/models/assistant/function/get_holdings.rb
+++ b/app/models/assistant/function/get_holdings.rb
@@ -105,8 +105,8 @@ class Assistant::Function::GetHoldings < Assistant::Function
         amount: holding.amount.to_f,
         formatted_amount: holding.amount_money.format,
         weight: holding.weight&.round(2),
-        average_cost: holding.avg_cost.to_f,
-        formatted_average_cost: holding.avg_cost.format,
+        average_cost: holding.avg_cost&.to_f,
+        formatted_average_cost: holding.avg_cost&.format,
         account: holding.account.name,
         date: holding.date
       }

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -133,8 +133,12 @@ class InvestmentStatement
     holdings = current_holdings.to_a
     return nil if holdings.empty?
 
-    current = holdings.sum(&:amount)
-    previous = holdings.sum { |h| h.qty * h.avg_cost.amount }
+    # Only include holdings with known cost basis in the calculation
+    holdings_with_cost_basis = holdings.select(&:avg_cost)
+    return nil if holdings_with_cost_basis.empty?
+
+    current = holdings_with_cost_basis.sum(&:amount)
+    previous = holdings_with_cost_basis.sum { |h| h.qty * h.avg_cost.amount }
 
     Trend.new(current: current, previous: previous)
   end

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -31,7 +31,7 @@
     </div>
 
     <div class="col-span-2 text-right">
-      <%= tag.p format_money holding.avg_cost %>
+      <%= tag.p holding.avg_cost ? format_money(holding.avg_cost) : t(".unknown"), class: holding.avg_cost ? nil : "text-secondary" %>
       <%= tag.p t(".per_share"), class: "font-normal text-secondary" %>
     </div>
 

--- a/config/locales/views/holdings/en.yml
+++ b/config/locales/views/holdings/en.yml
@@ -8,6 +8,7 @@ en:
     holding:
       per_share: per share
       shares: "%{qty} shares"
+      unknown: "--"
     index:
       average_cost: Average cost
       holdings: Holdings


### PR DESCRIPTION
## Summary
  - Fix `avg_cost` returning current market price when cost basis is unknown (was showing misleading $0 gain/loss)
  - Preserve provider-supplied cost_basis during holding materialization instead of overwriting with nil
  - Display "--" and "No cost basis" in UI when cost basis is genuinely unknown

## Problem
  Holdings without trade records (e.g., transferred-in positions, SimpleFIN-only holdings) were displaying incorrect unrealized gain/loss calculated against $0 cost basis. Provider-supplied cost_basis was also being overwritten during sync.

## Solution
  - `avg_cost` now returns nil when no trades exist and no stored cost_basis
  - `Materializer` splits holdings into two batches: those with computed cost_basis (upsert with value) and those without (upsert without column, preserving existing)
  - UI gracefully handles nil values

## Testing
  - [x] Holdings with trades show calculated cost basis
  - [x] Holdings with provider cost_basis show that value
  - [x] Holdings without either show "--" / "No cost basis"
  - [x] Provider cost_basis preserved after re-sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of unknown cost basis values—now displays '--' instead of potential errors
  * Improved unrealized gains and trend calculations to exclude holdings without valid cost basis
  * Enhanced null-safety for cost-related calculations to prevent errors and ensure data accuracy

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->