### PR TITLE
refactor: Move money market tickers config to initializer

### DIFF
--- a/config/initializers/simplefin.rb
+++ b/config/initializers/simplefin.rb
@@ -12,4 +12,22 @@ Rails.application.configure do
   pending_env = ENV["SIMPLEFIN_INCLUDE_PENDING"].to_s.strip.downcase
   config.x.simplefin.include_pending = pending_env.blank? ? true : !falsy.include?(pending_env)
   config.x.simplefin.debug_raw = truthy.include?(ENV["SIMPLEFIN_DEBUG_RAW"].to_s.strip.downcase)
+
+  # Common money market fund tickers that should be treated as cash equivalents
+  # These are settlement funds that users consider "cash available to invest"
+  # SimpleFIN doesn't provide is_cash_equivalent metadata like Plaid does,
+  # so we detect by ticker symbol and description patterns
+  config.x.simplefin.money_market_tickers = %w[
+    VMFXX VMMXX VMRXX VUSXX
+    SPAXX FDRXX SPRXX FZFXX FDLXX
+    SWVXX SNVXX SNOXX
+    TTTXX PRTXX
+  ].freeze
+
+  # Patterns that indicate money market funds (case-insensitive)
+  config.x.simplefin.money_market_patterns = [
+    /money\s*market/i,
+    /settlement\s*fund/i,
+    /cash\s*reserve/i
+  ].freeze
 end


### PR DESCRIPTION
Summary:

Moves the MONEY_MARKET_TICKERS and MONEY_MARKET_PATTERNS constants from SimplefinAccount::Investments::BalanceCalculator to config/initializers/simplefin.rb. This makes the list of settlement fund tickers configurable without modifying model code, and keeps SimpleFIN-specific configuration in one place. SimpleFIN requires this detection because it doesn't provide is_cash_equivalent metadata like Plaid does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * System configuration for money market fund identification is now more flexible. Previously fixed identification criteria based on ticker symbols and fund names can now be customized through system settings, enabling administrators to adjust fund recognition without requiring code changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->