### PR TITLE
Fix `production` image problems on Indexa PR

### DIFF
--- a/app/jobs/indexa_capital_activities_fetch_job.rb
+++ b/app/jobs/indexa_capital_activities_fetch_job.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class IndexaCapitalActivitiesFetchJob < ApplicationJob
-  include Sidekiq::Throttled::Job
-
   queue_as :default
 
   sidekiq_options lock: :until_executed,

--- a/lib/generators/provider/family/templates/activities_fetch_job.rb.tt
+++ b/lib/generators/provider/family/templates/activities_fetch_job.rb.tt
@@ -2,7 +2,6 @@
 
 class <%= class_name %>ActivitiesFetchJob < ApplicationJob
   include <%= class_name %>Account::DataHelpers
-  include Sidekiq::Throttled::Job
 
   queue_as :default
 


### PR DESCRIPTION
The sidekiq-throttled gem is not in the Gemfile, so including Sidekiq::Throttled::Job causes an uninitialized constant NameError at boot time, breaking production builds.

https://claude.ai/code/session_01Bj7xgndJt28BcUHW1v1M9S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed job throttling configuration from activity fetch background jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->