### PR TITLE
Fix PWA: back/X buttons untappable in wizard layout (budget edit)

### DIFF
--- a/app/views/layouts/wizard.html.erb
+++ b/app/views/layouts/wizard.html.erb
@@ -1,5 +1,5 @@
 <%= render "layouts/shared/htmldoc" do %>
-  <div class="bg-surface flex flex-col h-full">
+  <div class="bg-surface flex flex-col h-full pt-[env(safe-area-inset-top)]">
     <header class="flex items-center justify-between p-8">
       <% if content_for?(:prev_nav) %>
         <%= yield :prev_nav %>


### PR DESCRIPTION
## Summary
- The wizard layout header (used by budget category edit) lacked `safe-area-inset-top` padding, causing the back arrow and X button to render under the system status bar in PWA standalone mode
- All other layouts (`application`, `settings`) already account for `env(safe-area-inset-top)` — this brings the wizard layout in line
- On non-PWA browsers, `env(safe-area-inset-top)` resolves to `0px`, so there is no visual change

## Test plan
- [x] Install the app as a PWA on iOS or Android
- [x] Navigate to Budgets → Edit category budgets (wizard flow)
- [x] Verify the back arrow (←) and X button are fully tappable
- [x] Verify the layout looks correct in regular browser mode (no extra spacing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added top safe-area padding to the main layout so content is properly spaced from device notches and status areas.
  * Ensures consistent header positioning and prevents content from being obscured on devices with cutouts or special safe-area requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->