### PR TITLE
fix(design-system): make inline <code> visible in prose dark mode

### DIFF
--- a/app/assets/tailwind/sure-design-system/prose.css
+++ b/app/assets/tailwind/sure-design-system/prose.css
@@ -14,3 +14,11 @@
 .prose:where([data-theme=dark], [data-theme=dark] *) thead th {
   color: theme(colors.white) !important;
 }
+
+/* Inline code in prose under dark mode. Without this the Tailwind Typography
+   plugin's default near-black foreground falls through and disappears against
+   the dark page background. */
+.prose:where([data-theme=dark], [data-theme=dark] *) code {
+  color: theme(colors.white) !important;
+  background-color: theme(colors.gray.800) !important;
+}


### PR DESCRIPTION
## Summary

Inline `<code>` elements inside `.prose` blocks were invisible in dark mode. URLs, code references, and any backtick-rendered text disappeared against the dark page background. This adds a dark-mode override for `<code>`, mirroring the pattern already used for `<strong>` and the heading family.

Closes #1624.

The problem:
<img width="1483" height="190" alt="Captura de pantalla 2026-05-01 211621" src="https://github.com/user-attachments/assets/010e5121-6969-478b-86f6-81d5521b1cb0" />
Does not happen in white mode:
<img width="1250" height="197" alt="Captura de pantalla 2026-05-01 211653" src="https://github.com/user-attachments/assets/07f75150-2e46-4909-99fb-f1d3d3bfb6cf" />


## What changes in this PR

One block added to `app/assets/tailwind/sure-design-system/prose.css`:

```css
.prose:where([data-theme=dark], [data-theme=dark] *) code {
  color: theme(colors.white) !important;
  background-color: theme(colors.gray.800) !important;
}
```

White text on a gray-800 chip in dark mode. Light mode keeps the Tailwind Typography plugin's defaults.

## Why match the existing `theme(colors.X)` syntax

The two pre-existing overrides in this file (for `<strong>` and headings) use `theme(colors.X)` rather than `var(--color-X)`. Staying consistent reads better than introducing a new convention for the same kind of rule. Both forms ultimately resolve to the same CSS variable via the `@theme` block.

## Affected pages

Every `.prose` consumer in the app, in dark mode. About a dozen places: AI chat (`prose--ai-chat`), GitHub release notes (`prose--github-release-notes`), dashboard prose blocks, settings panels with help text (Mercury, etc.), and any other markdown rendering.

Spotted on the **Mercury settings panel** at `/settings/providers` during the visual review of #1621.

## Test plan

- [x] `bundle exec rails tailwindcss:build` succeeds.
- [ ] CI green.
- [ ] In dark mode, visit a page with prose + inline code:
  - Settings → Providers → Mercury — the "Note: For sandbox testing..." paragraph contains a code-wrapped URL that should now be readable.
  - AI chat with any code in the response.
  - Any release-notes page.
- [ ] In light mode, confirm code chips still look the same as before (Typography plugin defaults).

## Notes

Opened as a draft because it touches dark-mode rendering across a dozen pages and the reviewer should pull and eyeball before merging.

If a reviewer also reports faint links inside `.prose` in dark mode, those go in the same override block. `<a>` already routes through `@apply text-link` (a token with light/dark variants), so links should be fine, but worth flagging if it's not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode code styling for improved readability with better contrast between text and background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->