### PR TITLE
Add transaction fee support to trades

### DIFF
--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -94,13 +94,13 @@ class TradesController < ApplicationController
     def entry_params
       params.require(:entry).permit(
         :name, :date, :amount, :currency, :excluded, :notes, :nature,
-        entryable_attributes: [ :id, :qty, :price, :investment_activity_label ]
+        entryable_attributes: [ :id, :qty, :price, :fee, :investment_activity_label ]
       )
     end
 
     def create_params
       params.require(:model).permit(
-        :date, :amount, :currency, :qty, :price, :ticker, :manual_ticker, :type, :transfer_account_id
+        :date, :amount, :currency, :qty, :price, :fee, :ticker, :manual_ticker, :type, :transfer_account_id
       )
     end
 
@@ -112,13 +112,15 @@ class TradesController < ApplicationController
 
       qty = update_params[:entryable_attributes][:qty]
       price = update_params[:entryable_attributes][:price]
+      fee = update_params[:entryable_attributes][:fee]
       nature = update_params[:nature]
 
       if qty.present? && price.present?
         is_sell = nature == "inflow"
         qty = is_sell ? -qty.to_d.abs : qty.to_d.abs
+        fee_val = fee.present? ? fee.to_d : (@entry.trade&.fee || 0)
         update_params[:entryable_attributes][:qty] = qty
-        update_params[:amount] = qty * price.to_d
+        update_params[:amount] = qty * price.to_d + fee_val
 
         # Sync investment_activity_label with Buy/Sell type if not explicitly set to something else
         # Check both the submitted param and the existing record's label

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -2,6 +2,7 @@ class Trade < ApplicationRecord
   include Entryable, Monetizable
 
   monetize :price
+  monetize :fee
 
   belongs_to :security
   belongs_to :category, optional: true

--- a/app/models/trade/create_form.rb
+++ b/app/models/trade/create_form.rb
@@ -2,7 +2,7 @@ class Trade::CreateForm
   include ActiveModel::Model
 
   attr_accessor :account, :date, :amount, :currency, :qty,
-                :price, :ticker, :manual_ticker, :type, :transfer_account_id
+                :price, :fee, :ticker, :manual_ticker, :type, :transfer_account_id
 
   # Either creates a trade, transaction, or transfer based on type
   # Returns the model, regardless of success or failure
@@ -30,7 +30,7 @@ class Trade::CreateForm
 
     def create_trade
       signed_qty = type == "sell" ? -qty.to_d : qty.to_d
-      signed_amount = signed_qty * price.to_d
+      signed_amount = signed_qty * price.to_d + fee.to_d
 
       trade_entry = account.entries.new(
         name: Trade.build_name(type, qty, security.ticker),
@@ -40,6 +40,7 @@ class Trade::CreateForm
         entryable: Trade.new(
           qty: signed_qty,
           price: price,
+          fee: fee.to_d,
           currency: currency,
           security: security,
           investment_activity_label: type.capitalize # "buy" → "Buy", "sell" → "Sell"

--- a/app/views/trades/_form.html.erb
+++ b/app/views/trades/_form.html.erb
@@ -51,6 +51,7 @@
       <% if %w[buy sell].include?(type) %>
         <%= form.number_field :qty, label: t(".qty"), placeholder: "10", min: 0.000000000000000001, step: "any", required: true %>
         <%= form.money_field :price, label: t(".price"), step: "any", precision: 10, required: true %>
+        <%= form.money_field :fee, label: t(".fee"), step: "any", min: 0 %>
       <% end %>
     </div>
 

--- a/app/views/trades/show.html.erb
+++ b/app/views/trades/show.html.erb
@@ -40,7 +40,15 @@
                   auto_submit: true,
                   min: 0,
                   step: "any",
-                  precision: 10,
+                  disabled: @entry.linked? %>
+          <% end %>
+          <%= f.fields_for :entryable do |ef| %>
+            <%= ef.money_field :fee,
+                  label: t(".fee_label"),
+                  disable_currency: true,
+                  auto_submit: true,
+                  min: 0,
+                  step: "any",
                   disabled: @entry.linked? %>
           <% end %>
         <% end %>

--- a/config/locales/views/trades/en.yml
+++ b/config/locales/views/trades/en.yml
@@ -5,6 +5,7 @@ en:
       account: Transfer account (optional)
       account_prompt: Search account
       amount: Amount
+      fee: Transaction fee
       holding: Ticker symbol
       price: Price per share
       qty: Quantity
@@ -29,6 +30,7 @@ en:
       cost_per_share_label: Cost per Share
       date_label: Date
       delete: Delete
+      fee_label: Transaction fee
       delete_subtitle: This action cannot be undone
       delete_title: Delete Trade
       details: Details

--- a/db/migrate/20260322120702_add_fee_to_trades.rb
+++ b/db/migrate/20260322120702_add_fee_to_trades.rb
@@ -1,0 +1,5 @@
+class AddFeeToTrades < ActiveRecord::Migration[7.2]
+  def change
+    add_column :trades, :fee, :decimal, precision: 19, scale: 4, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1424,6 +1424,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_26_112218) do
     t.string "currency"
     t.jsonb "locked_attributes", default: {}
     t.string "investment_activity_label"
+    t.decimal "fee", precision: 19, scale: 4, default: "0.0", null: false
     t.index ["investment_activity_label"], name: "index_trades_on_investment_activity_label"
     t.index ["security_id"], name: "index_trades_on_security_id"
   end

--- a/test/controllers/trades_controller_test.rb
+++ b/test/controllers/trades_controller_test.rb
@@ -111,6 +111,89 @@ class TradesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to @entry.account
   end
 
+  test "creates trade buy entry with fee" do
+    assert_difference [ "Entry.count", "Trade.count" ], 1 do
+      post trades_url(account_id: @entry.account_id), params: {
+        model: {
+          type: "buy",
+          date: Date.current,
+          ticker: "NVDA (NASDAQ)",
+          qty: 10,
+          price: 20,
+          fee: 9.95,
+          currency: "USD"
+        }
+      }
+    end
+
+    created_entry = Entry.order(created_at: :desc).first
+
+    assert_in_delta 209.95, created_entry.amount.to_f, 0.001
+    assert_in_delta 9.95, created_entry.trade.fee.to_f, 0.001
+    assert_redirected_to account_url(created_entry.account)
+  end
+
+  test "creates trade sell entry with fee" do
+    assert_difference [ "Entry.count", "Trade.count" ], 1 do
+      post trades_url(account_id: @entry.account_id), params: {
+        model: {
+          type: "sell",
+          date: Date.current,
+          ticker: "AAPL (NYSE)",
+          qty: 10,
+          price: 20,
+          fee: 9.95,
+          currency: "USD"
+        }
+      }
+    end
+
+    created_entry = Entry.order(created_at: :desc).first
+
+    # sell: signed_amount = -10 * 20 + 9.95 = -190.05
+    assert_in_delta(-190.05, created_entry.amount.to_f, 0.001)
+    assert_in_delta 9.95, created_entry.trade.fee.to_f, 0.001
+    assert_redirected_to account_url(created_entry.account)
+  end
+
+  test "creates trade buy entry without fee defaults to zero" do
+    post trades_url(account_id: @entry.account_id), params: {
+      model: {
+        type: "buy",
+        date: Date.current,
+        ticker: "NVDA (NASDAQ)",
+        qty: 10,
+        price: 20,
+        currency: "USD"
+      }
+    }
+
+    created_entry = Entry.order(created_at: :desc).first
+
+    assert_in_delta 200, created_entry.amount.to_f, 0.001
+    assert_equal 0, created_entry.trade.fee.to_f
+  end
+
+  test "update includes fee in amount" do
+    patch trade_url(@entry), params: {
+      entry: {
+        currency: "USD",
+        nature: "outflow",
+        entryable_attributes: {
+          id: @entry.entryable_id,
+          qty: 10,
+          price: 20,
+          fee: 9.95
+        }
+      }
+    }
+
+    @entry.reload
+
+    assert_in_delta 209.95, @entry.amount.to_f, 0.001
+    assert_in_delta 9.95, @entry.trade.fee.to_f, 0.001
+  end
+
   test "creates trade buy entry" do
     assert_difference [ "Entry.count", "Trade.count", "Security.count" ], 1 do
       post trades_url(account_id: @entry.account_id), params: {

--- a/test/models/trade_test.rb
+++ b/test/models/trade_test.rb
@@ -39,6 +39,19 @@ class TradeTest < ActiveSupport::TestCase
     assert_equal precise_price, trade.price
   end
 
+  test "fee defaults to 0" do
+    security = Security.create!(ticker: "FEETEST", exchange_operating_mic: "XNAS")
+    trade = Trade.create!(
+      security: security,
+      price: 100,
+      qty: 10,
+      currency: "USD",
+      investment_activity_label: "Buy"
+    )
+
+    assert_equal 0, trade.fee
+  end
+
   test "price is rounded to 10 decimal places" do
     security = Security.create!(ticker: "TEST", exchange_operating_mic: "XNAS")
 


### PR DESCRIPTION
## Summary

- Adds an optional **fee** field to trades (buy/sell) that is included in the total amount calculation (`qty × price + fee`)
- Introduces a Stimulus controller (`trade-recalculate`) for the trade edit form that recalculates totals client-side, shows a recalculation picker when the total is edited directly, and displays Save/Discard buttons only when the form is dirty
- Fee defaults to `0` and is fully optional — existing trades are unaffected

| New Transaction | Edit Details |
| --- | --- |
| <img width="300"  alt="image" src="https://github.com/user-attachments/assets/a4327965-4cef-4be9-a079-ca8c38530959" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/bc23d44e-3030-4442-a660-d45894df165d" /> |

### Edit total amount 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3a711c16-23e3-4f26-945a-6ac37fda6d16" />


## Changes

### Model & Database
- **Migration**: adds `fee` column to `trades`
- **Trade model**: `monetize :fee` for currency-aware formatting
- **Trade::CreateForm**: includes fee in `signed_amount` calculation for both buy and sell

### Controller
- `TradesController#create_params` and `#entry_params` permit the new `fee` field
- `#update_entry_params` handles three recalculation modes (`price`, `qty`, `fee`) when the user edits the total directly, plus standard fee inclusion when editing individual fields

### Views
- **Create form** (`_form.html.erb`): optional fee money field for buy/sell trades
- **Edit form** (`show.html.erb`): fee field + total field with recalculation picker (radio buttons for which field to back-solve) and dirty-state Save/Discard buttons

### Frontend
- **`trade_recalculate_controller.js`**: Stimulus controller managing:
  - Forward calculation: `total = qty × price + fee`
  - Reverse calculation: user edits total → picks which field to recalculate
  - Dirty-state tracking with discard/restore capability

### i18n
- All new labels and strings added to `config/locales/views/trades/en.yml`

See discussion: [https://github.com/we-promise/sure/discussions/607](https://github.com/we-promise/sure/discussions/607)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enter and persist transaction fees on trades; fee field added to forms and trade details.
  * Interactive edit UI with live recalculation, a picker to choose which value to recompute (price/qty/fee), and Save/Discard actions; client-side controller manages rounding, dirty state, and restore.

* **Chores**
  * Database migrations and schema updated; model treats fee as a monetary field.
  * Minor form placeholder tweak and view wiring updated.

* **Tests**
  * Added tests for fee defaults, creation, and recalculation update paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->