### PR TITLE
Mobile-only GitHub workflow builds

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Prepare release assets
         run: |
+          set -euo pipefail
           mkdir -p ${{ runner.temp }}/release-assets
 
           echo "=== Downloaded artifacts ==="
@@ -83,6 +84,12 @@ jobs:
 
           echo "Release assets:"
           ls -la "${{ runner.temp }}/release-assets/"
+
+          # Fail early if no assets were produced
+          if [ -z "$(ls -A "${{ runner.temp }}/release-assets/")" ]; then
+            echo "::error::No release assets were produced"
+            exit 1
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated mobile release workflow that publishes Android APK and packaged iOS app artifacts as a GitHub Release, packaging and renaming outputs for distribution.
  * Automatically derives the published version from the tag, sets draft/prerelease status for alpha/beta/rc tags, and includes diagnostic listings plus a mobile-specific release description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->