### PR TITLE
fix: foreign currency defaulting to 1:1 exchange rate due to timezone mismatch

### DIFF
--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -62,15 +62,21 @@ module Accountable
       self.name.pluralize.titleize
     end
 
+    # Sums the balances of all active accounts of this type, converting foreign currencies to the family's currency.
+    # @return [BigDecimal] total balance in the family's currency
     def balance_money(family)
-      family.accounts
-            .active
-            .joins(sanitize_sql_array([
-              "LEFT JOIN exchange_rates ON exchange_rates.date = :current_date AND accounts.currency = exchange_rates.from_currency AND exchange_rates.to_currency = :family_currency",
-              { current_date: Date.current.to_s, family_currency: family.currency }
-            ]))
-            .where(accountable_type: self.name)
-            .sum("accounts.balance * COALESCE(exchange_rates.rate, 1)")
+      accounts = family.accounts.active.where(accountable_type: self.name).to_a
+
+      foreign_currencies = accounts.filter_map { |a| a.currency if a.currency != family.currency }
+      rates = ExchangeRate.rates_for(foreign_currencies, to: family.currency, date: Date.current)
+
+      accounts.sum(BigDecimal(0)) { |account|
+        if account.currency == family.currency
+          account.balance
+        else
+          account.balance * (rates[account.currency] || 1)
+        end
+      }
     end
   end
 

--- a/db/migrate/20260217120000_add_composite_index_on_accounts_family_status_type.rb
+++ b/db/migrate/20260217120000_add_composite_index_on_accounts_family_status_type.rb
@@ -1,0 +1,9 @@
+class AddCompositeIndexOnAccountsFamilyStatusType < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :accounts, [ :family_id, :status, :accountable_type ],
+      name: "index_accounts_on_family_id_status_accountable_type",
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_11_120001) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_11_120001) do
     t.index ["currency"], name: "index_accounts_on_currency"
     t.index ["family_id", "accountable_type"], name: "index_accounts_on_family_id_and_accountable_type"
     t.index ["family_id", "id"], name: "index_accounts_on_family_id_and_id"
+    t.index ["family_id", "status", "accountable_type"], name: "index_accounts_on_family_id_status_accountable_type"
     t.index ["family_id", "status"], name: "index_accounts_on_family_id_and_status"
     t.index ["family_id"], name: "index_accounts_on_family_id"
     t.index ["import_id"], name: "index_accounts_on_import_id"

--- a/test/models/balance/chart_series_builder_test.rb
+++ b/test/models/balance/chart_series_builder_test.rb
@@ -52,11 +52,11 @@ class Balance::ChartSeriesBuilderTest < ActiveSupport::TestCase
     )
 
     # Only 1 rate in DB. We'll be missing the first and last days in the series.
-    # This rate should be applied to 1 day ago and today, but not 2 days ago (will fall back to 1)
+    # This rate should be applied to all days: LOCF for future dates, nearest future rate for earlier dates.
     ExchangeRate.create!(date: 1.day.ago.to_date, from_currency: "USD", to_currency: "EUR", rate: 2)
 
     expected = [
-      1000, # No rate available, so fall back to 1:1 conversion (1000 USD = 1000 EUR)
+      2000, # No prior rate, so use nearest future rate (2:1 from 1 day ago): 1000 * 2 = 2000
       2200, # Rate available, so use 2:1 conversion (1100 USD = 2200 EUR)
       2400 # Rate NOT available, but LOCF will use the last available rate, so use 2:1 conversion (1200 USD = 2400 EUR)
     ]


### PR DESCRIPTION
When a user in an ahead-of-UTC timezone (e.g. Tokyo) adds an account in a currency whose trading day hasn't started yet (e.g. Armenian AMD) - no exchange rate exists for that date in the database.
 
Both the balance sheet sidebar and net worth chart fell back to a 1:1 conversion rate via `COALESCE(rate, 1)`, treating e.g. 100 AMD as $100 USD instead of ~$0.27. This caused inflated totals and a ~50% "loss" on the chart once the correct rate appeared the next day.

Fixed by using `Money#exchange_to` (which fetches rates on demand) for sidebar totals, and by falling back to the nearest future rate in the chart's SQL query when no prior rate exists.

Before/After UI screenshots

_Sidebar:_

<img src="https://github.com/user-attachments/assets/e5d02df0-1fd3-4317-8339-5623817d132b" width="300" />
<img src="https://github.com/user-attachments/assets/27fd416b-e629-42b1-a5da-43f6aa10a7ca" width="300" />


_Chart:_

<img src="https://github.com/user-attachments/assets/c556266c-36d3-4782-bfea-cdb67d7d6a25" width="300" />
<img src="https://github.com/user-attachments/assets/e0bf85cd-8aea-4fab-a54c-628529182754" width="300" />


Note: AI tools were used in the generation of this code. Implementation have been manually verified 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reused nearest cached exchange rate within a short lookback window when available; fallback behavior for missing rates clarified.

* **Performance**
  * Balance calculations now use a cache-backed account loader and batch rate lookups for faster multi-currency totals.
  * Added a concurrent composite database index to speed account queries.

* **Tests**
  * Added tests covering cached-rate reuse and lookback-window behavior.

* **Other**
  * Chart series expectations adjusted to reflect nearest-rate application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->