### PR TITLE
Fix misleading 'AI' copy in budget autosuggest

### DIFF
--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -2,6 +2,6 @@ class LoansController < ApplicationController
   include AccountableResource
 
   permitted_accountable_attributes(
-    :id, :rate_type, :interest_rate, :term_months, :initial_balance
+    :id, :subtype, :rate_type, :interest_rate, :term_months, :initial_balance
   )
 end

--- a/app/views/budgets/edit.html.erb
+++ b/app/views/budgets/edit.html.erb
@@ -25,7 +25,7 @@
             <div class="ml-2 space-y-1 text-sm">
               <h4 class="text-primary">Autosuggest income & spending budget</h4>
               <p class="text-secondary">
-                This will be based on transaction history. AI can make mistakes, verify before continuing.
+                Calculation based solely on medians, adjust as appropriate.
               </p>
             </div>
 


### PR DESCRIPTION
Replaced 'AI can make mistakes, verify before continuing.' with 'Calculation based solely on medians, adjust as appropriate.'

The autosuggest feature uses simple median calculations on transaction history, not an LLM or AI model.