### PR TITLE
Feature: persist new transaction data when tabbing from Expense/Income to Transfer (and back)

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -7,6 +7,8 @@ class TransfersController < ApplicationController
   def new
     @transfer = Transfer.new
     @from_account_id = params[:from_account_id]
+    @amount = params[:amount]
+    @date = params[:date]
   end
 
   def show

--- a/app/javascript/controllers/transaction_type_tabs_controller.js
+++ b/app/javascript/controllers/transaction_type_tabs_controller.js
@@ -2,9 +2,21 @@ import { Controller } from "@hotwired/stimulus"
 
 const ACTIVE_CLASSES = ["bg-container", "text-primary", "shadow-sm"]
 const INACTIVE_CLASSES = ["hover:bg-container", "text-subdued", "hover:text-primary", "hover:shadow-sm"]
+const STORAGE_KEY = "transaction_form_state"
 
 export default class extends Controller {
   static targets = ["tab", "natureField"]
+
+  connect() {
+    // Back on the transaction form — any pending submit listener is no longer needed
+    this.#removeClearListener()
+
+    const saved = sessionStorage.getItem(STORAGE_KEY)
+    if (!saved) return
+
+    sessionStorage.removeItem(STORAGE_KEY)
+    this.#restoreState(JSON.parse(saved))
+  }
 
   selectTab(event) {
     event.preventDefault()
@@ -17,5 +29,121 @@ export default class extends Controller {
       tab.classList.remove(...(isActive ? INACTIVE_CLASSES : ACTIVE_CLASSES))
       tab.classList.add(...(isActive ? ACTIVE_CLASSES : INACTIVE_CLASSES))
     })
+  }
+
+  saveAndNavigate(event) {
+    event.preventDefault()
+
+    const state = this.#captureState()
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+
+    // If the user submits the transfer form without returning to expense/income,
+    // this listener clears the saved state so it doesn't appear next time.
+    this.#addClearListener()
+
+    const url = new URL(event.currentTarget.href)
+    const amount = state["entry[amount]"]
+    if (amount) url.searchParams.set("amount", amount)
+
+    const date = state["entry[date]"]
+    if (date) url.searchParams.set("date", date)
+
+    Turbo.visit(url.toString(), { frame: "modal" })
+  }
+
+  // private
+
+  #addClearListener() {
+    this.#removeClearListener()
+    this._clearListener = (e) => {
+      if (e.detail.success) {
+        sessionStorage.removeItem(STORAGE_KEY)
+        this.#removeClearListener()
+      }
+    }
+    document.addEventListener("turbo:submit-end", this._clearListener)
+  }
+
+  #removeClearListener() {
+    if (this._clearListener) {
+      document.removeEventListener("turbo:submit-end", this._clearListener)
+      this._clearListener = null
+    }
+  }
+
+  #captureState() {
+    const form = this.element.closest("form")
+    if (!form) return {}
+
+    const state = {}
+
+    // Standard visible inputs, selects, textareas
+    form.querySelectorAll("input:not([type=hidden]), select, textarea").forEach(el => {
+      if (!el.name) return
+
+      if (el.tagName === "SELECT" && el.multiple) {
+        state[el.name] = Array.from(el.selectedOptions).map(o => o.value)
+      } else {
+        state[el.name] = el.value
+      }
+    })
+
+    // Custom DS::Select components store their value in a hidden input
+    form.querySelectorAll("input[data-form-dropdown-target='input']").forEach(el => {
+      if (el.name) state[el.name] = el.value
+    })
+
+    // Preserve the nature hidden field
+    const natureField = form.querySelector("input[name='entry[nature]']")
+    if (natureField) state[natureField.name] = natureField.value
+
+    return state
+  }
+
+  #restoreState(state) {
+    const form = this.element.closest("form")
+    if (!form) return
+
+    for (const [name, value] of Object.entries(state)) {
+      const el = form.querySelector(`[name="${CSS.escape(name)}"]`)
+      if (!el) continue
+
+      if (el.dataset.formDropdownTarget === "input") {
+        this.#restoreCustomSelect(el, value)
+      } else if (el.tagName === "SELECT" && el.multiple) {
+        Array.from(el.options).forEach(opt => {
+          opt.selected = value.includes(opt.value)
+        })
+        el.dispatchEvent(new Event("change", { bubbles: true }))
+      } else {
+        el.value = value
+        el.dispatchEvent(new Event("change", { bubbles: true }))
+      }
+    }
+  }
+
+  #restoreCustomSelect(hiddenInput, value) {
+    hiddenInput.value = value
+
+    const container = hiddenInput.closest("[data-controller~='select']")
+    if (!container) return
+
+    const option = container.querySelector(`[data-value="${CSS.escape(value)}"]`)
+    const button = container.querySelector("[data-select-target='button']")
+
+    if (button) {
+      button.textContent = option
+        ? (option.dataset.filterName || option.textContent.trim())
+        : button.textContent
+    }
+
+    container.querySelectorAll("[role='option']").forEach(opt => {
+      const isSelected = opt.dataset.value == value
+      opt.setAttribute("aria-selected", String(isSelected))
+      opt.classList.toggle("bg-container-inset", isSelected)
+      opt.querySelector(".check-icon")?.classList.toggle("hidden", !isSelected)
+    })
+
+    hiddenInput.dispatchEvent(new Event("change", { bubbles: true }))
   }
 }

--- a/app/javascript/controllers/transaction_type_tabs_controller.js
+++ b/app/javascript/controllers/transaction_type_tabs_controller.js
@@ -93,10 +93,6 @@ export default class extends Controller {
       if (el.name) state[el.name] = el.value
     })
 
-    // Preserve the nature hidden field
-    const natureField = form.querySelector("input[name='entry[nature]']")
-    if (natureField) state[natureField.name] = natureField.value
-
     return state
   }
 

--- a/app/javascript/controllers/transaction_type_tabs_controller.js
+++ b/app/javascript/controllers/transaction_type_tabs_controller.js
@@ -134,7 +134,7 @@ export default class extends Controller {
     }
 
     container.querySelectorAll("[role='option']").forEach(opt => {
-      const isSelected = opt.dataset.value == value
+      const isSelected = opt.dataset.value === value
       opt.setAttribute("aria-selected", String(isSelected))
       opt.classList.toggle("bg-container-inset", isSelected)
       opt.querySelector(".check-icon")?.classList.toggle("hidden", !isSelected)

--- a/app/views/shared/_transaction_type_tabs.html.erb
+++ b/app/views/shared/_transaction_type_tabs.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <%= link_to new_transfer_path(from_account_id: account_id),
-              data: { turbo_frame: :modal },
+              data: { turbo_frame: :modal, action: "click->transaction-type-tabs#saveAndNavigate" },
               class: "flex-1 min-w-0 flex px-4 py-1 rounded-lg items-center space-x-2 justify-center text-sm #{active_tab == 'transfer' ? 'bg-container text-primary shadow-sm' : 'hover:bg-container text-subdued hover:text-primary hover:shadow-sm'}" do %>
     <%= icon "arrow-right-left" %>
     <%= tag.span class: "truncate" do %>

--- a/app/views/transfers/_form.html.erb
+++ b/app/views/transfers/_form.html.erb
@@ -31,9 +31,9 @@
     <%= f.collection_select :from_account_id, @accounts, :id, :name, { prompt: t(".select_account"), label: t(".from"), selected: @from_account_id, variant: :logo }, { required: true, data: { transfer_form_target: "fromAccount", action: "change->transfer-form#checkCurrencyDifference" } } %>
     <%= f.collection_select :to_account_id, @accounts, :id, :name, { prompt: t(".select_account"), label: t(".to"), variant: :logo }, { required: true, data: { transfer_form_target: "toAccount", action: "change->transfer-form#checkCurrencyDifference" } } %>
     
-    <%= f.date_field :date, value: transfer.inflow_transaction&.entry&.date || Date.current, label: t(".date"), required: true, max: Date.current, data: { transfer_form_target: "date", action: "change->transfer-form#checkCurrencyDifference" } %>
+    <%= f.date_field :date, value: transfer.inflow_transaction&.entry&.date || @date || Date.current, label: t(".date"), required: true, max: Date.current, data: { transfer_form_target: "date", action: "change->transfer-form#checkCurrencyDifference" } %>
     
-    <%= f.number_field :amount, label: t(".source_amount"), required: true, min: 0, placeholder: "100", step: 0.00000001, data: { transfer_form_target: "amount", action: "input->transfer-form#onSourceAmountChange" } %>
+    <%= f.number_field :amount, label: t(".source_amount"), required: true, min: 0, placeholder: "100", step: 0.00000001, value: @amount, data: { transfer_form_target: "amount", action: "input->transfer-form#onSourceAmountChange" } %>
     
     <% convert_input = capture do %>
       <%= f.number_field :exchange_rate,


### PR DESCRIPTION
As per https://github.com/we-promise/sure/issues/1400#issuecomment-4218811867

## Summary

- Switching between Expense and Income tabs no longer wipes entered form data — the switch is now handled entirely client-side via a Stimulus controller, with no server round-trip.
- Switching to the Transfer tab saves all transaction form state to `sessionStorage` before navigating; returning to Expense/Income restores it fully, including custom DS::Select dropdowns (account, category, merchant) and multi-select tags.
- Amount and date are pre-populated on the Transfer form when arriving from an Expense/Income tab.
- Saved state is cleared automatically after any successful form submission so stale data never reappears on the next "New transaction" open.

## What changed

### `app/javascript/controllers/transaction_type_tabs_controller.js` (new file)

New Stimulus controller that owns all tab-switching behaviour in the New Transaction modal.

**Expense ↔ Income (client-side only):**
`selectTab` intercepts the click, updates the hidden `entry[nature]` field (`outflow`/`inflow`), and swaps the active/inactive CSS classes on the tab links. No server request is made, so no form data is lost.

**Expense/Income → Transfer (`saveAndNavigate`):**
Before the Turbo Frame navigation to `/transfers/new`, all transaction form field values are serialised into `sessionStorage`. The amount and date are also appended as URL params so the Transfer form can pre-populate those fields immediately. A document-level `turbo:submit-end` listener is registered at this point to clear the saved state if the user submits the Transfer form without returning.

**Transfer → Expense/Income (`connect`):**
On controller mount, any pending submit listener is removed (since we're back on the form), then `sessionStorage` is checked. If saved state is found it is consumed and removed immediately, then every field is restored:

- Standard inputs, date fields, and textareas: `.value =` + `change` event.
- Native multi-selects (tags): iterates `<option>` elements and sets `.selected`, then dispatches `change`.
- `DS::Select` custom dropdowns (account, category, merchant): sets the hidden `[data-form-dropdown-target="input"]` value, updates the visible button label, and syncs `aria-selected` / check-icon state on each option item.

**State cleanup (`#addClearListener` / `#removeClearListener`):**
A self-removing `turbo:submit-end` listener is registered whenever state is saved. It fires on the first successful submission — whether that's the Transfer form (controller already disconnected) or the transaction form — and clears `sessionStorage`. `connect()` also removes the listener if the user navigates back to Expense/Income, since the state is consumed there instead.

### `app/views/shared/_transaction_type_tabs.html.erb`

- Expense and Income tab links: added `data-action`, `data-nature`, and `data-transaction-type-tabs-target` attributes so the Stimulus controller can intercept clicks and update the hidden field. The `turbo_frame: :modal` attribute is kept but never reached for these two tabs (the controller calls `preventDefault`). In the Transfer form context — where the controller is absent — these links still navigate normally via Turbo.
- Transfer tab link: added `data-action="click->transaction-type-tabs#saveAndNavigate"` so the controller can serialise state before navigation. No change to navigation behaviour.

### `app/views/transactions/_form.html.erb`

Added `data-controller="transaction-type-tabs"` to the wrapping `<section>` and `data-transaction-type-tabs-target="natureField"` to the hidden `entry[nature]` field, connecting the form to the controller.

### `app/controllers/transfers_controller.rb`

`new` action now reads `params[:amount]` and `params[:date]` into `@amount` and `@date` instance variables for use by the form.

### `app/views/transfers/_form.html.erb`

Amount field: `value: @amount` added — pre-populates from the transaction form when arriving via the Transfer tab.
Date field: `@date` inserted into the fallback chain (`transfer date || @date || Date.current`) — pre-populates from the transaction form when arriving via the Transfer tab.

## Test plan

- [x] Open New Transaction modal. Enter values in all fields: description, account, amount, category, date, merchant, tags, notes.
- [x] Click **Income** tab — all entered values are preserved.
- [x] Click **Expense** tab — all entered values are preserved.
- [x] Click **Transfer** tab — the Transfer form opens with amount and date pre-populated from what was entered.
- [x] Click **Expense** or **Income** tab from the Transfer form — all previously entered transaction values are restored, including account and category dropdowns.
- [x] With restored values, submit the transaction — confirm the created transaction has the correct values.
- [x] Open New Transaction, fill in fields, click Transfer, then click **Create transfer** — confirm transfer is created, then open New Transaction again and confirm no stale data appears.
- [x] Open New Transaction, fill in fields, click Transfer, click **Expense**, then click **Add transaction** — confirm transaction is created and opening New Transaction again shows a blank form.
- [x] Open New Transaction from an account page (account pre-selected) — confirm the Transfer tab still pre-populates `from_account_id` as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form state persistence: current transaction form values are saved when switching transaction types and restored when returning to the transfer form.
  * Navigation preserves and forwards amount/date so the transfer form is pre-filled when opened.
  * Transfer form now prefers incoming amount/date values for reliable pre-population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->