### PR TITLE
Fix account Subtypes not getting updated/saved

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,6 +41,12 @@ class Account < ApplicationRecord
   delegated_type :accountable, types: Accountable::TYPES, dependent: :destroy
   delegate :subtype, to: :accountable, allow_nil: true
 
+  # Writer for subtype that delegates to the accountable
+  # This allows forms to set subtype directly on the account
+  def subtype=(value)
+    accountable&.subtype = value
+  end
+
   accepts_nested_attributes_for :accountable, update_only: true
 
   # Account state machine

--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -8,13 +8,20 @@ class Investment < ApplicationRecord
     "401k" => { short: "401(k)", long: "401(k)" },
     "roth_401k" => { short: "Roth 401(k)", long: "Roth 401(k)" },
     "403b" => { short: "403(b)", long: "403(b)" },
+    "457b" => { short: "457(b)", long: "457(b)" },
     "tsp" => { short: "TSP", long: "Thrift Savings Plan" },
     "529_plan" => { short: "529 Plan", long: "529 Plan" },
     "hsa" => { short: "HSA", long: "Health Savings Account" },
     "mutual_fund" => { short: "Mutual Fund", long: "Mutual Fund" },
     "ira" => { short: "IRA", long: "Traditional IRA" },
     "roth_ira" => { short: "Roth IRA", long: "Roth IRA" },
-    "angel" => { short: "Angel", long: "Angel" }
+    "sep_ira" => { short: "SEP IRA", long: "SEP IRA" },
+    "simple_ira" => { short: "SIMPLE IRA", long: "SIMPLE IRA" },
+    "angel" => { short: "Angel", long: "Angel" },
+    "trust" => { short: "Trust", long: "Trust" },
+    "ugma" => { short: "UGMA", long: "UGMA" },
+    "utma" => { short: "UTMA", long: "UTMA" },
+    "other" => { short: "Other", long: "Other Investment" }
   }.freeze
 
   class << self

--- a/app/models/plaid_account/type_mappable.rb
+++ b/app/models/plaid_account/type_mappable.rb
@@ -62,11 +62,18 @@ module PlaidAccount::TypeMappable
         "retirement" => "retirement",
         "401k" => "401k",
         "roth 401k" => "roth_401k",
+        "403b" => "403b",
+        "457b" => "457b",
         "529" => "529_plan",
         "hsa" => "hsa",
         "mutual fund" => "mutual_fund",
         "roth" => "roth_ira",
-        "ira" => "ira"
+        "ira" => "ira",
+        "sep ira" => "sep_ira",
+        "simple ira" => "simple_ira",
+        "trust" => "trust",
+        "ugma" => "ugma",
+        "utma" => "utma"
       }
     },
     other: {


### PR DESCRIPTION
The Account model only delegated the subtype reader to the accountable, but not the writer. This caused form submissions with `account[subtype]` to be silently ignored since there was no setter method on Account.

Changes:
- Add `subtype=` writer method to Account that delegates to accountable
- Add additional investment subtypes (457b, sep_ira, simple_ira, trust, ugma, utma, other) to Investment::SUBTYPES for better coverage
- Update PlaidAccount::TypeMappable with additional investment subtype mappings (403b, 457b, sep_ira, simple_ira, trust, ugma, utma)

Fixes #502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expanded range of investment account types including 457(b), 403(b), SEP IRA, SIMPLE IRA, Trust, UGMA, and UTMA accounts.
  * Enhanced account type recognition and classification for improved identification of investment accounts from connected financial institutions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->