### PR TITLE
Fix home page double AppBar inconsistency with settings/more pages

### DIFF
--- a/mobile/lib/screens/dashboard_screen.dart
+++ b/mobile/lib/screens/dashboard_screen.dart
@@ -175,7 +175,7 @@ class DashboardScreenState extends State<DashboardScreen> {
                 children: [
                   const Icon(Icons.error, color: Colors.white),
                   const SizedBox(width: 12),
-                  Expanded(child: Text(transactionsProvider.error!)),
+                  const Expanded(child: Text('Sync failed. Please try again.')),
                 ],
               ),
               backgroundColor: Colors.red,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable sync success detection and lifecycle handling to prevent stale indicators and ensure proper dismissal.
  * Error handling now shows a red error snackbar when sync fails.

* **Refactor**
  * Consolidated sync completion flow into a single helper that manages timed display and cancellation of the success indicator.

* **New Features**
  * Replaced the AppBar icon with an in-body animated top banner showing a green "Synced" indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->