### PR TITLE
Skip unnecessary sync when account balance unchanged on update

### DIFF
--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -41,15 +41,14 @@ module AccountableResource
   end
 
   def update
-    # Handle balance update if provided
-    if account_params[:balance].present?
+    # Handle balance update if the value actually changed
+    if account_params[:balance].present? && account_params[:balance].to_d != @account.balance
       result = @account.set_current_balance(account_params[:balance].to_d)
       unless result.success?
         @error_message = result.error_message
         render :edit, status: :unprocessable_entity
         return
       end
-      @account.sync_later
     end
 
     # Update remaining account attributes


### PR DESCRIPTION
While working on a larger new feature (limited account sharing), I discovered that the account "update" action was calling `set_current_balance` (which triggers `sync_later` internally) on every form submission, even when the balance hadn't changed. This caused the account to enter a syncing state, replacing the visible balance with a pulsing skeleton placeholder which never disappeared because there was actually nothing to sync...it was a manual account:

<img width="910" height="519" alt="image" src="https://github.com/user-attachments/assets/7b106f9d-dacf-4fa8-b29e-e85a6a2dd471" />

This minor fix compares the submitted balance against the current value and only calls `set_current_balance` when it actually differs. Also removes a redundant `sync_later` call that duplicated the one already inside `set_current_balance`.

I tested the original flow (edit account, click "update" with no changes) and the unexpected behavior is now gone. I also tried actually editing the balance on the account, and it also worked correctly, updating the balance shown in the account list immediately without getting stuck with a placeholder forever (or at all, really).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved balance update efficiency by only processing updates when the balance value actually changes, eliminating unnecessary sync operations and reducing system overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->