### PR TITLE
Move account logo determination in dedicated method

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -244,7 +244,15 @@ class Account < ApplicationRecord
   end
 
   def logo_url
-    provider&.logo_url
+    if institution_domain.present? && Setting.brand_fetch_client_id.present?
+      logo_size = Setting.brand_fetch_logo_size
+
+      "https://cdn.brandfetch.io/#{institution_domain}/icon/fallback/lettermark/w/#{logo_size}/h/#{logo_size}?c=#{Setting.brand_fetch_client_id}"
+    elsif provider&.logo_url.present?
+      provider.logo_url
+    elsif logo.attached?
+      Rails.application.routes.url_helpers.rails_blob_path(logo, only_path: true)
+    end
   end
 
   def destroy_later

--- a/app/views/accounts/_logo.html.erb
+++ b/app/views/accounts/_logo.html.erb
@@ -7,13 +7,16 @@
   "full" => "w-full h-full"
 } %>
 
-<% if account.institution_domain.present? && Setting.brand_fetch_client_id.present? %>
-  <% logo_size = Setting.brand_fetch_logo_size %>
-  <%= image_tag "https://cdn.brandfetch.io/#{account.institution_domain}/icon/fallback/lettermark/w/#{logo_size}/h/#{logo_size}?c=#{Setting.brand_fetch_client_id}", class: "shrink-0 rounded-full #{size_classes[size]}" %>
-<% elsif account.logo_url.present? %>
-  <%= image_tag account.logo_url, class: "shrink-0 rounded-full #{size_classes[size]}", loading: "lazy" %>
-<% elsif account.logo.attached? %>
-  <%= image_tag account.logo, class: "shrink-0 rounded-full #{size_classes[size]}" %>
+<% if account.logo_url.present? %>
+  <%= image_tag account.logo_url,
+        class: "shrink-0 rounded-full #{size_classes[size]}",
+        loading: "lazy" %>
 <% else %>
-  <%= render DS::FilledIcon.new(variant: :text, hex_color: color || account.accountable.color, text: account.name, size: size, rounded: true) %>
+  <%= render DS::FilledIcon.new(
+        variant: :text,
+        hex_color: color || account.accountable.color,
+        text: account.name,
+        size: size,
+        rounded: true
+      ) %>
 <% end %>


### PR DESCRIPTION
This PR moves the logic for determining the account logo from the view to the model. This allows to access the logo URL outside of the view and use it in the select UI (for example).

<img width="570" height="359" alt="Screenshot 2026-03-12 alle 20 52 23" src="https://github.com/user-attachments/assets/397f1229-9e49-4565-8187-4c5258deb6d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logo display with enhanced URL resolution strategy and lazy image loading for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->