### PR TITLE
chore: track Sure build bootstrap skill

### DIFF
--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: sure-openclaw-build-bootstrap
+description: Bootstrap a lean, repeatable Sure build and test environment inside an OpenClaw workspace or similar container/VM. Use when setting up a fresh build environment, auditing missing dependencies before running Sure tests, or turning environment learnings into a repeatable bootstrap flow.
+---
+
+# Sure OpenClaw build bootstrap
+
+Use this skill when you need to stand up or re-audit a Sure development environment inside an existing OpenClaw-hosted machine, especially when the goal is to run the Rails test and lint suite without introducing nested Docker or local Postgres state.
+
+## Goal
+
+Create a repeatable bootstrap flow that keeps the environment lean:
+
+- run directly inside the current OpenClaw container or VM when that is the better fit
+- prefer the repo devcontainer when the host is a normal non-virtualized machine
+- avoid nested Docker or devcontainers as runtime when already inside a constrained VM or container
+- prefer rebuildable local services over persistent heavyweight state
+- prefer external Postgres for app data when disk is limited
+
+## Workflow
+
+1. Run a baseline environment audit before installing anything.
+2. Let the audit decide whether to prefer an in-place bootstrap or the repo devcontainer.
+3. Compare the host state with the repo's declared expectations.
+4. Install only missing pieces.
+5. Keep persistent caches under `/root` or another durable host path.
+6. Treat local Redis as acceptable, but avoid local Postgres data unless there is a strong reason.
+7. Re-run the audit after each material setup step.
+
+## Step 1, baseline audit
+
+Use the helper script first:
+
+```bash
+python3 .openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py /path/to/sure
+```
+
+Optional JSON output:
+
+```bash
+python3 .openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py /path/to/sure --json
+```
+
+The script checks:
+
+- whether the host appears virtualized or containerized
+- whether core tools are present
+- which Ruby and Bundler versions the repo expects
+- whether the current Node version drifts from the devcontainer reference
+- available disk space and current repo size
+- whether the environment should prefer a lean in-place bootstrap or a devcontainer-first approach
+
+If you need to debug or extend it manually, these are the underlying checks:
+
+```bash
+ruby -v
+bundle -v
+node -v
+npm -v
+psql --version
+redis-server --version
+df -h / /root /tmp
+du -sh /path/to/sure
+cat .ruby-version
+grep -n '^BUNDLED WITH$' -A1 Gemfile.lock
+grep -n '^ruby ' Gemfile
+```
+
+## Current known baseline from the first audit
+
+On the first reference host, the baseline was:
+
+- Ruby: missing
+- Bundler: missing
+- Node: `v24.14.1`
+- npm: `11.11.0`
+- `psql`: missing
+- `redis-server`: missing
+- Sure checkout size: `138M`
+- free space on `/`: about `6.8G`
+- free space on `/root`: about `6.0G`
+- repo requires Ruby `3.4.7`
+- `Gemfile.lock` expects Bundler `2.6.7`
+- devcontainer reference uses Node `20.x`, PostgreSQL client, and Redis
+
+This tells you the environment cannot run Rails tests yet, but it has enough free space to proceed with a lean bootstrap.
+
+## Decision rules
+
+- If the audit says the host is not virtualized, strongly consider the repo devcontainer as the default setup path.
+- If the audit says the host is already virtualized or containerized, prefer a lean in-place bootstrap unless there is a strong reason to nest containers.
+- If Ruby is absent, install the repo-required version first.
+- If Bundler is absent, install the exact lockfile-compatible version.
+- If Node is present but newer than the repo reference, note the drift rather than changing it immediately.
+- If `psql` is absent, install client tooling only unless the task explicitly requires local Postgres.
+- If Redis is absent, install and run it locally.
+- Do not assume devcontainer contents should be mirrored exactly. Use it as reference, not runtime.
+
+## Resources
+
+- `scripts/audit_sure_build_env.py` for a repeatable baseline audit and strategy recommendation.
+- `references/baseline-environment-audit.md` for the captured step 1 findings and rationale.

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -27,6 +27,45 @@ Create a repeatable bootstrap flow that keeps the environment lean:
 6. Treat local Redis as acceptable, but avoid local Postgres data unless there is a strong reason.
 7. Re-run the audit after each material setup step.
 
+## Step 2, install only missing OS packages
+
+On the first reference host, the missing OS-level pieces were:
+
+- `build-essential`
+- `pkg-config`
+- `libpq-dev`
+- `postgresql-client`
+- `redis-server`
+- `libyaml-dev`
+- `libvips`
+- `libvips-dev`
+- `libxml2-dev`
+- `libxslt1-dev`
+- `zlib1g-dev`
+
+Install them with:
+
+```bash
+apt-get update && apt-get install -y --no-install-recommends \
+  build-essential pkg-config libpq-dev postgresql-client redis-server \
+  libyaml-dev libvips libvips-dev libxml2-dev libxslt1-dev zlib1g-dev
+```
+
+Then clean package metadata if image size matters:
+
+```bash
+apt-get clean && rm -rf /var/lib/apt/lists/*
+```
+
+After this step on the reference host:
+
+- `psql` became available
+- `redis-server` became available
+- native build tooling became available
+- Ruby and Bundler were still missing, so Rails work was still blocked on the next step
+
+Important note: `libvips-dev` pulls a large transitive dependency set on Debian Bookworm. Keep it because Sure's devcontainer references it, but treat it as the heaviest part of this OS-package step.
+
 ## Step 1, baseline audit
 
 Use the helper script first:

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -47,6 +47,49 @@ Interpretation:
 
 If the audit reports `stop-and-free-disk-space`, do that before the next bootstrap step.
 
+## Step 3, install Ruby and Bundler
+
+Preferred path on the reference host:
+
+- install `rbenv` and `ruby-build` from apt
+- update the `ruby-build` plugin inside `/root/.rbenv/plugins/ruby-build` because Debian Bookworm's packaged definitions are too old for Ruby `3.4.7`
+- install Ruby `3.4.7` with `rbenv`
+- install Bundler `2.6.7` with `gem`
+
+Install missing Ruby build helpers:
+
+```bash
+apt-get install -y --no-install-recommends \
+  rbenv ruby-build libreadline-dev libgdbm-dev libgdbm-compat-dev bison
+```
+
+Refresh `ruby-build` definitions and install Ruby:
+
+```bash
+mkdir -p /root/.rbenv/plugins
+rm -rf /root/.rbenv/plugins/ruby-build
+git clone --depth=1 https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build
+
+export RBENV_ROOT=/root/.rbenv
+export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+eval "$(rbenv init -)"
+export RUBY_BUILD_CACHE_PATH=/root/.cache/ruby-build
+
+rbenv install -s 3.4.7
+rbenv global 3.4.7
+rbenv rehash
+```
+
+Install the lockfile-compatible Bundler:
+
+```bash
+gem install bundler -v 2.6.7 --no-document
+rbenv rehash
+bundle -v
+```
+
+Important note: the host may still also have Debian's system Ruby on PATH. The audit helper is expected to prefer the `rbenv` Ruby and Bundler when they match repo requirements.
+
 ## Step 2, install only missing OS packages
 
 On the first reference host, the missing OS-level pieces were:
@@ -159,5 +202,5 @@ This tells you the environment cannot run Rails tests yet, but it has enough fre
 
 ## Resources
 
-- `scripts/audit_sure_build_env.py` for a repeatable baseline audit and strategy recommendation.
-- `references/baseline-environment-audit.md` for the captured step 1 findings and rationale.
+- `scripts/audit_sure_build_env.py` for a repeatable baseline audit, disk-space gate, and strategy recommendation.
+- `references/baseline-environment-audit.md` for the captured step-by-step findings and rationale.

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -257,6 +257,35 @@ POSTGRES_USER=root POSTGRES_DB=sure_development bundle exec rails db:prepare
 
 If this succeeds, the environment has crossed from package bootstrap into a working local Rails dev runtime.
 
+## Validation milestone, full model suite
+
+On the reference host, after the runtime bootstrap was complete, this passed successfully:
+
+```bash
+export RBENV_ROOT=/root/.rbenv
+export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+eval "$(rbenv init -)"
+POSTGRES_USER=root bundle exec rails test test/models
+```
+
+Observed result on the reference host:
+
+- `2183 runs`
+- `8778 assertions`
+- `0 failures`
+- `0 errors`
+- `1 skip`
+
+Non-blocking observations:
+
+- one skipped test was reported
+- one test was reported as missing assertions
+- Ruby 3.4 emitted future frozen-string warnings from the `marcel` gem
+
+Treat those as follow-up cleanup items, not environment bootstrap failures.
+
+After this milestone, the next useful validation step is usually the controller or integration layer.
+
 ## Resources
 
 - `scripts/audit_sure_build_env.py` for a repeatable baseline audit, disk-space gate, and strategy recommendation.

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -22,10 +22,30 @@ Create a repeatable bootstrap flow that keeps the environment lean:
 1. Run a baseline environment audit before installing anything.
 2. Let the audit decide whether to prefer an in-place bootstrap or the repo devcontainer.
 3. Compare the host state with the repo's declared expectations.
-4. Install only missing pieces.
-5. Keep persistent caches under `/root` or another durable host path.
-6. Treat local Redis as acceptable, but avoid local Postgres data unless there is a strong reason.
-7. Re-run the audit after each material setup step.
+4. Gate every material bootstrap step on disk space. Do not continue if the audit fails the disk check.
+5. Install only missing pieces.
+6. Keep persistent caches under `/root` or another durable host path.
+7. Treat local Redis as acceptable, but avoid local Postgres data unless there is a strong reason.
+8. Re-run the audit after each material setup step.
+
+## Disk-space gating rules
+
+Treat disk headroom as a hard safety check, not just a nice-to-have.
+
+Current audit gates:
+
+- `/` must have at least `2 GiB` free
+- `/root` must have at least `4 GiB` free
+- `/tmp` must have at least `1 GiB` free
+- `/root` should also keep a preferred buffer of at least `2x` current repo size, with a `2 GiB` floor
+
+Interpretation:
+
+- `pass`: safe to continue
+- `warn`: above hard minimums but below preferred buffer, continue carefully
+- `fail`: stop and free disk before installing more dependencies or caches
+
+If the audit reports `stop-and-free-disk-space`, do that before the next bootstrap step.
 
 ## Step 2, install only missing OS packages
 
@@ -63,6 +83,7 @@ After this step on the reference host:
 - `redis-server` became available
 - native build tooling became available
 - Ruby and Bundler were still missing, so Rails work was still blocked on the next step
+- disk-space gate still passed after installation, which is required before moving on
 
 Important note: `libvips-dev` pulls a large transitive dependency set on Debian Bookworm. Keep it because Sure's devcontainer references it, but treat it as the heaviest part of this OS-package step.
 
@@ -87,6 +108,7 @@ The script checks:
 - which Ruby and Bundler versions the repo expects
 - whether the current Node version drifts from the devcontainer reference
 - available disk space and current repo size
+- whether hard disk-space gates pass before continuing
 - whether the environment should prefer a lean in-place bootstrap or a devcontainer-first approach
 
 If you need to debug or extend it manually, these are the underlying checks:

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -286,6 +286,31 @@ Treat those as follow-up cleanup items, not environment bootstrap failures.
 
 After this milestone, the next useful validation step is usually the controller or integration layer.
 
+## Validation milestone, integration suite
+
+On the reference host, after models and controllers were already green, this also passed successfully:
+
+```bash
+export RBENV_ROOT=/root/.rbenv
+export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+eval "$(rbenv init -)"
+POSTGRES_USER=root bundle exec rails test test/integration
+```
+
+Observed result on the reference host:
+
+- `21 runs`
+- `49 assertions`
+- `0 failures`
+- `0 errors`
+- `0 skips`
+
+Non-blocking observations:
+
+- Ruby 3.4 emitted future frozen-string warnings from the `marcel` gem
+
+At this point, the next most useful surface is the JavaScript and lint layer.
+
 ## Resources
 
 - `scripts/audit_sure_build_env.py` for a repeatable baseline audit, disk-space gate, and strategy recommendation.

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -51,10 +51,12 @@ If the audit reports `stop-and-free-disk-space`, do that before the next bootstr
 
 Preferred path on the reference host:
 
+- read `.ruby-version` from the repo and use that exact Ruby version
+- read `Gemfile.lock` and use the exact `BUNDLED WITH` version
 - install `rbenv` and `ruby-build` from apt
-- update the `ruby-build` plugin inside `/root/.rbenv/plugins/ruby-build` because Debian Bookworm's packaged definitions are too old for Ruby `3.4.7`
-- install Ruby `3.4.7` with `rbenv`
-- install Bundler `2.6.7` with `gem`
+- update the `ruby-build` plugin inside `/root/.rbenv/plugins/ruby-build` because Debian Bookworm's packaged definitions may be too old for the repo-required Ruby
+- install the repo-required Ruby with `rbenv`
+- install the lockfile-compatible Bundler with `gem`
 
 Install missing Ruby build helpers:
 
@@ -63,9 +65,12 @@ apt-get install -y --no-install-recommends \
   rbenv ruby-build libreadline-dev libgdbm-dev libgdbm-compat-dev bison
 ```
 
-Refresh `ruby-build` definitions and install Ruby:
+Refresh `ruby-build` definitions and install Ruby from repo metadata:
 
 ```bash
+RUBY_VERSION="$(tr -d '[:space:]' < .ruby-version)"
+BUNDLER_VERSION="$(awk '/^BUNDLED WITH$/{getline; gsub(/^[[:space:]]+/, ""); print; exit}' Gemfile.lock)"
+
 mkdir -p /root/.rbenv/plugins
 rm -rf /root/.rbenv/plugins/ruby-build
 git clone --depth=1 https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build
@@ -75,20 +80,24 @@ export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
 eval "$(rbenv init -)"
 export RUBY_BUILD_CACHE_PATH=/root/.cache/ruby-build
 
-rbenv install -s 3.4.7
-rbenv global 3.4.7
+rbenv install -s "$RUBY_VERSION"
+rbenv global "$RUBY_VERSION"
 rbenv rehash
 ```
 
 Install the lockfile-compatible Bundler:
 
 ```bash
-gem install bundler -v 2.6.7 --no-document
+gem install bundler -v "$BUNDLER_VERSION" --no-document
 rbenv rehash
 bundle -v
 ```
 
-Important note: the host may still also have Debian's system Ruby on PATH. The audit helper is expected to prefer the `rbenv` Ruby and Bundler when they match repo requirements.
+Important notes:
+
+- never hardcode the Ruby version in the bootstrap flow, always read `.ruby-version`
+- never hardcode the Bundler version in the bootstrap flow, always read `Gemfile.lock`
+- the host may still also have Debian's system Ruby on PATH, so the audit helper is expected to prefer the `rbenv` Ruby and Bundler when they match repo requirements
 
 ## Step 2, install only missing OS packages
 

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/SKILL.md
@@ -209,7 +209,56 @@ This tells you the environment cannot run Rails tests yet, but it has enough fre
 - If Redis is absent, install and run it locally.
 - Do not assume devcontainer contents should be mirrored exactly. Use it as reference, not runtime.
 
+## Step 4, runtime services and database bootstrap
+
+After Ruby, Bundler, and gems are in place, validate the runtime services.
+
+Redis on this host does not auto-start through system services, so a lightweight local start is acceptable:
+
+```bash
+redis-server --daemonize yes
+redis-cli ping
+```
+
+For PostgreSQL, prefer client-only by default, but once `rails db:prepare` is the next blocker, install the minimal local server path:
+
+```bash
+apt-get update && apt-get install -y --no-install-recommends postgresql
+pg_ctlcluster --skip-systemctl-redirect 15 main start
+pg_isready -h 127.0.0.1 -p 5432
+```
+
+For this bootstrap host, local development auth was relaxed to `trust` on loopback so Rails could prepare the database without extra secret wiring:
+
+```bash
+PG_HBA_CONF=/etc/postgresql/15/main/pg_hba.conf
+sed -i 's/^local\s\+all\s\+all\s\+peer$/local   all             all                                     trust/' "$PG_HBA_CONF"
+sed -i 's/^host\s\+all\s\+all\s\+127.0.0.1\/32\s\+scram-sha-256$/host    all             all             127.0.0.1\/32            trust/' "$PG_HBA_CONF"
+sed -i 's/^host\s\+all\s\+all\s\+::1\/128\s\+scram-sha-256$/host    all             all             ::1\/128                 trust/' "$PG_HBA_CONF"
+pg_ctlcluster --skip-systemctl-redirect 15 main reload
+```
+
+Then create the expected local role and databases:
+
+```bash
+runuser -l postgres -c "createuser -s root" 2>/dev/null || true
+runuser -l postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='sure_development'\" | grep -q 1 || createdb sure_development"
+runuser -l postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='sure_test'\" | grep -q 1 || createdb sure_test"
+```
+
+Finally run the Rails bootstrap check:
+
+```bash
+export RBENV_ROOT=/root/.rbenv
+export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+eval "$(rbenv init -)"
+POSTGRES_USER=root POSTGRES_DB=sure_development bundle exec rails db:prepare
+```
+
+If this succeeds, the environment has crossed from package bootstrap into a working local Rails dev runtime.
+
 ## Resources
 
 - `scripts/audit_sure_build_env.py` for a repeatable baseline audit, disk-space gate, and strategy recommendation.
+- `scripts/install_repo_ruby_and_bundler.sh` for repo-driven Ruby and Bundler setup.
 - `references/baseline-environment-audit.md` for the captured step-by-step findings and rationale.

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -117,6 +117,34 @@ Disk effect observed on the reference host:
 - the heaviest dependency expansion came from `libvips-dev`
 - the post-install state still cleared the hard disk gate, so it was safe to continue
 
+## Step 3 result, Ruby and Bundler installed
+
+Installed on the reference host:
+
+- `rbenv`
+- `ruby-build`
+- `libreadline-dev`
+- `libgdbm-dev`
+- `libgdbm-compat-dev`
+- `bison`
+
+Then:
+
+- updated `/root/.rbenv/plugins/ruby-build` to a current upstream release so Ruby `3.4.7` was available
+- installed Ruby `3.4.7` via `rbenv`
+- installed Bundler `2.6.7`
+
+Re-audit result after install:
+
+- Ruby: present, `3.4.7`, detected via `/root/.rbenv/shims/ruby`
+- Bundler: present, `2.6.7`, detected via `/root/.rbenv/shims/bundle`
+- disk-space gate: still `pass`
+
+Important finding:
+
+- Debian's system Ruby may still exist on the host and can appear earlier on PATH in bare shells
+- the audit helper must therefore prefer the `rbenv` toolchain when it matches repo requirements
+
 ## Suggested follow-up audit checks after installs
 
 Preferred:
@@ -128,6 +156,12 @@ python3 .openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_
 Then add:
 
 ```bash
+export RBENV_ROOT=/root/.rbenv
+export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+eval "$(rbenv init -)"
+
+ruby -v
+bundle -v
 bundle config list
 npm config get cache
 ```

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -25,7 +25,24 @@ Audit timestamp context: 2026-04-26, Discord build thread for SureBot environmen
 
 - `/` free: about `6.8G`
 - `/root` free: about `6.0G`
+- `/tmp` free: about `6.8G`
 - Sure repo size: `138M`
+
+### Disk-space gate
+
+Use disk space as a bootstrap gate, not just an observation.
+
+Hard minimums:
+
+- `/`: `2 GiB`
+- `/root`: `4 GiB`
+- `/tmp`: `1 GiB`
+
+Preferred safety buffer:
+
+- `/root`: at least `2x` current repo size, with a `2 GiB` floor
+
+If any hard minimum fails, stop and free space before continuing.
 
 ### Repo-declared expectations
 
@@ -91,11 +108,14 @@ Re-audit result after install:
 - `gcc`, `make`, and `pkg-config`: present
 - Ruby: still missing
 - Bundler: still missing
+- disk-space gate: still `pass`
 
 Disk effect observed on the reference host:
 
 - `/` free dropped from about `6.8G` to about `6.3G`
+- `/root` stayed around `6.0G` free
 - the heaviest dependency expansion came from `libvips-dev`
+- the post-install state still cleared the hard disk gate, so it was safe to continue
 
 ## Suggested follow-up audit checks after installs
 

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -149,6 +149,21 @@ Important findings:
 - the Ruby bootstrap script should never hardcode a version, it should always read `.ruby-version`
 - the Bundler bootstrap script should never hardcode a version, it should always read `Gemfile.lock`
 
+## Step 4 result, runtime services and db bootstrap validated
+
+Observed on the reference host:
+
+- Redis package was installed but not running by default
+- `redis-server --daemonize yes` worked
+- `bundle exec rails runner 'puts Redis.new.ping'` returned `PONG`
+- local PostgreSQL server was not present initially, so `rails db:prepare` failed with `PG::ConnectionBad` against `127.0.0.1:5432`
+- after installing local PostgreSQL 15, starting the cluster manually, relaxing loopback auth to `trust`, and creating `sure_development` plus `sure_test`, `rails db:prepare` succeeded
+
+Important implication:
+
+- client-only PostgreSQL is the right default preference during early bootstrap
+- but once `db:prepare` is the active blocker, a minimal local PostgreSQL server becomes justified for a self-contained development runtime on this host
+
 ## Suggested follow-up audit checks after installs
 
 Preferred:
@@ -168,6 +183,8 @@ ruby -v
 bundle -v
 bundle config list
 npm config get cache
+redis-cli ping
+POSTGRES_USER=root POSTGRES_DB=sure_development bundle exec rails db:prepare
 ```
 
 This confirms both the toolchain and the persistence strategy.

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -78,8 +78,8 @@ At baseline, the environment is incomplete for Rails work:
    - If already virtualized or containerized, prefer a lean in-place bootstrap.
    - If not virtualized, consider the repo devcontainer the default path.
 2. Install only what is missing.
-3. Pin Ruby to `3.4.7`.
-4. Use Bundler `2.6.7` to match the lockfile.
+3. Read Ruby version from `.ruby-version` and install exactly that version.
+4. Read Bundler version from `Gemfile.lock` and install exactly that version.
 5. Prefer PostgreSQL client tooling instead of local PostgreSQL server.
 6. Install Redis locally.
 7. Keep caches and dependency storage under `/root`.
@@ -130,9 +130,11 @@ Installed on the reference host:
 
 Then:
 
-- updated `/root/.rbenv/plugins/ruby-build` to a current upstream release so Ruby `3.4.7` was available
-- installed Ruby `3.4.7` via `rbenv`
-- installed Bundler `2.6.7`
+- read Ruby version from `.ruby-version`
+- read Bundler version from `Gemfile.lock`
+- updated `/root/.rbenv/plugins/ruby-build` to a current upstream release so the repo-required Ruby was available
+- installed the repo-required Ruby via `rbenv`
+- installed the lockfile-compatible Bundler
 
 Re-audit result after install:
 
@@ -140,10 +142,12 @@ Re-audit result after install:
 - Bundler: present, `2.6.7`, detected via `/root/.rbenv/shims/bundle`
 - disk-space gate: still `pass`
 
-Important finding:
+Important findings:
 
 - Debian's system Ruby may still exist on the host and can appear earlier on PATH in bare shells
 - the audit helper must therefore prefer the `rbenv` toolchain when it matches repo requirements
+- the Ruby bootstrap script should never hardcode a version, it should always read `.ruby-version`
+- the Bundler bootstrap script should never hardcode a version, it should always read `Gemfile.lock`
 
 ## Suggested follow-up audit checks after installs
 

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -164,6 +164,25 @@ Important implication:
 - client-only PostgreSQL is the right default preference during early bootstrap
 - but once `db:prepare` is the active blocker, a minimal local PostgreSQL server becomes justified for a self-contained development runtime on this host
 
+## Validation milestone, full model suite
+
+After the runtime bootstrap was complete on the reference host, the full model suite passed:
+
+- command: `POSTGRES_USER=root bundle exec rails test test/models`
+- result: `2183 runs, 8778 assertions, 0 failures, 0 errors, 1 skip`
+
+Non-blocking follow-up notes:
+
+- one skipped test remained
+- one test reported missing assertions
+- Ruby 3.4 emitted future frozen-string warnings from `marcel`
+
+Interpretation:
+
+- the environment is no longer merely bootable
+- it is strong enough to execute the full Rails model layer successfully
+- the next likely breakpoints, if any, should be above the model layer
+
 ## Suggested follow-up audit checks after installs
 
 Preferred:

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -183,6 +183,23 @@ Interpretation:
 - it is strong enough to execute the full Rails model layer successfully
 - the next likely breakpoints, if any, should be above the model layer
 
+## Validation milestone, integration suite
+
+After models and controllers were already passing on the reference host, the integration layer also passed:
+
+- command: `POSTGRES_USER=root bundle exec rails test test/integration`
+- result: `21 runs, 49 assertions, 0 failures, 0 errors, 0 skips`
+
+Non-blocking follow-up notes:
+
+- Ruby 3.4 emitted future frozen-string warnings from `marcel`
+
+Interpretation:
+
+- the local bootstrap now covers Rails boot, DB prep, models, controllers, and integration tests
+- the next likely breakpoints, if any, are now outside the core Rails request/data path
+- the JavaScript and lint surface is the next logical validation target
+
 ## Suggested follow-up audit checks after installs
 
 Preferred:

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -200,6 +200,29 @@ Interpretation:
 - the next likely breakpoints, if any, are now outside the core Rails request/data path
 - the JavaScript and lint surface is the next logical validation target
 
+## Validation milestone, JS and CI-match lint
+
+After the Rails-side validation passed on the reference host:
+
+- `node test/javascript/parse_locale_float_test.mjs` passed with `38/38` tests green
+- `npm run lint` passed, which matches the current GitHub Actions `lint_js` job
+- `npm run style:check` failed with Biome formatter/check findings, which explains the earlier mismatch with local stricter validation
+
+Interpretation:
+
+- JavaScript runtime sanity is good
+- current GitHub CI and local CI-matched lint agree
+- stricter style-check findings are real repo formatting debt, not bootstrap failure
+
+## Parking lot, out of scope for bootstrap proof
+
+Keep these as follow-up ideas, not current blockers:
+
+- consider aligning local default Node with CI/devcontainer Node 20.x, or explicitly documenting why Node 24 is acceptable for bootstrap validation
+- consider adding `npm run style:check` to GitHub CI if the repo wants formatter cleanliness enforced there too
+- consider cleaning the current Biome formatting findings in a separate workstream rather than mixing them into bootstrap proof work
+- consider reviewing Ruby 3.4 frozen-string future warnings from dependencies like `marcel`, `rack`, and `rack-test`
+
 ## Suggested follow-up audit checks after installs
 
 Preferred:

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -1,0 +1,86 @@
+# Baseline environment audit
+
+This reference captures the first real audit of the Sure repository running inside the existing OpenClaw workspace container.
+
+## Why this matters
+
+Before installing anything, confirm what already exists. This prevents unnecessary packages, avoids masking version drift, and gives future bootstrap runs a stable starting point.
+
+## Reference host result
+
+Audit timestamp context: 2026-04-26, Discord build thread for SureBot environment setup.
+
+### Tool availability
+
+- `ruby`: missing
+- `bundle`: missing
+- `node`: `v24.14.1`
+- `npm`: `11.11.0`
+- `psql`: missing
+- `redis-server`: missing
+- `git`: present, `2.39.5`
+- `curl`: present, `7.88.1`
+
+### Disk and repo footprint
+
+- `/` free: about `6.8G`
+- `/root` free: about `6.0G`
+- Sure repo size: `138M`
+
+### Repo-declared expectations
+
+- `.ruby-version`: `3.4.7`
+- `Gemfile` defers Ruby version to `.ruby-version`
+- `Gemfile.lock` expects Bundler `2.6.7`
+- `package.json` is light and currently only declares Biome-based JS tooling
+
+### Devcontainer reference hints
+
+The repo's devcontainer is useful as a source of expectations, but should not be treated as the runtime target for this environment.
+
+Observed hints:
+
+- Ruby `3.4.x` slim Bookworm image
+- `postgresql-client`
+- `libpq-dev`
+- Redis service
+- Node `20.x`
+
+## Interpretation
+
+At baseline, the environment is incomplete for Rails work:
+
+- Rails commands cannot run because Ruby and Bundler are absent.
+- Database connectivity checks cannot run because `psql` is absent.
+- Local cache or background job assumptions that depend on Redis will fail until Redis is installed.
+- Node and npm are already available, so JavaScript lint tooling is likely the least risky part of the bootstrap.
+
+## Bootstrap implications
+
+1. Decide strategy from host classification first.
+   - If already virtualized or containerized, prefer a lean in-place bootstrap.
+   - If not virtualized, consider the repo devcontainer the default path.
+2. Install only what is missing.
+3. Pin Ruby to `3.4.7`.
+4. Use Bundler `2.6.7` to match the lockfile.
+5. Prefer PostgreSQL client tooling instead of local PostgreSQL server.
+6. Install Redis locally.
+7. Keep caches and dependency storage under `/root`.
+8. Record version drift when the host has a newer Node than the repo reference, but do not change it unless the repo proves sensitive to that drift.
+
+## Suggested follow-up audit checks after installs
+
+Preferred:
+
+```bash
+python3 .openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py /path/to/sure
+```
+
+Then add:
+
+```bash
+bundle config list
+npm config get cache
+```
+
+This confirms both the toolchain and the persistence strategy.

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/references/baseline-environment-audit.md
@@ -68,6 +68,35 @@ At baseline, the environment is incomplete for Rails work:
 7. Keep caches and dependency storage under `/root`.
 8. Record version drift when the host has a newer Node than the repo reference, but do not change it unless the repo proves sensitive to that drift.
 
+## Step 2 result, missing OS packages installed
+
+Installed on the reference host:
+
+- `build-essential`
+- `pkg-config`
+- `libpq-dev`
+- `postgresql-client`
+- `redis-server`
+- `libyaml-dev`
+- `libvips`
+- `libvips-dev`
+- `libxml2-dev`
+- `libxslt1-dev`
+- `zlib1g-dev`
+
+Re-audit result after install:
+
+- `psql`: present, `15.16`
+- `redis-server`: present, `7.0.15`
+- `gcc`, `make`, and `pkg-config`: present
+- Ruby: still missing
+- Bundler: still missing
+
+Disk effect observed on the reference host:
+
+- `/` free dropped from about `6.8G` to about `6.3G`
+- the heaviest dependency expansion came from `libvips-dev`
+
 ## Suggested follow-up audit checks after installs
 
 Preferred:

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py
@@ -168,17 +168,52 @@ def du(path):
 
 def version_for(cmd, args):
     if not shutil.which(cmd):
-        return {'present': False, 'version': None}
+        return {'present': False, 'version': None, 'source': None}
     res = run([cmd] + args)
     out = res['output'].splitlines()[0] if res['output'] else ''
-    return {'present': True, 'version': out}
+    return {'present': True, 'version': out, 'source': shutil.which(cmd)}
+
+
+def version_for_path(path, args):
+    if not Path(path).exists():
+        return {'present': False, 'version': None, 'source': None}
+    res = run([path] + args)
+    out = res['output'].splitlines()[0] if res['output'] else ''
+    return {'present': res['ok'], 'version': out if res['ok'] else None, 'source': path}
+
+
+def detect_ruby_toolchain(ruby_req, bundler_req):
+    system_ruby = version_for('ruby', ['-v'])
+    system_bundle = version_for('bundle', ['-v'])
+    rbenv_ruby = version_for_path('/root/.rbenv/shims/ruby', ['-v'])
+    rbenv_bundle = version_for_path('/root/.rbenv/shims/bundle', ['-v'])
+
+    chosen_ruby = system_ruby
+    chosen_bundle = system_bundle
+
+    if rbenv_ruby['present'] and ruby_req and ruby_req in (rbenv_ruby['version'] or ''):
+        chosen_ruby = rbenv_ruby
+    elif not system_ruby['present'] and rbenv_ruby['present']:
+        chosen_ruby = rbenv_ruby
+
+    if rbenv_bundle['present'] and bundler_req and bundler_req in (rbenv_bundle['version'] or ''):
+        chosen_bundle = rbenv_bundle
+    elif not system_bundle['present'] and rbenv_bundle['present']:
+        chosen_bundle = rbenv_bundle
+
+    return chosen_ruby, chosen_bundle, {
+        'system_ruby': system_ruby,
+        'system_bundle': system_bundle,
+        'rbenv_ruby': rbenv_ruby,
+        'rbenv_bundle': rbenv_bundle,
+    }
 
 
 def recommend(virt, ruby, bundler, node, psql, redis, ruby_req, bundler_req, node_hint, disk_health):
     missing = []
-    if not ruby['present']:
+    if not ruby['present'] or (ruby_req and ruby_req not in (ruby['version'] or '')):
         missing.append('Ruby')
-    if not bundler['present']:
+    if not bundler['present'] or (bundler_req and bundler_req not in (bundler['version'] or '')):
         missing.append('Bundler')
     if not psql['present']:
         missing.append('PostgreSQL client')
@@ -241,7 +276,8 @@ def markdown_report(data):
         item = data['tools'][key]
         name = key.replace('_', '-')
         if item['present']:
-            lines.append(f"- {name}: `{item['version']}`")
+            suffix = f" via `{item['source']}`" if item.get('source') else ''
+            lines.append(f"- {name}: `{item['version']}`{suffix}")
         else:
             lines.append(f"- {name}: **missing**")
     lines.append('')
@@ -281,6 +317,10 @@ def main():
     repo = Path(args[0]).resolve() if args else Path.cwd()
     output_json = '--json' in sys.argv[1:]
 
+    ruby_required = parse_ruby_version(repo)
+    bundler_required = parse_bundler_version(repo)
+    ruby_tool, bundler_tool, ruby_detection = detect_ruby_toolchain(ruby_required, bundler_required)
+
     data = {
         'host': {
             'platform': platform.platform(),
@@ -289,8 +329,8 @@ def main():
         },
         'virtualization': detect_virtualization(),
         'tools': {
-            'ruby': version_for('ruby', ['-v']),
-            'bundler': version_for('bundle', ['-v']),
+            'ruby': ruby_tool,
+            'bundler': bundler_tool,
             'node': version_for('node', ['-v']),
             'npm': version_for('npm', ['-v']),
             'psql': version_for('psql', ['--version']),
@@ -298,9 +338,10 @@ def main():
             'git': version_for('git', ['--version']),
             'curl': version_for('curl', ['--version']),
         },
+        'tool_detection': ruby_detection,
         'repo': {
-            'ruby_required': parse_ruby_version(repo),
-            'bundler_required': parse_bundler_version(repo),
+            'ruby_required': ruby_required,
+            'bundler_required': bundler_required,
             'node_hint': parse_node_hint(repo),
             'size': du(repo),
         },

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+import json
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd):
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        out = (proc.stdout or proc.stderr or '').strip()
+        return {
+            'ok': proc.returncode == 0,
+            'code': proc.returncode,
+            'output': out,
+        }
+    except FileNotFoundError:
+        return {'ok': False, 'code': 127, 'output': 'command not found'}
+
+
+def read_text(path):
+    try:
+        return Path(path).read_text()
+    except Exception:
+        return None
+
+
+def parse_ruby_version(repo):
+    text = read_text(repo / '.ruby-version')
+    return text.strip() if text else None
+
+
+def parse_bundler_version(repo):
+    lock = read_text(repo / 'Gemfile.lock')
+    if not lock:
+        return None
+    m = re.search(r'^BUNDLED WITH\n\s+([^\n]+)', lock, flags=re.M)
+    return m.group(1).strip() if m else None
+
+
+def parse_node_hint(repo):
+    dockerfile = read_text(repo / '.devcontainer' / 'Dockerfile') or ''
+    m = re.search(r'setup_(\d+)\.x', dockerfile)
+    if m:
+        return f"{m.group(1)}.x"
+    return None
+
+
+def detect_virtualization():
+    evidence = []
+    kind = None
+
+    if shutil.which('systemd-detect-virt'):
+        res = run(['systemd-detect-virt'])
+        if res['ok'] and res['output']:
+            kind = res['output'].splitlines()[0].strip()
+            evidence.append(f"systemd-detect-virt={kind}")
+
+    if Path('/.dockerenv').exists():
+        evidence.append('/.dockerenv present')
+        kind = kind or 'docker'
+
+    cgroup = read_text('/proc/1/cgroup') or ''
+    cgroup_lower = cgroup.lower()
+    for token, label in [('docker', 'docker'), ('containerd', 'container'), ('kubepods', 'kubernetes'), ('lxc', 'lxc')]:
+        if token in cgroup_lower:
+            evidence.append(f'/proc/1/cgroup mentions {token}')
+            kind = kind or label
+            break
+
+    cpuinfo = read_text('/proc/cpuinfo') or ''
+    if 'hypervisor' in cpuinfo.lower():
+        evidence.append('/proc/cpuinfo includes hypervisor flag')
+        kind = kind or 'vm'
+
+    product_name = read_text('/sys/class/dmi/id/product_name')
+    if product_name:
+        pn = product_name.strip()
+        lowered = pn.lower()
+        if any(x in lowered for x in ['kvm', 'virtual', 'vmware', 'virtualbox', 'firecracker']):
+            evidence.append(f'product_name={pn}')
+            kind = kind or 'vm'
+
+    virtualized = bool(evidence)
+    return {
+        'virtualized': virtualized,
+        'kind': kind or ('unknown' if virtualized else 'none'),
+        'evidence': evidence,
+    }
+
+
+def disk_usage(paths):
+    results = {}
+    for p in paths:
+        res = run(['df', '-h', p])
+        results[p] = res['output']
+    return results
+
+
+def du(path):
+    res = run(['du', '-sh', str(path)])
+    return res['output']
+
+
+def version_for(cmd, args):
+    if not shutil.which(cmd):
+        return {'present': False, 'version': None}
+    res = run([cmd] + args)
+    out = res['output'].splitlines()[0] if res['output'] else ''
+    return {'present': True, 'version': out}
+
+
+def recommend(virt, ruby, bundler, node, psql, redis, ruby_req, bundler_req, node_hint):
+    missing = []
+    if not ruby['present']:
+        missing.append('Ruby')
+    if not bundler['present']:
+        missing.append('Bundler')
+    if not psql['present']:
+        missing.append('PostgreSQL client')
+    if not redis['present']:
+        missing.append('Redis server')
+
+    strategy = 'lean-in-place-bootstrap' if virt['virtualized'] else 'prefer-devcontainer'
+
+    rationale = []
+    if virt['virtualized']:
+        rationale.append('Detected a virtualized/containerized environment, so reusing the current runtime is usually simpler than nesting devcontainers.')
+    else:
+        rationale.append('No clear virtualization/container evidence detected, so the repo devcontainer is a strong default for reproducible setup on a normal host.')
+
+    if missing:
+        rationale.append('Missing components: ' + ', '.join(missing) + '.')
+    else:
+        rationale.append('Core toolchain looks present already.')
+
+    if ruby_req and (not ruby['present'] or ruby_req not in (ruby['version'] or '')):
+        rationale.append(f'Repo expects Ruby {ruby_req}.')
+    if bundler_req and (not bundler['present'] or bundler_req not in (bundler['version'] or '')):
+        rationale.append(f'Lockfile expects Bundler {bundler_req}.')
+    if node_hint and node['present'] and node_hint.split('.')[0] not in (node['version'] or ''):
+        rationale.append(f'Repo devcontainer references Node {node_hint}; current host differs, which is drift to note but not necessarily fix immediately.')
+
+    return strategy, rationale, missing
+
+
+def markdown_report(data):
+    lines = []
+    lines.append('# Sure build environment audit')
+    lines.append('')
+    lines.append('## Host classification')
+    lines.append('')
+    lines.append(f"- Virtualized: **{'yes' if data['virtualization']['virtualized'] else 'no'}**")
+    lines.append(f"- Kind: **{data['virtualization']['kind']}**")
+    if data['virtualization']['evidence']:
+        lines.append('- Evidence:')
+        for item in data['virtualization']['evidence']:
+            lines.append(f'  - {item}')
+    else:
+        lines.append('- Evidence: none detected')
+    lines.append('')
+    lines.append('## Recommendation')
+    lines.append('')
+    lines.append(f"- Strategy: **{data['recommendation']['strategy']}**")
+    for item in data['recommendation']['rationale']:
+        lines.append(f'- {item}')
+    lines.append('')
+    lines.append('## Toolchain')
+    lines.append('')
+    for key in ['ruby', 'bundler', 'node', 'npm', 'psql', 'redis_server', 'git', 'curl']:
+        item = data['tools'][key]
+        name = key.replace('_', '-')
+        if item['present']:
+            lines.append(f"- {name}: `{item['version']}`")
+        else:
+            lines.append(f"- {name}: **missing**")
+    lines.append('')
+    lines.append('## Repo expectations')
+    lines.append('')
+    lines.append(f"- Ruby required: `{data['repo']['ruby_required'] or 'unknown'}`")
+    lines.append(f"- Bundler required: `{data['repo']['bundler_required'] or 'unknown'}`")
+    lines.append(f"- Devcontainer Node hint: `{data['repo']['node_hint'] or 'unknown'}`")
+    lines.append('')
+    lines.append('## Storage')
+    lines.append('')
+    lines.append(f"- Sure repo size: `{data['repo']['size']}`")
+    lines.append('- Disk snapshots:')
+    for path, out in data['disk'].items():
+        first = out.splitlines()[1] if len(out.splitlines()) > 1 else out
+        lines.append(f'  - `{path}`: `{first}`')
+    lines.append('')
+    if data['recommendation']['missing']:
+        lines.append('## Missing pieces to install next')
+        lines.append('')
+        for item in data['recommendation']['missing']:
+            lines.append(f'- {item}')
+        lines.append('')
+    return '\n'.join(lines)
+
+
+def main():
+    args = [arg for arg in sys.argv[1:] if arg != '--json']
+    repo = Path(args[0]).resolve() if args else Path.cwd()
+    output_json = '--json' in sys.argv[1:]
+
+    data = {
+        'host': {
+            'platform': platform.platform(),
+            'python': platform.python_version(),
+            'repo': str(repo),
+        },
+        'virtualization': detect_virtualization(),
+        'tools': {
+            'ruby': version_for('ruby', ['-v']),
+            'bundler': version_for('bundle', ['-v']),
+            'node': version_for('node', ['-v']),
+            'npm': version_for('npm', ['-v']),
+            'psql': version_for('psql', ['--version']),
+            'redis_server': version_for('redis-server', ['--version']),
+            'git': version_for('git', ['--version']),
+            'curl': version_for('curl', ['--version']),
+        },
+        'repo': {
+            'ruby_required': parse_ruby_version(repo),
+            'bundler_required': parse_bundler_version(repo),
+            'node_hint': parse_node_hint(repo),
+            'size': du(repo),
+        },
+        'disk': disk_usage(['/','/root','/tmp']),
+    }
+
+    strategy, rationale, missing = recommend(
+        data['virtualization'],
+        data['tools']['ruby'],
+        data['tools']['bundler'],
+        data['tools']['node'],
+        data['tools']['psql'],
+        data['tools']['redis_server'],
+        data['repo']['ruby_required'],
+        data['repo']['bundler_required'],
+        data['repo']['node_hint'],
+    )
+    data['recommendation'] = {
+        'strategy': strategy,
+        'rationale': rationale,
+        'missing': missing,
+    }
+
+    if output_json:
+        print(json.dumps(data, indent=2))
+    else:
+        print(markdown_report(data))
+
+
+if __name__ == '__main__':
+    main()

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/audit_sure_build_env.py
@@ -96,8 +96,69 @@ def disk_usage(paths):
     results = {}
     for p in paths:
         res = run(['df', '-h', p])
-        results[p] = res['output']
+        total, used, free = shutil.disk_usage(p)
+        results[p] = {
+            'df_h': res['output'],
+            'bytes': {
+                'total': total,
+                'used': used,
+                'free': free,
+            },
+        }
     return results
+
+
+def gib(bytes_value):
+    return round(bytes_value / (1024 ** 3), 2)
+
+
+def assess_disk(repo_size_text, disk):
+    repo_size_bytes = None
+    m = re.match(r'^(\d+(?:\.\d+)?)([KMGTP])\s', repo_size_text or '')
+    if m:
+        scale = {'K': 1024, 'M': 1024 ** 2, 'G': 1024 ** 3, 'T': 1024 ** 4, 'P': 1024 ** 5}
+        repo_size_bytes = int(float(m.group(1)) * scale[m.group(2)])
+
+    checks = []
+    overall = 'pass'
+
+    thresholds = {
+        '/': 2 * 1024 ** 3,
+        '/root': 4 * 1024 ** 3,
+        '/tmp': 1 * 1024 ** 3,
+    }
+
+    for path, minimum in thresholds.items():
+        free = disk[path]['bytes']['free']
+        status = 'pass' if free >= minimum else 'fail'
+        if status == 'fail':
+            overall = 'fail'
+        checks.append({
+            'path': path,
+            'status': status,
+            'free_gib': gib(free),
+            'minimum_gib': gib(minimum),
+            'reason': f"Need at least {gib(minimum)} GiB free on {path} before continuing.",
+        })
+
+    if repo_size_bytes is not None:
+        root_free = disk['/root']['bytes']['free']
+        buffer_target = max(2 * repo_size_bytes, 2 * 1024 ** 3)
+        status = 'pass' if root_free >= buffer_target else 'warn'
+        if status == 'warn' and overall != 'fail':
+            overall = 'warn'
+        checks.append({
+            'path': '/root',
+            'status': status,
+            'free_gib': gib(root_free),
+            'minimum_gib': gib(buffer_target),
+            'reason': 'Recommended free space on /root is at least 2x current repo size, with a 2 GiB floor, to leave room for gems, node modules, and caches.',
+        })
+
+    return {
+        'status': overall,
+        'checks': checks,
+    }
 
 
 def du(path):
@@ -113,7 +174,7 @@ def version_for(cmd, args):
     return {'present': True, 'version': out}
 
 
-def recommend(virt, ruby, bundler, node, psql, redis, ruby_req, bundler_req, node_hint):
+def recommend(virt, ruby, bundler, node, psql, redis, ruby_req, bundler_req, node_hint, disk_health):
     missing = []
     if not ruby['present']:
         missing.append('Ruby')
@@ -136,6 +197,12 @@ def recommend(virt, ruby, bundler, node, psql, redis, ruby_req, bundler_req, nod
         rationale.append('Missing components: ' + ', '.join(missing) + '.')
     else:
         rationale.append('Core toolchain looks present already.')
+
+    if disk_health['status'] == 'fail':
+        strategy = 'stop-and-free-disk-space'
+        rationale.append('Disk-space gate failed. Free space before installing more dependencies or caches.')
+    elif disk_health['status'] == 'warn':
+        rationale.append('Disk space is above the hard minimum, but below the preferred safety buffer. Continue carefully and monitor growth.')
 
     if ruby_req and (not ruby['present'] or ruby_req not in (ruby['version'] or '')):
         rationale.append(f'Repo expects Ruby {ruby_req}.')
@@ -188,9 +255,17 @@ def markdown_report(data):
     lines.append('')
     lines.append(f"- Sure repo size: `{data['repo']['size']}`")
     lines.append('- Disk snapshots:')
-    for path, out in data['disk'].items():
+    for path, details in data['disk'].items():
+        out = details['df_h']
         first = out.splitlines()[1] if len(out.splitlines()) > 1 else out
         lines.append(f'  - `{path}`: `{first}`')
+    lines.append('')
+    lines.append('## Disk-space gate')
+    lines.append('')
+    lines.append(f"- Overall status: **{data['disk_health']['status']}**")
+    for check in data['disk_health']['checks']:
+        lines.append(f"- `{check['path']}`: **{check['status']}**, free `{check['free_gib']}` GiB, threshold `{check['minimum_gib']}` GiB")
+        lines.append(f"  - {check['reason']}")
     lines.append('')
     if data['recommendation']['missing']:
         lines.append('## Missing pieces to install next')
@@ -231,6 +306,7 @@ def main():
         },
         'disk': disk_usage(['/','/root','/tmp']),
     }
+    data['disk_health'] = assess_disk(data['repo']['size'], data['disk'])
 
     strategy, rationale, missing = recommend(
         data['virtualization'],
@@ -242,6 +318,7 @@ def main():
         data['repo']['ruby_required'],
         data['repo']['bundler_required'],
         data['repo']['node_hint'],
+        data['disk_health'],
     )
     data['recommendation'] = {
         'strategy': strategy,

--- a/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/install_repo_ruby_and_bundler.sh
+++ b/.openclaw/skills/sure-openclaw-build-bootstrap/scripts/install_repo_ruby_and_bundler.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${1:-$(pwd)}"
+cd "$REPO_DIR"
+
+RUBY_VERSION="$(tr -d '[:space:]' < .ruby-version)"
+BUNDLER_VERSION="$(awk '/^BUNDLED WITH$/{getline; gsub(/^[[:space:]]+/, ""); print; exit}' Gemfile.lock)"
+
+if [[ -z "$RUBY_VERSION" ]]; then
+  echo "Failed to read Ruby version from .ruby-version" >&2
+  exit 1
+fi
+
+if [[ -z "$BUNDLER_VERSION" ]]; then
+  echo "Failed to read Bundler version from Gemfile.lock" >&2
+  exit 1
+fi
+
+apt-get install -y --no-install-recommends \
+  rbenv ruby-build libreadline-dev libgdbm-dev libgdbm-compat-dev bison
+
+mkdir -p /root/.rbenv/plugins
+rm -rf /root/.rbenv/plugins/ruby-build
+git clone --depth=1 https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build
+
+export RBENV_ROOT=/root/.rbenv
+export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+eval "$(rbenv init -)"
+export RUBY_BUILD_CACHE_PATH=/root/.cache/ruby-build
+
+rbenv install -s "$RUBY_VERSION"
+rbenv global "$RUBY_VERSION"
+rbenv rehash
+
+gem install bundler -v "$BUNDLER_VERSION" --no-document
+rbenv rehash
+
+ruby -v
+bundle -v


### PR DESCRIPTION
## Summary
- add an in-repo OpenClaw bootstrap skill under `.openclaw/skills/sure-openclaw-build-bootstrap/`
- capture the baseline audit, disk-space gating, and repo-driven Ruby/Bundler bootstrap flow
- validate the resulting environment end to end against Rails, DB, Redis, tests, and CI-matched JS lint

## Validated on the reference host
- host classified as virtualized (`kvm`), so lean in-place bootstrap was preferred over nested devcontainers
- disk-space gating was added to the audit and remained green through bootstrap
- installed missing OS/build dependencies, PostgreSQL client tooling, and Redis
- installed repo-driven Ruby and Bundler from `.ruby-version` and `Gemfile.lock`
- verified Rails boot, local Redis connectivity, local PostgreSQL connectivity, and `rails db:prepare`
- passed `rails test test/models`
- passed `rails test test/controllers`
- passed `rails test test/integration`
- passed the JS unit test `test/javascript/parse_locale_float_test.mjs`
- passed CI-matched JS lint with `npm run lint`

## Notes
- `npm run style:check` still reports Biome formatter findings, but GitHub CI currently runs `npm run lint`, not `style:check`
- Ruby 3.4 emits some non-blocking future frozen-string warnings from dependencies like `marcel`, `rack`, and `rack-test`
- this PR is focused on proving and documenting the bootstrap path, not cleaning unrelated repo formatting debt

## Why
This turns issue #1557 into a repo-tracked, repeatable bootstrap workflow and proves that the resulting environment is actually usable, not just theoretically configured.

Closes #1557
