### PR TITLE
i18n: Extract hardcoded strings (Part 2/3)

### DIFF
--- a/app/views/loans/_form.html.erb
+++ b/app/views/loans/_form.html.erb
@@ -19,7 +19,7 @@
                                  min: 0,
                                  step: 0.005 %>
         <%= loan_form.select :rate_type,
-                           [["Fixed", "fixed"], ["Variable", "variable"], ["Adjustable", "adjustable"]],
+                           [[t("loans.form.rate_type_fixed"), "fixed"], [t("loans.form.rate_type_variable"), "variable"], [t("loans.form.rate_type_adjustable"), "adjustable"]],
                            { label: t("loans.form.rate_type") } %>
       </div>
 

--- a/app/views/loans/tabs/_overview.html.erb
+++ b/app/views/loans/tabs/_overview.html.erb
@@ -46,7 +46,7 @@
 
 <div class="flex justify-center py-8">
   <%= render DS::Link.new(
-    text: "Edit loan details",
+    text: t(".edit_loan_details"),
     variant: "ghost",
     href: edit_loan_path(account),
     frame: :modal

--- a/app/views/lunchflow_items/_api_error.html.erb
+++ b/app/views/lunchflow_items/_api_error.html.erb
@@ -1,24 +1,24 @@
 <%# locals: (error_message:, return_path:) %>
 <%= turbo_frame_tag "modal" do %>
   <%= render DS::Dialog.new do |dialog| %>
-    <% dialog.with_header(title: "Lunch Flow Connection Error") %>
+    <% dialog.with_header(title: t("lunchflow_items.api_error.title")) %>
     <% dialog.with_body do %>
       <div class="space-y-4">
         <div class="flex items-start gap-3">
           <%= icon("alert-circle", class: "text-destructive w-5 h-5 shrink-0 mt-0.5") %>
           <div class="text-sm">
-            <p class="font-medium text-primary mb-2">Unable to connect to Lunch Flow</p>
+            <p class="font-medium text-primary mb-2"><%= t("lunchflow_items.api_error.unable_to_connect") %></p>
             <p class="text-secondary"><%= error_message %></p>
           </div>
         </div>
 
         <div class="bg-surface rounded-lg p-4 space-y-2 text-sm">
-          <p class="font-medium text-primary">Common Issues:</p>
+          <p class="font-medium text-primary"><%= t("lunchflow_items.api_error.common_issues") %></p>
           <ul class="list-disc list-inside space-y-1 text-secondary">
-            <li><strong>Invalid API Key:</strong> Check your API key in Provider Settings</li>
-            <li><strong>Expired Credentials:</strong> Generate a new API key from Lunch Flow</li>
-            <li><strong>Network Issue:</strong> Check your internet connection</li>
-            <li><strong>Service Down:</strong> Lunch Flow API may be temporarily unavailable</li>
+            <li><%= raw t("lunchflow_items.api_error.invalid_api_key") %></li>
+            <li><%= raw t("lunchflow_items.api_error.expired_credentials") %></li>
+            <li><%= raw t("lunchflow_items.api_error.network_issue") %></li>
+            <li><%= raw t("lunchflow_items.api_error.service_down") %></li>
           </ul>
         </div>
 
@@ -26,7 +26,7 @@
           <%= link_to settings_providers_path,
                       class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
-            Check Provider Settings
+            <%= t("lunchflow_items.api_error.check_settings") %>
           <% end %>
         </div>
       </div>

--- a/app/views/lunchflow_items/_setup_required.html.erb
+++ b/app/views/lunchflow_items/_setup_required.html.erb
@@ -1,23 +1,23 @@
 <%= turbo_frame_tag "modal" do %>
   <%= render DS::Dialog.new do |dialog| %>
-    <% dialog.with_header(title: "Lunch Flow Setup Required") %>
+    <% dialog.with_header(title: t("lunchflow_items.setup_required.title")) %>
     <% dialog.with_body do %>
       <div class="space-y-4">
         <div class="flex items-start gap-3">
           <%= icon("alert-circle", class: "text-warning w-5 h-5 shrink-0 mt-0.5") %>
           <div class="text-sm text-secondary">
-            <p class="font-medium text-primary mb-2">API Key Not Configured</p>
-            <p>Before you can link Lunch Flow accounts, you need to configure your Lunch Flow API key.</p>
+            <p class="font-medium text-primary mb-2"><%= t("lunchflow_items.setup_required.api_key_not_configured") %></p>
+            <p><%= t("lunchflow_items.setup_required.before_linking") %></p>
           </div>
         </div>
 
         <div class="bg-surface rounded-lg p-4 space-y-2 text-sm">
-          <p class="font-medium text-primary">Setup Steps:</p>
+          <p class="font-medium text-primary"><%= t("lunchflow_items.setup_required.setup_steps") %></p>
           <ol class="list-decimal list-inside space-y-1 text-secondary">
-            <li>Go to <strong>Settings → Providers</strong></li>
-            <li>Find the <strong>Lunch Flow</strong> section</li>
-            <li>Enter your Lunch Flow API key</li>
-            <li>Return here to link your accounts</li>
+            <li><%= raw t("lunchflow_items.setup_required.step_1") %></li>
+            <li><%= raw t("lunchflow_items.setup_required.step_2") %></li>
+            <li><%= t("lunchflow_items.setup_required.step_3") %></li>
+            <li><%= t("lunchflow_items.setup_required.step_4") %></li>
           </ol>
         </div>
 
@@ -25,7 +25,7 @@
           <%= link_to settings_providers_path,
                       class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
-            Go to Provider Settings
+            <%= t("lunchflow_items.setup_required.go_to_settings") %>
           <% end %>
         </div>
       </div>

--- a/app/views/lunchflow_items/_subtype_select.html.erb
+++ b/app/views/lunchflow_items/_subtype_select.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     <% end %>
     <%= select_tag "account_subtypes[#{lunchflow_account.id}]",
-                  options_for_select([["Select #{account_type == 'Depository' ? 'subtype' : 'type'}", ""]] + subtype_config[:options], selected_value),
+                  options_for_select([[account_type == 'Depository' ? t("lunchflow_items.subtype_select.select_subtype") : t("lunchflow_items.subtype_select.select_type"), ""]] + subtype_config[:options], selected_value),
                   { class: "appearance-none bg-container border border-primary rounded-md px-3 py-2 text-sm leading-6 text-primary focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none w-full" } %>
   <% else %>
     <p class="text-sm text-secondary"><%= subtype_config[:message] %></p>

--- a/app/views/lunchflow_items/setup_accounts.html.erb
+++ b/app/views/lunchflow_items/setup_accounts.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Set Up Lunch Flow Accounts" %>
+<% content_for :title, t(".page_title") %>
 
 <%= render DS::Dialog.new do |dialog| %>
   <% dialog.with_header(title: t(".title")) do %>

--- a/app/views/messages/_chat_form.html.erb
+++ b/app/views/messages/_chat_form.html.erb
@@ -10,7 +10,7 @@
     <%# In the future, this will be a dropdown with different AI models %>
     <%= f.hidden_field :ai_model, value: default_ai_model %>
 
-    <%= f.text_area :content, placeholder: "Ask anything ...", value: message_hint,
+    <%= f.text_area :content, placeholder: t("messages.chat_form.placeholder"), value: message_hint,
                   class: "w-full border-0 focus:ring-0 text-sm resize-none px-1 bg-transparent",
                   data: { chat_target: "input", action: "input->chat#autoResize keydown->chat#handleInputKeyDown" },
                   rows: 1 %>
@@ -19,7 +19,7 @@
       <div class="items-center gap-1 hidden lg:flex">
         <%# These are disabled for now, but in the future, will all open specific menus with their own context and search %>
         <% ["plus", "command", "at-sign", "mouse-pointer-click"].each do |icon| %>
-          <%= icon(icon, as_button: true, disabled: true, class: "cursor-not-allowed", title: "Coming soon") %>
+          <%= icon(icon, as_button: true, disabled: true, class: "cursor-not-allowed", title: t("messages.chat_form.coming_soon")) %>
         <% end %>
       </div>
 
@@ -27,5 +27,5 @@
     </div>
   <% end %>
 
-  <p class="text-xs text-secondary">AI responses are informational only and are not financial advice.</p>
+  <p class="text-xs text-secondary"><%= t("messages.chat_form.disclaimer") %></p>
 </div>

--- a/app/views/oidc_accounts/link.html.erb
+++ b/app/views/oidc_accounts/link.html.erb
@@ -1,50 +1,48 @@
 <%
-  header_title @user_exists ? "Link OIDC Account" : "Create Account"
+  header_title @user_exists ? t(".link_oidc_account") : t(".create_account_title")
 %>
 
 <% if @user_exists %>
   <div class="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
-    <h3 class="text-sm font-medium text-yellow-800 mb-2">Verify Your Identity</h3>
+    <h3 class="text-sm font-medium text-yellow-800 mb-2"><%= t(".verify_identity") %></h3>
     <p class="text-sm text-yellow-700">
-      To link your <%= @pending_auth["provider"] %> account<% if @pending_auth["email"].present? %> (<%= @pending_auth["email"] %>)<% end %>,
-      please verify your identity by entering your password.
+      <%= raw t(".verify_identity_description_html", provider: @pending_auth["provider"], email: @pending_auth["email"].presence || "") %>
     </p>
   </div>
 
   <%= styled_form_with url: create_link_oidc_account_path, class: "space-y-4", data: { turbo: false } do |form| %>
     <%= form.email_field :email,
-      label: "Email",
+      label: t(".email"),
       autofocus: false,
       autocomplete: "email",
       required: "required",
-      placeholder: "Enter your email",
+      placeholder: t(".email_placeholder"),
       value: @email %>
 
     <%= form.password_field :password,
-      label: "Password",
+      label: t(".password"),
       required: "required",
-      placeholder: "Enter your password",
+      placeholder: t(".password_placeholder"),
       autocomplete: "current-password" %>
 
     <div class="text-sm text-gray-600 mt-2">
-      <p>This helps ensure that only you can link external accounts to your profile.</p>
+      <p><%= t(".security_note") %></p>
     </div>
 
-    <%= form.submit "Link Account" %>
+    <%= form.submit t(".link_account") %>
   <% end %>
 <% else %>
   <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-md">
-    <h3 class="text-sm font-medium text-blue-800 mb-2">Create New Account</h3>
+    <h3 class="text-sm font-medium text-blue-800 mb-2"><%= t(".create_new_account") %></h3>
     <p class="text-sm text-blue-700">
-      No account found with the email <strong><%= @pending_auth["email"] %></strong>.
-      Click below to create a new account using your <%= @pending_auth["provider"] %> identity.
+      <%= raw t(".no_account_found_html", email: @pending_auth["email"], provider: @pending_auth["provider"]) %>
     </p>
   </div>
 
   <div class="space-y-4">
     <div class="p-4 bg-container border border-secondary rounded-md">
       <p class="text-sm text-primary">
-        <strong>Email:</strong> <%= @pending_auth["email"] %>
+        <strong><%= t(".email") %>:</strong> <%= @pending_auth["email"] %>
       </p>
       <% if @pending_auth["name"].present? %>
         <p class="text-sm text-primary mt-2">
@@ -55,7 +53,7 @@
 
     <% if @allow_account_creation %>
       <%= render DS::Button.new(
-        text: "Create Account",
+        text: t(".create_account"),
         href: create_user_oidc_account_path,
         full_width: true,
         variant: :primary,
@@ -64,7 +62,7 @@
       ) %>
     <% else %>
       <p class="text-xs text-secondary">
-        <%= t("oidc_accounts.link.account_creation_disabled") %>
+        <%= t(".account_creation_disabled") %>
       </p>
     <% end %>
   </div>
@@ -72,7 +70,7 @@
 
 <div class="mt-6 text-center">
   <%= render DS::Link.new(
-    text: "Cancel",
+    text: t(".cancel"),
     href: new_session_path,
     variant: :default,
     class: "font-medium text-sm text-primary hover:underline transition"

--- a/app/views/onboardings/_logout.html.erb
+++ b/app/views/onboardings/_logout.html.erb
@@ -1,5 +1,5 @@
  <%= render DS::Button.new(
-        text: "Sign out",
+        text: t('.sign_out'),
         icon: "log-out",
         icon_position: :right,
         variant: "ghost",

--- a/app/views/onboardings/_onboarding_nav.html.erb
+++ b/app/views/onboardings/_onboarding_nav.html.erb
@@ -1,10 +1,10 @@
 <%# locals: (user:) %>
 
 <% steps = [
-  { name: "Setup", path: onboarding_path, is_complete: user.first_name.present?, step_number: 1 },
-  { name: "Preferences", path: preferences_onboarding_path, is_complete: user.set_onboarding_preferences_at.present?, step_number: 2 },
-  { name: "Goals", path: goals_onboarding_path , is_complete: user.set_onboarding_goals_at.present?, step_number: 3 },
-  { name: "Start", path: trial_onboarding_path, is_complete: user.onboarded?, step_number: 4 },
+  { name: t("onboardings.onboarding_nav.setup"), path: onboarding_path, is_complete: user.first_name.present?, step_number: 1 },
+  { name: t("onboardings.onboarding_nav.preferences"), path: preferences_onboarding_path, is_complete: user.set_onboarding_preferences_at.present?, step_number: 2 },
+  { name: t("onboardings.onboarding_nav.goals"), path: goals_onboarding_path , is_complete: user.set_onboarding_goals_at.present?, step_number: 3 },
+  { name: t("onboardings.onboarding_nav.start"), path: trial_onboarding_path, is_complete: user.onboarded?, step_number: 4 },
 ] %>
 
 <%# Don't show last step if self hosted %>

--- a/app/views/onboardings/goals.html.erb
+++ b/app/views/onboardings/goals.html.erb
@@ -15,8 +15,8 @@
 <div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-6 px-4 md:px-0">
   <div>
     <div class="space-y-1 mb-6 text-center">
-      <h1 class="text-2xl font-medium md:text-2xl">What brings you here?</h1>
-      <p class="text-secondary text-sm">Select one or more goals that you have with using <%= product_name %> as your personal finance tool.</p>
+      <h1 class="text-2xl font-medium md:text-2xl"><%= t('.title') %></h1>
+      <p class="text-secondary text-sm"><%= t('.description', product_name: product_name) %></p>
     </div>
 
     <%= form_with model: @user do |form| %>
@@ -26,14 +26,14 @@
 
       <div class="space-y-3">
         <% [
-          { icon: "layers", label: "See all my accounts in one place", value: "unified_accounts" },
-          { icon: "banknote", label: "Understand cashflow and expenses", value: "cashflow" },
-          { icon: "pie-chart", label: "Manage financial plans and budgeting", value: "budgeting" },
-          { icon: "users", label: "Manage finances with a partner", value: "partner" },
-          { icon: "area-chart", label: "Track investments", value: "investments" },
-          { icon: "bot", label: "Let AI help me understand my finances", value: "ai_insights" },
-          { icon: "settings-2", label: "Analyze and optimize accounts", value: "optimization" },
-          { icon: "frown", label: "Reduce financial stress or anxiety", value: "reduce_stress" }
+          { icon: "layers", label: t('.goal_unified_accounts'), value: "unified_accounts" },
+          { icon: "banknote", label: t('.goal_cashflow'), value: "cashflow" },
+          { icon: "pie-chart", label: t('.goal_budgeting'), value: "budgeting" },
+          { icon: "users", label: t('.goal_partner'), value: "partner" },
+          { icon: "area-chart", label: t('.goal_investments'), value: "investments" },
+          { icon: "bot", label: t('.goal_ai_insights'), value: "ai_insights" },
+          { icon: "settings-2", label: t('.goal_optimization'), value: "optimization" },
+          { icon: "frown", label: t('.goal_reduce_stress'), value: "reduce_stress" }
         ].each do |goal| %>
           <label class="flex items-center gap-2.5 p-4 rounded-lg border border-tertiary cursor-pointer hover:bg-container transition-colors [&:has(input:checked)]:border-solid [&:has(input:checked)]:bg-container">
             <%= form.check_box :goals, { multiple: true, class: "sr-only" }, goal[:value], nil %>
@@ -45,7 +45,7 @@
 
       <div class="mt-6">
         <%= render DS::Button.new(
-          text: "Next",
+          text: t('.next'),
           full_width: true
         ) %>
       </div>

--- a/app/views/onboardings/preferences.html.erb
+++ b/app/views/onboardings/preferences.html.erb
@@ -68,7 +68,7 @@
       <%= form.hidden_field :redirect_to, value: "goals" %>
 
       <div class="mb-4">
-        <%= form.select :theme, [["System", "system"], ["Light", "light"], ["Dark", "dark"]], { label: "Color theme" }, data: { action: "onboarding#setTheme" } %>
+        <%= form.select :theme, [[t(".system"), "system"], [t(".light"), "light"], [t(".dark"), "dark"]], { label: t(".color_theme") }, data: { action: "onboarding#setTheme" } %>
       </div>
 
       <div class="space-y-4 mb-4">

--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -13,8 +13,8 @@
 <div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-6 px-4 md:px-0">
   <div>
     <div class="space-y-1 mb-6 text-center">
-      <h1 class="text-2xl font-medium md:text-2xl">Let's set up your account</h1>
-      <p class="text-secondary text-sm">First things first, let's get your profile set up.</p>
+      <h1 class="text-2xl font-medium md:text-2xl"><%= t(".title_setup") %></h1>
+      <p class="text-secondary text-sm"><%= t(".subtitle_setup") %></p>
     </div>
 
     <%= styled_form_with model: @user do |form| %>
@@ -26,24 +26,24 @@
       </div>
 
       <div class="flex flex-col md:flex-row md:justify-between md:items-center md:gap-4 space-y-4 md:space-y-0 mb-4">
-        <%= form.text_field :first_name, placeholder: "First name", label: "First name", container_class: "bg-container md:w-1/2 w-full", required: true %>
-        <%= form.text_field :last_name, placeholder: "Last name", label: "Last name", container_class: "bg-container md:w-1/2 w-full", required: true %>
+        <%= form.text_field :first_name, placeholder: t(".first_name_placeholder"), label: t(".first_name"), container_class: "bg-container md:w-1/2 w-full", required: true %>
+        <%= form.text_field :last_name, placeholder: t(".last_name_placeholder"), label: t(".last_name"), container_class: "bg-container md:w-1/2 w-full", required: true %>
       </div>
 
       <% unless @invitation %>
         <div class="space-y-4 mb-4">
           <%= form.fields_for :family do |family_form| %>
-            <%= family_form.text_field :name, placeholder: "Household name", label: "Household name" %>
+            <%= family_form.text_field :name, placeholder: t(".household_name_placeholder"), label: t(".household_name") %>
 
             <%= family_form.select :country,
               country_options,
-              { label: "Country" },
+              { label: t(".country") },
               required: true %>
           <% end %>
         </div>
       <% end %>
 
-      <%= form.submit "Continue" %>
+      <%= form.submit t(".continue") %>
     <% end %>
   </div>
 </div>

--- a/app/views/onboardings/trial.html.erb
+++ b/app/views/onboardings/trial.html.erb
@@ -17,34 +17,34 @@
     <%= image_tag "logo-color.png", class: "w-16 mb-6" %>
 
     <p class="text-xl lg:text-3xl text-primary font-display font-medium">
-      Try Sure for 14 days.
+      <%= t('.try_sure') %>
     </p>
 
     <h2 class="text-xl lg:text-3xl font-display text-secondary font-medium mb-2">
-      No credit card required
+      <%= t('.no_credit_card') %>
     </h2>
 
     <p class="text-sm text-secondary text-center mb-8">
-      Starting the trial activates your account for Sure.  You won't need to enter payment details.
+      <%= t('.trial_description') %>
     </p>
 
     <div class="w-full">
       <% if Current.family.can_start_trial? %>
         <%= render DS::Button.new(
-        text: "Try Sure for 14 days",
+        text: t('.try_sure'),
         href: subscription_path,
         full_width: true,
         data: { turbo: false }
       ) %>
       <% elsif Current.family.trialing? %>
         <%= render DS::Link.new(
-          text: "Continue trial",
+          text: t('.continue_trial'),
           href: root_path,
           full_width: true,
         ) %>
       <% else %>
         <%= render DS::Link.new(
-          text: "Upgrade",
+          text: t('.upgrade'),
           href: upgrade_subscription_path,
           full_width: true,
         ) %>
@@ -53,7 +53,7 @@
   </div>
 
   <div class="space-y-8">
-    <h2 class="text-center text-lg lg:text-2xl font-medium text-primary">How your trial will work</h2>
+    <h2 class="text-center text-lg lg:text-2xl font-medium text-primary"><%= t('.how_trial_works') %></h2>
 
     <div class="flex gap-3">
       <div class="rounded-xl p-1 bg-gray-400/20 theme-dark:bg-gray-500/20 flex flex-col justify-between items-center text-secondary">
@@ -64,70 +64,70 @@
 
       <div class="space-y-12">
         <div class="space-y-1.5 text-sm">
-          <p class="text-primary font-medium">Today</p>
-          <p class="text-secondary">You'll get free access to Sure for 14 days</p>
+          <p class="text-primary font-medium"><%= t('.today') %></p>
+          <p class="text-secondary"><%= t('.today_description') %></p>
         </div>
 
         <div class="space-y-1.5 text-sm">
-          <p class="text-primary font-medium">In 13 days (<%= 13.days.from_now.strftime("%B %d") %>)</p>
-          <p class="text-secondary">We'll notify you to remind you when your trial will end.</p>
+          <p class="text-primary font-medium"><%= t('.in_13_days', date: I18n.l(13.days.from_now, format: "%B %d")) %></p>
+          <p class="text-secondary"><%= t('.in_13_days_description') %></p>
         </div>
 
         <div class="space-y-1.5 text-sm">
-          <p class="text-primary font-medium">In 14 days (<%= 14.days.from_now.strftime("%B %d") %>)</p>
-          <p class="text-secondary">Your trial ends &mdash; subscribe to continue using Sure</p>
+          <p class="text-primary font-medium"><%= t('.in_14_days', date: I18n.l(14.days.from_now, format: "%B %d")) %></p>
+          <p class="text-secondary"><%= t('.in_14_days_description') %></p>
         </div>
       </div>
     </div>
   </div>
 
   <div class="space-y-8 max-w-2xl mx-auto">
-    <h2 class="text-center text-lg lg:text-2xl font-medium text-primary">Here's what's included</h2>
+    <h2 class="text-center text-lg lg:text-2xl font-medium text-primary"><%= t('.whats_included') %></h2>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-x-12 gap-y-6 text-secondary">
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "landmark", variant: :surface) %>
-        <p class="text-sm text-primary text-center">More than 10,000 institutions to connect to</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_institutions') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "layers", variant: :surface) %>
-        <p class="text-sm text-primary text-center">Connect unlimited accounts and account types</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_unlimited_accounts') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "chart-line", variant: :surface) %>
-        <p class="text-sm text-primary text-center">Performance and investment returns across portfolio</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_investments') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "credit-card", variant: :surface) %>
-        <p class="text-sm text-primary text-center">Comprehensive transaction tracking experience</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_transactions') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render "chats/ai_avatar" %>
-        <p class="text-sm text-primary text-center">Unlimited access and chats with Sure AI</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_ai') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "keyboard", variant: :surface) %>
-        <p class="text-sm text-primary text-center">Manual account tracking that works well</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_manual') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "globe-2", variant: :surface) %>
-        <p class="text-sm text-primary text-center">Multiple currencies and near global coverage</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_currencies') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "ship", variant: :surface) %>
-        <p class="text-sm text-primary text-center">Early access to newly released features</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_early_access') %></p>
       </div>
 
       <div class="flex flex-col gap-4 items-center">
         <%= render DS::FilledIcon.new(icon: "messages-square", variant: :surface) %>
-        <p class="text-sm text-primary text-center">Priority human support from team</p>
+        <p class="text-sm text-primary text-center"><%= t('.feature_support') %></p>
       </div>
     </div>
   </div>

--- a/app/views/pages/changelog.html.erb
+++ b/app/views/pages/changelog.html.erb
@@ -15,13 +15,13 @@
         <% end %>
         <div>
           <a class="text-primary font-medium text-sm" href="https://github.com/<%= @release_notes[:username] %>"><%= "@#{@release_notes[:username]}" %></a>
-          <div class="text-secondary text-sm"><%= @release_notes[:published_at]&.strftime("%B %d, %Y") || "Date unavailable" %></div>
+          <div class="text-secondary text-sm"><%= @release_notes[:published_at] ? I18n.l(@release_notes[:published_at], format: :long) : t("pages.changelog.date_unavailable") %></div>
         </div>
       </div>
     </div>
     <div class="w-full md:w-2/3 text-secondary text-sm prose prose--github-release-notes">
       <h2 class="mb-5 text-xl text-primary"><%= @release_notes[:name] %></h2>
-      <%= (@release_notes[:body] || "No release notes available").html_safe %>
+      <%= (@release_notes[:body] || t("pages.changelog.no_release_notes")).html_safe %>
     </div>
   </div>
 </div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -27,7 +27,7 @@
   </div>
 <% end %>
 
-<div class="w-full space-y-6 pb-6 lg:pb-12" data-controller="dashboard-sortable" data-action="dragover->dashboard-sortable#dragOver drop->dashboard-sortable#drop" role="list" aria-label="Dashboard sections">
+<div class="w-full space-y-6 pb-6 lg:pb-12" data-controller="dashboard-sortable" data-action="dragover->dashboard-sortable#dragOver drop->dashboard-sortable#drop" role="list" aria-label="<%= t("pages.dashboard.sections_label") %>">
   <% if Current.family.accounts.any? %>
     <% @dashboard_sections.each do |section| %>
       <% next unless section[:visible] %>
@@ -42,7 +42,7 @@
         tabindex="0"
         role="listitem"
         aria-grabbed="false"
-        aria-label="<%= t(section[:title]) %> section. Press Enter or Space to grab for reordering, then use arrow keys to move."
+        aria-label="<%= t(section[:title]) %> <%= t("pages.dashboard.section_instructions") %>"
         data-action="
           dragstart->dashboard-sortable#dragStart
           dragend->dashboard-sortable#dragEnd

--- a/app/views/pages/dashboard/_balance_sheet.html.erb
+++ b/app/views/pages/dashboard/_balance_sheet.html.erb
@@ -37,13 +37,13 @@
 
         <div class="bg-container-inset rounded-xl p-1 space-y-1 overflow-x-auto">
           <div class="px-4 py-2 flex items-center uppercase text-xs font-medium text-secondary">
-            <div class="w-40">Name</div>
+            <div class="w-40"><%= t("pages.dashboard.balance_sheet.name") %></div>
             <div class="ml-auto text-right flex items-center gap-6">
               <div class="w-24">
-                <p>Weight</p>
+                <p><%= t("pages.dashboard.balance_sheet.weight") %></p>
               </div>
               <div class="w-40">
-                <p>Value</p>
+                <p><%= t("pages.dashboard.balance_sheet.value") %></p>
               </div>
             </div>
           </div>

--- a/app/views/pages/feedback.html.erb
+++ b/app/views/pages/feedback.html.erb
@@ -1,22 +1,22 @@
-<%= content_for :page_title, "Feedback" %>
+<%= content_for :page_title, t("pages.feedback.page_title") %>
 
 <div class="bg-container shadow-border-xs rounded-xl p-4">
-  <h2 class="text-lg font-medium text-primary mb-1">Leave feedback</h2>
-  <p class="text-sm text-secondary mb-4">Let us know if you have any specific feedback. Feel free to include links to videos or screenshots.</p>
+  <h2 class="text-lg font-medium text-primary mb-1"><%= t("pages.feedback.title") %></h2>
+  <p class="text-sm text-secondary mb-4"><%= t("pages.feedback.subtitle") %></p>
   <div class="flex flex-col md:flex-row gap-4">
     <%= link_to "https://github.com/we-promise/sure/discussions/categories/feature-requests", target: "_blank", rel: "noopener noreferrer", class: "w-full md:w-1/3 flex flex-col items-center p-4 border border-alpha-black-25 rounded-xl hover:bg-container-hover" do %>
       <%= image_tag "github-icon.svg", class: "w-8 h-8 mb-2" %>
-      <span class="text-sm font-medium text-primary text-center">Write a feature request</span>
+      <span class="text-sm font-medium text-primary text-center"><%= t("pages.feedback.feature_request") %></span>
     <% end %>
 
     <%= link_to "https://github.com/we-promise/sure/issues/new?assignees=&labels=bug&template=bug_report.md&title=", target: "_blank", rel: "noopener noreferrer", class: "w-full md:w-1/3 flex flex-col items-center p-4 border border-alpha-black-25 rounded-xl hover:bg-container-hover" do %>
       <%= image_tag "github-icon.svg", class: "w-8 h-8 mb-2" %>
-      <span class="text-sm font-medium text-primary text-center">File a bug report</span>
+      <span class="text-sm font-medium text-primary text-center"><%= t("pages.feedback.bug_report") %></span>
     <% end %>
 
     <%= link_to "https://discord.gg/36ZGBsxYEK", target: "_blank", rel: "noopener noreferrer", class: "w-full md:w-1/3 flex flex-col items-center p-4 border border-alpha-black-25 rounded-xl hover:bg-container-hover" do %>
       <%= image_tag "discord-icon.svg", class: "w-8 h-8 mb-2" %>
-      <span class="text-sm font-medium text-primary text-center">Discuss <%= product_name %> with others</span>
+      <span class="text-sm font-medium text-primary text-center"><%= t("pages.feedback.discuss", product: product_name) %></span>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/redis_configuration_error.html.erb
+++ b/app/views/pages/redis_configuration_error.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Redis Configuration Required - Sure" %>
+<% content_for :title, t(".title") %>
 
 <div class="flex items-center justify-center h-full p-4 sm:p-6 lg:p-8">
   <div class="w-full max-w-md sm:max-w-lg lg:max-w-2xl">
@@ -8,8 +8,8 @@
         <div class="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
           <%= icon "alert-triangle", class: "w-8 h-8 text-red-600" %>
         </div>
-        <h1 class="text-xl sm:text-2xl font-bold text-primary mb-2">Redis Configuration Required</h1>
-        <p class="text-sm sm:text-base text-muted">Your self-hosted Sure installation needs Redis to be properly configured.</p>
+        <h1 class="text-xl sm:text-2xl font-bold text-primary mb-2"><%= t(".title") %></h1>
+        <p class="text-sm sm:text-base text-muted"><%= t(".subtitle") %></p>
       </div>
 
       <!-- Explanation -->
@@ -18,8 +18,8 @@
           <div class="flex items-start">
             <%= icon "info", class: "w-5 h-5 text-amber-600 mt-0.5 mr-3 flex-shrink-0" %>
             <div class="text-sm text-amber-800">
-              <p><strong>Why is Redis required?</strong></p>
-              <p class="mt-1">Sure uses Redis to power Sidekiq background jobs for tasks like syncing account data, processing imports, and other background operations that keep your financial data up to date.</p>
+              <p><strong><%= t(".why_required") %></strong></p>
+              <p class="mt-1"><%= t(".explanation") %></p>
             </div>
           </div>
         </div>
@@ -27,7 +27,7 @@
         <!-- Primary CTA -->
         <div class="text-center space-y-4">
           <%= render DS::Link.new(
-            text: "View Setup Guide",
+            text: t(".view_setup_guide"),
             href: "https://github.com/we-promise/sure/blob/main/docs/hosting/docker.md",
             variant: "primary",
             size: "lg",
@@ -36,16 +36,16 @@
             target: "_blank",
             rel: "noopener noreferrer"
           ) %>
-          <p class="text-sm text-muted">Follow our complete Docker setup guide to configure Redis</p>
+          <p class="text-sm text-muted"><%= t(".setup_guide_note") %></p>
         </div>
       </div>
 
       <!-- Secondary CTA -->
       <div class="pt-6 border-t border-primary">
         <div class="text-center space-y-3">
-          <p class="text-sm text-muted">Once you've configured Redis, refresh this page to continue.</p>
+          <p class="text-sm text-muted"><%= t(".refresh_note") %></p>
           <%= render DS::Button.new(
-            text: "Refresh Page",
+            text: t(".refresh_page"),
             variant: "secondary",
             icon: "refresh-cw",
             type: "button",

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -23,7 +23,7 @@
                                        placeholder: t("properties.form.area_placeholder"),
                                        min: 0 %>
         <%= property_form.select :area_unit,
-                                 [["Square Feet", "sqft"], ["Square Meters", "sqm"]],
+                                 [[t("properties.form.area_unit_square_feet"), "sqft"], [t("properties.form.area_unit_square_meters"), "sqm"]],
                                  { label: t("properties.form.area_unit") } %>
       </div>
 

--- a/app/views/properties/_form_tabs.html.erb
+++ b/app/views/properties/_form_tabs.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (account:, active_tab:) %>
 
 <div class="flex flex-col gap-0.5 w-[156px] shrink-0">
-  <%= render "properties/form_tab", label: "Overview", href: account.new_record? ? nil : edit_property_path(@account), active: active_tab == "overview" %>
-  <%= render "properties/form_tab", label: "Value", href: account.new_record? ? nil : balances_property_path(@account), active: active_tab == "value" %>
-  <%= render "properties/form_tab", label: "Address", href: account.new_record? ? nil : address_property_path(@account), active: active_tab == "address" %>
+  <%= render "properties/form_tab", label: t("properties.form_tabs.overview"), href: account.new_record? ? nil : edit_property_path(@account), active: active_tab == "overview" %>
+  <%= render "properties/form_tab", label: t("properties.form_tabs.value"), href: account.new_record? ? nil : balances_property_path(@account), active: active_tab == "value" %>
+  <%= render "properties/form_tab", label: t("properties.form_tabs.address"), href: account.new_record? ? nil : address_property_path(@account), active: active_tab == "address" %>
 </div>

--- a/app/views/properties/_overview_fields.html.erb
+++ b/app/views/properties/_overview_fields.html.erb
@@ -2,20 +2,20 @@
 
 <div class="flex flex-col gap-2">
   <%= form.text_field :name,
-                  label: "Name",
-                  placeholder: "Vacation home",
+                  label: t("properties.overview_fields.name"),
+                  placeholder: t("properties.overview_fields.name_placeholder"),
                   required: true %>
 
   <%= form.select :subtype,
                 Property::SUBTYPES.map { |k, v| [v[:long], k] },
-                { prompt: "Select type", label: "Property type" }, required: true %>
+                { prompt: t("properties.overview_fields.select_type"), label: t("properties.overview_fields.property_type") }, required: true %>
 
   <%= form.hidden_field :accountable_type, value: "Property" %>
 
   <%= form.fields_for :accountable do |property_form| %>
     <div class="flex items-center gap-2">
       <%= property_form.number_field :year_built,
-                    label: "Year Built (optional)",
+                    label: t("properties.overview_fields.year_built"),
                     placeholder: "1990",
                     min: 1800,
                     max: Time.current.year %>
@@ -23,12 +23,12 @@
 
     <div class="flex items-center gap-2">
       <%= property_form.number_field :area_value,
-                      label: "Area (optional)",
+                      label: t("properties.overview_fields.area"),
                       placeholder: "1200",
                       min: 0 %>
       <%= property_form.select :area_unit,
-                      [["Square Feet", "sqft"], ["Square Meters", "sqm"]],
-                      { label: "Area Unit" } %>
+                      [[t("properties.overview_fields.square_feet"), "sqft"], [t("properties.overview_fields.square_meters"), "sqm"]],
+                      { label: t("properties.overview_fields.area_unit") } %>
     </div>
   <% end %>
 

--- a/app/views/properties/address.html.erb
+++ b/app/views/properties/address.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Enter property manually") %>
+  <% dialog.with_header(title: t(".enter_property_manually")) %>
   <% dialog.with_body do %>
     <div class="flex gap-4">
       <!-- Left sidebar with tabs -->
@@ -13,25 +13,25 @@
 
             <%= form.fields_for :address do |address_form| %>
               <%= address_form.text_field :line1,
-                    label: "Address Line 1",
-                    placeholder: "123 Main Street" %>
+                    label: t(".address_line_1"),
+                    placeholder: t(".address_line_1_placeholder") %>
 
               <div class="flex items-center gap-2">
                 <%= address_form.text_field :locality,
-                      label: "City",
-                      placeholder: "San Francisco" %>
+                      label: t(".city"),
+                      placeholder: t(".city_placeholder") %>
                 <%= address_form.text_field :region,
-                      label: "State/Region",
-                      placeholder: "CA" %>
+                      label: t(".state_region"),
+                      placeholder: t(".state_region_placeholder") %>
               </div>
 
               <div class="flex items-center gap-2">
                 <%= address_form.text_field :postal_code,
-                      label: "Postal Code",
-                      placeholder: "12345" %>
+                      label: t(".postal_code"),
+                      placeholder: t(".postal_code_placeholder") %>
                 <%= address_form.text_field :country,
-                      label: "Country",
-                      placeholder: "USA" %>
+                      label: t(".country"),
+                      placeholder: t(".country_placeholder") %>
               </div>
             <% end %>
           </div>
@@ -39,7 +39,7 @@
           <!-- Save button -->
           <div class="flex justify-end mt-4">
             <%= render DS::Button.new(
-              text: "Save",
+              text: t(".save"),
               variant: "primary",
             ) %>
           </div>

--- a/app/views/properties/balances.html.erb
+++ b/app/views/properties/balances.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Enter property manually") %>
+  <% dialog.with_header(title: t(".title")) %>
   <% dialog.with_body do %>
     <div class="flex gap-4">
       <%= render "properties/form_tabs", account: @account, active_tab: "value" %>
@@ -11,15 +11,15 @@
             <%= render "properties/form_alert", notice: @success_message, error: @error_message %>
 
             <%= form.money_field :balance,
-                label: "Estimated market value",
-                label_tooltip: "The estimated market value of your property. This number can often be found on sites like Zillow or Redfin, and is never an exact number.",
+                label: t(".estimated_market_value"),
+                label_tooltip: t(".estimated_market_value_tooltip"),
                 placeholder: "0" %>
           </div>
 
           <!-- Next button -->
           <div class="flex justify-end mt-4">
             <%= render DS::Button.new(
-              text: @account.active? ? "Save" : "Next",
+              text: @account.active? ? t(".save") : t(".next"),
               variant: "primary",
             ) %>
           </div>

--- a/app/views/properties/edit.html.erb
+++ b/app/views/properties/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Enter property manually") %>
+  <% dialog.with_header(title: t(".title")) %>
   <% dialog.with_body do %>
     <div class="flex gap-4">
       <!-- Left sidebar with tabs -->
@@ -16,7 +16,7 @@
           <!-- Save button -->
           <div class="flex justify-end mt-4">
             <%= render DS::Button.new(
-              text: @account.active? ? "Save" : "Next",
+              text: @account.active? ? t(".save") : t(".next"),
               variant: "primary",
             ) %>
           </div>

--- a/app/views/properties/new.html.erb
+++ b/app/views/properties/new.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Enter property manually") %>
+  <% dialog.with_header(title: t(".enter_property_manually")) %>
   <% dialog.with_body do %>
     <div class="flex gap-4">
       <!-- Left sidebar with tabs -->
@@ -16,7 +16,7 @@
           <!-- Create button -->
           <div class="flex justify-end mt-4">
             <%= render DS::Button.new(
-              text: "Next",
+              text: t(".next"),
               variant: "primary",
             ) %>
           </div>

--- a/app/views/properties/tabs/_overview.html.erb
+++ b/app/views/properties/tabs/_overview.html.erb
@@ -30,7 +30,7 @@
 
 <div class="flex justify-center py-8">
   <%= render DS::Link.new(
-    text: "Edit account details",
+    text: t(".edit_account_details"),
     href: edit_property_path(account),
     variant: "ghost",
     frame: :modal

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -74,19 +74,19 @@
     <div class="space-y-1 my-4">
       <div class="flex items-center gap-2 text-secondary text-sm" data-password-validator-target="requirementType" data-requirement-type="length">
         <%= icon("check", size: "sm") %>
-        <span>Minimum 8 characters</span>
+        <span><%= t(".password_min_length") %></span>
       </div>
       <div class="flex items-center gap-2 text-secondary text-sm" data-password-validator-target="requirementType" data-requirement-type="case">
         <%= icon("check", size: "sm") %>
-        <span>Upper and lowercase letters</span>
+        <span><%= t(".password_case") %></span>
       </div>
       <div class="flex items-center gap-2 text-secondary text-sm" data-password-validator-target="requirementType" data-requirement-type="number">
         <%= icon("check", size: "sm") %>
-        <span>A number (0-9)</span>
+        <span><%= t(".password_number") %></span>
       </div>
       <div class="flex items-center gap-2 text-secondary text-sm" data-password-validator-target="requirementType" data-requirement-type="special">
         <%= icon("check", size: "sm") %>
-        <span>A special character (!, @, #, $, %, etc)</span>
+        <span><%= t(".password_special") %></span>
       </div>
     </div>
   </div>

--- a/app/views/reports/_budget_performance.html.erb
+++ b/app/views/reports/_budget_performance.html.erb
@@ -4,7 +4,7 @@
       <%= t("reports.budget_performance.title") %>
     </h2>
     <p class="text-sm text-tertiary">
-      <%= start_date.strftime("%B %Y") %>
+      <%= I18n.l(start_date, format: "%B %Y") %>
     </p>
   </div>
 

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -90,8 +90,8 @@
     <%# Period Display %>
     <div class="text-sm text-secondary">
       <%= t("reports.index.showing_period",
-            start: @start_date.strftime("%b %-d, %Y"),
-            end: @end_date.strftime("%b %-d, %Y")) %>
+            start: I18n.l(@start_date, format: :long),
+            end: I18n.l(@end_date, format: :long)) %>
     </div>
   </div>
 <% end %>
@@ -107,7 +107,7 @@
     </section>
 
     <%# Collapsible & Reorderable Sections %>
-    <div data-controller="reports-sortable" data-action="dragover->reports-sortable#dragOver drop->reports-sortable#drop" role="list" aria-label="Reports sections">
+    <div data-controller="reports-sortable" data-action="dragover->reports-sortable#dragOver drop->reports-sortable#drop" role="list" aria-label="<%= t("reports.index.sections_label") %>">
       <% @reports_sections.each do |section| %>
         <% next unless section[:visible] %>
         <section
@@ -121,7 +121,7 @@
           tabindex="0"
           role="listitem"
           aria-grabbed="false"
-          aria-label="<%= t(section[:title]) %> section. Press Enter or Space to grab for reordering, then use arrow keys to move."
+          aria-label="<%= t(section[:title]) %> <%= t("reports.index.section_instructions") %>"
           data-action="
             dragstart->reports-sortable#dragStart
             dragend->reports-sortable#dragEnd

--- a/app/views/reports/print.html.erb
+++ b/app/views/reports/print.html.erb
@@ -1,13 +1,13 @@
 <% content_for :title do %>
-  <%= t("reports.print.document_title") %> - <%= @start_date.strftime("%B %d, %Y") %> to <%= @end_date.strftime("%B %d, %Y") %>
+  <%= t("reports.print.document_title") %> - <%= I18n.l(@start_date, format: :long) %> to <%= I18n.l(@end_date, format: :long) %>
 <% end %>
 
 <div class="tufte-report">
   <%# Header %>
   <header class="tufte-header">
     <h1 class="tufte-title"><%= t("reports.print.title") %></h1>
-    <span class="tufte-period"><%= @start_date.strftime("%B %d, %Y") %> – <%= @end_date.strftime("%B %d, %Y") %></span>
-    <p class="tufte-meta"><%= Current.family.name %> · <%= t("reports.print.generated_on", date: Time.current.strftime("%B %d, %Y")) %></p>
+    <span class="tufte-period"><%= I18n.l(@start_date, format: :long) %> – <%= I18n.l(@end_date, format: :long) %></span>
+    <p class="tufte-meta"><%= Current.family.name %> · <%= t("reports.print.generated_on", date: I18n.l(Time.current, format: :long)) %></p>
   </header>
 
   <%# Summary %>
@@ -340,6 +340,6 @@
   <% end %>
 
   <footer class="tufte-footer">
-    <%= product_name %> · <%= @start_date.strftime("%B %Y") %> – <%= @end_date.strftime("%B %Y") %>
+    <%= product_name %> · <%= I18n.l(@start_date, format: "%B %Y") %> – <%= I18n.l(@end_date, format: "%B %Y") %>
   </footer>
 </div>

--- a/app/views/rule/actions/_action.html.erb
+++ b/app/views/rule/actions/_action.html.erb
@@ -15,7 +15,7 @@
                 data: { rule__actions_target: "actionValue" } do %>
       <%# Initial rendering based on the action executor type. %>
       <%# Subsequent renders are injected by the Stimulus controller, which uses the templates from below. %>
-      <span class="font-medium text-primary uppercase text-xs">to</span>
+      <span class="font-medium text-primary uppercase text-xs"><%= t("rules.rule.to") %></span>
       <% if action.executor.type == "select" %>
         <%= form.select :value, action.options || [], {} %>
       <% elsif action.executor.type == "text" %>
@@ -32,12 +32,12 @@
 
   <%# Templates for different input types - these will be cloned and used by the Stimulus controller %>
   <template data-rule--actions-target="selectTemplate">
-    <span class="font-medium text-primary uppercase text-xs">to</span>
+    <span class="font-medium text-primary uppercase text-xs"><%= t("rules.rule.to") %></span>
     <%= form.select :value, [], {} %>
   </template>
 
   <template data-rule--actions-target="textTemplate">
-    <span class="font-medium text-primary uppercase text-xs">to</span>
+    <span class="font-medium text-primary uppercase text-xs"><%= t("rules.rule.to") %></span>
     <%= form.text_field :value, placeholder: t("rules.actions.value_placeholder") %>
   </template>
 

--- a/app/views/rule/conditions/_condition.html.erb
+++ b/app/views/rule/conditions/_condition.html.erb
@@ -9,7 +9,7 @@
   <%# Condition groups pass in show_prefix: false for subconditions since the ANY/ALL selector makes that clear %>
   <% if show_prefix %>
     <div class="pl-2" data-condition-prefix>
-      <span class="font-medium uppercase text-xs">and</span>
+      <span class="font-medium uppercase text-xs"><%= t("rule.conditions.condition.and") %></span>
     </div>
   <% end %>
 
@@ -27,9 +27,9 @@
         <%= form.select :value, condition.options, {} %>
       <% else %>
         <% if condition.filter.type == "number" %>
-          <%= form.number_field :value, placeholder: "10", step: 0.01 %>
+          <%= form.number_field :value, placeholder: t("rule.conditions.condition.number_placeholder"), step: 0.01 %>
         <% else %>
-          <%= form.text_field :value, placeholder: "Enter a value" %>
+          <%= form.text_field :value, placeholder: t("rule.conditions.condition.enter_value") %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/rule/conditions/_condition_group.html.erb
+++ b/app/views/rule/conditions/_condition_group.html.erb
@@ -11,11 +11,11 @@
     <div class="flex items-center gap-2">
       <%# Show prefix on condition groups, except the first one %>
       <div class="pl-2" data-condition-prefix>
-        <span class="font-medium uppercase text-xs">and</span>
+        <span class="font-medium uppercase text-xs"><%= t("rules.form.condition_group.and") %></span>
       </div>
-      <p class="text-sm text-secondary">match</p>
-      <%= form.select :operator, [["all", "and"], ["any", "or"]], { container_class: "w-fit" }, data: { rules_target: "operatorField" } %>
-      <p class="text-sm text-secondary">of the following conditions</p>
+      <p class="text-sm text-secondary"><%= t("rules.form.condition_group.match") %></p>
+      <%= form.select :operator, [[t("rules.form.condition_group.all"), "and"], [t("rules.form.condition_group.any"), "or"]], { container_class: "w-fit" }, data: { rules_target: "operatorField" } %>
+      <p class="text-sm text-secondary"><%= t("rules.form.condition_group.of_following") %></p>
     </div>
 
     <%= icon(
@@ -40,7 +40,7 @@
   </ul>
 
   <%= render DS::Button.new(
-    text: "Add condition",
+    text: t("rules.form.condition_group.add_condition"),
     leading_icon: "plus",
     variant: "ghost",
     type: "button",

--- a/app/views/rules/_category_rule_cta.html.erb
+++ b/app/views/rules/_category_rule_cta.html.erb
@@ -1,21 +1,21 @@
 <%# locals: (cta:) %>
 
-<% message = "Updated to #{cta[:category_name]}" %>
-<% description = "You can create a rule to automatically categorize transactions like this one" %>
+<% message = t('.updated_to_category', category_name: cta[:category_name]) %>
+<% description = t('.create_rule_description') %>
 
 <%= render "shared/notifications/cta", message: message, description: description do %>
   <%= form_with model: Current.user, url: rule_prompt_settings_user_path(Current.user), method: :patch do |f| %>
     <div class="flex gap-2 items-center mb-3 -mt-1">
       <%= f.check_box :rule_prompts_disabled, class: "checkbox checkbox--light" %>
-      <%= f.label :rule_prompts_disabled, "Don't show this again", class: "text-xs text-secondary" %>
+      <%= f.label :rule_prompts_disabled, t('.dont_show_again'), class: "text-xs text-secondary" %>
     </div>
 
     <%= f.hidden_field :rule_prompt_dismissed_at, value: Time.current %>
 
     <%= tag.div class:"flex gap-2 justify-end" do %>
-      <%= render DS::Button.new(text: "Dismiss", variant: "secondary") %>
+      <%= render DS::Button.new(text: t('.dismiss'), variant: "secondary") %>
       <% rule_href = new_rule_path(resource_type: "transaction", action_type: "set_transaction_category", action_value: cta[:category_id], name: cta[:merchant_name]) %>
-      <%= render DS::Link.new(text: "Create rule", variant: "primary", href: rule_href, frame: :modal) %>
+      <%= render DS::Link.new(text: t('.create_rule'), variant: "primary", href: rule_href, frame: :modal) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -12,16 +12,16 @@
   <section class="space-y-4">
     <div class="flex items-center gap-1 text-secondary">
       <%= icon "tag", size: "sm" %>
-      <h3 class="text-sm font-medium text-primary">Rule name (optional)</h3>
+      <h3 class="text-sm font-medium text-primary"><%= t('.name_label') %></h3>
     </div>
     <div class="ml-6">
-      <%= f.text_field :name, placeholder: "Enter a name for this rule", class: "form-field__input" %>
+      <%= f.text_field :name, placeholder: t('.name_placeholder'), class: "form-field__input" %>
     </div>
   </section>
 
   <section class="space-y-4">
     <div class="flex items-center gap-1 text-secondary">
-      <h3 class="text-sm font-medium text-primary">IF</h3>
+      <h3 class="text-sm font-medium text-primary"><%= t('.if_label') %></h3>
     </div>
 
     <%# Condition Group template, used by Stimulus controller to add new conditions dynamically %>
@@ -50,15 +50,15 @@
       </ul>
 
       <div class="flex items-center gap-2">
-        <%= render DS::Button.new(text: "Add condition", icon: "plus", variant: "ghost", type: "button", data: { action: "rules#addCondition" }) %>
-        <%= render DS::Button.new(text: "Add condition group", icon: "copy-plus", variant: "ghost", type: "button", data: { action: "rules#addConditionGroup" }) %>
+        <%= render DS::Button.new(text: t('.add_condition'), icon: "plus", variant: "ghost", type: "button", data: { action: "rules#addCondition" }) %>
+        <%= render DS::Button.new(text: t('.add_condition_group'), icon: "copy-plus", variant: "ghost", type: "button", data: { action: "rules#addConditionGroup" }) %>
       </div>
     </div>
   </section>
 
   <section class="space-y-4">
     <div class="flex items-center gap-1 text-secondary">
-      <h3 class="text-sm font-medium text-primary">THEN</h3>
+      <h3 class="text-sm font-medium text-primary"><%= t('.then_label') %></h3>
     </div>
 
     <%# Action template, used by Stimulus controller to add new actions dynamically %>
@@ -75,25 +75,25 @@
         <% end %>
       </ul>
 
-      <%= render DS::Button.new(text: "Add action", icon: "plus", variant: "ghost", type: "button", data: { action: "rules#addAction" }) %>
+      <%= render DS::Button.new(text: t('.add_action'), icon: "plus", variant: "ghost", type: "button", data: { action: "rules#addAction" }) %>
     </div>
   </section>
 
   <section class="space-y-4">
     <div class="flex items-center gap-1 text-secondary">
-      <h3 class="text-sm font-medium text-primary">FOR</h3>
+      <h3 class="text-sm font-medium text-primary"><%= t('.for_label') %></h3>
     </div>
 
     <div class="ml-6 space-y-3">
       <div class="flex items-center gap-2">
         <%= f.radio_button :effective_date_enabled, false, checked: rule.effective_date.nil?, data: { action: "rules#clearEffectiveDate" } %>
-        <%= f.label :effective_date_enabled_false, "All past and future #{rule.resource_type}s", class: "text-sm text-primary" %>
+        <%= f.label :effective_date_enabled_false, t('.all_resources', resource: rule.resource_type.pluralize), class: "text-sm text-primary" %>
       </div>
 
       <div class="flex items-center gap-2">
         <div class="flex items-center gap-2">
           <%= f.radio_button :effective_date_enabled, true, checked: rule.effective_date.present? %>
-          <%= f.label :effective_date_enabled_true, "Starting from", class: "text-sm text-primary" %>
+          <%= f.label :effective_date_enabled_true, t('.starting_from'), class: "text-sm text-primary" %>
         </div>
 
         <%= f.date_field :effective_date, container_class: "w-fit", data: { rules_target: "effectiveDateInput" } %>

--- a/app/views/rules/_rule.html.erb
+++ b/app/views/rules/_rule.html.erb
@@ -8,7 +8,7 @@
     <% if rule.conditions.any? %>
       <div class="flex items-center gap-2 mt-1">
         <div class="flex items-center gap-1 text-secondary w-16 shrink-0">
-          <span class="font-mono text-xs">IF</span>
+          <span class="font-mono text-xs"><%= t("rules.rule.if") %></span>
         </div>
         <p class="flex items-center flex-wrap gap-1.5 m-0">
           <span class="px-2 py-1 border border-secondary rounded-full">
@@ -19,14 +19,14 @@
             <% end %>
           </span>
           <% if rule.conditions.count > 1 %>
-            and <%= rule.conditions.count - 1 %> more <%= rule.conditions.count - 1 == 1 ? "condition" : "conditions" %>
+            <%= t("rules.rule.and_more_conditions", count: rule.conditions.count - 1) %>
           <% end %>
         </p>
       </div>
     <% end %>
     <div class="flex items-center gap-2 mt-1">
       <div class="flex items-center gap-1 text-secondary w-16 shrink-0">
-        <span class="font-mono text-xs">THEN</span>
+        <span class="font-mono text-xs"><%= t("rules.rule.then") %></span>
       </div>
       <p class="flex items-center flex-wrap gap-1.5 m-0">
         <span class="px-2 py-1 border border-secondary rounded-full">
@@ -34,27 +34,27 @@
             <%= t("rules.no_action") %>
           <% else %>
             <% if rule.actions.first.value && rule.actions.first.options %>
-              <%= rule.actions.first.executor.label %> to <%= rule.actions.first.value_display %>
+              <%= rule.actions.first.executor.label %> <%= t("rules.rule.to") %> <%= rule.actions.first.value_display %>
             <% else %>
               <%= rule.actions.first.executor.label %>
             <% end %>
           <% end %>
         </span>
         <% if rule.actions.count > 1 %>
-          and <%= rule.actions.count - 1 %> more <%= rule.actions.count - 1 == 1 ? "action" : "actions" %>
+          <%= t("rules.rule.and_more_actions", count: rule.actions.count - 1) %>
         <% end %>
       </p>
     </div>
     <div class="flex items-center gap-2 mt-1">
       <div class="flex items-center gap-1 text-secondary w-16 shrink-0">
-        <span class="font-mono text-xs">FOR</span>
+        <span class="font-mono text-xs"><%= t("rules.rule.for") %></span>
       </div>
       <p class="flex items-center flex-wrap gap-1.5 m-0">
         <span class="px-2 py-1 border border-secondary rounded-full">
           <% if rule.effective_date.nil? %>
-            All past and future <%= rule.resource_type.pluralize %>
+            <%= t("rules.rule.all_past_future", resource_type: rule.resource_type.pluralize) %>
           <% else %>
-            <%= rule.resource_type.pluralize %> on or after <%= rule.effective_date.strftime("%b %-d, %Y") %>
+            <%= t("rules.rule.on_or_after", resource_type: rule.resource_type.pluralize, date: I18n.l(rule.effective_date, format: :long)) %>
           <% end %>
         </span>
       </p>
@@ -65,11 +65,11 @@
       <%= f.toggle :active, { data: { auto_submit_form_target: "auto" } } %>
     <% end %>
     <%= render DS::Menu.new do |menu| %>
-      <% menu.with_item(variant: "link", text: "Edit", href: edit_rule_path(rule), icon: "pencil", data: { turbo_frame: "modal" }) %>
-      <% menu.with_item(variant: "link", text: "Re-apply rule", href: confirm_rule_path(rule), icon: "refresh-cw", data: { turbo_frame: "modal" }) %>
+      <% menu.with_item(variant: "link", text: t('.edit'), href: edit_rule_path(rule), icon: "pencil", data: { turbo_frame: "modal" }) %>
+      <% menu.with_item(variant: "link", text: t('.reapply'), href: confirm_rule_path(rule), icon: "refresh-cw", data: { turbo_frame: "modal" }) %>
       <% menu.with_item(
         variant: "button",
-        text: "Delete",
+        text: t('.delete'),
         href: rule_path(rule),
         icon: "trash-2",
         method: :delete,

--- a/app/views/rules/confirm.html.erb
+++ b/app/views/rules/confirm.html.erb
@@ -1,18 +1,16 @@
 <%= render DS::Dialog.new(reload_on_close: params[:reload_on_close].present?) do |dialog| %>
   <%
     title = if @rule.name.present?
-              "Confirm changes to \"#{@rule.name}\""
+              t(".confirm_changes_with_name", name: @rule.name)
             else
-              "Confirm changes"
+              t(".confirm_changes")
             end
   %>
   <% dialog.with_header(title: title) %>
 
   <% dialog.with_body do %>
     <p class="text-secondary text-sm mb-4">
-      You are about to apply this rule to
-      <span class="text-primary font-medium"><%= @rule.affected_resource_count %> <%= @rule.resource_type.pluralize %></span>
-      that meet the specified rule criteria.  Please confirm if you wish to proceed with this change.
+      <%= t(".confirm_message_html", count: @rule.affected_resource_count, resource_type: @rule.resource_type.pluralize) %>
     </p>
 
     <% if @rule.actions.any? { |a| a.action_type == "auto_categorize" } %>
@@ -21,25 +19,23 @@
         <div class="flex items-start gap-2">
           <%= icon "info", class: "w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0" %>
           <div class="text-xs">
-            <p class="font-medium text-blue-900 mb-1">AI Cost Estimation</p>
+            <p class="font-medium text-blue-900 mb-1"><%= t(".ai_cost_title") %></p>
             <% if @estimated_cost.present? %>
               <p class="text-blue-700">
-                This will use AI to categorize <%= affected_count %> transaction<%= "s" if affected_count != 1 %>.
-                Estimated cost: <span class="font-semibold">~$<%= sprintf("%.4f", @estimated_cost) %></span>
+                <%= t(".ai_cost_with_estimate", count: affected_count, cost: sprintf("%.4f", @estimated_cost)) %>
               </p>
             <% else %>
               <p class="text-blue-700">
-                This will use AI to categorize <%= affected_count %> transaction<%= "s" if affected_count != 1 %>.
                 <% if @selected_model.present? %>
-                  <span class="font-semibold">Cost estimation unavailable for model "<%= @selected_model %>".</span>
+                  <%= t(".ai_cost_no_model", count: affected_count, model: @selected_model) %>
                 <% else %>
-                  <span class="font-semibold">Cost estimation unavailable (no LLM provider configured).</span>
+                  <%= t(".ai_cost_no_provider", count: affected_count) %>
                 <% end %>
-                You may incur costs, please check with the model provider for the most up-to-date prices.
+                <%= t(".ai_cost_warning") %>
               </p>
             <% end %>
             <p class="text-blue-600 mt-1">
-              <%= link_to "View usage history", settings_llm_usage_path, class: "underline hover:text-blue-800" %>
+              <%= link_to t(".view_usage"), settings_llm_usage_path, class: "underline hover:text-blue-800" %>
             </p>
           </div>
         </div>
@@ -47,7 +43,7 @@
     <% end %>
 
     <%= render DS::Button.new(
-      text: "Confirm changes",
+      text: t(".confirm_button"),
       href: apply_rule_path(@rule),
       method: :post,
       full_width: true,

--- a/app/views/rules/edit.html.erb
+++ b/app/views/rules/edit.html.erb
@@ -1,11 +1,11 @@
-<%= link_to "Back to rules", rules_path %>
+<%= link_to t("rules.edit.back_to_rules"), rules_path %>
 
 <%= render DS::Dialog.new do |dialog| %>
   <%
     title = if @rule.name.present?
-              "Edit #{@rule.resource_type} rule \"#{@rule.name}\""
+              t("rules.edit.title_with_name", resource_type: @rule.resource_type, name: @rule.name)
             else
-              "Edit #{@rule.resource_type} rule"
+              t("rules.edit.title", resource_type: @rule.resource_type)
             end
   %>
   <% dialog.with_header(title: title) %>

--- a/app/views/rules/index.html.erb
+++ b/app/views/rules/index.html.erb
@@ -1,11 +1,11 @@
 <header class="flex items-center justify-between">
-  <h1 class="text-primary text-xl font-medium">Rules</h1>
+  <h1 class="text-primary text-xl font-medium"><%= t('.title') %></h1>
   <div class="flex items-center gap-2">
     <% if @rules.any? %>
       <%= render DS::Menu.new do |menu| %>
         <% menu.with_item(
           variant: "button",
-          text: "Delete all rules",
+          text: t('.delete_all'),
           href: destroy_all_rules_path,
           icon: "trash-2",
           method: :delete,
@@ -20,7 +20,7 @@
       ) %>
     <% end %>
     <%= render DS::Link.new(
-      text: "New rule",
+      text: t('.new_rule'),
       variant: "primary",
       href: new_rule_path(resource_type: "transaction"),
       icon: "plus",
@@ -32,7 +32,7 @@
   <div class="flex items-center gap-2 mb-2 py-4">
     <%= icon("circle-alert", size: "sm") %>
     <p class="text-sm text-secondary">
-      AI-enabled rule actions will cost money.  Be sure to filter as narrowly as possible to avoid unnecessary costs.
+      <%= t('.ai_cost_warning') %>
     </p>
   </div>
 <% end %>
@@ -41,15 +41,15 @@
     <div class="bg-container-inset rounded-xl">
       <div class="flex justify-between px-4 py-2 text-xs uppercase">
         <div class="flex items-center gap-1.5 font-medium text-secondary">
-          <p>Rules</p>
+          <p><%= t('.rules') %></p>
           <span class="text-subdued">&middot;</span>
           <p><%= @rules.count %></p>
         </div>
         <div class="flex items-center gap-1">
-          <span class="text-secondary">Sort by:</span>
+          <span class="text-secondary"><%= t('.sort_by') %></span>
           <%= form_with url: rules_path, method: :get, local: true, class: "flex items-center", data: { controller: "auto-submit-form" } do |form| %>
             <%= form.select :sort_by,
-                      options_for_select([["Name", "name"], ["Updated At", "updated_at"]], @sort_by),
+                      options_for_select([[t('.sort_name'), "name"], [t('.sort_updated_at'), "updated_at"]], @sort_by),
                       {},
                       class: "min-w-[120px] bg-transparent rounded border-none cursor-pointer text-primary uppercase text-xs w-auto",
                       data: { auto_submit_form_target: "auto", autosubmit_trigger_event: "change" } %>
@@ -60,7 +60,7 @@
             variant: "icon",
             icon: "arrow-up-down",
             size: :sm,
-            title: "Toggle sort direction"
+            title: t('.toggle_sort_direction')
           ) %>
         </div>
       </div>
@@ -73,11 +73,11 @@
   <% else %>
     <div class="flex justify-center items-center py-20">
       <div class="text-center flex flex-col items-center max-w-[500px]">
-        <p class="text-sm text-primary font-medium mb-1">No rules yet</p>
-        <p class="text-sm text-secondary mb-4">Set up rules to perform actions to your transactions and other data on every account sync.</p>
+        <p class="text-sm text-primary font-medium mb-1"><%= t('.empty_title') %></p>
+        <p class="text-sm text-secondary mb-4"><%= t('.empty_description') %></p>
         <div class="flex items-center gap-2">
           <%= render DS::Link.new(
-            text: "New rule",
+            text: t('.new_rule'),
             variant: "primary",
             href: new_rule_path(resource_type: "transaction"),
             icon: "plus",
@@ -126,7 +126,7 @@
           <% @recent_runs.each do |run| %>
             <tr class="<%= "bg-red-50 theme-dark:bg-red-950/30" if run.failed? %>">
               <td class="px-4 py-3 text-sm text-primary whitespace-nowrap">
-                <%= run.executed_at.strftime("%b %d, %Y %I:%M %p") %>
+                <%= I18n.l(run.executed_at, format: :long) %>
               </td>
               <td class="px-4 py-3 text-sm text-primary text-center">
                 <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium <%= run.execution_type == "manual" ? "bg-blue-50 text-blue-700 theme-dark:bg-blue-950/30 theme-dark:text-blue-400" : "bg-purple-50 text-purple-700 theme-dark:bg-purple-950/30 theme-dark:text-purple-400" %>">

--- a/app/views/rules/new.html.erb
+++ b/app/views/rules/new.html.erb
@@ -1,7 +1,7 @@
-<%= link_to "Back to rules", rules_path %>
+<%= link_to t(".back_to_rules"), rules_path %>
 
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "New #{@rule.resource_type} rule") %>
+  <% dialog.with_header(title: t(".title", resource_type: @rule.resource_type)) %>
   <% dialog.with_body do %>
     <%= render "rules/form", rule: @rule %>
   <% end %>

--- a/app/views/settings/_settings_nav.html.erb
+++ b/app/views/settings/_settings_nav.html.erb
@@ -26,13 +26,13 @@ nav_sections = [
       header: t(".advanced_section_title"),
       items: [
         { label: t(".ai_prompts_label"), path: settings_ai_prompts_path, icon: "bot" },
-        { label: "LLM Usage", path: settings_llm_usage_path, icon: "activity" },
+        { label: t(".llm_usage_label"), path: settings_llm_usage_path, icon: "activity" },
         { label: t(".api_keys_label"), path: settings_api_key_path, icon: "key" },
         { label: t(".self_hosting_label"), path: settings_hosting_path, icon: "database", if: self_hosted? },
-        { label: "Providers", path: settings_providers_path, icon: "plug" },
+        { label: t(".providers_label"), path: settings_providers_path, icon: "plug" },
         { label: t(".imports_label"), path: imports_path, icon: "download" },
-        { label: "SSO Providers", path: admin_sso_providers_path, icon: "key-round", if: Current.user&.super_admin? },
-        { label: "Users", path: admin_users_path, icon: "users", if: Current.user&.super_admin? }
+        { label: t(".sso_providers_label"), path: admin_sso_providers_path, icon: "key-round", if: Current.user&.super_admin? },
+        { label: t(".users_label"), path: admin_users_path, icon: "users", if: Current.user&.super_admin? }
       ]
     } : nil
   ),
@@ -55,9 +55,9 @@ nav_sections = [
       href: previous_path,
       variant: "ghost",
     ) %>
-    <%= link_to previous_path, class: "hidden md:block uppercase bg-surface-inset-hover rounded-sm px-1 py-0.5 text-xs text-secondary shadow-sm ml-1 pointer-events-none", data: { controller: "hotkey", hotkey: "Escape" } do %>
-      <kbd>esc</kbd>
-    <% end %>
+    <span class="hidden md:block uppercase bg-surface-inset-hover rounded-sm px-1 py-0.5 text-xs text-secondary shadow-sm ml-1">
+      <kbd><%= t(".esc") %></kbd>
+    </span>
   </div>
   <nav class="space-y-4 hidden md:block">
     <% nav_sections.compact.each do |section| %>

--- a/app/views/settings/_user_avatar_field.html.erb
+++ b/app/views/settings/_user_avatar_field.html.erb
@@ -12,7 +12,7 @@
     <div class="relative flex justify-center items-center bg-surface-inset size-26 md:size-24 rounded-full border-primary border border-dashed overflow-hidden">
       <%# The image preview once user has uploaded a new file  %>
       <div data-profile-image-preview-target="previewImage" class="h-full w-full flex justify-center items-center hidden">
-        <img src="" alt="Preview" class="w-full h-full rounded-full object-cover">
+        <img src="" alt="<%= t(".preview_alt") %>" class="w-full h-full rounded-full object-cover">
       </div>
 
       <%# The placeholder image for empty avatar field  %>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -1,6 +1,6 @@
-<%= content_for :page_title, "API Key Created" %>
+<%= content_for :page_title, t("settings.api_keys.created.title") %>
 
-<%= settings_section title: "API Key Created Successfully", subtitle: "Your new API key has been generated successfully." do %>
+<%= settings_section title: t("settings.api_keys.created.success_title"), subtitle: t("settings.api_keys.created.success_description") do %>
   <div class="space-y-4">
     <div class="p-3 shadow-border-xs bg-container rounded-lg">
       <div class="flex items-start gap-3">
@@ -11,21 +11,21 @@
           variant: :success
         ) %>
         <div class="flex-1">
-          <h3 class="font-medium text-primary">API Key Created Successfully!</h3>
-          <p class="text-secondary text-sm mt-1">Your new API key "<%= @api_key.name %>" has been created and is ready to use.</p>
+          <h3 class="font-medium text-primary"><%= t("settings.api_keys.show.created.heading") %></h3>
+          <p class="text-secondary text-sm mt-1"><%= t("settings.api_keys.show.created.description", name: @api_key.name) %></p>
         </div>
       </div>
     </div>
 
     <div class="bg-surface-inset rounded-xl p-4">
-      <h4 class="font-medium text-primary mb-3">Your API Key</h4>
-      <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
+      <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.your_api_key") %></h4>
+      <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.show.copy_key_instructions") %></p>
 
       <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
         <div class="flex items-center justify-between gap-3">
           <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
           <%= render DS::Button.new(
-            text: "Copy API Key",
+            text: t(".copy_key"),
             variant: "ghost",
             icon: "copy",
             data: { action: "clipboard#copy" }
@@ -35,29 +35,23 @@
     </div>
 
     <div class="bg-surface-inset rounded-xl p-4">
-      <h4 class="font-medium text-primary mb-3">Key Details</h4>
+      <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.key_name") %></h4>
       <div class="space-y-2 text-sm">
         <div class="flex justify-between">
-          <span class="text-secondary">Name:</span>
+          <span class="text-secondary"><%= t("settings.api_keys.show.current_api_key.key_name") %>:</span>
           <span class="text-primary font-medium"><%= @api_key.name %></span>
         </div>
         <div class="flex justify-between">
-          <span class="text-secondary">Permissions:</span>
+          <span class="text-secondary"><%= t("settings.api_keys.created.permissions") %>:</span>
           <span class="text-primary">
             <%= @api_key.scopes.map { |scope|
-              case scope
-              when "read_accounts" then "View Accounts"
-              when "read_transactions" then "View Transactions"
-              when "read_balances" then "View Balances"
-              when "write_transactions" then "Create Transactions"
-              else scope.humanize
-              end
+              t("settings.api_keys_controller.scope_descriptions.#{scope}", default: scope.humanize)
             }.join(", ") %>
           </span>
         </div>
         <div class="flex justify-between">
-          <span class="text-secondary">Created:</span>
-          <span class="text-primary"><%= @api_key.created_at.strftime("%B %d, %Y at %I:%M %p") %></span>
+          <span class="text-secondary"><%= t("settings.api_keys.show.current_api_key.created_at") %>:</span>
+          <span class="text-primary"><%= I18n.l(@api_key.created_at, format: :long) %></span>
         </div>
       </div>
     </div>
@@ -66,18 +60,18 @@
       <div class="flex items-start gap-2">
         <%= icon("alert-triangle", class: "w-5 h-5 text-warning-600 mt-0.5") %>
         <div>
-          <h4 class="font-medium text-warning-800 text-sm">Important Security Note</h4>
+          <h4 class="font-medium text-warning-800 text-sm"><%= t("settings.api_keys.created.critical_warning_title") %></h4>
           <p class="text-warning-700 text-sm mt-1">
-            This is the only time your API key will be displayed. Make sure to copy it now and store it securely.
-            If you lose this key, you'll need to generate a new one.
+            <%= t("settings.api_keys.created.critical_warning_1") %>
+            <%= t("settings.api_keys.created.critical_warning_3") %>
           </p>
         </div>
       </div>
     </div>
 
     <div class="bg-surface-inset rounded-xl p-4">
-      <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-      <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
+      <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.usage_instructions_title") %></h4>
+      <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.created.usage_instructions") %></p>
       <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
         curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
       </div>
@@ -85,7 +79,7 @@
 
     <div class="flex justify-end pt-4 border-t border-primary">
       <%= render DS::Link.new(
-        text: "Continue to API Key Settings",
+        text: t(".continue"),
         href: settings_api_key_path,
         variant: "primary"
       ) %>

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -2,10 +2,10 @@
   <div class="relative max-w-4xl mx-auto flex flex-col w-full h-full">
     <div class="grow space-y-4 overflow-y-auto -mx-1 px-1 pb-12">
       <h1 class="text-primary text-3xl md:text-xl font-medium">
-        API Key Created
+        <%= t("settings.api_keys.created.title") %>
       </h1>
 
-      <%= settings_section title: "API Key Created Successfully", subtitle: "Your new API key has been generated successfully." do %>
+      <%= settings_section title: t("settings.api_keys.created.success_title"), subtitle: t("settings.api_keys.created.success_description") do %>
         <div class="space-y-4">
           <div class="p-3 shadow-border-xs bg-container rounded-lg">
             <div class="flex items-start gap-3">
@@ -16,21 +16,21 @@
                 variant: :success
               ) %>
               <div class="flex-1">
-                <h3 class="font-medium text-primary">API Key Created Successfully!</h3>
-                <p class="text-secondary text-sm mt-1">Your new API key "<%= @api_key.name %>" has been created and is ready to use.</p>
+                <h3 class="font-medium text-primary"><%= t("settings.api_keys.show.created.heading") %></h3>
+                <p class="text-secondary text-sm mt-1"><%= t("settings.api_keys.show.created.description", name: @api_key.name) %></p>
               </div>
             </div>
           </div>
 
           <div class="bg-surface-inset rounded-xl p-4">
-            <h4 class="font-medium text-primary mb-3">Your API Key</h4>
-            <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
+            <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.your_api_key") %></h4>
+            <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.show.copy_key_instructions") %></p>
 
             <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
               <div class="flex items-center justify-between gap-3">
                 <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
                 <%= render DS::Button.new(
-                  text: "Copy API Key",
+                  text: t("settings.api_keys.created.copy_key"),
                   variant: "ghost",
                   icon: "copy",
                   data: { action: "clipboard#copy" }
@@ -40,29 +40,23 @@
           </div>
 
           <div class="bg-surface-inset rounded-xl p-4">
-            <h4 class="font-medium text-primary mb-3">Key Details</h4>
+            <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.key_name") %></h4>
             <div class="space-y-2 text-sm">
               <div class="flex justify-between">
-                <span class="text-secondary">Name:</span>
+                <span class="text-secondary"><%= t("settings.api_keys.show.current_api_key.key_name") %>:</span>
                 <span class="text-primary font-medium"><%= @api_key.name %></span>
               </div>
               <div class="flex justify-between">
-                <span class="text-secondary">Permissions:</span>
+                <span class="text-secondary"><%= t("settings.api_keys.created.permissions") %>:</span>
                 <span class="text-primary">
                   <%= @api_key.scopes.map { |scope|
-                    case scope
-                    when "read_accounts" then "View Accounts"
-                    when "read_transactions" then "View Transactions"
-                    when "read_balances" then "View Balances"
-                    when "write_transactions" then "Create Transactions"
-                    else scope.humanize
-                    end
+                    t("settings.api_keys_controller.scope_descriptions.#{scope}", default: scope.humanize)
                   }.join(", ") %>
                 </span>
               </div>
               <div class="flex justify-between">
-                <span class="text-secondary">Created:</span>
-                <span class="text-primary"><%= @api_key.created_at.strftime("%B %d, %Y at %I:%M %p") %></span>
+                <span class="text-secondary"><%= t("settings.api_keys.show.current_api_key.created_at") %>:</span>
+                <span class="text-primary"><%= I18n.l(@api_key.created_at, format: :long) %></span>
               </div>
             </div>
           </div>
@@ -71,18 +65,18 @@
             <div class="flex items-start gap-2">
               <%= icon("alert-triangle", class: "w-5 h-5 text-warning-600 mt-0.5") %>
               <div>
-                <h4 class="font-medium text-warning-800 text-sm">Important Security Note</h4>
+                <h4 class="font-medium text-warning-800 text-sm"><%= t("settings.api_keys.created.critical_warning_title") %></h4>
                 <p class="text-warning-700 text-sm mt-1">
-                  This is the only time your API key will be displayed. Make sure to copy it now and store it securely.
-                  If you lose this key, you'll need to generate a new one.
+                  <%= t("settings.api_keys.created.critical_warning_1") %>
+                  <%= t("settings.api_keys.created.critical_warning_3") %>
                 </p>
               </div>
             </div>
           </div>
 
           <div class="bg-surface-inset rounded-xl p-4">
-            <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-            <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
+            <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.usage_instructions_title") %></h4>
+            <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.created.usage_instructions") %></p>
             <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
               curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
             </div>
@@ -90,7 +84,7 @@
 
           <div class="flex justify-end pt-4 border-t border-primary">
             <%= render DS::Link.new(
-              text: "Continue to API Key Settings",
+              text: t("settings.api_keys.created.continue"),
               href: settings_api_key_path,
               variant: "primary"
             ) %>

--- a/app/views/settings/api_keys/new.html.erb
+++ b/app/views/settings/api_keys/new.html.erb
@@ -1,20 +1,20 @@
-<%= content_for :page_title, "Create New API Key" %>
+<%= content_for :page_title, t(".page_title") %>
 
-<%= settings_section title: nil, subtitle: "Generate a new API key to access your Sure data programmatically." do %>
+<%= settings_section title: nil, subtitle: t(".subtitle") do %>
   <%= styled_form_with model: @api_key, url: settings_api_key_path, class: "space-y-4" do |form| %>
     <%= form.text_field :name,
-        placeholder: "e.g., My Budget App, Portfolio Tracker",
-        label: "API Key Name",
-        help_text: "Choose a descriptive name to help you identify this key later." %>
+        placeholder: t(".name_placeholder"),
+        label: t(".name_label"),
+        help_text: t(".name_help") %>
 
     <div>
-      <%= form.label :scopes, "Permissions", class: "block text-sm font-medium text-primary mb-2" %>
-      <p class="text-sm text-secondary mb-3">Select the permissions this API key should have:</p>
+      <%= form.label :scopes, t(".permissions_label"), class: "block text-sm font-medium text-primary mb-2" %>
+      <p class="text-sm text-secondary mb-3"><%= t(".permissions_help") %></p>
 
       <div class="space-y-2">
         <% [
-          ["read", "Read Only", "View your accounts, transactions, and balances"],
-          ["read_write", "Read/Write", "View your data and create new transactions"]
+          ["read", t(".scope_read_only"), t(".scope_read_only_description")],
+          ["read_write", t(".scope_read_write"), t(".scope_read_write_description")]
         ].each do |value, label, description| %>
           <div class="bg-surface-inset rounded-lg p-3 border border-primary">
             <label class="flex items-start gap-3 cursor-pointer">
@@ -34,10 +34,9 @@
       <div class="flex items-start gap-2">
         <%= icon("alert-triangle", class: "w-5 h-5 text-warning-600 mt-0.5") %>
         <div>
-          <h4 class="font-medium text-warning-800 text-sm">Security Warning</h4>
+          <h4 class="font-medium text-warning-800 text-sm"><%= t(".security_warning_title") %></h4>
           <p class="text-warning-700 text-sm mt-1">
-            Your API key will be displayed only once after creation. Make sure to copy and store it securely.
-            Anyone with access to this key can access your data according to the permissions you select.
+            <%= t(".security_warning") %>
           </p>
         </div>
       </div>
@@ -45,13 +44,13 @@
 
     <div class="flex justify-end gap-3 pt-4 border-t border-primary">
       <%= render DS::Link.new(
-        text: "Cancel",
+        text: t(".cancel"),
         href: settings_api_key_path,
         variant: "ghost"
       ) %>
 
       <%= render DS::Button.new(
-        text: "Save API Key",
+        text: t(".save_api_key"),
         variant: "primary",
         type: "submit"
       ) %>

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -1,6 +1,6 @@
 <% if @newly_created && @plain_key %>
   <header class="flex items-center justify-between">
-    <h1 class="text-primary text-xl font-medium">API Key Created Successfully</h1>
+    <h1 class="text-primary text-xl font-medium"><%= t(".created.title") %></h1>
   </header>
 
   <div class="bg-container rounded-xl shadow-border-xs p-4">
@@ -14,21 +14,21 @@
             variant: :success
           ) %>
           <div class="flex-1">
-            <h3 class="font-medium text-primary">API Key Created Successfully!</h3>
-            <p class="text-secondary text-sm mt-1">Your new API key "<%= @current_api_key.name %>" has been created and is ready to use.</p>
+            <h3 class="font-medium text-primary"><%= t(".created.heading") %></h3>
+            <p class="text-secondary text-sm mt-1"><%= t(".created.description", name: @current_api_key.name) %></p>
           </div>
         </div>
       </div>
 
       <div class="bg-surface-inset rounded-xl p-4">
-        <h4 class="font-medium text-primary mb-3">Your API Key</h4>
-        <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
+        <h4 class="font-medium text-primary mb-3"><%= t(".your_api_key") %></h4>
+        <p class="text-secondary text-sm mb-3"><%= t(".copy_key_instructions") %></p>
 
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
           <div class="flex items-center justify-between gap-3">
             <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
             <%= render DS::Button.new(
-              text: "Copy API Key",
+              text: t(".copy_api_key"),
               variant: "ghost",
               icon: "copy",
               data: { action: "clipboard#copy" }
@@ -38,8 +38,8 @@
       </div>
 
       <div class="bg-surface-inset rounded-xl p-4">
-        <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-        <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
+        <h4 class="font-medium text-primary mb-3"><%= t(".how_to_use") %></h4>
+        <p class="text-secondary text-sm mb-3"><%= t(".header_instructions") %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
           curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
         </div>
@@ -47,7 +47,7 @@
 
       <div class="flex justify-end pt-4 border-t border-primary">
         <%= render DS::Link.new(
-          text: "Continue to API Key Settings",
+          text: t(".continue_to_settings"),
           href: settings_api_key_path,
           variant: "primary"
         ) %>
@@ -56,9 +56,9 @@
   </div>
 <% elsif @current_api_key %>
   <header class="flex items-center justify-between">
-    <h1 class="text-primary text-xl font-medium">Your API Key</h1>
+    <h1 class="text-primary text-xl font-medium"><%= t(".your_api_key") %></h1>
     <%= render DS::Link.new(
-      text: "Create New Key",
+      text: t(".create_new_key"),
       href: new_settings_api_key_path(regenerate: true),
       variant: "secondary"
     ) %>
@@ -77,30 +77,30 @@
           <div class="text-sm space-y-1">
             <p class="text-primary font-medium"><%= @current_api_key.name %></p>
             <p class="text-secondary">
-              Created <%= time_ago_in_words(@current_api_key.created_at) %> ago
+              <%= t(".created_ago", time: time_ago_in_words(@current_api_key.created_at)) %>
               <% if @current_api_key.last_used_at %>
-                • Last used <%= time_ago_in_words(@current_api_key.last_used_at) %> ago
+                • <%= t(".last_used_ago", time: time_ago_in_words(@current_api_key.last_used_at)) %>
               <% else %>
-                • Never used
+                • <%= t(".never_used") %>
               <% end %>
             </p>
           </div>
         </div>
 
         <div class="rounded-md bg-success px-2 py-1">
-          <p class="text-success-foreground font-medium text-xs">Active</p>
+          <p class="text-success-foreground font-medium text-xs"><%= t(".active") %></p>
         </div>
       </div>
 
       <div class="bg-surface-inset rounded-xl p-4">
-        <h4 class="font-medium text-primary mb-3">Permissions</h4>
+        <h4 class="font-medium text-primary mb-3"><%= t(".permissions") %></h4>
         <div class="flex flex-wrap gap-2">
           <% @current_api_key.scopes.each do |scope| %>
             <span class="inline-flex items-center gap-1 px-2 py-1 bg-primary text-primary-foreground rounded-full text-xs font-medium">
               <%= icon("shield-check", class: "w-3 h-3") %>
               <%= case scope
-                  when "read" then "Read Only"
-                  when "read_write" then "Read/Write"
+                  when "read" then t(".scope_read_only")
+                  when "read_write" then t(".scope_read_write")
                   else scope.humanize
                   end %>
             </span>
@@ -109,14 +109,14 @@
       </div>
 
       <div class="bg-surface-inset rounded-xl p-4">
-        <h4 class="font-medium text-primary mb-3">Your API Key</h4>
-        <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
+        <h4 class="font-medium text-primary mb-3"><%= t(".your_api_key") %></h4>
+        <p class="text-secondary text-sm mb-3"><%= t(".copy_key_instructions") %></p>
 
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
           <div class="flex items-center justify-between gap-3">
             <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
             <%= render DS::Button.new(
-              text: "Copy API Key",
+              text: t(".copy_api_key"),
               variant: "ghost",
               icon: "copy",
               data: { action: "clipboard#copy" }
@@ -126,8 +126,8 @@
       </div>
 
       <div class="bg-surface-inset rounded-xl p-4">
-        <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-        <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
+        <h4 class="font-medium text-primary mb-3"><%= t(".how_to_use") %></h4>
+        <p class="text-secondary text-sm mb-3"><%= t(".header_instructions") %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
           curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
         </div>
@@ -135,12 +135,12 @@
 
       <div class="flex justify-end pt-4 border-t border-primary">
         <%= render DS::Button.new(
-          text: "Revoke Key",
+          text: t(".revoke_key"),
           href: settings_api_key_path,
           method: :delete,
           variant: "destructive",
           data: {
-            turbo_confirm: "Are you sure you want to revoke this API key?"
+            turbo_confirm: t(".revoke_confirm")
           }
         ) %>
       </div>

--- a/app/views/settings/bank_sync/show.html.erb
+++ b/app/views/settings/bank_sync/show.html.erb
@@ -1,10 +1,10 @@
-<%= content_for :page_title, "Bank Sync" %>
+<%= content_for :page_title, t(".page_title") %>
 
 <div class="bg-container rounded-xl shadow-border-xs p-4">
   <% if @providers.any? %>
     <div class="rounded-xl bg-container-inset space-y-1 p-1">
       <div class="flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-secondary uppercase">
-        <p>PROVIDERS</p>
+        <p><%= t(".providers") %></p>
         <span class="text-subdued">&middot;</span>
         <p><%= @providers.count %></p>
       </div>
@@ -18,8 +18,8 @@
   <% else %>
     <div class="flex justify-center items-center py-20">
       <div class="text-center flex flex-col items-center max-w-[300px]">
-        <p class="text-primary mb-1 font-medium text-sm">No providers configured</p>
-        <p class="text-secondary text-sm">Configure providers to link your bank accounts.</p>
+        <p class="text-primary mb-1 font-medium text-sm"><%= t(".no_providers") %></p>
+        <p class="text-secondary text-sm"><%= t(".configure_providers") %></p>
       </div>
     </div>
   <% end %>

--- a/app/views/settings/billings/show.html.erb
+++ b/app/views/settings/billings/show.html.erb
@@ -13,29 +13,29 @@
         <div class="text-sm space-y-1">
           <% if @family.has_active_subscription? %>
             <p class="text-primary">
-              <span>You are currently subscribed to the <span class="font-medium"><%= @family.subscription.name %></span>.</span>
+              <%= t('.subscribed_html', plan: @family.subscription.name) %>
 
               <% if @family.next_billing_date %>
-                <span>Your plan renews on <span class="font-medium"><%= @family.next_billing_date.strftime("%B %d, %Y") %></span>.</span>
+                <%= t('.renews_on_html', date: I18n.l(@family.next_billing_date, format: :long)) %>
               <% end %>
             </p>
           <% elsif @family.trialing? %>
             <p class="text-primary">
-              You are currently trialing <%= product_name %>
+              <%= t('.trialing', product_name: product_name) %>
               <span class="text-secondary">
-                (<%= @family.days_left_in_trial %> days remaining)
+                (<%= t('.days_remaining', days: @family.days_left_in_trial) %>)
               </span>
             </p>
           <% else %>
-            <p class="text-primary">You are currently <span class="font-medium">not subscribed</span></p>
-            <p class="text-secondary">Once you subscribe to <%= product_name %>, you'll see your billing settings here.</p>
+            <p class="text-primary"><%= t('.not_subscribed_html') %></p>
+            <p class="text-secondary"><%= t('.subscribe_prompt', product_name: product_name) %></p>
           <% end %>
         </div>
       </div>
 
       <% if @family.has_active_subscription? %>
         <%= render DS::Link.new(
-          text: "Manage",
+          text: t('.manage'),
           icon: "external-link",
           variant: "primary",
           icon_position: "right",
@@ -44,7 +44,7 @@
         ) %>
       <% else %>
         <%= render DS::Link.new(
-          text: "Choose plan",
+          text: t('.choose_plan'),
           variant: "primary",
           icon: "plus",
           icon_position: "right",
@@ -55,7 +55,7 @@
 
     <div class="flex items-center gap-2">
       <%= image_tag "stripe-logo.svg", class: "w-5 h-5 shrink-0" %>
-      <p class="text-secondary text-sm">Billing via Stripe</p>
+      <p class="text-secondary text-sm"><%= t('.billing_via_stripe') %></p>
     </div>
   </div>
 <% end %>

--- a/app/views/settings/guides/show.html.erb
+++ b/app/views/settings/guides/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Guides" %>
+<%= content_for :page_title, t(".page_title") %>
 
 <div class="bg-container rounded-xl shadow-border-xs p-4 prose prose-sm max-w-none">
   <%= @guide_content.html_safe %>

--- a/app/views/settings/hostings/_brand_fetch_settings.html.erb
+++ b/app/views/settings/hostings/_brand_fetch_settings.html.erb
@@ -2,22 +2,16 @@
   <div>
     <h2 class="font-medium mb-1"><%= t(".title") %></h2>
     <% if ENV["BRAND_FETCH_CLIENT_ID"].present? %>
-      <p class="text-sm text-secondary">You have successfully configured your Brand Fetch Client ID through the BRAND_FETCH_CLIENT_ID environment variable.</p>
+      <p class="text-sm text-secondary"><%= t(".env_configured_message") %></p>
     <% else %>
       <div class="text-secondary text-sm mb-4">
         <span><%= t(".description") %></span>
         <details class="inline">
-          <summary class="cursor-pointer font-medium text-secondary underline inline"> (show details)</summary>
+          <summary class="cursor-pointer font-medium text-secondary underline inline"> <%= t(".show_details") %></summary>
           <ol class="text-sm text-secondary mt-2 list-decimal ml-6 space-y-2">
-            <li>
-              Visit <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> and create a free Brand Fetch Developer account.
-            </li>
-            <li>
-              Go to the <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a> page.
-            </li>
-            <li>
-              Tap the eye icon under the "Your Client ID" section to reveal your <strong>Client ID</strong> and paste it below.
-            </li>
+            <li><%= t(".step1_html").html_safe %></li>
+            <li><%= t(".step2_html").html_safe %></li>
+            <li><%= t(".step3_html").html_safe %></li>
           </ol>
         </details>
       </div>

--- a/app/views/settings/hostings/_twelve_data_settings.html.erb
+++ b/app/views/settings/hostings/_twelve_data_settings.html.erb
@@ -7,17 +7,11 @@
       <div class="text-secondary text-sm mb-4">
         <span><%= t(".description") %></span>
         <details class="inline">
-          <summary class="cursor-pointer font-medium text-secondary underline inline"> (show details)</summary>
+          <summary class="cursor-pointer font-medium text-secondary underline inline"> <%= t(".show_details") %></summary>
           <ol class="text-sm text-secondary mt-2 list-decimal ml-6 space-y-2">
-            <li>
-              Visit <a href="https://twelvedata.com/register" target="_blank" rel="noopener noreferrer" class="underline">twelvedata.com</a> and create a free Twelve Data Developer account.
-            </li>
-            <li>
-              Go to the <a href="https://twelvedata.com/account/api-keys" target="_blank" rel="noopener noreferrer" class="underline">API Keys</a> page.
-            </li>
-            <li>
-              Reveal your <strong>Secret Key</strong> and paste it below.
-            </li>
+            <li><%= t(".step1_html").html_safe %></li>
+            <li><%= t(".step2_html").html_safe %></li>
+            <li><%= t(".step3_html").html_safe %></li>
           </ol>
         </details>
       </div>

--- a/app/views/settings/llm_usages/show.html.erb
+++ b/app/views/settings/llm_usages/show.html.erb
@@ -1,21 +1,21 @@
 <div class="bg-container rounded-xl shadow-border-xs p-4">
   <div class="mb-6">
-    <h1 class="text-2xl font-semibold text-primary">LLM Usage & Costs</h1>
-    <p class="text-sm text-secondary mt-1">Track your AI usage and estimated costs</p>
+    <h1 class="text-2xl font-semibold text-primary"><%= t(".title") %></h1>
+    <p class="text-sm text-secondary mt-1"><%= t(".subtitle") %></p>
   </div>
 
   <!-- Date Range Filter -->
   <div class="mb-6">
     <%= form_with url: settings_llm_usage_path, method: :get, class: "flex gap-4 items-end flex-wrap" do |f| %>
       <div class="w-full md:w-auto">
-        <%= f.label :start_date, "Start Date", class: "block text-sm font-medium text-primary mb-1" %>
+        <%= f.label :start_date, t(".start_date"), class: "block text-sm font-medium text-primary mb-1" %>
         <%= f.date_field :start_date, value: @start_date, class: "rounded-lg border border-primary px-3 py-2 text-sm bg-container-inset text-primary w-full" %>
       </div>
       <div class="w-full md:w-auto">
-        <%= f.label :end_date, "End Date", class: "block text-sm font-medium text-primary mb-1" %>
+        <%= f.label :end_date, t(".end_date"), class: "block text-sm font-medium text-primary mb-1" %>
         <%= f.date_field :end_date, value: @end_date, class: "rounded-lg border border-primary px-3 py-2 text-sm bg-container-inset text-primary w-full" %>
       </div>
-      <%= render DS::Button.new(variant: :primary, size: :md, type: "submit", text: "Filter", class: "md:w-auto w-full justify-center") %>
+      <%= render DS::Button.new(variant: :primary, size: :md, type: "submit", text: t(".filter"), class: "md:w-auto w-full justify-center") %>
     <% end %>
   </div>
 
@@ -24,7 +24,7 @@
     <div class="bg-container-inset rounded-lg p-4">
       <div class="flex items-center gap-2 mb-2">
         <%= icon "activity", class: "w-5 h-5 text-secondary" %>
-        <p class="text-xs font-medium text-secondary uppercase">Total Requests</p>
+        <p class="text-xs font-medium text-secondary uppercase"><%= t(".total_requests") %></p>
       </div>
       <p class="text-2xl font-semibold text-primary"><%= number_with_delimiter(@statistics[:total_requests]) %></p>
     </div>
@@ -32,19 +32,18 @@
     <div class="bg-container-inset rounded-lg p-4">
       <div class="flex items-center gap-2 mb-2">
         <%= icon "hash", class: "w-5 h-5 text-secondary" %>
-        <p class="text-xs font-medium text-secondary uppercase">Total Tokens</p>
+        <p class="text-xs font-medium text-secondary uppercase"><%= t(".total_tokens") %></p>
       </div>
       <p class="text-2xl font-semibold text-primary"><%= number_with_delimiter(@statistics[:total_tokens]) %></p>
       <p class="text-xs text-secondary mt-1">
-        <%= number_with_delimiter(@statistics[:total_prompt_tokens]) %> prompt /
-        <%= number_with_delimiter(@statistics[:total_completion_tokens]) %> completion
+        <%= t(".prompt_completion", prompt: number_with_delimiter(@statistics[:total_prompt_tokens]), completion: number_with_delimiter(@statistics[:total_completion_tokens])) %>
       </p>
     </div>
 
     <div class="bg-container-inset rounded-lg p-4">
       <div class="flex items-center gap-2 mb-2">
         <%= icon "dollar-sign", class: "w-5 h-5 text-secondary" %>
-        <p class="text-xs font-medium text-secondary uppercase">Total Cost</p>
+        <p class="text-xs font-medium text-secondary uppercase"><%= t(".total_cost") %></p>
       </div>
       <p class="text-2xl font-semibold text-primary">$<%= sprintf("%.2f", @statistics[:total_cost]) %></p>
     </div>
@@ -52,15 +51,14 @@
     <div class="bg-container-inset rounded-lg p-4">
       <div class="flex items-center gap-2 mb-2">
         <%= icon "trending-up", class: "w-5 h-5 text-secondary" %>
-        <p class="text-xs font-medium text-secondary uppercase">Avg Cost/Request</p>
+        <p class="text-xs font-medium text-secondary uppercase"><%= t(".avg_cost_per_request") %></p>
       </div>
       <p class="text-2xl font-semibold text-primary">
         $<%= sprintf("%.4f", @statistics[:avg_cost]) %>
       </p>
       <% if @statistics[:requests_with_cost] < @statistics[:total_requests] %>
         <p class="text-xs text-secondary mt-1">
-          Based on <%= number_with_delimiter(@statistics[:requests_with_cost]) %> of
-          <%= number_with_delimiter(@statistics[:total_requests]) %> requests with cost data
+          <%= t(".requests_with_cost", with_cost: number_with_delimiter(@statistics[:requests_with_cost]), total: number_with_delimiter(@statistics[:total_requests])) %>
         </p>
       <% end %>
     </div>
@@ -69,7 +67,7 @@
   <!-- Cost by Operation -->
   <% if @statistics[:by_operation].any? %>
     <div class="mb-6">
-      <h2 class="text-lg font-semibold text-primary mb-3">Cost by Operation</h2>
+      <h2 class="text-lg font-semibold text-primary mb-3"><%= t(".cost_by_operation") %></h2>
       <div class="bg-container-inset rounded-lg p-4">
         <div class="space-y-2">
           <% @statistics[:by_operation].each do |operation, cost| %>
@@ -86,7 +84,7 @@
   <!-- Cost by Model -->
   <% if @statistics[:by_model].any? %>
     <div class="mb-6">
-      <h2 class="text-lg font-semibold text-primary mb-3">Cost by Model</h2>
+      <h2 class="text-lg font-semibold text-primary mb-3"><%= t(".cost_by_model") %></h2>
       <div class="bg-container-inset rounded-lg p-4">
         <div class="space-y-2">
           <% @statistics[:by_model].each do |model, cost| %>
@@ -102,24 +100,24 @@
 
   <!-- Recent Usage Table -->
   <div>
-    <h2 class="text-lg font-semibold text-primary mb-3">Recent Usage</h2>
+    <h2 class="text-lg font-semibold text-primary mb-3"><%= t(".recent_usage") %></h2>
     <div class="bg-container-inset rounded-lg overflow-hidden">
       <% if @llm_usages.any? %>
         <table class="w-full">
           <thead class="bg-surface-default border-b border-primary">
             <tr>
-              <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase">Date</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase">Operation</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase">Model</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-secondary uppercase">Tokens</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-secondary uppercase">Cost</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase"><%= t(".date") %></th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase"><%= t(".operation") %></th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase"><%= t(".model") %></th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-secondary uppercase"><%= t(".tokens") %></th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-secondary uppercase"><%= t(".cost") %></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
             <% @llm_usages.each do |usage| %>
               <tr class="<%= "bg-red-50 theme-dark:bg-red-950/30" if usage.failed? %>">
                 <td class="px-4 py-3 text-sm text-primary whitespace-nowrap">
-                  <%= usage.created_at.strftime("%b %d, %Y %I:%M %p") %>
+                  <%= I18n.l(usage.created_at, format: :long) %>
                 </td>
                 <td class="px-4 py-3 text-sm text-primary">
                   <%= usage.operation.humanize %>
@@ -132,12 +130,12 @@
                     <div data-controller="tooltip" class="inline-flex justify-end">
                       <div class="inline-flex items-center gap-1 cursor-help">
                         <%= icon "alert-circle", class: "w-4 h-4 text-red-600 theme-dark:text-red-400" %>
-                        <span class="text-red-600 theme-dark:text-red-400 font-medium">Failed</span>
+                        <span class="text-red-600 theme-dark:text-red-400 font-medium"><%= t(".failed") %></span>
                       </div>
                       <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-800 text-sm p-3 rounded w-72 text-left break-words whitespace-normal shadow-lg hidden">
                         <div class="text-white">
                           <% if usage.http_status_code.present? %>
-                            <p class="text-xs mt-1 text-gray-300">HTTP Status: <%= usage.http_status_code %></p>
+                            <p class="text-xs mt-1 text-gray-300"><%= t(".http_status", code: usage.http_status_code) %></p>
                           <% end %>
                           <p class="text-xs"><%= usage.error_message %></p>
                         </div>
@@ -159,7 +157,7 @@
         </table>
       <% else %>
         <div class="p-8 text-center">
-          <p class="text-secondary">No usage data found for the selected period</p>
+          <p class="text-secondary"><%= t(".no_usage_data") %></p>
         </div>
       <% end %>
     </div>
@@ -170,11 +168,9 @@
     <div class="flex items-start gap-2">
       <%= icon "info", class: "w-5 h-5 text-blue-600 mt-0.5" %>
       <div>
-        <p class="text-sm font-medium text-blue-900">About Cost Estimates</p>
+        <p class="text-sm font-medium text-blue-900"><%= t(".about_cost_estimates") %></p>
         <p class="text-xs text-blue-700 mt-1">
-          Costs are estimated based on OpenAI's pricing as of 2025. Actual costs may vary.
-          Pricing is per 1 million tokens and varies by model.
-          Custom or self-hosted models will show "N/A" and are not included in cost totals.
+          <%= t(".cost_estimates_description") %>
         </p>
       </div>
     </div>

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -40,7 +40,7 @@
             { label: t(".country") },
             { data: { auto_submit_form_target: "auto" } } %>
 
-        <p class="text-xs italic pl-2 text-secondary">Please note, we are still working on translations for various languages.</p>
+        <p class="text-xs italic pl-2 text-secondary"><%= t(".translations_note") %></p>
       <% end %>
     <% end %>
   </div>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -9,7 +9,7 @@
 
       <% if @user.unconfirmed_email.present? %>
         <p class="mt-2 text-sm text-gray-600">
-          You have requested to change your email to <%= @user.unconfirmed_email %>. Please go to your email and confirm for the change to take effect. If you haven't received the email, please check your spam folder, or <%= link_to "request a new confirmation email", resend_confirmation_email_user_path(@user), class: "hover:underline text-secondary" %>.
+          <%= t(".unconfirmed_email_notice_html", email: @user.unconfirmed_email, link: link_to(t(".resend_confirmation_link"), resend_confirmation_email_user_path(@user), class: "hover:underline text-secondary")) %>
         </p>
       <% end %>
 

--- a/app/views/settings/providers/_enable_banking_panel.html.erb
+++ b/app/views/settings/providers/_enable_banking_panel.html.erb
@@ -1,18 +1,18 @@
 <div class="space-y-4">
   <div class="prose prose-sm text-secondary">
-    <p class="text-primary font-medium">Setup instructions:</p>
+    <p class="text-primary font-medium"><%= t("settings.providers.enable_banking_panel.setup_instructions") %></p>
     <ol>
-      <li>Visit your <a href="https://enablebanking.com" target="_blank" rel="noopener noreferrer" class="link">Enable Banking</a> developer account to get your credentials</li>
-      <li>Select your country code from the dropdown below</li>
-      <li>Enter your Application ID and paste your Client Certificate (including the private key)</li>
-      <li>Click Save Configuration, then use "Add Connection" to link your bank</li>
+      <li><%= raw t("settings.providers.enable_banking_panel.step1_html") %></li>
+      <li><%= t("settings.providers.enable_banking_panel.step2") %></li>
+      <li><%= t("settings.providers.enable_banking_panel.step3") %></li>
+      <li><%= t("settings.providers.enable_banking_panel.step4") %></li>
     </ol>
 
-    <p class="text-primary font-medium">Field descriptions:</p>
+    <p class="text-primary font-medium"><%= t("settings.providers.enable_banking_panel.field_descriptions") %></p>
     <ul>
-      <li><strong>Country Code:</strong> ISO 3166-1 alpha-2 country code (e.g., GB, DE, FR) - determines available banks</li>
-      <li><strong>Application ID:</strong> The ID generated in your Enable Banking developer account</li>
-      <li><strong>Client Certificate:</strong> The certificate generated when you created your application (must include the private key)</li>
+      <li><strong><%= t("settings.providers.enable_banking_panel.country_label") %>:</strong> <%= t("settings.providers.enable_banking_panel.country_code_description") %></li>
+      <li><strong><%= t("settings.providers.enable_banking_panel.application_id_label") %>:</strong> <%= t("settings.providers.enable_banking_panel.application_id_description") %></li>
+      <li><strong><%= t("settings.providers.enable_banking_panel.client_certificate_label") %>:</strong> <%= t("settings.providers.enable_banking_panel.client_certificate_description") %></li>
     </ul>
   </div>
 
@@ -38,8 +38,8 @@
                        class: "space-y-3" do |form| %>
     <% if has_authenticated_connections && !is_new_record %>
       <div class="p-3 rounded-md bg-warning/10 text-warning text-sm">
-        <p class="font-medium">Configuration locked</p>
-        <p class="text-xs mt-1">Credentials cannot be changed while you have active bank connections. Remove all connections first to update credentials.</p>
+        <p class="font-medium"><%= t("settings.providers.enable_banking_panel.configuration_locked") %></p>
+        <p class="text-xs mt-1"><%= t("settings.providers.enable_banking_panel.credentials_locked_note") %></p>
       </div>
     <% end %>
 
@@ -78,18 +78,18 @@
                         ["Sweden (SE)", "SE"],
                         ["United Kingdom (GB)", "GB"]
                       ], enable_banking_item.country_code),
-                      { label: true, include_blank: "Select country..." },
-                      { label: "Country", class: "form-field__input", disabled: has_authenticated_connections && !is_new_record } %>
+                      { label: true, include_blank: t("settings.providers.enable_banking_panel.select_country") },
+                      { label: t("settings.providers.enable_banking_panel.country_label"), class: "form-field__input", disabled: has_authenticated_connections && !is_new_record } %>
 
       <%= form.text_field :application_id,
-                          label: "Application ID",
-                          placeholder: is_new_record ? "Enter application ID" : "Enter new ID to update",
+                          label: t("settings.providers.enable_banking_panel.application_id_label"),
+                          placeholder: is_new_record ? t("settings.providers.enable_banking_panel.application_id_placeholder_new") : t("settings.providers.enable_banking_panel.application_id_placeholder_update"),
                           value: enable_banking_item.application_id,
                           disabled: has_authenticated_connections && !is_new_record %>
     </div>
 
     <%= form.text_area :client_certificate,
-                        label: "Client Certificate (with Private Key)",
+                        label: t("settings.providers.enable_banking_panel.client_certificate_label"),
                         placeholder: "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
                         rows: 6,
                         class: "form-field__input font-mono text-xs",
@@ -97,7 +97,7 @@
 
     <% unless has_authenticated_connections && !is_new_record %>
       <div class="flex justify-end">
-        <%= form.submit is_new_record ? "Save Configuration" : "Update Configuration",
+        <%= form.submit is_new_record ? t("settings.providers.enable_banking_panel.save_configuration") : t("settings.providers.enable_banking_panel.update_configuration"),
                         class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
       </div>
     <% end %>
@@ -118,22 +118,22 @@
             <% if item.session_valid? %>
               <div class="w-2 h-2 bg-success rounded-full"></div>
               <div>
-                <p class="text-sm font-medium text-primary"><%= item.aspsp_name || "Connected Bank" %></p>
+                <p class="text-sm font-medium text-primary"><%= item.aspsp_name || t("settings.providers.enable_banking_panel.connected_bank") %></p>
                 <p class="text-xs text-secondary">
-                  Session expires: <%= item.session_expires_at&.strftime("%b %d, %Y") || "Unknown" %>
+                  <%= t("settings.providers.enable_banking_panel.session_expires", date: item.session_expires_at ? I18n.l(item.session_expires_at, format: :long) : t("settings.providers.enable_banking_panel.unknown")) %>
                 </p>
               </div>
             <% elsif item.session_expired? %>
               <div class="w-2 h-2 bg-warning rounded-full"></div>
               <div>
-                <p class="text-sm font-medium text-primary"><%= item.aspsp_name || "Connection" %></p>
-                <p class="text-xs text-destructive">Session expired - reconnect</p>
+                <p class="text-sm font-medium text-primary"><%= item.aspsp_name || t("settings.providers.enable_banking_panel.connection") %></p>
+                <p class="text-xs text-destructive"><%= t("settings.providers.enable_banking_panel.session_expired") %></p>
               </div>
             <% else %>
               <div class="w-2 h-2 bg-secondary rounded-full"></div>
               <div>
-                <p class="text-sm font-medium text-primary">Configured</p>
-                <p class="text-xs text-secondary">Ready to link accounts</p>
+                <p class="text-sm font-medium text-primary"><%= t("settings.providers.enable_banking_panel.configured") %></p>
+                <p class="text-xs text-secondary"><%= t("settings.providers.enable_banking_panel.ready_to_link") %></p>
               </div>
             <% end %>
           </div>
@@ -144,28 +144,28 @@
                             method: :post,
                             class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-primary bg-container border border-primary hover:bg-gray-50 transition-colors",
                             data: { turbo: false } do %>
-                Sync
+                <%= t("settings.providers.enable_banking_panel.sync") %>
               <% end %>
             <% elsif item.session_expired? %>
               <%= button_to reauthorize_enable_banking_item_path(item),
                             method: :post,
                             class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-white bg-warning hover:opacity-90 transition-colors",
                             data: { turbo: false } do %>
-                Reconnect
+                <%= t("settings.providers.enable_banking_panel.reconnect") %>
               <% end %>
             <% else %>
               <%= link_to select_bank_enable_banking_item_path(item),
                           class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
                           data: { turbo_frame: "modal" } do %>
-                Connect Bank
+                <%= t("settings.providers.enable_banking_panel.connect_bank") %>
               <% end %>
             <% end %>
 
             <%= button_to enable_banking_item_path(item),
                           method: :delete,
                           class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 transition-colors",
-                          data: { turbo_confirm: "Are you sure you want to remove this connection?" } do %>
-              Remove
+                          data: { turbo_confirm: t("settings.providers.enable_banking_panel.remove_confirm") } do %>
+              <%= t("settings.providers.enable_banking_panel.remove") %>
             <% end %>
           </div>
         </div>
@@ -179,7 +179,7 @@
                         class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
                         data: { turbo_frame: "modal" } do %>
             <%= icon "plus", size: "sm" %>
-            Add Connection
+            <%= t("settings.providers.enable_banking_panel.add_connection") %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/settings/providers/_lunchflow_panel.html.erb
+++ b/app/views/settings/providers/_lunchflow_panel.html.erb
@@ -1,16 +1,16 @@
 <div class="space-y-4">
   <div class="prose prose-sm text-secondary">
-    <p class="text-primary font-medium">Setup instructions:</p>
+    <p class="text-primary font-medium"><%= t("settings.providers.lunchflow_panel.setup_instructions") %></p>
     <ol>
-      <li>Visit <a href="https://www.lunchflow.app" target="_blank" rel="noopener noreferrer" class="link">Lunch Flow</a> to get your API key</li>
-      <li>Paste your API key below and click the Save button</li>
-      <li>After a successful connection, go to the Accounts tab to set up new accounts and link them to your existing ones</li>
+      <li><%= raw t("settings.providers.lunchflow_panel.step1_html") %></li>
+      <li><%= t("settings.providers.lunchflow_panel.step2") %></li>
+      <li><%= raw t("settings.providers.lunchflow_panel.step3_html", accounts_url: accounts_path) %></li>
     </ol>
 
-    <p class="text-primary font-medium">Field descriptions:</p>
+    <p class="text-primary font-medium"><%= t("settings.providers.lunchflow_panel.field_descriptions") %></p>
     <ul>
-      <li><strong>API Key:</strong> Your Lunch Flow API key for authentication (required)</li>
-      <li><strong>Base URL:</strong> Base URL for Lunch Flow API (optional, defaults to https://lunchflow.app/api/v1)</li>
+      <li><strong><%= t("settings.providers.lunchflow_panel.api_key_label") %>:</strong> <%= t("settings.providers.lunchflow_panel.api_key_description") %></li>
+      <li><strong><%= t("settings.providers.lunchflow_panel.base_url_label") %>:</strong> <%= t("settings.providers.lunchflow_panel.base_url_description") %></li>
     </ul>
   </div>
 
@@ -34,17 +34,17 @@
                        data: { turbo: true },
                        class: "space-y-3" do |form| %>
     <%= form.text_field :api_key,
-                        label: "API Key",
-                        placeholder: is_new_record ? "Paste API key here" : "Enter new API key to update",
+                        label: t("settings.providers.lunchflow_panel.api_key_label"),
+                        placeholder: is_new_record ? t("settings.providers.lunchflow_panel.api_key_placeholder_new") : t("settings.providers.lunchflow_panel.api_key_placeholder_update"),
                         type: :password %>
 
     <%= form.text_field :base_url,
-                        label: "Base URL (Optional)",
-                        placeholder: "https://lunchflow.app/api/v1 (default)",
+                        label: t("settings.providers.lunchflow_panel.base_url_label"),
+                        placeholder: t("settings.providers.lunchflow_panel.base_url_placeholder"),
                         value: lunchflow_item.base_url %>
 
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? "Save Configuration" : "Update Configuration",
+      <%= form.submit is_new_record ? t("settings.providers.lunchflow_panel.save_configuration") : t("settings.providers.lunchflow_panel.update_configuration"),
                       class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
     </div>
   <% end %>
@@ -53,10 +53,10 @@
   <div class="flex items-center gap-2">
     <% if items&.any? %>
       <div class="w-2 h-2 bg-success rounded-full"></div>
-      <p class="text-sm text-secondary">Configured and ready to use. Visit the <a href="<%= accounts_path %>" class="link">Accounts</a> tab to manage and set up accounts.</p>
+      <p class="text-sm text-secondary"><%= raw t("settings.providers.lunchflow_panel.configured_html", accounts_url: accounts_path) %></p>
     <% else %>
       <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
-      <p class="text-sm text-secondary">Not configured</p>
+      <p class="text-sm text-secondary"><%= t("settings.providers.lunchflow_panel.not_configured") %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/providers/_provider_form.html.erb
+++ b/app/views/settings/providers/_provider_form.html.erb
@@ -14,12 +14,12 @@
     <% env_configured = configuration.fields.any? { |f| f.env_key && ENV[f.env_key].present? } %>
     <% if env_configured %>
       <p class="text-sm text-secondary">
-        Configuration can be set via environment variables or overridden below.
+        <%= t("settings.providers.provider_form.env_configuration_note") %>
       </p>
     <% end %>
 
     <% if configuration.fields.any? { |f| f.description.present? } %>
-      <p class="text-secondary text-sm mb-4">Field descriptions:</p>
+      <p class="text-secondary text-sm mb-4"><%= t("settings.providers.provider_form.field_descriptions") %></p>
       <ul class="text-sm text-secondary mb-4 list-disc ml-6 space-y-2">
         <% configuration.fields.each do |field| %>
           <% if field.description.present? %>
@@ -61,13 +61,13 @@
         <%= form.text_field field.setting_key,
                             label: field.label,
                             type: input_type,
-                            placeholder: field.default || (field.required ? "" : "Optional"),
+                            placeholder: field.default || (field.required ? "" : t("settings.providers.provider_form.optional")),
                             value: display_value,
                             disabled: disabled %>
       <% end %>
 
       <div class="flex justify-end">
-        <%= form.submit "Save Configuration",
+        <%= form.submit t("settings.providers.provider_form.save_configuration"),
                         class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
       </div>
     </div>
@@ -77,10 +77,10 @@
   <div class="flex items-center gap-2 mt-4">
     <% if configuration.configured? %>
       <div class="w-2 h-2 bg-success rounded-full"></div>
-      <p class="text-sm text-secondary">Configured and ready to use</p>
+      <p class="text-sm text-secondary"><%= t("settings.providers.provider_form.configured") %></p>
     <% else %>
       <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
-      <p class="text-sm text-secondary">Not configured</p>
+      <p class="text-sm text-secondary"><%= t("settings.providers.provider_form.not_configured") %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/providers/_simplefin_panel.html.erb
+++ b/app/views/settings/providers/_simplefin_panel.html.erb
@@ -1,15 +1,15 @@
 <div class="space-y-4">
   <div class="prose prose-sm text-secondary">
-    <p class="text-primary font-medium">Setup instructions:</p>
+    <p class="text-primary font-medium"><%= t("settings.providers.simplefin_panel.setup_instructions") %></p>
     <ol>
-      <li>Visit <a href="https://beta-bridge.simplefin.org" target="_blank" rel="noopener noreferrer" class="link">SimpleFIN Bridge</a> to get your one-time setup token</li>
-      <li>Paste the token below and click the Save button to enable SimpleFIN bank data sync</li>
-      <li>After a successful connection, go to the Accounts tab to set up new accounts and link them to your existing ones</li>
+      <li><%= raw t("settings.providers.simplefin_panel.step1_html") %></li>
+      <li><%= t("settings.providers.simplefin_panel.step2") %></li>
+      <li><%= raw t("settings.providers.simplefin_panel.step3_html", accounts_url: accounts_path) %></li>
     </ol>
 
-    <p class="text-primary font-medium">Field descriptions:</p>
+    <p class="text-primary font-medium"><%= t("settings.providers.simplefin_panel.field_descriptions") %></p>
     <ul>
-      <li><strong>Setup Token:</strong> Your SimpleFIN one-time setup token from SimpleFIN Bridge (consumed on first use)</li>
+      <li><strong><%= t("settings.providers.simplefin_panel.setup_token_label") %>:</strong> <%= t("settings.providers.simplefin_panel.setup_token_description") %></li>
     </ul>
   </div>
 
@@ -26,12 +26,12 @@
                        data: { turbo: true },
                        class: "space-y-3" do |form| %>
     <%= form.text_field :setup_token,
-                        label: "Setup Token",
-                        placeholder: "Paste SimpleFIN setup token",
+                        label: t("settings.providers.simplefin_panel.setup_token_label"),
+                        placeholder: t("settings.providers.simplefin_panel.setup_token_placeholder"),
                         type: :password %>
 
     <div class="flex justify-end">
-      <%= form.submit "Save Configuration",
+      <%= form.submit t("settings.providers.simplefin_panel.save_configuration"),
                       class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
     </div>
   <% end %>
@@ -39,10 +39,10 @@
   <div class="flex items-center gap-2">
     <% if @simplefin_items&.any? %>
       <div class="w-2 h-2 bg-success rounded-full"></div>
-      <p class="text-sm text-secondary">Configured and ready to use. Visit the <a href="<%= accounts_path %>" class="link">Accounts</a> tab to manage and set up accounts.</p>
+      <p class="text-sm text-secondary"><%= raw t("settings.providers.simplefin_panel.configured_html", accounts_url: accounts_path) %></p>
     <% else %>
       <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
-      <p class="text-sm text-secondary">Not configured</p>
+      <p class="text-sm text-secondary"><%= t("settings.providers.simplefin_panel.not_configured") %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/providers/show.html.erb
+++ b/app/views/settings/providers/show.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :page_title, "Sync Providers" %>
+<%= content_for :page_title, t(".page_title") %>
 
 <div class="space-y-4">
   <div>
     <p class="text-secondary mb-4">
-      Configure credentials for third-party sync providers. Settings configured here will override environment variables.
+      <%= t(".description") %>
     </p>
   </div>
 
@@ -14,25 +14,25 @@
     <% end %>
   <% end %>
 
-  <%= settings_section title: "Lunch Flow", collapsible: true, open: false do %>
+  <%= settings_section title: t(".lunchflow_title"), collapsible: true, open: false do %>
     <turbo-frame id="lunchflow-providers-panel">
       <%= render "settings/providers/lunchflow_panel" %>
     </turbo-frame>
   <% end %>
 
-  <%= settings_section title: "SimpleFIN", collapsible: true, open: false do %>
+  <%= settings_section title: t(".simplefin_title"), collapsible: true, open: false do %>
     <turbo-frame id="simplefin-providers-panel">
       <%= render "settings/providers/simplefin_panel" %>
     </turbo-frame>
   <% end %>
 
-  <%= settings_section title: "Enable Banking (beta)", collapsible: true, open: false do %>
+  <%= settings_section title: t(".enable_banking_title"), collapsible: true, open: false do %>
     <turbo-frame id="enable_banking-providers-panel">
       <%= render "settings/providers/enable_banking_panel" %>
     </turbo-frame>
   <% end %>
 
-  <%= settings_section title: "CoinStats", collapsible: true, open: false do %>
+  <%= settings_section title: t(".coinstats_title"), collapsible: true, open: false do %>
     <turbo-frame id="coinstats-providers-panel">
       <%= render "settings/providers/coinstats_panel" %>
     </turbo-frame>

--- a/app/views/settings/securities/show.html.erb
+++ b/app/views/settings/securities/show.html.erb
@@ -10,11 +10,11 @@
 
         <div class="text-sm space-y-1">
           <% if Current.user.otp_required? %>
-            <p class="text-primary">Two-factor authentication is <span class="font-medium text-green-600">enabled</span></p>
-            <p class="text-secondary">Your account is protected with an additional layer of security.</p>
+            <p class="text-primary"><%= t(".mfa_enabled_html") %></p>
+            <p class="text-secondary"><%= t(".mfa_enabled_description") %></p>
           <% else %>
-            <p class="text-primary">Two-factor authentication is <span class="font-medium text-red-600">disabled</span></p>
-            <p class="text-secondary">Enable 2FA to add an extra layer of security to your account.</p>
+            <p class="text-primary"><%= t(".mfa_disabled_html") %></p>
+            <p class="text-secondary"><%= t(".mfa_disabled_description") %></p>
           <% end %>
         </div>
       </div>

--- a/app/views/shared/_app_version.html.erb
+++ b/app/views/shared/_app_version.html.erb
@@ -1,3 +1,3 @@
 <div class="flex items-center py-0.5 px-0.5 gap-1 fixed right-1 top-1 shadow-xs border border-alpha-black-50 rounded-md bg-container">
-  <p class="text-xs text-secondary pl-2">Version: <%= Sure.version.to_release_tag %></p>
+  <p class="text-xs text-secondary pl-2"><%= t("shared.app_version.version_label") %> <%= Sure.version.to_release_tag %></p>
 </div>

--- a/app/views/simplefin_items/_simplefin_item.html.erb
+++ b/app/views/simplefin_items/_simplefin_item.html.erb
@@ -38,7 +38,7 @@
                           data: { turbo_frame: :modal },
                           class: "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-warning/10 text-warning hover:bg-warning/20 transition-colors" do %>
                 <%= icon "alert-circle", size: "xs" %>
-                <span><%= header_unlinked_count %> <%= header_unlinked_count == 1 ? "account" : "accounts" %> need setup</span>
+                <span><%= t(".accounts_need_setup", count: header_unlinked_count) %></span>
               <% end %>
             <% end %>
             <% if simplefin_item.scheduled_for_deletion? %>
@@ -54,20 +54,20 @@
             <% if stats.present? %>
               <div class="flex items-center gap-2 mt-1">
                 <% if stats["unlinked_accounts"].to_i > 0 %>
-                  <%= render DS::Tooltip.new(text: "Accounts need setup", icon: "link-2", size: "sm") %>
-                  <span class="text-xs text-secondary">Unlinked: <%= stats["unlinked_accounts"].to_i %></span>
+                  <%= render DS::Tooltip.new(text: t(".tooltip_accounts_need_setup"), icon: "link-2", size: "sm") %>
+                  <span class="text-xs text-secondary"><%= t(".unlinked_count", count: stats["unlinked_accounts"].to_i) %></span>
                 <% end %>
 
                 <% if stats["accounts_skipped"].to_i > 0 %>
-                  <%= render DS::Tooltip.new(text: "Some accounts were skipped due to errors during sync", icon: "alert-triangle", size: "sm", color: "warning") %>
-                  <span class="text-xs text-warning">Skipped: <%= stats["accounts_skipped"].to_i %></span>
+                  <%= render DS::Tooltip.new(text: t(".tooltip_accounts_skipped"), icon: "alert-triangle", size: "sm", color: "warning") %>
+                  <span class="text-xs text-warning"><%= t(".skipped_count", count: stats["accounts_skipped"].to_i) %></span>
                 <% end %>
 
                 <% if stats["rate_limited"].present? || stats["rate_limited_at"].present? %>
                   <% ts = stats["rate_limited_at"] %>
                   <% ago = (ts.present? ? (begin; time_ago_in_words(Time.parse(ts)); rescue StandardError; nil; end) : nil) %>
                   <%= render DS::Tooltip.new(
-                        text: (ago ? "Rate limited (" + ago + " ago)" : "Rate limited recently"),
+                        text: (ago ? t(".rate_limited_with_time", time: ago) : t(".rate_limited")),
                         icon: "clock",
                         size: "sm",
                         color: "warning"
@@ -82,7 +82,7 @@
                 <% end %>
 
                 <% if stats["total_accounts"].to_i > 0 %>
-                  <span class="text-xs text-secondary">Total: <%= stats["total_accounts"].to_i %></span>
+                  <span class="text-xs text-secondary"><%= t(".total_count", count: stats["total_accounts"].to_i) %></span>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/simplefin_items/_subtype_select.html.erb
+++ b/app/views/simplefin_items/_subtype_select.html.erb
@@ -12,13 +12,13 @@
       <% if needs_attention %>
         <div class="flex items-center gap-1 text-warning text-xs mb-2">
           <%= icon "alert-circle", size: "xs" %>
-          <span>Please select a <%= account_type == "Depository" ? "subtype" : "type" %></span>
+          <span><%= account_type == "Depository" ? t("simplefin_items.subtype_select.please_select_subtype") : t("simplefin_items.subtype_select.please_select_type") %></span>
         </div>
       <% end %>
       <%= label_tag "account_subtypes[#{simplefin_account.id}]", subtype_config[:label],
                    class: "block text-sm font-medium text-primary mb-2" %>
       <%= select_tag "account_subtypes[#{simplefin_account.id}]",
-                    options_for_select([["Select #{account_type == 'Depository' ? 'subtype' : 'type'}", ""]] + subtype_config[:options], selected_value),
+                    options_for_select([[account_type == 'Depository' ? t("simplefin_items.subtype_select.select_subtype") : t("simplefin_items.subtype_select.select_type"), ""]] + subtype_config[:options], selected_value),
                     { class: "appearance-none bg-container border border-primary rounded-md px-3 py-2 text-sm leading-6 text-primary focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none w-full",
                       data: { action: "change->account-type-selector#clearWarning" } } %>
     </div>

--- a/app/views/simplefin_items/edit.html.erb
+++ b/app/views/simplefin_items/edit.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, "Update SimpleFin Connection" %>
+<% content_for :title, t(".title") %>
 
 <%= turbo_frame_tag "modal" do %>
   <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Update SimpleFin Connection") do %>
+  <% dialog.with_header(title: t(".title")) do %>
     <div class="flex items-center gap-2">
       <%= icon "building-2", class: "text-primary" %>
-      <span class="text-primary">Get a new setup token to reconnect your SimpleFin account</span>
+      <span class="text-primary"><%= t(".header_description") %></span>
     </div>
   <% end %>
 
@@ -16,12 +16,12 @@
           <%= icon "info", size: "sm", class: "text-primary mt-0.5 flex-shrink-0" %>
           <div>
             <p class="text-sm text-primary mb-2">
-              <strong>Your SimpleFIN connection needs to be updated:</strong>
+              <strong><%= t(".connection_needs_update") %></strong>
             </p>
             <ol class="text-xs text-secondary space-y-1 list-decimal list-inside">
-              <li>Visit <a href="https://bridge.simplefin.org/simplefin/create" target="_blank" rel="noopener noreferrer" class="text-link hover:text-link underline">SimpleFIN Bridge</a> to create a new setup token</li>
-              <li>Copy the token and paste it below</li>
-              <li>Click "Update" to restore access</li>
+              <li><%= raw t(".step_1_html") %></li>
+              <li><%= t(".step_2") %></li>
+              <li><%= t(".step_3") %></li>
             </ol>
           </div>
         </div>
@@ -46,14 +46,14 @@
 
       <div class="flex gap-3">
         <%= render DS::Button.new(
-          text: "Update",
+          text: t(".update"),
           variant: "primary",
           icon: "refresh-cw",
           type: "submit",
           class: "flex-1"
         ) %>
         <%= render DS::Link.new(
-          text: "Cancel",
+          text: t(".cancel"),
           variant: "secondary",
           href: accounts_path
         ) %>

--- a/app/views/simplefin_items/select_existing_account.html.erb
+++ b/app/views/simplefin_items/select_existing_account.html.erb
@@ -1,7 +1,7 @@
 <%# Modal: Link an existing manual account to a SimpleFIN account %>
 <%= turbo_frame_tag "modal" do %>
   <%= render DS::Dialog.new do |dialog| %>
-    <% dialog.with_header(title: "Link SimpleFIN account") %>
+    <% dialog.with_header(title: t(".header_title")) %>
 
     <% dialog.with_body do %>
       <% if @available_simplefin_accounts.blank? %>
@@ -33,8 +33,8 @@
           </div>
 
           <div class="flex items-center justify-end gap-2">
-            <%= render DS::Button.new(text: "Link", variant: :primary, icon: "link-2", type: :submit) %>
-            <%= render DS::Link.new(text: "Cancel", variant: :secondary, href: accounts_path, data: { turbo_frame: "_top" }) %>
+            <%= render DS::Button.new(text: t(".link"), variant: :primary, icon: "link-2", type: :submit) %>
+            <%= render DS::Link.new(text: t(".cancel"), variant: :secondary, href: accounts_path, data: { turbo_frame: "_top" }) %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/simplefin_items/setup_accounts.html.erb
+++ b/app/views/simplefin_items/setup_accounts.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, "Set Up SimpleFin Accounts" %>
+<% content_for :title, t(".title") %>
 
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Set Up Your SimpleFin Accounts") do %>
+  <% dialog.with_header(title: t(".header_title")) do %>
     <div class="flex items-center gap-2">
       <%= icon "building-2", class: "text-primary" %>
-      <span class="text-primary">Choose the correct account types for your imported accounts</span>
+      <span class="text-primary"><%= t(".header_description") %></span>
     </div>
   <% end %>
 
@@ -15,7 +15,7 @@
                   data: {
                     controller: "loading-button",
                     action: "submit->loading-button#showLoading",
-                    loading_button_loading_text_value: "Creating Accounts...",
+                    loading_button_loading_text_value: t(".creating_accounts"),
                     turbo_frame: "_top"
                   },
                   class: "space-y-6" do |form| %>
@@ -26,14 +26,14 @@
             <%= icon "info", size: "sm", class: "text-primary mt-0.5 flex-shrink-0" %>
             <div>
               <p class="text-sm text-primary mb-2">
-                <strong>Choose the correct account type for each SimpleFin account:</strong>
+                <strong><%= t(".account_type_instructions") %></strong>
               </p>
               <ul class="text-xs text-secondary space-y-1 list-disc list-inside">
-                <li><strong>Checking or Savings</strong> - Regular bank accounts</li>
-                <li><strong>Credit Card</strong> - Credit card accounts</li>
-                <li><strong>Investment</strong> - Brokerage, 401(k), IRA accounts</li>
-                <li><strong>Loan or Mortgage</strong> - Debt accounts</li>
-                <li><strong>Other Asset</strong> - Everything else</li>
+                <li><%= t(".account_type_checking_or_savings") %></li>
+                <li><%= t(".account_type_credit_card") %></li>
+                <li><%= t(".account_type_investment") %></li>
+                <li><%= t(".account_type_loan") %></li>
+                <li><%= t(".account_type_other") %></li>
               </ul>
             </div>
           </div>
@@ -45,12 +45,10 @@
             <%= icon "clock", size: "sm", class: "text-primary mt-0.5 flex-shrink-0" %>
             <div class="flex-1">
               <p class="text-sm text-primary mb-2">
-                <strong>Transaction History:</strong>
+                <strong><%= t(".transaction_history") %></strong>
               </p>
               <p class="text-xs text-secondary">
-                SimpleFin typically provides <strong>60-90 days</strong> of transaction history, depending on your bank.
-                After initial setup, new transactions will sync automatically going forward.
-                Historical data availability varies by institution and account type.
+                <%= t(".transaction_history_description") %>
               </p>
             </div>
           </div>
@@ -73,14 +71,14 @@
                   <% end %>
                 </h3>
                 <p class="text-sm text-secondary">
-                  Balance: <%= number_to_currency(simplefin_account.current_balance || 0, unit: simplefin_account.currency) %>
+                  <%= t(".balance") %> <%= number_to_currency(simplefin_account.current_balance || 0, unit: simplefin_account.currency) %>
                 </p>
               </div>
             </div>
 
             <div class="space-y-3" data-controller="account-type-selector" data-account-type-selector-account-id-value="<%= simplefin_account.id %>">
               <div>
-                <%= label_tag "account_types[#{simplefin_account.id}]", "Account Type:",
+                <%= label_tag "account_types[#{simplefin_account.id}]", t(".account_type_label"),
                              class: "block text-sm font-medium text-primary mb-2" %>
                 <%= select_tag "account_types[#{simplefin_account.id}]",
                               options_for_select(@account_type_options, selected_type),
@@ -126,7 +124,7 @@
 
       <div class="flex gap-3">
         <%= render DS::Button.new(
-          text: "Create Accounts",
+          text: t(".create_accounts"),
           variant: "primary",
           icon: "plus",
           type: "submit",
@@ -134,7 +132,7 @@
           data: { loading_button_target: "button" }
         ) %>
         <%= render DS::Link.new(
-          text: "Cancel",
+          text: t(".cancel"),
           variant: "secondary",
           href: accounts_path
         ) %>

--- a/app/views/subscriptions/_plan_choice.html.erb
+++ b/app/views/subscriptions/_plan_choice.html.erb
@@ -16,15 +16,15 @@
       <p class="font-display text-xl lg:text-3xl font-medium text-primary">$<%= price %><%= frequency %></p>
 
       <% if plan == "annual" %>
-        <span class="text-sm text-secondary mb-1">or <%= Money.new(price.to_f / 52).format %>/week</span>
+        <span class="text-sm text-secondary mb-1"><%= t("subscriptions.plan_choice.or_weekly", amount: Money.new(price.to_f / 52).format) %></span>
       <% end %>
     </div>
 
     <p class="text-sm text-secondary">
       <% if plan == "annual" %>
-        Billed annually, 2 months free
+        <%= t("subscriptions.plan_choice.billed_annually") %>
       <% else %>
-        Billed monthly
+        <%= t("subscriptions.plan_choice.billed_monthly") %>
       <% end %>
     </p>
   <% end %>

--- a/app/views/subscriptions/upgrade.html.erb
+++ b/app/views/subscriptions/upgrade.html.erb
@@ -1,17 +1,17 @@
 <div class="flex flex-col h-full justify-between bg-surface">
   <nav class="p-4">
-    <h1 class="sr-only">Upgrade</h1>
+    <h1 class="sr-only"><%= t('.title') %></h1>
 
     <div class="flex justify-end gap-2">
       <%= render DS::Link.new(
-        text: "Account Settings",
+        text: t('.account_settings'),
         icon: "settings",
         variant: "ghost",
         href: settings_profile_path,
       ) %>
 
       <%= render DS::Button.new(
-        text: "Sign out",
+        text: t('.sign_out'),
         icon: "log-out",
         icon_position: :right,
         variant: "ghost",
@@ -25,18 +25,18 @@
     <%= image_tag "logo-color.png", class: "w-16 mb-6" %>
 
     <% if Current.family.trialing? %>
-      <p class="text-xl lg:text-3xl text-primary font-display font-medium">Your trial has <%= Current.family.days_left_in_trial %> days remaining</p>
+      <p class="text-xl lg:text-3xl text-primary font-display font-medium"><%= t('.trial_remaining', days: Current.family.days_left_in_trial) %></p>
     <% else %>
-      <p class="text-xl lg:text-3xl text-primary font-display font-medium">Your trial is over</p>
+      <p class="text-xl lg:text-3xl text-primary font-display font-medium"><%= t('.trial_over') %></p>
     <% end %>
 
     <h2 class="text-xl lg:text-3xl font-display font-medium mb-2">
-      <span class="text-secondary">Unlock</span>
+      <span class="text-secondary"><%= t('.unlock') %></span>
       <span class="bg-gradient-to-r from-[#EABE7F] to-[#957049] bg-clip-text text-transparent">Sure</span>
-      <span class="text-secondary">today</span>
+      <span class="text-secondary"><%= t('.today') %></span>
     </h2>
 
-    <p class="text-sm text-secondary mb-8">To continue using Sure pick a plan below.</p>
+    <p class="text-sm text-secondary mb-8"><%= t('.pick_plan') %></p>
 
     <%= form_with url: new_subscription_path, method: :get, class: "max-w-xs", data: { turbo: false } do |form| %>
       <div class="space-y-4 mb-6">
@@ -46,13 +46,13 @@
 
       <div class="text-center space-y-2">
         <%= render DS::Button.new(
-          text: "Subscribe and unlock Sure",
+          text: t('.subscribe'),
           variant: "primary",
           full_width: true
         ) %>
 
         <p class="text-xs text-secondary">
-          In the next step, you'll be redirected to Stripe which handles our billing.
+          <%= t('.stripe_redirect') %>
         </p>
       </div>
     <% end %>

--- a/app/views/tag/deletions/new.html.erb
+++ b/app/views/tag/deletions/new.html.erb
@@ -22,7 +22,7 @@
       ) %>
 
       <%= render DS::Button.new(
-        text: "Delete and reassign",
+        text: t(".delete_and_reassign"),
         data: { deletion_target: "safeSubmitButton" },
         hidden: true,
         full_width: true

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -5,7 +5,7 @@
   <%= render DS::Menu.new do |menu| %>
     <% menu.with_item(
           variant: "button",
-          text: "Delete all",
+          text: t(".delete_all"),
           href: destroy_all_tags_path,
           method: :delete,
           icon: "trash-2",

--- a/app/views/trades/_form.html.erb
+++ b/app/views/trades/_form.html.erb
@@ -10,11 +10,11 @@
 
     <div class="space-y-2">
       <%= form.select :type, [
-          ["Buy", "buy"],
-          ["Sell", "sell"],
-          ["Deposit", "deposit"],
-          ["Withdrawal", "withdrawal"],
-          ["Interest", "interest"]
+          [t(".buy"), "buy"],
+          [t(".sell"), "sell"],
+          [t(".deposit"), "deposit"],
+          [t(".withdrawal"), "withdrawal"],
+          [t(".interest"), "interest"]
       ],
       { label: t(".type"), selected: type },
       { data: {
@@ -34,7 +34,7 @@
                             required: true %>
           </div>
         <% else %>
-          <%= form.text_field :manual_ticker, label: "Ticker symbol", placeholder: "AAPL", required: true %>
+          <%= form.text_field :manual_ticker, label: t(".ticker_symbol"), placeholder: t(".ticker_symbol_placeholder"), required: true %>
         <% end %>
       <% end %>
 

--- a/app/views/trades/_header.html.erb
+++ b/app/views/trades/_header.html.erb
@@ -18,7 +18,7 @@
       </h3>
 
       <% if entry.linked? %>
-        <span title="Linked with Plaid">
+        <span title="<%= t(".linked_with_plaid") %>">
           <%= icon("refresh-ccw", size: "sm") %>
         </span>
       <% end %>

--- a/app/views/trades/show.html.erb
+++ b/app/views/trades/show.html.erb
@@ -20,8 +20,8 @@
 
           <div class="flex items-center gap-2">
             <%= f.select :nature,
-                          [["Buy", "outflow"], ["Sell", "inflow"]],
-                          { container_class: "w-1/3", label: "Type", selected: @entry.amount.negative? ? "inflow" : "outflow" },
+                          [[t(".buy"), "outflow"], [t(".sell"), "inflow"]],
+                          { container_class: "w-1/3", label: t(".type"), selected: @entry.amount.negative? ? "inflow" : "outflow" },
                           { data: { "auto-submit-form-target": "auto" }, disabled: @entry.linked? } %>
 
             <%= f.fields_for :entryable do |ef| %>

--- a/app/views/transactions/_header.html.erb
+++ b/app/views/transactions/_header.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
     <% if entry.linked? %>
-      <span title="Linked with Plaid">
+      <span title="<%= t("transactions.header.linked_with_plaid") %>">
         <%= icon("refresh-ccw", size: "sm") %>
       </span>
     <% end %>

--- a/app/views/transactions/_selection_bar.html.erb
+++ b/app/views/transactions/_selection_bar.html.erb
@@ -9,13 +9,13 @@
     <%= turbo_frame_tag "bulk_transaction_edit_drawer" %>
     <%= link_to new_transactions_bulk_update_path,
                 class: "p-1.5 group/edit hover:bg-inverse flex items-center justify-center rounded-md",
-                title: "Edit",
+                title: t("transactions.selection_bar.edit"),
                 data: { turbo_frame: "bulk_transaction_edit_drawer" } do %>
       <%= icon "pencil-line", class: "group-hover/edit:text-inverse" %>
     <% end %>
 
     <%= form_with url: transactions_bulk_deletion_path, data: { turbo_confirm: true, turbo_frame: "_top" } do %>
-      <button type="button" data-bulk-select-scope-param="bulk_delete" data-action="bulk-select#submitBulkRequest" class="p-1.5 group/delete hover:bg-inverse flex items-center justify-center rounded-md" title="Delete">
+      <button type="button" data-bulk-select-scope-param="bulk_delete" data-action="bulk-select#submitBulkRequest" class="p-1.5 group/delete hover:bg-inverse flex items-center justify-center rounded-md" title="<%= t("transactions.selection_bar.delete") %>">
         <%= icon "trash-2", class: "group-hover/delete:text-inverse" %>
       </button>
     <% end %>

--- a/app/views/transactions/_summary.html.erb
+++ b/app/views/transactions/_summary.html.erb
@@ -1,17 +1,17 @@
 <%# locals: (totals:) %>
 <div class="grid grid-cols-1 md:grid-cols-3 bg-container rounded-xl shadow-border-xs md:divide-x divide-y md:divide-y-0 divide-alpha-black-100 theme-dark:divide-alpha-white-200">
   <div class="p-4 space-y-2">
-    <p class="text-sm text-secondary">Total transactions</p>
+    <p class="text-sm text-secondary"><%= t("transactions.summary.total_transactions") %></p>
     <p class="text-primary font-medium text-xl" id="total-transactions"><%= totals.count.round(0) %></p>
   </div>
   <div class="p-4 space-y-2">
-    <p class="text-sm text-secondary">Income</p>
+    <p class="text-sm text-secondary"><%= t("transactions.summary.income") %></p>
     <p class="text-primary font-medium text-xl" id="total-income">
       <%= totals.income_money.format %>
     </p>
   </div>
   <div class="p-4 space-y-2">
-    <p class="text-sm text-secondary">Expenses</p>
+    <p class="text-sm text-secondary"><%= t("transactions.summary.expenses") %></p>
     <p class="text-primary font-medium text-xl" id="total-expense">
       <%= totals.expense_money.format %>
     </p>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -73,7 +73,7 @@
 
                   <div class="flex items-center gap-1 flex-shrink-0">
                     <% if transaction.one_time? %>
-                      <span class="text-orange-500" title="One-time <%= entry.amount.negative? ? "income" : "expense" %> (excluded from averages)">
+                      <span class="text-orange-500" title="<%= entry.amount.negative? ? t("transactions.transaction.one_time_income_title") : t("transactions.transaction.one_time_expense_title") %>">
                         <%= icon "asterisk", size: "sm", color: "current" %>
                       </span>
                     <% end %>

--- a/app/views/transactions/_transfer_match.html.erb
+++ b/app/views/transactions/_transfer_match.html.erb
@@ -2,21 +2,21 @@
 
 <div id="<%= dom_id(transaction, "transfer_match") %>" class="flex items-center gap-1">
   <% if transaction.transfer.confirmed? %>
-    <span title="<%= transaction.transfer.payment? ? "Payment" : "Transfer" %> is confirmed">
+    <span title="<%= transaction.transfer.payment? ? t(".payment_confirmed") : t(".transfer_confirmed") %>">
       <%= icon "link-2", size: "sm", class: "text-secondary" %>
     </span>
   <% elsif transaction.transfer.pending? %>
     <span class="hidden lg:inline-flex items-center rounded-full bg-surface-inset px-2 py-0.5 text-xs font-medium text-secondary">
-      Auto-matched
+      <%= t(".auto_matched") %>
     </span>
     <span class="inline-flex lg:hidden items-center rounded-full bg-surface-inset px-2 py-0.5 text-xs font-medium text-secondary">
-      A/M
+      <%= t(".auto_matched_short") %>
     </span>
 
     <%= button_to transfer_path(transaction.transfer, transfer: { status: "confirmed" }),
                     method: :patch,
                     class: "text-secondary flex items-center justify-center cursor-pointer",
-                    title: "Confirm match" do %>
+                    title: t(".confirm_match") do %>
       <%= icon "check", size: "sm", class: "text-secondary hover:text-primary" %>
     <% end %>
 
@@ -24,7 +24,7 @@
                     method: :patch,
                     data: { turbo: false },
                     class: "text-secondary hover:text-primary flex items-center justify-center cursor-pointer",
-                    title: "Reject match" do %>
+                    title: t(".reject_match") do %>
       <%= icon "x", size: "sm", class: "text-subdued hover:text-primary" %>
     <% end %>
   <% end %>

--- a/app/views/transactions/bulk_updates/new.html.erb
+++ b/app/views/transactions/bulk_updates/new.html.erb
@@ -1,28 +1,28 @@
 <%= render DS::Dialog.new(variant: "drawer", frame: "bulk_transaction_edit_drawer") do |dialog| %>
-  <% dialog.with_header(title: "Edit transactions", data: { bulk_select_target: "bulkEditDrawerHeader" }) %>
+  <% dialog.with_header(title: t(".title"), data: { bulk_select_target: "bulkEditDrawerHeader" }) %>
 
   <% dialog.with_body do %>
     <%= styled_form_with url: transactions_bulk_update_path, scope: "bulk_update", class: "h-full flex flex-col justify-between gap-4", data: { turbo_frame: "_top" } do |form| %>
       <div class="space-y-4">
-        <%= render DS::Disclosure.new(title: "Overview", open: true) do %>
+        <%= render DS::Disclosure.new(title: t(".overview"), open: true) do %>
           <div class="pb-6 space-y-2">
-            <%= form.date_field :date, label: "Date", max: Date.current %>
+            <%= form.date_field :date, label: t(".date"), max: Date.current %>
           </div>
         <% end %>
 
-        <%= render DS::Disclosure.new(title: "Transactions", open: true) do %>
+        <%= render DS::Disclosure.new(title: t(".transactions"), open: true) do %>
           <div class="space-y-2">
-            <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: "Select a category", label: "Category", class: "text-subdued" } %>
-            <%= form.collection_select :merchant_id, Current.family.available_merchants.alphabetically, :id, :name, { prompt: "Select a merchant", label: "Merchant", class: "text-subdued" } %>
-            <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: "None", multiple: true, label: "Tags", container_class: "h-40" } %>
-            <%= form.text_area :notes, label: "Notes", placeholder: "Enter a note that will be applied to selected transactions", rows: 5 %>
+            <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: t(".select_category"), label: t(".category"), class: "text-subdued" } %>
+            <%= form.collection_select :merchant_id, Current.family.available_merchants.alphabetically, :id, :name, { prompt: t(".select_merchant"), label: t(".merchant"), class: "text-subdued" } %>
+            <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: t(".none"), multiple: true, label: t(".tags"), container_class: "h-40" } %>
+            <%= form.text_area :notes, label: t(".notes"), placeholder: t(".notes_placeholder"), rows: 5 %>
           </div>
         <% end %>
       </div>
 
       <div class="flex justify-end gap-2 mt-auto">
-        <%= render DS::Button.new(text: "Cancel", variant: "ghost", data: { action: "click->DS--dialog#close" }) %>
-        <%= render DS::Button.new(text: "Save", data: { bulk_select_scope_param: "bulk_update", action: "bulk-select#submitBulkRequest" }) %>
+        <%= render DS::Button.new(text: t(".cancel"), variant: "ghost", data: { action: "click->DS--dialog#close" }) %>
+        <%= render DS::Button.new(text: t(".save"), data: { bulk_select_scope_param: "bulk_update", action: "bulk-select#submitBulkRequest" }) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,16 +1,16 @@
 <div class="space-y-4 pb-6 lg:pb-12 flex flex-col">
   <header class="flex justify-between items-center text-primary font-medium">
-    <h1 class="text-xl">Transactions</h1>
+    <h1 class="text-xl"><%= t(".title") %></h1>
     <div class="flex items-center gap-5">
       <div class="flex items-center gap-2">
         <%= render DS::Menu.new do |menu| %>
-          <% menu.with_item(variant: "link", text: "New rule", href: new_rule_path(resource_type: "transaction"), icon: "plus", data: { turbo_frame: :modal }) %>
-          <% menu.with_item(variant: "link", text: "Edit rules", href: rules_path, icon: "git-branch", data: { turbo_frame: :_top }) %>
-          <% menu.with_item(variant: "link", text: "Edit categories", href: categories_path, icon: "shapes", data: { turbo_frame: :_top }) %>
-          <% menu.with_item(variant: "link", text: "Edit tags", href: tags_path, icon: "tags", data: { turbo_frame: :_top }) %>
-          <% menu.with_item(variant: "link", text: "Edit merchants", href: family_merchants_path, icon: "store", data: { turbo_frame: :_top }) %>
-          <% menu.with_item(variant: "link", text: "Edit imports", href: imports_path, icon: "hard-drive-upload", data: { turbo_frame: :_top }) %>
-          <% menu.with_item(variant: "link", text: "Import", href: new_import_path, icon: "download", data: { turbo_frame: "modal", class_name: "md:!hidden" }) %>
+          <% menu.with_item(variant: "link", text: t(".new_rule"), href: new_rule_path(resource_type: "transaction"), icon: "plus", data: { turbo_frame: :modal }) %>
+          <% menu.with_item(variant: "link", text: t(".edit_rules"), href: rules_path, icon: "git-branch", data: { turbo_frame: :_top }) %>
+          <% menu.with_item(variant: "link", text: t(".edit_categories"), href: categories_path, icon: "shapes", data: { turbo_frame: :_top }) %>
+          <% menu.with_item(variant: "link", text: t(".edit_tags"), href: tags_path, icon: "tags", data: { turbo_frame: :_top }) %>
+          <% menu.with_item(variant: "link", text: t(".edit_merchants"), href: family_merchants_path, icon: "store", data: { turbo_frame: :_top }) %>
+          <% menu.with_item(variant: "link", text: t(".edit_imports"), href: imports_path, icon: "hard-drive-upload", data: { turbo_frame: :_top }) %>
+          <% menu.with_item(variant: "link", text: t(".import"), href: new_import_path, icon: "download", data: { turbo_frame: "modal", class_name: "md:!hidden" }) %>
         <% end %>
 
         <div class="hidden md:flex">
@@ -24,7 +24,7 @@
         </div>
 
         <%= render DS::Link.new(
-            text: "New transaction",
+            text: t(".new_transaction"),
             icon: "plus",
             variant: "primary",
             href: new_transaction_path,
@@ -56,7 +56,7 @@
       <%= f.file_field "import[csv_file]", class: "hidden", data: { drag_and_drop_import_target: "input" }, accept: ".csv" %>
     <% end %>
 
-    <%= render "imports/drag_drop_overlay", title: "Drop CSV to import", subtitle: "Upload transactions directly" %>
+    <%= render "imports/drag_drop_overlay", title: t(".drop_csv_title"), subtitle: t(".drop_csv_subtitle") %>
 
     <%= render "transactions/searches/search" %>
 
@@ -75,11 +75,11 @@
                                   action: "bulk-select#togglePageSelection",
                                   checkbox_toggle_target: "selectionEntry"
                                 } %>
-              <p>transaction</p>
+              <p><%= t(".column_transaction") %></p>
             </div>
 
-            <p class="col-span-2 md:block hidden">category</p>
-            <p class="col-span-2 col-start-11 md:col-start-auto justify-self-end md:block">amount</p>
+            <p class="col-span-2 md:block hidden"><%= t(".column_category") %></p>
+            <p class="col-span-2 col-start-11 md:col-start-auto justify-self-end md:block"><%= t(".column_amount") %></p>
           </div>
         <% end %>
 

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "New transaction") %>
+  <% dialog.with_header(title: t(".title")) %>
   <% dialog.with_body do %>
     <%= render "form", entry: @entry, income_categories: @income_categories, expense_categories: @expense_categories %>
   <% end %>

--- a/app/views/transactions/searches/_form.html.erb
+++ b/app/views/transactions/searches/_form.html.erb
@@ -10,7 +10,7 @@
       <div class="flex items-center px-3 py-2 gap-2 border border-secondary rounded-lg focus-within:ring-secondary focus-within:border-secondary">
         <%= icon("search") %>
         <%= form.text_field :search,
-                            placeholder: "Search transactions ...",
+                            placeholder: t('.search_placeholder'),
                             value: @q[:search],
                             class: "form-field__input placeholder:text-sm placeholder:text-secondary",
                             "data-auto-submit-form-target": "auto" %>
@@ -21,7 +21,7 @@
       <% menu.with_button(
         id: "transaction-filters-button",
         type: "button",
-        text: "Filter",
+        text: t('.filter'),
         variant: "outline",
         icon: "list-filter"
       ) %>

--- a/app/views/transactions/searches/filters/_account_filter.html.erb
+++ b/app/views/transactions/searches/filters/_account_filter.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (form:) %>
 <div data-controller="list-filter">
   <div class="relative">
-    <input type="search" autocomplete="off" placeholder="Filter accounts" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full border border-secondary rounded-md py-2 pl-10 pr-3 bg-container focus:ring-gray-500 sm:text-sm">
+    <input type="search" autocomplete="off" placeholder="<%= t('.filter_placeholder') %>" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full border border-secondary rounded-md py-2 pl-10 pr-3 bg-container focus:ring-gray-500 sm:text-sm">
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">

--- a/app/views/transactions/searches/filters/_category_filter.html.erb
+++ b/app/views/transactions/searches/filters/_category_filter.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (form:) %>
 <div data-controller="list-filter">
   <div class="relative">
-    <input type="search" autocomplete="off" placeholder="Filter category" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full bg-container border border-secondary rounded-md py-2 pl-10 pr-3 focus:ring-gray-500 sm:text-sm">
+    <input type="search" autocomplete="off" placeholder="<%= t('.filter_placeholder') %>" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full bg-container border border-secondary rounded-md py-2 pl-10 pr-3 focus:ring-gray-500 sm:text-sm">
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">

--- a/app/views/transactions/searches/filters/_date_filter.html.erb
+++ b/app/views/transactions/searches/filters/_date_filter.html.erb
@@ -1,11 +1,11 @@
 <%# locals: (form:) %>
 <div class="p-3">
   <%= form.date_field :start_date,
-                      placeholder: "Start date",
+                      placeholder: t('.start_date'),
                       value: @q[:start_date],
                       class: "block w-full border border-secondary rounded-md bg-container py-2 pl-3 pr-3  focus:ring-gray-500 sm:text-sm" %>
   <%= form.date_field :end_date,
-                      placeholder: "End date",
+                      placeholder: t('.end_date'),
                       value: @q[:end_date],
                       class: "block w-full border border-secondary rounded-md bg-container py-2 pl-3 pr-3  focus:ring-gray-500 sm:text-sm mt-2" %>
 </div>

--- a/app/views/transactions/searches/filters/_merchant_filter.html.erb
+++ b/app/views/transactions/searches/filters/_merchant_filter.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (form:) %>
 <div data-controller="list-filter">
   <div class="relative">
-    <input type="search" autocomplete="off" placeholder="Filter merchants" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full bg-container border border-secondary rounded-md py-2 pl-10 pr-3 focus:ring-gray-500 sm:text-sm">
+    <input type="search" autocomplete="off" placeholder="<%= t('.filter_placeholder') %>" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full bg-container border border-secondary rounded-md py-2 pl-10 pr-3 focus:ring-gray-500 sm:text-sm">
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">

--- a/app/views/transactions/searches/filters/_tag_filter.html.erb
+++ b/app/views/transactions/searches/filters/_tag_filter.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (form:) %>
 <div data-controller="list-filter">
   <div class="relative">
-    <input type="search" autocomplete="off" placeholder="Filter tags" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full bg-container border border-secondary rounded-md py-2 pl-10 pr-3 focus:ring-gray-500 sm:text-sm">
+    <input type="search" autocomplete="off" placeholder="<%= t('.filter_placeholder') %>" data-list-filter-target="input" data-action="input->list-filter#filter" class="block w-full bg-container border border-secondary rounded-md py-2 pl-10 pr-3 focus:ring-gray-500 sm:text-sm">
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -19,7 +19,7 @@
                 <div class="flex items-center justify-between">
                   <div>
                     <p class="text-sm font-medium text-primary"><%= potential_match.name %></p>
-                    <p class="text-xs text-secondary"><%= potential_match.date.strftime("%b %d, %Y") %> • <%= potential_match.account.name %></p>
+                    <p class="text-xs text-secondary"><%= I18n.l(potential_match.date, format: :long) %> • <%= potential_match.account.name %></p>
                   </div>
                   <p class="text-sm font-medium <%= potential_match.amount.negative? ? "text-green-600" : "text-primary" %>">
                     <%= format_money(-potential_match.amount_money) %>
@@ -65,7 +65,7 @@
           <% unless @entry.transaction.transfer? %>
             <div class="flex items-center gap-2">
               <%= f.select :nature,
-                    [["Expense", "outflow"], ["Income", "inflow"]],
+                    [[t(".expense"), "outflow"], [t(".income"), "inflow"]],
                     { container_class: "w-1/3", label: t(".nature"), selected: @entry.amount.negative? ? "inflow" : "outflow" },
                     { data: { "auto-submit-form-target": "auto" }, disabled: @entry.linked? } %>
 
@@ -139,7 +139,7 @@
     <% end %>
 
     <% if (details = build_transaction_extra_details(@entry)) %>
-      <% dialog.with_section(title: "Additional details", open: false) do %>
+      <% dialog.with_section(title: t(".additional_details"), open: false) do %>
         <div class="px-3 py-2 space-y-3">
           <% if details[:kind] == :simplefin %>
             <% sf = details[:simplefin] %>
@@ -147,19 +147,19 @@
               <dl class="space-y-2">
                 <% if sf[:payee].present? %>
                   <div class="flex items-center justify-between gap-2">
-                    <dt class="text-secondary text-sm">Payee</dt>
+                    <dt class="text-secondary text-sm"><%= t(".payee") %></dt>
                     <dd class="text-sm text-primary"><%= sf[:payee] %></dd>
                   </div>
                 <% end %>
                 <% if sf[:description].present? %>
                   <div class="flex items-center justify-between gap-2">
-                    <dt class="text-secondary text-sm">Description</dt>
+                    <dt class="text-secondary text-sm"><%= t(".description") %></dt>
                     <dd class="text-sm text-primary"><%= sf[:description] %></dd>
                   </div>
                 <% end %>
                 <% if sf[:memo].present? %>
                   <div class="flex items-center justify-between gap-2">
-                    <dt class="text-secondary text-sm">Memo</dt>
+                    <dt class="text-secondary text-sm"><%= t(".memo") %></dt>
                     <dd class="text-sm text-primary"><%= sf[:memo] %></dd>
                   </div>
                 <% end %>
@@ -168,7 +168,7 @@
 
             <% if details[:provider_extras].present? %>
               <div class="pt-2">
-                <h4 class="text-sm text-secondary mb-1">Provider extras</h4>
+                <h4 class="text-sm text-secondary mb-1"><%= t(".provider_extras") %></h4>
                 <dl class="space-y-2">
                   <% details[:provider_extras].each do |ex| %>
                     <div class="flex items-center justify-between gap-2">
@@ -252,12 +252,12 @@
 
         <div class="flex items-center justify-between gap-4 p-3">
           <div class="text-sm space-y-1">
-            <h4 class="text-primary">Transfer or Debt Payment?</h4>
-            <p class="text-secondary">Transfers and payments are special types of transactions that indicate money movement between 2 accounts.</p>
+            <h4 class="text-primary"><%= t(".transfer_question") %></h4>
+            <p class="text-secondary"><%= t(".transfer_description") %></p>
           </div>
 
           <%= render DS::Link.new(
-            text: "Open matcher",
+            text: t(".open_matcher"),
             icon: "arrow-left-right",
             variant: "outline",
             href: new_transaction_transfer_match_path(@entry),

--- a/app/views/transfer_matches/_matching_fields.html.erb
+++ b/app/views/transfer_matches/_matching_fields.html.erb
@@ -3,15 +3,15 @@
 <% if candidates.any? %>
   <div data-controller="transfer-match" class="space-y-2">
     <p class="text-sm text-secondary">
-      Select a method for matching your transactions.
+      <%= t(".select_method") %>
     </p>
 
     <%= form.select :method,
               [
-                ["Match existing transaction (recommended)", "existing"],
-                ["Create new transaction", "new"]
+                [t(".match_existing"), "existing"],
+                [t(".create_new"), "new"]
               ],
-              { selected: "existing", label: "Matching method" },
+              { selected: "existing", label: t(".matching_method") },
               data: { action: "change->transfer-match#update" } %>
 
     <div data-transfer-match-target="existingSelect">
@@ -19,19 +19,18 @@
                 candidates.map { |entry|
                   [entry_name_detailed(entry), entry.id]
                 },
-                { label: "Matching transaction" } %>
+                { label: t(".matching_transaction") } %>
     </div>
 
     <div data-transfer-match-target="newSelect" class="hidden">
       <%= form.select :target_account_id,
                 accounts.map { |account| [account.name, account.id] },
-                { label: "Target account" } %>
+                { label: t(".target_account") } %>
     </div>
   </div>
 <% else %>
   <p class="text-sm text-secondary">
-    We couldn't find any transactions to match from your other accounts.
-    Please select an account and we will create a new inflow transaction for you.
+    <%= t(".no_transactions_found") %>
   </p>
 
   <%= form.hidden_field :method, value: "new" %>
@@ -39,6 +38,6 @@
   <div>
     <%= form.select :target_account_id,
                 accounts.map { |account| [account.name, account.id] },
-                { label: "Target account" } %>
+                { label: t(".target_account") } %>
   </div>
 <% end %>

--- a/app/views/transfer_matches/new.html.erb
+++ b/app/views/transfer_matches/new.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Match transfer or payment") %>
+  <% dialog.with_header(title: t(".title")) %>
   <% dialog.with_body do %>
     <%= styled_form_with(
           url: transaction_transfer_match_path(@entry),
@@ -10,7 +10,7 @@
       <section class="space-y-4">
         <div class="space-y-2">
           <h2 class="text-sm font-medium text-gray-700">
-            <%= @entry.amount.positive? ? "From account: #{@entry.account.name}" : "From account" %>
+            <%= @entry.amount.positive? ? t(".from_account", account_name: @entry.account.name) : t(".from_account_label") %>
           </h2>
 
           <% if @entry.amount.positive? %>
@@ -18,7 +18,7 @@
                   :entry_id,
                   [[entry_name_detailed(@entry), @entry.id]],
                   {
-                    label: "Outflow transaction",
+                    label: t(".outflow_transaction"),
                     selected: @entry.id,
                   },
                   disabled: true
@@ -37,7 +37,7 @@
       <section class="space-y-4">
         <div class="space-y-2">
           <h2 class="text-sm font-medium text-gray-700">
-            <%= @entry.amount.negative? ? "To account: #{@entry.account.name}" : "To account" %>
+            <%= @entry.amount.negative? ? t(".to_account", account_name: @entry.account.name) : t(".to_account_label") %>
           </h2>
 
           <% if @entry.amount.negative? %>
@@ -45,7 +45,7 @@
                   :entry_id,
                   [[entry_name_detailed(@entry), @entry.id]],
                   {
-                    label: "Inflow transaction",
+                    label: t(".inflow_transaction"),
                     selected: @entry.id,
                   },
                   disabled: true
@@ -57,7 +57,7 @@
         </div>
       </section>
 
-      <%= f.submit "Create transfer match" %>
+      <%= f.submit t(".submit") %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/transfers/_account_links.html.erb
+++ b/app/views/transfers/_account_links.html.erb
@@ -6,8 +6,8 @@
   <% if first_account %>
     <%= link_to first_account.name, account_path(first_account, tab: "activity"), class: "hover:underline", data: { turbo_frame: "_top" } %>
   <% else %>
-    <span class="text-warning text-xs italic" title="Transfer ID: <%= transfer.id %>">
-      Data Error: Missing account
+    <span class="text-warning text-xs italic" title="<%= t("transfers.account_links.transfer_id", id: transfer.id) %>">
+      <%= t("transfers.account_links.data_error_missing_account") %>
     </span>
   <% end %>
 
@@ -18,8 +18,8 @@
   <% if second_account %>
     <%= link_to second_account.name, account_path(second_account, tab: "activity"), class: "hover:underline", data: { turbo_frame: "_top" } %>
   <% else %>
-    <span class="text-warning text-xs italic" title="Transfer ID: <%= transfer.id %>">
-      Data Error: Missing account
+    <span class="text-warning text-xs italic" title="<%= t("transfers.account_links.transfer_id", id: transfer.id) %>">
+      <%= t("transfers.account_links.data_error_missing_account") %>
     </span>
   <% end %>
 </div>

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -26,7 +26,7 @@
       <div class="pb-4 px-3 pt-2 text-sm space-y-3 text-primary">
         <div class="space-y-3">
           <dl class="flex items-center gap-2 justify-between">
-            <dt class="text-secondary">From</dt>
+            <dt class="text-secondary"><%= t(".from") %></dt>
             <dd class="flex items-center gap-2 font-medium">
               <%= render "accounts/logo", account: @transfer.from_account, size: "sm" %>
               <%= link_to @transfer.from_account.name, account_path(@transfer.from_account), data: { turbo_frame: "_top" } %>
@@ -34,12 +34,12 @@
           </dl>
 
           <dl class="flex items-center gap-2 justify-between">
-            <dt class="text-secondary">Date</dt>
+            <dt class="text-secondary"><%= t(".date") %></dt>
             <dd class="font-medium"><%= l(@transfer.outflow_transaction.entry.date, format: :long) %></dd>
           </dl>
 
           <dl class="flex items-center gap-2 justify-between">
-            <dt class="text-secondary">Amount</dt>
+            <dt class="text-secondary"><%= t(".amount") %></dt>
             <dd class="font-medium text-red-500"><%= format_money @transfer.outflow_transaction.entry.amount_money * -1 %></dd>
           </dl>
         </div>
@@ -48,7 +48,7 @@
 
         <div class="space-y-3">
           <dl class="flex items-center gap-2 justify-between">
-            <dt class="text-secondary">To</dt>
+            <dt class="text-secondary"><%= t(".to") %></dt>
             <dd class="flex items-center gap-2 font-medium">
               <%= render "accounts/logo", account: @transfer.to_account, size: "sm" %>
               <%= link_to @transfer.to_account.name, account_path(@transfer.to_account), data: { turbo_frame: "_top" } %>
@@ -56,12 +56,12 @@
           </dl>
 
           <dl class="flex items-center gap-2 justify-between">
-            <dt class="text-secondary">Date</dt>
+            <dt class="text-secondary"><%= t(".date") %></dt>
             <dd class="font-medium"><%= l(@transfer.inflow_transaction.entry.date, format: :long) %></dd>
           </dl>
 
           <dl class="flex items-center gap-2 justify-between">
-            <dt class="text-secondary">Amount</dt>
+            <dt class="text-secondary"><%= t(".amount") %></dt>
             <dd class="font-medium text-green-500">+<%= format_money @transfer.inflow_transaction.entry.amount_money * -1 %></dd>
           </dl>
         </div>
@@ -72,7 +72,7 @@
       <%= styled_form_with model: @transfer,
               data: { controller: "auto-submit-form" }, class: "space-y-2" do |f| %>
         <% if @transfer.categorizable? %>
-          <%= f.collection_select :category_id, @categories.alphabetically, :id, :name, { label: "Category", include_blank: "Uncategorized", selected: @transfer.outflow_transaction.category&.id }, "data-auto-submit-form-target": "auto" %>
+          <%= f.collection_select :category_id, @categories.alphabetically, :id, :name, { label: t(".category"), include_blank: t(".uncategorized"), selected: @transfer.outflow_transaction.category&.id }, "data-auto-submit-form-target": "auto" %>
         <% end %>
 
         <%= f.text_area :notes,

--- a/app/views/users/_user_menu.html.erb
+++ b/app/views/users/_user_menu.html.erb
@@ -19,7 +19,7 @@
       <% if self_hosted? %>
         <div class="px-4 py-3 border-t border-tertiary">
           <p class="text-sm">
-            <span class="font-medium text-primary">Version:</span>
+            <span class="font-medium text-primary"><%= t(".version") %>:</span>
             <%= link_to Sure.version.to_release_tag, "https://github.com/we-promise/sure/releases/tag/#{Sure.version.to_release_tag}", target: "_blank", class: "hover:underline" %>
 
             <% if Sure.commit_sha.present? %>
@@ -30,16 +30,16 @@
       <% end %>
     <% end %>
 
-    <% menu.with_item(variant: "link", text: "Settings", icon: "settings", href: accounts_path(return_to: request.fullpath)) %>
-    <% menu.with_item(variant: "link", text: "Changelog", icon: "box", href: changelog_path) %>
+    <% menu.with_item(variant: "link", text: t(".settings"), icon: "settings", href: accounts_path(return_to: request.fullpath)) %>
+    <% menu.with_item(variant: "link", text: t(".changelog"), icon: "box", href: changelog_path) %>
 
     <% if self_hosted? %>
-      <% menu.with_item(variant: "link", text: "Feedback", icon: "megaphone", href: feedback_path) %>
+      <% menu.with_item(variant: "link", text: t(".feedback"), icon: "megaphone", href: feedback_path) %>
     <% end %>
-    <% menu.with_item(variant: "link", text: "Contact", icon: "message-square-more", href: "https://discord.gg/36ZGBsxYEK") %>
+    <% menu.with_item(variant: "link", text: t(".contact"), icon: "message-square-more", href: "https://discord.gg/36ZGBsxYEK") %>
 
     <% menu.with_item(variant: "divider") %>
 
-    <% menu.with_item(variant: "button", text: "Log out", icon: "log-out", href: session_path(Current.session), method: :delete) %>
+    <% menu.with_item(variant: "button", text: t(".log_out"), icon: "log-out", href: session_path(Current.session), method: :delete) %>
   <% end %>
 </div>

--- a/app/views/valuations/_confirmation_contents.html.erb
+++ b/app/views/valuations/_confirmation_contents.html.erb
@@ -5,47 +5,46 @@
     <% brokerage_cash = reconciliation_dry_run.new_cash_balance || 0 %>
     <% holdings_value = reconciliation_dry_run.new_balance - brokerage_cash %>
 
-    <p>This will <%= action_verb %> the account value on <span class="font-medium text-primary"><%= entry.date.strftime("%B %d, %Y") %></span> to:</p>
+    <p><%= t("valuations.confirmation_contents.investment_intro", action: action_verb, date: I18n.l(entry.date, format: :long)) %></p>
 
     <div class="bg-container rounded-lg p-4 space-y-2 border border-primary">
       <div class="flex justify-between">
-        <span>Total account value</span>
+        <span><%= t("valuations.confirmation_contents.total_account_value") %></span>
         <span class="font-medium text-primary"><%= Money.new(reconciliation_dry_run.new_balance, account.currency).format %></span>
       </div>
       <div class="flex justify-between text-xs">
-        <span>Holdings value</span>
+        <span><%= t("valuations.confirmation_contents.holdings_value") %></span>
         <span><%= Money.new(holdings_value, account.currency).format %></span>
       </div>
       <div class="flex justify-between text-xs">
-        <span>Brokerage cash</span>
+        <span><%= t("valuations.confirmation_contents.brokerage_cash") %></span>
         <span class="<%= brokerage_cash.negative? ? "text-red-500" : "text-green-500" %>"><%= Money.new(brokerage_cash, account.currency).format %></span>
       </div>
     </div>
   <% else %>
     <p><%= action_verb.capitalize %>
       <% if account.depository? %>
-        account balance
+        <%= t("valuations.confirmation_contents.account_balance") %>
       <% elsif account.credit_card? %>
-        credit card balance
+        <%= t("valuations.confirmation_contents.credit_card_balance") %>
       <% elsif account.loan? %>
-        loan balance
+        <%= t("valuations.confirmation_contents.loan_balance") %>
       <% elsif account.property? %>
-        property value
+        <%= t("valuations.confirmation_contents.property_value") %>
       <% elsif account.vehicle? %>
-        vehicle value
+        <%= t("valuations.confirmation_contents.vehicle_value") %>
       <% elsif account.crypto? %>
-        crypto balance
+        <%= t("valuations.confirmation_contents.crypto_balance") %>
       <% elsif account.other_asset? %>
-        asset value
+        <%= t("valuations.confirmation_contents.asset_value") %>
       <% elsif account.other_liability? %>
-        liability balance
+        <%= t("valuations.confirmation_contents.liability_balance") %>
       <% else %>
-        balance
+        <%= t("valuations.confirmation_contents.balance") %>
       <% end %>
-      on <span class="font-medium text-primary"><%= entry.date.strftime("%B %d, %Y") %></span> to
-      <span class="font-medium text-primary"><%= entry.amount_money.format %></span>.
+      <%= t("valuations.confirmation_contents.on_date_to", date: I18n.l(entry.date, format: :long), amount: entry.amount_money.format) %>
     </p>
   <% end %>
 
-  <p>All future transactions and balances will be recalculated based on this <%= is_update ? "change" : "update" %>.</p>
+  <p><%= is_update ? t("valuations.confirmation_contents.recalculation_change") : t("valuations.confirmation_contents.recalculation_update") %></p>
 </div>

--- a/app/views/valuations/confirm_create.html.erb
+++ b/app/views/valuations/confirm_create.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Confirm new balance") %>
+  <% dialog.with_header(title: t(".title")) %>
   <% dialog.with_body do %>
     <%= styled_form_with model: @entry, url: valuations_path, class: "space-y-4" do |form| %>
       <%= form.hidden_field :account_id %>
@@ -13,7 +13,7 @@
           action_verb: "set",
           is_update: false %>
 
-      <%= form.submit "Confirm" %>
+      <%= form.submit t(".confirm") %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/valuations/confirm_update.html.erb
+++ b/app/views/valuations/confirm_update.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Update balance") %>
+  <% dialog.with_header(title: t(".title")) %>
   <% dialog.with_body do %>
     <%= styled_form_with model: @entry, url: valuation_path(@entry), method: :patch, class: "space-y-4", data: { turbo_frame: :_top } do |form| %>
       <%= form.hidden_field :date %>
@@ -12,7 +12,7 @@
           action_verb: "update",
           is_update: true %>
 
-      <%= form.submit "Update" %>
+      <%= form.submit t(".update") %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/valuations/show.html.erb
+++ b/app/views/valuations/show.html.erb
@@ -24,12 +24,12 @@
                 max: Date.current %>
 
           <%= f.money_field :amount,
-                label: "Account value on date",
+                label: t(".account_value_on_date"),
                 disable_currency: true %>
 
           <div class="flex justify-end">
             <%= render DS::Button.new(
-              text: "Update value",
+              text: t(".update_value"),
               variant: :primary,
               type: "submit"
             ) %>

--- a/app/views/vehicles/_form.html.erb
+++ b/app/views/vehicles/_form.html.erb
@@ -25,7 +25,7 @@
                                     placeholder: t("vehicles.form.mileage_placeholder"),
                                     min: 0 %>
         <%= vehicle_form.select :mileage_unit,
-                              [["Miles", "mi"], ["Kilometers", "km"]],
+                              [[t("vehicles.form.mileage_unit_miles"), "mi"], [t("vehicles.form.mileage_unit_kilometers"), "km"]],
                               { label: t("vehicles.form.mileage_unit") } %>
       </div>
     <% end %>

--- a/app/views/vehicles/tabs/_overview.html.erb
+++ b/app/views/vehicles/tabs/_overview.html.erb
@@ -34,7 +34,7 @@
 
 <div class="flex justify-center py-8">
   <%= render DS::Link.new(
-    text: "Edit account details",
+    text: t(".edit_account_details"),
     variant: "ghost",
     href: edit_vehicle_path(account),
     frame: :modal

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -1,0 +1,124 @@
+---
+en:
+  # Controller flash messages
+  valuations:
+    create:
+      account_updated: Account updated
+    update:
+      entry_updated: Entry updated
+
+  chats:
+    update:
+      updated: Chat updated
+    destroy:
+      deleted: Chat was successfully deleted
+
+  transfer_matches:
+    create:
+      created: Transfer created
+
+  rules:
+    apply:
+      activated: "%{resource_type} rule activated"
+    update:
+      updated: Rule updated
+    destroy:
+      deleted: Rule deleted
+    destroy_all:
+      all_deleted: All rules deleted
+
+  tags:
+    destroy_all:
+      all_deleted: All tags deleted
+
+  categories:
+    destroy_all:
+      all_deleted: All categories deleted
+
+  transactions:
+    create:
+      created: Transaction created
+    update:
+      updated: Transaction updated
+
+  holdings:
+    destroy:
+      cannot_delete: You cannot delete this holding
+
+  subscriptions:
+    upgrade:
+      already_subscribed: You are already subscribed.
+    create:
+      welcome: Welcome to Sure!
+      trial_already_used: You have already started or completed a trial. Please upgrade to continue.
+    success:
+      subscription_created: Welcome to Sure! Your subscription has been created.
+      subscription_error: Something went wrong processing your subscription. Please contact us to get this fixed.
+
+  invite_codes:
+    create:
+      not_allowed: You are not allowed to generate invite codes
+      generated: Code generated
+    destroy:
+      deleted: Code deleted
+
+  imports:
+    publish:
+      started: Your import has started in the background.
+      max_row_count_exceeded: Your import exceeds the maximum row count of %{count}.
+    create:
+      file_too_large: "File is too large. Maximum size is %{size}MB."
+      invalid_file_type: Invalid file type. Please upload a CSV file.
+      csv_uploaded: CSV uploaded successfully.
+    show:
+      finalize_upload: Please finalize your file upload.
+      finalize_mappings: Please finalize your mappings before proceeding.
+    revert:
+      reverting: Import is reverting in the background.
+    apply_template:
+      template_applied: Template applied.
+      no_template: No template found, please manually configure your import.
+    destroy:
+      deleted: Your import has been deleted.
+
+  import:
+    uploads:
+      update:
+        csv_uploaded: CSV uploaded successfully.
+        invalid_csv: Must be valid CSV with headers and at least one row of data
+    cleans:
+      show:
+        configure_first: Please configure your import before proceeding.
+    confirms:
+      show:
+        invalid_data: You have invalid data, please edit until all errors are resolved
+
+  family_exports:
+    create:
+      started: Export started. You'll be able to download it shortly.
+    download:
+      not_ready: Export not ready for download
+    destroy:
+      deleted: Export deleted successfully
+    access_denied: Access denied
+
+  settings:
+    api_keys:
+      create:
+        created: Your API key has been created successfully
+      destroy:
+        revoked: API key has been revoked successfully
+        revoke_failed: Failed to revoke API key
+    providers:
+      update:
+        updated: Provider settings updated successfully
+        no_changes: No changes were made
+        update_failed: "Failed to update provider settings: %{error}"
+      not_authorized: Not authorized
+    profiles:
+      destroy:
+        member_removed: Member removed successfully.
+        member_remove_failed: Failed to remove member.
+
+  self_hostable:
+    redis_configured: Redis is now configured properly! You can now setup your Sure application.

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -4,6 +4,22 @@ fr:
     brand_name: "%{brand_name}"
     product_name: "%{product_name}"
   activerecord:
+    models:
+      category: catégorie
+      rule: règle
+      tag: étiquette
+      account: compte
+      transaction: transaction
+      entry: entrée
+      balance: solde
+      transfer: virement
+      import: importation
+      merchant: vendeur
+      holding: avoir
+      trade: opération
+      security: titre
+      family: foyer
+      user: utilisateur
     errors:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
@@ -23,18 +39,18 @@ fr:
     - sam
     abbr_month_names:
     -
-    - jan.
-    - fév.
-    - mars
-    - avr.
-    - mai
-    - juin
-    - juil.
-    - août
-    - sept.
-    - oct.
-    - nov.
-    - déc.
+    - Jan.
+    - Fév.
+    - Mars
+    - Avr.
+    - Mai
+    - Juin
+    - Juil.
+    - Août
+    - Sept.
+    - Oct.
+    - Nov.
+    - Déc.
     day_names:
     - dimanche
     - lundi
@@ -49,18 +65,18 @@ fr:
       short: "%-d %b"
     month_names:
     -
-    - janvier
-    - février
-    - mars
-    - avril
-    - mai
-    - juin
-    - juillet
-    - août
-    - septembre
-    - octobre
-    - novembre
-    - décembre
+    - Janvier
+    - Février
+    - Mars
+    - Avril
+    - Mai
+    - Juin
+    - Juillet
+    - Août
+    - Septembre
+    - Octobre
+    - Novembre
+    - Décembre
     order:
     - :day
     - :month

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -72,8 +72,11 @@ en:
         able_to: 'This application will be able to'
       show:
         title: 'Authorization code'
+        authorization_code_label: 'Authorization Code:'
+        copy_instructions: 'Copy this code and paste it into the application.'
       form_post:
         title: 'Submit this form'
+        redirecting: 'Redirecting you back to the application...'
 
     authorized_applications:
       confirmations:

--- a/config/locales/doorkeeper.fr.yml
+++ b/config/locales/doorkeeper.fr.yml
@@ -1,0 +1,154 @@
+fr:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Nom'
+        redirect_uri: 'URI de redirection'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'ne peut pas contenir de fragment.'
+              invalid_uri: 'doit être une URI valide.'
+              unspecified_scheme: 'doit spécifier un schéma.'
+              relative_uri: 'doit être une URI absolue.'
+              secured_uri: 'doit être une URI HTTPS/SSL.'
+              forbidden_uri: 'est interdit par le serveur.'
+            scopes:
+              not_match_configured: "ne correspond pas à la configuration du serveur."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Êtes-vous sûr ?'
+      buttons:
+        edit: 'Modifier'
+        destroy: 'Supprimer'
+        submit: 'Soumettre'
+        cancel: 'Annuler'
+        authorize: 'Autoriser'
+      form:
+        error: 'Oups ! Vérifiez votre formulaire pour les erreurs possibles'
+      help:
+        confidential: "L'application sera utilisée là où le secret client peut être gardé confidentiel. Les applications mobiles natives et les applications monopage sont considérées comme non confidentielles."
+        redirect_uri: 'Utilisez une ligne par URI'
+        blank_redirect_uri: "Laissez vide si vous avez configuré votre fournisseur pour utiliser les identifiants client, les identifiants de mot de passe du propriétaire de la ressource ou tout autre type d'autorisation qui ne nécessite pas d'URI de redirection."
+        scopes: 'Séparez les portées par des espaces. Laissez vide pour utiliser les portées par défaut.'
+      edit:
+        title: "Modifier l'application"
+      index:
+        title: 'Vos applications'
+        new: 'Nouvelle application'
+        name: 'Nom'
+        callback_url: 'URL de rappel'
+        confidential: 'Confidentiel ?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Oui'
+          'no': 'Non'
+      new:
+        title: 'Nouvelle application'
+      show:
+        title: 'Application : %{name}'
+        application_id: 'UID'
+        secret: 'Secret'
+        secret_hashed: 'Secret haché'
+        scopes: 'Portées'
+        confidential: 'Confidentiel'
+        callback_urls: 'URLs de rappel'
+        actions: 'Actions'
+        not_defined: 'Non défini'
+
+    authorizations:
+      buttons:
+        authorize: 'Autoriser'
+        deny: 'Refuser'
+      error:
+        title: 'Une erreur est survenue'
+      new:
+        title: 'Autorisation requise'
+        prompt: 'Autoriser %{client_name} à utiliser votre compte ?'
+        able_to: 'Cette application pourra'
+      show:
+        title: "Code d'autorisation"
+        authorization_code_label: "Code d'autorisation :"
+        copy_instructions: "Copiez ce code et collez-le dans l'application."
+      form_post:
+        title: 'Soumettre ce formulaire'
+        redirecting: "Redirection vers l'application..."
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Êtes-vous sûr ?'
+      buttons:
+        revoke: 'Révoquer'
+      index:
+        title: 'Vos applications autorisées'
+        application: 'Application'
+        created_at: 'Créé le'
+        date_format: '%d/%m/%Y %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pré-autorisation'
+
+    errors:
+      messages:
+        invalid_request:
+          unknown: "La requête manque un paramètre requis, inclut une valeur de paramètre non prise en charge, ou est autrement malformée."
+          missing_param: 'Paramètre requis manquant : %{value}.'
+          request_not_authorized: "La requête doit être autorisée. Le paramètre requis pour autoriser la requête est manquant ou invalide."
+          invalid_code_challenge: 'Le défi de code est requis.'
+        invalid_redirect_uri: "L'URI de redirection demandée est malformée ou ne correspond pas à l'URI de redirection du client."
+        unauthorized_client: "Le client n'est pas autorisé à effectuer cette requête en utilisant cette méthode."
+        access_denied: "Le propriétaire de la ressource ou le serveur d'autorisation a refusé la requête."
+        invalid_scope: 'La portée demandée est invalide, inconnue ou malformée.'
+        invalid_code_challenge_method:
+          zero: "Le serveur d'autorisation ne prend pas en charge PKCE car il n'y a pas de valeurs code_challenge_method acceptées."
+          one: 'Le code_challenge_method doit être %{challenge_methods}.'
+          other: 'Le code_challenge_method doit être un parmi %{challenge_methods}.'
+        server_error: "Le serveur d'autorisation a rencontré une condition inattendue qui l'a empêché de traiter la requête."
+        temporarily_unavailable: "Le serveur d'autorisation est actuellement incapable de traiter la requête en raison d'une surcharge temporaire ou d'une maintenance du serveur."
+
+        credential_flow_not_configured: "Le flux des identifiants de mot de passe du propriétaire de la ressource a échoué car Doorkeeper.configure.resource_owner_from_credentials n'est pas configuré."
+        resource_owner_authenticator_not_configured: "La recherche du propriétaire de la ressource a échoué car Doorkeeper.configure.resource_owner_authenticator n'est pas configuré."
+        admin_authenticator_not_configured: "L'accès au panneau d'administration est interdit car Doorkeeper.configure.admin_authenticator n'est pas configuré."
+
+        unsupported_response_type: "Le serveur d'autorisation ne prend pas en charge ce type de réponse."
+        unsupported_response_mode: "Le serveur d'autorisation ne prend pas en charge ce mode de réponse."
+
+        invalid_client: "L'authentification du client a échoué en raison d'un client inconnu, d'aucune authentification client incluse, ou d'une méthode d'authentification non prise en charge."
+        invalid_grant: "L'autorisation fournie est invalide, expirée, révoquée, ne correspond pas à l'URI de redirection utilisée dans la requête d'autorisation, ou a été émise à un autre client."
+        unsupported_grant_type: "Le type d'autorisation n'est pas pris en charge par le serveur d'autorisation."
+
+        invalid_token:
+          revoked: "Le jeton d'accès a été révoqué"
+          expired: "Le jeton d'accès a expiré"
+          unknown: "Le jeton d'accès est invalide"
+        revoke:
+          unauthorized: "Vous n'êtes pas autorisé à révoquer ce jeton"
+
+        forbidden_token:
+          missing_scope: 'L''accès à cette ressource nécessite la portée "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: 'Application créée.'
+        destroy:
+          notice: 'Application supprimée.'
+        update:
+          notice: 'Application mise à jour.'
+      authorized_applications:
+        destroy:
+          notice: 'Application révoquée.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'Fournisseur OAuth2'
+          applications: 'Applications'
+          home: 'Accueil'
+      application:
+        title: 'Autorisation OAuth requise'

--- a/config/locales/models/account/fr.yml
+++ b/config/locales/models/account/fr.yml
@@ -11,12 +11,12 @@ fr:
         subtype: Sous-type
     models:
       account: Compte
-      account/credit: Carte de Crédit
-      account/depository: Compte Bancaire
+      account/credit_card: Carte de Crédit
+      account/depository: Liquidités
       account/investment: Investissement
+      account/crypto: Cryptomonnaie
       account/loan: Prêt
       account/other_asset: Autre Actif
       account/other_liability: Autre Passif
       account/property: Immobilier
       account/vehicle: Véhicule
-      account/crypto: Cryptomonnaie

--- a/config/locales/models/account_order/en.yml
+++ b/config/locales/models/account_order/en.yml
@@ -1,0 +1,15 @@
+---
+en:
+  account_orders:
+    name_asc:
+      label: Name (A-Z)
+      label_short: Name ↑
+    name_desc:
+      label: Name (Z-A)
+      label_short: Name ↓
+    balance_asc:
+      label: Balance (Low to High)
+      label_short: Balance ↑
+    balance_desc:
+      label: Balance (High to Low)
+      label_short: Balance ↓

--- a/config/locales/models/account_order/fr.yml
+++ b/config/locales/models/account_order/fr.yml
@@ -1,0 +1,15 @@
+---
+fr:
+  account_orders:
+    name_asc:
+      label: Nom (A-Z)
+      label_short: Nom ↑
+    name_desc:
+      label: Nom (Z-A)
+      label_short: Nom ↓
+    balance_asc:
+      label: Solde (croissant)
+      label_short: Solde ↑
+    balance_desc:
+      label: Solde (décroissant)
+      label_short: Solde ↓

--- a/config/locales/models/period/en.yml
+++ b/config/locales/models/period/en.yml
@@ -1,0 +1,54 @@
+---
+en:
+  periods:
+    last_day:
+      label: Last Day
+      label_short: 1D
+      comparison_label: vs. yesterday
+    current_week:
+      label: Current Week
+      label_short: WTD
+      comparison_label: vs. start of week
+    last_7_days:
+      label: Last 7 Days
+      label_short: 7D
+      comparison_label: vs. last week
+    current_month:
+      label: Current Month
+      label_short: MTD
+      comparison_label: vs. start of month
+    last_month:
+      label: Last Month
+      label_short: LM
+      comparison_label: vs. last month
+    last_30_days:
+      label: Last 30 Days
+      label_short: 30D
+      comparison_label: vs. last 30 days
+    last_90_days:
+      label: Last 90 Days
+      label_short: 90D
+      comparison_label: vs. last quarter
+    current_year:
+      label: Current Year
+      label_short: YTD
+      comparison_label: vs. start of year
+    last_365_days:
+      label: Last 365 Days
+      label_short: 365D
+      comparison_label: vs. 1 year ago
+    last_5_years:
+      label: Last 5 Years
+      label_short: 5Y
+      comparison_label: vs. 5 years ago
+    last_10_years:
+      label: Last 10 Years
+      label_short: 10Y
+      comparison_label: vs. 10 years ago
+    all_time:
+      label: All Time
+      label_short: All
+      comparison_label: vs. beginning
+    custom:
+      label: Custom Period
+      label_short: Custom

--- a/config/locales/models/period/fr.yml
+++ b/config/locales/models/period/fr.yml
@@ -1,0 +1,54 @@
+---
+fr:
+  periods:
+    last_day:
+      label: Dernier jour
+      label_short: 1J
+      comparison_label: vs. hier
+    current_week:
+      label: Semaine en cours
+      label_short: SDC
+      comparison_label: vs. début de semaine
+    last_7_days:
+      label: 7 derniers jours
+      label_short: 7J
+      comparison_label: vs. semaine dernière
+    current_month:
+      label: Mois en cours
+      label_short: MDC
+      comparison_label: vs. début du mois
+    last_month:
+      label: Mois dernier
+      label_short: MD
+      comparison_label: vs. mois dernier
+    last_30_days:
+      label: 30 derniers jours
+      label_short: 30J
+      comparison_label: vs. 30 derniers jours
+    last_90_days:
+      label: 90 derniers jours
+      label_short: 90J
+      comparison_label: vs. dernier trimestre
+    current_year:
+      label: Année en cours
+      label_short: ADC
+      comparison_label: vs. début d'année
+    last_365_days:
+      label: 365 derniers jours
+      label_short: 365J
+      comparison_label: vs. il y a 1 an
+    last_5_years:
+      label: 5 dernières années
+      label_short: 5A
+      comparison_label: vs. il y a 5 ans
+    last_10_years:
+      label: 10 dernières années
+      label_short: 10A
+      comparison_label: vs. il y a 10 ans
+    all_time:
+      label: Tout le temps
+      label_short: Tout
+      comparison_label: vs. début
+    custom:
+      label: Période personnalisée
+      label_short: Perso


### PR DESCRIPTION
## Summary
- Part 2 of 3 PRs to internationalize hardcoded English strings
- Extracts strings from settings, imports, and additional views
- Adds model locale files (account_order, period)

## Test plan
- [ ] Verify all pages render correctly with English locale
- [ ] Run `bin/rails test` to ensure tests pass

**Note:** This PR should be merged after Part 1 (#664)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive localization support for English and French languages across the entire application.
  * All user-facing text, labels, buttons, messages, and date/time formatting are now translatable and locale-aware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->