### PR TITLE
Updated list of Canadian registered accounts

### DIFF
--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -37,13 +37,13 @@ class Investment < ApplicationRecord
     "rdsp" => { short: "RDSP", long: "Registered Disability Savings Plan", region: "ca", tax_treatment: :tax_advantaged },
     "resp" => { short: "RESP", long: "Registered Education Savings Plan", region: "ca", tax_treatment: :tax_advantaged },
     "dpsp" => { short: "DPSP", long: "Deferred Profit Sharing Plan", region: "ca", tax_treatment: :tax_deferred },
-    "rrif" => { short: "RRIF", long: "Registered Retirement Income Fund", region: "ca", tax_treatment: :tax_deferred },
-    "lira" => { short: "LIRA", long: "Locked-In Retirement Account", region: "ca", tax_treatment: :tax_deferred },
     "prpp" => { short: "PRPP", long: "Pooled Registered Pension Plan", region: "ca", tax_treatment: :tax_deferred },
+    "lira" => { short: "LIRA", long: "Locked-In Retirement Account", region: "ca", tax_treatment: :tax_deferred },
+    "rrif" => { short: "RRIF", long: "Registered Retirement Income Fund", region: "ca", tax_treatment: :tax_deferred },
     "lif" => { short: "LIF", long: "Life Income Fund", region: "ca", tax_treatment: :tax_deferred },
-    "rlif" => { short: "RLIF", long: "Restricted Life Income Fund", region: "ca", tax_treatment: :tax_deferred },
-    "prif" => { short: "PRIF", long: "Prescribed Registered Retirement Income Fund", region: "ca", tax_treatment: :tax_deferred },
     "lrif" => { short: "LRIF", long: "Locked-In Retirement Income Fund", region: "ca", tax_treatment: :tax_deferred },
+    "prif" => { short: "PRIF", long: "Prescribed Registered Retirement Income Fund", region: "ca", tax_treatment: :tax_deferred },
+    "rlif" => { short: "RLIF", long: "Restricted Life Income Fund", region: "ca", tax_treatment: :tax_deferred },
 
     # === Australia ===
     "super" => { short: "Super", long: "Superannuation", region: "au", tax_treatment: :tax_deferred },


### PR DESCRIPTION
Resolution to https://github.com/we-promise/sure/issues/1253.

I found a few new registered accounts than what I put in the issue since then, most of which are just [tax-deferred retirement accounts of some flavour or another](https://www.finiki.org/wiki/Locked-in_accounts), and then there's [the PRPP, which is yet another RRSP-like variation](https://www.canada.ca/en/revenue-agency/services/tax/pooled-registered-pension-plan-prpp/pooled-registered-pension-plan-prpp-questions-answers-administrators.html).

Changes have been tested both locally on my dev environment, as well as in Docker by passing through an edited version of investment.rb via the compose.yml file. No abnormal behaviour was observed due to these changes.

The new accounts show up in the subtype selector when creating a new investment account, display correctly in the account sidebar/settings, and have the correct tags:

<img width="504" height="654" alt="image" src="https://github.com/user-attachments/assets/13a48681-77bc-492b-baba-0d350afe469d" />



<img width="1791" height="857" alt="image" src="https://github.com/user-attachments/assets/c39587b5-b14d-44e0-877d-abecad4ba300" />



<img width="919" height="933" alt="image" src="https://github.com/user-attachments/assets/399d1885-2b3c-4775-9453-abea314a6bc4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Canadian account types: FHSA, RDSP, DPSP, PRPP, LIF, RLIF, PRIF, LRIF and Non-Registered, expanding coverage of Canadian investment account options.
  * Adjusted ordering of Canadian account types in lists and displays, moving RRSP to follow TFSA for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->