### PR TITLE
fix: don't load User model in migration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,7 @@ class User < ApplicationRecord
   normalizes :first_name, :last_name, with: ->(value) { value.strip.presence }
 
   enum :role, { guest: "guest", member: "member", admin: "admin", super_admin: "super_admin" }, validate: true
+  attribute :ui_layout, :string
   enum :ui_layout, { dashboard: "dashboard", intro: "intro" }, validate: true, prefix: true
 
   before_validation :apply_ui_layout_defaults

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,6 @@ class User < ApplicationRecord
   normalizes :first_name, :last_name, with: ->(value) { value.strip.presence }
 
   enum :role, { guest: "guest", member: "member", admin: "admin", super_admin: "super_admin" }, validate: true
-  attribute :ui_layout, :string
   enum :ui_layout, { dashboard: "dashboard", intro: "intro" }, validate: true, prefix: true
 
   before_validation :apply_ui_layout_defaults

--- a/db/migrate/20240520074309_add_admin_role_to_current_users.rb
+++ b/db/migrate/20240520074309_add_admin_role_to_current_users.rb
@@ -1,5 +1,5 @@
 class AddAdminRoleToCurrentUsers < ActiveRecord::Migration[7.2]
   def up
-    User.update_all(role: "admin")
+    execute "UPDATE users SET role = 'admin'"
   end
 end


### PR DESCRIPTION
Fixes #1533.

As dosubot said at https://github.com/we-promise/sure/issues/1533#issuecomment-4281785376

> The cleanest fix would be to replace the User.update_all call with raw SQL

...which is what this PR does. It ensures the User model never gets loaded, so we no longer get this issue when doing `bin/rails db:drop db:create db:migrate db:seed`:

> Undeclared attribute type for enum 'ui_layout' in User.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database migration script for role assignment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->