### PR TITLE
Investments currency fix

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -501,6 +501,13 @@ class ReportsController < ApplicationController
 
       trades_by_treatment = sell_trades.group_by { |t| t.entry.account.tax_treatment || :taxable }
 
+      # Batch-fetch FX rates for every currency present in this scope so mixed-
+      # currency holdings/trades are summed in family currency, not raw.
+      foreign_currencies = (current_holdings.map(&:currency) + sell_trades.map(&:currency))
+                             .compact.uniq.reject { |c| c == currency }
+      rates = ExchangeRate.rates_for(foreign_currencies, to: currency, date: Date.current)
+      convert = ->(amount, from) { from == currency ? amount : amount * (rates[from] || 1) }
+
       # Build metrics per treatment
       %i[taxable tax_deferred tax_exempt tax_advantaged].each_with_object({}) do |treatment, hash|
         holdings = holdings_by_treatment[treatment] || []
@@ -509,13 +516,13 @@ class ReportsController < ApplicationController
         # Sum unrealized gains from holdings (only those with known cost basis)
         unrealized = holdings.sum do |h|
           trend = h.trend
-          trend ? trend.value : 0
+          trend ? convert.call(trend.value, h.currency) : 0
         end
 
         # Sum realized gains from sell trades
         realized = trades.sum do |t|
           gain = t.realized_gain_loss
-          gain ? gain.value : 0
+          gain ? convert.call(gain.value, t.currency) : 0
         end
 
         # Only include treatment groups that have some activity

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -501,12 +501,31 @@ class ReportsController < ApplicationController
 
       trades_by_treatment = sell_trades.group_by { |t| t.entry.account.tax_treatment || :taxable }
 
-      # Batch-fetch FX rates for every currency present in this scope so mixed-
-      # currency holdings/trades are summed in family currency, not raw.
-      foreign_currencies = (current_holdings.map(&:currency) + sell_trades.map(&:currency))
-                             .compact.uniq.reject { |c| c == currency }
-      rates = ExchangeRate.rates_for(foreign_currencies, to: currency, date: Date.current)
-      convert = ->(amount, from) { from == currency ? amount : amount * (rates[from] || 1) }
+      # Unwrap helper: Trend#value / realized_gain_loss#value are Money objects,
+      # and this codebase's Money keeps the source currency through `*` and
+      # through `Money.new(money, _)`. Unwrapping to BigDecimal first keeps sums
+      # and the final Money.new(..., currency) correctly labeled in family currency.
+      to_numeric = ->(value) { value.is_a?(Money) ? value.amount : value }
+
+      # Unrealized gains mark holdings to market, so convert at today's FX.
+      foreign_holding_currencies = current_holdings.map(&:currency).compact.uniq.reject { |c| c == currency }
+      holding_rates = ExchangeRate.rates_for(foreign_holding_currencies, to: currency, date: Date.current)
+      convert_current = ->(amount, from) {
+        numeric = to_numeric.call(amount)
+        from == currency ? numeric : numeric * (holding_rates[from] || 1)
+      }
+
+      # Realized gains are locked at trade time, so convert each at its own
+      # entry-date FX. Mirrors InvestmentStatement::Totals, which also uses
+      # entry-date rates for contributions/withdrawals on this same card.
+      foreign_trade_currencies = sell_trades.map(&:currency).compact.uniq.reject { |c| c == currency }
+      rates_by_trade_date = sell_trades.map { |t| t.entry.date }.uniq.each_with_object({}) do |date, memo|
+        memo[date] = ExchangeRate.rates_for(foreign_trade_currencies, to: currency, date: date)
+      end
+      convert_trade = ->(amount, from, date) {
+        numeric = to_numeric.call(amount)
+        from == currency ? numeric : numeric * (rates_by_trade_date.dig(date, from) || 1)
+      }
 
       # Build metrics per treatment
       %i[taxable tax_deferred tax_exempt tax_advantaged].each_with_object({}) do |treatment, hash|
@@ -516,13 +535,13 @@ class ReportsController < ApplicationController
         # Sum unrealized gains from holdings (only those with known cost basis)
         unrealized = holdings.sum do |h|
           trend = h.trend
-          trend ? convert.call(trend.value, h.currency) : 0
+          trend ? convert_current.call(trend.value, h.currency) : 0
         end
 
         # Sum realized gains from sell trades
         realized = trades.sum do |t|
           gain = t.realized_gain_loss
-          gain ? convert.call(gain.value, t.currency) : 0
+          gain ? convert_trade.call(gain.value, t.currency, t.entry.date) : 0
         end
 
         # Only include treatment groups that have some activity

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -201,10 +201,17 @@ class InvestmentStatement
       end
     end
 
+    # Unwrap Money first because this codebase's Money (lib/money.rb) ignores
+    # the currency arg of `Money.new` when the payload is already a Money, and
+    # `Money * numeric` preserves the source currency — so multiplying a
+    # foreign-currency Money by a rate would FX-scale the amount but keep the
+    # wrong currency label, corrupting downstream sums.
     def convert_to_family_currency(amount, from_currency)
-      return amount if amount.nil? || from_currency == family.currency
+      return amount if amount.nil?
+      numeric = amount.is_a?(Money) ? amount.amount : amount
+      return numeric if from_currency == family.currency
       rate = exchange_rates[from_currency] || 1
-      amount * rate
+      numeric * rate
     end
 
     def all_time_totals

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -38,7 +38,7 @@ class InvestmentStatement
 
   # Total portfolio value across all investment accounts
   def portfolio_value
-    investment_accounts.sum(&:balance)
+    investment_accounts.sum { |a| convert_to_family_currency(a.balance, a.currency) }
   end
 
   def portfolio_value_money
@@ -47,7 +47,7 @@ class InvestmentStatement
 
   # Total cash in investment accounts
   def cash_balance
-    investment_accounts.sum(&:cash_balance)
+    investment_accounts.sum { |a| convert_to_family_currency(a.cash_balance, a.currency) }
   end
 
   def cash_balance_money
@@ -63,55 +63,60 @@ class InvestmentStatement
     Money.new(holdings_value, family.currency)
   end
 
-  # All current holdings across investment accounts
+  # All current holdings across investment accounts. Holdings are returned in
+  # their native currency; callers that aggregate across accounts must convert
+  # to family currency via convert_to_family_currency.
   def current_holdings
     return Holding.none unless investment_accounts.any?
 
-    account_ids = investment_accounts.pluck(:id)
-
     # Get the latest holding for each security per account
     Holding
-      .where(account_id: account_ids)
-      .where(currency: family.currency)
+      .where(account_id: investment_account_ids)
       .where.not(qty: 0)
       .where(
         id: Holding
-          .where(account_id: account_ids)
-          .where(currency: family.currency)
+          .where(account_id: investment_account_ids)
           .select("DISTINCT ON (holdings.account_id, holdings.security_id) holdings.id")
           .order(Arel.sql("holdings.account_id, holdings.security_id, holdings.date DESC"))
       )
       .includes(:security, :account)
-      .order(amount: :desc)
   end
 
-  # Top holdings by value
+  # Top holdings by family-currency value
   def top_holdings(limit: 5)
-    current_holdings.limit(limit)
+    current_holdings
+      .to_a
+      .sort_by { |h| -convert_to_family_currency(h.amount, h.currency) }
+      .first(limit)
   end
 
-  # Portfolio allocation by security type/sector (simplified for now)
+  # Portfolio allocation by security. Weights and amounts are computed in the
+  # family's currency so cross-currency holdings compare correctly.
   def allocation
-    holdings = current_holdings.to_a
-    total = holdings.sum(&:amount)
+    converted = current_holdings.to_a.map do |holding|
+      [ holding, convert_to_family_currency(holding.amount, holding.currency) ]
+    end
 
+    total = converted.sum { |_, value| value }
     return [] if total.zero?
 
-    holdings.map do |holding|
-      HoldingAllocation.new(
-        security: holding.security,
-        amount: holding.amount_money,
-        weight: (holding.amount / total * 100).round(2),
-        trend: holding.trend
-      )
-    end
+    converted
+      .sort_by { |_, value| -value }
+      .map do |holding, value|
+        HoldingAllocation.new(
+          security: holding.security,
+          amount: Money.new(value, family.currency),
+          weight: (value / total * 100).round(2),
+          trend: holding.trend
+        )
+      end
   end
 
-  # Unrealized gains across all holdings
+  # Unrealized gains across all holdings, summed in family currency
   def unrealized_gains
     current_holdings.sum do |holding|
       trend = holding.trend
-      trend ? trend.value : 0
+      trend ? convert_to_family_currency(trend.value, holding.currency) : 0
     end
   end
 
@@ -138,25 +143,37 @@ class InvestmentStatement
     holdings_with_cost_basis = holdings.select(&:avg_cost)
     return nil if holdings_with_cost_basis.empty?
 
-    current = holdings_with_cost_basis.sum(&:amount)
-    previous = holdings_with_cost_basis.sum { |h| h.qty * h.avg_cost.amount }
-
-    Trend.new(current: current, previous: previous)
-  end
-
-  # Day change across portfolio
-  def day_change
-    holdings = current_holdings.to_a
-    changes = holdings.map(&:day_change).compact
-
-    return nil if changes.empty?
-
-    current = changes.sum { |t| t.current.is_a?(Money) ? t.current.amount : t.current }
-    previous = changes.sum { |t| t.previous.is_a?(Money) ? t.previous.amount : t.previous }
+    current = holdings_with_cost_basis.sum do |h|
+      convert_to_family_currency(h.amount, h.currency)
+    end
+    previous = holdings_with_cost_basis.sum do |h|
+      convert_to_family_currency(h.qty * h.avg_cost.amount, h.currency)
+    end
 
     Trend.new(
       current: Money.new(current, family.currency),
       previous: Money.new(previous, family.currency)
+    )
+  end
+
+  # Day change across portfolio, summed in family currency
+  def day_change
+    changes = current_holdings.to_a.filter_map do |h|
+      t = h.day_change
+      next nil unless t
+      curr = t.current.is_a?(Money) ? t.current.amount : t.current
+      prev = t.previous.is_a?(Money) ? t.previous.amount : t.previous
+      [
+        convert_to_family_currency(curr, h.currency),
+        convert_to_family_currency(prev, h.currency)
+      ]
+    end
+
+    return nil if changes.empty?
+
+    Trend.new(
+      current: Money.new(changes.sum { |c, _| c }, family.currency),
+      previous: Money.new(changes.sum { |_, p| p }, family.currency)
     )
   end
 
@@ -170,6 +187,26 @@ class InvestmentStatement
   end
 
   private
+    # Today's rates for every currency present on the family's investment
+    # accounts and their holdings. Mirrors BalanceSheet::AccountTotals#exchange_rates.
+    def exchange_rates
+      @exchange_rates ||= begin
+        account_currencies = investment_accounts.map(&:currency)
+        holding_currencies = Holding.where(account_id: investment_account_ids).distinct.pluck(:currency)
+        foreign = (account_currencies + holding_currencies)
+                    .compact
+                    .uniq
+                    .reject { |c| c == family.currency }
+        ExchangeRate.rates_for(foreign, to: family.currency, date: Date.current)
+      end
+    end
+
+    def convert_to_family_currency(amount, from_currency)
+      return amount if amount.nil? || from_currency == family.currency
+      rate = exchange_rates[from_currency] || 1
+      amount * rate
+    end
+
     def all_time_totals
       @all_time_totals ||= totals(period: Period.all_time)
     end

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -1,0 +1,128 @@
+require "test_helper"
+
+class InvestmentStatementTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:empty)
+    # families(:empty) defaults to currency "USD"
+    @statement = InvestmentStatement.new(@family, user: nil)
+  end
+
+  test "portfolio_value and cash_balance with a single-currency family" do
+    create_investment_account(balance: 1000, cash_balance: 100)
+
+    assert_equal 1000, @statement.portfolio_value
+    assert_equal 100, @statement.cash_balance
+    assert_equal 900, @statement.holdings_value
+  end
+
+  test "portfolio_value converts foreign-currency accounts to family currency" do
+    create_investment_account(balance: 1921.92, cash_balance: -162, currency: "USD")
+    create_investment_account(balance: 1000, cash_balance: 1000, currency: "EUR")
+
+    ExchangeRate.create!(
+      from_currency: "EUR",
+      to_currency: "USD",
+      date: Date.current,
+      rate: 1.1
+    )
+
+    # 1921.92 + 1000 * 1.1 = 3021.92
+    assert_in_delta 3021.92, @statement.portfolio_value, 0.001
+    # -162 + 1000 * 1.1 = 938
+    assert_in_delta 938, @statement.cash_balance, 0.001
+    # 3021.92 - 938 = 2083.92
+    assert_in_delta 2083.92, @statement.holdings_value, 0.001
+  end
+
+  test "portfolio_value falls back to 1:1 when FX rate is missing" do
+    create_investment_account(balance: 1921.92, currency: "USD")
+    create_investment_account(balance: 1000, currency: "EUR")
+
+    # No ExchangeRate row → rates_for defaults to 1
+    assert_in_delta 2921.92, @statement.portfolio_value, 0.001
+  end
+
+  test "current_holdings includes holdings from every investment account regardless of currency" do
+    usd_account = create_investment_account(balance: 2100, currency: "USD")
+    eur_account = create_investment_account(balance: 2000, currency: "EUR")
+
+    usd_security = Security.create!(ticker: "AAPL", name: "Apple")
+    eur_security = Security.create!(ticker: "ASML", name: "ASML")
+
+    Holding.create!(
+      account: usd_account, security: usd_security, date: Date.current,
+      qty: 10, price: 210, amount: 2100, currency: "USD"
+    )
+    Holding.create!(
+      account: eur_account, security: eur_security, date: Date.current,
+      qty: 4, price: 500, amount: 2000, currency: "EUR"
+    )
+
+    assert_equal 2, @statement.current_holdings.count
+  end
+
+  test "top_holdings ranks by family-currency value across currencies" do
+    usd_account = create_investment_account(balance: 2100, currency: "USD")
+    eur_account = create_investment_account(balance: 2000, currency: "EUR")
+
+    usd_security = Security.create!(ticker: "AAPL", name: "Apple")
+    eur_security = Security.create!(ticker: "ASML", name: "ASML")
+
+    Holding.create!(
+      account: usd_account, security: usd_security, date: Date.current,
+      qty: 10, price: 210, amount: 2100, currency: "USD"
+    )
+    Holding.create!(
+      account: eur_account, security: eur_security, date: Date.current,
+      qty: 4, price: 500, amount: 2000, currency: "EUR"
+    )
+
+    ExchangeRate.create!(
+      from_currency: "EUR", to_currency: "USD",
+      date: Date.current, rate: 1.1
+    )
+
+    # 2000 EUR = 2200 USD > 2100 USD, so ASML outranks AAPL in family currency
+    top = @statement.top_holdings(limit: 2)
+    assert_equal %w[ASML AAPL], top.map(&:ticker)
+  end
+
+  test "allocation weights sum to 100% with mixed currencies" do
+    usd_account = create_investment_account(balance: 2100, currency: "USD")
+    eur_account = create_investment_account(balance: 2000, currency: "EUR")
+
+    usd_security = Security.create!(ticker: "AAPL", name: "Apple")
+    eur_security = Security.create!(ticker: "ASML", name: "ASML")
+
+    Holding.create!(
+      account: usd_account, security: usd_security, date: Date.current,
+      qty: 10, price: 210, amount: 2100, currency: "USD"
+    )
+    Holding.create!(
+      account: eur_account, security: eur_security, date: Date.current,
+      qty: 4, price: 500, amount: 2000, currency: "EUR"
+    )
+
+    ExchangeRate.create!(
+      from_currency: "EUR", to_currency: "USD",
+      date: Date.current, rate: 1.1
+    )
+
+    allocation = @statement.allocation
+    assert_equal 2, allocation.size
+    assert_in_delta 100.0, allocation.sum(&:weight), 0.01
+    # Every row is labeled in family currency
+    assert allocation.all? { |a| a.amount.currency.iso_code == "USD" }
+  end
+
+  private
+    def create_investment_account(balance:, cash_balance: 0, currency: "USD")
+      @family.accounts.create!(
+        name: "Investment #{SecureRandom.hex(3)}",
+        balance: balance,
+        cash_balance: cash_balance,
+        currency: currency,
+        accountable: Investment.new
+      )
+    end
+end

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -115,6 +115,68 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert allocation.all? { |a| a.amount.currency.iso_code == "USD" }
   end
 
+  test "unrealized_gains sums in family currency with mixed-currency holdings" do
+    usd_account = create_investment_account(balance: 2100, currency: "USD")
+    eur_account = create_investment_account(balance: 2000, currency: "EUR")
+
+    usd_security = Security.create!(ticker: "AAPL", name: "Apple")
+    eur_security = Security.create!(ticker: "ASML", name: "ASML")
+
+    Holding.create!(
+      account: usd_account, security: usd_security, date: Date.current,
+      qty: 10, price: 210, amount: 2100, currency: "USD",
+      cost_basis: 200, cost_basis_locked: true
+    )
+    Holding.create!(
+      account: eur_account, security: eur_security, date: Date.current,
+      qty: 4, price: 500, amount: 2000, currency: "EUR",
+      cost_basis: 450, cost_basis_locked: true
+    )
+
+    ExchangeRate.create!(
+      from_currency: "EUR", to_currency: "USD",
+      date: Date.current, rate: 1.1
+    )
+
+    # AAPL unrealized = 2100 - (10 * 200) = 100 USD
+    # ASML unrealized = 2000 - (4 * 450) = 200 EUR → 220 USD @ 1.1
+    # Total = 320 USD
+    assert_in_delta 320, @statement.unrealized_gains, 0.001
+    assert_equal "USD", @statement.unrealized_gains_money.currency.iso_code
+  end
+
+  test "unrealized_gains_trend is denominated in family currency" do
+    usd_account = create_investment_account(balance: 2100, currency: "USD")
+    eur_account = create_investment_account(balance: 2000, currency: "EUR")
+
+    usd_security = Security.create!(ticker: "AAPL", name: "Apple")
+    eur_security = Security.create!(ticker: "ASML", name: "ASML")
+
+    Holding.create!(
+      account: usd_account, security: usd_security, date: Date.current,
+      qty: 10, price: 210, amount: 2100, currency: "USD",
+      cost_basis: 200, cost_basis_locked: true
+    )
+    Holding.create!(
+      account: eur_account, security: eur_security, date: Date.current,
+      qty: 4, price: 500, amount: 2000, currency: "EUR",
+      cost_basis: 450, cost_basis_locked: true
+    )
+
+    ExchangeRate.create!(
+      from_currency: "EUR", to_currency: "USD",
+      date: Date.current, rate: 1.1
+    )
+
+    trend = @statement.unrealized_gains_trend
+    assert_equal "USD", trend.current.currency.iso_code
+    assert_equal "USD", trend.previous.currency.iso_code
+    # current = 2100 USD + (2000 EUR * 1.1) = 4300 USD
+    assert_in_delta 4300, trend.current.amount, 0.001
+    # previous (cost basis) = (10 * 200) USD + (4 * 450 * 1.1) EUR→USD = 2000 + 1980 = 3980 USD
+    assert_in_delta 3980, trend.previous.amount, 0.001
+  end
+
   private
     def create_investment_account(balance:, cash_balance: 0, currency: "USD")
       @family.accounts.create!(


### PR DESCRIPTION
## Summary                                                                                                                                                                  
Fix multi-currency bug in `InvestmentStatement` that caused the dashboard's Investments value, Top Holdings, Unrealized Gains, and the Reports "Gains by Tax Treatment" card to sum balances across currencies without FX conversion, then mislabel the raw sum as the family currency. 
       
The sibling `InvestmentStatement::Totals` service and `BalanceSheet::AccountTotals` already handled FX correctly — this PR brings `InvestmentStatement`'s balance/holdings  aggregation to the same pattern, reusing `ExchangeRate.rates_for`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Portfolio value, cash balance, holdings, day-change and gains now consistently convert multi-currency accounts into the family currency before aggregation and reporting
  * Top holdings and allocation rankings are now based on family-currency values
  * FX fallback applied when no rate exists

* **Tests**
  * Added tests covering multi-currency scenarios, conversions, and reporting accuracy
<!-- end of auto-generated comment: release notes by coderabbit.ai -->