### PR TITLE
fix: Global scrollbar styling with dark mode support

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -147,42 +147,42 @@
   }
 }
 
-/* Global custom scrollbar - Light mode */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
+/* Windows-specific scrollbar styling with dark mode support */
+.windows {
+  ::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
 
-::-webkit-scrollbar-track {
-  background: transparent;
-}
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
 
-::-webkit-scrollbar-thumb {
-  background: rgba(156, 163, 175, 0.5);
-  border-radius: 4px;
-}
+  ::-webkit-scrollbar-thumb {
+    background: var(--color-alpha-black-500);
+    border-radius: 10px;
+  }
 
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(156, 163, 175, 0.7);
-}
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--color-alpha-black-700);
+  }
 
-/* Global custom scrollbar - Dark mode */
-[data-theme=dark] ::-webkit-scrollbar-thumb {
-  background: rgba(75, 85, 99, 0.6);
-}
-
-[data-theme=dark] ::-webkit-scrollbar-thumb:hover {
-  background: rgba(75, 85, 99, 0.8);
-}
-
-/* Firefox scrollbar */
-* {
+  /* Firefox scrollbar */
   scrollbar-width: thin;
-  scrollbar-color: rgba(156, 163, 175, 0.5) transparent;
+  scrollbar-color: var(--color-alpha-black-500) transparent;
 }
 
-[data-theme=dark] * {
-  scrollbar-color: rgba(75, 85, 99, 0.6) transparent;
+/* Windows dark mode */
+[data-theme=dark] .windows {
+  ::-webkit-scrollbar-thumb {
+    background: var(--color-alpha-white-500);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--color-alpha-white-700);
+  }
+
+  scrollbar-color: var(--color-alpha-white-500) transparent;
 }
 
 /* Thin scrollbar variant */
@@ -192,13 +192,29 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(156, 163, 175, 0.5);
+    background: var(--color-alpha-black-500);
     border-radius: 10px;
   }
 
   &::-webkit-scrollbar-thumb:hover {
-    background: rgba(156, 163, 175, 0.7);
+    background: var(--color-alpha-black-700);
   }
+
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-alpha-black-500) transparent;
+}
+
+/* Scrollbar dark mode */
+[data-theme=dark] .scrollbar {
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-alpha-white-500);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--color-alpha-white-700);
+  }
+
+  scrollbar-color: var(--color-alpha-white-500) transparent;
 }
 
 .no-scrollbar::-webkit-scrollbar {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -147,34 +147,57 @@
   }
 }
 
-/* Custom scrollbar implementation for Windows browsers */
-.windows {
-  ::-webkit-scrollbar {
-    width: 4px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: #d6d6d6;
-    border-radius: 10px;
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    background: #a6a6a6;
-  }  
+/* Global custom scrollbar - Light mode */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
 }
 
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(156, 163, 175, 0.5);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(156, 163, 175, 0.7);
+}
+
+/* Global custom scrollbar - Dark mode */
+[data-theme=dark] ::-webkit-scrollbar-thumb {
+  background: rgba(75, 85, 99, 0.6);
+}
+
+[data-theme=dark] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(75, 85, 99, 0.8);
+}
+
+/* Firefox scrollbar */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(156, 163, 175, 0.5) transparent;
+}
+
+[data-theme=dark] * {
+  scrollbar-color: rgba(75, 85, 99, 0.6) transparent;
+}
+
+/* Thin scrollbar variant */
 .scrollbar {
   &::-webkit-scrollbar {
     width: 4px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: #d6d6d6;
+    background: rgba(156, 163, 175, 0.5);
     border-radius: 10px;
   }
 
   &::-webkit-scrollbar-thumb:hover {
-    background: #a6a6a6;
+    background: rgba(156, 163, 175, 0.7);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix ugly/old scrollbar appearance in Chrome dark mode
- Add global webkit-scrollbar styles (previously limited to `.windows` class only)
- Add dark mode support with `[data-theme=dark]` selector
- Add Firefox scrollbar support with `scrollbar-width` and `scrollbar-color`
- Use semi-transparent colors that adapt to theme

## Problem
Scrollbars were using Chrome's default styling in dark mode, appearing old/ugly. The custom scrollbar CSS was only applied to `.windows` class and didn't support dark mode.

## Test plan
- [x] Verify scrollbars look modern in Chrome light mode
- [x] Verify scrollbars look modern in Chrome dark mode
- [x] Verify scrollbars work in Firefox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reworked Windows scrollbar styling for better cross-browser consistency
  * Replaced hard-coded colors with theme-aware CSS variables
  * Added dark-mode scrollbar appearances and theme-aware rules
  * Introduced a thin scrollbar variant with its own hover states
  * Ensured Firefox scrollbar properties align with the new theming and hover behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->