### PR TITLE
Fix budget donut chart hiding center content on segment hover

### DIFF
--- a/app/javascript/controllers/donut_chart_controller.js
+++ b/app/javascript/controllers/donut_chart_controller.js
@@ -26,14 +26,14 @@ export default class extends Controller {
     this.#draw();
     document.addEventListener("turbo:load", this.#redraw);
     this.element.addEventListener("mouseleave", this.#clearSegmentHover);
-    this.contentContainerTarget.addEventListener("mouseenter", this.#clearSegmentHover);
+    this.contentContainerTarget.addEventListener("mouseleave", this.#clearSegmentHover);
   }
 
   disconnect() {
     this.#teardown();
     document.removeEventListener("turbo:load", this.#redraw);
     this.element.removeEventListener("mouseleave", this.#clearSegmentHover);
-    this.contentContainerTarget.removeEventListener("mouseenter", this.#clearSegmentHover);
+    this.contentContainerTarget.removeEventListener("mouseleave", this.#clearSegmentHover);
   }
 
   get #data() {
@@ -153,8 +153,12 @@ export default class extends Controller {
           this.#handleSegmentHover(event);
         }, 10);
       })
-      .on("mouseleave", () => {
+      .on("mouseleave", (event, d) => {
         clearTimeout(hoverTimeout);
+        const leavingUnused = d.data.id === this.unusedSegmentIdValue;
+        if (leavingUnused || !this.contentContainerTarget.contains(event.relatedTarget)) {
+          this.#clearSegmentHover();
+        }
       })
       .on("click", (event, d) => {
         if (this.enableClickValue) {

--- a/app/javascript/controllers/donut_chart_controller.js
+++ b/app/javascript/controllers/donut_chart_controller.js
@@ -26,12 +26,14 @@ export default class extends Controller {
     this.#draw();
     document.addEventListener("turbo:load", this.#redraw);
     this.element.addEventListener("mouseleave", this.#clearSegmentHover);
+    this.contentContainerTarget.addEventListener("mouseenter", this.#clearSegmentHover);
   }
 
   disconnect() {
     this.#teardown();
     document.removeEventListener("turbo:load", this.#redraw);
     this.element.removeEventListener("mouseleave", this.#clearSegmentHover);
+    this.contentContainerTarget.removeEventListener("mouseenter", this.#clearSegmentHover);
   }
 
   get #data() {


### PR DESCRIPTION
fixes issue #1550 

## Summary

- Hovering over an arc segment in the Budget "Spent" donut chart hid the center content (including the Edit Budget link) until the mouse fully left the chart boundary
- Added a mouseenter listener on contentContainerTarget so the default content is restored as soon as the mouse moves into the hollow center of the donut
- The fix is a one-line addition in connect() with its corresponding cleanup in disconnect()

## Test

- Open the Budget tab with at least one spending category
- Hover over a colored arc segment — center content should show the segment detail
- Move the mouse into the hollow center of the donut — default content (Edit Budget link) should reappear immediately and be clickable
- Move back over an arc segment — segment detail should show again
- Move mouse fully off the chart — default content remains visible

## Notes

- No new targets or values added to the Stimulus controller
- Existing mouseleave behavior on the outer element is unchanged



https://github.com/user-attachments/assets/05db2cc9-e3ca-46e9-92c0-df4304c19a6b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed donut chart hover so active segment clears when the pointer leaves the chart content area.
  * Prevented hover from being cleared when moving within the chart content, avoiding spurious flicker.
  * Leaving the "unused" slice now clears hover immediately for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->