### PR TITLE
Refactor: Use Encryptable concern in CoinbaseItem

### DIFF
--- a/app/models/coinbase_item.rb
+++ b/app/models/coinbase_item.rb
@@ -1,16 +1,8 @@
 class CoinbaseItem < ApplicationRecord
   include Syncable, Provided, Unlinking
+  include Encryptable
 
   enum :status, { good: "good", requires_update: "requires_update" }, default: :good
-
-  # Helper to detect if ActiveRecord Encryption is configured for this app
-  def self.encryption_ready?
-    creds_ready = Rails.application.credentials.active_record_encryption.present?
-    env_ready = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"].present? &&
-                ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"].present? &&
-                ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"].present?
-    creds_ready || env_ready
-  end
 
   # Encrypt sensitive credentials if ActiveRecord encryption is configured
   # api_key uses deterministic encryption for querying, api_secret uses standard encryption


### PR DESCRIPTION
Remove the duplicated encryption_ready? method in favor of the Encryptable concern which provides the exact same functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated encryption configuration by moving credential encryption setup to a shared module, improving code maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->