### PR TITLE
Fix select is hidden inside dialog

### DIFF
--- a/app/components/DS/dialog.html.erb
+++ b/app/components/DS/dialog.html.erb
@@ -2,7 +2,7 @@
   <%= tag.dialog class: "w-full h-full bg-transparent theme-dark:backdrop:bg-alpha-black-900 backdrop:bg-overlay pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] #{(drawer? || responsive?) ? "lg:p-3" : "lg:p-1"}", **merged_opts do %>
     <%= tag.div class: dialog_outer_classes do %>
       <%= tag.div class: dialog_inner_classes, data: { DS__dialog_target: "content" } do %>
-        <div class="grow py-4 space-y-4 flex flex-col">
+        <div class="grow py-4 space-y-4 flex flex-col <%= 'overflow-auto' if scrollable %>">
           <% if header? %>
             <%= header %>
           <% end %>

--- a/app/components/DS/dialog.rb
+++ b/app/components/DS/dialog.rb
@@ -33,7 +33,7 @@ class DS::Dialog < DesignSystemComponent
     end
   end
 
-  attr_reader :variant, :auto_open, :reload_on_close, :width, :disable_frame, :content_class, :disable_click_outside, :opts, :responsive
+  attr_reader :variant, :auto_open, :reload_on_close, :width, :disable_frame, :content_class, :disable_click_outside, :opts, :responsive, :scrollable
 
   VARIANTS = %w[modal drawer].freeze
   WIDTHS = {
@@ -43,7 +43,7 @@ class DS::Dialog < DesignSystemComponent
     full: "lg:max-w-full"
   }.freeze
 
-  def initialize(variant: "modal", auto_open: true, reload_on_close: false, width: "md", frame: nil, disable_frame: false, content_class: nil, disable_click_outside: false, responsive: false, **opts)
+  def initialize(variant: "modal", auto_open: true, reload_on_close: false, width: "md", frame: nil, disable_frame: false, content_class: nil, disable_click_outside: false, responsive: false, scrollable: true, **opts)
     @variant = variant.to_sym
     @auto_open = auto_open
     @reload_on_close = reload_on_close
@@ -53,6 +53,7 @@ class DS::Dialog < DesignSystemComponent
     @content_class = content_class
     @disable_click_outside = disable_click_outside
     @responsive = responsive
+    @scrollable = scrollable
     @opts = opts
   end
 

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,4 +1,4 @@
-<%= render DS::Dialog.new do |dialog| %>
+<%= render DS::Dialog.new(scrollable: false) do |dialog| %>
   <% dialog.with_header(title: "New transaction") %>
   <% dialog.with_body do %>
     <%= render "form", entry: @entry, categories: @categories %>

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -1,4 +1,4 @@
-<%= render DS::Dialog.new do |dialog| %>
+<%= render DS::Dialog.new(scrollable: false) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
   <% dialog.with_body do %>
     <%= render "form", transfer: @transfer %>


### PR DESCRIPTION

## Changes

<table>
<tr>
<td>
<img width="717" height="708" alt="Screenshot 2026-03-14 135452" src="https://github.com/user-attachments/assets/427518a6-9f1c-474e-b598-72d97e145657" />
</td>
<td>
<img width="739" height="795" alt="Screenshot 2026-03-14 140019" src="https://github.com/user-attachments/assets/58f29d85-445e-4f4d-aa0a-0b7b7bad26c7" />
</td>
</tr>
<tr>
<td>
Before: The Select is hidden within the Dialog container boundaries
</td>
<td>
After: The Select is no longer within the Dialog container boundaries
</td>
</tr>
</table>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dialogs now support configurable scroll behavior. The scroll setting can be toggled per dialog instance.

* **Bug Fixes**
  * Fixed overflow handling in certain dialog views to prevent unintended scrolling in transaction and transfer forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
