### PR TITLE
Add workflow to build mobile apps from main without tagging

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -214,16 +214,24 @@ jobs:
             # No README yet — create one
             printf "# Sure\n\n%s\n" "$SECTION" > "$README"
           elif grep -q '<!-- MOBILE_DOWNLOADS_START -->' "$README"; then
-            # Replace existing mobile section between markers
-            awk '
-              /<!-- MOBILE_DOWNLOADS_START -->/ { skip=1; next }
-              /<!-- MOBILE_DOWNLOADS_END -->/   { skip=0; next }
-              !skip { print }
-            ' "$README" > "${README}.tmp"
+            # Write section to a temp file so awk can read it without quoting issues
+            printf '%s\n' "$SECTION" > "${README}.section"
 
-            # Re-insert the updated section at the end
-            printf "%s\n\n%s\n" "$(cat "${README}.tmp")" "$SECTION" > "$README"
-            rm "${README}.tmp"
+            # In-place replacement: keep content before/after the markers,
+            # replace the block between them with the new section
+            awk '
+              /<!-- MOBILE_DOWNLOADS_START -->/ {
+                while ((getline line < SECFILE) > 0) print line
+                close(SECFILE)
+                skip=1
+                next
+              }
+              /<!-- MOBILE_DOWNLOADS_END -->/ { skip=0; next }
+              !skip { print }
+            ' SECFILE="${README}.section" "$README" > "${README}.tmp"
+
+            mv "${README}.tmp" "$README"
+            rm "${README}.section"
           else
             # Append mobile section to existing README
             printf "\n%s\n" "$SECTION" >> "$README"


### PR DESCRIPTION
Adds a new `mobile-main-build.yml` workflow that can be triggered manually via workflow_dispatch to build Android APK and iOS unsigned builds from the main branch. Uses a `main-YYYYMMDDHHMI` stamp for versioning (e.g. sure-main-202602181259.apk) and updates the gh-pages README.md MOBILE_DOWNLOADS section with direct download links.

https://claude.ai/code/session_01TDfNkNxQ6uWxQxLAwJY5Qa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated mobile build and release workflow that produces Android APKs and iOS artifacts, creates releases, and tags builds.
* **Documentation**
  * Automatically updates project release page with latest mobile download links and included build metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->