### PR TITLE
feat: Update gh-pages README with latest mobile release links

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -112,3 +112,84 @@ jobs:
             - **iOS Build**: Unsigned iOS build (requires code signing for installation)
 
             > **Note**: These are builds intended for testing purposes. For production use, please build from source with proper signing credentials.
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Update README with latest mobile release links
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ github.ref_name }}"
+          REPO="${{ github.repository }}"
+
+          # Build download links based on which assets were produced
+          LINKS=""
+          if [ -f "${{ runner.temp }}/release-assets/sure-${VERSION}.apk" ]; then
+            LINKS="${LINKS}- **Android APK**: [sure-${VERSION}.apk](https://github.com/${REPO}/releases/download/${TAG}/sure-${VERSION}.apk)\n"
+          fi
+          if [ -f "${{ runner.temp }}/release-assets/sure-${VERSION}-debug.apk" ]; then
+            LINKS="${LINKS}- **Android Debug APK**: [sure-${VERSION}-debug.apk](https://github.com/${REPO}/releases/download/${TAG}/sure-${VERSION}-debug.apk)\n"
+          fi
+          if [ -f "${{ runner.temp }}/release-assets/sure-${VERSION}-ios-unsigned.zip" ]; then
+            LINKS="${LINKS}- **iOS Build (unsigned)**: [sure-${VERSION}-ios-unsigned.zip](https://github.com/${REPO}/releases/download/${TAG}/sure-${VERSION}-ios-unsigned.zip)\n"
+          fi
+
+          # Build the mobile downloads section
+          SECTION="$(cat <<BLOCK
+          <!-- MOBILE_DOWNLOADS_START -->
+          ## Latest Mobile Release: ${VERSION}
+
+          **Release page**: [${TAG}](https://github.com/${REPO}/releases/tag/${TAG})
+
+          ### Direct Downloads
+
+          $(echo -e "$LINKS")
+
+          > **Note**: These are builds intended for testing purposes. For production use, please build from source with proper signing credentials.
+          <!-- MOBILE_DOWNLOADS_END -->
+          BLOCK
+          )"
+
+          # Strip leading whitespace from heredoc indentation
+          SECTION="$(echo "$SECTION" | sed 's/^          //')"
+
+          README="gh-pages/README.md"
+
+          if [ ! -f "$README" ]; then
+            # No README yet — create one
+            printf "# Sure\n\n%s\n" "$SECTION" > "$README"
+          elif grep -q '<!-- MOBILE_DOWNLOADS_START -->' "$README"; then
+            # Replace existing mobile section between markers
+            awk '
+              /<!-- MOBILE_DOWNLOADS_START -->/ { skip=1; next }
+              /<!-- MOBILE_DOWNLOADS_END -->/   { skip=0; next }
+              !skip { print }
+            ' "$README" > "${README}.tmp"
+
+            # Re-insert the updated section at the end
+            printf "%s\n\n%s\n" "$(cat "${README}.tmp")" "$SECTION" > "$README"
+            rm "${README}.tmp"
+          else
+            # Append mobile section to existing README
+            printf "\n%s\n" "$SECTION" >> "$README"
+          fi
+
+          echo "Updated README.md:"
+          cat "$README"
+
+      - name: Push updated README to gh-pages
+        run: |
+          cd gh-pages
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No README changes to push."
+            exit 0
+          fi
+          git commit -m "Update mobile download links for ${{ steps.version.outputs.version }}"
+          git push


### PR DESCRIPTION
Added three new steps to the `mobile-release` job in `.github/workflows/mobile-release.yml`:

1. **Checkout gh-pages branch** — checks out `gh-pages` into a `gh-pages/` subdirectory using `actions/checkout@v4`.
    
2. **Update README with latest mobile release links** — builds a markdown section with direct download links for whichever assets were produced (Android APK, Android debug APK, iOS unsigned zip). It uses `<!-- MOBILE_DOWNLOADS_START -->` / `<!-- MOBILE_DOWNLOADS_END -->` HTML comment markers so that:
    
    - If no README exists yet, it creates one.
    - If the markers already exist (from a previous release), it replaces just that section.
    - If the README exists but has no markers, it appends the section.
3. **Push updated README to gh-pages** — configures git, commits the README change, and pushes. Skips gracefully if there are no changes.
    

The download links point directly to the GitHub release assets (e.g., `https://github.com/we-promise/sure/releases/download/mobile-v1.0.0/sure-v1.0.0.apk`) and also include a link to the full release page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated mobile release publishing now generates dynamic download links for all platform variants—Android APK, Android Debug APK, and iOS
  * Enhanced release documentation with automatic updates containing latest release version information and direct platform-specific download links
  * Improved release workflow with better error handling for artifact management and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->