### PR TITLE
fix: resolve flaky chats system test race condition

### DIFF
--- a/test/system/chats_test.rb
+++ b/test/system/chats_test.rb
@@ -32,17 +32,23 @@ class ChatsTest < ApplicationSystemTestCase
   test "sidebar shows last viewed chat" do
     with_env_overrides OPENAI_ACCESS_TOKEN: "test-token" do
       @user.update!(ai_enabled: true)
+      chat_title = @user.chats.first.title
 
       visit root_url
 
-      click_on @user.chats.first.title
+      click_on chat_title
+
+      # Wait for the chat to actually load before refreshing
+      within "#chat-container" do
+        assert_selector "h1", text: chat_title
+      end
 
       # Page refresh
       visit root_url
 
       # After page refresh, we're still on the last chat we were viewing
       within "#chat-container" do
-        assert_selector "h1", text: @user.chats.first.title
+        assert_selector "h1", text: chat_title
       end
     end
   end


### PR DESCRIPTION
## Summary
- Fixes intermittent failure in `ChatsTest#test_sidebar_shows_last_viewed_chat` caused by a race condition
- After `click_on` triggers a Turbo frame navigation, the test now waits for the chat to fully load before issuing `visit root_url`, ensuring `last_viewed_chat` is persisted server-side
- Without this gate assertion, the page refresh could fire before the Turbo frame request completed, so `last_viewed_chat` was never set and the sidebar showed "Chats" instead of the expected chat title

## Test plan
- [x] CI system tests pass consistently (this test was failing ~50% of runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced "sidebar shows last viewed chat" test with improved wait conditions and assertions to ensure reliable verification of the last viewed chat functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->