### PR TITLE
fix: Enable scrolling on login page for small mobile devices

### DIFF
--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -1,5 +1,5 @@
 <%= render "layouts/shared/htmldoc" do %>
-  <div class="flex flex-col min-h-full overflow-y-auto">
+  <div class="flex flex-col h-full overflow-y-auto">
     <div class="flex flex-col min-h-full px-6 py-12 bg-surface">
       <div class="grow flex flex-col justify-center">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">


### PR DESCRIPTION
Changed auth layout containers from `h-full` to `min-h-full` and added `overflow-y-auto` to allow content to scroll when it exceeds viewport height on small mobile phones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved authentication layout to allow vertical scrolling when content exceeds the viewport. The inner content now uses a minimum-height instead of a fixed full-height to preserve padding and background appearance while ensuring content remains accessible across screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->