### PR TITLE
feat: Change protected indicator styling

### DIFF
--- a/app/views/entries/_protection_indicator.html.erb
+++ b/app/views/entries/_protection_indicator.html.erb
@@ -22,7 +22,7 @@
             <p class="text-sm font-medium"><%= t("entries.protection.locked_fields_label") %></p>
             <% entry.locked_fields_with_timestamps.each do |field, timestamp| %>
               <div class="flex items-center justify-between text-xs gap-2 mb-1">
-                <span><%= field.humanize %></span>
+                <span><%= entry.class.human_attribute_name(field) %></span>
                 <hr class="grow border-dashed border-secondary">
                 <span><%= timestamp.respond_to?(:strftime) ? l(timestamp.to_date, format: :long) : timestamp %></span>
               </div>


### PR DESCRIPTION
Following the discussion on https://github.com/we-promise/sure/issues/775, this PR aims to modify the UI of the newly introduced “Protected from sync” section to better align with the rest of the elements in the transaction details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the protection indicator into a compact, themed rounded container with updated colors.
  * Summary row now shows a colored lock icon, uppercase title, and a right-aligned chevron for clarity.
  * Locked fields presented in a rounded inset block with a two-column layout, smaller text, dashed separators, and timestamps; description and unlock action restyled to match the new block layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->