### PR TITLE
Fix uncategorized budget category showing incorrect spending

### DIFF
--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -209,6 +209,7 @@ class BudgetCategory < ApplicationRecord
 
   def subcategories
     return BudgetCategory.none unless category.parent_id.nil?
+    return BudgetCategory.none if category.id.nil?
 
     budget.budget_categories
       .joins(:category)

--- a/test/models/budget_category_test.rb
+++ b/test/models/budget_category_test.rb
@@ -162,6 +162,15 @@ class BudgetCategoryTest < ActiveSupport::TestCase
     assert_equal 40.0, standalone_bc.percent_of_budget_spent
   end
 
+  test "uncategorized budget category returns no subcategories" do
+    uncategorized_bc = BudgetCategory.uncategorized
+    uncategorized_bc.budget = @budget
+
+    # Before the fix, this would return all top-level categories because
+    # category.id is nil, causing WHERE parent_id IS NULL to match all roots
+    assert_empty uncategorized_bc.subcategories
+  end
+
   test "parent with only inheriting subcategories shares entire budget" do
     # Set subcategory_with_limit to also inherit
     @subcategory_with_limit_bc.update!(budgeted_spending: 0)


### PR DESCRIPTION
## Summary

- Fix `BudgetCategory#subcategories` returning all top-level categories for the synthetic uncategorized budget category
- The query `WHERE parent_id = category.id` matched `WHERE parent_id IS NULL` when `category.id` was nil, inflating `actual_spending` and producing a large negative `available_to_spend`
- Add a nil guard on `category.id` to return an empty relation for synthetic categories

## Root Cause

`BudgetCategory.uncategorized` creates a virtual budget category whose underlying `Category` is also synthetic (not persisted, `id` is nil). When `subcategories` ran `WHERE categories.parent_id = ?` with a nil id, ActiveRecord translated it to `WHERE parent_id IS NULL`, which matched every top-level category in the budget.

This caused the parent pool calculation in `available_to_spend` to subtract all top-level spending from the uncategorized budget (which has $0 budgeted), resulting in a large negative value.

## Test plan

- [x] Added test: uncategorized budget category returns no subcategories
- [x] Verify uncategorized row no longer shows inflated "over budget" on the budget page

Fixes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where uncategorized budget categories could incorrectly return subcategories. They now properly return an empty list as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->