### PR TITLE
feat: visual hierarchy for categories in the transaction filter sidebar

### DIFF
--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -22,4 +22,12 @@ module CategoriesHelper
   def family_categories
     [ Category.uncategorized ].concat(Current.family.categories.alphabetically)
   end
+
+  # Like `family_categories`, but ordered so each parent is immediately
+  # followed by its subcategories. Intended for the transaction filter
+  # sidebar, which renders a flat checkbox list and uses visual indentation
+  # + a down-arrow icon to convey the parent→child relationship.
+  def family_categories_with_hierarchy
+    [ Category.uncategorized ].concat(Current.family.categories.alphabetically_by_hierarchy)
+  end
 end

--- a/app/views/transactions/searches/filters/_category_filter.html.erb
+++ b/app/views/transactions/searches/filters/_category_filter.html.erb
@@ -5,8 +5,8 @@
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
-    <% family_categories.each do |category| %>
-      <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= category.name %>">
+    <% family_categories_with_hierarchy.each do |category| %>
+      <div class="filterable-item flex items-center gap-2 p-2 <%= "ml-4" if category.subcategory? %>" data-filter-name="<%= category.name %>">
         <%= form.check_box :categories,
                            {
                              multiple: true,
@@ -15,7 +15,10 @@
                            },
                            category.name,
                            nil %>
-        <%= form.label :categories, category.name, value: category.name, class: "text-sm text-primary cursor-pointer" do %>
+        <%= form.label :categories, category.name, value: category.name, class: "text-sm text-primary cursor-pointer flex items-center gap-1" do %>
+          <% if category.subcategory? %>
+            <%= icon("corner-down-right", size: "sm", class: "text-secondary") %>
+          <% end %>
           <%= render partial: "categories/badge", locals: { category: category } %>
         <% end %>
       </div>

--- a/test/helpers/categories_helper_test.rb
+++ b/test/helpers/categories_helper_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class CategoriesHelperTest < ActionView::TestCase
+  include CategoriesHelper
+
+  setup do
+    @family = families(:dylan_family)
+    Current.stubs(:family).returns(@family)
+  end
+
+  test "family_categories prepends Uncategorized and sorts alphabetically" do
+    categories = family_categories
+
+    assert_equal "Uncategorized", categories.first.name
+    assert categories.length > 1
+
+    # Everything after Uncategorized is plain alphabetical.
+    rest = categories.drop(1).map(&:name)
+    assert_equal rest.sort, rest
+  end
+
+  test "family_categories_with_hierarchy prepends Uncategorized and orders parents before their children" do
+    categories = family_categories_with_hierarchy
+
+    assert_equal "Uncategorized", categories.first.name
+    assert categories.length > 1
+
+    rest = categories.drop(1)
+    rest.each_with_index do |category, index|
+      next unless category.subcategory?
+      # Parent of each subcategory must appear earlier in the list, so
+      # consumers (the filter sidebar) can apply a hanging indent without
+      # reshuffling.
+      parent_index = rest.find_index { |c| c.id == category.parent_id }
+      assert parent_index, "Parent of '#{category.name}' should be in the list"
+      assert parent_index < index,
+        "Parent '#{category.parent&.name}' should appear before subcategory '#{category.name}'"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `family_categories_with_hierarchy` view helper (parents first, each followed by its subcategories) and renders the transaction filter checkbox list with a hanging indent plus a `corner-down-right` glyph on children. Users can now see the parent→subcategory relationship in the filter UI itself without having to trace the category badges.

**No filter semantics change.** The server still auto-includes subcategories when a parent is selected (current main behavior). This PR closes only the transparency gap.

## Why this scope

This PR originally bundled three concerns:

1. Visual hierarchy in the sidebar (this scope) ✅
2. A cascading-checkbox Stimulus controller ❌ dropped
3. A backend change to `apply_category_filter` that stops auto-including subcategories when a parent is checked ❌ dropped

Concerns 2 and 3 were coupled to @alessiocappa's approved-but-stalled #829 ("Exclude subcategories from transactions filter"). Without #829 merged, the cascading UI is redundant with main's current auto-inclusion behavior — checking "Food" already shows Food + Restaurants transactions server-side; auto-checking the child boxes in JS would be decorative, not functional.

Keeping just the hierarchy-visibility piece, which:
- Is useful regardless of the semantic question #829 is raising
- Is reviewable on its own
- Doesn't commit the project to a semantic filter-behavior change
- Lets a future PR (resurrecting #829 or not) layer the cascading UX on top

## Changes

- `app/helpers/categories_helper.rb` — new `family_categories_with_hierarchy` helper.
- `app/views/transactions/searches/filters/_category_filter.html.erb` — use the new helper, add `ml-4` and a `corner-down-right` icon for subcategories.
- `test/helpers/categories_helper_test.rb` — cover both helpers (alphabetical ordering + parent-before-child invariant).

## Tests

- Full suite: 3232 runs, 0 failures
- `bin/rubocop` + `bin/brakeman` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Category filters now display in hierarchical structure with parent categories followed by subcategories
  * Subcategories are visually indented for improved clarity
  * Added cascading selection behavior for category filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->