### PR TITLE
fix: Register sync_all_accounts cron job on Sidekiq startup

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -58,6 +58,14 @@ end
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+
+  # Initialize auto-sync scheduler when Sidekiq server starts
+  config.on(:startup) do
+    AutoSyncScheduler.sync!
+    Rails.logger.info("[AutoSyncScheduler] Initialized sync_all_accounts cron job")
+  rescue => e
+    Rails.logger.error("[AutoSyncScheduler] Failed to initialize: #{e.message}")
+  end
 end
 
 Sidekiq.configure_client do |config|
@@ -67,14 +75,4 @@ end
 Sidekiq::Cron.configure do |config|
   # 10 min "catch-up" window in case worker process is re-deploying when cron tick occurs
   config.reschedule_grace_period = 600
-end
-
-# Initialize auto-sync scheduler when Sidekiq server starts
-Sidekiq.configure_server do |config|
-  config.on(:startup) do
-    AutoSyncScheduler.sync!
-    Rails.logger.info("[AutoSyncScheduler] Initialized sync_all_accounts cron job")
-  rescue => e
-    Rails.logger.error("[AutoSyncScheduler] Failed to initialize: #{e.message}")
-  end
 end


### PR DESCRIPTION
AutoSyncScheduler.sync! was only called when changing settings in the UI, so the nightly sync job was never registered. Now it's initialized when Sidekiq starts, ensuring accounts sync nightly as configured.

On a fresh installation, pre-fix:
```
p@dev-server:~$ docker exec dev-docker-worker-1 bin/rails runner "puts Sidekiq::Cron::Job.all.map(&:name).inspect" 2>/dev/null
["import_market_data", "clean_syncs", "run_security_health_checks", "sync_hourly", "clean_data"]
```

On a fresh installation, post-fix:

```
p@dev-server:~$ docker exec dev-docker-worker-1 bin/rails runner "puts Sidekiq::Cron::Job.all.map(&:name).inspect" 2>/dev/null
["import_market_data", "clean_syncs", "run_security_health_checks", "sync_hourly", "clean_data", "sync_all_accounts"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Server startup now triggers automatic data synchronization on initialization, with success and error logging and improved error handling for more reliable startup behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->