### PR TITLE
Fix CSV export using inverted amount sign convention

### DIFF
--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -64,14 +64,19 @@ class Family::DataExporter
       CSV.generate do |csv|
         csv << [ "date", "account_name", "amount", "name", "category", "tags", "notes", "currency" ]
 
-        # Only export transactions from accounts belonging to this family
+        # Only export transactions from accounts belonging to this family.
+        #
+        # Amount sign convention: Sure stores amounts with positive = outflow (expense)
+        # and negative = inflow (income). The CSV import template and standard user
+        # expectation is the opposite: positive = inflow, negative = outflow.
+        # We negate here so the exported CSV is round-trip compatible with re-import.
         @family.transactions
           .includes(:category, :tags, entry: :account)
           .find_each do |transaction|
             csv << [
               transaction.entry.date.iso8601,
               transaction.entry.account.name,
-              transaction.entry.amount.to_s,
+              (-transaction.entry.amount).to_s,
               transaction.entry.name,
               transaction.category&.name,
               transaction.tags.pluck(:name).join(","),

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -341,4 +341,50 @@ class Family::DataExporterTest < ActiveSupport::TestCase
       refute ndjson_content.include?(other_rule.name)
     end
   end
+
+  test "exports transaction amounts with inflows-positive convention for round-trip import compatibility" do
+    # Sure stores amounts internally as: positive = outflow (expense), negative = inflow (income)
+    # The CSV import template uses the opposite: positive = inflow, negative = outflow.
+    # Export must negate amounts so exported CSVs can be re-imported without sign inversion.
+
+    # Expense: internally stored as +50.00 → should export as -50.00
+    expense_entry = @account.entries.create!(
+      date: "2024-01-15",
+      name: "Coffee Shop",
+      amount: 50.00,
+      currency: "USD",
+      entryable: Transaction.new(kind: :standard)
+    )
+
+    # Income: internally stored as -1500.00 → should export as +1500.00
+    income_entry = @account.entries.create!(
+      date: "2024-01-16",
+      name: "Salary",
+      amount: -1500.00,
+      currency: "USD",
+      entryable: Transaction.new(kind: :standard)
+    )
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      csv = CSV.parse(zip.read("transactions.csv"), headers: true)
+
+      expense_row = csv.find { |row| row["name"] == "Coffee Shop" }
+      income_row  = csv.find { |row| row["name"] == "Salary" }
+
+      assert_not_nil expense_row, "Expense transaction not found in CSV"
+      assert_not_nil income_row,  "Income transaction not found in CSV"
+
+      # Expense (outflow) must be negative in export
+      assert expense_row["amount"].to_d < 0,
+        "Expense should export as negative (inflows-positive convention), got #{expense_row["amount"]}"
+      assert_equal(-50.00, expense_row["amount"].to_d)
+
+      # Income (inflow) must be positive in export
+      assert income_row["amount"].to_d > 0,
+        "Income should export as positive (inflows-positive convention), got #{income_row["amount"]}"
+      assert_equal 1500.00, income_row["amount"].to_d
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #1092

The data exporter wrote transaction amounts using Sure's **internal** sign convention (positive = outflow/expense, negative = inflow/income), while the CSV import template and standard user expectation uses the **opposite** convention (positive = inflow, negative = outflow).

## Root cause

`Family::DataExporter#generate_transactions_csv` exported `entry.amount` directly. Sure internally stores expenses as positive and income as negative. The import template shows the opposite (e.g. `-45.99` for grocery expense, `+1500.00` for salary).

This meant:
- A $100 deposit (inflow, stored as `-100`) exported as `-100` → re-import reads it as an expense
- A $100 transfer out (outflow, stored as `+100`) exported as `+100` → re-import reads it as income

## Fix

Negate the amount in `generate_transactions_csv` so the exported CSV uses the inflows-positive convention, making export → re-import round-trips produce correct results.

## Test added

New test in `data_exporter_test.rb` verifies:
- Expense (internally stored as `+50.00`) exports as `-50.00`
- Income (internally stored as `-1500.00`) exports as `+1500.00`

All 12 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected transaction amount signs in CSV exports to match the import template format, ensuring transactions can be reliably round-tripped through export and re-import cycles.

* **Tests**
  * Added test to validate transaction export sign convention compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->