### PR TITLE
Add :intro_ui Flipper flag and guard guest invite option

### DIFF
--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -11,9 +11,9 @@
       <%= form.select :role,
         options_for_select([
           [t(".role_member"), "member"],
-          [t(".role_guest", default: "Guest"), "guest"],
+          (Flipper.enabled?(:intro_ui) ? [t(".role_guest", default: "Guest"), "guest"] : nil),
           [t(".role_admin"), "admin"]
-        ]),
+        ].compact),
         {},
         { label: t(".role_label") } %>
 

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -27,14 +27,22 @@ unless Rails.env.test?
     auth_source = ENV.fetch("AUTH_PROVIDERS_SOURCE") do
       Rails.configuration.app_mode.self_hosted? ? "db" : "yaml"
     end.downcase
+    default_ui_layout = ENV.fetch("DEFAULT_UI_LAYOUT", "").downcase
 
     # Ensure feature exists before enabling/disabling
     Flipper.add(:db_sso_providers) unless Flipper.exist?(:db_sso_providers)
+    if default_ui_layout.in?(%w[dashboard intro])
+      Flipper.add(:intro_ui, tags: [:intro_ui]) unless Flipper.exist?(:intro_ui)
+    end
 
     if auth_source == "db"
       Flipper.enable(:db_sso_providers)
     else
       Flipper.disable(:db_sso_providers)
+    end
+
+    if default_ui_layout.in?(%w[dashboard intro])
+      default_ui_layout == "intro" ? Flipper.enable(:intro_ui) : Flipper.disable(:intro_ui)
     end
   rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
     # Database not ready yet (e.g., during initial setup or migrations)


### PR DESCRIPTION
### Motivation
- Place the intro UI behind a Flipper feature flag so the intro experience can be toggled by environment/DB while keeping most code active for manual DB activation. 

### Description
- Add `default_ui_layout = ENV.fetch("DEFAULT_UI_LAYOUT", "").downcase` and create/enable the `:intro_ui` Flipper flag in `config/initializers/flipper.rb` when `DEFAULT_UI_LAYOUT` is `dashboard` or `intro`.
- Guard the Guest role option in the invitations UI by conditionally including the guest option only when `Flipper.enabled?(:intro_ui)` in `app/views/invitations/new.html.erb`.
- Leave all other intro-related code unguarded so manually enabling the `intro` flag in the DB activates the experience as intended.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989236adde88332bae25eb187237ad0)