### PR TITLE
Added ca_file option to use the SSL_CA_FILE specified file if present

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,7 +84,7 @@ Rails.application.configure do
     password:            ENV["SMTP_PASSWORD"],
     tls:                 ENV["SMTP_TLS_ENABLED"] == "true",
     openssl_verify_mode: ENV["SMTP_TLS_SKIP_VERIFY"] == "true" ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER,
-    ca_file:             Rails.configuration.x.ssl.ca_file
+    ca_file:             ENV["SSL_CA_FILE"]
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
As per suggestion added ca_file pass through for STMP settings. This fixes #1301 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated production email configuration to include an SSL CA file for stronger certificate validation and adjusted SMTP verification settings for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->