### PR TITLE
fix: Net chart tooltip position in PWA

### DIFF
--- a/app/javascript/controllers/time_series_chart_controller.js
+++ b/app/javascript/controllers/time_series_chart_controller.js
@@ -289,7 +289,7 @@ export default class extends Controller {
       .append("div")
       .attr(
         "class",
-        "bg-container text-sm font-sans absolute p-2 border border-secondary rounded-lg pointer-events-none opacity-0",
+        "bg-container text-sm font-sans absolute p-2 border border-secondary rounded-lg pointer-events-none opacity-0 top-0",
       );
   }
 


### PR DESCRIPTION
Fix an overflow issue on the dashboard page in PWA mode. The tooltip for the net worth chart is too low on the screen causing excessive scrolling in PWA mode. By forcing the tooltip’s position with the class `top-0` it remains fixed at the top and then adjusts based on mouse hover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted tooltip positioning on the time series chart for improved visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->