### PR TITLE
Use cache store for Rack session to prevent OmniAuth callback overflow

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,13 @@
+# Use the Rails cache store (Redis in production) for the framework-level
+# Rack session. The application's own user authentication is handled by
+# the database-backed Session model (`_session_token`); this session is
+# only used by middleware such as OmniAuth during the OIDC callback flow.
+#
+# Storing it in the cookie (Rails' default) overflows the 4KB limit when
+# OmniAuth writes the full auth hash for IdPs that return many group
+# claims. See: https://github.com/we-promise/sure/issues/1571
+Rails.application.config.session_store :cache_store,
+  key: "_sure_session",
+  expire_after: 1.hour,
+  httponly: true,
+  secure: Rails.env.production?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,8 +6,26 @@
 # Storing it in the cookie (Rails' default) overflows the 4KB limit when
 # OmniAuth writes the full auth hash for IdPs that return many group
 # claims. See: https://github.com/we-promise/sure/issues/1571
-Rails.application.config.session_store :cache_store,
-  key: "_sure_session",
-  expire_after: 1.hour,
-  httponly: true,
-  secure: Rails.env.production?
+#
+# Falls back to the cookie store in environments where the cache is
+# `NullStore` (e.g. development without caching, test). NullStore drops
+# all writes, which would break multi-step flows like OmniAuth, MFA, and
+# mobile SSO that rely on session state surviving across requests.
+cache_store_config = Rails.application.config.cache_store
+cache_store_type = cache_store_config.is_a?(Array) ? cache_store_config.first : cache_store_config
+
+session_ttl = ENV.fetch("RACK_SESSION_TTL_HOURS", "1").to_i.hours
+
+if cache_store_type == :null_store
+  Rails.application.config.session_store :cookie_store,
+    key: "_sure_session",
+    expire_after: session_ttl,
+    httponly: true,
+    secure: Rails.env.production?
+else
+  Rails.application.config.session_store :cache_store,
+    key: "_sure_session",
+    expire_after: session_ttl,
+    httponly: true,
+    secure: Rails.env.production?
+end


### PR DESCRIPTION
Closes #1571.

      Configures Rails' framework-level Rack session to use the existing
      cache store (Redis in production) instead of the default `CookieStore`.

      Sure already has a database-backed `Session` model handling user
      authentication state via the `_session_token` cookie. The Rails-level
      Rack session (`_sure_session`) is only used incidentally by middleware
      — most notably OmniAuth during the OIDC callback, which writes the
      full auth hash to `rack.session`. For IdPs returning many group claims
      (24+ in my case), the encrypted payload exceeds the 4KB cookie limit
      and `commit_session` raises `ActionDispatch::Cookies::CookieOverflow`.

      Moving this session to the cache store eliminates the size constraint
      without changing user-facing auth behavior. Redis is already a
      required dependency for Sidekiq, Action Cable, and the Rails cache,
      so no new infrastructure.

      One-hour TTL is sufficient since the Rack session only needs to
      survive the OAuth round-trip; durable auth state lives in the
      `Session` model.

      ## Testing

      - Reproduced the original `CookieOverflow` on `main` with an Authentik
        OIDC user belonging to 24 groups.
      - Applied this initializer locally; SSO callback now completes
        successfully and the session is stored in Redis (`redis-cli keys '*'`
        shows new session keys after login).
      - Local password login continues to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved session handling for more reliable multi-step flows; sessions now expire after one hour by default (configurable).
  * Session cookies are HttpOnly and use secure-only transmission in production to enhance security and privacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->