### PR TITLE
Fix DemoFamilyRefreshJob demo email config lookup

### DIFF
--- a/app/jobs/demo_family_refresh_job.rb
+++ b/app/jobs/demo_family_refresh_job.rb
@@ -5,7 +5,7 @@ class DemoFamilyRefreshJob < ApplicationJob
     period_end = Time.current
     period_start = period_end - 24.hours
 
-    demo_email = Rails.application.config_for(:demo).fetch("email")
+    demo_email = Rails.application.config_for(:demo).with_indifferent_access.fetch(:email)
     demo_user = User.find_by(email: demo_email)
     old_family = demo_user&.family
 

--- a/test/jobs/demo_family_refresh_job_test.rb
+++ b/test/jobs/demo_family_refresh_job_test.rb
@@ -61,4 +61,15 @@ class DemoFamilyRefreshJobTest < ActiveJob::TestCase
       assert_match(/\+deleting-/, @demo_user.email)
     end
   end
+
+  test "reads demo email when config_for returns symbol keys" do
+    Rails.application.stubs(:config_for).with(:demo).returns({ email: @demo_email })
+
+    generator = mock
+    generator.expects(:generate_default_data!).with(skip_clear: true, email: @demo_email)
+    Demo::Generator.expects(:new).returns(generator)
+
+    DemoFamilyRefreshJob.perform_now
+  end
+
 end

--- a/test/jobs/demo_family_refresh_job_test.rb
+++ b/test/jobs/demo_family_refresh_job_test.rb
@@ -71,5 +71,4 @@ class DemoFamilyRefreshJobTest < ActiveJob::TestCase
 
     DemoFamilyRefreshJob.perform_now
   end
-
 end


### PR DESCRIPTION
### Motivation
- `DemoFamilyRefreshJob` raised `key not found: "email"` when `Rails.application.config_for(:demo)` returned symbol keys instead of string keys, causing the demo refresh to fail.

### Description
- Read the demo config with indifferent access and fetch the email via `Rails.application.config_for(:demo).with_indifferent_access.fetch(:email)` so both string and symbol keys are supported.
- Add a regression test that stubs `config_for(:demo)` to return symbol-keyed config and asserts the job passes the expected email to `Demo::Generator`.

### Testing
- Ran `bin/rails test test/jobs/demo_family_refresh_job_test.rb`, which executed 2 runs and 12 assertions with `0 failures` and `0 errors`.
- The new regression test covering symbol-keyed `config_for` output passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d898c37ef883328edd6d383fd579db)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the demo family refresh job’s configuration handling so it reliably reads the demo email setting, improving consistency of demo data refreshes.

* **Tests**
  * Added a test to validate the demo family refresh job reads the configured email and invokes the demo data generation with the expected options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->