### PR TITLE
Fix unable to add trades with manual ticker

### DIFF
--- a/app/views/trades/_form.html.erb
+++ b/app/views/trades/_form.html.erb
@@ -29,7 +29,7 @@
           <div class="form-field combobox">
             <%= form.combobox :ticker,
                             securities_path(country_code: Current.family.country),
-                            name_when_new: "entry[manual_ticker]",
+                            name_when_new: "model[manual_ticker]",
                             label: t(".holding"),
                             placeholder: t(".ticker_placeholder"),
                             required: true %>


### PR DESCRIPTION
@dosubot's suggested fix from issue [#1319](https://github.com/we-promise/sure/issues/1319#issue-4165988327)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form parameter handling when entering a new ticker symbol in the trade form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->