### PR TITLE
Add primary text color to amount in header

### DIFF
--- a/app/views/trades/_header.html.erb
+++ b/app/views/trades/_header.html.erb
@@ -8,7 +8,7 @@
 
     <div class="flex items-center gap-4">
       <h3 class="font-medium">
-        <span class="text-2xl">
+        <span class="text-2xl text-primary">
           <%= format_money entry.amount_money %>
         </span>
 

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -3,7 +3,7 @@
     <div class="space-y-1">
       <div class="flex items-center gap-4">
         <h3 class="font-medium">
-          <span class="text-2xl">
+          <span class="text-2xl text-primary">
             <%= format_money @transfer.amount_abs %>
           </span>
 

--- a/app/views/valuations/_header.html.erb
+++ b/app/views/valuations/_header.html.erb
@@ -10,6 +10,10 @@
       <span class="text-2xl text-primary">
         <%= format_money entry.amount_money %>
       </span>
+
+      <span class="text-lg text-secondary">
+        <%= entry.currency %>
+      </span>
     </h3>
   </div>
 


### PR DESCRIPTION
Applied the 'text-primary' class to the amount display in the valuations header for improved visual emphasis and consistency with the design system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display currency label alongside amount in valuation headers.

* **Style**
  * Updated amount styling to use primary color theming across headers for clearer emphasis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->