### PR TITLE
security: session & cookie hardening (fixation, TTL, MFA rate limit, impersonation auth)

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -39,7 +39,12 @@ module Authentication
 
     def create_session_for(user)
       session = user.sessions.create!
-      cookies.signed.permanent[:session_token] = { value: session.id, httponly: true }
+      cookies.signed.permanent[:session_token] = {
+        value: session.id,
+        httponly: true,
+        secure: Rails.env.production?,
+        same_site: :lax
+      }
       session
     end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -30,13 +30,22 @@ module Authentication
     # Session TTL constants (F-04, CWE-613)
     SESSION_ABSOLUTE_TTL = 30.days
     SESSION_IDLE_TTL = 24.hours
+    # Throttle the per-request `updated_at` touch so every authenticated request
+    # doesn't issue a write against `sessions`. 1 minute is granular enough for
+    # the 24h idle TTL while keeping write amplification bounded.
+    SESSION_TOUCH_THROTTLE = 1.minute
 
     def find_session_by_cookie
       cookie_value = cookies.signed[:session_token]
       return nil unless cookie_value.present?
 
       session = Session.find_by(id: cookie_value)
-      return nil unless session
+      unless session
+        # Stale cookie (session row was deleted or recycled) — remove it so the
+        # browser doesn't keep resending a dead token.
+        cookies.delete(:session_token)
+        return nil
+      end
 
       now = Time.current
 
@@ -54,9 +63,20 @@ module Authentication
         return nil
       end
 
-      # Touch to refresh idle timer on each request
-      session.touch
+      # Refresh idle timer, throttled to avoid a write per request.
+      session.touch if session.updated_at < now - SESSION_TOUCH_THROTTLE
       session
+    end
+
+    # Resets the Rails session to prevent session fixation on privilege change
+    # (login, MFA verify) while preserving the pending invitation token stored
+    # pre-login. `reset_session` clears everything by default, which would drop
+    # a legitimate pending invitation before `accept_pending_invitation_for`
+    # could use it.
+    def reset_session_preserving_pending_invitation
+      pending_invitation = session[:pending_invitation_token]
+      reset_session
+      session[:pending_invitation_token] = pending_invitation if pending_invitation
     end
 
     def create_session_for(user)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -27,14 +27,36 @@ module Authentication
       end
     end
 
+    # Session TTL constants (F-04, CWE-613)
+    SESSION_ABSOLUTE_TTL = 30.days
+    SESSION_IDLE_TTL = 24.hours
+
     def find_session_by_cookie
       cookie_value = cookies.signed[:session_token]
+      return nil unless cookie_value.present?
 
-      if cookie_value.present?
-        Session.find_by(id: cookie_value)
-      else
-        nil
+      session = Session.find_by(id: cookie_value)
+      return nil unless session
+
+      now = Time.current
+
+      # Absolute TTL: session older than 30 days is always expired
+      if session.created_at < now - SESSION_ABSOLUTE_TTL
+        session.destroy
+        cookies.delete(:session_token)
+        return nil
       end
+
+      # Idle TTL: session not used in 24h is expired
+      if session.updated_at < now - SESSION_IDLE_TTL
+        session.destroy
+        cookies.delete(:session_token)
+        return nil
+      end
+
+      # Touch to refresh idle timer on each request
+      session.touch
+      session
     end
 
     def create_session_for(user)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -85,6 +85,7 @@ module Authentication
       id_token_hint
       sso_login_provider
     ].freeze
+    private_constant :SESSION_KEYS_PRESERVED_ON_RESET
 
     def reset_session_preserving_handoff
       preserved = SESSION_KEYS_PRESERVED_ON_RESET.each_with_object({}) do |k, h|

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -73,11 +73,30 @@ module Authentication
     # pre-login. `reset_session` clears everything by default, which would drop
     # a legitimate pending invitation before `accept_pending_invitation_for`
     # could use it.
-    def reset_session_preserving_pending_invitation
-      pending_invitation = session[:pending_invitation_token]
+    # Keys preserved across a privilege-change `reset_session`:
+    # - pending_invitation_token: must survive so accept_pending_invitation_for
+    #   can still honour an invite that the user followed before signing in.
+    # - id_token_hint / sso_login_provider: required for RP-initiated federated
+    #   logout. Set on OIDC sign-in BEFORE the privilege-change reset (so the
+    #   provider data exists to be preserved here). Without preserving them,
+    #   federated logout falls back to local-only, breaking IdP single sign-out.
+    SESSION_KEYS_PRESERVED_ON_RESET = %i[
+      pending_invitation_token
+      id_token_hint
+      sso_login_provider
+    ].freeze
+
+    def reset_session_preserving_handoff
+      preserved = SESSION_KEYS_PRESERVED_ON_RESET.each_with_object({}) do |k, h|
+        v = session[k]
+        h[k] = v if v.present?
+      end
       reset_session
-      session[:pending_invitation_token] = pending_invitation if pending_invitation
+      preserved.each { |k, v| session[k] = v }
     end
+
+    # Backwards-compatible alias. Prefer `reset_session_preserving_handoff`.
+    alias_method :reset_session_preserving_pending_invitation, :reset_session_preserving_handoff
 
     def create_session_for(user)
       session = user.sessions.create!

--- a/app/controllers/impersonation_sessions_controller.rb
+++ b/app/controllers/impersonation_sessions_controller.rb
@@ -33,6 +33,8 @@ class ImpersonationSessionsController < ApplicationController
   end
 
   def complete
+    # PT-005: Only the impersonator or the impersonated user may end the session.
+    raise_unauthorized! unless [ @impersonation_session.impersonator, @impersonation_session.impersonated ].include?(Current.true_user)
     @impersonation_session.complete!
     redirect_to root_path, notice: t(".success")
   end

--- a/app/controllers/impersonation_sessions_controller.rb
+++ b/app/controllers/impersonation_sessions_controller.rb
@@ -40,6 +40,13 @@ class ImpersonationSessionsController < ApplicationController
     raise_unauthorized! if @impersonation_session.nil?
     raise_unauthorized! unless [ @impersonation_session.impersonator, @impersonation_session.impersonated ].include?(Current.true_user)
     @impersonation_session.complete!
+    # Clear the active_impersonator_session reference on the caller's browser
+    # session when it still points at this (now completed) record. Without
+    # this, Current.session keeps a dangling pointer and impersonation-aware UI
+    # (banner, Current.user resolution) continues as if the session were active.
+    if Current.session&.active_impersonator_session_id == @impersonation_session.id
+      Current.session.update!(active_impersonator_session: nil)
+    end
     redirect_to root_path, notice: t(".success")
   end
 

--- a/app/controllers/impersonation_sessions_controller.rb
+++ b/app/controllers/impersonation_sessions_controller.rb
@@ -34,6 +34,10 @@ class ImpersonationSessionsController < ApplicationController
 
   def complete
     # PT-005: Only the impersonator or the impersonated user may end the session.
+    # set_impersonation_session already scopes by Current.true_user, so a missing
+    # record means the caller is not a participant; this check also defends
+    # against future changes to the scope.
+    raise_unauthorized! if @impersonation_session.nil?
     raise_unauthorized! unless [ @impersonation_session.impersonator, @impersonation_session.impersonated ].include?(Current.true_user)
     @impersonation_session.complete!
     redirect_to root_path, notice: t(".success")

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -40,7 +40,14 @@ class MfaController < ApplicationController
     end
 
     # TTL: MFA flow expires after 5 minutes (PT-003)
-    if session[:mfa_started_at].present? && Time.current - Time.parse(session[:mfa_started_at].to_s) > 5.minutes
+    # Use a non-raising parse so a tampered/legacy value redirects the user
+    # cleanly instead of producing a 500.
+    started_at = begin
+      Time.zone.parse(session[:mfa_started_at].to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+    if session[:mfa_started_at].present? && (started_at.nil? || Time.current - started_at > 5.minutes)
       session.delete(:mfa_user_id)
       session.delete(:mfa_attempts)
       session.delete(:mfa_started_at)
@@ -49,10 +56,9 @@ class MfaController < ApplicationController
     end
 
     if @user&.verify_otp?(params[:code])
-      session.delete(:mfa_user_id)
-      session.delete(:mfa_attempts)
-      session.delete(:mfa_started_at)
-      reset_session # Prevent session fixation (PT-003)
+      # reset_session clears the mfa_* keys (and everything else) — keep the
+      # pending invitation token so post-MFA login can still honour the invite.
+      reset_session_preserving_pending_invitation # FIX-01 / PT-003
       @session = create_session_for(@user)
       flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(@user)
       redirect_to root_path

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -29,8 +29,30 @@ class MfaController < ApplicationController
   def verify_code
     @user = User.find_by(id: session[:mfa_user_id])
 
+    # Rate limit: max 5 attempts, then force re-login (PT-003)
+    session[:mfa_attempts] = (session[:mfa_attempts] || 0) + 1
+    if session[:mfa_attempts] > 5
+      session.delete(:mfa_user_id)
+      session.delete(:mfa_attempts)
+      session.delete(:mfa_started_at)
+      redirect_to new_session_path, alert: t(".too_many_attempts", default: "Too many attempts. Please sign in again.")
+      return
+    end
+
+    # TTL: MFA flow expires after 5 minutes (PT-003)
+    if session[:mfa_started_at].present? && Time.current - Time.parse(session[:mfa_started_at].to_s) > 5.minutes
+      session.delete(:mfa_user_id)
+      session.delete(:mfa_attempts)
+      session.delete(:mfa_started_at)
+      redirect_to new_session_path, alert: t(".session_expired", default: "MFA session expired. Please sign in again.")
+      return
+    end
+
     if @user&.verify_otp?(params[:code])
       session.delete(:mfa_user_id)
+      session.delete(:mfa_attempts)
+      session.delete(:mfa_started_at)
+      reset_session # Prevent session fixation (PT-003)
       @session = create_session_for(@user)
       flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(@user)
       redirect_to root_path

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -30,6 +30,25 @@ class MfaController < ApplicationController
   def verify_code
     @user = User.find_by(id: session[:mfa_user_id])
 
+    # Rate limit: max 5 attempts, then force re-login (PT-003)
+    session[:mfa_attempts] = (session[:mfa_attempts] || 0) + 1
+    if session[:mfa_attempts] > 5
+      session.delete(:mfa_user_id)
+      session.delete(:mfa_attempts)
+      session.delete(:mfa_started_at)
+      redirect_to new_session_path, alert: t(".too_many_attempts", default: "Too many attempts. Please sign in again.")
+      return
+    end
+
+    # TTL: MFA flow expires after 5 minutes (PT-003)
+    if session[:mfa_started_at].present? && Time.current - Time.parse(session[:mfa_started_at].to_s) > 5.minutes
+      session.delete(:mfa_user_id)
+      session.delete(:mfa_attempts)
+      session.delete(:mfa_started_at)
+      redirect_to new_session_path, alert: t(".session_expired", default: "MFA session expired. Please sign in again.")
+      return
+    end
+
     if @user&.verify_otp?(params[:code])
       complete_mfa_sign_in(@user)
       redirect_to root_path
@@ -112,6 +131,9 @@ class MfaController < ApplicationController
 
     def complete_mfa_sign_in(user)
       session.delete(:mfa_user_id)
+      session.delete(:mfa_attempts)
+      session.delete(:mfa_started_at)
+      reset_session # Prevent session fixation (PT-003)
       @session = create_session_for(user)
       flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(user)
     end

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -41,7 +41,14 @@ class MfaController < ApplicationController
     end
 
     # TTL: MFA flow expires after 5 minutes (PT-003)
-    if session[:mfa_started_at].present? && Time.current - Time.parse(session[:mfa_started_at].to_s) > 5.minutes
+    # Use a non-raising parse so a tampered/legacy value redirects the user
+    # cleanly instead of producing a 500.
+    started_at = begin
+      Time.zone.parse(session[:mfa_started_at].to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+    if session[:mfa_started_at].present? && (started_at.nil? || Time.current - started_at > 5.minutes)
       session.delete(:mfa_user_id)
       session.delete(:mfa_attempts)
       session.delete(:mfa_started_at)
@@ -133,7 +140,9 @@ class MfaController < ApplicationController
       session.delete(:mfa_user_id)
       session.delete(:mfa_attempts)
       session.delete(:mfa_started_at)
-      reset_session # Prevent session fixation (PT-003)
+      # reset_session clears the mfa_* keys (and everything else) — keep the
+      # pending invitation token so post-MFA login can still honour the invite.
+      reset_session_preserving_pending_invitation # FIX-01 / PT-003
       @session = create_session_for(user)
       flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(user)
     end

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -30,6 +30,26 @@ class MfaController < ApplicationController
   def verify_code
     @user = User.find_by(id: session[:mfa_user_id])
 
+    # TTL FIRST: MFA flow expires after 5 minutes (PT-003). Checked before the
+    # attempt counter so a user who comes back late sees "session expired"
+    # instead of a misleading "too many attempts" when the real cause is TTL.
+    # Use a non-raising parse so a tampered/legacy value redirects the user
+    # cleanly instead of producing a 500. Boundary is inclusive (>=) so that
+    # iso8601 second-precision timestamps don't permit a verify at exactly the
+    # TTL boundary.
+    started_at = begin
+      Time.zone.parse(session[:mfa_started_at].to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+    if session[:mfa_started_at].present? && (started_at.nil? || Time.current - started_at >= 5.minutes)
+      session.delete(:mfa_user_id)
+      session.delete(:mfa_attempts)
+      session.delete(:mfa_started_at)
+      redirect_to new_session_path, alert: t(".session_expired", default: "MFA session expired. Please sign in again.")
+      return
+    end
+
     # Rate limit: max 5 attempts, then force re-login (PT-003)
     session[:mfa_attempts] = (session[:mfa_attempts] || 0) + 1
     if session[:mfa_attempts] > 5
@@ -37,22 +57,6 @@ class MfaController < ApplicationController
       session.delete(:mfa_attempts)
       session.delete(:mfa_started_at)
       redirect_to new_session_path, alert: t(".too_many_attempts", default: "Too many attempts. Please sign in again.")
-      return
-    end
-
-    # TTL: MFA flow expires after 5 minutes (PT-003)
-    # Use a non-raising parse so a tampered/legacy value redirects the user
-    # cleanly instead of producing a 500.
-    started_at = begin
-      Time.zone.parse(session[:mfa_started_at].to_s)
-    rescue ArgumentError, TypeError
-      nil
-    end
-    if session[:mfa_started_at].present? && (started_at.nil? || Time.current - started_at > 5.minutes)
-      session.delete(:mfa_user_id)
-      session.delete(:mfa_attempts)
-      session.delete(:mfa_started_at)
-      redirect_to new_session_path, alert: t(".session_expired", default: "MFA session expired. Please sign in again.")
       return
     end
 

--- a/app/controllers/oidc_accounts_controller.rb
+++ b/app/controllers/oidc_accounts_controller.rb
@@ -51,7 +51,11 @@ class OidcAccountsController < ApplicationController
       session.delete(:pending_oidc_auth)
 
       if user.otp_required?
+        # MFA handoff: set TTL + attempt counter so verify_code enforces them
+        # (see SessionsController#create — same invariants apply here).
         session[:mfa_user_id] = user.id
+        session[:mfa_started_at] = Time.current.iso8601
+        session[:mfa_attempts] = 0
         redirect_to verify_mfa_path
       else
         @session = create_session_for(user)

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -38,6 +38,8 @@ class PasswordResetsController < ApplicationController
     end
 
     if @user.update(password_params)
+      # Invalidate all existing sessions after password reset (FIX-13)
+      @user.sessions.destroy_all
       redirect_to new_session_path, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -66,6 +66,7 @@ class SessionsController < ApplicationController
         redirect_to verify_mfa_path
       else
         log_super_admin_override_login(user)
+        reset_session # Prevent session fixation (FIX-01)
         @session = create_session_for(user)
         flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(user)
         redirect_to root_path
@@ -183,6 +184,7 @@ class SessionsController < ApplicationController
         session[:mfa_user_id] = user.id
         redirect_to verify_mfa_path
       else
+        reset_session # Prevent session fixation (FIX-01)
         @session = create_session_for(user)
         flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(user)
         redirect_to root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -63,6 +63,8 @@ class SessionsController < ApplicationController
       if user.otp_required?
         log_super_admin_override_login(user)
         session[:mfa_user_id] = user.id
+        session[:mfa_started_at] = Time.current.iso8601
+        session[:mfa_attempts] = 0
         redirect_to verify_mfa_path
       else
         log_super_admin_override_login(user)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -68,7 +68,7 @@ class SessionsController < ApplicationController
         redirect_to verify_mfa_path
       else
         log_super_admin_override_login(user)
-        reset_session # Prevent session fixation (FIX-01)
+        reset_session_preserving_pending_invitation # FIX-01 + preserve invitation token
         @session = create_session_for(user)
         flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(user)
         redirect_to root_path
@@ -186,7 +186,7 @@ class SessionsController < ApplicationController
         session[:mfa_user_id] = user.id
         redirect_to verify_mfa_path
       else
-        reset_session # Prevent session fixation (FIX-01)
+        reset_session_preserving_pending_invitation # FIX-01 + preserve invitation token
         @session = create_session_for(user)
         flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(user)
         redirect_to root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -183,7 +183,12 @@ class SessionsController < ApplicationController
 
       # MFA check: If user has MFA enabled, require verification
       if user.otp_required?
+        # Mirror the local-password MFA handoff so verify_code's TTL + attempt
+        # limit are actually enforced for OIDC logins (otherwise mfa_started_at
+        # is absent and the 5-min TTL check is silently skipped).
         session[:mfa_user_id] = user.id
+        session[:mfa_started_at] = Time.current.iso8601
+        session[:mfa_attempts] = 0
         redirect_to verify_mfa_path
       else
         reset_session_preserving_pending_invitation # FIX-01 + preserve invitation token

--- a/test/controllers/impersonation_sessions_controller_test.rb
+++ b/test/controllers/impersonation_sessions_controller_test.rb
@@ -109,4 +109,16 @@ class ImpersonationSessionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "rejected", impersonator_session.reload.status
     assert_redirected_to root_path
   end
+
+  # PT-005: Only the impersonator or the impersonated may complete.
+  test "unrelated user cannot complete another impersonation session" do
+    sign_in users(:family_admin)
+
+    impersonator_session = impersonation_sessions(:in_progress)
+
+    put complete_impersonation_session_path(impersonator_session)
+
+    assert_response :not_found
+    assert_equal "in_progress", impersonator_session.reload.status
+  end
 end

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -116,4 +116,37 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     assert_nil @user.otp_secret
     assert_empty @user.otp_backup_codes
   end
+
+  # ── Security tests added with pentest fixes (PT-003) ─────────────────────────
+
+  test "MFA verify_code rate-limits after 5 attempts" do
+    other_user = users(:family_admin)
+    other_user.setup_mfa!
+    other_user.enable_mfa!
+
+    sign_out
+    # Simulate partial login with MFA pending
+    post sessions_path, params: { email: other_user.email, password: user_password_test }
+
+    6.times do
+      post verify_mfa_path, params: { code: "000000" }
+    end
+
+    assert_redirected_to new_session_path
+  end
+
+  test "MFA session expires after TTL" do
+    other_user = users(:family_admin)
+    other_user.setup_mfa!
+    other_user.enable_mfa!
+
+    sign_out
+    post sessions_path, params: { email: other_user.email, password: user_password_test }
+
+    # Travel past the 5 minute TTL window
+    travel_to(6.minutes.from_now) do
+      post verify_mfa_path, params: { code: ROTP::TOTP.new(other_user.otp_secret).now }
+      assert_redirected_to new_session_path
+    end
+  end
 end

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -145,8 +145,20 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
 
     # Travel past the 5 minute TTL window
     travel_to(6.minutes.from_now) do
+      # Capture how many sessions the user had before the MFA attempt so we
+      # can assert no new one was created. Any existing session from sign-in
+      # below is from the sign_out/post cycle above (which creates an MFA
+      # handoff but no auth session yet).
+      before = Session.where(user_id: other_user.id).count
+
       post verify_mfa_path, params: { code: ROTP::TOTP.new(other_user.otp_secret).now }
+
       assert_redirected_to new_session_path
+      # Negative assertion: the TTL branch cleared the MFA handoff and the OTP
+      # was NOT accepted as a legitimate login.
+      assert_nil session[:mfa_user_id], "MFA handoff should be cleared on TTL expiry"
+      assert_equal before, Session.where(user_id: other_user.id).count,
+        "No auth session should be created when MFA expires"
     end
   end
 end

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -246,6 +246,39 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     assert_empty @user.webauthn_credentials
   end
 
+  # ── Security tests added with pentest fixes (PT-003) ─────────────────────────
+
+  test "MFA verify_code rate-limits after 5 attempts" do
+    other_user = users(:family_admin)
+    other_user.setup_mfa!
+    other_user.enable_mfa!
+
+    sign_out
+    # Simulate partial login with MFA pending
+    post sessions_path, params: { email: other_user.email, password: user_password_test }
+
+    6.times do
+      post verify_mfa_path, params: { code: "000000" }
+    end
+
+    assert_redirected_to new_session_path
+  end
+
+  test "MFA session expires after TTL" do
+    other_user = users(:family_admin)
+    other_user.setup_mfa!
+    other_user.enable_mfa!
+
+    sign_out
+    post sessions_path, params: { email: other_user.email, password: user_password_test }
+
+    # Travel past the 5 minute TTL window
+    travel_to(6.minutes.from_now) do
+      post verify_mfa_path, params: { code: ROTP::TOTP.new(other_user.otp_secret).now }
+      assert_redirected_to new_session_path
+    end
+  end
+
   private
     def register_webauthn_credential(origin: "http://www.example.com", rp_id: "www.example.com")
       client = WebAuthn::FakeClient.new(origin)

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -274,8 +274,20 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
 
     # Travel past the 5 minute TTL window
     travel_to(6.minutes.from_now) do
+      # Capture how many sessions the user had before the MFA attempt so we
+      # can assert no new one was created. Any existing session from sign-in
+      # below is from the sign_out/post cycle above (which creates an MFA
+      # handoff but no auth session yet).
+      before = Session.where(user_id: other_user.id).count
+
       post verify_mfa_path, params: { code: ROTP::TOTP.new(other_user.otp_secret).now }
+
       assert_redirected_to new_session_path
+      # Negative assertion: the TTL branch cleared the MFA handoff and the OTP
+      # was NOT accepted as a legitimate login.
+      assert_nil session[:mfa_user_id], "MFA handoff should be cleared on TTL expiry"
+      assert_equal before, Session.where(user_id: other_user.id).count,
+        "No auth session should be created when MFA expires"
     end
   end
 

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -87,4 +87,17 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     sso_user.reload
     assert_nil sso_user.password_digest, "SSO-only user should still have nil password_digest"
   end
+
+  # Security: Password reset should invalidate all active sessions (FIX-13)
+  test "update invalidates all existing sessions" do
+    sign_in @user
+    session_count_before = @user.reload.sessions.count
+    assert session_count_before >= 1
+
+    token = @user.generate_token_for(:password_reset)
+    patch password_reset_path(token: token),
+      params: { user: { password: "NewPassword123!", password_confirmation: "NewPassword123!" } }
+
+    assert_equal 0, @user.reload.sessions.count, "All sessions should be destroyed after password reset"
+  end
 end

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -94,7 +94,7 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     session_count_before = @user.reload.sessions.count
     assert session_count_before >= 1
 
-    token = @user.generate_token_for(:password_reset)
+    token = @user.generate_token_for(:password_reset) # pipelock:ignore
     patch password_reset_path(token: token),
       params: { user: { password: "NewPassword123!", password_confirmation: "NewPassword123!" } }
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -689,4 +689,29 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_not_equal old_session_id, session.id, "Session ID should change on login to prevent fixation"
   end
+
+  # F-04: Session TTL — absolute (30d) and idle (24h) expiry enforced server-side.
+  test "session is expired after 30d absolute TTL" do
+    sign_in @user
+    db_session = Session.order(created_at: :desc).find_by!(user_id: @user.id)
+
+    # Backdate the session past the absolute TTL.
+    db_session.update_columns(created_at: 31.days.ago, updated_at: 1.hour.ago)
+
+    get root_url
+    assert_redirected_to new_session_url
+    assert_not Session.exists?(db_session.id), "Expired session should be destroyed"
+  end
+
+  test "session is expired after 24h idle TTL" do
+    sign_in @user
+    db_session = Session.order(created_at: :desc).find_by!(user_id: @user.id)
+
+    # Session is young in absolute terms but idle beyond the idle TTL.
+    db_session.update_columns(created_at: 2.days.ago, updated_at: 25.hours.ago)
+
+    get root_url
+    assert_redirected_to new_session_url
+    assert_not Session.exists?(db_session.id), "Idle-expired session should be destroyed"
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -684,10 +684,31 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   test "session fixation: new session created on login (reset_session)" do
     get new_session_url # establish session
     old_session_id = session.id
+    # Seed a sentinel to prove the old session was actually cleared, not just
+    # that session.id happened to differ.
+    session[:pre_auth_sentinel] = "seed"
 
     sign_in @user
 
+    assert_nil session[:pre_auth_sentinel], "Pre-auth session data should be cleared by reset_session"
     assert_not_equal old_session_id, session.id, "Session ID should change on login to prevent fixation"
+  end
+
+  test "session fixation: pending invitation token survives reset_session" do
+    invitation = invitations(:one)
+
+    # GET /sessions/new?invitation=<token> triggers store_pending_invitation_if_valid,
+    # which puts the token into the session BEFORE the POST that calls reset_session.
+    get new_session_url(invitation: invitation.token)
+
+    # Signing in as a user whose email doesn't match the invitation means
+    # accept_pending_invitation_for short-circuits without consuming the token,
+    # so the post-reset session should still carry it — which can only happen
+    # if reset_session_preserving_pending_invitation restored it.
+    sign_in @user
+
+    assert_equal invitation.token, session[:pending_invitation_token],
+      "Token must be preserved across reset_session so accept_pending_invitation_for can honor it"
   end
 
   # F-04: Session TTL — absolute (30d) and idle (24h) expiry enforced server-side.

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -678,4 +678,15 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
   end
+
+  # ── Security tests added with pentest fixes ──────────────────────────────────
+
+  test "session fixation: new session created on login (reset_session)" do
+    get new_session_url # establish session
+    old_session_id = session.id
+
+    sign_in @user
+
+    assert_not_equal old_session_id, session.id, "Session ID should change on login to prevent fixation"
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -20,7 +20,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:openid_connect] = nil
   end
 
-  def setup_omniauth_mock(provider:, uid:, email:, name:, first_name: nil, last_name: nil)
+  def setup_omniauth_mock(provider:, uid:, email:, name:, first_name: nil, last_name: nil, id_token: nil)
     OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new({
       provider: provider,
       uid: uid,
@@ -29,7 +29,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         name: name,
         first_name: first_name,
         last_name: last_name
-      }.compact
+      }.compact,
+      credentials: id_token ? { id_token: id_token } : {}
     })
   end
 
@@ -180,7 +181,40 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to verify_mfa_path
     assert_equal @user.id, session[:mfa_user_id]
+    # Invariant: OIDC MFA handoff must set TTL + attempt counter so verify_code
+    # actually enforces them (otherwise the 5-min TTL is silently skipped).
+    assert session[:mfa_started_at].present?, "OIDC MFA handoff must set mfa_started_at for TTL enforcement"
+    assert_equal 0, session[:mfa_attempts]
     assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "OIDC logout hints survive MFA verification (federated logout works post-MFA)" do
+    @user.setup_mfa!
+    @user.enable_mfa!
+    @user.sessions.destroy_all
+    oidc_identity = oidc_identities(:bob_google)
+
+    setup_omniauth_mock(
+      provider: oidc_identity.provider,
+      uid: oidc_identity.uid,
+      email: @user.email,
+      name: "Bob Dylan",
+      id_token: "fake-id-token-for-rp-logout"
+    )
+
+    get "/auth/openid_connect/callback"
+    assert_redirected_to verify_mfa_path
+    assert_equal "fake-id-token-for-rp-logout", session[:id_token_hint]
+    assert_equal oidc_identity.provider, session[:sso_login_provider]
+
+    totp = ROTP::TOTP.new(@user.otp_secret, issuer: "Sure Finances")
+    post verify_mfa_path, params: { code: totp.now }
+    assert_redirected_to root_path
+
+    # After privilege-change reset_session, OIDC logout hints must still be
+    # present so destroy can redirect to the IdP for RP-initiated logout.
+    assert_equal "fake-id-token-for-rp-logout", session[:id_token_hint]
+    assert_equal oidc_identity.provider, session[:sso_login_provider]
   end
 
   test "redirects to account linking when no OIDC identity exists" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -211,10 +211,46 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     post verify_mfa_path, params: { code: totp.now }
     assert_redirected_to root_path
 
-    # After privilege-change reset_session, OIDC logout hints must still be
-    # present so destroy can redirect to the IdP for RP-initiated logout.
+    # Positive: OIDC logout hints must still be present so destroy can redirect
+    # to the IdP for RP-initiated logout.
     assert_equal "fake-id-token-for-rp-logout", session[:id_token_hint]
     assert_equal oidc_identity.provider, session[:sso_login_provider]
+
+    # Negative: mfa_* handoff keys must be wiped after successful verification.
+    # The preserve list is intentionally narrow — anything not explicitly listed
+    # in SESSION_KEYS_PRESERVED_ON_RESET must not survive a privilege change.
+    assert_nil session[:mfa_user_id]
+    assert_nil session[:mfa_started_at]
+    assert_nil session[:mfa_attempts]
+  end
+
+  test "OIDC MFA flow enforces 5-min TTL (regression: TTL was skipped for OIDC)" do
+    @user.setup_mfa!
+    @user.enable_mfa!
+    @user.sessions.destroy_all
+    oidc_identity = oidc_identities(:bob_google)
+
+    setup_omniauth_mock(
+      provider: oidc_identity.provider,
+      uid: oidc_identity.uid,
+      email: @user.email,
+      name: "Bob Dylan"
+    )
+
+    get "/auth/openid_connect/callback"
+    assert_redirected_to verify_mfa_path
+    assert session[:mfa_started_at].present?, "OIDC MFA handoff must seed mfa_started_at for TTL to fire"
+
+    # Travel past TTL — even a valid TOTP must be rejected and the user
+    # bounced back to sign-in. Previously the TTL was silently skipped because
+    # mfa_started_at was absent from the OIDC handoff.
+    travel_to(6.minutes.from_now) do
+      totp = ROTP::TOTP.new(@user.otp_secret, issuer: "Sure Finances")
+      post verify_mfa_path, params: { code: totp.now }
+      assert_redirected_to new_session_path
+      assert_not Session.exists?(user_id: @user.id)
+      assert_nil session[:mfa_user_id]
+    end
   end
 
   test "redirects to account linking when no OIDC identity exists" do


### PR DESCRIPTION

## Summary

Session lifecycle, cookie security attributes, MFA flow rate limiting, and impersonation authorization.

Part of the security hardening originally bundled in #1104 (closed), now split by functional area per @jjmata's feedback. Companion PRs: #1516 #1517 #1519 #1520 #1521.

## Findings addressed (7)

| ID | Severity | CWE | Fix |
|----|----------|-----|-----|
| FIX-01 | HIGH | CWE-384 | Session fixation on non-MFA login — `reset_session` added in `sessions_controller.rb` (all login paths incl. OIDC) |
| FIX-13 | MED | CWE-613 | Password reset doesn't invalidate sessions — all sessions for user revoked on reset in `password_resets_controller.rb` |
| F-04 | MED | CWE-613 | Sessions never expire — `SESSION_ABSOLUTE_TTL = 30.days` + `SESSION_IDLE_TTL = 24.hours` enforced in `concerns/authentication.rb` |
| PT-002 / C1 | MED | — | Cookie flags hardened in `authentication.rb`: `secure: Rails.env.production?`, `same_site: :lax` |
| PT-003 | MED | CWE-307 | MFA rate limit + verify-flow TTL + `reset_session` on verify in `mfa_controller.rb` |
| PT-005 | MED | CWE-862 | Impersonation complete authorized to impersonator OR impersonated (with nil-guard) |

## Migration notes

Existing long-lived sessions will be invalidated on first request after deploy (expected — was the goal).

## Tests

- New coverage in `sessions_controller_test.rb`, `mfa_controller_test.rb`, `password_resets_controller_test.rb`, `impersonation_sessions_controller_test.rb`.
- Full suite: 3232 runs, 0 failures.
- `bin/rubocop` clean.

## Out of scope

- Auth bypasses (deactivated users, signup closure, MFA password re-auth) → #1519
- Session throttling / OTP rate limiting via Rack::Attack → #1520
- CSP / CORS / DNS rebinding → #1516

## Related

- #1087 — Security Audit Report
- #1104 — Original bundled PR (closed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now expire after 30 days (absolute) or 24 hours idle.
  * MFA verification enforces a 5-minute TTL and locks out after 5 failed attempts.
  * Password resets now invalidate all existing sessions.
  * Stronger authorization for completing impersonation sessions.

* **Improvements**
  * Session handling hardened to prevent session fixation while preserving pending invitation tokens.

* **Tests**
  * New tests covering MFA throttling/expiration, session TTLs, impersonation auth, password-reset session invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->