### PR TITLE
feat: Import pending transactions from Enable Banking only if option is enabled

### DIFF
--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -231,6 +231,7 @@ class EnableBankingItem::Importer
 
     def fetch_and_store_transactions(enable_banking_account)
       start_date = determine_sync_start_date(enable_banking_account)
+      include_pending = include_pending?
 
       all_transactions = fetch_paginated_transactions(
         enable_banking_account,
@@ -240,7 +241,7 @@ class EnableBankingItem::Importer
       )
 
       # Also fetch pending transactions (visible for 1-3 days before they become BOOK) if setting is enabled
-      pending_transactions = if include_pending?
+      pending_transactions = if include_pending
         fetch_paginated_transactions(
           enable_banking_account,
           start_date: start_date,
@@ -277,8 +278,19 @@ class EnableBankingItem::Importer
 
       transactions_count = all_transactions.count
 
+      existing_transactions = enable_banking_account.raw_transactions_payload.to_a
+      include_pending = include_pending?
+
+      removed_pending = false
+
+      unless include_pending
+        removed_pending = existing_transactions.reject! do |tx|
+          tx = tx.with_indifferent_access
+          tx.dig(:extra, :enable_banking, :pending) || tx[:_pending]
+        end
+      end
+
       if all_transactions.any?
-        existing_transactions = enable_banking_account.raw_transactions_payload.to_a
 
         # C4: Remove stored PDNG entries that have now settled as BOOK.
         # When a BOOK transaction arrives with the same transaction_id as a stored
@@ -296,17 +308,15 @@ class EnableBankingItem::Importer
 
         include_pending = include_pending?
 
-        if !include_pending
-          removed_pending = existing_transactions.reject! do |tx|
-            tx = tx.with_indifferent_access
-            tx.dig(:extra, :enable_banking, :pending) || tx[:_pending]
-          end
-        else
-          removed_pending = existing_transactions.reject! do |tx|
+        if include_pending
+          removed_pending ||= existing_transactions.reject! do |tx|
             tx = tx.with_indifferent_access
             pending_flag = tx.dig(:extra, :enable_banking, :pending) || tx[:_pending]
             next false unless pending_flag
-            tx[:transaction_id].present? ? book_ids.include?(tx[:transaction_id]) : book_entry_refs.include?(tx[:entry_reference].presence)
+
+            tx[:transaction_id].present? ?
+              book_ids.include?(tx[:transaction_id]) :
+              book_entry_refs.include?(tx[:entry_reference].presence)
           end
         end
 
@@ -324,6 +334,10 @@ class EnableBankingItem::Importer
         if new_transactions.any? || removed_pending
           enable_banking_account.upsert_enable_banking_transactions_snapshot!(existing_transactions + new_transactions)
         end
+      elsif removed_pending
+        enable_banking_account.upsert_enable_banking_transactions_snapshot!(
+          existing_transactions
+        )
       end
 
       { success: true, transactions_count: transactions_count }

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -225,6 +225,10 @@ class EnableBankingItem::Importer
       existing
     end
 
+    def include_pending?
+      Setting.syncs_include_pending
+    end
+
     def fetch_and_store_transactions(enable_banking_account)
       start_date = determine_sync_start_date(enable_banking_account)
 
@@ -235,13 +239,17 @@ class EnableBankingItem::Importer
         psu_headers: enable_banking_item.build_psu_headers
       )
 
-      # Also fetch pending transactions (visible for 1-3 days before they become BOOK)
-      pending_transactions = fetch_paginated_transactions(
-        enable_banking_account,
-        start_date: start_date,
-        transaction_status: "PDNG",
-        psu_headers: enable_banking_item.build_psu_headers
-      )
+      # Also fetch pending transactions (visible for 1-3 days before they become BOOK) if setting is enabled
+      pending_transactions = if include_pending?
+        fetch_paginated_transactions(
+          enable_banking_account,
+          start_date: start_date,
+          transaction_status: "PDNG",
+          psu_headers: enable_banking_item.build_psu_headers
+        )
+      else
+        []
+      end
 
       book_ids = all_transactions
         .map { |tx| tx.with_indifferent_access[:transaction_id].presence }
@@ -286,11 +294,20 @@ class EnableBankingItem::Importer
           .map { |tx| tx.with_indifferent_access[:entry_reference].presence }
           .compact.to_set
 
-        removed_pending = existing_transactions.reject! do |tx|
-          tx = tx.with_indifferent_access
-          pending_flag = tx.dig(:extra, :enable_banking, :pending) || tx[:_pending]
-          next false unless pending_flag
-          tx[:transaction_id].present? ? book_ids.include?(tx[:transaction_id]) : book_entry_refs.include?(tx[:entry_reference].presence)
+        include_pending = include_pending?
+
+        if !include_pending
+          removed_pending = existing_transactions.reject! do |tx|
+            tx = tx.with_indifferent_access
+            tx.dig(:extra, :enable_banking, :pending) || tx[:_pending]
+          end
+        else
+          removed_pending = existing_transactions.reject! do |tx|
+            tx = tx.with_indifferent_access
+            pending_flag = tx.dig(:extra, :enable_banking, :pending) || tx[:_pending]
+            next false unless pending_flag
+            tx[:transaction_id].present? ? book_ids.include?(tx[:transaction_id]) : book_entry_refs.include?(tx[:entry_reference].presence)
+          end
         end
 
         existing_ids = existing_transactions.map { |tx|

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -240,16 +240,15 @@ class EnableBankingItem::Importer
         psu_headers: enable_banking_item.build_psu_headers
       )
 
-      # Also fetch pending transactions (visible for 1-3 days before they become BOOK) if setting is enabled
-      pending_transactions = if include_pending
-        fetch_paginated_transactions(
+      pending_transactions = []
+      if include_pending
+        # Also fetch pending transactions (visible for 1-3 days before they become BOOK) if setting is enabled
+        pending_transactions = fetch_paginated_transactions(
           enable_banking_account,
           start_date: start_date,
           transaction_status: "PDNG",
           psu_headers: enable_banking_item.build_psu_headers
         )
-      else
-        []
       end
 
       book_ids = all_transactions
@@ -279,7 +278,6 @@ class EnableBankingItem::Importer
       transactions_count = all_transactions.count
 
       existing_transactions = enable_banking_account.raw_transactions_payload.to_a
-      include_pending = include_pending?
 
       removed_pending = false
 
@@ -305,8 +303,6 @@ class EnableBankingItem::Importer
           .reject { |tx| tx.with_indifferent_access[:_pending] }
           .map { |tx| tx.with_indifferent_access[:entry_reference].presence }
           .compact.to_set
-
-        include_pending = include_pending?
 
         if include_pending
           removed_pending ||= existing_transactions.reject! do |tx|


### PR DESCRIPTION
Partially solves https://github.com/we-promise/sure/issues/1470

Import pending transactions from Enable Banking only if the option is enabled in settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable pending-transaction handling for banking syncs—pending items can be included or excluded based on system settings.

* **Refactor**
  * Improved transaction reconciliation and settlement behavior so pending items are fetched, removed, and stored consistently when enabled; snapshot updates now occur when new transactions appear or pending entries are settled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->