### PR TITLE
Fix trade drawer header width regression

### DIFF
--- a/app/views/trades/show.html.erb
+++ b/app/views/trades/show.html.erb
@@ -1,10 +1,10 @@
 <%= render DS::Dialog.new(frame: "drawer", responsive: true) do |dialog| %>
   <% dialog.with_header(custom_header: true) do %>
-    <div class="flex items-start justify-between gap-4">
-      <div class="min-w-0 grow">
-        <%= render "trades/header", entry: @entry %>
+    <div class="relative">
+      <div class="absolute right-0 top-0 z-10">
+        <%= dialog.close_button %>
       </div>
-      <%= dialog.close_button %>
+      <%= render "trades/header", entry: @entry %>
     </div>
   <% end %>
   <% trade = @entry.trade %>

--- a/app/views/trades/show.html.erb
+++ b/app/views/trades/show.html.erb
@@ -1,7 +1,9 @@
 <%= render DS::Dialog.new(frame: "drawer", responsive: true) do |dialog| %>
   <% dialog.with_header(custom_header: true) do %>
     <div class="flex items-start justify-between gap-4">
-      <%= render "trades/header", entry: @entry %>
+      <div class="min-w-0 grow">
+        <%= render "trades/header", entry: @entry %>
+      </div>
       <%= dialog.close_button %>
     </div>
   <% end %>


### PR DESCRIPTION
### Motivation
- Fix a layout regression in the trade drawer where the overview disclosure rows collapsed into a narrow column leaving a large empty right gutter; investigation via `git log`/`git show`/`git blame` indicated PR #1248 only added fee inputs and did not introduce this layout change.

### Description
- Wrap the `trades/header` partial in a `<div class="min-w-0 grow">` inside `app/views/trades/show.html.erb` so the header content takes available horizontal space before the close button and prevents disclosure rows from shrinking.

### Testing
- Ran `bundle exec erb_lint app/views/trades/show.html.erb` which passed, and attempted `bin/rails test test/controllers/trades_controller_test.rb` which executed but surfaced test-environment errors due to the missing asset `tailwind.css` unrelated to this small template change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d0db66f88332aba09fe5acc63556)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the trades page header layout to better handle content overflow and responsiveness.
  * Moved the dialog close button to a fixed corner so it stays consistently positioned.
  * Reduced layout shifts in the header for a more stable and predictable viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->