### PR TITLE
fix(helm): use expected health endpoint

### DIFF
--- a/charts/sure/values.yaml
+++ b/charts/sure/values.yaml
@@ -314,7 +314,7 @@ web:
   # Probes
   livenessProbe:
     httpGet:
-      path: /
+      path: /up
       port: http
     initialDelaySeconds: 20
     periodSeconds: 10
@@ -322,7 +322,7 @@ web:
     failureThreshold: 6
   readinessProbe:
     httpGet:
-      path: /
+      path: /up
       port: http
     initialDelaySeconds: 10
     periodSeconds: 5
@@ -330,7 +330,7 @@ web:
     failureThreshold: 6
   startupProbe:
     httpGet:
-      path: /
+      path: /up
       port: http
     failureThreshold: 30
     periodSeconds: 5


### PR DESCRIPTION
the liveness / readiness probes were making requests to the root of the web server.  this causes the health check to fail in some cases because a redirect may occur in unexpected ways

This change updates the kubernetes health checks to test against the rails "up" health controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated health check endpoints for the web service to improve service monitoring and availability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->