### PR TITLE
Add YNAB API sync script (#1255)

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -3,15 +3,14 @@
 class Api::V1::AccountsController < Api::V1::BaseController
   include Pagy::Backend
 
-  # Ensure proper scope authorization for read access
-  before_action :ensure_read_scope
+  before_action -> { authorize_scope!(:read) }, only: %i[index show]
+  before_action -> { authorize_scope!(:read_write) }, only: %i[create]
+  before_action :set_account, only: %i[show]
 
   def index
-    # Test with Pagy pagination
     family = current_resource_owner.family
     accounts_query = family.accounts.accessible_by(current_resource_owner).visible.alphabetically
 
-    # Handle pagination with Pagy
     @pagy, @accounts = pagy(
       accounts_query,
       page: safe_page_param,
@@ -19,41 +18,59 @@ class Api::V1::AccountsController < Api::V1::BaseController
     )
 
     @per_page = safe_per_page_param
-
-    # Rails will automatically use app/views/api/v1/accounts/index.json.jbuilder
     render :index
   rescue => e
-    Rails.logger.error "AccountsController error: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
+    Rails.logger.error "AccountsController#index error: #{e.message}"
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
+  end
 
-    render json: {
-      error: "internal_server_error",
-      message: "Error: #{e.message}"
-    }, status: :internal_server_error
-end
+  def show
+    render :show
+  end
 
-    private
+  def create
+    family = current_resource_owner.family
 
-      def ensure_read_scope
-        authorize_scope!(:read)
-      end
+    accountable_attrs = {}
+    accountable_attrs[:subtype] = account_params[:subtype] if account_params[:subtype].present?
 
+    attributes = {
+      family: family,
+      name: account_params[:name],
+      balance: account_params[:balance] || 0,
+      currency: account_params[:currency] || family.currency,
+      accountable_type: account_params[:accountable_type],
+      accountable_attributes: accountable_attrs
+    }
 
+    @account = Account.create_and_sync(attributes, skip_initial_sync: true)
+    render :show, status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: "validation_failed", message: e.message }, status: :unprocessable_entity
+  rescue => e
+    Rails.logger.error "AccountsController#create error: #{e.message}"
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
+  end
 
-      def safe_page_param
-        page = params[:page].to_i
-        page > 0 ? page : 1
-      end
+  private
 
-      def safe_per_page_param
-        per_page = params[:per_page].to_i
+    def set_account
+      @account = current_resource_owner.family.accounts.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "not_found", message: "Account not found" }, status: :not_found
+    end
 
-        # Default to 25, max 100
-        case per_page
-        when 1..100
-          per_page
-        else
-          25
-        end
-      end
+    def account_params
+      params.require(:account).permit(:name, :accountable_type, :balance, :currency, :subtype, :institution_name)
+    end
+
+    def safe_page_param
+      page = params[:page].to_i
+      page > 0 ? page : 1
+    end
+
+    def safe_per_page_param
+      per_page = params[:per_page].to_i
+      per_page.between?(1, 100) ? per_page : 25
+    end
 end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -3,8 +3,9 @@
 class Api::V1::CategoriesController < Api::V1::BaseController
   include Pagy::Backend
 
-  before_action :ensure_read_scope
-  before_action :set_category, only: :show
+  before_action :ensure_read_scope, only: %i[index show]
+  before_action -> { authorize_scope!(:read_write) }, only: %i[create update destroy]
+  before_action :set_category, only: %i[show update destroy]
 
   def index
     family = current_resource_owner.family
@@ -25,24 +26,89 @@ class Api::V1::CategoriesController < Api::V1::BaseController
     render :index
   rescue => e
     Rails.logger.error "CategoriesController#index error: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-
-    render json: {
-      error: "internal_server_error",
-      message: "Error: #{e.message}"
-    }, status: :internal_server_error
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
   end
 
   def show
     render :show
   rescue => e
     Rails.logger.error "CategoriesController#show error: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
+  end
 
-    render json: {
-      error: "internal_server_error",
-      message: "Error: #{e.message}"
-    }, status: :internal_server_error
+  def create
+    family = current_resource_owner.family
+
+    @category = family.categories.new(category_params)
+
+    # Auto-assign color if not provided
+    @category.color ||= Category::COLORS.sample
+
+    # Auto-assign icon if not provided
+    @category.lucide_icon ||= Category.suggested_icon(@category.name)
+
+    # Validate parent belongs to same family
+    if @category.parent_id.present?
+      unless family.categories.exists?(id: @category.parent_id)
+        render json: {
+          error: "validation_failed",
+          message: "Parent category not found in this family",
+          errors: [ "Parent category not found in this family" ]
+        }, status: :unprocessable_entity
+        return
+      end
+    end
+
+    if @category.save
+      @category = family.categories.includes(:parent, :subcategories).find(@category.id)
+      render :show, status: :created
+    else
+      render json: {
+        error: "validation_failed",
+        message: @category.errors.full_messages.join(", "),
+        errors: @category.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  rescue => e
+    Rails.logger.error "CategoriesController#create error: #{e.message}"
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
+  end
+
+  def update
+    # Validate parent belongs to same family if parent_id is being changed
+    if params[:category]&.key?(:parent_id) && params[:category][:parent_id].present?
+      family = current_resource_owner.family
+      unless family.categories.exists?(id: params[:category][:parent_id])
+        render json: {
+          error: "validation_failed",
+          message: "Parent category not found in this family",
+          errors: [ "Parent category not found in this family" ]
+        }, status: :unprocessable_entity
+        return
+      end
+    end
+
+    if @category.update(category_params)
+      @category = current_resource_owner.family.categories.includes(:parent, :subcategories).find(@category.id)
+      render :show
+    else
+      render json: {
+        error: "validation_failed",
+        message: @category.errors.full_messages.join(", "),
+        errors: @category.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  rescue => e
+    Rails.logger.error "CategoriesController#update error: #{e.message}"
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
+  end
+
+  def destroy
+    @category.destroy!
+    head :no_content
+  rescue => e
+    Rails.logger.error "CategoriesController#destroy error: #{e.message}"
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
   end
 
   private
@@ -59,6 +125,10 @@ class Api::V1::CategoriesController < Api::V1::BaseController
 
     def ensure_read_scope
       authorize_scope!(:read)
+    end
+
+    def category_params
+      params.require(:category).permit(:name, :color, :lucide_icon, :parent_id)
     end
 
     def apply_filters(query)

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -3,7 +3,7 @@
 class Api::V1::CategoriesController < Api::V1::BaseController
   include Pagy::Backend
 
-  before_action :ensure_read_scope, only: %i[index show]
+  before_action -> { authorize_scope!(:read) }, only: %i[index show]
   before_action -> { authorize_scope!(:read_write) }, only: %i[create update destroy]
   before_action :set_category, only: %i[show update destroy]
 
@@ -121,10 +121,6 @@ class Api::V1::CategoriesController < Api::V1::BaseController
         error: "not_found",
         message: "Category not found"
       }, status: :not_found
-    end
-
-    def ensure_read_scope
-      authorize_scope!(:read)
     end
 
     def category_params

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -3,7 +3,8 @@
 module Api
   module V1
     # API v1 endpoint for merchants
-    # Provides read-only access to family and provider merchants
+    # Provides read access to family and provider merchants,
+    # and write access to create family merchants
     #
     # @example List all merchants
     #   GET /api/v1/merchants
@@ -11,8 +12,13 @@ module Api
     # @example Get a specific merchant
     #   GET /api/v1/merchants/:id
     #
+    # @example Create a new merchant
+    #   POST /api/v1/merchants
+    #   { "merchant": { "name": "Acme Corp", "color": "#e99537", "website_url": "https://acme.com" } }
+    #
     class MerchantsController < BaseController
-      before_action -> { authorize_scope!(:read) }
+      before_action -> { authorize_scope!(:read) }, only: %i[index show]
+      before_action -> { authorize_scope!(:read_write) }, only: %i[create]
 
       # List all merchants available to the family
       #
@@ -71,7 +77,34 @@ module Api
         render json: { error: "Failed to fetch merchant" }, status: :internal_server_error
       end
 
+      # Create a new family merchant
+      #
+      # @param name [String] Merchant name (required)
+      # @param color [String] Hex color code (optional, auto-assigned if not provided)
+      # @param website_url [String] Merchant website URL (optional)
+      # @return [Hash] JSON merchant object with status 201
+      def create
+        family = current_resource_owner.family
+        @merchant = family.merchants.new(merchant_params)
+
+        if @merchant.save
+          render json: merchant_json(@merchant), status: :created
+        else
+          render json: { error: @merchant.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      rescue StandardError => e
+        Rails.logger.error("API Merchant Create Error: #{e.message}")
+        render json: { error: "Failed to create merchant" }, status: :internal_server_error
+      end
+
       private
+
+        # Strong parameters for merchant creation
+        #
+        # @return [ActionController::Parameters] Permitted parameters
+        def merchant_params
+          params.require(:merchant).permit(:name, :color, :website_url)
+        end
 
         # Serialize a merchant to JSON format
         #
@@ -82,6 +115,8 @@ module Api
             id: merchant.id,
             name: merchant.name,
             type: merchant.type,
+            color: merchant.color,
+            website_url: merchant.try(:website_url),
             created_at: merchant.created_at,
             updated_at: merchant.updated_at
           }

--- a/app/controllers/api/v1/transfers_controller.rb
+++ b/app/controllers/api/v1/transfers_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Api::V1::TransfersController < Api::V1::BaseController
+  before_action -> { authorize_scope!(:read_write) }
+
+  def create
+    family = current_resource_owner.family
+
+    @transfer = Transfer::Creator.new(
+      family: family,
+      source_account_id: transfer_params[:source_account_id],
+      destination_account_id: transfer_params[:destination_account_id],
+      date: Date.parse(transfer_params[:date]),
+      amount: transfer_params[:amount].to_d
+    ).create
+
+    if @transfer.persisted?
+      render json: transfer_json(@transfer), status: :created
+    else
+      render json: { error: @transfer.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Account not found" }, status: :not_found
+  rescue Date::Error, TypeError
+    render json: { error: "Invalid date format. Use YYYY-MM-DD." }, status: :unprocessable_entity
+  rescue => e
+    Rails.logger.error "TransfersController#create error: #{e.message}"
+    render json: { error: "internal_server_error", message: "Error: #{e.message}" }, status: :internal_server_error
+  end
+
+  private
+
+    def transfer_params
+      params.require(:transfer).permit(:source_account_id, :destination_account_id, :date, :amount)
+    end
+
+    def transfer_json(transfer)
+      {
+        id: transfer.id,
+        source_account: {
+          id: transfer.from_account&.id,
+          name: transfer.from_account&.name
+        },
+        destination_account: {
+          id: transfer.to_account&.id,
+          name: transfer.to_account&.name
+        },
+        date: transfer.date,
+        amount: transfer.amount_abs&.amount&.to_s,
+        status: transfer.status,
+        created_at: transfer.created_at,
+        updated_at: transfer.updated_at
+      }
+    end
+end

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -71,7 +71,7 @@ module ImportsHelper
 
   private
     def permitted_import_types
-      %w[transaction_import trade_import account_import mint_import category_import rule_import]
+      %w[transaction_import trade_import account_import mint_import category_import rule_import ynab_import]
     end
 
     DryRunResource = Struct.new(:label, :icon, :text_class, :bg_class, keyword_init: true)

--- a/app/models/family_merchant.rb
+++ b/app/models/family_merchant.rb
@@ -11,7 +11,7 @@ class FamilyMerchant < Merchant
 
   private
     def set_default_color
-      self.color = COLORS.sample
+      self.color ||= COLORS.sample
     end
 
     def should_generate_logo?

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -9,7 +9,7 @@ class Import < ApplicationRecord
 
   DOCUMENT_TYPES = %w[bank_statement credit_card_statement investment_statement financial_document contract other].freeze
 
-  TYPES = %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport PdfImport QifImport SureImport].freeze
+  TYPES = %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport PdfImport QifImport SureImport YnabImport].freeze
   SIGNAGE_CONVENTIONS = %w[inflows_positive inflows_negative]
   SEPARATORS = [ [ "Comma (,)", "," ], [ "Semicolon (;)", ";" ] ].freeze
 

--- a/app/models/ynab_import.rb
+++ b/app/models/ynab_import.rb
@@ -1,0 +1,111 @@
+class YnabImport < Import
+  after_create :set_mappings
+
+  OUTFLOW_COL = "Outflow".freeze
+  INFLOW_COL = "Inflow".freeze
+
+  def generate_rows_from_csv
+    rows.destroy_all
+
+    mapped_rows = csv_rows.map do |row|
+      {
+        account: row[account_col_label].to_s,
+        date: row[date_col_label].to_s,
+        amount: compute_signed_amount(row).to_s("F"),
+        currency: default_currency.to_s,
+        name: (row[name_col_label] || default_row_name).to_s,
+        category: row[category_col_label].to_s,
+        tags: row[tags_col_label].to_s,
+        notes: row[notes_col_label].to_s
+      }
+    end
+
+    rows.insert_all!(mapped_rows)
+    update_column(:rows_count, rows.count)
+  end
+
+  def import!
+    transaction do
+      mappings.each(&:create_mappable!)
+
+      rows.each do |row|
+        mapped_account = if account
+          account
+        else
+          mappings.accounts.mappable_for(row.account)
+        end
+        category = mappings.categories.mappable_for(row.category)
+        tags = row.tags_list.map { |tag| mappings.tags.mappable_for(tag) }.compact
+
+        effective_currency = mapped_account.currency.presence || family.currency
+
+        entry = mapped_account.entries.build \
+          date: row.date_iso,
+          amount: row.signed_amount,
+          name: row.name,
+          currency: effective_currency,
+          notes: row.notes,
+          entryable: Transaction.new(category: category, tags: tags),
+          import: self
+
+        entry.save!
+      end
+    end
+  end
+
+  def mapping_steps
+    [ Import::CategoryMapping, Import::TagMapping, Import::AccountMapping ]
+  end
+
+  def required_column_keys
+    %i[date amount]
+  end
+
+  def column_keys
+    %i[date amount name currency category tags account notes]
+  end
+
+  def csv_template
+    template = <<-CSV
+      Account,Flag,Date,Payee,Category Group/Category,Category Group,Category,Memo,Outflow,Inflow,Cleared
+      Checking,,01/15/2024,Grocery Store,Immediate Obligations: Groceries,Immediate Obligations,Groceries,Weekly groceries,$78.32,$0.00,Cleared
+      Checking,,01/16/2024,ACME Corp,Income: Salary,Income,Salary,Bi-weekly paycheck,$0.00,"$2,500.00",Cleared
+      Credit Card,,01/17/2024,Coffee Shop,Quality of Life: Dining Out,Quality of Life,Dining Out,Morning coffee,$4.25,$0.00,Cleared
+    CSV
+
+    CSV.parse(template, headers: true)
+  end
+
+  private
+    # YNAB uses two columns: Outflow (expenses) and Inflow (income).
+    # In Sure, positive = outflow (expense), negative = inflow (income).
+    def compute_signed_amount(csv_row)
+      outflow = sanitize_ynab_amount(csv_row[OUTFLOW_COL])
+      inflow = sanitize_ynab_amount(csv_row[INFLOW_COL])
+      outflow - inflow
+    end
+
+    def sanitize_ynab_amount(value)
+      return 0.to_d if value.blank?
+
+      # Strip currency symbols, spaces, then normalize number format
+      cleaned = value.to_s.gsub(/[^\d.,\-]/, "")
+      return 0.to_d if cleaned.blank?
+
+      # Handle comma as thousands separator (US format: $2,500.00)
+      cleaned.gsub(",", "").to_d
+    end
+
+    def set_mappings
+      self.signage_convention = "inflows_negative"
+      self.date_col_label = "Date"
+      self.date_format = "%m/%d/%Y"
+      self.name_col_label = "Payee"
+      self.amount_col_label = OUTFLOW_COL
+      self.account_col_label = "Account"
+      self.category_col_label = "Category"
+      self.notes_col_label = "Memo"
+
+      save!
+    end
+end

--- a/app/views/api/v1/accounts/show.json.jbuilder
+++ b/app/views/api/v1/accounts/show.json.jbuilder
@@ -1,0 +1,8 @@
+json.id @account.id
+json.name @account.name
+json.balance @account.balance_money.format
+json.currency @account.currency
+json.classification @account.classification
+json.account_type @account.accountable_type.underscore
+json.created_at @account.created_at.iso8601
+json.updated_at @account.updated_at.iso8601

--- a/app/views/import/configurations/_ynab_import.html.erb
+++ b/app/views/import/configurations/_ynab_import.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (import:) %>
+
+<div class="flex items-center justify-between border border-secondary rounded-lg bg-green-500/5 p-5 gap-4 mb-4">
+  <span class="text-green-500">
+    <%= icon("check-circle", color: "current") %>
+  </span>
+  <p class="text-sm text-primary italic"><%= t(".pre_configured") %></p>
+</div>
+
+<%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
+  <div class="flex items-center gap-4">
+    <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label") }, label: true, required: true, disabled: import.complete? %>
+  </div>
+
+  <% unless import.account.present? %>
+    <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account" }, disabled: import.complete? %>
+  <% end %>
+
+  <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" }, disabled: import.complete? %>
+  <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>
+  <%= form.select :notes_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Notes (optional)" }, disabled: import.complete? %>
+
+  <%= form.submit "Apply configuration", disabled: import.complete? %>
+<% end %>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -31,7 +31,7 @@
 
     <%
       import_type = params[:type].presence || @pending_import&.type
-      active_tab = import_type.present? && !import_type.in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) ? "raw_data" : "financial_tools"
+      active_tab = import_type.present? && !import_type.in?(%w[MintImport QifImport SureImport YnabImport DocumentImport PdfImport]) ? "raw_data" : "financial_tools"
     %>
     <%= render DS::Tabs.new(active_tab: active_tab) do |tabs| %>
       <% tabs.with_nav do |nav| %>
@@ -42,7 +42,7 @@
       <% tabs.with_panel(tab_id: "financial_tools") do %>
         <div class="rounded-xl bg-container-inset p-1">
           <ul class="bg-container shadow-border-xs rounded-lg">
-            <% if @pending_import.present? && params[:type].present? && params[:type].in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) %>
+            <% if @pending_import.present? && params[:type].present? && params[:type].in?(%w[MintImport QifImport SureImport YnabImport DocumentImport PdfImport]) %>
               <li>
                 <%= link_to import_path(@pending_import), class: "flex items-center justify-between p-4 group cursor-pointer", data: { turbo: false } do %>
                   <div class="flex items-center gap-2">
@@ -99,6 +99,16 @@
                 enabled: true %>
             <% end %>
 
+            <% if params[:type].nil? || params[:type] == "YnabImport" %>
+              <%= render "imports/import_option",
+                type: "YnabImport",
+                icon_name: "wallet",
+                icon_bg_class: "bg-blue-500/5",
+                icon_text_class: "text-blue-500",
+                label: t(".import_ynab"),
+                enabled: true %>
+            <% end %>
+
             <% if params[:type].nil? || params[:type] == "QifImport" %>
               <%= render "imports/import_option",
                 type: "QifImport",
@@ -108,15 +118,6 @@
                 label: t(".import_qif"),
                 enabled: true %>
             <% end %>
-
-            <%= render "imports/import_option",
-              type: "TransactionImport",
-              icon_name: "bar-chart-2",
-              icon_bg_class: "bg-gray-500/5",
-              icon_text_class: "text-gray-400",
-              label: t(".import_ynab"),
-              enabled: false,
-              disabled_message: t(".coming_soon") %>
 
             <% if (params[:type].nil? || params[:type].in?(%w[DocumentImport PdfImport])) && @document_upload_extensions.any? %>
               <li>
@@ -153,7 +154,7 @@
       <% tabs.with_panel(tab_id: "raw_data") do %>
         <div class="rounded-xl bg-container-inset p-1">
           <ul class="bg-container shadow-border-xs rounded-lg">
-            <% if @pending_import.present? && params[:type].present? && !params[:type].in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) %>
+            <% if @pending_import.present? && params[:type].present? && !params[:type].in?(%w[MintImport QifImport SureImport YnabImport DocumentImport PdfImport]) %>
               <li>
                 <%= link_to import_path(@pending_import), class: "flex items-center justify-between p-4 group cursor-pointer", data: { turbo: false } do %>
                   <div class="flex items-center gap-2">

--- a/bin/ynab_sync
+++ b/bin/ynab_sync
@@ -1,0 +1,460 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# YNAB → Sure Sync Script
+#
+# Reads data from the YNAB API and imports it into Sure via the Sure API.
+#
+# Usage:
+#   ruby bin/ynab_sync
+#
+# Environment variables:
+#   YNAB_TOKEN        - YNAB Personal Access Token (required)
+#                       Get one at: https://app.ynab.com/settings/developer
+#   SURE_API_KEY      - Sure API key with read_write scope (required)
+#   SURE_BASE_URL     - Sure API base URL (default: http://localhost:3000)
+#   YNAB_PLAN_ID      - YNAB budget/plan ID (default: "last-used")
+#   YNAB_SINCE_DATE   - Only import transactions on or after this date (YYYY-MM-DD)
+#   DRY_RUN           - Set to "true" to preview without creating anything
+#
+# The script will:
+#   1. Fetch accounts, categories, and transactions from YNAB
+#   2. Fetch existing accounts and categories from Sure
+#   3. Display mappings and ask for confirmation
+#   4. Create transactions in Sure via the API
+
+require "net/http"
+require "json"
+require "uri"
+require "bigdecimal"
+
+# --- Configuration ---
+
+YNAB_TOKEN      = ENV.fetch("YNAB_TOKEN")      { abort "Error: YNAB_TOKEN environment variable is required" }
+SURE_API_KEY    = ENV.fetch("SURE_API_KEY")     { abort "Error: SURE_API_KEY environment variable is required" }
+SURE_BASE_URL   = ENV.fetch("SURE_BASE_URL", "http://localhost:3000")
+YNAB_PLAN_ID    = ENV.fetch("YNAB_PLAN_ID", "last-used")
+YNAB_SINCE_DATE = ENV["YNAB_SINCE_DATE"]
+DRY_RUN         = ENV["DRY_RUN"] == "true"
+
+YNAB_BASE_URL = "https://api.ynab.com/v1"
+
+# --- API Clients ---
+
+module YnabClient
+  module_function
+
+  def get(path)
+    uri = URI("#{YNAB_BASE_URL}#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req["Authorization"] = "Bearer #{YNAB_TOKEN}"
+    req["Accept"] = "application/json"
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 10, read_timeout: 30) { |http| http.request(req) }
+
+    unless response.is_a?(Net::HTTPSuccess)
+      abort "YNAB API error (#{response.code}): #{response.body}"
+    end
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def fetch_accounts
+    data = get("/plans/#{YNAB_PLAN_ID}/accounts")
+    data.dig(:data, :accounts)&.reject { |a| a[:deleted] } || []
+  end
+
+  def fetch_categories
+    data = get("/plans/#{YNAB_PLAN_ID}/categories")
+    groups = data.dig(:data, :category_groups) || []
+    groups.reject { |g| g[:deleted] }
+  end
+
+  def fetch_transactions
+    path = "/plans/#{YNAB_PLAN_ID}/transactions"
+    path += "?since_date=#{YNAB_SINCE_DATE}" if YNAB_SINCE_DATE
+    data = get(path)
+    data.dig(:data, :transactions)&.reject { |t| t[:deleted] } || []
+  end
+end
+
+module SureClient
+  module_function
+
+  def get(path)
+    uri = URI("#{SURE_BASE_URL}/api/v1#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req["X-Api-Key"] = SURE_API_KEY
+    req["Accept"] = "application/json"
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https", open_timeout: 10, read_timeout: 30) { |http| http.request(req) }
+
+    unless response.is_a?(Net::HTTPSuccess)
+      abort "Sure API error on GET #{path} (#{response.code}): #{response.body}"
+    end
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def post(path, body)
+    uri = URI("#{SURE_BASE_URL}/api/v1#{path}")
+    req = Net::HTTP::Post.new(uri)
+    req["X-Api-Key"] = SURE_API_KEY
+    req["Content-Type"] = "application/json"
+    req["Accept"] = "application/json"
+    req.body = body.to_json
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https", open_timeout: 10, read_timeout: 30) { |http| http.request(req) }
+
+    case response.code.to_i
+    when 200, 201, 202
+      JSON.parse(response.body, symbolize_names: true)
+    when 422
+      parsed = JSON.parse(response.body, symbolize_names: true) rescue {}
+      { error: true, status: 422, message: parsed[:message] || response.body }
+    when 429
+      { error: true, status: 429, message: "Rate limited" }
+    else
+      { error: true, status: response.code.to_i, message: response.body }
+    end
+  end
+
+  def fetch_accounts
+    all = []
+    page = 1
+    loop do
+      data = get("/accounts?page=#{page}&per_page=100")
+      accounts = data[:accounts] || []
+      all.concat(accounts)
+      break if accounts.size < 100
+      page += 1
+    end
+    all
+  end
+
+  def fetch_categories
+    all = []
+    page = 1
+    loop do
+      data = get("/categories?page=#{page}&per_page=100")
+      categories = data[:categories] || []
+      all.concat(categories)
+      break if categories.size < 100
+      page += 1
+    end
+    all
+  end
+end
+
+# --- Data Mapping ---
+
+# YNAB amounts are in milliunits (1000 = $1.00)
+# YNAB: negative = outflow (expense), positive = inflow (income)
+# Sure API: uses `nature` param — "expense" or "income" with positive amount
+def milliunit_to_decimal(milliunits)
+  # Preserve full precision — some currencies use 3 decimal places (JOD, KWD)
+  BigDecimal(milliunits.to_s) / 1000
+end
+
+# Map YNAB account types to Sure account types
+ACCOUNT_TYPE_MAP = {
+  "checking"       => "Depository",
+  "savings"        => "Depository",
+  "cash"           => "Depository",
+  "creditCard"     => "CreditCard",
+  "lineOfCredit"   => "CreditCard",
+  "otherAsset"     => "OtherAsset",
+  "otherLiability" => "Loan",
+  "mortgage"       => "Loan",
+  "autoLoan"       => "Loan",
+  "studentLoan"    => "Loan",
+  "personalLoan"   => "Loan",
+  "medicalDebt"    => "Loan",
+  "otherDebt"      => "Loan"
+}.freeze
+
+def build_account_mapping(ynab_accounts, sure_accounts)
+  mapping = {}
+
+  ynab_accounts.each do |ya|
+    # Try exact name match first, then case-insensitive
+    match = sure_accounts.find { |sa| sa[:name] == ya[:name] } ||
+            sure_accounts.find { |sa| sa[:name]&.downcase == ya[:name]&.downcase }
+
+    mapping[ya[:id]] = {
+      ynab_name: ya[:name],
+      ynab_type: ya[:type],
+      sure_account: match,
+      sure_id: match&.dig(:id),
+      matched: !match.nil?
+    }
+  end
+
+  mapping
+end
+
+def build_category_mapping(ynab_category_groups, sure_categories)
+  mapping = {}
+
+  ynab_category_groups.each do |group|
+    next if group[:name] == "Internal Master Category" # YNAB internal
+
+    categories = group[:categories]&.reject { |c| c[:deleted] } || []
+
+    categories.each do |cat|
+      # Try matching by category name (ignore group)
+      match = sure_categories.find { |sc| sc[:name]&.downcase == cat[:name]&.downcase } ||
+              sure_categories.find { |sc| sc[:name]&.downcase == "#{group[:name]}: #{cat[:name]}"&.downcase }
+
+      mapping[cat[:id]] = {
+        ynab_group: group[:name],
+        ynab_name: cat[:name],
+        sure_category: match,
+        sure_id: match&.dig(:id),
+        matched: !match.nil?
+      }
+    end
+  end
+
+  mapping
+end
+
+# --- Display ---
+
+def print_header(title)
+  puts "\n#{"=" * 60}"
+  puts "  #{title}"
+  puts "=" * 60
+end
+
+def print_account_mapping(mapping)
+  print_header("Account Mapping")
+
+  matched = mapping.values.select { |m| m[:matched] }
+  unmatched = mapping.values.reject { |m| m[:matched] }
+
+  if matched.any?
+    puts "\n  Matched (#{matched.size}):"
+    matched.each do |m|
+      puts "    #{m[:ynab_name]} (#{m[:ynab_type]}) → #{m[:sure_account][:name]}"
+    end
+  end
+
+  if unmatched.any?
+    puts "\n  Unmatched (#{unmatched.size}) — transactions for these will be skipped:"
+    unmatched.each do |m|
+      puts "    #{m[:ynab_name]} (#{m[:ynab_type]}) → [no match in Sure]"
+    end
+  end
+end
+
+def print_category_mapping(mapping)
+  print_header("Category Mapping")
+
+  matched = mapping.values.select { |m| m[:matched] }
+  unmatched = mapping.values.reject { |m| m[:matched] }
+
+  if matched.any?
+    puts "\n  Matched (#{matched.size}):"
+    matched.each do |m|
+      puts "    #{m[:ynab_group]}: #{m[:ynab_name]} → #{m[:sure_category][:name]}"
+    end
+  end
+
+  if unmatched.any?
+    puts "\n  Unmatched (#{unmatched.size}) — transactions will be imported without category:"
+    unmatched.each do |m|
+      puts "    #{m[:ynab_group]}: #{m[:ynab_name]}"
+    end
+  end
+end
+
+# --- Import ---
+
+def fetch_existing_transactions(account_mapping)
+  existing = {}
+
+  account_mapping.each do |_ynab_id, mapping|
+    next unless mapping[:sure_id]
+
+    sure_id = mapping[:sure_id]
+    page = 1
+    loop do
+      params = "account_id=#{sure_id}&page=#{page}&per_page=100"
+      params += "&start_date=#{YNAB_SINCE_DATE}" if YNAB_SINCE_DATE
+      data = SureClient.get("/transactions?#{params}")
+      txns = data[:transactions] || []
+      txns.each do |t|
+        # Key: account_id + date + signed_amount_cents + name for dedup
+        key = "#{t.dig(:account, :id)}|#{t[:date]}|#{t[:signed_amount_cents]}|#{t[:name]}"
+        existing[key] ||= 0
+        existing[key] += 1
+      end
+      break if txns.size < 100
+      page += 1
+    end
+  end
+
+  existing
+end
+
+def transaction_dedup_key(sure_account_id, date, amount_cents, name = nil)
+  "#{sure_account_id}|#{date}|#{amount_cents}|#{name}"
+end
+
+def import_transactions(transactions, account_mapping, category_mapping)
+  # Filter to only transactions with mapped accounts, excluding transfers
+  importable = transactions.select { |t|
+    account_mapping.dig(t[:account_id], :sure_id) && t[:transfer_account_id].nil?
+  }
+  transfers = transactions.count { |t| t[:transfer_account_id] }
+  skipped_no_account = transactions.size - importable.size - transfers
+
+  print_header("Import Summary")
+  puts "\n  Total YNAB transactions: #{transactions.size}"
+  puts "  Transfers (skipped):     #{transfers}"
+  puts "  No account match:        #{skipped_no_account}"
+  puts "  Ready to import:         #{importable.size}"
+
+  if importable.empty?
+    puts "\n  Nothing to import."
+    return
+  end
+
+  # Fetch existing transactions for deduplication
+  puts "\n  Checking for duplicates..."
+  existing = fetch_existing_transactions(account_mapping)
+
+  duplicates = 0
+  to_import = []
+
+  importable.each do |txn|
+    sure_account_id = account_mapping.dig(txn[:account_id], :sure_id)
+    amount = milliunit_to_decimal(txn[:amount])
+    # Sure stores: positive = outflow, negative = inflow. YNAB: negative = outflow.
+    # So we negate: YNAB -500 (outflow) → Sure +500, YNAB +500 (inflow) → Sure -500
+    signed_cents = (amount * -100).round.to_i
+    name = txn[:payee_name] || txn[:import_payee_name] || "YNAB Import"
+    key = transaction_dedup_key(sure_account_id, txn[:date], signed_cents, name)
+
+    if existing[key] && existing[key] > 0
+      existing[key] -= 1
+      duplicates += 1
+    else
+      to_import << txn
+    end
+  end
+
+  puts "  Duplicates found:        #{duplicates}"
+  puts "  New to import:           #{to_import.size}"
+
+  if DRY_RUN
+    puts "\n  DRY RUN — no transactions will be created."
+    return
+  end
+
+  if to_import.empty?
+    puts "\n  All transactions already exist. Nothing to import."
+    return
+  end
+
+  print "\n  Proceed? (y/N): "
+  answer = $stdin.gets&.strip&.downcase
+  unless answer == "y"
+    puts "  Aborted."
+    return
+  end
+
+  created = 0
+  errors = 0
+
+  to_import.each_with_index do |txn, idx|
+    sure_account_id = account_mapping.dig(txn[:account_id], :sure_id)
+    sure_category_id = category_mapping.dig(txn[:category_id], :sure_id)
+
+    amount = milliunit_to_decimal(txn[:amount])
+    # YNAB: negative = outflow, positive = inflow
+    nature = amount < 0 ? "expense" : "income"
+
+    params = {
+      transaction: {
+        account_id: sure_account_id,
+        name: txn[:payee_name] || txn[:import_payee_name] || "YNAB Import",
+        amount: amount.abs.to_f,
+        date: txn[:date],
+        nature: nature,
+        notes: txn[:memo]
+      }.compact
+    }
+
+    params[:transaction][:category_id] = sure_category_id if sure_category_id
+
+    result = SureClient.post("/transactions", params)
+
+    if result[:error] && result[:status] == 429
+      puts "\n  Rate limited — waiting 5 seconds..."
+      sleep 5
+      result = SureClient.post("/transactions", params)
+    end
+
+    if result[:error]
+      errors += 1
+      $stderr.puts "  Error importing '#{params[:transaction][:name]}' (#{txn[:date]}): #{result[:message]}"
+    else
+      created += 1
+    end
+
+    # Progress
+    if (idx + 1) % 50 == 0
+      puts "  Progress: #{idx + 1}/#{to_import.size} (#{created} created, #{errors} errors)"
+    end
+  end
+
+  print_header("Results")
+  puts "\n  Created:  #{created}"
+  puts "  Errors:   #{errors}"
+  puts "  Skipped:  #{duplicates} (duplicates)"
+end
+
+# --- Main ---
+
+def main
+  puts "YNAB → Sure Sync"
+  puts "-" * 40
+  puts "YNAB Plan:     #{YNAB_PLAN_ID}"
+  puts "Sure URL:      #{SURE_BASE_URL}"
+  puts "Since date:    #{YNAB_SINCE_DATE || '(all)'}"
+  puts "Dry run:       #{DRY_RUN}"
+
+  # 1. Fetch data from both APIs
+  puts "\nFetching YNAB data..."
+  ynab_accounts = YnabClient.fetch_accounts
+  puts "  #{ynab_accounts.size} accounts"
+
+  ynab_categories = YnabClient.fetch_categories
+  cat_count = ynab_categories.sum { |g| g[:categories]&.reject { |c| c[:deleted] }&.size || 0 }
+  puts "  #{cat_count} categories in #{ynab_categories.size} groups"
+
+  ynab_transactions = YnabClient.fetch_transactions
+  puts "  #{ynab_transactions.size} transactions"
+
+  puts "\nFetching Sure data..."
+  sure_accounts = SureClient.fetch_accounts
+  puts "  #{sure_accounts.size} accounts"
+
+  sure_categories = SureClient.fetch_categories
+  puts "  #{sure_categories.size} categories"
+
+  # 2. Build mappings
+  account_mapping = build_account_mapping(ynab_accounts, sure_accounts)
+  category_mapping = build_category_mapping(ynab_categories, sure_categories)
+
+  # 3. Display mappings
+  print_account_mapping(account_mapping)
+  print_category_mapping(category_mapping)
+
+  # 4. Import transactions
+  import_transactions(ynab_transactions, account_mapping, category_mapping)
+end
+
+main

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -43,6 +43,9 @@ en:
         instructions: Select continue to parse your CSV and move on to the clean step.
       mint_import:
         date_format_label: Date format
+      ynab_import:
+        pre_configured: We have pre-configured your YNAB import for you. Outflow and Inflow columns will be merged automatically. Please proceed to the next step.
+        date_format_label: Date format
       rule_import:
         description: Configure your rule import. Rules will be created or updated based
           on the CSV data.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -398,10 +398,11 @@ Rails.application.routes.draw do
       patch "auth/enable_ai", to: "auth#enable_ai"
 
       # Production API endpoints
-      resources :accounts, only: [ :index, :show ]
-      resources :categories, only: [ :index, :show ]
-      resources :merchants, only: %i[index show]
+      resources :accounts, only: [ :index, :show, :create ]
+      resources :categories, only: [ :index, :show, :create, :update, :destroy ]
+      resources :merchants, only: %i[index show create]
       resources :tags, only: %i[index show create update destroy]
+      resources :transfers, only: [ :create ]
 
       resources :transactions, only: [ :index, :show, :create, :update, :destroy ]
       resources :trades, only: [ :index, :show, :create, :update, :destroy ]

--- a/test/controllers/api/v1/accounts_controller_test.rb
+++ b/test/controllers/api/v1/accounts_controller_test.rb
@@ -4,214 +4,99 @@ require "test_helper"
 
 class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:family_admin) # dylan_family user
-    @other_family_user = users(:family_member)
-    @other_family_user.update!(family: families(:empty))
-
-    @oauth_app = Doorkeeper::Application.create!(
-      name: "Test API App",
-      redirect_uri: "https://example.com/callback",
-      scopes: "read read_write"
-    )
+    @user = users(:family_admin)
+    @family = families(:dylan_family)
+    @api_key = api_keys(:active_key)
+    @read_key = api_keys(:read_only_key)
   end
 
-  test "should require authentication" do
-    get "/api/v1/accounts"
-    assert_response :unauthorized
+  test "can list accounts" do
+    get api_v1_accounts_url, headers: api_headers
+
+    assert_response :ok
 
     response_body = JSON.parse(response.body)
-    assert_equal "unauthorized", response_body["error"]
-  end
-
-  test "should require read_accounts scope" do
-  # TODO: Re-enable this test after fixing scope checking
-  skip "Scope checking temporarily disabled - needs configuration fix"
-
-  # Create token with wrong scope - using a non-existent scope to test rejection
-  access_token = Doorkeeper::AccessToken.create!(
-    application: @oauth_app,
-    resource_owner_id: @user.id,
-    scopes: "invalid_scope" # Wrong scope
-  )
-
-  get "/api/v1/accounts", params: {}, headers: {
-    "Authorization" => "Bearer #{access_token.token}"
-  }
-
-  assert_response :forbidden
-
-  # Doorkeeper returns a standard OAuth error response
-  response_body = JSON.parse(response.body)
-  assert_equal "insufficient_scope", response_body["error"]
-end
-
-  test "should return user's family accounts successfully" do
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
-    get "/api/v1/accounts", params: {}, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    # Should have accounts array
     assert response_body.key?("accounts")
     assert response_body["accounts"].is_a?(Array)
-
-    # Should have pagination metadata
-    assert response_body.key?("pagination")
-    assert response_body["pagination"].key?("page")
-    assert response_body["pagination"].key?("per_page")
-    assert response_body["pagination"].key?("total_count")
-    assert response_body["pagination"].key?("total_pages")
-
-    # All accounts should belong to user's family
-    response_body["accounts"].each do |account|
-      # We'll validate this by checking the user's family has these accounts
-      family_account_names = @user.family.accounts.pluck(:name)
-      assert_includes family_account_names, account["name"]
-    end
-  end
-
-  test "should only return active accounts" do
-    # Make one account inactive
-    inactive_account = accounts(:depository)
-    inactive_account.disable!
-
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
-    get "/api/v1/accounts", params: {}, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    # Should not include the inactive account
-    account_names = response_body["accounts"].map { |a| a["name"] }
-    assert_not_includes account_names, inactive_account.name
-  end
-
-  test "should not return other family's accounts" do
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @other_family_user.id,  # User from different family
-      scopes: "read"
-    )
-
-    get "/api/v1/accounts", params: {}, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    # Should return empty array since other family has no accounts in fixtures
-    assert_equal [], response_body["accounts"]
-    assert_equal 0, response_body["pagination"]["total_count"]
-  end
-
-  test "should handle pagination parameters" do
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
-    # Test with pagination params
-    get "/api/v1/accounts", params: { page: 1, per_page: 2 }, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    # Should respect per_page limit
-    assert response_body["accounts"].length <= 2
-    assert_equal 1, response_body["pagination"]["page"]
-    assert_equal 2, response_body["pagination"]["per_page"]
-  end
-
-  test "should return proper account data structure" do
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
-    get "/api/v1/accounts", params: {}, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    # Should have at least one account from fixtures
     assert response_body["accounts"].length > 0
+  end
 
-    account = response_body["accounts"].first
+  test "can show account" do
+    account = @family.accounts.visible.first
 
-    # Check required fields are present
-    required_fields = %w[id name balance currency classification account_type]
-    required_fields.each do |field|
-      assert account.key?(field), "Account should have #{field} field"
+    get api_v1_account_url(account), headers: api_headers
+
+    assert_response :ok
+
+    response_body = JSON.parse(response.body)
+    assert_equal account.id, response_body["id"]
+    assert_equal account.name, response_body["name"]
+    assert_equal account.currency, response_body["currency"]
+    assert response_body.key?("balance")
+    assert response_body.key?("classification")
+    assert response_body.key?("account_type")
+    assert response_body.key?("created_at")
+    assert response_body.key?("updated_at")
+  end
+
+  test "returns 404 for unknown account" do
+    get api_v1_account_url(id: SecureRandom.uuid), headers: api_headers
+
+    assert_response :not_found
+
+    response_body = JSON.parse(response.body)
+    assert_equal "not_found", response_body["error"]
+  end
+
+  test "can create account" do
+    assert_difference -> { @family.accounts.count }, 1 do
+      post api_v1_accounts_url,
+           params: { account: { name: "New Savings", accountable_type: "Depository", balance: 1000, currency: "USD" } },
+           headers: api_headers
     end
 
-    # Check data types
-    assert account["id"].is_a?(String), "ID should be string (UUID)"
-    assert account["name"].is_a?(String), "Name should be string"
-    assert account["balance"].is_a?(String), "Balance should be string (money)"
-    assert account["currency"].is_a?(String), "Currency should be string"
-    assert %w[asset liability].include?(account["classification"]), "Classification should be asset or liability"
-  end
+    assert_response :created
 
-  test "should handle invalid pagination parameters gracefully" do
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
-    # Test with invalid page number
-    get "/api/v1/accounts", params: { page: -1, per_page: "invalid" }, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
-
-    # Should still return success with default pagination
-    assert_response :success
     response_body = JSON.parse(response.body)
-
-    # Should have pagination info (with defaults applied)
-    assert response_body.key?("pagination")
-    assert response_body["pagination"]["page"] >= 1
-    assert response_body["pagination"]["per_page"] > 0
+    assert_equal "New Savings", response_body["name"]
+    assert_equal "USD", response_body["currency"]
+    assert_equal "depository", response_body["account_type"]
+    assert response_body.key?("id")
+    assert response_body.key?("balance")
   end
 
-  test "should sort accounts alphabetically" do
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
+  test "returns 422 for invalid account" do
+    assert_no_difference -> { @family.accounts.count } do
+      post api_v1_accounts_url,
+           params: { account: { accountable_type: "Depository" } },
+           headers: api_headers
+    end
 
-    get "/api/v1/accounts", params: {}, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
+    assert_response :unprocessable_entity
 
-    assert_response :success
     response_body = JSON.parse(response.body)
-
-    # Should be sorted alphabetically by name
-    account_names = response_body["accounts"].map { |a| a["name"] }
-    assert_equal account_names.sort, account_names
+    assert_equal "validation_failed", response_body["error"]
   end
+
+  test "requires read_write scope for create" do
+    assert_no_difference -> { @family.accounts.count } do
+      post api_v1_accounts_url,
+           params: { account: { name: "Blocked Account", accountable_type: "Depository" } },
+           headers: api_headers(@read_key)
+    end
+
+    assert_response :forbidden
+  end
+
+  test "requires authentication" do
+    get api_v1_accounts_url
+
+    assert_response :unauthorized
+  end
+
+  private
+
+    def api_headers(key = @api_key)
+      { "X-Api-Key" => key.display_key }
+    end
 end

--- a/test/controllers/api/v1/accounts_controller_test.rb
+++ b/test/controllers/api/v1/accounts_controller_test.rb
@@ -6,8 +6,8 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:family_admin)
     @family = families(:dylan_family)
-    @api_key = api_keys(:active_key)
-    @read_key = api_keys(:read_only_key)
+    @api_key = api_keys(:active_key) # pipelock:ignore Credential in URL
+    @read_key = api_keys(:read_only_key) # pipelock:ignore Credential in URL
   end
 
   test "can list accounts" do
@@ -46,6 +46,18 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
 
     response_body = JSON.parse(response.body)
     assert_equal "not_found", response_body["error"]
+  end
+
+  test "returns 404 for account from another family" do
+    other_family = families(:empty)
+    other_account = Account.create!(
+      family: other_family, name: "Other Account", currency: "USD",
+      balance: 100, accountable: Depository.new
+    )
+
+    get api_v1_account_url(other_account), headers: api_headers
+
+    assert_response :not_found
   end
 
   test "can create account" do
@@ -88,9 +100,22 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
-  test "requires authentication" do
+  test "requires authentication for index" do
     get api_v1_accounts_url
+    assert_response :unauthorized
+  end
 
+  test "requires authentication for show" do
+    account = @family.accounts.visible.first
+    get api_v1_account_url(account)
+    assert_response :unauthorized
+  end
+
+  test "requires authentication for create" do
+    assert_no_difference -> { @family.accounts.count } do
+      post api_v1_accounts_url,
+           params: { account: { name: "No Auth", accountable_type: "Depository" } }
+    end
     assert_response :unauthorized
   end
 

--- a/test/controllers/api/v1/categories_controller_test.rb
+++ b/test/controllers/api/v1/categories_controller_test.rb
@@ -4,46 +4,27 @@ require "test_helper"
 
 class Api::V1::CategoriesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:family_admin) # dylan_family user
-    @other_family_user = users(:family_member)
-    @other_family_user.update!(family: families(:empty))
+    @user = users(:family_admin)
+    @family = families(:dylan_family)
 
-    @oauth_app = Doorkeeper::Application.create!(
-      name: "Test API App",
-      redirect_uri: "https://example.com/callback",
-      scopes: "read read_write"
-    )
-
-    @access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
+    @api_key = api_keys(:active_key)
+    @read_key = api_keys(:read_only_key)
 
     @category = categories(:food_and_drink)
     @subcategory = categories(:subcategory)
   end
 
-  # Index action tests
+  # INDEX action tests
 
-  test "should require authentication" do
-    get "/api/v1/categories"
-    assert_response :unauthorized
-
-    response_body = JSON.parse(response.body)
-    assert_equal "unauthorized", response_body["error"]
-  end
-
-  test "should return user's family categories successfully" do
-    get "/api/v1/categories", params: {}, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
+  test "can list categories" do
+    get api_v1_categories_url, headers: api_headers(@api_key)
 
     assert_response :success
     response_body = JSON.parse(response.body)
 
     assert response_body.key?("categories")
     assert response_body["categories"].is_a?(Array)
+    assert response_body["categories"].length > 0
 
     assert response_body.key?("pagination")
     assert response_body["pagination"].key?("page")
@@ -52,140 +33,235 @@ class Api::V1::CategoriesControllerTest < ActionDispatch::IntegrationTest
     assert response_body["pagination"].key?("total_pages")
   end
 
-  test "should not return other family's categories" do
-    access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @other_family_user.id,
-      scopes: "read"
-    )
+  # SHOW action tests
 
-    get "/api/v1/categories", params: {}, headers: {
-      "Authorization" => "Bearer #{access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    # Should not include dylan_family's categories
-    category_names = response_body["categories"].map { |c| c["name"] }
-    assert_not_includes category_names, @category.name
-  end
-
-  test "should return proper category data structure" do
-    get "/api/v1/categories", params: {}, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    assert response_body["categories"].length > 0
-
-    category = response_body["categories"].find { |c| c["name"] == @category.name }
-    assert category.present?, "Should find the food_and_drink category"
-
-    required_fields = %w[id name color icon subcategories_count created_at updated_at]
-    required_fields.each do |field|
-      assert category.key?(field), "Category should have #{field} field"
-    end
-
-    assert category["id"].is_a?(String), "ID should be string (UUID)"
-    assert category["name"].is_a?(String), "Name should be string"
-    assert category["color"].is_a?(String), "Color should be string"
-    assert category["icon"].is_a?(String), "Icon should be string"
-  end
-
-  test "should include parent information for subcategories" do
-    get "/api/v1/categories", params: {}, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    subcategory = response_body["categories"].find { |c| c["name"] == @subcategory.name }
-    assert subcategory.present?, "Should find the subcategory"
-
-    assert subcategory["parent"].present?, "Subcategory should have parent"
-    assert_equal @category.id, subcategory["parent"]["id"]
-    assert_equal @category.name, subcategory["parent"]["name"]
-  end
-
-  test "should handle pagination parameters" do
-    get "/api/v1/categories", params: { page: 1, per_page: 2 }, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    assert response_body["categories"].length <= 2
-    assert_equal 1, response_body["pagination"]["page"]
-    assert_equal 2, response_body["pagination"]["per_page"]
-  end
-
-  test "should filter for roots only" do
-    get "/api/v1/categories", params: { roots_only: true }, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    response_body["categories"].each do |category|
-      assert_nil category["parent"], "Root categories should not have a parent"
-    end
-  end
-
-  test "should sort categories alphabetically" do
-    get "/api/v1/categories", params: {}, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
-
-    assert_response :success
-    response_body = JSON.parse(response.body)
-
-    category_names = response_body["categories"].map { |c| c["name"] }
-    assert_equal category_names.sort, category_names
-  end
-
-  # Show action tests
-
-  test "should return a single category" do
-    get "/api/v1/categories/#{@category.id}", params: {}, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
+  test "can show category" do
+    get api_v1_category_url(@category), headers: api_headers(@api_key)
 
     assert_response :success
     response_body = JSON.parse(response.body)
 
     assert_equal @category.id, response_body["id"]
     assert_equal @category.name, response_body["name"]
-    assert_equal @category.color, response_body["color"]
-    assert_equal @category.lucide_icon, response_body["icon"]
   end
 
-  test "should return 404 for non-existent category" do
-    get "/api/v1/categories/00000000-0000-0000-0000-000000000000", params: {}, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
+  # CREATE action tests
+
+  test "can create category" do
+    category_params = {
+      category: {
+        name: "New Test Category",
+        color: "#4da568",
+        lucide_icon: "shopping-cart"
+      }
     }
 
-    assert_response :not_found
+    assert_difference -> { @family.categories.count }, 1 do
+      post api_v1_categories_url,
+           params: category_params,
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+
     response_body = JSON.parse(response.body)
-    assert_equal "not_found", response_body["error"]
+    assert_equal "New Test Category", response_body["name"]
+    assert_equal "#4da568", response_body["color"]
+    assert_equal "shopping-cart", response_body["icon"]
+    assert_nil response_body["parent"]
   end
 
-  test "should not return category from another family" do
+  test "can create subcategory" do
+    category_params = {
+      category: {
+        name: "Fast Food",
+        parent_id: @category.id
+      }
+    }
+
+    assert_difference -> { @family.categories.count }, 1 do
+      post api_v1_categories_url,
+           params: category_params,
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+
+    response_body = JSON.parse(response.body)
+    assert_equal "Fast Food", response_body["name"]
+    assert response_body["parent"].present?
+    assert_equal @category.id, response_body["parent"]["id"]
+    assert_equal @category.name, response_body["parent"]["name"]
+  end
+
+  test "can create category with auto-assigned color and icon" do
+    category_params = {
+      category: {
+        name: "Groceries Test"
+      }
+    }
+
+    post api_v1_categories_url,
+         params: category_params,
+         headers: api_headers(@api_key)
+
+    assert_response :created
+
+    response_body = JSON.parse(response.body)
+    assert_equal "Groceries Test", response_body["name"]
+    assert response_body["color"].present?
+    assert response_body["icon"].present?
+  end
+
+  test "returns 422 for invalid category" do
+    category_params = {
+      category: {
+        color: "#4da568"
+        # Missing required name
+      }
+    }
+
+    assert_no_difference -> { @family.categories.count } do
+      post api_v1_categories_url,
+           params: category_params,
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :unprocessable_entity
+
+    response_body = JSON.parse(response.body)
+    assert_equal "validation_failed", response_body["error"]
+    assert response_body["errors"].is_a?(Array)
+  end
+
+  test "returns 422 for parent_id from another family" do
+    other_family_category = families(:empty).categories.create!(
+      name: "Other Family Cat",
+      color: "#FF0000",
+      lucide_icon: "shapes"
+    )
+
+    category_params = {
+      category: {
+        name: "Sneaky Subcategory",
+        parent_id: other_family_category.id
+      }
+    }
+
+    post api_v1_categories_url,
+         params: category_params,
+         headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+
+    response_body = JSON.parse(response.body)
+    assert_equal "validation_failed", response_body["error"]
+  end
+
+  test "requires read_write scope for create" do
+    category_params = {
+      category: {
+        name: "Should Fail",
+        color: "#4da568"
+      }
+    }
+
+    post api_v1_categories_url,
+         params: category_params,
+         headers: api_headers(@read_key)
+
+    assert_response :forbidden
+  end
+
+  # UPDATE action tests
+
+  test "can update category" do
+    new_name = "Updated Category Name"
+
+    patch api_v1_category_url(@category),
+          params: { category: { name: new_name } },
+          headers: api_headers(@api_key)
+
+    assert_response :success
+
+    response_body = JSON.parse(response.body)
+    assert_equal new_name, response_body["name"]
+    assert_equal @category.id, response_body["id"]
+  end
+
+  test "can partially update category" do
+    original_name = @category.name
+
+    patch api_v1_category_url(@category),
+          params: { category: { color: "#db5a54" } },
+          headers: api_headers(@api_key)
+
+    assert_response :success
+
+    response_body = JSON.parse(response.body)
+    assert_equal original_name, response_body["name"]
+    assert_equal "#db5a54", response_body["color"]
+  end
+
+  test "requires read_write scope for update" do
+    patch api_v1_category_url(@category),
+          params: { category: { name: "Should Fail" } },
+          headers: api_headers(@read_key)
+
+    assert_response :forbidden
+  end
+
+  test "returns 404 for updating non-existent category" do
+    patch api_v1_category_url(id: SecureRandom.uuid),
+          params: { category: { name: "Not Found" } },
+          headers: api_headers(@api_key)
+
+    assert_response :not_found
+  end
+
+  # DESTROY action tests
+
+  test "can delete category" do
+    category_to_delete = @family.categories.create!(
+      name: "Delete Me #{SecureRandom.hex(4)}",
+      color: "#c44fe9",
+      lucide_icon: "shapes"
+    )
+
+    assert_difference -> { @family.categories.count }, -1 do
+      delete api_v1_category_url(category_to_delete), headers: api_headers(@api_key)
+    end
+
+    assert_response :no_content
+  end
+
+  test "requires read_write scope for destroy" do
+    delete api_v1_category_url(@category), headers: api_headers(@read_key)
+
+    assert_response :forbidden
+  end
+
+  test "returns 404 for deleting non-existent category" do
+    delete api_v1_category_url(id: SecureRandom.uuid), headers: api_headers(@api_key)
+
+    assert_response :not_found
+  end
+
+  test "returns 404 for deleting category from another family" do
     other_family_category = families(:empty).categories.create!(
       name: "Other Family Category",
       color: "#FF0000",
-      classification_unused: "expense"
+      lucide_icon: "shapes"
     )
 
-    get "/api/v1/categories/#{other_family_category.id}", params: {}, headers: {
-      "Authorization" => "Bearer #{@access_token.token}"
-    }
+    delete api_v1_category_url(other_family_category), headers: api_headers(@api_key)
 
     assert_response :not_found
   end
+
+  private
+
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.display_key }
+    end
 end

--- a/test/controllers/api/v1/categories_controller_test.rb
+++ b/test/controllers/api/v1/categories_controller_test.rb
@@ -7,8 +7,8 @@ class Api::V1::CategoriesControllerTest < ActionDispatch::IntegrationTest
     @user = users(:family_admin)
     @family = families(:dylan_family)
 
-    @api_key = api_keys(:active_key)
-    @read_key = api_keys(:read_only_key)
+    @api_key = api_keys(:active_key) # pipelock:ignore Credential in URL
+    @read_key = api_keys(:read_only_key) # pipelock:ignore Credential in URL
 
     @category = categories(:food_and_drink)
     @subcategory = categories(:subcategory)
@@ -156,6 +156,13 @@ class Api::V1::CategoriesControllerTest < ActionDispatch::IntegrationTest
 
     response_body = JSON.parse(response.body)
     assert_equal "validation_failed", response_body["error"]
+  end
+
+  test "create requires authentication" do
+    post api_v1_categories_url,
+         params: { category: { name: "No Auth" } }
+
+    assert_response :unauthorized
   end
 
   test "requires read_write scope for create" do

--- a/test/controllers/api/v1/merchants_controller_test.rb
+++ b/test/controllers/api/v1/merchants_controller_test.rb
@@ -12,8 +12,8 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal @user.family_id, @other_family_user.family_id,
       "Test setup error: @other_family_user must belong to a different family"
 
-    @api_key = api_keys(:active_key)
-    @read_only_api_key = api_keys(:read_only_key)
+    @api_key = api_keys(:active_key) # pipelock:ignore Credential in URL
+    @read_only_api_key = api_keys(:read_only_key) # pipelock:ignore Credential in URL
 
     @merchant = @family.merchants.first || @family.merchants.create!(
       name: "Test Merchant"
@@ -113,7 +113,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
 
     assert_difference -> { @family.merchants.count }, 1 do
       post api_v1_merchants_url,
-           params: { merchant: { name: merchant_name, color: "#e99537" } },
+           params: { merchant: { name: merchant_name, color: "#123456" } },
            headers: api_headers(@api_key)
     end
 
@@ -121,7 +121,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
 
     merchant = JSON.parse(response.body)
     assert_equal merchant_name, merchant["name"]
-    assert merchant["color"].present?
+    assert_equal "#123456", merchant["color"]
     assert_equal "FamilyMerchant", merchant["type"]
   end
 
@@ -165,7 +165,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   test "create fails without name" do
     assert_no_difference -> { @family.merchants.count } do
       post api_v1_merchants_url,
-           params: { merchant: { color: "#e99537" } },
+           params: { merchant: { color: "#123456" } },
            headers: api_headers(@api_key)
     end
 

--- a/test/controllers/api/v1/merchants_controller_test.rb
+++ b/test/controllers/api/v1/merchants_controller_test.rb
@@ -5,25 +5,17 @@ require "test_helper"
 class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:family_admin)
+    @family = @user.family
     @other_family_user = users(:empty)
 
     # Verify cross-family isolation setup is correct
     assert_not_equal @user.family_id, @other_family_user.family_id,
       "Test setup error: @other_family_user must belong to a different family"
 
-    @oauth_app = Doorkeeper::Application.create!(
-      name: "Test App",
-      redirect_uri: "https://example.com/callback",
-      scopes: "read"
-    )
+    @api_key = api_keys(:active_key)
+    @read_only_api_key = api_keys(:read_only_key)
 
-    @access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
-    @merchant = @user.family.merchants.first || @user.family.merchants.create!(
+    @merchant = @family.merchants.first || @family.merchants.create!(
       name: "Test Merchant"
     )
   end
@@ -36,7 +28,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index returns user's family merchants successfully" do
-    get api_v1_merchants_url, headers: auth_headers
+    get api_v1_merchants_url, headers: api_headers(@api_key)
 
     assert_response :success
 
@@ -51,11 +43,16 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
     assert merchant.key?("updated_at")
   end
 
+  test "index works with read-only API key" do
+    get api_v1_merchants_url, headers: api_headers(@read_only_api_key)
+
+    assert_response :success
+  end
+
   test "index does not return merchants from other families" do
-    # Create a merchant in another family
     other_merchant = @other_family_user.family.merchants.create!(name: "Other Merchant")
 
-    get api_v1_merchants_url, headers: auth_headers
+    get api_v1_merchants_url, headers: api_headers(@api_key)
 
     assert_response :success
     merchants = JSON.parse(response.body)
@@ -73,7 +70,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show returns merchant successfully" do
-    get api_v1_merchant_url(@merchant), headers: auth_headers
+    get api_v1_merchant_url(@merchant), headers: api_headers(@api_key)
 
     assert_response :success
 
@@ -83,7 +80,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show returns 404 for non-existent merchant" do
-    get api_v1_merchant_url(id: SecureRandom.uuid), headers: auth_headers
+    get api_v1_merchant_url(id: SecureRandom.uuid), headers: api_headers(@api_key)
 
     assert_response :not_found
   end
@@ -91,14 +88,93 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   test "show returns 404 for merchant from another family" do
     other_merchant = @other_family_user.family.merchants.create!(name: "Other Merchant")
 
-    get api_v1_merchant_url(other_merchant), headers: auth_headers
+    get api_v1_merchant_url(other_merchant), headers: api_headers(@api_key)
 
     assert_response :not_found
   end
 
+  # Create action tests
+  test "create requires authentication" do
+    post api_v1_merchants_url, params: { merchant: { name: "New Merchant" } }
+
+    assert_response :unauthorized
+  end
+
+  test "create requires read_write scope" do
+    post api_v1_merchants_url,
+         params: { merchant: { name: "New Merchant" } },
+         headers: api_headers(@read_only_api_key)
+
+    assert_response :forbidden
+  end
+
+  test "create merchant successfully" do
+    merchant_name = "New Merchant #{SecureRandom.hex(4)}"
+
+    assert_difference -> { @family.merchants.count }, 1 do
+      post api_v1_merchants_url,
+           params: { merchant: { name: merchant_name, color: "#e99537" } },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+
+    merchant = JSON.parse(response.body)
+    assert_equal merchant_name, merchant["name"]
+    assert merchant["color"].present?
+    assert_equal "FamilyMerchant", merchant["type"]
+  end
+
+  test "create merchant with auto-assigned color" do
+    merchant_name = "Auto Color Merchant #{SecureRandom.hex(4)}"
+
+    post api_v1_merchants_url,
+         params: { merchant: { name: merchant_name } },
+         headers: api_headers(@api_key)
+
+    assert_response :created
+
+    merchant = JSON.parse(response.body)
+    assert_equal merchant_name, merchant["name"]
+    assert merchant["color"].present?
+    assert_includes FamilyMerchant::COLORS, merchant["color"]
+  end
+
+  test "create merchant with website_url" do
+    merchant_name = "Website Merchant #{SecureRandom.hex(4)}"
+
+    post api_v1_merchants_url,
+         params: { merchant: { name: merchant_name, website_url: "https://example.com" } },
+         headers: api_headers(@api_key)
+
+    assert_response :created
+
+    merchant = JSON.parse(response.body)
+    assert_equal merchant_name, merchant["name"]
+    assert_equal "https://example.com", merchant["website_url"]
+  end
+
+  test "create fails with duplicate name in same family" do
+    post api_v1_merchants_url,
+         params: { merchant: { name: @merchant.name } },
+         headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+  end
+
+  test "create fails without name" do
+    assert_no_difference -> { @family.merchants.count } do
+      post api_v1_merchants_url,
+           params: { merchant: { color: "#e99537" } },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   private
 
-    def auth_headers
-      { "Authorization" => "Bearer #{@access_token.token}" }
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.display_key }
     end
 end

--- a/test/controllers/api/v1/transfers_controller_test.rb
+++ b/test/controllers/api/v1/transfers_controller_test.rb
@@ -7,8 +7,8 @@ class Api::V1::TransfersControllerTest < ActionDispatch::IntegrationTest
     @user = users(:family_admin)
     @family = families(:dylan_family)
 
-    @rw_api_key = api_keys(:active_key)
-    @ro_api_key = api_keys(:read_only_key)
+    @rw_api_key = api_keys(:active_key) # pipelock:ignore Credential in URL
+    @ro_api_key = api_keys(:read_only_key) # pipelock:ignore Credential in URL
 
     @source_account = accounts(:depository)
     @destination_account = accounts(:credit_card)
@@ -73,61 +73,113 @@ class Api::V1::TransfersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create returns 404 for non-existent source account" do
-    post api_v1_transfers_url,
-         params: {
-           transfer: {
-             source_account_id: SecureRandom.uuid,
-             destination_account_id: @destination_account.id,
-             date: Date.current.to_s,
-             amount: "100.00"
-           }
-         },
-         headers: api_headers(@rw_api_key)
+    assert_no_difference -> { Transfer.count } do
+      post api_v1_transfers_url,
+           params: {
+             transfer: {
+               source_account_id: SecureRandom.uuid,
+               destination_account_id: @destination_account.id,
+               date: Date.current.to_s,
+               amount: "100.00"
+             }
+           },
+           headers: api_headers(@rw_api_key)
+    end
 
     assert_response :not_found
   end
 
   test "create returns 404 for non-existent destination account" do
-    post api_v1_transfers_url,
-         params: {
-           transfer: {
-             source_account_id: @source_account.id,
-             destination_account_id: SecureRandom.uuid,
-             date: Date.current.to_s,
-             amount: "100.00"
-           }
-         },
-         headers: api_headers(@rw_api_key)
+    assert_no_difference -> { Transfer.count } do
+      post api_v1_transfers_url,
+           params: {
+             transfer: {
+               source_account_id: @source_account.id,
+               destination_account_id: SecureRandom.uuid,
+               date: Date.current.to_s,
+               amount: "100.00"
+             }
+           },
+           headers: api_headers(@rw_api_key)
+    end
+
+    assert_response :not_found
+  end
+
+  test "create returns 404 for destination account from another family" do
+    other_account = Account.create!(
+      family: families(:empty), name: "Other Account", currency: "USD",
+      balance: 100, accountable: Depository.new
+    )
+
+    assert_no_difference -> { Transfer.count } do
+      post api_v1_transfers_url,
+           params: {
+             transfer: {
+               source_account_id: @source_account.id,
+               destination_account_id: other_account.id,
+               date: Date.current.to_s,
+               amount: "100.00"
+             }
+           },
+           headers: api_headers(@rw_api_key)
+    end
+
+    assert_response :not_found
+  end
+
+  test "create returns 404 for source account from another family" do
+    other_account = Account.create!(
+      family: families(:empty), name: "Other Account", currency: "USD",
+      balance: 100, accountable: Depository.new
+    )
+
+    assert_no_difference -> { Transfer.count } do
+      post api_v1_transfers_url,
+           params: {
+             transfer: {
+               source_account_id: other_account.id,
+               destination_account_id: @destination_account.id,
+               date: Date.current.to_s,
+               amount: "100.00"
+             }
+           },
+           headers: api_headers(@rw_api_key)
+    end
 
     assert_response :not_found
   end
 
   test "create returns 422 for invalid date" do
-    post api_v1_transfers_url,
-         params: {
-           transfer: {
-             source_account_id: @source_account.id,
-             destination_account_id: @destination_account.id,
-             date: "not-a-date",
-             amount: "100.00"
-           }
-         },
-         headers: api_headers(@rw_api_key)
+    assert_no_difference -> { Transfer.count } do
+      post api_v1_transfers_url,
+           params: {
+             transfer: {
+               source_account_id: @source_account.id,
+               destination_account_id: @destination_account.id,
+               date: "not-a-date",
+               amount: "100.00"
+             }
+           },
+           headers: api_headers(@rw_api_key)
+    end
 
     assert_response :unprocessable_entity
   end
 
   test "create returns 422 for same source and destination account" do
-    post api_v1_transfers_url,
-         params: {
-           transfer: {
-             source_account_id: @source_account.id,
-             destination_account_id: @source_account.id,
-             date: Date.current.to_s,
-             amount: "100.00"
-           }
-         },
-         headers: api_headers(@rw_api_key)
+    assert_no_difference -> { Transfer.count } do
+      post api_v1_transfers_url,
+           params: {
+             transfer: {
+               source_account_id: @source_account.id,
+               destination_account_id: @source_account.id,
+               date: Date.current.to_s,
+               amount: "100.00"
+             }
+           },
+           headers: api_headers(@rw_api_key)
+    end
 
     assert_response :unprocessable_entity
   end

--- a/test/controllers/api/v1/transfers_controller_test.rb
+++ b/test/controllers/api/v1/transfers_controller_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::TransfersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = families(:dylan_family)
+
+    @rw_api_key = api_keys(:active_key)
+    @ro_api_key = api_keys(:read_only_key)
+
+    @source_account = accounts(:depository)
+    @destination_account = accounts(:credit_card)
+  end
+
+  # Create action tests
+  test "create requires authentication" do
+    post api_v1_transfers_url, params: {
+      transfer: {
+        source_account_id: @source_account.id,
+        destination_account_id: @destination_account.id,
+        date: Date.current.to_s,
+        amount: "100.00"
+      }
+    }
+
+    assert_response :unauthorized
+  end
+
+  test "create requires read_write scope" do
+    post api_v1_transfers_url,
+         params: {
+           transfer: {
+             source_account_id: @source_account.id,
+             destination_account_id: @destination_account.id,
+             date: Date.current.to_s,
+             amount: "100.00"
+           }
+         },
+         headers: api_headers(@ro_api_key)
+
+    assert_response :forbidden
+  end
+
+  test "create transfer successfully" do
+    assert_difference -> { Transfer.count }, 1 do
+      post api_v1_transfers_url,
+           params: {
+             transfer: {
+               source_account_id: @source_account.id,
+               destination_account_id: @destination_account.id,
+               date: Date.current.to_s,
+               amount: "150.00"
+             }
+           },
+           headers: api_headers(@rw_api_key)
+    end
+
+    assert_response :created
+
+    transfer = JSON.parse(response.body)
+    assert transfer["id"].present?
+    assert_equal @source_account.id, transfer["source_account"]["id"]
+    assert_equal @source_account.name, transfer["source_account"]["name"]
+    assert_equal @destination_account.id, transfer["destination_account"]["id"]
+    assert_equal @destination_account.name, transfer["destination_account"]["name"]
+    assert_equal Date.current.to_s, transfer["date"]
+    assert_equal "150.0", transfer["amount"]
+    assert_equal "confirmed", transfer["status"]
+    assert transfer["created_at"].present?
+    assert transfer["updated_at"].present?
+  end
+
+  test "create returns 404 for non-existent source account" do
+    post api_v1_transfers_url,
+         params: {
+           transfer: {
+             source_account_id: SecureRandom.uuid,
+             destination_account_id: @destination_account.id,
+             date: Date.current.to_s,
+             amount: "100.00"
+           }
+         },
+         headers: api_headers(@rw_api_key)
+
+    assert_response :not_found
+  end
+
+  test "create returns 404 for non-existent destination account" do
+    post api_v1_transfers_url,
+         params: {
+           transfer: {
+             source_account_id: @source_account.id,
+             destination_account_id: SecureRandom.uuid,
+             date: Date.current.to_s,
+             amount: "100.00"
+           }
+         },
+         headers: api_headers(@rw_api_key)
+
+    assert_response :not_found
+  end
+
+  test "create returns 422 for invalid date" do
+    post api_v1_transfers_url,
+         params: {
+           transfer: {
+             source_account_id: @source_account.id,
+             destination_account_id: @destination_account.id,
+             date: "not-a-date",
+             amount: "100.00"
+           }
+         },
+         headers: api_headers(@rw_api_key)
+
+    assert_response :unprocessable_entity
+  end
+
+  test "create returns 422 for same source and destination account" do
+    post api_v1_transfers_url,
+         params: {
+           transfer: {
+             source_account_id: @source_account.id,
+             destination_account_id: @source_account.id,
+             date: Date.current.to_s,
+             amount: "100.00"
+           }
+         },
+         headers: api_headers(@rw_api_key)
+
+    assert_response :unprocessable_entity
+  end
+
+  private
+
+    def api_headers(key)
+      { "X-Api-Key" => key.display_key }
+    end
+end

--- a/test/controllers/api/v1/transfers_controller_test.rb
+++ b/test/controllers/api/v1/transfers_controller_test.rb
@@ -150,6 +150,27 @@ class Api::V1::TransfersControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "create returns 404 for account from another family" do
+    other_family = families(:empty)
+    other_account = Account.create!(
+      family: other_family, name: "Other Account", currency: "USD",
+      balance: 100, accountable: Depository.new
+    )
+
+    post api_v1_transfers_url,
+         params: {
+           transfer: {
+             source_account_id: @source_account.id,
+             destination_account_id: other_account.id,
+             date: Date.current.to_s,
+             amount: "100.00"
+           }
+         },
+         headers: api_headers(@rw_api_key)
+
+    assert_response :not_found
+  end
+
   test "create returns 422 for invalid date" do
     assert_no_difference -> { Transfer.count } do
       post api_v1_transfers_url,

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -34,8 +34,9 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "button", text: "Import investments", count: 0
     assert_select "button", text: "Import from Mint", count: 1
     assert_select "button", text: "Import from Quicken (QIF)", count: 1
+    assert_select "button", text: "Import from YNAB", count: 1
     assert_select "span", text: "Import accounts first to unlock this option.", count: 2
-    assert_select "div[aria-disabled=true]", count: 3
+    assert_select "div[aria-disabled=true]", count: 2
   end
 
   test "creates import" do

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -27,6 +27,14 @@ revoked_key:
   expires_at: null
   revoked_at: <%= 1.hour.ago %>
 
+read_only_key:
+  display_key: "test_read_only_key_123"
+  name: "Read Only API Key"
+  user: family_admin
+  scopes: [ "read" ]
+  expires_at: <%= 1.year.from_now %>
+  source: "mobile"
+
 one:
   id: <%= SecureRandom.uuid %>
   user: family_admin

--- a/test/fixtures/files/imports/ynab.csv
+++ b/test/fixtures/files/imports/ynab.csv
@@ -1,0 +1,5 @@
+"Account","Flag","Date","Payee","Category Group/Category","Category Group","Category","Memo","Outflow","Inflow","Cleared"
+"Checking","","01/15/2024","Grocery Store","Immediate Obligations: Groceries","Immediate Obligations","Groceries","Weekly groceries","$78.32","$0.00","Cleared"
+"Checking","","01/16/2024","ACME Corp","Income: Salary","Income","Salary","Bi-weekly paycheck","$0.00","$2,500.00","Cleared"
+"Credit Card","","01/17/2024","Coffee Shop","Quality of Life: Dining Out","Quality of Life","Dining Out","Morning coffee","$4.25","$0.00","Uncleared"
+"Checking","","01/18/2024","[Transfer: Credit Card]","","","","Payment to credit card","$200.00","$0.00","Cleared"

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -13,6 +13,11 @@ account:
   type: AccountImport
   status: pending
 
+ynab:
+  family: dylan_family
+  type: YnabImport
+  status: pending
+
 pdf:
   family: dylan_family
   type: PdfImport

--- a/test/models/ynab_import_test.rb
+++ b/test/models/ynab_import_test.rb
@@ -1,0 +1,141 @@
+require "test_helper"
+
+class YnabImportTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper, ImportInterfaceTest
+
+  setup do
+    @subject = @import = imports(:ynab)
+  end
+
+  test "auto-configures column mappings on create" do
+    import = Import.create!(
+      type: "YnabImport",
+      family: families(:dylan_family)
+    )
+
+    assert_equal "Date", import.date_col_label
+    assert_equal "%m/%d/%Y", import.date_format
+    assert_equal "Payee", import.name_col_label
+    assert_equal "Account", import.account_col_label
+    assert_equal "Category", import.category_col_label
+    assert_equal "Memo", import.notes_col_label
+    assert_equal "inflows_negative", import.signage_convention
+  end
+
+  test "computes signed amount from outflow and inflow columns" do
+    import = load_ynab_import
+
+    rows = import.rows.order(:date)
+
+    # Outflow $78.32 → positive (expense in Sure)
+    assert_equal "78.32", rows[0].amount
+
+    # Inflow $2,500.00 → negative (income in Sure)
+    assert_equal "-2500.0", rows[1].amount
+
+    # Outflow $4.25 → positive
+    assert_equal "4.25", rows[2].amount
+
+    # Outflow $200.00 (transfer)
+    assert_equal "200.0", rows[3].amount
+  end
+
+  test "maps payee to name and memo to notes" do
+    import = load_ynab_import
+
+    rows = import.rows.order(:date)
+
+    assert_equal "Grocery Store", rows[0].name
+    assert_equal "Weekly groceries", rows[0].notes
+    assert_equal "ACME Corp", rows[1].name
+    assert_equal "Bi-weekly paycheck", rows[1].notes
+  end
+
+  test "maps category and account columns" do
+    import = load_ynab_import
+
+    rows = import.rows.order(:date)
+
+    assert_equal "Groceries", rows[0].category
+    assert_equal "Checking", rows[0].account
+    assert_equal "Salary", rows[1].category
+    assert_equal "Checking", rows[1].account
+    assert_equal "Dining Out", rows[2].category
+    assert_equal "Credit Card", rows[2].account
+  end
+
+  test "imports full YNAB export with accounts, categories, and transactions" do
+    import = load_ynab_import
+
+    # Set up mappings
+    import.mappings.create! key: "Groceries", create_when_empty: true, type: "Import::CategoryMapping"
+    import.mappings.create! key: "Salary", create_when_empty: true, type: "Import::CategoryMapping"
+    import.mappings.create! key: "Dining Out", create_when_empty: true, type: "Import::CategoryMapping"
+    import.mappings.create! key: "", create_when_empty: false, mappable: nil, type: "Import::CategoryMapping"
+    import.mappings.create! key: "Checking", mappable: accounts(:depository), type: "Import::AccountMapping"
+    import.mappings.create! key: "Credit Card", mappable: accounts(:credit_card), type: "Import::AccountMapping"
+
+    assert_difference "Entry.count", 4 do
+      import.publish
+    end
+
+    assert import.complete?
+  end
+
+  test "handles amounts with dollar signs and comma separators" do
+    configure_ynab_mappings(@import)
+
+    csv = <<~CSV
+      "Account","Flag","Date","Payee","Category Group/Category","Category Group","Category","Memo","Outflow","Inflow","Cleared"
+      "Checking","","01/15/2024","Large Purchase","Bills: Rent","Bills","Rent","Monthly rent","$1,250.00","$0.00","Cleared"
+      "Checking","","01/16/2024","Employer","Income: Salary","Income","Salary","Paycheck","$0.00","$5,432.10","Cleared"
+    CSV
+
+    @import.update!(raw_file_str: csv)
+    @import.generate_rows_from_csv
+    @import.reload
+
+    rows = @import.rows.order(:date)
+
+    assert_equal "1250.0", rows[0].amount
+    assert_equal "-5432.1", rows[1].amount
+  end
+
+  test "handles rows where both outflow and inflow are zero" do
+    configure_ynab_mappings(@import)
+
+    csv = <<~CSV
+      "Account","Flag","Date","Payee","Category Group/Category","Category Group","Category","Memo","Outflow","Inflow","Cleared"
+      "Checking","","01/15/2024","Zero Transaction","","","","Test","$0.00","$0.00","Cleared"
+    CSV
+
+    @import.update!(raw_file_str: csv)
+    @import.generate_rows_from_csv
+    @import.reload
+
+    assert_equal "0.0", @import.rows.first.amount
+  end
+
+  private
+    def configure_ynab_mappings(import)
+      import.update!(
+        date_col_label: "Date",
+        date_format: "%m/%d/%Y",
+        name_col_label: "Payee",
+        amount_col_label: "Outflow",
+        account_col_label: "Account",
+        category_col_label: "Category",
+        notes_col_label: "Memo",
+        signage_convention: "inflows_negative"
+      )
+    end
+
+    def load_ynab_import
+      configure_ynab_mappings(@import)
+      csv_content = file_fixture("imports/ynab.csv").read
+      @import.update!(raw_file_str: csv_content)
+      @import.generate_rows_from_csv
+      @import.reload
+      @import
+    end
+end


### PR DESCRIPTION
## Summary

- Add `bin/ynab_sync` script for direct YNAB API migration into Sure
- Use BigDecimal for milliunit conversion to preserve 3-decimal currency precision (JOD, KWD)
- Strengthen dedup fingerprint with payee name to avoid collisions on same-day, same-amount purchases

Depends on #1370 (3 of 3 PRs for #1255)

## Details

**API Sync Script (`bin/ynab_sync`):**
- Connects to YNAB API (`/plans/{id}/accounts`, `/categories`, `/transactions`)
- Maps YNAB milliunits to decimal amounts with `nature` param
- Auto-maps accounts and categories by name (exact, then case-insensitive)
- Skips transfers, supports `DRY_RUN`, `YNAB_SINCE_DATE`, rate limit backoff
- Usage: `YNAB_TOKEN=xxx SURE_API_KEY=xxx ruby bin/ynab_sync`

## Test plan

- [ ] `DRY_RUN=true YNAB_TOKEN=xxx SURE_API_KEY=xxx ruby bin/ynab_sync` — preview mode works
- [ ] `bin/rails test` — full test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Create, update, and delete accounts, categories, and merchants via API
  * New transfer functionality to move funds between accounts
  * YNAB import support with automatic column mapping and CSV parsing
  * YNAB data synchronization utility for bulk account and transaction imports

* **Tests**
  * Updated API authentication tests to use API key credentials
  * Added comprehensive test coverage for transfers and YNAB import workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->