### PR TITLE
feat: Allow creating budgets up to 2 years ahead

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -29,13 +29,14 @@ class Budget < ApplicationRecord
     end
 
     def budget_date_valid?(date, family:)
-      if family.uses_custom_month_start?
-        budget_start = family.custom_month_start_for(date)
-        budget_start >= oldest_valid_budget_date(family) && budget_start <= family.custom_month_end_for(Date.current)
+      budget_start = if family.uses_custom_month_start?
+        family.custom_month_start_for(date)
       else
-        beginning_of_month = date.beginning_of_month
-        beginning_of_month >= oldest_valid_budget_date(family) && beginning_of_month <= Date.current.end_of_month
+        date.beginning_of_month
       end
+
+      budget_start >= oldest_valid_budget_date(family) &&
+        budget_start <= latest_valid_budget_start_date(family)
     end
 
     def find_or_bootstrap(family, start_date:)
@@ -69,6 +70,14 @@ class Budget < ApplicationRecord
         two_years_ago = 2.years.ago.beginning_of_month
         oldest_entry_date = family.oldest_entry_date.beginning_of_month
         [ two_years_ago, oldest_entry_date ].min
+      end
+
+      def latest_valid_budget_start_date(family)
+        if family.uses_custom_month_start?
+          family.current_custom_month_period.start_date + 2.years
+        else
+          Date.current.beginning_of_month + 2.years
+        end
       end
   end
 
@@ -151,8 +160,6 @@ class Budget < ApplicationRecord
   end
 
   def next_budget_param
-    return nil if current?
-
     next_date = start_date + 1.month
     return nil unless self.class.budget_date_valid?(next_date, family: family)
 


### PR DESCRIPTION
### Summary

This PR updates the budget date constraint so users can create budgets for future periods (up to 2 years ahead), instead of being limited to the current month. Closes [#270](https://github.com/we-promise/sure/discussions/270))

### What changed

* **Before:** maximum budget creating date was capped at the **current month**.
* **After:** maximum budget creating date is capped at **today + 2 years**.
* Keeps existing validation behavior intact (same error handling/UI messaging), only expands the allowed upper bound.

### Why

Users commonly plan budgets ahead of time; restricting creation to only the current month blocks forward planning. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved budget date validation logic with enhanced support for future budget dates (up to 2 years ahead) and custom month-start schedules.

* **Tests**
  * Expanded test coverage for budget scenarios, including future date limits and custom month-start configuration validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->