### PR TITLE
Add FX regression coverage for summary and aggregation paths

### DIFF
--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
   include EntriesTestHelper
+  include FxRegressionTestHelper
 
   setup do
     sign_in @user = users(:family_admin)
@@ -41,6 +42,27 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     get root_path
     assert_response :ok
     assert_select "[data-controller='sankey-chart']"
+  end
+
+  test "dashboard outflows donut shows family-currency converted foreign amounts" do
+    @family.accounts.each { |account| account.entries.delete_all }
+
+    food = @family.categories.create!(name: "NGN Food", color: "#22c55e")
+    ngn_account = create_foreign_account!(family: @family, name: "NGN Wallet", currency: "NGN")
+
+    travel_to Date.new(2026, 4, 30) do
+      create_transaction(account: ngn_account, amount: 1000, currency: "NGN", category: food, date: Date.current)
+      create_transaction(account: ngn_account, amount: -250, currency: "NGN", category: food, date: Date.current)
+      create_exchange_rate!(from: "NGN", to: "USD", rate: 0.01, date: Date.current)
+
+      get root_path
+      assert_response :ok
+
+      assert_includes response.body, "$7.50"
+      assert_includes response.body, "&quot;amount&quot;:7.5"
+      refute_includes response.body, "$750.00"
+      refute_includes response.body, "&quot;amount&quot;:750.0"
+    end
   end
 
   test "changelog" do

--- a/test/models/budget_test.rb
+++ b/test/models/budget_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
 
 class BudgetTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+  include FxRegressionTestHelper
+
   setup do
     @family = families(:empty)
   end
@@ -223,6 +226,54 @@ class BudgetTest < ActiveSupport::TestCase
     assert_equal 0, budget.budget_category_actual_spending(
       budget.budget_categories.find_by(category: category)
     )
+  end
+
+  test "estimated income and spending use family-currency converted medians" do
+    family = Family.create!(name: "FX Budget Family", currency: "USD")
+    groceries = family.categories.create!(name: "Groceries", color: "#10b981")
+    income = family.categories.create!(name: "Income", color: "#6366f1")
+
+    usd_account = family.accounts.create!(name: "USD Checking", currency: "USD", balance: 0, accountable: Depository.new)
+    eur_account = create_foreign_account!(family: family, name: "EUR Checking", currency: "EUR")
+
+    create_transaction(account: usd_account, amount: 100, currency: "USD", category: groceries, date: Date.new(2026, 3, 5))
+    create_transaction(account: eur_account, amount: 100, currency: "EUR", category: groceries, date: Date.new(2026, 4, 5))
+    create_transaction(account: usd_account, amount: -300, currency: "USD", category: income, date: Date.new(2026, 3, 10))
+    create_transaction(account: eur_account, amount: -100, currency: "EUR", category: income, date: Date.new(2026, 4, 10))
+
+    create_exchange_rate!(from: "EUR", to: "USD", rate: 1.2, date: Date.new(2026, 4, 5))
+    create_exchange_rate!(from: "EUR", to: "USD", rate: 1.5, date: Date.new(2026, 4, 10))
+
+    travel_to Date.new(2026, 4, 30) do
+      budget = Budget.find_or_bootstrap(family, start_date: Date.current.beginning_of_month)
+
+      assert_equal 110, budget.estimated_spending
+      assert_equal 225, budget.estimated_income
+    end
+  end
+
+  test "actual_spending and budget category totals use family-currency converted amounts" do
+    family = Family.create!(name: "FX Actual Budget Family", currency: "USD")
+    groceries = family.categories.create!(name: "Groceries", color: "#10b981")
+
+    usd_account = family.accounts.create!(name: "USD Checking", currency: "USD", balance: 0, accountable: Depository.new)
+    eur_account = create_foreign_account!(family: family, name: "EUR Checking", currency: "EUR")
+
+    travel_to Date.new(2026, 4, 20) do
+      budget = Budget.find_or_bootstrap(family, start_date: Date.current.beginning_of_month)
+      budget_category = budget.budget_categories.find_by!(category: groceries)
+
+      create_transaction(account: usd_account, amount: 100, currency: "USD", category: groceries, date: Date.current)
+      create_transaction(account: eur_account, amount: 100, currency: "EUR", category: groceries, date: Date.current)
+      create_exchange_rate!(from: "EUR", to: "USD", rate: 1.2, date: Date.current)
+
+      budget = Budget.find(budget.id)
+      budget.sync_budget_categories
+      budget_category = budget.budget_categories.find_by!(category: groceries)
+
+      assert_equal 220, budget.actual_spending
+      assert_equal 220, budget.budget_category_actual_spending(budget_category)
+    end
   end
 
   test "to_donut_segments_json only includes top-level budget categories" do

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class IncomeStatementTest < ActiveSupport::TestCase
   include EntriesTestHelper
+  include FxRegressionTestHelper
 
   setup do
     @family = families(:empty)
@@ -28,6 +29,21 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_equal 4, totals.transactions_count
   end
 
+  test "calculates totals for transactions in family currency when entries are mixed-currency" do
+    foreign_account = create_foreign_account!(family: @family, currency: "EUR")
+
+    create_transaction(account: foreign_account, amount: 100, currency: "EUR", category: @groceries_category, date: Date.current)
+    create_transaction(account: foreign_account, amount: -250, currency: "EUR", category: @income_category, date: Date.current)
+    create_exchange_rate!(from: "EUR", to: @family.currency, rate: 1.2, date: Date.current)
+
+    income_statement = IncomeStatement.new(@family)
+    totals = income_statement.totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal Money.new(1300, @family.currency), totals.income_money
+    assert_equal Money.new(1020, @family.currency), totals.expense_money
+    assert_equal 6, totals.transactions_count
+  end
+
   test "calculates expenses for a period" do
     income_statement = IncomeStatement.new(@family)
     expense_totals = income_statement.expense_totals(period: Period.last_30_days)
@@ -37,6 +53,19 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_equal expected_total_expense, expense_totals.total
     assert_equal expected_total_expense, expense_totals.category_totals.find { |ct| ct.category.id == @groceries_category.id }.total
     assert_equal expected_total_expense, expense_totals.category_totals.find { |ct| ct.category.id == @food_category.id }.total
+  end
+
+  test "calculates expense category totals in family currency for mixed-currency entries" do
+    foreign_account = create_foreign_account!(family: @family, currency: "EUR")
+    create_transaction(account: foreign_account, amount: 100, currency: "EUR", category: @groceries_category, date: Date.current)
+    create_exchange_rate!(from: "EUR", to: @family.currency, rate: 1.2, date: Date.current)
+
+    income_statement = IncomeStatement.new(@family)
+    expense_totals = income_statement.expense_totals(period: Period.last_30_days)
+
+    assert_equal 1020, expense_totals.total
+    assert_equal 1020, expense_totals.category_totals.find { |ct| ct.category.id == @groceries_category.id }.total
+    assert_equal 1020, expense_totals.category_totals.find { |ct| ct.category.id == @food_category.id }.total
   end
 
   test "calculates income for a period" do
@@ -148,6 +177,30 @@ class IncomeStatementTest < ActiveSupport::TestCase
     # CORRECT BUSINESS LOGIC: Calculates average of time-period totals for budget planning
     # All transactions in same month = monthly total of 600, so average = 600.0
     assert_equal 600.0, income_statement.avg_expense(interval: "month", category: @groceries_category)
+  end
+
+  test "family and category stats convert foreign currency before median and average aggregation" do
+    Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
+
+    foreign_account = create_foreign_account!(family: @family, currency: "EUR")
+
+    travel_to Date.new(2026, 4, 30) do
+      create_transaction(account: @checking_account, amount: 100, currency: "USD", category: @groceries_category, date: Date.new(2026, 3, 5))
+      create_transaction(account: foreign_account, amount: 100, currency: "EUR", category: @groceries_category, date: Date.new(2026, 4, 5))
+      create_transaction(account: @checking_account, amount: -300, currency: "USD", category: @income_category, date: Date.new(2026, 3, 10))
+      create_transaction(account: foreign_account, amount: -100, currency: "EUR", category: @income_category, date: Date.new(2026, 4, 10))
+
+      create_exchange_rate!(from: "EUR", to: "USD", rate: 1.2, date: Date.new(2026, 4, 5))
+      create_exchange_rate!(from: "EUR", to: "USD", rate: 1.5, date: Date.new(2026, 4, 10))
+
+      income_statement = IncomeStatement.new(@family)
+
+      assert_equal 110.0, income_statement.median_expense(interval: "month")
+      assert_equal 110.0, income_statement.avg_expense(interval: "month")
+      assert_equal 110.0, income_statement.median_expense(interval: "month", category: @groceries_category)
+      assert_equal 110.0, income_statement.avg_expense(interval: "month", category: @groceries_category)
+      assert_equal 225.0, income_statement.median_income(interval: "month")
+    end
   end
 
   # NEW TESTS: Transfer and Kind Filtering

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -589,6 +589,28 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_nil net.net_expense_categories.find { |ct| ct.category.id == @food_category.id }
   end
 
+  test "net_category_totals converts foreign currency before netting categories" do
+    Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all
+
+    foreign_account = create_foreign_account!(family: @family, currency: "NGN")
+
+    create_transaction(account: @checking_account, amount: 100, currency: "USD", category: @food_category, date: Date.current)
+    create_transaction(account: foreign_account, amount: 1000, currency: "NGN", category: @food_category, date: Date.current)
+    create_transaction(account: foreign_account, amount: -250, currency: "NGN", category: @food_category, date: Date.current)
+
+    create_exchange_rate!(from: "NGN", to: @family.currency, rate: 0.01, date: Date.current)
+
+    net = IncomeStatement.new(@family).net_category_totals(period: Period.last_30_days)
+
+    assert_equal 107.5, net.total_net_expense
+    assert_equal 0, net.total_net_income
+
+    food_net = net.net_expense_categories.find { |ct| ct.category.id == @food_category.id }
+    assert_not_nil food_net
+    assert_equal 107.5, food_net.total
+    assert_in_delta 100.0, food_net.weight, 0.1
+  end
+
   test "empty account_ids returns no results for category stats" do
     results = IncomeStatement::CategoryStats.new(@family, account_ids: []).call
     assert_empty results

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Transaction::SearchTest < ActiveSupport::TestCase
   include EntriesTestHelper
+  include FxRegressionTestHelper
 
   setup do
     @family = families(:dylan_family)
@@ -322,9 +323,9 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     )
 
     # Create exchange rate EUR -> USD
-    ExchangeRate.create!(
-      from_currency: "EUR",
-      to_currency: "USD",
+    create_exchange_rate!(
+      from: "EUR",
+      to: "USD",
       rate: 1.1,
       date: eur_entry.date
     )
@@ -344,6 +345,24 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     # EUR 100 * 1.1 + USD 50 = 110 + 50 = 160
     assert_equal Money.new(160, "USD"), totals.expense_money
     assert_equal Money.new(0, "USD"), totals.income_money
+  end
+
+  test "totals converts mixed-currency transfer inflow and outflow totals" do
+    foreign_account = create_foreign_account!(family: @family, currency: "EUR")
+    create_exchange_rate!(from: "EUR", to: "USD", rate: 1.2, date: Date.current)
+
+    create_transaction(account: foreign_account, amount: 100, currency: "EUR", kind: "funds_movement")
+    create_transaction(account: foreign_account, amount: -50, currency: "EUR", kind: "funds_movement")
+    create_transaction(account: @checking_account, amount: 25, currency: "USD", kind: "funds_movement")
+    create_transaction(account: @checking_account, amount: -40, currency: "USD", kind: "funds_movement")
+
+    search = Transaction::Search.new(@family)
+    totals = search.totals
+
+    assert_equal Money.new(0, "USD"), totals.expense_money
+    assert_equal Money.new(0, "USD"), totals.income_money
+    assert_equal Money.new(100, "USD"), totals.transfer_inflow_money
+    assert_equal Money.new(145, "USD"), totals.transfer_outflow_money
   end
 
   test "totals handles missing exchange rates gracefully" do

--- a/test/support/fx_regression_test_helper.rb
+++ b/test/support/fx_regression_test_helper.rb
@@ -1,0 +1,19 @@
+module FxRegressionTestHelper
+  def create_exchange_rate!(from:, to:, rate:, date: Date.current)
+    ExchangeRate.create!(
+      from_currency: from,
+      to_currency: to,
+      rate: rate,
+      date: date
+    )
+  end
+
+  def create_foreign_account!(family:, name: "Foreign Account", currency: "EUR", accountable: Depository.new)
+    family.accounts.create!(
+      name: name,
+      currency: currency,
+      balance: 0,
+      accountable: accountable
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- add shared FX regression helpers for foreign-currency accounts and dated exchange rates
- cover income statement totals, period/category totals, and family/category stats with mixed-currency assertions
- cover transaction search transfer totals and budget-facing aggregations so they sum in family currency

Closes #1607.

## Testing
- Attempted to run targeted model tests locally
- Current shell is blocked before Rails boot by Ruby psych loading failing with `libyaml-0.so.2` missing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regression test coverage for foreign exchange functionality to ensure accurate multi-currency conversion in budget calculations, income statement totals, category-level expenses, and transaction searches.
  * Added integration test validating that the dashboard outflows donut chart correctly converts foreign-currency transaction amounts to the family currency for display.
  * Introduced test helper utilities for seeding exchange rates and foreign-currency accounts in regression tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->