### PR TITLE
Fix:Bug:API Key copy action lacks success feedback (Copied! text/icon/tooltip) after clicking <Copy API Key>

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = ["source", "iconDefault", "iconSuccess", "textDefault", "textSuccess"];
+  static values = { successDuration: { type: Number, default: 2500 } };
 
   copy(event) {
     event.preventDefault();
@@ -29,7 +30,7 @@ export default class extends Controller {
       this.toggleTarget("iconSuccess", true);
       this.toggleTarget("textDefault", false);
       this.toggleTarget("textSuccess", true);
-    }, 2000);
+    }, this.successDurationValue);
   }
 
   disconnect() {

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["source", "iconDefault", "iconSuccess"];
+  static targets = ["source", "iconDefault", "iconSuccess", "textDefault", "textSuccess"];
 
   copy(event) {
     event.preventDefault();
@@ -18,11 +18,28 @@ export default class extends Controller {
   }
 
   showSuccess() {
-    this.iconDefaultTarget.classList.add("hidden");
-    this.iconSuccessTarget.classList.remove("hidden");
-    setTimeout(() => {
-      this.iconDefaultTarget.classList.remove("hidden");
-      this.iconSuccessTarget.classList.add("hidden");
-    }, 3000);
+    this.toggleTarget("iconDefault", true);
+    this.toggleTarget("iconSuccess", false);
+    this.toggleTarget("textDefault", true);
+    this.toggleTarget("textSuccess", false);
+
+    clearTimeout(this.resetTimeout);
+    this.resetTimeout = setTimeout(() => {
+      this.toggleTarget("iconDefault", false);
+      this.toggleTarget("iconSuccess", true);
+      this.toggleTarget("textDefault", false);
+      this.toggleTarget("textSuccess", true);
+    }, 2000);
+  }
+
+  disconnect() {
+    clearTimeout(this.resetTimeout);
+  }
+
+  toggleTarget(targetName, hide) {
+    const hasTarget = this[`has${targetName[0].toUpperCase()}${targetName.slice(1)}Target`];
+    if (!hasTarget) return;
+
+    this[`${targetName}Target`].classList.toggle("hidden", hide);
   }
 }

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -19,17 +19,11 @@ export default class extends Controller {
   }
 
   showSuccess() {
-    this._toggleTarget("iconDefault", true);
-    this._toggleTarget("iconSuccess", false);
-    this._toggleTarget("textDefault", true);
-    this._toggleTarget("textSuccess", false);
+    this._setSuccessState(true);
 
     this._clearResetTimeout();
     this.resetTimeout = setTimeout(() => {
-      this._toggleTarget("iconDefault", false);
-      this._toggleTarget("iconSuccess", true);
-      this._toggleTarget("textDefault", false);
-      this._toggleTarget("textSuccess", true);
+      this._setSuccessState(false);
       this.resetTimeout = null;
     }, this.successDurationValue);
   }
@@ -43,10 +37,15 @@ export default class extends Controller {
     this.resetTimeout = null;
   }
 
-  _toggleTarget(targetName, hide) {
-    const hasTarget = this[`has${targetName[0].toUpperCase()}${targetName.slice(1)}Target`];
-    if (!hasTarget) return;
+  _setSuccessState(successVisible) {
+    this._toggleIfTargetExists(this.hasIconDefaultTarget, this.iconDefaultTarget, successVisible);
+    this._toggleIfTargetExists(this.hasIconSuccessTarget, this.iconSuccessTarget, !successVisible);
+    this._toggleIfTargetExists(this.hasTextDefaultTarget, this.textDefaultTarget, successVisible);
+    this._toggleIfTargetExists(this.hasTextSuccessTarget, this.textSuccessTarget, !successVisible);
+  }
 
-    this[`${targetName}Target`].classList.toggle("hidden", hide);
+  _toggleIfTargetExists(hasTarget, target, hide) {
+    if (!hasTarget) return;
+    target.classList.toggle("hidden", hide);
   }
 }

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -19,25 +19,31 @@ export default class extends Controller {
   }
 
   showSuccess() {
-    this.toggleTarget("iconDefault", true);
-    this.toggleTarget("iconSuccess", false);
-    this.toggleTarget("textDefault", true);
-    this.toggleTarget("textSuccess", false);
+    this._toggleTarget("iconDefault", true);
+    this._toggleTarget("iconSuccess", false);
+    this._toggleTarget("textDefault", true);
+    this._toggleTarget("textSuccess", false);
 
-    clearTimeout(this.resetTimeout);
+    this._clearResetTimeout();
     this.resetTimeout = setTimeout(() => {
-      this.toggleTarget("iconDefault", false);
-      this.toggleTarget("iconSuccess", true);
-      this.toggleTarget("textDefault", false);
-      this.toggleTarget("textSuccess", true);
+      this._toggleTarget("iconDefault", false);
+      this._toggleTarget("iconSuccess", true);
+      this._toggleTarget("textDefault", false);
+      this._toggleTarget("textSuccess", true);
+      this.resetTimeout = null;
     }, this.successDurationValue);
   }
 
   disconnect() {
-    clearTimeout(this.resetTimeout);
+    this._clearResetTimeout();
   }
 
-  toggleTarget(targetName, hide) {
+  _clearResetTimeout() {
+    clearTimeout(this.resetTimeout);
+    this.resetTimeout = null;
+  }
+
+  _toggleTarget(targetName, hide) {
     const hasTarget = this[`has${targetName[0].toUpperCase()}${targetName.slice(1)}Target`];
     if (!hasTarget) return;
 

--- a/app/views/settings/api_keys/_copy_button.html.erb
+++ b/app/views/settings/api_keys/_copy_button.html.erb
@@ -1,0 +1,8 @@
+<button type="button"
+        data-action="clipboard#copy"
+        class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-surface-inset-hover">
+  <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
+  <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
+  <span data-clipboard-target="textDefault"><%= t("settings.api_keys.shared.copy_key") %></span>
+  <span class="hidden" data-clipboard-target="textSuccess"><%= t("settings.api_keys.shared.copied") %></span>
+</button>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -24,12 +24,12 @@
       <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
         <div class="flex items-center justify-between gap-3">
           <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
-          <%= render DS::Button.new(
-            text: "Copy API Key",
-            variant: "ghost",
-            icon: "copy",
-            data: { action: "clipboard#copy" }
-          ) %>
+          <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
+            <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
+            <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
+            <span data-clipboard-target="textDefault">Copy API Key</span>
+            <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
+          </button>
         </div>
       </div>
     </div>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -24,12 +24,7 @@
       <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
         <div class="flex items-center justify-between gap-3">
           <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
-          <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
-            <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
-            <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
-            <span data-clipboard-target="textDefault">Copy API Key</span>
-            <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
-          </button>
+          <%= render "settings/api_keys/copy_button" %>
         </div>
       </div>
     </div>

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -29,12 +29,7 @@
             <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
               <div class="flex items-center justify-between gap-3">
                 <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
-                <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
-                  <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
-                  <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
-                  <span data-clipboard-target="textDefault">Copy API Key</span>
-                  <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
-                </button>
+                <%= render "settings/api_keys/copy_button" %>
               </div>
             </div>
           </div>

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -29,12 +29,12 @@
             <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
               <div class="flex items-center justify-between gap-3">
                 <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
-                <%= render DS::Button.new(
-                  text: "Copy API Key",
-                  variant: "ghost",
-                  icon: "copy",
-                  data: { action: "clipboard#copy" }
-                ) %>
+                <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
+                  <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
+                  <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
+                  <span data-clipboard-target="textDefault">Copy API Key</span>
+                  <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
+                </button>
               </div>
             </div>
           </div>

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -25,12 +25,7 @@
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
           <div class="flex items-center justify-between gap-3">
             <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
-            <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
-              <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
-              <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
-              <span data-clipboard-target="textDefault">Copy API Key</span>
-              <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
-            </button>
+            <%= render "settings/api_keys/copy_button" %>
           </div>
         </div>
       </div>
@@ -113,12 +108,7 @@
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
           <div class="flex items-center justify-between gap-3">
             <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
-            <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
-              <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
-              <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
-              <span data-clipboard-target="textDefault">Copy API Key</span>
-              <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
-            </button>
+            <%= render "settings/api_keys/copy_button" %>
           </div>
         </div>
       </div>

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -25,12 +25,12 @@
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
           <div class="flex items-center justify-between gap-3">
             <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
-            <%= render DS::Button.new(
-              text: "Copy API Key",
-              variant: "ghost",
-              icon: "copy",
-              data: { action: "clipboard#copy" }
-            ) %>
+            <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
+              <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
+              <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
+              <span data-clipboard-target="textDefault">Copy API Key</span>
+              <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
+            </button>
           </div>
         </div>
       </div>
@@ -113,12 +113,12 @@
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
           <div class="flex items-center justify-between gap-3">
             <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
-            <%= render DS::Button.new(
-              text: "Copy API Key",
-              variant: "ghost",
-              icon: "copy",
-              data: { action: "clipboard#copy" }
-            ) %>
+            <button type="button" data-action="clipboard#copy" class="font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700">
+              <span data-clipboard-target="iconDefault"><%= icon("copy", size: "md") %></span>
+              <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", size: "md") %></span>
+              <span data-clipboard-target="textDefault">Copy API Key</span>
+              <span class="hidden" data-clipboard-target="textSuccess">Copied!</span>
+            </button>
           </div>
         </div>
       </div>

--- a/config/locales/views/settings/api_keys/en.yml
+++ b/config/locales/views/settings/api_keys/en.yml
@@ -11,6 +11,9 @@ en:
         read_balances: "View Balances"
         write_transactions: "Create Transactions"
     api_keys:
+      shared:
+        copy_key: "Copy API Key"
+        copied: "Copied!"
       show:
         title: "API Key Management"
         no_api_key:

--- a/test/system/settings/api_keys_test.rb
+++ b/test/system/settings/api_keys_test.rb
@@ -83,6 +83,23 @@ class Settings::ApiKeysTest < ApplicationSystemTestCase
     assert_text "/api/v1/accounts"
   end
 
+  test "should show temporary copied feedback when copying api key" do
+    ApiKey.create!(
+      user: @user,
+      name: "Clipboard API Key",
+      display_key: "clipboard_key_123",
+      scopes: [ "read" ]
+    )
+
+    visit settings_api_key_path
+    page.execute_script("Object.defineProperty(navigator, 'clipboard', { value: { writeText: () => Promise.resolve() }, writable: true, configurable: true })")
+
+    click_button "Copy API Key"
+
+    assert_selector 'span[data-clipboard-target="textSuccess"]', text: "Copied!", visible: true
+    assert_selector 'span[data-clipboard-target="iconSuccess"]', visible: true
+  end
+
   test "should allow regenerating API key" do
     api_key = ApiKey.create!(
       user: @user,

--- a/test/system/settings/api_keys_test.rb
+++ b/test/system/settings/api_keys_test.rb
@@ -96,8 +96,10 @@ class Settings::ApiKeysTest < ApplicationSystemTestCase
 
     click_button "Copy API Key"
 
-    assert_selector 'span[data-clipboard-target="textSuccess"]', text: "Copied!", visible: true
-    assert_selector 'span[data-clipboard-target="iconSuccess"]', visible: true
+    using_wait_time 5 do
+      assert_selector 'span[data-clipboard-target="textSuccess"]', text: "Copied!", visible: true
+      assert_selector 'span[data-clipboard-target="iconSuccess"]', visible: true
+    end
   end
 
   test "should allow regenerating API key" do


### PR DESCRIPTION
### Description
This PR improves the API key copy-to-clipboard UX by adding immediate, temporary success feedback after clicking Copy API Key.
Previously, the key was copied correctly but the UI did not show a clear confirmation state.

Closes #1563 

**Changes made:**
Updated clipboard_controller.js to support optional text targets (textDefault, textSuccess) and to toggle both icon and text success states.
Added reset handling (disconnect) and target-safe toggling so existing clipboard usages remain compatible.
Replaced API key copy buttons in:
app/views/settings/api_keys/show.html.erb
app/views/settings/api_keys/created.html.erb
app/views/settings/api_keys/created.turbo_stream.erb with markup that shows Copied! and a check icon briefly after successful copy.
Added system test coverage in test/system/settings/api_keys_test.rb for the temporary copied-feedback behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared copy button component for API keys with localized labels and visible success text.

* **Bug Fixes**
  * Success feedback now swaps both icon and text.
  * Feedback timeout is configurable (default 2.5s) and pending timers are cleared on teardown to prevent delayed UI updates.

* **Tests**
  * Added a system test covering the copy-to-clipboard flow and success feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->