### PR TITLE
fix(storage): properly fallback to GCS_KEYFILE when GCS_KEYFILE_JSON is blank

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -35,5 +35,5 @@ generic_s3:
 google:
   service: GCS
   project: <%= ENV["GCS_PROJECT"] %>
-  credentials: <%= ENV.fetch("GCS_KEYFILE_JSON") { ENV["GCS_KEYFILE"] } %>
+  credentials: <%= ENV["GCS_KEYFILE_JSON"].presence || ENV["GCS_KEYFILE"] %>
   bucket: <%= ENV["GCS_BUCKET"] %>


### PR DESCRIPTION
This resolves #1525 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Google Cloud Storage credential configuration handling to support environment variable fallback, providing more flexible credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->