### PR TITLE
fix: Use right arrow position when collapsing sections

### DIFF
--- a/app/javascript/controllers/dashboard_section_controller.js
+++ b/app/javascript/controllers/dashboard_section_controller.js
@@ -33,7 +33,7 @@ export default class extends Controller {
 
   collapse(persist = true) {
     this.contentTarget.classList.add("hidden");
-    this.chevronTarget.classList.add("rotate-180");
+    this.chevronTarget.classList.add("-rotate-90");
     this.collapsedValue = true;
     if (this.hasButtonTarget) {
       this.buttonTarget.setAttribute("aria-expanded", "false");
@@ -45,7 +45,7 @@ export default class extends Controller {
 
   expand() {
     this.contentTarget.classList.remove("hidden");
-    this.chevronTarget.classList.remove("rotate-180");
+    this.chevronTarget.classList.remove("-rotate-90");
     this.collapsedValue = false;
     if (this.hasButtonTarget) {
       this.buttonTarget.setAttribute("aria-expanded", "true");

--- a/app/javascript/controllers/reports_section_controller.js
+++ b/app/javascript/controllers/reports_section_controller.js
@@ -33,7 +33,7 @@ export default class extends Controller {
 
   collapse(persist = true) {
     this.contentTarget.classList.add("hidden");
-    this.chevronTarget.classList.add("rotate-180");
+    this.chevronTarget.classList.add("-rotate-90");
     this.collapsedValue = true;
     if (this.hasButtonTarget) {
       this.buttonTarget.setAttribute("aria-expanded", "false");
@@ -45,7 +45,7 @@ export default class extends Controller {
 
   expand() {
     this.contentTarget.classList.remove("hidden");
-    this.chevronTarget.classList.remove("rotate-180");
+    this.chevronTarget.classList.remove("-rotate-90");
     this.collapsedValue = false;
     if (this.hasButtonTarget) {
       this.buttonTarget.setAttribute("aria-expanded", "true");

--- a/app/javascript/controllers/transactions_section_controller.js
+++ b/app/javascript/controllers/transactions_section_controller.js
@@ -33,7 +33,7 @@ export default class extends Controller {
 
   collapse(persist = true) {
     this.contentTarget.classList.add("hidden");
-    this.chevronTarget.classList.add("rotate-180");
+    this.chevronTarget.classList.add("-rotate-90");
     this.collapsedValue = true;
     if (this.hasButtonTarget) {
       this.buttonTarget.setAttribute("aria-expanded", "false");
@@ -45,7 +45,7 @@ export default class extends Controller {
 
   expand() {
     this.contentTarget.classList.remove("hidden");
-    this.chevronTarget.classList.remove("rotate-180");
+    this.chevronTarget.classList.remove("-rotate-90");
     this.collapsedValue = false;
     if (this.hasButtonTarget) {
       this.buttonTarget.setAttribute("aria-expanded", "true");


### PR DESCRIPTION
A minor adjustment to use the correct classes for displaying the arrow in the appropriate position when sections are collapsed.  Typically, collapsed sections in other areas like the sidebar with accounts are shown with an arrow pointing to the right rather than the top as is currently the case for dashboard and reports sections:

**Before**:

<img width="3166" height="2358" alt="localhost_3000_ (1)" src="https://github.com/user-attachments/assets/4c597fd7-f5b2-46a2-9bfc-7940c568a780" />

**After**:

<img width="3166" height="2358" alt="localhost_3000_" src="https://github.com/user-attachments/assets/458bbfbf-c92e-4f13-bea9-446a95997037" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated chevron icon rotation behavior across collapsible sections for improved visual consistency and clarity during collapse/expand interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->