### PR TITLE
Fix transaction search account scope bypass

### DIFF
--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -29,8 +29,8 @@ class Transaction::Search
       # This already joins entries + accounts. To avoid expensive double-joins, don't join them again (causes full table scan)
       query = family.transactions.merge(Entry.excluding_split_parents)
 
-      # Scope to accessible accounts when provided
-      query = query.where(entries: { account_id: accessible_account_ids }) if accessible_account_ids&.any?
+      # Scope to accessible accounts when provided (including an empty array, which should yield no results)
+      query = query.where(entries: { account_id: accessible_account_ids }) unless accessible_account_ids.nil?
 
       query = apply_active_accounts_filter(query, active_accounts_only)
       query = apply_category_filter(query, categories)
@@ -88,11 +88,11 @@ class Transaction::Search
                   .take
 
         Totals.new(
-          count: result.transactions_count.to_i,
-          income_money: Money.new(result.income_total, family.currency),
-          expense_money: Money.new(result.expense_total, family.currency),
-          transfer_inflow_money: Money.new(result.transfer_inflow_total, family.currency),
-          transfer_outflow_money: Money.new(result.transfer_outflow_total, family.currency)
+          count: result&.transactions_count.to_i,
+          income_money: Money.new((result&.income_total || 0), family.currency),
+          expense_money: Money.new((result&.expense_total || 0), family.currency),
+          transfer_inflow_money: Money.new((result&.transfer_inflow_total || 0), family.currency),
+          transfer_outflow_money: Money.new((result&.transfer_outflow_total || 0), family.currency)
         )
       end
     end

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -625,4 +625,25 @@ class Transaction::SearchTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "empty accessible_account_ids yields no visible transactions" do
+    create_transaction(account: @checking_account, amount: 100)
+
+    search = Transaction::Search.new(@family, filters: {}, accessible_account_ids: [])
+
+    assert_empty search.transactions_scope
+  end
+
+  test "totals handles empty accessible_account_ids without raising" do
+    create_transaction(account: @checking_account, amount: 100)
+
+    search = Transaction::Search.new(@family, filters: {}, accessible_account_ids: [])
+    totals = search.totals
+
+    assert_equal 0, totals.count
+    assert_equal Money.new(0, @family.currency), totals.expense_money
+    assert_equal Money.new(0, @family.currency), totals.income_money
+    assert_equal Money.new(0, @family.currency), totals.transfer_inflow_money
+    assert_equal Money.new(0, @family.currency), totals.transfer_outflow_money
+  end
 end


### PR DESCRIPTION
### Motivation
- Prevent an authorization bypass where an empty `accessible_account_ids` array caused the account filter to be skipped and returned all `family.transactions`.
- Avoid crashes or nil handling in totals computation when the scoped aggregate returns no row.

### Description
- Apply the account filter whenever `accessible_account_ids` is provided (including an empty array) by changing the guard to `unless accessible_account_ids.nil?` in `Transaction::Search#transactions_scope` (file `app/models/transaction/search.rb`).
- Harden `Transaction::Search#totals` to tolerate `nil` aggregate results and return zero-valued totals instead of raising.
- Add regression tests in `test/models/transaction/search_test.rb` that assert an empty `accessible_account_ids` yields no visible transactions and that `totals` returns zero-valued `Money` objects without raising.

### Testing
- Ran the model tests with `bin/rails test test/models/transaction/search_test.rb` and iterated on a failing assertion until assertions matched `Money` semantics; final test run passed with `22 runs, 149 assertions, 0 failures, 0 errors, 0 skips`.
- Changes touched `app/models/transaction/search.rb` and `test/models/transaction/search_test.rb` and tests were updated/added to cover the regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce09d66b083329e303791148538a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account access filtering logic to correctly handle restricted access scenarios.
  * Enhanced robustness of transaction totals calculations with safer null handling and defaults.

* **Tests**
  * Added test coverage for edge cases with limited account access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->