### PR TITLE
feat(docker): Allow secrets to be supplied via docker *_FILE env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 # SECRET_KEY_BASE_FILE=/run/secrets/secret_key_base
 # OPENAI_ACCESS_TOKEN_FILE=/run/secrets/openai_access_token
 #
-# If both FOO and FOO_FILE are set, FOO takes precedence.
+# If both FOO and FOO_FILE are set, FOO takes precedence, even if FOO is empty.
 # Some path/runtime variables are intentionally denylisted and do not support
 # *_FILE indirection (for example SSL_CA_FILE and SSL_CERT_FILE).
 

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,15 @@
 # If you're a developer setting up your local environment, please use `.env.local.example` instead.
 # ========================================================================================================
 
+# Most Sure application environment variables can also be supplied via a matching
+# *_FILE variable. This is useful for Docker/Kubernetes secrets. Example:
+# SECRET_KEY_BASE_FILE=/run/secrets/secret_key_base
+# OPENAI_ACCESS_TOKEN_FILE=/run/secrets/openai_access_token
+#
+# If both FOO and FOO_FILE are set, FOO takes precedence.
+# Some path/runtime variables are intentionally denylisted and do not support
+# *_FILE indirection (for example SSL_CA_FILE and SSL_CERT_FILE).
+
 # Required self-hosting vars
 # --------------------------------------------------------------------------------------------------------
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,7 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
+require_relative "env_file_loader"
+Sure::EnvFileLoader.load!
+
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/env_file_loader.rb
+++ b/config/env_file_loader.rb
@@ -12,9 +12,9 @@ module Sure
     ].freeze
 
     def load!(env: ENV, warn_io: $stderr)
-      env.keys.grep(/_FILE\z/).sort.each do |file_key|
+      env.keys.grep(/_FILE\z/).reject { |file_key| DENYLIST.include?(file_key) }.sort.each do |file_key|
         base_key = file_key.delete_suffix("_FILE")
-        next if denylisted?(file_key, base_key, warn_io)
+        next if DENYLIST.include?(base_key)
         next if env.key?(base_key)
 
         path = env[file_key].to_s.strip
@@ -30,14 +30,6 @@ module Sure
     rescue SystemCallError => e
       warn_io.puts("[env] Unable to load #{file_key} for #{base_key} from #{path}: #{e.message}")
       nil
-    end
-
-    def denylisted?(file_key, base_key, warn_io)
-      denylisted_key = [file_key, base_key].find { |key| DENYLIST.include?(key) }
-      return false unless denylisted_key
-
-      warn_io.puts("[env] Ignoring #{file_key}: #{denylisted_key} is not eligible for *_FILE loading")
-      true
     end
   end
 end

--- a/config/env_file_loader.rb
+++ b/config/env_file_loader.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Sure
+  module EnvFileLoader
+    module_function
+
+    DENYLIST = %w[
+      BUNDLE_GEMFILE
+      PIDFILE
+      SSL_CA_FILE
+      SSL_CERT_FILE
+    ].freeze
+
+    def load!(env: ENV, warn_io: $stderr)
+      env.keys.grep(/_FILE\z/).sort.each do |file_key|
+        base_key = file_key.delete_suffix("_FILE")
+        next if denylisted?(base_key, file_key, warn_io)
+        next if env[base_key].to_s != ""
+
+        path = env[file_key].to_s.strip
+        next if path.empty?
+
+        content = read(path, file_key: file_key, base_key: base_key, warn_io: warn_io)
+        env[base_key] = content unless content.nil?
+      end
+    end
+
+    def read(path, file_key:, base_key:, warn_io: $stderr)
+      File.read(path).chomp
+    rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR => e
+      warn_io.puts("[env] Unable to load #{file_key} for #{base_key} from #{path}: #{e.message}")
+      nil
+    end
+
+    def denylisted?(base_key, file_key, warn_io)
+      return false unless DENYLIST.include?(base_key)
+
+      warn_io.puts("[env] Ignoring #{file_key}: #{base_key} is not eligible for *_FILE loading")
+      true
+    end
+  end
+end

--- a/config/env_file_loader.rb
+++ b/config/env_file_loader.rb
@@ -14,7 +14,7 @@ module Sure
     def load!(env: ENV, warn_io: $stderr)
       env.keys.grep(/_FILE\z/).sort.each do |file_key|
         base_key = file_key.delete_suffix("_FILE")
-        next if denylisted?(base_key, file_key, warn_io)
+        next if denylisted?(file_key, base_key, warn_io)
         next if env.key?(base_key)
 
         path = env[file_key].to_s.strip
@@ -32,10 +32,11 @@ module Sure
       nil
     end
 
-    def denylisted?(base_key, file_key, warn_io)
-      return false unless DENYLIST.include?(base_key)
+    def denylisted?(file_key, base_key, warn_io)
+      denylisted_key = [file_key, base_key].find { |key| DENYLIST.include?(key) }
+      return false unless denylisted_key
 
-      warn_io.puts("[env] Ignoring #{file_key}: #{base_key} is not eligible for *_FILE loading")
+      warn_io.puts("[env] Ignoring #{file_key}: #{denylisted_key} is not eligible for *_FILE loading")
       true
     end
   end

--- a/config/env_file_loader.rb
+++ b/config/env_file_loader.rb
@@ -27,7 +27,7 @@ module Sure
 
     def read(path, file_key:, base_key:, warn_io: $stderr)
       File.read(path).chomp
-    rescue SystemCallError => e
+    rescue SystemCallError, ArgumentError, TypeError => e
       warn_io.puts("[env] Unable to load #{file_key} for #{base_key} from #{path}: #{e.message}")
       nil
     end

--- a/config/env_file_loader.rb
+++ b/config/env_file_loader.rb
@@ -27,7 +27,7 @@ module Sure
 
     def read(path, file_key:, base_key:, warn_io: $stderr)
       File.read(path).chomp
-    rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR => e
+    rescue SystemCallError => e
       warn_io.puts("[env] Unable to load #{file_key} for #{base_key} from #{path}: #{e.message}")
       nil
     end

--- a/config/env_file_loader.rb
+++ b/config/env_file_loader.rb
@@ -15,7 +15,7 @@ module Sure
       env.keys.grep(/_FILE\z/).sort.each do |file_key|
         base_key = file_key.delete_suffix("_FILE")
         next if denylisted?(base_key, file_key, warn_io)
-        next if env[base_key].to_s != ""
+        next if env.key?(base_key)
 
         path = env[file_key].to_s.strip
         next if path.empty?

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -110,7 +110,7 @@ OIDC_CLIENT_SECRET_FILE=/run/secrets/oidc_client_secret
 
 Notes:
 
-- If both `FOO` and `FOO_FILE` are set, Sure uses `FOO`.
+- If both `FOO` and `FOO_FILE` are set, Sure uses `FOO`, even if `FOO` is an empty string.
 - Secret files may include a trailing newline; Sure strips it automatically.
 - This support is implemented by Sure itself, so it applies to app secrets loaded during boot such as `SECRET_KEY_BASE`, OpenAI tokens, OIDC secrets, SMTP passwords, and Active Record encryption keys.
 - Some variables are intentionally denylisted and do not support `*_FILE` indirection, especially low-level path/runtime variables such as `SSL_CA_FILE` and `SSL_CERT_FILE`.

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -51,7 +51,7 @@ At this point, the only file in your current working directory should be `compos
 
 ### Step 3 (optional): Configure your environment
 
-By default, our `compose.example.yml` file runs without any configuration.  
+By default, our `compose.example.yml` file runs without any configuration.
 That said, if you would like extra security (important if you're running outside of a local network), you can follow the steps below to set things up.
 
 If you're running the app locally and don't care much about security, you can skip this step.
@@ -95,11 +95,34 @@ SECRET_KEY_BASE="replacemewiththegeneratedstringfromthepriorstep"
 POSTGRES_PASSWORD="replacemewithyourdesireddatabasepassword"
 ```
 
+#### Using Docker secrets with `*_FILE` variables
+
+Sure supports Docker/Kubernetes-style secret files for application secrets. For most Sure application environment variables, you can provide a matching `*_FILE` variable that points to a file containing the secret value.
+
+For example:
+
+```txt
+SECRET_KEY_BASE_FILE=/run/secrets/secret_key_base
+OPENAI_ACCESS_TOKEN_FILE=/run/secrets/openai_access_token
+SMTP_PASSWORD_FILE=/run/secrets/smtp_password
+OIDC_CLIENT_SECRET_FILE=/run/secrets/oidc_client_secret
+```
+
+Notes:
+
+- If both `FOO` and `FOO_FILE` are set, Sure uses `FOO`.
+- Secret files may include a trailing newline; Sure strips it automatically.
+- This support is implemented by Sure itself, so it applies to app secrets loaded during boot such as `SECRET_KEY_BASE`, OpenAI tokens, OIDC secrets, SMTP passwords, and Active Record encryption keys.
+- Some variables are intentionally denylisted and do not support `*_FILE` indirection, especially low-level path/runtime variables such as `SSL_CA_FILE` and `SSL_CERT_FILE`.
+- Non-app containers in your compose stack (such as Postgres) may have their own secret-file conventions; check their image documentation separately.
+
+If you want to use Docker secrets, add the relevant `*_FILE` variables to the `web` and `worker` services in your `compose.yml`.
+
 #### Using HTTPS
 
-Assuming you want to access your instance from the internet, you should have secured your URL address with an SSL certificate.  
-The Docker instance runs in plain HTTP and you need to tell it that you are redirecting your HTTPS stream to the HTTP one.  
-To do this, edit the `compose.yml` file and find the line stating:  
+Assuming you want to access your instance from the internet, you should have secured your URL address with an SSL certificate.
+The Docker instance runs in plain HTTP and you need to tell it that you are redirecting your HTTPS stream to the HTTP one.
+To do this, edit the `compose.yml` file and find the line stating:
 
 ```yaml
 RAILS_ASSUME_SSL: "false"
@@ -216,12 +239,14 @@ docker compose -f compose.ai.yml --profile ai up -d
 The external assistant delegates chat to a remote AI agent instead of calling LLMs directly. The agent calls back to Sure's `/mcp` endpoint for financial data (accounts, transactions, balance sheet).
 
 1. Set the MCP endpoint credentials in your `.env`:
+
    ```bash
    MCP_API_TOKEN=generate-a-random-token-here
    MCP_USER_EMAIL=your@email.com   # must match an existing Sure user
    ```
 
 2. Set the external assistant connection:
+
    ```bash
    EXTERNAL_ASSISTANT_URL=https://your-agent/v1/chat/completions
    EXTERNAL_ASSISTANT_TOKEN=your-agent-api-token
@@ -291,7 +316,7 @@ If you are trying to get Sure started for the **first time** and run into databa
 
 If you run into this issue, you can optionally **reset the database**.
 
-**PLEASE NOTE: this will delete any existing data that you have in your Sure database, so proceed with caution.**  For first-time users of the app just trying to get started, you're generally safe to run the commands below.
+**PLEASE NOTE: this will delete any existing data that you have in your Sure database, so proceed with caution.** For first-time users of the app just trying to get started, you're generally safe to run the commands below.
 
 By running the commands below, you will delete your existing Sure database and "reset" it.
 

--- a/test/lib/env_file_loader_test.rb
+++ b/test/lib/env_file_loader_test.rb
@@ -83,6 +83,19 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
     file.close!
   end
 
+  test "warns and leaves base env var unset when path contains null bytes" do
+    env = {
+      "OPENAI_ACCESS_TOKEN_FILE" => "bad\0path"
+    }
+    warning_output = StringIO.new
+
+    Sure::EnvFileLoader.load!(env: env, warn_io: warning_output)
+
+    assert_nil env["OPENAI_ACCESS_TOKEN"]
+    assert_includes warning_output.string, "OPENAI_ACCESS_TOKEN_FILE"
+    assert_includes warning_output.string, "null byte"
+  end
+
   test "denylisted runtime _FILE variables are ignored without warnings" do
     env = {
       "SSL_CA_FILE" => "/path/that/does/not/exist"

--- a/test/lib/env_file_loader_test.rb
+++ b/test/lib/env_file_loader_test.rb
@@ -39,6 +39,23 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
     file.close!
   end
 
+  test "empty direct env var still takes precedence over matching _FILE value" do
+    file = Tempfile.new("secret")
+    file.write("file-secret\n")
+    file.flush
+
+    env = {
+      "OPENAI_ACCESS_TOKEN" => "",
+      "OPENAI_ACCESS_TOKEN_FILE" => file.path
+    }
+
+    Sure::EnvFileLoader.load!(env: env)
+
+    assert_equal "", env["OPENAI_ACCESS_TOKEN"]
+  ensure
+    file.close!
+  end
+
   test "warns and leaves base env var unset when file cannot be read" do
     env = {
       "OPENAI_ACCESS_TOKEN_FILE" => "/path/that/does/not/exist"

--- a/test/lib/env_file_loader_test.rb
+++ b/test/lib/env_file_loader_test.rb
@@ -68,6 +68,21 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
     assert_includes warning_output.string, "OPENAI_ACCESS_TOKEN_FILE"
   end
 
+  test "warns and leaves base env var unset when path raises another system call error" do
+    file = Tempfile.new("not-a-directory")
+    env = {
+      "OPENAI_ACCESS_TOKEN_FILE" => File.join(file.path, "nested", "secret")
+    }
+    warning_output = StringIO.new
+
+    Sure::EnvFileLoader.load!(env: env, warn_io: warning_output)
+
+    assert_nil env["OPENAI_ACCESS_TOKEN"]
+    assert_includes warning_output.string, "OPENAI_ACCESS_TOKEN_FILE"
+  ensure
+    file.close!
+  end
+
   test "denylisted variables are ignored" do
     file = Tempfile.new("secret")
     file.write("/tmp/custom-ca.pem\n")

--- a/test/lib/env_file_loader_test.rb
+++ b/test/lib/env_file_loader_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stringio"
+require "tempfile"
+require_relative "../../config/env_file_loader"
+
+class EnvFileLoaderTest < ActiveSupport::TestCase
+  test "loads base env var from matching _FILE path" do
+    file = Tempfile.new("secret")
+    file.write("super-secret\n")
+    file.flush
+
+    env = {
+      "OPENAI_ACCESS_TOKEN_FILE" => file.path
+    }
+
+    Sure::EnvFileLoader.load!(env: env)
+
+    assert_equal "super-secret", env["OPENAI_ACCESS_TOKEN"]
+  ensure
+    file.close!
+  end
+
+  test "direct env var takes precedence over matching _FILE value" do
+    file = Tempfile.new("secret")
+    file.write("file-secret\n")
+    file.flush
+
+    env = {
+      "OPENAI_ACCESS_TOKEN" => "direct-secret",
+      "OPENAI_ACCESS_TOKEN_FILE" => file.path
+    }
+
+    Sure::EnvFileLoader.load!(env: env)
+
+    assert_equal "direct-secret", env["OPENAI_ACCESS_TOKEN"]
+  ensure
+    file.close!
+  end
+
+  test "warns and leaves base env var unset when file cannot be read" do
+    env = {
+      "OPENAI_ACCESS_TOKEN_FILE" => "/path/that/does/not/exist"
+    }
+    warning_output = StringIO.new
+
+    Sure::EnvFileLoader.load!(env: env, warn_io: warning_output)
+
+    assert_nil env["OPENAI_ACCESS_TOKEN"]
+    assert_includes warning_output.string, "OPENAI_ACCESS_TOKEN_FILE"
+  end
+
+  test "denylisted variables are ignored" do
+    file = Tempfile.new("secret")
+    file.write("/tmp/custom-ca.pem\n")
+    file.flush
+
+    env = {
+      "SSL_CA_FILE_FILE" => file.path
+    }
+    warning_output = StringIO.new
+
+    Sure::EnvFileLoader.load!(env: env, warn_io: warning_output)
+
+    assert_nil env["SSL_CA_FILE"]
+    assert_includes warning_output.string, "SSL_CA_FILE_FILE"
+    assert_includes warning_output.string, "not eligible"
+  ensure
+    file.close!
+  end
+end

--- a/test/lib/env_file_loader_test.rb
+++ b/test/lib/env_file_loader_test.rb
@@ -83,7 +83,7 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
     file.close!
   end
 
-  test "denylisted _FILE variables are ignored without attempting to read them" do
+  test "denylisted runtime _FILE variables are ignored without warnings" do
     env = {
       "SSL_CA_FILE" => "/path/that/does/not/exist"
     }
@@ -92,9 +92,7 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
     Sure::EnvFileLoader.load!(env: env, warn_io: warning_output)
 
     assert_nil env["SSL_CA"]
-    assert_includes warning_output.string, "Ignoring SSL_CA_FILE"
-    assert_includes warning_output.string, "not eligible"
-    refute_includes warning_output.string, "Unable to load SSL_CA_FILE"
+    assert_empty warning_output.string
   end
 
   test "_FILE indirection cannot create a denylisted source key" do
@@ -111,9 +109,7 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
 
     assert_nil env["SSL_CA_FILE"]
     assert_nil env["SSL_CA"]
-    assert_includes warning_output.string, "Ignoring SSL_CA_FILE_FILE"
-    assert_includes warning_output.string, "SSL_CA_FILE is not eligible"
-    refute_includes warning_output.string, "Unable to load SSL_CA_FILE_FILE"
+    assert_empty warning_output.string
   ensure
     file.close!
   end

--- a/test/lib/env_file_loader_test.rb
+++ b/test/lib/env_file_loader_test.rb
@@ -83,7 +83,21 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
     file.close!
   end
 
-  test "denylisted variables are ignored" do
+  test "denylisted _FILE variables are ignored without attempting to read them" do
+    env = {
+      "SSL_CA_FILE" => "/path/that/does/not/exist"
+    }
+    warning_output = StringIO.new
+
+    Sure::EnvFileLoader.load!(env: env, warn_io: warning_output)
+
+    assert_nil env["SSL_CA"]
+    assert_includes warning_output.string, "Ignoring SSL_CA_FILE"
+    assert_includes warning_output.string, "not eligible"
+    refute_includes warning_output.string, "Unable to load SSL_CA_FILE"
+  end
+
+  test "_FILE indirection cannot create a denylisted source key" do
     file = Tempfile.new("secret")
     file.write("/tmp/custom-ca.pem\n")
     file.flush
@@ -96,8 +110,10 @@ class EnvFileLoaderTest < ActiveSupport::TestCase
     Sure::EnvFileLoader.load!(env: env, warn_io: warning_output)
 
     assert_nil env["SSL_CA_FILE"]
-    assert_includes warning_output.string, "SSL_CA_FILE_FILE"
-    assert_includes warning_output.string, "not eligible"
+    assert_nil env["SSL_CA"]
+    assert_includes warning_output.string, "Ignoring SSL_CA_FILE_FILE"
+    assert_includes warning_output.string, "SSL_CA_FILE is not eligible"
+    refute_includes warning_output.string, "Unable to load SSL_CA_FILE_FILE"
   ensure
     file.close!
   end


### PR DESCRIPTION
## Summary

Add support for supplying self-hosted app secrets via `*_FILE` environment variables. https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images

This introduces an early boot-time env loader so the Rails app can read secret values from files before initialization, which makes Docker/Kubernetes secret mounting easier to use for self-hosted deployments.

## What changed

- Added a boot-time env file loader in `config/boot.rb`
- Added `config/env_file_loader.rb` to resolve supported `FOO_FILE` variables into `FOO`
- Preserved precedence for direct env vars (`FOO` wins over `FOO_FILE`)
- Strip trailing newlines from secret file contents
- Warn instead of crashing when a secret file cannot be read
- Added a denylist for env vars that should **not** be resolved via `*_FILE`
  - `BUNDLE_GEMFILE`
  - `PIDFILE`
  - `SSL_CA_FILE`
  - `SSL_CERT_FILE`
- Added focused tests covering:
  - successful `*_FILE` loading
  - direct env var precedence
  - unreadable file warnings
  - denylisted variables being ignored
- Updated self-hosting docs in:
  - `.env.example`
  - `docs/hosting/docker.md`

## Why

Self-hosted users commonly provide secrets through mounted files rather than plain env vars, especially in Docker and Kubernetes environments.

Supporting `*_FILE` values allows secrets like `SECRET_KEY_BASE`, OpenAI tokens, SMTP passwords, OIDC client secrets, and Active Record encryption keys to be injected securely without requiring broader refactors across the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load secrets from files via the *_FILE convention during startup; base env vars take precedence even when empty; certain low-level path/runtime vars are denylisted from *_FILE indirection.

* **Documentation**
  * Updated .env example and Docker hosting docs with usage, precedence rules, newline stripping, and denylist guidance.

* **Tests**
  * Added tests for file-loading, precedence, denylist behavior, and failure warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->