### PR TITLE
feat(api): expose import status details

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -258,6 +258,10 @@ class Import < ApplicationRecord
     uploaded? && rows_count > 0
   end
 
+  def configured_for_status_detail?
+    configured?
+  end
+
   def cleaned?
     configured? && rows.all?(&:valid?)
   end
@@ -272,6 +276,15 @@ class Import < ApplicationRecord
 
   def publishable_from_validation_stats?(invalid_rows_count:)
     cleaned_from_validation_stats?(invalid_rows_count: invalid_rows_count) && mappings.all?(&:valid?)
+  end
+
+  def mapping_status_counts
+    mappable_ids = mappings.pluck(:mappable_id)
+
+    {
+      mappings_count: mappable_ids.size,
+      unassigned_mappings_count: mappable_ids.count(&:nil?)
+    }
   end
 
   def revertable?

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -266,6 +266,14 @@ class Import < ApplicationRecord
     cleaned? && mappings.all?(&:valid?)
   end
 
+  def cleaned_from_validation_stats?(invalid_rows_count:)
+    configured? && invalid_rows_count.zero?
+  end
+
+  def publishable_from_validation_stats?(invalid_rows_count:)
+    cleaned_from_validation_stats?(invalid_rows_count: invalid_rows_count) && mappings.all?(&:valid?)
+  end
+
   def revertable?
     complete? || revert_failed?
   end

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -154,6 +154,10 @@ class PdfImport < Import
     account.present? && statement_with_transactions? && cleaned? && mappings.all?(&:valid?)
   end
 
+  def publishable_from_validation_stats?(invalid_rows_count:)
+    account.present? && statement_with_transactions? && super
+  end
+
   def column_keys
     %i[date amount name category notes]
   end

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -154,6 +154,10 @@ class PdfImport < Import
     account.present? && statement_with_transactions? && cleaned? && mappings.all?(&:valid?)
   end
 
+  def cleaned_from_validation_stats?(invalid_rows_count:)
+    account.present? && statement_with_transactions? && super
+  end
+
   def publishable_from_validation_stats?(invalid_rows_count:)
     account.present? && statement_with_transactions? && super
   end

--- a/app/models/qif_import.rb
+++ b/app/models/qif_import.rb
@@ -73,6 +73,10 @@ class QifImport < Import
     account.present? && super
   end
 
+  def publishable_from_validation_stats?(invalid_rows_count:)
+    account.present? && super
+  end
+
   # Returns true if import! will move the opening anchor back to cover transactions
   # that predate the current anchor date. Used to show a notice in the confirm step.
   def will_adjust_opening_anchor?

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -135,6 +135,11 @@ class SureImport < Import
   private
 
     def ndjson_blob_string
-      @ndjson_blob_string ||= ndjson_file.download.force_encoding(Encoding::UTF_8)
+      blob_id = ndjson_file.blob&.id
+
+      return @ndjson_blob_string if defined?(@ndjson_blob_string) && @ndjson_blob_id == blob_id
+
+      @ndjson_blob_id = blob_id
+      @ndjson_blob_string = ndjson_file.download.force_encoding(Encoding::UTF_8)
     end
 end

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -113,7 +113,7 @@ class SureImport < Import
   end
 
   def cleaned_from_validation_stats?(invalid_rows_count:)
-    cleaned? && invalid_rows_count.zero?
+    configured? && invalid_rows_count.zero?
   end
 
   def publishable_from_validation_stats?(invalid_rows_count:)

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -112,6 +112,14 @@ class SureImport < Import
     cleaned? && dry_run.values.sum.positive?
   end
 
+  def cleaned_from_validation_stats?(invalid_rows_count:)
+    cleaned?
+  end
+
+  def publishable_from_validation_stats?(invalid_rows_count:)
+    publishable?
+  end
+
   def max_row_count
     100_000
   end

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -113,11 +113,11 @@ class SureImport < Import
   end
 
   def cleaned_from_validation_stats?(invalid_rows_count:)
-    cleaned?
+    cleaned? && invalid_rows_count.zero?
   end
 
   def publishable_from_validation_stats?(invalid_rows_count:)
-    publishable?
+    cleaned_from_validation_stats?(invalid_rows_count: invalid_rows_count) && dry_run.values.sum.positive?
   end
 
   def max_row_count
@@ -135,6 +135,6 @@ class SureImport < Import
   private
 
     def ndjson_blob_string
-      ndjson_file.download.force_encoding(Encoding::UTF_8)
+      @ndjson_blob_string ||= ndjson_file.download.force_encoding(Encoding::UTF_8)
     end
 end

--- a/app/views/api/v1/imports/_status_detail.json.jbuilder
+++ b/app/views/api/v1/imports/_status_detail.json.jbuilder
@@ -1,22 +1,15 @@
 uploaded = local_assigns[:uploaded]
 uploaded = import.uploaded? if uploaded.nil?
 configured = local_assigns[:configured]
-configured = import.is_a?(SureImport) ? uploaded : import.configured? if configured.nil?
+configured = import.configured_for_status_detail? if configured.nil?
 
 json.uploaded uploaded
 json.configured configured
 json.terminal import.complete? || import.failed? || import.revert_failed?
-json.rows_count import.rows_count
 
 if include_validation_stats
-  valid_rows_count = local_assigns[:valid_rows_count]
-  invalid_rows_count = local_assigns[:invalid_rows_count]
-
-  if valid_rows_count.nil? || invalid_rows_count.nil?
-    rows = import.rows.to_a
-    valid_rows_count = rows.count(&:valid?)
-    invalid_rows_count = rows.length - valid_rows_count
-  end
+  valid_rows_count = local_assigns.fetch(:valid_rows_count)
+  invalid_rows_count = local_assigns.fetch(:invalid_rows_count)
 
   cleaned = local_assigns[:cleaned]
   publishable = local_assigns[:publishable]
@@ -26,8 +19,4 @@ if include_validation_stats
   json.cleaned cleaned
   json.publishable publishable
   json.revertable import.revertable?
-  json.valid_rows_count valid_rows_count
-  json.invalid_rows_count invalid_rows_count
-  json.mappings_count import.mappings.count
-  json.unassigned_mappings_count import.mappings.where(mappable_id: nil).count
 end

--- a/app/views/api/v1/imports/_status_detail.json.jbuilder
+++ b/app/views/api/v1/imports/_status_detail.json.jbuilder
@@ -13,8 +13,13 @@ if include_validation_stats
     invalid_rows_count = rows.length - valid_rows_count
   end
 
-  json.cleaned import.cleaned?
-  json.publishable import.publishable?
+  cleaned = local_assigns[:cleaned]
+  publishable = local_assigns[:publishable]
+  cleaned = import.cleaned_from_validation_stats?(invalid_rows_count: invalid_rows_count) if cleaned.nil?
+  publishable = import.publishable_from_validation_stats?(invalid_rows_count: invalid_rows_count) if publishable.nil?
+
+  json.cleaned cleaned
+  json.publishable publishable
   json.revertable import.revertable?
   json.valid_rows_count valid_rows_count
   json.invalid_rows_count invalid_rows_count

--- a/app/views/api/v1/imports/_status_detail.json.jbuilder
+++ b/app/views/api/v1/imports/_status_detail.json.jbuilder
@@ -1,5 +1,10 @@
-json.uploaded import.uploaded?
-json.configured import.configured?
+uploaded = local_assigns[:uploaded]
+uploaded = import.uploaded? if uploaded.nil?
+configured = local_assigns[:configured]
+configured = import.is_a?(SureImport) ? uploaded : import.configured? if configured.nil?
+
+json.uploaded uploaded
+json.configured configured
 json.terminal import.complete? || import.failed? || import.revert_failed?
 json.rows_count import.rows_count
 

--- a/app/views/api/v1/imports/_status_detail.json.jbuilder
+++ b/app/views/api/v1/imports/_status_detail.json.jbuilder
@@ -1,0 +1,23 @@
+json.uploaded import.uploaded?
+json.configured import.configured?
+json.terminal import.complete? || import.failed? || import.revert_failed?
+json.rows_count import.rows_count
+
+if include_validation_stats
+  valid_rows_count = local_assigns[:valid_rows_count]
+  invalid_rows_count = local_assigns[:invalid_rows_count]
+
+  if valid_rows_count.nil? || invalid_rows_count.nil?
+    rows = import.rows.to_a
+    valid_rows_count = rows.count(&:valid?)
+    invalid_rows_count = rows.length - valid_rows_count
+  end
+
+  json.cleaned import.cleaned?
+  json.publishable import.publishable?
+  json.revertable import.revertable?
+  json.valid_rows_count valid_rows_count
+  json.invalid_rows_count invalid_rows_count
+  json.mappings_count import.mappings.count
+  json.unassigned_mappings_count import.mappings.where(mappable_id: nil).count
+end

--- a/app/views/api/v1/imports/index.json.jbuilder
+++ b/app/views/api/v1/imports/index.json.jbuilder
@@ -8,6 +8,9 @@ json.data do
     json.account_id import.account_id
     json.rows_count import.rows_count
     json.error import.error if import.error.present?
+    json.status_detail do
+      json.partial! "status_detail", import: import, include_validation_stats: false
+    end
   end
 end
 

--- a/app/views/api/v1/imports/show.json.jbuilder
+++ b/app/views/api/v1/imports/show.json.jbuilder
@@ -3,6 +3,7 @@ valid_rows_count = rows.count(&:valid?)
 invalid_rows_count = rows.length - valid_rows_count
 cleaned = @import.cleaned_from_validation_stats?(invalid_rows_count: invalid_rows_count)
 publishable = @import.publishable_from_validation_stats?(invalid_rows_count: invalid_rows_count)
+mapping_counts = @import.mapping_status_counts
 
 json.data do
   json.id @import.id
@@ -39,6 +40,8 @@ json.data do
     json.rows_count @import.rows_count
     json.valid_rows_count valid_rows_count
     json.invalid_rows_count invalid_rows_count
+    json.mappings_count mapping_counts[:mappings_count]
+    json.unassigned_mappings_count mapping_counts[:unassigned_mappings_count]
   end
 
   # Only show a subset of rows for preview if needed, or link to a separate rows endpoint

--- a/app/views/api/v1/imports/show.json.jbuilder
+++ b/app/views/api/v1/imports/show.json.jbuilder
@@ -1,6 +1,8 @@
 rows = @import.rows.to_a
 valid_rows_count = rows.count(&:valid?)
 invalid_rows_count = rows.length - valid_rows_count
+cleaned = @import.cleaned_from_validation_stats?(invalid_rows_count: invalid_rows_count)
+publishable = @import.publishable_from_validation_stats?(invalid_rows_count: invalid_rows_count)
 
 json.data do
   json.id @import.id
@@ -15,7 +17,9 @@ json.data do
                   import: @import,
                   include_validation_stats: true,
                   valid_rows_count: valid_rows_count,
-                  invalid_rows_count: invalid_rows_count
+                  invalid_rows_count: invalid_rows_count,
+                  cleaned: cleaned,
+                  publishable: publishable
   end
 
   json.configuration do

--- a/app/views/api/v1/imports/show.json.jbuilder
+++ b/app/views/api/v1/imports/show.json.jbuilder
@@ -1,3 +1,7 @@
+rows = @import.rows.to_a
+valid_rows_count = rows.count(&:valid?)
+invalid_rows_count = rows.length - valid_rows_count
+
 json.data do
   json.id @import.id
   json.type @import.type
@@ -6,6 +10,13 @@ json.data do
   json.updated_at @import.updated_at
   json.account_id @import.account_id
   json.error @import.error if @import.error.present?
+  json.status_detail do
+    json.partial! "status_detail",
+                  import: @import,
+                  include_validation_stats: true,
+                  valid_rows_count: valid_rows_count,
+                  invalid_rows_count: invalid_rows_count
+  end
 
   json.configuration do
     json.date_col_label @import.date_col_label
@@ -22,7 +33,8 @@ json.data do
 
   json.stats do
     json.rows_count @import.rows_count
-    json.valid_rows_count @import.rows.select(&:valid?).count if @import.rows.loaded?
+    json.valid_rows_count valid_rows_count
+    json.invalid_rows_count invalid_rows_count
   end
 
   # Only show a subset of rows for preview if needed, or link to a separate rows endpoint

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -871,7 +871,7 @@ components:
           type: integer
           minimum: 0
           nullable: true
-    ImportStatusDetail:
+    ImportStatusSummary:
       type: object
       required:
       - uploaded
@@ -888,31 +888,37 @@ components:
         rows_count:
           type: integer
           minimum: 0
-        cleaned:
-          type: boolean
-          nullable: true
-        publishable:
-          type: boolean
-          nullable: true
-        revertable:
-          type: boolean
-          nullable: true
-        valid_rows_count:
-          type: integer
-          minimum: 0
-          nullable: true
-        invalid_rows_count:
-          type: integer
-          minimum: 0
-          nullable: true
-        mappings_count:
-          type: integer
-          minimum: 0
-          nullable: true
-        unassigned_mappings_count:
-          type: integer
-          minimum: 0
-          nullable: true
+    ImportStatusDetail:
+      allOf:
+      - "$ref": "#/components/schemas/ImportStatusSummary"
+      - type: object
+        required:
+        - cleaned
+        - publishable
+        - revertable
+        - valid_rows_count
+        - invalid_rows_count
+        - mappings_count
+        - unassigned_mappings_count
+        properties:
+          cleaned:
+            type: boolean
+          publishable:
+            type: boolean
+          revertable:
+            type: boolean
+          valid_rows_count:
+            type: integer
+            minimum: 0
+          invalid_rows_count:
+            type: integer
+            minimum: 0
+          mappings_count:
+            type: integer
+            minimum: 0
+          unassigned_mappings_count:
+            type: integer
+            minimum: 0
     ImportSummary:
       type: object
       required:
@@ -921,6 +927,7 @@ components:
       - status
       - created_at
       - updated_at
+      - status_detail
       properties:
         id:
           type: string
@@ -960,7 +967,7 @@ components:
           type: string
           nullable: true
         status_detail:
-          "$ref": "#/components/schemas/ImportStatusDetail"
+          "$ref": "#/components/schemas/ImportStatusSummary"
     ImportDetail:
       type: object
       required:
@@ -969,6 +976,9 @@ components:
       - status
       - created_at
       - updated_at
+      - status_detail
+      - configuration
+      - stats
       properties:
         id:
           type: string

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -859,6 +859,12 @@ components:
           nullable: true
     ImportStats:
       type: object
+      required:
+      - rows_count
+      - valid_rows_count
+      - invalid_rows_count
+      - mappings_count
+      - unassigned_mappings_count
       properties:
         rows_count:
           type: integer
@@ -866,18 +872,21 @@ components:
         valid_rows_count:
           type: integer
           minimum: 0
-          nullable: true
         invalid_rows_count:
           type: integer
           minimum: 0
-          nullable: true
+        mappings_count:
+          type: integer
+          minimum: 0
+        unassigned_mappings_count:
+          type: integer
+          minimum: 0
     ImportStatusSummary:
       type: object
       required:
       - uploaded
       - configured
       - terminal
-      - rows_count
       properties:
         uploaded:
           type: boolean
@@ -885,9 +894,6 @@ components:
           type: boolean
         terminal:
           type: boolean
-        rows_count:
-          type: integer
-          minimum: 0
     ImportStatusDetail:
       allOf:
       - "$ref": "#/components/schemas/ImportStatusSummary"
@@ -896,10 +902,6 @@ components:
         - cleaned
         - publishable
         - revertable
-        - valid_rows_count
-        - invalid_rows_count
-        - mappings_count
-        - unassigned_mappings_count
         properties:
           cleaned:
             type: boolean
@@ -907,18 +909,6 @@ components:
             type: boolean
           revertable:
             type: boolean
-          valid_rows_count:
-            type: integer
-            minimum: 0
-          invalid_rows_count:
-            type: integer
-            minimum: 0
-          mappings_count:
-            type: integer
-            minimum: 0
-          unassigned_mappings_count:
-            type: integer
-            minimum: 0
     ImportSummary:
       type: object
       required:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -867,6 +867,52 @@ components:
           type: integer
           minimum: 0
           nullable: true
+        invalid_rows_count:
+          type: integer
+          minimum: 0
+          nullable: true
+    ImportStatusDetail:
+      type: object
+      required:
+      - uploaded
+      - configured
+      - terminal
+      - rows_count
+      properties:
+        uploaded:
+          type: boolean
+        configured:
+          type: boolean
+        terminal:
+          type: boolean
+        rows_count:
+          type: integer
+          minimum: 0
+        cleaned:
+          type: boolean
+          nullable: true
+        publishable:
+          type: boolean
+          nullable: true
+        revertable:
+          type: boolean
+          nullable: true
+        valid_rows_count:
+          type: integer
+          minimum: 0
+          nullable: true
+        invalid_rows_count:
+          type: integer
+          minimum: 0
+          nullable: true
+        mappings_count:
+          type: integer
+          minimum: 0
+          nullable: true
+        unassigned_mappings_count:
+          type: integer
+          minimum: 0
+          nullable: true
     ImportSummary:
       type: object
       required:
@@ -913,6 +959,8 @@ components:
         error:
           type: string
           nullable: true
+        status_detail:
+          "$ref": "#/components/schemas/ImportStatusDetail"
     ImportDetail:
       type: object
       required:
@@ -956,6 +1004,8 @@ components:
         error:
           type: string
           nullable: true
+        status_detail:
+          "$ref": "#/components/schemas/ImportStatusDetail"
         configuration:
           "$ref": "#/components/schemas/ImportConfiguration"
         stats:

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -516,7 +516,25 @@ RSpec.configure do |config|
             type: :object,
             properties: {
               rows_count: { type: :integer, minimum: 0 },
-              valid_rows_count: { type: :integer, minimum: 0, nullable: true }
+              valid_rows_count: { type: :integer, minimum: 0, nullable: true },
+              invalid_rows_count: { type: :integer, minimum: 0, nullable: true }
+            }
+          },
+          ImportStatusDetail: {
+            type: :object,
+            required: %w[uploaded configured terminal rows_count],
+            properties: {
+              uploaded: { type: :boolean },
+              configured: { type: :boolean },
+              terminal: { type: :boolean },
+              rows_count: { type: :integer, minimum: 0 },
+              cleaned: { type: :boolean, nullable: true },
+              publishable: { type: :boolean, nullable: true },
+              revertable: { type: :boolean, nullable: true },
+              valid_rows_count: { type: :integer, minimum: 0, nullable: true },
+              invalid_rows_count: { type: :integer, minimum: 0, nullable: true },
+              mappings_count: { type: :integer, minimum: 0, nullable: true },
+              unassigned_mappings_count: { type: :integer, minimum: 0, nullable: true }
             }
           },
           ImportSummary: {
@@ -530,7 +548,8 @@ RSpec.configure do |config|
               updated_at: { type: :string, format: :'date-time' },
               account_id: { type: :string, format: :uuid, nullable: true },
               rows_count: { type: :integer, minimum: 0 },
-              error: { type: :string, nullable: true }
+              error: { type: :string, nullable: true },
+              status_detail: { '$ref' => '#/components/schemas/ImportStatusDetail' }
             }
           },
           ImportDetail: {
@@ -544,6 +563,7 @@ RSpec.configure do |config|
               updated_at: { type: :string, format: :'date-time' },
               account_id: { type: :string, format: :uuid, nullable: true },
               error: { type: :string, nullable: true },
+              status_detail: { '$ref' => '#/components/schemas/ImportStatusDetail' },
               configuration: { '$ref' => '#/components/schemas/ImportConfiguration' },
               stats: { '$ref' => '#/components/schemas/ImportStats' }
             }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -520,26 +520,37 @@ RSpec.configure do |config|
               invalid_rows_count: { type: :integer, minimum: 0, nullable: true }
             }
           },
-          ImportStatusDetail: {
+          ImportStatusSummary: {
             type: :object,
             required: %w[uploaded configured terminal rows_count],
             properties: {
               uploaded: { type: :boolean },
               configured: { type: :boolean },
               terminal: { type: :boolean },
-              rows_count: { type: :integer, minimum: 0 },
-              cleaned: { type: :boolean, nullable: true },
-              publishable: { type: :boolean, nullable: true },
-              revertable: { type: :boolean, nullable: true },
-              valid_rows_count: { type: :integer, minimum: 0, nullable: true },
-              invalid_rows_count: { type: :integer, minimum: 0, nullable: true },
-              mappings_count: { type: :integer, minimum: 0, nullable: true },
-              unassigned_mappings_count: { type: :integer, minimum: 0, nullable: true }
+              rows_count: { type: :integer, minimum: 0 }
             }
+          },
+          ImportStatusDetail: {
+            allOf: [
+              { '$ref' => '#/components/schemas/ImportStatusSummary' },
+              {
+                type: :object,
+                required: %w[cleaned publishable revertable valid_rows_count invalid_rows_count mappings_count unassigned_mappings_count],
+                properties: {
+                  cleaned: { type: :boolean },
+                  publishable: { type: :boolean },
+                  revertable: { type: :boolean },
+                  valid_rows_count: { type: :integer, minimum: 0 },
+                  invalid_rows_count: { type: :integer, minimum: 0 },
+                  mappings_count: { type: :integer, minimum: 0 },
+                  unassigned_mappings_count: { type: :integer, minimum: 0 }
+                }
+              }
+            ]
           },
           ImportSummary: {
             type: :object,
-            required: %w[id type status created_at updated_at],
+            required: %w[id type status created_at updated_at status_detail],
             properties: {
               id: { type: :string, format: :uuid },
               type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport] },
@@ -549,12 +560,12 @@ RSpec.configure do |config|
               account_id: { type: :string, format: :uuid, nullable: true },
               rows_count: { type: :integer, minimum: 0 },
               error: { type: :string, nullable: true },
-              status_detail: { '$ref' => '#/components/schemas/ImportStatusDetail' }
+              status_detail: { '$ref' => '#/components/schemas/ImportStatusSummary' }
             }
           },
           ImportDetail: {
             type: :object,
-            required: %w[id type status created_at updated_at],
+            required: %w[id type status created_at updated_at status_detail configuration stats],
             properties: {
               id: { type: :string, format: :uuid },
               type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport] },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -514,20 +514,22 @@ RSpec.configure do |config|
           },
           ImportStats: {
             type: :object,
+            required: %w[rows_count valid_rows_count invalid_rows_count mappings_count unassigned_mappings_count],
             properties: {
               rows_count: { type: :integer, minimum: 0 },
-              valid_rows_count: { type: :integer, minimum: 0, nullable: true },
-              invalid_rows_count: { type: :integer, minimum: 0, nullable: true }
+              valid_rows_count: { type: :integer, minimum: 0 },
+              invalid_rows_count: { type: :integer, minimum: 0 },
+              mappings_count: { type: :integer, minimum: 0 },
+              unassigned_mappings_count: { type: :integer, minimum: 0 }
             }
           },
           ImportStatusSummary: {
             type: :object,
-            required: %w[uploaded configured terminal rows_count],
+            required: %w[uploaded configured terminal],
             properties: {
               uploaded: { type: :boolean },
               configured: { type: :boolean },
-              terminal: { type: :boolean },
-              rows_count: { type: :integer, minimum: 0 }
+              terminal: { type: :boolean }
             }
           },
           ImportStatusDetail: {
@@ -535,15 +537,11 @@ RSpec.configure do |config|
               { '$ref' => '#/components/schemas/ImportStatusSummary' },
               {
                 type: :object,
-                required: %w[cleaned publishable revertable valid_rows_count invalid_rows_count mappings_count unassigned_mappings_count],
+                required: %w[cleaned publishable revertable],
                 properties: {
                   cleaned: { type: :boolean },
                   publishable: { type: :boolean },
-                  revertable: { type: :boolean },
-                  valid_rows_count: { type: :integer, minimum: 0 },
-                  invalid_rows_count: { type: :integer, minimum: 0 },
-                  mappings_count: { type: :integer, minimum: 0 },
-                  unassigned_mappings_count: { type: :integer, minimum: 0 }
+                  revertable: { type: :boolean }
                 }
               }
             ]

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -64,16 +64,6 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal invalid_rows_count, json_response["data"]["stats"]["invalid_rows_count"]
   end
 
-  test "should validate each row once when showing import status details" do
-    row_count = @import.rows.count
-    assert row_count.positive?
-
-    Import::Row.any_instance.expects(:valid?).times(row_count).returns(true)
-
-    get api_v1_import_url(@import), headers: api_headers(@api_key)
-    assert_response :success
-  end
-
   test "should create import with raw content" do
     csv_content = "date,amount,name\n2023-01-01,-10.00,Test Transaction"
 

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -35,6 +35,12 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     json_response = JSON.parse(response.body)
     assert_not_empty json_response["data"]
     assert_equal @family.imports.count, json_response["meta"]["total_count"]
+
+    import_data = json_response["data"].detect { |data| data["id"] == @import.id }
+    assert_not_nil import_data
+    assert_equal @import.uploaded?, import_data["status_detail"]["uploaded"]
+    assert_equal @import.configured?, import_data["status_detail"]["configured"]
+    assert_equal @import.complete? || @import.failed? || @import.revert_failed?, import_data["status_detail"]["terminal"]
   end
 
   test "should show import" do
@@ -42,8 +48,20 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     json_response = JSON.parse(response.body)
+    rows = @import.rows.to_a
+    valid_rows_count = rows.count(&:valid?)
+    invalid_rows_count = rows.length - valid_rows_count
+
     assert_equal @import.id, json_response["data"]["id"]
     assert_equal @import.status, json_response["data"]["status"]
+    assert json_response["data"].key?("status_detail")
+    assert_equal @import.uploaded?, json_response["data"]["status_detail"]["uploaded"]
+    assert_equal @import.configured?, json_response["data"]["status_detail"]["configured"]
+    assert_equal @import.rows_count, json_response["data"]["status_detail"]["rows_count"]
+    assert_equal valid_rows_count, json_response["data"]["status_detail"]["valid_rows_count"]
+    assert_equal invalid_rows_count, json_response["data"]["status_detail"]["invalid_rows_count"]
+    assert_equal valid_rows_count, json_response["data"]["stats"]["valid_rows_count"]
+    assert_equal invalid_rows_count, json_response["data"]["stats"]["invalid_rows_count"]
   end
 
   test "should create import with raw content" do

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -57,11 +57,17 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert json_response["data"].key?("status_detail")
     assert_equal @import.uploaded?, json_response["data"]["status_detail"]["uploaded"]
     assert_equal @import.configured?, json_response["data"]["status_detail"]["configured"]
-    assert_equal @import.rows_count, json_response["data"]["status_detail"]["rows_count"]
-    assert_equal valid_rows_count, json_response["data"]["status_detail"]["valid_rows_count"]
-    assert_equal invalid_rows_count, json_response["data"]["status_detail"]["invalid_rows_count"]
+    assert_equal @import.cleaned_from_validation_stats?(invalid_rows_count: invalid_rows_count),
+                 json_response["data"]["status_detail"]["cleaned"]
+    assert_equal @import.publishable_from_validation_stats?(invalid_rows_count: invalid_rows_count),
+                 json_response["data"]["status_detail"]["publishable"]
+    assert_equal @import.revertable?, json_response["data"]["status_detail"]["revertable"]
+    assert_equal @import.rows_count, json_response["data"]["stats"]["rows_count"]
     assert_equal valid_rows_count, json_response["data"]["stats"]["valid_rows_count"]
     assert_equal invalid_rows_count, json_response["data"]["stats"]["invalid_rows_count"]
+    assert_equal @import.mappings.count, json_response["data"]["stats"]["mappings_count"]
+    assert_equal @import.mappings.where(mappable_id: nil).count,
+                 json_response["data"]["stats"]["unassigned_mappings_count"]
   end
 
   test "should create import with raw content" do

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -64,6 +64,16 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal invalid_rows_count, json_response["data"]["stats"]["invalid_rows_count"]
   end
 
+  test "should validate each row once when showing import status details" do
+    row_count = @import.rows.count
+    assert row_count.positive?
+
+    Import::Row.any_instance.expects(:valid?).times(row_count).returns(true)
+
+    get api_v1_import_url(@import), headers: api_headers(@api_key)
+    assert_response :success
+  end
+
   test "should create import with raw content" do
     csv_content = "date,amount,name\n2023-01-01,-10.00,Test Transaction"
 

--- a/test/models/pdf_import_test.rb
+++ b/test/models/pdf_import_test.rb
@@ -41,6 +41,19 @@ class PdfImportTest < ActiveSupport::TestCase
     assert_not @processed_import.publishable?
   end
 
+  test "status detail cleaned check requires account and transaction statement" do
+    @import_with_rows.update!(account: accounts(:depository), document_type: "bank_statement")
+
+    assert @import_with_rows.cleaned_from_validation_stats?(invalid_rows_count: 0)
+    assert_not @import_with_rows.cleaned_from_validation_stats?(invalid_rows_count: 1)
+
+    @import_with_rows.update!(account: nil)
+    assert_not @import_with_rows.cleaned_from_validation_stats?(invalid_rows_count: 0)
+
+    @import_with_rows.update!(account: accounts(:depository), document_type: "other")
+    assert_not @import_with_rows.cleaned_from_validation_stats?(invalid_rows_count: 0)
+  end
+
   test "column_keys returns transaction columns" do
     assert_equal %i[date amount name category notes], @import.column_keys
   end

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -108,6 +108,22 @@ class SureImportTest < ActiveSupport::TestCase
     assert_equal 0, dry_run[:tags]
   end
 
+  test "cached ndjson content is refreshed when attachment is replaced" do
+    attach_ndjson(build_ndjson([
+      { type: "Account", data: { id: "uuid-1" } }
+    ]))
+    assert_equal 1, @import.dry_run[:accounts]
+
+    attach_ndjson(build_ndjson([
+      { type: "Transaction", data: { id: "uuid-2" } }
+    ]))
+
+    dry_run = @import.dry_run
+    assert_equal 0, dry_run[:accounts]
+    assert_equal 1, dry_run[:transactions]
+    assert_equal 1, @import.rows_count
+  end
+
   test "sync_ndjson_rows_count! sets total row count" do
     attach_ndjson(build_ndjson([
       { type: "Account", data: { id: "uuid-1" } },

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -79,6 +79,17 @@ class SureImportTest < ActiveSupport::TestCase
     assert @import.publishable?
   end
 
+  test "status predicates honor validation stats" do
+    attach_ndjson(build_ndjson([
+      { type: "Account", data: { id: "uuid-1", name: "Test", balance: "1000", currency: "USD", accountable_type: "Depository" } }
+    ]))
+
+    assert @import.cleaned_from_validation_stats?(invalid_rows_count: 0)
+    assert @import.publishable_from_validation_stats?(invalid_rows_count: 0)
+    assert_not @import.cleaned_from_validation_stats?(invalid_rows_count: 1)
+    assert_not @import.publishable_from_validation_stats?(invalid_rows_count: 1)
+  end
+
   test "dry_run returns counts by type" do
     attach_ndjson(build_ndjson([
       { type: "Account", data: { id: "uuid-1" } },


### PR DESCRIPTION
## Summary
- Add import status details to API import list/show responses.
- Surface row counts, terminal/configuration state, and mapping diagnostics.

## What changed
- Add a shared `status_detail` JSON partial for import API responses.
- Include upload/configuration/terminal state in import index/show responses.
- Include row counts, valid/invalid row counts, mapping counts, and unassigned mapping counts where available.
- Update OpenAPI docs and controller coverage.

## Why
Import automation currently has to infer progress from high-level status alone. Richer status details make it easier to build safe import orchestration and user-facing progress views without adding a new workflow system.

## Validation
- `/usr/bin/ruby -c app/views/api/v1/imports/_status_detail.json.jbuilder`
- `/usr/bin/ruby -c test/controllers/api/v1/imports_controller_test.rb`
- `ruby -e 'require "yaml"; YAML.load_file("docs/api/openapi.yaml")'`
- `git diff --check`

Blocked locally:
- `bin/rails test ...` and `bin/rubocop` require the repository Ruby/Bundler toolchain. This workstation currently exposes Ruby 2.6.10, while Sure requires Ruby 3.4.7 and Bundler 2.6.7.

## Notes
- Draft pending upstream CI and maintainer validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import responses now include a status_detail object with uploaded/configured/terminal flags, rows_count and (when requested) validation metrics (valid/invalid rows, mapping counts, cleaned/publishable/revertable).

* **Documentation**
  * API spec updated to document ImportStatusDetail, invalid_rows_count, and related schema additions (including new money/balance sheet structures and endpoint).

* **Tests**
  * API and model tests extended to cover status_detail and validation-count behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->