### PR TITLE
fix(android): remove dead buildscript block and kotlin_version reference

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    id "org.jetbrains.kotlin.android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -99,6 +99,3 @@ flutter {
     source '../..'
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
Both files look clean. Here's what was done:

mobile/android/build.gradle — removed the entire buildscript { } block (lines 1–12). It declared AGP 8.1.0 and Kotlin 1.9.0 via the legacy classpath mechanism, but both are already declared in settings.gradle's pluginManagement block (AGP 8.5.0, Kotlin 1.9.24) using the modern plugins DSL.

mobile/android/app/build.gradle — removed the dependencies block containing implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version". That line was the only consumer of ext.kotlin_version, and since Kotlin Gradle plugin 1.4+, the stdlib is added automatically — the explicit dependency was both redundant and would have broken once kotlin_version was undefined.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified Android build configuration by removing legacy buildscript declarations.
  * Updated the Kotlin Android plugin identifier to a newer, standardized form.
  * Removed an explicit Kotlin standard library dependency that was previously declared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->