### PR TITLE
chore(pipelock): bump chart default to v2.2.0, add CI scan badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/we-promise/sure)
 [![View performance data on Skylight](https://badges.skylight.io/typical/s6PEZSKwcklL.svg)](https://oss.skylight.io/app/applications/s6PEZSKwcklL)
 [![Dosu](https://raw.githubusercontent.com/dosu-ai/assets/main/dosu-badge.svg)](https://app.dosu.dev/a72bdcfd-15f5-4edc-bd85-ea0daa6c3adc/ask)
+[![Pipelock Security Scan](https://github.com/we-promise/sure/actions/workflows/pipelock.yml/badge.svg)](https://github.com/we-promise/sure/actions/workflows/pipelock.yml)
 
 <img width="1270" height="1140" alt="sure_shot" src="https://github.com/user-attachments/assets/9c6e03cc-3490-40ab-9a68-52e042c51293" />
 

--- a/charts/sure/CHANGELOG.md
+++ b/charts/sure/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Sure Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Bumped `pipelock.image.tag` from `2.0.0` to `2.2.0` (three minor releases behind latest). Floating `@v2` CI action pin picks up patch/minor updates automatically.
+- Refreshed pipelock feature notes in the chart README, `docs/hosting/pipelock.md`, and `pipelock.example.yaml` to reference the upstream changelog instead of a single version.
+
+### Added
+- README: CI scan status badge for the pipelock workflow.
+
 ## [0.6.9-alpha] - 2026-03-24
 
 ### Changed

--- a/charts/sure/README.md
+++ b/charts/sure/README.md
@@ -645,7 +645,7 @@ hpa:
 - **Forward proxy** (port 8888): Scans outbound HTTPS from Faraday-based AI clients. Auto-injected via `HTTPS_PROXY` env vars when enabled.
 - **MCP reverse proxy** (port 8889): Scans inbound MCP traffic from external AI assistants.
 
-v2.0 adds enhanced tool poisoning detection (full JSON schema scanning), per-read kill switch preemption on long-lived connections, trusted domain allowlisting, and MCP tool redirect profiles. Process sandboxing and attack simulation are also available via `extraConfig` and CLI.
+Recent pipelock releases add enhanced tool poisoning detection (full JSON schema scanning), per-read kill switch preemption, trusted domain allowlisting, MCP tool redirect profiles, signed action receipts, per-pattern DLP warn mode, and the `pipelock posture verify` / `pipelock session` CLIs. Process sandboxing and attack simulation are also available via `extraConfig` and CLI. See the [pipelock changelog](https://github.com/luckyPipewrench/pipelock/releases) for details.
 
 ### Enabling Pipelock
 
@@ -653,7 +653,7 @@ v2.0 adds enhanced tool poisoning detection (full JSON schema scanning), per-rea
 pipelock:
   enabled: true
   image:
-    tag: "2.0.0"
+    tag: "2.2.0"
   mode: balanced   # strict, balanced, or audit
 ```
 
@@ -685,7 +685,7 @@ pipelock:
 
 ### Validating your config
 
-Pipelock v2.0 includes two CLI tools for config validation:
+Pipelock includes CLI tools for config validation:
 
 ```bash
 # Run 24 synthetic attack scenarios against your config

--- a/charts/sure/values.yaml
+++ b/charts/sure/values.yaml
@@ -497,7 +497,7 @@ pipelock:
   enabled: false
   image:
     repository: ghcr.io/luckypipewrench/pipelock
-    tag: "2.0.0"
+    tag: "2.2.0"
     pullPolicy: IfNotPresent
     imagePullSecrets: []
   replicas: 1

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -112,7 +112,7 @@ x-rails-env: &rails_env
 
 services:
   pipelock:
-    image: ghcr.io/luckypipewrench/pipelock:latest  # pin to a specific version (e.g., :2.0.0) for production
+    image: ghcr.io/luckypipewrench/pipelock:latest  # pin to a specific version (e.g., :2.2.0) for production
     container_name: pipelock
     hostname: pipelock
     restart: unless-stopped

--- a/docs/hosting/pipelock.md
+++ b/docs/hosting/pipelock.md
@@ -77,13 +77,13 @@ Enable Pipelock in your Helm values:
 pipelock:
   enabled: true
   image:
-    tag: "2.0.0"
+    tag: "2.2.0"
   mode: balanced
 ```
 
 This creates a separate Deployment, Service, and ConfigMap. The chart auto-injects `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` into web and worker pods.
 
-v2.0 adds trusted domain allowlisting, MCP tool redirect profiles, enhanced tool poisoning detection (full JSON schema scanning), and per-read kill switch preemption on long-lived connections. Process sandboxing and attack simulation are also available via `extraConfig` and CLI.
+Recent pipelock releases add trusted domain allowlisting, MCP tool redirect profiles, enhanced tool poisoning detection (full JSON schema scanning), per-read kill switch preemption, signed action receipts, per-pattern DLP warn mode, and the `pipelock posture verify` / `pipelock session` CLI commands. See the [pipelock changelog](https://github.com/luckyPipewrench/pipelock/releases) for details.
 
 ### Exposing MCP to external agents (Kubernetes)
 

--- a/pipelock.example.yaml
+++ b/pipelock.example.yaml
@@ -1,8 +1,10 @@
 # Pipelock configuration for Docker Compose
 # See https://github.com/luckyPipewrench/pipelock for full options.
 #
-# New in v2.0: trusted_domains, redirect profiles, attack simulation,
-# security scoring, process sandbox, and enhanced tool poisoning detection.
+# Recent additions: trusted_domains, redirect profiles, attack simulation,
+# security scoring, process sandbox, enhanced tool poisoning detection, signed
+# action receipts, per-pattern DLP warn mode, and the `pipelock posture verify`
+# / `pipelock session` CLIs.
 # Run `pipelock simulate --config <file>` to test your config against 24 attack scenarios.
 # Run `pipelock audit score --config <file>` for a security posture score (0-100).
 
@@ -54,7 +56,7 @@ mcp_tool_scanning:
 mcp_tool_policy:
   enabled: false
   action: warn
-  # Redirect profiles (v2.0): route matched tool calls to audited handler programs
+  # Redirect profiles: route matched tool calls to audited handler programs
   # instead of blocking. The handler returns a synthetic MCP response.
   # redirect_profiles:
   #   safe-fetch:


### PR DESCRIPTION
## Summary

Bumps the Sure Helm chart's pipelock image default from `2.0.0` to `2.2.0` (three minor releases behind latest), adds a CI scan status badge to the README, and refreshes version-specific notes in the chart README, hosting docs, and `pipelock.example.yaml` to reference the upstream changelog instead of pinning to a single version.

## Why

Pipelock has shipped v2.1 and v2.2 since the last chart bump. Users installing the chart with defaults get a release that's missing several months of fixes and features. The `@v2` workflow pin already floats across minor versions, so CI was already picking up v2.2 — but the chart default was stuck on v2.0.0.

## What's new in pipelock since v2.0 (major items)

- **Signed action receipts** from the MCP proxy (cryptographic audit trail for tool calls)
- **Per-pattern DLP warn mode** for safer rule rollouts
- **`pipelock posture verify`** — CI gate for posture scoring
- **`pipelock session`** — airlock inspection and recovery CLI
- **Init sidecar + agent identity bootstrap**
- **Stego stripping + SVG active-content hardening**

Full changelog: https://github.com/luckyPipewrench/pipelock/releases

<img width="429" height="540" alt="image" src="https://github.com/user-attachments/assets/d19a615f-4b95-4232-b61e-d0d20fba6a89" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Pipelock feature documentation to reflect v2.2.0 capabilities, including signed action receipts, per-pattern DLP warn mode, and new CLI commands.
  * Updated Pipelock configuration examples to version 2.2.0.

* **Chores**
  * Added CI security scan status badge to repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->