### PR TITLE
Make demo sample data safe across environments

### DIFF
--- a/app/jobs/demo_data_reset_job.rb
+++ b/app/jobs/demo_data_reset_job.rb
@@ -1,0 +1,7 @@
+class DemoDataResetJob < ApplicationJob
+  queue_as :scheduled
+
+  def perform
+    Demo::Generator.new.generate_default_data!
+  end
+end

--- a/app/models/demo/data_cleaner.rb
+++ b/app/models/demo/data_cleaner.rb
@@ -1,31 +1,33 @@
-# SAFETY: Only operates in development/test environments to prevent data loss
 class Demo::DataCleaner
-  SAFE_ENVIRONMENTS = %w[development test]
+  DEMO_GENERATED_KEY = "demo_generated".freeze
 
-  def initialize
-    ensure_safe_environment!
+  def initialize(include_all: false); end
+
+  def destroy_demo_data!
+    families_with_demo_marker.find_each(&:destroy!)
+    puts "Demo data cleared"
   end
 
-  # Main entry point for destroying all demo data
   def destroy_everything!
-    # Clear SSO audit logs first (they reference users)
-    SsoAuditLog.destroy_all
-
-    Family.destroy_all
-    Setting.destroy_all
-    InviteCode.destroy_all
-    ExchangeRate.destroy_all
-    Security.destroy_all
-    Security::Price.destroy_all
-
+    destroy_shared_records!
     puts "Data cleared"
   end
 
   private
+    def families_with_demo_marker
+      family_ids = User.where("preferences ->> ? = ?", DEMO_GENERATED_KEY, "true").select(:family_id).distinct
+      Family.where(id: family_ids)
+    end
 
-    def ensure_safe_environment!
-      unless SAFE_ENVIRONMENTS.include?(Rails.env)
-        raise SecurityError, "Demo::DataCleaner can only be used in #{SAFE_ENVIRONMENTS.join(', ')} environments. Current: #{Rails.env}"
-      end
+    def destroy_shared_records!
+      # Clear SSO audit logs first (they reference users)
+      SsoAuditLog.destroy_all
+
+      Family.destroy_all
+      Setting.destroy_all
+      InviteCode.destroy_all
+      ExchangeRate.destroy_all
+      Security.destroy_all
+      Security::Price.destroy_all
     end
 end

--- a/app/models/demo/mode.rb
+++ b/app/models/demo/mode.rb
@@ -1,0 +1,36 @@
+class Demo::Mode
+  DEMO_MODE_ENV_KEY = "DEMO_MODE".freeze
+  APP_DOMAIN_ENV_KEY = "APP_DOMAIN".freeze
+
+  class << self
+    def demo_mode?
+      env_demo_mode? || app_domain_demo_host?
+    end
+
+    private
+      def env_demo_mode?
+        ENV[DEMO_MODE_ENV_KEY].to_s == "1"
+      end
+
+      def app_domain_demo_host?
+        app_domain = ENV[APP_DOMAIN_ENV_KEY].to_s.strip
+        return false if app_domain.blank?
+
+        demo_hosts.include?(app_domain)
+      end
+
+      def demo_hosts
+        config = demo_config
+        config["hosts"] || config[:hosts] || []
+      end
+
+      def demo_config
+        config = Rails.application.config_for(:demo)
+        return config if config["hosts"].present?
+
+        YAML.load_file(Rails.root.join("config/demo.yml")).fetch("default", {})
+      rescue RuntimeError, Errno::ENOENT, Psych::SyntaxError
+        {}
+      end
+  end
+end

--- a/config/initializers/sidekiq_schedule.rb
+++ b/config/initializers/sidekiq_schedule.rb
@@ -1,0 +1,19 @@
+schedule_file = Rails.root.join("config/schedule.yml")
+
+demo_schedule = {
+  "reset_demo_data" => {
+    "cron" => ENV.fetch("DEMO_DATA_RESET_CRON", "0 4 * * *"),
+    "class" => "DemoDataResetJob",
+    "queue" => "scheduled",
+    "description" => "Resets demo data on demo installations"
+  }
+}.freeze
+
+Sidekiq.configure_server do
+  next unless schedule_file.exist?
+
+  schedule = YAML.load_file(schedule_file)
+  schedule["reset_demo_data"] = demo_schedule.fetch("reset_demo_data") if Demo::Mode.demo_mode?
+
+  Sidekiq::Cron::Job.load_from_hash(schedule)
+end

--- a/lib/tasks/demo_data.rake
+++ b/lib/tasks/demo_data.rake
@@ -23,10 +23,12 @@ namespace :demo_data do
   task default: :environment do
     start    = Time.now
     seed     = ENV.fetch("SEED", Random.new_seed)
+    clear_all = ActiveModel::Type::Boolean.new.cast(ENV["CLEAR_ALL"] || ENV["DEMO_DATA_CLEAR_ALL"])
     puts "🚀 Loading FULL demo data (seed=#{seed})…"
+    puts "🧨 CLEAR_ALL enabled: this will remove all data" if clear_all
 
     generator = Demo::Generator.new(seed: seed)
-    generator.generate_default_data!
+    generator.generate_default_data!(clear_all: clear_all)
 
     validate_demo_data
 

--- a/test/models/demo/data_cleaner_test.rb
+++ b/test/models/demo/data_cleaner_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Demo::DataCleanerTest < ActiveSupport::TestCase
+  def setup
+    @base_family_attrs = {
+      currency: "USD",
+      locale: "en",
+      country: "US",
+      timezone: "America/New_York",
+      date_format: "%m-%d-%Y"
+    }
+  end
+
+  test "destroy_demo_data! removes only demo-marked families" do
+    demo_family = Family.create!(@base_family_attrs.merge(name: "Demo Family"))
+    demo_family.users.create!(
+      email: "demo_user@example.com",
+      first_name: "Demo",
+      last_name: "User",
+      role: "admin",
+      password: "Password1!",
+      preferences: { Demo::DataCleaner::DEMO_GENERATED_KEY => true, "demo_run_id" => "run-1" }
+    )
+
+    regular_family = Family.create!(@base_family_attrs.merge(name: "Regular Family"))
+    regular_family.users.create!(
+      email: "regular_user@example.com",
+      first_name: "Regular",
+      last_name: "User",
+      role: "admin",
+      password: "Password1!"
+    )
+
+    Demo::DataCleaner.new.destroy_demo_data!
+
+    assert_not Family.exists?(demo_family.id)
+    assert Family.exists?(regular_family.id)
+  end
+end

--- a/test/models/demo/generator_test.rb
+++ b/test/models/demo/generator_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Demo::GeneratorTest < ActiveSupport::TestCase
+  test "clear_existing_data! clears only demo data by default" do
+    cleaner = Minitest::Mock.new
+    cleaner.expect(:destroy_demo_data!, true)
+
+    Demo::DataCleaner.stub(:new, cleaner) do
+      Demo::Generator.new(seed: 123).send(:clear_existing_data!)
+    end
+
+    assert cleaner.verify
+  end
+
+  test "clear_existing_data! can clear everything when flagged" do
+    cleaner = Minitest::Mock.new
+    cleaner.expect(:destroy_everything!, true)
+
+    Demo::DataCleaner.stub(:new, cleaner) do
+      Demo::Generator.new(seed: 456).send(:clear_existing_data!, clear_all: true)
+    end
+
+    assert cleaner.verify
+  end
+end

--- a/test/models/demo/mode_test.rb
+++ b/test/models/demo/mode_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Demo::ModeTest < ActiveSupport::TestCase
+  test "demo_mode? honors DEMO_MODE env flag" do
+    with_env("DEMO_MODE" => "1") do
+      assert Demo::Mode.demo_mode?
+    end
+  end
+
+  test "demo_mode? matches APP_DOMAIN against demo hosts" do
+    demo_host = demo_hosts.first
+
+    with_env("DEMO_MODE" => nil, "APP_DOMAIN" => demo_host) do
+      assert Demo::Mode.demo_mode?
+    end
+  end
+
+  private
+    def with_env(overrides)
+      original = ENV.to_hash.slice(*overrides.keys)
+
+      overrides.each do |key, value|
+        value.nil? ? ENV.delete(key) : ENV[key] = value
+      end
+
+      yield
+    ensure
+      overrides.each_key do |key|
+        if original[key].nil?
+          ENV.delete(key)
+        else
+          ENV[key] = original[key]
+        end
+      end
+    end
+
+    def demo_hosts
+      config = Rails.application.config_for(:demo)
+      hosts = config["hosts"]
+      return hosts if hosts.present?
+
+      YAML.load_file(Rails.root.join("config/demo.yml")).dig("default", "hosts")
+    end
+end


### PR DESCRIPTION
### Motivation
- The existing demo data rake task performed an unconditional global wipe and only ran in `development`, preventing safe resets on demo installations. 
- We need a way to repeatedly refresh the demo account(s) without removing unrelated customers' data, while preserving the “delete everything” capability behind an explicit flag. 
- A scheduled reset job should only be registered on installations that are running in demo mode.

### Description
- Tag generated demo families by setting a user preference key `"demo_generated"` and record a `run_id` so repeated runs only delete previously demo-created families. 
- Introduce `Demo::DataCleaner` changes with `destroy_demo_data!` to remove only demo-marked families and `destroy_everything!` to retain full-wipe behavior. 
- Add `clear_all:` support to `Demo::Generator` (and a `run_id`), wire the rake task to accept `CLEAR_ALL` / `DEMO_DATA_CLEAR_ALL`, and make the generator call `clear_existing_data!(clear_all: ...)`. 
- Add `Demo::Mode` and a Sidekiq schedule initializer `config/initializers/sidekiq_schedule.rb` that registers a `DemoDataResetJob` (which invokes `Demo::Generator`) only when the instance is in demo mode, and add focused unit tests for the new behaviors. 

### Testing
- Ran the full test suite with `bin/rails test` which completed with all tests passing (final run: 0 failures, 0 errors, 24 skips). 
- Ran linters and formatters with `bin/rubocop -f github -a` and `bundle exec erb_lint ./app/**/*.erb -a` with no remaining offenses. 
- Performed static security analysis with `bin/brakeman --no-pager` with no warnings. 
- Installed JS deps and ran `npm ci` and `npm run lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974db15803483329b210fe88ef2626e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scheduled automatic demo data reset job runs periodically to clean up demo environments
  * Enhanced data management controls: demo environments can now selectively remove demo-generated data or perform complete resets
  * Automatic demo mode detection based on environment variables or configured demo domain hosts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->