### PR TITLE
Fix SimpleFIN dormant credit cards showing credit limit as debt

### DIFF
--- a/app/models/simplefin_account/processor.rb
+++ b/app/models/simplefin_account/processor.rb
@@ -46,7 +46,9 @@ class SimplefinAccount::Processor
       avail = to_decimal(simplefin_account.available_balance)
 
       # Choose an observed value prioritizing posted balance first
-      observed = bal.nonzero? ? bal : avail
+      # Use available_balance only when current_balance is truly missing (nil),
+      # not when it's explicitly zero (e.g., dormant credit card with no debt)
+      observed = simplefin_account.current_balance.nil? ? avail : bal
 
       # Determine if this should be treated as a liability for normalization
       is_linked_liability = [ "CreditCard", "Loan" ].include?(account.accountable_type)


### PR DESCRIPTION
## Summary

Fixes a bug where dormant credit cards with $0 balance were incorrectly showing their credit limit as debt owed.

**Root Cause:**
When SimpleFIN reports `current_balance: 0` and `available_balance: -3800` (negative credit limit), the processor used `.nonzero?` to choose between them. This treated explicit zero the same as missing data, causing fallback to the negative available_balance, which then normalized to positive debt.

**Fix:**
Changed balance selection logic from `.nonzero?` to `.nil?` check. Now only falls back to `available_balance` when `current_balance` is truly missing (nil), not when explicitly zero.

**Impact:**
  - Dormant credit cards with no debt now correctly show $0 balance
  - All existing test cases pass
  - Added test case for this specific scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account balance calculation to correctly handle dormant accounts with zero current balance, ensuring accurate balance display instead of deriving values from alternative balance sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->