### PR TITLE
fix: skip DemoFamilyRefreshJob in self-hosted mode

### DIFF
--- a/app/jobs/demo_family_refresh_job.rb
+++ b/app/jobs/demo_family_refresh_job.rb
@@ -2,6 +2,8 @@ class DemoFamilyRefreshJob < ApplicationJob
   queue_as :scheduled
 
   def perform
+    return unless Rails.application.config.app_mode.managed?
+
     period_end = Time.current
     period_start = period_end - 24.hours
 


### PR DESCRIPTION
DemoFamilyRefreshJob runs daily via cron and recreates a demo family from scratch. This is a managed-mode-only feature (the public hosted instance), but the job had no app_mode guard, so self-hosted instances were also creating and refreshing a demo family every day.

This results in every self-host instance of sure getting the demo family with the well-known credentials created.

It may be worth considering a separate one-time fix that deactivates the demo family users, and/or entries in the release notes or a separate security advisories alerting users that they need to deactivate the demo users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a background process would incorrectly execute outside of managed mode environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->