### PR TITLE
Fix `pgvector` migration to only run when explicitly configured

### DIFF
--- a/db/migrate/20260316120000_create_vector_store_chunks.rb
+++ b/db/migrate/20260316120000_create_vector_store_chunks.rb
@@ -28,11 +28,15 @@ class CreateVectorStoreChunks < ActiveRecord::Migration[7.2]
 
   private
 
-    # Check if the pgvector extension is installed in the PostgreSQL server,
-    # not just whether it is enabled in this database. This lets the migration
-    # run harmlessly on plain Postgres (CI, dev without pgvector) while still
-    # creating the table on pgvector-capable servers.
+    # Only run this migration when pgvector is explicitly configured as the
+    # vector store provider AND the extension is actually available on the
+    # PostgreSQL server. Previously we only checked server availability,
+    # which caused failures in production Docker environments where the
+    # extension may be present but the DB user lacks superuser privileges
+    # to enable it.
     def pgvector_available?
+      return false unless ENV["VECTOR_STORE_PROVIDER"].to_s.downcase == "pgvector"
+
       result = ActiveRecord::Base.connection.execute(
         "SELECT 1 FROM pg_available_extensions WHERE name = 'vector' LIMIT 1"
       )


### PR DESCRIPTION
The migration previously checked only if the pgvector extension was available on the PostgreSQL server. In production Docker environments (e.g., managed Postgres services), the extension may be present but the database user lacks superuser privileges to enable it, causing the migration to fail.

Now the migration requires VECTOR_STORE_PROVIDER=pgvector to be set before attempting to enable the extension, matching the application's own configuration pattern in VectorStore::Registry.

https://claude.ai/code/session_017YYBFXGwamXpGwwDZxe8Pv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database initialization process by requiring explicit vector store configuration, ensuring operations only proceed when properly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->