### PR TITLE
Use design-system UI component for simple select elements

### DIFF
--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -1,6 +1,6 @@
 <%# locals: form:, method:, collection:, options: {} %>
 
-<div class="relative" data-controller="select <%= "list-filter" if searchable %> form-dropdown" data-action="dropdown:select->form-dropdown#onSelect" <%= tag.attributes(html_options.slice("data-no-focus")) %>>
+<div class="relative w-full" data-controller="select <%= "list-filter" if searchable %> form-dropdown" data-action="dropdown:select->form-dropdown#onSelect" <%= tag.attributes(html_options.slice("data-no-focus")) %>>
   <div class="form-field <%= options[:container_class] %>">
     <div class="form-field__body cursor-pointer"
      data-action="click->select#toggle click->select#focusButton">

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -4,7 +4,7 @@
   <div class="form-field <%= options[:container_class] %>">
     <div class="form-field__body cursor-pointer"
         data-action="click->select#toggle click->select#focusButton">
-        <%= form.label method, options[:label], class: "form-field__label cursor-pointer" id: "#{method}_label" if options[:label].present? %>
+        <%= form.label method, options[:label], class: "form-field__label cursor-pointer", id: "#{method}_label" if options[:label].present? %>
         <%= form.hidden_field method,
             value: @selected_value,
             data: {

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -1,10 +1,10 @@
 <%# locals: form:, method:, collection:, options: {} %>
 
-<div class="relative" data-controller="select <%= "list-filter" if searchable %> form-dropdown" data-action="dropdown:select->form-dropdown#onSelect">
+<div class="relative" data-controller="select <%= "list-filter" if searchable %> form-dropdown" data-action="dropdown:select->form-dropdown#onSelect" <%= tag.attributes(html_options.slice("data-no-focus")) %>>
   <div class="form-field <%= options[:container_class] %>">
     <div class="form-field__body cursor-pointer"
         data-action="click->select#toggle click->select#focusButton">
-        <%= form.label method, options[:label], class: "form-field__label cursor-pointer" if options[:label].present? %>
+        <%= form.label method, options[:label], class: "form-field__label cursor-pointer" id: "#{method}_label" if options[:label].present? %>
         <%= form.hidden_field method,
             value: @selected_value,
             data: {

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -2,8 +2,9 @@
 
 <div class="relative" data-controller="select <%= "list-filter" if searchable %> form-dropdown" data-action="dropdown:select->form-dropdown#onSelect">
   <div class="form-field <%= options[:container_class] %>">
-    <div class="form-field__body">
-        <%= form.label method, options[:label], class: "form-field__label" if options[:label].present? %>
+    <div class="form-field__body cursor-pointer"
+        data-action="click->select#toggle click->select#focusButton">
+        <%= form.label method, options[:label], class: "form-field__label cursor-pointer" if options[:label].present? %>
         <%= form.hidden_field method,
             value: @selected_value,
             data: {
@@ -13,7 +14,6 @@
         <button type="button"
                 class="form-field__input w-full <%= "pointer-events-none" if disabled? %>"
                 data-select-target="button"
-                data-action="click->select#toggle"
                 aria-haspopup="listbox"
                 aria-expanded="<%= @selected_value.present? ? "true" : "false" %>"
                 aria-labelledby="<%= "#{method}_label" %>"

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -13,8 +13,10 @@
             class: "hidden",
             disabled: disabled?,
             data: { "form-dropdown-target": "input" } do %>
+        <% normalized_selected = @selected_value.respond_to?(:id) ? @selected_value.id : @selected_value %>
         <% items.each do |item| %>
-          <option value="<%= item[:value] %>" <%= "selected" if item[:value].to_s == @selected_value.to_s %>>
+          <% option_value = item[:value].respond_to?(:id) ? item[:value].id : item[:value] %>
+          <option value="<%= option_value %>" <%= "selected" if option_value.to_s == normalized_selected.to_s %>>
             <%= item[:label] %>
           </option>
         <% end %>
@@ -24,7 +26,9 @@
               class="form-field__input w-full <%= "pointer-events-none" if disabled? %>"
               data-select-target="button"
               aria-haspopup="listbox"
-              aria-expanded="<%= @selected_value.present? ? "true" : "false" %>"
+              aria-expanded="false"
+              <%= %(aria-labelledby="#{form.field_id(method)}_label") if options[:label].present? %>
+              <%= %(aria-label="#{method.to_s.humanize}") unless options[:label].present? %>
               aria-labelledby="<%= "#{form.field_id(method)}_label" %>"
               <%= "disabled" if disabled? %>>
         <%= selected_label %>

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -37,7 +37,15 @@
     <div data-list-filter-target="list" data-select-target="content" class="flex flex-col gap-0.5 max-h-64 overflow-auto"
           role="listbox" tabindex="-1">
       <% items.each do |item| %>
-        <% is_selected = item[:value] == selected_value %>
+        <% is_selected = begin
+          item_value = item[:value]
+          item_value = item_value.id if item_value.respond_to?(:id)
+
+          sel_val = @selected_value
+          sel_val = sel_val.id if sel_val.respond_to?(:id)
+
+          item_value.to_s == sel_val.to_s
+        end %>
         <% obj = item[:object] %>
 
         <div class="filterable-item text-sm cursor-pointer flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-container-inset-hover <%= "bg-container-inset" if is_selected %>"

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -3,23 +3,32 @@
 <div class="relative" data-controller="select <%= "list-filter" if searchable %> form-dropdown" data-action="dropdown:select->form-dropdown#onSelect" <%= tag.attributes(html_options.slice("data-no-focus")) %>>
   <div class="form-field <%= options[:container_class] %>">
     <div class="form-field__body cursor-pointer"
-        data-action="click->select#toggle click->select#focusButton">
-        <%= form.label method, options[:label], class: "form-field__label cursor-pointer", id: "#{method}_label" if options[:label].present? %>
-        <%= form.hidden_field method,
-            value: @selected_value,
-            data: {
-              "form-dropdown-target": "input",
-              "auto-submit-target": "auto"
-            } %>
-        <button type="button"
-                class="form-field__input w-full <%= "pointer-events-none" if disabled? %>"
-                data-select-target="button"
-                aria-haspopup="listbox"
-                aria-expanded="<%= @selected_value.present? ? "true" : "false" %>"
-                aria-labelledby="<%= "#{method}_label" %>"
-                <%= "disabled" if disabled? %>>
-          <%= selected_label %>
-        </button>
+     data-action="click->select#toggle click->select#focusButton">
+      <%= form.label method, options[:label],
+            class: "form-field__label cursor-pointer",
+            id: "#{form.field_id(method)}_label" if options[:label].present? %>
+
+      <%= tag.select name: form.field_name(method),
+            id: form.field_id(method),
+            class: "hidden",
+            disabled: disabled?,
+            data: { "form-dropdown-target": "input" } do %>
+        <% items.each do |item| %>
+          <option value="<%= item[:value] %>" <%= "selected" if item[:value].to_s == @selected_value.to_s %>>
+            <%= item[:label] %>
+          </option>
+        <% end %>
+      <% end %>
+
+      <button type="button"
+              class="form-field__input w-full <%= "pointer-events-none" if disabled? %>"
+              data-select-target="button"
+              aria-haspopup="listbox"
+              aria-expanded="<%= @selected_value.present? ? "true" : "false" %>"
+              aria-labelledby="<%= "#{form.field_id(method)}_label" %>"
+              <%= "disabled" if disabled? %>>
+        <%= selected_label %>
+      </button>
     </div>
   </div>
   <div class="absolute z-50 p-1.5 w-full min-w-32 rounded-lg shadow-lg shadow-border-xs bg-container mt-1.5 transition duration-150 ease-out -translate-y-1 opacity-0 hidden" data-select-target="menu">

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -11,13 +11,14 @@
               "auto-submit-target": "auto"
             } %>
         <button type="button"
-                class="form-field__input w-full"
+                class="form-field__input w-full <%= "pointer-events-none" if disabled? %>"
                 data-select-target="button"
                 data-action="click->select#toggle"
                 aria-haspopup="listbox"
                 aria-expanded="<%= @selected_value.present? ? "true" : "false" %>"
-                aria-labelledby="<%= "#{method}_label" %>">
-          <%= selected_item&.dig(:label) || @placeholder %>
+                aria-labelledby="<%= "#{method}_label" %>"
+                <%= "disabled" if disabled? %>>
+          <%= selected_label %>
         </button>
     </div>
   </div>

--- a/app/components/DS/select.rb
+++ b/app/components/DS/select.rb
@@ -33,12 +33,14 @@ module DS
     end
 
     def selected_item
-      return nil if selected_value.nil?
-
       items.find do |item|
-        item[:object] == selected_value ||
-        item[:value] == selected_value ||
-        (item[:value].respond_to?(:id) && selected_value.respond_to?(:id) && item[:value].id == selected_value.id)
+        item_value = item[:value]
+        item_value = item_value.id if item_value.respond_to?(:id)
+        
+        selected_val = selected_value
+        selected_val = selected_val.id if selected_val.respond_to?(:id)
+
+        item_value.to_s == selected_val.to_s
       end
     end
 

--- a/app/components/DS/select.rb
+++ b/app/components/DS/select.rb
@@ -36,7 +36,7 @@ module DS
       items.find do |item|
         item_value = item[:value]
         item_value = item_value.id if item_value.respond_to?(:id)
-        
+
         selected_val = selected_value
         selected_val = selected_val.id if selected_val.respond_to?(:id)
 

--- a/app/components/DS/select.rb
+++ b/app/components/DS/select.rb
@@ -1,21 +1,24 @@
 module DS
   class Select < ViewComponent::Base
-    attr_reader :form, :method, :items, :selected_value, :placeholder, :variant, :searchable, :options
+    attr_reader :form, :method, :items, :selected_value, :placeholder, :variant, :searchable, :html_options, :options
 
     VARIANTS = %i[simple logo badge].freeze
     HEX_COLOR_REGEX = /\A#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\z/
     RGB_COLOR_REGEX = /\Argb\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)\z/
     DEFAULT_COLOR = "#737373"
 
-    def initialize(form:, method:, items:, selected: nil, placeholder: I18n.t("helpers.select.default_label"), variant: :simple, include_blank: nil, searchable: false, **options)
+    def initialize(form:, method:, items:, selected: nil, placeholder: I18n.t("helpers.select.default_label"), variant: :simple, include_blank: nil, searchable: false, html_options: {}, **options)
       @form = form
       @method = method
       @placeholder = placeholder
       @variant = variant
       @searchable = searchable
       @options = options
+      @html_options = html_options
 
       normalized_items = normalize_items(items)
+
+      @selected_value = selected
 
       if include_blank
         normalized_items.unshift({
@@ -30,7 +33,31 @@ module DS
     end
 
     def selected_item
-      items.find { |item| item[:value] == selected_value }
+      return nil if selected_value.nil?
+
+      items.find do |item|
+        item[:object] == selected_value ||
+        item[:value] == selected_value ||
+        (item[:value].respond_to?(:id) && selected_value.respond_to?(:id) && item[:value].id == selected_value.id)
+      end
+    end
+
+    def selected_label
+      if selected_item
+        selected_item[:label]
+      else
+        if selected_value.respond_to?(:name)
+          selected_value.name
+        elsif selected_value.respond_to?(:id)
+          selected_value.id.to_s
+        else
+          placeholder
+        end
+      end
+    end
+
+    def disabled?
+      html_options[:disabled].present?
     end
 
     # Returns the color for a given item (used in :badge variant)

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -21,11 +21,10 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
 
   def select(method, choices, options = {}, html_options = {})
     is_multiple = html_options[:multiple] || options[:multiple]
+    is_html_string = choices.is_a?(ActiveSupport::SafeBuffer)
 
-    if is_multiple
-      html_options[:multiple] = true # normalizza
-
-      field_options = normalize_options(options, html_options)
+    if is_multiple || is_html_string
+      html_options[:multiple] = true if is_multiple
 
       return build_field(method, field_options, html_options) do |merged_html_options|
         super(method, choices, options, merged_html_options)
@@ -69,7 +68,7 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
     selected_value =
       if options.key?(:selected)
         options[:selected]
-      elsif @object.respond_to?(method)
+      elsif @object&.respond_to?(method)
         @object.public_send(method)
       end
 
@@ -217,7 +216,7 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
           { value: value, label: label, object: nil }
         end
       else
-        []
+        raise ArgumentError, "Unsupported choices type: #{choices.class}"
       end
     end
 end

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -20,11 +20,41 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select(method, choices, options = {}, html_options = {})
-    field_options = normalize_options(options, html_options)
+    # fallback to default Rails select if multiple
+    if html_options[:multiple]
+      field_options = normalize_options(options, html_options)
 
-    build_field(method, field_options, html_options) do |merged_html_options|
-      super(method, choices, options, merged_html_options)
+      return build_field(method, field_options, html_options) do |merged_html_options|
+        super(method, choices, options, merged_html_options)
+      end
     end
+
+    selected_value = options[:selected] || @object&.public_send(method)
+
+    placeholder =
+      options[:prompt] ||
+      options[:include_blank] ||
+      options[:placeholder] ||
+      I18n.t("helpers.select.default_label")
+
+    items = normalize_select_choices(choices)
+
+    @template.render(
+      DS::Select.new(
+        form: self,
+        method: method,
+        items: items,
+        selected: selected_value,
+        placeholder: placeholder,
+        searchable: options.fetch(:searchable, false),
+        variant: options.fetch(:variant, :simple),
+        include_blank: options[:include_blank],
+        label: options[:label],
+        container_class: options[:container_class],
+        label_tooltip: options[:label_tooltip],
+        html_options: html_options
+      )
+    )
   end
 
   def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
@@ -152,6 +182,33 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
           @template.icon("help-circle", size: "sm", color: "default", class: "cursor-help"),
           @template.tag.div(tooltip_text, role: "tooltip", data: { tooltip_target: "tooltip" }, class: "tooltip bg-gray-700 text-sm p-2 rounded w-64 text-white")
         ])
+      end
+    end
+
+    def normalize_select_choices(choices)
+      case choices
+      when Array
+        choices.map do |item|
+          case item
+          when Array
+            # [["Label", value]]
+            { value: item[1], label: item[0], object: nil }
+          when String, Symbol
+            { value: item, label: item.to_s.humanize, object: nil }
+          else
+            if item.respond_to?(:id) && item.respond_to?(:name)
+              { value: item.id, label: item.name, object: item }
+            else
+              { value: item, label: item.to_s, object: nil }
+            end
+          end
+        end
+      when Hash
+        choices.map do |label, value|
+          { value: value, label: label, object: nil }
+        end
+      else
+        []
       end
     end
 end

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -20,7 +20,6 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select(method, choices, options = {}, html_options = {})
-
     is_multiple = html_options[:multiple] || options[:multiple]
     is_html_string = choices.is_a?(ActiveSupport::SafeBuffer)
 

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -29,7 +29,12 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
       end
     end
 
-    selected_value = options[:selected] || @object&.public_send(method)
+    selected_value =
+      if options.key?(:selected)
+        options[:selected]
+      elsif @object.respond_to?(method)
+        @object.public_send(method)
+      end
 
     placeholder =
       options[:prompt] ||
@@ -62,8 +67,9 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
       if options.key?(:selected)
         options[:selected]
       elsif @object.respond_to?(method)
-        @object.public_send(method)
+        @object.public_send(method) # lasciare così
       end
+
     placeholder = options[:prompt] || options[:include_blank] || options[:placeholder] || I18n.t("helpers.select.default_label")
 
     @template.render(

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -20,13 +20,13 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select(method, choices, options = {}, html_options = {})
-    field_options = normalize_options(options, html_options)
 
     is_multiple = html_options[:multiple] || options[:multiple]
     is_html_string = choices.is_a?(ActiveSupport::SafeBuffer)
 
     if is_multiple || is_html_string
       html_options[:multiple] = true if is_multiple
+      field_options = normalize_options(options, html_options)
 
       return build_field(method, field_options, html_options) do |merged_html_options|
         super(method, choices, options, merged_html_options)

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -20,6 +20,8 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select(method, choices, options = {}, html_options = {})
+    field_options = normalize_options(options, html_options)
+
     is_multiple = html_options[:multiple] || options[:multiple]
     is_html_string = choices.is_a?(ActiveSupport::SafeBuffer)
 

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -20,8 +20,11 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select(method, choices, options = {}, html_options = {})
-    # fallback to default Rails select if multiple
-    if html_options[:multiple]
+    is_multiple = html_options[:multiple] || options[:multiple]
+
+    if is_multiple
+      html_options[:multiple] = true # normalizza
+
       field_options = normalize_options(options, html_options)
 
       return build_field(method, field_options, html_options) do |merged_html_options|

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -70,7 +70,7 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
       if options.key?(:selected)
         options[:selected]
       elsif @object.respond_to?(method)
-        @object.public_send(method) # lasciare così
+        @object.public_send(method)
       end
 
     placeholder = options[:prompt] || options[:include_blank] || options[:placeholder] || I18n.t("helpers.select.default_label")

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
   }
 
   toggle = () => {
-    if ((this.hasFieldTarget && this.inputTarget.disabled) || this.buttonTarget.disabled) return
+    if ((this.hasFieldTarget && this.fieldTarget.disabled) || this.buttonTarget.disabled) return
 
     this.isOpen ? this.close() : this.openMenu()
   }
@@ -70,7 +70,7 @@ export default class extends Controller {
     this.buttonTarget.textContent = label
     if (this.hasFieldTarget) {
       this.fieldTarget.value = value
-      this.inputTarget.dispatchEvent(new Event("change", { bubbles: true }))
+      this.fieldTarget.dispatchEvent(new Event("change", { bubbles: true }))
     }
 
     const previousSelected = this.menuTarget.querySelector("[aria-selected='true']")

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { autoUpdate } from "@floating-ui/dom"
 
 export default class extends Controller {
-  static targets = ["button", "menu", "input"]
+  static targets = ["button", "menu", "field"]
   static values = {
     placement: { type: String, default: "bottom-start" },
     offset: { type: Number, default: 6 }
@@ -69,7 +69,7 @@ export default class extends Controller {
 
     this.buttonTarget.textContent = label
     if (this.hasInputTarget) {
-      this.inputTarget.value = value
+      this.fieldTarget.value = value
       this.inputTarget.dispatchEvent(new Event("change", { bubbles: true }))
     }
 

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -30,7 +30,13 @@ export default class extends Controller {
   }
 
   toggle = () => {
+    if ((this.hasInputTarget && this.inputTarget.disabled) || this.buttonTarget.disabled) return
+
     this.isOpen ? this.close() : this.openMenu()
+  }
+
+  focusButton() {
+    if (this.hasButtonTarget) this.buttonTarget.focus()
   }
 
   openMenu() {

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -92,7 +92,7 @@ export default class extends Controller {
     }))
 
     this.close()
-    this.buttonTarget.focus()
+    if (!this.element.dataset.noFocus) this.buttonTarget.focus()
   }
 
   focusSearch() {

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -36,7 +36,7 @@ export default class extends Controller {
   }
 
   focusButton() {
-    if (this.hasButtonTarget) this.buttonTarget.focus()
+    if (this.hasButtonTarget && !this.element.dataset.noFocus) this.buttonTarget.focus()
   }
 
   openMenu() {

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
   }
 
   toggle = () => {
-    if ((this.hasInputTarget && this.inputTarget.disabled) || this.buttonTarget.disabled) return
+    if ((this.hasFieldTarget && this.inputTarget.disabled) || this.buttonTarget.disabled) return
 
     this.isOpen ? this.close() : this.openMenu()
   }
@@ -68,7 +68,7 @@ export default class extends Controller {
     const label = selectedElement.dataset.filterName || selectedElement.textContent.trim()
 
     this.buttonTarget.textContent = label
-    if (this.hasInputTarget) {
+    if (this.hasFieldTarget) {
       this.fieldTarget.value = value
       this.inputTarget.dispatchEvent(new Event("change", { bubbles: true }))
     }

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -31,14 +31,14 @@
   <div class="flex items-center gap-4">
     <%= form.select :amount_col_label,
                     import.csv_headers,
-                    { label: "Amount", container_class: "w-2/5", prompt: "Select column" },
+                    { label: "Amount", prompt: "Select column" },
                     required: true %>
     <%= form.select :currency_col_label,
                     import.csv_headers,
-                    { include_blank: "Default", label: "Currency", container_class: "w-1/5" } %>
+                    { include_blank: "Default", label: "Currency" } %>
     <%= form.select :number_format,
                     Import::NUMBER_FORMATS.keys,
-                    { label: "Format", prompt: "Select format", container_class: "w-2/5" },
+                    { label: "Format", prompt: "Select format" },
                     required: true %>
   </div>
 

--- a/app/views/shared/_money_field.html.erb
+++ b/app/views/shared/_money_field.html.erb
@@ -67,11 +67,15 @@
       <% unless options[:hide_currency] %>
         <div>
           <%= form.select currency_method,
-                        Money::Currency.as_options.map(&:iso_code),
-                        { inline: true, selected: currency.iso_code },
+                        Money::Currency.as_options.map { |c| [c.iso_code, c.iso_code] },
+                        { 
+                          inline: true, 
+                          selected: currency.iso_code,
+                          container_class: "border-0 p-0 focus-within:ring-0",
+                        },
                         {
-                          class: "w-fit pr-5 disabled:text-subdued form-field__input",
                           disabled: options[:disable_currency],
+                          no_focus: true,
                           data: {
                             "money-field-target": "currency",
                             action: "change->money-field#handleCurrencyChange",

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -67,10 +67,9 @@
             <div class="flex items-center gap-2">
               <%= f.select :nature,
                     [["Expense", "outflow"], ["Income", "inflow"]],
-                    { container_class: "w-1/3", label: t(".nature"), selected: @entry.amount.negative? ? "inflow" : "outflow" },
+                    { label: t(".nature"), selected: @entry.amount.negative? ? "inflow" : "outflow" },
                     { data: { "auto-submit-form-target": "auto" }, disabled: @entry.linked? || split_locked || edit_locked } %>
               <%= f.money_field :amount, label: t(".amount"),
-                    container_class: "w-2/3",
                     auto_submit: true,
                     min: 0,
                     value: @entry.amount.abs,

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,6 +5,24 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     Capybara.default_max_wait_time = 5
   end
 
+  def select_custom(label_text, value)
+    normalized = label_text.gsub("*", "").strip
+    label = find("label", text: /#{Regexp.escape(normalized)}/i)
+    field = label.find(:xpath, "./ancestor::*[contains(@class, 'form-field')][1]")
+    field.find("[data-select-target='button']").click
+
+    find("[role='option']", text: value).click
+  end
+
+  def assert_custom_selected(label_text, value)
+    normalized = label_text.gsub("*", "").strip
+    label = find("label", text: /#{Regexp.escape(normalized)}/i)
+    field = label.find(:xpath, "./ancestor::*[contains(@class, 'form-field')][1]")
+    button = field.find("[data-select-target='button']")
+    print button.text value
+    assert_includes button.text, value
+  end
+
   driven_by :selenium, using: ENV["CI"].present? ? :headless_chrome : ENV.fetch("E2E_BROWSER", :chrome).to_sym, screen_size: [ 1400, 1400 ]
 
   private

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -348,7 +348,10 @@ end
     assert_select "input[type='number'][name='entry[amount]']" do |elements|
       assert_equal sprintf("%.2f", @entry.amount.abs), elements.first["value"]
     end
-    assert_select "input[type='hidden'][name='entry[entryable_attributes][merchant_id]']"
+    assert_select "select[name='entry[entryable_attributes][merchant_id]'] option[selected]" do |options|
+      selected_value = options.first["value"]
+      assert_equal @entry.entryable.merchant_id.to_s, selected_value
+    end
   end
 
   test "new with invalid duplicate_entry_id renders empty form" do

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -28,7 +28,7 @@ class AccountsTest < ApplicationSystemTestCase
 
     account_name = "[system test] Property Account"
     fill_in "Name*", with: account_name
-    select_label "Property type*", "Single Family Home"
+    select_custom "Property type*", "Single Family Home"
     fill_in "Year Built (optional)", with: 2005
     fill_in "Area (optional)", with: 2250
 
@@ -86,7 +86,7 @@ class AccountsTest < ApplicationSystemTestCase
     assert_account_created "Loan" do
       fill_in "account[accountable_attributes][initial_balance]", with: 1000
       fill_in "Interest rate", with: 5.25
-      select_label "Rate type", "Fixed"
+      select_custom "Rate type", "Fixed"
       fill_in "Term (months)", with: 360
     end
   end
@@ -161,16 +161,6 @@ class AccountsTest < ApplicationSystemTestCase
       assert_equal updated_institution_name, created_account[:institution_name]
       assert_equal updated_institution_domain, created_account[:institution_domain]
       assert_equal updated_notes, created_account[:notes]
-    end
-
-    def select_label(label_text, value)
-      normalized = label_text.gsub("*", "").strip
-
-      label = find("label", text: /#{Regexp.escape(normalized)}/i)
-      field = label.find(:xpath, "./ancestor::*[contains(@class, 'form-field')][1]")
-      field.find("[data-select-target='button']").click
-
-      find("[role='option']", text: value).click
     end
 
     def humanized_accountable(accountable_type)

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -28,7 +28,7 @@ class AccountsTest < ApplicationSystemTestCase
 
     account_name = "[system test] Property Account"
     fill_in "Name*", with: account_name
-    select "Single Family Home", from: "Property type*"
+    select_label "Property type*", "Single Family Home"
     fill_in "Year Built (optional)", with: 2005
     fill_in "Area (optional)", with: 2250
 
@@ -86,7 +86,7 @@ class AccountsTest < ApplicationSystemTestCase
     assert_account_created "Loan" do
       fill_in "account[accountable_attributes][initial_balance]", with: 1000
       fill_in "Interest rate", with: 5.25
-      select "Fixed", from: "Rate type"
+      select_label "Rate type", "Fixed"
       fill_in "Term (months)", with: 360
     end
   end
@@ -161,6 +161,16 @@ class AccountsTest < ApplicationSystemTestCase
       assert_equal updated_institution_name, created_account[:institution_name]
       assert_equal updated_institution_domain, created_account[:institution_domain]
       assert_equal updated_notes, created_account[:notes]
+    end
+
+    def select_label(label_text, value)
+      normalized = label_text.gsub("*", "").strip
+
+      label = find("label", text: /#{Regexp.escape(normalized)}/i)
+      field = label.find(:xpath, "./ancestor::*[contains(@class, 'form-field')][1]")
+      field.find("[data-select-target='button']").click
+
+      find("[role='option']", text: value).click
     end
 
     def humanized_accountable(accountable_type)

--- a/test/system/property_test.rb
+++ b/test/system/property_test.rb
@@ -15,11 +15,7 @@ class PropertiesEditTest < ApplicationSystemTestCase
     click_link "[system test] Property Account"
     find("[data-testid='account-menu']").click
     click_on "Edit"
-    assert_selector "#account_accountable_attributes_subtype"
-    assert_selector(
-        "#account_accountable_attributes_subtype option[selected]",
-        text: "Single Family Home"
-    )
+    assert_custom_selected("Property type", "Single Family Home")
   end
 
   private
@@ -36,7 +32,7 @@ class PropertiesEditTest < ApplicationSystemTestCase
 
       account_name = "[system test] Property Account"
       fill_in "Name*", with: account_name
-      select "Single Family Home", from: "Property type*"
+      select_custom "Property type*", "Single Family Home"
       fill_in "Year Built (optional)", with: 2005
       fill_in "Area (optional)", with: 2250
 

--- a/test/system/trades_test.rb
+++ b/test/system/trades_test.rb
@@ -43,7 +43,8 @@ class TradesTest < ApplicationSystemTestCase
 
     open_new_trade_modal
 
-    select "Sell", from: "Type"
+    find("label", text: "Type").click
+    click_on "Sell"
     fill_in "Ticker symbol", with: "AAPL"
     fill_in "Date", with: Date.current
     fill_in "Quantity", with: qty


### PR DESCRIPTION
Following PR https://github.com/we-promise/sure/pull/1071, this PR uses the new design system component already implemented for some dropdown elements (the one using `collection_select`) also for other select elements, instead of using the standard browser HTML element.

This applies globally to all the select elements (e.g.: when creating new transactions, accounts, trades, but also in the preferences page).

| Before  | After |
| ------------- | ------------- |
| <img width="849" height="561" alt="Screenshot 2026-03-30 alle 19 31 47" src="https://github.com/user-attachments/assets/50837971-fa5d-466c-9ff3-051e73aa19f4" /> | <img width="843" height="637" alt="Screenshot 2026-03-30 alle 19 31 25" src="https://github.com/user-attachments/assets/578b7c6d-788a-4ea2-b1f9-9633181576ae" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select fields accept extra HTML attributes (e.g., no-focus, disabled) and render a hidden native select so the chosen label is consistently displayed.
  * JS exposes a focus helper to better control button focus.

* **Bug Fixes**
  * Selection matching is more robust across object/value types.
  * Focus handling avoids unwanted autofocus and respects disabled controls.

* **Refactor**
  * Select rendering and choice normalization streamlined; currency selector spacing and no-focus behavior adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->