### PR TITLE
fix(imports): preserve account status from backups

### DIFF
--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -92,7 +92,7 @@ class Family::DataImporter
           institution_name: data["institution_name"],
           institution_domain: data["institution_domain"],
           notes: data["notes"],
-          status: "active"
+          status: importable_account_status(data["status"])
         )
 
         account.save!
@@ -106,6 +106,10 @@ class Family::DataImporter
         @id_mappings[:accounts][old_id] = account.id
         @created_accounts << account
       end
+    end
+
+    def importable_account_status(status)
+      status.to_s.in?(%w[active disabled draft]) ? status.to_s : "active"
     end
 
     def import_categories(records)

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -31,6 +31,52 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal "Depository", account.accountable_type
   end
 
+  test "imports non-destructive account status from ndjson" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "disabled-account",
+          name: "Closed Checking",
+          balance: "0.00",
+          currency: "USD",
+          accountable_type: "Depository",
+          status: "disabled"
+        }
+      }
+    ])
+
+    importer = Family::DataImporter.new(@family, ndjson)
+    result = importer.import!
+
+    account = result[:accounts].first
+    assert_equal "Closed Checking", account.name
+    assert_equal "disabled", account.status
+  end
+
+  test "does not import pending deletion account status" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "pending-delete-account",
+          name: "Pending Delete Checking",
+          balance: "0.00",
+          currency: "USD",
+          accountable_type: "Depository",
+          status: "pending_deletion"
+        }
+      }
+    ])
+
+    importer = Family::DataImporter.new(@family, ndjson)
+    result = importer.import!
+
+    account = result[:accounts].first
+    assert_equal "Pending Delete Checking", account.name
+    assert_equal "active", account.status
+  end
+
   test "imports categories with parent relationships" do
     ndjson = build_ndjson([
       {


### PR DESCRIPTION
## Summary
- Preserve non-destructive account status values when importing Sure NDJSON backups.
- Keep `pending_deletion` out of backup import state restoration.

## What changed
- Map imported account `status` values for `active`, `disabled`, and `draft` instead of hard-coding every imported account to `active`.
- Fall back to `active` for missing, unknown, or destructive status values.
- Add importer coverage for disabled account preservation and pending-deletion fallback.

## Why
Sure family export includes account status, but NDJSON import currently loses disabled/closed account state by making every account active. That weakens backup round trips and migration verification, especially for historical or closed manual accounts.

## Validation
- `/usr/bin/ruby -c app/models/family/data_importer.rb`
- `/usr/bin/ruby -c test/models/family/data_importer_test.rb`
- `git diff --check`

Blocked locally:
- `bin/rails test test/models/family/data_importer_test.rb` requires the repository Ruby/Bundler toolchain. This workstation currently exposes Ruby 2.6.10, while Sure requires Ruby 3.4.7 and Bundler 2.6.7.

## Notes
- Draft pending upstream CI and maintainer validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved account import to properly preserve status values from source data. Supported statuses are active, disabled, and draft. Unrecognized or missing statuses default to active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->