### PR TITLE
Remove legacy role normalization and use stored roles directly

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -16,7 +16,6 @@ class Invitation < ApplicationRecord
   validates_uniqueness_of :email, scope: :family_id, message: "has already been invited to this family"
   validate :inviter_is_admin
 
-  before_validation :normalize_role
   before_validation :generate_token, on: :create
   before_create :set_expiration
 
@@ -33,8 +32,7 @@ class Invitation < ApplicationRecord
     return false unless emails_match?(user)
 
     transaction do
-      target_role = User.normalize_role(role).to_s
-      user.update!(family_id: family_id, role: target_role)
+      user.update!(family_id: family_id, role: role.to_s)
       update!(accepted_at: Time.current)
     end
     true
@@ -53,10 +51,6 @@ class Invitation < ApplicationRecord
         self.token = SecureRandom.hex(32)
         break unless self.class.exists?(token: token)
       end
-    end
-
-    def normalize_role
-      self.role = User.normalize_role(role).to_s if role.present?
     end
 
     def set_expiration

--- a/app/models/sso_provider.rb
+++ b/app/models/sso_provider.rb
@@ -107,7 +107,7 @@ class SsoProvider < ApplicationRecord
 
     def validate_default_role_setting
       default_role = settings&.dig("default_role") || settings&.dig(:default_role)
-      default_role = User.normalize_role(default_role).to_s
+      default_role = default_role.to_s
       return if default_role.blank?
 
       unless User.roles.key?(default_role)
@@ -121,7 +121,7 @@ class SsoProvider < ApplicationRecord
       normalized_settings = settings.deep_dup
 
       default_role = normalized_settings["default_role"] || normalized_settings[:default_role]
-      normalized_settings["default_role"] = User.normalize_role(default_role).to_s if default_role.present?
+      normalized_settings["default_role"] = default_role.to_s if default_role.present?
 
       role_mapping = normalized_settings["role_mapping"] || normalized_settings[:role_mapping]
       if role_mapping.is_a?(Hash)
@@ -131,8 +131,7 @@ class SsoProvider < ApplicationRecord
         role_mapping["member"] = merged_member_groups if merged_member_groups.present?
 
         guest_groups = Array(role_mapping["guest"])
-        legacy_intro_groups = Array(role_mapping.delete("intro"))
-        merged_guest_groups = (guest_groups + legacy_intro_groups).map(&:to_s).reject(&:blank?).uniq
+        merged_guest_groups = guest_groups.map(&:to_s).reject(&:blank?).uniq
         role_mapping["guest"] = merged_guest_groups if merged_guest_groups.present?
 
         normalized_settings["role_mapping"] = role_mapping

--- a/app/views/admin/sso_providers/_form.html.erb
+++ b/app/views/admin/sso_providers/_form.html.erb
@@ -196,7 +196,7 @@
           [t("admin.sso_providers.form.role_member"), "member"],
           [t("admin.sso_providers.form.role_admin"), "admin"],
           [t("admin.sso_providers.form.role_super_admin"), "super_admin"]
-        ], User.normalize_role(sso_provider.settings&.dig("default_role")).to_s.presence || "member"),
+        ], sso_provider.settings&.dig("default_role").to_s.presence || "member"),
         { label: t("admin.sso_providers.form.default_role_label"), include_blank: false } %>
     <p class="text-xs text-secondary -mt-2"><%= t("admin.sso_providers.form.default_role_help") %></p>
 


### PR DESCRIPTION
### Motivation
- Legacy role normalization and mappings for `intro`/`member` were added during a migration and are no longer required, causing extra transformations and complexity.
- The code should treat roles as stored (including the new `guest` role) and avoid implicit normalization to reduce surprises and preserve user-provided values.

### Description
- Remove `User.normalize_role` and the user-level `before_validation` role normalization hook and update `role_for_new_family_creator` to use the provided `fallback_role` directly.
- Stop normalizing invitation roles and assign the invitation `role` string directly in `Invitation#accept_for` while removing the `before_validation :normalize_role` callback.
- Simplify SSO provider handling by no longer calling `User.normalize_role` for `default_role`, stop merging a legacy `intro` role mapping into `guest`, and persist settings `default_role`/`role_mapping` values as strings/arrays.
- Update the SSO provider admin form to select the stored `default_role` value without invoking normalization.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e5e7b954833292ad4f0f22a5b3b3)