### PR TITLE
Feature: AI sidebar hidden by default for members and guests if AI is disabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -379,6 +379,10 @@ class User < ApplicationRecord
         self.show_sidebar = true unless show_sidebar
         self.show_ai_sidebar = true unless show_ai_sidebar
       end
+
+      if new_record? && member? && !ai_available?
+        self.show_ai_sidebar = false
+      end
     end
 
     def leaving_guest_role?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -289,6 +289,38 @@ class UserTest < ActiveSupport::TestCase
     assert user.show_ai_sidebar?
   end
 
+  test "new guest defaults show_ai_sidebar to false when AI is not available" do
+    Rails.application.config.app_mode.stubs(:self_hosted?).returns(true)
+    previous = Setting.openai_access_token
+    with_env_overrides OPENAI_ACCESS_TOKEN: nil, EXTERNAL_ASSISTANT_URL: nil, EXTERNAL_ASSISTANT_TOKEN: nil do
+      Setting.openai_access_token = nil
+      user = User.new(
+        family: families(:empty),
+        email: "guest-no-ai@example.com",
+        password: "Password1!",
+        password_confirmation: "Password1!",
+        role: :guest
+      )
+      assert user.save, user.errors.full_messages.to_sentence
+      assert_not user.show_ai_sidebar?
+    end
+  ensure
+    Setting.openai_access_token = previous
+  end
+
+  test "new guest defaults show_ai_sidebar to false when AI is available" do
+    Rails.application.config.app_mode.stubs(:self_hosted?).returns(false)
+    user = User.new(
+      family: families(:empty),
+      email: "guest-with-ai@example.com",
+      password: "Password1!",
+      password_confirmation: "Password1!",
+      role: :guest
+    )
+    assert user.save, user.errors.full_messages.to_sentence
+    assert_not user.show_ai_sidebar?
+  end
+
   test "update_dashboard_preferences handles concurrent updates atomically" do
     @user.update!(preferences: {})
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -238,6 +238,57 @@ class UserTest < ActiveSupport::TestCase
     assert user.show_ai_sidebar?
   end
 
+  test "new member defaults show_ai_sidebar to false when AI is not available" do
+    Rails.application.config.app_mode.stubs(:self_hosted?).returns(true)
+    previous = Setting.openai_access_token
+    with_env_overrides OPENAI_ACCESS_TOKEN: nil, EXTERNAL_ASSISTANT_URL: nil, EXTERNAL_ASSISTANT_TOKEN: nil do
+      Setting.openai_access_token = nil
+      user = User.new(
+        family: families(:empty),
+        email: "member-no-ai@example.com",
+        password: "Password1!",
+        password_confirmation: "Password1!",
+        role: :member
+      )
+      assert user.save, user.errors.full_messages.to_sentence
+      assert_not user.show_ai_sidebar?
+    end
+  ensure
+    Setting.openai_access_token = previous
+  end
+
+  test "new admin defaults show_ai_sidebar to true even when AI is not available" do
+    Rails.application.config.app_mode.stubs(:self_hosted?).returns(true)
+    previous = Setting.openai_access_token
+    with_env_overrides OPENAI_ACCESS_TOKEN: nil, EXTERNAL_ASSISTANT_URL: nil, EXTERNAL_ASSISTANT_TOKEN: nil do
+      Setting.openai_access_token = nil
+      user = User.new(
+        family: families(:empty),
+        email: "admin-no-ai@example.com",
+        password: "Password1!",
+        password_confirmation: "Password1!",
+        role: :admin
+      )
+      assert user.save, user.errors.full_messages.to_sentence
+      assert user.show_ai_sidebar?
+    end
+  ensure
+    Setting.openai_access_token = previous
+  end
+
+  test "new member defaults show_ai_sidebar to true when AI is available" do
+    Rails.application.config.app_mode.stubs(:self_hosted?).returns(false)
+    user = User.new(
+      family: families(:empty),
+      email: "member-with-ai@example.com",
+      password: "Password1!",
+      password_confirmation: "Password1!",
+      role: :member
+    )
+    assert user.save, user.errors.full_messages.to_sentence
+    assert user.show_ai_sidebar?
+  end
+
   test "update_dashboard_preferences handles concurrent updates atomically" do
     @user.update!(preferences: {})
 


### PR DESCRIPTION
https://github.com/we-promise/sure/discussions/203#discussioncomment-16612308 refers.

When AI is disabled, new guest and member accounts now have the AI sidebar hidden i.e. the value of `show_ai_sidebar` is set to `false` for those accounts. However, administrator accounts still have the AI sidebar shown by default, regardless of the value of `ai_enabled`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the AI sidebar is hidden by default for newly created member users when AI is not available.

* **Tests**
  * Added tests covering AI sidebar default behavior for member, guest, and admin roles under AI-available and AI-unavailable conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->