### PR TITLE
[ExchangeRate::Importer]: just import vaild echange rate from provider

### DIFF
--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -1,9 +1,7 @@
 class ExchangeRate::Importer
   MissingExchangeRateError = Class.new(StandardError)
   MissingStartRateError = Class.new(StandardError)
-  def window_day
-    @window_day = 5
-  end
+
   def initialize(exchange_rate_provider:, from:, to:, start_date:, end_date:, clear_cache: false)
     @exchange_rate_provider = exchange_rate_provider
     @from = from

--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -101,6 +101,7 @@ class ExchangeRate::Importer
         )
 
         if provider_response.success?
+          Rails.logger.debug("Fetched #{provider_response.data.size} rates from #{exchange_rate_provider.class.name} for #{from}/#{to} between #{provider_fetch_start_date} and #{end_date}")
           provider_response.data.index_by(&:date)
         else
           message = "#{exchange_rate_provider.class.name} could not fetch exchange rate pair from: #{from} to: #{to} between: #{effective_start_date} and: #{Date.current}.  Provider error: #{provider_response.error.message}"

--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -32,7 +32,10 @@ class ExchangeRate::Importer
     filtered_rates = provider_rates.select { |date, _| date >= effective_start_date }
     filtered_rates.each do |date, r|
       rate = r&.rate
-      next unless rate.present? && rate.to_f > 0
+      unless rate.present? && rate.to_f > 0
+        Rails.logger.warn("Discarding invalid exchange rate for #{from}/#{to} on #{date}")
+        next
+      end
 
       updated_rates << {
         from_currency: from,
@@ -55,7 +58,7 @@ class ExchangeRate::Importer
       upsert_rows(updated_rates)
       upsert_rows(inverse_rates)
     else
-      Rails.logger.debug("No valid rates to sync for #{from} to #{to} between #{start_date} and #{end_date} after filtering provider response")
+      Rails.logger.warn("No valid rates to sync for #{from} to #{to} between #{start_date} and #{end_date} after filtering provider response")
     end
 
     # Also backfill inverse rows for any forward rates that existed in the DB

--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -11,7 +11,8 @@ class ExchangeRate::Importer
     @clear_cache = clear_cache
   end
 
-  # Constructs a daily series of rates for the given currency pair for date range
+  # Constructs ExchangeRate records for the given date range and currency pair by fetching
+  # We don't need to fill everyday exhange_rate, because when ExhangeRate.find_or_fetch_rate wiill handle it
   def import_provider_rates
     if !clear_cache && all_rates_exist?
       Rails.logger.info("No new rates to sync for #{from} to #{to} between #{start_date} and #{end_date}, skipping")
@@ -24,56 +25,31 @@ class ExchangeRate::Importer
       return
     end
 
-    prev_rate_value = start_rate_value
+    updated_rates = []
+    inverse_rates = []
 
-    unless prev_rate_value.present?
-      error = MissingStartRateError.new("Could not find a start rate for #{from} to #{to} between #{start_date} and #{end_date}")
-      Rails.logger.error(error.message)
-      Sentry.capture_exception(error)
-      return
-    end
+    provider_rates.each do |date, r|
+      rate = r&.rate
+      next unless rate.present? && rate.to_f > 0
 
-    gapfilled_rates = effective_start_date.upto(end_date).map do |date|
-      db_rate_value = db_rates[date]&.rate
-      provider_rate_value = provider_rates[date]&.rate
-
-      chosen_rate = if clear_cache
-        provider_rate_value || db_rate_value   # overwrite when possible
-      else
-        db_rate_value || provider_rate_value   # fill gaps
-      end
-
-      # Gapfill with LOCF strategy (last observation carried forward)
-      # Treat nil or zero rates as invalid and use previous rate
-      if chosen_rate.nil? || chosen_rate.to_f <= 0
-        chosen_rate = prev_rate_value
-      end
-
-      prev_rate_value = chosen_rate
-
-      {
+      updated_rates << {
         from_currency: from,
         to_currency: to,
         date: date,
-        rate: chosen_rate
+        rate: rate
+      }
+
+      # Compute and upsert inverse rates (e.g., EUR→USD from USD→EUR) to avoid
+      # separate API calls for the reverse direction.
+      inverse_rates << {
+        from_currency: to,
+        to_currency: from,
+        date: date,
+        rate: (BigDecimal("1") / BigDecimal(rate.to_s)).round(12)
       }
     end
 
-    upsert_rows(gapfilled_rates)
-
-    # Compute and upsert inverse rates (e.g., EUR→USD from USD→EUR) to avoid
-    # separate API calls for the reverse direction.
-    inverse_rates = gapfilled_rates.filter_map do |row|
-      next if row[:rate].to_f <= 0
-
-      {
-        from_currency: row[:to_currency],
-        to_currency: row[:from_currency],
-        date: row[:date],
-        rate: (BigDecimal("1") / BigDecimal(row[:rate].to_s)).round(12)
-      }
-    end
-
+    upsert_rows(updated_rates)
     upsert_rows(inverse_rates)
 
     # Also backfill inverse rows for any forward rates that existed in the DB
@@ -102,27 +78,14 @@ class ExchangeRate::Importer
       total_upsert_count
     end
 
-    # Since provider may not return values on weekends and holidays, we grab the first rate from the provider that is on or before the start date
-    def start_rate_value
-      provider_rate_value = provider_rates.select { |date, _| date <= start_date }.max_by { |date, _| date }&.last&.rate
-      db_rate_value = db_rates[start_date]&.rate
-      provider_rate_value || db_rate_value
-    end
 
     # No need to fetch/upsert rates for dates that we already have in the DB
     def effective_start_date
-      return start_date if clear_cache
+      @effective_start_date ||= begin
+        return start_date if clear_cache
 
-      first_missing_date = nil
-
-      start_date.upto(end_date) do |date|
-        unless db_rates.key?(date)
-          first_missing_date = date
-          break
-        end
+        (start_date..end_date).find { |date| !db_rates.key?(date) } || end_date
       end
-
-      first_missing_date || end_date
     end
 
     def provider_rates

--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -1,7 +1,9 @@
 class ExchangeRate::Importer
   MissingExchangeRateError = Class.new(StandardError)
   MissingStartRateError = Class.new(StandardError)
-
+  def window_day
+    @window_day = 5
+  end
   def initialize(exchange_rate_provider:, from:, to:, start_date:, end_date:, clear_cache: false)
     @exchange_rate_provider = exchange_rate_provider
     @from = from
@@ -28,7 +30,9 @@ class ExchangeRate::Importer
     updated_rates = []
     inverse_rates = []
 
-    provider_rates.each do |date, r|
+    # Because provider_rates contains -5days data
+    filtered_rates = provider_rates.select { |date, _| date >= effective_start_date }
+    filtered_rates.each do |date, r|
       rate = r&.rate
       next unless rate.present? && rate.to_f > 0
 

--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -57,8 +57,10 @@ class ExchangeRate::Importer
     if updated_rates.any?
       upsert_rows(updated_rates)
       upsert_rows(inverse_rates)
-    else
-      Rails.logger.warn("No valid rates to sync for #{from} to #{to} between #{start_date} and #{end_date} after filtering provider response")
+      Rails.logger.debug("Upserted #{updated_rates.size} rates for #{from} to #{to} between #{effective_start_date} and #{end_date}")
+      if filtered_rates.any?
+        Rails.logger.warn("No valid rates to sync for #{from} to #{to} between #{start_date} and #{end_date} after filtering provider response")
+      end
     end
 
     # Also backfill inverse rows for any forward rates that existed in the DB

--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -53,8 +53,12 @@ class ExchangeRate::Importer
       }
     end
 
-    upsert_rows(updated_rates)
-    upsert_rows(inverse_rates)
+    if updated_rates.any?
+      upsert_rows(updated_rates)
+      upsert_rows(inverse_rates)
+    else
+      Rails.logger.debug("No valid rates to sync for #{from} to #{to} between #{start_date} and #{end_date} after filtering provider response")
+    end
 
     # Also backfill inverse rows for any forward rates that existed in the DB
     # before effective_start_date (i.e. dates not covered by gapfilled_rates).

--- a/app/models/exchange_rate/provided.rb
+++ b/app/models/exchange_rate/provided.rb
@@ -58,6 +58,13 @@ module ExchangeRate::Provided
     def rates_for(currencies, to:, date: Date.current)
       currencies.uniq.each_with_object({}) do |currency, map|
         rate = find_or_fetch_rate(from: currency, to: to, date: date)
+        if rate.nil?
+          Rails.logger.warn("No exchange rate found for #{currency}/#{to}, using 1")
+        else
+          if rate.date != date
+            Rails.logger.warn("Fallback FX rate #{currency}/#{to}: using #{rate.date} for #{date} (gap=#{date - rate.date})")
+          end
+        end
         map[currency] = rate&.rate || 1
       end
     end


### PR DESCRIPTION
We don't need to fill everyday exhange_rate, because when ExhangeRate.find_or_fetch_rate wiill handle it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exchange rate importer now only ingests valid provider-returned rates, avoids deriving missing start rates from invalid data, and skips updates when no valid rates are available to prevent incorrect entries.

* **Chores**
  * Improved logging: summary debug after fetch and warnings when provider rates are missing or dates differ, aiding visibility and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->