### PR TITLE
fix(accounts): add duplicate action to activity view

### DIFF
--- a/app/javascript/controllers/bulk_select_controller.js
+++ b/app/javascript/controllers/bulk_select_controller.js
@@ -138,8 +138,13 @@ export default class extends Controller {
       count > 0;
 
     if (this.hasDuplicateLinkTarget) {
-      this.duplicateLinkTarget.classList.toggle("hidden", count !== 1);
-      if (count === 1) {
+      const selectedRow = this._selectedRow();
+      const canDuplicate =
+        count === 1 && selectedRow?.dataset.entryType === "Transaction";
+
+      this.duplicateLinkTarget.classList.toggle("hidden", !canDuplicate);
+
+      if (canDuplicate) {
         const url = new URL(
           this.duplicateLinkTarget.href,
           window.location.origin,
@@ -156,6 +161,14 @@ export default class extends Controller {
     }
 
     return this.pluralLabelValue;
+  }
+
+  _selectedRow() {
+    if (this.selectedIdsValue.length !== 1) return null;
+
+    return this.rowTargets.find(
+      (row) => row.dataset.id === this.selectedIdsValue[0],
+    );
   }
 
   _updateGroups() {

--- a/app/views/entries/_selection_bar.html.erb
+++ b/app/views/entries/_selection_bar.html.erb
@@ -7,6 +7,17 @@
 
   <div class="flex items-center gap-1 text-secondary">
     <%= turbo_frame_tag "bulk_transaction_edit_drawer" %>
+
+    <%= link_to new_transaction_path,
+                class: "p-1.5 group/duplicate hover:bg-inverse flex items-center justify-center rounded-md hidden",
+                title: t("transactions.selection_bar.duplicate"),
+                data: {
+                  turbo_frame: "modal",
+                  bulk_select_target: "duplicateLink"
+                } do %>
+      <%= icon "copy", class: "group-hover/duplicate:text-inverse" %>
+    <% end %>
+
     <%= link_to new_transactions_bulk_update_path,
                 class: "p-1.5 group/edit hover:bg-inverse flex items-center justify-center rounded-md",
                 title: "Edit",

--- a/app/views/trades/_trade.html.erb
+++ b/app/views/trades/_trade.html.erb
@@ -10,6 +10,7 @@
                         class: "checkbox checkbox--light hidden lg:block",
                         data: {
                           id: entry.id,
+                          entry_type: entry.entryable_type,
                           "bulk-select-target": "row",
                           action: "bulk-select#toggleRowSelection",
                           checkbox_toggle_target: "selectionEntry"

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -12,6 +12,7 @@
             class: "checkbox checkbox--light hidden lg:block",
             data: {
               id: entry.id,
+              entry_type: entry.entryable_type,
               "bulk-select-target": "row",
               action: "bulk-select#toggleRowSelection",
               checkbox_toggle_target: "selectionEntry"

--- a/app/views/valuations/_valuation.html.erb
+++ b/app/views/valuations/_valuation.html.erb
@@ -11,7 +11,7 @@
       <div class="col-span-8 flex items-center gap-3 lg:gap-4">
         <%= check_box_tag dom_id(entry, "selection"),
                         class: "checkbox checkbox--light hidden lg:block",
-                        data: { id: entry.id, "bulk-select-target": "row", action: "bulk-select#toggleRowSelection", checkbox_toggle_target: "selectionEntry" } %>
+                        data: { id: entry.id, entry_type: entry.entryable_type, "bulk-select-target": "row", action: "bulk-select#toggleRowSelection", checkbox_toggle_target: "selectionEntry" } %>
 
         <div class="flex items-center gap-3">
           <%= render DS::FilledIcon.new(icon: icon, size: "md", hex_color: color, rounded: true) %>

--- a/test/system/account_activity_test.rb
+++ b/test/system/account_activity_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class AccountActivityTest < ApplicationSystemTestCase
+  setup do
+    sign_in users(:family_admin)
+
+    @account = accounts(:depository)
+    @transaction_entry = @account.entries.create!(
+      name: "Duplicate source",
+      date: Date.current,
+      amount: 42.50,
+      currency: "USD",
+      entryable: Transaction.new
+    )
+    @valuation_entry = @account.entries.create!(
+      name: "Current balance",
+      date: 1.day.ago.to_date,
+      amount: 1000,
+      currency: "USD",
+      entryable: Valuation.new
+    )
+  end
+
+  test "account activity shows duplicate action for a selected transaction" do
+    visit account_url(@account, tab: "activity")
+
+    find("#" + dom_id(@transaction_entry, "selection")).check
+
+    within "#entry-selection-bar" do
+      assert_selector "a[title='Duplicate']:not(.hidden)"
+    end
+  end
+
+  test "account activity hides duplicate action for a selected valuation" do
+    visit account_url(@account, tab: "activity")
+
+    find("#" + dom_id(@valuation_entry, "selection")).check
+
+    within "#entry-selection-bar" do
+      assert_selector "a[title='Duplicate'].hidden", visible: false
+    end
+  end
+end


### PR DESCRIPTION
I saw that in all transactions tab, there was a duplicate button in the bulk select toolbar when a transaction is selected but not in the accounts view.

Hence adding it as I usually add transactions from the accounts tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Duplicate" action button in the selection bar. Select a single transaction to reveal the button and quickly create a copy of that transaction.

* **Tests**
  * Added system tests to verify duplicate action visibility for different entry types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->