### PR TITLE
fix: Locale-aware currency formatting

### DIFF
--- a/lib/money/formatting.rb
+++ b/lib/money/formatting.rb
@@ -31,11 +31,11 @@ module Money::Formatting
     end
 
     def locale_options(locale)
-      locale_sym = locale.to_sym
+      locale_sym = (locale || I18n.locale || :en).to_sym
 
-      # French locale: symbol after number with space, comma as decimal separator
+      # French locale: symbol after number with non-breaking space, comma as decimal separator
       if locale_sym == :fr
-        return { delimiter: " ", separator: ",", format: "%n %u" }
+        return { delimiter: "\u00A0", separator: ",", format: "%n\u00A0%u" }
       end
 
       # German locale: symbol after number with space, comma as decimal separator

--- a/test/lib/money_test.rb
+++ b/test/lib/money_test.rb
@@ -91,8 +91,9 @@ class MoneyTest < ActiveSupport::TestCase
   end
 
   test "formats correctly for French locale" do
-    assert_equal "1 000,12 €", Money.new(1000.12, :eur).format(locale: :fr)
-    assert_equal "1 000,12 $", Money.new(1000.12, :usd).format(locale: :fr)
+    # French uses non-breaking spaces (NBSP = \u00A0) between thousands and before currency symbol
+    assert_equal "1\u00A0000,12\u00A0€", Money.new(1000.12, :eur).format(locale: :fr)
+    assert_equal "1\u00A0000,12\u00A0$", Money.new(1000.12, :usd).format(locale: :fr)
   end
 
   test "formats correctly for German locale" do
@@ -106,6 +107,10 @@ class MoneyTest < ActiveSupport::TestCase
 
   test "formats correctly for Italian locale" do
     assert_equal "1.000,12 €", Money.new(1000.12, :eur).format(locale: :it)
+  end
+
+  test "formats correctly for Portuguese (Brazil) locale" do
+    assert_equal "R$ 1.000,12", Money.new(1000.12, :brl).format(locale: :"pt-BR")
   end
 
   test "converts currency when rate available" do


### PR DESCRIPTION
## Summary
- Add locale-specific currency formatting for proper international display
- French (fr): symbol after number with space (`1 000,12 €`)
- German (de): symbol after number (`1.000,12 €`)
- Spanish (es): symbol after number (`1.000,12 €`)
- Italian (it): symbol after number (`1.000,12 €`)
- Portuguese-Brazil (pt-BR): symbol before with space (`R$ 1.000,12`)

## Test plan
- [x] Unit tests for all new locale formats
- [x] Manual verification in Docker environment
- [ ] Verify dashboard displays correctly with FR locale

## Changes
- `lib/money/formatting.rb`: Added locale-specific format overrides
- `test/lib/money_test.rb`: Added tests for FR, DE, ES, IT locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit locale-specific currency formatting for French, German, Spanish, Italian, and Portuguese (Brazil) locales, improving delimiters, separators, and format presentation.

* **Tests**
  * Added tests covering currency formatting for FR, DE, ES, IT, and PT-BR to ensure consistent display across these locales.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->