### PR TITLE
Add backup service to Docker Compose configuration

### DIFF
--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -102,7 +102,7 @@ services:
       - sure_net
 
   web:
-    image: ghcr.io/we-promise/sure:latest
+    image: ghcr.io/we-promise/sure:stable
     volumes:
       - app-storage:/rails/storage
     ports:
@@ -119,7 +119,7 @@ services:
       - sure_net
 
   worker:
-    image: ghcr.io/we-promise/sure:latest
+    image: ghcr.io/we-promise/sure:stable
     command: bundle exec sidekiq
     volumes:
       - app-storage:/rails/storage

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -46,7 +46,7 @@ x-rails-env: &rails_env
 
 services:
   web:
-    image: ghcr.io/we-promise/sure:latest
+    image: ghcr.io/we-promise/sure:stable
     volumes:
       - app-storage:/rails/storage
     ports:
@@ -63,7 +63,7 @@ services:
       - sure_net
 
   worker:
-    image: ghcr.io/we-promise/sure:latest
+    image: ghcr.io/we-promise/sure:stable
     command: bundle exec sidekiq
     volumes:
       - app-storage:/rails/storage


### PR DESCRIPTION
I run a [Postgres backup container](https://github.com/prodrigestivill/docker-postgres-backup-local) that automatically runs a scheduled backup daily (based on my config). 

Based on the discussion [here](https://github.com/we-promise/sure/discussions/629#discussioncomment-15486133) , this PR adds the Docker Compose config, so anyone could set it up and have it running if they wish to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated database backup service with daily scheduling, configurable retention (7 days / 4 weeks / 6 months) and host-backed backup storage.
  * Added AI-related deployment profiles to enable AI mode for relevant services.

* **Chores**
  * Updated service images to use the stable tag and standardized configuration comment/formatting for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->