### PR TITLE
Allow custom OpenAI model names

### DIFF
--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -32,11 +32,14 @@ class Provider::Openai < Provider
   end
 
   def supports_model?(model)
+    requested_model = model.to_s
+
     # If using custom uri_base, support any model
     return true if custom_provider?
+    return true if requested_model == @default_model
 
     # Otherwise, check if model starts with any supported OpenAI prefix
-    DEFAULT_OPENAI_MODEL_PREFIXES.any? { |prefix| model.start_with?(prefix) }
+    DEFAULT_OPENAI_MODEL_PREFIXES.any? { |prefix| requested_model.start_with?(prefix) }
   end
 
   def provider_name
@@ -46,6 +49,8 @@ class Provider::Openai < Provider
   def supported_models_description
     if custom_provider?
       @default_model.present? ? "configured model: #{@default_model}" : "any model"
+    elsif explicit_non_openai_model?
+      "configured model: #{@default_model}; otherwise models starting with: #{DEFAULT_OPENAI_MODEL_PREFIXES.join(', ')}"
     else
       "models starting with: #{DEFAULT_OPENAI_MODEL_PREFIXES.join(', ')}"
     end
@@ -243,6 +248,10 @@ class Provider::Openai < Provider
 
   private
     attr_reader :client
+
+    def explicit_non_openai_model?
+      @default_model.present? && DEFAULT_OPENAI_MODEL_PREFIXES.none? { |prefix| @default_model.start_with?(prefix) }
+    end
 
     def native_chat_response(
       prompt:,

--- a/app/views/settings/hostings/_openai_settings.html.erb
+++ b/app/views/settings/hostings/_openai_settings.html.erb
@@ -11,57 +11,50 @@
   <%= styled_form_with model: Setting.new,
                        url: settings_hosting_path,
                        method: :patch,
-                       class: "space-y-4",
-                       data: {
-                         controller: "auto-submit-form",
-                         "auto-submit-form-trigger-event-value": "blur"
-                       } do |form| %>
-  <%= form.password_field :openai_access_token,
-                          label: t(".access_token_label"),
-                          placeholder: t(".access_token_placeholder"),
-                          value: (Setting.openai_access_token.present? ? "********" : nil),
-                          autocomplete: "off",
-                          autocapitalize: "none",
-                          spellcheck: "false",
-                          inputmode: "text",
-                          disabled: ENV["OPENAI_ACCESS_TOKEN"].present?,
-                          data: { "auto-submit-form-target": "auto" } %>
+                       class: "space-y-4" do |form| %>
+    <%= form.password_field :openai_access_token,
+                            label: t(".access_token_label"),
+                            placeholder: t(".access_token_placeholder"),
+                            value: (Setting.openai_access_token.present? ? "********" : nil),
+                            autocomplete: "off",
+                            autocapitalize: "none",
+                            spellcheck: "false",
+                            inputmode: "text",
+                            disabled: ENV["OPENAI_ACCESS_TOKEN"].present? %>
 
-  <%= form.text_field :openai_uri_base,
-                      label: t(".uri_base_label"),
-                      placeholder: t(".uri_base_placeholder"),
-                      value: Setting.openai_uri_base,
-                      autocomplete: "off",
-                      autocapitalize: "none",
-                      spellcheck: "false",
-                      inputmode: "url",
-                      disabled: ENV["OPENAI_URI_BASE"].present?,
-                      data: { "auto-submit-form-target": "auto" } %>
+    <%= form.text_field :openai_uri_base,
+                        label: t(".uri_base_label"),
+                        placeholder: t(".uri_base_placeholder"),
+                        value: Setting.openai_uri_base,
+                        autocomplete: "off",
+                        autocapitalize: "none",
+                        spellcheck: "false",
+                        inputmode: "url",
+                        disabled: ENV["OPENAI_URI_BASE"].present? %>
 
-  <%= form.text_field :openai_model,
-                      label: t(".model_label"),
-                      placeholder: t(".model_placeholder"),
-                      value: Setting.openai_model,
-                      autocomplete: "off",
-                      autocapitalize: "none",
-                      spellcheck: "false",
-                      inputmode: "text",
-                      disabled: ENV["OPENAI_MODEL"].present?,
-                      data: { "auto-submit-form-target": "auto" } %>
+    <%= form.text_field :openai_model,
+                        label: t(".model_label"),
+                        placeholder: t(".model_placeholder"),
+                        value: Setting.openai_model,
+                        autocomplete: "off",
+                        autocapitalize: "none",
+                        spellcheck: "false",
+                        inputmode: "text",
+                        disabled: ENV["OPENAI_MODEL"].present? %>
 
-  <%= form.select :openai_json_mode,
-                  options_for_select(
-                    [
-                      [t(".json_mode_auto"), ""],
-                      [t(".json_mode_strict"), "strict"],
-                      [t(".json_mode_none"), "none"],
-                      [t(".json_mode_json_object"), "json_object"]
-                    ],
-                    Setting.openai_json_mode
-                  ),
-                  { label: t(".json_mode_label") },
-                  { disabled: ENV["LLM_JSON_MODE"].present?,
-                    data: { "auto-submit-form-target": "auto" } } %>
-  <p class="text-xs text-secondary mt-1"><%= t(".json_mode_help") %></p>
+    <%= form.select :openai_json_mode,
+                    options_for_select(
+                      [
+                        [t(".json_mode_auto"), ""],
+                        [t(".json_mode_strict"), "strict"],
+                        [t(".json_mode_none"), "none"],
+                        [t(".json_mode_json_object"), "json_object"]
+                      ],
+                      Setting.openai_json_mode
+                    ),
+                    { label: t(".json_mode_label") },
+                    { disabled: ENV["LLM_JSON_MODE"].present? } %>
+    <p class="text-xs text-secondary mt-1"><%= t(".json_mode_help") %></p>
+    <%= render DS::Button.new(variant: :primary, size: :md, type: "submit", text: "Save Configuration") %>
   <% end %>
 </div>

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -272,9 +272,22 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     assert_equal "Custom OpenAI-compatible (https://custom-api.example.com/v1)", custom_provider.provider_name
   end
 
+  test "supports explicitly configured non-openai model on standard provider" do
+    provider = Provider::Openai.new("test-token", model: "llama3.2:3b")
+
+    assert provider.supports_model?("llama3.2:3b")
+    refute provider.supports_model?("mistral:7b")
+  end
+
   test "supported_models_description returns model prefixes for standard provider" do
     expected = "models starting with: gpt-4, gpt-5, o1, o3"
     assert_equal expected, @subject.supported_models_description
+  end
+
+  test "supported_models_description includes explicitly configured non-openai model on standard provider" do
+    provider = Provider::Openai.new("test-token", model: "llama3.2:3b")
+
+    assert_equal "configured model: llama3.2:3b; otherwise models starting with: gpt-4, gpt-5, o1, o3", provider.supported_models_description
   end
 
   test "supported_models_description returns configured model for custom provider" do


### PR DESCRIPTION
Support explicitly configured non-OpenAI model identifiers on the existing OpenAI provider path so self-hosted endpoints like Ollama can be used without separate integration code. Also switch the OpenAI settings form to explicit submission so custom base URL and model changes are saved together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring non-OpenAI models within the OpenAI provider settings.

* **Bug Fixes**
  * OpenAI settings form now requires an explicit "Save Configuration" button click instead of auto-submitting on field changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->