### PR TITLE
Feature: implement fiscal year configuration with FYTD period

### DIFF
--- a/app/controllers/concerns/periodable.rb
+++ b/app/controllers/concerns/periodable.rb
@@ -9,7 +9,7 @@ module Periodable
     def set_period
       if params[:period].present?
         period_key = params[:period]
-        Current.user&.update!(default_period: period_key) if Period.available_key?(period_key)
+        Current.user&.update!(default_period: period_key) if Period.valid_key?(period_key)
       else
         period_key = Current.user&.default_period
       end

--- a/app/controllers/concerns/periodable.rb
+++ b/app/controllers/concerns/periodable.rb
@@ -9,7 +9,7 @@ module Periodable
     def set_period
       if params[:period].present?
         period_key = params[:period]
-        Current.user&.update!(default_period: period_key) if Period.valid_key?(period_key)
+        Current.user&.update!(default_period: period_key) if Period.available_key?(period_key)
       else
         period_key = Current.user&.default_period
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -106,7 +106,7 @@ class UsersController < ApplicationController
     end
 
     def user_params
-      family_attrs = [ :name, :currency, :country, :date_format, :timezone, :locale, :month_start_day, :id ]
+      family_attrs = [ :name, :currency, :country, :date_format, :timezone, :locale, :month_start_day, :fiscal_year_start_month, :fiscal_year_start_day, :id ]
       if Current.user.admin?
         family_attrs.push(:moniker, :default_account_sharing)
         family_attrs << { enabled_currencies: [] }

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -49,6 +49,8 @@ class Family < ApplicationRecord
   validates :date_format, inclusion: { in: DATE_FORMATS.map(&:last) }
   validates :month_start_day, inclusion: { in: 1..28 }
   validates :moniker, inclusion: { in: MONIKERS }
+  validates :fiscal_year_start_month, inclusion: { in: 1..12 }
+  validates :fiscal_year_start_day, inclusion: { in: 1..28 }
   validates :assistant_type, inclusion: { in: ASSISTANT_TYPES }
   validates :default_account_sharing, inclusion: { in: SHARING_DEFAULTS }
 
@@ -116,6 +118,16 @@ class Family < ApplicationRecord
     start_date = custom_month_start_for(Date.current)
     end_date = custom_month_end_for(Date.current)
     Period.custom(start_date: start_date, end_date: end_date)
+  end
+
+  def uses_fiscal_year?
+    fiscal_year_start_month != 1 || fiscal_year_start_day != 1
+  end
+
+  def current_fiscal_year_start
+    today = Date.current
+    fy_start_this_year = Date.new(today.year, fiscal_year_start_month, fiscal_year_start_day)
+    fy_start_this_year <= today ? fy_start_this_year : fy_start_this_year - 1.year
   end
 
   def assigned_merchants

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -58,6 +58,16 @@ class Period
       label: "Current Year",
       comparison_label: "vs. start of year"
     },
+    "fiscal_year_to_date" => {
+      date_range: -> {
+        family = Current.family
+        start_date = family ? family.current_fiscal_year_start : Date.current.beginning_of_year
+        [ start_date, Date.current ]
+      },
+      label_short: "FYTD",
+      label: "Financial Year",
+      comparison_label: "vs. start of financial year"
+    },
     "last_365_days" => {
       date_range: -> { [ 365.days.ago.to_date, Date.current ] },
       label_short: "365D",

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -61,6 +61,9 @@ class Period
     "fiscal_year_to_date" => {
       date_range: -> {
         family = Current.family
+        # When family is nil the fallback silently produces a YTD-equivalent range
+        # (beginning_of_year..today) identical to current_year; callers such as
+        # Periodable should guard against this with uses_fiscal_year?.
         start_date = family ? family.current_fiscal_year_start : Date.current.beginning_of_year
         [ start_date, Date.current ]
       },
@@ -124,7 +127,10 @@ class Period
     end
 
     def all
-      PERIODS.map { |key, period| from_key(key) }
+      PERIODS.filter_map do |key, _period|
+        next if key == "fiscal_year_to_date" && !Current.family&.uses_fiscal_year?
+        from_key(key)
+      end
     end
 
     def as_options

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -59,14 +59,9 @@ class Period
       comparison_label: "vs. start of year"
     },
     "fiscal_year_to_date" => {
-      date_range: -> {
-        family = Current.family
-        # When family is nil the fallback silently produces a YTD-equivalent range
-        # (beginning_of_year..today) identical to current_year; callers such as
-        # Periodable should guard against this with uses_fiscal_year?.
-        start_date = family ? family.current_fiscal_year_start : Date.current.beginning_of_year
-        [ start_date, Date.current ]
-      },
+      # Availability is gated by Period.available_key?, so Current.family is guaranteed
+      # to be present and uses_fiscal_year? when this lambda is evaluated via from_key.
+      date_range: -> { [ Current.family.current_fiscal_year_start, Date.current ] },
       label_short: "FYTD",
       label: "Financial Year",
       comparison_label: "vs. start of financial year"

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -112,8 +112,16 @@ class Period
       PERIODS.key?(key)
     end
 
+    # Returns true only when the key exists in PERIODS and is available for the
+    # given family. "fiscal_year_to_date" is unavailable for families whose
+    # fiscal year starts on Jan 1 (the default) because it would produce a range
+    # identical to current_year.
+    def available_key?(key, family = Current.family)
+      PERIODS.key?(key) && (key != "fiscal_year_to_date" || family&.uses_fiscal_year?)
+    end
+
     def from_key(key)
-      unless PERIODS.key?(key)
+      unless available_key?(key)
         raise InvalidKeyError, "Invalid period key: #{key}"
       end
 
@@ -128,8 +136,7 @@ class Period
 
     def all
       PERIODS.filter_map do |key, _period|
-        next if key == "fiscal_year_to_date" && !Current.family&.uses_fiscal_year?
-        from_key(key)
+        from_key(key) if available_key?(key)
       end
     end
 

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -130,9 +130,7 @@ class Period
     end
 
     def all
-      PERIODS.filter_map do |key, _period|
-        from_key(key) if available_key?(key)
-      end
+      PERIODS.keys.select { |key| available_key?(key) }.map { |key| from_key(key) }
     end
 
     def as_options

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -59,9 +59,14 @@ class Period
       comparison_label: "vs. start of year"
     },
     "fiscal_year_to_date" => {
-      # Availability is gated by Period.available_key?, so Current.family is guaranteed
-      # to be present and uses_fiscal_year? when this lambda is evaluated via from_key.
-      date_range: -> { [ Current.family.current_fiscal_year_start, Date.current ] },
+      date_range: -> {
+        family = Current.family
+        # When family is nil the fallback silently produces a YTD-equivalent range
+        # (beginning_of_year..today) identical to current_year; callers such as
+        # Periodable should guard against this with uses_fiscal_year?.
+        start_date = family ? family.current_fiscal_year_start : Date.current.beginning_of_year
+        [ start_date, Date.current ]
+      },
       label_short: "FYTD",
       label: "Financial Year",
       comparison_label: "vs. start of financial year"
@@ -107,18 +112,8 @@ class Period
       PERIODS.key?(key)
     end
 
-    # Returns true only when the key exists in PERIODS and is available for the
-    # given family. "fiscal_year_to_date" is unavailable for families whose
-    # fiscal year starts on Jan 1 (the default) because it would produce a range
-    # identical to current_year.
-    def available_key?(key, family = nil)
-      return false unless PERIODS.key?(key)
-      return true unless key == "fiscal_year_to_date"
-      (family || Current.family)&.uses_fiscal_year?
-    end
-
     def from_key(key)
-      unless available_key?(key)
+      unless PERIODS.key?(key)
         raise InvalidKeyError, "Invalid period key: #{key}"
       end
 
@@ -132,7 +127,10 @@ class Period
     end
 
     def all
-      PERIODS.keys.select { |key| available_key?(key) }.map { |key| from_key(key) }
+      PERIODS.filter_map do |key, _period|
+        next if key == "fiscal_year_to_date" && !Current.family&.uses_fiscal_year?
+        from_key(key)
+      end
     end
 
     def as_options

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -111,8 +111,10 @@ class Period
     # given family. "fiscal_year_to_date" is unavailable for families whose
     # fiscal year starts on Jan 1 (the default) because it would produce a range
     # identical to current_year.
-    def available_key?(key, family = Current.family)
-      PERIODS.key?(key) && (key != "fiscal_year_to_date" || family&.uses_fiscal_year?)
+    def available_key?(key, family = nil)
+      return false unless PERIODS.key?(key)
+      return true unless key == "fiscal_year_to_date"
+      (family || Current.family)&.uses_fiscal_year?
     end
 
     def from_key(key)

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -33,6 +33,14 @@
             <%= t(".month_start_day_warning") %>
           </div>
         <% end %>
+        <%= family_form.select :fiscal_year_start_month,
+            Date::MONTHNAMES.compact.each_with_index.map { |name, i| [name, i + 1] },
+            { label: t(".fiscal_year_start_month"), hint: t(".fiscal_year_start_hint") },
+            { data: { auto_submit_form_target: "auto" } } %>
+        <%= family_form.select :fiscal_year_start_day,
+            (1..28).map { |day| [day.ordinalize, day] },
+            { label: t(".fiscal_year_start_day") },
+            { data: { auto_submit_form_target: "auto" } } %>
         <p class="text-xs italic pl-2 text-secondary">Please note, we are still working on translations for various languages.</p>
       <% end %>
     <% end %>

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -33,14 +33,17 @@
             <%= t(".month_start_day_warning") %>
           </div>
         <% end %>
-        <%= family_form.select :fiscal_year_start_month,
-            Date::MONTHNAMES.compact.each_with_index.map { |name, i| [name, i + 1] },
-            { label: t(".fiscal_year_start_month"), hint: t(".fiscal_year_start_hint") },
-            { data: { auto_submit_form_target: "auto" } } %>
-        <%= family_form.select :fiscal_year_start_day,
-            (1..28).map { |day| [day.ordinalize, day] },
-            { label: t(".fiscal_year_start_day") },
-            { data: { auto_submit_form_target: "auto" } } %>
+        <% if @user.family.uses_fiscal_year? %>
+          <%= family_form.select :fiscal_year_start_month,
+              Date::MONTHNAMES.compact.each_with_index.map { |name, i| [name, i + 1] },
+              { label: t(".fiscal_year_start_month") },
+              { data: { auto_submit_form_target: "auto" } } %>
+          <%= family_form.select :fiscal_year_start_day,
+              (1..28).map { |day| [day.ordinalize, day] },
+              { label: t(".fiscal_year_start_day") },
+              { data: { auto_submit_form_target: "auto" } } %>
+          <p class="text-xs text-secondary pl-2"><%= t(".fiscal_year_start_hint") %></p>
+        <% end %>
         <p class="text-xs italic pl-2 text-secondary">Please note, we are still working on translations for various languages.</p>
       <% end %>
     <% end %>

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -33,15 +33,17 @@
             <%= t(".month_start_day_warning") %>
           </div>
         <% end %>
-        <%= family_form.select :fiscal_year_start_month,
-            Date::MONTHNAMES.compact.each_with_index.map { |name, i| [name, i + 1] },
-            { label: t(".fiscal_year_start_month") },
-            { data: { auto_submit_form_target: "auto" } } %>
-        <%= family_form.select :fiscal_year_start_day,
-            (1..28).map { |day| [day.ordinalize, day] },
-            { label: t(".fiscal_year_start_day") },
-            { data: { auto_submit_form_target: "auto" } } %>
-        <p class="text-xs text-secondary pl-2"><%= t(".fiscal_year_start_hint") %></p>
+        <% if @user.family.uses_fiscal_year? %>
+          <%= family_form.select :fiscal_year_start_month,
+              Date::MONTHNAMES.compact.each_with_index.map { |name, i| [name, i + 1] },
+              { label: t(".fiscal_year_start_month") },
+              { data: { auto_submit_form_target: "auto" } } %>
+          <%= family_form.select :fiscal_year_start_day,
+              (1..28).map { |day| [day.ordinalize, day] },
+              { label: t(".fiscal_year_start_day") },
+              { data: { auto_submit_form_target: "auto" } } %>
+          <p class="text-xs text-secondary pl-2"><%= t(".fiscal_year_start_hint") %></p>
+        <% end %>
         <p class="text-xs italic pl-2 text-secondary">Please note, we are still working on translations for various languages.</p>
       <% end %>
     <% end %>

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -33,17 +33,15 @@
             <%= t(".month_start_day_warning") %>
           </div>
         <% end %>
-        <% if @user.family.uses_fiscal_year? %>
-          <%= family_form.select :fiscal_year_start_month,
-              Date::MONTHNAMES.compact.each_with_index.map { |name, i| [name, i + 1] },
-              { label: t(".fiscal_year_start_month") },
-              { data: { auto_submit_form_target: "auto" } } %>
-          <%= family_form.select :fiscal_year_start_day,
-              (1..28).map { |day| [day.ordinalize, day] },
-              { label: t(".fiscal_year_start_day") },
-              { data: { auto_submit_form_target: "auto" } } %>
-          <p class="text-xs text-secondary pl-2"><%= t(".fiscal_year_start_hint") %></p>
-        <% end %>
+        <%= family_form.select :fiscal_year_start_month,
+            Date::MONTHNAMES.compact.each_with_index.map { |name, i| [name, i + 1] },
+            { label: t(".fiscal_year_start_month") },
+            { data: { auto_submit_form_target: "auto" } } %>
+        <%= family_form.select :fiscal_year_start_day,
+            (1..28).map { |day| [day.ordinalize, day] },
+            { label: t(".fiscal_year_start_day") },
+            { data: { auto_submit_form_target: "auto" } } %>
+        <p class="text-xs text-secondary pl-2"><%= t(".fiscal_year_start_hint") %></p>
         <p class="text-xs italic pl-2 text-secondary">Please note, we are still working on translations for various languages.</p>
       <% end %>
     <% end %>

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -58,6 +58,9 @@ en:
         month_start_day: Budget month starts on
         month_start_day_hint: Set when your budget month starts (e.g., payday)
         month_start_day_warning: Your budgets and MTD calculations will use this custom start day instead of the 1st of each month.
+        fiscal_year_start_month: Financial year starts in
+        fiscal_year_start_day: Financial year starts on
+        fiscal_year_start_hint: Set the start of your financial year for FYTD calculations (e.g., March 1 for a March - February fiscal year)
         currencies_title: "%{moniker} Currencies"
         currencies_subtitle: Choose which currencies appear in money fields for your %{moniker}
         base_currency_label: Base currency

--- a/db/migrate/20260421000000_add_fiscal_year_start_to_families.rb
+++ b/db/migrate/20260421000000_add_fiscal_year_start_to_families.rb
@@ -1,0 +1,14 @@
+class AddFiscalYearStartToFamilies < ActiveRecord::Migration[7.2]
+  def change
+    add_column :families, :fiscal_year_start_month, :integer, default: 1, null: false
+    add_column :families, :fiscal_year_start_day, :integer, default: 1, null: false
+
+    add_check_constraint :families,
+      "fiscal_year_start_month >= 1 AND fiscal_year_start_month <= 12",
+      name: "fiscal_year_start_month_range"
+
+    add_check_constraint :families,
+      "fiscal_year_start_day >= 1 AND fiscal_year_start_day <= 28",
+      name: "fiscal_year_start_day_range"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -595,7 +595,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_120000) do
     t.string "assistant_type", default: "builtin", null: false
     t.string "default_account_sharing", default: "shared", null: false
     t.string "enabled_currencies", array: true
+    t.integer "fiscal_year_start_month", default: 1, null: false
+    t.integer "fiscal_year_start_day", default: 1, null: false
     t.check_constraint "default_account_sharing::text = ANY (ARRAY['shared'::character varying::text, 'private'::character varying::text])", name: "chk_families_default_account_sharing"
+    t.check_constraint "fiscal_year_start_day >= 1 AND fiscal_year_start_day <= 28", name: "fiscal_year_start_day_range"
+    t.check_constraint "fiscal_year_start_month >= 1 AND fiscal_year_start_month <= 12", name: "fiscal_year_start_month_range"
     t.check_constraint "month_start_day >= 1 AND month_start_day <= 28", name: "month_start_day_range"
   end
 

--- a/test/models/family/fiscal_year_test.rb
+++ b/test/models/family/fiscal_year_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class Family::FiscalYearTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "fiscal_year_start_month and fiscal_year_start_day default to 1" do
+    assert_equal 1, @family.fiscal_year_start_month
+    assert_equal 1, @family.fiscal_year_start_day
+  end
+
+  test "validates fiscal_year_start_month is between 1 and 12" do
+    @family.fiscal_year_start_month = 0
+    assert_not @family.valid?
+
+    @family.fiscal_year_start_month = 13
+    assert_not @family.valid?
+
+    @family.fiscal_year_start_month = 3
+    assert @family.valid?
+  end
+
+  test "validates fiscal_year_start_day is between 1 and 28" do
+    @family.fiscal_year_start_day = 0
+    assert_not @family.valid?
+
+    @family.fiscal_year_start_day = 29
+    assert_not @family.valid?
+
+    @family.fiscal_year_start_day = 1
+    assert @family.valid?
+  end
+
+  test "uses_fiscal_year? returns false when start is January 1" do
+    @family.fiscal_year_start_month = 1
+    @family.fiscal_year_start_day = 1
+    assert_not @family.uses_fiscal_year?
+  end
+
+  test "uses_fiscal_year? returns true when start month is not January" do
+    @family.fiscal_year_start_month = 3
+    assert @family.uses_fiscal_year?
+  end
+
+  test "uses_fiscal_year? returns true when start day is not 1" do
+    @family.fiscal_year_start_day = 15
+    assert @family.uses_fiscal_year?
+  end
+
+  test "current_fiscal_year_start returns this year's start when today is on or after it" do
+    @family.fiscal_year_start_month = 3
+    @family.fiscal_year_start_day = 1
+
+    travel_to Date.new(2026, 4, 21) do
+      assert_equal Date.new(2026, 3, 1), @family.current_fiscal_year_start
+    end
+  end
+
+  test "current_fiscal_year_start rolls back one year when today is before the start" do
+    @family.fiscal_year_start_month = 7
+    @family.fiscal_year_start_day = 1
+
+    travel_to Date.new(2026, 4, 21) do
+      assert_equal Date.new(2025, 7, 1), @family.current_fiscal_year_start
+    end
+  end
+
+  test "current_fiscal_year_start returns Jan 1 of current year for default settings" do
+    travel_to Date.new(2026, 4, 21) do
+      assert_equal Date.new(2026, 1, 1), @family.current_fiscal_year_start
+    end
+  end
+end

--- a/test/models/family/fiscal_year_test.rb
+++ b/test/models/family/fiscal_year_test.rb
@@ -52,10 +52,6 @@ class Family::FiscalYearTest < ActiveSupport::TestCase
     @family.fiscal_year_start_month = 3
     @family.fiscal_year_start_day = 1
 
-    travel_to Date.new(2026, 3, 1) do
-      assert_equal Date.new(2026, 3, 1), `@family.current_fiscal_year_start`
-    end
-
     travel_to Date.new(2026, 4, 21) do
       assert_equal Date.new(2026, 3, 1), @family.current_fiscal_year_start
     end

--- a/test/models/family/fiscal_year_test.rb
+++ b/test/models/family/fiscal_year_test.rb
@@ -52,6 +52,10 @@ class Family::FiscalYearTest < ActiveSupport::TestCase
     @family.fiscal_year_start_month = 3
     @family.fiscal_year_start_day = 1
 
+    travel_to Date.new(2026, 3, 1) do
+      assert_equal Date.new(2026, 3, 1), `@family.current_fiscal_year_start`
+    end
+
     travel_to Date.new(2026, 4, 21) do
       assert_equal Date.new(2026, 3, 1), @family.current_fiscal_year_start
     end

--- a/test/models/family/fiscal_year_test.rb
+++ b/test/models/family/fiscal_year_test.rb
@@ -57,6 +57,15 @@ class Family::FiscalYearTest < ActiveSupport::TestCase
     end
   end
 
+  test "current_fiscal_year_start returns this year's start on the exact boundary date" do
+    @family.fiscal_year_start_month = 3
+    @family.fiscal_year_start_day = 1
+
+    travel_to Date.new(2026, 3, 1) do
+      assert_equal Date.new(2026, 3, 1), @family.current_fiscal_year_start
+    end
+  end
+
   test "current_fiscal_year_start rolls back one year when today is before the start" do
     @family.fiscal_year_start_month = 7
     @family.fiscal_year_start_day = 1

--- a/test/models/period_test.rb
+++ b/test/models/period_test.rb
@@ -84,6 +84,7 @@ class PeriodTest < ActiveSupport::TestCase
 
   test "fiscal_year_to_date has correct labels" do
     mock_family = mock("family")
+    mock_family.stubs(:uses_fiscal_year?).returns(true)
     mock_family.expects(:current_fiscal_year_start).returns(Date.current.beginning_of_year)
     Current.expects(:family).at_least_once.returns(mock_family)
 
@@ -94,6 +95,7 @@ class PeriodTest < ActiveSupport::TestCase
 
   test "fiscal_year_to_date uses family's fiscal year start" do
     mock_family = mock("family")
+    mock_family.stubs(:uses_fiscal_year?).returns(true)
     mock_family.expects(:current_fiscal_year_start).returns(Date.new(2026, 3, 1))
     Current.expects(:family).at_least_once.returns(mock_family)
 
@@ -104,13 +106,11 @@ class PeriodTest < ActiveSupport::TestCase
     end
   end
 
-  test "fiscal_year_to_date falls back to beginning of year when no family" do
-    Current.expects(:family).returns(nil)
+  test "fiscal_year_to_date raises for nil family" do
+    Current.expects(:family).at_least_once.returns(nil)
 
-    travel_to Date.new(2026, 4, 21) do
-      period = Period.from_key("fiscal_year_to_date")
-      assert_equal Date.new(2026, 1, 1), period.start_date
-      assert_equal Date.current, period.end_date
+    assert_raises(Period::InvalidKeyError) do
+      Period.from_key("fiscal_year_to_date")
     end
   end
 end

--- a/test/models/period_test.rb
+++ b/test/models/period_test.rb
@@ -81,4 +81,36 @@ class PeriodTest < ActiveSupport::TestCase
     assert_equal 5.years.ago.to_date, period.start_date
     assert_equal Date.current, period.end_date
   end
+
+  test "fiscal_year_to_date has correct labels" do
+    mock_family = mock("family")
+    mock_family.expects(:current_fiscal_year_start).returns(Date.current.beginning_of_year)
+    Current.expects(:family).at_least_once.returns(mock_family)
+
+    period = Period.from_key("fiscal_year_to_date")
+    assert_equal "Financial Year", period.label
+    assert_equal "FYTD", period.label_short
+  end
+
+  test "fiscal_year_to_date uses family's fiscal year start" do
+    mock_family = mock("family")
+    mock_family.expects(:current_fiscal_year_start).returns(Date.new(2026, 3, 1))
+    Current.expects(:family).at_least_once.returns(mock_family)
+
+    travel_to Date.new(2026, 4, 21) do
+      period = Period.from_key("fiscal_year_to_date")
+      assert_equal Date.new(2026, 3, 1), period.start_date
+      assert_equal Date.current, period.end_date
+    end
+  end
+
+  test "fiscal_year_to_date falls back to beginning of year when no family" do
+    Current.expects(:family).returns(nil)
+
+    travel_to Date.new(2026, 4, 21) do
+      period = Period.from_key("fiscal_year_to_date")
+      assert_equal Date.new(2026, 1, 1), period.start_date
+      assert_equal Date.current, period.end_date
+    end
+  end
 end

--- a/test/models/period_test.rb
+++ b/test/models/period_test.rb
@@ -84,7 +84,6 @@ class PeriodTest < ActiveSupport::TestCase
 
   test "fiscal_year_to_date has correct labels" do
     mock_family = mock("family")
-    mock_family.stubs(:uses_fiscal_year?).returns(true)
     mock_family.expects(:current_fiscal_year_start).returns(Date.current.beginning_of_year)
     Current.expects(:family).at_least_once.returns(mock_family)
 
@@ -95,7 +94,6 @@ class PeriodTest < ActiveSupport::TestCase
 
   test "fiscal_year_to_date uses family's fiscal year start" do
     mock_family = mock("family")
-    mock_family.stubs(:uses_fiscal_year?).returns(true)
     mock_family.expects(:current_fiscal_year_start).returns(Date.new(2026, 3, 1))
     Current.expects(:family).at_least_once.returns(mock_family)
 
@@ -106,11 +104,13 @@ class PeriodTest < ActiveSupport::TestCase
     end
   end
 
-  test "fiscal_year_to_date raises for nil family" do
-    Current.expects(:family).at_least_once.returns(nil)
+  test "fiscal_year_to_date falls back to beginning of year when no family" do
+    Current.expects(:family).returns(nil)
 
-    assert_raises(Period::InvalidKeyError) do
-      Period.from_key("fiscal_year_to_date")
+    travel_to Date.new(2026, 4, 21) do
+      period = Period.from_key("fiscal_year_to_date")
+      assert_equal Date.new(2026, 1, 1), period.start_date
+      assert_equal Date.current, period.end_date
     end
   end
 end


### PR DESCRIPTION
https://github.com/we-promise/sure/discussions/1411 refers.

- Adds configurable fiscal year start (month + day) to each family, defaulting to January 1.
- Introduces a new **Financial Year to Date (FYTD)** period option that uses the family's fiscal year start to compute the date range.
- Exposes two new preference fields in **Settings → Preferences** so users can set their fiscal year start month and day.
- Backs the feature with a DB migration adding `fiscal_year_start_month` and `fiscal_year_start_day` columns with check constraints and non-null defaults.

---

## What changed

### Database — `db/migrate/20260421000000_add_fiscal_year_start_to_families.rb` / `db/schema.rb`

Two integer columns are added to the `families` table:

- `fiscal_year_start_month` — integer, default `1`, not null, constrained to `1..12`
- `fiscal_year_start_day` — integer, default `1`, not null, constrained to `1..28`

Both columns have database-level check constraints (`fiscal_year_start_month_range`, `fiscal_year_start_day_range`) mirroring the ActiveRecord validations. The day ceiling is `28` — the same conservative limit used by `month_start_day` — to avoid invalid dates in short months.

### Model — `app/models/family.rb`

Two new instance methods expose fiscal-year logic to the rest of the app:

- `uses_fiscal_year?` — returns `true` when the family's fiscal year does **not** start on January 1, useful for conditional UI display.
- `current_fiscal_year_start` — returns the most recent past (or today's) fiscal year start date, handling the year-boundary roll-over correctly (if the configured start falls after today, it steps back one year).

### Period model — `app/models/period.rb`

A new `"fiscal_year_to_date"` entry is registered in the period definitions hash. Its `date_range` lambda reads `Current.family` and calls `current_fiscal_year_start` to compute the start; it gracefully falls back to `Date.current.beginning_of_year` when no family context is available. Labels: short `"FYTD"`, long `"Financial Year"`, comparison `"vs. start of financial year"`.

### Preferences UI — `app/views/settings/preferences/show.html.erb`

Two `select` fields are added to the preferences form immediately after the existing `month_start_day` block:

- **Financial year starts in** — month selector built from `Date::MONTHNAMES`, auto-submits on change.
- **Financial year starts on** — day selector using ordinal labels (`1st`, `2nd`, …, `28th`), auto-submits on change.

Both fields include a hint string directing users to an example (`March 1 for a March – February fiscal year`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can configure a custom fiscal-year start (month and day) in family settings.
  * Added "Financial Year to Date" (FYTD) reporting period that appears when a fiscal year is configured.

* **Validation & Data**
  * Fiscal-year month/day validated to sensible ranges, stored with safe defaults and DB constraints.

* **UI**
  * Preferences include auto-submitting selects and a hint to configure fiscal-year start.

* **Tests**
  * Added tests for fiscal-year logic and FYTD period behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->