### PR TITLE
Remove relative positioning from net worth chart div

### DIFF
--- a/app/views/pages/dashboard/_net_worth_chart.html.erb
+++ b/app/views/pages/dashboard/_net_worth_chart.html.erb
@@ -26,7 +26,7 @@
   <% if series.any? %>
     <div
     id="netWorthChart"
-    class="w-full flex-1 relative min-h-52"
+    class="w-full flex-1 min-h-52"
     data-controller="time-series-chart"
     data-time-series-chart-data-value="<%= series.to_json %>"></div>
   <% else %>


### PR DESCRIPTION
The 'relative' class was removed from the net worth chart container, the tooltip with info was not on the pointer but way off. The chart should now rely on default positioning.
This bug was introduced in [653](https://github.com/we-promise/sure/pull/653)

before:
<img width="1680" height="905" alt="Scherm­afbeelding 2026-01-17 om 18 57 46" src="https://github.com/user-attachments/assets/49debe5b-c453-4b9c-93f1-519c584bbaf8" />

after:
<img width="1680" height="905" alt="Scherm­afbeelding 2026-01-17 om 19 16 24" src="https://github.com/user-attachments/assets/d935591d-6bb4-4cf8-8c5a-dbd67d970381" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted the positioning behavior of the net worth chart on the dashboard for improved layout display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->