### PR TITLE
Fix IndexaCapital sync, account setup, and balance/type bugs

### DIFF
--- a/app/controllers/indexa_capital_items_controller.rb
+++ b/app/controllers/indexa_capital_items_controller.rb
@@ -222,9 +222,10 @@ class IndexaCapitalItemsController < ApplicationController
   end
 
   def complete_account_setup
-    account_configs = params[:accounts] || {}
+    account_ids = Array(params[:account_ids]).reject(&:blank?)
+    sync_start_dates = params[:sync_start_dates] || {}
 
-    if account_configs.empty?
+    if account_ids.empty?
       redirect_to setup_accounts_indexa_capital_item_path(@indexa_capital_item), alert: t(".no_accounts")
       return
     end
@@ -232,19 +233,18 @@ class IndexaCapitalItemsController < ApplicationController
     created_count = 0
     skipped_count = 0
 
-    account_configs.each do |indexa_capital_account_id, config|
-      next if config[:account_type] == "skip"
-
+    account_ids.each do |indexa_capital_account_id|
       indexa_capital_account = @indexa_capital_item.indexa_capital_accounts.find_by(id: indexa_capital_account_id)
       next unless indexa_capital_account
       next if indexa_capital_account.account_provider.present?
 
-      accountable_type = infer_accountable_type(config[:account_type], config[:subtype])
-      account = create_account_from_indexa_capital(indexa_capital_account, accountable_type, config)
+      sync_start_date = sync_start_dates[indexa_capital_account_id].presence
+      accountable_type = infer_accountable_type(indexa_capital_account.account_type)
+      account = create_account_from_indexa_capital(indexa_capital_account, accountable_type, { sync_start_date: sync_start_date })
 
       if account&.persisted?
         indexa_capital_account.ensure_account_provider!(account)
-        indexa_capital_account.update!(sync_start_date: config[:sync_start_date]) if config[:sync_start_date].present?
+        indexa_capital_account.update!(sync_start_date: sync_start_date) if sync_start_date
         created_count += 1
       else
         skipped_count += 1

--- a/app/controllers/indexa_capital_items_controller.rb
+++ b/app/controllers/indexa_capital_items_controller.rb
@@ -245,25 +245,19 @@ class IndexaCapitalItemsController < ApplicationController
       raw_sync_start_date = sync_start_dates[indexa_capital_account_id]
       sync_start_date = (Date.parse(raw_sync_start_date.to_s) rescue nil) if raw_sync_start_date.present?
 
-      account = create_account_from_indexa_capital(indexa_capital_account, "Investment", {})
-
-      unless account&.persisted?
-        skipped_count += 1
-        next
-      end
-
-      # Account row exists from this point on — count it as created even if
-      # the provider link or sync_start_date persistence below raises.
-      created_count += 1
-
-      begin
+      # Wrap creation, provider link, and sync_start_date persistence in a
+      # single transaction so a failure in ensure_account_provider! (or the
+      # sync_start_date update) rolls back the Account row instead of leaving
+      # an orphan that is also wrongly counted as "created".
+      ActiveRecord::Base.transaction do
+        account = create_account_from_indexa_capital(indexa_capital_account, "Investment", {})
         indexa_capital_account.ensure_account_provider!(account)
         indexa_capital_account.update!(sync_start_date: sync_start_date) if sync_start_date
-      rescue => e
-        Rails.logger.error "IndexaCapitalItemsController#complete_account_setup - post-create error for #{indexa_capital_account.id}: #{e.message}"
       end
+
+      created_count += 1
     rescue => e
-      Rails.logger.error "IndexaCapitalItemsController#complete_account_setup - Error: #{e.message}"
+      Rails.logger.error "IndexaCapitalItemsController#complete_account_setup - Error linking #{indexa_capital_account_id}: #{e.message}"
       skipped_count += 1
     end
 

--- a/app/controllers/indexa_capital_items_controller.rb
+++ b/app/controllers/indexa_capital_items_controller.rb
@@ -238,15 +238,29 @@ class IndexaCapitalItemsController < ApplicationController
       next unless indexa_capital_account
       next if indexa_capital_account.account_provider.present?
 
-      sync_start_date = sync_start_dates[indexa_capital_account_id].presence
-      account = create_account_from_indexa_capital(indexa_capital_account, "Investment", { sync_start_date: sync_start_date })
+      # Parse the form-supplied date up front so a malformed value is silently
+      # dropped rather than aborting the loop body after the account is
+      # already persisted (which would mark a successfully-created account
+      # as "skipped").
+      raw_sync_start_date = sync_start_dates[indexa_capital_account_id]
+      sync_start_date = (Date.parse(raw_sync_start_date.to_s) rescue nil) if raw_sync_start_date.present?
 
-      if account&.persisted?
+      account = create_account_from_indexa_capital(indexa_capital_account, "Investment", {})
+
+      unless account&.persisted?
+        skipped_count += 1
+        next
+      end
+
+      # Account row exists from this point on — count it as created even if
+      # the provider link or sync_start_date persistence below raises.
+      created_count += 1
+
+      begin
         indexa_capital_account.ensure_account_provider!(account)
         indexa_capital_account.update!(sync_start_date: sync_start_date) if sync_start_date
-        created_count += 1
-      else
-        skipped_count += 1
+      rescue => e
+        Rails.logger.error "IndexaCapitalItemsController#complete_account_setup - post-create error for #{indexa_capital_account.id}: #{e.message}"
       end
     rescue => e
       Rails.logger.error "IndexaCapitalItemsController#complete_account_setup - Error: #{e.message}"

--- a/app/controllers/indexa_capital_items_controller.rb
+++ b/app/controllers/indexa_capital_items_controller.rb
@@ -239,8 +239,7 @@ class IndexaCapitalItemsController < ApplicationController
       next if indexa_capital_account.account_provider.present?
 
       sync_start_date = sync_start_dates[indexa_capital_account_id].presence
-      accountable_type = infer_accountable_type(indexa_capital_account.account_type)
-      account = create_account_from_indexa_capital(indexa_capital_account, accountable_type, { sync_start_date: sync_start_date })
+      account = create_account_from_indexa_capital(indexa_capital_account, "Investment", { sync_start_date: sync_start_date })
 
       if account&.persisted?
         indexa_capital_account.ensure_account_provider!(account)

--- a/app/models/indexa_capital_account/data_helpers.rb
+++ b/app/models/indexa_capital_account/data_helpers.rb
@@ -39,6 +39,25 @@ module IndexaCapitalAccount::DataHelpers
       nil
     end
 
+    # Extract the canonical security key from an Indexa fiscal-results row.
+    # Indexa's response shape varies between endpoints (and across time), so
+    # try the nested instrument hash first, then a few flat fallbacks. Both
+    # HoldingsProcessor and Processor#calculate_holdings_value go through
+    # this helper so they can't disagree on which rows refer to the same
+    # security.
+    def extract_instrument_key(data)
+      return nil unless data.respond_to?(:[])
+
+      hash = data.respond_to?(:with_indifferent_access) ? data.with_indifferent_access : data
+      instrument = hash[:instrument]
+      if instrument.is_a?(Hash)
+        nested = instrument.with_indifferent_access
+        return nested[:identifier] || nested[:isin_code] || nested[:isin]
+      end
+
+      hash[:identifier] || hash[:isin_code] || hash[:isin] || hash[:symbol] || hash[:ticker]
+    end
+
     def parse_date(date_value)
       return nil if date_value.nil?
 

--- a/app/models/indexa_capital_account/holdings_processor.rb
+++ b/app/models/indexa_capital_account/holdings_processor.rb
@@ -13,11 +13,26 @@ class IndexaCapitalAccount::HoldingsProcessor
     holdings_data = @indexa_capital_account.raw_holdings_payload
     return if holdings_data.blank?
 
-    Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing #{holdings_data.size} holdings"
+    # Indexa returns a time series — many rows per security across dates.
+    # Reduce to the latest-dated row per security so each holding reflects
+    # the current position, not whichever snapshot happens to be processed
+    # last in payload order.
+    latest_per_security = {}
+    holdings_data.each do |holding_data|
+      data = holding_data.with_indifferent_access
+      ticker = extract_ticker(data)
+      next if ticker.blank?
 
-    holdings_data.each_with_index do |holding_data, idx|
-      Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing holding #{idx + 1}/#{holdings_data.size}"
-      process_holding(holding_data.with_indifferent_access)
+      date = data[:date].to_s
+      existing = latest_per_security[ticker]
+      latest_per_security[ticker] = data if existing.nil? || date > existing[:date].to_s
+    end
+
+    Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing #{latest_per_security.size} holdings (deduped from #{holdings_data.size} time-series rows)"
+
+    latest_per_security.each_value.with_index do |holding_data, idx|
+      Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing holding #{idx + 1}/#{latest_per_security.size}"
+      process_holding(holding_data)
     rescue => e
       Rails.logger.error "IndexaCapitalAccount::HoldingsProcessor - Failed to process holding #{idx + 1}: #{e.class} - #{e.message}"
       Rails.logger.error e.backtrace.first(5).join("\n") if e.backtrace

--- a/app/models/indexa_capital_account/holdings_processor.rb
+++ b/app/models/indexa_capital_account/holdings_processor.rb
@@ -13,26 +13,26 @@ class IndexaCapitalAccount::HoldingsProcessor
     holdings_data = @indexa_capital_account.raw_holdings_payload
     return if holdings_data.blank?
 
-    # Indexa returns a time series — many rows per security across dates.
-    # Reduce to the latest-dated row per security so each holding reflects
-    # the current position, not whichever snapshot happens to be processed
-    # last in payload order.
-    latest_per_security = {}
+    # The importer normalises to total_fiscal_results (one aggregated row
+    # per security). Defensively dedupe in case a future variant feeds the
+    # per-tax-lot fiscal_results array through here — same key extraction
+    # as Processor#calculate_holdings_value via the shared DataHelpers
+    # method, so the two can't disagree on which rows refer to the same
+    # security.
+    per_security = {}
     holdings_data.each do |holding_data|
-      data = holding_data.with_indifferent_access
-      ticker = extract_ticker(data)
-      next if ticker.blank?
+      data = holding_data.respond_to?(:with_indifferent_access) ? holding_data.with_indifferent_access : holding_data
+      key = extract_instrument_key(data)
+      next if key.blank?
 
-      date = data[:date].to_s
-      existing = latest_per_security[ticker]
-      latest_per_security[ticker] = data if existing.nil? || date > existing[:date].to_s
+      per_security[key] = data
     end
 
-    Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing #{latest_per_security.size} holdings (deduped from #{holdings_data.size} time-series rows)"
+    Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing #{per_security.size} holdings (from #{holdings_data.size} input rows)"
 
-    latest_per_security.each_value.with_index do |holding_data, idx|
-      Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing holding #{idx + 1}/#{latest_per_security.size}"
-      process_holding(holding_data)
+    per_security.each_value.with_index do |data, idx|
+      Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing holding #{idx + 1}/#{per_security.size}"
+      process_holding(data)
     rescue => e
       Rails.logger.error "IndexaCapitalAccount::HoldingsProcessor - Failed to process holding #{idx + 1}: #{e.class} - #{e.message}"
       Rails.logger.error e.backtrace.first(5).join("\n") if e.backtrace
@@ -60,7 +60,7 @@ class IndexaCapitalAccount::HoldingsProcessor
     #   profit_loss → unrealized P&L
     #   subscription_date → purchase date
     def process_holding(data)
-      ticker = extract_ticker(data)
+      ticker = extract_instrument_key(data)
       return if ticker.blank?
 
       Rails.logger.info "IndexaCapitalAccount::HoldingsProcessor - Processing holding for ticker: #{ticker}"
@@ -93,19 +93,6 @@ class IndexaCapitalAccount::HoldingsProcessor
       # Store cost basis from cost_price (average purchase price per unit)
       cost_price = parse_decimal(data[:cost_price])
       update_holding_cost_basis(security, cost_price) if cost_price.present?
-    end
-
-    # Extract ISIN from instrument data as ticker
-    def extract_ticker(data)
-      # Indexa Capital uses ISIN codes nested under instrument
-      instrument = data[:instrument]
-      if instrument.is_a?(Hash)
-        instrument = instrument.with_indifferent_access
-        return instrument[:identifier] || instrument[:isin]
-      end
-
-      # Fallback to flat fields
-      data[:isin] || data[:identifier] || data[:symbol] || data[:ticker]
     end
 
     # Override security name extraction for Indexa Capital

--- a/app/models/indexa_capital_account/processor.rb
+++ b/app/models/indexa_capital_account/processor.rb
@@ -90,15 +90,17 @@ class IndexaCapitalAccount::Processor
       holdings_data = indexa_capital_account.raw_holdings_payload || []
       return 0 if holdings_data.empty?
 
-      # Indexa returns a time series: dedupe by instrument/identifier and keep
-      # the latest-dated row's amount per security so we don't double-count.
-      latest_per_security = {}
+      # The importer normalises to total_fiscal_results (one aggregated row
+      # per security) so a plain sum is correct. We still defensively dedupe
+      # by instrument key in case a future provider variant feeds the
+      # per-tax-lot fiscal_results array through here — the last value wins,
+      # consistent with how HoldingsProcessor upserts holdings.
+      per_security = {}
       holdings_data.each do |holding|
-        data = holding.is_a?(Hash) ? holding.with_indifferent_access : {}
-        instrument = data.dig(:instrument, :identifier) || data.dig(:instrument, :isin_code) || data[:identifier] || data[:isin_code]
+        instrument = extract_instrument_key(holding)
         next if instrument.blank?
 
-        date = data[:date].to_s
+        data = holding.respond_to?(:with_indifferent_access) ? holding.with_indifferent_access : holding
         amount = parse_decimal(data[:amount])
         unless amount
           titles = parse_decimal(data[:titles] || data[:quantity] || data[:units]) || 0
@@ -106,13 +108,10 @@ class IndexaCapitalAccount::Processor
           amount = titles * price
         end
 
-        existing = latest_per_security[instrument]
-        if existing.nil? || date > existing[:date]
-          latest_per_security[instrument] = { date: date, amount: amount }
-        end
+        per_security[instrument] = amount || 0
       end
 
-      latest_per_security.values.sum { |row| row[:amount] || 0 }
+      per_security.values.sum
     end
 
     def calculate_cash_balance

--- a/app/models/indexa_capital_account/processor.rb
+++ b/app/models/indexa_capital_account/processor.rb
@@ -121,5 +121,4 @@ class IndexaCapitalAccount::Processor
       Rails.logger.info "IndexaCapitalAccount::Processor - Cash balance from API: #{cash.inspect}"
       cash || BigDecimal("0")
     end
-
 end

--- a/app/models/indexa_capital_account/processor.rb
+++ b/app/models/indexa_capital_account/processor.rb
@@ -70,22 +70,49 @@ class IndexaCapitalAccount::Processor
     end
 
     def calculate_total_balance
-      # Calculate total from holdings + cash for accuracy
+      # Trust the API's reported balance when available — Indexa's holdings payload
+      # contains time-series snapshots (one row per security per date), so summing
+      # the raw entries double-counts. Fall back to a per-security latest-snapshot
+      # sum + cash only when the API total is missing.
+      if indexa_capital_account.current_balance.present?
+        Rails.logger.info "IndexaCapitalAccount::Processor - Using API total: #{indexa_capital_account.current_balance}"
+        return indexa_capital_account.current_balance
+      end
+
       holdings_value = calculate_holdings_value
       cash_value = indexa_capital_account.cash_balance || 0
-
       calculated_total = holdings_value + cash_value
+      Rails.logger.info "IndexaCapitalAccount::Processor - Using calculated total (API balance missing): holdings=#{holdings_value} + cash=#{cash_value} = #{calculated_total}"
+      calculated_total
+    end
 
-      # Use calculated total if we have holdings, otherwise trust API value
-      if holdings_value > 0
-        Rails.logger.info "IndexaCapitalAccount::Processor - Using calculated total: holdings=#{holdings_value} + cash=#{cash_value} = #{calculated_total}"
-        calculated_total
-      elsif indexa_capital_account.current_balance.present?
-        Rails.logger.info "IndexaCapitalAccount::Processor - Using API total: #{indexa_capital_account.current_balance}"
-        indexa_capital_account.current_balance
-      else
-        calculated_total
+    def calculate_holdings_value
+      holdings_data = indexa_capital_account.raw_holdings_payload || []
+      return 0 if holdings_data.empty?
+
+      # Indexa returns a time series: dedupe by instrument/identifier and keep
+      # the latest-dated row's amount per security so we don't double-count.
+      latest_per_security = {}
+      holdings_data.each do |holding|
+        data = holding.is_a?(Hash) ? holding.with_indifferent_access : {}
+        instrument = data.dig(:instrument, :identifier) || data.dig(:instrument, :isin_code) || data[:identifier] || data[:isin_code]
+        next if instrument.blank?
+
+        date = data[:date].to_s
+        amount = parse_decimal(data[:amount])
+        unless amount
+          titles = parse_decimal(data[:titles] || data[:quantity] || data[:units]) || 0
+          price = parse_decimal(data[:price]) || 0
+          amount = titles * price
+        end
+
+        existing = latest_per_security[instrument]
+        if existing.nil? || date > existing[:date]
+          latest_per_security[instrument] = { date: date, amount: amount }
+        end
       end
+
+      latest_per_security.values.sum { |row| row[:amount] || 0 }
     end
 
     def calculate_cash_balance
@@ -96,21 +123,4 @@ class IndexaCapitalAccount::Processor
       cash || BigDecimal("0")
     end
 
-    def calculate_holdings_value
-      holdings_data = indexa_capital_account.raw_holdings_payload || []
-      return 0 if holdings_data.empty?
-
-      holdings_data.sum do |holding|
-        data = holding.is_a?(Hash) ? holding.with_indifferent_access : {}
-        # Indexa Capital: amount = total market value, or titles * price
-        amount = parse_decimal(data[:amount])
-        if amount
-          amount
-        else
-          titles = parse_decimal(data[:titles] || data[:quantity] || data[:units]) || 0
-          price = parse_decimal(data[:price]) || 0
-          titles * price
-        end
-      end
-    end
 end

--- a/app/models/indexa_capital_item/importer.rb
+++ b/app/models/indexa_capital_item/importer.rb
@@ -125,13 +125,21 @@ class IndexaCapitalItem::Importer
       end
     end
 
-    # fiscal-results response may be an array or a hash containing an array
+    # fiscal-results response may be an array or a hash containing an array.
+    # Prefer total_fiscal_results: it contains one aggregated row per security
+    # with current titles/amount/cost. fiscal_results is per tax lot and also
+    # includes historical rebalance events (e.g. virtual sells/buys that
+    # generated tax events), so summing/iterating it over-counts the position.
     def normalize_holdings_response(data)
       return data if data.is_a?(Array)
       return [] if data.nil?
 
-      # Try common response shapes
-      data[:fiscal_results] || data[:results] || data[:positions] || data[:data] || []
+      data[:total_fiscal_results].presence ||
+        data[:fiscal_results] ||
+        data[:results] ||
+        data[:positions] ||
+        data[:data] ||
+        []
     end
 
     def prune_removed_accounts(upstream_account_ids)

--- a/app/models/indexa_capital_item/importer.rb
+++ b/app/models/indexa_capital_item/importer.rb
@@ -108,11 +108,19 @@ class IndexaCapitalItem::Importer
 
       begin
         holdings_data = indexa_capital_provider.get_holdings(account_number: account_number)
-
         stats["api_requests"] = stats.fetch("api_requests", 0) + 1
 
-        # The API returns fiscal-results which may be a hash with an array inside
         holdings_array = normalize_holdings_response(holdings_data)
+
+        # Pension plans return empty fiscal-results. Fall back to the portfolio
+        # endpoint, which exposes positions for both mutual fund and pension
+        # accounts in a uniform shape we can adapt to the same structure.
+        if holdings_array.empty?
+          Rails.logger.info "IndexaCapitalItem::Importer - fiscal-results empty for #{account_number}, falling back to /portfolio"
+          portfolio_data = indexa_capital_provider.get_portfolio(account_number: account_number)
+          stats["api_requests"] = stats.fetch("api_requests", 0) + 1
+          holdings_array = positions_from_portfolio(portfolio_data)
+        end
 
         if holdings_array.any?
           holdings_hashes = holdings_array.map { |h| sdk_object_to_hash(h) }
@@ -122,6 +130,25 @@ class IndexaCapitalItem::Importer
       rescue => e
         Rails.logger.warn "IndexaCapitalItem::Importer - Failed to fetch holdings: #{e.message}"
         register_error(e, context: "holdings", account_id: indexa_capital_account.id)
+      end
+    end
+
+    # Adapt /accounts/{id}/portfolio positions into the shape that
+    # HoldingsProcessor expects (i.e. the same field set as a
+    # total_fiscal_results row). Adds a derived cost_price (per-share cost)
+    # since portfolio rows only carry cost_amount.
+    def positions_from_portfolio(portfolio_data)
+      data = portfolio_data.is_a?(Hash) ? portfolio_data.with_indifferent_access : {}
+      Array(data[:instrument_accounts]).flat_map do |account|
+        Array(account.is_a?(Hash) ? account.with_indifferent_access[:positions] : nil).map do |pos|
+          row = (pos.is_a?(Hash) ? pos.with_indifferent_access : {}).dup
+          titles = row[:titles].to_d if row[:titles]
+          cost_amount = row[:cost_amount].to_d if row[:cost_amount]
+          if row[:cost_price].blank? && titles && titles.nonzero? && cost_amount
+            row[:cost_price] = (cost_amount / titles).to_s
+          end
+          row
+        end
       end
     end
 

--- a/app/models/indexa_capital_item/sync_complete_event.rb
+++ b/app/models/indexa_capital_item/sync_complete_event.rb
@@ -1,0 +1,22 @@
+class IndexaCapitalItem::SyncCompleteEvent
+  attr_reader :indexa_capital_item
+
+  def initialize(indexa_capital_item)
+    @indexa_capital_item = indexa_capital_item
+  end
+
+  def broadcast
+    indexa_capital_item.accounts.each do |account|
+      account.broadcast_sync_complete
+    end
+
+    indexa_capital_item.broadcast_replace_to(
+      indexa_capital_item.family,
+      target: "indexa_capital_item_#{indexa_capital_item.id}",
+      partial: "indexa_capital_items/indexa_capital_item",
+      locals: { indexa_capital_item: indexa_capital_item }
+    )
+
+    indexa_capital_item.family.broadcast_sync_complete
+  end
+end

--- a/app/models/provider/indexa_capital.rb
+++ b/app/models/provider/indexa_capital.rb
@@ -55,6 +55,21 @@ class Provider::IndexaCapital
     end
   end
 
+  # GET /accounts/{account_number}/portfolio → current snapshot with positions.
+  # Used as a fallback when fiscal-results is empty (e.g. pension plans, where
+  # Indexa returns {fiscal_results: [], total_fiscal_results: []} but exposes
+  # the same positions through this endpoint).
+  def get_portfolio(account_number:)
+    sanitize_account_number!(account_number)
+    with_retries("get_portfolio") do
+      response = self.class.get(
+        "#{base_url}/accounts/#{account_number}/portfolio",
+        headers: auth_headers
+      )
+      handle_response(response)
+    end
+  end
+
   # GET /accounts/{account_number}/performance → latest portfolio total_amount
   def get_account_balance(account_number:)
     sanitize_account_number!(account_number)

--- a/test/controllers/indexa_capital_items_controller_test.rb
+++ b/test/controllers/indexa_capital_items_controller_test.rb
@@ -56,9 +56,7 @@ class IndexaCapitalItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_difference "Account.count", 1 do
       post complete_account_setup_indexa_capital_item_url(@item), params: {
-        accounts: {
-          ica.id => { account_type: "investment", subtype: "brokerage" }
-        }
+        account_ids: [ ica.id ]
       }
     end
 
@@ -80,21 +78,15 @@ class IndexaCapitalItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_no_difference "Account.count" do
       post complete_account_setup_indexa_capital_item_url(@item), params: {
-        accounts: {
-          ica.id => { account_type: "investment" }
-        }
+        account_ids: [ ica.id ]
       }
     end
   end
 
-  test "complete_account_setup with all skipped redirects to setup" do
-    ica = indexa_capital_accounts(:mutual_fund)
-
+  test "complete_account_setup with no selected accounts redirects to setup" do
     assert_no_difference "Account.count" do
       post complete_account_setup_indexa_capital_item_url(@item), params: {
-        accounts: {
-          ica.id => { account_type: "skip" }
-        }
+        account_ids: []
       }
     end
 

--- a/test/models/indexa_capital_account/processor_test.rb
+++ b/test/models/indexa_capital_account/processor_test.rb
@@ -35,9 +35,37 @@ class IndexaCapitalAccount::ProcessorTest < ActiveSupport::TestCase
     assert_nothing_raised { processor.process }
   end
 
-  test "processor updates account balance from holdings value" do
+  test "processor trusts API current_balance over holdings sum when present" do
     @indexa_capital_account.update!(
       current_balance: 38905.21,
+      raw_holdings_payload: [
+        {
+          "amount" => 16333.96,
+          "titles" => 32.26,
+          "price" => 506.32,
+          "instrument" => { "identifier" => "IE00BFPM9V94", "name" => "Vanguard US 500" }
+        },
+        {
+          "amount" => 10759.05,
+          "titles" => 40.34,
+          "price" => 266.71,
+          "instrument" => { "identifier" => "IE00BFPM9L96", "name" => "Vanguard European" }
+        }
+      ]
+    )
+
+    @account.update!(balance: 0)
+
+    processor = IndexaCapitalAccount::Processor.new(@indexa_capital_account)
+    processor.process
+
+    @account.reload
+    assert_in_delta 38905.21, @account.balance.to_f, 0.01
+  end
+
+  test "processor falls back to holdings sum when current_balance is missing" do
+    @indexa_capital_account.update!(
+      current_balance: nil,
       raw_holdings_payload: [
         {
           "amount" => 16333.96,


### PR DESCRIPTION
Four related Indexa Capital regressions, all reproduced against `:stable` while self-hosting. The first three block account creation outright; the fourth makes balances visibly wrong on accounts that did get through.

## 1. Missing `IndexaCapitalItem::SyncCompleteEvent`

`Syncable#sync_broadcaster` (`app/models/concerns/syncable.rb:84`) does `self.class::SyncCompleteEvent.new(self)`. Plaid, Lunchflow, Mercury, SimpleFIN, SnapTrade, Sophtron, Coinbase, Coinstats, Binance, EnableBanking, Account, and Family all ship the class — `IndexaCapitalItem` was the only one missing it. The resulting `NameError` was swallowed by `Sync#perform_post_sync`'s `rescue`, so syncs looked successful but per-account and per-item Turbo broadcasts never fired:

```
Error performing post-sync for IndexaCapitalItem (<id>):
uninitialized constant IndexaCapitalItem::SyncCompleteEvent
```

Added the class, modeled on `LunchflowItem::SyncCompleteEvent`.

## 2. `complete_account_setup` never created accounts

The "Set Up Your IndexaCapital Accounts" dialog (`app/views/indexa_capital_items/setup_accounts.html.erb`) submits:

- `account_ids[]` — array of selected `indexa_capital_account` ids
- `sync_start_dates[<id>]` — per-account sync start date

But `IndexaCapitalItemsController#complete_account_setup` was reading `params[:accounts]`, which never exists on the request. Every submit hit the empty-config branch and bounced back with `flash[:alert] = t(".no_accounts")` ("No accounts to set up.") — accounts were never created.

Rewrote `complete_account_setup` to consume the form's actual params.

## 3. Wrong accountable type on imported accounts

The form has no account-type picker — Indexa Capital is an investment-only broker. `complete_account_setup` was passing `indexa_capital_account.account_type` (values like `"mutual"` / `"pension"`) to `infer_accountable_type`, which doesn't recognize those keys and falls through to `"Depository"`. Imported accounts were created as Cash depository accounts, hiding holdings/trades surfaces in the UI.

Hard-coded the accountable type to `"Investment"`.

## 4. Balance double-counting

`IndexaCapitalAccount::Processor#calculate_total_balance` summed every row in `raw_holdings_payload`. Indexa returns a time series (one row per security per date), so the naive sum multiplies the real balance. Reproduced against my account: 89 raw rows for 9 securities, naive sum = €180,039.08, latest-snapshot-per-security sum = €91,487.40, API-reported `current_balance` = €91,633.48. The Sure account was stored at €180,039.08.

Fix:
- Trust the API's `current_balance` when present.
- If we have to fall back to a computed total (API balance missing), dedupe `raw_holdings_payload` by instrument and take the latest-dated amount per security.

## Test plan
- [ ] Trigger a sync on an Indexa Capital item; no `uninitialized constant` error in `worker` logs; the item card refreshes via Turbo Stream when the sync completes.
- [ ] In "Set Up Your IndexaCapital Accounts", select one or more accounts and submit. Each is created as an `Investment` account, the modal closes, and a sync is enqueued.
- [ ] Submit the form with no accounts selected; the "No accounts to set up." alert still fires.
- [ ] After sync, an Indexa Capital account's stored `balance` and current-anchor valuation match the API's reported `current_balance` (no doubling).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sync-complete broadcasts with UI replace and coordinated notifications.
  * Fallback portfolio fetch when primary holdings are empty, improving holdings coverage.

* **Bug Fixes**
  * Account setup respects selected account IDs and per-account start dates, avoids duplicate provider accounts, and reports created accounts more reliably.
  * Holdings deduplicated and aggregated to prevent double-counting; provider-reported balances are preferred.
* **Other**
  * Improved logging for sync and holdings processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->