### PR TITLE
docs(security): add attack surface map

### DIFF
--- a/docs/security/ATTACK-SURFACE.md
+++ b/docs/security/ATTACK-SURFACE.md
@@ -1,0 +1,58 @@
+# ATTACK-SURFACE.md (template)
+
+> Goal: keep a short, accurate map of what can be attacked and how it is protected.
+
+## Service summary
+- Name:
+- Repo:
+- Owner/team:
+- Env(s): local / staging / prod
+
+## Entry points
+### Public HTTP
+- Base URL(s):
+- Reverse proxy / ingress:
+- Auth method(s): (JWT, OAuth, session cookie, API key)
+
+### Webhooks (inbound)
+List all inbound webhooks and how they’re verified:
+- Provider / path:
+- Verification: (signature / secret token / none)
+- Replay protection: (timestamp/nonce)
+- Rate limiting: (edge/app)
+
+### Background jobs / queues
+- Queue tech:
+- Who can enqueue jobs:
+
+## Authentication & authorization
+- User model / tenants:
+- Access control strategy:
+- Known sensitive endpoints:
+
+## Data stores
+- DB(s):
+- Object store / file storage:
+- Secrets storage:
+
+## File uploads
+- Endpoints:
+- Allowed content-types:
+- Validation: magic-bytes / size caps / AV scanning:
+
+## Rate limiting & abuse controls
+- Edge rate limiting:
+- App rate limiting:
+- Trusted proxy handling:
+
+## Observability
+- Audit logging:
+- Security alerts:
+
+## Hardening checklist
+- [ ] Disable docs/openapi in prod
+- [ ] Security headers
+- [ ] CORS allowlist tight
+- [ ] Webhooks authenticated
+- [ ] Token revocation enforced
+- [ ] Backups + restore tested


### PR DESCRIPTION

## Summary

Part 7 of 7 in the pentest re-submission from the closed #1104 (split by functional area per @jjmata). **Documentation only** — no code changes.

Adds `docs/security/ATTACK-SURFACE.md`: a living reference for trust boundaries, auth paths, and data flows. Useful context for reviewing the companion code PRs and for any future security work.

See #1087 for the full index.

## Why only this doc

The original #1104 bundle also carried six dated pentest reports and a template. Those were working notes from my audit iterations — not reference material the project needs to carry. The finding IDs (FIX-XX / F-XX / CRIT-02 / HIGH-XX) referenced in the companion code PRs are self-explanatory with CWE IDs and file locations; no separate report file is needed for traceability.

## Out of scope

All code-level fixes live in companion PRs (PR-1 through PR-6).

## Related

- #1087 — Security Audit Report (index)
- #1104 — Original bundled PR (closed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new security documentation template for documenting application attack surfaces, including structured sections covering service metadata, inbound entry points, authentication and authorization, data storage inventory, file upload handling, rate limiting controls, observability practices, and security hardening checklist items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->