### PR TITLE
feat: allow toggling all AI features.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ SECRET_KEY_BASE=secret-value
 # --------------------------------------------------------------------------------------------------------
 
 # Optional: OpenAI-compatible API endpoint config
+# Set OPENAI_ACCESS_TOKEN to "DISABLED" to completely hide AI features from the UI
 OPENAI_ACCESS_TOKEN=
 OPENAI_MODEL=
 OPENAI_URI_BASE=

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,6 +1,7 @@
 class ChatsController < ApplicationController
   include ActionView::RecordIdentifier
 
+  guard_feature unless: -> { Current.user.ai_enabled? }
   before_action :set_chat, only: [ :show, :edit, :update, :destroy ]
 
   def index

--- a/app/controllers/settings/ai_prompts_controller.rb
+++ b/app/controllers/settings/ai_prompts_controller.rb
@@ -1,6 +1,8 @@
 class Settings::AiPromptsController < ApplicationController
   layout "settings"
 
+  guard_feature unless: -> { Current.user.ai_available? }
+
   def show
     @breadcrumbs = [
       [ "Home", root_path ],

--- a/app/controllers/settings/llm_usages_controller.rb
+++ b/app/controllers/settings/llm_usages_controller.rb
@@ -1,6 +1,8 @@
 class Settings::LlmUsagesController < ApplicationController
   layout "settings"
 
+  guard_feature unless: -> { Current.user.ai_available? }
+
   def show
     @breadcrumbs = [
       [ "Home", root_path ],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,6 +148,7 @@ class User < ApplicationRecord
   end
 
   def ai_available?
+    return false if ENV["OPENAI_ACCESS_TOKEN"] == "DISABLED"
     return true unless Rails.application.config.app_mode.self_hosted?
 
     effective_type = ENV["ASSISTANT_TYPE"].presence || family&.assistant_type.presence || "builtin"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,8 @@ else
     { name: t(".nav.transactions"), path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
     { name: t(".nav.reports"), path: reports_path, icon: "chart-bar", icon_custom: false, active: page_active?(reports_path) },
     { name: t(".nav.budgets"), path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
-    { name: t(".nav.assistant"), path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
-  ]
+    (Current.user.ai_available? ? { name: t(".nav.assistant"), path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true } : nil)
+  ].compact
 end %>
 
 <% desktop_nav_items = mobile_nav_items.reject { |item| item[:mobile_only] } %>
@@ -164,7 +164,9 @@ end %>
               <%= icon("eye", size: "sm", class: "hidden", data: { privacy_mode_target: "iconOn" }) %>
             </button>
 
-            <%= icon("panel-right", as_button: true, data: { action: "app-layout#toggleRightSidebar" }) %>
+            <% if Current.user.ai_available? %>
+              <%= icon("panel-right", as_button: true, data: { action: "app-layout#toggleRightSidebar" }) %>
+            <% end %>
           </div>
         </div>
       <% end %>
@@ -177,25 +179,27 @@ end %>
     <% end %>
 
     <%# DESKTOP - Right sidebar %>
-    <%= tag.div class: class_names(
-          "hidden lg:block h-full shrink-0 max-w-[400px] transition-all duration-300 border-divider",
-          Current.user.show_ai_sidebar? ? [expanded_sidebar_class, "border-l"] : [collapsed_sidebar_class, "border-l-0"],
-        ),
-        inert: !Current.user.show_ai_sidebar?,
-        data: { app_layout_target: "rightSidebar" } do %>
-      <%= tag.div id: "chat-container", class: "relative h-full px-4 overflow-y-auto", data: { controller: "chat hotkey", turbo_permanent: true } do %>
-        <div class="flex flex-col h-full justify-between shrink-0">
-          <%= turbo_frame_tag chat_frame, src: chat_view_path(@chat), loading: "lazy", class: "h-full" do %>
-            <div class="flex justify-center items-center h-full">
-              <%= icon("loader-circle", class: "animate-spin") %>
+    <% if Current.user.ai_available? %>
+      <%= tag.div class: class_names(
+            "hidden lg:block h-full shrink-0 max-w-[400px] transition-all duration-300 border-divider",
+            Current.user.show_ai_sidebar? ? [expanded_sidebar_class, "border-l"] : [collapsed_sidebar_class, "border-l-0"],
+          ),
+          inert: !Current.user.show_ai_sidebar?,
+          data: { app_layout_target: "rightSidebar" } do %>
+        <%= tag.div id: "chat-container", class: "relative h-full px-4 overflow-y-auto", data: { controller: "chat hotkey", turbo_permanent: true } do %>
+          <div class="flex flex-col h-full justify-between shrink-0">
+            <%= turbo_frame_tag chat_frame, src: chat_view_path(@chat), loading: "lazy", class: "h-full" do %>
+              <div class="flex justify-center items-center h-full">
+                <%= icon("loader-circle", class: "animate-spin") %>
+              </div>
+            <% end %>
+          </div>
+
+          <% unless Current.user.ai_enabled? %>
+            <div class="absolute backdrop-blur-lg inset-0 h-full w-full flex flex-col justify-center items-center px-4">
+              <%= render "chats/ai_consent" %>
             </div>
           <% end %>
-        </div>
-
-        <% unless Current.user.ai_enabled? %>
-          <div class="absolute backdrop-blur-lg inset-0 h-full w-full flex flex-col justify-center items-center px-4">
-            <%= render "chats/ai_consent" %>
-          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/settings/_settings_nav.html.erb
+++ b/app/views/settings/_settings_nav.html.erb
@@ -26,8 +26,8 @@ nav_sections = [
     Current.user&.admin? ? {
       header: t(".advanced_section_title"),
       items: [
-        { label: t(".ai_prompts_label"), path: settings_ai_prompts_path, icon: "bot" },
-        { label: "LLM Usage", path: settings_llm_usage_path, icon: "activity" },
+        { label: t(".ai_prompts_label"), path: settings_ai_prompts_path, icon: "bot", if: Current.user.ai_available? },
+        { label: "LLM Usage", path: settings_llm_usage_path, icon: "activity", if: Current.user.ai_available? },
         { label: t(".api_keys_label"), path: settings_api_key_path, icon: "key" },
         { label: t(".self_hosting_label"), path: settings_hosting_path, icon: "database", if: self_hosted? },
         { label: "Providers", path: settings_providers_path, icon: "plug" },

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -197,6 +197,12 @@ class UserTest < ActiveSupport::TestCase
     @user.family.update!(assistant_type: "builtin")
   end
 
+  test "ai_available? returns false when OPENAI_ACCESS_TOKEN is set to DISABLED" do
+    with_env_overrides OPENAI_ACCESS_TOKEN: "DISABLED" do
+      assert_not @user.ai_available?
+    end
+  end
+
   test "intro layout collapses sidebars and enables ai" do
     user = User.new(
       family: families(:empty),


### PR DESCRIPTION
I do not like AI features in my financial tools - I don't like to rely on them for financial advice etc. This PR adds an env-var toggle to disable all AI features.

Disclaimer: I am not a Ruby engineer, and this code was generated by AI - posting upstream with encouragement from #681 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI UI, navigation and settings now show only when AI is available for the current user.
  * Controllers handling AI functionality are gated when AI is not available/enabled for the user.

* **Documentation**
  * Added guidance to the example environment config to allow fully disabling AI features via a special value.

* **Tests**
  * Added test coverage verifying AI availability can be disabled via the environment setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->