### PR TITLE
Fixing consistency issues with pluralization in UI

### DIFF
--- a/app/views/accounts/_account.html.erb
+++ b/app/views/accounts/_account.html.erb
@@ -30,7 +30,7 @@
             <% end %>
           </div>
           <% if account.long_subtype_label %>
-            <p class="text-sm text-secondary truncate"><%= account.long_subtype_label %></p>
+            <p class="text-sm text-secondary truncate"><%= account.long_subtype_label.singularize %></p>
           <% end %>
           <% if account.supports_default? && is_default %>
             <p class="text-xs text-secondary opacity-50"><%= t("accounts.account.default_label") %></p>

--- a/app/views/accounts/_accountable_group.html.erb
+++ b/app/views/accounts/_accountable_group.html.erb
@@ -38,7 +38,7 @@
                 <%= icon("users", class: "w-3 h-3 text-secondary shrink-0") %>
               <% end %>
             </div>
-            <%= tag.p account.short_subtype_label, class: "text-sm text-secondary truncate" %>
+            <%= tag.p account.short_subtype_label.singularize, class: "text-sm text-secondary truncate" %>
           </div>
 
           <div class="ml-auto text-right grow h-10">

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -111,14 +111,14 @@ en:
       new_account_group: "New %{account_group}"
     types:
       depository: Cash
-      investment: Investment
+      investment: Investments
       crypto: Crypto
-      property: Property
-      vehicle: Vehicle
-      other_asset: Other Asset
-      credit_card: Credit Card
-      loan: Loan
-      other_liability: Other Liability
+      property: Properties
+      vehicle: Vehicles
+      other_asset: Other Assets
+      credit_card: Credit Cards
+      loan: Loans
+      other_liability: Other Liabilities
     tax_treatments:
       taxable: Taxable
       tax_deferred: Tax-Deferred


### PR DESCRIPTION
Closes https://github.com/we-promise/sure/issues/1303.

From the testing I've done on my dev environment, the issue can be fixed by pluralizing the category type names in config/locales/views/accounts/en.yml, and by singularizing any displayed subtype labels for the sidebar and Settings/General/Accounts by adding .singularize to the app/views/accounts/_account.html.erb and app/views/accounts/_accountable_group.html.erb files.

The format of all the asset/liability category types should now all be plural category with singular subtype label, as shown in this screenshot from the accounts sidebar:

<img width="302" height="845" alt="image" src="https://github.com/user-attachments/assets/50a40984-0bd6-437c-956c-df0ac8529d21" />

And this one from Settings/General/Accounts:
<img width="526" height="765" alt="image" src="https://github.com/user-attachments/assets/fd5d0b80-c943-4218-9e2f-6c3f8d8d9f51" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected account type labels to display in singular form across account views, improving consistency and clarity in how account categories are presented to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->