### PR TITLE
Add YNAB CSV import support (#1255)

### DIFF
--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -71,7 +71,7 @@ module ImportsHelper
 
   private
     def permitted_import_types
-      %w[transaction_import trade_import account_import mint_import category_import rule_import]
+      %w[transaction_import trade_import account_import mint_import category_import rule_import ynab_import]
     end
 
     DryRunResource = Struct.new(:label, :icon, :text_class, :bg_class, keyword_init: true)

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -9,7 +9,7 @@ class Import < ApplicationRecord
 
   DOCUMENT_TYPES = %w[bank_statement credit_card_statement investment_statement financial_document contract other].freeze
 
-  TYPES = %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport PdfImport QifImport SureImport].freeze
+  TYPES = %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport PdfImport QifImport SureImport YnabImport].freeze
   SIGNAGE_CONVENTIONS = %w[inflows_positive inflows_negative]
   SEPARATORS = [ [ "Comma (,)", "," ], [ "Semicolon (;)", ";" ] ].freeze
 

--- a/app/models/ynab_import.rb
+++ b/app/models/ynab_import.rb
@@ -1,0 +1,113 @@
+class YnabImport < Import
+  after_create :set_mappings
+
+  OUTFLOW_COL = "Outflow".freeze
+  INFLOW_COL = "Inflow".freeze
+
+  def generate_rows_from_csv
+    rows.destroy_all
+
+    mapped_rows = csv_rows.map do |row|
+      {
+        account: row[account_col_label].to_s,
+        date: row[date_col_label].to_s,
+        amount: compute_signed_amount(row).to_s("F"),
+        currency: default_currency.to_s,
+        name: (row[name_col_label] || default_row_name).to_s,
+        category: row[category_col_label].to_s,
+        tags: row[tags_col_label].to_s,
+        notes: row[notes_col_label].to_s
+      }
+    end
+
+    rows.insert_all!(mapped_rows)
+    update_column(:rows_count, rows.count)
+  end
+
+  def import!
+    transaction do
+      mappings.each(&:create_mappable!)
+
+      rows.each do |row|
+        mapped_account = if account
+          account
+        else
+          mappings.accounts.mappable_for(row.account)
+        end
+        category = mappings.categories.mappable_for(row.category)
+        tags = row.tags_list.map { |tag| mappings.tags.mappable_for(tag) }.compact
+
+        effective_currency = mapped_account.currency.presence || family.currency
+
+        entry = mapped_account.entries.build \
+          date: row.date_iso,
+          amount: row.signed_amount,
+          name: row.name,
+          currency: effective_currency,
+          notes: row.notes,
+          entryable: Transaction.new(category: category, tags: tags),
+          import: self
+
+        entry.save!
+      end
+    end
+  end
+
+  def mapping_steps
+    [ Import::CategoryMapping, Import::TagMapping, Import::AccountMapping ]
+  end
+
+  def required_column_keys
+    %i[date amount]
+  end
+
+  def column_keys
+    %i[date amount name currency category tags account notes]
+  end
+
+  def csv_template
+    template = <<-CSV
+      Account,Flag,Date,Payee,Category Group/Category,Category Group,Category,Memo,Outflow,Inflow,Cleared
+      Checking,,01/15/2024,Grocery Store,Immediate Obligations: Groceries,Immediate Obligations,Groceries,Weekly groceries,$78.32,$0.00,Cleared
+      Checking,,01/16/2024,ACME Corp,Income: Salary,Income,Salary,Bi-weekly paycheck,$0.00,"$2,500.00",Cleared
+      Credit Card,,01/17/2024,Coffee Shop,Quality of Life: Dining Out,Quality of Life,Dining Out,Morning coffee,$4.25,$0.00,Cleared
+    CSV
+
+    CSV.parse(template, headers: true)
+  end
+
+  private
+    # YNAB uses two columns: Outflow (expenses) and Inflow (income).
+    # In Sure, positive = outflow (expense), negative = inflow (income).
+    def compute_signed_amount(csv_row)
+      outflow = sanitize_ynab_amount(csv_row[OUTFLOW_COL])
+      inflow = sanitize_ynab_amount(csv_row[INFLOW_COL])
+      outflow - inflow
+    end
+
+    def sanitize_ynab_amount(value)
+      return 0.to_d if value.blank?
+
+      # Strip currency symbols, spaces, then normalize number format
+      cleaned = value.to_s.gsub(/[^\d.,\-]/, "")
+      return 0.to_d if cleaned.blank?
+
+      # Handle comma as thousands separator (US format: $2,500.00)
+      cleaned.gsub(",", "").to_d
+    end
+
+    def set_mappings
+      self.signage_convention = "inflows_negative"
+      self.date_col_label = "Date"
+      self.date_format = "%m/%d/%Y"
+      self.name_col_label = "Payee"
+      # YNAB uses dual Outflow/Inflow columns merged by compute_signed_amount,
+      # but amount_col_label is required for the configuration step validation.
+      self.amount_col_label = OUTFLOW_COL
+      self.account_col_label = "Account"
+      self.category_col_label = "Category"
+      self.notes_col_label = "Memo"
+
+      save!
+    end
+end

--- a/app/views/import/configurations/_ynab_import.html.erb
+++ b/app/views/import/configurations/_ynab_import.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (import:) %>
+
+<div class="flex items-center justify-between border border-secondary rounded-lg bg-green-500/5 p-5 gap-4 mb-4">
+  <span class="text-green-500">
+    <%= icon("check-circle", color: "current") %>
+  </span>
+  <p class="text-sm text-primary italic"><%= t(".pre_configured") %></p>
+</div>
+
+<%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
+  <div class="flex items-center gap-4">
+    <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label") }, label: true, required: true, disabled: import.complete? %>
+  </div>
+
+  <% unless import.account.present? %>
+    <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account" }, disabled: import.complete? %>
+  <% end %>
+
+  <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" }, disabled: import.complete? %>
+  <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>
+  <%= form.select :notes_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Notes (optional)" }, disabled: import.complete? %>
+
+  <%= form.submit "Apply configuration", disabled: import.complete? %>
+<% end %>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -31,7 +31,7 @@
 
     <%
       import_type = params[:type].presence || @pending_import&.type
-      active_tab = import_type.present? && !import_type.in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) ? "raw_data" : "financial_tools"
+      active_tab = import_type.present? && !import_type.in?(%w[MintImport QifImport SureImport YnabImport DocumentImport PdfImport]) ? "raw_data" : "financial_tools"
     %>
     <%= render DS::Tabs.new(active_tab: active_tab) do |tabs| %>
       <% tabs.with_nav do |nav| %>
@@ -42,7 +42,7 @@
       <% tabs.with_panel(tab_id: "financial_tools") do %>
         <div class="rounded-xl bg-container-inset p-1">
           <ul class="bg-container shadow-border-xs rounded-lg">
-            <% if @pending_import.present? && params[:type].present? && params[:type].in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) %>
+            <% if @pending_import.present? && params[:type].present? && params[:type].in?(%w[MintImport QifImport SureImport YnabImport DocumentImport PdfImport]) %>
               <li>
                 <%= link_to import_path(@pending_import), class: "flex items-center justify-between p-4 group cursor-pointer", data: { turbo: false } do %>
                   <div class="flex items-center gap-2">
@@ -99,6 +99,16 @@
                 enabled: true %>
             <% end %>
 
+            <% if params[:type].nil? || params[:type] == "YnabImport" %>
+              <%= render "imports/import_option",
+                type: "YnabImport",
+                icon_name: "wallet",
+                icon_bg_class: "bg-blue-500/5",
+                icon_text_class: "text-blue-500",
+                label: t(".import_ynab"),
+                enabled: true %>
+            <% end %>
+
             <% if params[:type].nil? || params[:type] == "QifImport" %>
               <%= render "imports/import_option",
                 type: "QifImport",
@@ -108,15 +118,6 @@
                 label: t(".import_qif"),
                 enabled: true %>
             <% end %>
-
-            <%= render "imports/import_option",
-              type: "TransactionImport",
-              icon_name: "bar-chart-2",
-              icon_bg_class: "bg-gray-500/5",
-              icon_text_class: "text-gray-400",
-              label: t(".import_ynab"),
-              enabled: false,
-              disabled_message: t(".coming_soon") %>
 
             <% if (params[:type].nil? || params[:type].in?(%w[DocumentImport PdfImport])) && @document_upload_extensions.any? %>
               <li>
@@ -153,7 +154,7 @@
       <% tabs.with_panel(tab_id: "raw_data") do %>
         <div class="rounded-xl bg-container-inset p-1">
           <ul class="bg-container shadow-border-xs rounded-lg">
-            <% if @pending_import.present? && params[:type].present? && !params[:type].in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) %>
+            <% if @pending_import.present? && params[:type].present? && !params[:type].in?(%w[MintImport QifImport SureImport YnabImport DocumentImport PdfImport]) %>
               <li>
                 <%= link_to import_path(@pending_import), class: "flex items-center justify-between p-4 group cursor-pointer", data: { turbo: false } do %>
                   <div class="flex items-center gap-2">

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -43,6 +43,9 @@ en:
         instructions: Select continue to parse your CSV and move on to the clean step.
       mint_import:
         date_format_label: Date format
+      ynab_import:
+        pre_configured: We have pre-configured your YNAB import for you. Outflow and Inflow columns will be merged automatically. Please proceed to the next step.
+        date_format_label: Date format
       rule_import:
         description: Configure your rule import. Rules will be created or updated based
           on the CSV data.
@@ -136,6 +139,7 @@ en:
       pdf_import: "PDF import"
       document_import: "Document import"
       sure_import: "Sure import"
+      ynab_import: "YNAB import"
     steps:
       upload: Upload
       configure: Configure
@@ -165,6 +169,7 @@ en:
           pdf_import: "PDF"
           document_import: "Document"
           sure_import: "Sure"
+          ynab_import: "YNAB"
         status:
           in_progress: In progress
           uploading: Processing rows

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -34,8 +34,9 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "button", text: "Import investments", count: 0
     assert_select "button", text: "Import from Mint", count: 1
     assert_select "button", text: "Import from Quicken (QIF)", count: 1
+    assert_select "button", text: "Import from YNAB", count: 1
     assert_select "span", text: "Import accounts first to unlock this option.", count: 2
-    assert_select "div[aria-disabled=true]", count: 3
+    assert_select "div[aria-disabled=true]", count: 2
   end
 
   test "creates import" do

--- a/test/fixtures/files/imports/ynab.csv
+++ b/test/fixtures/files/imports/ynab.csv
@@ -1,0 +1,5 @@
+"Account","Flag","Date","Payee","Category Group/Category","Category Group","Category","Memo","Outflow","Inflow","Cleared"
+"Checking","","01/15/2024","Grocery Store","Immediate Obligations: Groceries","Immediate Obligations","Groceries","Weekly groceries","$78.32","$0.00","Cleared"
+"Checking","","01/16/2024","ACME Corp","Income: Salary","Income","Salary","Bi-weekly paycheck","$0.00","$2,500.00","Cleared"
+"Credit Card","","01/17/2024","Coffee Shop","Quality of Life: Dining Out","Quality of Life","Dining Out","Morning coffee","$4.25","$0.00","Uncleared"
+"Checking","","01/18/2024","[Transfer: Credit Card]","","","","Payment to credit card","$200.00","$0.00","Cleared"

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -13,6 +13,11 @@ account:
   type: AccountImport
   status: pending
 
+ynab:
+  family: dylan_family
+  type: YnabImport
+  status: pending
+
 pdf:
   family: dylan_family
   type: PdfImport

--- a/test/models/ynab_import_test.rb
+++ b/test/models/ynab_import_test.rb
@@ -1,0 +1,141 @@
+require "test_helper"
+
+class YnabImportTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper, ImportInterfaceTest
+
+  setup do
+    @subject = @import = imports(:ynab)
+  end
+
+  test "auto-configures column mappings on create" do
+    import = Import.create!(
+      type: "YnabImport",
+      family: families(:dylan_family)
+    )
+
+    assert_equal "Date", import.date_col_label
+    assert_equal "%m/%d/%Y", import.date_format
+    assert_equal "Payee", import.name_col_label
+    assert_equal "Account", import.account_col_label
+    assert_equal "Category", import.category_col_label
+    assert_equal "Memo", import.notes_col_label
+    assert_equal "inflows_negative", import.signage_convention
+  end
+
+  test "computes signed amount from outflow and inflow columns" do
+    import = load_ynab_import
+
+    rows = import.rows.order(:date)
+
+    # Outflow $78.32 → positive (expense in Sure)
+    assert_equal "78.32", rows[0].amount
+
+    # Inflow $2,500.00 → negative (income in Sure)
+    assert_equal "-2500.0", rows[1].amount
+
+    # Outflow $4.25 → positive
+    assert_equal "4.25", rows[2].amount
+
+    # Outflow $200.00 (transfer)
+    assert_equal "200.0", rows[3].amount
+  end
+
+  test "maps payee to name and memo to notes" do
+    import = load_ynab_import
+
+    rows = import.rows.order(:date)
+
+    assert_equal "Grocery Store", rows[0].name
+    assert_equal "Weekly groceries", rows[0].notes
+    assert_equal "ACME Corp", rows[1].name
+    assert_equal "Bi-weekly paycheck", rows[1].notes
+  end
+
+  test "maps category and account columns" do
+    import = load_ynab_import
+
+    rows = import.rows.order(:date)
+
+    assert_equal "Groceries", rows[0].category
+    assert_equal "Checking", rows[0].account
+    assert_equal "Salary", rows[1].category
+    assert_equal "Checking", rows[1].account
+    assert_equal "Dining Out", rows[2].category
+    assert_equal "Credit Card", rows[2].account
+  end
+
+  test "imports full YNAB export with accounts, categories, and transactions" do
+    import = load_ynab_import
+
+    # Set up mappings
+    import.mappings.create! key: "Groceries", create_when_empty: true, type: "Import::CategoryMapping"
+    import.mappings.create! key: "Salary", create_when_empty: true, type: "Import::CategoryMapping"
+    import.mappings.create! key: "Dining Out", create_when_empty: true, type: "Import::CategoryMapping"
+    import.mappings.create! key: "", create_when_empty: false, mappable: nil, type: "Import::CategoryMapping"
+    import.mappings.create! key: "Checking", mappable: accounts(:depository), type: "Import::AccountMapping"
+    import.mappings.create! key: "Credit Card", mappable: accounts(:credit_card), type: "Import::AccountMapping"
+
+    assert_difference "Entry.count", 4 do
+      import.publish
+    end
+
+    assert import.complete?
+  end
+
+  test "handles amounts with dollar signs and comma separators" do
+    configure_ynab_mappings(@import)
+
+    csv = <<~CSV
+      "Account","Flag","Date","Payee","Category Group/Category","Category Group","Category","Memo","Outflow","Inflow","Cleared"
+      "Checking","","01/15/2024","Large Purchase","Bills: Rent","Bills","Rent","Monthly rent","$1,250.00","$0.00","Cleared"
+      "Checking","","01/16/2024","Employer","Income: Salary","Income","Salary","Paycheck","$0.00","$5,432.10","Cleared"
+    CSV
+
+    @import.update!(raw_file_str: csv)
+    @import.generate_rows_from_csv
+    @import.reload
+
+    rows = @import.rows.order(:date)
+
+    assert_equal "1250.0", rows[0].amount
+    assert_equal "-5432.1", rows[1].amount
+  end
+
+  test "handles rows where both outflow and inflow are zero" do
+    configure_ynab_mappings(@import)
+
+    csv = <<~CSV
+      "Account","Flag","Date","Payee","Category Group/Category","Category Group","Category","Memo","Outflow","Inflow","Cleared"
+      "Checking","","01/15/2024","Zero Transaction","","","","Test","$0.00","$0.00","Cleared"
+    CSV
+
+    @import.update!(raw_file_str: csv)
+    @import.generate_rows_from_csv
+    @import.reload
+
+    assert_equal "0.0", @import.rows.first.amount
+  end
+
+  private
+    def configure_ynab_mappings(import)
+      import.update!(
+        date_col_label: "Date",
+        date_format: "%m/%d/%Y",
+        name_col_label: "Payee",
+        amount_col_label: "Outflow",
+        account_col_label: "Account",
+        category_col_label: "Category",
+        notes_col_label: "Memo",
+        signage_convention: "inflows_negative"
+      )
+    end
+
+    def load_ynab_import
+      configure_ynab_mappings(@import)
+      csv_content = file_fixture("imports/ynab.csv").read
+      @import.update!(raw_file_str: csv_content)
+      @import.generate_rows_from_csv
+      @import.reload
+      @import
+    end
+end


### PR DESCRIPTION
## Summary

- Add `YnabImport` model for CSV exports following the `MintImport` pattern, handling YNAB's dual Outflow/Inflow columns with automatic column pre-configuration
- Register `YnabImport` in import types, helper allowlist, and UI with wallet icon

Closes #1255 (1 of 3 PRs)

## Details

**CSV Import (`YnabImport`):**
- Auto-configures YNAB column headers (Payee → name, Memo → notes, Category, Account, Date)
- Merges Outflow/Inflow into a single signed amount (outflow - inflow)
- Strips `$` signs and comma thousands separators
- Full mapping step for categories, tags, and accounts

## Test plan

- [ ] `bin/rails test test/models/ynab_import_test.rb` — YNAB import model tests
- [ ] `bin/rails test` — full test suite passes
- [ ] Manual: upload a YNAB CSV export and verify transactions import correctly