### PR TITLE
fix: Add border to Merchant's logo

### DIFF
--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -22,7 +22,7 @@
             <div class="hidden lg:flex">
               <% if transaction.merchant&.logo_url.present? %>
                 <%= image_tag Setting.transform_brand_fetch_url(transaction.merchant.logo_url),
-                    class: "w-9 h-9 rounded-full",
+                    class: "w-9 h-9 rounded-full border border-secondary",
                     loading: "lazy" %>
               <% else %>
                 <div class="hidden lg:flex">


### PR DESCRIPTION
A small change to add a border to the merchant logo, to better display logos with a white background, especially when the light theme is used.

| Before  | After |
| ------------- | ------------- |
| <img width="928" height="128" alt="Screenshot 2026-01-25 alle 16 57 50" src="https://github.com/user-attachments/assets/5e5a3f0c-19c2-4e0d-94b8-acd58aca8da1" /> | <img width="926" height="124" alt="Screenshot 2026-01-25 alle 16 58 11" src="https://github.com/user-attachments/assets/38450076-ef47-4848-abfe-9e34f9ebef87" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a border to merchant logos in transaction details on large screens for improved visual distinction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->