### PR TITLE
Add timestamp

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.9.0)
+    addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     aes_key_wrap (1.1.0)
     afm (1.0.0)
@@ -294,7 +294,7 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     json-schema (5.2.2)
-      addressable (~> 2.9.0)
+      addressable (~> 2.8)
       bigdecimal (~> 3.1)
     jwt (2.10.2)
       base64
@@ -305,7 +305,7 @@ GEM
       json (~> 2.0)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
-      addressable (~> 2.9.0)
+      addressable (~> 2.8)
       childprocess (~> 5.0)
       logger (~> 1.6)
     letter_opener (1.10.0)
@@ -756,7 +756,7 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     webmock (3.25.1)
-      addressable (>= 2.9.0)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 7.0)
     aes_key_wrap (1.1.0)
     afm (1.0.0)
@@ -294,7 +294,7 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     json-schema (5.2.2)
-      addressable (~> 2.8)
+      addressable (~> 2.9.0)
       bigdecimal (~> 3.1)
     jwt (2.10.2)
       base64
@@ -305,7 +305,7 @@ GEM
       json (~> 2.0)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
-      addressable (~> 2.8)
+      addressable (~> 2.9.0)
       childprocess (~> 5.0)
       logger (~> 1.6)
     letter_opener (1.10.0)
@@ -756,7 +756,7 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     webmock (3.25.1)
-      addressable (>= 2.8.0)
+      addressable (>= 2.9.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -283,7 +283,7 @@ end
     def transaction_params
       params.require(:transaction).permit(
         :account_id, :date, :amount, :name, :description, :notes, :currency,
-        :category_id, :merchant_id, :nature, tag_ids: []
+        :category_id, :merchant_id, :nature, :transacted_at, tag_ids: []
       )
     end
 
@@ -294,6 +294,7 @@ end
         amount: calculate_signed_amount,
         currency: transaction_params[:currency] || current_resource_owner.family.currency,
         notes: transaction_params[:notes],
+        transacted_at: parse_transacted_at_param,
         entryable_type: "Transaction",
         entryable_attributes: {
           category_id: transaction_params[:category_id],
@@ -324,7 +325,20 @@ end
         entry_params[:amount] = calculate_signed_amount
       end
 
+      if transaction_params.key?(:transacted_at)
+        entry_params[:transacted_at] = parse_transacted_at_param
+      end
+
       entry_params.compact
+    end
+
+    def parse_transacted_at_param
+      raw = transaction_params[:transacted_at]
+      return nil if raw.blank?
+
+      Time.zone.parse(raw.to_s)
+    rescue ArgumentError, TypeError
+      nil
     end
 
     # Check if tag_ids was explicitly provided in the request.

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -404,7 +404,8 @@ class TransactionsController < ApplicationController
         name: duplicate_source.name,
         amount: duplicate_source.amount.abs,
         currency: duplicate_source.currency,
-        notes: duplicate_source.notes
+        notes: duplicate_source.notes,
+        transacted_at: duplicate_source.transacted_at
       )
       @entry.entryable.assign_attributes(
         category_id: duplicate_source.entryable.category_id,

--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -25,8 +25,9 @@ class Account::ProviderImportAdapter
   # @param pending_transaction_id [String, nil] Plaid's linking ID for pending→posted reconciliation
   # @param extra [Hash, nil] Optional provider-specific metadata to merge into transaction.extra
   # @param investment_activity_label [String, nil] Optional activity type label (e.g., "Buy", "Dividend")
+  # @param transacted_at [Time, nil] Optional best-effort timestamp of when the transaction occurred (UTC)
   # @return [Entry] The created or updated entry
-  def import_transaction(external_id:, amount:, currency:, date:, name:, source:, category_id: nil, merchant: nil, notes: nil, pending_transaction_id: nil, extra: nil, investment_activity_label: nil)
+  def import_transaction(external_id:, amount:, currency:, date:, name:, source:, category_id: nil, merchant: nil, notes: nil, pending_transaction_id: nil, extra: nil, investment_activity_label: nil, transacted_at: nil)
     raise ArgumentError, "external_id is required" if external_id.blank?
     raise ArgumentError, "source is required" if source.blank?
 
@@ -120,7 +121,8 @@ class Account::ProviderImportAdapter
       entry.assign_attributes(
         amount: amount,
         currency: currency,
-        date: date
+        date: date,
+        transacted_at: transacted_at
       )
 
       # Use enrichment pattern to respect user overrides

--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -553,8 +553,9 @@ class Account::ProviderImportAdapter
   # @param external_id [String, nil] Provider's unique ID (optional, for deduplication)
   # @param source [String] Provider name
   # @param activity_label [String, nil] Investment activity label (e.g., "Buy", "Sell", "Reinvestment")
+  # @param transacted_at [Time, nil] Optional best-effort timestamp (UTC) for intra-day ordering
   # @return [Entry] The created entry with trade
-  def import_trade(security:, quantity:, price:, amount:, currency:, date:, name: nil, external_id: nil, source:, activity_label: nil)
+  def import_trade(security:, quantity:, price:, amount:, currency:, date:, name: nil, external_id: nil, source:, activity_label: nil, transacted_at: nil)
     raise ArgumentError, "security is required" if security.nil?
     raise ArgumentError, "source is required" if source.blank?
 
@@ -599,7 +600,8 @@ class Account::ProviderImportAdapter
         date: date,
         amount: amount,
         currency: currency,
-        name: trade_name
+        name: trade_name,
+        transacted_at: transacted_at
       )
 
       entry.save!

--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -25,9 +25,8 @@ class Account::ProviderImportAdapter
   # @param pending_transaction_id [String, nil] Plaid's linking ID for pending→posted reconciliation
   # @param extra [Hash, nil] Optional provider-specific metadata to merge into transaction.extra
   # @param investment_activity_label [String, nil] Optional activity type label (e.g., "Buy", "Dividend")
-  # @param transacted_at [Time, nil] Optional best-effort timestamp of when the transaction occurred (UTC)
   # @return [Entry] The created or updated entry
-  def import_transaction(external_id:, amount:, currency:, date:, name:, source:, category_id: nil, merchant: nil, notes: nil, pending_transaction_id: nil, extra: nil, investment_activity_label: nil, transacted_at: nil)
+  def import_transaction(external_id:, amount:, currency:, date:, name:, source:, category_id: nil, merchant: nil, notes: nil, pending_transaction_id: nil, extra: nil, investment_activity_label: nil)
     raise ArgumentError, "external_id is required" if external_id.blank?
     raise ArgumentError, "source is required" if source.blank?
 
@@ -121,8 +120,7 @@ class Account::ProviderImportAdapter
       entry.assign_attributes(
         amount: amount,
         currency: currency,
-        date: date,
-        transacted_at: transacted_at
+        date: date
       )
 
       # Use enrichment pattern to respect user overrides

--- a/app/models/coinstats_entry/processor.rb
+++ b/app/models/coinstats_entry/processor.rb
@@ -49,7 +49,8 @@ class CoinstatsEntry::Processor
           date: date,
           name: name,
           source: "coinstats",
-          activity_label: trade_activity_label
+          activity_label: trade_activity_label,
+          transacted_at: transacted_at
         )
       end
     else
@@ -63,7 +64,8 @@ class CoinstatsEntry::Processor
         merchant: merchant,
         notes: notes,
         extra: extra_metadata,
-        investment_activity_label: transaction_activity_label
+        investment_activity_label: transaction_activity_label,
+        transacted_at: transacted_at
       )
     end
   rescue ArgumentError => e
@@ -269,6 +271,26 @@ class CoinstatsEntry::Processor
     rescue ArgumentError, TypeError => e
       Rails.logger.error("CoinStats transaction date parsing failed: #{e.message}")
       raise ArgumentError, "Invalid date format: #{timestamp.inspect}"
+    end
+
+    def transacted_at
+      timestamp = data[:date]
+      return nil unless timestamp.present?
+
+      case timestamp
+      when Integer, Float
+        Time.at(timestamp).in_time_zone
+      when String
+        Time.zone.parse(timestamp)
+      when Time, ActiveSupport::TimeWithZone, DateTime
+        timestamp.in_time_zone
+      when Date
+        nil
+      else
+        nil
+      end
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def merchant

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -32,7 +32,8 @@ class EnableBankingEntry::Processor
         source: "enable_banking",
         merchant: merchant,
         notes: notes,
-        extra: extra
+        extra: extra,
+        transacted_at: transacted_at
       )
     rescue ArgumentError => e
       Rails.logger.error "EnableBankingEntry::Processor - Validation error for transaction #{external_id}: #{e.message}"
@@ -218,5 +219,19 @@ class EnableBankingEntry::Processor
     rescue ArgumentError, TypeError => e
       Rails.logger.error("Failed to parse Enable Banking transaction date '#{date_value}': #{e.message}")
       raise ArgumentError, "Unable to parse transaction date: #{date_value.inspect}"
+    end
+
+    # Best-effort: prefer a field that may include a time component (ISO8601 with clock time).
+    def transacted_at
+      raw = data[:transaction_date].presence || data[:booking_date].presence || data[:value_date].presence
+      return nil unless raw.is_a?(String)
+
+      parsed = Time.zone.parse(raw)
+      return nil if parsed.nil?
+
+      # Date-only strings parse to midnight; Entry will default to midday when blank — skip storing midnight.
+      parsed.to_date == date && parsed == parsed.beginning_of_day ? nil : parsed
+    rescue ArgumentError, TypeError
+      nil
     end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -122,7 +122,10 @@ class Entry < ApplicationRecord
     else scope
     end
 
-    scope.includes(entryable: :merchant).merge(Entry.reverse_chronological).to_a
+    # Use simple date ordering here (not Entry.reverse_chronological): merging the full
+    # chronological scope with includes() produces SELECT DISTINCT ... ORDER BY in PostgreSQL,
+    # which requires ORDER BY expressions in the select list (PG::InvalidColumnReference).
+    scope.includes(entryable: :merchant).order(date: :desc, id: :desc).to_a
   end
 
   # Auto-exclude stale pending transactions for an account

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -33,7 +33,7 @@ class Entry < ApplicationRecord
     order(
       date: :asc,
       Arel.sql("CASE WHEN entries.entryable_type = 'Valuation' THEN 1 ELSE 0 END") => :asc,
-      created_at: :asc
+      Arel.sql("COALESCE(entries.transacted_at, entries.created_at)") => :asc
     )
   }
 
@@ -41,7 +41,7 @@ class Entry < ApplicationRecord
     order(
       date: :desc,
       Arel.sql("CASE WHEN entries.entryable_type = 'Valuation' THEN 1 ELSE 0 END") => :desc,
-      created_at: :desc
+      Arel.sql("COALESCE(entries.transacted_at, entries.created_at)") => :desc
     )
   }
 
@@ -389,6 +389,7 @@ class Entry < ApplicationRecord
         child_entries.create!(
           account: account,
           date: date,
+          transacted_at: transacted_at,
           name: split_attrs[:name],
           amount: split_attrs[:amount],
           currency: currency,

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -23,6 +23,11 @@ class Entry < ApplicationRecord
   validate :cannot_unexclude_split_parent
   validate :split_child_date_matches_parent
 
+  # Best-effort wall time for ordering within a calendar day. Providers set when available;
+  # otherwise we default to local noon on `date`. When `date` changes without an explicit
+  # `transacted_at` update, we keep the clock time and move it to the new day.
+  before_validation :assign_transacted_at_best_effort
+
   before_destroy :prevent_individual_child_deletion, if: :split_child?
 
   scope :visible, -> {
@@ -117,7 +122,7 @@ class Entry < ApplicationRecord
     else scope
     end
 
-    scope.includes(entryable: :merchant).order(entries: { date: :desc }).to_a
+    scope.includes(entryable: :merchant).merge(Entry.reverse_chronological).to_a
   end
 
   # Auto-exclude stale pending transactions for an account
@@ -489,6 +494,23 @@ class Entry < ApplicationRecord
   end
 
   private
+
+    def assign_transacted_at_best_effort
+      return unless date.present?
+
+      if transacted_at.blank?
+        self.transacted_at = date.in_time_zone(Time.zone).middle_of_day
+        return
+      end
+
+      if date_changed? && !transacted_at_changed?
+        self.transacted_at = transacted_at.in_time_zone(Time.zone).change(
+          year: date.year,
+          month: date.month,
+          day: date.day
+        )
+      end
+    end
 
     def cannot_unexclude_split_parent
       return unless excluded_changed?(from: true, to: false) && split_parent?

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -33,7 +33,7 @@ class Entry < ApplicationRecord
     order(
       date: :asc,
       Arel.sql("CASE WHEN entries.entryable_type = 'Valuation' THEN 1 ELSE 0 END") => :asc,
-      Arel.sql("COALESCE(entries.transacted_at, entries.created_at)") => :asc
+      created_at: :asc
     )
   }
 
@@ -41,7 +41,7 @@ class Entry < ApplicationRecord
     order(
       date: :desc,
       Arel.sql("CASE WHEN entries.entryable_type = 'Valuation' THEN 1 ELSE 0 END") => :desc,
-      Arel.sql("COALESCE(entries.transacted_at, entries.created_at)") => :desc
+      created_at: :desc
     )
   }
 
@@ -389,7 +389,6 @@ class Entry < ApplicationRecord
         child_entries.create!(
           account: account,
           date: date,
-          transacted_at: transacted_at,
           name: split_attrs[:name],
           amount: split_attrs[:amount],
           currency: currency,

--- a/app/models/lunchflow_entry/processor.rb
+++ b/app/models/lunchflow_entry/processor.rb
@@ -39,7 +39,8 @@ class LunchflowEntry::Processor
         source: "lunchflow",
         merchant: merchant,
         notes: notes,
-        extra: extra_metadata
+        extra: extra_metadata,
+        transacted_at: transacted_at
       )
     rescue ArgumentError => e
       # Re-raise validation errors (missing required fields, invalid data)
@@ -203,6 +204,27 @@ class LunchflowEntry::Processor
     rescue ArgumentError, TypeError => e
       Rails.logger.error("Failed to parse Lunchflow transaction date '#{data[:date]}': #{e.message}")
       raise ArgumentError, "Unable to parse transaction date: #{data[:date].inspect}"
+    end
+
+    def transacted_at
+      raw = data[:date]
+      case raw
+      when String
+        parsed = Time.zone.parse(raw)
+        if parsed && parsed.to_date == date && parsed == parsed.beginning_of_day
+          nil
+        else
+          parsed
+        end
+      when Integer, Float
+        Time.at(raw).in_time_zone
+      when Time, ActiveSupport::TimeWithZone, DateTime
+        raw.in_time_zone
+      else
+        nil
+      end
+    rescue ArgumentError, TypeError
+      nil
     end
 
     # Build extra metadata hash with pending status

--- a/app/models/mercury_entry/processor.rb
+++ b/app/models/mercury_entry/processor.rb
@@ -36,7 +36,8 @@ class MercuryEntry::Processor
         name: name,
         source: "mercury",
         merchant: merchant,
-        notes: notes
+        notes: notes,
+        transacted_at: transacted_at
       )
     rescue ArgumentError => e
       # Re-raise validation errors (missing required fields, invalid data)
@@ -162,5 +163,22 @@ class MercuryEntry::Processor
     rescue ArgumentError, TypeError => e
       Rails.logger.error("Failed to parse Mercury transaction date '#{date_value}': #{e.message}")
       raise ArgumentError, "Unable to parse transaction date: #{date_value.inspect}"
+    end
+
+    def transacted_at
+      raw = data[:postedAt].presence || data[:createdAt].presence
+
+      case raw
+      when String
+        Time.zone.parse(raw)
+      when Integer, Float
+        Time.at(raw).in_time_zone
+      when Time, ActiveSupport::TimeWithZone, DateTime
+        raw.in_time_zone
+      else
+        nil
+      end
+    rescue ArgumentError, TypeError
+      nil
     end
 end

--- a/app/models/plaid_entry/processor.rb
+++ b/app/models/plaid_entry/processor.rb
@@ -17,7 +17,6 @@ class PlaidEntry::Processor
       category_id: matched_category&.id,
       merchant: merchant,
       pending_transaction_id: pending_transaction_id, # Plaid's linking ID for pending→posted
-      transacted_at: transacted_at,
       extra: {
         plaid: {
           pending: plaid_transaction["pending"],
@@ -56,14 +55,6 @@ class PlaidEntry::Processor
 
     def date
       plaid_transaction["date"]
-    end
-
-    def transacted_at
-      raw = plaid_transaction["datetime"] || plaid_transaction["authorized_datetime"]
-      return nil unless raw.present?
-      Time.parse(raw).utc
-    rescue ArgumentError, TypeError
-      nil
     end
 
     # Plaid provides this linking ID when a posted transaction matches a pending one

--- a/app/models/plaid_entry/processor.rb
+++ b/app/models/plaid_entry/processor.rb
@@ -17,6 +17,7 @@ class PlaidEntry::Processor
       category_id: matched_category&.id,
       merchant: merchant,
       pending_transaction_id: pending_transaction_id, # Plaid's linking ID for pending→posted
+      transacted_at: transacted_at,
       extra: {
         plaid: {
           pending: plaid_transaction["pending"],
@@ -55,6 +56,14 @@ class PlaidEntry::Processor
 
     def date
       plaid_transaction["date"]
+    end
+
+    def transacted_at
+      raw = plaid_transaction["datetime"] || plaid_transaction["authorized_datetime"]
+      return nil unless raw.present?
+      Time.parse(raw).utc
+    rescue ArgumentError, TypeError
+      nil
     end
 
     # Plaid provides this linking ID when a posted transaction matches a pending one

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -20,6 +20,7 @@ class SimplefinEntry::Processor
       source: "simplefin",
       merchant: merchant,
       notes: notes,
+      transacted_at: transacted_at,
       extra: extra_metadata
     )
   end
@@ -172,6 +173,42 @@ class SimplefinEntry::Processor
     def transacted_date
       val = data[:transacted_at]
       Simplefin::DateUtils.parse_provider_date(val)
+    end
+
+    def transacted_at
+      acct_type = simplefin_account&.account_type.to_s.strip.downcase.tr(" ", "_")
+      if %w[credit_card credit loan mortgage].include?(acct_type)
+        transacted_time || posted_time
+      else
+        posted_time || transacted_time
+      end
+    end
+
+    def posted_time
+      val = data[:posted]
+      return nil if val == 0 || val == "0"
+      parse_provider_time(val)
+    end
+
+    def transacted_time
+      parse_provider_time(data[:transacted_at])
+    end
+
+    def parse_provider_time(val)
+      return nil if val.nil?
+      case val
+      when Integer, Float
+        return nil if val.to_i == 0
+        Time.at(val).utc
+      when String
+        Time.parse(val).utc
+      when Time, DateTime
+        val.utc
+      else
+        nil
+      end
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def merchant

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -20,7 +20,6 @@ class SimplefinEntry::Processor
       source: "simplefin",
       merchant: merchant,
       notes: notes,
-      transacted_at: transacted_at,
       extra: extra_metadata
     )
   end
@@ -173,42 +172,6 @@ class SimplefinEntry::Processor
     def transacted_date
       val = data[:transacted_at]
       Simplefin::DateUtils.parse_provider_date(val)
-    end
-
-    def transacted_at
-      acct_type = simplefin_account&.account_type.to_s.strip.downcase.tr(" ", "_")
-      if %w[credit_card credit loan mortgage].include?(acct_type)
-        transacted_time || posted_time
-      else
-        posted_time || transacted_time
-      end
-    end
-
-    def posted_time
-      val = data[:posted]
-      return nil if val == 0 || val == "0"
-      parse_provider_time(val)
-    end
-
-    def transacted_time
-      parse_provider_time(data[:transacted_at])
-    end
-
-    def parse_provider_time(val)
-      return nil if val.nil?
-      case val
-      when Integer, Float
-        return nil if val.to_i == 0
-        Time.at(val).utc
-      when String
-        Time.parse(val).utc
-      when Time, DateTime
-        val.utc
-      else
-        nil
-      end
-    rescue ArgumentError, TypeError
-      nil
     end
 
     def merchant

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -233,7 +233,7 @@ class Transaction < ApplicationRecord
       .where.not(id: entry.id)
       .where(currency: currency)
       .where(conditions.join(" AND "))
-      .order(date: :desc, created_at: :desc)
+      .merge(Entry.reverse_chronological)
       .limit(limit)
       .offset(offset)
   end

--- a/app/views/api/v1/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v1/transactions/_transaction.json.jbuilder
@@ -2,7 +2,6 @@
 
 json.id transaction.id
 json.date transaction.entry.date
-json.transacted_at transaction.entry.transacted_at&.iso8601
 json.amount transaction.entry.amount_money.format
 
 # Agent/automation-friendly numeric fields (avoid localized parsing and clarify sign)

--- a/app/views/api/v1/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v1/transactions/_transaction.json.jbuilder
@@ -2,6 +2,7 @@
 
 json.id transaction.id
 json.date transaction.entry.date
+json.transacted_at transaction.entry.transacted_at&.iso8601
 json.amount transaction.entry.amount_money.format
 
 # Agent/automation-friendly numeric fields (avoid localized parsing and clarify sign)

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -4,7 +4,7 @@
 
 <%= turbo_frame_tag dom_id(entry) do %>
   <%= turbo_frame_tag dom_id(transaction) do %>
-    <div class="group flex lg:grid lg:grid-cols-12 items-center text-primary text-sm font-medium p-3 lg:p-4 <%= "pl-8 lg:pl-12" if in_split_group %>">
+    <div class="group flex lg:grid lg:grid-cols-12 items-center text-primary text-sm font-medium p-3 lg:p-4 <%= "pl-8 lg:pl-12" if in_split_group %>"<% if entry.transacted_at.present? %> title="<%= l(entry.transacted_at, format: :short) %>"<% end %>>
 
       <div class="pr-4 lg:pr-10 flex items-center gap-3 lg:gap-4 col-span-8 min-w-0">
         <%= check_box_tag dom_id(entry, "selection"),

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [],
+    "ignore": ["**/vendor/**", "**/node_modules/**", "**/tmp/**"],
     "include": ["./app/javascript/**/*.js"]
   },
   "formatter": {

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -49,13 +49,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "85e2c11853dd6c69b1953a6ec3ad661cd0ce3df55e4e5beff92365b6ed601171",
+      "fingerprint": "83aa818fee2af4e924f17d00f7ecbed94a68c8721b4f040a0581e128850ce2eb",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/api/v1/transactions_controller.rb",
-      "line": 255,
+      "line": 285,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:transaction).permit(:account_id, :date, :amount, :name, :description, :notes, :currency, :category_id, :merchant_id, :nature, :tag_ids => ([]))",
+      "code": "params.require(:transaction).permit(:account_id, :date, :amount, :name, :description, :notes, :currency, :category_id, :merchant_id, :nature, :transacted_at, :tag_ids => ([]))",
       "render_path": null,
       "location": {
         "type": "method",
@@ -67,7 +67,7 @@
       "cwe_id": [
         915
       ],
-      "note": "account_id is properly validated in create action - line 79 ensures account belongs to user's family: family.accounts.find(transaction_params[:account_id])"
+      "note": "account_id is properly validated in create action - line 79 ensures account belongs to user's family: family.accounts.find(transaction_params[:account_id]); transacted_at is parsed with Time.zone.parse and assigned only to Entry#transacted_at"
     },
     {
       "warning_type": "Mass Assignment",

--- a/db/migrate/20260414120000_add_transacted_at_to_entries.rb
+++ b/db/migrate/20260414120000_add_transacted_at_to_entries.rb
@@ -1,0 +1,5 @@
+class AddTransactedAtToEntries < ActiveRecord::Migration[7.2]
+  def change
+    add_column :entries, :transacted_at, :datetime, null: true
+  end
+end

--- a/db/migrate/20260414120000_add_transacted_at_to_entries.rb
+++ b/db/migrate/20260414120000_add_transacted_at_to_entries.rb
@@ -1,5 +1,0 @@
-class AddTransactedAtToEntries < ActiveRecord::Migration[7.2]
-  def change
-    add_column :entries, :transacted_at, :datetime, null: true
-  end
-end

--- a/db/migrate/20260414200000_remove_obsolete_recurring_transactions_family_merchant_index.rb
+++ b/db/migrate/20260414200000_remove_obsolete_recurring_transactions_family_merchant_index.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Superseded by idx_recurring_txns_acct_merchant / idx_recurring_txns_acct_name (account-scoped).
+# Leaving the old index caused RecordNotUnique when the same merchant+amount existed on two accounts.
+class RemoveObsoleteRecurringTransactionsFamilyMerchantIndex < ActiveRecord::Migration[7.2]
+  def up
+    remove_index :recurring_transactions,
+      name: "idx_recurring_txns_on_family_merchant_amount_currency",
+      if_exists: true
+  end
+
+  def down
+    add_index :recurring_transactions,
+      [ :family_id, :merchant_id, :amount, :currency ],
+      unique: true,
+      name: "idx_recurring_txns_on_family_merchant_amount_currency"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1155,7 +1155,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.index ["account_id"], name: "index_recurring_transactions_on_account_id"
     t.index ["family_id", "account_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_acct_merchant", unique: true, where: "(merchant_id IS NOT NULL)"
     t.index ["family_id", "account_id", "name", "amount", "currency"], name: "idx_recurring_txns_acct_name", unique: true, where: "((name IS NOT NULL) AND (merchant_id IS NULL))"
-    t.index ["family_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_on_family_merchant_amount_currency", unique: true
     t.index ["family_id", "status"], name: "index_recurring_transactions_on_family_id_and_status"
     t.index ["family_id"], name: "index_recurring_transactions_on_family_id"
     t.index ["merchant_id"], name: "index_recurring_transactions_on_merchant_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.index ["account_id"], name: "index_account_shares_on_account_id"
     t.index ["user_id", "include_in_finances"], name: "index_account_shares_on_user_id_and_include_in_finances"
     t.index ["user_id"], name: "index_account_shares_on_user_id"
-    t.check_constraint "permission::text = ANY (ARRAY['full_control'::character varying::text, 'read_write'::character varying::text, 'read_only'::character varying::text])", name: "chk_account_shares_permission"
+    t.check_constraint "permission::text = ANY (ARRAY['full_control'::character varying, 'read_write'::character varying, 'read_only'::character varying]::text[])", name: "chk_account_shares_permission"
   end
 
   create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -53,7 +53,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.uuid "accountable_id"
     t.decimal "balance", precision: 19, scale: 4
     t.string "currency"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
@@ -246,8 +246,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "parent_id"
-    t.string "lucide_icon", default: "shapes", null: false
     t.string "classification_unused", default: "expense", null: false
+    t.string "lucide_icon", default: "shapes", null: false
     t.index ["family_id"], name: "index_categories_on_family_id"
   end
 
@@ -465,6 +465,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.boolean "user_modified", default: false, null: false
     t.boolean "import_locked", default: false, null: false
     t.uuid "parent_entry_id"
+    t.datetime "transacted_at"
     t.index "lower((name)::text)", name: "index_entries_on_lower_name"
     t.index ["account_id", "date"], name: "index_entries_on_account_id_and_date"
     t.index ["account_id", "source", "external_id"], name: "index_entries_on_account_source_and_external_id", unique: true, where: "((external_id IS NOT NULL) AND (source IS NOT NULL))"
@@ -590,12 +591,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.datetime "latest_sync_completed_at", default: -> { "CURRENT_TIMESTAMP" }
     t.boolean "recurring_transactions_disabled", default: false, null: false
     t.integer "month_start_day", default: 1, null: false
-    t.string "vector_store_id"
     t.string "moniker", default: "Family", null: false
+    t.string "vector_store_id"
     t.string "assistant_type", default: "builtin", null: false
     t.string "default_account_sharing", default: "shared", null: false
     t.string "enabled_currencies", array: true
-    t.check_constraint "default_account_sharing::text = ANY (ARRAY['shared'::character varying::text, 'private'::character varying::text])", name: "chk_families_default_account_sharing"
+    t.check_constraint "default_account_sharing::text = ANY (ARRAY['shared'::character varying, 'private'::character varying]::text[])", name: "chk_families_default_account_sharing"
     t.check_constraint "month_start_day >= 1 AND month_start_day <= 28", name: "month_start_day_range"
   end
 
@@ -711,11 +712,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "exchange_operating_mic"
     t.string "category_parent"
     t.string "category_color"
     t.string "category_classification"
     t.string "category_icon"
+    t.string "exchange_operating_mic"
     t.string "resource_type"
     t.boolean "active"
     t.string "effective_date"
@@ -754,9 +755,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.string "exchange_operating_mic_col_label"
     t.string "amount_type_strategy", default: "signed_amount"
     t.string "amount_type_inflow_value"
-    t.integer "rows_to_skip", default: 0, null: false
     t.integer "rows_count", default: 0, null: false
     t.string "amount_type_identifier_value"
+    t.integer "rows_to_skip", default: 0, null: false
     t.text "ai_summary"
     t.string "document_type"
     t.jsonb "extracted_data"
@@ -1154,6 +1155,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.index ["account_id"], name: "index_recurring_transactions_on_account_id"
     t.index ["family_id", "account_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_acct_merchant", unique: true, where: "(merchant_id IS NOT NULL)"
     t.index ["family_id", "account_id", "name", "amount", "currency"], name: "idx_recurring_txns_acct_name", unique: true, where: "((name IS NOT NULL) AND (merchant_id IS NULL))"
+    t.index ["family_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_on_family_merchant_amount_currency", unique: true
     t.index ["family_id", "status"], name: "index_recurring_transactions_on_family_id_and_status"
     t.index ["family_id"], name: "index_recurring_transactions_on_family_id"
     t.index ["merchant_id"], name: "index_recurring_transactions_on_merchant_id"
@@ -1350,9 +1352,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.jsonb "raw_activities_payload", default: []
     t.datetime "last_holdings_sync"
     t.datetime "last_activities_sync"
+    t.boolean "activities_fetch_pending", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "activities_fetch_pending", default: false
     t.date "sync_start_date"
     t.index ["snaptrade_item_id", "snaptrade_account_id"], name: "index_snaptrade_accounts_on_item_and_snaptrade_account_id", unique: true, where: "(snaptrade_account_id IS NOT NULL)"
     t.index ["snaptrade_item_id"], name: "index_snaptrade_accounts_on_snaptrade_item_id"
@@ -1555,9 +1557,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.datetime "set_onboarding_preferences_at"
     t.datetime "set_onboarding_goals_at"
     t.string "default_account_order", default: "name_asc"
+    t.string "ui_layout"
     t.jsonb "preferences", default: {}, null: false
     t.string "locale"
-    t.string "ui_layout"
     t.uuid "default_account_id"
     t.index ["default_account_id"], name: "index_users_on_default_account_id"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.index ["account_id"], name: "index_account_shares_on_account_id"
     t.index ["user_id", "include_in_finances"], name: "index_account_shares_on_user_id_and_include_in_finances"
     t.index ["user_id"], name: "index_account_shares_on_user_id"
-    t.check_constraint "permission::text = ANY (ARRAY['full_control'::character varying, 'read_write'::character varying, 'read_only'::character varying]::text[])", name: "chk_account_shares_permission"
+    t.check_constraint "permission::text = ANY (ARRAY['full_control'::character varying::text, 'read_write'::character varying::text, 'read_only'::character varying::text])", name: "chk_account_shares_permission"
   end
 
   create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -53,7 +53,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.uuid "accountable_id"
     t.decimal "balance", precision: 19, scale: 4
     t.string "currency"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
@@ -246,8 +246,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "parent_id"
-    t.string "classification_unused", default: "expense", null: false
     t.string "lucide_icon", default: "shapes", null: false
+    t.string "classification_unused", default: "expense", null: false
     t.index ["family_id"], name: "index_categories_on_family_id"
   end
 
@@ -465,7 +465,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.boolean "user_modified", default: false, null: false
     t.boolean "import_locked", default: false, null: false
     t.uuid "parent_entry_id"
-    t.datetime "transacted_at"
     t.index "lower((name)::text)", name: "index_entries_on_lower_name"
     t.index ["account_id", "date"], name: "index_entries_on_account_id_and_date"
     t.index ["account_id", "source", "external_id"], name: "index_entries_on_account_source_and_external_id", unique: true, where: "((external_id IS NOT NULL) AND (source IS NOT NULL))"
@@ -591,12 +590,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.datetime "latest_sync_completed_at", default: -> { "CURRENT_TIMESTAMP" }
     t.boolean "recurring_transactions_disabled", default: false, null: false
     t.integer "month_start_day", default: 1, null: false
-    t.string "moniker", default: "Family", null: false
     t.string "vector_store_id"
+    t.string "moniker", default: "Family", null: false
     t.string "assistant_type", default: "builtin", null: false
     t.string "default_account_sharing", default: "shared", null: false
     t.string "enabled_currencies", array: true
-    t.check_constraint "default_account_sharing::text = ANY (ARRAY['shared'::character varying, 'private'::character varying]::text[])", name: "chk_families_default_account_sharing"
+    t.check_constraint "default_account_sharing::text = ANY (ARRAY['shared'::character varying::text, 'private'::character varying::text])", name: "chk_families_default_account_sharing"
     t.check_constraint "month_start_day >= 1 AND month_start_day <= 28", name: "month_start_day_range"
   end
 
@@ -712,11 +711,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "exchange_operating_mic"
     t.string "category_parent"
     t.string "category_color"
     t.string "category_classification"
     t.string "category_icon"
-    t.string "exchange_operating_mic"
     t.string "resource_type"
     t.boolean "active"
     t.string "effective_date"
@@ -755,9 +754,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.string "exchange_operating_mic_col_label"
     t.string "amount_type_strategy", default: "signed_amount"
     t.string "amount_type_inflow_value"
+    t.integer "rows_to_skip", default: 0, null: false
     t.integer "rows_count", default: 0, null: false
     t.string "amount_type_identifier_value"
-    t.integer "rows_to_skip", default: 0, null: false
     t.text "ai_summary"
     t.string "document_type"
     t.jsonb "extracted_data"
@@ -1155,7 +1154,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.index ["account_id"], name: "index_recurring_transactions_on_account_id"
     t.index ["family_id", "account_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_acct_merchant", unique: true, where: "(merchant_id IS NOT NULL)"
     t.index ["family_id", "account_id", "name", "amount", "currency"], name: "idx_recurring_txns_acct_name", unique: true, where: "((name IS NOT NULL) AND (merchant_id IS NULL))"
-    t.index ["family_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_on_family_merchant_amount_currency", unique: true
     t.index ["family_id", "status"], name: "index_recurring_transactions_on_family_id_and_status"
     t.index ["family_id"], name: "index_recurring_transactions_on_family_id"
     t.index ["merchant_id"], name: "index_recurring_transactions_on_merchant_id"
@@ -1352,9 +1350,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.jsonb "raw_activities_payload", default: []
     t.datetime "last_holdings_sync"
     t.datetime "last_activities_sync"
-    t.boolean "activities_fetch_pending", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "activities_fetch_pending", default: false
     t.date "sync_start_date"
     t.index ["snaptrade_item_id", "snaptrade_account_id"], name: "index_snaptrade_accounts_on_item_and_snaptrade_account_id", unique: true, where: "(snaptrade_account_id IS NOT NULL)"
     t.index ["snaptrade_item_id"], name: "index_snaptrade_accounts_on_snaptrade_item_id"
@@ -1557,9 +1555,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_120000) do
     t.datetime "set_onboarding_preferences_at"
     t.datetime "set_onboarding_goals_at"
     t.string "default_account_order", default: "name_asc"
-    t.string "ui_layout"
     t.jsonb "preferences", default: {}, null: false
     t.string "locale"
+    t.string "ui_layout"
     t.uuid "default_account_id"
     t.index ["default_account_id"], name: "index_users_on_default_account_id"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/spec/requests/api/v1/transactions_spec.rb
+++ b/spec/requests/api/v1/transactions_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe 'API V1 Transactions', type: :request do
               category_id: { type: :string, format: :uuid, description: 'Category ID' },
               merchant_id: { type: :string, format: :uuid, description: 'Merchant ID' },
               nature: { type: :string, enum: %w[income expense inflow outflow], description: 'Transaction nature (determines sign)' },
+              transacted_at: { type: :string, format: :'date-time', description: 'Optional ISO8601 time for intra-day ordering' },
               tag_ids: { type: :array, items: { type: :string, format: :uuid }, description: 'Array of tag IDs' }
             },
             required: %w[account_id date amount name]
@@ -281,6 +282,7 @@ RSpec.describe 'API V1 Transactions', type: :request do
               category_id: { type: :string, format: :uuid },
               merchant_id: { type: :string, format: :uuid },
               nature: { type: :string, enum: %w[income expense inflow outflow] },
+              transacted_at: { type: :string, format: :'date-time', description: 'Optional ISO8601 time for intra-day ordering' },
               tag_ids: {
                 type: :array,
                 items: { type: :string, format: :uuid },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -303,6 +303,8 @@ RSpec.configure do |config|
             properties: {
               id: { type: :string, format: :uuid },
               date: { type: :string, format: :date },
+              transacted_at: { type: :string, format: :'date-time', nullable: true,
+                               description: 'Best-effort time-of-day for ordering within the calendar date' },
               amount: { type: :string },
               currency: { type: :string },
               name: { type: :string },

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -179,6 +179,29 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @account.id, response_data["account"]["id"]
   end
 
+  test "should create transaction with optional transacted_at" do
+    ts = Time.zone.parse("2024-06-15T14:22:00Z")
+    transaction_params = {
+      transaction: {
+        account_id: @account.id,
+        name: "Timed Transaction",
+        amount: 10.00,
+        date: Date.new(2024, 6, 15),
+        currency: "USD",
+        nature: "expense",
+        transacted_at: ts.iso8601
+      }
+    }
+
+    post api_v1_transactions_url,
+         params: transaction_params,
+         headers: api_headers(@api_key)
+
+    assert_response :created
+    response_data = JSON.parse(response.body)
+    assert_equal ts.to_i, Time.iso8601(response_data["transacted_at"]).to_i
+  end
+
   test "should reject create with read-only API key" do
     transaction_params = {
       transaction: {

--- a/test/models/account/entry_test.rb
+++ b/test/models/account/entry_test.rb
@@ -49,6 +49,43 @@ class EntryTest < ActiveSupport::TestCase
     @entry.sync_account_later
   end
 
+  test "assigns transacted_at to middle of day when blank on create" do
+    family = families(:empty)
+    account = family.accounts.create!(name: "Test", balance: 0, currency: "USD", accountable: Depository.new)
+    d = Date.new(2024, 6, 15)
+
+    entry = account.entries.create!(
+      name: "Coffee",
+      date: d,
+      amount: -5,
+      currency: "USD",
+      entryable: Transaction.new
+    )
+
+    assert_equal d.in_time_zone(Time.zone).middle_of_day, entry.transacted_at
+  end
+
+  test "realigns transacted_at calendar day when date changes without changing time field" do
+    family = families(:empty)
+    account = family.accounts.create!(name: "Test", balance: 0, currency: "USD", accountable: Depository.new)
+    d1 = Date.new(2024, 6, 15)
+    d2 = Date.new(2024, 6, 20)
+    t = Time.zone.local(2024, 6, 15, 8, 30, 0)
+
+    entry = account.entries.create!(
+      name: "Coffee",
+      date: d1,
+      amount: -5,
+      currency: "USD",
+      transacted_at: t,
+      entryable: Transaction.new
+    )
+
+    entry.update!(date: d2)
+
+    assert_equal Time.zone.local(2024, 6, 20, 8, 30, 0), entry.transacted_at
+  end
+
   test "can search entries" do
     family = families(:empty)
     account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new


### PR DESCRIPTION
feat #1333 

## Summary

  Adds a nullable `transacted_at` (datetime) column to the `entries` table so that transactions on the same date can be sorted by time-of-day when providers supply that data. This is a **best-effort** enhancement — when time data is unavailable (manual entries, CSV imports), sorting gracefully falls back to the existing `created_at` behavior.

  ### Problem

  Currently, entries only have a `date` (DATE) column. When multiple transactions land on the same day, the only sort tiebreaker is `created_at` — which reflects **import order**, not when the transaction actually happened. Meanwhile, providers like Plaid and SimpleFIN already supply time-of-day data that we were discarding.

  ### Solution

  - New nullable `transacted_at` datetime column on `entries`
  - Ordering scopes use `COALESCE(entries.transacted_at, entries.created_at)` as the intraday tiebreaker
  - Plaid processor now extracts `datetime` / `authorized_datetime` fields
  - SimpleFIN processor now preserves time-of-day from Unix timestamps (previously converted to Date only)
  - `date` remains the authoritative accounting/display date — completely independent from `transacted_at`
  - No UI grouping changes; entries still grouped by `date`

  ## How it works

  <!-- Add your diagram here showing the timestamp flow:
       Provider API → Processor (extracts time) → ProviderImportAdapter → Entry.transacted_at → COALESCE in ORDER BY -->

  ## Database change

  <!-- Add your DB screenshot here showing the new transacted_at column on the entries table -->

  | Column | Type | Nullable | Purpose |
  |--------|------|----------|---------|
  | `transacted_at` | `datetime` | Yes | Best-effort timestamp from provider (UTC) |

  ## UI impact

  <!-- Add your UI screenshot here showing that sorting is improved but display is unchanged -->

  - **Sorting**: Transactions on the same date now sort by actual transaction time when available
  - **Display**: No visible UI changes — date grouping unchanged
  - **API**: `transacted_at` exposed as ISO 8601 in `/api/v1/transactions` responses

  ## Files changed

  | File | Change |
  |------|--------|
  | `db/migrate/20260414120000_add_transacted_at_to_entries.rb` | Add nullable `transacted_at` column
  |
  | `app/models/entry.rb` | Update ordering scopes + propagate in `split!` |
  | `app/models/account/provider_import_adapter.rb` | Accept and assign `transacted_at:` param |
  | `app/models/plaid_entry/processor.rb` | Extract `datetime`/`authorized_datetime` from Plaid |
  | `app/models/simplefin_entry/processor.rb` | Preserve time from Unix timestamps |
  | `app/views/api/v1/transactions/_transaction.json.jbuilder` | Expose in API response |

  ## Design decisions

  - **`date` and `transacted_at` are independent** — a Plaid transaction can have `date: 2026-04-14` but `transacted_at: 2026-04-13T23:50:00Z`. This avoids timezone-induced date drift.
  - **No backfill** — existing entries lack reliable time data; backfilling from `created_at` would be misleading.
  - **Other providers deferred** — Mercury, CoinStats, etc. can be enhanced incrementally in follow-up PRs.

  ## Test plan

  - [x] Entry/transaction/transfer model tests pass (43 tests, 0 failures)
  - [x] Rubocop clean on all changed files
  - [x] Brakeman: 0 security warnings
  - [ ] Verify Plaid sync populates `transacted_at` with real data
  - [ ] Verify SimpleFIN sync populates `transacted_at` with real data
  - [ ] Verify manual/CSV entries have `transacted_at: null` (expected)
  - [ ] Verify transaction list sorting is unchanged for entries without timestamps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional transaction timestamp (transacted_at) for intra-day ordering; transactions now sort using it when present. Imports from many providers attempt to capture and persist this timestamp. Split transactions inherit the parent timestamp.

* **API / Docs**
  * API accepts transacted_at on create/update and returns it in transaction JSON; Swagger docs updated.

* **UI**
  * Transaction items show a short tooltip with the transacted_at time when available.

* **Database**
  * Added transacted_at column on entries.

* **Tests**
  * Added tests for transacted_at behavior and API create/echo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->