### PR TITLE
fix(budgets): stop auto-matched transfers leaking into category cards

### DIFF
--- a/app/controllers/budget_categories_controller.rb
+++ b/app/controllers/budget_categories_controller.rb
@@ -7,7 +7,15 @@ class BudgetCategoriesController < ApplicationController
   end
 
   def show
+    # The aggregate `Budget#actual_spending` already excludes transactions
+    # whose kind is in BUDGET_EXCLUDED_KINDS (funds_movement, one_time,
+    # cc_payment) via IncomeStatement. The drilldown list must apply the
+    # same filter, otherwise a matched transfer (post-#874 the matcher
+    # correctly tags inflow as funds_movement and outflow per destination
+    # account) shows under the Uncategorized card -- or any retained
+    # category -- even though the aggregate ignores it. See issue #1059.
     @recent_transactions = @budget.transactions
+                                  .where.not(transactions: { kind: Transaction::BUDGET_EXCLUDED_KINDS })
 
     if params[:id] == BudgetCategory.uncategorized.id
       @budget_category = @budget.uncategorized_budget_category

--- a/test/controllers/budget_categories_controller_test.rb
+++ b/test/controllers/budget_categories_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class BudgetCategoriesControllerTest < ActionDispatch::IntegrationTest
   include ActionView::RecordIdentifier
+  include EntriesTestHelper
 
   setup do
     sign_in users(:family_admin)
@@ -106,5 +107,59 @@ class BudgetCategoriesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_equal 0.0, @electric_budget_category.reload.budgeted_spending.to_f
+  end
+
+  test "show drilldown excludes BUDGET_EXCLUDED_KINDS transfers from recent transactions" do
+    # Issue #1059: a matched depository <-> CC pair becomes
+    # (cc_payment outflow + funds_movement inflow). Both kinds are in
+    # BUDGET_EXCLUDED_KINDS so the budget aggregate excludes them, but
+    # the per-category drilldown previously listed them anyway --
+    # appearing under whatever category they retained (or under
+    # Uncategorized once the matcher cleared the category). Filter
+    # them out so the drilldown matches the aggregate.
+    create_transaction(
+      date: @budget.start_date,
+      account: accounts(:depository),
+      amount: 500,
+      name: "BUG_1059_REPRO_OUTFLOW"
+    )
+    create_transaction(
+      date: @budget.start_date,
+      account: accounts(:credit_card),
+      amount: -500,
+      name: "BUG_1059_REPRO_INFLOW"
+    )
+    @family.auto_match_transfers!
+
+    get budget_budget_category_path(@budget, BudgetCategory.uncategorized.id)
+    assert_response :success
+    refute_includes @response.body, "BUG_1059_REPRO_OUTFLOW",
+      "matched cc_payment outflow must not appear in Uncategorized drilldown"
+    refute_includes @response.body, "BUG_1059_REPRO_INFLOW",
+      "matched funds_movement inflow must not appear in Uncategorized drilldown"
+  end
+
+  test "show drilldown still lists loan_payment transfers (intentionally budget-tracked)" do
+    # loan_payment is NOT in BUDGET_EXCLUDED_KINDS. The drilldown should
+    # keep showing loan_payment transfers so the user can see what's
+    # under Uncategorized (or whichever category they manually set).
+    create_transaction(
+      date: @budget.start_date,
+      account: accounts(:depository),
+      amount: 500,
+      name: "MORTGAGE_REPRO_OUTFLOW"
+    )
+    create_transaction(
+      date: @budget.start_date,
+      account: accounts(:loan),
+      amount: -500,
+      name: "MORTGAGE_REPRO_INFLOW"
+    )
+    @family.auto_match_transfers!
+
+    get budget_budget_category_path(@budget, BudgetCategory.uncategorized.id)
+    assert_response :success
+    assert_includes @response.body, "MORTGAGE_REPRO_OUTFLOW",
+      "loan_payment outflow remains visible (kind is not BUDGET_EXCLUDED)"
   end
 end


### PR DESCRIPTION
Refs #1059.

When you auto-match a $500 expense from your checking account against the matching deposit on your credit card, the resulting transfer pair was leaving traces under "Recent transactions" of each budget category card even though `Budget#actual_spending` (via `IncomeStatement`) already excluded `BUDGET_EXCLUDED_KINDS` from the totals. So the user saw $X listed under a category while the totals showed $X less. The aggregate and the drilldown disagreed.

This PR makes them agree by applying the same kind filter on the drilldown.

## A note on signs

Sure stores transaction amounts the accountant way: an expense (money leaving the account) is a positive amount, an income or deposit is negative. So `amount: +500` below means a $500 expense, `amount: -500` means a $500 deposit.

## The fix

`BudgetCategoriesController#show` was building `@recent_transactions` from `Budget#transactions` with no kind filter:

```ruby
@recent_transactions = @budget.transactions
                              .where.not(transactions: { kind: Transaction::BUDGET_EXCLUDED_KINDS })
```

`loan_payment` and `investment_contribution` are intentionally NOT in `BUDGET_EXCLUDED_KINDS` (both are budget-tracked), so transfers of those kinds still appear in their drilldown lists. Only `funds_movement` / `one_time` / `cc_payment` are filtered, matching what the aggregate already does.

## What changed since the first round

An earlier draft of this PR also cleared `category_id` on auto-matched outflows whose resulting kind landed in `BUDGET_EXCLUDED_KINDS`, with the rationale that "kind says transfer, category points at Food & Dining" is an inconsistent state. Codex correctly flagged the data-loss risk: `Transfer#reject!` resets `kind` to `standard` but does NOT restore the previously-cleared category, so rejecting an incorrect auto-match would permanently drop the user's original categorisation.

Reverted that part. The controller filter alone fixes the user-visible bug. The remaining inconsistency between `kind = funds_movement` and a retained category is harmless because every relevant view filters one or the other (aggregate filters by kind, list filters by kind, manual category-edit UI gates on `categorizable?`).

## How to reproduce

1. Open the demo app with two depository accounts and a credit card.
2. On the depository account, add a transaction dated today, expense of $500 (`amount: +500`), category "Food & Drink".
3. On the credit card account, add a transaction dated today, deposit of $500 (`amount: -500`).
4. From `bin/rails console`, run `Family.find(<id>).auto_match_transfers!`.
5. Open `/budgets/<current_month>` and click the Food & Drink card. Before this PR the $500 still appeared under "Recent transactions"; after, it doesn't.

## What's left for follow-ups

The mortgage scenario in #1059 is not a leak, it's a missing feature. A bank-to-mortgage match becomes a `loan_payment` transfer; that's intentionally budget-tracked, but the matcher doesn't auto-assign a category the way #924 does for investment contributions. The natural follow-up is a `loan_payments_category` plus matcher and import-adapter auto-assignment. That changes what shows up where in the budget, so I'd rather have a maintainer signoff first than pile it into this PR.

## Tests

`test/controllers/budget_categories_controller_test.rb`

- The matched depository ↔ credit_card pair does not appear in the Uncategorised drilldown after the matcher runs.
- The matched depository ↔ loan pair stays visible in the drilldown.

`bin/rails test`: 3239 runs, 0 failures, 0 errors, 24 skips on the latest `upstream/main`. `bin/rubocop -f github` and `bundle exec erb_lint` clean on touched files.

## Test plan for reviewers

- [ ] Run the reproduction above and confirm the $500 disappears from the Food & Drink card after this branch is checked out.
- [ ] Run `bin/rails test test/controllers/budget_categories_controller_test.rb` and confirm both new tests pass.
- [ ] Optional: build a depository ↔ loan pair, run the matcher, confirm the matched `loan_payment` row still appears in the relevant drilldown (because `loan_payment` is intentionally budget-tracked).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain excluded transaction types (such as matched transfers) were incorrectly appearing in budget category drilldown views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
