### PR TITLE
fix: show Edit button in account view bulk selection bar

### DIFF
--- a/app/views/entries/_selection_bar.html.erb
+++ b/app/views/entries/_selection_bar.html.erb
@@ -6,6 +6,14 @@
   </div>
 
   <div class="flex items-center gap-1 text-secondary">
+    <%= turbo_frame_tag "bulk_transaction_edit_drawer" %>
+    <%= link_to new_transactions_bulk_update_path,
+                class: "p-1.5 group/edit hover:bg-inverse flex items-center justify-center rounded-md",
+                title: "Edit",
+                data: { turbo_frame: "bulk_transaction_edit_drawer" } do %>
+      <%= icon "pencil-line", class: "group-hover/edit:text-inverse" %>
+    <% end %>
+
     <%= form_with url: transactions_bulk_deletion_path, data: { turbo_confirm: CustomConfirm.for_resource_deletion("entry").to_data_attribute, turbo_frame: "_top" } do %>
       <button type="button" data-bulk-select-scope-param="bulk_delete" data-action="bulk-select#submitBulkRequest" class="p-1.5 group/delete hover:bg-inverse flex items-center justify-center rounded-md" title="Delete">
         <%= icon "trash-2", class: "group-hover/delete:text-inverse" %>


### PR DESCRIPTION
Closes: #994 

### Related issue
Inconsistent bulk action menu between account view and transactions view: when selecting multiple transactions in the account view (Home → open account from left panel), only the Delete button appeared, while the transactions view showed both Edit and Delete.

### Description / changes
- Updated app/views/entries/_selection_bar.html.erb to match app/views/transactions/_selection_bar.html.erb.
- Added an Edit button (pencil icon) that opens the bulk edit drawer.
- Wired the selection bar to the bulk_transaction_edit_drawer Turbo frame so the bulk edit form loads correctly from the account view.

### Expected behavior
- When selecting multiple transactions/entries in the account view Activity tab, the bottom selection bar shows both Edit and Delete.
- Edit opens the bulk edit drawer (date, category, merchant, tags, notes) and updates the selected entries on Save.
- Delete bulk-deletes the selected entries with confirmation.
- Account and transactions views now behave the same when multiple entries are selected.

### Screenshots after applied
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/c1e8a48a-4acd-45b7-96b9-b6356e0ef4d3" />
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/e1b31eeb-294e-45de-9483-a83c1ec8a7d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bulk edit control to the selection bar, allowing users to edit multiple entries simultaneously via an in-frame drawer interface alongside existing bulk deletion options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->