### PR TITLE
Replace whole-file pipelock exclude with inline suppression

### DIFF
--- a/.github/workflows/pipelock.yml
+++ b/.github/workflows/pipelock.yml
@@ -24,5 +24,3 @@ jobs:
           test-vectors: 'false'
           exclude-paths: |
             config/locales/views/reports/
-            # False positive: client.rb stores Bearer token and sends Authorization header by design
-            app/models/assistant/external/client.rb

--- a/app/models/assistant/external/client.rb
+++ b/app/models/assistant/external/client.rb
@@ -20,7 +20,7 @@ class Assistant::External::Client
 
   def initialize(url:, token:, agent_id: "main", session_key: "agent:main:main")
     @url = url
-    @token = token
+    @token = token # pipelock:ignore Credential in URL
     @agent_id = agent_id
     @session_key = session_key
   end


### PR DESCRIPTION
## Summary
- Replace the whole-file exclude for `client.rb` in the pipelock CI workflow with an inline `# pipelock:ignore Credential in URL` annotation on the specific false-positive line
- The rest of the file is now scanned normally, so future changes with actual secrets will be caught

Addresses [this comment](https://github.com/we-promise/sure/pull/1069#discussion_r2076789891) from @jjmata on #1069.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to expand coverage of authentication components
  * Refined credential handling directives for improved security validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->