### PR TITLE
Fix comma decimal separator truncated in cost basis price inputs

### DIFF
--- a/app/javascript/controllers/cost_basis_form_controller.js
+++ b/app/javascript/controllers/cost_basis_form_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { parseLocalized } from "helpers/number_helpers"
 
 // Handles bidirectional conversion between total cost basis and per-share cost
 // in the manual cost basis entry form.
@@ -9,7 +10,7 @@ export default class extends Controller {
   // Called when user types in the total cost basis field
   // Updates the per-share display and input to show the calculated value
   updatePerShare() {
-    const total = Number.parseFloat(this.totalTarget.value) || 0
+    const total = parseLocalized(this.totalTarget.value)
     const qty = this.qtyValue || 1
     const perShare = qty > 0 ? (total / qty).toFixed(2) : "0.00"
     this.perShareValueTarget.textContent = perShare
@@ -21,10 +22,12 @@ export default class extends Controller {
   // Called when user types in the per-share field
   // Updates the total cost basis field with the calculated value
   updateTotal() {
-    const perShare = Number.parseFloat(this.perShareTarget.value) || 0
+    const perShare = parseLocalized(this.perShareTarget.value)
     const qty = this.qtyValue || 1
     const total = (perShare * qty).toFixed(2)
     this.totalTarget.value = total
     this.perShareValueTarget.textContent = perShare.toFixed(2)
   }
 }
+
+

--- a/app/javascript/controllers/drawer_cost_basis_controller.js
+++ b/app/javascript/controllers/drawer_cost_basis_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { parseLocalized } from "helpers/number_helpers"
 
 // Handles the inline cost basis editor in the holding drawer.
 // Shows/hides the form and handles bidirectional total <-> per-share conversion.
@@ -13,7 +14,7 @@ export default class extends Controller {
 
   // Called when user types in total cost basis field
   updatePerShare() {
-    const total = Number.parseFloat(this.totalTarget.value) || 0
+    const total = parseLocalized(this.totalTarget.value)
     const qty = this.qtyValue || 1
     const perShare = qty > 0 ? (total / qty).toFixed(2) : "0.00"
     this.perShareValueTarget.textContent = perShare
@@ -24,7 +25,7 @@ export default class extends Controller {
 
   // Called when user types in per-share field
   updateTotal() {
-    const perShare = Number.parseFloat(this.perShareTarget.value) || 0
+    const perShare = parseLocalized(this.perShareTarget.value)
     const qty = this.qtyValue || 1
     const total = (perShare * qty).toFixed(2)
     this.totalTarget.value = total

--- a/app/javascript/helpers/number_helpers.js
+++ b/app/javascript/helpers/number_helpers.js
@@ -1,0 +1,40 @@
+/**
+ * Parse a user-entered number that may use a comma as the decimal separator
+ * (common in French, German, Spanish, Portuguese, and other locales).
+ *
+ * Examples:
+ *   "256,54"    → 256.54   (French/German: comma is decimal)
+ *   "1.256,54"  → 1256.54  (German: dot thousands, comma decimal)
+ *   "1,256.54"  → 1256.54  (US: comma thousands, dot decimal)
+ *   "256.54"    → 256.54   (standard)
+ *   "256"       → 256
+ *   ""          → 0
+ *
+ * Strategy: whichever separator appears last is the decimal separator.
+ * All prior occurrences of the other separator are treated as thousands
+ * grouping and stripped.
+ *
+ * @param {string|number} value
+ * @returns {number}
+ */
+export function parseLocalized(value) {
+  if (value === null || value === undefined || value === "") return 0
+
+  const s = String(value).trim()
+  if (!s) return 0
+
+  const lastComma = s.lastIndexOf(",")
+  const lastDot   = s.lastIndexOf(".")
+
+  let normalized
+
+  if (lastComma > lastDot) {
+    // Comma is the decimal separator (e.g. "1.256,54" or "256,54")
+    normalized = s.replace(/\./g, "").replace(",", ".")
+  } else {
+    // Dot is the decimal separator, or no fractional part (e.g. "1,256.54" or "256")
+    normalized = s.replace(/,/g, "")
+  }
+
+  return Number.parseFloat(normalized) || 0
+}


### PR DESCRIPTION
## Summary

Fixes #1138

When users enter prices using a comma as the decimal separator (French: `256,54`, German: `1.256,54`), JavaScript's `Number.parseFloat()` stops at the comma and silently drops everything after it. Entering `256,54` stored `256.00`.

## Root cause

Both cost basis Stimulus controllers used `Number.parseFloat(value)` directly:

```js
// Before — breaks for comma-decimal locales
const total = Number.parseFloat(this.totalTarget.value) || 0
// "256,54".parseFloat() → 256  ❌
```

## Fix

New shared helper `app/javascript/helpers/number_helpers.js` exports `parseLocalized()` which detects the decimal separator by finding which separator (comma or dot) appears **last** — that's the decimal; earlier occurrences of the other separator are thousands grouping.

```js
// After
import { parseLocalized } from "helpers/number_helpers"
const total = parseLocalized(this.totalTarget.value)
// parseLocalized("256,54")   → 256.54  ✅
// parseLocalized("1.256,54") → 1256.54 ✅
// parseLocalized("1,256.54") → 1256.54 ✅
// parseLocalized("256.54")   → 256.54  ✅
```

## Files changed

- `helpers/number_helpers.js` — new shared `parseLocalized()` utility with full JSDoc  
- `cost_basis_form_controller.js` — import and use `parseLocalized`  
- `drawer_cost_basis_controller.js` — import and use `parseLocalized`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for international number formats in cost basis forms. Input fields now correctly parse numbers using either comma or dot as decimal separators, accommodating different regional conventions.
  * Cost basis form fields now auto-sync to maintain consistency across related inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->