### PR TITLE
fix: maintain activity tab during pagination from holdings tab

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -42,7 +42,11 @@ class AccountsController < ApplicationController
     @q = params.fetch(:q, {}).permit(:search, status: [])
     entries = @account.entries.where(excluded: false).search(@q).reverse_chronological
 
-    @pagy, @entries = pagy(entries, limit: safe_per_page)
+    @pagy, @entries = pagy(
+      entries,
+      limit: safe_per_page,
+      params: request.query_parameters.except("tab").merge("tab" => "activity")
+    )
 
     @activity_feed_data = Account::ActivityFeedData.new(@account, @entries)
   end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -16,6 +16,27 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "activity pagination keeps activity tab when loaded from holdings tab" do
+    investment = accounts(:investment)
+
+    11.times do |i|
+      Entry.create!(
+        account: investment,
+        name: "Test investment activity #{i}",
+        date: Date.current - i.days,
+        amount: 10 + i,
+        currency: investment.currency,
+        entryable: Transaction.new
+      )
+    end
+
+    get account_url(investment, tab: "holdings")
+
+    assert_response :success
+    assert_select "a[href*='page=2'][href*='tab=activity']"
+    assert_select "a[href*='page=2'][href*='tab=holdings']", count: 0
+  end
+
   test "should sync account" do
     post sync_account_url(@account)
     assert_redirected_to account_url(@account)


### PR DESCRIPTION
## Summary

  Fixes a tab-state bug on investment account pages where activity pagination links could keep tab=holdings and force the UI back to
  holdings unexpectedly.

  ## Reproduction

  1. Open an investment account.
  2. Go to Holdings.
  3. Click New activity, create/save a transaction.
  4. Return to Activity.
  5. Use pagination.

  Before: pagination links include tab=holdings, so tab state gets stuck.
  After: activity pagination links use tab=activity and no longer force holdings.

  ## Root Cause

<img width="768" height="250" alt="2026-03-03_00-05-42" src="https://github.com/user-attachments/assets/945cf94a-8b7d-4846-ad3f-8576a82b0586" />

  The account page renders both tab panels, and when URL had tab=holdings, activity-feed pagination links were generated from that
  query state.

  ## Fix

  In AccountsController#show, pass explicit Pagy params for activity feed pagination:

  - remove incoming tab
  - force tab=activity for generated pagination URLs

  ## Tests

  Added controller regression test:

  - test "activity pagination keeps activity tab when loaded from holdings tab"
  - Verifies generated pagination links include tab=activity and not tab=holdings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination behavior to properly maintain the activity tab view when navigating through pages. The selected tab is now correctly preserved when switching between paginated results, preventing unexpected navigation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->