### PR TITLE
feat: add per-account filter to cashflow Sankey chart

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,7 +16,9 @@ class PagesController < ApplicationController
     family_currency = Current.family.currency
 
     # Use IncomeStatement for all cashflow data (now includes categorized trades)
-    income_statement = Current.family.income_statement
+    selected_account_id = params[:account_id]
+    account_ids = selected_account_id.present? ? [ selected_account_id ] : nil
+    income_statement = Current.family.income_statement(user: Current.user, account_ids: account_ids)
     income_totals = income_statement.income_totals(period: @period)
     expense_totals = income_statement.expense_totals(period: @period)
     net_totals = income_statement.net_category_totals(period: @period)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,7 +19,7 @@ class PagesController < ApplicationController
     selected_account_id = params[:account_id].presence
     if selected_account_id
       account = Current.user.accessible_accounts.find_by(id: selected_account_id)
-      account_ids = account ? [account.id] : nil
+      account_ids = account ? [ account.id ] : nil
     else
       account_ids = nil
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,8 +16,13 @@ class PagesController < ApplicationController
     family_currency = Current.family.currency
 
     # Use IncomeStatement for all cashflow data (now includes categorized trades)
-    selected_account_id = params[:account_id]
-    account_ids = selected_account_id.present? ? [ selected_account_id ] : nil
+    selected_account_id = params[:account_id].presence
+    if selected_account_id
+      account = Current.user.accessible_accounts.find_by(id: selected_account_id)
+      account_ids = account ? [account.id] : nil
+    else
+      account_ids = nil
+    end
     income_statement = Current.family.income_statement(user: Current.user, account_ids: account_ids)
     income_totals = income_statement.income_totals(period: @period)
     expense_totals = income_statement.expense_totals(period: @period)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,7 +18,7 @@ class PagesController < ApplicationController
     # Use IncomeStatement for all cashflow data (now includes categorized trades)
     selected_account_id = params[:account_id].presence
     if selected_account_id
-      account = Current.user.accessible_accounts.find_by(id: selected_account_id)
+      account = Current.user.finance_accounts.find_by(id: selected_account_id)
       account_ids = account ? [ account.id ] : nil
     else
       account_ids = nil

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -148,8 +148,8 @@ class Family < ApplicationRecord
     BalanceSheet.new(self, user: user)
   end
 
-  def income_statement(user: Current.user)
-    IncomeStatement.new(self, user: user)
+  def income_statement(user: Current.user, account_ids: nil)
+    IncomeStatement.new(self, user: user, account_ids: account_ids)
   end
 
   # Returns the Investment Contributions category for this family, creating it if it doesn't exist.

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -7,6 +7,12 @@ class IncomeStatement
 
   attr_reader :family, :user
 
+  def initialize(family, user: nil, account_ids: nil)
+    @family = family
+    @user = user || Current.user
+    @forced_account_ids = account_ids
+  end
+
   def totals(transactions_scope: nil, date_range:)
     # Default to excluding pending transactions from budget/analytics calculations
     # Pending transactions shouldn't affect budget totals until they post
@@ -180,12 +186,6 @@ class IncomeStatement
       @category_stats[interval] ||= Rails.cache.fetch([
         "income_statement", "category_stats", family.id, user&.id, interval, included_account_ids_hash, family.entries_cache_version
       ]) { CategoryStats.new(family, interval:, account_ids: included_account_ids).call }
-    end
-
-    def initialize(family, user: nil, account_ids: nil)
-      @family = family
-      @user = user || Current.user
-      @forced_account_ids = account_ids
     end
 
     def included_account_ids

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -7,11 +7,6 @@ class IncomeStatement
 
   attr_reader :family, :user
 
-  def initialize(family, user: nil)
-    @family = family
-    @user = user || Current.user
-  end
-
   def totals(transactions_scope: nil, date_range:)
     # Default to excluding pending transactions from budget/analytics calculations
     # Pending transactions shouldn't affect budget totals until they post
@@ -187,8 +182,18 @@ class IncomeStatement
       ]) { CategoryStats.new(family, interval:, account_ids: included_account_ids).call }
     end
 
+    def initialize(family, user: nil, account_ids: nil)
+      @family = family
+      @user = user || Current.user
+      @forced_account_ids = account_ids
+    end
+
     def included_account_ids
-      @included_account_ids ||= user ? user.finance_accounts.pluck(:id) : nil
+      @included_account_ids ||= if @forced_account_ids
+        @forced_account_ids
+      elsif user
+        user.finance_accounts.pluck(:id)
+      end
     end
 
     def included_account_ids_hash

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -1,13 +1,18 @@
 <%# locals: (sankey_data:, period:) %>
 <div id="cashflow-sankey-chart">
   <div class="flex justify-end items-center gap-4 px-4 mb-4">
-    <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
-      <%= form.select :period,
-                Period.as_options,
-                { selected: period.key },
-                data: { "auto-submit-form-target": "auto" },
-                class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
-    <% end %>
+      <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
+  <%= form.select :account_id,
+            [["All accounts", ""]] + Current.user.finance_accounts.map { |a| [a.name, a.id] },
+            { selected: params[:account_id] },
+            data: { "auto-submit-form-target": "auto" },
+            class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+  <%= form.select :period,
+            Period.as_options,
+            { selected: period.key },
+            data: { "auto-submit-form-target": "auto" },
+            class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+<% end %>  
   </div>
   <% if sankey_data[:links].present? %>
     <div class="w-full h-96">

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -3,7 +3,7 @@
   <div class="flex justify-end items-center gap-4 px-4 mb-4">
       <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
   <%= form.select :account_id,
-            [["All accounts", ""]] + Current.user.finance_accounts.map { |a| [a.name, a.id] },
+            [[t("pages.dashboard.cashflow_sankey.all_accounts"), ""]] + Current.user.finance_accounts.map { |a| [a.name, a.id] },
             { selected: params[:account_id] },
             data: { "auto-submit-form-target": "auto" },
             class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -33,6 +33,7 @@ en:
         no_data_title: "No cash flow data for this time period"
         no_data_description: "Add transactions to display cash flow data or expand the time period"
         add_transaction: "Add transaction"
+        all_accounts: "All accounts"
       no_accounts:
         title: "No accounts yet"
         description: "Add accounts to display net worth data"

--- a/config/locales/views/transactions/fr.yml
+++ b/config/locales/views/transactions/fr.yml
@@ -1,21 +1,26 @@
 ---
 fr:
   transactions:
+    unknown_name: Transaction inconnue 
+    selection_bar:
+      duplicate: Dupliquer
+      edit: Éditer
     form:
       account: Compte
       account_prompt: Sélectionnez un compte
       amount: Montant
       category: Catégorie
-      category_prompt: Sélectionnez une catégorie
+      category_prompt: Sélectionner une catégorie
       date: Date
-      description: Libellé
-      description_placeholder: Libellé de la transaction
+      description: Description
+      description_placeholder: Décrivez la transaction
       expense: Dépense
       income: Revenu
+      merchant_label: Marchand
       none: (aucun)
       note_label: Notes
-      note_placeholder: Entrez une note
-      submit: Ajouter la transaction
+      note_placeholder: Saisissez une note
+      submit: Ajouter une transaction
       tags_label: Étiquettes
       transfer: Transfert
     new:
@@ -26,47 +31,178 @@ fr:
       category_label: Catégorie
       date_label: Date
       delete: Supprimer
-      delete_subtitle: Cette action supprime définitivement la transaction, affecte vos soldes historiques et ne peut pas être annulée.
+      delete_subtitle: Cette opération supprime définitivement la transaction, a une incidence sur l'historique de vos soldes et ne peut pas être annulée.
       delete_title: Supprimer la transaction
       details: Détails
+      attachments:  Pièces jointes
+      exclude: Exclure
+      exclude_description: Les transactions exclues seront retirées des calculs budgétaires et des rapports.
+      activity_type: Type d'opération
+      activity_type_description: Type d'opération d'investissement (achat, vente, dividende, etc.). Détecté automatiquement ou défini manuellement.
+      one_time_title: "%{type} ponctuel"
+      one_time_description: Les opérations ponctuelles seront exclues de certains calculs budgétaires et rapports afin de vous aider à vous concentrer sur l'essentiel.
+      convert_to_trade_title: Convertir en opération sur titres
+      convert_to_trade_description: Convertissez cette transaction en une opération d'achat ou de vente avec les détails du titre pour le suivi du portefeuille.
+      convert_to_trade_button: Convertir en transaction
+      pending_duplicate_merger_title: Doublon avec une transaction enregistrée ?
+      pending_duplicate_merger_description: Fusionner manuellement cette transaction en attente avec sa version enregistrée.
+      pending_duplicate_merger_button: Lancer la fusion
       merchant_label: Marchand
-      name_label: Nom
+      name_label: Name
       nature: Type
-      none: "(aucun)"
+      none: "(Aucun)"
       note_label: Notes
-      note_placeholder: Entrez une note
+      note_placeholder: Saisissez une note
       overview: Aperçu
       settings: Paramètres
       tags_label: Étiquettes
-      uncategorized: "(non catégorisée)"
+      tab_transactions: Transactions
+      tab_upcoming: À venir
+      uncategorized: "(Sans catégorie)"
+    activity_labels:
+      buy: Achat
+      sell: Vente
+      sweep_in: Transfert entrant
+      sweep_out: Transfert sortant
+      dividend: Dividende
+      reinvestment: Réinvestissement
+      interest: Intérêts
+      fee: Frais
+      transfer: Transfert
+      contribution: Cotisation
+      withdrawal: Retrait
+      exchange: Échange
+      other: Autre
+    mark_recurring: Marquer comme récurrent
+    mark_recurring_subtitle: Enregistrez cette transaction comme récurrente. L'écart de montant est calculé automatiquement à partir des transactions similaires des 6 derniers mois.
+    mark_recurring_title: Transaction réccurente
+    potential_duplicate_title: Doublon potentiel détecté
+    potential_duplicate_description: Cette transaction en attente est peut-être identique à la transaction enregistrée ci-dessous. Si c'est le cas, fusionnez-les pour éviter les doublons.
+    merge_duplicate: Oui, les fusionner
+    keep_both: Non, garder les deux
+    split_parent_row:
+      split_label: "Diviser"
+    transaction:
+      pending: En attente
+      pending_tooltip: Transaction en attente — susceptible de changer une fois enregistrée
+      linked_with_provider: Lié à %{provider}
+      activity_type_tooltip: Type d'opération d'investissement
+      possible_duplicate: Doublon ?
+      potential_duplicate_tooltip: Il s'agit peut-être d'un doublon d'une autre transaction
+      review_recommended: À vérifier
+      review_recommended_tooltip: Écart de montant important — vérifiez s'il s'agit d'un doublon
+      split: Divisée
+      split_tooltip: Cette transaction a été divisée en plusieurs entrées
+      split_child_tooltip: Fait partie d'une transaction divisée
+    merge_duplicate:
+      success: Transactions fusionnées avec succès
+      failure: Impossible de fusionner les transactions
+    dismiss_duplicate:
+      success: Transactions conservées séparément
+      failure: Impossible d'ignorer la suggestion de doublon
+    pending_duplicate_merge:
+      possible_duplicate: Doublon ?
+      possible_duplicate_short: Dup?
+      review_recommended: À vérifier
+      review_recommended_short: Ver
+      confirm_title: "Fusionner avec la transaction enregistrée (%{posted_amount})"
+      reject_title: Conserver comme transactions séparées
+    summary:
+      total_transactions: Nombre total de transactions
+      income: Revenu
+      expenses: Dépenses
+      inflow: Entrées
+      outflow: Sorties
     header:
       edit_categories: Modifier les catégories
       edit_imports: Modifier les importations
-      edit_merchants: Modifier les marchands
+      edit_merchants: Modifier les marchants
       edit_tags: Modifier les étiquettes
       import: Importer
-    transaction:
-      linked_with_provider: Lié avec %{provider}
     index:
-      transaction: transaction
-      transactions: transactions
-    searches:
+      transaction: Transaction
+      transactions: Transactions
+      import: Importer
+    list:
+      drag_drop_title: Déposez un CSV pour importer
+      drag_drop_subtitle: Importez des transactions directement
+      transaction: Transaction
+      transactions: Transactions
+    toggle_recurring_section: Afficher/masquer les transactions récurrentes à venir
+    search:
       filters:
-        amount_filter:
-          equal_to: Égal à
-          greater_than: Supérieur à
-          less_than: Inférieur à
-          placeholder: '0'
+        account: Compte
+        date: Date
+        type: Type
+        status: Status
+        amount: Montant
+        category: Catégorie
+        tag: Étiquette
+        merchant: Marchand
+    convert_to_trade:
+      title: Convertir en opération sur titres
+      description: Convertissez cette transaction en opération avec les détails du titre
+      date_label: "Date :"
+      account_label: "Compte :"
+      amount_label: "Montant :"
+      security_label: Titre
+      security_prompt: Sélectionnez un titre...
+      security_custom: "+ Saisir un symbole personnalisé"
+      security_not_listed_hint: Vous ne trouvez pas votre titre ? Sélectionnez « Saisir un symbole personnalisé » en bas de la liste.
+      ticker_placeholder: AAPL
+      ticker_hint: Saisissez le symbole boursier de l'action ou de l'ETF (par exemple, AAPL, MSFT)
+      ticker_search_placeholder: Rechercher un symbole boursier...
+      ticker_search_hint: Recherchez par symbole boursier ou nom de société, ou saisissez un symbole personnalisé
+      price_mismatch_title: Le prix peut ne pas correspondre
+      price_mismatch_message: "Le prix que vous avez indiqué (%{entered_price}/action) diffère considérablement du cours actuel de %{ticker} (%{market_price}). Si cela vous semble incorrect, vous avez peut-être sélectionné le mauvais titre — essayez d'utiliser « Saisir un symbole boursier personnalisé » pour indiquer le bon."
+      quantity_label: Quantité (actions)
+      quantity_placeholder: ex. 20
+      quantity_hint: Nombre d'actions échangées
+      price_label: Prix par action
+      price_placeholder: ex. 52.15
+      price_hint: Prix par action (%{currency})
+      qty_or_price_hint: Indiquez au moins la quantité OU le prix. L'autre sera calculé à partir du montant de la transaction (%{amount}).
+      trade_type_label: Type d’opération
+      trade_type_hint: Acheter ou vendre des actions d'un titre
+      exchange_label: Échange (facultatif)
+      exchange_placeholder: XNAS
+      exchange_hint: Laisser vide pour une détection automatique
+      cancel: Annuler
+      submit: Convertir en opération
+      success: Transaction convertie en opération
+      conversion_note: "Convertie depuis la transaction : %{original_name} (%{original_date})"
+      errors:
+        not_investment_account: Seules les opérations effectuées sur des comptes d'investissement peuvent être converties en transactions
+        already_converted: Cette transaction a déjà été convertie ou exclue
+        enter_ticker: Veuillez saisir un symbole boursier
+        security_not_found: Le titre sélectionné n'existe plus. Veuillez en choisir un autre.
+        select_security: Veuillez sélectionner ou saisir un titre
+        enter_qty_or_price: Veuillez saisir soit la quantité, soit le prix par action. L'autre valeur sera calculée à partir du montant de la transaction.
+        invalid_qty_or_price: Quantité ou prix incorrect(e). Veuillez saisir des valeurs positives valides.
+        conversion_failed: "Échec de la conversion de la transaction : %{error}"
+        unexpected_error: "Erreur inattendue lors de la conversion: %{error}"
+      searches:
+        filters:
+          amount_filter:
+            equal_to: Égal à
+            greater_than: Supérieur à
+            less_than: Inférieur à
+            placeholder: '0'
         badge:
           expense: Dépense
           income: Revenu
-          on_or_after: le %{date} et après
-          on_or_before: le %{date} et avant
-          transfer: Transfert
+          on_or_after: on or after %{date}
+          on_or_before: on or before %{date}
+          transfer: Transfer
+          confirmed: Confirmed
+          pending: Pending
         type_filter:
           expense: Dépense
           income: Revenu
           transfer: Transfert
+        status_filter:
+          confirmed: Confirmé
+          pending: En attente
       menu:
         account_filter: Compte
         amount_filter: Montant
@@ -75,10 +211,31 @@ fr:
         category_filter: Catégorie
         clear_filters: Effacer les filtres
         date_filter: Date
-        merchant_filter: Marchand
-        tag_filter: Étiquette
+        merchant_filter: Marchant
+        status_filter: Statut
+        tag_filter: Étiqsette
         type_filter: Type
       search:
-        equal_to: égal à
-        greater_than: supérieur à
-        less_than: inférieur à
+        equal_to: Égal à
+        greater_than: Supérieur à
+        less_than: Inférieur à
+      form:
+        toggle_selection_checkboxes: Cocher ou décocher toutes les cases
+    attachments:
+      cannot_exceed: "Le nombre de pièces jointes ne doit pas dépasser %{count} par transaction"
+      uploaded_one: "Pièce jointe importé avec succès"
+      uploaded_many: "%{count} pièces jointes importées avec succès"
+      failed_upload: "Échec de l'import : %{error}"
+      no_files_selected: "Aucun fichier sélectionné"
+      attachment_deleted: "Pièce jointe supprimée avec succès"
+      failed_delete: "Échec de la suppression : %{error}"
+      upload_failed: "Échec de l'import. Réessayez ou contactez le support."
+      delete_failed: "Échec de la suppression. Réessayez ou contactez le support."
+      upload: "Importer"
+      no_attachments: "Aucune pièce jointe"
+      select_up_to: "Sélectionnez jusqu'à %{count} fichiers (images ou PDF, max %{size} Mo chacun) • %{used} sur %{count} utilisés"
+      files:
+        one: "Fichier (1)"
+        other: "Fichiers (%{count})"
+      browse_to_add: "Parcourir pour ajouter des fichiers"
+      max_reached: "Nombre maximum de fichiers atteint (%{count}/%{max}). Supprimez un fichier existant pour en importer un autre."


### PR DESCRIPTION
## Summary

Adds a per-account filter to the cashflow Sankey chart on the dashboard.

## Changes

- `IncomeStatement`: added optional `account_ids` parameter to `initialize` and `included_account_ids` method to support filtering by specific accounts
- `Family`: passed `account_ids` through to `IncomeStatement`
- `PagesController`: reads `params[:account_id]` and passes it to `income_statement`
- `_cashflow_sankey.html.erb`: added an account dropdown selector next to the period selector

## Demo

Selecting a specific account from the dropdown filters the Sankey chart to show only that account's cashflow. Selecting "All accounts" restores the default behavior.

## Screenshots 
<img width="597" height="689" alt="image" src="https://github.com/user-attachments/assets/efd5ea64-5c52-4ac6-9957-e384817f626a" />

<img width="591" height="433" alt="image" src="https://github.com/user-attachments/assets/21f44e80-eff0-4adc-8d04-6e2834743a18" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard cashflow: add account filter (per-account or "All accounts") and show account-scoped totals with period selection.

* **Documentation**
  * Expanded French translations for transaction interfaces: actions, workflows, duplicate/merge flows, search filters, attachments, labels and messages.

* **Localization**
  * Added English label for cashflow "All accounts" option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->