### PR TITLE
feat(mobile): lock chat input while bot is responding + 20s timeout

### DIFF
--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -284,14 +284,6 @@ class ChatProvider with ChangeNotifier {
 
   /// Poll for updates
   Future<void> _pollForUpdates(String accessToken, String chatId) async {
-    if (_pollingStartTime != null &&
-        DateTime.now().difference(_pollingStartTime!) >= _pollingTimeout) {
-      _stopPolling();
-      _errorMessage = 'The assistant took too long to respond. Please try again.';
-      notifyListeners();
-      return;
-    }
-
     try {
       final result = await _chatService.getChat(
         accessToken: accessToken,
@@ -351,16 +343,28 @@ class ChatProvider with ChangeNotifier {
             _lastAssistantContentLength = newLen;
             // Content is growing — reset the inactivity clock.
             _pollingStartTime = DateTime.now();
+            return; // progress made, don't evaluate timeout this tick
           } else {
             // Content stable: no growth since last poll — done.
             _stopPolling();
             _lastAssistantContentLength = null;
             notifyListeners();
+            return;
           }
         }
       }
     } catch (e) {
+      // Network error — allow polling to continue; timeout check below will
+      // stop it if the deadline has passed.
       debugPrint('Polling error: ${e.toString()}');
+    }
+
+    // Evaluate timeout only after the attempt, and only when no progress was made.
+    if (_pollingStartTime != null &&
+        DateTime.now().difference(_pollingStartTime!) >= _pollingTimeout) {
+      _stopPolling();
+      _errorMessage = 'The assistant took too long to respond. Please try again.';
+      notifyListeners();
     }
   }
 

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -15,6 +15,7 @@ class ChatProvider with ChangeNotifier {
   String? _errorMessage;
   Timer? _pollingTimer;
   DateTime? _pollingStartTime;
+  bool _isPollingRequestInFlight = false;
 
   static const _pollingTimeout = Duration(seconds: 20);
 
@@ -270,7 +271,13 @@ class ChatProvider with ChangeNotifier {
     notifyListeners();
 
     _pollingTimer = Timer.periodic(const Duration(seconds: 2), (timer) async {
-      await _pollForUpdates(accessToken, chatId);
+      if (_isPollingRequestInFlight) return;
+      _isPollingRequestInFlight = true;
+      try {
+        await _pollForUpdates(accessToken, chatId);
+      } finally {
+        _isPollingRequestInFlight = false;
+      }
     });
   }
 
@@ -279,6 +286,7 @@ class ChatProvider with ChangeNotifier {
     _pollingTimer?.cancel();
     _pollingTimer = null;
     _pollingStartTime = null;
+    _isPollingRequestInFlight = false;
     _isWaitingForResponse = false;
   }
 
@@ -339,18 +347,24 @@ class ChatProvider with ChangeNotifier {
         final lastMessage = updatedChat.messages.lastOrNull;
         if (lastMessage != null && lastMessage.isAssistant) {
           final newLen = lastMessage.content.length;
-          if (newLen > (_lastAssistantContentLength ?? 0)) {
+          final previousLen = _lastAssistantContentLength;
+
+          if (newLen > (previousLen ?? -1)) {
             _lastAssistantContentLength = newLen;
-            // Content is growing — reset the inactivity clock.
-            _pollingStartTime = DateTime.now();
-            return; // progress made, don't evaluate timeout this tick
-          } else {
-            // Content stable: no growth since last poll — done.
+            if (newLen > 0) {
+              // Content is growing — reset the inactivity clock.
+              _pollingStartTime = DateTime.now();
+              return; // progress made, don't evaluate timeout this tick
+            }
+            // newLen == 0: empty placeholder, keep polling
+          } else if (newLen > 0) {
+            // Content stable and non-empty: no growth since last poll — done.
             _stopPolling();
             _lastAssistantContentLength = null;
             notifyListeners();
             return;
           }
+          // newLen == 0 with previousLen already 0: still empty, keep polling
         }
       }
     } catch (e) {

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -288,6 +288,7 @@ class ChatProvider with ChangeNotifier {
     _pollingStartTime = null;
     _isPollingRequestInFlight = false;
     _isWaitingForResponse = false;
+    _lastAssistantContentLength = null;
   }
 
   /// Poll for updates

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -348,6 +348,8 @@ class ChatProvider with ChangeNotifier {
           final newLen = lastMessage.content.length;
           if (newLen > (_lastAssistantContentLength ?? 0)) {
             _lastAssistantContentLength = newLen;
+            // Content is growing — reset the inactivity clock.
+            _pollingStartTime = DateTime.now();
           } else {
             // Content stable: no growth since last poll — done.
             _stopPolling();

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -14,6 +14,9 @@ class ChatProvider with ChangeNotifier {
   bool _isWaitingForResponse = false;
   String? _errorMessage;
   Timer? _pollingTimer;
+  DateTime? _pollingStartTime;
+
+  static const _pollingTimeout = Duration(seconds: 20);
 
   /// Content length of the last assistant message from the previous poll.
   /// Used to detect when the LLM has finished writing (no growth between polls).
@@ -262,6 +265,7 @@ class ChatProvider with ChangeNotifier {
     _pollingTimer?.cancel();
     _lastAssistantContentLength = null;
     _isWaitingForResponse = true;
+    _pollingStartTime = DateTime.now();
     notifyListeners();
 
     _pollingTimer = Timer.periodic(const Duration(seconds: 2), (timer) async {
@@ -273,11 +277,20 @@ class ChatProvider with ChangeNotifier {
   void _stopPolling() {
     _pollingTimer?.cancel();
     _pollingTimer = null;
+    _pollingStartTime = null;
     _isWaitingForResponse = false;
   }
 
   /// Poll for updates
   Future<void> _pollForUpdates(String accessToken, String chatId) async {
+    if (_pollingStartTime != null &&
+        DateTime.now().difference(_pollingStartTime!) >= _pollingTimeout) {
+      _stopPolling();
+      _errorMessage = 'The assistant took too long to respond. Please try again.';
+      notifyListeners();
+      return;
+    }
+
     try {
       final result = await _chatService.getChat(
         accessToken: accessToken,

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -27,6 +27,7 @@ class ChatProvider with ChangeNotifier {
   bool get isLoading => _isLoading;
   bool get isSendingMessage => _isSendingMessage;
   bool get isWaitingForResponse => _isWaitingForResponse;
+  bool get isPolling => _pollingTimer != null;
   String? get errorMessage => _errorMessage;
 
   /// Fetch list of chats

--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -34,6 +34,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
 
   ChatProvider? _chatProvider;
   bool _listenerAdded = false;
+  bool _isSendInFlight = false;
 
   @override
   void initState() {
@@ -120,9 +121,12 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
   }
 
   Future<void> _sendMessage() async {
+    if (_isSendInFlight) return;
     final content = _messageController.text.trim();
     if (content.isEmpty) return;
+    setState(() => _isSendInFlight = true);
 
+    try {
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     final chatProvider = Provider.of<ChatProvider>(context, listen: false);
 
@@ -182,6 +186,9 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
         );
       }
     });
+    } finally {
+      if (mounted) setState(() => _isSendInFlight = false);
+    }
   }
 
   Future<void> _editTitle() async {
@@ -359,7 +366,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
                     actions: <Type, Action<Intent>>{
                       _SendMessageIntent: CallbackAction<_SendMessageIntent>(
                         onInvoke: (_) {
-                          if (!chatProvider.isSendingMessage && !chatProvider.isWaitingForResponse && !chatProvider.isPolling) _sendMessage();
+                          if (!_isSendInFlight && !chatProvider.isSendingMessage && !chatProvider.isWaitingForResponse && !chatProvider.isPolling) _sendMessage();
                           return null;
                         },
                       ),
@@ -387,7 +394,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
                         const SizedBox(width: 8),
                         IconButton(
                           icon: const Icon(Icons.send),
-                          onPressed: (chatProvider.isSendingMessage || chatProvider.isWaitingForResponse || chatProvider.isPolling)
+                          onPressed: (_isSendInFlight || chatProvider.isSendingMessage || chatProvider.isWaitingForResponse || chatProvider.isPolling)
                               ? null
                               : _sendMessage,
                           color: colorScheme.primary,

--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -359,7 +359,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
                     actions: <Type, Action<Intent>>{
                       _SendMessageIntent: CallbackAction<_SendMessageIntent>(
                         onInvoke: (_) {
-                          if (!chatProvider.isSendingMessage) _sendMessage();
+                          if (!chatProvider.isSendingMessage && !chatProvider.isWaitingForResponse) _sendMessage();
                           return null;
                         },
                       ),
@@ -387,7 +387,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
                         const SizedBox(width: 8),
                         IconButton(
                           icon: const Icon(Icons.send),
-                          onPressed: chatProvider.isSendingMessage
+                          onPressed: (chatProvider.isSendingMessage || chatProvider.isWaitingForResponse)
                               ? null
                               : _sendMessage,
                           color: colorScheme.primary,

--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -68,7 +68,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
   void _onChatChanged() {
     if (!mounted) return;
     final chatProvider = Provider.of<ChatProvider>(context, listen: false);
-    if (chatProvider.isWaitingForResponse || chatProvider.isSendingMessage) {
+    if (chatProvider.isWaitingForResponse || chatProvider.isSendingMessage || chatProvider.isPolling) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _scrollToBottom();
       });
@@ -359,7 +359,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
                     actions: <Type, Action<Intent>>{
                       _SendMessageIntent: CallbackAction<_SendMessageIntent>(
                         onInvoke: (_) {
-                          if (!chatProvider.isSendingMessage && !chatProvider.isWaitingForResponse) _sendMessage();
+                          if (!chatProvider.isSendingMessage && !chatProvider.isWaitingForResponse && !chatProvider.isPolling) _sendMessage();
                           return null;
                         },
                       ),
@@ -387,7 +387,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
                         const SizedBox(width: 8),
                         IconButton(
                           icon: const Icon(Icons.send),
-                          onPressed: (chatProvider.isSendingMessage || chatProvider.isWaitingForResponse)
+                          onPressed: (chatProvider.isSendingMessage || chatProvider.isWaitingForResponse || chatProvider.isPolling)
                               ? null
                               : _sendMessage,
                           color: colorScheme.primary,


### PR DESCRIPTION
## Summary

- **Input lock**: send button and Enter shortcut are disabled for the full response lifecycle (`isSendingMessage || isWaitingForResponse`), not just during the initial HTTP POST. Prevents users from queuing up multiple messages while a response is in flight.
- **20s timeout**: if the bot never responds (stuck poll), the waiting flag resets automatically, an error message is surfaced, and the input unlocks — no manual refresh needed.
- **`_isWaitingForResponse` flag**: tracks the full polling cycle from `_startPolling` to `_stopPolling`, exposed as a getter so the UI can react to it.

## Test plan

- [ ] Send a message — send button disabled until response fully arrives
- [ ] Try typing and hitting Enter mid-response — should not send
- [ ] Simulate a stuck response (e.g. kill network) — input should unlock after 20s with error message
- [ ] Normal flow unaffected — button re-enables cleanly after response stabilises

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 20-second absolute timeout for stalled assistant responses; you'll see an error prompting to try again if no progress.
  * Progressive assistant updates reset the timeout so ongoing responses continue without interruption.
  * Polling now avoids overlapping requests and stops when the timeout is exceeded.
  * Send action/button is blocked while the assistant is busy, polling, or a send is already in flight to prevent duplicates.

* **New Features**
  * Conversation view auto-scrolls to follow live assistant updates while a response is in progress.
  * UI exposes a polling state so the app can reflect ongoing response polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->