### PR TITLE
Add fade-in/out animation to notification removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,36 @@ Sidekiq handles asynchronous tasks:
 - **NEVER create new styles** in design system files without permission
 - **Always generate semantic HTML**
 
+### Animation Patterns
+
+The design system provides standardized enter/exit animation utilities in `animation-utils.css`. Use these with the `element-removal` Stimulus controller for consistent dismissible elements.
+
+**Available animation presets:**
+- `animate-fade-up-*` - Fade + translate up (notifications, toasts)
+- `animate-fade-*` - Simple fade (overlays, dialogs)
+- `animate-scale-*` - Scale + fade (modals, popovers)
+
+Each preset has three states: `-initial`, `-visible`, `-exit`
+
+**Standard transition:**
+- `transition-enter-exit` - Applies `transition-all duration-300 ease-out`
+
+**Usage with element-removal controller:**
+```erb
+<%= tag.div class: "transition-enter-exit animate-fade-up-initial",
+            data: {
+              controller: "element-removal",
+              element_removal_initial_class: "animate-fade-up-initial",
+              element_removal_visible_class: "animate-fade-up-visible",
+              element_removal_exit_class: "animate-fade-up-exit"
+            } do %>
+  <!-- Content auto-fades in on connect, fades out on remove -->
+  <button data-action="click->element-removal#remove">Close</button>
+<% end %>
+```
+
+**Important:** Always use design system animation tokens. Never hardcode animation classes like `opacity-0 translate-y-[-8px]` directly in templates.
+
 ## Component Architecture
 
 ### ViewComponent vs Partials Decision Making

--- a/app/assets/tailwind/maybe-design-system.css
+++ b/app/assets/tailwind/maybe-design-system.css
@@ -10,6 +10,7 @@
 @import './maybe-design-system/text-utils.css';
 @import './maybe-design-system/border-utils.css';
 @import './maybe-design-system/component-utils.css';
+@import './maybe-design-system/animation-utils.css';
 
 @custom-variant theme-dark (&:where([data-theme=dark], [data-theme=dark] *));
 

--- a/app/assets/tailwind/maybe-design-system/animation-utils.css
+++ b/app/assets/tailwind/maybe-design-system/animation-utils.css
@@ -1,0 +1,58 @@
+/*
+  Animation utilities for enter/exit transitions.
+  Use with element-removal controller for dismissible elements.
+
+  Available presets:
+  - animate-fade-up-*: Fade + translate up (notifications, toasts)
+  - animate-fade-*: Simple fade (overlays, dialogs)
+  - animate-scale-*: Scale + fade (modals, popovers)
+
+  Each preset has three states:
+  - *-initial: Starting state (hidden)
+  - *-visible: Visible state (shown)
+  - *-exit: Exit state (hidden, for removal)
+*/
+
+/* Fade up animation (notifications, toasts) */
+@utility animate-fade-up-initial {
+  @apply opacity-0 -translate-y-2;
+}
+
+@utility animate-fade-up-visible {
+  @apply opacity-100 translate-y-0;
+}
+
+@utility animate-fade-up-exit {
+  @apply opacity-0 -translate-y-2;
+}
+
+/* Fade animation (dialogs, overlays) */
+@utility animate-fade-initial {
+  @apply opacity-0;
+}
+
+@utility animate-fade-visible {
+  @apply opacity-100;
+}
+
+@utility animate-fade-exit {
+  @apply opacity-0;
+}
+
+/* Scale animation (modals, popovers) */
+@utility animate-scale-initial {
+  @apply opacity-0 scale-95;
+}
+
+@utility animate-scale-visible {
+  @apply opacity-100 scale-100;
+}
+
+@utility animate-scale-exit {
+  @apply opacity-0 scale-95;
+}
+
+/* Standard transition preset for enter/exit animations */
+@utility transition-enter-exit {
+  @apply transition-all duration-300 ease-out;
+}

--- a/app/controllers/concerns/notifiable.rb
+++ b/app/controllers/concerns/notifiable.rb
@@ -16,7 +16,7 @@ module Notifiable
       end.compact
 
       view_context.safe_join(
-        notifications.map { |notification| view_context.tag.div(view_context.render(**notification)) }
+        notifications.map { |notification| view_context.render(**notification) }
       )
     end
 
@@ -26,7 +26,7 @@ module Notifiable
       notification = resolve_cta(flash[:cta])
       return nil unless notification
 
-      view_context.tag.div(view_context.render(**notification))
+      view_context.render(**notification)
     end
 
     def flash_notification_stream_items

--- a/app/controllers/concerns/notifiable.rb
+++ b/app/controllers/concerns/notifiable.rb
@@ -48,7 +48,7 @@ module Notifiable
     end
 
     def resolve_cta(cta)
-      case cta["type"] || cta[:type]
+      case cta[:type]
       when "category_rule"
         { partial: "rules/category_rule_cta", locals: { cta: } }
       end

--- a/app/controllers/concerns/notifiable.rb
+++ b/app/controllers/concerns/notifiable.rb
@@ -21,10 +21,10 @@ module Notifiable
     end
 
     def render_flash_cta
-      return nil unless flash[:cta]
+      return view_context.content_tag(:div, "", id: "cta") unless flash[:cta]
 
       notification = resolve_cta(flash[:cta])
-      return nil unless notification
+      return view_context.content_tag(:div, "", id: "cta") unless notification
 
       view_context.render(**notification)
     end

--- a/app/javascript/controllers/element_removal_controller.js
+++ b/app/javascript/controllers/element_removal_controller.js
@@ -2,7 +2,11 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="element-removal"
 export default class extends Controller {
+  static ANIMATION_DURATION = 300;
+
   connect() {
+    this.isRemoving = false;
+
     // Trigger fade-in animation
     requestAnimationFrame(() => {
       this.element.classList.remove("opacity-0", "translate-y-[-8px]");
@@ -11,6 +15,9 @@ export default class extends Controller {
   }
 
   remove() {
+    if (this.isRemoving) return;
+    this.isRemoving = true;
+
     // Trigger fade-out animation
     this.element.classList.remove("opacity-100", "translate-y-0");
     this.element.classList.add("opacity-0", "translate-y-[-8px]");
@@ -18,6 +25,6 @@ export default class extends Controller {
     // Wait for animation to complete before removing
     setTimeout(() => {
       this.element.remove();
-    }, 300); // Match duration-300
+    }, this.constructor.ANIMATION_DURATION);
   }
 }

--- a/app/javascript/controllers/element_removal_controller.js
+++ b/app/javascript/controllers/element_removal_controller.js
@@ -2,7 +2,22 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="element-removal"
 export default class extends Controller {
+  connect() {
+    // Trigger fade-in animation
+    requestAnimationFrame(() => {
+      this.element.classList.remove("opacity-0", "translate-y-[-8px]");
+      this.element.classList.add("opacity-100", "translate-y-0");
+    });
+  }
+
   remove() {
-    this.element.remove();
+    // Trigger fade-out animation
+    this.element.classList.remove("opacity-100", "translate-y-0");
+    this.element.classList.add("opacity-0", "translate-y-[-8px]");
+    
+    // Wait for animation to complete before removing
+    setTimeout(() => {
+      this.element.remove();
+    }, 300); // Match duration-300
   }
 }

--- a/app/javascript/controllers/element_removal_controller.js
+++ b/app/javascript/controllers/element_removal_controller.js
@@ -14,6 +14,14 @@ export default class extends Controller {
     });
   }
 
+  handleAnimationEnd(event) {
+    // Only trigger removal when the stroke-fill animation completes (the timer)
+    // Ignore other animations like spinner animations
+    if (event.animationName === "stroke-fill") {
+      this.remove();
+    }
+  }
+
   remove() {
     if (this.isRemoving) return;
     this.isRemoving = true;

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -19,7 +19,7 @@
     <% end %>
 
     <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]">
-      <div id="notification-tray" class="space-y-1 w-full">
+      <div id="notification-tray" class="space-y-3 w-full">
         <%= render_flash_notifications %>
       </div>
 

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -23,9 +23,7 @@
         <%= render_flash_notifications %>
       </div>
 
-      <div id="cta">
-        <%= render_flash_cta %>
-      </div>
+      <%= render_flash_cta %>
     </div>
 
     <% if Current.family %>

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -21,7 +21,9 @@
     <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]">
       <div id="notification-tray" class="space-y-1 w-full">
         <%= render_flash_notifications %>
+      </div>
 
+      <div id="cta">
         <%= render_flash_cta %>
       </div>
     </div>

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -22,7 +22,7 @@
       <div id="notification-tray" class="space-y-1 w-full">
         <%= render_flash_notifications %>
 
-        <div id="cta"></div>
+        <%= render_flash_cta %>
       </div>
     </div>
 

--- a/app/views/shared/notifications/_alert.html.erb
+++ b/app/views/shared/notifications/_alert.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (message:) %>
 
-<%= tag.div class: "flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
+<%= tag.div class: "flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px] mb-3",
             data: { controller: "element-removal" } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-destructive">

--- a/app/views/shared/notifications/_alert.html.erb
+++ b/app/views/shared/notifications/_alert.html.erb
@@ -1,7 +1,12 @@
 <%# locals: (message:) %>
 
-<%= tag.div class: "flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px] mb-3",
-            data: { controller: "element-removal" } do %>
+<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg mb-3 transition-enter-exit animate-fade-up-initial",
+            data: {
+              controller: "element-removal",
+              element_removal_initial_class: "animate-fade-up-initial",
+              element_removal_visible_class: "animate-fade-up-visible",
+              element_removal_exit_class: "animate-fade-up-exit"
+            } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-destructive">
       <%= icon "x", size: "xs", color: "white" %>

--- a/app/views/shared/notifications/_alert.html.erb
+++ b/app/views/shared/notifications/_alert.html.erb
@@ -16,6 +16,13 @@
   <%= tag.p message, class: "text-primary text-sm font-medium line-clamp-3 min-w-0", title: message %>
 
   <div class="ml-auto">
-    <%= icon "x", data: { action: "click->element-removal#remove" }, class: "cursor-pointer" %>
+    <%= render DS::Button.new(
+      variant: :icon,
+      size: :sm,
+      icon: "x",
+      class: "inline-flex",
+      data: { action: "click->element-removal#remove" },
+      aria: { label: t("reports.google_sheets_instructions.close") }
+    ) %>
   </div>
 <% end %>

--- a/app/views/shared/notifications/_alert.html.erb
+++ b/app/views/shared/notifications/_alert.html.erb
@@ -1,10 +1,7 @@
 <%# locals: (message:) %>
 
 <%= tag.div class: "flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
-            data: {
-              controller: "element-removal",
-              action: "animationend->element-removal#remove"
-            } do %>
+            data: { controller: "element-removal" } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-destructive">
       <%= icon "x", size: "xs", color: "white" %>

--- a/app/views/shared/notifications/_alert.html.erb
+++ b/app/views/shared/notifications/_alert.html.erb
@@ -1,7 +1,10 @@
 <%# locals: (message:) %>
 
-<%= tag.div class: "flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg",
-            data: { controller: "element-removal" } do %>
+<%= tag.div class: "flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
+            data: {
+              controller: "element-removal",
+              action: "animationend->element-removal#remove"
+            } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-destructive">
       <%= icon "x", size: "xs", color: "white" %>

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (message:, description:) %>
 
-<%= tag.div id: "cta", class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
+<%= tag.div id: "cta", class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px] mb-3",
             data: { controller: "element-removal" } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (message:, description:) %>
 
 <div id="cta">
-  <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-enter-exit animate-fade-up-initial",
+  <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg mb-3 transition-enter-exit animate-fade-up-initial",
               data: {
                 controller: "element-removal",
                 element_removal_initial_class: "animate-fade-up-initial",
@@ -23,8 +23,15 @@
     <%= yield %>
   </div>
 
-  <div class="absolute -top-2 -right-2">
-    <%= icon "x", class: "p-0.5 hidden group-hover:inline-block border border-alpha-black-50 border-solid rounded-lg bg-container text-subdued cursor-pointer", data: { action: "click->element-removal#remove" } %>
+  <div class="ml-auto">
+    <%= render DS::Button.new(
+      variant: :icon,
+      size: :sm,
+      icon: "x",
+      class: "inline-flex",
+      data: { action: "click->element-removal#remove" },
+      aria: { label: t("reports.google_sheets_instructions.close") }
+    ) %>
   </div>
   <% end %>
 </div>

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -1,12 +1,13 @@
 <%# locals: (message:, description:) %>
 
-<%= tag.div id: "cta", class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg mb-3 transition-enter-exit animate-fade-up-initial",
-            data: {
-              controller: "element-removal",
-              element_removal_initial_class: "animate-fade-up-initial",
-              element_removal_visible_class: "animate-fade-up-visible",
-              element_removal_exit_class: "animate-fade-up-exit"
-            } do %>
+<div id="cta">
+  <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-enter-exit animate-fade-up-initial",
+              data: {
+                controller: "element-removal",
+                element_removal_initial_class: "animate-fade-up-initial",
+                element_removal_visible_class: "animate-fade-up-visible",
+                element_removal_exit_class: "animate-fade-up-exit"
+              } do %>
     <div class="h-5 w-5 shrink-0 p-px text-primary">
       <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">
         <%= icon "check", size: "xs", color: "current" %>
@@ -25,4 +26,5 @@
   <div class="absolute -top-2 -right-2">
     <%= icon "x", class: "p-0.5 hidden group-hover:inline-block border border-alpha-black-50 border-solid rounded-lg bg-container text-subdued cursor-pointer", data: { action: "click->element-removal#remove" } %>
   </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -1,24 +1,23 @@
 <%# locals: (message:, description:) %>
 
-<div id="cta">
-  <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
-              data: {
-                controller: "element-removal",
-                action: "animationend->element-removal#remove"
-              } do %>
-    <div class="h-5 w-5 shrink-0 p-px text-primary">
-      <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">
-        <%= icon "check", size: "xs", color: "current" %>
-      </div>
+<%= tag.div id: "cta", class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
+            data: { controller: "element-removal" } do %>
+  <div class="h-5 w-5 shrink-0 p-px text-primary">
+    <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">
+      <%= icon "check", size: "xs", color: "current" %>
+    </div>
+  </div>
+
+  <div class="space-y-4">
+    <div class="space-y-1">
+      <%= tag.p message, class: "text-primary text-sm font-medium" %>
+      <%= tag.p description, class: "text-secondary text-sm" %>
     </div>
 
-    <div class="space-y-4">
-      <div class="space-y-1">
-        <%= tag.p message, class: "text-primary text-sm font-medium" %>
-        <%= tag.p description, class: "text-secondary text-sm" %>
-      </div>
+    <%= yield %>
+  </div>
 
-      <%= yield %>
-    </div>
-  <% end %>
-</div>
+  <div class="absolute -top-2 -right-2">
+    <%= icon "x", class: "p-0.5 hidden group-hover:inline-block border border-alpha-black-50 border-solid rounded-lg bg-container text-subdued cursor-pointer", data: { action: "click->element-removal#remove" } %>
+  </div>
+<% end %>

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -1,7 +1,11 @@
 <%# locals: (message:, description:) %>
 
 <div id="cta">
-  <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs", data: { controller: "element-removal" } do %>
+  <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
+              data: {
+                controller: "element-removal",
+                action: "animationend->element-removal#remove"
+              } do %>
     <div class="h-5 w-5 shrink-0 p-px text-primary">
       <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">
         <%= icon "check", size: "xs", color: "current" %>

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -1,18 +1,23 @@
 <%# locals: (message:, description:) %>
 
-<%= tag.div id: "cta", class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px] mb-3",
-            data: { controller: "element-removal" } do %>
-  <div class="h-5 w-5 shrink-0 p-px text-primary">
-    <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">
-      <%= icon "check", size: "xs", color: "current" %>
+<%= tag.div id: "cta", class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg mb-3 transition-enter-exit animate-fade-up-initial",
+            data: {
+              controller: "element-removal",
+              element_removal_initial_class: "animate-fade-up-initial",
+              element_removal_visible_class: "animate-fade-up-visible",
+              element_removal_exit_class: "animate-fade-up-exit"
+            } do %>
+    <div class="h-5 w-5 shrink-0 p-px text-primary">
+      <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">
+        <%= icon "check", size: "xs", color: "current" %>
+      </div>
     </div>
-  </div>
 
-  <div class="space-y-4">
-    <div class="space-y-1">
-      <%= tag.p message, class: "text-primary text-sm font-medium" %>
-      <%= tag.p description, class: "text-secondary text-sm" %>
-    </div>
+    <div class="space-y-4">
+      <div class="space-y-1">
+        <%= tag.p message, class: "text-primary text-sm font-medium" %>
+        <%= tag.p description, class: "text-secondary text-sm" %>
+      </div>
 
     <%= yield %>
   </div>

--- a/app/views/shared/notifications/_notice.html.erb
+++ b/app/views/shared/notifications/_notice.html.erb
@@ -1,9 +1,12 @@
 <%# locals: (message:, description: nil) %>
 
-<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px] mb-3",
+<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg mb-3 transition-enter-exit animate-fade-up-initial",
             data: {
               controller: "element-removal",
-              action: "animationend->element-removal#handleAnimationEnd"
+              element_removal_initial_class: "animate-fade-up-initial",
+              element_removal_visible_class: "animate-fade-up-visible",
+              element_removal_exit_class: "animate-fade-up-exit",
+              action: "animationend->element-removal#remove"
             } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-success">

--- a/app/views/shared/notifications/_notice.html.erb
+++ b/app/views/shared/notifications/_notice.html.erb
@@ -24,16 +24,22 @@
     </div>
   </div>
 
-  <div class="ml-auto">
-    <div class="h-5 shrink-0">
+  <div class="ml-auto relative h-5 w-5">
+    <div class="h-5 w-5 shrink-0 group-hover:hidden">
       <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
         <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
         <circle class="origin-center -rotate-90 animate-stroke-fill" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
       </svg>
     </div>
-  </div>
-
-  <div class="absolute -top-2 -right-2">
-    <%= icon "x", class: "p-0.5 hidden group-hover:inline-block border border-alpha-black-50 border-solid rounded-lg bg-container text-subdued cursor-pointer", data: { action: "click->element-removal#remove" } %>
+    <div class="absolute inset-0 hidden group-hover:flex items-center justify-center">
+      <%= render DS::Button.new(
+        variant: :icon,
+        size: :sm,
+        icon: "x",
+        class: "!h-5 !w-5 !p-0 !min-w-0 rounded",
+        data: { action: "click->element-removal#remove" },
+        aria: { label: t("reports.google_sheets_instructions.close") }
+      ) %>
+    </div>
   </div>
 <% end %>

--- a/app/views/shared/notifications/_notice.html.erb
+++ b/app/views/shared/notifications/_notice.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (message:, description: nil) %>
 
-<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
+<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px] mb-3",
             data: {
               controller: "element-removal",
               action: "animationend->element-removal#handleAnimationEnd"

--- a/app/views/shared/notifications/_notice.html.erb
+++ b/app/views/shared/notifications/_notice.html.erb
@@ -1,9 +1,10 @@
 <%# locals: (message:, description: nil) %>
 
-<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs",
+<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
             data: {
               controller: "element-removal",
-              action: "animationend->element-removal#remove"
+              action: "animationend->element-removal#remove",
+              element_removal_target: "notification"
             } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-success">

--- a/app/views/shared/notifications/_notice.html.erb
+++ b/app/views/shared/notifications/_notice.html.erb
@@ -3,8 +3,7 @@
 <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
             data: {
               controller: "element-removal",
-              action: "animationend->element-removal#remove",
-              element_removal_target: "notification"
+              action: "animationend->element-removal#remove"
             } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-success">

--- a/app/views/shared/notifications/_notice.html.erb
+++ b/app/views/shared/notifications/_notice.html.erb
@@ -1,9 +1,9 @@
 <%# locals: (message:, description: nil) %>
 
-<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
+<%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg transition-all duration-300 ease-out opacity-0 translate-y-[-8px]",
             data: {
               controller: "element-removal",
-              action: "animationend->element-removal#remove"
+              action: "animationend->element-removal#handleAnimationEnd"
             } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-success">


### PR DESCRIPTION
Enhanced the element_removal_controller to animate notifications with fade-in on mount and fade-out before removal. Updated the notification partial to include initial animation classes and transition properties for a smoother user experience.

before:

https://github.com/user-attachments/assets/ee60f336-b6ac-4801-a996-377b9511b4c0

after:

https://github.com/user-attachments/assets/d7f233be-63c0-4c21-ad68-26e8556c12fd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications and CTAs gain staged enter/visible/exit animations and explicit dismiss buttons; CTAs render separately from standard notifications.
* **Bug Fixes**
  * Dismissal flow is robust: guards against duplicate removals, waits for animation end with a timeout fallback, and cleans up listeners/timeouts.
* **Style**
  * Updated spacing, shadows, and transition classes for consistent appearance.
* **Documentation**
  * Added animation patterns and utility classes for standardized enter/exit transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->