### PR TITLE
Remove fixed height on budget chart

### DIFF
--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -9,7 +9,7 @@
     <%# Top Section: Donut and Summary side by side %>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <%# Budget Donut %>
-      <div class="h-[300px] bg-container rounded-xl shadow-border-xs p-8">
+      <div class="min-h-[300px] bg-container rounded-xl shadow-border-xs p-8">
         <% if !@budget.initialized? && @source_budget.present? %>
           <%= render "budgets/copy_previous_prompt", budget: @budget, source_budget: @source_budget %>
         <% elsif @budget.initialized? && @budget.available_to_allocate.negative? %>


### PR DESCRIPTION
A very small change to the budget chart. Instead of having a fixed height, it is now filling all the available space on desktop. No impacts on mobile, as the previously fixed height is now used as the min height.

| Before  | After |
| ------------- | ------------- |
| <img width="1318" height="395" alt="Screenshot 2026-03-04 alle 20 09 48" src="https://github.com/user-attachments/assets/412fdbd4-4a4e-4d40-8f6c-5f72edade03f" /> | <img width="1319" height="399" alt="Screenshot 2026-03-04 alle 20 09 18" src="https://github.com/user-attachments/assets/64dfb7e5-1b80-4639-9a07-c71bcfc429f7" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the height constraints on the Budget visualization to allow for more flexible layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->