### PR TITLE
fix(recurring): make account-scoping migration resilient to legacy duplicates

### DIFF
--- a/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
+++ b/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
@@ -1,5 +1,19 @@
 class AddAccountIdToRecurringTransactions < ActiveRecord::Migration[7.2]
   def up
+    # Some long-lived self-hosted instances can already contain duplicate recurring
+    # rows because older name-based uniqueness was reflected in schema.rb but was not
+    # enforced by a migration on upgraded databases. Deduplicate on the pre-migration
+    # shape first so the migration can recover cleanly after a rollback.
+    dedupe_recurring_transactions!(
+      partition_columns: %w[family_id merchant_id amount currency],
+      where_clause: "merchant_id IS NOT NULL"
+    )
+
+    dedupe_recurring_transactions!(
+      partition_columns: %w[family_id name amount currency],
+      where_clause: "merchant_id IS NULL AND name IS NOT NULL"
+    )
+
     add_reference :recurring_transactions, :account, type: :uuid, null: true, foreign_key: true
 
     # Backfill account_id from the most recent matching entry
@@ -25,6 +39,18 @@ class AddAccountIdToRecurringTransactions < ActiveRecord::Migration[7.2]
       WHERE rt.id = subquery.recurring_transaction_id
     SQL
 
+    # Deduplicate again after backfill because rows that were distinct at the
+    # family level can collapse onto the same account-scoped uniqueness key.
+    dedupe_recurring_transactions!(
+      partition_columns: %w[family_id account_id merchant_id amount currency],
+      where_clause: "merchant_id IS NOT NULL"
+    )
+
+    dedupe_recurring_transactions!(
+      partition_columns: %w[family_id account_id name amount currency],
+      where_clause: "merchant_id IS NULL AND name IS NOT NULL"
+    )
+
     # Remove old unique indexes
     remove_index :recurring_transactions, name: "idx_recurring_txns_merchant", if_exists: true
     remove_index :recurring_transactions, name: "idx_recurring_txns_name", if_exists: true
@@ -42,6 +68,29 @@ class AddAccountIdToRecurringTransactions < ActiveRecord::Migration[7.2]
       where: "name IS NOT NULL AND merchant_id IS NULL",
       name: "idx_recurring_txns_acct_name"
   end
+
+  private
+    def dedupe_recurring_transactions!(partition_columns:, where_clause:)
+      execute <<~SQL
+        WITH ranked AS (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY #{partition_columns.join(', ')}
+                   ORDER BY manual DESC,
+                            (status = 'active') DESC,
+                            last_occurrence_date DESC NULLS LAST,
+                            updated_at DESC,
+                            id DESC
+                 ) AS row_num
+          FROM recurring_transactions
+          WHERE #{where_clause}
+        )
+        DELETE FROM recurring_transactions
+        WHERE id IN (
+          SELECT id FROM ranked WHERE row_num > 1
+        )
+      SQL
+    end
 
   def down
     remove_index :recurring_transactions, name: "idx_recurring_txns_acct_merchant", if_exists: true

--- a/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
+++ b/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
@@ -69,6 +69,25 @@ class AddAccountIdToRecurringTransactions < ActiveRecord::Migration[7.2]
       name: "idx_recurring_txns_acct_name"
   end
 
+  def down
+    remove_index :recurring_transactions, name: "idx_recurring_txns_acct_merchant", if_exists: true
+    remove_index :recurring_transactions, name: "idx_recurring_txns_acct_name", if_exists: true
+
+    add_index :recurring_transactions,
+      [ :family_id, :merchant_id, :amount, :currency ],
+      unique: true,
+      where: "merchant_id IS NOT NULL",
+      name: "idx_recurring_txns_merchant"
+
+    add_index :recurring_transactions,
+      [ :family_id, :name, :amount, :currency ],
+      unique: true,
+      where: "name IS NOT NULL AND merchant_id IS NULL",
+      name: "idx_recurring_txns_name"
+
+    remove_reference :recurring_transactions, :account
+  end
+
   private
 
     def dedupe_recurring_transactions!(partition_columns:, where_clause:)
@@ -92,23 +111,4 @@ class AddAccountIdToRecurringTransactions < ActiveRecord::Migration[7.2]
         )
       SQL
     end
-
-  def down
-    remove_index :recurring_transactions, name: "idx_recurring_txns_acct_merchant", if_exists: true
-    remove_index :recurring_transactions, name: "idx_recurring_txns_acct_name", if_exists: true
-
-    add_index :recurring_transactions,
-      [ :family_id, :merchant_id, :amount, :currency ],
-      unique: true,
-      where: "merchant_id IS NOT NULL",
-      name: "idx_recurring_txns_merchant"
-
-    add_index :recurring_transactions,
-      [ :family_id, :name, :amount, :currency ],
-      unique: true,
-      where: "name IS NOT NULL AND merchant_id IS NULL",
-      name: "idx_recurring_txns_name"
-
-    remove_reference :recurring_transactions, :account
-  end
 end

--- a/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
+++ b/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
@@ -70,27 +70,28 @@ class AddAccountIdToRecurringTransactions < ActiveRecord::Migration[7.2]
   end
 
   private
-    def dedupe_recurring_transactions!(partition_columns:, where_clause:)
-      execute <<~SQL
-        WITH ranked AS (
-          SELECT id,
-                 ROW_NUMBER() OVER (
-                   PARTITION BY #{partition_columns.join(', ')}
-                   ORDER BY manual DESC,
-                            (status = 'active') DESC,
-                            last_occurrence_date DESC NULLS LAST,
-                            updated_at DESC,
-                            id DESC
-                 ) AS row_num
-          FROM recurring_transactions
-          WHERE #{where_clause}
-        )
-        DELETE FROM recurring_transactions
-        WHERE id IN (
-          SELECT id FROM ranked WHERE row_num > 1
-        )
-      SQL
-    end
+
+  def dedupe_recurring_transactions!(partition_columns:, where_clause:)
+    execute <<~SQL
+      WITH ranked AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY #{partition_columns.join(', ')}
+                 ORDER BY manual DESC,
+                          (status = 'active') DESC,
+                          last_occurrence_date DESC NULLS LAST,
+                          updated_at DESC,
+                          id DESC
+               ) AS row_num
+        FROM recurring_transactions
+        WHERE #{where_clause}
+      )
+      DELETE FROM recurring_transactions
+      WHERE id IN (
+        SELECT id FROM ranked WHERE row_num > 1
+      )
+    SQL
+  end
 
   def down
     remove_index :recurring_transactions, name: "idx_recurring_txns_acct_merchant", if_exists: true

--- a/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
+++ b/db/migrate/20260326112218_add_account_id_to_recurring_transactions.rb
@@ -71,27 +71,27 @@ class AddAccountIdToRecurringTransactions < ActiveRecord::Migration[7.2]
 
   private
 
-  def dedupe_recurring_transactions!(partition_columns:, where_clause:)
-    execute <<~SQL
-      WITH ranked AS (
-        SELECT id,
-               ROW_NUMBER() OVER (
-                 PARTITION BY #{partition_columns.join(', ')}
-                 ORDER BY manual DESC,
-                          (status = 'active') DESC,
-                          last_occurrence_date DESC NULLS LAST,
-                          updated_at DESC,
-                          id DESC
-               ) AS row_num
-        FROM recurring_transactions
-        WHERE #{where_clause}
-      )
-      DELETE FROM recurring_transactions
-      WHERE id IN (
-        SELECT id FROM ranked WHERE row_num > 1
-      )
-    SQL
-  end
+    def dedupe_recurring_transactions!(partition_columns:, where_clause:)
+      execute <<~SQL
+        WITH ranked AS (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY #{partition_columns.join(', ')}
+                   ORDER BY manual DESC,
+                            (status = 'active') DESC,
+                            last_occurrence_date DESC NULLS LAST,
+                            updated_at DESC,
+                            id DESC
+                 ) AS row_num
+          FROM recurring_transactions
+          WHERE #{where_clause}
+        )
+        DELETE FROM recurring_transactions
+        WHERE id IN (
+          SELECT id FROM ranked WHERE row_num > 1
+        )
+      SQL
+    end
 
   def down
     remove_index :recurring_transactions, name: "idx_recurring_txns_acct_merchant", if_exists: true


### PR DESCRIPTION
## Summary

Fix self-hosted upgrade failures in the recurring transaction account-scoping migration.

The migration currently fails with `PG::UniqueViolation` while creating `idx_recurring_txns_acct_name` on some long-lived upgraded databases. The root cause appears to be legacy duplicate recurring transaction rows that were possible on upgraded instances because older name-based uniqueness expectations were reflected in `schema.rb` but not fully enforced by a migration.

This hotfix makes the migration resilient by deduplicating recurring transactions twice:

1. **Before** `account_id` is added/backfilled, using the pre-migration uniqueness shape
2. **After** `account_id` is backfilled, using the new account-scoped uniqueness shape

That covers both:
- duplicates that already existed on older self-hosted databases
- rows that only collide after the backfill collapses them onto the same account-scoped key

## Changes

- dedupe merchant-based recurring rows on `(family_id, merchant_id, amount, currency)` before adding `account_id`
- dedupe name-based recurring rows on `(family_id, name, amount, currency)` before adding `account_id`
- backfill `account_id` as before
- dedupe merchant-based recurring rows on `(family_id, account_id, merchant_id, amount, currency)` after backfill
- dedupe name-based recurring rows on `(family_id, account_id, name, amount, currency)` after backfill
- keep the most relevant surviving row by preferring:
  - `manual = true`
  - active status
  - latest `last_occurrence_date`
  - latest `updated_at`
  - highest `id`

## Why this approach

Affected self-hosted installs never persist `account_id` because the migration rolls back transactionally on failure. So a post-backfill-only cleanup is not enough. The migration needs to clean the old table shape first, then clean again after the backfill.

## Notes

- This is targeted at self-hosted upgraded instances, especially long-lived ones.
- I could not run a local Ruby syntax check in the current OpenClaw container because `ruby` is not installed there, but the change is scoped to a single migration file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database maintenance for recurring transactions: deduplication now runs both before and after linking transactions to accounts.
  * Reduced risk of duplicated or collapsed recurring entries when accounts are associated, improving consistency of recurring transaction grouping.
  * Fewer duplicate or confusing recurring items visible after account-related updates, resulting in cleaner transaction lists for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->