### PR TITLE
Expand AI docs: external assistant, MCP, architecture, troubleshooting

### DIFF
--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -823,14 +823,14 @@ ollama pull model-name  # Install a model
    ```
    If the env var is unset, check the family setting in the database or Settings UI.
 
-2. **Can Sure reach the agent?** Test from inside the worker pod:
+2. **Can Sure reach the agent?** Test from inside the worker pod (use `sh -c` so the env var expands inside the pod, not locally):
    ```bash
    kubectl exec deploy/sure-worker -c sidekiq -- \
-     curl -s -o /dev/null -w "%{http_code}" \
-     -H "Authorization: Bearer $TOKEN" \
+     sh -c 'curl -s -o /dev/null -w "%{http_code}" \
+     -H "Authorization: Bearer $EXTERNAL_ASSISTANT_TOKEN" \
      -H "Content-Type: application/json" \
-     -d '{"model":"test","messages":[{"role":"user","content":"ping"}]}' \
-     http://your-agent-url/v1/chat/completions
+     -d "{\"model\":\"test\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
+     $EXTERNAL_ASSISTANT_URL'
    ```
    - **Exit code 7 (connection refused):** Network policy is blocking. Check egress rules, and remember to use the `targetPort`, not the service port.
    - **HTTP 401/403:** Token mismatch between Sure's `EXTERNAL_ASSISTANT_TOKEN` and the agent's expected token.


### PR DESCRIPTION
## Summary
- Add architecture overview explaining Sure's two independent AI pipelines (chat vs auto-categorization) and how they route differently based on `ASSISTANT_TYPE`
- Document the MCP callback endpoint (`/mcp`) with protocol details, authentication, available tools, and curl examples so external agent developers can integrate
- Add setup guidance for external assistants: OpenClaw gateway example, Kubernetes network policy gotchas (targetPort vs servicePort after DNAT), Pipelock notes, and `NO_PROXY` behavior
- Add troubleshooting section for "Failed to generate response" with step-by-step diagnosis
- Fix stale function list (4 -> 7 tools), incorrect env-vs-UI precedence statement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for Two AI Pipelines architecture (Chat Assistant and Auto-Categorization).
  * Documented MCP integration for external agents, authentication, routing options, and available tools.
  * Expanded External AI Assistant configuration, session and routing examples, and per-family overrides.
  * Added Kubernetes, networking, and gateway deployment guidance and NetworkPolicy examples.
  * Enhanced access control, troubleshooting for response failures, cache management, observability, and document search guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->