### PR TITLE
fix: enhance text contrast for prose headings, and blockquote paragraphs in dark mode on the Guide page

### DIFF
--- a/app/assets/tailwind/maybe-design-system.css
+++ b/app/assets/tailwind/maybe-design-system.css
@@ -248,6 +248,18 @@
   color: theme(colors.white) !important;
 }
 
+/* Specific override for headings in prose under dark mode */
+.prose:where([data-theme=dark], [data-theme=dark] *) h1,
+.prose:where([data-theme=dark], [data-theme=dark] *) h2,
+.prose:where([data-theme=dark], [data-theme=dark] *) h3,
+.prose:where([data-theme=dark], [data-theme=dark] *) h4,
+.prose:where([data-theme=dark], [data-theme=dark] *) h5,
+.prose:where([data-theme=dark], [data-theme=dark] *) h6,
+.prose:where([data-theme=dark], [data-theme=dark] *) blockquote,
+.prose:where([data-theme=dark], [data-theme=dark] *) thead th {
+  color: theme(colors.white) !important;
+}
+
 @layer base {
   [data-theme="dark"] { 
     --color-success: var(--color-green-500);


### PR DESCRIPTION
### Description
This PR fixes an accessibility and readability issue where headings (`h1` through `h6`) within `.prose` blocks were difficult to read when Dark Mode was enabled. 

**The Problem:**
Tailwind's typography plugin was applying its default heading color variable (`var(--tw-prose-headings)`) to prose headings, which overrode the application's global dark theme text color. This resulted in dark text on a dark background.

**The Solution:**
Added a specific CSS override targeting `.prose` headings when the `[data-theme=dark]` attribute is active. It explicitly sets the heading colors to `theme(colors.white)` to ensure proper contrast and readability, mirroring the intended behavior of standard text elements in dark mode.

### Visual Changes

| Before | After |
| --- | --- |
| <img width="946" height="472" alt="Screenshot 2026-04-03 223536" src="https://github.com/user-attachments/assets/cadf4a8b-828e-4ebf-82ab-38f588a6e677" /> | <img width="964" height="582" alt="image" src="https://github.com/user-attachments/assets/f11d2f16-ab9f-405e-b2c7-cfc19ff3a416" /> |

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX improvement

### Testing
- Toggled dark mode on/off to verify the new styles only apply when `[data-theme=dark]` is active.
- Verified that standard light mode prose headings are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode text visibility for headings, quotes, and table headers to enhance readability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->