### PR TITLE
Support negation rule filters 

### DIFF
--- a/app/models/rule/condition_filter.rb
+++ b/app/models/rule/condition_filter.rb
@@ -6,7 +6,7 @@ class Rule::ConditionFilter
   OPERATORS_MAP = {
     "text" => [ [ "Contains", "like" ], [ "Does not contain", "not_like" ], [ "Equal to", "=" ], [ "Not equal to", "!=" ], [ "Is empty", "is_null" ] ],
     "number" => [ [ "Greater than", ">" ], [ "Greater or equal to", ">=" ], [ "Less than", "<" ], [ "Less than or equal to", "<=" ], [ "Is equal to", "=" ], [ "Not equal to", "!=" ] ],
-    "select" => [ [ "Equal to", "=" ], [ "Is empty", "is_null" ] ]
+    "select" => [ [ "Equal to", "=" ], [ "Not equal to", "!=" ], [ "Is empty", "is_null" ] ]
   }
 
   def initialize(rule)
@@ -94,7 +94,11 @@ class Rule::ConditionFilter
       when "is_null"
         "IS NULL"
       else
-        operator
+        if operator == "!=" && type == "select"
+          "IS DISTINCT FROM"
+        else
+          operator
+        end
       end
     end
 

--- a/app/models/rule/condition_filter.rb
+++ b/app/models/rule/condition_filter.rb
@@ -4,7 +4,7 @@ class Rule::ConditionFilter
   TYPES = [ "text", "number", "select" ]
 
   OPERATORS_MAP = {
-    "text" => [ [ "Contains", "like" ], [ "Equal to", "=" ], [ "Is empty", "is_null" ] ],
+    "text" => [ [ "Contains", "like" ], [ "Equal to", "=" ], [ "Not equal to", "!=" ], [ "Is empty", "is_null" ] ],
     "number" => [ [ "Greater than", ">" ], [ "Greater or equal to", ">=" ], [ "Less than", "<" ], [ "Less than or equal to", "<=" ], [ "Is equal to", "=" ] ],
     "select" => [ [ "Equal to", "=" ], [ "Is empty", "is_null" ] ]
   }

--- a/app/models/rule/condition_filter.rb
+++ b/app/models/rule/condition_filter.rb
@@ -4,7 +4,7 @@ class Rule::ConditionFilter
   TYPES = [ "text", "number", "select" ]
 
   OPERATORS_MAP = {
-    "text" => [ [ "Contains", "like" ], [ "Equal to", "=" ], [ "Not equal to", "!=" ], [ "Is empty", "is_null" ] ],
+    "text" => [ [ "Contains", "like" ], [ "Does not contain", "not_like" ], [ "Equal to", "=" ], [ "Not equal to", "!=" ], [ "Is empty", "is_null" ] ],
     "number" => [ [ "Greater than", ">" ], [ "Greater or equal to", ">=" ], [ "Less than", "<" ], [ "Less than or equal to", "<=" ], [ "Is equal to", "=" ] ],
     "select" => [ [ "Equal to", "=" ], [ "Is empty", "is_null" ] ]
   }
@@ -74,7 +74,7 @@ class Rule::ConditionFilter
       else
         normalized_value = normalize_value(value)
         normalized_field = normalize_field(field)
-        sanitized_value = operator == "like" ? "%#{ActiveRecord::Base.sanitize_sql_like(normalized_value)}%" : normalized_value
+        sanitized_value = %w[like not_like].include?(operator) ? "%#{ActiveRecord::Base.sanitize_sql_like(normalized_value)}%" : normalized_value
 
         ActiveRecord::Base.sanitize_sql_for_conditions([
           "#{normalized_field} #{sanitize_operator(operator)} ?",
@@ -89,6 +89,8 @@ class Rule::ConditionFilter
       case operator
       when "like"
         "ILIKE"
+      when "not_like"
+        "NOT ILIKE"
       when "is_null"
         "IS NULL"
       else

--- a/app/models/rule/condition_filter.rb
+++ b/app/models/rule/condition_filter.rb
@@ -5,7 +5,7 @@ class Rule::ConditionFilter
 
   OPERATORS_MAP = {
     "text" => [ [ "Contains", "like" ], [ "Does not contain", "not_like" ], [ "Equal to", "=" ], [ "Not equal to", "!=" ], [ "Is empty", "is_null" ] ],
-    "number" => [ [ "Greater than", ">" ], [ "Greater or equal to", ">=" ], [ "Less than", "<" ], [ "Less than or equal to", "<=" ], [ "Is equal to", "=" ] ],
+    "number" => [ [ "Greater than", ">" ], [ "Greater or equal to", ">=" ], [ "Less than", "<" ], [ "Less than or equal to", "<=" ], [ "Is equal to", "=" ], [ "Not equal to", "!=" ] ],
     "select" => [ [ "Equal to", "=" ], [ "Is empty", "is_null" ] ]
   }
 

--- a/app/models/rule/condition_filter/transaction_details.rb
+++ b/app/models/rule/condition_filter/transaction_details.rb
@@ -23,7 +23,11 @@ class Rule::ConditionFilter::TransactionDetails < Rule::ConditionFilter
       # Note: For JSONB fields, both operators use contains semantics rather than exact match
       # because searching within structured JSON data makes contains more useful than exact equality
       sanitized_value = "%#{ActiveRecord::Base.sanitize_sql_like(value)}%"
-      sql_operator = operator == "like" ? "ILIKE" : "LIKE"
+      sql_operator = case operator
+      when "like" then "ILIKE"
+      when "!=" then "NOT LIKE"
+      else "LIKE"
+      end
 
       scope.where("transactions.extra::text #{sql_operator} ?", sanitized_value)
     end

--- a/app/models/rule/condition_filter/transaction_details.rb
+++ b/app/models/rule/condition_filter/transaction_details.rb
@@ -18,13 +18,14 @@ class Rule::ConditionFilter::TransactionDetails < Rule::ConditionFilter
       # Check if extra field is empty or null
       scope.where("transactions.extra IS NULL OR transactions.extra = '{}'::jsonb")
     else
-      # For both "like" and "=" operators, perform contains search
-      # "like" is case-insensitive (ILIKE), "=" is case-sensitive (LIKE)
+      # For both "like/not_like" and "=/!=" operators, perform contains search
+      # "like/not_like" is case-insensitive (ILIKE), "=/!=" is case-sensitive (LIKE)
       # Note: For JSONB fields, both operators use contains semantics rather than exact match
       # because searching within structured JSON data makes contains more useful than exact equality
       sanitized_value = "%#{ActiveRecord::Base.sanitize_sql_like(value)}%"
       sql_operator = case operator
       when "like" then "ILIKE"
+      when "not_like" then "NOT ILIKE"
       when "!=" then "NOT LIKE"
       else "LIKE"
       end

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -56,6 +56,22 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_equal 3, filtered.count
   end
 
+  test "applies transaction_amount condition with not equal operator using absolute values" do
+    scope = @rule_scope
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_amount",
+      operator: "!=",
+      value: "50"
+    )
+
+    scope = condition.prepare(scope)
+
+    filtered = condition.apply(scope)
+    assert_equal 4, filtered.count
+  end
+
   test "applies transaction_merchant condition" do
     scope = @rule_scope
 

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -88,6 +88,23 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_equal 2, filtered.count
   end
 
+  test "applies transaction_merchant condition with not equal operator including transactions without merchant" do
+    scope = @rule_scope
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_merchant",
+      operator: "!=",
+      value: @whole_foods_merchant.id
+    )
+
+    scope = condition.prepare(scope)
+    filtered = condition.apply(scope)
+
+    assert_equal 3, filtered.count
+    assert(filtered.none? { |t| t.merchant_id == @whole_foods_merchant.id })
+  end
+
   test "applies compound and condition" do
     scope = @rule_scope
 
@@ -160,6 +177,25 @@ class Rule::ConditionTest < ActiveSupport::TestCase
 
     assert_equal 1, filtered.count
     assert_equal @grocery_category.id, filtered.first.category_id
+  end
+
+  test "applies transaction_category condition with not equal operator including uncategorized" do
+    scope = @rule_scope
+
+    @account.transactions.first.update!(category: @grocery_category)
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_category",
+      operator: "!=",
+      value: @grocery_category.id
+    )
+
+    scope = condition.prepare(scope)
+    filtered = condition.apply(scope)
+
+    assert_equal 4, filtered.count
+    assert(filtered.none? { |t| t.category_id == @grocery_category.id })
   end
 
   test "applies is_null condition for transaction_category" do

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -139,6 +139,27 @@ class RuleTest < ActiveSupport::TestCase
     assert_equal @groceries_category, tea_entry.transaction.category
   end
 
+  test "transaction name does not contain operator excludes substring matches" do
+    coffee_entry = create_transaction(date: Date.current, account: @account, name: "Coffee Shop Daily", amount: 10)
+    tea_entry = create_transaction(date: Date.current, account: @account, name: "Tea House", amount: 20)
+
+    rule = Rule.create!(
+      family: @family,
+      resource_type: "transaction",
+      effective_date: 1.day.ago.to_date,
+      conditions: [ Rule::Condition.new(condition_type: "transaction_name", operator: "not_like", value: "Coffee") ],
+      actions: [ Rule::Action.new(action_type: "set_transaction_category", value: @groceries_category.id) ]
+    )
+
+    rule.apply
+
+    coffee_entry.reload
+    tea_entry.reload
+
+    assert_nil coffee_entry.transaction.category
+    assert_equal @groceries_category, tea_entry.transaction.category
+  end
+
   # Artificial limitation put in place to prevent users from creating overly complex rules
   # Rules should be shallow and wide
   test "no nested compound conditions" do
@@ -287,6 +308,52 @@ class RuleTest < ActiveSupport::TestCase
 
     assert_nil paypal_entry.transaction.category, "Details containing 'Whole Foods' should not match !="
     assert_equal @groceries_category, paypal_entry2.transaction.category, "Details without 'Whole Foods' should match !="
+  end
+
+  test "rule matching on transaction details with does not contain operator" do
+    paypal_entry = create_transaction(
+      date: Date.current,
+      account: @account,
+      name: "PayPal",
+      amount: 50
+    )
+    paypal_entry.transaction.update!(
+      extra: {
+        "simplefin" => {
+          "payee" => "Whole Foods via PayPal"
+        }
+      }
+    )
+
+    paypal_entry2 = create_transaction(
+      date: Date.current,
+      account: @account,
+      name: "PayPal",
+      amount: 100
+    )
+    paypal_entry2.transaction.update!(
+      extra: {
+        "simplefin" => {
+          "payee" => "Amazon via PayPal"
+        }
+      }
+    )
+
+    rule = Rule.create!(
+      family: @family,
+      resource_type: "transaction",
+      effective_date: 1.day.ago.to_date,
+      conditions: [ Rule::Condition.new(condition_type: "transaction_details", operator: "not_like", value: "Whole Foods") ],
+      actions: [ Rule::Action.new(action_type: "set_transaction_category", value: @groceries_category.id) ]
+    )
+
+    rule.apply
+
+    paypal_entry.reload
+    paypal_entry2.reload
+
+    assert_nil paypal_entry.transaction.category, "Details containing 'Whole Foods' should not match not_like"
+    assert_equal @groceries_category, paypal_entry2.transaction.category, "Details without 'Whole Foods' should match not_like"
   end
 
   test "rule matching on transaction notes" do

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -118,6 +118,27 @@ class RuleTest < ActiveSupport::TestCase
     assert_equal @groceries_category, transaction_entry.transaction.category
   end
 
+  test "transaction name not equal operator matches other names only" do
+    coffee_entry = create_transaction(date: Date.current, account: @account, name: "Coffee", amount: 10)
+    tea_entry = create_transaction(date: Date.current, account: @account, name: "Tea", amount: 20)
+
+    rule = Rule.create!(
+      family: @family,
+      resource_type: "transaction",
+      effective_date: 1.day.ago.to_date,
+      conditions: [ Rule::Condition.new(condition_type: "transaction_name", operator: "!=", value: "Coffee") ],
+      actions: [ Rule::Action.new(action_type: "set_transaction_category", value: @groceries_category.id) ]
+    )
+
+    rule.apply
+
+    coffee_entry.reload
+    tea_entry.reload
+
+    assert_nil coffee_entry.transaction.category
+    assert_equal @groceries_category, tea_entry.transaction.category
+  end
+
   # Artificial limitation put in place to prevent users from creating overly complex rules
   # Rules should be shallow and wide
   test "no nested compound conditions" do
@@ -220,6 +241,52 @@ class RuleTest < ActiveSupport::TestCase
 
     assert_equal @groceries_category, paypal_entry.transaction.category, "PayPal transaction with 'Whole Foods' in details should be categorized"
     assert_nil paypal_entry2.transaction.category, "PayPal transaction without 'Whole Foods' in details should not be categorized"
+  end
+
+  test "rule matching on transaction details with not equal operator" do
+    paypal_entry = create_transaction(
+      date: Date.current,
+      account: @account,
+      name: "PayPal",
+      amount: 50
+    )
+    paypal_entry.transaction.update!(
+      extra: {
+        "simplefin" => {
+          "payee" => "Whole Foods via PayPal"
+        }
+      }
+    )
+
+    paypal_entry2 = create_transaction(
+      date: Date.current,
+      account: @account,
+      name: "PayPal",
+      amount: 100
+    )
+    paypal_entry2.transaction.update!(
+      extra: {
+        "simplefin" => {
+          "payee" => "Amazon via PayPal"
+        }
+      }
+    )
+
+    rule = Rule.create!(
+      family: @family,
+      resource_type: "transaction",
+      effective_date: 1.day.ago.to_date,
+      conditions: [ Rule::Condition.new(condition_type: "transaction_details", operator: "!=", value: "Whole Foods") ],
+      actions: [ Rule::Action.new(action_type: "set_transaction_category", value: @groceries_category.id) ]
+    )
+
+    rule.apply
+
+    paypal_entry.reload
+    paypal_entry2.reload
+
+    assert_nil paypal_entry.transaction.category, "Details containing 'Whole Foods' should not match !="
+    assert_equal @groceries_category, paypal_entry2.transaction.category, "Details without 'Whole Foods' should match !="
   end
 
   test "rule matching on transaction notes" do


### PR DESCRIPTION
Add support to the following operators in Rules:
 - Not equal to (For text, numbers and select)
 - Not like
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "not equal" (!=) and "not like" operators for rule conditions, enabling users to exclude transactions based on specific amounts, merchants, categories, and transaction details. These operators provide more flexible filtering options.

* **Tests**
  * Expanded test coverage for the new exclusion operators across multiple transaction field types to ensure reliable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->