### PR TITLE
perf: Defer `autoUpdate` until menu is open to fix slow profile icon rendering

### DIFF
--- a/app/components/DS/menu_controller.js
+++ b/app/components/DS/menu_controller.js
@@ -24,7 +24,6 @@ export default class extends Controller {
     this.show = this.showValue;
     this.boundUpdate = this.update.bind(this);
     this.addEventListeners();
-    this.startAutoUpdate();
   }
 
   disconnect() {
@@ -66,14 +65,18 @@ export default class extends Controller {
     this.show = !this.show;
     this.contentTarget.classList.toggle("hidden", !this.show);
     if (this.show) {
+      this.startAutoUpdate();
       this.update();
       this.focusFirstElement();
+    } else {
+      this.stopAutoUpdate();
     }
   };
 
   close() {
     this.show = false;
     this.contentTarget.classList.add("hidden");
+    this.stopAutoUpdate();
   }
 
   focusFirstElement() {


### PR DESCRIPTION
The `autoUpdate` from `@floating-ui/dom` was being started in `connect()`, causing immediate layout/size calculations for every menu instance on page load even while closed. Moved `autoUpdate` to only run when the menu is open, and stop when closed/toggled off.

https://claude.ai/code/session_01FkTsyLvEod4qN6T5dNidkL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed menu position tracking to activate only when the menu is open and deactivate when closed, improving performance and ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->