### PR TITLE
fix: Adjust chat page UI on mobile (PWA)

### DIFF
--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="chat hotkey">
+<div data-controller="chat hotkey" class="h-full">
   <%= turbo_frame_tag chat_frame do %>
     <div class="flex flex-col h-full md:p-4">
       <% if show_demo_warning? %>

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -15,7 +15,7 @@
         <% end %>
       </div>
 
-      <div id="messages" class="grow overflow-y-auto p-4 space-y-6 pb-24 lg:pb-4" data-chat-target="messages">
+      <div id="messages" class="grow overflow-y-auto p-4 space-y-6 lg:pb-4" data-chat-target="messages">
         <% if @chat.conversation_messages.any? %>
           <% @chat.conversation_messages.ordered.each do |message| %>
             <%= render message %>
@@ -36,7 +36,7 @@
       </div>
 
       <%# DESKTOP - Chat form %>
-      <div class="p-4 pt-0 lg:mt-auto fixed lg:static left-0 bottom-16 w-full bg-surface">
+      <div class="px-4 pt-4 lg:pt-0 lg:mt-auto sticky lg:static left-0 bottom-0 w-full bg-surface">
         <%= render "messages/chat_form", chat: @chat %>
       </div>
     </div>


### PR DESCRIPTION
This PR addresses mobile layout issues on the chat page, with a particular focus on the text input positioning.
Previously, the input field was fixed to the bottom of the screen and could overlap or slide behind the navigation bar, especially when the on-screen keyboard was open.

| Before | After |
| ------------- | ------------- |
| <img width="590" height="1278" alt="IMG_4308" src="https://github.com/user-attachments/assets/ce0af647-d05e-431d-a5b7-ad13341fdc2e" />  | <img width="590" height="1278" alt="IMG_4307" src="https://github.com/user-attachments/assets/443f6511-e421-4212-8624-ddc30361a365" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized message container spacing for enhanced visual consistency and improved overall readability throughout the chat interface.
  * Improved chat input area positioning with sticky layout and refined padding, ensuring the input field remains accessible and prominently visible while users scroll through message history, delivering a more seamless and uninterrupted conversation experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->