### PR TITLE
Fix broken ProcessPdfJob and ImportsController tests

### DIFF
--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -40,11 +40,12 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     adapter.stubs(:supported_extensions).returns(%w[.csv .pdf])
     VectorStore::Registry.stubs(:adapter).returns(adapter)
 
-    @user.family.expects(:upload_document).with do |file_content:, filename:, **|
+    family_document = family_documents(:tax_return)
+    Family.any_instance.expects(:upload_document).with do |file_content:, filename:, **|
       assert_not_empty file_content
       assert_equal "valid.csv", filename
       true
-    end.returns(family_documents(:tax_return))
+    end.returns(family_document)
 
     assert_no_difference "Import.count" do
       post imports_url, params: {


### PR DESCRIPTION
### Motivation
- Tests were failing due to mismatched test expectations around PDF processing (bank-statement flow) and a controller test that mocked `upload_document` on the wrong object instance, causing the vector-store adapter mock to be exercised unexpectedly.

### Description
- Adjusted `test/jobs/process_pdf_job_test.rb` to stub the `extract_transactions` step to set `extracted_data` (including one transaction) so the job's downstream behavior aligns with the current implementation, and updated the final status expectation accordingly.
- Restored the `skips if PDF not uploaded` expectation to match the job's behavior when no PDF is attached.
- Updated `test/controllers/imports_controller_test.rb` to expect `upload_document` on the runtime `Family` instance by using `Family.any_instance.expects(:upload_document)` and return a fixture `family_document`, preventing unintended adapter calls.
- Committed the test adjustments and kept assertions ensuring file contents and filenames are validated in the mocked upload flows.

### Testing
- Ran `bin/rails test test/jobs/process_pdf_job_test.rb:56` and it passed after changes.
- Ran `bin/rails test test/jobs/process_pdf_job_test.rb:56 test/controllers/imports_controller_test.rb:38` and both targeted tests passed.
- When running broader controller tests earlier an unrelated asset error (`The asset 'tailwind.css' was not found in the load path`) surfaced during full controller runs; this is unrelated to the test fixes and was observed as an automated test error before the targeted fixes were green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cc955719c8332ba3aa43a98d93963)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for import and PDF processing workflows with improved assertions and mocking patterns. Updated validation of data transformation steps and status transitions to better reflect actual operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->