### PR TITLE
fix: prevent New rule modal from closing when removing conditions or …

### DIFF
--- a/app/javascript/controllers/rule/actions_controller.js
+++ b/app/javascript/controllers/rule/actions_controller.js
@@ -11,6 +11,9 @@ export default class extends Controller {
   ];
 
   remove(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    
     if (e.params.destroy) {
       this.destroyFieldTarget.value = true;
       this.element.classList.add("hidden");

--- a/app/javascript/controllers/rule/conditions_controller.js
+++ b/app/javascript/controllers/rule/conditions_controller.js
@@ -26,6 +26,9 @@ export default class extends Controller {
   }
 
   remove(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    
     // Find the parent rules controller before removing the condition
     const rulesEl = this.element.closest('[data-controller~="rules"]');
 


### PR DESCRIPTION
Closes: #968 
## Root Cause ##
Clicking the trash icon to remove a condition/action triggers the rule controllers `remove` handler, which removes the element from the DOM. The click then bubbles to the dialog's `clickOutside` handler.
Because the target node is no longer in the document, `contentTarget.contains(e.target)` returns false, so the dialog treats the click as outside and closes.

https://github.com/user-attachments/assets/f2d0a319-103a-4239-be61-a17a4e9cf817

## Solution ##
Call `e.preventDefault()` and `e.stopPropagation()` at the start of the `remove` handlers in:
- rule/conditions_controller.js (IF conditions and condition groups)
- rule/actions_controller.js (THEN actions)

Stopping propagation ensures the remove click does not reach the dialog's click-outside logic, so the modal stays open.
No other listeners in the propagation path depend on this event, so this change is safe and directly addresses the cause of the bug.

https://github.com/user-attachments/assets/66d41bac-7cda-4ec5-b652-4f3de0e88b6b

## Conclusion & Why this implementation is good? ##
Using  `stopPropagation` here is safe and appropriate:
1. The only parent listener we affect is `DS--dialog#clickOutside`, which we want to avoid triggering.
2. Turbo, form submission, and hotkeys are unchanged.
3. The change is localized to the remove handlers and fixes the root cause of the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of removal actions for rules and conditions by preventing unintended side effects and default browser behaviors during the removal process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->