### PR TITLE
Add `sso_audit_logs` association and clear logs in demo data cleaner

### DIFF
--- a/app/models/demo/data_cleaner.rb
+++ b/app/models/demo/data_cleaner.rb
@@ -8,6 +8,9 @@ class Demo::DataCleaner
 
   # Main entry point for destroying all demo data
   def destroy_everything!
+    # Clear SSO audit logs first (they reference users)
+    SsoAuditLog.destroy_all
+
     Family.destroy_all
     Setting.destroy_all
     InviteCode.destroy_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :impersonator_support_sessions, class_name: "ImpersonationSession", foreign_key: :impersonator_id, dependent: :destroy
   has_many :impersonated_support_sessions, class_name: "ImpersonationSession", foreign_key: :impersonated_id, dependent: :destroy
   has_many :oidc_identities, dependent: :destroy
+  has_many :sso_audit_logs, dependent: :nullify
   accepts_nested_attributes_for :family, update_only: true
 
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }


### PR DESCRIPTION
PR #538 added sso_audit_logs table with a foreign key to users, but forgot to add the has_many association in the User model. All other user-related tables (sessions, api_keys, oidc_identities, etc.) work fine because they have dependent: :destroy associations that Rails auto-manages.

- Added `has_many :sso_audit_logs` association to `User` model with `dependent: :nullify`.
- Updated `Demo::DataCleaner` to clear SSO audit logs before destroying related data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system maintenance routines with enhanced audit log management to ensure proper data handling during cleanup operations and when user accounts are removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->