### PR TITLE
fix: values visible in privacy mode

### DIFF
--- a/app/views/transactions/_split_parent_row.html.erb
+++ b/app/views/transactions/_split_parent_row.html.erb
@@ -64,6 +64,6 @@
   </div>
 
   <div class="shrink-0 col-span-4 lg:col-span-2 ml-auto flex items-center justify-end gap-2">
-    <%= content_tag :p, format_money(-entry.amount_money) %>
+    <%= content_tag :p, format_money(-entry.amount_money), class: "privacy-sensitive" %>
   </div>
 </div>

--- a/app/views/transactions/convert_to_trade.html.erb
+++ b/app/views/transactions/convert_to_trade.html.erb
@@ -25,7 +25,7 @@
         </div>
         <div class="text-sm">
           <span class="text-secondary"><%= t(".amount_label") %></span>
-          <span class="font-medium <%= @entry.amount.negative? ? "text-green-600" : "text-primary" %>"><%= format_money(@entry.amount_money.abs) %></span>
+          <span class="font-medium privacy-sensitive <%= @entry.amount.negative? ? "text-green-600" : "text-primary" %>"><%= format_money(@entry.amount_money.abs) %></span>
         </div>
       </div>
 

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -22,7 +22,7 @@
                     <p class="text-sm font-medium text-primary"><%= potential_match.name %></p>
                     <p class="text-xs text-secondary"><%= potential_match.date.strftime("%b %d, %Y") %> • <%= potential_match.account.name %></p>
                   </div>
-                  <p class="text-sm font-medium <%= potential_match.amount.negative? ? "text-green-600" : "text-primary" %>">
+                  <p class="text-sm font-medium privacy-sensitive <%= potential_match.amount.negative? ? "text-green-600" : "text-primary" %>">
                     <%= format_money(-potential_match.amount_money) %>
                   </p>
                 </div>

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -96,6 +96,20 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_dom "#total-transactions", count: 1, text: "1"
   end
 
+  test "split parent rows mark amount as privacy-sensitive" do
+    entry = create_transaction(account: accounts(:depository), amount: 100, name: "Split parent")
+
+    entry.split!([
+      { name: "Part 1", amount: 60, category_id: nil },
+      { name: "Part 2", amount: 40, category_id: nil }
+    ])
+
+    get transactions_url
+
+    assert_response :success
+    assert_select ".split-group > div.opacity-50 p.privacy-sensitive", count: 1
+  end
+
   test "can paginate" do
   family = families(:empty)
   sign_in users(:empty)


### PR DESCRIPTION
fix #1471 

## Summary

- Fix Privacy Mode coverage in Transactions by ensuring all transaction amount displays are marked privacy-sensitive.
- Specifically covers split-group “parent” rows and the transaction drawer’s potential-duplicate alert amount.

## Changes

- Add privacy-sensitive to the split-parent transaction amount row (app/views/transactions/_split_parent_row.html.erb).
- Add privacy-sensitive to the potential-duplicate amount in the transaction drawer (app/views/transactions/show.html.erb).
- Add a small Minitest regression assertion to prevent future omissions (test/controllers/transactions_controller_test.rb).

## Test plan

- bin/rails test test/controllers/transactions_controller_test.rb
- Manual: Enable Privacy Mode → open Transactions → confirm amounts blur for:
   - normal rows
   - split-parent rows (those with “Split” badge)
   - drawer potential-duplicate card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied privacy-sensitive styling indicators to transaction amounts across transaction views, including split transactions, to improve identification of sensitive financial data.

* **Tests**
  * Added test coverage verifying privacy-sensitive styling for split parent transaction amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->