### PR TITLE
Add default currency to price and fee fields

### DIFF
--- a/app/views/trades/_form.html.erb
+++ b/app/views/trades/_form.html.erb
@@ -51,7 +51,7 @@
       <%= form.date_field :date, label: true, value: model.date || Date.current, required: true %>
 
       <% unless %w[buy sell].include?(type) %>
-        <%= form.money_field :amount, label: t(".amount"), value: model.amount, required: true %>
+        <%= form.money_field :amount, label: t(".amount"), value: model.amount, required: true, default_currency: account&.currency %>
       <% end %>
 
       <% if %w[deposit withdrawal].include?(type) %>

--- a/app/views/trades/_form.html.erb
+++ b/app/views/trades/_form.html.erb
@@ -60,8 +60,8 @@
 
       <% if %w[buy sell].include?(type) %>
         <%= form.number_field :qty, label: t(".qty"), placeholder: "10", min: 0.000000000000000001, step: "any", required: true %>
-        <%= form.money_field :price, label: t(".price"), step: "any", precision: 10, required: true %>
-        <%= form.money_field :fee, label: t(".fee"), step: "any", min: 0 %>
+        <%= form.money_field :price, label: t(".price"), step: "any", precision: 10, required: true, default_currency: account&.currency %>
+        <%= form.money_field :fee, label: t(".fee"), step: "any", min: 0, default_currency: account&.currency %>
       <% end %>
     </div>
 


### PR DESCRIPTION
Set account currency as default currency instead of defaulting to USD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trade form price and fee fields now default to the account currency for buy/sell trades.
  * Trade form amount field now defaults to the account currency for non-buy/sell trade types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->