### PR TITLE
Added option to skip TLS verification for mailer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,7 @@ SMTP_PORT=465
 SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_TLS_ENABLED=true
+SMTP_TLS_SKIP_VERIFY=false
 
 # Address that emails are sent from
 EMAIL_SENDER=

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,11 +78,12 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV["APP_DOMAIN"] }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:   ENV["SMTP_ADDRESS"],
-    port:      ENV["SMTP_PORT"],
-    user_name: ENV["SMTP_USERNAME"],
-    password:  ENV["SMTP_PASSWORD"],
-    tls:       ENV["SMTP_TLS_ENABLED"] == "true"
+    address:             ENV["SMTP_ADDRESS"],
+    port:                ENV["SMTP_PORT"],
+    user_name:           ENV["SMTP_USERNAME"],
+    password:            ENV["SMTP_PASSWORD"],
+    tls:                 ENV["SMTP_TLS_ENABLED"] == "true",
+    openssl_verify_mode: ENV["SMTP_TLS_SKIP_VERIFY"] == "true" ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
Added `SMTP_TLS_SKIP_VERIFY` env variable. If set to `true` the `action_mailer.smtp_settings` option `openssl_verify_mode` is set to `VERIFY_NONE`. This fixes #1288 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new environment toggle to control SMTP TLS certificate verification, with the default set to enforce verification.
  * Production mail delivery now respects this toggle, allowing TLS certificate verification to be optionally skipped when explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->