### PR TITLE
Fix SimpleFIN inverting Loan account balances

### DIFF
--- a/app/models/simplefin_account/processor.rb
+++ b/app/models/simplefin_account/processor.rb
@@ -91,13 +91,16 @@ class SimplefinAccount::Processor
         if account.accountable_type == "Loan"
           balance = observed.abs
           Rails.logger.info(
-            "SimpleFIN loan sign: trusted bank-reported magnitude for sfa=#{simplefin_account.id}, " \
+            "SimpleFIN liability sign: classification=loan sfa=#{simplefin_account.id}"
+          )
+          Rails.logger.debug(
+            "SimpleFIN liability sign (loan) amounts: sfa=#{simplefin_account.id} " \
             "observed=#{observed.to_s('F')} stored=#{balance.to_s('F')}"
           )
           Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
             category: "simplefin",
             message: "liability_sign=loan",
-            data: { sfa_id: simplefin_account.id, observed: observed.to_s("F"), stored: balance.to_s("F") }
+            data: { sfa_id: simplefin_account.id }
           )) rescue nil
         else
           # 1) Try transaction-history heuristic when enabled
@@ -110,36 +113,45 @@ class SimplefinAccount::Processor
             when :credit
               balance = -observed.abs
               Rails.logger.info(
-                "SimpleFIN overpayment heuristic: classified as credit for sfa=#{simplefin_account.id}, " \
+                "SimpleFIN overpayment heuristic: classified as credit for sfa=#{simplefin_account.id} " \
+                "tx_count=#{result.metrics[:tx_count]}"
+              )
+              Rails.logger.debug(
+                "SimpleFIN overpayment heuristic (credit) amounts: sfa=#{simplefin_account.id} " \
                 "observed=#{observed.to_s('F')} metrics=#{result.metrics.slice(:charges_total, :payments_total, :tx_count).inspect}"
               )
               Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
                 category: "simplefin",
                 message: "liability_sign=credit",
-                data: { sfa_id: simplefin_account.id, observed: observed.to_s("F") }
+                data: { sfa_id: simplefin_account.id }
               )) rescue nil
             when :debt
               balance = observed.abs
               Rails.logger.info(
-                "SimpleFIN overpayment heuristic: classified as debt for sfa=#{simplefin_account.id}, " \
+                "SimpleFIN overpayment heuristic: classified as debt for sfa=#{simplefin_account.id} " \
+                "tx_count=#{result.metrics[:tx_count]}"
+              )
+              Rails.logger.debug(
+                "SimpleFIN overpayment heuristic (debt) amounts: sfa=#{simplefin_account.id} " \
                 "observed=#{observed.to_s('F')} metrics=#{result.metrics.slice(:charges_total, :payments_total, :tx_count).inspect}"
               )
               Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
                 category: "simplefin",
                 message: "liability_sign=debt",
-                data: { sfa_id: simplefin_account.id, observed: observed.to_s("F") }
+                data: { sfa_id: simplefin_account.id }
               )) rescue nil
             else
               # 2) Fall back to existing sign-only logic (log unknown for observability)
               begin
-                obs = {
-                  reason: result.reason,
-                  tx_count: result.metrics[:tx_count],
-                  charges_total: result.metrics[:charges_total],
-                  payments_total: result.metrics[:payments_total],
-                  observed: observed.to_s("F")
-                }.compact
-                Rails.logger.info("SimpleFIN overpayment heuristic: unknown; falling back #{obs.inspect}")
+                Rails.logger.info(
+                  "SimpleFIN overpayment heuristic: unknown for sfa=#{simplefin_account.id} " \
+                  "reason=#{result.reason} tx_count=#{result.metrics[:tx_count]}; falling back"
+                )
+                Rails.logger.debug(
+                  "SimpleFIN overpayment heuristic (unknown) amounts: sfa=#{simplefin_account.id} " \
+                  "observed=#{observed.to_s('F')} " \
+                  "charges_total=#{result.metrics[:charges_total]} payments_total=#{result.metrics[:payments_total]}"
+                )
               rescue
                 # no-op
               end

--- a/app/models/simplefin_account/processor.rb
+++ b/app/models/simplefin_account/processor.rb
@@ -80,57 +80,69 @@ class SimplefinAccount::Processor
 
       balance = observed
       if is_liability
-        # 1) Try transaction-history heuristic when enabled
-        begin
-          result = SimplefinAccount::Liabilities::OverpaymentAnalyzer
-            .new(simplefin_account, observed_balance: observed)
-            .call
+        # Loans report principal outstanding as a positive balance from the
+        # bank's perspective. The OverpaymentAnalyzer is designed for credit-
+        # like liabilities (where charges/payments distinguish debt vs.
+        # credit) and returns :unknown for loans with no transaction
+        # history, which then falls through to a fallback that negates the
+        # observed value — inverting the meaning so the loan ends up
+        # _adding_ to net worth instead of subtracting from it. Trust the
+        # bank's sign for Loans and skip the heuristic.
+        if account.accountable_type == "Loan"
+          balance = observed.abs
+        else
+          # 1) Try transaction-history heuristic when enabled
+          begin
+            result = SimplefinAccount::Liabilities::OverpaymentAnalyzer
+              .new(simplefin_account, observed_balance: observed)
+              .call
 
-          case result.classification
-          when :credit
-            balance = -observed.abs
-            Rails.logger.info(
-              "SimpleFIN overpayment heuristic: classified as credit for sfa=#{simplefin_account.id}, " \
-              "observed=#{observed.to_s('F')} metrics=#{result.metrics.slice(:charges_total, :payments_total, :tx_count).inspect}"
-            )
-            Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
-              category: "simplefin",
-              message: "liability_sign=credit",
-              data: { sfa_id: simplefin_account.id, observed: observed.to_s("F") }
-            )) rescue nil
-          when :debt
-            balance = observed.abs
-            Rails.logger.info(
-              "SimpleFIN overpayment heuristic: classified as debt for sfa=#{simplefin_account.id}, " \
-              "observed=#{observed.to_s('F')} metrics=#{result.metrics.slice(:charges_total, :payments_total, :tx_count).inspect}"
-            )
-            Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
-              category: "simplefin",
-              message: "liability_sign=debt",
-              data: { sfa_id: simplefin_account.id, observed: observed.to_s("F") }
-            )) rescue nil
-          else
-            # 2) Fall back to existing sign-only logic (log unknown for observability)
-            begin
-              obs = {
-                reason: result.reason,
-                tx_count: result.metrics[:tx_count],
-                charges_total: result.metrics[:charges_total],
-                payments_total: result.metrics[:payments_total],
-                observed: observed.to_s("F")
-              }.compact
-              Rails.logger.info("SimpleFIN overpayment heuristic: unknown; falling back #{obs.inspect}")
-            rescue
-              # no-op
+            case result.classification
+            when :credit
+              balance = -observed.abs
+              Rails.logger.info(
+                "SimpleFIN overpayment heuristic: classified as credit for sfa=#{simplefin_account.id}, " \
+                "observed=#{observed.to_s('F')} metrics=#{result.metrics.slice(:charges_total, :payments_total, :tx_count).inspect}"
+              )
+              Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
+                category: "simplefin",
+                message: "liability_sign=credit",
+                data: { sfa_id: simplefin_account.id, observed: observed.to_s("F") }
+              )) rescue nil
+            when :debt
+              balance = observed.abs
+              Rails.logger.info(
+                "SimpleFIN overpayment heuristic: classified as debt for sfa=#{simplefin_account.id}, " \
+                "observed=#{observed.to_s('F')} metrics=#{result.metrics.slice(:charges_total, :payments_total, :tx_count).inspect}"
+              )
+              Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
+                category: "simplefin",
+                message: "liability_sign=debt",
+                data: { sfa_id: simplefin_account.id, observed: observed.to_s("F") }
+              )) rescue nil
+            else
+              # 2) Fall back to existing sign-only logic (log unknown for observability)
+              begin
+                obs = {
+                  reason: result.reason,
+                  tx_count: result.metrics[:tx_count],
+                  charges_total: result.metrics[:charges_total],
+                  payments_total: result.metrics[:payments_total],
+                  observed: observed.to_s("F")
+                }.compact
+                Rails.logger.info("SimpleFIN overpayment heuristic: unknown; falling back #{obs.inspect}")
+              rescue
+                # no-op
+              end
+              balance = normalize_liability_balance(observed, bal, avail)
             end
+          rescue NameError
+            # Analyzer not loaded; keep legacy behavior
+            balance = normalize_liability_balance(observed, bal, avail)
+          rescue => e
+            Rails.logger.warn("SimpleFIN overpayment heuristic error for sfa=#{simplefin_account.id}: #{e.class} - #{e.message}")
             balance = normalize_liability_balance(observed, bal, avail)
           end
-        rescue NameError
-          # Analyzer not loaded; keep legacy behavior
-          balance = normalize_liability_balance(observed, bal, avail)
-        rescue => e
-          Rails.logger.warn("SimpleFIN overpayment heuristic error for sfa=#{simplefin_account.id}: #{e.class} - #{e.message}")
-          balance = normalize_liability_balance(observed, bal, avail)
         end
       end
 

--- a/app/models/simplefin_account/processor.rb
+++ b/app/models/simplefin_account/processor.rb
@@ -90,6 +90,15 @@ class SimplefinAccount::Processor
         # bank's sign for Loans and skip the heuristic.
         if account.accountable_type == "Loan"
           balance = observed.abs
+          Rails.logger.info(
+            "SimpleFIN loan sign: trusted bank-reported magnitude for sfa=#{simplefin_account.id}, " \
+            "observed=#{observed.to_s('F')} stored=#{balance.to_s('F')}"
+          )
+          Sentry.add_breadcrumb(Sentry::Breadcrumb.new(
+            category: "simplefin",
+            message: "liability_sign=loan",
+            data: { sfa_id: simplefin_account.id, observed: observed.to_s("F"), stored: balance.to_s("F") }
+          )) rescue nil
         else
           # 1) Try transaction-history heuristic when enabled
           begin

--- a/test/models/simplefin_account_processor_test.rb
+++ b/test/models/simplefin_account_processor_test.rb
@@ -64,6 +64,32 @@ class SimplefinAccountProcessorTest < ActiveSupport::TestCase
     assert_equal BigDecimal("50000"), acct.reload.balance
   end
 
+  # Many banks (and most mortgage feeds) report the loan principal
+  # outstanding as a positive number from the bank's books. The old
+  # liability path ran every Loan through OverpaymentAnalyzer +
+  # normalize_liability_balance, and the latter's fallback for
+  # `:unknown` classifications returned `-observed`, flipping a
+  # bank-reported `+50000` into `-50000`. That bug made loans _add_ to
+  # net worth instead of subtracting, so this test pins the corrected
+  # behaviour.
+  test "preserves positive provider balance for loan liabilities" do
+    sfin_acct = SimplefinAccount.create!(
+      simplefin_item: @item,
+      name: "Mortgage",
+      account_id: "loan_2",
+      currency: "USD",
+      account_type: "mortgage",
+      current_balance: BigDecimal("50000")
+    )
+
+    acct = accounts(:loan)
+    acct.update!(simplefin_account: sfin_acct)
+
+    SimplefinAccount::Processor.new(sfin_acct).send(:process_account!)
+
+    assert_equal BigDecimal("50000"), acct.reload.balance
+  end
+
   test "positive provider balance (overpayment) becomes negative for credit card liabilities" do
     sfin_acct = SimplefinAccount.create!(
       simplefin_item: @item,


### PR DESCRIPTION
## Summary

`SimplefinAccount::Processor#process_account!` (`app/models/simplefin_account/processor.rb`) routes every liability through `OverpaymentAnalyzer` + `normalize_liability_balance`. That heuristic is built around credit-card-like liabilities, where transaction history distinguishes debt vs. credit. For a `Loan` account with only the opening anchor (no payment history), the analyzer returns `:unknown` and the fallback negates the observed value:

```ruby
def normalize_liability_balance(observed, bal, avail)
  ...
  -observed
end
```

That's wrong for loans: the bank reports the principal outstanding as a positive number from its own books. Negating it stores the loan balance as negative, so `BalanceSheet#net_worth = assets - liabilities` ends up _adding_ the loan instead of subtracting it (off by 2× the loan amount).

Example with a hypothetical mortgage:

| Step | Value |
|---|---|
| Bank-reported balance (`raw_payload['balance']`) | `100000.00` |
| Stored on the Sure account by current code | `-100000.00` |
| Net-worth distortion | inflated by 2 × 100000 |

## Fix

Short-circuit `Loan` accountables straight to `observed.abs` and skip the analyzer/fallback entirely. Loans don't have credit-vs-debt ambiguity — if the loan is paid off the balance is 0, not negative. Credit cards still go through the existing heuristic.

Diff is 12 lines of logic; the larger churn in the file is a re-indent of the existing `else` branch to satisfy `Layout/IndentationWidth`.

## Test plan
- [x] Link a SimpleFIN-reported Loan account whose bank-side balance is positive (most mortgages report this way). Confirm `account.balance` ends up positive after sync, the Loan appears under Liabilities, and Net Worth = Assets − Liabilities.
- [x] Re-run a sync that previously stored a negative loan balance; the patched code must overwrite it with the absolute value.
- [x] Verify Credit Card accounts keep going through the existing analyzer/fallback path (their behaviour is unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Linked loan accounts now preserve the provider-reported principal sign and use absolute balances, preventing incorrect negation and improving displayed liability balances.
* **Tests**
  * Added a unit test to ensure loan balances reported as positive remain positive after processing, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->