### PR TITLE
fix(api): Use authorize_scope! for merchants and tags controllers

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -12,7 +12,7 @@ module Api
     #   GET /api/v1/merchants/:id
     #
     class MerchantsController < BaseController
-      before_action :ensure_read_scope
+      before_action -> { authorize_scope!(:read) }
 
       # List all merchants available to the family
       #

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -13,8 +13,8 @@ module Api
     #   { "tag": { "name": "WhiteHouse", "color": "#3b82f6" } }
     #
     class TagsController < BaseController
-      before_action :ensure_read_scope, only: %i[index show]
-      before_action :ensure_write_scope, only: %i[create update destroy]
+      before_action -> { authorize_scope!(:read) }, only: %i[index show]
+      before_action -> { authorize_scope!(:read_write) }, only: %i[create update destroy]
       before_action :set_tag, only: %i[show update destroy]
 
       # List all tags belonging to the family


### PR DESCRIPTION
The previous implementation used ensure_read_scope and ensure_write_scope, which are not defined in BaseController. 

  This fix uses authorize_scope!(:read) and authorize_scope!(:read_write), which are the actual methods available.

  Error fixed:
  NoMethodError (undefined method 'ensure_read_scope' for Api::V1::TagsController)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authorization handling in API controllers by standardizing the permission verification mechanism for read and write scopes across endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->