### PR TITLE
fix: stretched main image on Github Pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-primer

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,8 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.markdown-body img {
+  height: auto;
+}


### PR DESCRIPTION
The image at https://we-promise.github.io/sure/ is stretched, like so:

<img width="2024" height="624" alt="Screenshot 2026-04-20 at 00 31 21" src="https://github.com/user-attachments/assets/6a56363f-e8cc-4a03-a2ba-c0299887d928" />

This PR fixes it so it looks like:

<img width="2002" height="502" alt="Screenshot 2026-04-20 at 00 31 33" src="https://github.com/user-attachments/assets/6ff2ca9f-a91e-41eb-9574-b4045d8c6fd8" />
