### PR TITLE
Fix: target="_blank" to contact button

### DIFF
--- a/app/views/users/_user_menu.html.erb
+++ b/app/views/users/_user_menu.html.erb
@@ -54,7 +54,7 @@
     <% if self_hosted? && !intro_mode %>
       <% menu.with_item(variant: "link", text: "Feedback", icon: "megaphone", href: feedback_path) %>
     <% end %>
-    <% menu.with_item(variant: "link", text: "Contact", icon: "message-square-more", href: "https://discord.gg/36ZGBsxYEK") %>
+    <% menu.with_item(variant: "link", text: "Contact", icon: "message-square-more", href: "https://discord.gg/36ZGBsxYEK", target: "_blank", rel: "noopener noreferrer") %>
 
     <% menu.with_item(variant: "divider") %>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contact menu item now opens the Discord invite link in a new browser tab/window, preserving your current navigation context and preventing interruption of in‑progress tasks. The link behavior has been adjusted to follow safe external-link handling so opening the invite won’t compromise the original page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->