### PR TITLE
Fix dashboard mobile: require press-and-hold to reorder sections

### DIFF
--- a/app/javascript/controllers/dashboard_sortable_controller.js
+++ b/app/javascript/controllers/dashboard_sortable_controller.js
@@ -22,8 +22,10 @@ export default class extends Controller {
 
   // ===== Mouse Drag Events =====
   dragStart(event) {
-    // On touch devices, cancel native drag — use touch events with hold delay instead
-    if (this.isTouchDevice()) {
+    // If a touch interaction is in progress, cancel native drag —
+    // use touch events with hold delay instead.
+    // This avoids blocking mouse/trackpad drag on touch-capable laptops.
+    if (this.isTouching || this.pendingSection) {
       event.preventDefault();
       return;
     }
@@ -32,10 +34,6 @@ export default class extends Controller {
     this.draggedElement.classList.add("opacity-50");
     this.draggedElement.setAttribute("aria-grabbed", "true");
     event.dataTransfer.effectAllowed = "move";
-  }
-
-  isTouchDevice() {
-    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
   }
 
   dragEnd(event) {

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -49,6 +49,7 @@
           touchstart->dashboard-sortable#touchStart
           touchmove->dashboard-sortable#touchMove
           touchend->dashboard-sortable#touchEnd
+          touchcancel->dashboard-sortable#touchEnd
           keydown->dashboard-sortable#handleKeyDown">
         <div class="px-4 py-2 flex items-center justify-between">
           <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- On mobile, swiping through dashboard sections (investments, net worth, balance sheets, etc.) accidentally triggers drag-to-reorder because the touch hold delay is only 150ms with no movement cancellation
- Increases hold delay from 150ms to 800ms so users must deliberately press and hold to enter reorder mode
- Cancels drag activation if the finger moves more than 10px (Euclidean distance) before the hold triggers, allowing normal scroll gestures to pass through unimpeded
- Cancels native HTML5 dragstart on touch devices to enforce the hold delay (previously bypassed the hold entirely, especially noticeable with collapsed sections)
- Prevents text selection from triggering during the hold period

**Note:** This does not fix the asymmetry when reordering uncollapsed sections — moving a section down requires more finger travel than moving it up, since the pointer must physically pass the tall section below. This is inherent to the center-point drag algorithm and is expected behavior.

## Test plan
- [x] On mobile (or touch device emulation), verify scrolling through dashboard sections works without triggering reorder
- [x] Verify press-and-hold for ~800ms on a section activates drag mode (with haptic feedback)
- [x] Verify collapsed sections cannot be instantly reordered by swiping (native drag is cancelled)
- [x] Verify no text selection appears during the hold period
- [x] Verify desktop drag-and-drop reordering is unaffected
- [x] Verify keyboard reordering (Enter/Space to grab, arrow keys to move) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)