### PR TITLE
fix: Budget tabs issues on mobile

### DIFF
--- a/app/views/budgets/_budget_tabs.html.erb
+++ b/app/views/budgets/_budget_tabs.html.erb
@@ -1,0 +1,31 @@
+<div class="w-full flex justify-center">
+    <div class="max-w-full w-full lg:w-auto overflow-x-auto no-scrollbar">
+        <div class="w-full inline-flex whitespace-nowrap bg-container-inset rounded-lg p-1 text-sm font-medium gap-0.5">
+
+        <button
+            data-action="click->budget-filter#setFilter"
+            data-budget-filter-filter-param="all"
+            data-budget-filter-target="tab"
+            class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 bg-white theme-dark:bg-gray-700 text-primary shadow-sm">
+            <%= t("budgets.show.filter.all") %>
+        </button>
+
+        <button
+            data-action="click->budget-filter#setFilter"
+            data-budget-filter-filter-param="over_budget"
+            data-budget-filter-target="tab"
+            class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 shadow-sm">
+            <%= t("budgets.show.filter.over_budget") %>
+        </button>
+
+        <button
+            data-action="click->budget-filter#setFilter"
+            data-budget-filter-filter-param="on_track"
+            data-budget-filter-target="tab"
+            class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 shadow-sm">
+            <%= t("budgets.show.filter.on_track") %>
+        </button>
+
+        </div>
+    </div>
+</div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -51,45 +51,15 @@
     <%= content_tag :div,
       class: "w-full bg-container rounded-xl shadow-border-xs p-4",
       data: (has_over_budget ? { controller: "budget-filter" } : {}) do %>
-      <div class="flex items-center mb-4 flex-nowrap">
+      <div class="flex items-center mb-4 flex-nowrap justify-between">
         <h2 class="text-lg font-medium shrink-0">
           <%= t("budgets.show.categories.title") %>
         </h2>
 
         <% if has_over_budget %>
-        <div class="flex-1 min-w-0 px-1">
-          <div class="w-full flex justify-center">
-            <div class="max-w-full overflow-x-auto no-scrollbar">
-              <div class="inline-flex whitespace-nowrap bg-container-inset rounded-lg p-1 text-sm font-medium gap-0.5">
-
-                <button
-                  data-action="click->budget-filter#setFilter"
-                  data-budget-filter-filter-param="all"
-                  data-budget-filter-target="tab"
-                  class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 bg-white theme-dark:bg-gray-700 text-primary shadow-sm">
-                  <%= t("budgets.show.filter.all") %>
-                </button>
-
-                <button
-                  data-action="click->budget-filter#setFilter"
-                  data-budget-filter-filter-param="over_budget"
-                  data-budget-filter-target="tab"
-                  class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 shadow-sm">
-                  <%= t("budgets.show.filter.over_budget") %>
-                </button>
-
-                <button
-                  data-action="click->budget-filter#setFilter"
-                  data-budget-filter-filter-param="on_track"
-                  data-budget-filter-target="tab"
-                  class="w-full inline-flex justify-center items-center text-sm font-medium px-2 py-1 rounded-md transition-colors duration-200 shadow-sm">
-                  <%= t("budgets.show.filter.on_track") %>
-                </button>
-
-              </div>
-            </div>
+          <div class="hidden lg:flex flex-1 min-w-0 px-1">
+            <%= render "budgets/budget_tabs" %>
           </div>
-        </div>
         <% end %>
 
         <div class="<%= has_over_budget ? "shrink-0 flex justify-end whitespace-nowrap" : "ml-auto" %>">
@@ -103,6 +73,11 @@
           <% end %>
         </div>
       </div>
+      <% if has_over_budget %>
+        <div class="flex lg:hidden flex-1 min-w-0 mb-4">
+          <%= render "budgets/budget_tabs" %>
+        </div>
+      <% end %>
 
       <%= render "budgets/budget_categories", budget: @budget %>
     <% end %>


### PR DESCRIPTION
This PR fixes a display issue of the new tabs to display on track/over budget on mobile.

| Before  | After |
| ------------- | ------------- |
| <img width="376" height="300" alt="Screenshot 2026-04-20 alle 21 29 21" src="https://github.com/user-attachments/assets/24b7a9ce-3dc1-402f-80b0-2e592e762f6e" /> | <img width="374" height="355" alt="Screenshot 2026-04-20 alle 21 28 57" src="https://github.com/user-attachments/assets/0fa96679-0b3c-4b53-b17a-c62a2f00fe4d" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Budget filtering interface has been reorganized for improved code structure with optimized responsive behavior across mobile and desktop displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->