### PR TITLE
Fix Errno::ENOENT when git is not installed

### DIFF
--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -10,6 +10,8 @@ module Sure
       else
         `git rev-parse HEAD`.chomp
       end
+    rescue Errno::ENOENT
+      nil
     end
 
     private


### PR DESCRIPTION
## Summary

- **`commit_sha` now rescues `Errno::ENOENT`** so environments without `git` installed (e.g. Docker containers, minimal dev setups) don't crash on boot. Previously, the backtick call to `git rev-parse HEAD` in `config/initializers/version.rb` would raise an unhandled exception if the `git` binary was missing.
- Returns `nil` when `git` is not available, which all existing callers already handle via `.present?` guards.

## Changes

### `config/initializers/version.rb`
- Added `rescue Errno::ENOENT` to the `commit_sha` method, returning `nil` when `git` is not installed

Closes #827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to gracefully manage scenarios where git is unavailable or the repository state is invalid, preventing potential failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->