### PR TITLE
fix(design-system): give cyan-900 a darker value than cyan-800

### DIFF
--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -98,7 +98,7 @@
   --color-cyan-600: #088AB2;
   --color-cyan-700: #0E7090;
   --color-cyan-800: #155B75;
-  --color-cyan-900: #155B75;
+  --color-cyan-900: #164E63;
   --color-cyan-tint-5: --alpha(var(--color-cyan-500) / 5%);
   --color-cyan-tint-10: --alpha(var(--color-cyan-500) / 10%);
   --color-blue-25: #F5FAFF;

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -126,7 +126,7 @@
       "600": { "$value": "#088AB2", "$type": "color" },
       "700": { "$value": "#0E7090", "$type": "color" },
       "800": { "$value": "#155B75", "$type": "color" },
-      "900": { "$value": "#155B75", "$type": "color" },
+      "900": { "$value": "#164E63", "$type": "color" },
       "tint-5":  { "$value": "{color.cyan.500|5%}",  "$type": "color" },
       "tint-10": { "$value": "{color.cyan.500|10%}", "$type": "color" }
     },


### PR DESCRIPTION
## Summary

Both `cyan-800` and `cyan-900` were defined as `#155B75` in `design/tokens/sure.tokens.json`, which left the cyan scale plateaued at the dark end. This PR sets `cyan-900` to `#164E63` (Tailwind v3's default for that step) so the scale progresses monotonically from light to dark like every other ladder.

Closes #1605.

## Why

The duplicate predates this work — it was introduced when the v4 design system first landed (upstream commit `a82c0303`). It was probably a copy-paste oversight; the file received fewer touches between then and the SoT migration in #1604.

The token has zero current usage in the codebase. `bg-cyan-900`, `text-cyan-900`, and `border-cyan-900` aren't referenced anywhere outside the design system source, so this change has no visual effect on the running app today. It just makes the scale internally consistent for any future use.

## Implementation

One value change in `design/tokens/sure.tokens.json`. `npm run tokens:build` regenerates `_generated.css` so the corresponding `--color-cyan-900` CSS variable updates too. Both files are committed together (per the workflow documented in `design/tokens/README.md`).

## Test plan

- [ ] `npm run tokens:build` produces no diff against the committed `_generated.css`.
- [ ] `bundle exec rails tailwindcss:build` succeeds.
- [ ] `bin/rails test` green.
- [ ] In the Lookbook tokens preview (when #1618 lands), the cyan ladder visibly darkens from 800 to 900.

## Notes

- Picked the Tailwind v3 default rather than introducing a new shade because the rest of Sure's cyan scale doesn't quite match Tailwind's vanilla cyan, but `cyan-900` was the single outlier preventing progression. If a designer wants a different value down the line, the token is now isolated and easy to change.
- This is unrelated to #1606 (fg-* deprecation); they're tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the cyan-900 design token color to a new shade, affecting the visual appearance of UI elements using this color throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->