### PR TITLE
Fix invite code being consumed on failed registration in invite-only mode

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -12,6 +12,11 @@ class RegistrationsController < ApplicationController
     @user = User.new(email: @invitation&.email)
   end
 
+  # Creates an account from registration form input.
+  #
+  # Handles invitation/default-family assignment and performs the final
+  # persistence through an atomic helper that claims invite codes only when
+  # signup succeeds.
   def create
     if @invitation
       @user.family = @invitation.family
@@ -39,21 +44,34 @@ class RegistrationsController < ApplicationController
 
   private
 
+    # Loads a pending invitation from URL or nested user params.
     def set_invitation
       token = params[:invitation]
       token ||= params[:user][:invitation] if params[:user].present?
       @invitation = Invitation.pending.find_by(token: token)
     end
 
+    # Builds a user from permitted params while excluding invitation fields.
     def set_user
       @user = User.new user_params.except(:invite_code, :invitation)
     end
 
+    # Returns permitted registration params or a specific param value.
+    #
+    # @param specific_param [Symbol, nil] optional key to return
+    # @return [ActionController::Parameters, Object]
     def user_params(specific_param = nil)
       params = self.params.require(:user).permit(:name, :email, :password, :password_confirmation, :invite_code, :invitation)
       specific_param ? params[specific_param] : params
     end
 
+    # Persists signup and consumes invite code atomically.
+    #
+    # In invite-only mode, this prevents valid invite codes from being burned
+    # when user validation fails. Returns true only when user save, invite
+    # claim, invitation acceptance, and session creation all succeed.
+    #
+    # @return [Boolean] true when signup fully succeeds
     def signup_with_invite_claim!
       invite_code = user_params[:invite_code]
       @invite_code_invalid = invite_code_required? && invite_code.blank?
@@ -79,6 +97,9 @@ class RegistrationsController < ApplicationController
       success
     end
 
+    # Applies password policy checks before attempting to save the user.
+    #
+    # Renders the signup form with unprocessable status when policy checks fail.
     def validate_password_requirements
       password = user_params[:password]
       return if password.blank? # Let Rails built-in validations handle blank passwords
@@ -104,6 +125,7 @@ class RegistrationsController < ApplicationController
       end
     end
 
+    # Prevents registration while onboarding is fully closed.
     def ensure_signup_open
       return unless Setting.onboarding_state == "closed"
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -12,11 +12,6 @@ class RegistrationsController < ApplicationController
     @user = User.new(email: @invitation&.email)
   end
 
-  # Creates an account from registration form input.
-  #
-  # Handles invitation/default-family assignment and performs the final
-  # persistence through an atomic helper that claims invite codes only when
-  # signup succeeds.
   def create
     if @invitation
       @user.family = @invitation.family
@@ -44,34 +39,22 @@ class RegistrationsController < ApplicationController
 
   private
 
-    # Loads a pending invitation from URL or nested user params.
     def set_invitation
       token = params[:invitation]
       token ||= params[:user][:invitation] if params[:user].present?
       @invitation = Invitation.pending.find_by(token: token)
     end
 
-    # Builds a user from permitted params while excluding invitation fields.
     def set_user
       @user = User.new user_params.except(:invite_code, :invitation)
     end
 
-    # Returns permitted registration params or a specific param value.
-    #
-    # @param specific_param [Symbol, nil] optional key to return
-    # @return [ActionController::Parameters, Object]
     def user_params(specific_param = nil)
       params = self.params.require(:user).permit(:name, :email, :password, :password_confirmation, :invite_code, :invitation)
       specific_param ? params[specific_param] : params
     end
 
-    # Persists signup and consumes invite code atomically.
-    #
-    # In invite-only mode, this prevents valid invite codes from being burned
-    # when user validation fails. Returns true only when user save, invite
-    # claim, invitation acceptance, and session creation all succeed.
-    #
-    # @return [Boolean] true when signup fully succeeds
+    # Keep save+claim atomic so failed signups never burn valid invite codes.
     def signup_with_invite_claim!
       invite_code = user_params[:invite_code]
       @invite_code_invalid = invite_code_required? && invite_code.blank?
@@ -97,9 +80,6 @@ class RegistrationsController < ApplicationController
       success
     end
 
-    # Applies password policy checks before attempting to save the user.
-    #
-    # Renders the signup form with unprocessable status when policy checks fail.
     def validate_password_requirements
       password = user_params[:password]
       return if password.blank? # Let Rails built-in validations handle blank passwords
@@ -125,7 +105,6 @@ class RegistrationsController < ApplicationController
       end
     end
 
-    # Prevents registration while onboarding is fully closed.
     def ensure_signup_open
       return unless Setting.onboarding_state == "closed"
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -6,7 +6,6 @@ class RegistrationsController < ApplicationController
   before_action :ensure_signup_open, if: :self_hosted?
   before_action :set_user, only: :create
   before_action :set_invitation
-  before_action :claim_invite_code, only: :create, if: :invite_code_required?
   before_action :validate_password_requirements, only: :create
 
   def new
@@ -29,10 +28,10 @@ class RegistrationsController < ApplicationController
       @user.role = User.role_for_new_family_creator
     end
 
-    if @user.save
-      @invitation&.update!(accepted_at: Time.current)
-      @session = create_session_for(@user)
+    if signup_with_invite_claim!
       redirect_to root_path, notice: t(".success")
+    elsif @invite_code_invalid
+      redirect_to new_registration_path, alert: t("registrations.create.invalid_invite_code")
     else
       render :new, status: :unprocessable_entity, alert: t(".failure")
     end
@@ -55,10 +54,29 @@ class RegistrationsController < ApplicationController
       specific_param ? params[specific_param] : params
     end
 
-    def claim_invite_code
-      unless InviteCode.claim! params[:user][:invite_code]
-        redirect_to new_registration_path, alert: t("registrations.create.invalid_invite_code")
+    def signup_with_invite_claim!
+      invite_code = user_params[:invite_code]
+      @invite_code_invalid = invite_code_required? && invite_code.blank?
+      return false if @invite_code_invalid
+
+      success = false
+
+      ActiveRecord::Base.transaction do
+        unless @user.save
+          raise ActiveRecord::Rollback
+        end
+
+        if invite_code_required? && !InviteCode.claim!(invite_code)
+          @invite_code_invalid = true
+          raise ActiveRecord::Rollback
+        end
+
+        @invitation&.update!(accepted_at: Time.current)
+        @session = create_session_for(@user)
+        success = true
       end
+
+      success
     end
 
     def validate_password_requirements

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -86,6 +86,19 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "invalid invite code does not create a user" do
+    with_env_overrides REQUIRE_INVITE_CODE: "true" do
+      assert_no_difference "User.count" do
+        post registration_url, params: { user: {
+          email: "valid@example.com",
+          password: "Password1!",
+          invite_code: "invalid-token-that-does-not-exist" } }
+      end
+
+      assert_redirected_to new_registration_url
+    end
+  end
+
   test "creating account from guest invitation assigns guest role and intro layout" do
     invitation = invitations(:one)
     invitation.update!(role: "guest", email: "guest-signup@example.com")

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -59,12 +59,30 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
       end
 
       assert_difference "User.count", +1 do
+        invite_code = InviteCode.generate!
         post registration_url, params: { user: {
           email: "john@example.com",
           password: "Password1!",
-          invite_code: InviteCode.generate! } }
+          invite_code: invite_code } }
         assert_redirected_to root_url
+        assert_not InviteCode.exists?(token: invite_code)
       end
+    end
+  end
+
+  test "invite code is not consumed when signup fails validation" do
+    with_env_overrides REQUIRE_INVITE_CODE: "true" do
+      invite_code = InviteCode.generate!
+
+      assert_no_difference "User.count" do
+        post registration_url, params: { user: {
+          email: "validationfail@example.com",
+          password: "weak",
+          invite_code: invite_code } }
+      end
+
+      assert_response :unprocessable_entity
+      assert InviteCode.exists?(token: invite_code)
     end
   end
 


### PR DESCRIPTION
### Description
This PR fixes a signup flow bug in invite-only mode where a valid invite code could be consumed even when account creation failed validation (for example, weak password), causing users to lose reusable invite codes on failed attempts.

Closes #1575 

**Changes made:**
Refactored registration create flow to claim invite codes atomically with user creation inside a transaction.
Removed pre-save invite code claim callback that consumed codes before signup success was guaranteed.
Added explicit invalid-invite handling in the new transactional flow while preserving existing validation error rendering behavior.
Updated/extended controller tests to verify:
invite code is consumed after successful signup, and
invite code is not consumed when signup fails validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invite-code handling at signup: invalid or missing invites now show a specific invalid-invite alert and return users to the registration form; invite codes are consumed only on successful signups.
* **Tests**
  * Added coverage asserting invite-code consumption on success, preservation when signup validation fails, and redirects for nonexistent codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->