### PR TITLE
FIX merchant regression

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -51,7 +51,8 @@ class Family < ApplicationRecord
       .where(family: self)
       .recently_unlinked
       .pluck(:merchant_id)
-    Merchant.where(id: (assigned_ids + recently_unlinked_ids).uniq)
+    family_merchant_ids = merchants.pluck(:id)
+    Merchant.where(id: (assigned_ids + recently_unlinked_ids + family_merchant_ids).uniq)
   end
 
   def auto_categorize_transactions_later(transactions, rule_run_id: nil)

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -6,4 +6,12 @@ class FamilyTest < ActiveSupport::TestCase
   def setup
     @syncable = families(:dylan_family)
   end
+
+  test "available_merchants includes family merchants without transactions" do
+    family = families(:dylan_family)
+
+    new_merchant = family.merchants.create!(name: "New Test Merchant")
+
+    assert_includes family.available_merchants, new_merchant
+  end
 end


### PR DESCRIPTION
The available_merchants method only returns merchants that either have transactions assigned or were recently unlinked, creating a chicken-and-egg problem for newly created FamilyMerchant records.

The fix is simple: include all FamilyMerchant records belonging to the family in the query, since these are user-created merchants that should always be available for selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Family merchants are now properly included in available merchant listings.

* **Tests**
  * Added test coverage to verify merchant availability queries include all family merchants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->