### PR TITLE
Fix module specifier path for parse_locale_float import

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,6 +7,7 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin_all_from "app/components", under: "controllers", to: ""
 pin_all_from "app/javascript/services", under: "services", to: "services"
+pin_all_from "app/javascript/utils", under: "utils", to: "utils"
 pin "@github/hotkey", to: "@github--hotkey.js" # @3.1.1
 pin "@simonwep/pickr", to: "@simonwep--pickr.js" # @1.9.1
 


### PR DESCRIPTION
The import used a bare module specifier 'utils/parse_locale_float' which browsers cannot resolve. Changed to relative path './utils/parse_locale_float'.

Fixes PWA controller loading errors:
- convert_to_trade_controller
- cost_basis_form_controller  
- drawer_cost_basis_controller
- money_field_controller

Root cause: PR #1176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application configuration to support utility modules in the browser environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->