### PR TITLE
i18n: Extract hardcoded strings (Part 1/3)

### DIFF
--- a/app/components/UI/account/activity_date.html.erb
+++ b/app/components/UI/account/activity_date.html.erb
@@ -21,7 +21,7 @@
         <div class="flex items-center gap-4">
           <div class="flex items-center gap-2">
             <span class="font-medium"><%= end_balance_money.format %></span>
-            <%= render DS::Tooltip.new(text: "The end of day balance, after all transactions and adjustments", placement: "left", size: "sm") %>
+            <%= render DS::Tooltip.new(text: t("components.ui.account.activity_date.balance_tooltip"), placement: "left", size: "sm") %>
           </div>
           <%= helpers.icon "chevron-down", class: "group-open:rotate-180" %>
         </div>
@@ -32,7 +32,7 @@
       <% if balance %>
         <%= render UI::Account::BalanceReconciliation.new(balance: balance, account: account) %>
       <% else %>
-        <p class="text-sm text-secondary">No balance data available for this date</p>
+        <p class="text-sm text-secondary"><%= t("components.ui.account.activity_date.no_balance_data") %></p>
       <% end %>
     </div>
   </details>

--- a/app/components/UI/account/chart.html.erb
+++ b/app/components/UI/account/chart.html.erb
@@ -21,7 +21,7 @@
       <div class="flex items-center gap-2">
         <% if account.investment? %>
           <%= form.select :chart_view,
-            [["Total value", "balance"], ["Holdings", "holdings_balance"], ["Cash", "cash_balance"]],
+            [[t("accounts.show.chart.total_value"), "balance"], [t("accounts.show.chart.holdings"), "holdings_balance"], [t("accounts.show.chart.cash"), "cash_balance"]],
             { selected: view },
             class: "bg-container border border-secondary rounded-lg text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0",
             data: { "auto-submit-form-target": "auto" } %>
@@ -50,7 +50,7 @@
         data-time-series-chart-data-value="<%= series.to_json %>"></div>
       <% else %>
         <div class="w-full h-full flex items-center justify-center">
-          <p class="text-secondary text-sm">No data available</p>
+          <p class="text-secondary text-sm"><%= t("accounts.show.chart.no_data") %></p>
         </div>
       <% end %>
     </div>

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -58,7 +58,7 @@ class CategoriesController < ApplicationController
 
   def destroy_all
     Current.family.categories.destroy_all
-    redirect_back_or_to categories_path, notice: "All categories deleted"
+    redirect_back_or_to categories_path, notice: t(".all_deleted")
   end
 
   def bootstrap

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -29,7 +29,7 @@ class ChatsController < ApplicationController
     @chat.update!(chat_params)
 
     respond_to do |format|
-      format.html { redirect_back_or_to chat_path(@chat), notice: "Chat updated" }
+      format.html { redirect_back_or_to chat_path(@chat), notice: t(".updated") }
       format.turbo_stream { render turbo_stream: turbo_stream.replace(dom_id(@chat, :title), partial: "chats/chat_title", locals: { chat: @chat }) }
     end
   end
@@ -38,7 +38,7 @@ class ChatsController < ApplicationController
     @chat.destroy
     clear_last_viewed_chat
 
-    redirect_to chats_path, notice: "Chat was successfully deleted"
+    redirect_to chats_path, notice: t(".deleted")
   end
 
   def retry

--- a/app/controllers/concerns/breadcrumbable.rb
+++ b/app/controllers/concerns/breadcrumbable.rb
@@ -7,7 +7,8 @@ module Breadcrumbable
 
   private
     # The default, unless specific controller or action explicitly overrides
+    # Stores i18n keys as symbols, resolved later in the view when locale is set
     def set_breadcrumbs
-      @breadcrumbs = [ [ "Home", root_path ], [ controller_name.titleize, nil ] ]
+      @breadcrumbs = [ [ :"breadcrumbs.home", root_path ], [ :"breadcrumbs.#{controller_name}", nil ] ]
     end
 end

--- a/app/controllers/concerns/self_hostable.rb
+++ b/app/controllers/concerns/self_hostable.rb
@@ -23,7 +23,7 @@ module SelfHostable
       if controller_name == "pages" && action_name == "redis_configuration_error"
         # If Redis is now working, redirect to home
         if redis_connected?
-          redirect_to root_path, notice: "Redis is now configured properly! You can now setup your Sure application."
+          redirect_to root_path, notice: I18n.t("self_hostable.redis_configured")
         end
 
         return

--- a/app/controllers/family_exports_controller.rb
+++ b/app/controllers/family_exports_controller.rb
@@ -13,9 +13,9 @@ class FamilyExportsController < ApplicationController
     FamilyDataExportJob.perform_later(@export)
 
     respond_to do |format|
-      format.html { redirect_to imports_path, notice: "Export started. You'll be able to download it shortly." }
+      format.html { redirect_to imports_path, notice: t(".started") }
       format.turbo_stream {
-        stream_redirect_to imports_path, notice: "Export started. You'll be able to download it shortly."
+        stream_redirect_to imports_path, notice: t(".started")
       }
     end
   end
@@ -29,13 +29,13 @@ class FamilyExportsController < ApplicationController
     if @export.downloadable?
       redirect_to @export.export_file, allow_other_host: true
     else
-      redirect_to imports_path, alert: "Export not ready for download"
+      redirect_to imports_path, alert: t(".not_ready")
     end
   end
 
   def destroy
     @export.destroy
-    redirect_to imports_path, notice: "Export deleted successfully"
+    redirect_to imports_path, notice: t(".deleted")
   end
 
   private
@@ -46,7 +46,7 @@ class FamilyExportsController < ApplicationController
 
     def require_admin
       unless Current.user.admin?
-        redirect_to root_path, alert: "Access denied"
+        redirect_to root_path, alert: t("family_exports.access_denied")
       end
     end
 end

--- a/app/controllers/family_merchants_controller.rb
+++ b/app/controllers/family_merchants_controller.rb
@@ -2,7 +2,7 @@ class FamilyMerchantsController < ApplicationController
   before_action :set_merchant, only: %i[edit update destroy]
 
   def index
-    @breadcrumbs = [ [ "Home", root_path ], [ "Merchants", nil ] ]
+    @breadcrumbs = [ [ :"breadcrumbs.home", root_path ], [ :"breadcrumbs.merchants", nil ] ]
 
     # Show all merchants for this family
     @family_merchants = Current.family.merchants.alphabetically

--- a/app/controllers/holdings_controller.rb
+++ b/app/controllers/holdings_controller.rb
@@ -38,7 +38,7 @@ class HoldingsController < ApplicationController
       @holding.destroy_holding_and_entries!
       flash[:notice] = t(".success")
     else
-      flash[:alert] = "You cannot delete this holding"
+      flash[:alert] = t(".cannot_delete")
     end
 
     respond_to do |format|

--- a/app/controllers/import/cleans_controller.rb
+++ b/app/controllers/import/cleans_controller.rb
@@ -4,7 +4,7 @@ class Import::CleansController < ApplicationController
   before_action :set_import
 
   def show
-    redirect_to import_configuration_path(@import), alert: "Please configure your import before proceeding." unless @import.configured?
+    redirect_to import_configuration_path(@import), alert: t(".configure_first") unless @import.configured?
 
     rows = @import.rows.ordered
 

--- a/app/controllers/import/confirms_controller.rb
+++ b/app/controllers/import/confirms_controller.rb
@@ -8,7 +8,7 @@ class Import::ConfirmsController < ApplicationController
       return redirect_to import_path(@import)
     end
 
-    redirect_to import_clean_path(@import), alert: "You have invalid data, please edit until all errors are resolved" unless @import.cleaned?
+    redirect_to import_clean_path(@import), alert: t(".invalid_data") unless @import.cleaned?
   end
 
   private

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -19,9 +19,9 @@ class Import::UploadsController < ApplicationController
       @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep])
       @import.save!(validate: false)
 
-      redirect_to import_configuration_path(@import, template_hint: true), notice: "CSV uploaded successfully."
+      redirect_to import_configuration_path(@import, template_hint: true), notice: t(".csv_uploaded")
     else
-      flash.now[:alert] = "Must be valid CSV with headers and at least one row of data"
+      flash.now[:alert] = t(".invalid_csv")
 
       render :show, status: :unprocessable_entity
     end

--- a/app/controllers/invite_codes_controller.rb
+++ b/app/controllers/invite_codes_controller.rb
@@ -6,15 +6,15 @@ class InviteCodesController < ApplicationController
   end
 
   def create
-    raise StandardError, "You are not allowed to generate invite codes" unless Current.user.admin?
+    raise StandardError, t(".not_allowed") unless Current.user.admin?
     InviteCode.generate!
-    redirect_back_or_to invite_codes_path, notice: "Code generated"
+    redirect_back_or_to invite_codes_path, notice: t(".generated")
   end
 
   def destroy
     code = InviteCode.find(params[:id])
     code.destroy
-    redirect_back_or_to invite_codes_path, notice: "Code deleted"
+    redirect_back_or_to invite_codes_path, notice: t(".deleted")
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,7 +19,7 @@ class PagesController < ApplicationController
 
     @dashboard_sections = build_dashboard_sections
 
-    @breadcrumbs = [ [ "Home", root_path ], [ "Dashboard", nil ] ]
+    @breadcrumbs = [ [ :"breadcrumbs.home", root_path ], [ :"breadcrumbs.dashboard", nil ] ]
   end
 
   def update_preferences

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,7 +12,7 @@ class ReportsController < ApplicationController
     # Build reports sections for collapsible/reorderable UI
     @reports_sections = build_reports_sections
 
-    @breadcrumbs = [ [ "Home", root_path ], [ "Reports", nil ] ]
+    @breadcrumbs = [ [ :"breadcrumbs.home", root_path ], [ :"breadcrumbs.reports", nil ] ]
   end
 
   def print

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -60,7 +60,7 @@ class RulesController < ApplicationController
   def apply
     @rule.update!(active: true)
     @rule.apply_later(ignore_attribute_locks: true)
-    redirect_back_or_to rules_path, notice: "#{@rule.resource_type.humanize} rule activated"
+    redirect_back_or_to rules_path, notice: t(".activated", resource_type: @rule.resource_type.humanize)
   end
 
   def confirm
@@ -86,8 +86,8 @@ class RulesController < ApplicationController
   def update
     if @rule.update(rule_params)
       respond_to do |format|
-        format.html { redirect_back_or_to rules_path, notice: "Rule updated" }
-        format.turbo_stream { stream_redirect_back_or_to rules_path, notice: "Rule updated" }
+        format.html { redirect_back_or_to rules_path, notice: t(".updated") }
+        format.turbo_stream { stream_redirect_back_or_to rules_path, notice: t(".updated") }
       end
     else
       render :edit, status: :unprocessable_entity
@@ -96,12 +96,12 @@ class RulesController < ApplicationController
 
   def destroy
     @rule.destroy
-    redirect_to rules_path, notice: "Rule deleted"
+    redirect_to rules_path, notice: t(".deleted")
   end
 
   def destroy_all
     Current.family.rules.destroy_all
-    redirect_to rules_path, notice: "All rules deleted"
+    redirect_to rules_path, notice: t(".all_deleted")
   end
 
   def confirm_all

--- a/app/controllers/settings/ai_prompts_controller.rb
+++ b/app/controllers/settings/ai_prompts_controller.rb
@@ -3,8 +3,8 @@ class Settings::AiPromptsController < ApplicationController
 
   def show
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "AI Prompts", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.ai_prompts", nil ]
     ]
     @family = Current.family
     @assistant_config = Assistant.config_for(OpenStruct.new(user: Current.user))

--- a/app/controllers/settings/api_keys_controller.rb
+++ b/app/controllers/settings/api_keys_controller.rb
@@ -7,8 +7,8 @@ class Settings::ApiKeysController < ApplicationController
 
   def show
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "API Key", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.api_key", nil ]
     ]
     @current_api_key = @api_key
   end
@@ -30,7 +30,7 @@ class Settings::ApiKeysController < ApplicationController
     existing_keys.each { |key| key.update_column(:revoked_at, Time.current) }
 
     if @api_key.save
-      flash[:notice] = "Your API key has been created successfully"
+      flash[:notice] = t(".created")
       redirect_to settings_api_key_path
     else
       # Restore existing keys if new key creation failed
@@ -41,9 +41,9 @@ class Settings::ApiKeysController < ApplicationController
 
   def destroy
     if @api_key&.revoke!
-      flash[:notice] = "API key has been revoked successfully"
+      flash[:notice] = t(".revoked")
     else
-      flash[:alert] = "Failed to revoke API key"
+      flash[:alert] = t(".revoke_failed")
     end
     redirect_to settings_api_key_path
   end

--- a/app/controllers/settings/bank_sync_controller.rb
+++ b/app/controllers/settings/bank_sync_controller.rb
@@ -5,28 +5,28 @@ class Settings::BankSyncController < ApplicationController
     @providers = [
       {
         name: "Lunch Flow",
-        description: "US, Canada, UK, EU, Brazil and Asia through multiple open banking providers.",
+        description: t("settings.bank_sync.show.lunchflow_description"),
         path: "https://lunchflow.app/features/sure-integration",
         target: "_blank",
         rel: "noopener noreferrer"
       },
       {
         name: "Plaid",
-        description: "US & Canada bank connections with transactions, investments, and liabilities.",
+        description: t("settings.bank_sync.show.plaid_description"),
         path: "https://github.com/we-promise/sure/blob/main/docs/hosting/plaid.md",
         target: "_blank",
         rel: "noopener noreferrer"
       },
       {
         name: "SimpleFIN",
-        description: "US & Canada connections via SimpleFIN protocol.",
+        description: t("settings.bank_sync.show.simplefin_description"),
         path: "https://beta-bridge.simplefin.org",
         target: "_blank",
         rel: "noopener noreferrer"
       },
       {
-        name: "Enable Banking (beta)",
-        description: "European bank connections via open banking APIs across multiple countries.",
+        name: t("settings.bank_sync.show.enable_banking_name"),
+        description: t("settings.bank_sync.show.enable_banking_description"),
         path: "https://enablebanking.com",
         target: "_blank",
         rel: "noopener noreferrer"

--- a/app/controllers/settings/guides_controller.rb
+++ b/app/controllers/settings/guides_controller.rb
@@ -3,8 +3,8 @@ class Settings::GuidesController < ApplicationController
 
   def show
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "Guides", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.guides", nil ]
     ]
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
       autolink: true,

--- a/app/controllers/settings/hostings_controller.rb
+++ b/app/controllers/settings/hostings_controller.rb
@@ -7,8 +7,8 @@ class Settings::HostingsController < ApplicationController
 
   def show
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "Self-Hosting", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.self_hosting", nil ]
     ]
 
     # Determine which providers are currently selected

--- a/app/controllers/settings/llm_usages_controller.rb
+++ b/app/controllers/settings/llm_usages_controller.rb
@@ -3,8 +3,8 @@ class Settings::LlmUsagesController < ApplicationController
 
   def show
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "LLM Usage", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.llm_usage", nil ]
     ]
     @family = Current.family
 

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -6,8 +6,8 @@ class Settings::ProfilesController < ApplicationController
     @users = Current.family.users.order(:created_at)
     @pending_invitations = Current.family.invitations.pending
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "Profile Info", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.profile_info", nil ]
     ]
   end
 
@@ -29,9 +29,9 @@ class Settings::ProfilesController < ApplicationController
     if @user.destroy
       # Also destroy the invitation associated with this user for this family
       Current.family.invitations.find_by(email: @user.email)&.destroy
-      flash[:notice] = "Member removed successfully."
+      flash[:notice] = t(".member_removed")
     else
-      flash[:alert] = "Failed to remove member."
+      flash[:alert] = t(".member_remove_failed")
     end
 
     redirect_to settings_profile_path

--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -7,8 +7,8 @@ class Settings::ProvidersController < ApplicationController
 
   def show
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "Sync Providers", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.sync_providers", nil ]
     ]
 
     prepare_show_context
@@ -65,13 +65,13 @@ class Settings::ProvidersController < ApplicationController
       # Reload provider configurations if needed
       reload_provider_configs(updated_fields)
 
-      redirect_to settings_providers_path, notice: "Provider settings updated successfully"
+      redirect_to settings_providers_path, notice: t(".updated")
     else
-      redirect_to settings_providers_path, notice: "No changes were made"
+      redirect_to settings_providers_path, notice: t(".no_changes")
     end
   rescue => error
     Rails.logger.error("Failed to update provider settings: #{error.message}")
-    flash.now[:alert] = "Failed to update provider settings: #{error.message}"
+    flash.now[:alert] = t(".update_failed", error: error.message)
     prepare_show_context
     render :show, status: :unprocessable_entity
   end
@@ -92,7 +92,7 @@ class Settings::ProvidersController < ApplicationController
     end
 
     def ensure_admin
-      redirect_to settings_providers_path, alert: "Not authorized" unless Current.user.admin?
+      redirect_to settings_providers_path, alert: t("settings.providers.not_authorized") unless Current.user.admin?
     end
 
     # Reload provider configurations after settings update

--- a/app/controllers/settings/securities_controller.rb
+++ b/app/controllers/settings/securities_controller.rb
@@ -3,8 +3,8 @@ class Settings::SecuritiesController < ApplicationController
 
   def show
     @breadcrumbs = [
-      [ "Home", root_path ],
-      [ "Security", nil ]
+      [ :"breadcrumbs.home", root_path ],
+      [ :"breadcrumbs.security", nil ]
     ]
     @oidc_identities = Current.user.oidc_identities.order(:provider)
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,7 +5,7 @@ class SubscriptionsController < ApplicationController
   # Upgrade page for unsubscribed users
   def upgrade
     if Current.family.subscription&.active?
-      redirect_to root_path, notice: "You are already subscribed."
+      redirect_to root_path, notice: t(".already_subscribed")
     else
       @plan = params[:plan] || "annual"
       render layout: "onboardings"
@@ -30,9 +30,9 @@ class SubscriptionsController < ApplicationController
   def create
     if Current.family.can_start_trial?
       Current.family.start_trial_subscription!
-      redirect_to root_path, notice: "Welcome to Sure!"
+      redirect_to root_path, notice: t(".welcome")
     else
-      redirect_to root_path, alert: "You have already started or completed a trial. Please upgrade to continue."
+      redirect_to root_path, alert: t(".trial_already_used")
     end
   end
 
@@ -51,9 +51,9 @@ class SubscriptionsController < ApplicationController
 
     if checkout_result.success?
       Current.family.start_subscription!(checkout_result.subscription_id)
-      redirect_to root_path, notice: "Welcome to Sure!  Your subscription has been created."
+      redirect_to root_path, notice: t(".subscription_created")
     else
-      redirect_to root_path, alert: "Something went wrong processing your subscription. Please contact us to get this fixed."
+      redirect_to root_path, alert: t(".subscription_error")
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -36,7 +36,7 @@ class TagsController < ApplicationController
 
   def destroy_all
     Current.family.tags.destroy_all
-    redirect_back_or_to tags_path, notice: "All tags deleted"
+    redirect_back_or_to tags_path, notice: t(".all_deleted")
   end
 
   private

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -70,7 +70,7 @@ class TransactionsController < ApplicationController
       @entry.lock_saved_attributes!
       @entry.transaction.lock_attr!(:tag_ids) if @entry.transaction.tags.any?
 
-      flash[:notice] = "Transaction created"
+      flash[:notice] = t(".created")
 
       respond_to do |format|
         format.html { redirect_back_or_to account_path(@entry.account) }
@@ -98,7 +98,7 @@ class TransactionsController < ApplicationController
       @entry.transaction.lock_attr!(:tag_ids) if @entry.transaction.tags.any?
 
       respond_to do |format|
-        format.html { redirect_back_or_to account_path(@entry.account), notice: "Transaction updated" }
+        format.html { redirect_back_or_to account_path(@entry.account), notice: t(".updated") }
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.replace(

--- a/app/controllers/transfer_matches_controller.rb
+++ b/app/controllers/transfer_matches_controller.rb
@@ -16,7 +16,7 @@ class TransferMatchesController < ApplicationController
 
     @transfer.sync_account_later
 
-    redirect_back_or_to transactions_path, notice: "Transfer created"
+    redirect_back_or_to transactions_path, notice: t(".created")
   end
 
   private

--- a/app/controllers/valuations_controller.rb
+++ b/app/controllers/valuations_controller.rb
@@ -39,8 +39,8 @@ class ValuationsController < ApplicationController
 
     if result.success?
       respond_to do |format|
-        format.html { redirect_back_or_to account_path(account), notice: "Account updated" }
-        format.turbo_stream { stream_redirect_back_or_to(account_path(account), notice: "Account updated") }
+        format.html { redirect_back_or_to account_path(account), notice: t(".account_updated") }
+        format.turbo_stream { stream_redirect_back_or_to(account_path(account), notice: t(".account_updated")) }
       end
     else
       @error_message = result.error_message
@@ -64,7 +64,7 @@ class ValuationsController < ApplicationController
       @entry.reload
 
       respond_to do |format|
-        format.html { redirect_back_or_to account_path(@entry.account), notice: "Entry updated" }
+        format.html { redirect_back_or_to account_path(@entry.account), notice: t(".entry_updated") }
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.replace(

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -159,6 +159,7 @@ module LanguagesHelper
     "fr",   # French - 61 translation files
     "de",   # German - 62 translation files
     "es",   # Spanish - 61 translation files
+    "fr",   # French - 62 translation files
     "tr",   # Turkish - 58 translation files
     "nb",   # Norwegian Bokmål - 57 translation files
     "ca",   # Catalan - 57 translation files

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,29 +1,29 @@
 module SettingsHelper
   SETTINGS_ORDER = [
     # General section
-    { name: "Accounts", path: :accounts_path },
-    { name: "Bank Sync", path: :settings_bank_sync_path },
-    { name: "Preferences", path: :settings_preferences_path },
-    { name: "Profile Info", path: :settings_profile_path },
-    { name: "Security", path: :settings_security_path },
-    { name: "Billing", path: :settings_billing_path, condition: :not_self_hosted? },
+    { name_key: "settings.settings_nav.accounts_label", path: :accounts_path },
+    { name_key: "settings.settings_nav.bank_sync_label", path: :settings_bank_sync_path },
+    { name_key: "settings.settings_nav.preferences_label", path: :settings_preferences_path },
+    { name_key: "settings.settings_nav.profile_label", path: :settings_profile_path },
+    { name_key: "settings.settings_nav.security_label", path: :settings_security_path },
+    { name_key: "settings.settings_nav.billing_label", path: :settings_billing_path, condition: :not_self_hosted? },
     # Transactions section
-    { name: "Categories", path: :categories_path },
-    { name: "Tags", path: :tags_path },
-    { name: "Rules", path: :rules_path },
-    { name: "Merchants", path: :family_merchants_path },
-    { name: "Recurring", path: :recurring_transactions_path },
+    { name_key: "settings.settings_nav.categories_label", path: :categories_path },
+    { name_key: "settings.settings_nav.tags_label", path: :tags_path },
+    { name_key: "settings.settings_nav.rules_label", path: :rules_path },
+    { name_key: "settings.settings_nav.merchants_label", path: :family_merchants_path },
+    { name_key: "settings.settings_nav.recurring_transactions_label", path: :recurring_transactions_path },
     # Advanced section
-    { name: "AI Prompts", path: :settings_ai_prompts_path, condition: :admin_user? },
-    { name: "LLM Usage", path: :settings_llm_usage_path, condition: :admin_user? },
-    { name: "API Key", path: :settings_api_key_path, condition: :admin_user? },
-    { name: "Self-Hosting", path: :settings_hosting_path, condition: :self_hosted_and_admin? },
-    { name: "Providers", path: :settings_providers_path, condition: :admin_user? },
-    { name: "Imports", path: :imports_path, condition: :admin_user? },
+    { name_key: "settings.settings_nav.ai_prompts_label", path: :settings_ai_prompts_path, condition: :admin_user? },
+    { name_key: "settings.settings_nav.llm_usage_label", path: :settings_llm_usage_path, condition: :admin_user? },
+    { name_key: "settings.settings_nav.api_keys_label", path: :settings_api_key_path, condition: :admin_user? },
+    { name_key: "settings.settings_nav.self_hosting_label", path: :settings_hosting_path, condition: :self_hosted_and_admin? },
+    { name_key: "settings.settings_nav.providers_label", path: :settings_providers_path, condition: :admin_user? },
+    { name_key: "settings.settings_nav.imports_label", path: :imports_path, condition: :admin_user? },
     # More section
-    { name: "Guides", path: :settings_guides_path },
-    { name: "What's new", path: :changelog_path },
-    { name: "Feedback", path: :feedback_path }
+    { name_key: "settings.settings_nav.guides_label", path: :settings_guides_path },
+    { name_key: "settings.settings_nav.whats_new_label", path: :changelog_path },
+    { name_key: "settings.settings_nav.feedback_label", path: :feedback_path }
   ]
 
   def adjacent_setting(current_path, offset)
@@ -39,7 +39,7 @@ module SettingsHelper
     render partial: "settings/settings_nav_link_large", locals: {
       path: send(adjacent[:path]),
       direction: offset > 0 ? "next" : "previous",
-      title: adjacent[:name]
+      title: I18n.t(adjacent[:name_key])
     }
   end
 

--- a/app/models/account_order.rb
+++ b/app/models/account_order.rb
@@ -33,11 +33,11 @@ class AccountOrder
   end
 
   def label
-    ORDERS.dig(key, :label)
+    I18n.t("account_orders.#{key}.label")
   end
 
   def label_short
-    ORDERS.dig(key, :label_short)
+    I18n.t("account_orders.#{key}.label_short")
   end
 
   def sql_order

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -95,7 +95,7 @@ class Budget < ApplicationRecord
   end
 
   def name
-    start_date.strftime("%B %Y")
+    I18n.l(start_date, format: "%B %Y")
   end
 
   def initialized?

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -157,24 +157,24 @@ class Period
   end
 
   def label
-    if key_metadata
-      key_metadata.fetch(:label)
+    if key
+      I18n.t("periods.#{key}.label")
     else
-      "Custom Period"
+      I18n.t("periods.custom.label")
     end
   end
 
   def label_short
-    if key_metadata
-      key_metadata.fetch(:label_short)
+    if key
+      I18n.t("periods.#{key}.label_short")
     else
-      "Custom"
+      I18n.t("periods.custom.label_short")
     end
   end
 
   def comparison_label
-    if key_metadata
-      key_metadata.fetch(:comparison_label)
+    if key
+      I18n.t("periods.#{key}.comparison_label")
     else
       "#{start_date.strftime(@date_format)} to #{end_date.strftime(@date_format)}"
     end

--- a/app/views/accounts/_account.html.erb
+++ b/app/views/accounts/_account.html.erb
@@ -12,7 +12,7 @@
               <%= account.name %>
             </span>
             <span class="text-red-500 animate-pulse">
-              (deletion in progress...)
+              (<%= t('.deletion_in_progress') %>)
             </span>
           </p>
         <% else %>
@@ -63,7 +63,7 @@
 
       <% if account.draft? %>
         <%= render DS::Link.new(
-          text: "Complete setup",
+          text: t('.complete_setup'),
           href: edit_account_path(account, return_to: return_to),
           variant: :outline,
           frame: :modal

--- a/app/views/accounts/_account_type.html.erb
+++ b/app/views/accounts/_account_type.html.erb
@@ -7,5 +7,5 @@
     hex_color: accountable.color,
   ) %>
 
-  <%= accountable.display_name.singularize %>
+  <%= t("accounts.types.#{accountable.class.name.underscore}") %>
 <% end %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -11,7 +11,7 @@
             frame: :_top
           ) %>
       <%= render DS::Link.new(
-        text: "New account",
+        text: t('.new_account'),
         href: new_account_path(return_to: accounts_path),
         variant: "primary",
         icon: "plus",

--- a/app/views/accounts/index/_account_groups.erb
+++ b/app/views/accounts/index/_account_groups.erb
@@ -3,7 +3,7 @@
 <% accounts.group_by(&:accountable_type).sort_by { |group, _| group }.each do |group, accounts| %>
   <div class="bg-container-inset p-1 rounded-xl">
     <div class="flex items-center px-4 py-2 text-xs font-medium text-secondary">
-      <p><%= Accountable.from_type(group).display_name %></p>
+      <p><%= t("accounts.types.#{group.underscore}") %></p>
       <span class="text-subdued mx-2">&middot;</span>
       <p><%= accounts.count %></p>
 

--- a/app/views/accounts/new/_container.html.erb
+++ b/app/views/accounts/new/_container.html.erb
@@ -20,8 +20,8 @@
     </div>
 
     <div class="p-2 text-subdued">
-      <button hidden data-controller="hotkey" data-hotkey="k,K,ArrowUp,ArrowLeft" data-action="list-keyboard-navigation#focusPrevious">Previous</button>
-      <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext">Next</button>
+      <button hidden data-controller="hotkey" data-hotkey="k,K,ArrowUp,ArrowLeft" data-action="list-keyboard-navigation#focusPrevious"><%= t("accounts.new.container.previous") %></button>
+      <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext"><%= t("accounts.new.container.next") %></button>
 
       <%= yield %>
     </div>
@@ -29,13 +29,13 @@
     <div class="border-t border-alpha-black-25 px-4 pt-4 text-secondary text-sm justify-between hidden md:flex">
       <div class="flex space-x-5">
         <div class="flex items-center space-x-2">
-          <span>Select</span>
+          <span><%= t("accounts.new.container.select") %></span>
           <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center">
             <%= icon("corner-down-left", size: "xs") %>
           </kbd>
         </div>
         <div class="flex items-center space-x-2">
-          <span>Navigate</span>
+          <span><%= t("accounts.new.container.navigate") %></span>
           <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center">
             <%= icon("arrow-up", size: "xs") %>
           </kbd>
@@ -45,8 +45,8 @@
         </div>
       </div>
       <div class="flex items-center space-x-2">
-        <button data-action="DS--dialog#close">Close</button>
-        <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
+        <button data-action="DS--dialog#close"><%= t("accounts.new.container.close") %></button>
+        <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs"><%= t("accounts.new.container.esc") %></kbd>
       </div>
     </div>
   </div>

--- a/app/views/accounts/show/_activity.html.erb
+++ b/app/views/accounts/show/_activity.html.erb
@@ -6,11 +6,11 @@
       <%= tag.h2 t(".title"), class: "font-medium text-lg" %>
       <% unless @account.linked? %>
         <%= render DS::Menu.new(variant: "button") do |menu| %>
-          <% menu.with_button(text: "New", variant: "secondary", icon: "plus") %>
+          <% menu.with_button(text: t(".new"), variant: "secondary", icon: "plus") %>
 
           <% menu.with_item(
               variant: "link",
-              text: "New balance",
+              text: t(".new_balance"),
               icon: "circle-dollar-sign",
               href: new_valuation_path(account_id: @account.id),
               data: { turbo_frame: :modal }) %>
@@ -19,7 +19,7 @@
             <% href = @account.investment? ? new_trade_path(account_id: @account.id) : new_transaction_path(account_id: @account.id) %>
             <% menu.with_item(
                 variant: "link",
-                text: "New transaction",
+                text: t(".new_transaction"),
                 icon: "credit-card",
                 href: href,
                 data: { turbo_frame: :modal }) %>
@@ -40,7 +40,7 @@
               <%= icon("search") %>
               <%= hidden_field_tag :account_id, @account.id %>
               <%= form.search_field :search,
-                            placeholder: "Search entries by name",
+                            placeholder: t(".search_placeholder"),
                             value: @q[:search],
                             class: "form-field__input placeholder:text-sm placeholder:text-secondary",
                             "data-auto-submit-form-target": "auto" %>

--- a/app/views/accounts/show/_header.html.erb
+++ b/app/views/accounts/show/_header.html.erb
@@ -11,7 +11,7 @@
             <h2 class="font-medium text-xl truncate <%= "animate-pulse" if account.syncing? %>"><%= title %></h2>
             <% if account.draft? %>
               <%= render DS::Link.new(
-                  text: "Complete setup",
+                  text: t('.complete_setup'),
                   href: edit_account_path(account),
                   variant: :outline,
                   size: :sm,

--- a/app/views/accounts/show/_menu.html.erb
+++ b/app/views/accounts/show/_menu.html.erb
@@ -1,12 +1,12 @@
 <%# locals: (account:) %>
 
 <%= render DS::Menu.new(testid: "account-menu") do |menu| %>
-  <% menu.with_item(variant: "link", text: "Edit", href: edit_account_path(account), icon: "pencil-line", data: { turbo_frame: :modal }) %>
+  <% menu.with_item(variant: "link", text: t('.edit'), href: edit_account_path(account), icon: "pencil-line", data: { turbo_frame: :modal }) %>
 
   <% unless account.crypto? %>
     <% menu.with_item(
       variant: "link",
-      text: "Import transactions",
+      text: t('.import_transactions'),
       href: imports_path({ import: { type: account.investment? ? "TradeImport" : "TransactionImport", account_id: account.id } }),
       icon: "download",
       data: { turbo_frame: :_top }
@@ -16,7 +16,7 @@
   <% unless account.linked? %>
     <% menu.with_item(
       variant: "button",
-      text: "Delete account",
+      text: t('.delete_account'),
       href: account_path(account),
       method: :delete,
       icon: "trash-2",

--- a/app/views/admin/sso_providers/_form.html.erb
+++ b/app/views/admin/sso_providers/_form.html.erb
@@ -6,7 +6,7 @@
       <%= icon "alert-circle", class: "w-5 h-5 text-destructive mr-2 shrink-0" %>
       <div>
         <p class="text-sm font-medium text-destructive">
-          <%= pluralize(sso_provider.errors.count, "error") %> prohibited this provider from being saved:
+          <%= t("admin.sso_providers.form.errors_title", count: sso_provider.errors.count) %>
         </p>
         <ul class="mt-2 text-sm text-destructive list-disc list-inside">
           <% sso_provider.errors.full_messages.each do |message| %>
@@ -20,38 +20,38 @@
 
 <%= styled_form_with model: [:admin, sso_provider], class: "space-y-6", data: { controller: "admin-sso-form" } do |form| %>
   <div class="space-y-4">
-    <h3 class="font-medium text-primary">Basic Information</h3>
+    <h3 class="font-medium text-primary"><%= t("admin.sso_providers.form.basic_information") %></h3>
 
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <%= form.select :strategy,
           options_for_select([
-            ["OpenID Connect", "openid_connect"],
-            ["SAML 2.0", "saml"],
-            ["Google OAuth2", "google_oauth2"],
-            ["GitHub", "github"]
+            [t("admin.sso_providers.form.strategy_openid_connect"), "openid_connect"],
+            [t("admin.sso_providers.form.strategy_saml"), "saml"],
+            [t("admin.sso_providers.form.strategy_google"), "google_oauth2"],
+            [t("admin.sso_providers.form.strategy_github"), "github"]
           ], sso_provider.strategy),
-          { label: "Strategy" },
+          { label: t("admin.sso_providers.form.strategy_label") },
           { data: { action: "change->admin-sso-form#toggleFields" } } %>
 
       <%= form.text_field :name,
-          label: "Name",
-          placeholder: "e.g., keycloak, authentik",
+          label: t("admin.sso_providers.form.name_label"),
+          placeholder: t("admin.sso_providers.form.name_placeholder"),
           required: true,
           data: { action: "input->admin-sso-form#updateCallbackUrl" } %>
     </div>
-    <p class="text-xs text-secondary -mt-2">Unique identifier (lowercase, numbers, underscores only)</p>
+    <p class="text-xs text-secondary -mt-2"><%= t("admin.sso_providers.form.name_help") %></p>
 
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <%= form.text_field :label,
-          label: "Button Label",
-          placeholder: "e.g., Sign in with Keycloak",
+          label: t("admin.sso_providers.form.label_label"),
+          placeholder: t("admin.sso_providers.form.label_placeholder"),
           required: true %>
 
       <div>
         <%= form.text_field :icon,
-            label: "Icon (optional)",
-            placeholder: "e.g., key, shield" %>
-        <p class="text-xs text-secondary mt-1">Lucide icon name for the login button</p>
+            label: t("admin.sso_providers.form.icon_label"),
+            placeholder: t("admin.sso_providers.form.icon_placeholder") %>
+        <p class="text-xs text-secondary mt-1"><%= t("admin.sso_providers.form.icon_help") %></p>
       </div>
     </div>
 
@@ -65,42 +65,42 @@
   </div>
 
   <div class="border-t border-primary pt-4 space-y-4">
-    <h3 class="font-medium text-primary">OAuth/OIDC Configuration</h3>
+    <h3 class="font-medium text-primary"><%= t("admin.sso_providers.form.oauth_configuration") %></h3>
 
     <div data-oidc-field class="<%= "hidden" unless sso_provider.strategy == "openid_connect" %>">
       <%= form.text_field :issuer,
-          label: "Issuer URL",
-          placeholder: "https://your-idp.example.com/realms/your-realm",
+          label: t("admin.sso_providers.form.issuer_label"),
+          placeholder: t("admin.sso_providers.form.issuer_placeholder"),
           data: { action: "blur->admin-sso-form#validateIssuer" } %>
-      <p class="text-xs text-secondary mt-1">OIDC issuer URL (validates .well-known/openid-configuration)</p>
+      <p class="text-xs text-secondary mt-1"><%= t("admin.sso_providers.form.issuer_help") %></p>
     </div>
 
     <%= form.text_field :client_id,
-        label: "Client ID",
-        placeholder: "your-client-id",
+        label: t("admin.sso_providers.form.client_id_label"),
+        placeholder: t("admin.sso_providers.form.client_id_placeholder"),
         required: true %>
 
     <%= form.password_field :client_secret,
-        label: "Client Secret",
-        placeholder: sso_provider.persisted? ? "••••••••" : "your-client-secret",
+        label: t("admin.sso_providers.form.client_secret_label"),
+        placeholder: sso_provider.persisted? ? t("admin.sso_providers.form.client_secret_placeholder_existing") : t("admin.sso_providers.form.client_secret_placeholder_new"),
         required: !sso_provider.persisted? %>
     <% if sso_provider.persisted? %>
-      <p class="text-xs text-secondary -mt-2">Leave blank to keep existing secret</p>
+      <p class="text-xs text-secondary -mt-2"><%= t("admin.sso_providers.form.client_secret_help_existing") %></p>
     <% end %>
 
     <div data-oidc-field class="<%= "hidden" unless sso_provider.strategy == "openid_connect" %>">
-      <label class="block text-sm font-medium text-primary mb-1">Callback URL</label>
+      <label class="block text-sm font-medium text-primary mb-1"><%= t("admin.sso_providers.form.callback_url_label") %></label>
       <div class="flex items-center gap-2">
         <code class="flex-1 bg-surface px-3 py-2 rounded text-sm text-secondary overflow-x-auto"
               data-admin-sso-form-target="callbackUrl"><%= "#{request.base_url}/auth/#{sso_provider.name.presence || 'PROVIDER_NAME'}/callback" %></code>
         <button type="button"
                 data-action="click->admin-sso-form#copyCallback"
                 class="p-2 text-secondary hover:text-primary shrink-0"
-                title="Copy to clipboard">
+                title="<%= t("admin.sso_providers.form.copy_button") %>">
           <%= icon "copy", class: "w-4 h-4" %>
         </button>
       </div>
-      <p class="text-xs text-secondary mt-1">Configure this URL in your identity provider</p>
+      <p class="text-xs text-secondary mt-1"><%= t("admin.sso_providers.form.callback_url_help") %></p>
     </div>
   </div>
 
@@ -172,18 +172,18 @@
     </details>
 
     <div>
-      <label class="block text-sm font-medium text-primary mb-1">SP Callback URL (ACS URL)</label>
+      <label class="block text-sm font-medium text-primary mb-1"><%= t("admin.sso_providers.form.sp_callback_url") %></label>
       <div class="flex items-center gap-2">
         <code class="flex-1 bg-surface px-3 py-2 rounded text-sm text-secondary overflow-x-auto"
               data-admin-sso-form-target="samlCallbackUrl"><%= "#{request.base_url}/auth/#{sso_provider.name.presence || 'PROVIDER_NAME'}/callback" %></code>
         <button type="button"
                 data-action="click->admin-sso-form#copySamlCallback"
                 class="p-2 text-secondary hover:text-primary shrink-0"
-                title="Copy to clipboard">
+                title="<%= t("admin.sso_providers.form.copy_button") %>">
           <%= icon "copy", class: "w-4 h-4" %>
         </button>
       </div>
-      <p class="text-xs text-secondary mt-1">Configure this URL as the Assertion Consumer Service URL in your IdP</p>
+      <p class="text-xs text-secondary mt-1"><%= t("admin.sso_providers.form.sp_callback_url_help") %></p>
     </div>
   </div>
 
@@ -272,8 +272,8 @@
     </div>
 
     <div class="flex gap-3">
-      <%= link_to "Cancel", admin_sso_providers_path, class: "px-4 py-2 text-sm font-medium text-secondary hover:text-primary" %>
-      <%= form.submit sso_provider.persisted? ? "Update Provider" : "Create Provider",
+      <%= link_to t("admin.sso_providers.form.cancel"), admin_sso_providers_path, class: "px-4 py-2 text-sm font-medium text-secondary hover:text-primary" %>
+      <%= form.submit sso_provider.persisted? ? t("admin.sso_providers.form.update_provider") : t("admin.sso_providers.form.create_provider"),
           class: "px-4 py-2 bg-primary text-inverse rounded-lg text-sm font-medium hover:bg-primary/90" %>
     </div>
   </div>

--- a/app/views/admin/sso_providers/edit.html.erb
+++ b/app/views/admin/sso_providers/edit.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :page_title, "Edit #{@sso_provider.label}" %>
+<%= content_for :page_title, t(".page_title", label: @sso_provider.label) %>
 
 <div class="space-y-4">
-  <p class="text-secondary">Update configuration for <%= @sso_provider.label %>.</p>
+  <p class="text-secondary"><%= t(".description", label: @sso_provider.label) %></p>
 
-  <%= settings_section title: "Provider Configuration" do %>
+  <%= settings_section title: t(".provider_configuration") do %>
     <%= render "form", sso_provider: @sso_provider %>
   <% end %>
 </div>

--- a/app/views/admin/sso_providers/index.html.erb
+++ b/app/views/admin/sso_providers/index.html.erb
@@ -1,14 +1,14 @@
-<%= content_for :page_title, "SSO Providers" %>
+<%= content_for :page_title, t(".page_title") %>
 
 <div class="space-y-4">
   <p class="text-secondary mb-4">
-    Manage single sign-on authentication providers for your instance.
+    <%= t(".description") %>
     <% unless Flipper.enabled?(:db_sso_providers) %>
-      <span class="text-warning">Changes require a server restart to take effect.</span>
+      <span class="text-warning"><%= t(".restart_required") %></span>
     <% end %>
   </p>
 
-  <%= settings_section title: "Configured Providers" do %>
+  <%= settings_section title: t(".configured_providers") do %>
     <% if @sso_providers.any? %>
       <div class="divide-y divide-primary">
         <% @sso_providers.each do |provider| %>
@@ -27,20 +27,20 @@
             <div class="flex items-center gap-2">
               <% if provider.enabled? %>
                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
-                  Enabled
+                  <%= t(".enabled") %>
                 </span>
               <% else %>
                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface text-secondary">
-                  Disabled
+                  <%= t(".disabled") %>
                 </span>
               <% end %>
-              <%= link_to edit_admin_sso_provider_path(provider), class: "p-1 text-secondary hover:text-primary", title: "Edit" do %>
+              <%= link_to edit_admin_sso_provider_path(provider), class: "p-1 text-secondary hover:text-primary", title: t(".edit") do %>
                 <%= icon "pencil", class: "w-4 h-4" %>
               <% end %>
-              <%= button_to toggle_admin_sso_provider_path(provider), method: :patch, class: "p-1 text-secondary hover:text-primary", title: provider.enabled? ? "Disable" : "Enable", form: { data: { turbo_confirm: "Are you sure you want to #{provider.enabled? ? 'disable' : 'enable'} this provider?" } } do %>
+              <%= button_to toggle_admin_sso_provider_path(provider), method: :patch, class: "p-1 text-secondary hover:text-primary", title: provider.enabled? ? t(".disable") : t(".enable"), form: { data: { turbo_confirm: provider.enabled? ? t("admin.sso_providers.toggle.confirm_disable") : t("admin.sso_providers.toggle.confirm_enable") } } do %>
                 <%= icon provider.enabled? ? "toggle-right" : "toggle-left", class: "w-4 h-4" %>
               <% end %>
-              <%= button_to admin_sso_provider_path(provider), method: :delete, class: "p-1 text-destructive hover:text-destructive", title: "Delete", form: { data: { turbo_confirm: "Are you sure you want to delete this provider? This action cannot be undone." } } do %>
+              <%= button_to admin_sso_provider_path(provider), method: :delete, class: "p-1 text-destructive hover:text-destructive", title: t(".delete"), form: { data: { turbo_confirm: t("admin.sso_providers.destroy.confirm") } } do %>
                 <%= icon "trash-2", class: "w-4 h-4" %>
               <% end %>
             </div>
@@ -50,14 +50,14 @@
     <% else %>
       <div class="text-center py-6">
         <%= icon "key", class: "w-12 h-12 mx-auto text-secondary mb-3" %>
-        <p class="text-secondary">No SSO providers configured yet.</p>
+        <p class="text-secondary"><%= t(".no_providers") %></p>
       </div>
     <% end %>
 
     <div class="pt-4 border-t border-primary">
       <%= link_to new_admin_sso_provider_path, class: "inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-secondary" do %>
         <%= icon "plus", class: "w-4 h-4" %>
-        Add Provider
+        <%= t(".add_provider") %>
       <% end %>
     </div>
   <% end %>
@@ -100,26 +100,25 @@
     <% end %>
   <% end %>
 
-  <%= settings_section title: "Configuration Mode", collapsible: true, open: false do %>
+  <%= settings_section title: t(".configuration_mode"), collapsible: true, open: false do %>
     <div class="space-y-3">
       <div class="flex items-center justify-between">
         <div>
-          <p class="font-medium text-primary">Database-backed providers</p>
-          <p class="text-sm text-secondary">Load providers from database instead of YAML config</p>
+          <p class="font-medium text-primary"><%= t(".database_backed_providers") %></p>
+          <p class="text-sm text-secondary"><%= t(".database_backed_description") %></p>
         </div>
         <% if Flipper.enabled?(:db_sso_providers) %>
           <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
-            Enabled
+            <%= t(".enabled") %>
           </span>
         <% else %>
           <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface text-secondary">
-            Disabled
+            <%= t(".disabled") %>
           </span>
         <% end %>
       </div>
       <p class="text-sm text-secondary">
-        Set <code class="bg-surface px-1 py-0.5 rounded text-xs">AUTH_PROVIDERS_SOURCE=db</code> to enable database-backed providers.
-        This allows changes without server restarts.
+        <%= raw t(".database_backed_help_html") %>
       </p>
     </div>
   <% end %>

--- a/app/views/admin/sso_providers/new.html.erb
+++ b/app/views/admin/sso_providers/new.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :page_title, "Add SSO Provider" %>
+<%= content_for :page_title, t(".page_title") %>
 
 <div class="space-y-4">
-  <p class="text-secondary">Configure a new single sign-on authentication provider.</p>
+  <p class="text-secondary"><%= t(".description") %></p>
 
-  <%= settings_section title: "Provider Configuration" do %>
+  <%= settings_section title: t(".provider_configuration") do %>
     <%= render "form", sso_provider: @sso_provider %>
   <% end %>
 </div>

--- a/app/views/assistant_messages/_assistant_message.html.erb
+++ b/app/views/assistant_messages/_assistant_message.html.erb
@@ -4,7 +4,7 @@
   <% if assistant_message.reasoning? %>
     <details class="group mb-1">
       <summary class="flex items-center gap-2">
-        <p class="text-secondary text-sm">Assistant reasoning</p>
+        <p class="text-secondary text-sm"><%= t("assistant_messages.assistant_message.assistant_reasoning") %></p>
         <%= icon("chevron-down", class: "group-open:transform group-open:rotate-180") %>
       </summary>
 

--- a/app/views/assistant_messages/_tool_calls.html.erb
+++ b/app/views/assistant_messages/_tool_calls.html.erb
@@ -3,15 +3,15 @@
 <details class="my-2 group mb-4">
   <summary class="text-secondary text-xs cursor-pointer flex items-center gap-2">
     <%= icon("chevron-right", class: "group-open:transform group-open:rotate-90") %>
-    <p>Tool Calls</p>
+    <p><%= t("assistant_messages.tool_calls.title") %></p>
   </summary>
 
   <div class="mt-2">
     <% message.tool_calls.each do |tool_call| %>
       <div class="bg-blue-50 border-blue-200 px-3 py-2 rounded-lg border mb-2">
-        <p class="text-secondary text-xs">Function:</p>
+        <p class="text-secondary text-xs"><%= t("assistant_messages.tool_calls.function") %></p>
         <p class="text-primary text-sm font-mono"><%= tool_call.function_name %></p>
-        <p class="text-secondary text-xs mt-2">Arguments:</p>
+        <p class="text-secondary text-xs mt-2"><%= t("assistant_messages.tool_calls.arguments") %></p>
         <pre class="text-primary text-sm font-mono whitespace-pre-wrap"><%= tool_call.function_arguments %></pre>
       </div>
     <% end %>

--- a/app/views/budget_categories/_allocation_progress.erb
+++ b/app/views/budget_categories/_allocation_progress.erb
@@ -9,10 +9,10 @@
     <% end %>
 
     <% if budget.available_to_allocate.negative? %>
-      <p class="text-primary text-sm">&gt; 100% set</p>
+      <p class="text-primary text-sm"><%= t("budget_categories.allocation_progress.over_100_set") %></p>
     <% else %>
       <p class="text-secondary text-sm">
-        <%= number_to_percentage(budget.allocated_percent, precision: 0) %> set
+        <%= t("budget_categories.allocation_progress.percent_set", percent: number_to_percentage(budget.allocated_percent, precision: 0)) %>
       </p>
     <% end %>
 
@@ -34,11 +34,11 @@
   <div class="text-sm">
     <% if budget.available_to_allocate.negative? %>
       <p class="text-secondary">
-        Budget exceeded by <span class="text-red-500"><%= format_money(budget.available_to_allocate_money.abs) %></span>
+        <%= t("budget_categories.allocation_progress.budget_exceeded") %> <span class="text-red-500"><%= format_money(budget.available_to_allocate_money.abs) %></span>
       </p>
     <% else %>
       <span class="text-primary"><%= format_money(budget.available_to_allocate_money) %></span>
-      <span class="text-secondary">left to allocate</span>
+      <span class="text-secondary"><%= t("budget_categories.allocation_progress.left_to_allocate") %></span>
     <% end %>
   </div>
 </div>

--- a/app/views/budget_categories/_confirm_button.html.erb
+++ b/app/views/budget_categories/_confirm_button.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id(budget, :confirm_button) %>">
   <%= render DS::Button.new(
-    text: "Confirm",
+    text: t('.confirm'),
     variant: "primary",
     full_width: true,
     href: budget_path(budget),

--- a/app/views/budget_categories/_no_categories.html.erb
+++ b/app/views/budget_categories/_no_categories.html.erb
@@ -1,18 +1,18 @@
 <div class="flex justify-center items-center">
   <div class="text-center flex flex-col items-center max-w-[500px]">
-    <h2 class="text-lg text-primary font-medium">Oops!</h2>
+    <h2 class="text-lg text-primary font-medium"><%= t('.oops') %></h2>
     <p class="text-secondary text-sm max-w-sm mx-auto mb-4">
-      You have not created or assigned any expense categories to your transactions yet.
+      <%= t('.no_categories_message') %>
     </p>
 
     <div class="flex items-center gap-2">
       <%= render DS::Button.new(
-        text: "Use defaults (recommended)",
+        text: t('.use_defaults'),
         href: bootstrap_categories_path,
       ) %>
 
       <%= render DS::Link.new(
-        text: "New category",
+        text: t('.new_category'),
         variant: "outline",
         icon: "plus",
         href: new_category_path,

--- a/app/views/budget_categories/index.html.erb
+++ b/app/views/budget_categories/index.html.erb
@@ -8,9 +8,9 @@
 <div>
   <div class="space-y-6">
     <div class="text-center space-y-2">
-      <h1 class="text-3xl text-primary font-medium">Edit your category budgets</h1>
+      <h1 class="text-3xl text-primary font-medium"><%= t("budget_categories.index.title") %></h1>
       <p class="text-secondary text-sm max-w-md mx-auto">
-        Adjust category budgets to set spending limits. Unallocated funds will be automatically assigned as uncategorized.
+        <%= t("budget_categories.index.description") %>
       </p>
     </div>
 

--- a/app/views/budget_categories/show.html.erb
+++ b/app/views/budget_categories/show.html.erb
@@ -1,7 +1,7 @@
 <%= render DS::Dialog.new(variant: :drawer) do |dialog| %>
   <% dialog.with_header do %>
     <div>
-      <p class="text-sm text-secondary">Category</p>
+      <p class="text-sm text-secondary"><%= t('.category') %></p>
       <h3 class="text-2xl font-medium text-primary">
         <%= @budget_category.name %>
       </h3>
@@ -26,12 +26,12 @@
   <% end %>
 
   <% dialog.with_body do %>
-    <% dialog.with_section(title: "Overview", open: true) do %>
+    <% dialog.with_section(title: t('.overview'), open: true) do %>
       <div class="pb-4">
         <dl class="space-y-3 px-3 py-2">
           <div class="flex items-center justify-between text-sm">
             <dt class="text-secondary">
-              <%= @budget_category.budget.start_date.strftime("%b %Y") %> spending
+              <%= t('.spending', date: I18n.l(@budget_category.budget.start_date, format: "%B %Y")) %>
             </dt>
             <dd class="text-primary font-medium">
               <%= format_money @budget_category.actual_spending_money %>
@@ -40,30 +40,30 @@
 
           <% if @budget_category.budget.initialized? %>
             <div class="flex items-center justify-between text-sm">
-              <dt class="text-secondary">Status</dt>
+              <dt class="text-secondary"><%= t('.status') %></dt>
               <% if @budget_category.available_to_spend.negative? %>
                 <dd class="flex items-center gap-1 text-red-500 font-medium">
                   <%= icon "alert-circle", size: "sm", color: "destructive" %>
                   <%= format_money @budget_category.available_to_spend_money.abs %>
-                  <span>overspent</span>
+                  <span><%= t('.overspent') %></span>
                 </dd>
               <% elsif @budget_category.available_to_spend.zero? %>
                 <dd class="flex items-center gap-1 text-orange-500 font-medium">
                   <%= icon "x-circle", size: "sm", color: "warning" %>
                   <%= format_money @budget_category.available_to_spend_money %>
-                  <span>left</span>
+                  <span><%= t('.left') %></span>
                 </dd>
               <% else %>
                 <dd class="text-primary flex items-center gap-1 text-green-500 font-medium">
                   <%= icon "check-circle", size: "sm", color: "success" %>
                   <%= format_money @budget_category.available_to_spend_money %>
-                  <span>left</span>
+                  <span><%= t('.left') %></span>
                 </dd>
               <% end %>
             </div>
 
             <div class="flex items-center justify-between text-sm">
-              <dt class="text-secondary">Budgeted</dt>
+              <dt class="text-secondary"><%= t('.budgeted') %></dt>
               <dd class="text-primary font-medium">
                 <%= format_money @budget_category.budgeted_spending_money %>
               </dd>
@@ -71,14 +71,14 @@
           <% end %>
 
           <div class="flex items-center justify-between text-sm">
-            <dt class="text-secondary">Monthly average spending</dt>
+            <dt class="text-secondary"><%= t('.monthly_average_spending') %></dt>
             <dd class="text-primary font-medium">
               <%= @budget_category.avg_monthly_expense_money.format %>
             </dd>
           </div>
 
           <div class="flex items-center justify-between text-sm">
-            <dt class="text-secondary">Monthly median spending</dt>
+            <dt class="text-secondary"><%= t('.monthly_median_spending') %></dt>
             <dd class="text-primary font-medium">
               <%= @budget_category.median_monthly_expense_money.format %>
             </dd>
@@ -87,7 +87,7 @@
       </div>
     <% end %>
 
-    <% dialog.with_section(title: "Recent Transactions", open: true) do %>
+    <% dialog.with_section(title: t('.recent_transactions'), open: true) do %>
       <div class="space-y-2">
         <div class="px-3 py-4 space-y-2">
           <% if @recent_transactions.any? %>
@@ -104,7 +104,7 @@
                   <div class="flex justify-between w-full">
                     <div>
                       <p class="text-secondary text-xs uppercase">
-                        <%= transaction.entry.date.strftime("%b %d") %>
+                        <%= I18n.l(transaction.entry.date, format: "%b %d") %>
                       </p>
                       <%= link_to transaction.entry.name,
                                   transactions_path,
@@ -120,7 +120,7 @@
             </ul>
 
             <%= render DS::Link.new(
-              text: "View all category transactions",
+              text: t('.view_all'),
               variant: "outline",
               full_width: true,
               href: transactions_path(q: {
@@ -132,7 +132,7 @@
             ) %>
           <% else %>
             <p class="text-secondary text-sm mb-4">
-              No transactions found for this budget period.
+              <%= t('.no_transactions') %>
             </p>
           <% end %>
         </div>

--- a/app/views/budgets/_actuals_summary.html.erb
+++ b/app/views/budgets/_actuals_summary.html.erb
@@ -2,7 +2,7 @@
 
 <div>
   <div class="p-4 border-b border-secondary">
-    <h3 class="text-sm text-secondary mb-2">Income</h3>
+    <h3 class="text-sm text-secondary mb-2"><%= t("budgets.actuals_summary.income") %></h3>
 
     <span class="inline-block mb-2 text-xl font-medium text-primary">
       <%= budget.actual_income_money.format %>
@@ -30,7 +30,7 @@
   </div>
 
   <div class="p-4">
-    <h3 class="text-sm text-secondary mb-2">Expenses</h3>
+    <h3 class="text-sm text-secondary mb-2"><%= t("budgets.actuals_summary.expenses") %></h3>
 
     <span class="inline-block mb-2 text-xl font-medium text-primary"><%= budget.actual_spending_money.format %></span>
 

--- a/app/views/budgets/_budget_categories.html.erb
+++ b/app/views/budgets/_budget_categories.html.erb
@@ -2,11 +2,11 @@
 
 <div>
   <div class="flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-secondary uppercase">
-    <p>Categories</p>
+    <p><%= t("budgets.budget_categories.categories") %></p>
     <span class="text-subdued">&middot;</span>
     <p><%= budget.budget_categories.count %></p>
 
-    <p class="ml-auto">Amount</p>
+    <p class="ml-auto"><%= t("budgets.budget_categories.amount") %></p>
   </div>
 
   <div class="bg-container py-1 shadow-border-xs rounded-md">

--- a/app/views/budgets/_budget_donut.html.erb
+++ b/app/views/budgets/_budget_donut.html.erb
@@ -5,7 +5,7 @@
     <div data-donut-chart-target="defaultContent" class="flex flex-col items-center">
       <% if budget.initialized? %>
         <div class="text-gray-600 text-sm mb-2">
-          <span>Spent</span>
+          <span><%= t('.spent') %></span>
         </div>
 
         <div class="mb-2 text-3xl font-medium <%= budget.available_to_spend.negative? ? "text-red-500" : "text-primary" %>">
@@ -13,7 +13,7 @@
         </div>
 
         <%= render DS::Link.new(
-          text: "of #{budget.budgeted_spending_money.format}",
+          text: t('.of_budget', amount: budget.budgeted_spending_money.format),
           variant: "secondary",
           icon: "pencil",
           icon_position: "right",
@@ -26,7 +26,7 @@
         </div>
 
         <%= render DS::Link.new(
-          text: "New budget",
+          text: t('.new_budget'),
           size: "sm",
           icon: "plus",
           href: edit_budget_path(budget)
@@ -47,7 +47,7 @@
           </p>
 
           <%= render DS::Link.new(
-            text: "of #{bc.budgeted_spending_money.format(precision: 0)}",
+            text: t('.of_budget', amount: bc.budgeted_spending_money.format(precision: 0)),
             variant: "secondary",
             icon: "pencil",
             icon_position: "right",
@@ -59,7 +59,7 @@
     <% end %>
 
     <div id="segment_unused" class="hidden">
-      <p class="text-sm text-secondary text-center mb-2">Unused</p>
+      <p class="text-sm text-secondary text-center mb-2"><%= t('.unused') %></p>
 
       <p class="text-3xl font-medium text-primary">
         <%= format_money(budget.available_to_spend_money) %>

--- a/app/views/budgets/_budget_header.html.erb
+++ b/app/views/budgets/_budget_header.html.erb
@@ -40,7 +40,7 @@
 
   <div class="ml-auto">
     <%= render DS::Link.new(
-        text: "Today",
+        text: t('.today'),
         variant: "outline",
         href: budget_path(Budget.date_to_param(Date.current)),
     ) %>

--- a/app/views/budgets/_budget_nav.html.erb
+++ b/app/views/budgets/_budget_nav.html.erb
@@ -1,8 +1,8 @@
 <%# locals: (budget:) %>
 
 <% steps = [
-  { name: "Setup", path: edit_budget_path(budget), is_complete: budget.initialized?, step_number: 1 },
-  { name: "Categories", path: budget_budget_categories_path(budget), is_complete: budget.allocations_valid?, step_number: 2 },
+  { name: t("budgets.budget_nav.setup"), path: edit_budget_path(budget), is_complete: budget.initialized?, step_number: 1 },
+  { name: t("budgets.budget_nav.categories"), path: budget_budget_categories_path(budget), is_complete: budget.allocations_valid?, step_number: 2 },
 ] %>
 
 <ul class="flex items-center gap-2">

--- a/app/views/budgets/_budgeted_summary.html.erb
+++ b/app/views/budgets/_budgeted_summary.html.erb
@@ -2,7 +2,7 @@
 
 <div>
   <div class="p-4 border-b border-secondary">
-    <h3 class="text-sm text-secondary mb-2">Expected income</h3>
+    <h3 class="text-sm text-secondary mb-2"><%= t("budgets.budgeted_summary.expected_income") %></h3>
 
     <span class="inline-block mb-2 text-xl font-medium text-primary">
       <%= format_money(budget.expected_income_money) %>
@@ -19,12 +19,12 @@
         <% end %>
       </div>
       <div class="flex justify-between text-sm">
-        <p class="text-secondary"><%= format_money(budget.actual_income_money) %> earned</p>
+        <p class="text-secondary"><%= t("budgets.budgeted_summary.amount_earned", amount: format_money(budget.actual_income_money)) %></p>
         <p class="font-medium">
           <% if budget.remaining_expected_income.negative? %>
-            <span class="text-green-500"><%= format_money(budget.remaining_expected_income_money.abs) %> over</span>
+            <span class="text-green-500"><%= t("budgets.budgeted_summary.amount_over", amount: format_money(budget.remaining_expected_income_money.abs)) %></span>
           <% else %>
-            <span class="text-primary"><%= format_money(budget.remaining_expected_income_money) %> left</span>
+            <span class="text-primary"><%= t("budgets.budgeted_summary.amount_left", amount: format_money(budget.remaining_expected_income_money)) %></span>
           <% end %>
         </p>
       </div>
@@ -32,7 +32,7 @@
   </div>
 
   <div class="p-4">
-    <h3 class="text-sm text-secondary mb-2">Budgeted</h3>
+    <h3 class="text-sm text-secondary mb-2"><%= t("budgets.budgeted_summary.budgeted") %></h3>
 
     <span class="inline-block mb-2 text-xl font-medium text-primary">
       <%= format_money(budget.budgeted_spending_money) %>
@@ -49,12 +49,12 @@
         <% end %>
       </div>
       <div class="flex justify-between text-sm">
-        <p class="text-secondary"><%= format_money(budget.actual_spending_money) %> spent</p>
+        <p class="text-secondary"><%= t("budgets.budgeted_summary.amount_spent", amount: format_money(budget.actual_spending_money)) %></p>
         <p class="font-medium">
           <% if budget.available_to_spend.negative? %>
-            <span class="text-destructive"><%= format_money(budget.available_to_spend_money.abs) %> over</span>
+            <span class="text-destructive"><%= t("budgets.budgeted_summary.amount_over", amount: format_money(budget.available_to_spend_money.abs)) %></span>
           <% else %>
-            <span class="text-primary"><%= format_money(budget.available_to_spend_money) %> left</span>
+            <span class="text-primary"><%= t("budgets.budgeted_summary.amount_left", amount: format_money(budget.available_to_spend_money)) %></span>
           <% end %>
         </p>
       </div>

--- a/app/views/budgets/_over_allocation_warning.html.erb
+++ b/app/views/budgets/_over_allocation_warning.html.erb
@@ -2,10 +2,10 @@
 
 <div class="flex flex-col gap-4 items-center justify-center h-full">
   <%= icon "alert-triangle", size: "lg", color: "destructive" %>
-  <p class="text-secondary text-sm text-center">You have over-allocated your budget.  Please fix your allocations.</p>
+  <p class="text-secondary text-sm text-center"><%= t('.over_allocated_message') %></p>
 
   <%= render DS::Link.new(
-    text: "Fix allocations",
+    text: t('.fix_allocations'),
     variant: "secondary",
     size: "sm",
     icon: "pencil",

--- a/app/views/budgets/_picker.html.erb
+++ b/app/views/budgets/_picker.html.erb
@@ -33,9 +33,10 @@
     </div>
 
     <div class="grid grid-cols-3 gap-2 text-sm text-center font-medium">
-      <% Date::ABBR_MONTHNAMES.compact.each do |month_name| %>
-        <% date = Date.strptime("#{month_name}-#{year}", "%b-%Y") %>
+      <% (1..12).each do |month_number| %>
+        <% date = Date.new(year, month_number, 1) %>
         <% param_key = Budget.date_to_param(date) %>
+        <% month_name = I18n.l(date, format: "%b") %>
 
         <% if Budget.budget_date_valid?(date, family: family) %>
           <%= render DS::Link.new(

--- a/app/views/budgets/edit.html.erb
+++ b/app/views/budgets/edit.html.erb
@@ -8,24 +8,24 @@
 <div>
   <div class="space-y-4">
     <div class="text-center space-y-2">
-      <h1 class="text-3xl text-primary font-medium">Setup your budget</h1>
+      <h1 class="text-3xl text-primary font-medium"><%= t(".title") %></h1>
       <p class="text-secondary text-sm max-w-sm mx-auto">
-        Enter your monthly earnings and planned spending below to setup your budget.
+        <%= t(".description") %>
       </p>
     </div>
 
     <div class="mx-auto max-w-lg">
       <%= styled_form_with model: @budget, class: "space-y-3", data: { controller: "budget-form" } do |f| %>
-        <%= f.money_field :budgeted_spending, label: "Budgeted spending", required: true, disable_currency: true %>
-        <%= f.money_field :expected_income, label: "Expected income", required: true, disable_currency: true %>
+        <%= f.money_field :budgeted_spending, label: t(".budgeted_spending"), required: true, disable_currency: true %>
+        <%= f.money_field :expected_income, label: t(".expected_income"), required: true, disable_currency: true %>
 
         <% if @budget.estimated_income && @budget.estimated_spending %>
           <div class="border border-tertiary rounded-lg p-3 flex">
             <%= icon "sparkles" %>
             <div class="ml-2 space-y-1 text-sm">
-              <h4 class="text-primary">Autosuggest income & spending budget</h4>
+              <h4 class="text-primary"><%= t(".autosuggest_title") %></h4>
               <p class="text-secondary">
-                This will be based on transaction history. AI can make mistakes, verify before continuing.
+                <%= t(".autosuggest_description") %>
               </p>
             </div>
 
@@ -40,7 +40,7 @@
           </div>
         <% end %>
 
-        <%= f.submit "Continue" %>
+        <%= f.submit t(".continue") %>
       <% end %>
     </div>
   </div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -47,11 +47,11 @@
     <%# Bottom Section: Categories full width %>
     <div class="w-full bg-container rounded-xl shadow-border-xs p-4">
       <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-medium">Categories</h2>
+        <h2 class="text-lg font-medium"><%= t('.categories') %></h2>
 
         <% if @budget.initialized? %>
           <%= render DS::Link.new(
-            text: "Edit",
+            text: t('.edit'),
             variant: "secondary",
             icon: "settings-2",
             href: budget_budget_categories_path(@budget)

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -14,7 +14,7 @@
           <div class="fixed right-0 sm:right-auto mx-2 sm:ml-8 sm:mr-0 mt-2 z-50 bg-container p-4 border border-alpha-black-25 rounded-2xl shadow-xs h-fit" data-category-target="popup">
             <div class="flex gap-2 flex-col mb-4" data-category-target="selection" style="<%= "display:none;" if @category.subcategory? %>">
               <div data-category-target="pickerSection"></div>
-              <h4 class="text-gray-500 text-sm">Color</h4>
+              <h4 class="text-gray-500 text-sm"><%= t(".color") %></h4>
               <div class="flex flex-wrap md:flex-nowrap gap-2 items-center" data-category-target="colorsSection">
                 <% Category::COLORS.each do |color| %>
                   <label class="relative">
@@ -34,14 +34,14 @@
                   <%= icon "palette", size: "2xl", data: { action: "click->category#toggleSections" } %>
                 </div>
                 <div data-category-target="validationMessage" class="hidden self-start flex gap-1 items-center text-xs text-destructive ">
-                  <span>Poor contrast, choose darker color or</span>
-                  <button type="button" class="underline cursor-pointer" data-action="category#autoAdjust">auto-adjust.</button>
+                  <span><%= t(".poor_contrast") %></span>
+                  <button type="button" class="underline cursor-pointer" data-action="category#autoAdjust"><%= t(".auto_adjust") %></button>
                 </div>
               </div>
             </div>
 
             <div class="flex flex-wrap gap-2 justify-center flex-col w-auto md:w-87">
-              <h4 class="text-secondary text-sm">Icon</h4>
+              <h4 class="text-secondary text-sm"><%= t(".icon") %></h4>
               <div class="flex flex-wrap gap-0.5 max-h-52 overflow-auto">
                 <% Category.icon_codes.each do |icon| %>
                   <label class="relative">
@@ -62,10 +62,10 @@
       <% end %>
 
       <div class="space-y-2">
-        <%= f.select :classification, [["Income", "income"], ["Expense", "expense"]], { label: "Classification" }, required: true %>
-        <%= f.text_field :name, placeholder: t(".placeholder"), required: true, autofocus: true, label: "Name", data: { color_avatar_target: "name" } %>
+        <%= f.select :classification, [[t(".income"), "income"], [t(".expense"), "expense"]], { label: t(".classification") }, required: true %>
+        <%= f.text_field :name, placeholder: t(".placeholder"), required: true, autofocus: true, label: t(".name"), data: { color_avatar_target: "name" } %>
         <% unless category.parent? %>
-          <%= f.select :parent_id, categories.pluck(:name, :id), { include_blank: "(unassigned)", label: "Parent category (optional)" }, disabled: category.parent?, data: { action: "change->category#handleParentChange" } %>
+          <%= f.select :parent_id, categories.pluck(:name, :id), { include_blank: t(".unassigned"), label: t(".parent_category") }, disabled: category.parent?, data: { action: "change->category#handleParentChange" } %>
         <% end %>
       </div>
     </section>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -5,7 +5,7 @@
     <%= render DS::Menu.new do |menu| %>
       <% menu.with_item(
           variant: "button",
-          text: "Delete all",
+          text: t(".delete_all"),
           href: destroy_all_categories_path,
           method: :delete,
           icon: "trash-2",

--- a/app/views/category/dropdowns/show.html.erb
+++ b/app/views/category/dropdowns/show.html.erb
@@ -61,7 +61,7 @@
                   data: { turbo_frame: "modal" } do %>
             <%= icon("refresh-cw") %>
 
-            <p>Match transfer/payment</p>
+            <p><%= t(".match_transfer") %></p>
           <% end %>
         <% end %>
 
@@ -78,7 +78,7 @@
             <% end %>
           </div>
 
-          <p>One-time <%= @transaction.entry.amount.negative? ? "income" : "expense" %></p>
+          <p><%= @transaction.entry.amount.negative? ? t(".one_time_income") : t(".one_time_expense") %></p>
 
           <span class="text-orange-500 ml-auto">
             <%= icon("asterisk", color: "current") %>

--- a/app/views/chats/_ai_consent.html.erb
+++ b/app/views/chats/_ai_consent.html.erb
@@ -3,14 +3,13 @@
     <%= render "chats/ai_avatar" %>
   </div>
 
-  <h3 class="text-sm font-medium text-primary mb-1 -mt-2 text-center">Enable AI Chats</h3>
+  <h3 class="text-sm font-medium text-primary mb-1 -mt-2 text-center"><%= t("chats.ai_consent.title") %></h3>
 
   <p class="text-gray-600 mb-4 text-sm text-center">
     <% if Current.user.ai_available? %>
-      AI chat can answer financial questions and provide insights based on your data. To use this feature you'll need to explicitly enable it.
+      <%= t("chats.ai_consent.description_available") %>
     <% else %>
-      To use the AI assistant, you need to set the <code class="bg-surface-inset px-1 py-0.5 rounded font-mono text-xs">OPENAI_ACCESS_TOKEN</code>
-      environment variable or configure it in the Self-Hosting settings of your instance.
+      <%= raw t("chats.ai_consent.description_unavailable_html") %>
     <% end %>
   </p>
 
@@ -18,9 +17,9 @@
     <%= form_with url: user_path(Current.user), method: :patch, class: "w-full", data: { turbo: false } do |form| %>
       <%= form.hidden_field "user[ai_enabled]", value: true %>
       <%= form.hidden_field "user[redirect_to]", value: "home" %>
-      <%= form.submit "Enable AI Chats", class: "cursor-pointer hover:bg-inverse-hover w-full py-2 px-4 bg-inverse fg-inverse rounded-lg text-sm font-medium" %>
+      <%= form.submit t("chats.ai_consent.enable_button"), class: "cursor-pointer hover:bg-inverse-hover w-full py-2 px-4 bg-inverse fg-inverse rounded-lg text-sm font-medium" %>
     <% end %>
   <% end %>
 
-  <p class="text-xs text-secondary text-center mt-2">Disable anytime.  All data sent to our LLM providers is anonymized.</p>
+  <p class="text-xs text-secondary text-center mt-2"><%= t("chats.ai_consent.disclaimer") %></p>
 </div>

--- a/app/views/chats/_ai_greeting.html.erb
+++ b/app/views/chats/_ai_greeting.html.erb
@@ -2,27 +2,27 @@
   <%= render "chats/ai_avatar" %>
 
   <div class="max-w-[85%] text-sm space-y-4 text-primary">
-    <p>Hey <%= Current.user&.first_name || "there" %>! I'm an AI/large-language-model that can help with your finances. I have access to the web and your account data.</p>
+    <p><%= t(".introduction", name: Current.user&.first_name || t(".default_name")) %></p>
 
     <p>
-      You can use <span class="bg-container border border-secondary px-1.5 py-0.5 rounded font-mono text-xs">/</span> to access commands
+      <%= t(".slash_commands_html") %>
     </p>
 
     <div class="space-y-3">
-      <p>Here's a few questions you can ask:</p>
+      <p><%= t(".questions_label") %></p>
 
       <% questions = [
         {
           icon: "chart-area",
-          text: "Evaluate investment portfolio"
+          text: t(".question_portfolio")
         },
         {
           icon: "wallet-minimal",
-          text: "Show spending insights"
+          text: t(".question_spending")
         },
         {
           icon: "alert-triangle",
-          text: "Find unusual patterns"
+          text: t(".question_patterns")
         }
       ] %>
 

--- a/app/views/chats/_chat.html.erb
+++ b/app/views/chats/_chat.html.erb
@@ -7,21 +7,21 @@
     <% end %>
 
     <p class="text-sm text-secondary">
-      <%= time_ago_in_words(chat.updated_at) %> ago
+      <%= t(".updated_ago", time: time_ago_in_words(chat.updated_at)) %>
     </p>
   </div>
 
   <%= render DS::Menu.new(icon_vertical: true) do |menu| %>
     <% menu.with_item(
       variant: "link",
-      text: "Edit chat title",
+      text: t(".edit_title"),
       href: edit_chat_path(chat, ctx: "list"),
       icon: "pencil",
       frame: dom_id(chat, "title")) %>
 
     <% menu.with_item(
       variant: "button",
-      text: "Delete chat",
+      text: t(".delete"),
       href: chat_path(chat),
       icon: "trash-2",
       method: :delete,

--- a/app/views/chats/_chat_nav.html.erb
+++ b/app/views/chats/_chat_nav.html.erb
@@ -10,7 +10,7 @@
       icon: "menu",
       href: path,
       frame: chat_frame,
-      text: "All chats"
+      text: t(".all_chats")
     ) %>
 
     <div class="grow">
@@ -19,19 +19,19 @@
   </div>
 
   <%= render DS::Menu.new(icon_vertical: true) do |menu| %>
-    <% menu.with_item(variant: "link", text: "Start new chat", href: new_chat_path, icon: "plus") %>
+    <% menu.with_item(variant: "link", text: t(".start_new"), href: new_chat_path, icon: "plus") %>
 
     <% unless chat.new_record? %>
       <% menu.with_item(
         variant: "link",
-        text: "Edit chat title",
+        text: t(".edit_title"),
         href: edit_chat_path(chat, ctx: "chat"),
         icon: "pencil",
         frame: dom_id(chat, "title")) %>
 
       <% menu.with_item(
         variant: "button",
-        text: "Delete chat",
+        text: t(".delete"),
         href: chat_path(chat),
         icon: "trash-2",
         method: :delete,

--- a/app/views/chats/_chat_title.html.erb
+++ b/app/views/chats/_chat_title.html.erb
@@ -2,7 +2,7 @@
 
 <%= turbo_frame_tag dom_id(chat, :title), class: "block" do %>
   <% if chat.new_record? || ctx == "chat" %>
-    <h3 class="text-sm font-medium text-primary"><%= chat.title || "New chat" %></h3>
+    <h3 class="text-sm font-medium text-primary"><%= chat.title || t("chats.chat_title.new_chat") %></h3>
   <% else %>
     <%= link_to chat_path(chat), data: { turbo_frame: chat_frame } do %>
       <h3 class="truncate text-sm font-medium text-primary"><%= chat.title %></h3>

--- a/app/views/chats/_error.html.erb
+++ b/app/views/chats/_error.html.erb
@@ -8,10 +8,10 @@
   <% end %>
 
   <div class="flex items-center justify-between gap-2">
-    <p class="text-xs text-red-500">Failed to generate response.  Please try again.</p>
+    <p class="text-xs text-red-500"><%= t(".error_message") %></p>
 
     <%= render DS::Button.new(
-      text: "Retry",
+      text: t(".retry"),
       href: retry_chat_path(chat),
     ) %>
   </div>

--- a/app/views/chats/_thinking_indicator.html.erb
+++ b/app/views/chats/_thinking_indicator.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (chat:, message: "Thinking ...") -%>
+<%# locals: (chat:, message: t("chats.thinking_indicator.thinking")) -%>
 
 <div id="thinking-indicator" class="flex items-start gap-3">
   <%= render "chats/ai_avatar" %>

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -10,14 +10,14 @@
       <% if @chats.any? %>
         <div class="grow flex flex-col">
           <div class="flex items-center justify-between my-6">
-            <h1 class="text-xl font-medium">Chats</h1>
+            <h1 class="text-xl font-medium"><%= t(".title") %></h1>
             <%= render DS::Link.new(
               id: "new-chat",
               icon: "plus",
               variant: "icon",
               href: new_chat_path,
               frame: chat_frame,
-              text: "New chat"
+              text: t(".new_chat")
             ) %>
           </div>
           <div class="space-y-2 px-0.5">
@@ -26,7 +26,7 @@
         </div>
       <% else %>
         <div class="grow flex flex-col">
-          <h1 class="sr-only">Chats</h1>
+          <h1 class="sr-only"><%= t(".title") %></h1>
           <div class="mt-auto py-8">
             <%= render "chats/ai_greeting" %>
           </div>

--- a/app/views/credit_cards/_overview.html.erb
+++ b/app/views/credit_cards/_overview.html.erb
@@ -28,7 +28,7 @@
 
 <div class="flex justify-center py-8">
   <%= render DS::Link.new(
-    text: "Edit account details",
+    text: t(".edit_account_details"),
     variant: "ghost",
     href: edit_credit_card_path(account),
     frame: :modal

--- a/app/views/doorkeeper/authorizations/error.html.erb
+++ b/app/views/doorkeeper/authorizations/error.html.erb
@@ -14,7 +14,7 @@
 
   <div class="text-center">
     <%= render DS::Link.new(
-      text: "Go back",
+      text: t("doorkeeper.authorizations.error.go_back"),
       href: "javascript:history.back()",
       variant: :secondary
     ) %>

--- a/app/views/doorkeeper/authorizations/form_post.html.erb
+++ b/app/views/doorkeeper/authorizations/form_post.html.erb
@@ -4,7 +4,7 @@
       <%= icon("loader-circle", class: "w-6 h-6 text-primary animate-spin") %>
     </div>
     <h1 class="text-2xl font-medium text-primary"><%= t(".title") %></h1>
-    <p class="text-sm text-secondary">Redirecting you back to the application...</p>
+    <p class="text-sm text-secondary"><%= t(".redirecting") %></p>
   </div>
 </div>
 

--- a/app/views/doorkeeper/authorizations/show.html.erb
+++ b/app/views/doorkeeper/authorizations/show.html.erb
@@ -7,11 +7,11 @@
   </div>
 
   <div class="bg-surface-inset rounded-lg p-4">
-    <p class="text-xs text-secondary mb-2">Authorization Code:</p>
+    <p class="text-xs text-secondary mb-2"><%= t(".authorization_code_label") %></p>
     <code id="authorization_code" class="block text-sm font-mono text-primary break-all"><%= params[:code] %></code>
   </div>
 
   <p class="text-sm text-secondary text-center">
-    Copy this code and paste it into the application.
+    <%= t(".copy_instructions") %>
   </p>
 </div>

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -20,29 +20,29 @@
           <div class="flex items-center gap-2">
             <%= tag.p enable_banking_item.institution_display_name, class: "font-medium text-primary" %>
             <% if enable_banking_item.scheduled_for_deletion? %>
-              <p class="text-destructive text-sm animate-pulse">Deletion in progress</p>
+              <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
             <% end %>
           </div>
-          <p class="text-xs text-secondary">Enable Banking</p>
+          <p class="text-xs text-secondary"><%= t(".provider_name") %></p>
           <% if enable_banking_item.syncing? %>
             <div class="text-secondary flex items-center gap-1">
               <%= icon "loader", size: "sm", class: "animate-spin" %>
-              <%= tag.span "Syncing..." %>
+              <%= tag.span t(".syncing") %>
             </div>
           <% elsif enable_banking_item.requires_update? %>
             <div class="text-warning flex items-center gap-1">
               <%= icon "alert-triangle", size: "sm", color: "warning" %>
-              <%= tag.span "Reconnect" %>
+              <%= tag.span t(".reconnect") %>
             </div>
           <% else %>
             <p class="text-secondary">
               <% if enable_banking_item.last_synced_at %>
-                Last synced <%= time_ago_in_words(enable_banking_item.last_synced_at) %> ago
+                <%= t(".last_synced", time: time_ago_in_words(enable_banking_item.last_synced_at)) %>
                 <% if enable_banking_item.sync_status_summary %>
                   · <%= enable_banking_item.sync_status_summary %>
                 <% end %>
               <% else %>
-                Never synced
+                <%= t(".never_synced") %>
               <% end %>
             </p>
           <% end %>
@@ -56,7 +56,7 @@
                         class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-lg text-white bg-warning hover:opacity-90 transition-colors",
                         data: { turbo: false } do %>
             <%= icon "refresh-cw", size: "sm" %>
-            Update
+            <%= t(".update") %>
           <% end %>
         <% elsif Rails.env.development? %>
           <%= icon(
@@ -69,7 +69,7 @@
         <%= render DS::Menu.new do |menu| %>
           <% menu.with_item(
             variant: "button",
-            text: "Delete",
+            text: t(".delete"),
             icon: "trash-2",
             href: enable_banking_item_path(enable_banking_item),
             method: :delete,
@@ -98,10 +98,10 @@
 
         <% if enable_banking_item.unlinked_accounts_count > 0 %>
           <div class="p-4 flex flex-col gap-3 items-center justify-center">
-            <p class="text-primary font-medium text-sm">Setup needed</p>
-            <p class="text-secondary text-sm"><%= pluralize(enable_banking_item.unlinked_accounts_count, "account") %> imported from Enable Banking need to be set up</p>
+            <p class="text-primary font-medium text-sm"><%= t(".setup_needed") %></p>
+            <p class="text-secondary text-sm"><%= t(".accounts_need_setup", count: pluralize(enable_banking_item.unlinked_accounts_count, "account")) %></p>
             <%= render DS::Link.new(
-              text: "Set up accounts",
+              text: t(".set_up_accounts"),
               icon: "settings",
               variant: "primary",
               href: setup_accounts_enable_banking_item_path(enable_banking_item),
@@ -110,8 +110,8 @@
           </div>
         <% elsif enable_banking_item.accounts.empty? && enable_banking_item.enable_banking_accounts.empty? %>
           <div class="p-4 flex flex-col gap-3 items-center justify-center">
-            <p class="text-primary font-medium text-sm">No accounts found</p>
-            <p class="text-secondary text-sm">No accounts were found from Enable Banking. Try syncing again.</p>
+            <p class="text-primary font-medium text-sm"><%= t(".no_accounts_found") %></p>
+            <p class="text-secondary text-sm"><%= t(".no_accounts_description") %></p>
           </div>
         <% end %>
       </div>

--- a/app/views/enable_banking_items/_subtype_select.html.erb
+++ b/app/views/enable_banking_items/_subtype_select.html.erb
@@ -6,7 +6,7 @@
          (enable_banking_account.name.downcase.include?("checking") ? "checking" :
           enable_banking_account.name.downcase.include?("savings") ? "savings" : "") : "" %>
     <%= select_tag "account_subtypes[#{enable_banking_account.id}]",
-                  options_for_select([["Select #{account_type == 'Depository' ? 'subtype' : 'type'}", ""]] + subtype_config[:options], selected_value),
+                  options_for_select([[account_type == 'Depository' ? t("enable_banking_items.subtype_select.select_subtype") : t("enable_banking_items.subtype_select.select_type"), ""]] + subtype_config[:options], selected_value),
                   { class: "appearance-none bg-container border border-primary rounded-md px-3 py-2 text-sm leading-6 text-primary focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none w-full" } %>
   <% else %>
     <p class="text-sm text-secondary"><%= subtype_config[:message] %></p>

--- a/app/views/enable_banking_items/new.html.erb
+++ b/app/views/enable_banking_items/new.html.erb
@@ -17,22 +17,22 @@
                     <% if item.session_valid? %>
                     <div class="w-2 h-2 bg-success rounded-full"></div>
                     <div>
-                        <p class="text-sm font-medium text-primary"><%= item.aspsp_name || "Connected Bank" %></p>
+                        <p class="text-sm font-medium text-primary"><%= item.aspsp_name || t(".connected_bank") %></p>
                         <p class="text-xs text-secondary">
-                        Session expires: <%= item.session_expires_at&.strftime("%b %d, %Y") || "Unknown" %>
+                        <%= t(".session_expires", date: item.session_expires_at ? I18n.l(item.session_expires_at, format: :long) : t(".unknown")) %>
                         </p>
                     </div>
                     <% elsif item.session_expired? %>
                     <div class="w-2 h-2 bg-warning rounded-full"></div>
                     <div>
                         <p class="text-sm font-medium text-primary"><%= item.aspsp_name || "Connection" %></p>
-                        <p class="text-xs text-destructive">Session expired - re-authorization required</p>
+                        <p class="text-xs text-destructive"><%= t(".session_expired") %></p>
                     </div>
                     <% else %>
                     <div class="w-2 h-2 bg-secondary rounded-full"></div>
                     <div>
-                        <p class="text-sm font-medium text-primary">Configured</p>
-                        <p class="text-xs text-secondary">Ready to connect a bank</p>
+                        <p class="text-sm font-medium text-primary"><%= t(".configured") %></p>
+                        <p class="text-xs text-secondary"><%= t(".ready_to_connect") %></p>
                     </div>
                     <% end %>
                 </div>
@@ -43,28 +43,28 @@
                                     method: :post,
                                     class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-primary bg-container border border-primary hover:bg-gray-50 transition-colors",
                                     data: { turbo: false } do %>
-                        Sync
+                        <%= t(".sync") %>
                     <% end %>
                     <% elsif item.session_expired? %>
                     <%= button_to reauthorize_enable_banking_item_path(item),
                                     method: :post,
                                     class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-white bg-warning hover:opacity-90 transition-colors",
                                     data: { turbo: false } do %>
-                        Reconnect
+                        <%= t(".reconnect") %>
                     <% end %>
                     <% else %>
                     <%= link_to select_bank_enable_banking_item_path(item),
                                 class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
                                 data: { turbo_frame: "modal" } do %>
-                        Connect Bank
+                        <%= t(".connect_bank") %>
                     <% end %>
                     <% end %>
 
                     <%= button_to enable_banking_item_path(item),
                                 method: :delete,
                                 class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 transition-colors",
-                                data: { turbo_confirm: "Are you sure you want to remove this connection?" } do %>
-                    Remove
+                                data: { turbo_confirm: t(".confirm_remove") } do %>
+                    <%= t(".remove") %>
                     <% end %>
                 </div>
                 </div>
@@ -78,7 +78,7 @@
                                 class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
                                 data: { turbo_frame: "modal" } do %>
                     <%= icon "plus", size: "sm" %>
-                    Add Connection
+                    <%= t(".add_connection") %>
                 <% end %>
                 </div>
             <% end %>
@@ -88,18 +88,18 @@
                 <div class="flex items-start gap-3">
                 <%= icon("alert-circle", class: "text-warning w-5 h-5 shrink-0 mt-0.5") %>
                 <div class="text-sm text-secondary">
-                    <p class="font-medium text-primary mb-2">Enable Banking connection not configured</p>
-                    <p>Before you can link Enable Banking accounts, you need to configure your Enable Banking connection.</p>
+                    <p class="font-medium text-primary mb-2"><%= t(".not_configured") %></p>
+                    <p><%= t(".configure_first") %></p>
                 </div>
                 </div>
 
                 <div class="bg-surface rounded-lg p-4 space-y-2 text-sm">
-                <p class="font-medium text-primary">Setup Steps:</p>
+                <p class="font-medium text-primary"><%= t(".setup_steps") %></p>
                 <ol class="list-decimal list-inside space-y-1 text-secondary">
-                    <li>Go to <strong>Settings → Providers</strong></li>
-                    <li>Find the <strong>Enable Banking</strong> section</li>
-                    <li>Enter your Enable Banking credentials</li>
-                    <li>Return here to link your accounts</li>
+                    <li><%= t(".step_1") %></li>
+                    <li><%= t(".step_2") %></li>
+                    <li><%= t(".step_3") %></li>
+                    <li><%= t(".step_4") %></li>
                 </ol>
                 </div>
 
@@ -107,7 +107,7 @@
                 <%= link_to settings_providers_path,
                             class: "w-full inline-flex items-center justify-center rounded-lg font-medium whitespace-nowrap rounded-lg hidden md:inline-flex px-3 py-2 text-sm text-inverse bg-inverse hover:bg-inverse-hover disabled:bg-gray-500 theme-dark:disabled:bg-gray-400",
                             data: { turbo: false } do %>
-                    Go to Provider Settings
+                    <%= t(".go_to_settings") %>
                 <% end %>
                 </div>
             </div>

--- a/app/views/enable_banking_items/select_existing_account.html.erb
+++ b/app/views/enable_banking_items/select_existing_account.html.erb
@@ -1,15 +1,15 @@
 <%# Modal: Link an existing manual account to a Enable Banking account %>
 <%= turbo_frame_tag "modal" do %>
   <%= render DS::Dialog.new do |dialog| %>
-    <% dialog.with_header(title: "Link Enable Banking account") %>
+    <% dialog.with_header(title: t(".header_title")) %>
 
     <% dialog.with_body do %>
       <% if @available_enable_banking_accounts.blank? %>
         <div class="p-4 text-sm text-secondary">
-          <p class="mb-2">All Enable Banking accounts appear to be linked already.</p>
+          <p class="mb-2"><%= t(".all_linked") %></p>
           <ul class="list-disc list-inside space-y-1">
-            <li>If you just connected or synced, try again after the sync completes.</li>
-            <li>To link a different account, first unlink it from the account’s actions menu.</li>
+            <li><%= t(".try_after_sync") %></li>
+            <li><%= t(".unlink_first") %></li>
           </ul>
         </div>
       <% else %>
@@ -22,7 +22,7 @@
                 <div class="flex flex-col">
                   <span class="text-sm text-primary font-medium"><%= eba.name.presence || eba.account_id %></span>
                   <span class="text-xs text-secondary">
-                    <%= eba.currency %> • Balance: <%= number_to_currency((eba.current_balance || 0), unit: eba.currency) %>
+                    <%= eba.currency %> • <%= t(".balance") %> <%= number_to_currency((eba.current_balance || 0), unit: eba.currency) %>
                   </span>
                 </div>
               </label>
@@ -30,8 +30,8 @@
           </div>
 
           <div class="flex items-center justify-end gap-2">
-            <%= render DS::Button.new(text: "Link", variant: :primary, icon: "link-2", type: :submit) %>
-            <%= render DS::Link.new(text: "Cancel", variant: :secondary, href: accounts_path, data: { turbo_frame: "_top" }) %>
+            <%= render DS::Button.new(text: t(".link"), variant: :primary, icon: "link-2", type: :submit) %>
+            <%= render DS::Link.new(text: t(".cancel"), variant: :secondary, href: accounts_path, data: { turbo_frame: "_top" }) %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/enable_banking_items/setup_accounts.html.erb
+++ b/app/views/enable_banking_items/setup_accounts.html.erb
@@ -1,8 +1,8 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Set Up Your Enable Banking Accounts") do %>
+  <% dialog.with_header(title: t(".title")) do %>
     <div class="flex items-center gap-2">
       <%= icon "building-2", class: "text-primary" %>
-      <span class="text-primary">Choose the correct account types for your imported accounts</span>
+      <span class="text-primary"><%= t(".header_description") %></span>
     </div>
   <% end %>
 
@@ -13,7 +13,7 @@
                   data: {
                     controller: "loading-button",
                     action: "submit->loading-button#showLoading",
-                    loading_button_loading_text_value: "Creating Accounts...",
+                    loading_button_loading_text_value: t(".creating_accounts"),
                     turbo_frame: "_top"
                   },
                   class: "space-y-6" do |form| %>
@@ -24,7 +24,7 @@
             <%= icon "info", size: "sm", class: "text-primary mt-0.5 flex-shrink-0" %>
             <div>
               <p class="text-sm text-primary mb-2">
-                <strong>Choose the correct account type for each Enable Banking account:</strong>
+                <strong><%= t(".account_type_instructions") %></strong>
               </p>
               <ul class="text-xs text-secondary space-y-1 list-disc list-inside">
                 <% @account_type_options.reject { |_, type| type == "skip" }.each do |label, _| %>
@@ -41,15 +41,15 @@
             <%= icon "calendar", size: "sm", class: "text-primary mt-0.5 flex-shrink-0" %>
             <div class="flex-1">
               <p class="text-sm text-primary mb-3">
-                <strong>Historical Data Range:</strong>
+                <strong><%= t(".historical_data_range") %></strong>
               </p>
               <%= form.date_field :sync_start_date,
-                    label: "Start syncing transactions from:",
+                    label: t(".start_sync_from"),
                     value: @enable_banking_item.sync_start_date || 3.months.ago.to_date,
                     min: 1.year.ago.to_date,
                     max: Date.current,
                     class: "w-full max-w-xs rounded-md border border-primary px-3 py-2 text-sm bg-container-inset text-primary",
-                    help_text: "Select how far back you want to sync transaction history. Maximum 1 year of history available." %>
+                    help_text: t(".sync_help_text") %>
             </div>
           </div>
         </div>
@@ -69,7 +69,7 @@
                     <p><%= enable_banking_account.account_type_display %></p>
                   <% end %>
                   <% if enable_banking_account.current_balance.present? %>
-                    <p>Balance: <%= number_to_currency(enable_banking_account.current_balance, unit: enable_banking_account.currency) %></p>
+                    <p><%= t(".balance") %> <%= number_to_currency(enable_banking_account.current_balance, unit: enable_banking_account.currency) %></p>
                   <% end %>
                 </div>
               </div>
@@ -77,7 +77,7 @@
 
             <div class="space-y-3" data-controller="account-type-selector" data-account-type-selector-account-id-value="<%= enable_banking_account.id %>">
               <div>
-                <%= label_tag "account_types[#{enable_banking_account.id}]", "Account Type:",
+                <%= label_tag "account_types[#{enable_banking_account.id}]", t(".account_type_label"),
                              class: "block text-sm font-medium text-primary mb-2" %>
                 <%= select_tag "account_types[#{enable_banking_account.id}]",
                               options_for_select(@account_type_options, "skip"),
@@ -100,7 +100,7 @@
 
       <div class="flex gap-3">
         <%= render DS::Button.new(
-          text: "Create Accounts",
+          text: t(".create_accounts"),
           variant: "primary",
           icon: "plus",
           type: "submit",
@@ -108,7 +108,7 @@
           data: { loading_button_target: "button" }
         ) %>
         <%= render DS::Link.new(
-          text: "Cancel",
+          text: t(".cancel"),
           variant: "secondary",
           href: accounts_path
         ) %>

--- a/app/views/entries/_selection_bar.html.erb
+++ b/app/views/entries/_selection_bar.html.erb
@@ -7,7 +7,7 @@
 
   <div class="flex items-center gap-1 text-secondary">
     <%= form_with url: transactions_bulk_deletion_path, data: { turbo_confirm: CustomConfirm.for_resource_deletion("entry").to_data_attribute, turbo_frame: "_top" } do %>
-      <button type="button" data-bulk-select-scope-param="bulk_delete" data-action="bulk-select#submitBulkRequest" class="p-1.5 group/delete hover:bg-inverse flex items-center justify-center rounded-md" title="Delete">
+      <button type="button" data-bulk-select-scope-param="bulk_delete" data-action="bulk-select#submitBulkRequest" class="p-1.5 group/delete hover:bg-inverse flex items-center justify-center rounded-md" title="<%= t("entries.selection_bar.delete") %>">
         <%= icon "trash-2", class: "group-hover/delete:text-inverse" %>
       </button>
     <% end %>

--- a/app/views/family_exports/_list.html.erb
+++ b/app/views/family_exports/_list.html.erb
@@ -9,7 +9,7 @@
         <div class="flex items-center justify-between mx-4 py-4">
           <div class="flex items-center gap-2 mb-1">
             <div>
-              <p class="text-sm font-medium text-primary">Export from <%= export.created_at.strftime("%B %d, %Y at %I:%M %p") %></p>
+              <p class="text-sm font-medium text-primary"><%= t(".export_from", date: l(export.created_at, format: :long)) %></p>
               <p class="text-xs text-secondary"><%= export.filename %></p>
             </div>
 
@@ -31,7 +31,7 @@
           <% if export.processing? || export.pending? %>
             <div class="flex items-center gap-2 text-secondary">
               <div class="animate-spin h-4 w-4 border-2 border-secondary border-t-transparent rounded-full"></div>
-              <span class="text-sm">Exporting...</span>
+              <span class="text-sm"><%= t(".exporting") %></span>
             </div>
           <% elsif export.completed? %>
             <div class="flex items-center gap-2">
@@ -39,7 +39,7 @@
                   method: :delete,
                   class: "flex items-center gap-2 text-destructive hover:text-destructive-hover",
                   data: {
-                    turbo_confirm: "Are you sure you want to delete this export? This action cannot be undone.",
+                    turbo_confirm: t(".delete_confirm"),
                     turbo_frame: "_top"
                   } do %>
                 <%= icon "trash-2", class: "w-5 h-5 text-destructive" %>
@@ -61,7 +61,7 @@
                   method: :delete,
                   class: "flex items-center gap-2 text-destructive hover:text-destructive-hover",
                   data: {
-                    turbo_confirm: "Are you sure you want to delete this failed export?",
+                    turbo_confirm: t(".delete_failed_confirm"),
                     turbo_frame: "_top"
                   } do %>
                 <%= icon "trash-2", class: "w-5 h-5 text-destructive" %>
@@ -71,7 +71,7 @@
         </div>
       <% end %>
     <% else %>
-      <p class="text-sm text-primary text-center py-4 mb-1 font-medium">No exports yet.</p>
+      <p class="text-sm text-primary text-center py-4 mb-1 font-medium"><%= t(".no_exports") %></p>
     <% end %>
   </div>
 <% end %>

--- a/app/views/family_exports/new.html.erb
+++ b/app/views/family_exports/new.html.erb
@@ -1,40 +1,40 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Export your data", subtitle: "Download all your financial data") %>
+  <% dialog.with_header(title: t(".title"), subtitle: t(".subtitle")) %>
 
   <% dialog.with_body do %>
     <div class="space-y-4">
       <div class="bg-container-inset rounded-lg p-4 space-y-3">
-        <h3 class="font-medium text-primary">What's included:</h3>
+        <h3 class="font-medium text-primary"><%= t(".whats_included") %></h3>
         <ul class="space-y-2 text-sm text-secondary">
           <li class="flex items-start gap-2">
             <%= icon "check", class: "shrink-0 mt-0.5 text-positive" %>
-            <span>All accounts and balances</span>
+            <span><%= t(".includes.accounts") %></span>
           </li>
           <li class="flex items-start gap-2">
             <%= icon "check", class: "shrink-0 mt-0.5 text-positive" %>
-            <span>Transaction history</span>
+            <span><%= t(".includes.transactions") %></span>
           </li>
           <li class="flex items-start gap-2">
             <%= icon "check", class: "shrink-0 mt-0.5 text-positive" %>
-            <span>Investment trades</span>
+            <span><%= t(".includes.trades") %></span>
           </li>
           <li class="flex items-start gap-2">
             <%= icon "check", class: "shrink-0 mt-0.5 text-positive" %>
-            <span>Categories, tags and rules</span>
+            <span><%= t(".includes.categories_tags_rules") %></span>
           </li>
         </ul>
       </div>
 
       <div class="bg-amber-50 border border-amber-200 rounded-lg p-3">
         <p class="text-sm text-amber-800">
-          <strong>Note:</strong> This export includes all of your data, but only some of the data can be imported back via the CSV import feature. We support account, transaction (with category and tags), and trade imports. Other account data cannot be imported and is for your records only.
+          <%= raw t(".note_html") %>
         </p>
       </div>
 
       <%= form_with url: family_exports_path, method: :post, class: "space-y-4" do |form| %>
         <div class="flex gap-3">
-          <%= link_to "Cancel", "#", class: "flex-1 text-center px-4 py-2 text-primary bg-surface border border-primary rounded-lg hover:bg-surface-hover", data: { action: "click->modal#close" } %>
-          <%= form.submit "Export data", class: "flex-1 bg-inverse fg-inverse rounded-lg px-4 py-2 cursor-pointer hover:bg-inverse-hover" %>
+          <%= link_to t(".cancel"), "#", class: "flex-1 text-center px-4 py-2 text-primary bg-surface border border-primary rounded-lg hover:bg-surface-hover", data: { action: "click->modal#close" } %>
+          <%= form.submit t(".export_data"), class: "flex-1 bg-inverse fg-inverse rounded-lg px-4 py-2 cursor-pointer hover:bg-inverse-hover" %>
         </div>
       <% end %>
     </div>

--- a/app/views/family_merchants/_family_merchant.html.erb
+++ b/app/views/family_merchants/_family_merchant.html.erb
@@ -18,10 +18,10 @@
   </td>
   <td class="py-3 px-4 text-sm text-right align-middle">
     <%= render DS::Menu.new do |menu| %>
-      <% menu.with_item(variant: "link", text: "Edit", href: edit_family_merchant_path(family_merchant), icon: "pencil", data: { turbo_frame: "modal" }) %>
+      <% menu.with_item(variant: "link", text: t('.edit'), href: edit_family_merchant_path(family_merchant), icon: "pencil", data: { turbo_frame: "modal" }) %>
       <% menu.with_item(
         variant: "button",
-        text: "Delete",
+        text: t('.delete'),
         href: family_merchant_path(family_merchant),
         icon: "trash-2",
         method: :delete,

--- a/app/views/holdings/_cost_basis_cell.html.erb
+++ b/app/views/holdings/_cost_basis_cell.html.erb
@@ -30,7 +30,7 @@
         <% else %>
           <div class="flex items-center gap-1 px-2 py-0.5 rounded text-secondary hover:text-primary hover:bg-gray-100 theme-dark:hover:bg-gray-700 transition-colors">
             <%= icon "pencil", size: "xs" %>
-            <span class="text-xs">Set</span>
+            <span class="text-xs"><%= t(".set") %></span>
           </div>
         <% end %>
       <% end %>

--- a/app/views/holdings/new.html.erb
+++ b/app/views/holdings/new.html.erb
@@ -1,1 +1,1 @@
-<p>Coming soon...</p>
+<p><%= t("holdings.new.coming_soon") %></p>

--- a/app/views/holdings/show.html.erb
+++ b/app/views/holdings/show.html.erb
@@ -170,7 +170,7 @@
             </ul>
 
           <% else %>
-            <p class="text-secondary">No trade history available for this holding.</p>
+            <p class="text-secondary"><%= t(".no_trade_history") %></p>
           <% end %>
         </div>
       </div>

--- a/app/views/impersonation_sessions/_approval_bar.html.erb
+++ b/app/views/impersonation_sessions/_approval_bar.html.erb
@@ -4,18 +4,18 @@
 <div class="sticky top-0 left-0 w-full bg-black flex items-center justify-between font-mono">
   <div class="flex items-center bg-red-600 text-inverse px-6 py-4">
     <%= icon "alert-triangle", size: "lg", color: "current", class: "mr-2" %>
-    <span class="text-inverse font-semibold uppercase">Access <%= in_progress_session.present? ? "Session" : "Request" %></span>
+    <span class="text-inverse font-semibold uppercase"><%= t("impersonation_sessions.approval_bar.access") %> <%= in_progress_session.present? ? t("impersonation_sessions.approval_bar.session") : t("impersonation_sessions.approval_bar.request") %></span>
   </div>
   <div class="flex items-center space-x-2 px-2 py-2 text-white gap-4">
     <% if pending_session.present? %>
-      <p class="text-xs max-w-3xl text-right">Sure support staff has requested access to your account (likely to help you with a support request). If you approve the request, all activity they take will be logged for security and audit purposes.</p>
-      <%= button_to "Approve", approve_impersonation_session_path(pending_session), method: :put, class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-green-500" %>
-      <%= button_to "Reject", reject_impersonation_session_path(pending_session), method: :put, class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
+      <p class="text-xs max-w-3xl text-right"><%= t("impersonation_sessions.approval_bar.pending_message") %></p>
+      <%= button_to t("impersonation_sessions.approval_bar.approve"), approve_impersonation_session_path(pending_session), method: :put, class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-green-500" %>
+      <%= button_to t("impersonation_sessions.approval_bar.reject"), reject_impersonation_session_path(pending_session), method: :put, class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
     <% elsif in_progress_session.present? %>
-      <p class="text-xs max-w-3xl text-right">Someone from the Sure Finances team is currently viewing your data.  You may end the session at any time.</p>
-      <%= button_to "End Session", complete_impersonation_session_path(in_progress_session), method: :put, class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+      <p class="text-xs max-w-3xl text-right"><%= t("impersonation_sessions.approval_bar.in_progress_message") %></p>
+      <%= button_to t("impersonation_sessions.approval_bar.end_session"), complete_impersonation_session_path(in_progress_session), method: :put, class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
     <% else %>
-      <p class="text-xs max-w-3xl text-right text-red-500">Something went wrong.  Please contact us.</p>
+      <p class="text-xs max-w-3xl text-right text-red-500"><%= t("impersonation_sessions.approval_bar.error_message") %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/impersonation_sessions/_super_admin_bar.html.erb
+++ b/app/views/impersonation_sessions/_super_admin_bar.html.erb
@@ -1,20 +1,20 @@
 <div class="sticky top-0 left-0 w-full bg-black flex items-center justify-between font-mono">
   <div class="flex items-center bg-red-600 px-6 py-4">
     <%= icon "alert-triangle", size: "lg", color: "current", class: "mr-2" %>
-    <span class="text-inverse font-semibold uppercase">Super Admin</span>
+    <span class="text-inverse font-semibold uppercase"><%= t("impersonation_sessions.super_admin_bar.title") %></span>
   </div>
   <div>
-    <%= link_to "Jobs", sidekiq_web_url, class: "text-white underline hover:text-gray-100" %>
+    <%= link_to t("impersonation_sessions.super_admin_bar.jobs"), sidekiq_web_url, class: "text-white underline hover:text-gray-100" %>
   </div>
 
   <div class="flex items-center space-x-2 px-2 py-2 text-white">
     <% if Current.session.active_impersonator_session.present? %>
       <div class="flex items-center space-x-3 bg-gray-800 border border-gray-700 rounded-md pl-3">
         <div class="text-sm">
-          Impersonating: <span class="font-semibold text-red-400"><%= Current.impersonated_user.email %></span>
+          <%= t("impersonation_sessions.super_admin_bar.impersonating") %>: <span class="font-semibold text-red-400"><%= Current.impersonated_user.email %></span>
         </div>
-        <%= button_to "Leave", leave_impersonation_sessions_path, method: :delete, class: "items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
-        <%= button_to "Terminate", complete_impersonation_session_path(Current.session.active_impersonator_session), method: :put, class: "items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
+        <%= button_to t("impersonation_sessions.super_admin_bar.leave"), leave_impersonation_sessions_path, method: :delete, class: "items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
+        <%= button_to t("impersonation_sessions.super_admin_bar.terminate"), complete_impersonation_session_path(Current.session.active_impersonator_session), method: :put, class: "items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
       </div>
     <% else %>
       <% if Current.true_user.impersonator_support_sessions.in_progress.any? %>
@@ -23,16 +23,16 @@
             Current.true_user.impersonator_support_sessions.in_progress.map { |session|
               ["#{session.impersonated.email} (#{session.status})", session.id]
             },
-            { prompt: "Join a session" },
+            { prompt: t("impersonation_sessions.super_admin_bar.join_session_prompt") },
             { class: "rounded-md text-sm border-0 focus:ring-0 ring-0 text-black font-mono" } %>
-          <%= f.submit "Join",
+          <%= f.submit t("impersonation_sessions.super_admin_bar.join"),
             class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
         <% end %>
       <% end %>
 
       <%= form_with model: ImpersonationSession.new, class: "flex items-center space-x-2" do |f| %>
-        <%= f.text_field :impersonated_id, class: "rounded-md text-sm border-0 focus:ring-0 ring-0 text-black font-mono w-96", placeholder: "UUID", autocomplete: "off" %>
-        <%= f.submit "Request Impersonation", class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
+        <%= f.text_field :impersonated_id, class: "rounded-md text-sm border-0 focus:ring-0 ring-0 text-black font-mono w-96", placeholder: t("impersonation_sessions.super_admin_bar.uuid_placeholder"), autocomplete: "off" %>
+        <%= f.submit t("impersonation_sessions.super_admin_bar.request_impersonation"), class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/import/cleans/show.html.erb
+++ b/app/views/import/cleans/show.html.erb
@@ -14,11 +14,11 @@
     <div class="bg-container border border-tertiary rounded-lg p-3 flex flex-col md:flex-row items-start md:items-center justify-between gap-2 md:gap-0">
       <div class="flex items-center gap-2">
         <%= icon "check-circle", size: "sm", color: "success" %>
-        <p class="text-success text-sm">Your data has been cleaned</p>
+        <p class="text-success text-sm"><%= t(".data_cleaned") %></p>
       </div>
 
       <%= render DS::Link.new(
-        text: "Next step",
+        text: t(".next_step"),
         variant: "primary",
         href: import_confirm_path(@import),
         frame: :_top,
@@ -35,8 +35,8 @@
 
       <div class="flex justify-center w-full md:w-auto">
         <div class="bg-gray-50 rounded-lg inline-flex p-1 space-x-2 text-sm text-primary font-medium w-full md:w-auto">
-          <%= link_to "All rows", import_clean_path(@import, per_page: params[:per_page], view: "all"), class: "p-2 rounded-lg flex-1 md:flex-auto text-center #{params[:view] != 'errors' ? 'bg-container' : ''}" %>
-          <%= link_to "Error rows", import_clean_path(@import, per_page: params[:per_page], view: "errors"), class: "p-2 rounded-lg flex-1 md:flex-auto text-center #{params[:view] == 'errors' ? 'bg-container' : ''}" %>
+          <%= link_to t(".all_rows"), import_clean_path(@import, per_page: params[:per_page], view: "all"), class: "p-2 rounded-lg flex-1 md:flex-auto text-center #{params[:view] != 'errors' ? 'bg-container' : ''}" %>
+          <%= link_to t(".error_rows"), import_clean_path(@import, per_page: params[:per_page], view: "errors"), class: "p-2 rounded-lg flex-1 md:flex-auto text-center #{params[:view] == 'errors' ? 'bg-container' : ''}" %>
         </div>
       </div>
     </div>

--- a/app/views/import/configurations/_account_import.html.erb
+++ b/app/views/import/configurations/_account_import.html.erb
@@ -1,10 +1,10 @@
 <%# locals: (import:) %>
 
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
-  <%= form.select :entity_type_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Entity Type" } %>
-  <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name" }, required: true %>
-  <%= form.select :amount_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Balance" }, required: true %>
-  <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Default", label: "Currency" } %>
+  <%= form.select :entity_type_col_label, import.csv_headers, { include_blank: t("import.configurations.account_import.leave_empty"), label: t("import.configurations.account_import.entity_type") } %>
+  <%= form.select :name_col_label, import.csv_headers, { include_blank: t("import.configurations.account_import.leave_empty"), label: t("import.configurations.account_import.name") }, required: true %>
+  <%= form.select :amount_col_label, import.csv_headers, { include_blank: t("import.configurations.account_import.leave_empty"), label: t("import.configurations.account_import.balance") }, required: true %>
+  <%= form.select :currency_col_label, import.csv_headers, { include_blank: t("import.configurations.account_import.default"), label: t("import.configurations.account_import.currency") } %>
 
-  <%= form.submit "Apply configuration", disabled: import.complete? %>
+  <%= form.submit t("import.configurations.account_import.apply_configuration"), disabled: import.complete? %>
 <% end %>

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -4,32 +4,32 @@
   <span class="text-green-500">
     <%= icon("check-circle", color: "current") %>
   </span>
-  <p class="text-sm text-primary italic">We have pre-configured your Mint import for you. Please proceed to the next step.</p>
+  <p class="text-sm text-primary italic"><%= t("import.configurations.mint_import.preconfigured_message") %></p>
 </div>
 
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
   <div class="flex items-center gap-4">
-    <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
+    <%= form.select :date_col_label, import.csv_headers, { include_blank: t("import.configurations.mint_import.leave_empty"), label: t("import.configurations.mint_import.date") }, required: true, disabled: import.complete? %>
     <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label")}, label: true, required: true, disabled: import.complete? %>
   </div>
 
   <div class="flex items-center gap-4">
-    <%= form.select :amount_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Amount" }, required: true, disabled: import.complete? %>
-    <%= form.select :signage_convention, [["Incomes are negative", "inflows_negative"], ["Incomes are positive", "inflows_positive"]], { label: true }, disabled: import.complete? %>
+    <%= form.select :amount_col_label, import.csv_headers, { include_blank: t("import.configurations.mint_import.leave_empty"), label: t("import.configurations.mint_import.amount") }, required: true, disabled: import.complete? %>
+    <%= form.select :signage_convention, [[t("import.configurations.mint_import.incomes_negative"), "inflows_negative"], [t("import.configurations.mint_import.incomes_positive"), "inflows_positive"]], { label: true }, disabled: import.complete? %>
   </div>
 
   <div class="flex items-center gap-4">
-    <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Currency" }, disabled: import.complete? %>
-    <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
+    <%= form.select :currency_col_label, import.csv_headers, { include_blank: t("import.configurations.mint_import.leave_empty"), label: t("import.configurations.mint_import.currency") }, disabled: import.complete? %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: t("import.configurations.mint_import.format"), prompt: t("import.configurations.mint_import.select_format") }, required: true %>
   </div>
 
   <% unless import.account.present? %>
-    <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
+    <%= form.select :account_col_label, import.csv_headers, { include_blank: t("import.configurations.mint_import.leave_empty"), label: t("import.configurations.mint_import.account_optional") }, disabled: import.complete? %>
   <% end %>
 
-  <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" }, disabled: import.complete? %>
-  <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>
-  <%= form.select :tags_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Tags (optional)" }, disabled: import.complete? %>
+  <%= form.select :name_col_label, import.csv_headers, { include_blank: t("import.configurations.mint_import.leave_empty"), label: t("import.configurations.mint_import.name_optional") }, disabled: import.complete? %>
+  <%= form.select :category_col_label, import.csv_headers, { include_blank: t("import.configurations.mint_import.leave_empty"), label: t("import.configurations.mint_import.category_optional") }, disabled: import.complete? %>
+  <%= form.select :tags_col_label, import.csv_headers, { include_blank: t("import.configurations.mint_import.leave_empty"), label: t("import.configurations.mint_import.tags_optional") }, disabled: import.complete? %>
 
-  <%= form.submit "Apply configuration", disabled: import.complete? %>
+  <%= form.submit t("import.configurations.mint_import.apply_configuration"), disabled: import.complete? %>
 <% end %>

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -3,38 +3,38 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
   <div class="space-y-4">
     <div class="flex items-center gap-4">
-      <%= form.select :date_col_label, import.csv_headers, { include_blank: "Select column", label: "Date" }, required: true %>
+      <%= form.select :date_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.select_column"), label: t("import.configurations.trade_import.date") }, required: true %>
       <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label")}, label: true, required: true %>
     </div>
 
     <div class="flex items-center gap-4">
-      <%= form.select :qty_col_label, import.csv_headers, { include_blank: "Select column", label: "Quantity" }, required: true %>
-      <%= form.select :signage_convention, [["Buys are positive qty", "inflows_positive"], ["Buys are negative qty", "inflows_negative"]], label: true, required: true %>
+      <%= form.select :qty_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.select_column"), label: t("import.configurations.trade_import.quantity") }, required: true %>
+      <%= form.select :signage_convention, [[t("import.configurations.trade_import.buys_positive"), "inflows_positive"], [t("import.configurations.trade_import.buys_negative"), "inflows_negative"]], label: true, required: true %>
     </div>
 
     <div class="flex items-center gap-4">
-      <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Default", label: "Currency" } %>
-      <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
+      <%= form.select :currency_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.default"), label: t("import.configurations.trade_import.currency") } %>
+      <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: t("import.configurations.trade_import.format"), prompt: t("import.configurations.trade_import.select_format") }, required: true %>
     </div>
 
-    <%= form.select :ticker_col_label, import.csv_headers, { include_blank: "Select column", label: "Ticker" }, required: true %>
-    <%= form.select :exchange_operating_mic_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Stock exchange code" } %>
-    <%= form.select :price_col_label, import.csv_headers, { include_blank: "Select column", label: "Price" }, required: true %>
+    <%= form.select :ticker_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.select_column"), label: t("import.configurations.trade_import.ticker") }, required: true %>
+    <%= form.select :exchange_operating_mic_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.leave_empty"), label: t("import.configurations.trade_import.stock_exchange_code") } %>
+    <%= form.select :price_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.select_column"), label: t("import.configurations.trade_import.price") }, required: true %>
 
     <% unless import.account.present? %>
-      <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account" } %>
+      <%= form.select :account_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.leave_empty"), label: t("import.configurations.trade_import.account") } %>
     <% end %>
 
-    <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name" } %>
+    <%= form.select :name_col_label, import.csv_headers, { include_blank: t("import.configurations.trade_import.leave_empty"), label: t("import.configurations.trade_import.name") } %>
 
     <% unless Security.provider %>
       <div class="alert alert-warning">
         <p>
-          <strong>Note:</strong> The security prices provider is not configured.  Your trade imports will work, but Sure will not backfill price history.  Please go to your settings to configure this.
+          <%= raw t("import.configurations.trade_import.no_provider_warning_html") %>
         </p>
       </div>
     <% end %>
   </div>
 
-  <%= form.submit "Apply configuration", disabled: import.complete? %>
+  <%= form.submit t("import.configurations.trade_import.apply_configuration"), disabled: import.complete? %>
 <% end %>

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -19,11 +19,11 @@
   <div class="flex items-center gap-4">
     <%= form.select :date_col_label,
                     import.csv_headers,
-                    { label: "Date", prompt: "Select column" },
+                    { label: t("import.configurations.transaction_import.date"), prompt: t("import.configurations.transaction_import.select_column") },
                     required: true %>
     <%= form.select :date_format,
                     Family::DATE_FORMATS,
-                    { label: t(".date_format_label"), prompt: "Select format" },
+                    { label: t(".date_format_label"), prompt: t("import.configurations.transaction_import.select_format") },
                     required: true %>
   </div>
 
@@ -31,21 +31,21 @@
   <div class="flex items-center gap-4">
     <%= form.select :amount_col_label,
                     import.csv_headers,
-                    { label: "Amount", container_class: "w-2/5", prompt: "Select column" },
+                    { label: t("import.configurations.transaction_import.amount"), container_class: "w-2/5", prompt: t("import.configurations.transaction_import.select_column") },
                     required: true %>
     <%= form.select :currency_col_label,
                     import.csv_headers,
-                    { include_blank: "Default", label: "Currency", container_class: "w-1/5" } %>
+                    { include_blank: t("import.configurations.transaction_import.default"), label: t("import.configurations.transaction_import.currency"), container_class: "w-1/5" } %>
     <%= form.select :number_format,
                     Import::NUMBER_FORMATS.keys,
-                    { label: "Format", prompt: "Select format", container_class: "w-2/5" },
+                    { label: t("import.configurations.transaction_import.format"), prompt: t("import.configurations.transaction_import.select_format"), container_class: "w-2/5" },
                     required: true %>
   </div>
 
   <%# Amount Type Strategy %>
   <%= form.select :amount_type_strategy,
                   Import::AMOUNT_TYPE_STRATEGIES.map { |strategy| [strategy.humanize, strategy] },
-                  { label: "Amount type strategy", prompt: "Select strategy" },
+                  { label: t("import.configurations.transaction_import.amount_type_strategy"), prompt: t("import.configurations.transaction_import.select_strategy") },
                   required: true,
                   data: {
                     action: "import#handleAmountTypeStrategyChange",
@@ -58,8 +58,8 @@
     <div class="flex items-center gap-2">
       <span class="text-sm shrink-0 text-secondary">↪</span>
       <%= form.select :signage_convention,
-                      [["Incomes are positive", "inflows_positive"], ["Incomes are negative", "inflows_negative"]],
-                      { label: "Amount type", prompt: "Select convention" },
+                      [[t("import.configurations.transaction_import.incomes_positive"), "inflows_positive"], [t("import.configurations.transaction_import.incomes_negative"), "inflows_negative"]],
+                      { label: t("import.configurations.transaction_import.amount_type"), prompt: t("import.configurations.transaction_import.select_convention") },
                       required: @import.amount_type_strategy == "signed_amount" %>
     </div>
   <% end %>
@@ -70,23 +70,23 @@
     <div class="space-y-2">
       <div class="flex items-center gap-2 text-sm">
         <span class="shrink-0 text-secondary">↪</span>
-        <span class="text-secondary">Set</span>
+        <span class="text-secondary"><%= t("import.configurations.transaction_import.set") %></span>
         <%= form.select :entity_type_col_label,
                         import.csv_headers,
-                        { prompt: "Select column", container_class: "w-48 px-3 py-1.5 border border-secondary rounded-md" },
+                        { prompt: t("import.configurations.transaction_import.select_column"), container_class: "w-48 px-3 py-1.5 border border-secondary rounded-md" },
                         required: @import.amount_type_strategy == "custom_column",
                         data: { action: "import#handleAmountTypeChange" } %>
-        <span class="text-secondary">as amount type column</span>
+        <span class="text-secondary"><%= t("import.configurations.transaction_import.as_amount_type_column") %></span>
       </div>
 
       <div class="items-center gap-2 text-sm <%= @import.entity_type_col_label.nil? ? "hidden" : "flex" %>" data-import-target="amountTypeValue">
         <span class="shrink-0 text-secondary">↪</span>
-        <span class="text-secondary">Set</span>
+        <span class="text-secondary"><%= t("import.configurations.transaction_import.set") %></span>
         <%= form.select :amount_type_inflow_value,
                         @import.selectable_amount_type_values,
-                        { prompt: "Select column", container_class: "w-48 px-3 py-1.5 border border-secondary rounded-md" },
+                        { prompt: t("import.configurations.transaction_import.select_column"), container_class: "w-48 px-3 py-1.5 border border-secondary rounded-md" },
                         required: @import.amount_type_strategy == "custom_column" %>
-        <span class="text-secondary">as "income" (inflow) value</span>
+        <span class="text-secondary"><%= t("import.configurations.transaction_import.as_income_inflow_value") %></span>
       </div>
     </div>
   <% end %>
@@ -95,21 +95,21 @@
   <% unless import.account.present? %>
     <%= form.select :account_col_label,
                     import.csv_headers,
-                    { include_blank: "Leave empty", label: "Account" } %>
+                    { include_blank: t("import.configurations.transaction_import.leave_empty"), label: t("import.configurations.transaction_import.account") } %>
   <% end %>
 
   <%= form.select :name_col_label,
                   import.csv_headers,
-                  { include_blank: "Leave empty", label: "Name" } %>
+                  { include_blank: t("import.configurations.transaction_import.leave_empty"), label: t("import.configurations.transaction_import.name") } %>
   <%= form.select :category_col_label,
                   import.csv_headers,
-                  { include_blank: "Leave empty", label: "Category" } %>
+                  { include_blank: t("import.configurations.transaction_import.leave_empty"), label: t("import.configurations.transaction_import.category") } %>
   <%= form.select :tags_col_label,
                   import.csv_headers,
-                  { include_blank: "Leave empty", label: "Tags" } %>
+                  { include_blank: t("import.configurations.transaction_import.leave_empty"), label: t("import.configurations.transaction_import.tags") } %>
   <%= form.select :notes_col_label,
                   import.csv_headers,
-                  { include_blank: "Leave empty", label: "Notes" } %>
+                  { include_blank: t("import.configurations.transaction_import.leave_empty"), label: t("import.configurations.transaction_import.notes") } %>
 
-  <%= form.submit "Apply configuration", disabled: import.complete? %>
+  <%= form.submit t("import.configurations.transaction_import.apply_configuration"), disabled: import.complete? %>
 <% end %>

--- a/app/views/import/configurations/show.html.erb
+++ b/app/views/import/configurations/show.html.erb
@@ -12,14 +12,14 @@
           <%= icon "sparkles" %>
         </span>
 
-        Template configuration found
+        <%= t(".template_found") %>
       </h3>
 
-      <p class="text-sm text-secondary">We found a configuration from a previous import for this account.  Would you like to apply it to this import?</p>
+      <p class="text-sm text-secondary"><%= t(".template_found_description") %></p>
 
       <div class="mt-4 flex gap-2 items-center">
-        <%= render DS::Link.new(text: "Manually configure", href: import_configuration_path(@import), variant: "outline") %>
-        <%= render DS::Button.new(text: "Apply template", href: apply_template_import_path(@import), method: :put, data: { turbo_frame: :_top }) %>
+        <%= render DS::Link.new(text: t(".manually_configure"), href: import_configuration_path(@import), variant: "outline") %>
+        <%= render DS::Button.new(text: t(".apply_template"), href: apply_template_import_path(@import), method: :put, data: { turbo_frame: :_top }) %>
       </div>
     </div>
   </div>
@@ -32,7 +32,7 @@
 
     <div class="mx-auto max-w-lg space-y-4">
       <%= render partial: permitted_import_configuration_path(@import), locals: { import: @import } %>
-      <%= render "imports/table", headers: @import.csv_headers, rows: @import.csv_sample, caption: "Sample data from your uploaded CSV" %>
+      <%= render "imports/table", headers: @import.csv_headers, rows: @import.csv_sample, caption: t(".sample_data_caption") %>
     </div>
   </div>
 <% end %>

--- a/app/views/import/confirms/_mappings.html.erb
+++ b/app/views/import/confirms/_mappings.html.erb
@@ -12,7 +12,7 @@
             <%= tag.p t(".no_accounts"), class: "text-sm" %>
 
             <%= render DS::Link.new(
-              text: "Create account",
+              text: t(".create_account"),
               variant: "primary",
               href: new_account_path(return_to: import_confirm_path(import)),
               frame: :modal
@@ -60,7 +60,7 @@
 
     <div class="flex justify-center w-full">
       <%= render DS::Link.new(
-        text: "Next",
+        text: t(".next"),
         variant: "primary",
         href: is_last_step ? import_path(import) : url_for(step: step_idx + 2),
         icon: "arrow-right",

--- a/app/views/import/mappings/_form.html.erb
+++ b/app/views/import/mappings/_form.html.erb
@@ -6,17 +6,17 @@
                      class: "grid grid-cols-3 gap-2 items-center",
                      data: { controller: "auto-submit-form" },
                      html: { id: dom_id(mapping, :form) } do |form| %>
-  <span><%= mapping.key.blank? ? "(unassigned)" : mapping.key %></span>
+  <span><%= mapping.key.blank? ? t("import.mappings.form.unassigned") : mapping.key %></span>
 
   <% if mapping.mappable_class.present? %>
     <%= form.hidden_field :mappable_type, value: mapping.mappable_class, id: dom_id(mapping, :mappable_type) %>
     <%= form.select :mappable_id,
                       mapping.selectable_values,
-                      { container_class: mapping.invalid? ? "border-red-500" : nil, include_blank: mapping.requires_selection? ? "Select an option" : "Leave unassigned", selected: mapping.create_when_empty? ? mapping.class::CREATE_NEW_KEY : mapping.mappable_id },
+                      { container_class: mapping.invalid? ? "border-red-500" : nil, include_blank: mapping.requires_selection? ? t("import.mappings.form.select_option") : t("import.mappings.form.leave_unassigned"), selected: mapping.create_when_empty? ? mapping.class::CREATE_NEW_KEY : mapping.mappable_id },
                       "data-auto-submit-form-target": "auto", "data-autosubmit-trigger-event": "change", disabled: mapping.import.complete?, id: dom_id(mapping, :mappable_id) %>
   <% else %>
     <%= form.select :value, mapping.selectable_values,
-                      { container_class: mapping.invalid? ? "border-red-500" : nil, include_blank: mapping.requires_selection? ? "Select an option" : "Leave unassigned" },
+                      { container_class: mapping.invalid? ? "border-red-500" : nil, include_blank: mapping.requires_selection? ? t("import.mappings.form.select_option") : t("import.mappings.form.leave_unassigned") },
                       "data-auto-submit-form-target": "auto", "data-autosubmit-trigger-event": "change", disabled: mapping.import.complete?, id: dom_id(mapping, :value) %>
   <% end %>
 

--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -6,7 +6,7 @@
 
 <div class="space-y-4" data-controller="drag-and-drop-import">
   <!-- Overlay -->
-  <%= render "imports/drag_drop_overlay", title: "Drop CSV to upload", subtitle: "Your file will be uploaded automatically" %>
+  <%= render "imports/drag_drop_overlay", title: t(".drop_csv_title"), subtitle: t(".drop_csv_subtitle") %>
 
   <div class="space-y-4 mx-auto max-w-md">
     <div class="text-center space-y-2">
@@ -16,8 +16,8 @@
 
     <%= render DS::Tabs.new(active_tab: params[:tab] || "csv-upload", url_param_key: "tab", testid: "import-tabs") do |tabs| %>
       <% tabs.with_nav do |nav| %>
-        <% nav.with_btn(id: "csv-upload", label: "Upload CSV") %>
-        <% nav.with_btn(id: "csv-paste", label: "Copy & Paste") %>
+        <% nav.with_btn(id: "csv-upload", label: t(".upload_csv_tab")) %>
+        <% nav.with_btn(id: "csv-paste", label: t(".copy_paste_tab")) %>
       <% end %>
 
       <% tabs.with_panel(tab_id: "csv-upload") do %>
@@ -25,7 +25,7 @@
           <%= form.select :col_sep, Import::SEPARATORS, label: true %>
 
           <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-            <%= form.select :account_id, @import.family.accounts.visible.pluck(:name, :id), { label: "Account (optional)", include_blank: "Multi-account import", selected: @import.account_id } %>
+            <%= form.select :account_id, @import.family.accounts.visible.pluck(:name, :id), { label: t(".account_optional"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
           <% end %>
 
           <div class="flex flex-col items-center justify-center w-full h-64 border border-secondary border-dashed rounded-xl cursor-pointer" data-controller="file-upload" data-action="click->file-upload#triggerFileInput" data-file-upload-target="uploadArea">
@@ -33,7 +33,7 @@
               <div data-file-upload-target="uploadText" class="flex flex-col items-center">
                 <%= icon("plus", size: "lg", class: "mb-4 mx-auto") %>
                 <p class="mb-2 text-md text-gray text-center">
-                  <span class="font-medium text-primary">Browse</span> to add your CSV file here
+                  <%= raw t(".browse_to_add_html") %>
                 </p>
               </div>
 
@@ -48,7 +48,7 @@
             </div>
           </div>
 
-          <%= form.submit "Upload CSV", disabled: @import.complete? %>
+          <%= form.submit t(".upload_csv"), disabled: @import.complete? %>
         <% end %>
       <% end %>
 
@@ -57,16 +57,16 @@
           <%= form.select :col_sep, Import::SEPARATORS, label: true %>
 
           <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-            <%= form.select :account_id, @import.family.accounts.visible.pluck(:name, :id), { label: "Account (optional)", include_blank: "Multi-account import", selected: @import.account_id } %>
+            <%= form.select :account_id, @import.family.accounts.visible.pluck(:name, :id), { label: t(".account_optional"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
           <% end %>
 
           <%= form.text_area :raw_file_str,
                        rows: 10,
                        required: true,
-                       placeholder: "Paste your CSV file contents here",
+                       placeholder: t(".paste_csv_placeholder"),
                        "data-auto-submit-form-target": "auto" %>
 
-          <%= form.submit "Upload CSV", disabled: @import.complete? %>
+          <%= form.submit t(".upload_csv"), disabled: @import.complete? %>
         <% end %>
       <% end %>
     <% end %>
@@ -74,7 +74,7 @@
 
   <div class="flex justify-center">
     <span class="text-secondary text-sm">
-      <%= link_to "Download a sample CSV", "/imports/#{@import.id}/upload/sample_csv", class: "text-primary underline", data: { turbo: false } %> to see the required CSV format
+      <%= raw t(".download_sample_html", download_link: link_to(t(".download_sample_link"), "/imports/#{@import.id}/upload/sample_csv", class: "text-primary underline", data: { turbo: false })) %>
     </span>
   </div>
 </div>

--- a/app/views/imports/_failure.html.erb
+++ b/app/views/imports/_failure.html.erb
@@ -7,10 +7,10 @@
     </div>
 
     <div class="text-center space-y-2">
-      <h1 class="font-medium text-primary text-center text-3xl">Import failed</h1>
-      <p class="text-sm text-secondary">Please check that your file format, for any errors and that all required fields are filled, then come back and try again.</p>
+      <h1 class="font-medium text-primary text-center text-3xl"><%= t(".title") %></h1>
+      <p class="text-sm text-secondary"><%= t(".message") %></p>
     </div>
 
-    <%= render DS::Button.new(text: "Try again", href: publish_import_path(import), full_width: true) %>
+    <%= render DS::Button.new(text: t(".try_again"), href: publish_import_path(import), full_width: true) %>
   </div>
 </div>

--- a/app/views/imports/_import.html.erb
+++ b/app/views/imports/_import.html.erb
@@ -6,7 +6,7 @@
         <%= import.account.name + " " %>
       <% end %>
 
-      <%= t(".label", type: import.type.titleize, datetime: import.updated_at.strftime("%b %-d, %Y at %l:%M %p")) %>
+      <%= t(".label", type: import.type.titleize, datetime: I18n.l(import.updated_at, format: :long)) %>
     <% end %>
 
     <% if import.pending? %>
@@ -43,7 +43,7 @@
           method: :put,
           class: "flex items-center gap-2 text-orange-500 hover:text-orange-600",
           data: {
-            turbo_confirm: "This will delete transactions that were imported, but you will still be able to review and re-import your data at any time."
+            turbo_confirm: t("imports.import.revert_confirm")
           } do %>
         <%= icon "rotate-ccw", class: "w-5 h-5 text-destructive" %>
       <% end %>

--- a/app/views/imports/_importing.html.erb
+++ b/app/views/imports/_importing.html.erb
@@ -7,13 +7,13 @@
     </div>
 
     <div class="text-center space-y-2">
-      <h1 class="font-medium text-primary text-center text-3xl">Import in progress</h1>
-      <p class="text-sm text-secondary">Your import is in progress. Check the imports menu for status updates or click 'Check Status' to refresh the page for updates. Feel free to continue using the app.</p>
+      <h1 class="font-medium text-primary text-center text-3xl"><%= t(".title") %></h1>
+      <p class="text-sm text-secondary"><%= t(".message") %></p>
     </div>
 
     <div class="space-y-2 flex flex-col">
-      <%= render DS::Link.new(text: "Check status", href: import_path(import), variant: "primary", full_width: true) %>
-      <%= render DS::Link.new(text: "Back to dashboard", href: root_path, variant: "secondary", full_width: true) %>
+      <%= render DS::Link.new(text: t(".check_status"), href: import_path(import), variant: "primary", full_width: true) %>
+      <%= render DS::Link.new(text: t(".back_to_dashboard"), href: root_path, variant: "secondary", full_width: true) %>
     </div>
   </div>
 </div>

--- a/app/views/imports/_nav.html.erb
+++ b/app/views/imports/_nav.html.erb
@@ -1,18 +1,18 @@
 <%# locals: (import:) %>
 
 <% steps = [
-  { name: "Upload", path: import_upload_path(import), is_complete: import.uploaded?, step_number: 1 },
-  { name: "Configure", path: import_configuration_path(import), is_complete: import.configured?, step_number: 2 },
-  { name: "Clean", path: import_clean_path(import), is_complete: import.cleaned?, step_number: 3 },
-  { name: "Map", path: import_confirm_path(import), is_complete: import.publishable?, step_number: 4 },
-  { name: "Confirm", path: import_path(import), is_complete: import.complete?, step_number: 5 }
-].reject { |step| step[:name] == "Map" && import.mapping_steps.empty? } %>
+  { name: t("import.nav.upload"), key: "upload", path: import_upload_path(import), is_complete: import.uploaded?, step_number: 1 },
+  { name: t("import.nav.configure"), key: "configure", path: import_configuration_path(import), is_complete: import.configured?, step_number: 2 },
+  { name: t("import.nav.clean"), key: "clean", path: import_clean_path(import), is_complete: import.cleaned?, step_number: 3 },
+  { name: t("import.nav.map"), key: "map", path: import_confirm_path(import), is_complete: import.publishable?, step_number: 4 },
+  { name: t("import.nav.confirm"), key: "confirm", path: import_path(import), is_complete: import.complete?, step_number: 5 }
+].reject { |step| step[:key] == "map" && import.mapping_steps.empty? } %>
 
 <% content_for :mobile_import_progress do %>
   <% active_step = steps.detect { |s| request.path.eql?(s[:path]) } %>
   <% if active_step.present? %>
     <div class="md:hidden text-center text-secondary text-md my-2">
-      <span class="text-gray-500">Step <%= active_step[:step_number] %> of <%= steps.size %></span>
+      <span class="text-gray-500"><%= t("import.nav.step_of", step: active_step[:step_number], total: steps.size) %></span>
     </div>
   <% end %>
 <% end %>

--- a/app/views/imports/_ready.html.erb
+++ b/app/views/imports/_ready.html.erb
@@ -8,8 +8,8 @@
 <div class="mx-auto max-w-2xl space-y-4">
   <div class="bg-container-inset rounded-xl p-1 space-y-1">
     <div class="flex justify-between items-center text-xs font-medium text-secondary uppercase px-5 py-3">
-      <p>item</p>
-      <p class="justify-self-end">count</p>
+      <p><%= t('.item') %></p>
+      <p class="justify-self-end"><%= t('.count') %></p>
     </div>
 
     <div class="bg-container shadow-border-xs rounded-lg text-sm">
@@ -35,5 +35,5 @@
     </div>
   </div>
 
-  <%= render DS::Button.new(text: "Publish import", href: publish_import_path(import), full_width: true) %>
+  <%= render DS::Button.new(text: t('.publish'), href: publish_import_path(import), full_width: true) %>
 </div>

--- a/app/views/imports/_revert_failure.html.erb
+++ b/app/views/imports/_revert_failure.html.erb
@@ -7,12 +7,12 @@
     </div>
 
     <div class="text-center space-y-2">
-      <h1 class="font-medium text-primary text-center text-3xl">Reverting import failed</h1>
-      <p class="text-sm text-secondary">Please try again or contact support.</p>
+      <h1 class="font-medium text-primary text-center text-3xl"><%= t("imports.revert_failure.title") %></h1>
+      <p class="text-sm text-secondary"><%= t("imports.revert_failure.message") %></p>
     </div>
 
     <%= render DS::Button.new(
-      text: "Try again",
+      text: t("imports.revert_failure.try_again"),
       full_width: true,
       href: revert_import_path(import)
     ) %>

--- a/app/views/imports/_success.html.erb
+++ b/app/views/imports/_success.html.erb
@@ -7,12 +7,12 @@
     </div>
 
     <div class="text-center space-y-2">
-      <h1 class="font-medium text-primary text-center text-3xl">Import successful</h1>
-      <p class="text-sm text-secondary">Your imported data has been successfully added to the app and is now ready for use.</p>
+      <h1 class="font-medium text-primary text-center text-3xl"><%= t(".title") %></h1>
+      <p class="text-sm text-secondary"><%= t(".message") %></p>
     </div>
 
     <%= render DS::Link.new(
-      text: "Back to dashboard",
+      text: t(".back_to_dashboard"),
       variant: "primary",
       full_width: true,
       href: root_path

--- a/app/views/invite_codes/_invite_code.html.erb
+++ b/app/views/invite_codes/_invite_code.html.erb
@@ -13,7 +13,7 @@
           <%= icon "check" %>
         </span>
       </button>
-      <%= button_to invite_code_path(invite_code), method: :delete, data: { confirm: "Are you sure?" }, class: "ml-2 text-red-600 text-xs" do %>
+      <%= button_to invite_code_path(invite_code), method: :delete, data: { confirm: t("invite_codes.invite_code.delete_confirm") }, class: "ml-2 text-red-600 text-xs" do %>
         <%= icon("trash-2", size: "sm", class: "inline mr-1") %>
       <% end %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,12 +91,12 @@
             <div class="px-4 py-3 space-y-4 bg-container shadow-border-xs rounded-xl">
               <div class="flex items-start justify-between">
                 <div>
-                  <p class="text-sm font-medium text-primary">Free trial</p>
-                  <p class="text-sm text-secondary"><%= Current.family.days_left_in_trial %> days remaining</p>
+                  <p class="text-sm font-medium text-primary"><%= t('layouts.application.free_trial') %></p>
+                  <p class="text-sm text-secondary"><%= t('layouts.application.days_remaining', days: Current.family.days_left_in_trial) %></p>
                 </div>
 
                 <%= render DS::Link.new(
-                  text: "Upgrade",
+                  text: t('layouts.application.upgrade'),
                   href: upgrade_subscription_path,
                 ) %>
               </div>

--- a/app/views/layouts/shared/_breadcrumbs.html.erb
+++ b/app/views/layouts/shared/_breadcrumbs.html.erb
@@ -2,16 +2,17 @@
 
 <div class="py-2 flex items-center gap-2">
   <% breadcrumbs.each_with_index do |(name, path), index| %>
+    <% display_name = name.is_a?(Symbol) ? t(name, default: name.to_s.split('.').last.titleize) : name %>
     <% if index > 0 %>
       <%= icon("chevron-right", color: "gray", size: "sm") %>
     <% end %>
 
     <% if path.present? && index < breadcrumbs.size - 1 %>
-      <%= link_to name, path, class: "text-sm text-gray-500 font-medium" %>
+      <%= link_to display_name, path, class: "text-sm text-gray-500 font-medium" %>
     <% elsif index == breadcrumbs.size - 1 %>
-      <span class="text-primary font-medium text-sm"><%= name %></span>
+      <span class="text-primary font-medium text-sm"><%= display_name %></span>
     <% else %>
-      <span class="text-sm text-gray-500 font-medium"><%= name %></span>
+      <span class="text-sm text-gray-500 font-medium"><%= display_name %></span>
     <% end %>
   <% end %>
 </div>

--- a/app/views/layouts/shared/_confirm_dialog.html.erb
+++ b/app/views/layouts/shared/_confirm_dialog.html.erb
@@ -5,17 +5,17 @@
     <form method="dialog" class="space-y-4">
       <div class="space-y-2">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="font-medium text-primary" data-confirm-dialog-target="title">Are you sure?</h3>
+          <h3 class="font-medium text-primary" data-confirm-dialog-target="title"><%= t('.default_title') %></h3>
           <%= icon("x", as_button: true, type: "submit", value: "cancel") %>
         </div>
 
-        <p class="text-sm text-secondary" data-confirm-dialog-target="subtitle">This action cannot be undone.</p>
+        <p class="text-sm text-secondary" data-confirm-dialog-target="subtitle"><%= t('.default_subtitle') %></p>
       </div>
 
       <div>
         <% ["primary", "outline-destructive", "destructive"].each do |variant| %>
           <%= render DS::Button.new(
-          text: "Confirm",
+          text: t('.confirm'),
           variant: variant,
           autofocus: true,
           full_width: true,

--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -1,10 +1,10 @@
 <footer class="p-6">
   <div class="space-y-2 text-center text-xs text-secondary">
-    <p>&copy; <%= Date.current.year %>, <%= brand_name %> <%= product_name %> (community fork of Maybe Finance)</p>
+    <p>&copy; <%= Date.current.year %>, <%= brand_name %> <%= product_name %> <%= t("layouts.shared.footer.copyright") %></p>
     <div class="flex justify-center items-center gap-2">
-      <%= link_to "Privacy Policy", privacy_path, class: "text-secondary", target: "_blank" %>
+      <%= link_to t("layouts.shared.footer.privacy_policy"), privacy_path, class: "text-secondary", target: "_blank" %>
       <span>&bull;</span>
-      <%= link_to "Terms of Service", terms_path, class: "text-secondary", target: "_blank" %>
+      <%= link_to t("layouts.shared.footer.terms_of_service"), terms_path, class: "text-secondary", target: "_blank" %>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Part 1 of 3 PRs to internationalize hardcoded English strings
- Extracts strings from core views and controllers to use Rails i18n `t()` helper
- Includes locale files for main functionality (accounts, transactions, etc.)

## Test plan
- [ ] Verify all pages render correctly with English locale
- [ ] Run `bin/rails test` to ensure tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM cost estimation for auto-categorize rules, displaying estimated costs based on transaction volume and selected model.

* **Chores**
  * Internationalized all user-facing text across controllers, views, and models to support multiple languages. Breadcrumbs, flash messages, buttons, labels, and descriptions now render localized content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->