### PR TITLE
Add Kosovo to country list

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -261,6 +261,7 @@ module LanguagesHelper
     KP: "🇰🇵 North Korea",
     KR: "🇰🇷 South Korea",
     KW: "🇰🇼 Kuwait",
+    XK: "🇽🇰 Kosovo",
     KG: "🇰🇬 Kyrgyzstan",
     LA: "🇱🇦 Laos",
     LV: "🇱🇻 Latvia",


### PR DESCRIPTION
## Summary

Kosovo was missing from the country selection dropdown in user preferences. This PR adds Kosovo to the `COUNTRY_MAPPING` constant.

## Changes

- Added Kosovo (XK) with flag emoji 🇽🇰 to the country list in `LanguagesHelper`
- Entry placed alphabetically between Kuwait and Kyrgyzstan
- Used ISO 3166-1 alpha-2 user-assigned code `XK` (standard code for Kosovo)

## Testing

- ✅ Helper tests pass
- ✅ Country appears correctly in preferences dropdown
- ✅ No breaking changes

## Related

This allows users from Kosovo to properly select their country in the application settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kosovo as a selectable locale and country option in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->