### PR TITLE
Add rswag API docs routes for development mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,13 @@ group :development do
   gem "foreman"
 end
 
+group :development, :test do
+  gem "rspec-rails"
+  gem "rswag-api"
+  gem "rswag-specs"
+  gem "rswag-ui"
+end
+
 group :test do
   gem "capybara"
   gem "selenium-webdriver"
@@ -132,8 +139,4 @@ group :test do
   gem "webmock"
   gem "climate_control"
   gem "simplecov", require: false
-  gem "rspec-rails"
-  gem "rswag-api"
-  gem "rswag-specs"
-  gem "rswag-ui"
 end

--- a/config/initializers/rswag.rb
+++ b/config/initializers/rswag.rb
@@ -1,0 +1,11 @@
+if defined?(Rswag::Ui) && Rails.env.development?
+  Rswag::Ui.configure do |c|
+    c.openapi_endpoint "/api-docs/openapi.yaml", "Sure API V1"
+  end
+end
+
+if defined?(Rswag::Api) && Rails.env.development?
+  Rswag::Api.configure do |c|
+    c.openapi_root = Rails.root.join("docs", "api").to_s
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,11 @@ Rails.application.routes.draw do
 
   mount Lookbook::Engine, at: "/design-system"
 
+  if Rails.env.development?
+    mount Rswag::Api::Engine => "/api-docs"
+    mount Rswag::Ui::Engine => "/api-docs"
+  end
+
   # Uses basic auth - see config/initializers/sidekiq.rb
   mount Sidekiq::Web => "/sidekiq"
 


### PR DESCRIPTION
Move rswag gems (rswag-api, rswag-ui, rspec-rails) from test-only to development+test group so Swagger UI is available in development. Mount Rswag::Api and Rswag::Ui engines at /api-docs behind a Rails.env.development? guard. Add initializer to configure the UI endpoint and API root directory.

https://claude.ai/code/session_011D98PaUEbXpREr8LyQqPvw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API documentation is now available in the development environment, providing interactive tools for exploring and testing API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->