### PR TITLE
feat: Enable Skylight ActiveJob probe for background worker visibility

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ module Sure
     }
 
     # Enable Skylight instrumentation for ActiveJob (background workers)
-    config.skylight.probes << "active_job"
+    config.skylight.probes << "active_job" if defined?(Skylight)
 
     # Enable Rack::Attack middleware for API rate limiting
     config.middleware.use Rack::Attack


### PR DESCRIPTION
### Summary

- Adds `config.skylight.probes << "active_job" to config/application.rb` so Skylight instruments background jobs (e.g. `SyncJob`, `SyncAllJob`)
- Currently Skylight only tracks web request endpoints. This change surfaces Sidekiq worker performance in the dashboard

### Context

While reviewing [#1081](https://github.com/we-promise/sure/pull/1081) (Balance::SyncCache indexing optimization), we found that the impacted code path runs entirely in background workers, which aren't visible in Skylight today. Enabling this probe will let us monitor background job performance going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced monitoring for background job processing to improve visibility into job performance and instrumentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->