### PR TITLE
Added ability to bulk-edit transaction names for multiple selected transactions

### DIFF
--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -16,7 +16,7 @@ class Transactions::BulkUpdatesController < ApplicationController
   private
     def bulk_update_params
       params.require(:bulk_update)
-            .permit(:date, :notes, :category_id, :merchant_id, entry_ids: [], tag_ids: [])
+            .permit(:date, :notes, :name, :category_id, :merchant_id, entry_ids: [], tag_ids: [])
     end
 
     # Check if tag_ids was explicitly provided in the request.

--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -1,7 +1,12 @@
+# frozen_string_literal: true
+
+# Controller for bulk updating multiple transactions at once
 class Transactions::BulkUpdatesController < ApplicationController
+  # Renders the bulk update form
   def new
   end
 
+  # Performs the bulk update on selected transactions
   def create
     # Skip split parents from bulk update - update children instead
     updated = Current.family
@@ -14,6 +19,8 @@ class Transactions::BulkUpdatesController < ApplicationController
   end
 
   private
+
+    # Returns the permitted params for bulk updating transactions
     def bulk_update_params
       params.require(:bulk_update)
             .permit(:date, :notes, :name, :category_id, :merchant_id, entry_ids: [], tag_ids: [])

--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -1,12 +1,7 @@
-# frozen_string_literal: true
-
-# Controller for bulk updating multiple transactions at once
 class Transactions::BulkUpdatesController < ApplicationController
-  # Renders the bulk update form
   def new
   end
 
-  # Performs the bulk update on selected transactions
   def create
     # Skip split parents from bulk update - update children instead
     updated = Current.family
@@ -19,8 +14,6 @@ class Transactions::BulkUpdatesController < ApplicationController
   end
 
   private
-
-    # Returns the permitted params for bulk updating transactions
     def bulk_update_params
       params.require(:bulk_update)
             .permit(:date, :notes, :name, :category_id, :merchant_id, entry_ids: [], tag_ids: [])

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -440,6 +440,7 @@ class Entry < ApplicationRecord
       bulk_attributes = {
         date: bulk_update_params[:date],
         notes: bulk_update_params[:notes],
+        name: bulk_update_params[:name],
         entryable_attributes: {
           category_id: bulk_update_params[:category_id],
           merchant_id: bulk_update_params[:merchant_id]

--- a/app/views/transactions/bulk_updates/new.html.erb
+++ b/app/views/transactions/bulk_updates/new.html.erb
@@ -1,15 +1,14 @@
 <%= render DS::Dialog.new(variant: "drawer", frame: "bulk_transaction_edit_drawer") do |dialog| %>
   <% dialog.with_header(title: "Edit transactions", data: { bulk_select_target: "bulkEditDrawerHeader" }) %>
-
   <% dialog.with_body do %>
     <%= styled_form_with url: transactions_bulk_update_path, scope: "bulk_update", class: "h-full flex flex-col justify-between gap-4", data: { turbo_frame: "_top" } do |form| %>
       <div class="space-y-4">
         <%= render DS::Disclosure.new(title: "Overview", open: true) do %>
           <%= form.date_field :date, label: "Date", max: Date.current %>
         <% end %>
-
         <%= render DS::Disclosure.new(title: "Transactions", open: true) do %>
           <div class="space-y-2">
+            <%= form.text_field :name, label: "Name", placeholder: "Enter a name that will be applied to selected transactions" %>
             <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: "Select a category", label: "Category", class: "text-subdued" } %>
             <%= form.collection_select :merchant_id, Current.family.available_merchants_for(Current.user).alphabetically, :id, :name, { prompt: "Select a merchant", label: "Merchant", class: "text-subdued" } %>
             <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: "None", multiple: true, label: "Tags", include_hidden: false } %>
@@ -17,7 +16,6 @@
           </div>
         <% end %>
       </div>
-
       <div class="flex justify-end gap-2 mt-auto">
         <%= render DS::Button.new(text: "Cancel", variant: "ghost", data: { action: "click->DS--dialog#close" }) %>
         <%= render DS::Button.new(text: "Save", data: { bulk_select_scope_param: "bulk_update", action: "bulk-select#submitBulkRequest" }) %>

--- a/app/views/transactions/bulk_updates/new.html.erb
+++ b/app/views/transactions/bulk_updates/new.html.erb
@@ -8,7 +8,7 @@
         <% end %>
         <%= render DS::Disclosure.new(title: "Transactions", open: true) do %>
           <div class="space-y-2">
-            <%= form.text_field :name, label: "Name", placeholder: "Enter a name that will be applied to selected transactions" %>
+            <%= form.text_field :name, label: t("transactions.bulk_updates.new.name_label"), placeholder: t("transactions.bulk_updates.new.name_placeholder") %>
             <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: "Select a category", label: "Category", class: "text-subdued" } %>
             <%= form.collection_select :merchant_id, Current.family.available_merchants_for(Current.user).alphabetically, :id, :name, { prompt: "Select a merchant", label: "Merchant", class: "text-subdued" } %>
             <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: "None", multiple: true, label: "Tags", include_hidden: false } %>

--- a/app/views/transactions/bulk_updates/new.html.erb
+++ b/app/views/transactions/bulk_updates/new.html.erb
@@ -1,11 +1,13 @@
 <%= render DS::Dialog.new(variant: "drawer", frame: "bulk_transaction_edit_drawer") do |dialog| %>
   <% dialog.with_header(title: "Edit transactions", data: { bulk_select_target: "bulkEditDrawerHeader" }) %>
+
   <% dialog.with_body do %>
     <%= styled_form_with url: transactions_bulk_update_path, scope: "bulk_update", class: "h-full flex flex-col justify-between gap-4", data: { turbo_frame: "_top" } do |form| %>
       <div class="space-y-4">
         <%= render DS::Disclosure.new(title: "Overview", open: true) do %>
           <%= form.date_field :date, label: "Date", max: Date.current %>
         <% end %>
+
         <%= render DS::Disclosure.new(title: "Transactions", open: true) do %>
           <div class="space-y-2">
             <%= form.text_field :name, label: t("transactions.bulk_updates.new.name_label"), placeholder: t("transactions.bulk_updates.new.name_placeholder") %>
@@ -16,6 +18,7 @@
           </div>
         <% end %>
       </div>
+
       <div class="flex justify-end gap-2 mt-auto">
         <%= render DS::Button.new(text: "Cancel", variant: "ghost", data: { action: "click->DS--dialog#close" }) %>
         <%= render DS::Button.new(text: "Save", data: { bulk_select_scope_param: "bulk_update", action: "bulk-select#submitBulkRequest" }) %>

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -1,6 +1,10 @@
 ---
 en:
   transactions:
+    bulk_updates:
+      new:
+        name_label: Name
+        name_placeholder: Enter a name that will be applied to selected transactions
     unknown_name: Unknown transaction
     selection_bar:
       duplicate: Duplicate


### PR DESCRIPTION
PR Summary:

Changes Made: Added ability to bulk-edit transaction names for multiple selected transactions.
Files Modified
1. app/controllers/transactions/bulk_updates_controller.rb - Added :name to permitted params
2. app/models/entry.rb - Added name: to bulk_attributes in bulk_update! method
3. app/views/transactions/bulk_updates/new.html.erb - Added text field for entering transaction name




Behavior
When users select multiple transactions and click the edit button, they can now change the name field which will be applied to all selected transactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk update now supports a "Name" field, allowing renaming of multiple selected transactions in one action. The bulk edit form includes a new Name input with English label and placeholder strings. Updates behave consistently with other standard bulk attributes and do not change existing tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->