### PR TITLE
Improve split Sankey transfer links and expanded dialog UX

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,7 +16,9 @@ class PagesController < ApplicationController
     family_currency = Current.family.currency
 
     # Use IncomeStatement for all cashflow data (now includes categorized trades)
-    income_statement = Current.family.income_statement
+    selected_account_id = params[:account_id]
+    account_ids = selected_account_id.present? ? [ selected_account_id ] : nil
+    income_statement = Current.family.income_statement(user: Current.user, account_ids: account_ids)
     income_totals = income_statement.income_totals(period: @period)
     expense_totals = income_statement.expense_totals(period: @period)
     net_totals = income_statement.net_category_totals(period: @period)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,16 +12,34 @@ class PagesController < ApplicationController
     @balance_sheet = Current.family.balance_sheet
     @investment_statement = Current.family.investment_statement
     @accounts = Current.user.accessible_accounts.visible.with_attached_logo
+    @finance_accounts = Current.user.finance_accounts.visible.alphabetically
+    @sankey_mode = resolved_sankey_mode
+    @selected_account = @sankey_mode == "aggregate" ? @finance_accounts.find_by(id: params[:account_id].presence) : nil
 
     family_currency = Current.family.currency
+    selected_account_ids = @selected_account ? [ @selected_account.id ] : nil
 
-    # Use IncomeStatement for all cashflow data (now includes categorized trades)
-    income_statement = Current.family.income_statement
-    income_totals = income_statement.income_totals(period: @period)
-    expense_totals = income_statement.expense_totals(period: @period)
-    net_totals = income_statement.net_category_totals(period: @period)
+    if @sankey_mode == "split"
+      income_statement = Current.family.income_statement(user: Current.user)
+      net_totals = income_statement.net_category_totals(period: @period)
+      @cashflow_sankey_data = build_split_cashflow_sankey_data(accounts: @finance_accounts, period: @period, currency: family_currency)
+    else
+      # Use IncomeStatement for all cashflow data (now includes categorized trades)
+      income_statement = Current.family.income_statement(user: Current.user, account_ids: selected_account_ids)
+      income_totals = income_statement.income_totals(period: @period)
+      expense_totals = income_statement.expense_totals(period: @period)
+      net_totals = income_statement.net_category_totals(period: @period)
+      transfer_flows = @selected_account ?
+        build_transfer_flows_for_account(
+          account: @selected_account,
+          period: @period,
+          currency: family_currency,
+          accessible_account_ids: @accounts.map(&:id).to_set
+        ) : nil
 
-    @cashflow_sankey_data = build_cashflow_sankey_data(net_totals, income_totals, expense_totals, family_currency)
+      @cashflow_sankey_data = build_cashflow_sankey_data(net_totals, income_totals, expense_totals, family_currency, transfer_flows: transfer_flows)
+    end
+
     @outflows_data = build_outflows_donut_data(net_totals)
 
     @dashboard_sections = build_dashboard_sections
@@ -89,7 +107,13 @@ class PagesController < ApplicationController
           key: "cashflow_sankey",
           title: "pages.dashboard.cashflow_sankey.title",
           partial: "pages/dashboard/cashflow_sankey",
-          locals: { sankey_data: @cashflow_sankey_data, period: @period },
+          locals: {
+            sankey_data: @cashflow_sankey_data,
+            period: @period,
+            finance_accounts: @finance_accounts,
+            selected_account_id: @selected_account&.id,
+            sankey_mode: @sankey_mode
+          },
           visible: @accounts.any?,
           collapsible: true
         },
@@ -145,7 +169,7 @@ class PagesController < ApplicationController
       Provider::Registry.get_provider(:github)
     end
 
-    def build_cashflow_sankey_data(net_totals, income_totals, expense_totals, currency)
+    def build_cashflow_sankey_data(net_totals, income_totals, expense_totals, currency, transfer_flows: nil)
       nodes = []
       links = []
       node_indices = {}
@@ -190,6 +214,13 @@ class PagesController < ApplicationController
         flow_direction: :outbound
       )
 
+      append_transfer_flows(
+        transfer_flows: transfer_flows,
+        add_node: add_node,
+        links: links,
+        cash_flow_idx: cash_flow_idx
+      )
+
       # Surplus/Deficit
       net = (total_income - total_expense).round(2)
       if net.positive?
@@ -199,6 +230,35 @@ class PagesController < ApplicationController
       end
 
       { nodes: nodes, links: links, currency_symbol: Money::Currency.new(currency).symbol }
+    end
+
+    def append_transfer_flows(transfer_flows:, add_node:, links:, cash_flow_idx:, key_namespace: nil, inbound_label_prefix: nil, outbound_label_prefix: nil)
+      return if transfer_flows.blank?
+
+      transfer_color = Category::TRANSFER_COLOR
+      inbound_base = transfer_flows[:total_inbound].to_f
+      outbound_base = transfer_flows[:total_outbound].to_f
+      key_prefix = key_namespace.present? ? "#{key_namespace}_" : ""
+      inbound_prefix = inbound_label_prefix.presence || "#{I18n.t("pages.dashboard.cashflow_sankey.from_label")} "
+      outbound_prefix = outbound_label_prefix.presence || "#{I18n.t("pages.dashboard.cashflow_sankey.to_label")} "
+
+      transfer_flows[:inbound].each do |flow|
+        value = flow[:value].to_f.round(2)
+        next if value.zero?
+
+        percentage = inbound_base.zero? ? 0 : (value / inbound_base * 100).round(1)
+        idx = add_node.call("#{key_prefix}transfer_in_#{flow[:key]}", "#{inbound_prefix}#{flow[:name]}", value, percentage, transfer_color)
+        links << { source: idx, target: cash_flow_idx, value: value, color: transfer_color, percentage: percentage, flow_type: "transfer_in" }
+      end
+
+      transfer_flows[:outbound].each do |flow|
+        value = flow[:value].to_f.round(2)
+        next if value.zero?
+
+        percentage = outbound_base.zero? ? 0 : (value / outbound_base * 100).round(1)
+        idx = add_node.call("#{key_prefix}transfer_out_#{flow[:key]}", "#{outbound_prefix}#{flow[:name]}", value, percentage, transfer_color)
+        links << { source: cash_flow_idx, target: idx, value: value, color: transfer_color, percentage: percentage, flow_type: "transfer_out" }
+      end
     end
 
     # Nets subcategory expense and income totals, grouped by parent_id.
@@ -241,8 +301,9 @@ class PagesController < ApplicationController
     #
     # flow_direction: :inbound  (subcategory -> parent -> cash_flow) for income
     #                 :outbound (cash_flow -> parent -> subcategory) for expenses
-    def process_net_category_nodes(categories:, total:, prefix:, net_subcategories_by_parent:, add_node:, links:, cash_flow_idx:, flow_direction:)
+    def process_net_category_nodes(categories:, total:, prefix:, net_subcategories_by_parent:, add_node:, links:, cash_flow_idx:, flow_direction:, key_namespace: nil)
       matching_direction = flow_direction == :inbound ? :income : :expense
+      key_prefix = key_namespace.present? ? "#{key_namespace}_" : ""
 
       categories.each do |ct|
         val = ct.total.to_f.round(2)
@@ -250,7 +311,7 @@ class PagesController < ApplicationController
 
         percentage = total.zero? ? 0 : (val / total * 100).round(1)
         color = ct.category.color.presence || Category::UNCATEGORIZED_COLOR
-        node_key = "#{prefix}_#{ct.category.id || ct.category.name}"
+        node_key = "#{key_prefix}#{prefix}_#{ct.category.id || ct.category.name}"
 
         all_subs = ct.category.id ? (net_subcategories_by_parent[ct.category.id] || []) : []
         same_side_subs = all_subs.select { |s| s[:net_direction] == matching_direction }
@@ -273,7 +334,7 @@ class PagesController < ApplicationController
             sub_val = sub[:total].to_f.round(2)
             sub_pct = val.zero? ? 0 : (sub_val / val * 100).round(1)
             sub_color = sub[:category].color.presence || color
-            sub_key = "#{prefix}_sub_#{sub[:category].id}"
+            sub_key = "#{key_prefix}#{prefix}_sub_#{sub[:category].id}"
             sub_idx = add_node.call(sub_key, sub[:category].name, sub_val, sub_pct, sub_color)
 
             if flow_direction == :inbound
@@ -300,7 +361,7 @@ class PagesController < ApplicationController
           sub_val = sub[:total].to_f.round(2)
           sub_pct = total.zero? ? 0 : (sub_val / total * 100).round(1)
           sub_color = sub[:category].color.presence || color
-          sub_key = "#{opposite_prefix}_sub_#{sub[:category].id}"
+          sub_key = "#{key_prefix}#{opposite_prefix}_sub_#{sub[:category].id}"
           sub_idx = add_node.call(sub_key, sub[:category].name, sub_val, sub_pct, sub_color)
 
           # Opposite direction: if parent is outbound (expense), this sub is inbound (income)
@@ -311,6 +372,374 @@ class PagesController < ApplicationController
           end
         end
       end
+    end
+
+    def build_split_cashflow_sankey_data(accounts:, period:, currency:)
+      nodes = []
+      links = []
+      node_indices = {}
+      account_lane_order = accounts.each_with_index.to_h { |account, idx| [ account.id, idx ] }
+
+      add_node = ->(unique_key, display_name, value, percentage, color) {
+        node_indices[unique_key] ||= begin
+          metadata = split_sankey_node_metadata(unique_key, account_lane_order)
+          nodes << {
+            name: display_name,
+            value: value.to_f.round(2),
+            percentage: percentage.to_f.round(1),
+            color: color
+          }.merge(metadata)
+          nodes.size - 1
+        end
+      }
+
+      income_flows_by_account_category = Hash.new(0.to_d)
+      expense_flows_by_account_category = Hash.new(0.to_d)
+      income_totals_by_category = Hash.new(0.to_d)
+      expense_totals_by_category = Hash.new(0.to_d)
+      income_totals_by_account = Hash.new(0.to_d)
+      expense_totals_by_account = Hash.new(0.to_d)
+      income_categories_by_key = {}
+      expense_categories_by_key = {}
+
+      accounts.each do |account|
+        income_statement = Current.family.income_statement(user: Current.user, account_ids: [ account.id ])
+        net_totals = income_statement.net_category_totals(period: period)
+
+        net_totals.net_income_categories.each do |category_total|
+          value = category_total.total.to_d
+          next if value.zero?
+
+          category_key = split_category_key(category_total)
+          income_flows_by_account_category[[ account.id, category_key ]] += value
+          income_totals_by_category[category_key] += value
+          income_totals_by_account[account.id] += value
+          income_categories_by_key[category_key] ||= category_total.category
+        end
+
+        net_totals.net_expense_categories.each do |category_total|
+          value = category_total.total.to_d
+          next if value.zero?
+
+          category_key = split_category_key(category_total)
+          expense_flows_by_account_category[[ account.id, category_key ]] += value
+          expense_totals_by_category[category_key] += value
+          expense_totals_by_account[account.id] += value
+          expense_categories_by_key[category_key] ||= category_total.category
+        end
+      end
+
+      transfer_overlay_data = build_split_transfer_overlays(accounts: accounts, period: period, currency: currency)
+      transfer_totals_by_account = transfer_overlay_data[:totals_by_account]
+
+      total_income = income_totals_by_category.values.sum.to_f.round(2)
+      total_expense = expense_totals_by_category.values.sum.to_f.round(2)
+
+      income_node_indices = {}
+      income_totals_by_category.sort_by { |_, value| -value.to_f }.each do |category_key, value|
+        category = split_category_for_key(category_key, category_lookup: income_categories_by_key)
+        percentage = total_income.zero? ? 0 : (value.to_f / total_income * 100).round(1)
+        income_node_indices[category_key] = add_node.call(
+          "split_income_#{category_key}",
+          category.name,
+          value.to_f.round(2),
+          percentage,
+          category.color.presence || Category::UNCATEGORIZED_COLOR
+        )
+      end
+
+      expense_node_indices = {}
+      expense_totals_by_category.sort_by { |_, value| -value.to_f }.each do |category_key, value|
+        category = split_category_for_key(category_key, category_lookup: expense_categories_by_key)
+        percentage = total_expense.zero? ? 0 : (value.to_f / total_expense * 100).round(1)
+        expense_node_indices[category_key] = add_node.call(
+          "split_expense_#{category_key}",
+          category.name,
+          value.to_f.round(2),
+          percentage,
+          category.color.presence || Category::UNCATEGORIZED_COLOR
+        )
+      end
+
+      account_node_indices = {}
+      accounts.each do |account|
+        has_category_flows = income_totals_by_account[account.id].positive? || expense_totals_by_account[account.id].positive?
+        next unless has_category_flows
+
+        node_value = [
+          income_totals_by_account[account.id].to_f,
+          expense_totals_by_account[account.id].to_f,
+          transfer_totals_by_account[account.id].to_f
+        ].max.round(2)
+
+        account_node_indices[account.id] = add_node.call(
+          "account_#{account.id}_cash_flow_node",
+          account.name,
+          node_value,
+          100.0,
+          "var(--color-success)"
+        )
+      end
+
+      income_flows_by_account_category.each do |(account_id, category_key), value|
+        account_idx = account_node_indices[account_id]
+        income_idx = income_node_indices[category_key]
+        next unless account_idx && income_idx
+
+        category = split_category_for_key(category_key, category_lookup: income_categories_by_key)
+        percentage = total_income.zero? ? 0 : (value.to_f / total_income * 100).round(1)
+        links << {
+          source: income_idx,
+          target: account_idx,
+          value: value.to_f.round(2),
+          color: category.color.presence || Category::UNCATEGORIZED_COLOR,
+          percentage: percentage
+        }
+      end
+
+      expense_flows_by_account_category.each do |(account_id, category_key), value|
+        account_idx = account_node_indices[account_id]
+        expense_idx = expense_node_indices[category_key]
+        next unless account_idx && expense_idx
+
+        category = split_category_for_key(category_key, category_lookup: expense_categories_by_key)
+        percentage = total_expense.zero? ? 0 : (value.to_f / total_expense * 100).round(1)
+        links << {
+          source: account_idx,
+          target: expense_idx,
+          value: value.to_f.round(2),
+          color: category.color.presence || Category::UNCATEGORIZED_COLOR,
+          percentage: percentage
+        }
+      end
+
+      transfer_overlays = transfer_overlay_data[:links].filter_map do |flow|
+        source_idx = account_node_indices[flow[:source_account_id]]
+        target_idx = account_node_indices[flow[:target_account_id]]
+        next unless source_idx && target_idx
+
+        {
+          source: source_idx,
+          target: target_idx,
+          value: flow[:value].to_f.round(2),
+          color: Category::TRANSFER_COLOR,
+          flow_type: "transfer_overlay",
+          source_name: flow[:source_name],
+          target_name: flow[:target_name]
+        }
+      end
+
+      {
+        nodes: nodes,
+        links: links,
+        transfer_overlays: transfer_overlays,
+        currency_symbol: Money::Currency.new(currency).symbol
+      }
+    end
+
+    def split_sankey_node_metadata(unique_key, account_lane_order)
+      account_id = unique_key[/\Aaccount_([^_]+)_/, 1]
+      return {} unless account_id
+
+      {
+        lane_order: account_lane_order.fetch(account_id, 0),
+        node_role: split_sankey_node_role(unique_key)
+      }
+    end
+
+    def split_category_key(category_total)
+      category = category_total.category
+      category.id.presence || category.name
+    end
+
+    def split_category_for_key(category_key, category_lookup:)
+      category_lookup.fetch(category_key)
+    end
+
+    def split_sankey_node_role(unique_key)
+      return "cash_flow" if unique_key.end_with?("_cash_flow_node")
+      return "surplus" if unique_key.end_with?("_surplus_node")
+      return "transfer_in" if unique_key.include?("_transfer_in_")
+      return "transfer_out" if unique_key.include?("_transfer_out_")
+      return "income_sub" if unique_key.include?("_income_sub_")
+      return "income" if unique_key.include?("_income_")
+      return "expense_sub" if unique_key.include?("_expense_sub_")
+      return "expense" if unique_key.include?("_expense_")
+
+      "other"
+    end
+
+    def build_split_transfer_overlays(accounts:, period:, currency:)
+      accounts_by_id = accounts.index_by(&:id)
+      account_ids = accounts_by_id.keys.to_set
+
+      transfer_transactions = Current.family.transactions
+        .visible
+        .excluding_pending
+        .in_period(period)
+        .where(kind: Transaction::TRANSFER_KINDS)
+        .where(entries: { excluded: false })
+        .includes(
+          :entry,
+          transfer_as_outflow: { inflow_transaction: { entry: :account } }
+        )
+
+      outflow_transactions = transfer_transactions.select(&:transfer_as_outflow)
+      return { links: [], totals_by_account: Hash.new(0.to_d) } if outflow_transactions.empty?
+
+      exchange_rates = exchange_rate_map_for_entries(outflow_transactions.map(&:entry), target_currency: currency)
+      directed_buckets = Hash.new(0.to_d)
+
+      outflow_transactions.each do |transaction|
+        source_entry = transaction.entry
+        destination_entry = transaction.transfer_as_outflow&.inflow_transaction&.entry
+        next unless source_entry && destination_entry
+
+        source_account = source_entry.account
+        destination_account = destination_entry.account
+        next unless source_account && destination_account
+        next unless account_ids.include?(source_account.id) && account_ids.include?(destination_account.id)
+
+        converted_amount = converted_entry_abs_amount(source_entry, target_currency: currency, exchange_rates: exchange_rates)
+        next if converted_amount.zero?
+
+        directed_buckets[[ source_account.id, destination_account.id ]] += converted_amount
+      end
+
+      links = []
+      totals_by_account = Hash.new(0.to_d)
+      pair_keys = directed_buckets.keys.map { |source_id, target_id| [ source_id, target_id ].sort }.uniq
+
+      pair_keys.each do |account_a_id, account_b_id|
+        forward = directed_buckets[[ account_a_id, account_b_id ]]
+        reverse = directed_buckets[[ account_b_id, account_a_id ]]
+        net_amount = forward - reverse
+        next if net_amount.zero?
+
+        source_id, target_id = net_amount.positive? ? [ account_a_id, account_b_id ] : [ account_b_id, account_a_id ]
+        source_account = accounts_by_id[source_id]
+        target_account = accounts_by_id[target_id]
+        next unless source_account && target_account
+
+        value = net_amount.abs.round(2)
+
+        links << {
+          source_account_id: source_id,
+          target_account_id: target_id,
+          source_name: source_account.name,
+          target_name: target_account.name,
+          value: value
+        }
+
+        totals_by_account[source_id] += value
+        totals_by_account[target_id] += value
+      end
+
+      {
+        links: links.sort_by { |flow| -flow[:value].to_f },
+        totals_by_account: totals_by_account
+      }
+    end
+
+    def build_transfer_flows_for_account(account:, period:, currency:, accessible_account_ids:)
+      transfer_transactions = Current.family.transactions
+        .visible
+        .excluding_pending
+        .in_period(period)
+        .where(kind: Transaction::TRANSFER_KINDS)
+        .where(entries: { account_id: account.id, excluded: false })
+        .includes(
+          :entry,
+          transfer_as_outflow: { inflow_transaction: { entry: :account } },
+          transfer_as_inflow: { outflow_transaction: { entry: :account } }
+        )
+
+      return { inbound: [], outbound: [], total_inbound: 0.0, total_outbound: 0.0 } if transfer_transactions.empty?
+
+      exchange_rates = exchange_rate_map_for_entries(transfer_transactions.map(&:entry), target_currency: currency)
+      buckets = {
+        inbound: Hash.new(0.to_d),
+        outbound: Hash.new(0.to_d)
+      }
+
+      transfer_transactions.each do |transaction|
+        entry = transaction.entry
+        next unless entry
+
+        counterparty = transfer_counterparty_account(transaction)
+        next unless counterparty
+        next unless accessible_account_ids.include?(counterparty.id)
+
+        converted_amount = converted_entry_abs_amount(entry, target_currency: currency, exchange_rates: exchange_rates)
+        next if converted_amount.zero?
+
+        direction = entry.amount.positive? ? :outbound : :inbound
+        buckets[direction][counterparty] += converted_amount
+      end
+
+      inbound = buckets[:inbound].map do |counterparty, amount|
+        {
+          key: counterparty.id,
+          name: counterparty.name,
+          value: amount.to_f.round(2)
+        }
+      end.sort_by { |flow| -flow[:value] }
+
+      outbound = buckets[:outbound].map do |counterparty, amount|
+        {
+          key: counterparty.id,
+          name: counterparty.name,
+          value: amount.to_f.round(2)
+        }
+      end.sort_by { |flow| -flow[:value] }
+
+      {
+        inbound: inbound,
+        outbound: outbound,
+        total_inbound: inbound.sum { |flow| flow[:value] }.round(2),
+        total_outbound: outbound.sum { |flow| flow[:value] }.round(2)
+      }
+    end
+
+    def transfer_counterparty_account(transaction)
+      if (outflow_transfer = transaction.transfer_as_outflow)
+        outflow_transfer.inflow_transaction&.entry&.account
+      elsif (inflow_transfer = transaction.transfer_as_inflow)
+        inflow_transfer.outflow_transaction&.entry&.account
+      end
+    end
+
+    def exchange_rate_map_for_entries(entries, target_currency:)
+      rate_keys = entries.filter_map do |entry|
+        next if entry.currency == target_currency
+
+        [ entry.date, entry.currency ]
+      end.uniq
+
+      return {} if rate_keys.empty?
+
+      dates = rate_keys.map(&:first).uniq
+      currencies = rate_keys.map(&:last).uniq
+
+      ExchangeRate
+        .where(date: dates, from_currency: currencies, to_currency: target_currency)
+        .pluck(:date, :from_currency, :rate)
+        .to_h { |date, from_currency, rate| [ [ date, from_currency ], rate.to_d ] }
+    end
+
+    def converted_entry_abs_amount(entry, target_currency:, exchange_rates:)
+      rate = if entry.currency == target_currency
+        1.to_d
+      else
+        exchange_rates.fetch([ entry.date, entry.currency ], 1.to_d)
+      end
+
+      (entry.amount.to_d.abs * rate).round(2)
+    end
+
+    def resolved_sankey_mode
+      mode = params[:sankey_mode].presence
+      mode.in?(%w[aggregate split]) ? mode : "aggregate"
     end
 
     def build_outflows_donut_data(net_totals)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,7 +19,7 @@ class PagesController < ApplicationController
     selected_account_id = params[:account_id].presence
     if selected_account_id
       account = Current.user.accessible_accounts.find_by(id: selected_account_id)
-      account_ids = account ? [account.id] : nil
+      account_ids = account ? [ account.id ] : nil
     else
       account_ids = nil
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -17,20 +17,29 @@ class PagesController < ApplicationController
     @selected_account = @sankey_mode == "aggregate" ? @finance_accounts.find_by(id: params[:account_id].presence) : nil
 
     family_currency = Current.family.currency
-    selected_account_ids = @selected_account ? [ @selected_account.id ] : nil
+    visible_account_ids = @finance_accounts.reorder(nil).pluck(:id)
+    selected_account_ids = @selected_account ? [ @selected_account.id ] : visible_account_ids
 
-    # Use IncomeStatement for all cashflow data (now includes categorized trades)
-    selected_account_id = params[:account_id].presence
-    if selected_account_id
-      account = Current.user.finance_accounts.find_by(id: selected_account_id)
-      account_ids = account ? [ account.id ] : nil
+    if @sankey_mode == "split"
+      income_statement = Current.family.income_statement(user: Current.user, account_ids: visible_account_ids)
+      net_totals = income_statement.net_category_totals(period: @period)
+      @cashflow_sankey_data = build_split_cashflow_sankey_data(accounts: @finance_accounts, period: @period, currency: family_currency)
     else
-      account_ids = nil
+      # Use IncomeStatement for all cashflow data (now includes categorized trades)
+      income_statement = Current.family.income_statement(user: Current.user, account_ids: selected_account_ids)
+      income_totals = income_statement.income_totals(period: @period)
+      expense_totals = income_statement.expense_totals(period: @period)
+      net_totals = income_statement.net_category_totals(period: @period)
+      transfer_flows = @selected_account ?
+        build_transfer_flows_for_account(
+          account: @selected_account,
+          period: @period,
+          currency: family_currency,
+          accessible_account_ids: @accounts.map(&:id).to_set
+        ) : nil
+
+      @cashflow_sankey_data = build_cashflow_sankey_data(net_totals, income_totals, expense_totals, family_currency, transfer_flows: transfer_flows)
     end
-    income_statement = Current.family.income_statement(user: Current.user, account_ids: account_ids)
-    income_totals = income_statement.income_totals(period: @period)
-    expense_totals = income_statement.expense_totals(period: @period)
-    net_totals = income_statement.net_category_totals(period: @period)
 
     @outflows_data = build_outflows_donut_data(net_totals)
 
@@ -385,41 +394,15 @@ class PagesController < ApplicationController
         end
       }
 
-      income_flows_by_account_category = Hash.new(0.to_d)
-      expense_flows_by_account_category = Hash.new(0.to_d)
-      income_totals_by_category = Hash.new(0.to_d)
-      expense_totals_by_category = Hash.new(0.to_d)
-      income_totals_by_account = Hash.new(0.to_d)
-      expense_totals_by_account = Hash.new(0.to_d)
-      income_categories_by_key = {}
-      expense_categories_by_key = {}
-
-      accounts.each do |account|
-        income_statement = Current.family.income_statement(user: Current.user, account_ids: [ account.id ])
-        net_totals = income_statement.net_category_totals(period: period)
-
-        net_totals.net_income_categories.each do |category_total|
-          value = category_total.total.to_d
-          next if value.zero?
-
-          category_key = split_category_key(category_total)
-          income_flows_by_account_category[[ account.id, category_key ]] += value
-          income_totals_by_category[category_key] += value
-          income_totals_by_account[account.id] += value
-          income_categories_by_key[category_key] ||= category_total.category
-        end
-
-        net_totals.net_expense_categories.each do |category_total|
-          value = category_total.total.to_d
-          next if value.zero?
-
-          category_key = split_category_key(category_total)
-          expense_flows_by_account_category[[ account.id, category_key ]] += value
-          expense_totals_by_category[category_key] += value
-          expense_totals_by_account[account.id] += value
-          expense_categories_by_key[category_key] ||= category_total.category
-        end
-      end
+      split_net_totals = build_split_net_totals_by_account(accounts: accounts, period: period)
+      income_flows_by_account_category = split_net_totals[:income_flows_by_account_category]
+      expense_flows_by_account_category = split_net_totals[:expense_flows_by_account_category]
+      income_totals_by_category = split_net_totals[:income_totals_by_category]
+      expense_totals_by_category = split_net_totals[:expense_totals_by_category]
+      income_totals_by_account = split_net_totals[:income_totals_by_account]
+      expense_totals_by_account = split_net_totals[:expense_totals_by_account]
+      income_categories_by_key = split_net_totals[:income_categories_by_key]
+      expense_categories_by_key = split_net_totals[:expense_categories_by_key]
 
       transfer_overlay_data = build_split_transfer_overlays(accounts: accounts, period: period, currency: currency)
       transfer_totals_by_account = transfer_overlay_data[:totals_by_account]
@@ -570,6 +553,121 @@ class PagesController < ApplicationController
       return "expense" if unique_key.include?("_expense_")
 
       "other"
+    end
+
+    def build_split_net_totals_by_account(accounts:, period:)
+      empty_result = {
+        income_flows_by_account_category: Hash.new(0.to_d),
+        expense_flows_by_account_category: Hash.new(0.to_d),
+        income_totals_by_category: Hash.new(0.to_d),
+        expense_totals_by_category: Hash.new(0.to_d),
+        income_totals_by_account: Hash.new(0.to_d),
+        expense_totals_by_account: Hash.new(0.to_d),
+        income_categories_by_key: {},
+        expense_categories_by_key: {}
+      }
+
+      account_ids = accounts.map(&:id)
+      return empty_result if account_ids.empty?
+
+      scoped_account_ids = account_ids - Current.family.tax_advantaged_account_ids
+      return empty_result if scoped_account_ids.empty?
+
+      classification_sql = <<~SQL.squish
+        CASE
+          WHEN transactions.kind IN ('investment_contribution', 'loan_payment') THEN 'expense'
+          WHEN entries.amount < 0 THEN 'income'
+          ELSE 'expense'
+        END
+      SQL
+
+      total_sql = <<~SQL.squish
+        ABS(
+          SUM(
+            CASE
+              WHEN transactions.kind IN ('investment_contribution', 'loan_payment') THEN ABS(entries.amount * COALESCE(er.rate, 1))
+              ELSE entries.amount * COALESCE(er.rate, 1)
+            END
+          )
+        )
+      SQL
+
+      exchange_join_sql = ActiveRecord::Base.sanitize_sql_array([
+        "LEFT JOIN exchange_rates er ON er.date = entries.date AND er.from_currency = entries.currency AND er.to_currency = ?",
+        Current.family.currency
+      ])
+
+      rows = Current.family.transactions
+        .visible
+        .excluding_pending
+        .in_period(period)
+        .where(entries: { account_id: scoped_account_ids, excluded: false })
+        .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
+        .where("transactions.investment_activity_label IS NULL OR transactions.investment_activity_label NOT IN (?)", Transaction::INTERNAL_MOVEMENT_LABELS)
+        .left_outer_joins(:category)
+        .joins(exchange_join_sql)
+        .group(
+          "entries.account_id",
+          "transactions.category_id",
+          "categories.parent_id",
+          classification_sql
+        )
+        .pluck(
+          Arel.sql("entries.account_id"),
+          Arel.sql("transactions.category_id"),
+          Arel.sql("categories.parent_id"),
+          Arel.sql(classification_sql),
+          Arel.sql(total_sql)
+        )
+
+      root_category_ids = rows.filter_map do |_account_id, category_id, parent_category_id, _classification, _total|
+        split_root_category_key(category_id, parent_category_id)
+      end.uniq
+
+      categories_by_id = Current.family.categories.where(id: root_category_ids).index_by(&:id)
+      uncategorized_category = Current.family.categories.uncategorized
+
+      raw_totals_by_account_category = Hash.new do |hash, key|
+        hash[key] = { income: 0.to_d, expense: 0.to_d }
+      end
+      categories_by_key = {}
+
+      rows.each do |account_id, category_id, parent_category_id, classification, total|
+        category_key = split_root_category_key(category_id, parent_category_id) || :uncategorized
+        category = category_key == :uncategorized ? uncategorized_category : categories_by_id[category_key]
+        next unless category
+
+        raw_totals_by_account_category[[ account_id, category_key ]][classification.to_sym] += total.to_d
+        categories_by_key[category_key] ||= category
+      end
+
+      result = empty_result
+
+      raw_totals_by_account_category.each do |(account_id, category_key), totals|
+        net_value = totals[:expense] - totals[:income]
+        next if net_value.zero?
+
+        category = categories_by_key.fetch(category_key)
+
+        if net_value.positive?
+          result[:expense_flows_by_account_category][[ account_id, category_key ]] += net_value
+          result[:expense_totals_by_category][category_key] += net_value
+          result[:expense_totals_by_account][account_id] += net_value
+          result[:expense_categories_by_key][category_key] ||= category
+        else
+          income_value = net_value.abs
+          result[:income_flows_by_account_category][[ account_id, category_key ]] += income_value
+          result[:income_totals_by_category][category_key] += income_value
+          result[:income_totals_by_account][account_id] += income_value
+          result[:income_categories_by_key][category_key] ||= category
+        end
+      end
+
+      result
+    end
+
+    def split_root_category_key(category_id, parent_category_id)
+      parent_category_id.presence || category_id.presence
     end
 
     def build_split_transfer_overlays(accounts:, period:, currency:)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -462,9 +462,23 @@ class PagesController < ApplicationController
       end
 
       account_node_indices = {}
+
+      # First, identify which accounts need nodes (those with flows or transfers)
+      accounts_with_flows = Set.new
+      income_totals_by_account.each do |account_id, total|
+        accounts_with_flows << account_id if total.positive?
+      end
+      expense_totals_by_account.each do |account_id, total|
+        accounts_with_flows << account_id if total.positive?
+      end
+      transfer_overlay_data[:links].each do |flow|
+        accounts_with_flows << flow[:source_account_id]
+        accounts_with_flows << flow[:target_account_id]
+      end
+
+      # Now add nodes for all accounts with flows/transfers
       accounts.each do |account|
-        has_category_flows = income_totals_by_account[account.id].positive? || expense_totals_by_account[account.id].positive?
-        next unless has_category_flows
+        next unless accounts_with_flows.include?(account.id)
 
         node_value = [
           income_totals_by_account[account.id].to_f,
@@ -513,26 +527,23 @@ class PagesController < ApplicationController
         }
       end
 
-      transfer_overlays = transfer_overlay_data[:links].filter_map do |flow|
+      transfer_overlay_data[:links].each do |flow|
         source_idx = account_node_indices[flow[:source_account_id]]
         target_idx = account_node_indices[flow[:target_account_id]]
         next unless source_idx && target_idx
 
-        {
+        links << {
           source: source_idx,
           target: target_idx,
           value: flow[:value].to_f.round(2),
           color: Category::TRANSFER_COLOR,
-          flow_type: "transfer_overlay",
-          source_name: flow[:source_name],
-          target_name: flow[:target_name]
+          percentage: 0
         }
       end
 
       {
         nodes: nodes,
         links: links,
-        transfer_overlays: transfer_overlays,
         currency_symbol: Money::Currency.new(currency).symbol
       }
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,8 +16,13 @@ class PagesController < ApplicationController
     family_currency = Current.family.currency
 
     # Use IncomeStatement for all cashflow data (now includes categorized trades)
-    selected_account_id = params[:account_id]
-    account_ids = selected_account_id.present? ? [ selected_account_id ] : nil
+    selected_account_id = params[:account_id].presence
+    if selected_account_id
+      account = Current.user.accessible_accounts.find_by(id: selected_account_id)
+      account_ids = account ? [account.id] : nil
+    else
+      account_ids = nil
+    end
     income_statement = Current.family.income_statement(user: Current.user, account_ids: account_ids)
     income_totals = income_statement.income_totals(period: @period)
     expense_totals = income_statement.expense_totals(period: @period)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,7 +18,7 @@ class PagesController < ApplicationController
     # Use IncomeStatement for all cashflow data (now includes categorized trades)
     selected_account_id = params[:account_id].presence
     if selected_account_id
-      account = Current.user.accessible_accounts.find_by(id: selected_account_id)
+      account = Current.user.finance_accounts.find_by(id: selected_account_id)
       account_ids = account ? [ account.id ] : nil
     else
       account_ids = nil

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -512,7 +512,7 @@ class PagesController < ApplicationController
           target: target_idx,
           value: flow[:value].to_f.round(2),
           color: Category::TRANSFER_COLOR,
-          percentage: 0
+          percentage: nil
         }
       end
 
@@ -524,13 +524,16 @@ class PagesController < ApplicationController
     end
 
     def split_sankey_node_metadata(unique_key, account_lane_order)
-      account_id = unique_key[/\Aaccount_([^_]+)_/, 1]
-      return {} unless account_id
-
-      {
-        lane_order: account_lane_order.fetch(account_id, 0),
+      metadata = {
         node_role: split_sankey_node_role(unique_key)
       }
+
+      account_id = unique_key[/\Aaccount_([^_]+)_/, 1]
+      return metadata unless account_id
+
+      metadata.merge(
+        lane_order: account_lane_order.fetch(account_id, 0)
+      )
     end
 
     def split_category_key(category_total)

--- a/app/javascript/controllers/sankey_chart_controller.js
+++ b/app/javascript/controllers/sankey_chart_controller.js
@@ -472,10 +472,12 @@ export default class extends Controller {
     const valueText = hasPercentage
       ? `${this.#formatCurrency(value)} (${percentageValue}%)`
       : `${this.#formatCurrency(value)}`;
+    const safeValueText = this.#escapeHtml(valueText);
+    const safeTitle = title ? this.#escapeHtml(title) : null;
 
-    const content = title
-      ? `${title}<br/>${valueText}`
-      : valueText;
+    const content = safeTitle
+      ? `${safeTitle}<br/>${safeValueText}`
+      : safeValueText;
 
     const isInDialog = this.#isInDialog();
     const x = isInDialog ? event.clientX : event.pageX;
@@ -525,5 +527,14 @@ export default class extends Controller {
     const sourceName = link?.source?.name || "Source";
     const targetName = link?.target?.name || "Destination";
     return `${sourceName} -> ${targetName}`;
+  }
+
+  #escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
   }
 }

--- a/app/javascript/controllers/sankey_chart_controller.js
+++ b/app/javascript/controllers/sankey_chart_controller.js
@@ -48,18 +48,11 @@ export default class extends Controller {
     other: 5
   };
   static MIN_LABEL_SPACING = 28; // Minimum vertical space needed for labels (2 lines)
-  static DIALOG_MIN_HEIGHT = 900;
-  static DIALOG_MAX_HEIGHT = 2600;
-  static DIALOG_NODE_HEIGHT = 42;
-  static TRANSFER_OVERLAY_OPACITY = 0.82;
-  static TRANSFER_OVERLAY_COLOR_START = "#444CE7";
-  static TRANSFER_OVERLAY_COLOR_END = "#9EA4FF";
 
   connect() {
     this.resizeObserver = new ResizeObserver(() => this.#draw());
     this.resizeObserver.observe(this.element);
     this.tooltip = null;
-    this.chartUid = Math.random().toString(36).slice(2, 10);
     this.#createTooltip();
     this.#draw();
   }
@@ -73,8 +66,6 @@ export default class extends Controller {
   #draw() {
     const { nodes = [], links = [] } = this.dataValue || {};
     if (!nodes.length || !links.length) return;
-
-    this.#ensureDialogChartHeight(nodes.length);
 
     // Hide tooltip and reset any hover states before redrawing
     this.#hideTooltip();
@@ -95,10 +86,9 @@ export default class extends Controller {
     this.#createGradients(svg, sankeyData.links);
 
     const linkPaths = this.#drawLinks(svg, sankeyData.links);
-    const transferOverlayPaths = this.#drawTransferOverlays(svg, sankeyData.nodes);
     const { nodeGroups, hiddenLabels } = this.#drawNodes(svg, sankeyData.nodes, width);
 
-    this.#attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels, transferOverlayPaths);
+    this.#attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels);
   }
 
   // Dynamic padding prevents padding from dominating when there are many nodes
@@ -112,7 +102,12 @@ export default class extends Controller {
   }
 
   #generateSankeyData(nodes, links, width, height, nodePadding) {
+    if (!nodes.length || !links.length) return { nodes: [], links: [] };
+
     const margin = this.constructor.EXTENT_MARGIN;
+    const mappedNodes = nodes.map(d => ({ ...d }));
+    const mappedLinks = links.map(d => ({ ...d }));
+
     const sankeyGenerator = sankey()
       .nodeWidth(this.nodeWidthValue)
       .nodePadding(nodePadding)
@@ -120,16 +115,13 @@ export default class extends Controller {
 
     const splitNodeComparator = this.#buildSplitNodeComparator(nodes);
     if (splitNodeComparator) {
-      this.splitLayerConfig = this.#buildSplitLayerConfig(nodes);
+      // Keep split links stably ordered without forcing custom node alignment.
       sankeyGenerator.linkSort(this.#buildSplitLinkComparator(nodes));
-      sankeyGenerator.nodeAlign((node, n) => this.#splitNodeLayer(node, n));
-    } else {
-      this.splitLayerConfig = null;
     }
 
     return sankeyGenerator({
-      nodes: nodes.map(d => ({ ...d })),
-      links: links.map(d => ({ ...d })),
+      nodes: mappedNodes,
+      links: mappedLinks,
     });
   }
 
@@ -166,51 +158,6 @@ export default class extends Controller {
 
       return d3.descending(a?.value ?? 0, b?.value ?? 0);
     };
-  }
-
-  #splitNodeLayer(node, columns) {
-    const layerConfig = this.splitLayerConfig || { left: 0, middle: 0, right: 0 };
-    const maxColumn = Math.max(0, (Number.isFinite(columns) && columns > 0 ? columns : 1) - 1);
-    const role = node?.node_role;
-
-    if (role === "cash_flow") return Math.min(maxColumn, layerConfig.middle);
-
-    if (this.#isSplitLeftRole(role)) {
-      return Math.min(maxColumn, layerConfig.left);
-    }
-
-    if (this.#isSplitRightRole(role)) {
-      return Math.min(maxColumn, layerConfig.right);
-    }
-
-    return Math.min(maxColumn, layerConfig.middle);
-  }
-
-  #buildSplitLayerConfig(nodes) {
-    const hasLeftColumn = nodes.some(node => this.#isSplitLeftRole(node?.node_role));
-    const hasRightColumn = nodes.some(node => this.#isSplitRightRole(node?.node_role));
-
-    if (hasLeftColumn && hasRightColumn) {
-      return { left: 0, middle: 1, right: 2 };
-    }
-
-    if (hasLeftColumn) {
-      return { left: 0, middle: 1, right: 1 };
-    }
-
-    if (hasRightColumn) {
-      return { left: 0, middle: 0, right: 1 };
-    }
-
-    return { left: 0, middle: 0, right: 0 };
-  }
-
-  #isSplitLeftRole(role) {
-    return role === "income" || role === "income_sub" || role === "transfer_in";
-  }
-
-  #isSplitRightRole(role) {
-    return role === "expense" || role === "expense_sub" || role === "transfer_out" || role === "surplus";
   }
 
   #splitLaneOrderForEndpoint(endpoint, nodes) {
@@ -281,108 +228,6 @@ export default class extends Controller {
       .attr("stroke", (d, i) => `url(#${this.#gradientId(d, i)})`)
       .attr("stroke-width", d => Math.max(1, d.width))
       .style("transition", "opacity 0.3s ease");
-  }
-
-  #drawTransferOverlays(svg, nodes) {
-    const overlays = Array.isArray(this.dataValue?.transfer_overlays) ? this.dataValue.transfer_overlays : [];
-    const validOverlays = overlays.filter((overlay) => (
-      Number.isFinite(overlay?.source)
-      && Number.isFinite(overlay?.target)
-      && overlay.source !== overlay.target
-      && nodes[overlay.source]
-      && nodes[overlay.target]
-      && Number(overlay.value) > 0
-    ));
-
-    if (!validOverlays.length) return null;
-
-    const defs = this.#ensureTransferOverlayDefs(svg);
-    const gradientId = this.#transferOverlayGradientId();
-    const markerId = this.#transferOverlayMarkerId();
-    const maxValue = d3.max(validOverlays, d => Number(d.value)) || 1;
-    const widthScale = d3.scaleLinear().domain([0, maxValue]).range([1.5, 8]);
-
-    const overlayGroup = svg.append("g").attr("class", "sankey-transfer-overlays");
-
-    return overlayGroup.selectAll("path")
-      .data(validOverlays)
-      .join("path")
-      .attr("class", "sankey-transfer-overlay")
-      .attr("d", d => this.#transferOverlayPath(d, nodes))
-      .attr("fill", "none")
-      .attr("stroke", `url(#${gradientId})`)
-      .attr("stroke-width", d => widthScale(Number(d.value)))
-      .attr("stroke-linecap", "round")
-      .attr("stroke-opacity", this.constructor.TRANSFER_OVERLAY_OPACITY)
-      .attr("marker-end", `url(#${markerId})`)
-      .style("pointer-events", "stroke")
-      .style("transition", "opacity 0.3s ease");
-  }
-
-  #transferOverlayPath(overlay, nodes) {
-    const sourceNode = nodes[overlay.source];
-    const targetNode = nodes[overlay.target];
-    if (!sourceNode || !targetNode) return "";
-
-    const sourceX = sourceNode.x1;
-    const targetX = targetNode.x0;
-    const sourceY = (sourceNode.y0 + sourceNode.y1) / 2;
-    const targetY = (targetNode.y0 + targetNode.y1) / 2;
-    const turnOffset = Math.max(90, Math.abs(sourceY - targetY) * 0.55);
-    const turnX = Math.max(sourceX, targetX) + turnOffset;
-
-    return `M ${sourceX},${sourceY} C ${turnX},${sourceY} ${turnX},${targetY} ${targetX},${targetY}`;
-  }
-
-  #ensureTransferOverlayDefs(svg) {
-    const defs = svg.select("defs").empty() ? svg.append("defs") : svg.select("defs");
-    const gradientId = this.#transferOverlayGradientId();
-    const markerId = this.#transferOverlayMarkerId();
-
-    if (defs.select(`#${gradientId}`).empty()) {
-      const gradient = defs.append("linearGradient")
-        .attr("id", gradientId)
-        .attr("gradientUnits", "objectBoundingBox")
-        .attr("x1", "0%")
-        .attr("x2", "100%")
-        .attr("y1", "0%")
-        .attr("y2", "0%");
-
-      gradient.append("stop")
-        .attr("offset", "0%")
-        .attr("stop-color", this.constructor.TRANSFER_OVERLAY_COLOR_START)
-        .attr("stop-opacity", 0.95);
-
-      gradient.append("stop")
-        .attr("offset", "100%")
-        .attr("stop-color", this.constructor.TRANSFER_OVERLAY_COLOR_END)
-        .attr("stop-opacity", 0.8);
-    }
-
-    if (defs.select(`#${markerId}`).empty()) {
-      defs.append("marker")
-        .attr("id", markerId)
-        .attr("viewBox", "0 -5 10 10")
-        .attr("refX", 9)
-        .attr("refY", 0)
-        .attr("markerWidth", 7)
-        .attr("markerHeight", 7)
-        .attr("orient", "auto")
-        .append("path")
-        .attr("d", "M0,-5L10,0L0,5")
-        .attr("fill", this.constructor.TRANSFER_OVERLAY_COLOR_START)
-        .attr("fill-opacity", 0.9);
-    }
-
-    return defs;
-  }
-
-  #transferOverlayGradientId() {
-    return `transfer-overlay-gradient-${this.chartUid}`;
-  }
-
-  #transferOverlayMarkerId() {
-    return `transfer-overlay-arrow-${this.chartUid}`;
   }
 
   #drawNodes(svg, nodes, width) {
@@ -479,20 +324,6 @@ export default class extends Controller {
     return hiddenLabels;
   }
 
-  #ensureDialogChartHeight(nodeCount) {
-    if (!this.#isInDialog()) return;
-
-    const preferredHeight = Math.max(
-      this.constructor.DIALOG_MIN_HEIGHT,
-      Math.min(this.constructor.DIALOG_MAX_HEIGHT, nodeCount * this.constructor.DIALOG_NODE_HEIGHT)
-    );
-
-    const currentHeight = Number.parseInt(this.element.style.height, 10);
-    if (currentHeight !== preferredHeight) {
-      this.element.style.height = `${preferredHeight}px`;
-    }
-  }
-
   #isInDialog() {
     return Boolean(this.element.closest("dialog"));
   }
@@ -559,7 +390,7 @@ export default class extends Controller {
     return this.constructor.SPLIT_LABEL_PRIORITY[node?.node_role] ?? this.constructor.SPLIT_LABEL_PRIORITY.other;
   }
 
-  #attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels, transferOverlayPaths = null) {
+  #attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels) {
     const applyHover = (targetLinks) => {
       const targetSet = new Set(targetLinks);
       const connectedNodes = new Set(targetLinks.flatMap(l => [l.source, l.target]));
@@ -570,10 +401,6 @@ export default class extends Controller {
 
       nodeGroups.style("opacity", d => connectedNodes.has(d) ? 1 : this.constructor.HOVER_OPACITY);
 
-      transferOverlayPaths
-        ?.style("opacity", this.constructor.HOVER_OPACITY)
-        .style("filter", "none");
-
       // Show labels for connected nodes (even if normally hidden)
       nodeGroups.selectAll("text")
         .style("opacity", d => connectedNodes.has(d) ? 1 : (hiddenLabels.has(d.index) ? 0 : this.constructor.HOVER_OPACITY));
@@ -582,9 +409,6 @@ export default class extends Controller {
     const resetHover = () => {
       linkPaths.style("opacity", 1).style("filter", "none");
       nodeGroups.style("opacity", 1);
-      transferOverlayPaths
-        ?.style("opacity", this.constructor.TRANSFER_OVERLAY_OPACITY)
-        .style("filter", "none");
 
       // Restore hidden labels to hidden state
       nodeGroups.selectAll("text")
@@ -621,28 +445,6 @@ export default class extends Controller {
         const connectedLinks = sankeyData.links.filter(l => l.source === d || l.target === d);
         applyHover(connectedLinks);
         this.#showTooltip(event, d.value, d.percentage, d.name);
-      })
-      .on("mousemove", event => this.#updateTooltipPosition(event))
-      .on("mouseleave", () => {
-        resetHover();
-        this.#hideTooltip();
-      });
-
-    transferOverlayPaths
-      ?.on("mouseenter", (event, d) => {
-        const sourceNode = sankeyData.nodes[d.source];
-        const targetNode = sankeyData.nodes[d.target];
-        const sourceName = d.source_name || sourceNode?.name || "Source account";
-        const targetName = d.target_name || targetNode?.name || "Destination account";
-        const connectedNodeIndices = new Set([ d.source, d.target ]);
-
-        linkPaths.style("opacity", this.constructor.HOVER_OPACITY).style("filter", "none");
-        transferOverlayPaths.style("opacity", overlay => (overlay === d ? 1 : this.constructor.HOVER_OPACITY));
-        nodeGroups.style("opacity", node => connectedNodeIndices.has(node.index) ? 1 : this.constructor.HOVER_OPACITY);
-        nodeGroups.selectAll("text")
-          .style("opacity", node => connectedNodeIndices.has(node.index) ? 1 : (hiddenLabels.has(node.index) ? 0 : this.constructor.HOVER_OPACITY));
-
-        this.#showTooltip(event, d.value, null, `${sourceName} -> ${targetName}`);
       })
       .on("mousemove", event => this.#updateTooltipPosition(event))
       .on("mouseleave", () => {

--- a/app/javascript/controllers/sankey_chart_controller.js
+++ b/app/javascript/controllers/sankey_chart_controller.js
@@ -467,9 +467,10 @@ export default class extends Controller {
   #showTooltip(event, value, percentage, title = null) {
     if (!this.tooltip) this.#createTooltip();
 
-    const hasPercentage = Number.isFinite(Number(percentage));
+    const hasPercentage = percentage !== null && percentage !== undefined && percentage !== "" && Number.isFinite(Number(percentage));
+    const percentageValue = hasPercentage ? Number(percentage) : null;
     const valueText = hasPercentage
-      ? `${this.#formatCurrency(value)} (${percentage || 0}%)`
+      ? `${this.#formatCurrency(value)} (${percentageValue}%)`
       : `${this.#formatCurrency(value)}`;
 
     const content = title

--- a/app/javascript/controllers/sankey_chart_controller.js
+++ b/app/javascript/controllers/sankey_chart_controller.js
@@ -25,12 +25,41 @@ export default class extends Controller {
     "var(--color-gray-400)": "#9E9E9E",
     "var(--color-gray-500)": "#737373"
   };
+  static SPLIT_ROLE_ORDER = {
+    income_sub: 10,
+    income: 20,
+    transfer_in: 30,
+    cash_flow: 40,
+    transfer_out: 50,
+    expense: 60,
+    expense_sub: 70,
+    surplus: 80,
+    other: 99
+  };
+  static SPLIT_LABEL_PRIORITY = {
+    cash_flow: 0,
+    transfer_in: 1,
+    transfer_out: 1,
+    income: 2,
+    expense: 2,
+    income_sub: 3,
+    expense_sub: 3,
+    surplus: 4,
+    other: 5
+  };
   static MIN_LABEL_SPACING = 28; // Minimum vertical space needed for labels (2 lines)
+  static DIALOG_MIN_HEIGHT = 900;
+  static DIALOG_MAX_HEIGHT = 2600;
+  static DIALOG_NODE_HEIGHT = 42;
+  static TRANSFER_OVERLAY_OPACITY = 0.82;
+  static TRANSFER_OVERLAY_COLOR_START = "#444CE7";
+  static TRANSFER_OVERLAY_COLOR_END = "#9EA4FF";
 
   connect() {
     this.resizeObserver = new ResizeObserver(() => this.#draw());
     this.resizeObserver.observe(this.element);
     this.tooltip = null;
+    this.chartUid = Math.random().toString(36).slice(2, 10);
     this.#createTooltip();
     this.#draw();
   }
@@ -44,6 +73,8 @@ export default class extends Controller {
   #draw() {
     const { nodes = [], links = [] } = this.dataValue || {};
     if (!nodes.length || !links.length) return;
+
+    this.#ensureDialogChartHeight(nodes.length);
 
     // Hide tooltip and reset any hover states before redrawing
     this.#hideTooltip();
@@ -64,9 +95,10 @@ export default class extends Controller {
     this.#createGradients(svg, sankeyData.links);
 
     const linkPaths = this.#drawLinks(svg, sankeyData.links);
+    const transferOverlayPaths = this.#drawTransferOverlays(svg, sankeyData.nodes);
     const { nodeGroups, hiddenLabels } = this.#drawNodes(svg, sankeyData.nodes, width);
 
-    this.#attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels);
+    this.#attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels, transferOverlayPaths);
   }
 
   // Dynamic padding prevents padding from dominating when there are many nodes
@@ -86,10 +118,110 @@ export default class extends Controller {
       .nodePadding(nodePadding)
       .extent([[margin, margin], [width - margin, height - margin]]);
 
+    const splitNodeComparator = this.#buildSplitNodeComparator(nodes);
+    if (splitNodeComparator) {
+      this.splitLayerConfig = this.#buildSplitLayerConfig(nodes);
+      sankeyGenerator.linkSort(this.#buildSplitLinkComparator(nodes));
+      sankeyGenerator.nodeAlign((node, n) => this.#splitNodeLayer(node, n));
+    } else {
+      this.splitLayerConfig = null;
+    }
+
     return sankeyGenerator({
       nodes: nodes.map(d => ({ ...d })),
       links: links.map(d => ({ ...d })),
     });
+  }
+
+  #buildSplitNodeComparator(nodes) {
+    const hasLaneOrdering = nodes.some(node => Number.isFinite(node?.lane_order));
+    if (!hasLaneOrdering) return null;
+
+    return (a, b) => {
+      const laneA = Number.isFinite(a?.lane_order) ? a.lane_order : Number.MAX_SAFE_INTEGER;
+      const laneB = Number.isFinite(b?.lane_order) ? b.lane_order : Number.MAX_SAFE_INTEGER;
+      if (laneA !== laneB) return laneA - laneB;
+
+      const roleA = this.constructor.SPLIT_ROLE_ORDER[a?.node_role] ?? this.constructor.SPLIT_ROLE_ORDER.other;
+      const roleB = this.constructor.SPLIT_ROLE_ORDER[b?.node_role] ?? this.constructor.SPLIT_ROLE_ORDER.other;
+      if (roleA !== roleB) return roleA - roleB;
+
+      return String(a?.name || "").localeCompare(String(b?.name || ""));
+    };
+  }
+
+  #buildSplitLinkComparator(nodes) {
+    return (a, b) => {
+      const sourceLaneA = this.#splitLaneOrderForEndpoint(a?.source, nodes);
+      const sourceLaneB = this.#splitLaneOrderForEndpoint(b?.source, nodes);
+      if (sourceLaneA !== sourceLaneB) return sourceLaneA - sourceLaneB;
+
+      const targetLaneA = this.#splitLaneOrderForEndpoint(a?.target, nodes);
+      const targetLaneB = this.#splitLaneOrderForEndpoint(b?.target, nodes);
+      if (targetLaneA !== targetLaneB) return targetLaneA - targetLaneB;
+
+      const sourceRoleA = this.#splitRoleOrderForEndpoint(a?.source, nodes);
+      const sourceRoleB = this.#splitRoleOrderForEndpoint(b?.source, nodes);
+      if (sourceRoleA !== sourceRoleB) return sourceRoleA - sourceRoleB;
+
+      return d3.descending(a?.value ?? 0, b?.value ?? 0);
+    };
+  }
+
+  #splitNodeLayer(node, columns) {
+    const layerConfig = this.splitLayerConfig || { left: 0, middle: 0, right: 0 };
+    const maxColumn = Math.max(0, (Number.isFinite(columns) && columns > 0 ? columns : 1) - 1);
+    const role = node?.node_role;
+
+    if (role === "cash_flow") return Math.min(maxColumn, layerConfig.middle);
+
+    if (this.#isSplitLeftRole(role)) {
+      return Math.min(maxColumn, layerConfig.left);
+    }
+
+    if (this.#isSplitRightRole(role)) {
+      return Math.min(maxColumn, layerConfig.right);
+    }
+
+    return Math.min(maxColumn, layerConfig.middle);
+  }
+
+  #buildSplitLayerConfig(nodes) {
+    const hasLeftColumn = nodes.some(node => this.#isSplitLeftRole(node?.node_role));
+    const hasRightColumn = nodes.some(node => this.#isSplitRightRole(node?.node_role));
+
+    if (hasLeftColumn && hasRightColumn) {
+      return { left: 0, middle: 1, right: 2 };
+    }
+
+    if (hasLeftColumn) {
+      return { left: 0, middle: 1, right: 1 };
+    }
+
+    if (hasRightColumn) {
+      return { left: 0, middle: 0, right: 1 };
+    }
+
+    return { left: 0, middle: 0, right: 0 };
+  }
+
+  #isSplitLeftRole(role) {
+    return role === "income" || role === "income_sub" || role === "transfer_in";
+  }
+
+  #isSplitRightRole(role) {
+    return role === "expense" || role === "expense_sub" || role === "transfer_out" || role === "surplus";
+  }
+
+  #splitLaneOrderForEndpoint(endpoint, nodes) {
+    if (Number.isFinite(endpoint?.lane_order)) return endpoint.lane_order;
+    if (Number.isFinite(endpoint)) return nodes[endpoint]?.lane_order ?? Number.MAX_SAFE_INTEGER;
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  #splitRoleOrderForEndpoint(endpoint, nodes) {
+    const role = endpoint?.node_role || (Number.isFinite(endpoint) ? nodes[endpoint]?.node_role : null);
+    return this.constructor.SPLIT_ROLE_ORDER[role] ?? this.constructor.SPLIT_ROLE_ORDER.other;
   }
 
   #createGradients(svg, links) {
@@ -97,6 +229,10 @@ export default class extends Controller {
 
     links.forEach((link, i) => {
       const gradientId = this.#gradientId(link, i);
+      const isTransferFlow = link?.flow_type === "transfer_in" || link?.flow_type === "transfer_out";
+      const gradientOpacity = isTransferFlow ? 0.2 : 0.1;
+      const sourceColor = isTransferFlow ? link.color : link.source.color;
+      const targetColor = isTransferFlow ? link.color : link.target.color;
       const gradient = defs.append("linearGradient")
         .attr("id", gradientId)
         .attr("gradientUnits", "userSpaceOnUse")
@@ -105,11 +241,11 @@ export default class extends Controller {
 
       gradient.append("stop")
         .attr("offset", "0%")
-        .attr("stop-color", this.#colorWithOpacity(link.source.color));
+        .attr("stop-color", this.#colorWithOpacity(sourceColor, gradientOpacity));
 
       gradient.append("stop")
         .attr("offset", "100%")
-        .attr("stop-color", this.#colorWithOpacity(link.target.color));
+        .attr("stop-color", this.#colorWithOpacity(targetColor, gradientOpacity));
     });
   }
 
@@ -145,6 +281,108 @@ export default class extends Controller {
       .attr("stroke", (d, i) => `url(#${this.#gradientId(d, i)})`)
       .attr("stroke-width", d => Math.max(1, d.width))
       .style("transition", "opacity 0.3s ease");
+  }
+
+  #drawTransferOverlays(svg, nodes) {
+    const overlays = Array.isArray(this.dataValue?.transfer_overlays) ? this.dataValue.transfer_overlays : [];
+    const validOverlays = overlays.filter((overlay) => (
+      Number.isFinite(overlay?.source)
+      && Number.isFinite(overlay?.target)
+      && overlay.source !== overlay.target
+      && nodes[overlay.source]
+      && nodes[overlay.target]
+      && Number(overlay.value) > 0
+    ));
+
+    if (!validOverlays.length) return null;
+
+    const defs = this.#ensureTransferOverlayDefs(svg);
+    const gradientId = this.#transferOverlayGradientId();
+    const markerId = this.#transferOverlayMarkerId();
+    const maxValue = d3.max(validOverlays, d => Number(d.value)) || 1;
+    const widthScale = d3.scaleLinear().domain([0, maxValue]).range([1.5, 8]);
+
+    const overlayGroup = svg.append("g").attr("class", "sankey-transfer-overlays");
+
+    return overlayGroup.selectAll("path")
+      .data(validOverlays)
+      .join("path")
+      .attr("class", "sankey-transfer-overlay")
+      .attr("d", d => this.#transferOverlayPath(d, nodes))
+      .attr("fill", "none")
+      .attr("stroke", `url(#${gradientId})`)
+      .attr("stroke-width", d => widthScale(Number(d.value)))
+      .attr("stroke-linecap", "round")
+      .attr("stroke-opacity", this.constructor.TRANSFER_OVERLAY_OPACITY)
+      .attr("marker-end", `url(#${markerId})`)
+      .style("pointer-events", "stroke")
+      .style("transition", "opacity 0.3s ease");
+  }
+
+  #transferOverlayPath(overlay, nodes) {
+    const sourceNode = nodes[overlay.source];
+    const targetNode = nodes[overlay.target];
+    if (!sourceNode || !targetNode) return "";
+
+    const sourceX = sourceNode.x1;
+    const targetX = targetNode.x0;
+    const sourceY = (sourceNode.y0 + sourceNode.y1) / 2;
+    const targetY = (targetNode.y0 + targetNode.y1) / 2;
+    const turnOffset = Math.max(90, Math.abs(sourceY - targetY) * 0.55);
+    const turnX = Math.max(sourceX, targetX) + turnOffset;
+
+    return `M ${sourceX},${sourceY} C ${turnX},${sourceY} ${turnX},${targetY} ${targetX},${targetY}`;
+  }
+
+  #ensureTransferOverlayDefs(svg) {
+    const defs = svg.select("defs").empty() ? svg.append("defs") : svg.select("defs");
+    const gradientId = this.#transferOverlayGradientId();
+    const markerId = this.#transferOverlayMarkerId();
+
+    if (defs.select(`#${gradientId}`).empty()) {
+      const gradient = defs.append("linearGradient")
+        .attr("id", gradientId)
+        .attr("gradientUnits", "objectBoundingBox")
+        .attr("x1", "0%")
+        .attr("x2", "100%")
+        .attr("y1", "0%")
+        .attr("y2", "0%");
+
+      gradient.append("stop")
+        .attr("offset", "0%")
+        .attr("stop-color", this.constructor.TRANSFER_OVERLAY_COLOR_START)
+        .attr("stop-opacity", 0.95);
+
+      gradient.append("stop")
+        .attr("offset", "100%")
+        .attr("stop-color", this.constructor.TRANSFER_OVERLAY_COLOR_END)
+        .attr("stop-opacity", 0.8);
+    }
+
+    if (defs.select(`#${markerId}`).empty()) {
+      defs.append("marker")
+        .attr("id", markerId)
+        .attr("viewBox", "0 -5 10 10")
+        .attr("refX", 9)
+        .attr("refY", 0)
+        .attr("markerWidth", 7)
+        .attr("markerHeight", 7)
+        .attr("orient", "auto")
+        .append("path")
+        .attr("d", "M0,-5L10,0L0,5")
+        .attr("fill", this.constructor.TRANSFER_OVERLAY_COLOR_START)
+        .attr("fill-opacity", 0.9);
+    }
+
+    return defs;
+  }
+
+  #transferOverlayGradientId() {
+    return `transfer-overlay-gradient-${this.chartUid}`;
+  }
+
+  #transferOverlayMarkerId() {
+    return `transfer-overlay-arrow-${this.chartUid}`;
   }
 
   #drawNodes(svg, nodes, width) {
@@ -241,6 +479,24 @@ export default class extends Controller {
     return hiddenLabels;
   }
 
+  #ensureDialogChartHeight(nodeCount) {
+    if (!this.#isInDialog()) return;
+
+    const preferredHeight = Math.max(
+      this.constructor.DIALOG_MIN_HEIGHT,
+      Math.min(this.constructor.DIALOG_MAX_HEIGHT, nodeCount * this.constructor.DIALOG_NODE_HEIGHT)
+    );
+
+    const currentHeight = Number.parseInt(this.element.style.height, 10);
+    if (currentHeight !== preferredHeight) {
+      this.element.style.height = `${preferredHeight}px`;
+    }
+  }
+
+  #isInDialog() {
+    return Boolean(this.element.closest("dialog"));
+  }
+
   // Calculate which labels should be hidden to prevent overlap
   #calculateHiddenLabels(nodes) {
     const hiddenLabels = new Set();
@@ -261,27 +517,49 @@ export default class extends Controller {
       // Sort by vertical position
       columnNodes.sort((a, b) => ((a.y0 + a.y1) / 2) - ((b.y0 + b.y1) / 2));
 
-      let lastVisibleY = Number.NEGATIVE_INFINITY;
+      let lastVisible = null;
 
       columnNodes.forEach(node => {
         const nodeY = (node.y0 + node.y1) / 2;
         const nodeHeight = node.y1 - node.y0;
+        const currentPriority = this.#labelPriority(node);
 
         if (isLargeGraph && nodeHeight > minSpacing * 1.5) {
-          lastVisibleY = nodeY;
-        } else if (nodeY - lastVisibleY < minSpacing) {
-          // Too close to previous visible label, hide this one
-          hiddenLabels.add(node.index);
-        } else {
-          lastVisibleY = nodeY;
+          lastVisible = { node, y: nodeY };
+          return;
         }
+
+        if (!lastVisible) {
+          lastVisible = { node, y: nodeY };
+          return;
+        }
+
+        if (nodeY - lastVisible.y < minSpacing) {
+          // If labels overlap, keep the higher-priority one for stable split-lane readability.
+          const lastPriority = this.#labelPriority(lastVisible.node);
+          if (currentPriority < lastPriority) {
+            hiddenLabels.add(lastVisible.node.index);
+            lastVisible = { node, y: nodeY };
+          } else {
+            hiddenLabels.add(node.index);
+          }
+          return;
+        }
+
+        lastVisible = { node, y: nodeY };
       });
     });
 
     return hiddenLabels;
   }
 
-  #attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels) {
+  #labelPriority(node) {
+    if (!Number.isFinite(node?.lane_order)) return 50;
+
+    return this.constructor.SPLIT_LABEL_PRIORITY[node?.node_role] ?? this.constructor.SPLIT_LABEL_PRIORITY.other;
+  }
+
+  #attachHoverEvents(linkPaths, nodeGroups, sankeyData, hiddenLabels, transferOverlayPaths = null) {
     const applyHover = (targetLinks) => {
       const targetSet = new Set(targetLinks);
       const connectedNodes = new Set(targetLinks.flatMap(l => [l.source, l.target]));
@@ -292,6 +570,10 @@ export default class extends Controller {
 
       nodeGroups.style("opacity", d => connectedNodes.has(d) ? 1 : this.constructor.HOVER_OPACITY);
 
+      transferOverlayPaths
+        ?.style("opacity", this.constructor.HOVER_OPACITY)
+        .style("filter", "none");
+
       // Show labels for connected nodes (even if normally hidden)
       nodeGroups.selectAll("text")
         .style("opacity", d => connectedNodes.has(d) ? 1 : (hiddenLabels.has(d.index) ? 0 : this.constructor.HOVER_OPACITY));
@@ -300,6 +582,10 @@ export default class extends Controller {
     const resetHover = () => {
       linkPaths.style("opacity", 1).style("filter", "none");
       nodeGroups.style("opacity", 1);
+      transferOverlayPaths
+        ?.style("opacity", this.constructor.TRANSFER_OVERLAY_OPACITY)
+        .style("filter", "none");
+
       // Restore hidden labels to hidden state
       nodeGroups.selectAll("text")
         .style("opacity", d => hiddenLabels.has(d.index) ? 0 : 1);
@@ -308,7 +594,7 @@ export default class extends Controller {
     linkPaths
       .on("mouseenter", (event, d) => {
         applyHover([d]);
-        this.#showTooltip(event, d.value, d.percentage);
+        this.#showTooltip(event, d.value, d.percentage, this.#linkTooltipTitle(d));
       })
       .on("mousemove", event => this.#updateTooltipPosition(event))
       .on("mouseleave", () => {
@@ -341,6 +627,28 @@ export default class extends Controller {
         resetHover();
         this.#hideTooltip();
       });
+
+    transferOverlayPaths
+      ?.on("mouseenter", (event, d) => {
+        const sourceNode = sankeyData.nodes[d.source];
+        const targetNode = sankeyData.nodes[d.target];
+        const sourceName = d.source_name || sourceNode?.name || "Source account";
+        const targetName = d.target_name || targetNode?.name || "Destination account";
+        const connectedNodeIndices = new Set([ d.source, d.target ]);
+
+        linkPaths.style("opacity", this.constructor.HOVER_OPACITY).style("filter", "none");
+        transferOverlayPaths.style("opacity", overlay => (overlay === d ? 1 : this.constructor.HOVER_OPACITY));
+        nodeGroups.style("opacity", node => connectedNodeIndices.has(node.index) ? 1 : this.constructor.HOVER_OPACITY);
+        nodeGroups.selectAll("text")
+          .style("opacity", node => connectedNodeIndices.has(node.index) ? 1 : (hiddenLabels.has(node.index) ? 0 : this.constructor.HOVER_OPACITY));
+
+        this.#showTooltip(event, d.value, null, `${sourceName} -> ${targetName}`);
+      })
+      .on("mousemove", event => this.#updateTooltipPosition(event))
+      .on("mouseleave", () => {
+        resetHover();
+        this.#hideTooltip();
+      });
   }
 
   // Tooltip methods
@@ -357,11 +665,16 @@ export default class extends Controller {
   #showTooltip(event, value, percentage, title = null) {
     if (!this.tooltip) this.#createTooltip();
 
-    const content = title
-      ? `${title}<br/>${this.#formatCurrency(value)} (${percentage || 0}%)`
-      : `${this.#formatCurrency(value)} (${percentage || 0}%)`;
+    const hasPercentage = Number.isFinite(Number(percentage));
+    const valueText = hasPercentage
+      ? `${this.#formatCurrency(value)} (${percentage || 0}%)`
+      : `${this.#formatCurrency(value)}`;
 
-    const isInDialog = !!this.element.closest("dialog");
+    const content = title
+      ? `${title}<br/>${valueText}`
+      : valueText;
+
+    const isInDialog = this.#isInDialog();
     const x = isInDialog ? event.clientX : event.pageX;
     const y = isInDialog ? event.clientY : event.pageY;
 
@@ -377,7 +690,7 @@ export default class extends Controller {
 
   #updateTooltipPosition(event) {
     if (this.tooltip) {
-      const isInDialog = !!this.element.closest("dialog");
+      const isInDialog = this.#isInDialog();
       const x = isInDialog ? event.clientX : event.pageX;
       const y = isInDialog ? event.clientY : event.pageY;
 
@@ -403,5 +716,11 @@ export default class extends Controller {
       maximumFractionDigits: 2
     });
     return this.currencySymbolValue + formatted;
+  }
+
+  #linkTooltipTitle(link) {
+    const sourceName = link?.source?.name || "Source";
+    const targetName = link?.target?.name || "Destination";
+    return `${sourceName} -> ${targetName}`;
   }
 }

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -935,21 +935,47 @@ class Demo::Generator
     end
 
     def create_transfer!(from_account, to_account, amount, name, date)
+      outflow_kind = transfer_outflow_kind(from_account: from_account, to_account: to_account)
+
       outflow = from_account.entries.create!(
-        entryable: Transaction.new,
+        entryable: Transaction.new(
+          kind: outflow_kind,
+          category: transfer_outflow_category(kind: outflow_kind, from_account: from_account)
+        ),
         amount: amount,
         name: name,
         currency: from_account.currency,
         date: date
       )
       inflow = to_account.entries.create!(
-        entryable: Transaction.new,
+        entryable: Transaction.new(kind: "funds_movement"),
         amount: -amount,
         name: name,
         currency: to_account.currency,
         date: date
       )
-      Transfer.create!(inflow_transaction: inflow.entryable, outflow_transaction: outflow.entryable)
+      Transfer.create!(
+        inflow_transaction: inflow.entryable,
+        outflow_transaction: outflow.entryable,
+        status: "confirmed"
+      )
+    end
+
+    def transfer_outflow_kind(from_account:, to_account:)
+      destination_is_investment = to_account.investment? || to_account.crypto?
+      source_is_investment = from_account.investment? || from_account.crypto?
+
+      if destination_is_investment && source_is_investment
+        "funds_movement"
+      else
+        Transfer.kind_for_account(to_account)
+      end
+    end
+
+    def transfer_outflow_category(kind:, from_account:)
+      return nil unless kind == "investment_contribution"
+
+      from_account.family.investment_contributions_category
     end
 
     def load_securities!

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -3,6 +3,7 @@ require "securerandom"
 class Demo::Generator
   # @param seed [Integer, String, nil] Seed value used to initialise the internal PRNG. If nil, the ENV variable DEMO_DATA_SEED will
   #   be honoured and default to a random seed when not present.
+  # @param seed_global_rng [Boolean] When true, also seed Ruby's global RNG. Set to false in tests that should not mutate global RNG state.
   #
   # Initialising an explicit PRNG gives us repeatable demo datasets while still
   #   allowing truly random data when the caller does not care about
@@ -10,7 +11,7 @@ class Demo::Generator
   #   will also be seeded so that *all* random behaviour inside this object –
   #   including library helpers that rely on Ruby's global RNG – follow the
   #   same deterministic sequence.
-  def initialize(seed: ENV.fetch("DEMO_DATA_SEED", nil))
+  def initialize(seed: ENV.fetch("DEMO_DATA_SEED", nil), seed_global_rng: true)
     # Convert the seed to an Integer if one was provided, otherwise fall back
     # to a random, but memoised, seed so the generator instance can report it
     # back to callers when needed (e.g. for debugging a specific run).
@@ -25,7 +26,7 @@ class Demo::Generator
     # Also seed Ruby's global RNG so helpers that rely on it (e.g.
     # Array#sample, Kernel.rand in invoked libraries, etc.) remain
     # deterministic for the lifetime of this generator instance.
-    srand(@seed)
+    srand(@seed) if seed_global_rng
   end
 
   # Expose the seed so callers can reproduce a run if necessary.

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -148,8 +148,8 @@ class Family < ApplicationRecord
     BalanceSheet.new(self, user: user)
   end
 
-  def income_statement(user: Current.user)
-    IncomeStatement.new(self, user: user)
+  def income_statement(user: Current.user, account_ids: nil)
+    IncomeStatement.new(self, user: user, account_ids: account_ids)
   end
 
   # Returns the Investment Contributions category for this family, creating it if it doesn't exist.

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -176,8 +176,8 @@ class Family < ApplicationRecord
     BalanceSheet.new(self, user: user)
   end
 
-  def income_statement(user: Current.user)
-    IncomeStatement.new(self, user: user)
+  def income_statement(user: Current.user, account_ids: nil)
+    IncomeStatement.new(self, user: user, account_ids: account_ids)
   end
 
   # Returns the Investment Contributions category for this family, creating it if it doesn't exist.

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -7,6 +7,12 @@ class IncomeStatement
 
   attr_reader :family, :user
 
+  def initialize(family, user: nil, account_ids: nil)
+    @family = family
+    @user = user || Current.user
+    @forced_account_ids = account_ids
+  end
+
   def totals(transactions_scope: nil, date_range:)
     # Default to excluding pending transactions from budget/analytics calculations
     # Pending transactions shouldn't affect budget totals until they post
@@ -180,12 +186,6 @@ class IncomeStatement
       @category_stats[interval] ||= Rails.cache.fetch([
         "income_statement", "category_stats", family.id, user&.id, interval, included_account_ids_hash, family.entries_cache_version
       ]) { CategoryStats.new(family, interval:, account_ids: included_account_ids).call }
-    end
-
-    def initialize(family, user: nil, account_ids: nil)
-      @family = family
-      @user = user || Current.user
-      @forced_account_ids = account_ids
     end
 
     def included_account_ids

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -7,9 +7,10 @@ class IncomeStatement
 
   attr_reader :family, :user
 
-  def initialize(family, user: nil)
+  def initialize(family, user: nil, account_ids: nil)
     @family = family
     @user = user || Current.user
+    @forced_account_ids = account_ids
   end
 
   def totals(transactions_scope: nil, date_range:)
@@ -188,7 +189,11 @@ class IncomeStatement
     end
 
     def included_account_ids
-      @included_account_ids ||= user ? user.finance_accounts.pluck(:id) : nil
+      @included_account_ids ||= if @forced_account_ids
+        @forced_account_ids
+      elsif user
+        user.finance_accounts.pluck(:id)
+      end
     end
 
     def included_account_ids_hash

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -7,11 +7,6 @@ class IncomeStatement
 
   attr_reader :family, :user
 
-  def initialize(family, user: nil)
-    @family = family
-    @user = user || Current.user
-  end
-
   def totals(transactions_scope: nil, date_range:)
     # Default to excluding pending transactions from budget/analytics calculations
     # Pending transactions shouldn't affect budget totals until they post
@@ -187,8 +182,18 @@ class IncomeStatement
       ]) { CategoryStats.new(family, interval:, account_ids: included_account_ids).call }
     end
 
+    def initialize(family, user: nil, account_ids: nil)
+      @family = family
+      @user = user || Current.user
+      @forced_account_ids = account_ids
+    end
+
     def included_account_ids
-      @included_account_ids ||= user ? user.finance_accounts.pluck(:id) : nil
+      @included_account_ids ||= if @forced_account_ids
+        @forced_account_ids
+      elsif user
+        user.finance_accounts.pluck(:id)
+      end
     end
 
     def included_account_ids_hash

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -1,20 +1,35 @@
 <%# locals: (sankey_data:, period:, finance_accounts:, selected_account_id:, sankey_mode:) %>
 <% account_options = [[t("pages.dashboard.cashflow_sankey.all_accounts"), ""]] + finance_accounts.map { |account| [account.name, account.id] } %>
+<%
+  dashboard_params = { period: period.key }
+  dashboard_params[:account_id] = selected_account_id if selected_account_id.present?
+  aggregate_active = sankey_mode == "aggregate"
+  split_active = sankey_mode == "split"
+%>
 <div id="cashflow-sankey-chart">
-  <div class="flex justify-end items-center gap-4 px-4 mb-4">
-      <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
-  <%= form.hidden_field :sankey_mode, value: sankey_mode %>
-  <%= form.select :account_id,
+  <div class="flex flex-wrap items-center justify-between gap-3 px-4 mb-4">
+    <div class="inline-flex items-center gap-0.5 rounded-lg bg-container-inset p-1">
+      <%= link_to t("pages.dashboard.cashflow_sankey.aggregate_mode"),
+        root_path(dashboard_params.merge(sankey_mode: "aggregate")),
+        class: "inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors #{aggregate_active ? "bg-container text-primary shadow-sm" : "text-secondary hover:text-primary"}" %>
+      <%= link_to t("transactions.split_parent_row.split_label"),
+        root_path(dashboard_params.merge(sankey_mode: "split")),
+        class: "inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors #{split_active ? "bg-container text-primary shadow-sm" : "text-secondary hover:text-primary"}" %>
+    </div>
+
+    <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" }, class: "flex items-center gap-4" do |form| %>
+      <%= form.hidden_field :sankey_mode, value: sankey_mode %>
+      <%= form.select :account_id,
             account_options,
             { selected: selected_account_id || "" },
             data: { "auto-submit-form-target": "auto" },
             class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
-  <%= form.select :period,
+      <%= form.select :period,
             Period.as_options,
             { selected: period.key },
             data: { "auto-submit-form-target": "auto" },
             class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
-<% end %>  
+    <% end %>
   </div>
   <% if sankey_mode == "split" %>
     <p class="px-4 mb-3 text-xs text-secondary"><%= t("pages.dashboard.cashflow_sankey.split_mode_transfer_hint") %></p>

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -1,10 +1,12 @@
 <%# locals: (sankey_data:, period:, finance_accounts:, selected_account_id:, sankey_mode:) %>
+<% account_options = [[t("pages.dashboard.cashflow_sankey.all_accounts"), ""]] + finance_accounts.map { |account| [account.name, account.id] } %>
 <div id="cashflow-sankey-chart">
   <div class="flex justify-end items-center gap-4 px-4 mb-4">
       <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
+  <%= form.hidden_field :sankey_mode, value: sankey_mode %>
   <%= form.select :account_id,
-            [[t("pages.dashboard.cashflow_sankey.all_accounts"), ""]] + Current.user.finance_accounts.map { |a| [a.name, a.id] },
-            { selected: params[:account_id] },
+            account_options,
+            { selected: selected_account_id || "" },
             data: { "auto-submit-form-target": "auto" },
             class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
   <%= form.select :period,

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -1,13 +1,18 @@
 <%# locals: (sankey_data:, period:) %>
 <div id="cashflow-sankey-chart">
   <div class="flex justify-end items-center gap-4 px-4 mb-4">
-    <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
-      <%= form.select :period,
-                Period.as_options,
-                { selected: period.key },
-                data: { "auto-submit-form-target": "auto" },
-                class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
-    <% end %>
+      <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
+  <%= form.select :account_id,
+            [["All accounts", ""]] + Current.user.finance_accounts.map { |a| [a.name, a.id] },
+            { selected: params[:account_id] },
+            data: { "auto-submit-form-target": "auto" },
+            class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+  <%= form.select :period,
+            Period.as_options,
+            { selected: period.key },
+            data: { "auto-submit-form-target": "auto" },
+            class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+<% end %>  
   </div>
   <% if sankey_data[:links].present? %>
     <div class="w-full h-96">

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -3,7 +3,7 @@
   <div class="flex justify-end items-center gap-4 px-4 mb-4">
       <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
   <%= form.select :account_id,
-            [["All accounts", ""]] + Current.user.finance_accounts.map { |a| [a.name, a.id] },
+            [[t("pages.dashboard.cashflow_sankey.all_accounts"), ""]] + Current.user.finance_accounts.map { |a| [a.name, a.id] },
             { selected: params[:account_id] },
             data: { "auto-submit-form-target": "auto" },
             class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -42,12 +42,12 @@
     <%= render DS::Dialog.new(id: "cashflow-expanded-dialog", auto_open: false, width: "custom", disable_frame: true, content_class: "!w-[96vw] max-w-[1650px]", data: { action: "close->cashflow-expand#restore" }) do |dialog| %>
       <% dialog.with_header(title: t("pages.dashboard.cashflow_sankey.title")) %>
       <% dialog.with_body do %>
-        <div class="w-full h-[92dvh] max-h-[96dvh] overflow-y-auto overscroll-contain">
+        <div class="w-full">
           <div
             data-controller="sankey-chart"
             data-sankey-chart-data-value="<%= sankey_data.to_json %>"
             data-sankey-chart-currency-symbol-value="<%= sankey_data[:currency_symbol] %>"
-            class="w-full min-h-[900px] h-full privacy-sensitive"></div>
+            class="w-full privacy-sensitive"></div>
         </div>
       <% end %>
     <% end %>

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -1,7 +1,26 @@
-<%# locals: (sankey_data:, period:) %>
+<%# locals: (sankey_data:, period:, finance_accounts:, selected_account_id:, sankey_mode:) %>
 <div id="cashflow-sankey-chart">
   <div class="flex justify-end items-center gap-4 px-4 mb-4">
     <%= form_with url: root_path, method: :get, data: { controller: "auto-submit-form", turbo_frame: "_top" } do |form| %>
+      <%= form.select :sankey_mode,
+                [
+                  [t("pages.dashboard.cashflow_sankey.view_modes.aggregate"), "aggregate"],
+                  [t("pages.dashboard.cashflow_sankey.view_modes.split_by_account"), "split"]
+                ],
+                { selected: sankey_mode },
+                data: { "auto-submit-form-target": "auto" },
+                class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+
+      <% if sankey_mode == "split" %>
+        <%= form.hidden_field :account_id, value: "" %>
+      <% else %>
+        <%= form.select :account_id,
+                  [[t("pages.dashboard.cashflow_sankey.all_accounts"), ""]] + finance_accounts.map { |account| [account.name, account.id] },
+                  { selected: selected_account_id },
+                  data: { "auto-submit-form-target": "auto" },
+                  class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
+      <% end %>
+
       <%= form.select :period,
                 Period.as_options,
                 { selected: period.key },
@@ -9,6 +28,9 @@
                 class: "bg-container border border-secondary font-medium rounded-lg px-3 py-2 text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0" %>
     <% end %>
   </div>
+  <% if sankey_mode == "split" %>
+    <p class="px-4 mb-3 text-xs text-secondary"><%= t("pages.dashboard.cashflow_sankey.split_mode_transfer_hint") %></p>
+  <% end %>
   <% if sankey_data[:links].present? %>
     <div class="w-full h-96">
       <div
@@ -20,12 +42,12 @@
     <%= render DS::Dialog.new(id: "cashflow-expanded-dialog", auto_open: false, width: "custom", disable_frame: true, content_class: "!w-[96vw] max-w-[1650px]", data: { action: "close->cashflow-expand#restore" }) do |dialog| %>
       <% dialog.with_header(title: t("pages.dashboard.cashflow_sankey.title")) %>
       <% dialog.with_body do %>
-        <div class="w-full h-[85dvh] max-h-[90dvh] overflow-y-auto overscroll-contain">
+        <div class="w-full h-[92dvh] max-h-[96dvh] overflow-y-auto overscroll-contain">
           <div
             data-controller="sankey-chart"
             data-sankey-chart-data-value="<%= sankey_data.to_json %>"
             data-sankey-chart-currency-symbol-value="<%= sankey_data[:currency_symbol] %>"
-            class="w-full h-full privacy-sensitive"></div>
+            class="w-full min-h-[900px] h-full privacy-sensitive"></div>
         </div>
       <% end %>
     <% end %>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -33,6 +33,7 @@ en:
         no_data_title: "No cash flow data for this time period"
         no_data_description: "Add transactions to display cash flow data or expand the time period"
         add_transaction: "Add transaction"
+        all_accounts: "All accounts"
       no_accounts:
         title: "No accounts yet"
         description: "Add accounts to display net worth data"

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -34,6 +34,7 @@ en:
         no_data_description: "Add transactions to display cash flow data or expand the time period"
         add_transaction: "Add transaction"
         all_accounts: "All accounts"
+        split_mode_transfer_hint: "Split view groups flows by account lane and shows direct account-to-account transfer links."
       no_accounts:
         title: "No accounts yet"
         description: "Add accounts to display net worth data"

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -33,6 +33,7 @@ en:
         no_data_title: "No cash flow data for this time period"
         no_data_description: "Add transactions to display cash flow data or expand the time period"
         add_transaction: "Add transaction"
+        aggregate_mode: "Aggregate"
         all_accounts: "All accounts"
         split_mode_transfer_hint: "Split view groups flows by account lane and shows direct account-to-account transfer links."
       no_accounts:

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -37,7 +37,7 @@ en:
         other_categories: "Other"
         from_label: "Transfer from"
         to_label: "Transfer to"
-        split_mode_transfer_hint: "Split view shows net account-to-account transfers as curved links. Income flows in from the left and expenses flow out to the right."
+        split_mode_transfer_hint: "Split view shows each account as its own cash flow lane. Income flows into account nodes, expenses flow out, and net transfers are shown as direct account-to-account links."
         view_modes:
           aggregate: "All accounts (combined)"
           split_by_account: "All accounts (split by account)"

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -33,6 +33,14 @@ en:
         no_data_title: "No cash flow data for this time period"
         no_data_description: "Add transactions to display cash flow data or expand the time period"
         add_transaction: "Add transaction"
+        all_accounts: "All accounts"
+        other_categories: "Other"
+        from_label: "Transfer from"
+        to_label: "Transfer to"
+        split_mode_transfer_hint: "Split view shows net account-to-account transfers as curved links. Income flows in from the left and expenses flow out to the right."
+        view_modes:
+          aggregate: "All accounts (combined)"
+          split_by_account: "All accounts (split by account)"
       no_accounts:
         title: "No accounts yet"
         description: "Add accounts to display net worth data"

--- a/config/locales/views/transactions/fr.yml
+++ b/config/locales/views/transactions/fr.yml
@@ -75,10 +75,10 @@ fr:
       other: Autre
     mark_recurring: Marquer comme récurrent
     mark_recurring_subtitle: Enregistrez cette transaction comme récurrente. L'écart de montant est calculé automatiquement à partir des transactions similaires des 6 derniers mois.
-    mark_recurring_title: Transaction réccurente
+    mark_recurring_title: Transaction récurrente
     potential_duplicate_title: Doublon potentiel détecté
     potential_duplicate_description: Cette transaction en attente est peut-être identique à la transaction enregistrée ci-dessous. Si c'est le cas, fusionnez-les pour éviter les doublons.
-    merge_duplicate: Oui, les fusionner
+    merge_duplicate_confirm: Oui, les fusionner
     keep_both: Non, garder les deux
     split_parent_row:
       split_label: "Diviser"
@@ -116,7 +116,7 @@ fr:
     header:
       edit_categories: Modifier les catégories
       edit_imports: Modifier les importations
-      edit_merchants: Modifier les marchants
+      edit_merchants: Modifier les marchands
       edit_tags: Modifier les étiquettes
       import: Importer
     index:
@@ -213,7 +213,7 @@ fr:
         date_filter: Date
         merchant_filter: Marchant
         status_filter: Statut
-        tag_filter: Étiqsette
+        tag_filter: Étiquette
         type_filter: Type
       search:
         equal_to: Égal à
@@ -223,7 +223,7 @@ fr:
         toggle_selection_checkboxes: Cocher ou décocher toutes les cases
     attachments:
       cannot_exceed: "Le nombre de pièces jointes ne doit pas dépasser %{count} par transaction"
-      uploaded_one: "Pièce jointe importé avec succès"
+      uploaded_one: "Pièce jointe importée avec succès"
       uploaded_many: "%{count} pièces jointes importées avec succès"
       failed_upload: "Échec de l'import : %{error}"
       no_files_selected: "Aucun fichier sélectionné"

--- a/config/locales/views/transactions/fr.yml
+++ b/config/locales/views/transactions/fr.yml
@@ -1,21 +1,26 @@
 ---
 fr:
   transactions:
+    unknown_name: Transaction inconnue 
+    selection_bar:
+      duplicate: Dupliquer
+      edit: Éditer
     form:
       account: Compte
       account_prompt: Sélectionnez un compte
       amount: Montant
       category: Catégorie
-      category_prompt: Sélectionnez une catégorie
+      category_prompt: Sélectionner une catégorie
       date: Date
-      description: Libellé
-      description_placeholder: Libellé de la transaction
+      description: Description
+      description_placeholder: Décrivez la transaction
       expense: Dépense
       income: Revenu
+      merchant_label: Marchand
       none: (aucun)
       note_label: Notes
-      note_placeholder: Entrez une note
-      submit: Ajouter la transaction
+      note_placeholder: Saisissez une note
+      submit: Ajouter une transaction
       tags_label: Étiquettes
       transfer: Transfert
     new:
@@ -26,47 +31,178 @@ fr:
       category_label: Catégorie
       date_label: Date
       delete: Supprimer
-      delete_subtitle: Cette action supprime définitivement la transaction, affecte vos soldes historiques et ne peut pas être annulée.
+      delete_subtitle: Cette opération supprime définitivement la transaction, a une incidence sur l'historique de vos soldes et ne peut pas être annulée.
       delete_title: Supprimer la transaction
       details: Détails
+      attachments:  Pièces jointes
+      exclude: Exclure
+      exclude_description: Les transactions exclues seront retirées des calculs budgétaires et des rapports.
+      activity_type: Type d'opération
+      activity_type_description: Type d'opération d'investissement (achat, vente, dividende, etc.). Détecté automatiquement ou défini manuellement.
+      one_time_title: "%{type} ponctuel"
+      one_time_description: Les opérations ponctuelles seront exclues de certains calculs budgétaires et rapports afin de vous aider à vous concentrer sur l'essentiel.
+      convert_to_trade_title: Convertir en opération sur titres
+      convert_to_trade_description: Convertissez cette transaction en une opération d'achat ou de vente avec les détails du titre pour le suivi du portefeuille.
+      convert_to_trade_button: Convertir en transaction
+      pending_duplicate_merger_title: Doublon avec une transaction enregistrée ?
+      pending_duplicate_merger_description: Fusionner manuellement cette transaction en attente avec sa version enregistrée.
+      pending_duplicate_merger_button: Lancer la fusion
       merchant_label: Marchand
-      name_label: Nom
+      name_label: Name
       nature: Type
-      none: "(aucun)"
+      none: "(Aucun)"
       note_label: Notes
-      note_placeholder: Entrez une note
+      note_placeholder: Saisissez une note
       overview: Aperçu
       settings: Paramètres
       tags_label: Étiquettes
-      uncategorized: "(non catégorisée)"
+      tab_transactions: Transactions
+      tab_upcoming: À venir
+      uncategorized: "(Sans catégorie)"
+    activity_labels:
+      buy: Achat
+      sell: Vente
+      sweep_in: Transfert entrant
+      sweep_out: Transfert sortant
+      dividend: Dividende
+      reinvestment: Réinvestissement
+      interest: Intérêts
+      fee: Frais
+      transfer: Transfert
+      contribution: Cotisation
+      withdrawal: Retrait
+      exchange: Échange
+      other: Autre
+    mark_recurring: Marquer comme récurrent
+    mark_recurring_subtitle: Enregistrez cette transaction comme récurrente. L'écart de montant est calculé automatiquement à partir des transactions similaires des 6 derniers mois.
+    mark_recurring_title: Transaction réccurente
+    potential_duplicate_title: Doublon potentiel détecté
+    potential_duplicate_description: Cette transaction en attente est peut-être identique à la transaction enregistrée ci-dessous. Si c'est le cas, fusionnez-les pour éviter les doublons.
+    merge_duplicate: Oui, les fusionner
+    keep_both: Non, garder les deux
+    split_parent_row:
+      split_label: "Diviser"
+    transaction:
+      pending: En attente
+      pending_tooltip: Transaction en attente — susceptible de changer une fois enregistrée
+      linked_with_provider: Lié à %{provider}
+      activity_type_tooltip: Type d'opération d'investissement
+      possible_duplicate: Doublon ?
+      potential_duplicate_tooltip: Il s'agit peut-être d'un doublon d'une autre transaction
+      review_recommended: À vérifier
+      review_recommended_tooltip: Écart de montant important — vérifiez s'il s'agit d'un doublon
+      split: Divisée
+      split_tooltip: Cette transaction a été divisée en plusieurs entrées
+      split_child_tooltip: Fait partie d'une transaction divisée
+    merge_duplicate:
+      success: Transactions fusionnées avec succès
+      failure: Impossible de fusionner les transactions
+    dismiss_duplicate:
+      success: Transactions conservées séparément
+      failure: Impossible d'ignorer la suggestion de doublon
+    pending_duplicate_merge:
+      possible_duplicate: Doublon ?
+      possible_duplicate_short: Dup?
+      review_recommended: À vérifier
+      review_recommended_short: Ver
+      confirm_title: "Fusionner avec la transaction enregistrée (%{posted_amount})"
+      reject_title: Conserver comme transactions séparées
+    summary:
+      total_transactions: Nombre total de transactions
+      income: Revenu
+      expenses: Dépenses
+      inflow: Entrées
+      outflow: Sorties
     header:
       edit_categories: Modifier les catégories
       edit_imports: Modifier les importations
-      edit_merchants: Modifier les marchands
+      edit_merchants: Modifier les marchants
       edit_tags: Modifier les étiquettes
       import: Importer
-    transaction:
-      linked_with_provider: Lié avec %{provider}
     index:
-      transaction: transaction
-      transactions: transactions
-    searches:
+      transaction: Transaction
+      transactions: Transactions
+      import: Importer
+    list:
+      drag_drop_title: Déposez un CSV pour importer
+      drag_drop_subtitle: Importez des transactions directement
+      transaction: Transaction
+      transactions: Transactions
+    toggle_recurring_section: Afficher/masquer les transactions récurrentes à venir
+    search:
       filters:
-        amount_filter:
-          equal_to: Égal à
-          greater_than: Supérieur à
-          less_than: Inférieur à
-          placeholder: '0'
+        account: Compte
+        date: Date
+        type: Type
+        status: Status
+        amount: Montant
+        category: Catégorie
+        tag: Étiquette
+        merchant: Marchand
+    convert_to_trade:
+      title: Convertir en opération sur titres
+      description: Convertissez cette transaction en opération avec les détails du titre
+      date_label: "Date :"
+      account_label: "Compte :"
+      amount_label: "Montant :"
+      security_label: Titre
+      security_prompt: Sélectionnez un titre...
+      security_custom: "+ Saisir un symbole personnalisé"
+      security_not_listed_hint: Vous ne trouvez pas votre titre ? Sélectionnez « Saisir un symbole personnalisé » en bas de la liste.
+      ticker_placeholder: AAPL
+      ticker_hint: Saisissez le symbole boursier de l'action ou de l'ETF (par exemple, AAPL, MSFT)
+      ticker_search_placeholder: Rechercher un symbole boursier...
+      ticker_search_hint: Recherchez par symbole boursier ou nom de société, ou saisissez un symbole personnalisé
+      price_mismatch_title: Le prix peut ne pas correspondre
+      price_mismatch_message: "Le prix que vous avez indiqué (%{entered_price}/action) diffère considérablement du cours actuel de %{ticker} (%{market_price}). Si cela vous semble incorrect, vous avez peut-être sélectionné le mauvais titre — essayez d'utiliser « Saisir un symbole boursier personnalisé » pour indiquer le bon."
+      quantity_label: Quantité (actions)
+      quantity_placeholder: ex. 20
+      quantity_hint: Nombre d'actions échangées
+      price_label: Prix par action
+      price_placeholder: ex. 52.15
+      price_hint: Prix par action (%{currency})
+      qty_or_price_hint: Indiquez au moins la quantité OU le prix. L'autre sera calculé à partir du montant de la transaction (%{amount}).
+      trade_type_label: Type d’opération
+      trade_type_hint: Acheter ou vendre des actions d'un titre
+      exchange_label: Échange (facultatif)
+      exchange_placeholder: XNAS
+      exchange_hint: Laisser vide pour une détection automatique
+      cancel: Annuler
+      submit: Convertir en opération
+      success: Transaction convertie en opération
+      conversion_note: "Convertie depuis la transaction : %{original_name} (%{original_date})"
+      errors:
+        not_investment_account: Seules les opérations effectuées sur des comptes d'investissement peuvent être converties en transactions
+        already_converted: Cette transaction a déjà été convertie ou exclue
+        enter_ticker: Veuillez saisir un symbole boursier
+        security_not_found: Le titre sélectionné n'existe plus. Veuillez en choisir un autre.
+        select_security: Veuillez sélectionner ou saisir un titre
+        enter_qty_or_price: Veuillez saisir soit la quantité, soit le prix par action. L'autre valeur sera calculée à partir du montant de la transaction.
+        invalid_qty_or_price: Quantité ou prix incorrect(e). Veuillez saisir des valeurs positives valides.
+        conversion_failed: "Échec de la conversion de la transaction : %{error}"
+        unexpected_error: "Erreur inattendue lors de la conversion: %{error}"
+      searches:
+        filters:
+          amount_filter:
+            equal_to: Égal à
+            greater_than: Supérieur à
+            less_than: Inférieur à
+            placeholder: '0'
         badge:
           expense: Dépense
           income: Revenu
-          on_or_after: le %{date} et après
-          on_or_before: le %{date} et avant
-          transfer: Transfert
+          on_or_after: on or after %{date}
+          on_or_before: on or before %{date}
+          transfer: Transfer
+          confirmed: Confirmed
+          pending: Pending
         type_filter:
           expense: Dépense
           income: Revenu
           transfer: Transfert
+        status_filter:
+          confirmed: Confirmé
+          pending: En attente
       menu:
         account_filter: Compte
         amount_filter: Montant
@@ -75,10 +211,31 @@ fr:
         category_filter: Catégorie
         clear_filters: Effacer les filtres
         date_filter: Date
-        merchant_filter: Marchand
-        tag_filter: Étiquette
+        merchant_filter: Marchant
+        status_filter: Statut
+        tag_filter: Étiqsette
         type_filter: Type
       search:
-        equal_to: égal à
-        greater_than: supérieur à
-        less_than: inférieur à
+        equal_to: Égal à
+        greater_than: Supérieur à
+        less_than: Inférieur à
+      form:
+        toggle_selection_checkboxes: Cocher ou décocher toutes les cases
+    attachments:
+      cannot_exceed: "Le nombre de pièces jointes ne doit pas dépasser %{count} par transaction"
+      uploaded_one: "Pièce jointe importé avec succès"
+      uploaded_many: "%{count} pièces jointes importées avec succès"
+      failed_upload: "Échec de l'import : %{error}"
+      no_files_selected: "Aucun fichier sélectionné"
+      attachment_deleted: "Pièce jointe supprimée avec succès"
+      failed_delete: "Échec de la suppression : %{error}"
+      upload_failed: "Échec de l'import. Réessayez ou contactez le support."
+      delete_failed: "Échec de la suppression. Réessayez ou contactez le support."
+      upload: "Importer"
+      no_attachments: "Aucune pièce jointe"
+      select_up_to: "Sélectionnez jusqu'à %{count} fichiers (images ou PDF, max %{size} Mo chacun) • %{used} sur %{count} utilisés"
+      files:
+        one: "Fichier (1)"
+        other: "Fichiers (%{count})"
+      browse_to_add: "Parcourir pour ajouter des fichiers"
+      max_reached: "Nombre maximum de fichiers atteint (%{count}/%{max}). Supprimez un fichier existant pour en importer un autre."

--- a/config/locales/views/transactions/fr.yml
+++ b/config/locales/views/transactions/fr.yml
@@ -48,7 +48,7 @@ fr:
       pending_duplicate_merger_description: Fusionner manuellement cette transaction en attente avec sa version enregistrée.
       pending_duplicate_merger_button: Lancer la fusion
       merchant_label: Marchand
-      name_label: Name
+      name_label: Nom
       nature: Type
       none: "(Aucun)"
       note_label: Notes
@@ -134,7 +134,7 @@ fr:
         account: Compte
         date: Date
         type: Type
-        status: Status
+        status: Statut
         amount: Montant
         category: Catégorie
         tag: Étiquette
@@ -191,11 +191,11 @@ fr:
         badge:
           expense: Dépense
           income: Revenu
-          on_or_after: on or after %{date}
-          on_or_before: on or before %{date}
-          transfer: Transfer
-          confirmed: Confirmed
-          pending: Pending
+          on_or_after: à partir du %{date}
+          on_or_before: au plus tard le %{date}
+          transfer: Transfert
+          confirmed: Confirmé
+          pending: En attente
         type_filter:
           expense: Dépense
           income: Revenu
@@ -211,7 +211,7 @@ fr:
         category_filter: Catégorie
         clear_filters: Effacer les filtres
         date_filter: Date
-        merchant_filter: Marchant
+        merchant_filter: Marchand
         status_filter: Statut
         tag_filter: Étiquette
         type_filter: Type

--- a/script/load_compact_sample_data.rb
+++ b/script/load_compact_sample_data.rb
@@ -28,8 +28,8 @@ class CompactSampleDataLoader
   attr_reader :family, :user, :today
 
   def initialize(email:)
-    @user = User.find_by(email: email) || User.order(:created_at).first
-    raise ActiveRecord::RecordNotFound, "No users found in this environment" unless @user
+    @user = User.find_by(email: email)
+    raise ActiveRecord::RecordNotFound, "User with email #{email} not found" unless @user
 
     @family = @user.family
     @today = Date.current
@@ -39,6 +39,8 @@ class CompactSampleDataLoader
   end
 
   def run!
+    ensure_safe_environment!
+
     puts "Loading compact sample data for family: #{family.name}"
     puts "Preserving user credentials for: #{user.email}"
 
@@ -59,6 +61,12 @@ class CompactSampleDataLoader
   end
 
   private
+
+    def ensure_safe_environment!
+      return if Rails.env.development? || Rails.env.test? || ENV["ALLOW_COMPACT_SAMPLE_DATA_RESET"] == "1"
+
+      raise "Refusing to reset family data outside development/test. Set ALLOW_COMPACT_SAMPLE_DATA_RESET=1 to override intentionally."
+    end
 
     def reset_family_financial_data!
       family.users.update_all(default_account_id: nil)

--- a/script/load_compact_sample_data.rb
+++ b/script/load_compact_sample_data.rb
@@ -1,0 +1,396 @@
+# frozen_string_literal: true
+
+class CompactSampleDataLoader
+  RESET_ASSOCIATIONS = %i[
+    budgets
+    recurring_transactions
+    rules
+    imports
+    plaid_items
+    simplefin_items
+    lunchflow_items
+    enable_banking_items
+    coinbase_items
+    binance_items
+    coinstats_items
+    snaptrade_items
+    indexa_capital_items
+    mercury_items
+    accounts
+    categories
+    tags
+    merchants
+    family_documents
+    family_exports
+    syncs
+  ].freeze
+
+  attr_reader :family, :user, :today
+
+  def initialize(email:)
+    @user = User.find_by(email: email) || User.order(:created_at).first
+    raise ActiveRecord::RecordNotFound, "No users found in this environment" unless @user
+
+    @family = @user.family
+    @today = Date.current
+    @opening_balances = {}
+    @accounts = {}
+    @categories = {}
+  end
+
+  def run!
+    puts "Loading compact sample data for family: #{family.name}"
+    puts "Preserving user credentials for: #{user.email}"
+
+    ActiveRecord::Base.transaction do
+      reset_family_financial_data!
+      create_categories!
+      create_accounts!
+      create_opening_valuations!
+      create_sample_transactions!
+      create_sample_transfers!
+      create_edge_cases!
+      update_balances_and_create_current_valuations!
+
+      user.update!(default_account: @accounts.fetch(:checking))
+    end
+
+    print_summary!
+  end
+
+  private
+
+    def reset_family_financial_data!
+      family.users.update_all(default_account_id: nil)
+      family.users.update_all(last_viewed_chat_id: nil)
+
+      RESET_ASSOCIATIONS.each do |association_name|
+        family.public_send(association_name).destroy_all
+      end
+    end
+
+    def create_categories!
+      @categories[:salary] = create_category!("Salary", "#22c55e", "circle-dollar-sign")
+      @categories[:freelance] = create_category!("Freelance", "#16a34a", "briefcase")
+      @categories[:bonus] = create_category!("Bonus", "#15803d", "sparkles")
+
+      @categories[:housing] = create_category!("Housing", "#dc2626", "home")
+      @categories[:utilities] = create_category!("Utilities", "#f59e0b", "lightbulb")
+      @categories[:groceries] = create_category!("Groceries", "#65a30d", "shopping-bag")
+      @categories[:dining] = create_category!("Dining", "#ea580c", "utensils")
+      @categories[:transport] = create_category!("Transportation", "#0284c7", "car")
+      @categories[:shopping] = create_category!("Shopping", "#2563eb", "shopping-cart")
+      @categories[:entertainment] = create_category!("Entertainment", "#7c3aed", "drama")
+      @categories[:healthcare] = create_category!("Healthcare", "#db2777", "pill")
+      @categories[:insurance] = create_category!("Insurance", "#4f46e5", "shield")
+      @categories[:travel] = create_category!("Travel", "#0891b2", "plane")
+      @categories[:interest] = create_category!("Loan Interest", "#475569", "receipt")
+    end
+
+    def create_accounts!
+      @accounts[:checking] = create_account!(
+        name: "Chase Checking",
+        accountable_type: "Depository",
+        subtype: "checking",
+        currency: "USD",
+        opening_balance: 12_000
+      )
+
+      @accounts[:savings] = create_account!(
+        name: "Marcus High-Yield Savings",
+        accountable_type: "Depository",
+        subtype: "savings",
+        currency: "USD",
+        opening_balance: 18_500
+      )
+
+      @accounts[:travel_eur] = create_account!(
+        name: "Travel EUR Account",
+        accountable_type: "Depository",
+        subtype: "checking",
+        currency: "EUR",
+        opening_balance: 800
+      )
+
+      @accounts[:amex] = create_account!(
+        name: "Amex Gold Card",
+        accountable_type: "CreditCard",
+        subtype: "credit_card",
+        currency: "USD",
+        opening_balance: 2_200
+      )
+
+      @accounts[:sapphire] = create_account!(
+        name: "Chase Sapphire",
+        accountable_type: "CreditCard",
+        subtype: "credit_card",
+        currency: "USD",
+        opening_balance: 1_400
+      )
+
+      @accounts[:mortgage] = create_account!(
+        name: "Home Mortgage",
+        accountable_type: "Loan",
+        subtype: "mortgage",
+        currency: "USD",
+        opening_balance: 285_000,
+        cash_balance: 0
+      )
+
+      @accounts[:student_loan] = create_account!(
+        name: "Student Loan",
+        accountable_type: "Loan",
+        subtype: "student",
+        currency: "USD",
+        opening_balance: 18_000,
+        cash_balance: 0
+      )
+
+      @accounts[:auto_loan] = create_account!(
+        name: "Auto Loan",
+        accountable_type: "Loan",
+        subtype: "auto",
+        currency: "USD",
+        opening_balance: 9_200,
+        cash_balance: 0
+      )
+
+      @accounts[:brokerage] = create_account!(
+        name: "Vanguard Brokerage",
+        accountable_type: "Investment",
+        subtype: "brokerage",
+        currency: "USD",
+        opening_balance: 46_000,
+        cash_balance: 2_500
+      )
+    end
+
+    def create_opening_valuations!
+      opening_date = today - 95.days
+
+      @accounts.each_value do |account|
+        opening_balance = @opening_balances.fetch(account.id)
+
+        account.entries.create!(
+          date: opening_date,
+          name: Valuation.build_opening_anchor_name(account.accountable_type),
+          amount: opening_balance,
+          currency: account.currency,
+          user_modified: true,
+          entryable: Valuation.new(kind: "opening_anchor")
+        )
+      end
+    end
+
+    def create_sample_transactions!
+      [ 2, 1, 0 ].each do |months_ago|
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 1), name: "Employer Payroll", amount: -4_800, category: @categories[:salary])
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 15), name: "Employer Payroll", amount: -4_800, category: @categories[:salary])
+
+        freelance_amount = months_ago == 1 ? -1_650 : -1_200
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 10), name: "Freelance Client Payout", amount: freelance_amount, category: @categories[:freelance])
+
+        create_transaction!(account: @accounts[:amex], date: month_day(months_ago, 5), name: "Whole Foods", amount: 430, category: @categories[:groceries])
+        create_transaction!(account: @accounts[:amex], date: month_day(months_ago, 9), name: "Neighborhood Bistro", amount: 185, category: @categories[:dining])
+        create_transaction!(account: @accounts[:amex], date: month_day(months_ago, 18), name: "City Transit", amount: 92, category: @categories[:transport])
+        create_transaction!(account: @accounts[:amex], date: month_day(months_ago, 22), name: "Online Retail", amount: 145, category: @categories[:shopping])
+
+        create_transaction!(account: @accounts[:sapphire], date: month_day(months_ago, 12), name: "Airline Ticket", amount: 160, category: @categories[:travel])
+        create_transaction!(account: @accounts[:sapphire], date: month_day(months_ago, 20), name: "Streaming + Music", amount: 120, category: @categories[:entertainment])
+
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 6), name: "Electric + Water Utility", amount: 245, category: @categories[:utilities])
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 7), name: "Home Insurance", amount: 190, category: @categories[:insurance])
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 8), name: "HOA Dues", amount: 360, category: @categories[:housing])
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 17), name: "Pharmacy", amount: 96, category: @categories[:healthcare])
+
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 3), name: "Mortgage Interest", amount: 980, category: @categories[:interest])
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 4), name: "Student Loan Interest", amount: 85, category: @categories[:interest])
+        create_transaction!(account: @accounts[:checking], date: month_day(months_ago, 4), name: "Auto Loan Interest", amount: 65, category: @categories[:interest])
+      end
+    end
+
+    def create_sample_transfers!
+      [ 2, 1, 0 ].each do |months_ago|
+        create_transfer!(from: @accounts[:checking], to: @accounts[:savings], amount: 600, date: month_day(months_ago, 2))
+
+        create_transfer!(from: @accounts[:checking], to: @accounts[:mortgage], amount: 1_650, date: month_day(months_ago, 3))
+        create_transfer!(from: @accounts[:checking], to: @accounts[:student_loan], amount: 320, date: month_day(months_ago, 4))
+        create_transfer!(from: @accounts[:checking], to: @accounts[:auto_loan], amount: 290, date: month_day(months_ago, 4))
+
+        create_transfer!(from: @accounts[:checking], to: @accounts[:brokerage], amount: 700, date: month_day(months_ago, 11))
+
+        create_transfer!(from: @accounts[:checking], to: @accounts[:amex], amount: 950, date: month_day(months_ago, 26))
+        create_transfer!(from: @accounts[:checking], to: @accounts[:sapphire], amount: 760, date: month_day(months_ago, 27))
+      end
+
+      create_transfer!(from: @accounts[:savings], to: @accounts[:checking], amount: 500, date: month_day(0, 13))
+
+      create_transfer!(
+        from: @accounts[:checking],
+        to: @accounts[:travel_eur],
+        amount: 350,
+        date: month_day(1, 24),
+        exchange_rate: 0.92
+      )
+
+      create_transfer!(
+        from: @accounts[:travel_eur],
+        to: @accounts[:checking],
+        amount: 120,
+        date: month_day(0, 9),
+        exchange_rate: 1.08
+      )
+    end
+
+    def create_edge_cases!
+      create_transaction!(
+        account: @accounts[:checking],
+        date: month_day(1, 20),
+        name: "Annual Bonus",
+        amount: -3_500,
+        category: @categories[:bonus],
+        kind: "one_time"
+      )
+
+      create_transaction!(
+        account: @accounts[:amex],
+        date: month_day(0, 28),
+        name: "Coffee Shop Pending",
+        amount: 63.25,
+        category: @categories[:dining],
+        extra: { "simplefin" => { "pending" => true } }
+      )
+
+      create_transaction!(
+        account: @accounts[:checking],
+        date: month_day(0, 23),
+        name: "Mystery Charge",
+        amount: 47.11,
+        category: nil
+      )
+
+      create_transaction!(
+        account: @accounts[:amex],
+        date: month_day(0, 21),
+        name: "Online Return",
+        amount: -42,
+        category: @categories[:shopping]
+      )
+    end
+
+    def update_balances_and_create_current_valuations!
+      @accounts.each_value do |account|
+        opening_balance = @opening_balances.fetch(account.id)
+        transaction_sum = account.entries.where(entryable_type: "Transaction").sum(:amount).to_d
+
+        final_balance = if account.liability?
+          opening_balance + transaction_sum
+        else
+          opening_balance - transaction_sum
+        end
+
+        account.update!(
+          balance: final_balance,
+          cash_balance: final_cash_balance_for(account, final_balance)
+        )
+
+        account.entries.create!(
+          date: today,
+          name: Valuation.build_current_anchor_name(account.accountable_type),
+          amount: final_balance,
+          currency: account.currency,
+          user_modified: true,
+          entryable: Valuation.new(kind: "current_anchor")
+        )
+      end
+    end
+
+    def final_cash_balance_for(account, final_balance)
+      if account.loan? || account.other_liability?
+        0
+      elsif account.investment? || account.crypto?
+        account.cash_balance
+      else
+        final_balance
+      end
+    end
+
+    def create_category!(name, color, icon)
+      family.categories.create!(name: name, color: color, lucide_icon: icon)
+    end
+
+    def create_account!(name:, accountable_type:, subtype:, currency:, opening_balance:, cash_balance: nil)
+      account = family.accounts.create!(
+        owner: user,
+        name: name,
+        balance: opening_balance,
+        cash_balance: cash_balance.nil? ? opening_balance : cash_balance,
+        currency: currency,
+        accountable: accountable_type.constantize.new(subtype: subtype)
+      )
+
+      @opening_balances[account.id] = opening_balance.to_d
+      account
+    end
+
+    def create_transaction!(account:, date:, name:, amount:, category:, kind: "standard", extra: {})
+      account.entries.create!(
+        date: date,
+        name: name,
+        amount: amount,
+        currency: account.currency,
+        user_modified: true,
+        entryable: Transaction.new(
+          category: category,
+          kind: kind,
+          extra: extra
+        )
+      )
+    end
+
+    def create_transfer!(from:, to:, amount:, date:, exchange_rate: nil)
+      transfer = Transfer::Creator.new(
+        family: family,
+        source_account_id: from.id,
+        destination_account_id: to.id,
+        date: date,
+        amount: amount,
+        exchange_rate: exchange_rate
+      ).create
+
+      raise "Transfer creation failed from #{from.name} to #{to.name}" unless transfer.persisted?
+
+      transfer
+    end
+
+    def month_day(months_ago, day)
+      month = today << months_ago
+      safe_day = [ day, Time.days_in_month(month.month, month.year) ].min
+      computed = Date.new(month.year, month.month, safe_day)
+
+      months_ago.zero? ? [ computed, today ].min : computed
+    end
+
+    def print_summary!
+      transfer_count = Transfer
+        .joins(outflow_transaction: { entry: :account })
+        .where(accounts: { family_id: family.id })
+        .count
+
+      puts ""
+      puts "Compact sample data load complete"
+      puts "Accounts: #{family.accounts.count}"
+      puts "Categories: #{family.categories.count}"
+      puts "Transactions: #{family.transactions.count}"
+      puts "Transfers: #{transfer_count}"
+      puts "Transaction kinds: #{family.transactions.group(:kind).count}"
+      puts ""
+      puts "Account balances:"
+      family.accounts.order(:name).each do |account|
+        puts "- #{account.name} (#{account.accountable_type}) -> #{account.balance.to_f.round(2)} #{account.currency}"
+      end
+    end
+end
+
+email = ENV.fetch("SAMPLE_EMAIL", "user@example.com")
+CompactSampleDataLoader.new(email: email).run!

--- a/script/load_compact_sample_data.rb
+++ b/script/load_compact_sample_data.rb
@@ -317,7 +317,7 @@ class CompactSampleDataLoader
       if account.loan? || account.other_liability?
         0
       elsif account.investment? || account.crypto?
-        account.cash_balance
+        final_balance
       else
         final_balance
       end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "cgi"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
   include EntriesTestHelper
@@ -43,6 +44,219 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-controller='sankey-chart']"
   end
 
+  test "dashboard shows transfer outflow in sankey for selected source account" do
+    source_account = @family.accounts.create!(
+      name: "Sankey Source Account",
+      currency: @family.currency,
+      balance: 2000,
+      accountable: Depository.new
+    )
+    destination_account = @family.accounts.create!(
+      name: "Sankey Credit Card",
+      currency: @family.currency,
+      balance: 800,
+      accountable: CreditCard.new
+    )
+
+    Transfer::Creator.new(
+      family: @family,
+      source_account_id: source_account.id,
+      destination_account_id: destination_account.id,
+      date: Date.current,
+      amount: 250
+    ).create
+
+    get root_path, params: { account_id: source_account.id }
+
+    assert_response :ok
+    sankey_data = extract_sankey_data
+    assert_not_nil sankey_data
+
+    cash_flow_idx = sankey_data["nodes"].index { |node| node["name"] == "Cash Flow" }
+    destination_idx = sankey_data["nodes"].index { |node| node["name"] == "#{I18n.t("pages.dashboard.cashflow_sankey.to_label")} #{destination_account.name}" }
+
+    assert_not_nil cash_flow_idx
+    assert_not_nil destination_idx
+    assert(
+      sankey_data["links"].any? { |link| link["source"] == cash_flow_idx && link["target"] == destination_idx },
+      "Expected a cash-flow outbound transfer link to the selected account's counterparty"
+    )
+  end
+
+  test "dashboard shows transfer inflow in sankey for selected destination account" do
+    source_account = @family.accounts.create!(
+      name: "Sankey Checking",
+      currency: @family.currency,
+      balance: 2000,
+      accountable: Depository.new
+    )
+    destination_account = @family.accounts.create!(
+      name: "Sankey Card",
+      currency: @family.currency,
+      balance: 800,
+      accountable: CreditCard.new
+    )
+
+    Transfer::Creator.new(
+      family: @family,
+      source_account_id: source_account.id,
+      destination_account_id: destination_account.id,
+      date: Date.current,
+      amount: 300
+    ).create
+
+    get root_path, params: { account_id: destination_account.id }
+
+    assert_response :ok
+    sankey_data = extract_sankey_data
+    assert_not_nil sankey_data
+
+    source_idx = sankey_data["nodes"].index { |node| node["name"] == "#{I18n.t("pages.dashboard.cashflow_sankey.from_label")} #{source_account.name}" }
+    cash_flow_idx = sankey_data["nodes"].index { |node| node["name"] == "Cash Flow" }
+
+    assert_not_nil source_idx
+    assert_not_nil cash_flow_idx
+    assert(
+      sankey_data["links"].any? { |link| link["source"] == source_idx && link["target"] == cash_flow_idx },
+      "Expected an inbound transfer link from counterparty account to cash flow"
+    )
+  end
+
+  test "dashboard split mode hides transfer nodes to reduce clutter" do
+    source_account = @family.accounts.create!(
+      name: "Sankey Split Source",
+      currency: @family.currency,
+      balance: 2000,
+      accountable: Depository.new
+    )
+    destination_account = @family.accounts.create!(
+      name: "Sankey Split Card",
+      currency: @family.currency,
+      balance: 800,
+      accountable: CreditCard.new
+    )
+
+    Transfer::Creator.new(
+      family: @family,
+      source_account_id: source_account.id,
+      destination_account_id: destination_account.id,
+      date: Date.current,
+      amount: 225
+    ).create
+
+    income_category = @family.categories.create!(name: "Split Overlay Income", color: "#0EA5E9")
+    expense_category = @family.categories.create!(name: "Split Overlay Expense", color: "#F97316")
+    create_transaction(account: source_account, amount: -400, category: income_category)
+    create_transaction(account: destination_account, amount: 120, category: expense_category)
+
+    get root_path, params: { sankey_mode: "split" }
+
+    assert_response :ok
+    sankey_data = extract_sankey_data
+    assert_not_nil sankey_data
+
+    transfer_prefixes = [
+      I18n.t("pages.dashboard.cashflow_sankey.from_label"),
+      I18n.t("pages.dashboard.cashflow_sankey.to_label")
+    ]
+
+    transfer_nodes = sankey_data["nodes"].select do |node|
+      transfer_prefixes.any? { |prefix| node["name"].start_with?(prefix) }
+    end
+
+    assert_empty transfer_nodes, "Expected split mode to hide transfer helper nodes"
+
+    transfer_overlays = sankey_data["transfer_overlays"] || []
+    assert(
+      transfer_overlays.any? do |overlay|
+        overlay["source_name"] == source_account.name && overlay["target_name"] == destination_account.name
+      end,
+      "Expected split mode to include net account-to-account transfer overlays"
+    )
+  end
+
+  test "dashboard split mode shares expense category nodes across accounts" do
+    shared_category = @family.categories.create!(
+      name: "Split Shared Expense Category",
+      color: "#3355FF"
+    )
+    first_account = @family.accounts.create!(
+      name: "Split Category Account One",
+      currency: @family.currency,
+      balance: 2200,
+      accountable: Depository.new
+    )
+    second_account = @family.accounts.create!(
+      name: "Split Category Account Two",
+      currency: @family.currency,
+      balance: 1600,
+      accountable: Depository.new
+    )
+
+    create_transaction(account: first_account, amount: 120, category: shared_category)
+    create_transaction(account: second_account, amount: 80, category: shared_category)
+
+    get root_path, params: { sankey_mode: "split" }
+
+    assert_response :ok
+    sankey_data = extract_sankey_data
+    assert_not_nil sankey_data
+
+    category_node_indices = sankey_data["nodes"].each_index.select do |index|
+      sankey_data["nodes"][index]["name"] == shared_category.name
+    end
+
+    first_account_idx = sankey_data["nodes"].index { |node| node["name"] == first_account.name }
+    second_account_idx = sankey_data["nodes"].index { |node| node["name"] == second_account.name }
+
+    assert_equal 1, category_node_indices.size
+    assert_not_nil first_account_idx
+    assert_not_nil second_account_idx
+
+    category_idx = category_node_indices.first
+    assert(
+      sankey_data["links"].any? { |link| link["source"] == first_account_idx && link["target"] == category_idx },
+      "Expected first account to link to shared expense category"
+    )
+    assert(
+      sankey_data["links"].any? { |link| link["source"] == second_account_idx && link["target"] == category_idx },
+      "Expected second account to link to shared expense category"
+    )
+  end
+
+  test "dashboard split mode keeps all expense categories visible" do
+    account = @family.accounts.create!(
+      name: "Split Expense Coverage Account",
+      currency: @family.currency,
+      balance: 5000,
+      accountable: Depository.new
+    )
+
+    expense_categories = 6.times.map do |idx|
+      @family.categories.create!(name: "Split Expense Category #{idx}", color: format("#AA%02X%02X", idx + 10, idx + 20))
+    end
+
+    expense_categories.each_with_index do |category, idx|
+      create_transaction(
+        account: account,
+        amount: 30 + idx,
+        category: category,
+        date: Date.current - idx.days
+      )
+    end
+
+    get root_path, params: { sankey_mode: "split" }
+
+    assert_response :ok
+    sankey_data = extract_sankey_data
+    assert_not_nil sankey_data
+
+    node_names = sankey_data["nodes"].map { |node| node["name"] }
+    expense_categories.each do |category|
+      assert_includes node_names, category.name
+    end
+  end
+
   test "changelog" do
     VCR.use_cassette("git_repository_provider/fetch_latest_release_notes") do
       get changelog_path
@@ -80,4 +294,12 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: "Test Release"
     # Should not crash even with nil values
   end
+
+  private
+    def extract_sankey_data
+      chart = Nokogiri::HTML(response.body).at_css("[data-controller='sankey-chart']")
+      return nil unless chart
+
+      JSON.parse(CGI.unescapeHTML(chart["data-sankey-chart-data-value"]))
+    end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -166,12 +166,13 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_empty transfer_nodes, "Expected split mode to hide transfer helper nodes"
 
-    transfer_overlays = sankey_data["transfer_overlays"] || []
     assert(
-      transfer_overlays.any? do |overlay|
-        overlay["source_name"] == source_account.name && overlay["target_name"] == destination_account.name
+      sankey_data["links"].any? do |link|
+        source = sankey_data["nodes"][link["source"]]
+        target = sankey_data["nodes"][link["target"]]
+        source && target && source["name"] == source_account.name && target["name"] == destination_account.name
       end,
-      "Expected split mode to include net account-to-account transfer overlays"
+      "Expected split mode to include net account-to-account transfer links"
     )
   end
 

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -15,6 +15,14 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test "dashboard renders sankey mode toggle links" do
+    get root_path
+
+    assert_response :ok
+    assert_select "#cashflow-sankey-chart a[href*='sankey_mode=aggregate']", count: 1
+    assert_select "#cashflow-sankey-chart a[href*='sankey_mode=split']", count: 1
+  end
+
   test "intro page requires guest role" do
     get intro_path
 

--- a/test/models/demo/generator_test.rb
+++ b/test/models/demo/generator_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class Demo::GeneratorTest < ActiveSupport::TestCase
+  setup do
+    @generator = Demo::Generator.new(seed: 123)
+  end
+
+  test "create_transfer! marks credit card payments as transfer kinds" do
+    transfer = nil
+
+    assert_difference "Transfer.count", 1 do
+      transfer = @generator.send(
+        :create_transfer!,
+        accounts(:depository),
+        accounts(:credit_card),
+        250,
+        "Amex Payment",
+        Date.current
+      )
+    end
+
+    assert_equal "cc_payment", transfer.outflow_transaction.kind
+    assert_equal "funds_movement", transfer.inflow_transaction.kind
+    assert transfer.outflow_transaction.transfer?
+    assert transfer.inflow_transaction.transfer?
+    assert_equal "confirmed", transfer.status
+  end
+
+  test "create_transfer! marks contributions to investment accounts" do
+    family = accounts(:depository).family
+    expected_category = ensure_investment_contributions_category(family)
+    transfer = nil
+
+    assert_difference "Transfer.count", 1 do
+      transfer = @generator.send(
+        :create_transfer!,
+        accounts(:depository),
+        accounts(:investment),
+        500,
+        "HSA Contribution",
+        Date.current
+      )
+    end
+
+    assert_equal "investment_contribution", transfer.outflow_transaction.kind
+    assert_equal expected_category.id, transfer.outflow_transaction.category_id
+    assert_equal "funds_movement", transfer.inflow_transaction.kind
+  end
+
+  test "create_transfer! keeps investment rollovers as funds movement" do
+    transfer = nil
+
+    assert_difference "Transfer.count", 1 do
+      transfer = @generator.send(
+        :create_transfer!,
+        accounts(:investment),
+        accounts(:crypto),
+        300,
+        "Rollover",
+        Date.current
+      )
+    end
+
+    assert_equal "funds_movement", transfer.outflow_transaction.kind
+    assert_equal "funds_movement", transfer.inflow_transaction.kind
+  end
+end

--- a/test/models/demo/generator_test.rb
+++ b/test/models/demo/generator_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Demo::GeneratorTest < ActiveSupport::TestCase
   setup do
-    @generator = Demo::Generator.new(seed: 123)
+    @generator = Demo::Generator.new(seed: 123, seed_global_rng: false)
   end
 
   test "create_transfer! marks credit card payments as transfer kinds" do

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -28,6 +28,15 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_equal 4, totals.transactions_count
   end
 
+  test "filters totals by provided account ids" do
+    income_statement = IncomeStatement.new(@family, account_ids: [ @checking_account.id ])
+    totals = income_statement.totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal Money.new(1000, @family.currency), totals.income_money
+    assert_equal Money.new(200, @family.currency), totals.expense_money
+    assert_equal 2, totals.transactions_count
+  end
+
   test "calculates expenses for a period" do
     income_statement = IncomeStatement.new(@family)
     expense_totals = income_statement.expense_totals(period: Period.last_30_days)


### PR DESCRIPTION
## Summary

Improves split-mode Sankey behavior and expanded-dialog usability for dashboard cashflow.

This PR is the upstream/main-targeted version of the stacked implementation previously opened against `feature/cashflow-account-filter-v2`.

## Why this change

Users reported several UX issues in split mode:

1. Transfer visualization semantics were inconsistent (overlay concept vs Sankey links).
2. Accounts with transfer-only activity could disappear from split mode.
3. Expanded Sankey dialog could grow vertically and feel unstable.
4. Helper copy referenced old curved-transfer behavior.

These changes make split mode easier to understand and more stable to use.

## What changed

### 1) Use direct Sankey links for account-to-account transfers in split mode

- In split mode, transfer flows are now appended directly into `links` in the Sankey payload.
- Removed split `transfer_overlays` payload generation.

### 2) Keep accounts that have transfer-only activity

- Account node inclusion now considers both category flows and transfer flows.
- Prevents missing account lanes when accounts only participate in transfers.

### 3) Remove obsolete transfer overlay rendering on the frontend

- Deleted overlay-specific draw/hover code in `sankey_chart_controller.js`.
- Unified hover/interaction model around standard Sankey links.

### 4) Fix expanded dialog vertical expansion behavior

- Removed forced chart-height logic that expanded dialog content based on node count.
- Removed the inner scroll/min-height wrapper from expanded Sankey markup.

### 5) Update split-mode helper copy

- Updated hint text to match current behavior: account lanes + direct net account-to-account links.

## Security / cleanup notes

- CSRF bypass and trusted-proxy workaround edits were explicitly removed before this PR.
- This PR contains only the required split-Sankey/UX changes.

## Files changed

- `app/controllers/pages_controller.rb`
- `app/javascript/controllers/sankey_chart_controller.js`
- `app/views/pages/dashboard/_cashflow_sankey.html.erb`
- `config/locales/views/pages/en.yml`
- `test/controllers/pages_controller_test.rb`

## Validation

- `bin/rails test test/controllers/pages_controller_test.rb`
- Result: 12 runs, 51 assertions, 0 failures, 0 errors, 0 skips

## UX impact

- Clearer mental model in split mode: all flows are represented as links in one Sankey system.
- Better completeness: transfer-only accounts remain visible.
- Better expanded experience: no forced vertical growth and less nested-scroll friction.

## Related context

- Related work: https://github.com/we-promise/sure/pull/1461
- Stacked branch PR (fork branch target): https://github.com/fenris-svartvarg/sure/pull/1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account filter for cashflow chart and a new "split" mode showing per-account lanes and direct transfers.

* **UI**
  * Mode toggle, account selector, split-mode hint, simplified chart/dialog sizing, improved Sankey label/ordering and safer tooltips.

* **Documentation**
  * Added Sankey UI labels and expanded French translations for transactions.

* **Tests**
  * New Sankey integration tests, IncomeStatement account-filter test, and demo transfer generator tests.

* **Chores**
  * Added compact sample data loader for development/testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->