### PR TITLE
Fix guest role UI defaults in User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -340,14 +340,14 @@ class User < ApplicationRecord
 
     def apply_role_based_ui_defaults
       if ui_layout_intro?
-        if role_guest?
+        if guest?
           self.show_sidebar = false
           self.show_ai_sidebar = false
           self.ai_enabled = true
         else
           self.ui_layout = "dashboard"
         end
-      elsif role_guest?
+      elsif guest?
         self.ui_layout = "intro"
         self.show_sidebar = false
         self.show_ai_sidebar = false


### PR DESCRIPTION
### Motivation
- Prevent a `NoMethodError` from occurring in callbacks (e.g., MFA setup) by using the enum-provided predicate instead of a missing helper when applying role-based UI defaults.

### Description
- Replace usages of `role_guest?` with the enum predicate `guest?` inside `User#apply_role_based_ui_defaults` in `app/models/user.rb` so layout and sidebar defaults are applied safely.

### Testing
- No automated tests were run for this change; please run `bin/rails test test/controllers/oidc_accounts_controller_test.rb` or the full suite to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d83d5ae88332b20d1a786c6a1d8f)