### PR TITLE
Restore legacy Plaid migration constant alias

### DIFF
--- a/db/migrate/20260219200001_scope_plaid_item_uniqueness.rb
+++ b/db/migrate/20260219200001_scope_plaid_item_uniqueness.rb
@@ -26,3 +26,7 @@ class ScopePlaidItemUniqueness < ActiveRecord::Migration[7.2]
     add_index :plaid_accounts, :plaid_id, name: "index_plaid_accounts_on_plaid_id", unique: true
   end
 end
+
+# Backwards-compatible alias for environments that may still reference the
+# original migration constant derived from the old filename.
+ScopePlaidAccountUniquenessToItem = ScopePlaidItemUniqueness unless defined?(ScopePlaidAccountUniquenessToItem)

--- a/test/migrations/scope_plaid_item_uniqueness_migration_test.rb
+++ b/test/migrations/scope_plaid_item_uniqueness_migration_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require Rails.root.join("db/migrate/20260219200001_scope_plaid_item_uniqueness")
+
+class ScopePlaidItemUniquenessMigrationTest < ActiveSupport::TestCase
+  test "defines the legacy migration constant alias" do
+    assert_equal ScopePlaidItemUniqueness, ScopePlaidAccountUniquenessToItem
+  end
+end


### PR DESCRIPTION
### Motivation
- Production boot fails with `NameError: uninitialized constant ScopePlaidAccountUniquenessToItem` because Rails derives the migration constant from the filename after a migration/class rename. 
- Provide a backwards-compatible alias so environments that still reference the old migration constant continue to boot and load migrations.

### Description
- Add a compatibility alias in `db/migrate/20260219200001_scope_plaid_item_uniqueness.rb`: `ScopePlaidAccountUniquenessToItem = ScopePlaidItemUniqueness unless defined?(ScopePlaidAccountUniquenessToItem)`.
- Add a regression test `test/migrations/scope_plaid_item_uniqueness_migration_test.rb` that requires the migration file and asserts the legacy constant resolves to the current migration class.

### Testing
- Ran `bin/rails test test/migrations/scope_plaid_item_uniqueness_migration_test.rb`, which passed (1 run, 1 assertion, 0 failures).
- Verified via `bin/rails runner 'require Rails.root.join("db/migrate/20260219200001_scope_plaid_item_uniqueness"); puts [ScopePlaidItemUniqueness.name, ScopePlaidAccountUniquenessToItem.name].inspect'` that both constants resolve to `ScopePlaidItemUniqueness`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bddc1ba3d08332b0f229c0fc2c4082)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added backwards-compatible constant alias for legacy code references.

* **Tests**
  * Added migration test to verify constant alias functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->