### PR TITLE
fix: use port configured in .env

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ..:/workspace:cached
       - bundle_cache:/bundle
     ports:
-      - "3000:3000"
+      - ${PORT:-3000}:3000
     command: sleep infinity
     environment:
       <<: *rails_env

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,10 @@
 # To enable / disable self-hosting features.
 SELF_HOSTED = true
 
+# Custom port config
+# For users who have other applications listening at 3000, this allows them to set a value puma will listen to.
+PORT=3000
+
 # SimpleFIN runtime flags (default-off)
 # Accepted truthy values: 1, true, yes, on
 # SIMPLEFIN_DEBUG_RAW: when truthy, logs the raw payload returned by SimpleFIN (debug-only; can be noisy)

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,5 +1,9 @@
 SELF_HOSTED=false
 
+# Custom port config
+# For users who have other applications listening at 3000, this allows them to set a value puma will listen to.
+PORT=3000
+
 # SimpleFIN runtime flags (default-off)
 # Accepted truthy values: 1, true, yes, on
 # SIMPLEFIN_DEBUG_RAW: when truthy, logs the raw payload returned by SimpleFIN (debug-only; can be noisy)

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -106,7 +106,7 @@ services:
     volumes:
       - app-storage:/rails/storage
     ports:
-      - "3000:3000"
+      - ${PORT:-3000}:3000
     restart: unless-stopped
     environment:
       <<: *rails_env

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -50,7 +50,7 @@ services:
     volumes:
       - app-storage:/rails/storage
     ports:
-      - 3000:3000
+      - ${PORT:-3000}:3000
     restart: unless-stopped
     environment:
       <<: *rails_env


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Web service host port is now resolved from an environment variable with a default of 3000, allowing flexible host-port assignment without altering configuration files.
  * Example environment files updated to document the PORT setting and include a test/example PORT entry so you can override the default when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->