### PR TITLE
feat: add transaction name autocomplete suggestions and UI integration

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -8,9 +8,7 @@ class TransactionsController < ApplicationController
     prefill_params_from_duplicate!
     super
     apply_duplicate_attributes!
-    @income_categories = Current.family.categories.incomes.alphabetically
-    @expense_categories = Current.family.categories.expenses.alphabetically
-    @categories = Current.family.categories.alphabetically
+    load_new_form_options
   end
 
   def index
@@ -64,6 +62,10 @@ class TransactionsController < ApplicationController
                                   .includes(:merchant)
   end
 
+  def name_suggestions
+    render json: { suggestions: transaction_name_suggestions(query: params[:query]) }
+  end
+
   def clear_filter
     updated_params = {
       "q" => search_params,
@@ -113,6 +115,7 @@ class TransactionsController < ApplicationController
         format.turbo_stream { stream_redirect_back_or_to(account_path(@entry.account)) }
       end
     else
+      load_new_form_options
       render :new, status: :unprocessable_entity
     end
   end
@@ -490,6 +493,73 @@ class TransactionsController < ApplicationController
 
     def preferences_params
       params.require(:preferences).permit(collapsed_sections: {})
+    end
+
+    def load_new_form_options
+      @categories = Current.family.categories.alphabetically
+    end
+
+    def transaction_name_suggestions(query:, limit: 8)
+      query_text = query.to_s.squish
+      return [] if query_text.length < 2
+
+      rows = Current.accessible_entries
+        .where(entryable_type: "Transaction", parent_entry_id: nil)
+        .where.not(name: [ nil, "" ])
+        .where("entries.name ILIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(query_text)}%")
+        .order(created_at: :desc)
+        .limit(500)
+        .pluck(:name, :created_at)
+
+      deduplicate_transaction_name_rows(rows, query: query_text, limit: limit)
+    end
+
+    def deduplicate_transaction_name_rows(rows, query:, limit:)
+      normalized_query = normalize_transaction_name(query)
+
+      grouped_names = rows.each_with_object({}) do |(name, created_at), grouped|
+        normalized_name = normalize_transaction_name(name)
+        next if normalized_name.blank?
+
+        bucket = grouped[normalized_name] ||= { latest_seen_at: created_at, variants: {} }
+        bucket[:latest_seen_at] = [ bucket[:latest_seen_at], created_at ].max
+
+        variant = bucket[:variants][name] ||= { count: 0, latest_seen_at: created_at }
+        variant[:count] += 1
+        variant[:latest_seen_at] = [ variant[:latest_seen_at], created_at ].max
+      end
+
+      grouped_names
+        .map do |normalized_name, data|
+          canonical_name = best_casing_variant_name(data[:variants])
+          next if canonical_name.blank?
+
+          {
+            canonical_name: canonical_name,
+            latest_seen_at: data[:latest_seen_at],
+            match_rank: transaction_name_match_rank(normalized_name, normalized_query)
+          }
+        end
+        .compact
+        .sort_by { |item| [ item[:match_rank], -item[:latest_seen_at].to_i ] }
+        .map { |item| item[:canonical_name] }
+        .first(limit)
+    end
+
+    def best_casing_variant_name(variants)
+      variants.max_by { |_, stats| [ stats[:count], stats[:latest_seen_at].to_i ] }&.first
+    end
+
+    def transaction_name_match_rank(normalized_name, normalized_query)
+      return 0 if normalized_name == normalized_query
+      return 1 if normalized_name.start_with?(normalized_query)
+      return 2 if normalized_name.split.any? { |word| word.start_with?(normalized_query) }
+
+      3
+    end
+
+    def normalize_transaction_name(name)
+      name.to_s.squish.downcase
     end
 
     # Helper methods for convert_to_trade

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -503,13 +503,26 @@ class TransactionsController < ApplicationController
       query_text = query.to_s.squish
       return [] if query_text.length < 2
 
+      normalized_query = normalize_transaction_name(query_text)
+      escaped_query = ActiveRecord::Base.sanitize_sql_like(normalized_query)
+      normalized_name_sql = "lower(regexp_replace(trim(entries.name), '\\s+', ' ', 'g'))"
+      match_rank_sql = <<~SQL.squish
+        CASE
+          WHEN #{normalized_name_sql} = #{ActiveRecord::Base.connection.quote(normalized_query)} THEN 0
+          WHEN #{normalized_name_sql} LIKE #{ActiveRecord::Base.connection.quote("#{escaped_query}%")} THEN 1
+          WHEN #{normalized_name_sql} LIKE #{ActiveRecord::Base.connection.quote("% #{escaped_query}%")} THEN 2
+          ELSE 3
+        END
+      SQL
+
       rows = Current.accessible_entries
         .where(entryable_type: "Transaction", parent_entry_id: nil)
         .where.not(name: [ nil, "" ])
-        .where("entries.name ILIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(query_text)}%")
-        .order(created_at: :desc)
+        .where("#{normalized_name_sql} LIKE ?", "%#{escaped_query}%")
+        .select("entries.name, entries.created_at, #{match_rank_sql} AS transaction_name_match_rank")
+        .order(Arel.sql("#{match_rank_sql} ASC, entries.created_at DESC"))
         .limit(500)
-        .pluck(:name, :created_at)
+        .map { |entry| [ entry.name, entry.created_at ] }
 
       deduplicate_transaction_name_rows(rows, query: query_text, limit: limit)
     end

--- a/app/javascript/controllers/transaction_name_suggestions_controller.js
+++ b/app/javascript/controllers/transaction_name_suggestions_controller.js
@@ -1,0 +1,212 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["input", "list", "menu", "empty"];
+  static values = {
+    url: String,
+    minLength: { type: Number, default: 2 },
+    debounce: { type: Number, default: 150 },
+  };
+
+  connect() {
+    this.abortController = null;
+    this.activeIndex = -1;
+    this.suggestions = [];
+    this.boundSelectSuggestion = this.selectSuggestion.bind(this);
+  }
+
+  disconnect() {
+    this.#cancelPendingRequest();
+    clearTimeout(this.timeout);
+  }
+
+  fetchSuggestions() {
+    clearTimeout(this.timeout);
+
+    const query = this.inputTarget.value.trim();
+    if (query.length < this.minLengthValue) {
+      this.#resetSuggestions();
+      return;
+    }
+
+    this.timeout = setTimeout(() => {
+      this.#loadSuggestions(query);
+    }, this.debounceValue);
+  }
+
+  handleFocus() {
+    if (this.inputTarget.value.trim().length >= this.minLengthValue && this.suggestions.length === 0) {
+      this.fetchSuggestions();
+      return;
+    }
+
+    if (this.inputTarget.value.trim().length >= this.minLengthValue && this.suggestions.length > 0) {
+      this.#showMenu();
+    }
+  }
+
+  handleBlur() {
+    window.setTimeout(() => this.#hideMenu(), 120);
+  }
+
+  handleKeydown(event) {
+    if (!this.#menuOpen() || this.suggestions.length === 0) {
+      return;
+    }
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        this.#moveActiveIndex(1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        this.#moveActiveIndex(-1);
+        break;
+      case "Enter":
+        if (this.activeIndex >= 0) {
+          event.preventDefault();
+          this.#selectSuggestion(this.suggestions[this.activeIndex]);
+        }
+        break;
+      case "Escape":
+        this.#hideMenu();
+        break;
+    }
+  }
+
+  selectSuggestion(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const { value } = event.currentTarget.dataset;
+    this.#selectSuggestion(value);
+  }
+
+  async #loadSuggestions(query) {
+    if (!this.hasUrlValue) return;
+
+    const url = new URL(this.urlValue, window.location.origin);
+    url.searchParams.set("query", query);
+
+    this.#cancelPendingRequest();
+    this.abortController = new AbortController();
+
+    try {
+      const response = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        signal: this.abortController.signal,
+      });
+
+      if (!response.ok) return;
+
+      const data = await response.json();
+      this.suggestions = data.suggestions || [];
+      this.activeIndex = -1;
+      this.#renderSuggestions();
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        this.#resetSuggestions();
+      }
+    }
+  }
+
+  #renderSuggestions() {
+    this.listTarget.innerHTML = "";
+
+    if (this.suggestions.length === 0) {
+      this.emptyTarget.classList.remove("hidden");
+      this.#showMenu();
+      this.#updateExpandedState(true);
+      return;
+    }
+
+    this.emptyTarget.classList.add("hidden");
+
+    this.suggestions.forEach((suggestion, index) => {
+      const item = document.createElement("li");
+      item.id = `transaction-name-suggestion-${index}`;
+      item.setAttribute("role", "option");
+      item.setAttribute("aria-selected", "false");
+      item.dataset.index = index;
+      item.dataset.value = suggestion;
+      item.className =
+        "cursor-pointer rounded-lg px-3 py-2 text-sm text-primary hover:bg-container-inset-hover";
+      item.textContent = suggestion;
+      item.addEventListener("mousedown", this.boundSelectSuggestion);
+
+      this.listTarget.appendChild(item);
+    });
+
+    this.#showMenu();
+    this.#updateExpandedState(true);
+  }
+
+  #moveActiveIndex(direction) {
+    const nextIndex = this.activeIndex + direction;
+
+    if (nextIndex < 0) {
+      this.activeIndex = this.suggestions.length - 1;
+    } else if (nextIndex >= this.suggestions.length) {
+      this.activeIndex = 0;
+    } else {
+      this.activeIndex = nextIndex;
+    }
+
+    this.#syncActiveOption();
+  }
+
+  #syncActiveOption() {
+    Array.from(this.listTarget.children).forEach((item, index) => {
+      const isActive = index === this.activeIndex;
+      item.setAttribute("aria-selected", isActive ? "true" : "false");
+      item.classList.toggle("bg-container-inset", isActive);
+
+      if (isActive) {
+        item.scrollIntoView({ block: "nearest" });
+        this.inputTarget.setAttribute("aria-activedescendant", item.id);
+      }
+    });
+
+    if (this.activeIndex < 0) {
+      this.inputTarget.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  #selectSuggestion(value) {
+    this.inputTarget.value = value;
+    this.#resetSuggestions();
+  }
+
+  #showMenu() {
+    this.menuTarget.classList.remove("hidden");
+  }
+
+  #hideMenu() {
+    this.menuTarget.classList.add("hidden");
+    this.#updateExpandedState(false);
+    this.inputTarget.removeAttribute("aria-activedescendant");
+  }
+
+  #menuOpen() {
+    return !this.menuTarget.classList.contains("hidden");
+  }
+
+  #updateExpandedState(expanded) {
+    this.inputTarget.setAttribute("aria-expanded", expanded ? "true" : "false");
+  }
+
+  #resetSuggestions() {
+    this.suggestions = [];
+    this.activeIndex = -1;
+    this.listTarget.innerHTML = "";
+    this.emptyTarget.classList.add("hidden");
+    this.#hideMenu();
+  }
+
+  #cancelPendingRequest() {
+    if (!this.abortController) return;
+    this.abortController.abort();
+    this.abortController = null;
+  }
+}

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -13,7 +13,37 @@
   </section>
 
   <section class="space-y-2">
-    <%= f.text_field :name, label: t(".description"), placeholder: t(".description_placeholder"), required: true %>
+    <div class="relative"
+         data-controller="transaction-name-suggestions"
+         data-transaction-name-suggestions-url-value="<%= name_suggestions_transactions_path %>">
+      <%= f.text_field :name,
+                       label: t(".description"),
+                       placeholder: t(".description_placeholder"),
+                       required: true,
+                       autocomplete: "off",
+                       role: "combobox",
+                       aria: {
+                         autocomplete: "list",
+                         controls: "transaction-name-suggestions-listbox",
+                         expanded: "false"
+                       },
+                       data: {
+                         action: "input->transaction-name-suggestions#fetchSuggestions focus->transaction-name-suggestions#handleFocus blur->transaction-name-suggestions#handleBlur keydown->transaction-name-suggestions#handleKeydown",
+                         transaction_name_suggestions_target: "input"
+                       } %>
+
+      <div class="absolute left-0 right-0 z-50 mt-1.5 hidden rounded-lg bg-container p-1.5 shadow-lg shadow-border-xs"
+           data-transaction-name-suggestions-target="menu">
+        <ul id="transaction-name-suggestions-listbox"
+            role="listbox"
+            class="max-h-64 overflow-auto"
+            data-transaction-name-suggestions-target="list"></ul>
+        <p class="hidden px-3 py-2 text-sm text-secondary"
+           data-transaction-name-suggestions-target="empty">
+          No matching descriptions
+        </p>
+      </div>
+    </div>
 
     <% if @entry.account_id %>
       <%= f.hidden_field :account_id %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,6 +304,7 @@ Rails.application.routes.draw do
 
     collection do
       delete :clear_filter
+      get :name_suggestions
       patch :update_preferences
     end
 

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -8,6 +8,72 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     @entry = entries(:transaction)
   end
 
+  test "new renders custom description suggestions UI without datalist" do
+    get new_transaction_url(account_id: @entry.account_id)
+
+    assert_response :success
+    assert_dom "[data-controller='transaction-name-suggestions']", count: 1
+    assert_dom "#transaction-name-suggestions-listbox", count: 1
+    assert_dom "datalist#transaction-name-suggestions", count: 0
+  end
+
+  test "name_suggestions returns case-insensitive deduped names" do
+    family = families(:empty)
+    sign_in users(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+
+    create_transaction(account: account, name: "Sample Vendor")
+    create_transaction(account: account, name: "sample vendor")
+    create_transaction(account: account, name: "Sample Vendor")
+
+    get name_suggestions_transactions_url(query: "sample"), as: :json
+
+    assert_response :success
+    suggestions = response.parsed_body["suggestions"]
+    assert_equal 1, suggestions.count { |name| name.downcase == "sample vendor" }
+  end
+
+  test "name_suggestions prioritizes exact then prefix matches" do
+    family = families(:empty)
+    sign_in users(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+
+    create_transaction(account: account, name: "Cost")
+    create_transaction(account: account, name: "Cost Center")
+    create_transaction(account: account, name: "Warehouse Cost")
+
+    get name_suggestions_transactions_url(query: "cost"), as: :json
+
+    assert_response :success
+    suggestions = response.parsed_body["suggestions"]
+    assert_equal [ "Cost", "Cost Center", "Warehouse Cost" ], suggestions.first(3)
+  end
+
+  test "name_suggestions returns empty for very short queries" do
+    get name_suggestions_transactions_url(query: "c"), as: :json
+
+    assert_response :success
+    assert_equal [], response.parsed_body["suggestions"]
+  end
+
+  test "create failure rerenders new form with custom suggestions UI" do
+    post transactions_url, params: {
+      entry: {
+        account_id: @entry.account_id,
+        name: "",
+        date: Date.current,
+        currency: "USD",
+        amount: 100,
+        nature: "outflow",
+        entryable_type: @entry.entryable_type
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_dom "[data-controller='transaction-name-suggestions']", count: 1
+    assert_dom "#transaction-name-suggestions-listbox", count: 1
+  end
+
   test "creates with transaction details" do
     assert_difference [ "Entry.count", "Transaction.count" ], 1 do
       post transactions_url, params: {

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -49,6 +49,24 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "Cost", "Cost Center", "Warehouse Cost" ], suggestions.first(3)
   end
 
+  test "name_suggestions keeps older exact matches ahead of many newer substring matches" do
+    family = families(:empty)
+    sign_in users(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+
+    create_transaction(account: account, name: "Cost")
+
+    501.times do |index|
+      create_transaction(account: account, name: "Miscost Example #{index}")
+    end
+
+    get name_suggestions_transactions_url(query: "cost"), as: :json
+
+    assert_response :success
+    suggestions = response.parsed_body["suggestions"]
+    assert_equal "Cost", suggestions.first
+  end
+
   test "name_suggestions returns empty for very short queries" do
     get name_suggestions_transactions_url(query: "c"), as: :json
 


### PR DESCRIPTION
## Summary

  This PR adds transaction name autocomplete to the New transaction form.

  ## What’s included

  - Added autocomplete suggestions to the description field using a datalist.
  - Added server-side suggestions loading for the form.
  - Added a suggestions endpoint for dynamic lookup while typing.
  - Suggestions are deduplicated case-insensitively and scoped to the current family.
  - Added controller tests covering:
      - Autocomplete rendering on new form
      - Deduped suggestions behavior
      - Dynamic lookup results for typed input

  ## Why

  To speed up manual transaction entry by letting users select previously used names instead of typing full descriptions each time.

  ## Testing

  - bin/rails test test/controllers/transactions_controller_test.rb

  ## Screenshots

1. New transaction form with description autocomplete enabled.
<img width="811" height="724" alt="2026-03-03_01-29-45" src="https://github.com/user-attachments/assets/c49cdfc4-01bd-4f7a-98b7-dd31192daa0f" />

2. Typing in description shows dynamic, family-scoped, case-insensitive deduplicated suggestions.
<img width="555" height="506" alt="2026-03-03_01-30-12" src="https://github.com/user-attachments/assets/536e6f6c-4fe7-4f37-8d93-63c0dbdc3ae8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added intelligent transaction name autocomplete suggestions that appear in real-time as you type, with keyboard navigation support (arrow keys to navigate, Enter to select, Escape to close) and case-insensitive deduplication for cleaner, faster transaction entry.

* **Tests**
  * Added comprehensive test coverage for the new transaction name suggestion and autocomplete features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->