### PR TITLE
feat: Add merchant logo in filter selection

### DIFF
--- a/app/views/transactions/searches/filters/_merchant_filter.html.erb
+++ b/app/views/transactions/searches/filters/_merchant_filter.html.erb
@@ -16,12 +16,12 @@
                            merchant.name,
                            nil %>
         <%= form.label :merchants, value: merchant.name, class: "text-sm text-primary flex items-center gap-2" do %>
-          <% if merchant.logo_url.present? %>
-            <%= image_tag Setting.transform_brand_fetch_url(merchant.logo_url),
-                class: "w-6 h-6 rounded-full border border-secondary",
-                loading: "lazy" %>
-          <% else %>
-            <div class="hidden lg:flex">
+          <div class="hidden lg:flex">
+            <% if merchant.logo_url.present? %>
+              <%= image_tag Setting.transform_brand_fetch_url(merchant.logo_url),
+                  class: "w-6 h-6 rounded-full border border-secondary",
+                  loading: "lazy" %>
+            <% else %>
               <%= render DS::FilledIcon.new(
                 variant: :text,
                 hex_color: merchant.color,
@@ -29,9 +29,8 @@
                 size: "sm",
                 rounded: true
               ) %>
-            </div>
-          <% end %>
-
+            <% end %>
+          </div>
           <%= merchant.name %>
         <% end %>
       </div>


### PR DESCRIPTION
This PR enhances the filter dropdown by displaying the merchant logo within the selection options, when available.
If a logo is provided in the merchant information, it will be shown in place of the default icon. If no logo is available, the existing icon-based behavior remains unchanged.

| Before | After |
| ------------- | ------------- |
| <img width="559" height="335" alt="Screenshot 2026-02-21 alle 00 04 28" src="https://github.com/user-attachments/assets/7148afec-911d-434b-84a5-d9d8671b32ed" /> | <img width="552" height="335" alt="Screenshot 2026-02-21 alle 00 04 03" src="https://github.com/user-attachments/assets/7cdfb79f-eb99-460e-8d6f-a198d244deb3" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Merchant filters now show merchant brand logos (lazy-loaded, sized, and styled) when available, with the original text-based icon as a fallback. The icon/logo display is responsive—hidden on smaller screens and visible on larger screens—to improve merchant recognition and maintain layout clarity across device sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->