### PR TITLE
Fix SSO provider warning timing

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -186,8 +186,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       Rails.configuration.x.auth.sso_providers << cfg.merge(name: name, strategy: "saml")
     end
   end
-end
 
-if Rails.configuration.x.auth.sso_providers.empty?
-  Rails.logger.warn("No SSO providers enabled; check auth.yml / ENV configuration or database providers")
+  if Rails.configuration.x.auth.sso_providers.empty?
+    Rails.logger.warn("No SSO providers enabled; check auth.yml / ENV configuration or database providers")
+  end
 end


### PR DESCRIPTION
### Motivation
- The initializer logged "No SSO providers enabled" before the OmniAuth provider registration completed, producing a misleading warning when providers are registered later (race condition). 

### Description
- Move the empty-check/warn into the `OmniAuth::Builder` block in `config/initializers/omniauth.rb` so the message is emitted after providers are registered and remove the duplicate warning at the file end. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874a9399788332ac12366304fb1568)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code formatting in SSO configuration for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->