### PR TITLE
Add tagged-release GitHub Actions workflow to run LLM evals

### DIFF
--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 env:
   EVAL_MODEL: gpt-4.1
   RAILS_ENV: test
@@ -20,7 +23,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -29,7 +32,7 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
       redis:
-        image: redis
+        image: redis:7.2
         ports:
           - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -51,6 +54,24 @@ jobs:
         run: |
           bin/rails db:create
           bin/rails db:schema:load
+
+      - name: Import eval datasets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          dataset_files=(db/eval_data/*.yml)
+
+          if [ ${#dataset_files[@]} -eq 0 ]; then
+            echo "::error::No eval dataset files found under db/eval_data/*.yml"
+            exit 1
+          fi
+
+          for dataset_file in "${dataset_files[@]}"; do
+            echo "Importing ${dataset_file}"
+            bundle exec rake "evals:import_dataset[${dataset_file}]"
+          done
 
       - name: Resolve available eval datasets
         id: datasets
@@ -83,7 +104,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -92,7 +113,7 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
       redis:
-        image: redis
+        image: redis:7.2
         ports:
           - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -112,6 +133,45 @@ jobs:
           bin/rails db:create
           bin/rails db:schema:load
 
+      - name: Import eval datasets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          dataset_files=(db/eval_data/*.yml)
+
+          if [ ${#dataset_files[@]} -eq 0 ]; then
+            echo "::error::No eval dataset files found under db/eval_data/*.yml"
+            exit 1
+          fi
+
+          for dataset_file in "${dataset_files[@]}"; do
+            echo "Importing ${dataset_file}"
+            bundle exec rake "evals:import_dataset[${dataset_file}]"
+          done
+
+      - name: Prepare dataset artifact names
+        id: dataset_slug
+        env:
+          DATASET: ${{ matrix.dataset }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          slug=$(printf '%s' "$DATASET" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')
+
+          if [ -z "$slug" ]; then
+            echo "::error::Could not generate dataset slug from '$DATASET'"
+            exit 1
+          fi
+
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+          echo "log_path=tmp/evals/${slug}.log" >> "$GITHUB_OUTPUT"
+          echo "json_path=tmp/evals/${slug}.json" >> "$GITHUB_OUTPUT"
+
       - name: Verify dataset exists
         env:
           DATASET: ${{ matrix.dataset }}
@@ -121,9 +181,11 @@ jobs:
       - name: Run eval
         env:
           DATASET: ${{ matrix.dataset }}
+          OPENAI_ACCESS_TOKEN: ${{ secrets.OPENAI_ACCESS_TOKEN }}
         run: |
+          set -euo pipefail
           mkdir -p tmp/evals
-          bundle exec rake "evals:run[${DATASET},${EVAL_MODEL}]" | tee "tmp/evals/${DATASET}.log"
+          bundle exec rake "evals:run[${DATASET},${EVAL_MODEL}]" | tee "${{ steps.dataset_slug.outputs.log_path }}"
 
       - name: Export run summary
         env:
@@ -134,21 +196,26 @@ jobs:
             run = Eval::Run.where(dataset: dataset, model: ENV.fetch("EVAL_MODEL")).order(created_at: :desc).first
             payload = {
               dataset: dataset.name,
+              dataset_metadata: dataset.metadata,
               model: ENV.fetch("EVAL_MODEL"),
               run_id: run.id,
               status: run.status,
               created_at: run.created_at,
               completed_at: run.completed_at,
-              metrics: run.metrics,
-              metadata: run.metadata
+              total_prompt_tokens: run.total_prompt_tokens,
+              total_completion_tokens: run.total_completion_tokens,
+              total_cost: run.total_cost,
+              metrics: run.metrics
             }
-            File.write("tmp/evals/#{dataset.name}.json", JSON.pretty_generate(payload))
+            File.write("${{ steps.dataset_slug.outputs.json_path }}", JSON.pretty_generate(payload))
           '
 
       - name: Upload eval artifact
         uses: actions/upload-artifact@v4
         with:
-          name: llm-evals-${{ matrix.dataset }}-${{ env.EVAL_MODEL }}
-          path: tmp/evals/${{ matrix.dataset }}.*
+          name: llm-evals-${{ steps.dataset_slug.outputs.slug }}-${{ env.EVAL_MODEL }}
+          path: |
+            ${{ steps.dataset_slug.outputs.log_path }}
+            ${{ steps.dataset_slug.outputs.json_path }}
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -1,0 +1,154 @@
+name: LLM Evals
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  EVAL_MODEL: gpt-4.1
+  RAILS_ENV: test
+  DATABASE_URL: postgres://postgres:postgres@localhost:5432
+  REDIS_URL: redis://localhost:6379
+  PLAID_CLIENT_ID: foo
+  PLAID_SECRET: bar
+
+jobs:
+  discover_datasets:
+    name: Discover eval datasets
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    outputs:
+      datasets: ${{ steps.datasets.outputs.datasets }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Prepare database
+        run: |
+          bin/rails db:create
+          bin/rails db:schema:load
+
+      - name: Resolve available eval datasets
+        id: datasets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DATASETS_JSON=$(bin/rails runner 'puts Eval::Dataset.order(:name).pluck(:name).to_json')
+
+          if [ "$DATASETS_JSON" = "[]" ]; then
+            echo "::error::No eval datasets found. Import one first with: rake evals:import_dataset[path/to/file.yml]"
+            exit 1
+          fi
+
+          {
+            echo "datasets<<EOF"
+            echo "$DATASETS_JSON"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  run_evals:
+    name: Run eval for ${{ matrix.dataset }}
+    needs: discover_datasets
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dataset: ${{ fromJson(needs.discover_datasets.outputs.datasets) }}
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Prepare database
+        run: |
+          bin/rails db:create
+          bin/rails db:schema:load
+
+      - name: Verify dataset exists
+        env:
+          DATASET: ${{ matrix.dataset }}
+        run: |
+          bin/rails runner 'dataset = Eval::Dataset.find_by(name: ENV.fetch("DATASET")); abort("Dataset not found: #{ENV.fetch("DATASET")}") if dataset.nil?'
+
+      - name: Run eval
+        env:
+          DATASET: ${{ matrix.dataset }}
+        run: |
+          mkdir -p tmp/evals
+          bundle exec rake "evals:run[${DATASET},${EVAL_MODEL}]" | tee "tmp/evals/${DATASET}.log"
+
+      - name: Export run summary
+        env:
+          DATASET: ${{ matrix.dataset }}
+        run: |
+          bin/rails runner '
+            dataset = Eval::Dataset.find_by!(name: ENV.fetch("DATASET"))
+            run = Eval::Run.where(dataset: dataset, model: ENV.fetch("EVAL_MODEL")).order(created_at: :desc).first
+            payload = {
+              dataset: dataset.name,
+              model: ENV.fetch("EVAL_MODEL"),
+              run_id: run.id,
+              status: run.status,
+              created_at: run.created_at,
+              completed_at: run.completed_at,
+              metrics: run.metrics,
+              metadata: run.metadata
+            }
+            File.write("tmp/evals/#{dataset.name}.json", JSON.pretty_generate(payload))
+          '
+
+      - name: Upload eval artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-evals-${{ matrix.dataset }}-${{ env.EVAL_MODEL }}
+          path: tmp/evals/${{ matrix.dataset }}.*
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -194,6 +194,7 @@ jobs:
           bin/rails runner '
             dataset = Eval::Dataset.find_by!(name: ENV.fetch("DATASET"))
             run = Eval::Run.where(dataset: dataset, model: ENV.fetch("EVAL_MODEL")).order(created_at: :desc).first
+            abort("No eval run found for dataset #{dataset.name} with model #{ENV.fetch("EVAL_MODEL")}") if run.nil?
             payload = {
               dataset: dataset.name,
               dataset_metadata: dataset.metadata,


### PR DESCRIPTION
### Motivation
- Run evaluations automatically for all imported eval datasets on every tagged release so model performance is recorded per release.
- Provide a single configurable default model via an environment variable so additional models can be added later without changing workflow logic.
- Ensure dataset loading is explicit and fail-fast with guidance to import datasets using the existing task `rake evals:import_dataset[path/to/file.yml]`.

### Description
- Add a new workflow file `.github/workflows/llm-evals.yml` that triggers on tag pushes matching `v*` and sets a default model via `EVAL_MODEL` (default `gpt-4.1`).
- Implement `discover_datasets` job that brings up Postgres and Redis services, prepares the Rails test DB with `bin/rails db:create` and `bin/rails db:schema:load`, and emits a JSON list of `Eval::Dataset` names to the workflow output; the job fails with a clear message if no datasets are found.
- Implement `run_evals` matrix job that fans out per-dataset runs using the discovered dataset list, provisions Postgres and Redis, prepares the DB, executes `bundle exec rake "evals:run[dataset_name,${EVAL_MODEL}]"`, writes a JSON run summary using `bin/rails runner`, and uploads per-dataset artifacts named `llm-evals-<dataset>-<model>`.
- Artifacts include the run log `tmp/evals/<dataset>.log` and the JSON summary `tmp/evals/<dataset>.json` for later inspection or CI consumption.

### Testing
- Verified the workflow YAML is syntactically loadable with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/llm-evals.yml')"` which returned successfully.
- Inspected the generated workflow file output with `sed -n` and `nl -ba` to confirm job structure, triggers, and steps are present as intended.
- Confirmed the workflow file is present at `.github/workflows/llm-evals.yml` in the working tree after creation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93a7a725c8332b3cd12ad2ac12bc7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated evaluation workflow triggered on version tags.
  * Discovers available evaluation datasets and runs evaluations per dataset/model in parallel.
  * Sets up a temporary test environment for each run and imports datasets as needed.
  * Produces per-dataset logs and JSON summaries with run status, metrics, token usage, and cost.
  * Uploads evaluation artifacts for review and analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->