### PR TITLE
Fix separators in breakdown table view

### DIFF
--- a/app/views/reports/_breakdown_table.html.erb
+++ b/app/views/reports/_breakdown_table.html.erb
@@ -49,9 +49,9 @@
                 color_class: color_class,
                 level: :subcategory
               %>
-            <% end %>
-            <% if sub_idx < group[:subcategories].size - 1 %>
-              <%= render "shared/ruler", classes: "mx-3 lg:mx-4" %>
+              <% if sub_idx < group[:subcategories].size - 1 %>
+                <%= render "shared/ruler", classes: "mx-3 lg:mx-4" %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>


### PR DESCRIPTION
Correct conditional logic for rendering column separators (rulers) in the reports breakdown table. The top-level check now compares idx to groups.size instead of group.size, and the subcategory check compares idx to group[:subcategories].size. This ensures separators are shown between categories and subcategories correctly, avoiding missing or extra rulers.

before:
<img width="961" height="886" alt="Scherm­afbeelding 2026-02-15 om 12 52 27" src="https://github.com/user-attachments/assets/c8849a5f-37d1-49f3-9bfb-4260af0b71c7" />

after:
<img width="961" height="886" alt="Scherm­afbeelding 2026-02-15 om 12 52 41" src="https://github.com/user-attachments/assets/08b2d860-52c3-4cfb-a596-73682f0e7a7d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected divider rendering in the breakdown table report so category and subcategory separators display consistently. This prevents missing or extra dividers when category or subcategory counts differ, ensuring visual grouping and boundaries are accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->