### PR TITLE
Ipv6 support

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,9 @@ x-db-env: &db_env
 
 x-rails-env: &rails_env
   DB_HOST: db
+  # Bind the dev server to all interfaces inside the container so Docker's
+  # published port reaches it from the host. Rails reads BINDING natively.
+  BINDING: "0.0.0.0"
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
   BUNDLE_PATH: /bundle

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,6 @@ x-db-env: &db_env
 
 x-rails-env: &rails_env
   DB_HOST: db
-  HOST: "0.0.0.0"
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
   BUNDLE_PATH: /bundle

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bundle exec ${DEBUG:+rdbg -O -n -c --} bin/rails server -b 0.0.0.0
+web: bundle exec ${DEBUG:+rdbg -O -n -c --} bin/rails server
 css: bundle exec bin/rails tailwindcss:watch 2>/dev/null
 worker: bundle exec sidekiq

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -255,10 +255,16 @@ services:
       # bypassing Pipelock's MCP scanning (auth token is still required).
       # For hardened deployments, use `expose: [3000]` instead and front
       # the web UI with a separate reverse proxy.
+      #
+      # To also publish on IPv6 (dual-stack), uncomment the line below AND
+      # set BINDING=:: in the environment block. See docs/hosting/docker.md
+      # "Binding to IPv6" for details.
+      # - "[::]:${PORT:-3000}:3000"
       - ${PORT:-3000}:3000
     restart: unless-stopped
     environment:
       <<: *rails_env
+      # BINDING: "::"  # Uncomment for IPv6 dual-stack inside the container
     depends_on:
       db:
         condition: service_healthy

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -67,13 +67,13 @@ services:
     ports:
       - ${PORT:-3000}:3000
       # To also publish on IPv6 (dual-stack), uncomment the line below AND
-      # set BIND_HOST=:: in the environment block. See docs/hosting/docker.md
+      # set BINDING=:: in the environment block. See docs/hosting/docker.md
       # "Binding to IPv6" for details.
       # - "[::]:${PORT:-3000}:3000"
     restart: unless-stopped
     environment:
       <<: *rails_env
-      # BIND_HOST: "::"  # Uncomment for IPv6 dual-stack inside the container
+      # BINDING: "::"  # Uncomment for IPv6 dual-stack inside the container
     depends_on:
       db:
         condition: service_healthy

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -66,9 +66,14 @@ services:
       - app-storage:/rails/storage
     ports:
       - ${PORT:-3000}:3000
+      # To also publish on IPv6 (dual-stack), uncomment the line below AND
+      # set BIND_HOST=:: in the environment block. See docs/hosting/docker.md
+      # "Binding to IPv6" for details.
+      # - "[::]:${PORT:-3000}:3000"
     restart: unless-stopped
     environment:
       <<: *rails_env
+      # BIND_HOST: "::"  # Uncomment for IPv6 dual-stack inside the container
     depends_on:
       db:
         condition: service_healthy

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -38,14 +38,10 @@ if rails_env == "production"
   preload_app!
 end
 
-# Bind address (host + port). Default 0.0.0.0 (IPv4 wildcard) for backwards
-# compatibility. Set BIND_HOST=:: to listen on IPv6; on any kernel with
-# net.ipv6.bindv6only=0 (the default on Linux/macOS) this gives dual-stack
-# automatically — IPv4 clients arrive as v4-mapped addresses.
-bind_host = ENV.fetch("BIND_HOST", "0.0.0.0")
-bind_port = ENV.fetch("PORT", 3000)
-bind_host_segment = bind_host.include?(":") ? "[#{bind_host}]" : bind_host
-bind "tcp://#{bind_host_segment}:#{bind_port}"
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+# The bind host is controlled via the Rails-native `BINDING` env var (set to
+# `0.0.0.0` in containers, or `::` for IPv6 dual-stack). See docs/hosting/docker.md.
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 environment rails_env

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -38,8 +38,14 @@ if rails_env == "production"
   preload_app!
 end
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT") { 3000 }
+# Bind address (host + port). Default 0.0.0.0 (IPv4 wildcard) for backwards
+# compatibility. Set BIND_HOST=:: to listen on IPv6; on any kernel with
+# net.ipv6.bindv6only=0 (the default on Linux/macOS) this gives dual-stack
+# automatically — IPv4 clients arrive as v4-mapped addresses.
+bind_host = ENV.fetch("BIND_HOST", "0.0.0.0")
+bind_port = ENV.fetch("PORT", 3000)
+bind_host_segment = bind_host.include?(":") ? "[#{bind_host}]" : bind_host
+bind "tcp://#{bind_host_segment}:#{bind_port}"
 
 # Specifies the `environment` that Puma will run in.
 environment rails_env

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -113,9 +113,9 @@ RAILS_ASSUME_SSL: "true"
 
 #### Binding to IPv6 (optional)
 
-By default Sure listens on `0.0.0.0:3000` (IPv4 wildcard) and Docker publishes the port on the host's IPv4 interface only. If you want the app reachable over IPv6 as well, two things need to change:
+By default Sure listens on `0.0.0.0:3000` (IPv4 wildcard) inside the container and Docker publishes the port on the host's IPv4 interface only. If you want the app reachable over IPv6 as well, two things need to change:
 
-1. **Tell the app to bind to `[::]`** by setting `BIND_HOST=::` in the container environment. On any kernel with `net.ipv6.bindv6only=0` (the default on Linux and macOS) a single `[::]` bind is **dual-stack**: it accepts both IPv6 and IPv4 clients from the same socket. You do not need two binds and you do not need two ports.
+1. **Tell the app to bind to `[::]`** by setting `BINDING=::` in the container environment. `BINDING` is Rails' native env var for the server bind address. On any kernel with `net.ipv6.bindv6only=0` (the default on Linux and macOS) a single `[::]` bind is **dual-stack**: it accepts both IPv6 and IPv4 clients from the same socket. You do not need two binds and you do not need two ports.
 2. **Tell Docker to publish the host port on IPv6** by adding a bracketed-host `ports:` entry alongside the existing IPv4 one.
 
 In `compose.yml`:
@@ -128,14 +128,25 @@ services:
       - "[::]:${PORT:-3000}:3000"
     environment:
       <<: *rails_env
-      BIND_HOST: "::"
+      BINDING: "::"
 ```
 
 With both changes in place, `http://127.0.0.1:3000/` and `http://[::1]:3000/` both work against the same container.
 
-**Note:** Docker's default userland proxy already bridges host-side IPv6 publishes to the container's internal IPv4 address, so in many setups just adding the `[::]:` port entry is enough. Setting `BIND_HOST=::` inside the container only becomes load-bearing when the Docker daemon has `"ipv6": true` + `"ip6tables": true` configured (uncommon for self-hosters) and forwards raw IPv6 packets into the container via netfilter instead of the proxy. Setting both is harmless and future-proof.
+**Note:** Docker's default userland proxy already bridges host-side IPv6 publishes to the container's internal IPv4 address, so in many setups just adding the `[::]:` port entry is enough. Setting `BINDING=::` inside the container only becomes load-bearing when the Docker daemon has `"ipv6": true` + `"ip6tables": true` configured (uncommon for self-hosters) and forwards raw IPv6 packets into the container via netfilter instead of the proxy. Setting both is harmless and future-proof.
 
 If you are running behind a reverse proxy that terminates TLS, nothing else changes — `proxy_pass http://[::1]:3000` and `proxy_pass http://127.0.0.1:3000` both work because the `[::]` bind is dual-stack.
+
+#### Local development bind
+
+For `bin/dev` on your own machine, the server now defaults to Rails' native `localhost` bind (`127.0.0.1` + `[::1]`) — only reachable from the same machine. If you need external access (phone on the same WiFi, devcontainer port forwarding, LAN testing), set the Rails-native env var:
+
+```bash
+BINDING=0.0.0.0 bin/dev   # reachable from LAN
+BINDING=::       bin/dev  # IPv6 dual-stack
+```
+
+The bundled devcontainer at `.devcontainer/docker-compose.yml` already pins `BINDING: "0.0.0.0"` so Docker port forwarding reaches the app — no manual override needed when using the devcontainer.
 
 ### Step 4: Run the app
 

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -111,6 +111,32 @@ and change it to `true`
 RAILS_ASSUME_SSL: "true"
 ```
 
+#### Binding to IPv6 (optional)
+
+By default Sure listens on `0.0.0.0:3000` (IPv4 wildcard) and Docker publishes the port on the host's IPv4 interface only. If you want the app reachable over IPv6 as well, two things need to change:
+
+1. **Tell the app to bind to `[::]`** by setting `BIND_HOST=::` in the container environment. On any kernel with `net.ipv6.bindv6only=0` (the default on Linux and macOS) a single `[::]` bind is **dual-stack**: it accepts both IPv6 and IPv4 clients from the same socket. You do not need two binds and you do not need two ports.
+2. **Tell Docker to publish the host port on IPv6** by adding a bracketed-host `ports:` entry alongside the existing IPv4 one.
+
+In `compose.yml`:
+
+```yaml
+services:
+  web:
+    ports:
+      - ${PORT:-3000}:3000
+      - "[::]:${PORT:-3000}:3000"
+    environment:
+      <<: *rails_env
+      BIND_HOST: "::"
+```
+
+With both changes in place, `http://127.0.0.1:3000/` and `http://[::1]:3000/` both work against the same container.
+
+**Note:** Docker's default userland proxy already bridges host-side IPv6 publishes to the container's internal IPv4 address, so in many setups just adding the `[::]:` port entry is enough. Setting `BIND_HOST=::` inside the container only becomes load-bearing when the Docker daemon has `"ipv6": true` + `"ip6tables": true` configured (uncommon for self-hosters) and forwards raw IPv6 packets into the container via netfilter instead of the proxy. Setting both is harmless and future-proof.
+
+If you are running behind a reverse proxy that terminates TLS, nothing else changes — `proxy_pass http://[::1]:3000` and `proxy_pass http://127.0.0.1:3000` both work because the `[::]` bind is dual-stack.
+
 ### Step 4: Run the app
 
 You are now ready to run the app. Start with the following command to make sure everything is working:


### PR DESCRIPTION
## Summary

  Make Sure reachable over IPv6 without editing the repo, using Rails' native `BINDING` env var. No new configuration surface invented — `BINDING` is the existing Rails-level
   knob; this PR just documents it and wires the devcontainer + `compose.example.yml` to it.

  Along the way, this fixes two latent issues in the bind plumbing:
  - `Procfile.dev` was hardcoding `-b 0.0.0.0`, exposing `bin/dev` to the entire local network by default (less secure than Rails' own `localhost` convention).
  - `.devcontainer/docker-compose.yml` had a dead `HOST: "0.0.0.0"` env var — Rails 7.2's `rails server` command reads `BINDING`, not `HOST`, so the old entry did nothing.

  ## Changes

  - **`Procfile.dev`** — drop the hardcoded `-b 0.0.0.0`. `bin/dev` now defaults to Rails' native `localhost` bind (`127.0.0.1` + `[::1]`), reachable only from the local
  machine. More secure by default.
  - **`.devcontainer/docker-compose.yml`** — replace the dead `HOST: "0.0.0.0"` with `BINDING: "0.0.0.0"`. Devcontainer users keep the port-forwarding experience; nothing to
  change in their workflow.
  - **`compose.example.yml`** — add a commented IPv6 section under `web.ports:` and `web.environment:` showing how to publish on `[::]` and set `BINDING: "::"` for
  dual-stack.
  - **`docs/hosting/docker.md`** — new "Binding to IPv6 (optional)" subsection plus a short "Local development bind" note covering `BINDING=0.0.0.0 bin/dev` (LAN/phone
  testing) and `BINDING=:: bin/dev` (IPv6 dual-stack).
  - **`config/puma.rb`** — touched only to update the comment near `port`, pointing readers at `BINDING`. No behavior change.

  ## Backwards compatibility

  | Entry point | Before | After | Same? |
  |---|---|---|---|
  | `bin/dev` | `0.0.0.0:3000` (all LAN interfaces) | `127.0.0.1` + `[::1]` (localhost only) | **Behavior change — more secure** |
  | Devcontainer (`.devcontainer/docker-compose.yml`) | `0.0.0.0:3000` via dead-`HOST` + `-b 0.0.0.0` | `0.0.0.0:3000` via `BINDING=0.0.0.0` env | ✓ identical |
  | Production Docker (`compose.example.yml`) | `0.0.0.0:3000` (Rails prod default) | `0.0.0.0:3000` (Rails prod default, unchanged) | ✓ identical |
  | IPv6 | Unsupported | Opt-in via `BINDING=::` | new |

  **Behavior change for `bin/dev`**: anyone previously relying on the `-b 0.0.0.0` default for mobile testing or LAN access needs to run `BINDING=0.0.0.0 bin/dev` from now on
   (or export it in their shell). Documented in `docs/hosting/docker.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for enabling IPv6 dual-stack in containerized setups, with notes on environment-driven binding and port mapping for IPv4/IPv6.

* **Chores**
  * Standardized server binding behavior across development and container configs and removed an explicit bind flag from the local dev server command to rely on the configured binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->