### PR TITLE
Allow category editing for investment/crypto transfers

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -80,6 +80,13 @@ class Transaction < ApplicationRecord
     TRANSFER_KINDS.include?(kind)
   end
 
+  def category_editable?
+    return true unless transfer?
+    return transfer.categorizable? if transfer.present?
+
+    kind.in?(%w[loan_payment investment_contribution])
+  end
+
   def set_category!(category)
     if category.is_a?(String)
       category = entry.account.family.categories.find_or_create_by!(

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -101,7 +101,7 @@ class Transfer < ApplicationRecord
   end
 
   def categorizable?
-    to_account&.accountable_type == "Loan"
+    to_account&.accountable_type.in?(%w[Loan Investment Crypto])
   end
 
   private

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -77,6 +77,8 @@
                     disabled: @entry.linked? || split_locked || edit_locked,
                     disable_currency: @entry.linked? || split_locked || edit_locked %>
             </div>
+          <% end %>
+          <% if @entry.transaction.category_editable? %>
             <%= f.fields_for :entryable do |ef| %>
               <%= ef.collection_select :category_id,
                       Current.family.categories.alphabetically,
@@ -103,6 +105,8 @@
               ),
               { label: t(".account_label") },
               { disabled: true } %>
+        <% end %>
+        <% if @entry.transaction.category_editable? %>
           <%= f.fields_for :entryable do |ef| %>
             <%= ef.collection_select :merchant_id,
                   Current.family.available_merchants_for(Current.user).alphabetically,

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -52,6 +52,26 @@ class TransactionTest < ActiveSupport::TestCase
     end
   end
 
+  test "category_editable? returns true for standard transactions" do
+    assert Transaction.new(kind: "standard").category_editable?
+  end
+
+  test "category_editable? returns true for investment_contribution without Transfer record" do
+    assert Transaction.new(kind: "investment_contribution").category_editable?
+  end
+
+  test "category_editable? returns true for loan_payment without Transfer record" do
+    assert Transaction.new(kind: "loan_payment").category_editable?
+  end
+
+  test "category_editable? returns false for funds_movement without Transfer record" do
+    refute Transaction.new(kind: "funds_movement").category_editable?
+  end
+
+  test "category_editable? returns false for cc_payment without Transfer record" do
+    refute Transaction.new(kind: "cc_payment").category_editable?
+  end
+
   test "ACTIVITY_LABELS contains all valid labels" do
     assert_includes Transaction::ACTIVITY_LABELS, "Buy"
     assert_includes Transaction::ACTIVITY_LABELS, "Sell"

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -124,4 +124,67 @@ class TransferTest < ActiveSupport::TestCase
   test "kind_for_account returns funds_movement for depository accounts" do
     assert_equal "funds_movement", Transfer.kind_for_account(accounts(:depository))
   end
+
+  test "categorizable? returns true for loan account transfers" do
+    outflow_entry = create_transaction(date: Date.current, account: accounts(:depository), amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: accounts(:loan), amount: -500)
+
+    transfer = Transfer.create!(
+      inflow_transaction: inflow_entry.transaction,
+      outflow_transaction: outflow_entry.transaction
+    )
+
+    assert transfer.categorizable?
+  end
+
+  test "categorizable? returns true for investment account transfers" do
+    outflow_entry = create_transaction(date: Date.current, account: accounts(:depository), amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: accounts(:investment), amount: -500)
+
+    transfer = Transfer.create!(
+      inflow_transaction: inflow_entry.transaction,
+      outflow_transaction: outflow_entry.transaction
+    )
+
+    assert transfer.categorizable?
+  end
+
+  test "categorizable? returns true for crypto account transfers" do
+    outflow_entry = create_transaction(date: Date.current, account: accounts(:depository), amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: accounts(:crypto), amount: -500)
+
+    transfer = Transfer.create!(
+      inflow_transaction: inflow_entry.transaction,
+      outflow_transaction: outflow_entry.transaction
+    )
+
+    assert transfer.categorizable?
+  end
+
+  test "categorizable? returns false for regular fund movement transfers" do
+    other_depository = families(:dylan_family).accounts.create!(
+      name: "Savings", balance: 5000, currency: "USD", accountable: Depository.new
+    )
+    outflow_entry = create_transaction(date: Date.current, account: accounts(:depository), amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: other_depository, amount: -500)
+
+    transfer = Transfer.create!(
+      inflow_transaction: inflow_entry.transaction,
+      outflow_transaction: outflow_entry.transaction
+    )
+
+    refute transfer.categorizable?
+  end
+
+  test "categorizable? returns false for credit card payment transfers" do
+    outflow_entry = create_transaction(date: Date.current, account: accounts(:depository), amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: accounts(:credit_card), amount: -500)
+
+    transfer = Transfer.create!(
+      inflow_transaction: inflow_entry.transaction,
+      outflow_transaction: outflow_entry.transaction
+    )
+
+    refute transfer.categorizable?
+  end
 end


### PR DESCRIPTION
## Summary

- Expand `Transfer#categorizable?` to include `Investment` and `Crypto` account types (alongside `Loan`)
- Extract category, merchant, and tag dropdowns in `transactions/show.html.erb` from the blanket `unless transfer?` guard so they render for categorizable transfers
- Nature/amount fields stay locked for all transfers (they shouldn't change direction)
- `funds_movement` and `cc_payment` transfers remain fully locked (not meaningful budget categories)

## Root Cause

The `unless @entry.transaction.transfer?` guard in the transaction detail view was introduced in #1585 (Jan 2025) when only `funds_movement`, `cc_payment`, and `loan_payment` existed. When `investment_contribution` was added to `TRANSFER_KINDS` in #987 (Feb 2026) to fix transfer display indicators, it also triggered this guard — hiding the category dropdown. `Transfer#categorizable?` was never updated to include investment/crypto accounts, so users couldn't change the auto-assigned "Investment Contributions" category.

Full analysis: https://github.com/we-promise/sure/issues/1089#issuecomment-4000914076

## Test plan

- [x] `categorizable?` returns `true` for Loan, Investment, and Crypto transfers
- [x] `categorizable?` returns `false` for Depository and CreditCard transfers
- [ ] Investment contribution transactions show category dropdown in detail view
- [ ] Changing category on an investment contribution saves correctly
- [ ] Regular fund movement transfers still have editing controls hidden
- [ ] CC payment transfers still have editing controls hidden
- [ ] `_transaction_category.html.erb` inline badge now shows category menu for investment transfers (uses existing `categorizable?` check)

Fixes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded categorization: transfers now treat Investment and Crypto (in addition to Loan) as categorizable.
  * Smarter form behavior: category and merchant fields are shown only when a transaction’s category is editable.
  * Transactions now evaluate whether their category is editable in more cases (including transfer-aware checks).

* **Tests**
  * Added unit tests covering transfer categorization and transaction category-editability rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->