### PR TITLE
Fix SimpleFIN liability balance sign when transaction history is incomplete

### DIFF
--- a/app/models/simplefin_account/liabilities/overpayment_analyzer.rb
+++ b/app/models/simplefin_account/liabilities/overpayment_analyzer.rb
@@ -184,6 +184,7 @@ class SimplefinAccount::Liabilities::OverpaymentAnalyzer
 
       # Sanity check: if transaction net is way off from observed balance, data is likely incomplete
       # (e.g., pending charges not in history yet). Use 10% tolerance or minimum $5.
+      # Note: SimpleFIN always sends negative for liabilities, so we compare magnitudes only.
       tolerance = [ BigDecimal("5"), @observed.abs * BigDecimal("0.10") ].max
       if (net.abs - @observed.abs).abs > tolerance
         return [ :unknown, "net-balance-mismatch" ]


### PR DESCRIPTION
Summary
- Adds a sanity check to the overpayment analyzer to detect when transaction history doesn't match the observed balance
- When the net of transactions differs from SimpleFIN's balance by more than 10% (or $5 minimum), falls back to the sign-based normalization logic
- Fixes accounts showing negative debt balances when pending charges aren't yet in transaction history

Problem
The overpayment analyzer was classifying accounts as "credit" based on transaction history (payments > charges), even when SimpleFIN reported a negative balance indicating debt. This caused debt balances to display as negative instead of positive.

Test plan
- Verified fix on development account with mismatched transaction history
- Existing tests pass (the tolerance allows legitimate overpayment detection while catching incomplete data)

<img width="690" height="411" alt="image" src="https://github.com/user-attachments/assets/636a1a51-123a-46f7-8477-099313265f33" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a net-balance sanity check to detect accounts with mismatched computed vs. observed balances. Accounts failing the check are now marked unknown to prevent misclassification. The check uses a tolerance to allow minor variance, improving reliability of account categorization and reducing false credit/debt labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->