### PR TITLE
Move debug logs and logout actions to settings screen

### DIFF
--- a/mobile/lib/screens/dashboard_screen.dart
+++ b/mobile/lib/screens/dashboard_screen.dart
@@ -12,7 +12,6 @@ import '../widgets/net_worth_card.dart';
 import '../widgets/currency_filter.dart';
 import 'transaction_form_screen.dart';
 import 'transactions_list_screen.dart';
-import 'log_viewer_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -339,34 +338,6 @@ class DashboardScreenState extends State<DashboardScreen> {
     }
   }
 
-  Future<void> _handleLogout() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Sign Out'),
-        content: const Text('Are you sure you want to sign out?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Sign Out'),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true && mounted) {
-      final authProvider = Provider.of<AuthProvider>(context, listen: false);
-      final accountsProvider = Provider.of<AccountsProvider>(context, listen: false);
-
-      accountsProvider.clearAccounts();
-      await authProvider.logout();
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -387,30 +358,6 @@ class DashboardScreenState extends State<DashboardScreen> {
                 ),
               ),
             ),
-          Semantics(
-            label: 'Open debug logs',
-            button: true,
-            child: IconButton(
-              icon: const Icon(Icons.bug_report),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const LogViewerScreen()),
-                );
-              },
-              tooltip: 'Debug Logs',
-            ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: _handleRefresh,
-            tooltip: 'Refresh',
-          ),
-          IconButton(
-            icon: const Icon(Icons.logout),
-            onPressed: _handleLogout,
-            tooltip: 'Sign Out',
-          ),
         ],
       ),
       body: Column(

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import '../services/offline_storage_service.dart';
 import '../services/log_service.dart';
 import '../services/preferences_service.dart';
 import '../services/user_service.dart';
+import 'log_viewer_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -352,6 +353,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ),
             onTap: () => _launchContactUrl(context),
+          ),
+
+          Semantics(
+            label: 'Open debug logs',
+            button: true,
+            child: ListTile(
+              leading: const Icon(Icons.bug_report),
+              title: const Text('Debug Logs'),
+              subtitle: const Text('View app diagnostic logs'),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const LogViewerScreen()),
+                );
+              },
+            ),
           ),
 
           const Divider(),


### PR DESCRIPTION
## Summary
Refactored the dashboard screen by moving debug logs access and logout functionality to the settings screen, improving navigation organization and reducing dashboard toolbar clutter.

## Key Changes
- Removed `_handleLogout()` method from DashboardScreen
- Removed debug logs (bug report icon), refresh, and logout buttons from the dashboard app bar
- Added debug logs option to SettingsScreen as a ListTile with icon, title, and subtitle
- Updated imports: removed `log_viewer_screen.dart` from dashboard, added it to settings

## Implementation Details
- The debug logs feature is now accessible via the settings screen with a more descriptive UI (ListTile format with subtitle "View app diagnostic logs")
- Logout functionality was completely removed from the dashboard toolbar (likely moved elsewhere or handled differently)
- The refresh button was also removed from the dashboard app bar
- Maintains the same Semantics label for accessibility ("Open debug logs")

https://claude.ai/code/session_017XQZdaEwUuRS75tJMcHzB9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Relocated Debug Logs feature from Dashboard to Settings screen
  * Removed Sign Out and Refresh buttons from Dashboard AppBar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->