### PR TITLE
fix(localization): update API usage instructions to include product name placeholder

### DIFF
--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -77,7 +77,7 @@
 
     <div class="bg-surface-inset rounded-xl p-4">
       <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-      <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
+      <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
       <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
         curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
       </div>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -77,7 +77,7 @@
 
     <div class="bg-surface-inset rounded-xl p-4">
       <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-      <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
+      <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.show.current_api_key.usage_instructions", product_name: product_name) %></p>
       <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
         curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
       </div>

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -37,7 +37,7 @@
 
       <div class="bg-surface-inset rounded-xl p-4">
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-        <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
+        <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
           curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
         </div>
@@ -125,7 +125,7 @@
 
       <div class="bg-surface-inset rounded-xl p-4">
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
-        <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
+        <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
           curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
         </div>

--- a/config/locales/views/settings/api_keys/en.yml
+++ b/config/locales/views/settings/api_keys/en.yml
@@ -37,7 +37,7 @@ en:
           never_expires: "Never expires"
           permissions: "Permissions"
           usage_instructions_title: "How to use your API key"
-          usage_instructions: "Include your API key in the X-Api-Key header when making requests to the Maybe API:"
+          usage_instructions: "Include your API key in the X-Api-Key header when making requests to the %{product_name} API:"
           regenerate_key: "Create New Key"
           revoke_key: "Revoke Key"
           revoke_confirmation: "Are you sure you want to revoke this API key? This action cannot be undone and will immediately disable all applications using this key."

--- a/config/locales/views/settings/api_keys/fr.yml
+++ b/config/locales/views/settings/api_keys/fr.yml
@@ -37,7 +37,7 @@ fr:
           never_expires: "N'expire jamais"
           permissions: "Autorisations"
           usage_instructions_title: "Comment utiliser votre clé API"
-          usage_instructions: "Incluez votre clé API dans l'en-tête X-Api-Key lors des requêtes à l'API Maybe :"
+          usage_instructions: "Incluez votre clé API dans l'en-tête X-Api-Key lors des requêtes à l'API %{product_name} :"
           regenerate_key: "Créer une nouvelle clé"
           revoke_key: "Révoquer la clé"
           revoke_confirmation: "Êtes-vous sûr(e) de vouloir révoquer cette clé API ? Cette action ne peut pas être annulée et désactivera immédiatement toutes les applications utilisant cette clé."


### PR DESCRIPTION
### Description
This PR resolves an issue where the brand name was hardcoded in the API keys settings locale files, preventing proper white-labeling and causing translation divergence.

Closes #1509

**Changes made:**
* Updated `usage_instructions` in `en.yml` to use `%{product_name} API`.
* Updated `usage_instructions` in `fr.yml` to use `l'API %{product_name}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * API key usage instructions updated in English and French to reference the product name dynamically.
  * When displaying API keys, the app now consistently shows the localized usage message that includes the product name, replacing the previous hard-coded text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->