### PR TITLE
quickfix: redis replication missing env vars 

### DIFF
--- a/charts/sure/templates/redis-operator-replication.yaml
+++ b/charts/sure/templates/redis-operator-replication.yaml
@@ -25,12 +25,11 @@ spec:
     redisSecret:
       name: {{ include "sure.redisSecretName" . }}
       key: {{ include "sure.redisPasswordKey" . }}
-    {{- if .Values.redisOperator.sentinel.enabled }}
-    env:
-      - name: REDIS_SENTINEL_HOSTS
-        value: {{ include "sure.redisSentinelHosts" . }}
-      - name: REDIS_SENTINEL_MASTER
-        value: {{ include "sure.redisSentinelMaster" . }}
+    {{- if .Values.redisOperator.sentinel.enabled}}
+    sentinel:
+      size: {{ .Values.redisOperator.replicas | default 3 }}
+      image: {{ printf "%s:%s" $imgRepo $imgTag | quote }}
+      imagePullPolicy: IfNotPresent
     {{- end }}
     {{- with $workloadResources }}
     resources:

--- a/charts/sure/templates/redis-operator-sentinel.yaml
+++ b/charts/sure/templates/redis-operator-sentinel.yaml
@@ -1,26 +1,26 @@
-{{- if and .Values.redisOperator.enabled .Values.redisOperator.managed.enabled (eq (.Values.redisOperator.mode | default "sentinel") "sentinel") }}
-{{- $name := .Values.redisOperator.name | default (printf "%s-redis" (include "sure.fullname" .)) -}}
-{{- $imgRepo := .Values.redisOperator.sentinel.image.repository | default "quay.io/opstree/redis-sentinel" -}}
-{{- $imgTag := .Values.redisOperator.sentinel.image.tag | default "v7.2.4" -}}
-apiVersion: redis.redis.opstreelabs.in/v1beta2
-kind: RedisSentinel
-metadata:
-  name: {{ $name | quote }}
-  labels:
-    app.kubernetes.io/component: redis
-    {{- include "sure.labels" . | nindent 4 }}
-spec:
-  clusterSize: {{ .Values.redisOperator.replicas | default 3 }}
-  redisSentinelConfig:
-    redisReplicationName: {{ $name | quote }}
-    masterGroupName: {{ (.Values.redisOperator.sentinel.masterGroupName | default "mymaster") | quote }}
-  kubernetesConfig:
-    image: {{ printf "%s:%s" $imgRepo $imgTag | quote }}
-    redisSecret:
-      name: {{ include "sure.redisSecretName" . }}
-      key: {{ include "sure.redisPasswordKey" . }}
-    {{- with .Values.redisOperator.workloadResources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-{{- end }}
+# {{- if and .Values.redisOperator.enabled .Values.redisOperator.managed.enabled (eq (.Values.redisOperator.mode | default "sentinel") "sentinel") }}
+# {{- $name := .Values.redisOperator.name | default (printf "%s-redis" (include "sure.fullname" .)) -}}
+# {{- $imgRepo := .Values.redisOperator.sentinel.image.repository | default "quay.io/opstree/redis-sentinel" -}}
+# {{- $imgTag := .Values.redisOperator.sentinel.image.tag | default "v7.2.4" -}}
+# apiVersion: redis.redis.opstreelabs.in/v1beta2
+# kind: RedisSentinel
+# metadata:
+#   name: {{ $name | quote }}
+#   labels:
+#     app.kubernetes.io/component: redis
+#     {{- include "sure.labels" . | nindent 4 }}
+# spec:
+#   clusterSize: {{ .Values.redisOperator.replicas | default 3 }}
+#   redisSentinelConfig:
+#     redisReplicationName: {{ $name | quote }}
+#     masterGroupName: {{ (.Values.redisOperator.sentinel.masterGroupName | default "mymaster") | quote }}
+#   kubernetesConfig:
+#     image: {{ printf "%s:%s" $imgRepo $imgTag | quote }}
+#     redisSecret:
+#       name: {{ include "sure.redisSecretName" . }}
+#       key: {{ include "sure.redisPasswordKey" . }}
+#     {{- with .Values.redisOperator.workloadResources }}
+#     resources:
+#       {{- toYaml . | nindent 6 }}
+#     {{- end }}
+# {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Redis Sentinel support for replication deployments, controllable via a configuration flag.
* **Changes**
  * Sentinel resource generation is currently disabled by default; enabling the Sentinel flag alone will not automatically deploy Sentinel instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->