### PR TITLE
Copilot assist - correct RateLimitError  test failure

### DIFF
--- a/test/jobs/sync_job_test.rb
+++ b/test/jobs/sync_job_test.rb
@@ -16,7 +16,7 @@ class SyncJobTest < ActiveJob::TestCase
     # retry_on adds a rescue handler as [exception_class_name_string, proc]
     handler_found = SyncJob.rescue_handlers.any? do |handler|
       handler.is_a?(Array) &&
-      handler[0] == "Provider::TwelveData::RateLimitError"
+      handler[0] == Provider::TwelveData::RateLimitError.name
     end
 
     assert handler_found, "SyncJob should have retry_on configured for Provider::TwelveData::RateLimitError"


### PR DESCRIPTION
I'm trying to pull request into https://github.com/we-promise/sure/pull/786/ 

Copilot suggested that the test isn't written correctly, it was supposed to pick up an array. 

Here was it's summary after it ran successfully:

> 
> # Summary
> ## The Problem:
> The test was checking SyncJob.rescue_handlers for a handler matching Provider::TwelveData::RateLimitError, but the way it was checking the structure was incorrect.
> 
> ## How retry_on works:
> When you use retry_on in ActiveJob, it registers rescue handlers as an array of [exception_class_name_string, proc] pairs. The test was looking for a Hash with an :exception key, which isn't how Rails structures this data.
> 
> ## The Solution:
> Updated the test to check for the correct structure: an array where the first element is the exception class name as a string ("Provider::TwelveData::RateLimitError"). The SyncJob already had the correct retry_on configuration in place (lines 5-8 of sync_job.rb), so only the test assertion needed to be fixed.
