### PR TITLE
fix: Table divider display issue on Safari

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -208,14 +208,17 @@
   position: relative;
 }
 
-.table-divider::after {
-  content: "";
-  position: absolute;
-  left: 1rem;
-  right: 1rem;
-  bottom: 0;
-  height: 1px;
-  background-color: var(--color-alpha-black-100);
+.table-divider {
+  background-image: linear-gradient(
+    to right,
+    transparent 1rem,
+    var(--color-alpha-black-100) 1rem,
+    var(--color-alpha-black-100) calc(100% - 1rem),
+    transparent calc(100% - 1rem)
+  );
+  background-repeat: no-repeat;
+  background-size: 100% 1px;
+  background-position: bottom;
 }
 
 [data-theme="dark"] .table-divider::after  {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -221,10 +221,12 @@
   background-position: bottom;
 }
 
-[data-theme="dark"] .table-divider::after  {
-  background-color: var(--color-alpha-white-200);
-}
-
-.table-divider:last-child::after {
-  display: none;
+[data-theme="dark"] .table-divider {
+  background-image: linear-gradient(
+    to right,
+    transparent 1rem,
+    var(--color-alpha-white-200) 1rem,
+    var(--color-alpha-white-200) calc(100% - 1rem),
+    transparent calc(100% - 1rem)
+  );
 }


### PR DESCRIPTION
The new `table-divider` class fails to render correctly on Safari. This PR addresses this issue by employing a cross-browser compatible approach.

| Before | After |
| ------------- | ------------- |
| <img width="1361" height="186" alt="Screenshot 2026-04-19 alle 18 46 46" src="https://github.com/user-attachments/assets/6b0da28b-fc2c-4699-8c65-75413ef68683" />  | <img width="1358" height="189" alt="Screenshot 2026-04-19 alle 18 46 07" src="https://github.com/user-attachments/assets/0e9c445a-dd65-41e5-b179-20f07997df65" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated table dividers to use a bottom-aligned gradient for a thinner, refined line with transparent edge fades.
  * Ensures consistent appearance in both light and dark modes.
  * Behavior change: the divider is now rendered uniformly, including the last row (previously suppressed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->