### PR TITLE
fix(ui): move repeat icon to the center on recurring transactions page

### DIFF
--- a/app/views/recurring_transactions/index.html.erb
+++ b/app/views/recurring_transactions/index.html.erb
@@ -59,7 +59,7 @@
     <div class="bg-container rounded-xl shadow-border-xs p-4">
       <% if @recurring_transactions.empty? %>
         <div class="text-center py-12">
-          <div class="text-secondary mb-4">
+          <div class="flex justify-center text-secondary mb-4">
             <%= icon "repeat", size: "xl" %>
           </div>
           <p class="text-primary font-medium mb-2"><%= t("recurring_transactions.empty.title") %></p>


### PR DESCRIPTION
Move the "repeat" icon on recurring transactions page from left to center.

### Before
<img width="465" height="324" alt="before" src="https://github.com/user-attachments/assets/927ad92a-03d3-4427-be1b-ba50c4d2bce2" />

### After
<img width="465" height="321" alt="after" src="https://github.com/user-attachments/assets/dc40920b-e872-48a9-a3b0-feeabded6003" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual centering of the icon displayed in the recurring transactions empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->