### PR TITLE
Refactor disabled import options: extract partial, fix accessibility

### DIFF
--- a/app/views/imports/_import_option.html.erb
+++ b/app/views/imports/_import_option.html.erb
@@ -1,0 +1,37 @@
+<%# locals: (type:, label:, icon_name: nil, icon_color: nil, enabled:, disabled_message: nil, button_class: "flex items-center justify-between p-4 group cursor-pointer w-full", image: nil) %>
+<li>
+  <% if enabled %>
+    <%= button_to imports_path(import: { type: type }), class: button_class, data: { turbo: false } do %>
+      <div class="flex items-center gap-2">
+        <% if image %>
+          <%= image_tag(image, alt: "#{label} logo", class: "w-8 h-8 rounded-md") %>
+        <% else %>
+          <div class="bg-<%= icon_color %>-500/5 rounded-md w-8 h-8 flex items-center justify-center">
+            <span class="text-<%= icon_color %>-500"><%= icon(icon_name, color: "current") %></span>
+          </div>
+        <% end %>
+        <span class="text-sm text-primary group-hover:text-secondary"><%= label %></span>
+      </div>
+      <%= icon("chevron-right") %>
+    <% end %>
+  <% else %>
+    <div class="flex items-center justify-between p-4 w-full opacity-50 cursor-not-allowed" aria-disabled="true">
+      <div class="flex items-center gap-2">
+        <% if image %>
+          <%= image_tag(image, alt: "#{label} logo", class: "w-8 h-8 rounded-md") %>
+        <% else %>
+          <div class="bg-<%= icon_color %>-500/5 rounded-md w-8 h-8 flex items-center justify-center">
+            <span class="text-<%= icon_color %>-500"><%= icon(icon_name, color: "current") %></span>
+          </div>
+        <% end %>
+        <div>
+          <span class="text-sm text-primary block"><%= label %></span>
+          <span class="text-xs text-secondary block"><%= disabled_message %></span>
+        </div>
+      </div>
+      <%= icon("lock", size: "sm", class: "text-secondary") %>
+    </div>
+  <% end %>
+
+  <%= render "shared/ruler" %>
+</li>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -3,7 +3,7 @@
 
   <% dialog.with_body do %>
     <% has_accounts = Current.family.accounts.any? %>
-    <% requires_account_message = t(".requires_account", default: "Import accounts first to unlock this option.") %>
+    <% requires_account_message = t(".requires_account") %>
 
     <div class="rounded-xl bg-container-inset p-1">
       <h3 class="uppercase text-secondary text-xs font-medium px-3 py-1.5"><%= t(".sources") %></h3>
@@ -29,154 +29,59 @@
         <% end %>
 
         <% if params[:type].nil? || params[:type] == "TransactionImport" %>
-          <li>
-            <% if has_accounts %>
-              <%= button_to imports_path(import: { type: "TransactionImport" }), class: "flex items-center justify-between p-4 group cursor-pointer w-full", data: { turbo: false } do %>
-                <div class="flex items-center gap-2">
-                  <div class="bg-indigo-500/5 rounded-md w-8 h-8 flex items-center justify-center">
-                    <span class="text-indigo-500">
-                      <%= icon("file-spreadsheet", color: "current") %>
-                    </span>
-                  </div>
-                  <span class="text-sm text-primary group-hover:text-secondary"><%= t(".import_transactions") %></span>
-                </div>
-                <%= icon("chevron-right") %>
-              <% end %>
-            <% else %>
-              <div class="flex items-center justify-between p-4 w-full opacity-50 cursor-not-allowed">
-                <div class="flex items-center gap-2">
-                  <div class="bg-indigo-500/5 rounded-md w-8 h-8 flex items-center justify-center">
-                    <span class="text-indigo-500"><%= icon("file-spreadsheet", color: "current") %></span>
-                  </div>
-                  <div>
-                    <span class="text-sm text-primary block"><%= t(".import_transactions") %></span>
-                    <span class="text-xs text-secondary block"><%= requires_account_message %></span>
-                  </div>
-                </div>
-                <%= icon("chevron-right") %>
-              </div>
-            <% end %>
-
-            <%= render "shared/ruler" %>
-          </li>
+          <%= render "imports/import_option",
+            type: "TransactionImport",
+            icon_name: "file-spreadsheet",
+            icon_color: "indigo",
+            label: t(".import_transactions"),
+            enabled: has_accounts,
+            disabled_message: requires_account_message %>
         <% end %>
 
         <% if params[:type].nil? || params[:type] == "TradeImport" %>
-          <li>
-            <% if has_accounts %>
-              <%= button_to imports_path(import: { type: "TradeImport" }), class: "flex items-center justify-between p-4 group cursor-pointer w-full", data: { turbo: false } do %>
-                <div class="flex items-center gap-2">
-                  <div class="bg-yellow-500/5 rounded-md w-8 h-8 flex items-center justify-center">
-                    <span class="text-yellow-500"><%= icon("square-percent", color: "current") %></span>
-                  </div>
-                  <span class="text-sm text-primary group-hover:text-secondary"><%= t(".import_portfolio") %></span>
-                </div>
-                <%= icon("chevron-right") %>
-              <% end %>
-            <% else %>
-              <div class="flex items-center justify-between p-4 w-full opacity-50 cursor-not-allowed">
-                <div class="flex items-center gap-2">
-                  <div class="bg-yellow-500/5 rounded-md w-8 h-8 flex items-center justify-center">
-                    <span class="text-yellow-500"><%= icon("square-percent", color: "current") %></span>
-                  </div>
-                  <div>
-                    <span class="text-sm text-primary block"><%= t(".import_portfolio") %></span>
-                    <span class="text-xs text-secondary block"><%= requires_account_message %></span>
-                  </div>
-                </div>
-                <%= icon("chevron-right") %>
-              </div>
-            <% end %>
-
-            <%= render "shared/ruler" %>
-          </li>
+          <%= render "imports/import_option",
+            type: "TradeImport",
+            icon_name: "square-percent",
+            icon_color: "yellow",
+            label: t(".import_portfolio"),
+            enabled: has_accounts,
+            disabled_message: requires_account_message %>
         <% end %>
 
         <% if params[:type].nil? || params[:type] == "AccountImport" %>
-          <li>
-            <%= button_to imports_path(import: { type: "AccountImport" }), class: "flex items-center justify-between p-4 group cursor-pointer w-full", data: { turbo: false } do %>
-              <div class="flex items-center gap-2">
-                <div class="bg-violet-500/5 rounded-md w-8 h-8 flex items-center justify-center">
-                  <span class="text-violet-500">
-                    <%= icon("building", color: "current") %>
-                  </span>
-                </div>
-                <span class="text-sm text-primary group-hover:text-secondary">
-                  <%= t(".import_accounts") %>
-                </span>
-              </div>
-              <%= icon("chevron-right") %>
-            <% end %>
-
-            <%= render "shared/ruler" %>
-          </li>
+          <%= render "imports/import_option",
+            type: "AccountImport",
+            icon_name: "building",
+            icon_color: "violet",
+            label: t(".import_accounts"),
+            enabled: true %>
         <% end %>
 
         <% if params[:type].nil? || params[:type] == "CategoryImport" %>
-          <li>
-            <%= button_to imports_path(import: { type: "CategoryImport" }), class: "flex items-center justify-between p-4 group cursor-pointer w-full", data: { turbo: false } do %>
-              <div class="flex items-center gap-2">
-                <div class="bg-blue-500/5 rounded-md w-8 h-8 flex items-center justify-center">
-                  <span class="text-blue-500">
-                    <%= icon("shapes", color: "current") %>
-                  </span>
-                </div>
-                <span class="text-sm text-primary group-hover:text-secondary">
-                  <%= t(".import_categories") %>
-                </span>
-              </div>
-              <%= icon("chevron-right") %>
-            <% end %>
-
-            <%= render "shared/ruler" %>
-          </li>
+          <%= render "imports/import_option",
+            type: "CategoryImport",
+            icon_name: "shapes",
+            icon_color: "blue",
+            label: t(".import_categories"),
+            enabled: true %>
         <% end %>
 
         <% if params[:type].nil? || params[:type] == "RuleImport" %>
-          <li>
-            <%= button_to imports_path(import: { type: "RuleImport" }), class: "flex items-center justify-between p-4 group cursor-pointer w-full", data: { turbo: false } do %>
-              <div class="flex items-center gap-2">
-                <div class="bg-green-500/5 rounded-md w-8 h-8 flex items-center justify-center">
-                  <span class="text-green-500">
-                    <%= icon("workflow", color: "current") %>
-                  </span>
-                </div>
-                <span class="text-sm text-primary group-hover:text-secondary">
-                  <%= t(".import_rules") %>
-                </span>
-              </div>
-              <%= icon("chevron-right") %>
-            <% end %>
-
-            <%= render "shared/ruler" %>
-          </li>
+          <%= render "imports/import_option",
+            type: "RuleImport",
+            icon_name: "workflow",
+            icon_color: "green",
+            label: t(".import_rules"),
+            enabled: true %>
         <% end %>
 
         <% if params[:type].nil? || params[:type] == "MintImport" || params[:type] == "TransactionImport" %>
-          <li>
-            <% if has_accounts %>
-              <%= button_to imports_path(import: { type: "MintImport" }), class: "flex items-center justify-between p-4 group w-full", data: { turbo: false } do %>
-                <div class="flex items-center gap-2">
-                  <%= image_tag("mint-logo.jpeg", alt: "Mint logo", class: "w-8 h-8 rounded-md") %>
-                  <span class="text-sm text-primary"><%= t(".import_mint") %></span>
-                </div>
-                <%= icon("chevron-right") %>
-              <% end %>
-            <% else %>
-              <div class="flex items-center justify-between p-4 w-full opacity-50 cursor-not-allowed">
-                <div class="flex items-center gap-2">
-                  <%= image_tag("mint-logo.jpeg", alt: "Mint logo", class: "w-8 h-8 rounded-md") %>
-                  <div>
-                    <span class="text-sm text-primary block"><%= t(".import_mint") %></span>
-                    <span class="text-xs text-secondary block"><%= requires_account_message %></span>
-                  </div>
-                </div>
-                <%= icon("chevron-right") %>
-              </div>
-            <% end %>
-
-            <%= render "shared/ruler" %>
-          </li>
+          <%= render "imports/import_option",
+            type: "MintImport",
+            image: "mint-logo.jpeg",
+            label: t(".import_mint"),
+            enabled: has_accounts,
+            disabled_message: requires_account_message %>
         <% end %>
 
         <% if (params[:type].nil? || params[:type].in?(%w[DocumentImport PdfImport])) && @document_upload_extensions.any? %>

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -102,9 +102,9 @@ en:
       import_portfolio: Import investments
       import_rules: Import rules
       import_transactions: Import transactions
-      requires_account: Import accounts first to unlock this option.
       import_file: Import document
       import_file_description: AI-powered analysis for PDFs and searchable upload for other supported files
+      requires_account: Import accounts first to unlock this option.
       resume: Resume %{type}
       sources: Sources
       title: New Import

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -23,7 +23,6 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#modal"
   end
 
-
   test "shows disabled account-dependent imports when family has no accounts" do
     sign_in users(:empty)
 
@@ -35,6 +34,7 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "button", text: "Import investments", count: 0
     assert_select "button", text: "Import from Mint", count: 0
     assert_select "span", text: "Import accounts first to unlock this option.", count: 3
+    assert_select "div[aria-disabled=true]", count: 3
   end
 
   test "creates import" do


### PR DESCRIPTION
Fixes:
- Extract _import_option partial to eliminate duplicated enabled/disabled markup across TransactionImport, TradeImport, and MintImport (also used by AccountImport, CategoryImport, RuleImport for consistency)
- Replace misleading chevron-right with lock icon in disabled state
- Add aria-disabled="true" for screen reader accessibility
- Remove redundant default: parameter from t() call
- Fix locale key ordering (requires_account after import_* keys)
- Fix extra blank line in test file
- Add assertion for aria-disabled attribute in test

https://claude.ai/code/session_016j9tDYEBfWX9Dzd99rAYjX