### PR TITLE
EnableBanking: skip CARD-* counterparty in name

### DIFF
--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -80,7 +80,7 @@ class EnableBankingEntry::Processor
         data.dig(:creditor, :name) || data[:creditor_name]
       end
 
-      return counterparty if counterparty.present?
+      return counterparty if counterparty.present? && !counterparty.match?(/\ACARD-\d+\z/i)
 
       # Fall back to bank_transaction_code description
       bank_tx_description = data.dig(:bank_transaction_code, :description)

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
+  def build_name(data)
+    processor = EnableBankingEntry::Processor.new(data, enable_banking_account: Object.new)
+    processor.send(:name)
+  end
+
+  test "skips technical card counterparty and falls back to bank tx description" do
+    name = build_name(
+      credit_debit_indicator: "CRDT",
+      debtor_name: "CARD-1234",
+      remittance_information: ["ACME SHOP"],
+      bank_transaction_code: { description: "Card Purchase" }
+    )
+
+    assert_equal "Card Purchase", name
+  end
+
+  test "uses counterparty when it is human readable" do
+    name = build_name(
+      credit_debit_indicator: "CRDT",
+      debtor_name: "ACME SHOP",
+      remittance_information: ["Receipt #42"],
+      bank_transaction_code: { description: "Transfer" }
+    )
+
+    assert_equal "ACME SHOP", name
+  end
+end

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -10,7 +10,7 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     name = build_name(
       credit_debit_indicator: "CRDT",
       debtor_name: "CARD-1234",
-      remittance_information: ["ACME SHOP"],
+      remittance_information: [ "ACME SHOP" ],
       bank_transaction_code: { description: "Card Purchase" }
     )
 
@@ -21,7 +21,7 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     name = build_name(
       credit_debit_indicator: "CRDT",
       debtor_name: "ACME SHOP",
-      remittance_information: ["Receipt #42"],
+      remittance_information: [ "Receipt #42" ],
       bank_transaction_code: { description: "Transfer" }
     )
 


### PR DESCRIPTION
Why:
With Wise (France), the counterparty is often a technical CARD-xxxx token; this hides the human-readable label and makes lists harder to scan.

What
Skip counterparty values matching /\ACARD-\d+\z/i when building the name.
Preserve existing priority order (counterparty → bank_transaction_code → remittance).
Add a test covering CARD-* fallback behavior.

Scope:
EnableBanking only.

Validation:
Added unit test: processor_test.rb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction naming now ignores technical card identifiers (e.g., CARD-1234) and falls back to the bank transaction description for clearer names.

* **Tests**
  * Added unit tests to verify selection between human-readable counterparties and fallback to transaction descriptions when counterparties are technical identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->