### PR TITLE
fix: Preserve tags on bulk edits

### DIFF
--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -14,6 +14,6 @@ class Transactions::BulkUpdatesController < ApplicationController
   private
     def bulk_update_params
       params.require(:bulk_update)
-            .permit(:date, :notes, :category_id, :merchant_id, entry_ids: [], tag_ids: [])
+            .permit(:date, :notes, :category_id, :merchant_id, :tags_touched, entry_ids: [], tag_ids: [])
     end
 end

--- a/app/javascript/controllers/bulk_update_tags_controller.js
+++ b/app/javascript/controllers/bulk_update_tags_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="bulk-update-tags"
+export default class extends Controller {
+  static targets = ["touched"];
+
+  touch() {
+    this.touchedTarget.value = "1";
+  }
+}
+

--- a/app/views/transactions/bulk_updates/new.html.erb
+++ b/app/views/transactions/bulk_updates/new.html.erb
@@ -14,7 +14,10 @@
           <div class="space-y-2">
             <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: "Select a category", label: "Category", class: "text-subdued" } %>
             <%= form.collection_select :merchant_id, Current.family.available_merchants.alphabetically, :id, :name, { prompt: "Select a merchant", label: "Merchant", class: "text-subdued" } %>
-            <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: "None", multiple: true, label: "Tags" } %>
+            <div data-controller="bulk-update-tags">
+              <%= form.hidden_field :tags_touched, value: "0", data: { bulk_update_tags_target: "touched" } %>
+              <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: "None", multiple: true, label: "Tags" }, data: { action: "change->bulk-update-tags#touch" } %>
+            </div>
             <%= form.text_area :notes, label: "Notes", placeholder: "Enter a note that will be applied to selected transactions", rows: 5 %>
           </div>
         <% end %>


### PR DESCRIPTION
Fixes #812 - a bulk edit bug where changing only category cleared existing transaction tags.

- Preserve tags when the Tags field is untouched during bulk updates
- Still allow explicitly updating or clearing tags (“None”)
- Add regression tests for preserve/update/clear behaviors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tag modification tracking during bulk updates to preserve existing tags when not explicitly changed.

* **Bug Fixes**
  * Improved tag handling logic to conditionally apply tags based on user interaction, preventing unintended tag removals.

* **Tests**
  * Added comprehensive test coverage for bulk update tag behavior under various scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->