### PR TITLE
feat: opening_balance_date and opening_balance(i18n)

### DIFF
--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -18,7 +18,7 @@
     <% if account.new_record? && !account.linked? %>
       <%= form.date_field :opening_balance_date,
           label: t(".opening_balance_date_label"),
-          value: Time.zone.today - 2.years,
+          value: Time.zone.today,
           required: true %>
     <% end %>
 

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -18,7 +18,7 @@
     <% if account.new_record? && !account.linked? %>
       <%= form.date_field :opening_balance_date,
           label: t(".opening_balance_date_label"),
-          value: Time.zone.today,
+          value: Time.zone.today - 2.years,
           required: true %>
     <% end %>
 

--- a/app/views/valuations/_header.html.erb
+++ b/app/views/valuations/_header.html.erb
@@ -2,7 +2,8 @@
 
 <%= tag.header class: "mb-4 space-y-1", id: dom_id(entry, :header) do %>
   <span class="text-secondary text-sm">
-    <%= entry.name %>
+    <% valuation = entry.entryable %>
+    <%= valuation.respond_to?(:opening_anchor?) && valuation.opening_anchor? ? t("valuations.show.opening_balance") : entry.name %>
   </span>
 
   <div class="flex items-center gap-4">

--- a/app/views/valuations/_valuation.html.erb
+++ b/app/views/valuations/_valuation.html.erb
@@ -17,10 +17,12 @@
           <%= render DS::FilledIcon.new(icon: icon, size: "md", hex_color: color, rounded: true) %>
 
           <div class="truncate text-primary">
-            <%= link_to entry.name,
-                        entry_path(entry),
-                        data: { turbo_frame: "drawer", turbo_prefetch: false },
-                        class: "hover:underline" %>
+            <%= link_to(
+                  valuation.opening_anchor? ? t("valuations.show.opening_balance") : entry.name,
+                  entry_path(entry),
+                  data: { turbo_frame: "drawer", turbo_prefetch: false },
+                  class: "hover:underline"
+                ) %>
           </div>
         </div>
       </div>

--- a/config/locales/views/valuations/de.yml
+++ b/config/locales/views/valuations/de.yml
@@ -28,3 +28,4 @@ de:
       note_placeholder: Füge zusätzliche Details zu diesem Eintrag hinzu
       overview: Übersicht
       settings: Einstellungen
+      opening_balance: Eröffnungssaldo

--- a/config/locales/views/valuations/en.yml
+++ b/config/locales/views/valuations/en.yml
@@ -28,3 +28,4 @@ en:
       note_placeholder: Add any additional details about this entry
       overview: Overview
       settings: Settings
+      opening_balance: "Opening balance"

--- a/config/locales/views/valuations/es.yml
+++ b/config/locales/views/valuations/es.yml
@@ -28,4 +28,4 @@ es:
       note_placeholder: Añade cualquier detalle adicional sobre esta entrada
       overview: Resumen
       settings: Configuración
-  opening_balance: Saldo inicial
+      opening_balance: Saldo inicial

--- a/config/locales/views/valuations/es.yml
+++ b/config/locales/views/valuations/es.yml
@@ -28,3 +28,4 @@ es:
       note_placeholder: Añade cualquier detalle adicional sobre esta entrada
       overview: Resumen
       settings: Configuración
+  opening_balance: Saldo inicial

--- a/config/locales/views/valuations/fr.yml
+++ b/config/locales/views/valuations/fr.yml
@@ -28,3 +28,4 @@ fr:
       note_placeholder: Ajoutez tout détail supplémentaire à ce bilan
       overview: Aperçu
       settings: Paramètres
+      opening_balance: Solde d'ouverture

--- a/config/locales/views/valuations/nb.yml
+++ b/config/locales/views/valuations/nb.yml
@@ -28,3 +28,4 @@ nb:
       note_placeholder: Legg til eventuelle tilleggsdetaljer om denne oppføringen
       overview: Oversikt
       settings: Innstillinger
+      opening_balance: Startsaldo

--- a/config/locales/views/valuations/nl.yml
+++ b/config/locales/views/valuations/nl.yml
@@ -28,3 +28,4 @@ nl:
       note_placeholder: Voeg eventuele aanvullende details toe over deze invoer
       overview: Overzicht
       settings: Instellingen
+      opening_balance: Beginsaldo

--- a/config/locales/views/valuations/pt-BR.yml
+++ b/config/locales/views/valuations/pt-BR.yml
@@ -28,3 +28,4 @@ pt-BR:
       note_placeholder: Adicione detalhes adicionais sobre esta entrada
       overview: Visão geral
       settings: Configurações
+  opening_balance: Saldo inicial

--- a/config/locales/views/valuations/pt-BR.yml
+++ b/config/locales/views/valuations/pt-BR.yml
@@ -28,4 +28,4 @@ pt-BR:
       note_placeholder: Adicione detalhes adicionais sobre esta entrada
       overview: Visão geral
       settings: Configurações
-  opening_balance: Saldo inicial
+      opening_balance: Saldo inicial

--- a/config/locales/views/valuations/ro.yml
+++ b/config/locales/views/valuations/ro.yml
@@ -24,4 +24,4 @@ ro:
       note_placeholder: Adaugă orice detalii suplimentare despre această înregistrare
       overview: Prezentare generală
       settings: Setări
-  opening_balance: Sold inițial
+      opening_balance: Sold inițial

--- a/config/locales/views/valuations/ro.yml
+++ b/config/locales/views/valuations/ro.yml
@@ -24,3 +24,4 @@ ro:
       note_placeholder: Adaugă orice detalii suplimentare despre această înregistrare
       overview: Prezentare generală
       settings: Setări
+  opening_balance: Sold inițial

--- a/config/locales/views/valuations/tr.yml
+++ b/config/locales/views/valuations/tr.yml
@@ -28,4 +28,4 @@ tr:
       note_placeholder: Bu girişle ilgili ek detaylar ekleyin
       overview: Genel Bakış
       settings: Ayarlar
-  opening_balance: Açılış bakiyesi
+      opening_balance: Açılış bakiyesi

--- a/config/locales/views/valuations/tr.yml
+++ b/config/locales/views/valuations/tr.yml
@@ -28,3 +28,4 @@ tr:
       note_placeholder: Bu girişle ilgili ek detaylar ekleyin
       overview: Genel Bakış
       settings: Ayarlar
+  opening_balance: Açılış bakiyesi

--- a/config/locales/views/valuations/zh-CN.yml
+++ b/config/locales/views/valuations/zh-CN.yml
@@ -30,3 +30,4 @@ zh-CN:
       note_placeholder: 添加此记录的其他详细信息
       overview: 概览
       settings: 设置
+      opening_balance: 初始余额

--- a/config/locales/views/valuations/zh-TW.yml
+++ b/config/locales/views/valuations/zh-TW.yml
@@ -28,3 +28,4 @@ zh-TW:
       note_placeholder: 加入關於此紀錄的額外資訊
       overview: 概覽
       settings: 設定
+  opening_balance: 初始餘額

--- a/config/locales/views/valuations/zh-TW.yml
+++ b/config/locales/views/valuations/zh-TW.yml
@@ -28,4 +28,4 @@ zh-TW:
       note_placeholder: 加入關於此紀錄的額外資訊
       overview: 概覽
       settings: 設定
-  opening_balance: 初始餘額
+      opening_balance: 初始餘額


### PR DESCRIPTION
Add multi-language support for opening balance label
 - Use `t("valuations.show.opening_balance")` for all opening balance display (list and detail views)
 - Add or update `opening_balance` translation in all major languages under `config/locales/views/valuations/`
 - Now "Opening balance" will be localized in all supported languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Opening balance entries in valuations now display a localized "Opening balance" label instead of the entry name, improving clarity when viewing balance entries. Support has been added for 12 languages including English, German, French, Spanish, Portuguese, Dutch, Norwegian, Romanian, Turkish, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->