### PR TITLE
Remove OPENAI_URI_BASE and OPENAI_MODEL from Helm secret values

### DIFF
--- a/charts/sure/values.yaml
+++ b/charts/sure/values.yaml
@@ -40,8 +40,6 @@ rails:
       ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT: ""
       # Third party optional keys
       OPENAI_ACCESS_TOKEN: ""
-      OPENAI_URI_BASE: ""
-      OPENAI_MODEL: ""
       OIDC_CLIENT_ID: ""
       OIDC_CLIENT_SECRET: ""
       OIDC_ISSUER: ""


### PR DESCRIPTION
These are optional app configuration values (not secrets), and listing them in rails.secret.values alongside required keys like SECRET_KEY_BASE makes users think they must be specified. Users who need them can set them via rails.extraEnv or rails.settings instead.

https://claude.ai/code/session_01BP8Nr2cZWDdu9zGL9vD8Mw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed two unused configuration values from default deployment settings to streamline configuration management and improve system maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->