### PR TITLE
feat: Support multiple crypto wallets with same token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,14 @@ scripts/
 .cursor/rules/dev_workflow.mdc
 .cursor/rules/taskmaster.mdc
 
+
+# Auto Claude data directory
+.auto-claude/
+
+# Auto Claude generated files
+.auto-claude-security.json
+.auto-claude-status
+.claude_settings.json
+.worktrees/
+.security-key
+logs/security/

--- a/app/models/coinstats_account.rb
+++ b/app/models/coinstats_account.rb
@@ -10,7 +10,7 @@ class CoinstatsAccount < ApplicationRecord
   has_one :account, through: :account_provider, source: :account
 
   validates :name, :currency, presence: true
-  validates :account_id, uniqueness: { scope: :coinstats_item_id, allow_nil: true }
+  validates :account_id, uniqueness: { scope: [ :coinstats_item_id, :wallet_address ], allow_nil: true }
 
   # Alias for compatibility with provider adapter pattern
   alias_method :current_account, :account

--- a/app/models/coinstats_item/wallet_linker.rb
+++ b/app/models/coinstats_item/wallet_linker.rb
@@ -85,7 +85,8 @@ class CoinstatsItem::WalletLinker
           name: account_name,
           currency: "USD",
           current_balance: current_balance,
-          account_id: token_id
+          account_id: token_id,
+          wallet_address: address
         )
 
         # Store wallet metadata for future syncs

--- a/db/migrate/20260116090336_add_wallet_address_to_coinstats_accounts.rb
+++ b/db/migrate/20260116090336_add_wallet_address_to_coinstats_accounts.rb
@@ -1,0 +1,16 @@
+class AddWalletAddressToCoinstatsAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :coinstats_accounts, :wallet_address, :string
+
+    # Supprimer l'ancien index simple sur account_id
+    remove_index :coinstats_accounts,
+                 name: "index_coinstats_accounts_on_account_id",
+                 if_exists: true
+
+    # Créer le nouvel index composite unique
+    add_index :coinstats_accounts,
+              [:coinstats_item_id, :account_id, :wallet_address],
+              unique: true,
+              name: "index_coinstats_accounts_on_item_account_and_wallet"
+  end
+end


### PR DESCRIPTION
## Summary
Permet aux utilisateurs d'importer plusieurs wallets contenant la même cryptomonnaie (ex: ETH sur différentes adresses de wallet).

## Changes
- Ajout de la colonne `wallet_address` à `coinstats_accounts`
- Mise à jour de la validation d'unicité pour inclure `wallet_address`
- Extraction et stockage de l'adresse du wallet dans `WalletLinker`
- Ajout d'un index composite unique sur `[coinstats_item_id, account_id, wallet_address]`
- Ajout de tests pour le support multi-wallet et la rétrocompatibilité

## Example
Les utilisateurs peuvent maintenant avoir :
- ETH (0xAAA...) → "Ethereum (0xAA...AA)"
- ETH (0xBBB...) → "Ethereum (0xBB...BB)"

## Testing
✅ Testé et validé fonctionnellement par l'utilisateur
✅ Testé dans Docker avec PostgreSQL
✅ Création multi-wallet : PASS
✅ Rejet des duplicatas : PASS
✅ Rétrocompatibilité : PASS

## CI Checks
✅ Rubocop : Aucune offense détectée
✅ Brakeman : Aucun problème de sécurité

## Migration
Exécuter `bin/rails db:migrate` pour appliquer la migration.

🤖 Généré avec [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced multi-wallet support: Account IDs can now be linked across multiple different wallet addresses while maintaining data integrity.

* **Tests**
  * Added comprehensive test coverage for multi-wallet scenarios, including backward compatibility.

* **Chores**
  * Updated development configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->