### PR TITLE
fix: use ProviderLoader for AuthConfig.sso_providers when DB providers enabled

### DIFF
--- a/app/models/auth_config.rb
+++ b/app/models/auth_config.rb
@@ -74,7 +74,17 @@ class AuthConfig
     end
 
     def sso_providers
-      Rails.configuration.x.auth.sso_providers || []
+      if FeatureFlags.db_sso_providers?
+        # After boot, OmniAuth registers successfully configured providers into
+        # Rails.configuration.x.auth.sso_providers. Prefer that filtered list
+        # so we never render login buttons for providers that couldn't be
+        # registered (e.g., missing required fields in YAML fallback).
+        # Fall back to ProviderLoader for pre-boot contexts.
+        registered = Rails.configuration.x.auth.sso_providers
+        registered&.any? ? registered : ProviderLoader.load_providers
+      else
+        Rails.configuration.x.auth.sso_providers || []
+      end
     end
   end
 end

--- a/app/models/oidc_identity.rb
+++ b/app/models/oidc_identity.rb
@@ -95,7 +95,7 @@ class OidcIdentity < ApplicationRecord
 
   # Find the configured provider for this identity
   def provider_config
-    Rails.configuration.x.auth.sso_providers&.find { |p| p[:name] == provider || p[:id] == provider }
+    AuthConfig.sso_providers&.find { |p| p[:name] == provider || p[:id] == provider }
   end
 
   # Validate that the stored issuer matches the configured provider's issuer


### PR DESCRIPTION
**Problem**
AuthConfig.sso_providers only ever read from the YAML config array (Rails.configuration.x.auth.sso_providers). Self-hosted setups that configure SSO providers via the DB admin UI had an empty provider list, so the login page never rendered the SSO divider or button.

**Fix**
Wire AuthConfig.sso_providers to ProviderLoader.load_providers when FeatureFlags.db_sso_providers? is true, falling back to YAML config otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * SSO provider configuration can now be sourced from an alternate, dynamic provider list when the new option is enabled, allowing more flexible provider management.
  * Maintains backward compatibility with existing static configuration so current sign-on behavior is preserved when the alternate source is not active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->