### PR TITLE
Remove legacy `user` role handling and clean up SSO role mapping and migration

### DIFF
--- a/app/models/sso_provider.rb
+++ b/app/models/sso_provider.rb
@@ -127,8 +127,7 @@ class SsoProvider < ApplicationRecord
       if role_mapping.is_a?(Hash)
         role_mapping = role_mapping.stringify_keys
         member_groups = Array(role_mapping["member"])
-        legacy_user_groups = Array(role_mapping.delete("user"))
-        merged_member_groups = (member_groups + legacy_user_groups).map(&:to_s).reject(&:blank?).uniq
+        merged_member_groups = member_groups.map(&:to_s).reject(&:blank?).uniq
         role_mapping["member"] = merged_member_groups if merged_member_groups.present?
 
         guest_groups = Array(role_mapping["guest"])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ApplicationRecord
     case role.to_s
     when "guest", "intro"
       :guest
-    when "member", "user"
+    when "member"
       :member
     else
       role

--- a/app/views/admin/sso_providers/_form.html.erb
+++ b/app/views/admin/sso_providers/_form.html.erb
@@ -227,7 +227,7 @@
         <div>
           <label class="block text-sm font-medium text-primary mb-1"><%= t("admin.sso_providers.form.member_groups") %></label>
           <input type="text" name="sso_provider[settings][role_mapping][member]"
-                 value="<%= Array(sso_provider.settings&.dig("role_mapping", "member").presence || sso_provider.settings&.dig("role_mapping", "user")).join(", ") %>"
+                 value="<%= Array(sso_provider.settings&.dig("role_mapping", "member")).join(", ") %>"
                  class="w-full px-3 py-2 border border-primary rounded-lg text-sm"
                  placeholder="* (all groups)"
                  autocomplete="off">

--- a/db/migrate/20260208110000_add_guest_role_and_intro_access.rb
+++ b/db/migrate/20260208110000_add_guest_role_and_intro_access.rb
@@ -2,12 +2,6 @@ class AddGuestRoleAndIntroAccess < ActiveRecord::Migration[7.2]
   def up
     execute <<~SQL.squish
       UPDATE users
-      SET role = 'member'
-      WHERE role = 'user'
-    SQL
-
-    execute <<~SQL.squish
-      UPDATE users
       SET role = 'guest',
           ui_layout = 'intro',
           show_sidebar = FALSE,
@@ -15,7 +9,6 @@ class AddGuestRoleAndIntroAccess < ActiveRecord::Migration[7.2]
           ai_enabled = TRUE
       WHERE role = 'intro'
          OR (role = 'member' AND ui_layout = 'intro')
-         OR (role = 'user' AND ui_layout = 'intro')
     SQL
 
     execute <<~SQL.squish
@@ -23,12 +16,6 @@ class AddGuestRoleAndIntroAccess < ActiveRecord::Migration[7.2]
       SET ui_layout = 'dashboard'
       WHERE role IN ('member', 'admin', 'super_admin')
         AND ui_layout = 'intro'
-    SQL
-
-    execute <<~SQL.squish
-      UPDATE invitations
-      SET role = 'member'
-      WHERE role = 'user'
     SQL
 
     execute <<~SQL.squish
@@ -48,12 +35,6 @@ class AddGuestRoleAndIntroAccess < ActiveRecord::Migration[7.2]
     SQL
 
     execute <<~SQL.squish
-      UPDATE invitations
-      SET role = 'user'
-      WHERE role = 'member'
-    SQL
-
-    execute <<~SQL.squish
       UPDATE users
       SET role = 'intro',
           ui_layout = 'intro',
@@ -63,12 +44,6 @@ class AddGuestRoleAndIntroAccess < ActiveRecord::Migration[7.2]
       WHERE role = 'guest'
     SQL
 
-    execute <<~SQL.squish
-      UPDATE users
-      SET role = 'user'
-      WHERE role = 'member'
-    SQL
-
-    change_column_default :users, :role, "user"
+    change_column_default :users, :role, "member"
   end
 end


### PR DESCRIPTION
### Motivation
- Remove legacy references to a non-existent `user` role to avoid ambiguity and accidental fallbacks in role normalization and SSO mappings.
- Simplify SSO provider settings handling so role mappings only reference valid roles and do not merge legacy keys.
- Ensure the guests/intro migration does not modify or revert a removed `user` role and keeps `member` as the default role.

### Description
- Removed the legacy `user` branch from `User.normalize_role` so only `guest`/`intro` and `member` map to the canonical roles.
- Simplified `SsoProvider#normalize_role_settings` by dropping the merging/deletion of a `role_mapping["user"]` key and only normalizing `member` and `guest` group lists.
- Updated the SSO provider admin form (`app/views/admin/sso_providers/_form.html.erb`) to stop falling back to `role_mapping[user]` for member groups.
- Adjusted the `AddGuestRoleAndIntroAccess` migration to remove SQL that referenced `role = 'user'` and to keep the `users` role default as `member` when rolling back.

### Testing
- No automated tests were executed for this change (no `bin/rails test` or linters were run as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e02dcfcc8332b3bc57563f583aa1)