### PR TITLE
Fix CI tests for inflows donut feature (#1067)

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,6 +23,7 @@ class PagesController < ApplicationController
 
     @cashflow_sankey_data = build_cashflow_sankey_data(net_totals, income_totals, expense_totals, family_currency)
     @outflows_data = build_outflows_donut_data(net_totals)
+    @inflows_data = build_inflows_donut_data(income_totals)
 
     @dashboard_sections = build_dashboard_sections
 
@@ -99,6 +100,14 @@ class PagesController < ApplicationController
           partial: "pages/dashboard/outflows_donut",
           locals: { outflows_data: @outflows_data, period: @period },
           visible: @accounts.any? && @outflows_data[:categories].present?,
+          collapsible: true
+        },
+        {
+          key: "inflows_donut",
+          title: "pages.dashboard.inflows_donut.title",
+          partial: "pages/dashboard/inflows_donut",
+          locals: { inflows_data: @inflows_data, period: @period },
+          visible: Current.family.accounts.any?,
           collapsible: true
         },
         {
@@ -311,6 +320,29 @@ class PagesController < ApplicationController
           end
         end
       end
+    end
+
+    def build_inflows_donut_data(income_totals)
+      currency_symbol = Money::Currency.new(income_totals.currency).symbol
+      total = income_totals.total
+
+      categories = income_totals.category_totals
+        .reject { |ct| ct.category.parent_id.present? || ct.total.zero? }
+        .sort_by { |ct| -ct.total }
+        .map do |ct|
+          {
+            id: ct.category.id,
+            name: ct.category.name,
+            amount: ct.total.to_f.round(2),
+            currency: ct.currency,
+            percentage: ct.weight.round(1),
+            color: ct.category.color.presence || Category::UNCATEGORIZED_COLOR,
+            icon: ct.category.lucide_icon,
+            clickable: !ct.category.other_investments?
+          }
+        end
+
+      { categories: categories, total: total.to_f.round(2), currency: income_totals.currency, currency_symbol: currency_symbol }
     end
 
     def build_outflows_donut_data(net_totals)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -393,7 +393,7 @@ class User < ApplicationRecord
     end
 
     def default_dashboard_section_order
-      %w[cashflow_sankey outflows_donut net_worth_chart balance_sheet]
+      %w[cashflow_sankey outflows_donut inflows_donut net_worth_chart balance_sheet]
     end
 
     def default_reports_section_order

--- a/app/views/pages/dashboard/_inflows_donut.html.erb
+++ b/app/views/pages/dashboard/_inflows_donut.html.erb
@@ -1,0 +1,141 @@
+<%# locals: (inflows_data:, period:) %>
+<div id="inflows-donut-section">
+  <div class="flex justify-end items-center gap-4 px-4 mb-4">
+    <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
+      <%= form.select :period,
+                Period.as_options,
+                { selected: period.key },
+                data: { "auto-submit-form-target": "auto" },
+                class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+    <% end %>
+  </div>
+
+  <div class="px-4">
+    <div class="flex flex-col lg:flex-row gap-8 items-center">
+      <!-- Donut Chart -->
+      <div class="<%= inflows_data[:categories].present? ? 'w-full lg:w-1/3 max-w-[300px]' : 'w-full' %> px-4">
+        <% if inflows_data[:categories].present? %>
+          <div class="h-[300px] relative"
+            data-controller="donut-chart"
+            data-donut-chart-segments-value="<%= inflows_data[:categories].to_json %>"
+            data-donut-chart-segment-opacity-value="0.9"
+            data-donut-chart-extended-hover-value="true"
+            data-donut-chart-hover-extension-value="3"
+            data-donut-chart-enable-click-value="true"
+            data-donut-chart-start-date-value="<%= period.date_range.first %>"
+            data-donut-chart-end-date-value="<%= period.date_range.last %>">
+            <div data-donut-chart-target="chartContainer" class="absolute inset-0 pointer-events-none"></div>
+
+            <div data-donut-chart-target="contentContainer" class="flex justify-center items-center h-full">
+              <div data-donut-chart-target="defaultContent" class="flex flex-col items-center">
+                <div class="text-secondary text-sm mb-2">
+                  <span><%= t("pages.dashboard.inflows_donut.total_inflows") %></span>
+                </div>
+
+                <div class="text-3xl font-medium text-primary privacy-sensitive">
+                  <%= format_money Money.new(inflows_data[:total], inflows_data[:currency]) %>
+                </div>
+              </div>
+
+              <% inflows_data[:categories].each do |category| %>
+                <div id="segment_<%= category[:id] %>" class="hidden">
+                  <div class="flex flex-col gap-2 items-center">
+                    <p class="text-sm text-secondary"><%= category[:name] %></p>
+
+                    <p class="text-3xl font-medium text-primary privacy-sensitive">
+                      <%= inflows_data[:currency_symbol] %><%= number_with_delimiter(category[:amount], delimiter: ",") %>
+                    </p>
+
+                    <p class="text-sm text-secondary privacy-sensitive"><%= category[:percentage] %>%</p>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% else %>
+          <!-- Empty state: no inflows message -->
+          <div class="flex items-center justify-center py-20">
+            <div class="text-center">
+              <p class="text-secondary text-base">
+                <%= t("pages.dashboard.inflows_donut.no_data_message") %>
+              </p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <% if inflows_data[:categories].present? %>
+        <!-- Category List -->
+        <div class="w-full lg:w-2/3 bg-container-inset rounded-xl p-1 space-y-1 overflow-x-auto">
+          <div class="px-4 py-2 flex items-center uppercase text-xs font-medium text-secondary">
+            <div class="w-16 lg:w-40">
+              <p><%= t("pages.dashboard.inflows_donut.categories") %><span class="text-subdued mx-1">&middot;</span><%= inflows_data[:categories].count %></p>
+            </div>
+            <div class="ml-auto text-right flex items-center gap-6">
+              <div class="w-16 lg:w-40">
+                <p><%= t("pages.dashboard.inflows_donut.value") %></p>
+              </div>
+              <div class="w-16">
+                <p><%= t("pages.dashboard.inflows_donut.weight") %></p>
+              </div>
+            </div>
+          </div>
+          <div class="py-3 shadow-border-xs rounded-lg bg-container font-medium text-sm max-w-full">
+            <% inflows_data[:categories].each_with_index do |category, idx| %>
+              <%
+                category_content = capture do
+              %>
+                <div class="flex items-center gap-3 flex-1 min-w-0">
+                  <div class="h-7 w-7 flex-shrink-0 group-hover:scale-105 transition-all duration-300 rounded-full flex justify-center items-center"
+                    style="
+                      background-color: color-mix(in oklab, <%= category[:color] %> 10%, transparent);
+                      border-color: color-mix(in oklab, <%= category[:color] %> 10%, transparent);
+                      color: <%= category[:color] %>;">
+                    <% if category[:icon] %>
+                      <%= icon(category[:icon], color: "current", size: "sm") %>
+                    <% else %>
+                      <%= render DS::FilledIcon.new(
+                        variant: :text,
+                        hex_color: category[:color],
+                        text: category[:name],
+                        size: "sm",
+                        rounded: true
+                      ) %>
+                    <% end %>
+                  </div>
+                  <span class="text-sm font-medium text-primary truncate"><%= category[:name] %></span>
+                </div>
+                <div class="flex items-center gap-4 flex-shrink-0 text-right">
+                  <span class="text-sm font-medium text-primary whitespace-nowrap privacy-sensitive"><%= format_money Money.new(category[:amount], category[:currency]) %></span>
+                  <span class="text-sm text-secondary whitespace-nowrap w-10 lg:w-15 privacy-sensitive"><%= category[:percentage] %>%</span>
+                </div>
+              <% end %>
+
+              <% if category[:clickable] != false %>
+                <%= link_to transactions_path(q: { categories: [category[:name]], start_date: period.date_range.first, end_date: period.date_range.last }),
+                    class: "flex items-center justify-between mx-3 p-3 rounded-lg cursor-pointer group gap-3",
+                    data: {
+                      turbo_frame: "_top",
+                      turbo_prefetch: false,
+                      category_id: category[:id],
+                      action: "mouseenter->donut-chart#highlightSegment mouseleave->donut-chart#unhighlightSegment"
+                    } do %>
+                  <%= category_content %>
+                <% end %>
+              <% else %>
+                <div class="flex items-center justify-between mx-3 p-3 rounded-lg group gap-3"
+                    data-category-id="<%= category[:id] %>"
+                    data-action="mouseenter->donut-chart#highlightSegment mouseleave->donut-chart#unhighlightSegment">
+                  <%= category_content %>
+                </div>
+              <% end %>
+              <% if idx < inflows_data[:categories].size - 1 %>
+                <%= render "shared/ruler", classes: "mx-3 lg:mx-4" %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -43,6 +43,13 @@ en:
         categories: "Categories"
         value: "Value"
         weight: "Weight"
+      inflows_donut:
+        title: "Inflows"
+        total_inflows: "Total Inflows"
+        categories: "Categories"
+        value: "Value"
+        weight: "Weight"
+        no_data_message: "No inflows for this period"
       investment_summary:
         title: "Investments"
         total_return: "Total Return"

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -14,6 +14,16 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test "dashboard includes inflows donut section when family has income in period" do
+    income_category = @family.categories.incomes.first
+    income_category ||= @family.categories.create!(name: "Wages", classification: "income", color: "#22c55e")
+    create_transaction(account: @family.accounts.first, name: "Salary", amount: -2000, category: income_category)
+
+    get root_path
+    assert_response :ok
+    assert_select "#inflows-donut-section"
+  end
+
   test "intro page requires guest role" do
     get intro_path
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -319,7 +319,7 @@ class UserTest < ActiveSupport::TestCase
       "Should return false when collapsed_sections key is missing"
 
     # dashboard_section_order should return default order when key is missing
-    assert_equal %w[cashflow_sankey outflows_donut net_worth_chart balance_sheet],
+    assert_equal %w[cashflow_sankey outflows_donut inflows_donut net_worth_chart balance_sheet],
       @user.dashboard_section_order,
       "Should return default order when section_order key is missing"
 


### PR DESCRIPTION
## Summary

- Fixes the CI test failures in #1067 by correctly implementing the inflows donut feature
- The original PR incorrectly changed `build_outflows_donut_data(net_totals)` to `build_outflows_donut_data(expense_totals)`, causing `NoMethodError` — `expense_totals` is a `PeriodTotal` which doesn't have `.total_net_expense` or `.net_expense_categories` methods
- This PR keeps the outflows donut using `net_totals` (correct) and adds the new inflows donut using `income_totals` which has the matching `.total` and `.category_totals` methods

### Changes
- Add `build_inflows_donut_data` method to pages controller
- Add `inflows_donut` dashboard section with empty state support
- Add `inflows_donut` to `default_dashboard_section_order` in User model
- Add locale strings and view partial for inflows donut
- Add controller test and update user test expectations

## Test plan

- [ ] Verify `bin/rails test test/controllers/pages_controller_test.rb` passes
- [ ] Verify `bin/rails test test/models/user_test.rb` passes
- [ ] Verify dashboard renders inflows donut when income transactions exist
- [ ] Verify empty state message shows when no inflows for selected period

https://claude.ai/code/session_011USfv8zibnNnwt9esPb86U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inflows donut chart to the dashboard that visualizes income by category
  * Chart displays total inflows with a period selector for flexible date range filtering
  * Category rows show amounts and percentages, with clickable links to view filtered transactions
  * Default dashboard layout now includes the inflows chart section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->