### PR TITLE
feat: Display shared budget as a badge

### DIFF
--- a/app/views/budget_categories/_budget_category.html.erb
+++ b/app/views/budget_categories/_budget_category.html.erb
@@ -67,7 +67,7 @@
             <%= format_money(budget_category.budgeted_spending_money) %>
           </span>
           <% if budget_category.inherits_parent_budget? %>
-            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-500/10 text-secondary"><%= t("reports.budget_performance.shared") %></span>
+            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-500/5 text-secondary"><%= t("reports.budget_performance.shared") %></span>
           <% end %>
         </div>
         <div class="whitespace-nowrap w-full sm:w-auto lg:ml-auto">


### PR DESCRIPTION
Enhance the “shared” budget indicator by adding a distinct styling and displaying it as a badge to increase its visibility.

| Before | After |
| ------------- | ------------- |
| <img width="956" height="694" alt="Screenshot 2026-01-24 alle 00 26 30" src="https://github.com/user-attachments/assets/ecc6077c-1885-4ed9-9b9d-32d3878df516" /> | <img width="956" height="701" alt="Screenshot 2026-01-24 alle 00 26 13" src="https://github.com/user-attachments/assets/018c812b-053f-4b31-b4a1-be1823e1773e" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced the text indicator for shared budgets with a styled badge for improved visual clarity.
  * Updated the layout container for better alignment and spacing of the budget amount display.
  * Improved spacing and alignment across budget displays; presentation-only change with no behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->