### PR TITLE
feat: Add table-divider class and use it in investments summary section

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -211,8 +211,8 @@
 .table-divider::after {
   content: "";
   position: absolute;
-  left: 16px;
-  right: 16px;
+  left: 1rem;
+  right: 1rem;
   bottom: 0;
   height: 1px;
   background-color: var(--color-alpha-black-100);

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -218,6 +218,10 @@
   background-color: var(--color-alpha-black-100);
 }
 
+[data-theme="dark"] .table-divider::after  {
+  background-color: var(--color-alpha-white-200);
+}
+
 .table-divider:last-child::after {
   display: none;
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -203,3 +203,21 @@
 .turbo-progress-bar {
   margin-top: env(safe-area-inset-top);
 }
+
+.table-divider {
+  position: relative;
+}
+
+.table-divider::after {
+  content: "";
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 0;
+  height: 1px;
+  background-color: var(--color-alpha-black-100);
+}
+
+.table-divider:last-child::after {
+  display: none;
+}

--- a/app/views/pages/dashboard/_investment_summary.html.erb
+++ b/app/views/pages/dashboard/_investment_summary.html.erb
@@ -40,7 +40,7 @@
           </thead>
           <tbody class="font-medium text-sm">
             <% holdings.each_with_index do |holding, idx| %>
-              <tr class="<%= idx < holdings.size - 1 ? "border-b border-divider" : "" %>">
+              <tr class="<%= idx < holdings.size - 1 ? "table-divider" : "" %>">
                 <td class="p-4">
                   <div class="flex items-center gap-3">
                     <% if holding.security.logo_url.present? %>

--- a/app/views/reports/_category_row.html.erb
+++ b/app/views/reports/_category_row.html.erb
@@ -4,7 +4,7 @@
   show_border = local_assigns.fetch(:show_border, false)
 %>
 
-<tr data-category="category-<%= item[:category_id] %>" class="text-secondary text-sm <%= show_border ? "border-b border-divider" : "" %>">
+<tr data-category="category-<%= item[:category_id] %>" class="text-secondary text-sm <%= show_border ? "table-divider" : "" %>">
   <td colspan="2" class="py-3 px-4 lg:px-6 <%= is_sub ? "pl-7 lg:pl-9" : "" %>">
     <div class="flex items-center gap-2">
       <% if is_sub %>

--- a/app/views/reports/_investment_performance.html.erb
+++ b/app/views/reports/_investment_performance.html.erb
@@ -72,7 +72,7 @@
             </thead>
             <tbody class="text-secondary text-sm">
               <% investment_metrics[:top_holdings].each_with_index do |holding, idx| %>
-                <tr class="<%= idx < investment_metrics[:top_holdings].size - 1 ? "border-b border-divider" : "" %>">
+                <tr class="<%= idx < investment_metrics[:top_holdings].size - 1 ? "table-divider" : "" %>">
                   <td class="py-3 px-4 lg:px-6">
                     <div class="flex items-center gap-3">
                       <% if (logo = holding.security.display_logo_url).present? %>

--- a/app/views/reports/_net_worth.html.erb
+++ b/app/views/reports/_net_worth.html.erb
@@ -50,7 +50,7 @@
         </thead>
         <tbody>
           <% net_worth_metrics[:asset_groups].each_with_index do |group, idx| %>
-            <tr class="<%= idx < net_worth_metrics[:asset_groups].size - 1 ? "border-b border-divider" : "" %>">
+            <tr class="<%= idx < net_worth_metrics[:asset_groups].size - 1 ? "table-divider" : "" %>">
               <td class="py-3 px-4 lg:px-6 text-sm font-medium text-secondary"><%= group[:name] %></td>
               <td class="py-3 px-4 lg:px-6 text-sm font-medium text-right text-success privacy-sensitive"><%= group[:total].format %></td>
             </tr>
@@ -77,7 +77,7 @@
         </thead>
         <tbody>
           <% net_worth_metrics[:liability_groups].each_with_index do |group, idx| %>
-            <tr class="<%= idx < net_worth_metrics[:liability_groups].size - 1 ? "border-b border-divider" : "" %>">
+            <tr class="<%= idx < net_worth_metrics[:liability_groups].size - 1 ? "table-divider" : "" %>">
               <td class="py-3 px-4 lg:px-6 text-sm font-medium text-secondary"><%= group[:name] %></td>
               <td class="py-3 px-4 lg:px-6 text-sm font-medium text-right text-destructive privacy-sensitive"><%= group[:total].format %></td>
             </tr>

--- a/app/views/reports/_trends_insights.html.erb
+++ b/app/views/reports/_trends_insights.html.erb
@@ -21,7 +21,7 @@
             </thead>
             <tbody class="text-secondary text-sm">
               <% trends_data.each_with_index do |trend, idx| %>
-                <tr class="<%= idx < trends_data.size - 1 ? "border-b border-divider" : "" %>">
+                <tr class="<%= idx < trends_data.size - 1 ? "table-divider" : "" %>">
                   <td class="py-3 px-4 lg:px-6">
                     <span class="flex items-center gap-2 <%= trend[:is_current_month] ? "font-medium" : "" %>">
                       <%= trend[:month] %>


### PR DESCRIPTION
Add CSS class to display a divider with padding in the new tables element, to keep UI consistent across all the sections.

| Before | After |
| ------------- | ------------- |
| <img width="1429" height="421" alt="Screenshot 2026-04-13 alle 19 57 07" src="https://github.com/user-attachments/assets/f459feca-52d1-4ac9-949a-bc43463cace1" /> | <img width="1424" height="417" alt="Screenshot 2026-04-13 alle 19 56 31" src="https://github.com/user-attachments/assets/d27db891-685f-4ccb-a208-ee90061e323a" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated table divider styling across investment, reports, net worth, and trends tables for cleaner row separation.
  * Ensures the last row has no divider and supports dark theme color for dividers.
  * Visual refinement improves consistency of separators without changing displayed data or layout logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->