### PR TITLE
fix: Exclude subcategories from transactions filter

### DIFF
--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -128,33 +128,18 @@ class Transaction::Search
       include_uncategorized = (categories & all_uncategorized_names).any?
       real_categories = categories - all_uncategorized_names
 
-      # Get parent category IDs for the given category names
-      parent_category_ids = family.categories.where(name: real_categories).pluck(:id)
-
       uncategorized_condition = "categories.id IS NULL AND transactions.kind NOT IN (?)"
 
-      # Build condition based on whether parent_category_ids is empty
-      if parent_category_ids.empty?
-        if include_uncategorized
-          query = query.left_joins(:category).where(
-            "categories.name IN (?) OR (#{uncategorized_condition})",
-            real_categories.presence || [], Transaction::TRANSFER_KINDS
-          )
-        else
-          query = query.left_joins(:category).where(categories: { name: real_categories })
-        end
+      if include_uncategorized
+        query = query.left_joins(:category).where(
+          "categories.name IN (?) OR (#{uncategorized_condition})",
+          real_categories, Transaction::TRANSFER_KINDS
+        )
       else
-        if include_uncategorized
-          query = query.left_joins(:category).where(
-            "categories.name IN (?) OR categories.parent_id IN (?) OR (#{uncategorized_condition})",
-            real_categories, parent_category_ids, Transaction::TRANSFER_KINDS
-          )
-        else
-          query = query.left_joins(:category).where(
-            "categories.name IN (?) OR categories.parent_id IN (?)",
-            real_categories, parent_category_ids
-          )
-        end
+        query = query.left_joins(:category).where(
+          "categories.name IN (?)",
+          real_categories
+        )
       end
 
       query

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -389,8 +389,7 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     assert_equal Money.new(0, "USD"), totals.income_money
   end
 
-  test "category filter includes subcategories" do
-    # Create a transaction with the parent category
+  test "category filter does not include subcategories" do
     parent_entry = create_transaction(
       account: @checking_account,
       amount: 100,
@@ -398,7 +397,6 @@ class Transaction::SearchTest < ActiveSupport::TestCase
       kind: "standard"
     )
 
-    # Create a transaction with the subcategory (fixture :subcategory has name "Restaurants", parent "Food & Drink")
     subcategory_entry = create_transaction(
       account: @checking_account,
       amount: 75,
@@ -406,30 +404,13 @@ class Transaction::SearchTest < ActiveSupport::TestCase
       kind: "standard"
     )
 
-    # Create a transaction with a different category
-    other_entry = create_transaction(
-      account: @checking_account,
-      amount: 50,
-      category: categories(:income),
-      kind: "standard"
-    )
-
-    # Filter by parent category only - should include both parent and subcategory transactions
     search = Transaction::Search.new(@family, filters: { categories: [ "Food & Drink" ] })
-    results = search.transactions_scope
-    result_ids = results.pluck(:id)
+    result_ids = search.transactions_scope.pluck(:id)
 
-    # Should include both parent and subcategory transactions
     assert_includes result_ids, parent_entry.entryable.id
-    assert_includes result_ids, subcategory_entry.entryable.id
-    # Should not include transactions with different category
-    assert_not_includes result_ids, other_entry.entryable.id
-
-    # Verify totals also include subcategory transactions
-    totals = search.totals
-    assert_equal 2, totals.count
-    assert_equal Money.new(175, "USD"), totals.expense_money # 100 + 75
+    assert_not_includes result_ids, subcategory_entry.entryable.id
   end
+
 
   test "totals respects type filters" do
     # Create expense and income transactions


### PR DESCRIPTION
Currently, when applying a category filter to transactions, selecting a parent category also includes transactions associated with its subcategories. This behavior can be confusing: while it is possible to explicitly filter by a specific subcategory, there is currently no way to view only the transactions that are directly associated with the parent category itself.

This PR updates the filtering logic so that only transactions matching the selected category are returned. Transactions belonging to subcategories are excluded unless those subcategories are explicitly selected in the filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Category filter now returns only transactions from the selected category (subcategories excluded) and correctly handles inclusion of uncategorized transactions.
* **Tests**
  * Updated tests to reflect the stricter category behavior; unrelated whitespace/formatting normalized in one test file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->