### PR TITLE
fix(Enable Banking): Restore legacy fallback for credit card balance calculation

### DIFF
--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -59,7 +59,8 @@ class EnableBankingAccount::Processor
           # Fallback: no credit_limit from API — compute it using available_credit defined at account level
           Rails.logger.info "Using stored available_credit fallback for account #{account.id}"
           available_credit = account.accountable.available_credit
-          balance = available_credit - balance
+          outstanding = balance.abs
+          balance = [ available_credit - outstanding, 0 ].max
         else
           # Fallback: no credit_limit from API — display raw outstanding balance
           # We cannot derive available credit without knowing the limit; leave balance unchanged.

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -55,6 +55,11 @@ class EnableBankingAccount::Processor
           unless account.accountable.present?
             Rails.logger.warn "EnableBankingAccount::Processor - CreditCard accountable missing for account #{account.id}"
           end
+        elsif account.accountable&.available_credit.present?
+          # Fallback: no credit_limit from API — compute it using available_credit defined at account level
+          Rails.logger.info "Using stored available_credit fallback for account #{account.id}"
+          available_credit = account.accountable.available_credit
+          balance = available_credit - balance
         else
           # Fallback: no credit_limit from API — display raw outstanding balance
           # We cannot derive available credit without knowing the limit; leave balance unchanged.

--- a/test/models/enable_banking_account/processor_test.rb
+++ b/test/models/enable_banking_account/processor_test.rb
@@ -61,6 +61,7 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
 
   test "falls back to stored available_credit when credit_limit is absent" do
     cc_account = accounts(:credit_card)
+    cc_account.accountable.update!(available_credit: 1000.0)
 
     @enable_banking_account.update!(current_balance: 300.00, credit_limit: nil)
 
@@ -69,7 +70,20 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
 
     EnableBankingAccount::Processor.new(@enable_banking_account).process
 
-    expected_balance = cc_account.accountable.available_credit - 300.0
-    assert_equal expected_balance, cc_account.reload.cash_balance
+    assert_equal 700.0, cc_account.reload.cash_balance
+  end
+
+  test "sets CC balance to raw outstanding when credit_limit is absent" do
+    cc_account = accounts(:credit_card)
+    cc_account.accountable.update!(available_credit: nil)
+
+    @enable_banking_account.update!(current_balance: 300.00, credit_limit: nil)
+
+    AccountProvider.find_by(provider: @enable_banking_account)&.destroy
+    AccountProvider.create!(account: cc_account, provider: @enable_banking_account)
+
+    EnableBankingAccount::Processor.new(@enable_banking_account).process
+
+    assert_equal 300.0, cc_account.reload.cash_balance
   end
 end

--- a/test/models/enable_banking_account/processor_test.rb
+++ b/test/models/enable_banking_account/processor_test.rb
@@ -59,14 +59,17 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
-  test "sets CC balance to raw outstanding when credit_limit is absent" do
+  test "falls back to stored available_credit when credit_limit is absent" do
     cc_account = accounts(:credit_card)
+
     @enable_banking_account.update!(current_balance: 300.00, credit_limit: nil)
+
     AccountProvider.find_by(provider: @enable_banking_account)&.destroy
     AccountProvider.create!(account: cc_account, provider: @enable_banking_account)
 
     EnableBankingAccount::Processor.new(@enable_banking_account).process
 
-    assert_equal 300.0, cc_account.reload.cash_balance
+    expected_balance = cc_account.accountable.available_credit - 300.0
+    assert_equal expected_balance, cc_account.reload.cash_balance
   end
 end


### PR DESCRIPTION
PR https://github.com/we-promise/sure/pull/1406 introduced a regression in the fallback logic for computing credit card balances via Enable Banking, which had been originally implemented in https://github.com/we-promise/sure/pull/663.

This PR restores the fallback behavior when no `credit_limit` is returned by the API, ensuring we continue to rely on the stored `available_credit` at the account level when necessary (e.g. when a manual credit limit is set).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credit card balances now fall back to stored available credit when external credit limit data is missing, recalculating the displayed balance as available credit minus outstanding instead of showing the raw outstanding.

* **Tests**
  * Test coverage added to verify the new fallback calculation and to confirm original behavior remains when stored available credit is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->