### PR TITLE
feat(ci): improve LLM eval visibility in GitHub Actions

### DIFF
--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -285,6 +285,7 @@ jobs:
           bundle exec rake "evals:run[${DATASET},${MODEL}]" | tee "${{ steps.dataset_slug.outputs.log_path }}"
 
       - name: Export run summary
+        id: export_summary
         env:
           DATASET: ${{ matrix.dataset }}
           MODEL: ${{ matrix.model }}
@@ -304,10 +305,17 @@ jobs:
               total_prompt_tokens: run.total_prompt_tokens,
               total_completion_tokens: run.total_completion_tokens,
               total_cost: run.total_cost,
-              metrics: run.metrics
+              metrics: run.metrics,
+              accuracy: run.accuracy || 0.0
             }
             File.write("${{ steps.dataset_slug.outputs.json_path }}", JSON.pretty_generate(payload))
-          '
+            puts "ACCURACY=#{payload[:accuracy]}"
+            puts "STATUS=#{payload[:status]}"
+          ' 2>&1 | tee /tmp/eval_output.txt
+          ACCURACY=$(grep "^ACCURACY=" /tmp/eval_output.txt | cut -d= -f2)
+          STATUS=$(grep "^STATUS=" /tmp/eval_output.txt | cut -d= -f2)
+          echo "accuracy=${ACCURACY}" >> "$GITHUB_OUTPUT"
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
 
       - name: Upload eval artifact
         uses: actions/upload-artifact@v4
@@ -318,6 +326,121 @@ jobs:
             ${{ steps.dataset_slug.outputs.json_path }}
           if-no-files-found: error
           retention-days: 30
+
+      - name: Output eval result
+        shell: bash
+        run: |
+          echo "### Eval Result: ${{ matrix.dataset }} / ${{ matrix.model }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Status**: ${{ steps.export_summary.outputs.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Accuracy**: ${{ steps.export_summary.outputs.accuracy }}%" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+  summarize_evals:
+    name: Summarize LLM Evals
+    needs: [check_openai, run_evals]
+    if: always() && needs.check_openai.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: eval-artifacts
+          pattern: llm-evals-*
+
+      - name: Generate summary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "# 🧪 LLM Evals Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Triggered by: \\`${{ github.ref }}\\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "---" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Find all JSON result files
+          shopt -s globstar nullglob
+          json_files=(eval-artifacts/**/*.json)
+
+          if [ ${#json_files[@]} -eq 0 ]; then
+            echo "⚠️ No eval results found." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Table header
+          echo "| Dataset | Model | Status | Accuracy | Cost | Duration |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|-------|--------|----------|------|----------|" >> "$GITHUB_STEP_SUMMARY"
+
+          all_passed=true
+          for json_file in "${json_files[@]}"; do
+            dataset=$(jq -r '.dataset' "$json_file")
+            model=$(jq -r '.model' "$json_file")
+            status=$(jq -r '.status' "$json_file")
+            accuracy=$(jq -r '.accuracy // 0' "$json_file")
+            cost=$(jq -r '.total_cost // 0' "$json_file")
+            duration=$(jq -r '.metrics.duration_seconds // 0' "$json_file")
+
+            # Status icon
+            if [ "$status" = "completed" ]; then
+              icon="✅"
+            else
+              icon="❌"
+              all_passed=false
+            fi
+
+            # Accuracy color (simplified for markdown)
+            echo "| $dataset | $model | $icon $status | ${accuracy}% | \$${cost} | ${duration}s |" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "---" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$all_passed" = "true" ]; then
+            echo "✅ **All evals passed!**" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ **Some evals failed. Check the details above.**" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "📦 Artifacts with full logs are available for download." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check eval thresholds
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          shopt -s globstar nullglob
+          json_files=(eval-artifacts/**/*.json)
+
+          failed=0
+          for json_file in "${json_files[@]}"; do
+            status=$(jq -r '.status' "$json_file")
+            accuracy=$(jq -r '.accuracy // 0' "$json_file")
+            dataset=$(jq -r '.dataset' "$json_file")
+            model=$(jq -r '.model' "$json_file")
+
+            if [ "$status" != "completed" ]; then
+              echo "::error::Eval for $dataset / $model did not complete successfully"
+              failed=$((failed + 1))
+            fi
+
+            # Fail if accuracy is below 70%
+            if [ "$(echo "$accuracy < 70" | bc)" -eq 1 ]; then
+              echo "::error::Accuracy for $dataset / $model is below threshold: ${accuracy}%"
+              failed=$((failed + 1))
+            fi
+          done
+
+          if [ $failed -gt 0 ]; then
+            echo "::error::$failed eval(s) failed or below threshold"
+            exit 1
+          fi
+
+          echo "All evals passed with acceptable accuracy."
 
   skip_evals:
     name: Skip evals (no valid OpenAI token/quota)

--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -289,7 +289,11 @@ jobs:
         env:
           DATASET: ${{ matrix.dataset }}
           MODEL: ${{ matrix.model }}
+          JSON_PATH: ${{ steps.dataset_slug.outputs.json_path }}
         run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$JSON_PATH")"
+
           bin/rails runner '
             dataset = Eval::Dataset.find_by!(name: ENV.fetch("DATASET"))
             run = Eval::Run.where(dataset: dataset, model: ENV.fetch("MODEL")).order(created_at: :desc).first
@@ -306,16 +310,14 @@ jobs:
               total_completion_tokens: run.total_completion_tokens,
               total_cost: run.total_cost,
               metrics: run.metrics,
-              accuracy: run.accuracy || 0.0
+              accuracy: run.accuracy || 0.0,
+              duration_seconds: run.duration_seconds
             }
-            File.write("${{ steps.dataset_slug.outputs.json_path }}", JSON.pretty_generate(payload))
-            puts "ACCURACY=#{payload[:accuracy]}"
-            puts "STATUS=#{payload[:status]}"
-          ' 2>&1 | tee /tmp/eval_output.txt
-          ACCURACY=$(grep "^ACCURACY=" /tmp/eval_output.txt | cut -d= -f2)
-          STATUS=$(grep "^STATUS=" /tmp/eval_output.txt | cut -d= -f2)
-          echo "accuracy=${ACCURACY}" >> "$GITHUB_OUTPUT"
-          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+            File.write(ENV.fetch("JSON_PATH"), JSON.pretty_generate(payload))
+          '
+
+          echo "accuracy=$(jq -r '.accuracy // 0' "$JSON_PATH")" >> "$GITHUB_OUTPUT"
+          echo "status=$(jq -r '.status' "$JSON_PATH")" >> "$GITHUB_OUTPUT"
 
       - name: Upload eval artifact
         uses: actions/upload-artifact@v4
@@ -356,7 +358,7 @@ jobs:
 
           echo "# 🧪 LLM Evals Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Triggered by: \\`${{ github.ref }}\\`" >> "$GITHUB_STEP_SUMMARY"
+          printf "Triggered by: \`%s\`\n" "$GITHUB_REF" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "---" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -375,24 +377,24 @@ jobs:
           echo "|---------|-------|--------|----------|------|----------|" >> "$GITHUB_STEP_SUMMARY"
 
           all_passed=true
+          accuracy_threshold=70
           for json_file in "${json_files[@]}"; do
             dataset=$(jq -r '.dataset' "$json_file")
             model=$(jq -r '.model' "$json_file")
             status=$(jq -r '.status' "$json_file")
             accuracy=$(jq -r '.accuracy // 0' "$json_file")
             cost=$(jq -r '.total_cost // 0' "$json_file")
-            duration=$(jq -r '.metrics.duration_seconds // 0' "$json_file")
+            duration=$(jq -r '.duration_seconds // 0' "$json_file")
 
-            # Status icon
-            if [ "$status" = "completed" ]; then
+            if [ "$status" = "completed" ] && awk -v accuracy="$accuracy" -v threshold="$accuracy_threshold" 'BEGIN { exit !((accuracy + 0) >= threshold) }'; then
               icon="✅"
             else
               icon="❌"
               all_passed=false
             fi
 
-            # Accuracy color (simplified for markdown)
-            echo "| $dataset | $model | $icon $status | ${accuracy}% | \$${cost} | ${duration}s |" >> "$GITHUB_STEP_SUMMARY"
+            printf '| %s | %s | %s %s | %s%% | \\$%s | %ss |\n' \
+              "$dataset" "$model" "$icon" "$status" "$accuracy" "$cost" "$duration" >> "$GITHUB_STEP_SUMMARY"
           done
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -417,6 +419,7 @@ jobs:
           json_files=(eval-artifacts/**/*.json)
 
           failed=0
+          accuracy_threshold=70
           for json_file in "${json_files[@]}"; do
             status=$(jq -r '.status' "$json_file")
             accuracy=$(jq -r '.accuracy // 0' "$json_file")
@@ -429,7 +432,7 @@ jobs:
             fi
 
             # Fail if accuracy is below 70%
-            if [ "$(echo "$accuracy < 70" | bc)" -eq 1 ]; then
+            if awk -v accuracy="$accuracy" -v threshold="$accuracy_threshold" 'BEGIN { exit !((accuracy + 0) < threshold) }'; then
               echo "::error::Accuracy for $dataset / $model is below threshold: ${accuracy}%"
               failed=$((failed + 1))
             fi


### PR DESCRIPTION
## Summary
Makes LLM eval results prominently visible in GitHub Actions UI instead of burying them in artifacts.

## Changes
- **Per-eval step summary**: Each eval run now outputs status + accuracy to `$GITHUB_STEP_SUMMARY` (visible in Actions tab)
- **New `summarize_evals` job**: Aggregates all matrix runs into a single markdown table showing Dataset | Model | Status | Accuracy | Cost | Duration
- **Visual indicators**: ✅/❌ icons for quick pass/fail scanning
- **Quality gates**: Workflow fails if:
  - Any eval doesn't complete
  - Accuracy drops below 70%
- **Overall status banner** at the end of summary

## Why
Currently eval results are only available as artifacts, requiring multiple clicks to find. Now results are front-and-center in the Actions UI when pushing `v*` tags.

## Testing
- [ ] Push a `v*` tag and verify summary appears in Actions tab
- [ ] Verify table renders correctly with multiple datasets/models
- [ ] Confirm workflow fails appropriately when accuracy < 70%

Closes: Request from @jjmata to make eval results more prominent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced evaluation metrics tracking and automated reporting, capturing accuracy and duration for each eval and surfacing them in CI run summaries.
* **New Features**
  * Added an aggregated evaluation report that lists dataset/model/status/accuracy/cost/duration and enforces a quality gate (fails workflow if any eval is incomplete or accuracy < 70%).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->