### PR TITLE
Fix category assignment in transaction overview on desktop (duplicate category menu IDs for mobile/desktop)

### DIFF
--- a/app/controllers/transaction_categories_controller.rb
+++ b/app/controllers/transaction_categories_controller.rb
@@ -24,9 +24,14 @@ class TransactionCategoriesController < ApplicationController
       format.turbo_stream do
         render turbo_stream: [
           turbo_stream.replace(
-            dom_id(transaction, :category_menu),
-            partial: "categories/menu",
-            locals: { transaction: transaction }
+            dom_id(transaction, "category_menu_mobile"),
+            partial: "transactions/transaction_category",
+            locals: { transaction: transaction, variant: "mobile" }
+          ),
+          turbo_stream.replace(
+            dom_id(transaction, "category_menu_desktop"),
+            partial: "transactions/transaction_category",
+            locals: { transaction: transaction, variant: "desktop" }
           ),
           turbo_stream.replace(
             "category_name_mobile_#{transaction.id}",

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -36,7 +36,7 @@
               <% end %>
             </div>
             <div class="flex md:hidden items-center gap-1 col-span-2 relative">
-              <%= render "transactions/transaction_category", transaction: transaction %>
+              <%= render "transactions/transaction_category", transaction: transaction, variant: "mobile" %>
               <% if transaction.merchant&.logo_url.present? %>
                 <%= image_tag transaction.merchant.logo_url,
                     class: "w-5 h-5 rounded-full absolute -bottom-1 -right-1 border border-secondary pointer-events-none",
@@ -137,7 +137,7 @@
       </div>
 
       <div class="hidden md:flex items-center gap-1 col-span-2">
-        <%= render "transactions/transaction_category", transaction: transaction %>
+        <%= render "transactions/transaction_category", transaction: transaction, variant: "desktop" %>
       </div>
 
       <div class="shrink-0 col-span-4 lg:col-span-2 ml-auto text-right">

--- a/app/views/transactions/_transaction_category.html.erb
+++ b/app/views/transactions/_transaction_category.html.erb
@@ -1,6 +1,6 @@
-<%# locals: (transaction:) %>
+<%# locals: (transaction:, variant:) %>
 
-<div id="<%= dom_id(transaction, "category_menu") %>">
+<div id="<%= dom_id(transaction, "category_menu_#{variant}") %>">
   <% if transaction.transfer&.categorizable? || transaction.transfer.nil? %>
     <%= render "categories/menu", transaction: transaction %>
   <% else %>

--- a/app/views/transfers/update.turbo_stream.erb
+++ b/app/views/transfers/update.turbo_stream.erb
@@ -2,13 +2,21 @@
   <%= turbo_stream.replace @transfer.inflow_transaction.entry %>
   <%= turbo_stream.replace @transfer.outflow_transaction.entry %>
 
-  <%= turbo_stream.replace dom_id(@transfer.inflow_transaction, "category_menu"),
+  <%= turbo_stream.replace dom_id(@transfer.inflow_transaction, "category_menu_mobile"),
                           partial: "transactions/transaction_category",
-                          locals: { transaction: @transfer.inflow_transaction } %>
+                          locals: { transaction: @transfer.inflow_transaction, variant: "mobile" } %>
 
-  <%= turbo_stream.replace dom_id(@transfer.outflow_transaction, "category_menu"),
+  <%= turbo_stream.replace dom_id(@transfer.inflow_transaction, "category_menu_desktop"),
                           partial: "transactions/transaction_category",
-                          locals: { transaction: @transfer.outflow_transaction } %>
+                          locals: { transaction: @transfer.inflow_transaction, variant: "desktop" } %>
+
+  <%= turbo_stream.replace dom_id(@transfer.outflow_transaction, "category_menu_mobile"),
+                          partial: "transactions/transaction_category",
+                          locals: { transaction: @transfer.outflow_transaction, variant: "mobile" } %>
+
+  <%= turbo_stream.replace dom_id(@transfer.outflow_transaction, "category_menu_desktop"),
+                          partial: "transactions/transaction_category",
+                          locals: { transaction: @transfer.outflow_transaction, variant: "desktop" } %>
 
   <%= turbo_stream.replace dom_id(@transfer.inflow_transaction, "transfer_match"),
                           partial: "transactions/transfer_match",


### PR DESCRIPTION
Problem
After b3af8bf1 added a mobile category menu, the transaction row rendered two menus with the same DOM id. Turbo stream updates only the first match, so on desktop the hidden mobile menu was updated/closed and the visible desktop menu stayed open, requiring another click to actually close the visible pane.

Fix
Give the mobile and desktop menus variant-specific DOM IDs and update both targets in the turbo stream response. This removes duplicate IDs and makes the first click close the pane consistently.

There are many ways to fix this: another way is to use a more aggressive replacement through turbo_stream:

turbo_stream.replace_all(
            "##{dom_id(transaction, :category_menu)}",

First PR, so definitely open to suggestions! This seems to work on my local build - making category assignment work normally again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Improved responsive design by rendering transaction category menus with distinct mobile and desktop variants, ensuring optimized layouts for each device type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->