### PR TITLE
Improve budget median: use last 6 months instead of all-time data

### DIFF
--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -159,11 +159,10 @@ class BudgetCategory < ApplicationRecord
   def suggested_daily_spending
     return nil unless available_to_spend > 0
 
-    budget_date = budget.start_date
-    return nil unless budget_date.month == Date.current.month && budget_date.year == Date.current.year
+    # Check if the current date falls within this budget's period
+    return nil unless Date.current.between?(budget.start_date, budget.end_date)
 
-    days_remaining = (budget_date.end_of_month - Date.current).to_i + 1
-    return nil unless days_remaining > 0
+    days_remaining = (budget.end_date - Date.current).to_i + 1
 
     {
       amount: Money.new((available_to_spend / days_remaining), budget.family.currency),

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -163,6 +163,7 @@ class BudgetCategory < ApplicationRecord
     return nil unless Date.current.between?(budget.start_date, budget.end_date)
 
     days_remaining = (budget.end_date - Date.current).to_i + 1
+    return nil unless days_remaining > 0
 
     {
       amount: Money.new((available_to_spend / days_remaining), budget.family.currency),

--- a/app/models/income_statement/category_stats.rb
+++ b/app/models/income_statement/category_stats.rb
@@ -1,4 +1,6 @@
 class IncomeStatement::CategoryStats
+  include IncomeStatement::StatsLookback
+
   def initialize(family, interval: "month")
     @family = family
     @interval = interval
@@ -29,7 +31,9 @@ class IncomeStatement::CategoryStats
       params = {
         target_currency: @family.currency,
         interval: @interval,
-        family_id: @family.id
+        family_id: @family.id,
+        lookback_start: lookback_start_date,
+        lookback_end: lookback_end_date
       }
 
       ids = @family.tax_advantaged_account_ids
@@ -68,6 +72,9 @@ class IncomeStatement::CategoryStats
           WHERE a.family_id = :family_id
             AND t.kind NOT IN (#{budget_excluded_kinds_sql})
             AND ae.excluded = false
+            AND ae.date >= :lookback_start
+            AND ae.date <= :lookback_end
+            AND a.status IN (#{visible_account_statuses_sql})
             AND (t.extra -> 'simplefin' ->> 'pending')::boolean IS DISTINCT FROM true
             AND (t.extra -> 'plaid' ->> 'pending')::boolean IS DISTINCT FROM true
             #{exclude_tax_advantaged_sql}

--- a/app/models/income_statement/category_stats.rb
+++ b/app/models/income_statement/category_stats.rb
@@ -33,7 +33,8 @@ class IncomeStatement::CategoryStats
         interval: @interval,
         family_id: @family.id,
         lookback_start: lookback_start_date,
-        lookback_end: lookback_end_date
+        lookback_end: lookback_end_date,
+        visible_statuses: visible_account_statuses
       }
 
       ids = @family.tax_advantaged_account_ids
@@ -74,7 +75,7 @@ class IncomeStatement::CategoryStats
             AND ae.excluded = false
             AND ae.date >= :lookback_start
             AND ae.date <= :lookback_end
-            AND a.status IN (#{visible_account_statuses_sql})
+            AND a.status IN (:visible_statuses)
             AND (t.extra -> 'simplefin' ->> 'pending')::boolean IS DISTINCT FROM true
             AND (t.extra -> 'plaid' ->> 'pending')::boolean IS DISTINCT FROM true
             #{exclude_tax_advantaged_sql}

--- a/app/models/income_statement/family_stats.rb
+++ b/app/models/income_statement/family_stats.rb
@@ -32,7 +32,8 @@ class IncomeStatement::FamilyStats
         interval: @interval,
         family_id: @family.id,
         lookback_start: lookback_start_date,
-        lookback_end: lookback_end_date
+        lookback_end: lookback_end_date,
+        visible_statuses: visible_account_statuses
       }
 
       ids = @family.tax_advantaged_account_ids
@@ -71,7 +72,7 @@ class IncomeStatement::FamilyStats
             AND ae.excluded = false
             AND ae.date >= :lookback_start
             AND ae.date <= :lookback_end
-            AND a.status IN (#{visible_account_statuses_sql})
+            AND a.status IN (:visible_statuses)
             AND (t.extra -> 'simplefin' ->> 'pending')::boolean IS DISTINCT FROM true
             AND (t.extra -> 'plaid' ->> 'pending')::boolean IS DISTINCT FROM true
             #{exclude_tax_advantaged_sql}

--- a/app/models/income_statement/stats_lookback.rb
+++ b/app/models/income_statement/stats_lookback.rb
@@ -1,0 +1,22 @@
+module IncomeStatement::StatsLookback
+  STATS_LOOKBACK_MONTHS = 6
+
+  # Matches Account.visible scope: where(status: ["draft", "active"])
+  VISIBLE_ACCOUNT_STATUSES = %w[draft active].freeze
+
+  private
+
+    def lookback_start_date
+      STATS_LOOKBACK_MONTHS.months.ago.beginning_of_month.to_date
+    end
+
+    # Always ends at the last completed month, regardless of how far back the
+    # window extends — STATS_LOOKBACK_MONTHS only controls the start date.
+    def lookback_end_date
+      1.month.ago.end_of_month.to_date
+    end
+
+    def visible_account_statuses_sql
+      @visible_account_statuses_sql ||= VISIBLE_ACCOUNT_STATUSES.map { |s| "'#{s}'" }.join(", ")
+    end
+end

--- a/app/models/income_statement/stats_lookback.rb
+++ b/app/models/income_statement/stats_lookback.rb
@@ -1,9 +1,6 @@
 module IncomeStatement::StatsLookback
   STATS_LOOKBACK_MONTHS = 6
 
-  # Matches Account.visible scope: where(status: ["draft", "active"])
-  VISIBLE_ACCOUNT_STATUSES = %w[draft active].freeze
-
   private
 
     def lookback_start_date
@@ -16,7 +13,8 @@ module IncomeStatement::StatsLookback
       1.month.ago.end_of_month.to_date
     end
 
-    def visible_account_statuses_sql
-      @visible_account_statuses_sql ||= VISIBLE_ACCOUNT_STATUSES.map { |s| "'#{s}'" }.join(", ")
+    # Derives visible statuses from Account.visible scope to avoid duplication.
+    def visible_account_statuses
+      Account.visible.where_values_hash["status"]
     end
 end

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -64,12 +64,13 @@ class IncomeStatementTest < ActiveSupport::TestCase
     # Clear existing transactions by deleting entries
     Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
 
-    # Create expenses: 100, 200, 300, 400, 500 (median should be 300)
-    create_transaction(account: @checking_account, amount: 100, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 200, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 300, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 400, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 500, category: @groceries_category)
+    # Create expenses in a past completed month (within the 6-month lookback window)
+    past_month = 2.months.ago.beginning_of_month.to_date
+    create_transaction(account: @checking_account, amount: 100, category: @groceries_category, date: past_month)
+    create_transaction(account: @checking_account, amount: 200, category: @groceries_category, date: past_month + 1.day)
+    create_transaction(account: @checking_account, amount: 300, category: @groceries_category, date: past_month + 2.days)
+    create_transaction(account: @checking_account, amount: 400, category: @groceries_category, date: past_month + 3.days)
+    create_transaction(account: @checking_account, amount: 500, category: @groceries_category, date: past_month + 4.days)
 
     income_statement = IncomeStatement.new(@family)
     # CORRECT BUSINESS LOGIC: Calculates median of time-period totals for budget planning
@@ -81,12 +82,13 @@ class IncomeStatementTest < ActiveSupport::TestCase
     # Clear existing transactions by deleting entries
     Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
 
-    # Create income: -200, -300, -400, -500, -600 (median should be -400, displayed as 400)
-    create_transaction(account: @checking_account, amount: -200, category: @income_category)
-    create_transaction(account: @checking_account, amount: -300, category: @income_category)
-    create_transaction(account: @checking_account, amount: -400, category: @income_category)
-    create_transaction(account: @checking_account, amount: -500, category: @income_category)
-    create_transaction(account: @checking_account, amount: -600, category: @income_category)
+    # Create income in a past completed month (within the 6-month lookback window)
+    past_month = 2.months.ago.beginning_of_month.to_date
+    create_transaction(account: @checking_account, amount: -200, category: @income_category, date: past_month)
+    create_transaction(account: @checking_account, amount: -300, category: @income_category, date: past_month + 1.day)
+    create_transaction(account: @checking_account, amount: -400, category: @income_category, date: past_month + 2.days)
+    create_transaction(account: @checking_account, amount: -500, category: @income_category, date: past_month + 3.days)
+    create_transaction(account: @checking_account, amount: -600, category: @income_category, date: past_month + 4.days)
 
     income_statement = IncomeStatement.new(@family)
     # CORRECT BUSINESS LOGIC: Calculates median of time-period totals for budget planning
@@ -98,10 +100,11 @@ class IncomeStatementTest < ActiveSupport::TestCase
     # Clear existing transactions by deleting entries
     Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
 
-    # Create expenses: 100, 200, 300 (average should be 200)
-    create_transaction(account: @checking_account, amount: 100, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 200, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 300, category: @groceries_category)
+    # Create expenses in a past completed month (within the 6-month lookback window)
+    past_month = 2.months.ago.beginning_of_month.to_date
+    create_transaction(account: @checking_account, amount: 100, category: @groceries_category, date: past_month)
+    create_transaction(account: @checking_account, amount: 200, category: @groceries_category, date: past_month + 1.day)
+    create_transaction(account: @checking_account, amount: 300, category: @groceries_category, date: past_month + 2.days)
 
     income_statement = IncomeStatement.new(@family)
     # CORRECT BUSINESS LOGIC: Calculates average of time-period totals for budget planning
@@ -113,17 +116,18 @@ class IncomeStatementTest < ActiveSupport::TestCase
     # Clear existing transactions by deleting entries
     Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
 
-    # Create different amounts for groceries vs other food
+    # Create different amounts for groceries vs other food in a past completed month
     other_food_category = @family.categories.create! name: "Restaurants", classification: "expense", parent: @food_category
+    past_month = 2.months.ago.beginning_of_month.to_date
 
-    # Groceries: 100, 300, 500 (median = 300)
-    create_transaction(account: @checking_account, amount: 100, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 300, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 500, category: @groceries_category)
+    # Groceries: 100, 300, 500 (monthly total = 900)
+    create_transaction(account: @checking_account, amount: 100, category: @groceries_category, date: past_month)
+    create_transaction(account: @checking_account, amount: 300, category: @groceries_category, date: past_month + 1.day)
+    create_transaction(account: @checking_account, amount: 500, category: @groceries_category, date: past_month + 2.days)
 
-    # Restaurants: 50, 150 (median = 100)
-    create_transaction(account: @checking_account, amount: 50, category: other_food_category)
-    create_transaction(account: @checking_account, amount: 150, category: other_food_category)
+    # Restaurants: 50, 150 (monthly total = 200)
+    create_transaction(account: @checking_account, amount: 50, category: other_food_category, date: past_month + 3.days)
+    create_transaction(account: @checking_account, amount: 150, category: other_food_category, date: past_month + 4.days)
 
     income_statement = IncomeStatement.new(@family)
     # CORRECT BUSINESS LOGIC: Calculates median of time-period totals for budget planning
@@ -138,11 +142,11 @@ class IncomeStatementTest < ActiveSupport::TestCase
     # Clear existing transactions by deleting entries
     Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
 
-    # Create different amounts for groceries
-    # Groceries: 100, 200, 300 (average = 200)
-    create_transaction(account: @checking_account, amount: 100, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 200, category: @groceries_category)
-    create_transaction(account: @checking_account, amount: 300, category: @groceries_category)
+    # Create groceries in a past completed month (within the 6-month lookback window)
+    past_month = 2.months.ago.beginning_of_month.to_date
+    create_transaction(account: @checking_account, amount: 100, category: @groceries_category, date: past_month)
+    create_transaction(account: @checking_account, amount: 200, category: @groceries_category, date: past_month + 1.day)
+    create_transaction(account: @checking_account, amount: 300, category: @groceries_category, date: past_month + 2.days)
 
     income_statement = IncomeStatement.new(@family)
     # CORRECT BUSINESS LOGIC: Calculates average of time-period totals for budget planning
@@ -224,33 +228,32 @@ class IncomeStatementTest < ActiveSupport::TestCase
     # Clear existing transactions
     Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
 
-    # Create transactions across multiple weeks to test interval behavior
-    # Week 1: 100, 200 (total: 300, median: 150)
-    create_transaction(account: @checking_account, amount: 100, category: @groceries_category, date: 3.weeks.ago)
-    create_transaction(account: @checking_account, amount: 200, category: @groceries_category, date: 3.weeks.ago + 1.day)
+    # Create transactions in past months across multiple weeks (within 6-month lookback window)
+    # Pin to the first Monday of a past completed month so PostgreSQL
+    # date_trunc('week') groupings are deterministic.
+    raw = 2.months.ago.beginning_of_month.to_date
+    base_date = raw + ((1 - raw.wday) % 7) # advance to the first Monday
 
-    # Week 2: 400, 600 (total: 1000, median: 500)
-    create_transaction(account: @checking_account, amount: 400, category: @groceries_category, date: 2.weeks.ago)
-    create_transaction(account: @checking_account, amount: 600, category: @groceries_category, date: 2.weeks.ago + 1.day)
+    # Week 1 (Mon/Tue): 100, 200 (total: 300)
+    create_transaction(account: @checking_account, amount: 100, category: @groceries_category, date: base_date)
+    create_transaction(account: @checking_account, amount: 200, category: @groceries_category, date: base_date + 1.day)
 
-    # Week 3: 800 (total: 800, median: 800)
-    create_transaction(account: @checking_account, amount: 800, category: @groceries_category, date: 1.week.ago)
+    # Week 2 (next Mon/Tue): 400, 600 (total: 1000)
+    create_transaction(account: @checking_account, amount: 400, category: @groceries_category, date: base_date + 7.days)
+    create_transaction(account: @checking_account, amount: 600, category: @groceries_category, date: base_date + 8.days)
+
+    # Week 3 (next Mon): 800 (total: 800)
+    create_transaction(account: @checking_account, amount: 800, category: @groceries_category, date: base_date + 14.days)
 
     income_statement = IncomeStatement.new(@family)
 
     month_median = income_statement.median_expense(interval: "month")
     week_median = income_statement.median_expense(interval: "week")
 
-    # CRITICAL TEST: Different intervals should return different results
-    # Month interval: median of monthly totals (if all in same month) vs individual transactions
-    # Week interval: median of weekly totals [300, 1000, 800] = 800 vs individual transactions [100,200,400,600,800] = 400
-    refute_equal month_median, week_median, "Different intervals should return different statistical results when data spans multiple time periods"
-
-    # Both should still be numeric
-    assert month_median.is_a?(Numeric)
-    assert week_median.is_a?(Numeric)
-    assert month_median > 0
-    assert week_median > 0
+    # Month interval: all in same month = total 2100, median = 2100
+    assert_equal 2100.0, month_median
+    # Week interval: weekly totals [300, 1000, 800], median = 800
+    assert_equal 800.0, week_median
   end
 
   # NEW TESTS: Edge Cases

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -257,6 +257,24 @@ class IncomeStatementTest < ActiveSupport::TestCase
   end
 
   # NEW TESTS: Edge Cases
+  test "excludes transactions outside the 6-month lookback window" do
+    # Clear existing transactions
+    Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
+
+    # Create a transaction well outside the lookback window (8 months ago)
+    old_date = 8.months.ago.beginning_of_month.to_date
+    create_transaction(account: @checking_account, amount: 9999, category: @groceries_category, date: old_date)
+
+    # Create a transaction inside the lookback window (2 months ago)
+    recent_date = 2.months.ago.beginning_of_month.to_date
+    create_transaction(account: @checking_account, amount: 200, category: @groceries_category, date: recent_date)
+
+    income_statement = IncomeStatement.new(@family)
+
+    # Only the recent transaction should be included; the old one should be excluded
+    assert_equal 200.0, income_statement.median_expense(interval: "month")
+  end
+
   test "handles empty dataset gracefully" do
     # Create a truly empty family
     empty_family = Family.create!(name: "Empty Test Family", currency: "USD")


### PR DESCRIPTION
Budget statistics now use a 6-month lookback window for median/average calculations, producing more realistic budget suggestions based on recent spending patterns rather than all-time historical data.

Changes:
- Add STATS_LOOKBACK_MONTHS (6) to FamilyStats and CategoryStats
- Filter stats queries to only include completed months within window
- Filter to active/draft accounts only
- Fix budget_category daily spending to use budget period dates instead of calendar month (supports custom month start)
- Update tests to create transactions within the lookback window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daily spending suggestion now respects a budget's actual date range and uses the budget end date for remaining-days; cache keys updated so stats refresh when the lookback window changes.

* **New Features**
  * Income statement adds a 6-month lookback window and restricts results to visible account statuses.

* **Tests**
  * Tests use dated transactions anchored to a past month for deterministic aggregates and add an edge case excluding data outside the 6-month lookback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->