### PR TITLE
Fix Docker image name for forks with uppercase usernames

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ toLower(github.repository) }}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description
Fixes Docker image publishing for forks with uppercase letters in the repository owner's username.

## Problem
Docker requires lowercase image names, but `github.repository` preserves the original casing of the username. This causes the publish workflow to fail when pushing images to GHCR for forks like `rubenRP/sure`.

## Solution
Use GitHub Actions' `toLower()` function to ensure the image name is always lowercase, making the workflow work correctly for any fork regardless of username casing.

## Changes
- Updated `IMAGE_NAME` env var in `.github/workflows/publish.yml` to use `toLower(github.repository)`

## Testing
This change will correctly convert repository names like `rubenRP/sure` to `rubenrp/sure`,  satisfying Docker's naming requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing workflow to standardize image naming conventions through repository identifier normalization, ensuring consistent image tagging across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->