### PR TITLE
Fix overlapping in transaction name

### DIFF
--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -27,7 +27,7 @@
           <% end %>
         </div>
 
-        <div class="max-w-full <%= "opacity-50 text-secondary" if entry.excluded %>">
+        <div class="max-w-full min-w-0 <%= "opacity-50 text-secondary" if entry.excluded %>">
           <%= content_tag :div, class: ["flex items-center gap-3 lg:gap-4"] do %>
             <div class="hidden lg:flex">
               <% if transaction.transfer? %>


### PR DESCRIPTION
| Before | After |
| ------------- | ------------- |
| <img width="358" height="174" alt="Screenshot 2026-04-11 alle 13 23 49" src="https://github.com/user-attachments/assets/10234439-c101-4489-b44b-1b71c4feb447" /> | <img width="364" height="183" alt="Screenshot 2026-04-11 alle 13 22 52" src="https://github.com/user-attachments/assets/fa02b672-d506-4226-8014-bbc494ce0f13" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed transaction row layout to prevent content overflow while maintaining styling for excluded entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->