### PR TITLE
Increase minimum for home build year

### DIFF
--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -13,7 +13,7 @@
         <%= property_form.number_field :year_built,
                                        label: t("properties.form.year_built"),
                                        placeholder: t("properties.form.year_built_placeholder"),
-                                       min: 1800,
+                                       min: 1500,
                                        max: Time.current.year %>
       </div>
 

--- a/app/views/properties/_overview_fields.html.erb
+++ b/app/views/properties/_overview_fields.html.erb
@@ -17,7 +17,7 @@
       <%= property_form.number_field :year_built,
                     label: "Year Built (optional)",
                     placeholder: "1990",
-                    min: 1800,
+                    min: 1500,
                     max: Time.current.year %>
     </div>
 


### PR DESCRIPTION
I tried to register a home built prior to 1800, but I was surprised that there was a minimum for this field. 
This is quite common in France to have houses built prior to 1800. 

This PR fixes that. 
I have put a minimum of 1500, that should cover most cases as the oldest house dates back to 1400 https://en.wikipedia.org/wiki/Maison_de_Jeanne but I would be happy to change this value. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the minimum year allowed for property year-built field from 1800 to 1500, enabling users to register and manage properties built in earlier centuries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->