### PR TITLE
Fix loan account subtype not persisting on create

### DIFF
--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -2,6 +2,6 @@ class LoansController < ApplicationController
   include AccountableResource
 
   permitted_accountable_attributes(
-    :id, :rate_type, :interest_rate, :term_months, :initial_balance
+    :id, :subtype, :rate_type, :interest_rate, :term_months, :initial_balance
   )
 end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -8,6 +8,8 @@ class Loan < ApplicationRecord
     "other" => { short: "Other Loan", long: "Other Loan" }
   }.freeze
 
+  validates :subtype, inclusion: { in: SUBTYPES.keys }, allow_blank: true
+
   def monthly_payment
     return nil if term_months.nil? || interest_rate.nil? || rate_type.nil? || rate_type != "fixed"
     return Money.new(0, account.currency) if account.loan.original_balance.amount.zero? || term_months.zero?

--- a/test/controllers/loans_controller_test.rb
+++ b/test/controllers/loans_controller_test.rb
@@ -23,6 +23,7 @@ class LoansControllerTest < ActionDispatch::IntegrationTest
           notes: "Mortgage notes",
           accountable_type: "Loan",
           accountable_attributes: {
+            subtype: "mortgage",
             interest_rate: 5.5,
             term_months: 60,
             rate_type: "fixed",
@@ -40,6 +41,7 @@ class LoansControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Local Bank", created_account[:institution_name]
     assert_equal "localbank.example", created_account[:institution_domain]
     assert_equal "Mortgage notes", created_account[:notes]
+    assert_equal "mortgage", created_account.accountable.subtype
     assert_equal 5.5, created_account.accountable.interest_rate
     assert_equal 60, created_account.accountable.term_months
     assert_equal "fixed", created_account.accountable.rate_type
@@ -63,6 +65,7 @@ class LoansControllerTest < ActionDispatch::IntegrationTest
           accountable_type: "Loan",
           accountable_attributes: {
             id: @account.accountable_id,
+            subtype: "auto",
             interest_rate: 4.5,
             term_months: 48,
             rate_type: "fixed",
@@ -79,6 +82,7 @@ class LoansControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated Bank", @account[:institution_name]
     assert_equal "updatedbank.example", @account[:institution_domain]
     assert_equal "Updated loan notes", @account[:notes]
+    assert_equal "auto", @account.accountable.subtype
     assert_equal 4.5, @account.accountable.interest_rate
     assert_equal 48, @account.accountable.term_months
     assert_equal "fixed", @account.accountable.rate_type

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -1,6 +1,13 @@
 require "test_helper"
 
 class LoanTest < ActiveSupport::TestCase
+  test "rejects invalid subtype" do
+    loan = Loan.new(subtype: "invalid")
+
+    assert_not loan.valid?
+    assert_includes loan.errors[:subtype], "is not included in the list"
+  end
+
   test "calculates correct monthly payment for fixed rate loan" do
     loan_account = Account.create! \
       family: families(:dylan_family),
@@ -8,6 +15,7 @@ class LoanTest < ActiveSupport::TestCase
       balance: 500000,
       currency: "USD",
       accountable: Loan.create!(
+        subtype: "mortgage",
         interest_rate: 3.5,
         term_months: 360,
         rate_type: "fixed"


### PR DESCRIPTION
The LoansController was missing :subtype in permitted_accountable_attributes,
causing form submissions with account[subtype] to be silently ignored.

This is the same bug that was fixed for Investment accounts in PR #1039
and Crypto accounts in PR #1022.

Fixes: loan account subtype not saving (v0.7.0-alpha.4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loan subtypes to improve categorization and management.

* **Bug Fixes**
  * Subtype input is now validated against the allowed list, preventing invalid subtype values.

* **Tests**
  * Coverage added/updated to assert subtype handling on create/update and model validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->