### PR TITLE
Add Docker Compose example with Pipelock agent firewall

### DIFF
--- a/compose.example.pipelock.yml
+++ b/compose.example.pipelock.yml
@@ -129,6 +129,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+      start_period: 30s
     networks:
       - sure_net
 


### PR DESCRIPTION
## Summary
- Adds `compose.example.pipelock.yml` alongside the existing standalone and AI examples
- Routes outbound HTTPS through Pipelock's scanner pipeline via HTTPS_PROXY
- Faraday-based clients (ruby-openai, market data) are covered automatically
- Three preset modes: balanced (default), strict, audit

## Coverage
- Documents which clients are proxied (Faraday) and which bypass (HTTParty/Net::HTTP)
- Notes that HTTPS_PROXY is cooperative; includes a k8s NetworkPolicy snippet for hard enforcement
- Monitoring section with log and endpoint reference

## Test plan
- [ ] `docker compose -f compose.example.pipelock.yml config` validates
- [ ] Pipelock healthcheck passes before web/worker start
- [ ] OpenAI calls route through proxy (visible in pipelock logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Docker Compose example demonstrating deployment with an outbound proxy integration, showing app, worker, database, cache, and backup services; includes proxy routing for outbound HTTPS, health checks, backup scheduling/retention, service dependencies, and customization notes for production use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->