### PR TITLE
feat(tokens): add $version field + document versioning policy

### DIFF
--- a/design/tokens/README.md
+++ b/design/tokens/README.md
@@ -23,6 +23,16 @@ git add design/tokens/sure.tokens.json app/assets/tailwind/sure-design-system/_g
 
 `bin/setup` runs the build automatically on a fresh checkout.
 
+## Versioning
+
+The root `$version` field follows semver, scoped to the token contract:
+
+- **Major** (`X.0.0`): breaking changes — token removed or renamed, value type changed, dark variant removed, semantic meaning changed.
+- **Minor** (`1.X.0`): additive changes — new tokens, new `$extensions.sure.*` keys, new top-level groups.
+- **Patch** (`1.0.X`): cosmetic / value tweaks that consumers don't need to know about — a hex shifts a few points without changing intent.
+
+Bump it when you commit. External consumers (Tokens Studio, future Figma sync, etc.) read this to decide whether their cached snapshot is stale.
+
 ## Schema
 
 The file uses the [W3C DTCG token format](https://design-tokens.github.io/community-group/format/): `$value`, `$type`, `$description`, `$extensions`. Tokens cross-reference via `{path.to.token}` placeholders.

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://design-tokens.github.io/community-group/format/",
+  "$version": "1.0.0",
   "$description": "Sure design tokens. Single source of truth. Hand-edit; run `npm run tokens:build` to regenerate CSS. Template syntax in $value strings: `{path.to.token}` resolves to `var(--path-to-token)`; `{path|N%}` becomes `--alpha(var(--path) / N%)`. Utility tokens whose value lacks `{}` are treated as raw Tailwind class lists for @apply.",
 
   "font": {


### PR DESCRIPTION
## Summary

Adds `$version: "1.0.0"` at the root of `design/tokens/sure.tokens.json` and documents the versioning policy in the README. External consumers (Tokens Studio, future Figma sync, AI design tooling, etc.) get a stable signal for when their cached snapshot of the token API is out of date.

## Why

The token JSON is now a public-ish contract. Consumers that aren't the Rails app (the upcoming markdown reference doc generator, future Figma sync, anything else) need a way to detect drift. Without a version, they'd have to checksum the whole file, which doesn't distinguish "value tweak" from "breaking schema change."

Semver, scoped to the token contract:

- **Major** (`X.0.0`): breaking — token removed or renamed, value type changed, dark variant removed, semantic meaning changed.
- **Minor** (`1.X.0`): additive — new tokens, new `$extensions.sure.*` keys, new top-level groups.
- **Patch** (`1.0.X`): cosmetic — a hex shifts a few points without changing intent.

## Implementation

One field added to the JSON, one section added to `design/tokens/README.md`. The build script already ignores top-level `$`-prefixed keys, so no code change is needed and `_generated.css` is byte-identical.

## Test plan

- [x] `npm run tokens:build` runs cleanly and produces zero diff against the committed `_generated.css`.
- [x] `bundle exec rails tailwindcss:build` succeeds.
- [ ] CI green.

## Notes

- Starts at `1.0.0` because the PR #1604 baseline is the v1 contract. Anything before that is pre-1.0 (the old hand-edited CSS era).
- No `CHANGELOG.md` for now — git log is sufficient until breaking changes start happening. Adding one preemptively would just be empty ceremony.
- Independent of #1605 (cyan-900 fix → bumps patch when that lands) and #1606 (fg-* deprecation → will bump major when the namespace is removed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on design token version semantics and cache snapshot management strategies.

* **New Features**
  * Introduced semantic versioning to the design token system, with initial version 1.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->