### PR TITLE
fix: inverted Buy/Sell type selection by changing amount.negative to …

### DIFF
--- a/app/views/trades/_header.html.erb
+++ b/app/views/trades/_header.html.erb
@@ -3,7 +3,7 @@
 <div id="<%= dom_id(entry, :header) %>">
   <%= tag.header class: "mb-4 space-y-1" do %>
     <span class="text-secondary text-sm">
-      <%= entry.amount.negative? ? t(".buy") : t(".sell") %>
+      <%= entry.amount.positive? ? t(".buy") : t(".sell") %>
     </span>
 
     <div class="flex items-center gap-4">

--- a/app/views/trades/show.html.erb
+++ b/app/views/trades/show.html.erb
@@ -23,7 +23,7 @@
           <div class="flex items-center gap-2">
             <%= f.select :nature,
                           [[t(".buy"), "outflow"], [t(".sell"), "inflow"]],
-                          { container_class: "w-1/3", label: t(".type_label"), selected: @entry.amount.negative? ? "outflow" : "inflow" },
+                          { container_class: "w-1/3", label: t(".type_label"), selected: @entry.amount.positive? ? "outflow" : "inflow" },
                           { data: { "auto-submit-form-target": "auto" }, disabled: @entry.linked? } %>
 
             <%= f.fields_for :entryable do |ef| %>


### PR DESCRIPTION
## Closes: #907 

## Fix Inverted Buy/Sell Type Selection in Trade Edit Form

## Problem
When editing investment trades, the type dropdown and header text displayed the **opposite** of the actual trade type:
- ❌ Buy trades showed "Sell" in the dropdown
- ❌ Sell trades showed "Buy" in the dropdown  
- ❌ Header text displayed incorrect trade type
- ❌ After editing quantity/price, the type would incorrectly change
- ❌ Visual indicators remained inconsistent even after manual correction

## Root Cause
The view layer used inverted logic to determine trade type from entry amount:

```ruby
# BEFORE
selected: @entry.amount.negative? ? "outflow" : "inflow"

# AFTER
selected: @entry.amount.positive? ? "outflow" : "inflow"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transaction type logic: buy/sell labels and inflow/outflow designations now display correctly based on transaction amount values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->