### PR TITLE
fix responsive issue in settings/api_key route page

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,17 +1,38 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["source"];
+  static targets = ["source", "iconDefault", "iconSuccess"];
 
   copy(event) {
     event.preventDefault();
     if (this.sourceTarget?.textContent) {
       navigator.clipboard
         .writeText(this.sourceTarget.textContent)
-        .then(() => {})
+        .then(() => {
+          this.showSuccess();
+        })
         .catch((error) => {
           console.error("Failed to copy text: ", error);
         });
     }
+  }
+
+  showSuccess() {
+    if (!this.hasIconDefaultTarget || !this.hasIconSuccessTarget) return;
+
+    this.iconDefaultTarget.classList.add("hidden");
+    this.iconSuccessTarget.classList.remove("hidden");
+
+    clearTimeout(this.resetTimeout);
+    this.resetTimeout = setTimeout(() => {
+      this.iconDefaultTarget.classList.remove("hidden");
+      this.iconSuccessTarget.classList.add("hidden");
+      this.resetTimeout = null;
+    }, 3000);
+  }
+
+  disconnect() {
+    clearTimeout(this.resetTimeout);
+    this.resetTimeout = null;
   }
 }

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,28 +1,17 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["source", "iconDefault", "iconSuccess"];
+  static targets = ["source"];
 
   copy(event) {
     event.preventDefault();
     if (this.sourceTarget?.textContent) {
       navigator.clipboard
         .writeText(this.sourceTarget.textContent)
-        .then(() => {
-          this.showSuccess();
-        })
+        .then(() => {})
         .catch((error) => {
           console.error("Failed to copy text: ", error);
         });
     }
-  }
-
-  showSuccess() {
-    this.iconDefaultTarget.classList.add("hidden");
-    this.iconSuccessTarget.classList.remove("hidden");
-    setTimeout(() => {
-      this.iconDefaultTarget.classList.remove("hidden");
-      this.iconSuccessTarget.classList.add("hidden");
-    }, 3000);
   }
 }

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -6,9 +6,9 @@
       </div>
     </div>
 
-    <main class="grow flex h-full">
-      <div class="relative max-w-4xl mx-auto flex flex-col w-full h-full">
-        <div class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]">
+    <main class="grow flex h-full min-w-0">
+      <div class="relative max-w-4xl mx-auto flex flex-col w-full h-full min-w-0">
+        <div class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch] min-w-0">
           <div class="sticky top-0 z-10 px-3 md:px-10 pt-1.5 md:pt-3 pb-3 bg-surface border-b border-tertiary shrink-0">
             <% if content_for?(:breadcrumbs) %>
               <%= yield :breadcrumbs %>
@@ -16,7 +16,7 @@
               <%= render "layouts/shared/breadcrumbs", breadcrumbs: @breadcrumbs %>
             <% end %>
 
-            <div class="flex items-center justify-between gap-4 mt-1.5 min-h-9">
+            <div class="flex flex-wrap items-center justify-between gap-3 mt-1.5 min-h-9">
               <% if content_for?(:page_title) %>
                 <h1 class="text-primary text-xl font-medium">
                   <%= content_for :page_title %>
@@ -25,7 +25,7 @@
                 <div></div>
               <% end %>
               <% if content_for?(:page_actions) %>
-                <div class="flex items-center gap-2 shrink-0">
+                <div class="flex items-center gap-2 max-w-full">
                   <%= yield :page_actions %>
                 </div>
               <% end %>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -22,14 +22,17 @@
       <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
 
       <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-        <div class="flex items-center justify-between gap-3">
-          <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
-          <%= render DS::Button.new(
-            text: "Copy API Key",
-            variant: "ghost",
-            icon: "copy",
-            data: { action: "clipboard#copy" }
-          ) %>
+        <div class="w-full overflow-hidden">
+          <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @api_key.plain_key %></code>
+          <div class="mt-2 flex justify-end">
+            <%= render DS::Button.new(
+              text: "Copy API Key",
+              variant: "ghost",
+              icon: "copy",
+              class: "shrink-0",
+              data: { action: "clipboard#copy" }
+            ) %>
+          </div>
         </div>
       </div>
     </div>
@@ -78,8 +81,8 @@
     <div class="bg-surface-inset rounded-xl p-4">
       <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
       <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.show.current_api_key.usage_instructions", product_name: product_name) %></p>
-      <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
-        curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
+      <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
+        curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
       </div>
     </div>
 

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -82,12 +82,15 @@
       <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
       <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.show.current_api_key.usage_instructions", product_name: product_name) %></p>
       <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
-        <div class="flex items-start gap-2 min-w-0">
-          <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
-          <button type="button" data-action="clipboard#copy" class="p-1.5 text-secondary hover:text-primary shrink-0" title="Copy curl command" aria-label="Copy curl command">
-            <span data-clipboard-target="iconDefault"><%= icon("copy", class: "w-4 h-4") %></span>
-            <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", class: "w-4 h-4") %></span>
-          </button>
+        <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+        <div class="mt-2 flex justify-end">
+          <%= render DS::Button.new(
+            text: "Copy",
+            variant: "ghost",
+            icon: "copy",
+            class: "shrink-0",
+            data: { action: "clipboard#copy" }
+          ) %>
         </div>
       </div>
     </div>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -81,8 +81,14 @@
     <div class="bg-surface-inset rounded-xl p-4">
       <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
       <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.show.current_api_key.usage_instructions", product_name: product_name) %></p>
-      <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
-        curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
+      <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
+        <div class="flex items-start gap-2 min-w-0">
+          <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+          <button type="button" data-action="clipboard#copy" class="p-1.5 text-secondary hover:text-primary shrink-0" title="Copy curl command" aria-label="Copy curl command">
+            <span data-clipboard-target="iconDefault"><%= icon("copy", class: "w-4 h-4") %></span>
+            <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", class: "w-4 h-4") %></span>
+          </button>
+        </div>
       </div>
     </div>
 

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -26,10 +26,10 @@
           <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @api_key.plain_key %></code>
           <div class="mt-2 flex justify-end">
             <%= render DS::Button.new(
-              title: t("settings.api_keys.created.copy_key"),
-              variant: "ghost",
+              variant: :icon,
               icon: "copy",
-              class: "shrink-0",
+              title: "Copy",
+              aria: { label: "Copy" },
               data: { action: "clipboard#copy" }
             ) %>
           </div>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -26,7 +26,7 @@
           <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @api_key.plain_key %></code>
           <div class="mt-2 flex justify-end">
             <%= render DS::Button.new(
-              text: "Copy API Key",
+              title: t("settings.api_keys.created.copy_key"),
               variant: "ghost",
               icon: "copy",
               class: "shrink-0",
@@ -79,7 +79,7 @@
     </div>
 
     <div class="bg-surface-inset rounded-xl p-4">
-      <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
+      <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.usage_instructions_title") %></h4>
       <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.show.current_api_key.usage_instructions", product_name: product_name) %></p>
       <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
         <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -87,12 +87,15 @@
             <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
             <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
             <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
-              <div class="flex items-start gap-2 min-w-0">
-                <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
-                <button type="button" data-action="clipboard#copy" class="p-1.5 text-secondary hover:text-primary shrink-0" title="Copy curl command" aria-label="Copy curl command">
-                  <span data-clipboard-target="iconDefault"><%= icon("copy", class: "w-4 h-4") %></span>
-                  <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", class: "w-4 h-4") %></span>
-                </button>
+              <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+              <div class="mt-2 flex justify-end">
+                <%= render DS::Button.new(
+                  text: "Copy",
+                  variant: "ghost",
+                  icon: "copy",
+                  class: "shrink-0",
+                  data: { action: "clipboard#copy" }
+                ) %>
               </div>
             </div>
           </div>

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -86,8 +86,14 @@
           <div class="bg-surface-inset rounded-xl p-4">
             <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
             <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
-            <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
-              curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
+            <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
+              <div class="flex items-start gap-2 min-w-0">
+                <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+                <button type="button" data-action="clipboard#copy" class="p-1.5 text-secondary hover:text-primary shrink-0" title="Copy curl command" aria-label="Copy curl command">
+                  <span data-clipboard-target="iconDefault"><%= icon("copy", class: "w-4 h-4") %></span>
+                  <span class="hidden" data-clipboard-target="iconSuccess"><%= icon("check", class: "w-4 h-4") %></span>
+                </button>
+              </div>
             </div>
           </div>
 

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -27,14 +27,17 @@
             <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
 
             <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-              <div class="flex items-center justify-between gap-3">
-                <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
-                <%= render DS::Button.new(
-                  text: "Copy API Key",
-                  variant: "ghost",
-                  icon: "copy",
-                  data: { action: "clipboard#copy" }
-                ) %>
+              <div class="w-full overflow-hidden">
+                <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @api_key.plain_key %></code>
+                <div class="mt-2 flex justify-end">
+                  <%= render DS::Button.new(
+                    text: "Copy API Key",
+                    variant: "ghost",
+                    icon: "copy",
+                    class: "shrink-0",
+                    data: { action: "clipboard#copy" }
+                  ) %>
+                </div>
               </div>
             </div>
           </div>
@@ -83,8 +86,8 @@
           <div class="bg-surface-inset rounded-xl p-4">
             <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
             <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
-            <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
-              curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
+            <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
+              curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
             </div>
           </div>
 

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -31,7 +31,7 @@
                 <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @api_key.plain_key %></code>
                 <div class="mt-2 flex justify-end">
                   <%= render DS::Button.new(
-                    text: "Copy API Key",
+                    title: t("settings.api_keys.created.copy_key"),
                     variant: "ghost",
                     icon: "copy",
                     class: "shrink-0",
@@ -84,7 +84,7 @@
           </div>
 
           <div class="bg-surface-inset rounded-xl p-4">
-            <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
+            <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.usage_instructions_title") %></h4>
             <p class="text-secondary text-sm mb-3">Include your API key in the X-Api-Key header when making requests:</p>
             <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
               <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -31,10 +31,10 @@
                 <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @api_key.plain_key %></code>
                 <div class="mt-2 flex justify-end">
                   <%= render DS::Button.new(
-                    title: t("settings.api_keys.created.copy_key"),
-                    variant: "ghost",
+                    variant: :icon,
                     icon: "copy",
-                    class: "shrink-0",
+                    title: "Copy",
+                    aria: { label: "Copy" },
                     data: { action: "clipboard#copy" }
                   ) %>
                 </div>

--- a/app/views/settings/api_keys/new.html.erb
+++ b/app/views/settings/api_keys/new.html.erb
@@ -51,7 +51,7 @@
       ) %>
 
       <%= render DS::Button.new(
-        text: "Save API Key",
+        text: t("settings.api_keys.new.save_key"),
         variant: "primary",
         type: "submit"
       ) %>

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -23,14 +23,17 @@
         <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
 
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-          <div class="flex items-center justify-between gap-3">
-            <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
-            <%= render DS::Button.new(
-              text: "Copy API Key",
-              variant: "ghost",
-              icon: "copy",
-              data: { action: "clipboard#copy" }
-            ) %>
+          <div class="w-full overflow-hidden">
+            <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
+            <div class="mt-2 flex justify-end">
+              <%= render DS::Button.new(
+                text: "Copy API Key",
+                variant: "ghost",
+                icon: "copy",
+                class: "shrink-0",
+                data: { action: "clipboard#copy" }
+              ) %>
+            </div>
           </div>
         </div>
       </div>
@@ -38,8 +41,8 @@
       <div class="bg-surface-inset rounded-xl p-4">
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
-        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
-          curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
+        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
+          curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
         </div>
       </div>
 
@@ -111,14 +114,17 @@
         <p class="text-secondary text-sm mb-3">Copy and store this key securely. You'll need it to authenticate your API requests.</p>
 
         <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-          <div class="flex items-center justify-between gap-3">
-            <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
-            <%= render DS::Button.new(
-              text: "Copy API Key",
-              variant: "ghost",
-              icon: "copy",
-              data: { action: "clipboard#copy" }
-            ) %>
+          <div class="w-full overflow-hidden">
+            <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
+            <div class="mt-2 flex justify-end">
+              <%= render DS::Button.new(
+                text: "Copy API Key",
+                variant: "ghost",
+                icon: "copy",
+                class: "shrink-0",
+                data: { action: "clipboard#copy" }
+              ) %>
+            </div>
           </div>
         </div>
       </div>
@@ -126,8 +132,8 @@
       <div class="bg-surface-inset rounded-xl p-4">
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
-        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary">
-          curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts
+        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
+          curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
         </div>
       </div>
 

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -41,8 +41,17 @@
       <div class="bg-surface-inset rounded-xl p-4">
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
-        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
-          curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
+        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
+          <div class="flex items-start gap-2 min-w-0">
+            <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+            <%= render DS::Button.new(
+              text: "Copy",
+              variant: "ghost",
+              icon: "copy",
+              class: "shrink-0",
+              data: { action: "clipboard#copy" }
+            ) %>
+          </div>
         </div>
       </div>
 
@@ -132,8 +141,17 @@
       <div class="bg-surface-inset rounded-xl p-4">
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
-        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-x-auto break-all">
-          curl -H "X-Api-Key: &lt;YOUR_API_KEY&gt;" <%= request.base_url %>/api/v1/accounts
+        <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
+          <div class="flex items-start gap-2 min-w-0">
+            <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+            <%= render DS::Button.new(
+              text: "Copy",
+              variant: "ghost",
+              icon: "copy",
+              class: "shrink-0",
+              data: { action: "clipboard#copy" }
+            ) %>
+          </div>
         </div>
       </div>
 

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -42,8 +42,8 @@
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
-          <div class="flex items-start gap-2 min-w-0">
-            <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+          <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+          <div class="mt-2 flex justify-end">
             <%= render DS::Button.new(
               text: "Copy",
               variant: "ghost",
@@ -142,8 +142,8 @@
         <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
-          <div class="flex items-start gap-2 min-w-0">
-            <code class="block flex-1 min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+          <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
+          <div class="mt-2 flex justify-end">
             <%= render DS::Button.new(
               text: "Copy",
               variant: "ghost",

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -156,7 +156,7 @@
 
       <div class="flex justify-end pt-4 border-t border-primary">
         <%= render DS::Button.new(
-          title: t("settings.api_keys.current_api_key.revoke_key"),
+          text: t("settings.api_keys.show.current_api_key.revoke_key"),
           href: settings_api_key_path,
           method: :delete,
           variant: "destructive",
@@ -171,7 +171,7 @@
   <%= content_for :page_title, t(".no_api_key.title") %>
   <%= content_for :page_actions do %>
     <%= render DS::Link.new(
-      title: t("settings.api_keys.no_api_key.create_api_key"),
+      text: t("settings.api_keys.show.no_api_key.create_api_key"),
       href: new_settings_api_key_path,
       variant: "primary"
     ) %>

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -44,10 +44,10 @@
           <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
           <div class="mt-2 flex justify-end">
             <%= render DS::Button.new(
-              text: "Copy",
-              variant: "ghost",
+              variant: :icon,
               icon: "copy",
-              class: "shrink-0",
+              title: "Copy",
+              aria: { label: "Copy" },
               data: { action: "clipboard#copy" }
             ) %>
           </div>
@@ -126,7 +126,7 @@
             <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
             <div class="mt-2 flex justify-end">
               <%= render DS::Button.new(
-                title: t("settings.api_keys.current_api_key.copy_key"),
+                title: t(".current_api_key.copy_key"),
                 variant: "ghost",
                 icon: "copy",
                 class: "shrink-0",
@@ -138,16 +138,16 @@
       </div>
 
       <div class="bg-surface-inset rounded-xl p-4">
-        <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.current_api_key.usage_instructions_title") %></h4>
+        <h4 class="font-medium text-primary mb-3"><%= t(".current_api_key.usage_instructions_title") %></h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
           <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
           <div class="mt-2 flex justify-end">
             <%= render DS::Button.new(
-              title: t("settings.api_keys.current_api_key.copy_key"),
-              variant: "ghost",
+              variant: :icon,
               icon: "copy",
-              class: "shrink-0",
+              title: "Copy",
+              aria: { label: "Copy" },
               data: { action: "clipboard#copy" }
             ) %>
           </div>

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -27,7 +27,6 @@
             <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
             <div class="mt-2 flex justify-end">
               <%= render DS::Button.new(
-                text: "Copy API Key",
                 variant: "ghost",
                 icon: "copy",
                 class: "shrink-0",
@@ -127,7 +126,7 @@
             <code id="api-key-display" class="block w-full min-w-0 overflow-x-auto font-mono text-sm text-primary break-all whitespace-pre-wrap" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
             <div class="mt-2 flex justify-end">
               <%= render DS::Button.new(
-                text: "Copy API Key",
+                title: t("settings.api_keys.current_api_key.copy_key"),
                 variant: "ghost",
                 icon: "copy",
                 class: "shrink-0",
@@ -139,13 +138,13 @@
       </div>
 
       <div class="bg-surface-inset rounded-xl p-4">
-        <h4 class="font-medium text-primary mb-3">How to use your API key</h4>
+        <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.current_api_key.usage_instructions_title") %></h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.usage_instructions", product_name: product_name) %></p>
         <div class="bg-container rounded-lg p-3 font-mono text-sm text-primary border border-primary max-w-full overflow-hidden" data-controller="clipboard">
           <code class="block w-full min-w-0 overflow-x-auto break-all whitespace-pre-wrap" data-clipboard-target="source">curl -H "X-Api-Key: <%= @current_api_key.plain_key %>" <%= request.base_url %>/api/v1/accounts</code>
           <div class="mt-2 flex justify-end">
             <%= render DS::Button.new(
-              text: "Copy",
+              title: t("settings.api_keys.current_api_key.copy_key"),
               variant: "ghost",
               icon: "copy",
               class: "shrink-0",
@@ -157,7 +156,7 @@
 
       <div class="flex justify-end pt-4 border-t border-primary">
         <%= render DS::Button.new(
-          text: "Revoke Key",
+          title: t("settings.api_keys.current_api_key.revoke_key"),
           href: settings_api_key_path,
           method: :delete,
           variant: "destructive",
@@ -172,7 +171,7 @@
   <%= content_for :page_title, t(".no_api_key.title") %>
   <%= content_for :page_actions do %>
     <%= render DS::Link.new(
-      text: t(".no_api_key.create_api_key"),
+      title: t("settings.api_keys.no_api_key.create_api_key"),
       href: new_settings_api_key_path,
       variant: "primary"
     ) %>

--- a/config/locales/views/settings/api_keys/en.yml
+++ b/config/locales/views/settings/api_keys/en.yml
@@ -39,7 +39,7 @@ en:
           usage_instructions_title: "How to use your API key"
           usage_instructions: "Include your API key in the X-Api-Key header when making requests to the %{product_name} API:"
           regenerate_key: "Create New Key"
-          revoke_key: "Revoke Key"
+          revoke_key: "Revoke API Key"
           revoke_confirmation: "Are you sure you want to revoke this API key? This action cannot be undone and will immediately disable all applications using this key."
       new:
         title: "Create API Key"
@@ -58,6 +58,7 @@ en:
         security_warning_title: "Important Security Notice"
         security_warning: "Your API key will be shown only once after creation. Store it securely and never share it publicly. If you lose it, you'll need to create a new one."
         create_key: "Create API Key"
+        save_key: "Save API Key"
         cancel: "Cancel"
       created:
         title: "API Key Created"

--- a/test/system/settings/api_keys_test.rb
+++ b/test/system/settings/api_keys_test.rb
@@ -79,7 +79,7 @@ class Settings::ApiKeysTest < ApplicationSystemTestCase
     visit settings_api_key_path
 
     assert_text "How to use your API key"
-    assert_text "curl -H \"X-Api-Key: <YOUR_API_KEY>\""
+    assert_text "curl -H \"X-Api-Key: test_key_123\""
     assert_text "/api/v1/accounts"
   end
 

--- a/test/system/settings/api_keys_test.rb
+++ b/test/system/settings/api_keys_test.rb
@@ -79,7 +79,7 @@ class Settings::ApiKeysTest < ApplicationSystemTestCase
     visit settings_api_key_path
 
     assert_text "How to use your API key"
-    assert_text "curl -H \"X-Api-Key: test_key_123\""
+    assert_text "curl -H \"X-Api-Key: <YOUR_API_KEY>\""
     assert_text "/api/v1/accounts"
   end
 

--- a/test/system/settings/api_keys_test.rb
+++ b/test/system/settings/api_keys_test.rb
@@ -43,8 +43,8 @@ class Settings::ApiKeysTest < ApplicationSystemTestCase
     api_key_display = find("#api-key-display")
     assert api_key_display.text.length > 30 # Should be a long hex string
 
-    # Should show copy buttons
-    assert_button "Copy API Key"
+    # Should expose a copy action for the generated API key
+    assert_selector '[data-action="clipboard#copy"]', minimum: 1
     assert_link "Create New Key"
   end
 

--- a/test/system/settings/api_keys_test.rb
+++ b/test/system/settings/api_keys_test.rb
@@ -65,7 +65,7 @@ class Settings::ApiKeysTest < ApplicationSystemTestCase
     assert_text "Read/Write"
     assert_text "Never used"
     assert_link "Create New Key"
-    assert_button "Revoke Key"
+    assert_button "Revoke API Key"
   end
 
   test "should show usage instructions and example curl command" do
@@ -121,7 +121,7 @@ class Settings::ApiKeysTest < ApplicationSystemTestCase
     visit settings_api_key_path
 
     # Click the revoke button to open the modal
-    click_button "Revoke Key"
+    click_button "Revoke API Key"
 
     # Wait for the dialog and then confirm
     assert_selector "#confirm-dialog", visible: true


### PR DESCRIPTION
### Description
This PR fixes a responsive layout issue on Settings > API Key in the medium-width range (roughly 768px–987px) where the content pane did not shrink correctly when the settings sidebar remained visible, causing the right side to be clipped.

It also improves API key block resilience by preventing long key/curl content from forcing overflow and cleans up curl snippet formatting.

Closes #1565

**Changes made:**
Updated app/views/layouts/settings.html.erb to allow proper content shrinking in split-pane widths (min-w-0 on right-pane containers, header row wrapping, safer page action container sizing).
Refactored API key display sections in:
app/views/settings/api_keys/show.html.erb
app/views/settings/api_keys/created.html.erb
app/views/settings/api_keys/created.turbo_stream.erb to use a stable two-row key/copy layout for narrow/medium widths.
Hardened key and curl snippet containers against overflow with wrapping/scroll-safe classes.
Replaced inline full-key curl examples with X-Api-Key: <YOUR_API_KEY> placeholder to avoid layout blowout from long tokens.
Removed extra leading spacing in curl snippet blocks by dropping whitespace-pre-wrap from the curl container.
Updated system test expectation in test/system/settings/api_keys_test.rb to match the placeholder curl snippet.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented horizontal overflow and ensured elements can shrink properly; copy confirmation feedback now reliably resets.

* **Style**
  * Improved header wrapping, spacing, and moved copy controls into dedicated right-aligned rows for clearer, more responsive API key displays.

* **Localization**
  * Replaced hardcoded texts with localized labels for save, copy, usage headings, and updated the revoke button wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->