### PR TITLE
Adding support for user-defined CA certificates on Android

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <application
         android:label="Sure Finance"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" /> <!-- Enables User Certs -->
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Android by default only lets apps use system certificates, so adding a network_security_config and referencing it in AndroidManifest.xml should let the app leverage certificates for custom domains. I think there might be a safer way to do this that selects specific user certificates instead of trusting all of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android app's network security configuration to establish explicit certificate validation policies for network connections, supporting both system and user certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->