### PR TITLE
Add appearance setting for 2 column layout

### DIFF
--- a/app/controllers/settings/appearances_controller.rb
+++ b/app/controllers/settings/appearances_controller.rb
@@ -10,7 +10,8 @@ class Settings::AppearancesController < ApplicationController
     @user.transaction do
       @user.lock!
       updated_prefs = (@user.preferences || {}).deep_dup
-      updated_prefs["show_split_grouped"] = params.dig(:user, :show_split_grouped) == "1"
+      updated_prefs["show_split_grouped"] = params.dig(:user, :show_split_grouped) == "1" if params.dig(:user, :show_split_grouped)
+      updated_prefs["dashboard_two_column"] = params.dig(:user, :dashboard_two_column) == "1" if params.dig(:user, :dashboard_two_column)
       @user.update!(preferences: updated_prefs)
     end
     redirect_to settings_appearance_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -320,6 +320,10 @@ class User < ApplicationRecord
     preferences&.dig("show_split_grouped") != false
   end
 
+  def dashboard_two_column?
+    preferences&.dig("dashboard_two_column") != false
+  end
+
   def update_transactions_preferences(prefs)
     transaction do
       lock!

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -29,7 +29,7 @@
   </div>
 <% end %>
 
-<div class="grid grid-cols-1 2xl:grid-cols-2 gap-6 pb-6 lg:pb-12" data-controller="dashboard-sortable" data-action="dragover->dashboard-sortable#dragOver drop->dashboard-sortable#drop" role="list" aria-label="Dashboard sections">
+<div class="grid grid-cols-1 <%= "2xl:grid-cols-2" if Current.user.dashboard_two_column? %> gap-6 pb-6 lg:pb-12" data-controller="dashboard-sortable" data-action="dragover->dashboard-sortable#dragOver drop->dashboard-sortable#drop" role="list" aria-label="Dashboard sections">
   <% if Current.family.accounts.any? %>
     <% @dashboard_sections.each do |section| %>
       <% next unless section[:visible] %>

--- a/app/views/settings/appearances/show.html.erb
+++ b/app/views/settings/appearances/show.html.erb
@@ -28,6 +28,27 @@
   </div>
 <% end %>
 
+<%= settings_section title: t(".dashboard_title"), subtitle: t(".dashboard_subtitle") do %>
+  <div>
+    <%= form_with url: settings_appearance_path, method: :patch,
+          class: "p-3",
+          data: { controller: "auto-submit-form" } do |f| %>
+      <div class="flex cursor-pointer items-center gap-4 justify-between">
+        <div class="text-sm space-y-1">
+          <h4 class="text-primary"><%= t(".dashboard_two_column_title") %></h4>
+          <p class="text-secondary"><%= t(".dashboard_two_column_description") %></p>
+        </div>
+        <%= render DS::Toggle.new(
+              id: "user_dashboard_two_column",
+              name: "user[dashboard_two_column]",
+              checked: @user.dashboard_two_column?,
+              data: { auto_submit_form_target: "auto" }
+        ) %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
 <%= settings_section title: t(".transactions_title"), subtitle: t(".transactions_subtitle") do %>
   <div>
     <%= form_with url: settings_appearance_path, method: :patch,

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -36,6 +36,10 @@ en:
         theme_system: System
         transactions_title: Transactions
         transactions_subtitle: Customize how transactions are displayed
+        dashboard_title: Dashboard
+        dashboard_subtitle: Customize how the dashboard is displayed
+        dashboard_two_column_title: Two-column layout
+        dashboard_two_column_description: Display dashboard widgets in two columns on large screens. When off, widgets stack in a single column.
         split_grouped_title: Group split transactions
         split_grouped_description: Show split transactions grouped under their parent in the transaction list. When off, split children appear as individual rows.
     preferences:


### PR DESCRIPTION
Adds a toggle to show dashboard on 2 columns or 1 based on preference.

<img width="865" height="196" alt="Screenshot 2026-03-24 at 19 07 05" src="https://github.com/user-attachments/assets/3b80425d-d225-46af-a8c3-110aa15771ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now customize their dashboard layout with a new toggle in Settings > Appearances
  * Dashboard supports a two-column layout option for extra-large screens, complementing the standard single-column view
  * Layout preference is saved per user and automatically applied to the dashboard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->