### PR TITLE
Preserve SnaptradeAccount on unlink, fix connection error handling 

### DIFF
--- a/app/controllers/snaptrade_items_controller.rb
+++ b/app/controllers/snaptrade_items_controller.rb
@@ -106,27 +106,17 @@ class SnaptradeItemsController < ApplicationController
 
   # Redirect user to SnapTrade connection portal
   def connect
-    # Ensure user is registered first
-    unless @snaptrade_item.user_registered?
-      begin
-        @snaptrade_item.ensure_user_registered!
-      rescue => e
-        Rails.logger.error "SnapTrade registration error: #{e.class} - #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
-        redirect_to settings_providers_path, alert: t(".registration_failed", message: e.message)
-        return
-      end
-    end
+    @snaptrade_item.ensure_user_registered! unless @snaptrade_item.user_registered?
 
-    # Get the connection portal URL - include item ID in callback for proper routing
     redirect_url = callback_snaptrade_items_url(item_id: @snaptrade_item.id)
-
-    begin
-      portal_url = @snaptrade_item.connection_portal_url(redirect_url: redirect_url)
-      redirect_to portal_url, allow_other_host: true
-    rescue => e
-      Rails.logger.error "SnapTrade connection portal error: #{e.class} - #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
-      redirect_to settings_providers_path, alert: t(".portal_error", message: e.message)
-    end
+    portal_url = @snaptrade_item.connection_portal_url(redirect_url: redirect_url)
+    redirect_to portal_url, allow_other_host: true
+  rescue ActiveRecord::Encryption::Errors::Decryption => e
+    Rails.logger.error "SnapTrade decryption error for item #{@snaptrade_item.id}: #{e.class} - #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
+    redirect_to settings_providers_path, alert: t(".decryption_failed")
+  rescue => e
+    Rails.logger.error "SnapTrade connection error: #{e.class} - #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
+    redirect_to settings_providers_path, alert: t(".connection_failed", message: e.message)
   end
 
   # Handle callback from SnapTrade after user connects brokerage

--- a/app/views/snaptrade_items/_connections_list.html.erb
+++ b/app/views/snaptrade_items/_connections_list.html.erb
@@ -53,7 +53,10 @@
                 <span class="w-1.5 h-1.5 rounded-full <%= account[:linked] ? "bg-success" : "bg-warning" %>"></span>
                 <%= account[:name] %>
                 <% unless account[:linked] %>
-                  <span class="text-warning">(<%= t("providers.snaptrade.needs_linking") %>)</span>
+                  <%= link_to "(#{t('providers.snaptrade.needs_linking')})",
+                        setup_accounts_snaptrade_item_path(snaptrade_item),
+                        class: "text-warning hover:text-primary underline",
+                        data: { turbo_frame: :modal } %>
                 <% end %>
               </li>
             <% end %>

--- a/config/locales/views/snaptrade_items/en.yml
+++ b/config/locales/views/snaptrade_items/en.yml
@@ -8,8 +8,8 @@ en:
     destroy:
       success: "Scheduled SnapTrade connection for deletion."
     connect:
-      registration_failed: "Failed to register with SnapTrade: %{message}"
-      portal_error: "Failed to connect to SnapTrade: %{message}"
+      decryption_failed: "Unable to read SnapTrade credentials. Please delete and recreate this connection."
+      connection_failed: "Failed to connect to SnapTrade: %{message}"
     callback:
       success: "Brokerage connected! Please select which accounts to link."
       no_item: "SnapTrade configuration not found."

--- a/test/controllers/snaptrade_items_controller_test.rb
+++ b/test/controllers/snaptrade_items_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in @user = users(:family_admin)
+    @snaptrade_item = snaptrade_items(:configured_item)
+  end
+
+  test "connect handles decryption error gracefully" do
+    SnaptradeItem.any_instance
+      .stubs(:user_registered?)
+      .raises(ActiveRecord::Encryption::Errors::Decryption.new("cannot decrypt"))
+
+    get connect_snaptrade_item_url(@snaptrade_item)
+
+    assert_redirected_to settings_providers_path
+    assert_match(/Unable to read SnapTrade credentials/, flash[:alert])
+  end
+
+  test "connect handles general error gracefully" do
+    SnaptradeItem.any_instance
+      .stubs(:user_registered?)
+      .raises(StandardError.new("something broke"))
+
+    get connect_snaptrade_item_url(@snaptrade_item)
+
+    assert_redirected_to settings_providers_path
+    assert_match(/Failed to connect/, flash[:alert])
+  end
+
+  test "connect redirects to portal when successful" do
+    portal_url = "https://app.snaptrade.com/portal/test123"
+
+    SnaptradeItem.any_instance.stubs(:user_registered?).returns(true)
+    SnaptradeItem.any_instance.stubs(:connection_portal_url).returns(portal_url)
+
+    get connect_snaptrade_item_url(@snaptrade_item)
+
+    assert_redirected_to portal_url
+  end
+end


### PR DESCRIPTION
- Stop destroying SnaptradeAccount records when unlinking accounts, following the Plaid pattern where provider accounts survive as "unlinked." This preserves the user's SnapTrade        
connection slot (5 free) and enables relinking via the existing account card link icon flow.                                                                                              
- Make "(needs linking)" text in the connections panel clickable, opening the setup accounts modal.                                                                                       
- Consolidate the connect action's two nested begin/rescue blocks into a single method-level rescue with specific handling for ActiveRecord encryption decryption errors (prevents 500s   
when credentials become unreadable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unlinked SnapTrade accounts now display as clickable links for convenient account setup.

* **Bug Fixes**
  * Enhanced error handling distinguishes between credential decryption failures and connection issues with clearer, targeted messages.
  * SnapTrade account records are now preserved when unlinking to maintain connection history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->