### PR TITLE
Normalize whitespace in text rule matching

### DIFF
--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -94,6 +94,30 @@ class RuleTest < ActiveSupport::TestCase
     assert_not transaction_entry.excluded, "Transaction should not be excluded when attribute is locked"
   end
 
+  test "transaction name rules normalize whitespace in comparisons" do
+    transaction_entry = create_transaction(
+      date: Date.current,
+      account: @account,
+      name: "Company  -   Mobile",
+      amount: 80
+    )
+
+    rule = Rule.create!(
+      family: @family,
+      resource_type: "transaction",
+      effective_date: 1.day.ago.to_date,
+      conditions: [ Rule::Condition.new(condition_type: "transaction_name", operator: "like", value: "Company - Mobile") ],
+      actions: [ Rule::Action.new(action_type: "set_transaction_category", value: @groceries_category.id) ]
+    )
+
+    assert_equal 1, rule.affected_resource_count
+
+    rule.apply
+    transaction_entry.reload
+
+    assert_equal @groceries_category, transaction_entry.transaction.category
+  end
+
   # Artificial limitation put in place to prevent users from creating overly complex rules
   # Rules should be shallow and wide
   test "no nested compound conditions" do


### PR DESCRIPTION
### Motivation

- Rules that match text fields (like `transaction_name`) failed when the stored name had irregular spacing (e.g. multiple spaces around hyphens), causing matches like "company - mobile" to return zero results (see #886). 
- The intent is to make text-based rule comparisons robust to extra or inconsistent whitespace so user-entered rule values match stored transaction names regardless of spacing.
- This is a backend change to normalize both the search value and the DB field during rule comparisons rather than relying on fragile frontend behavior.

### Description

- Normalize the input value and the database field in `Rule::ConditionFilter#build_sanitized_where_condition` for text filters by adding `normalize_value` and `normalize_field` helpers and using a sanitized `BTRIM(REGEXP_REPLACE(... '[[:space:]]+', ' ', 'g'))` expression for the field. 
- Use the normalized value with `ActiveRecord::Base.sanitize_sql_like` when the operator is `like` so `%`-wrapped comparisons work against the normalized DB field. 
- Added a regression test `transaction name rules normalize whitespace in comparisons` in `test/models/rule_test.rb` that verifies a rule with value `"Company - Mobile"` matches a transaction named `"Company  -   Mobile"`.

### Testing

- Ran `bin/rails test test/models/rule_test.rb` and the suite completed successfully with all tests passing (`10 runs, 18 assertions, 0 failures`).
- The new test verifies the whitespace-normalized comparison and prevents future regressions for this scenario.
- Changes touch `app/models/rule/condition_filter.rb` and `test/models/rule_test.rb` and are scoped to text-based rule matching logic (no UI changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822ba970508332a29235293370f0f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced whitespace normalization in rule conditions for more consistent and predictable matching behavior across transaction evaluations.

* **Tests**
  * Added test coverage to verify proper whitespace normalization when evaluating rule conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->