### PR TITLE
Normalize legacy SSO icon data before validation

### DIFF
--- a/app/models/sso_provider.rb
+++ b/app/models/sso_provider.rb
@@ -23,6 +23,12 @@ class SsoProvider < ApplicationRecord
   }
   validates :label, presence: true
   validates :enabled, inclusion: { in: [ true, false ] }
+  validates :icon, format: {
+    with: /\A\S+\z/,
+    message: "cannot be blank or contain only whitespace"
+  }, allow_nil: true
+
+  before_validation :normalize_icon
 
   # Strategy-specific validations
   validate :validate_oidc_fields, if: -> { strategy == "openid_connect" }
@@ -44,7 +50,7 @@ class SsoProvider < ApplicationRecord
       strategy: strategy,
       name: name,
       label: label,
-      icon: icon,
+      icon: icon.present? && icon.strip.present? ? icon.strip : nil,
       issuer: issuer,
       client_id: client_id,
       client_secret: client_secret,
@@ -54,6 +60,10 @@ class SsoProvider < ApplicationRecord
   end
 
   private
+    def normalize_icon
+      self.icon = icon.to_s.strip.presence
+    end
+
     def validate_oidc_fields
       if issuer.blank?
         errors.add(:issuer, "is required for OpenID Connect providers")

--- a/app/views/settings/securities/show.html.erb
+++ b/app/views/settings/securities/show.html.erb
@@ -53,7 +53,8 @@
           <div class="flex items-center justify-between bg-container p-4 shadow-border-xs rounded-lg">
             <div class="flex items-center gap-3">
               <div class="w-9 h-9 shrink-0 bg-surface rounded-full flex items-center justify-center">
-                <%= icon identity.provider_config&.dig(:icon) || "key", class: "w-5 h-5 text-secondary" %>
+                <% icon_name = identity.provider_config&.dig(:icon).presence || "key" %>
+                <%= icon icon_name, class: "w-5 h-5 text-secondary" %>
               </div>
               <div>
                 <p class="font-medium text-primary"><%= identity.provider_config&.dig(:label) || identity.provider.titleize %></p>

--- a/test/models/sso_provider_test.rb
+++ b/test/models/sso_provider_test.rb
@@ -232,6 +232,38 @@ class SsoProviderTest < ActiveSupport::TestCase
     assert_equal 1, oidc_providers.count
   end
 
+
+
+  test "normalizes icon by stripping whitespace before validation" do
+    provider = SsoProvider.new(
+      strategy: "openid_connect",
+      name: "icon_normalized",
+      label: "Icon Normalized",
+      icon: "  key  ",
+      issuer: "https://test.example.com",
+      client_id: "test_client",
+      client_secret: "test_secret"
+    )
+
+    assert provider.valid?
+    assert_equal "key", provider.icon
+  end
+
+  test "normalizes whitespace-only icon to nil" do
+    provider = SsoProvider.new(
+      strategy: "openid_connect",
+      name: "icon_nil",
+      label: "Icon Nil",
+      icon: "   ",
+      issuer: "https://test.example.com",
+      client_id: "test_client",
+      client_secret: "test_secret"
+    )
+
+    assert provider.valid?
+    assert_nil provider.icon
+  end
+
   test "to_omniauth_config returns correct hash" do
     provider = SsoProvider.create!(
       strategy: "openid_connect",


### PR DESCRIPTION
### Motivation
- Legacy SSO provider records contained icon values with leading/trailing whitespace or whitespace-only strings which started failing newly-introduced stricter validation. 
- The intent is to sanitize existing icon data before enforcing format validation so pre-existing rows do not break when saving or validating providers. 
- Also ensure runtime code that renders icons falls back safely when an icon is blank-like.

### Description
- Add `before_validation :normalize_icon` to `SsoProvider` which strips the `icon` string and sets it to `nil` when blank. 
- Add an optional `icon` format validation that requires non-whitespace tokens (`with: /\A\S+\z/`) while allowing `nil`. 
- Make `to_omniauth_config` defensive by returning a stripped `icon` or `nil` so blank icons are not leaked into auth config, and update the settings view to resolve `icon` with `.presence` and a safe fallback. 
- Add model tests covering normalization of padded icon strings and whitespace-only icons to ensure behavior is correct.

### Testing
- Ran the model test file with `bin/rails test test/models/sso_provider_test.rb` which ran 19 tests with `0 failures`, `0 errors`, and `1 skip`. 
- Ran `bin/rubocop app/models/sso_provider.rb test/models/sso_provider_test.rb` with no offenses detected. 
- The new tests asserting normalization behavior passed locally as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b97f44e3c8332bb25fa42e30e3d7e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO provider icon handling by normalizing whitespace and ensuring consistent fallback behavior for empty icon values.

* **Tests**
  * Added tests to verify icon normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->