### PR TITLE
fix: adjust style in new budget tab and sections

### DIFF
--- a/app/javascript/controllers/budget_filter_controller.js
+++ b/app/javascript/controllers/budget_filter_controller.js
@@ -32,7 +32,8 @@ export default class extends Controller {
 
     this.tabTargets.forEach((tab) => {
       const isActive = tab.dataset.budgetFilterFilterParam === filter;
-      tab.classList.toggle("bg-container", isActive);
+      tab.classList.toggle("bg-white", isActive);
+      tab.classList.toggle("theme-dark:bg-gray-700", isActive);
       tab.classList.toggle("text-primary", isActive);
       tab.classList.toggle("shadow-sm", isActive);
       tab.classList.toggle("text-secondary", !isActive);

--- a/app/views/budgets/_category_section.html.erb
+++ b/app/views/budgets/_category_section.html.erb
@@ -11,7 +11,7 @@
   end
 %>
 
-<div data-budget-filter-target="<%= target %>">
+<div class="bg-container-inset rounded-xl p-1" data-budget-filter-target="<%= target %>">
 
   <!-- Section Header -->
   <div class="flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-secondary uppercase">

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -66,7 +66,7 @@
                   data-action="click->budget-filter#setFilter"
                   data-budget-filter-filter-param="all"
                   data-budget-filter-target="tab"
-                  class="px-3 py-1.5 rounded-md transition-colors bg-container text-primary shadow-sm">
+                  class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 bg-white theme-dark:bg-gray-700 text-primary shadow-sm">
                   <%= t("budgets.show.filter.all") %>
                 </button>
 
@@ -74,7 +74,7 @@
                   data-action="click->budget-filter#setFilter"
                   data-budget-filter-filter-param="over_budget"
                   data-budget-filter-target="tab"
-                  class="px-3 py-1.5 rounded-md transition-colors text-secondary">
+                  class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 shadow-sm">
                   <%= t("budgets.show.filter.over_budget") %>
                 </button>
 
@@ -82,7 +82,7 @@
                   data-action="click->budget-filter#setFilter"
                   data-budget-filter-filter-param="on_track"
                   data-budget-filter-target="tab"
-                  class="px-3 py-1.5 rounded-md transition-colors text-secondary">
+                  class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 shadow-sm">
                   <%= t("budgets.show.filter.on_track") %>
                 </button>
 
@@ -104,9 +104,7 @@
         </div>
       </div>
 
-      <div class="bg-container-inset rounded-xl p-1">
-        <%= render "budgets/budget_categories", budget: @budget %>
-      </div>
+      <%= render "budgets/budget_categories", budget: @budget %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Use the same classes to highlight the selected tab in the budget section, keeping the same style used in “Budgeted”/“Actual” tabs.

| Before | After |
| ------------- | ------------- |
| <img width="901" height="644" alt="Screenshot 2026-04-13 alle 23 10 15" src="https://github.com/user-attachments/assets/752798f3-5b17-41c0-b393-81e49c2c3d6e" />  | <img width="907" height="637" alt="Screenshot 2026-04-13 alle 23 09 50" src="https://github.com/user-attachments/assets/38383e1e-4e53-4f11-b02d-bba2a390e32e" /> |

Properly separate containers for "Over budget" and "On track" sections by using different backgrounds and spacing.

| Before | After |
| ------------- | ------------- |
| <img width="865" height="828" alt="Screenshot 2026-04-13 alle 23 11 37" src="https://github.com/user-attachments/assets/53e08b5d-4fdb-4237-b453-091a2fa6d975" /> | <img width="855" height="884" alt="Screenshot 2026-04-13 alle 23 12 01" src="https://github.com/user-attachments/assets/d7f03bc5-c79e-4246-aecb-0b575ee728b9" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated budget filter tab styling with improved visual hierarchy and full-width layout
  * Enhanced category section styling with refined spacing and background styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->