### PR TITLE
Move misindented transaction show keys to correct YAML nesting      

### DIFF
--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -40,6 +40,16 @@ en:
       convert_to_trade_title: Convert to Security Trade
       convert_to_trade_description: Convert this transaction into a Buy or Sell trade with security details for portfolio tracking.
       convert_to_trade_button: Convert to Trade
+      merchant_label: Merchant
+      name_label: Name
+      nature: Type
+      none: "(none)"
+      note_label: Notes
+      note_placeholder: Enter a note
+      overview: Overview
+      settings: Settings
+      tags_label: Tags
+      uncategorized: "(uncategorized)"
     activity_labels:
       buy: Buy
       sell: Sell
@@ -57,16 +67,6 @@ en:
     mark_recurring: Mark as Recurring
     mark_recurring_subtitle: Track this as a recurring transaction. Amount variance is automatically calculated from past 6 months of similar transactions.
     mark_recurring_title: Recurring Transaction
-    merchant_label: Merchant
-    name_label: Name
-    nature: Type
-    none: "(none)"
-    note_label: Notes
-    note_placeholder: Enter a note
-    overview: Overview
-    settings: Settings
-    tags_label: Tags
-    uncategorized: "(uncategorized)"
     potential_duplicate_title: Possible duplicate detected
     potential_duplicate_description: This pending transaction may be the same as the posted transaction below. If so, merge them to avoid double-counting.
     merge_duplicate: Yes, merge them

--- a/config/locales/views/transactions/nl.yml
+++ b/config/locales/views/transactions/nl.yml
@@ -40,6 +40,16 @@ nl:
       convert_to_trade_title: Converteer naar Effectentransactie
       convert_to_trade_description: Converteer deze transactie naar een Koop- of Verkooptransactie met effectendetails voor portfoliobeheer.
       convert_to_trade_button: Converteer naar Trade
+      merchant_label: Handelaar
+      name_label: Naam
+      nature: Type
+      none: "(geen)"
+      note_label: Notities
+      note_placeholder: Voer een notitie in
+      overview: Overzicht
+      settings: Instellingen
+      tags_label: Tags
+      uncategorized: "(ongecategoriseerd)"
     activity_labels:
       buy: Kopen
       sell: Verkopen
@@ -57,16 +67,6 @@ nl:
     mark_recurring: Markeer als Terugkerend
     mark_recurring_subtitle: Volg dit als een terugkerende transactie. Bedragvariatie wordt automatisch berekend uit de afgelopen 6 maanden van vergelijkbare transacties.
     mark_recurring_title: Terugkerende Transactie
-    merchant_label: Handelaar
-    name_label: Naam
-    nature: Type
-    none: "(geen)"
-    note_label: Notities
-    note_placeholder: Voer een notitie in
-    overview: Overzicht
-    settings: Instellingen
-    tags_label: Tags
-    uncategorized: "(ongecategoriseerd)"
     potential_duplicate_title: Mogelijk duplicaat gedetecteerd
     potential_duplicate_description: Deze wachtende transactie kan hetzelfde zijn als de geposte transactie hieronder. Indien ja, voeg ze samen om dubbeltelling te voorkomen.
     merge_duplicate: Ja, voeg ze samen


### PR DESCRIPTION
## Summary                                                                                                                                                                       
Fix locale file indentation bug where several keys were incorrectly placed                                                                                                       
at the `transactions:` level instead of under `transactions.show:`.                                                                                                              
                                                                                                                                                                                 
## Problem                                                                                                                                                                       
Keys like `note_placeholder`, `merchant_label`, `overview`, `settings`, etc.                                                                                                     
were at 4-space indent (direct children of `transactions:`), but the view                                                                                                        
`transactions/show.html.erb` uses relative translation lookups like                                                                                                              
`t(".note_placeholder")` which resolve to `transactions.show.note_placeholder`.                                                                                                  
                                                                                                                                                                                 
This caused `translation_missing` HTML spans when viewing transaction details.          

Before:
<img width="1313" height="402" alt="image" src="https://github.com/user-attachments/assets/e4d1a835-0a1b-4671-a899-91404f74ab8c" />

After:
<img width="1362" height="389" alt="image" src="https://github.com/user-attachments/assets/62d67835-09ab-4bec-910a-bef56481b54e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized localization resources for improved structure and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->