### PR TITLE
Require admin role for API family reset endpoint

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V1::UsersController < Api::V1::BaseController
   before_action :ensure_write_scope
+  before_action :ensure_admin, only: :reset
 
   def reset
     FamilyResetJob.perform_later(Current.family)
@@ -23,5 +24,12 @@ class Api::V1::UsersController < Api::V1::BaseController
 
     def ensure_write_scope
       authorize_scope!(:write)
+    end
+
+    def ensure_admin
+      return true if current_resource_owner&.admin?
+
+      render_json({ error: "forbidden", message: I18n.t("users.reset.unauthorized") }, status: :forbidden)
+      false
     end
 end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -50,6 +50,24 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
 
   # -- Reset -----------------------------------------------------------------
 
+
+  test "reset requires admin role" do
+    non_admin_api_key = ApiKey.create!(
+      user: users(:family_member),
+      name: "Member Read-Write Key",
+      scopes: [ "read_write" ],
+      display_key: "test_member_#{SecureRandom.hex(8)}"
+    )
+
+    assert_no_enqueued_jobs only: FamilyResetJob do
+      delete "/api/v1/users/reset", headers: api_headers(non_admin_api_key)
+    end
+
+    assert_response :forbidden
+    body = JSON.parse(response.body)
+    assert_equal "You are not authorized to perform this action", body["message"]
+  end
+
   test "reset enqueues FamilyResetJob and returns 200" do
     assert_enqueued_with(job: FamilyResetJob) do
       delete "/api/v1/users/reset", headers: api_headers(@api_key)


### PR DESCRIPTION
### Motivation
- Close an authorization gap where `DELETE /api/v1/users/reset` only enforced write scope and allowed any family member with a `read_write` API key or OAuth token to enqueue a destructive `FamilyResetJob` for the whole family.

### Description
- Add an admin authorization guard to `Api::V1::UsersController#reset` via `before_action :ensure_admin, only: :reset` and an `ensure_admin` helper that returns a JSON 403 when the caller is not an admin. 
- Preserve the existing scope check (`ensure_write_scope`) so the endpoint still requires write scope in addition to admin role.
- Add an integration test in `test/controllers/api/v1/users_controller_test.rb` that asserts a non-admin with `read_write` scope cannot enqueue `FamilyResetJob` and receives a `403` with the expected authorization message.

### Testing
- Ran the focused controller tests with `bin/rails test test/controllers/api/v1/users_controller_test.rb` and they passed (`9 runs, 0 failures`).
- Ran the full test suite with `bin/rails test` and it completed with no failures (`2450 runs, 0 failures, 24 skips`).
- Ran linting with `bin/rubocop app/controllers/api/v1/users_controller.rb test/controllers/api/v1/users_controller_test.rb` and there were no offenses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f1b4eeb083329b0dae2f8ec07d89)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The reset action now requires admin authorization. Non-admin users attempting to access this endpoint will receive a 403 Forbidden error response.

* **Tests**
  * Added test coverage to verify admin authorization requirement for the reset action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->