### PR TITLE
Optimize item display for trade and transaction

### DIFF
--- a/app/views/categories/_badge.html.erb
+++ b/app/views/categories/_badge.html.erb
@@ -1,5 +1,9 @@
-<%# locals: (category:) %>
+<%# locals: (category:, truncate_width: 0 ) %>
+
 <% category ||= Category.uncategorized %>
+<% should_truncate = truncate_width.to_i > 0 %>
+<% text_classes = should_truncate ? "truncate" : "" %>
+<% max_width_style = should_truncate ? "max-width: #{truncate_width}px;" : "" %>
 
 <div>
   <span class="flex items-center gap-1 text-sm font-medium rounded-full px-1.5 py-1 border truncate focus-visible:outline-none focus-visible:ring-0"
@@ -10,6 +14,11 @@
     <% if category.lucide_icon.present? %>
       <%= icon category.lucide_icon, size: "sm", color: "current" %>
     <% end %>
-    <%= category.name %>
+    <span
+      class="<%= text_classes %>"
+      style="<%= max_width_style %>"
+      <%= "title='#{category.name}'" if should_truncate %>>
+      <%= category.name %>
+    </span>
   </span>
 </div>

--- a/app/views/entries/_logo.html.erb
+++ b/app/views/entries/_logo.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (name:, logo_url: nil, size: :lg, add_cls_attr: nil) %>
+
+<% config = DS::FilledIcon::SIZES.fetch(size, DS::FilledIcon::SIZES[:lg]) %>
+
+<% classes = [
+  config[:container_size],
+  "rounded-full border border-secondary object-cover",
+  add_cls_attr
+].compact.join(" ") %>
+
+<% if logo_url %>
+  <%= image_tag Setting.transform_brand_fetch_url(logo_url),
+      class: classes,
+      loading: "lazy",
+      onerror: "this.style.display='none'" %>
+<% else %>
+  <div class="<%= config[:container_size] %> flex items-center justify-center">
+    <%= render DS::FilledIcon.new(
+      variant: :text,
+      text: name,
+      size: size,
+      rounded: true
+    ) %>
+  </div>
+<% end %>

--- a/app/views/investment_activity/_badge.html.erb
+++ b/app/views/investment_activity/_badge.html.erb
@@ -24,7 +24,7 @@
   end
 %>
 
-<span class="inline-flex items-center gap-1 text-xs font-medium rounded px-1.5 py-0.5 border"
+<span class="inline-flex items-center gap-1 text-sm font-medium rounded-full px-1.5 py-0.1 border"
       style="
         background-color: color-mix(in oklab, <%= color %> 10%, transparent);
         border-color: color-mix(in oklab, <%= color %> 20%, transparent);

--- a/app/views/investment_activity/_quick_edit_badge.html.erb
+++ b/app/views/investment_activity/_quick_edit_badge.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (entry:, entryable:) %>
+<%# locals: (entry:, entryable:, activity_labels: nil, can_convert: nil, show_none: false) %>
 <%
   label = entryable.investment_activity_label
   has_label = label.present?
@@ -34,10 +34,11 @@
     "var(--color-gray-400)" # slightly lighter for empty state
   end
 
-  activity_labels = is_trade ? Trade::ACTIVITY_LABELS : Transaction::ACTIVITY_LABELS
+  activity_labels = activity_labels || ( is_trade ? Trade::ACTIVITY_LABELS : Transaction::ACTIVITY_LABELS )
   entryable_type = is_trade ? "Trade" : "Transaction"
   convert_url = is_transaction ? convert_to_trade_transaction_path(entryable) : nil
   income_trade = is_trade && %w[Dividend Interest].include?(label)
+  can_convert =  can_convert ||  !( entry.linked? || income_trade )
 %>
 
 <div class="relative"
@@ -51,7 +52,7 @@
      <% end %>>
 
   <button type="button"
-          class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 <%= income_trade ? "cursor-default" : "cursor-pointer hover:opacity-80" %> transition-opacity"
+          class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 <%= can_convert ? "cursor-pointer hover:opacity-80" : "cursor-default" %> transition-opacity"
           style="<% if has_label %>
             background-color: color-mix(in oklab, <%= color %> 15%, transparent);
             border: 1px solid color-mix(in oklab, <%= color %> 25%, transparent);
@@ -61,7 +62,7 @@
             border: 1px solid var(--color-border-secondary);
             color: var(--color-text-secondary);
           <% end %>"
-          <% unless income_trade %>
+          <% if can_convert %>
           data-action="click->activity-label-quick-edit#toggle"
           data-activity-label-quick-edit-target="badge"
           <% end %>
@@ -72,17 +73,17 @@
       <%= icon "tag", size: "xs", color: "current" %>
       <span><%= t("transactions.show.activity_type") %></span>
     <% end %>
-    <% unless income_trade %>
+    <% if can_convert %>
       <%= icon "chevron-down", size: "xs", color: "current" %>
     <% end %>
   </button>
 
-  <% unless income_trade %>
+  <% if can_convert %>
     <!-- Dropdown menu -->
     <div class="hidden absolute right-0 z-50 mt-1 w-44 rounded-lg border border-primary bg-container shadow-lg"
          data-activity-label-quick-edit-target="dropdown">
       <div class="py-1 max-h-64 overflow-y-auto">
-        <% if has_label %>
+        <% if has_label && show_none %>
           <button type="button"
                   class="w-full text-left px-3 py-1.5 text-sm text-secondary hover:bg-surface-inset transition-colors border-b border-primary"
                   data-action="click->activity-label-quick-edit#select"

--- a/app/views/investment_activity/_quick_edit_badge.html.erb
+++ b/app/views/investment_activity/_quick_edit_badge.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (entry:, entryable:, activity_labels: nil, disable_convert: nil, show_none: false) %>
+<%# locals: (entry:, entryable:, activity_labels: nil, disable_convert: true, show_none: false) %>
 <%
   label = entryable.investment_activity_label
   has_label = label.present?

--- a/app/views/investment_activity/_quick_edit_badge.html.erb
+++ b/app/views/investment_activity/_quick_edit_badge.html.erb
@@ -52,7 +52,7 @@
      <% end %>>
 
   <button type="button"
-          class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 <%= can_convert ? "cursor-pointer hover:opacity-80" : "cursor-default" %> transition-opacity"
+          class="inline-flex items-center gap-1 text-sm font-medium rounded-full px-2.5 py-1 <%= can_convert ? "cursor-pointer hover:opacity-80" : "cursor-default" %> transition-opacity"
           style="<% if has_label %>
             background-color: color-mix(in oklab, <%= color %> 15%, transparent);
             border: 1px solid color-mix(in oklab, <%= color %> 25%, transparent);

--- a/app/views/investment_activity/_quick_edit_badge.html.erb
+++ b/app/views/investment_activity/_quick_edit_badge.html.erb
@@ -3,8 +3,10 @@
   label = entryable.investment_activity_label
   has_label = label.present?
 
+  is_trade = entryable.is_a?(Trade)
+  is_transaction = entryable.is_a?(Transaction)
   # Build the correct URL based on entryable type
-  update_url = entryable.is_a?(Transaction) ? transaction_path(entry) : trade_path(entry)
+  update_url = is_transaction ? transaction_path(entry) : trade_path(entry)
 
   # Color mapping for different investment activity labels using design system tokens
   color = if has_label
@@ -32,10 +34,10 @@
     "var(--color-gray-400)" # slightly lighter for empty state
   end
 
-  activity_labels = entryable.is_a?(Trade) ? Trade::ACTIVITY_LABELS : Transaction::ACTIVITY_LABELS
-  entryable_type = entryable.is_a?(Trade) ? "Trade" : "Transaction"
-  convert_url = entryable.is_a?(Transaction) ? convert_to_trade_transaction_path(entryable) : nil
-  income_trade = entryable.is_a?(Trade) && %w[Dividend Interest].include?(label)
+  activity_labels = is_trade ? Trade::ACTIVITY_LABELS : Transaction::ACTIVITY_LABELS
+  entryable_type = is_trade ? "Trade" : "Transaction"
+  convert_url = is_transaction ? convert_to_trade_transaction_path(entryable) : nil
+  income_trade = is_trade && %w[Dividend Interest].include?(label)
 %>
 
 <div class="relative"

--- a/app/views/investment_activity/_quick_edit_badge.html.erb
+++ b/app/views/investment_activity/_quick_edit_badge.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (entry:, entryable:, activity_labels: nil, can_convert: nil, show_none: false) %>
+<%# locals: (entry:, entryable:, activity_labels: nil, disable_convert: nil, show_none: false) %>
 <%
   label = entryable.investment_activity_label
   has_label = label.present?
@@ -38,7 +38,7 @@
   entryable_type = is_trade ? "Trade" : "Transaction"
   convert_url = is_transaction ? convert_to_trade_transaction_path(entryable) : nil
   income_trade = is_trade && %w[Dividend Interest].include?(label)
-  can_convert =  can_convert ||  !( entry.linked? || income_trade )
+  disable_convert ||= income_trade || entry.linked?
 %>
 
 <div class="relative"
@@ -52,7 +52,7 @@
      <% end %>>
 
   <button type="button"
-          class="inline-flex items-center gap-1 text-sm font-medium rounded-full px-2.5 py-1 <%= can_convert ? "cursor-pointer hover:opacity-80" : "cursor-default" %> transition-opacity"
+          class="inline-flex items-center gap-1 text-sm font-medium rounded-full px-2.5 py-1 <%= disable_convert ? "cursor-default" : "cursor-pointer hover:opacity-80" %> transition-opacity"
           style="<% if has_label %>
             background-color: color-mix(in oklab, <%= color %> 15%, transparent);
             border: 1px solid color-mix(in oklab, <%= color %> 25%, transparent);
@@ -62,9 +62,9 @@
             border: 1px solid var(--color-border-secondary);
             color: var(--color-text-secondary);
           <% end %>"
-          <% if can_convert %>
-          data-action="click->activity-label-quick-edit#toggle"
-          data-activity-label-quick-edit-target="badge"
+          <% unless disable_convert %>
+            data-action="click->activity-label-quick-edit#toggle"
+            data-activity-label-quick-edit-target="badge"
           <% end %>
           title="<%= has_label ? t("transactions.transaction.activity_type_tooltip") : t("transactions.show.activity_type") %>">
     <% if has_label %>
@@ -73,12 +73,12 @@
       <%= icon "tag", size: "xs", color: "current" %>
       <span><%= t("transactions.show.activity_type") %></span>
     <% end %>
-    <% if can_convert %>
+    <% unless disable_convert %>
       <%= icon "chevron-down", size: "xs", color: "current" %>
     <% end %>
   </button>
 
-  <% if can_convert %>
+  <% unless disable_convert %>
     <!-- Dropdown menu -->
     <div class="hidden absolute right-0 z-50 mt-1 w-44 rounded-lg border border-primary bg-container shadow-lg"
          data-activity-label-quick-edit-target="dropdown">

--- a/app/views/trades/_trade.html.erb
+++ b/app/views/trades/_trade.html.erb
@@ -1,64 +1,59 @@
 <%# locals: (entry:, balance_trend: nil, **) %>
 
 <% trade = entry.entryable %>
+<% logo_url = trade.security&.logo_url.presence %>
 
 <%= turbo_frame_tag dom_id(entry) do %>
   <%= turbo_frame_tag dom_id(trade) do %>
-    <div class="group grid grid-cols-12 items-center <%= entry.excluded ? "text-secondary bg-surface-inset" : "text-primary" %> text-sm font-medium p-4">
-      <div class="col-span-8 flex items-center gap-4">
+    <div class="group flex lg:grid lg:grid-cols-12 items-center text-primary text-sm font-medium p-3 lg:p-4 <%= entry.excluded ? "text-secondary bg-surface-inset" : "text-primary" %>">
+      <div class="col-span-8 flex items-center gap-4 min-w-0">
         <%= check_box_tag dom_id(entry, "selection"),
-                        class: "checkbox checkbox--light hidden lg:block",
-                        data: {
-                          id: entry.id,
-                          entry_type: entry.entryable_type,
-                          "bulk-select-target": "row",
-                          action: "bulk-select#toggleRowSelection",
-                          checkbox_toggle_target: "selectionEntry"
-                        } %>
+          class: "checkbox checkbox--light hidden lg:block",
+          data: {
+            id: entry.id,
+            entry_type: entry.entryable_type,
+            "bulk-select-target": "row",
+            action: "bulk-select#toggleRowSelection",
+            checkbox_toggle_target: "selectionEntry"
+          } %>
 
-        <div class="max-w-full">
-          <%= tag.div class: ["flex items-center gap-2 min-w-0"] do %>
-            <div class="hidden lg:flex">
-              <%= render DS::FilledIcon.new(
-                variant: :text,
-                text: entry.name,
-                size: "sm",
-                rounded: true
-              ) %>
-            </div>
+        <div class="flex md:hidden items-center gap-1 col-span-2 relative shrink-0">
+            <%= render "entries/logo", name: entry.name, logo_url: logo_url, size: :md %>
+        </div>
+              
 
-            <div class="flex lg:hidden">
-              <%= render "investment_activity/quick_edit_badge", entry: entry, entryable: trade %>
-            </div>
-
-            <div class="truncate flex-shrink">
-              <%= link_to entry.name,
-                        entry_path(entry),
-                        data: { turbo_frame: "drawer", turbo_prefetch: false },
-                        class: "hover:underline" %>
-            </div>
-          <% end %>
+        <div class="min-w-0 flex items-center gap-3 lg:gap-4 flex-1 <%= "opacity-50" if entry.excluded %>">
+          <div class="hidden md:flex flex-shrink-0">
+            <%= render "entries/logo", name: entry.name, logo_url: logo_url, size: :lg %>
+          </div>
+          <%= link_to entry.name,
+              entry_path(entry),
+              data: { turbo_frame: "drawer", turbo_prefetch: false },
+              class: "block truncate hover:underline" %>
         </div>
       </div>
 
-      <div class="hidden lg:flex col-span-2 items-center">
-        <%= render "investment_activity/quick_edit_badge", entry: entry, entryable: trade %>
+      <div class="hidden md:flex col-span-2 items-center">
+        <%= render "investment_activity/quick_edit_badge",
+            entry: entry, entryable: trade %>
       </div>
 
-      <div class="shrink-0 col-span-4 lg:col-span-2 ml-auto flex items-center justify-end gap-2">
-        <%# Protection indicator - shows on hover when entry is protected from sync %>
+      <div class="col-span-4 lg:col-span-2 ml-auto flex items-center justify-end gap-2 shrink-0">
         <% if entry.protected_from_sync? && !entry.excluded? %>
           <%= link_to entry_path(entry),
-                data: { turbo_frame: "drawer", turbo_prefetch: false },
-                class: "invisible group-hover:visible transition-opacity",
-                title: t("entries.protection.tooltip") do %>
+              data: { turbo_frame: "drawer", turbo_prefetch: false },
+              class: "invisible group-hover:visible",
+              title: t("entries.protection.tooltip") do %>
             <%= icon "lock", size: "sm", class: "text-secondary" %>
           <% end %>
         <% end %>
-        <%= content_tag :p,
-                    format_money(-entry.amount_money),
-                    class: ["text-green-600": entry.amount.negative?] %>
+
+        <p class="<%= entry.amount.negative? ? 'text-green-600' : '' %>">
+          <%= format_money(-entry.amount_money) %>
+        </p>
+
       </div>
     </div>
+
   <% end %>
 <% end %>

--- a/app/views/transactions/_split_parent_row.html.erb
+++ b/app/views/transactions/_split_parent_row.html.erb
@@ -1,5 +1,8 @@
 <%# locals: (entry:) %>
-<% transaction = entry.entryable %>
+<% 
+  transaction = entry.entryable
+  logo_url = transaction.merchant&.logo_url.presence 
+%>
 
 <div class="group flex lg:grid lg:grid-cols-12 items-center text-sm font-medium p-3 lg:p-4 opacity-50 text-secondary">
   <div class="pr-4 lg:pr-10 flex items-center gap-3 lg:gap-4 col-span-8 min-w-0">
@@ -8,21 +11,11 @@
 
     <div class="max-w-full">
       <div class="flex items-center gap-3 lg:gap-4">
-        <div class="hidden lg:flex">
-          <% if transaction.merchant&.logo_url.present? %>
-            <%= image_tag Setting.transform_brand_fetch_url(transaction.merchant.logo_url),
-                class: "w-9 h-9 rounded-full border border-secondary",
-                loading: "lazy" %>
-          <% else %>
-            <div class="hidden lg:flex">
-              <%= render DS::FilledIcon.new(
-                variant: :text,
-                text: entry.name,
-                size: "lg",
-                rounded: true
-              ) %>
-            </div>
-          <% end %>
+        <div class="hidden md:flex">
+          <%= render "entries/logo", name: entry.name, logo_url: logo_url, size: :lg %>
+        </div>
+        <div class="md:hidden">
+          <%= render "entries/logo", name: entry.name, logo_url: logo_url, size: :md %>
         </div>
 
         <div class="truncate">

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -1,6 +1,8 @@
 <%# locals: (entry:, balance_trend: nil, view_ctx: "global", in_split_group: false) %>
-
-<% transaction = entry.entryable %>
+<% 
+  transaction = entry.entryable
+  logo_url = transaction.merchant&.logo_url.presence 
+%>
 
 <%= turbo_frame_tag dom_id(entry) do %>
   <%= turbo_frame_tag dom_id(transaction) do %>
@@ -20,16 +22,14 @@
 
         <div class="flex md:hidden items-center gap-1 col-span-2 relative shrink-0">
           <%= render "transactions/transaction_category", transaction: transaction, variant: "mobile" %>
-          <% if transaction.merchant&.logo_url.present? %>
-            <%= image_tag Setting.transform_brand_fetch_url(transaction.merchant.logo_url),
-                class: "w-5 h-5 rounded-full absolute -bottom-1 -right-1 border border-secondary pointer-events-none",
-                loading: "lazy" %>
+          <% if logo_url %>
+            <%= render "entries/logo", name: entry.name, logo_url: logo_url, size: :sm ,add_cls_attr: "absolute -bottom-1 -right-1 pointer-events-none"%>
           <% end %>
         </div>
 
         <div class="max-w-full min-w-0 <%= "opacity-50 text-secondary" if entry.excluded %>">
           <%= content_tag :div, class: ["flex items-center gap-3 lg:gap-4"] do %>
-            <div class="hidden lg:flex">
+            <div class="hidden md:flex">
               <% if transaction.transfer? %>
                 <%= render DS::FilledIcon.new(
                   icon: "arrow-right-left",
@@ -37,19 +37,8 @@
                   size: "lg",
                   rounded: true
                 ) %>
-              <% elsif transaction.merchant&.logo_url.present? %>
-                <%= image_tag Setting.transform_brand_fetch_url(transaction.merchant.logo_url),
-                    class: "w-9 h-9 rounded-full border border-secondary",
-                    loading: "lazy" %>
               <% else %>
-                <div class="hidden lg:flex">
-                  <%= render DS::FilledIcon.new(
-                    variant: :text,
-                    text: entry.name,
-                    size: "lg",
-                    rounded: true
-                  ) %>
-                </div>
+                <%= render "entries/logo", name: entry.name, logo_url: logo_url, size: :lg %>
               <% end %>
             </div>
 


### PR DESCRIPTION
# Trade
## Before

<img width="2682" height="1566" alt="image" src="https://github.com/user-attachments/assets/133f49f5-b4da-415e-85d6-7af84899743a" />
<img width="814" height="1448" alt="image" src="https://github.com/user-attachments/assets/33f0a5ba-034b-42d8-b7bd-45916895f30e" />


## Now
<img width="2694" height="1540" alt="image" src="https://github.com/user-attachments/assets/c37376ae-8ab0-490d-bf77-95354a62313c" />
<img width="850" height="1576" alt="image" src="https://github.com/user-attachments/assets/414bcce3-9db4-4902-9617-d403689f0d78" />


# Notice
I disabled `quick_edit_badge` for tread at fe42a36f48a6f346244b7b1b4032b09f2a163bb3

Beacause:
 1. for `Buy/Sell` it will only update `investment_activity_label` in `DB:Trade`. It  won't update name and amount in `DB:entries`, this make the UI show wrong infomaton


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable logo component with graceful placeholder fallback.
  * Optional category name truncation with tooltip support.

* **Style**
  * Updated investment activity badge sizing and rounded styling.

* **Improvements**
  * More consistent logo display across responsive views.
  * Quick-edit badge now accepts optional inputs to control labels, conversion enablement, and whether a “none” option is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->