### PR TITLE
Fix potential timing attack in Sidekiq Web UI auth

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,7 +5,7 @@ if Rails.env.production?
     configured_username = ::Digest::SHA256.hexdigest(ENV.fetch("SIDEKIQ_WEB_USERNAME", "sure"))
     configured_password = ::Digest::SHA256.hexdigest(ENV.fetch("SIDEKIQ_WEB_PASSWORD", "sure"))
 
-    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), configured_username) &&
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), configured_username) &
       ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), configured_password)
   end
 end


### PR DESCRIPTION
### Summary                                                                                                                          
                                                                                                                                   
  - Swap `&&` for `&` when comparing Sidekiq Web UI credentials                                                                        
  - `&&` short-circuits, and with timing attack it could theoretically leak whether a username is valid                                                                            
  - `&` ensures both secure_compare calls always run, which is the whole point of using `secure_compare `in the first place
                                                                                                                                   
 ### Test plan       
                                                                                                                                   
  - Verify Sidekiq Web UI still requires valid credentials to access   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication validation logic in background job processing configuration to refine secure credential verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->