### PR TITLE
Add safe-area padding for PWA on import page

### DIFF
--- a/app/views/layouts/imports.html.erb
+++ b/app/views/layouts/imports.html.erb
@@ -1,5 +1,5 @@
 <%= render "layouts/shared/htmldoc" do %>
-  <div class="flex flex-col h-full bg-container">
+  <div class="flex flex-col h-full bg-container pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
     <header class="flex items-center justify-between p-8">
       <%= render DS::Link.new(
         variant: "icon",


### PR DESCRIPTION
This PR introduces additional padding at the top and bottom on the imports page, to prevent button overlaps with the top notch on mobile devices. It resolves the same issue already addressed in PR https://github.com/we-promise/sure/pull/1076 on the budget page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced layout spacing to properly accommodate device safe areas, ensuring content displays correctly on all device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->