### PR TITLE
Increase FX rate deviation tolerance to 10% when matching transfers

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -1,5 +1,5 @@
 module Family::AutoTransferMatchable
-  def transfer_match_candidates(date_window: 4)
+  def transfer_match_candidates(date_window: 4, exchange_rate_tolerance: 0.1)
     Entry.select([
       "inflow_candidates.entryable_id as inflow_transaction_id",
       "outflow_candidates.entryable_id as outflow_transaction_id",
@@ -39,7 +39,7 @@ module Family::AutoTransferMatchable
           inflow_candidates.amount = -outflow_candidates.amount
         ) OR (
           inflow_candidates.currency <> outflow_candidates.currency AND
-          ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0)) BETWEEN 0.95 AND 1.05
+          ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0)) BETWEEN #{1 - exchange_rate_tolerance} AND #{1 + exchange_rate_tolerance}
         )
       ")
       .where(existing_transfers: { id: nil })

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -45,7 +45,7 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
 
     # test no match outside of slippage tolerance
     create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 1000)
-    create_transaction(date: Date.current, account: @credit_card, amount: -1320, currency: "CAD")
+    create_transaction(date: Date.current, account: @credit_card, amount: -1250, currency: "CAD")
 
     assert_difference -> { Transfer.count } => 0 do
       @family.auto_match_transfers!

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -27,7 +27,7 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
       @family.auto_match_transfers!
     end
 
-    # test match within lower 5% bound
+    # test match within lower 10% bound
     create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 1000)
     create_transaction(date: Date.current, account: @credit_card, amount: -1330, currency: "CAD")
 
@@ -35,7 +35,7 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
       @family.auto_match_transfers!
     end
 
-    # test match within upper 5% bound
+    # test match within upper 10% bound
     create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 1500)
     create_transaction(date: Date.current, account: @credit_card, amount: -2189, currency: "CAD")
 


### PR DESCRIPTION
For certain banks such as Revolut, the exchange rate used to convert money between their accounts lies quite often outside of the current 5% tolerance for transfer matching. For example, if I look at a SEK -> CZK transfer I did on 2026-01-05, the exchange rate fetched from Twelve Data was `2.4649` while the FX rate Revolut used was `2.2514` (almost 10% difference).

Based on my testing, 10% _should_ cover all the cases I've seen but it's possible I'll be back to bump it even further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Automatic transfer matching now supports a configurable exchange-rate tolerance, letting matching use dynamic ± tolerance bounds for more flexible cross-currency comparisons.

* **Tests**
  * Matching tests updated to reflect the wider tolerance (10% bounds) and a revised example transaction value to align with the new tolerance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->