### PR TITLE
MERGE doc/adding_https_info INTO main

### DIFF
--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -98,8 +98,8 @@ POSTGRES_PASSWORD="replacemewithyourdesireddatabasepassword"
 #### Using HTTPS
 
 Assuming you want to access your instance from the internet, you should have secured your URL address with an SSL certificate.  
-The docker instance runs in plain HTTP and you need to tell it that you are redirecting your HTTPS stream to the HTTP one.  
-To do this, edit the `compose.yml` file and find the line stating :  
+The Docker instance runs in plain HTTP and you need to tell it that you are redirecting your HTTPS stream to the HTTP one.  
+To do this, edit the `compose.yml` file and find the line stating:  
 
 ```yaml
 RAILS_ASSUME_SSL: "false"


### PR DESCRIPTION
Updates documentation to include HTTPS configuration and improve initial setup.
- Suggests using `.env.example` for easier configuration.
- Adds instructions for enabling HTTPS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Docker hosting guide: environment file workflow now fetches the template automatically instead of manual creation.
  * Added a "Using HTTPS" subsection with guidance to enable SSL/TLS and an example showing RAILS_ASSUME_SSL set to true.
  * Minor wording and formatting refinements to clarify optional security configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->