### PR TITLE
Fix reports mobile: require press-and-hold to reorder sections

### DIFF
--- a/app/javascript/controllers/reports_sortable_controller.js
+++ b/app/javascript/controllers/reports_sortable_controller.js
@@ -3,15 +3,17 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["section", "handle"];
 
-  // Short delay to prevent accidental touches on the grip handle
+  // Hold delay to require deliberate press-and-hold before activating drag mode
   static values = {
-    holdDelay: { type: Number, default: 150 },
+    holdDelay: { type: Number, default: 800 },
   };
 
   connect() {
     this.draggedElement = null;
     this.placeholder = null;
+    this.touchStartX = 0;
     this.touchStartY = 0;
+    this.currentTouchX = 0;
     this.currentTouchY = 0;
     this.isTouching = false;
     this.keyboardGrabbedElement = null;
@@ -21,6 +23,13 @@ export default class extends Controller {
 
   // ===== Mouse Drag Events =====
   dragStart(event) {
+    // If a touch interaction is in progress, cancel native drag —
+    // use touch events with hold delay instead.
+    if (this.isTouching || this.pendingSection) {
+      event.preventDefault();
+      return;
+    }
+
     this.draggedElement = event.currentTarget;
     this.draggedElement.classList.add("opacity-50");
     this.draggedElement.setAttribute("aria-grabbed", "true");
@@ -78,9 +87,15 @@ export default class extends Controller {
     if (!section) return;
 
     this.pendingSection = section;
+    this.touchStartX = event.touches[0].clientX;
     this.touchStartY = event.touches[0].clientY;
+    this.currentTouchX = this.touchStartX;
     this.currentTouchY = this.touchStartY;
     this.holdActivated = false;
+
+    // Prevent text selection while waiting for hold to activate
+    section.style.userSelect = "none";
+    section.style.webkitUserSelect = "none";
 
     // Start hold timer
     this.holdTimer = setTimeout(() => {
@@ -104,10 +119,23 @@ export default class extends Controller {
   }
 
   touchMove(event) {
-    if (!this.holdActivated || !this.isTouching || !this.draggedElement) return;
+    const touchX = event.touches[0].clientX;
+    const touchY = event.touches[0].clientY;
+
+    // If hold hasn't activated yet, cancel if user moves too far (scrolling or swiping)
+    if (!this.holdActivated) {
+      const dx = touchX - this.touchStartX;
+      const dy = touchY - this.touchStartY;
+      if (dx * dx + dy * dy > 100) { // 10px radius
+        this.cancelHold();
+      }
+      return;
+    }
+
+    if (!this.isTouching || !this.draggedElement) return;
 
     event.preventDefault();
-    this.currentTouchY = event.touches[0].clientY;
+    this.currentTouchY = touchY;
 
     const afterElement = this.getDragAfterElement(this.currentTouchY);
     this.clearPlaceholders();
@@ -152,6 +180,12 @@ export default class extends Controller {
   }
 
   resetTouchState() {
+    // Restore text selection
+    if (this.pendingSection) {
+      this.pendingSection.style.userSelect = "";
+      this.pendingSection.style.webkitUserSelect = "";
+    }
+
     this.isTouching = false;
     this.draggedElement = null;
     this.pendingSection = null;

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -130,6 +130,7 @@
             touchstart->reports-sortable#touchStart
             touchmove->reports-sortable#touchMove
             touchend->reports-sortable#touchEnd
+            touchcancel->reports-sortable#touchEnd
             keydown->reports-sortable#handleKeyDown">
           <div class="px-4 py-2 flex items-center justify-between">
             <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Port the dashboard's proven touch reorder behavior (from PR #1210) to the reports page
- Increase hold delay from 150ms to 800ms so scrolling doesn't accidentally trigger drag mode
- Add 10px movement threshold to cancel hold when user is scrolling/swiping
- Prevent text selection during the hold wait period
- Guard `dragStart` to prevent native drag firing during touch interaction
- Add `touchcancel` event binding for interrupted gestures

The reports page sortable controller was added after #1210 landed and didn't inherit the touch improvements. This brings it to parity with the dashboard controller.

## Test plan

- [ ] On mobile (iOS Safari / Android Chrome): scroll the reports page without accidentally triggering section reorder
- [ ] On mobile: press and hold a section grip handle for 800ms — drag mode activates with haptic feedback
- [ ] On mobile: start a hold, then scroll away — hold cancels, no drag mode
- [ ] On desktop: mouse drag still works immediately (no hold delay for mouse)
- [ ] Keyboard reorder (Enter/Space to grab, arrows to move) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined touch-based report reordering with extended activation delay and improved movement sensitivity detection.
  * Enhanced handling of cancelled touch interactions during report sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->