### PR TITLE
Feature: improve transfer matcher UI copy

### DIFF
--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -349,7 +349,7 @@
           <div class="flex items-center justify-between gap-4 p-3">
             <div class="text-sm space-y-1">
               <h4 class="text-primary">Transfer or Debt Payment?</h4>
-              <p class="text-secondary">Connect this transaction to its counterpart in another account.</p>
+              <p class="text-secondary"><%= t(".transfer_matcher_description") %></p>
             </div>
             <%= render DS::Link.new(
               text: "Open matcher",

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -349,7 +349,7 @@
           <div class="flex items-center justify-between gap-4 p-3">
             <div class="text-sm space-y-1">
               <h4 class="text-primary">Transfer or Debt Payment?</h4>
-              <p class="text-secondary">Connect this transaction to its counterpart in another account. Both sides must already exist as separate transactions.</p>
+              <p class="text-secondary">Connect this transaction to its counterpart in another account.</p>
             </div>
             <%= render DS::Link.new(
               text: "Open matcher",

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -349,7 +349,7 @@
           <div class="flex items-center justify-between gap-4 p-3">
             <div class="text-sm space-y-1">
               <h4 class="text-primary">Transfer or Debt Payment?</h4>
-              <p class="text-secondary">Transfers and payments are special types of transactions that indicate money movement between 2 accounts.</p>
+              <p class="text-secondary">Connect this transaction to its counterpart in another account. Both sides must already exist as separate transactions.</p>
             </div>
             <%= render DS::Link.new(
               text: "Open matcher",

--- a/app/views/transfer_matches/new.html.erb
+++ b/app/views/transfer_matches/new.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Match transfer or payment", subtitle: "Match the corresponding transaction in another account or create one if it doesn't exist.") %>
+  <% dialog.with_header(title: t(".header.title"), subtitle: t(".header.subtitle")) %>
   <% dialog.with_body do %>
     <%= styled_form_with(
           url: transaction_transfer_match_path(@entry),

--- a/app/views/transfer_matches/new.html.erb
+++ b/app/views/transfer_matches/new.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Match transfer or payment", subtitle: "You have a record of money leaving (or arriving). Match it to the corresponding transaction in another account, or create one if it doesn't exist yet.") %>
+  <% dialog.with_header(title: "Match transfer or payment", subtitle: "Match the corresponding transaction in another account or create one if it doesn't exist.") %>
   <% dialog.with_body do %>
     <%= styled_form_with(
           url: transaction_transfer_match_path(@entry),

--- a/app/views/transfer_matches/new.html.erb
+++ b/app/views/transfer_matches/new.html.erb
@@ -1,5 +1,5 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: "Match transfer or payment") %>
+  <% dialog.with_header(title: "Match transfer or payment", subtitle: "You have a record of money leaving (or arriving). Match it to the corresponding transaction in another account, or create one if it doesn't exist yet.") %>
   <% dialog.with_body do %>
     <%= styled_form_with(
           url: transaction_transfer_match_path(@entry),

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -45,6 +45,7 @@ en:
       convert_to_trade_title: Convert to Security Trade
       convert_to_trade_description: Convert this transaction into a Buy or Sell trade with security details for portfolio tracking.
       convert_to_trade_button: Convert to Trade
+      transfer_matcher_description: Connect this transaction to its counterpart in another account.
       pending_duplicate_merger_title: Duplicate of Posted Transaction?
       pending_duplicate_merger_description: Manually merge this pending transaction with its posted version.
       pending_duplicate_merger_button: Open merger

--- a/config/locales/views/transfer_matches/en.yml
+++ b/config/locales/views/transfer_matches/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  transfer_matches:
+    new:
+      header:
+        title: Match transfer or payment
+        subtitle: Match the corresponding transaction in another account or create one if it doesn't exist.


### PR DESCRIPTION
https://github.com/we-promise/sure/discussions/1490#discussioncomment-16617109 refers.

The Transfer Matcher and the New Transfer feature are easy to confuse. A **New Transfer** creates both sides of a transfer (outflow and inflow) simultaneously. The **Transfer Matcher** is different: you open it from a single existing transaction - typically one that arrived via bank sync - and either link it to the corresponding transaction in another account, or create that counterpart if it doesn't exist yet.

If only one of your accounts is bank-synced, the outflow may appear automatically while the inflow (in a manually-managed account) needs to be created. The transfer matcher handles both cases in one step.

The previous copy ("Transfers and payments are special types of transactions that indicate money movement between 2 accounts") described what a transfer is rather than what the matcher does, which caused confusion. The updated copy makes the purpose of the matcher explicit.

### Changes

#### Updated Transfer Matcher copy in the transaction drawer

<img width="400" height="68" alt="Screenshot 2026-04-19 at 22 10 54" src="https://github.com/user-attachments/assets/2c324fa4-de21-4d32-8faf-6ea8d1a4aa77" />

#### Added a subtitle to the Transfer Matcher dialog

<img width="400" height="375" alt="Screenshot 2026-04-19 at 22 10 47" src="https://github.com/user-attachments/assets/fb2565c3-4bc1-411f-8d68-eb9d912da8d4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Transfer/Debt Payment settings description to use a localized, clearer message explaining how transactions connect across accounts.
  * Added a translated dialog header and a new descriptive subtitle for the transfer/payment matching dialog to clarify matching existing transactions or creating a new one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->