### PR TITLE
refactor(design-system): migrate fg-* utilities to text-* and remove namespace

### DIFF
--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -434,6 +434,14 @@
   }
 }
 
+@utility border-inverse {
+  @apply border-alpha-white-200;
+
+  @variant theme-dark {
+    @apply border-alpha-black-300;
+  }
+}
+
 @utility button-bg-primary {
   @apply bg-gray-900;
 

--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -302,70 +302,6 @@
   @apply bg-surface-inset animate-pulse;
 }
 
-@utility fg-gray {
-  @apply text-gray-500;
-
-  @variant theme-dark {
-    @apply text-gray-400;
-  }
-}
-
-@utility fg-contrast {
-  @apply text-gray-400;
-
-  @variant theme-dark {
-    @apply text-gray-500;
-  }
-}
-
-@utility fg-inverse {
-  @apply text-white;
-
-  @variant theme-dark {
-    @apply text-gray-900;
-  }
-}
-
-@utility fg-primary {
-  @apply text-gray-900;
-
-  @variant theme-dark {
-    @apply text-white;
-  }
-}
-
-@utility fg-primary-variant {
-  @apply text-gray-800;
-
-  @variant theme-dark {
-    @apply text-gray-50;
-  }
-}
-
-@utility fg-secondary {
-  @apply text-gray-50;
-
-  @variant theme-dark {
-    @apply text-gray-400;
-  }
-}
-
-@utility fg-secondary-variant {
-  @apply text-gray-100;
-
-  @variant theme-dark {
-    @apply text-gray-500;
-  }
-}
-
-@utility fg-subdued {
-  @apply text-gray-400;
-
-  @variant theme-dark {
-    @apply text-gray-500;
-  }
-}
-
 @utility text-primary {
   @apply text-gray-900;
 
@@ -558,7 +494,7 @@
   @apply bg-gray-50;
 
   @variant theme-dark {
-    @apply bg-gray-800 fg-inverse;
+    @apply bg-gray-800 text-inverse;
   }
 }
 

--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -199,14 +199,14 @@
     --color-success: var(--color-green-500);
     --color-warning: var(--color-yellow-400);
     --color-destructive: var(--color-red-400);
-    --color-shadow: --alpha(var(--color-black) / 25%);
+    --color-shadow: --alpha(var(--color-white) / 8%);
     --budget-unused-fill: var(--color-gray-500);
     --budget-unallocated-fill: var(--color-gray-700);
-    --shadow-xs: 0px 1px 2px 0px --alpha(var(--color-black) / 25%);
-    --shadow-sm: 0px 1px 6px 0px --alpha(var(--color-black) / 30%);
-    --shadow-md: 0px 4px 8px -2px --alpha(var(--color-black) / 35%);
-    --shadow-lg: 0px 12px 16px -4px --alpha(var(--color-black) / 40%);
-    --shadow-xl: 0px 20px 24px -4px --alpha(var(--color-black) / 50%);
+    --shadow-xs: 0px 1px 2px 0px --alpha(var(--color-white) / 8%);
+    --shadow-sm: 0px 1px 6px 0px --alpha(var(--color-white) / 8%);
+    --shadow-md: 0px 4px 8px -2px --alpha(var(--color-white) / 8%);
+    --shadow-lg: 0px 12px 16px -4px --alpha(var(--color-white) / 8%);
+    --shadow-xl: 0px 20px 24px -4px --alpha(var(--color-white) / 8%);
   }
 }
 

--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -199,14 +199,14 @@
     --color-success: var(--color-green-500);
     --color-warning: var(--color-yellow-400);
     --color-destructive: var(--color-red-400);
-    --color-shadow: --alpha(var(--color-white) / 8%);
+    --color-shadow: --alpha(var(--color-black) / 25%);
     --budget-unused-fill: var(--color-gray-500);
     --budget-unallocated-fill: var(--color-gray-700);
-    --shadow-xs: 0px 1px 2px 0px --alpha(var(--color-white) / 8%);
-    --shadow-sm: 0px 1px 6px 0px --alpha(var(--color-white) / 8%);
-    --shadow-md: 0px 4px 8px -2px --alpha(var(--color-white) / 8%);
-    --shadow-lg: 0px 12px 16px -4px --alpha(var(--color-white) / 8%);
-    --shadow-xl: 0px 20px 24px -4px --alpha(var(--color-white) / 8%);
+    --shadow-xs: 0px 1px 2px 0px --alpha(var(--color-black) / 25%);
+    --shadow-sm: 0px 1px 6px 0px --alpha(var(--color-black) / 30%);
+    --shadow-md: 0px 4px 8px -2px --alpha(var(--color-black) / 35%);
+    --shadow-lg: 0px 12px 16px -4px --alpha(var(--color-black) / 40%);
+    --shadow-xl: 0px 20px 24px -4px --alpha(var(--color-black) / 50%);
   }
 }
 

--- a/app/components/DS/buttonish.rb
+++ b/app/components/DS/buttonish.rb
@@ -2,11 +2,11 @@ class DS::Buttonish < DesignSystemComponent
   VARIANTS = {
     primary: {
       container_classes: "text-inverse bg-inverse hover:bg-inverse-hover disabled:bg-gray-500 theme-dark:disabled:bg-gray-400",
-      icon_classes: "fg-inverse"
+      icon_classes: "text-inverse"
     },
     secondary: {
       container_classes: "text-primary bg-gray-200 theme-dark:bg-gray-700 hover:bg-gray-300 theme-dark:hover:bg-gray-600 disabled:bg-gray-200 theme-dark:disabled:bg-gray-600",
-      icon_classes: "fg-primary"
+      icon_classes: "text-primary"
     },
     destructive: {
       container_classes: "text-inverse bg-red-500 theme-dark:bg-red-400 hover:bg-red-600 theme-dark:hover:bg-red-500 disabled:bg-red-200 theme-dark:disabled:bg-red-600",
@@ -14,23 +14,23 @@ class DS::Buttonish < DesignSystemComponent
     },
     outline: {
       container_classes: "text-primary border border-secondary bg-transparent hover:bg-surface-hover",
-      icon_classes: "fg-gray"
+      icon_classes: "text-secondary"
     },
     outline_destructive: {
       container_classes: "text-destructive border border-secondary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700",
-      icon_classes: "fg-gray"
+      icon_classes: "text-secondary"
     },
     ghost: {
       container_classes: "text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700",
-      icon_classes: "fg-gray"
+      icon_classes: "text-secondary"
     },
     icon: {
       container_classes: "hover:bg-gray-100 theme-dark:hover:bg-gray-700",
-      icon_classes: "fg-gray"
+      icon_classes: "text-secondary"
     },
     icon_inverse: {
       container_classes: "bg-inverse hover:bg-inverse-hover",
-      icon_classes: "fg-inverse"
+      icon_classes: "text-inverse"
     }
   }.freeze
 

--- a/app/components/DS/dialog.html.erb
+++ b/app/components/DS/dialog.html.erb
@@ -1,5 +1,5 @@
 <%= wrapper_element do %>
-  <%= tag.dialog class: "w-full h-full bg-transparent theme-dark:backdrop:bg-alpha-black-900 backdrop:bg-overlay pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] #{(drawer? || responsive?) ? "lg:p-3" : "lg:p-1"}", **merged_opts do %>
+  <%= tag.dialog class: "w-full h-full bg-transparent text-primary theme-dark:backdrop:bg-alpha-black-900 backdrop:bg-overlay pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] #{(drawer? || responsive?) ? "lg:p-3" : "lg:p-1"}", **merged_opts do %>
     <%= tag.div class: dialog_outer_classes do %>
       <%= tag.div class: dialog_inner_classes, data: { DS__dialog_target: "content" } do %>
         <div class="grow py-4 space-y-4 flex flex-col <%= "overflow-auto" if scrollable %>">

--- a/app/components/DS/link.rb
+++ b/app/components/DS/link.rb
@@ -6,7 +6,7 @@ class DS::Link < DS::Buttonish
   VARIANTS = VARIANTS.reverse_merge(
     default: {
       container_classes: "",
-      icon_classes: "fg-gray"
+      icon_classes: "text-secondary"
     }
   ).freeze
 

--- a/app/components/DS/tooltip.html.erb
+++ b/app/components/DS/tooltip.html.erb
@@ -2,7 +2,7 @@
   <%= helpers.icon icon_name, size: size, color: color %>
 
   <div role="tooltip" data-DS--tooltip-target="tooltip" class="hidden absolute z-50 bg-gray-700 text-sm px-1.5 py-1 rounded-md">
-    <div class="fg-inverse font-normal max-w-[200px]">
+    <div class="text-inverse font-normal max-w-[200px]">
       <%= tooltip_content %>
     </div>
   </div>

--- a/app/components/DS/tooltip.html.erb
+++ b/app/components/DS/tooltip.html.erb
@@ -1,7 +1,7 @@
 <span data-controller="DS--tooltip" data-DS--tooltip-placement-value="<%= placement %>" data-DS--tooltip-offset-value="<%= offset %>" data-DS--tooltip-cross-axis-value="<%= cross_axis %>" class="inline-flex">
   <%= helpers.icon icon_name, size: size, color: color %>
 
-  <div role="tooltip" data-DS--tooltip-target="tooltip" class="hidden absolute z-50 bg-gray-700 text-sm px-1.5 py-1 rounded-md">
+  <div role="tooltip" data-DS--tooltip-target="tooltip" class="hidden absolute z-50 bg-inverse text-sm px-1.5 py-1 rounded-md">
     <div class="text-inverse font-normal max-w-[200px]">
       <%= tooltip_content %>
     </div>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,7 @@ module ApplicationHelper
   def icon(key, size: "md", color: "default", custom: false, as_button: false, **opts)
     extra_classes = opts.delete(:class)
     sizes = { xs: "w-3 h-3", sm: "w-4 h-4", md: "w-5 h-5", lg: "w-6 h-6", xl: "w-7 h-7", "2xl": "w-8 h-8" }
-    colors = { default: "fg-gray", white: "fg-inverse", success: "text-success", warning: "text-warning", destructive: "text-destructive", current: "text-current" }
+    colors = { default: "text-secondary", white: "text-inverse", success: "text-success", warning: "text-warning", destructive: "text-destructive", current: "text-current" }
 
     icon_classes = class_names(
       "shrink-0",

--- a/app/javascript/controllers/time_series_chart_controller.js
+++ b/app/javascript/controllers/time_series_chart_controller.js
@@ -110,7 +110,7 @@ export default class extends Controller {
       .attr("cx", this._d3InitialContainerWidth / 2)
       .attr("cy", this._d3InitialContainerHeight / 2)
       .attr("r", 4)
-      .attr("class", "fg-subdued")
+      .attr("class", "text-subdued")
       .style("fill", "currentColor");
   }
 
@@ -220,7 +220,7 @@ export default class extends Controller {
     // Style ticks
     this._d3Group
       .selectAll(".tick text")
-      .attr("class", "fg-gray")
+      .attr("class", "text-secondary")
       .style("font-size", "12px")
       .style("font-weight", "500")
       .attr("text-anchor", "middle")
@@ -334,7 +334,7 @@ export default class extends Controller {
         // Guideline
         this._d3Group
           .append("line")
-          .attr("class", "guideline fg-subdued")
+          .attr("class", "guideline text-subdued")
           .attr("x1", this._d3XScale(d.date))
           .attr("y1", 0)
           .attr("x2", this._d3XScale(d.date))

--- a/app/views/accounts/_account_type.html.erb
+++ b/app/views/accounts/_account_type.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (accountable:) %>
 
 <%= link_to new_polymorphic_path(accountable, step: "method_select", return_to: params[:return_to]),
-            class: "flex items-center gap-4 w-full text-center focus:outline-hidden hover:bg-surface-hover focus:bg-surface-hover fg-primary border border-transparent block px-2 rounded-lg p-2" do %>
+            class: "flex items-center gap-4 w-full text-center focus:outline-hidden hover:bg-surface-hover focus:bg-surface-hover text-primary border border-transparent block px-2 rounded-lg p-2" do %>
   <%= render DS::FilledIcon.new(
     icon: accountable.icon,
     hex_color: accountable.color,

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -27,7 +27,7 @@
     <% unless params[:return_to].present? %>
       <%= button_to imports_path(import: { type: "AccountImport" }),
               data: { turbo_frame: :_top },
-            class: "flex items-center gap-4 w-full text-center focus:outline-hidden hover:bg-surface-hover focus:bg-surface-hover fg-primary border border-transparent block px-2 rounded-lg p-2" do %>
+            class: "flex items-center gap-4 w-full text-center focus:outline-hidden hover:bg-surface-hover focus:bg-surface-hover text-primary border border-transparent block px-2 rounded-lg p-2" do %>
         <%= render DS::FilledIcon.new(
           icon: "download",
           hex_color: "#F79009",

--- a/app/views/chats/_ai_consent.html.erb
+++ b/app/views/chats/_ai_consent.html.erb
@@ -18,7 +18,7 @@
     <%= form_with url: user_path(Current.user), method: :patch, class: "w-full", data: { turbo: false } do |form| %>
       <%= form.hidden_field "user[ai_enabled]", value: true %>
       <%= form.hidden_field "user[redirect_to]", value: "home" %>
-      <%= form.submit "Enable AI Chats", class: "cursor-pointer hover:bg-inverse-hover w-full py-2 px-4 bg-inverse fg-inverse rounded-lg text-sm font-medium" %>
+      <%= form.submit "Enable AI Chats", class: "cursor-pointer hover:bg-inverse-hover w-full py-2 px-4 bg-inverse text-inverse rounded-lg text-sm font-medium" %>
     <% end %>
   <% end %>
 

--- a/app/views/family_exports/new.html.erb
+++ b/app/views/family_exports/new.html.erb
@@ -34,7 +34,7 @@
       <%= form_with url: family_exports_path, method: :post, class: "space-y-4" do |form| %>
         <div class="flex gap-3">
           <%= link_to "Cancel", "#", class: "flex-1 text-center px-4 py-2 text-primary bg-surface border border-primary rounded-lg hover:bg-surface-hover", data: { action: "click->modal#close" } %>
-          <%= form.submit "Export data", class: "flex-1 bg-inverse fg-inverse rounded-lg px-4 py-2 cursor-pointer hover:bg-inverse-hover" %>
+          <%= form.submit "Export data", class: "flex-1 bg-inverse text-inverse rounded-lg px-4 py-2 cursor-pointer hover:bg-inverse-hover" %>
         </div>
       <% end %>
     </div>

--- a/app/views/holdings/_missing_price_tooltip.html.erb
+++ b/app/views/holdings/_missing_price_tooltip.html.erb
@@ -3,7 +3,7 @@
     <%= icon "info", size: "sm", color: "current" %>
     <%= tag.span t(".missing_data"), class: "font-normal text-xs" %>
   </div>
-  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-700 text-sm p-2 rounded w-64">
+  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-2 rounded w-64">
     <div class="text-inverse">
       <%= t(".description") %>
     </div>

--- a/app/views/holdings/_missing_price_tooltip.html.erb
+++ b/app/views/holdings/_missing_price_tooltip.html.erb
@@ -4,7 +4,7 @@
     <%= tag.span t(".missing_data"), class: "font-normal text-xs" %>
   </div>
   <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-700 text-sm p-2 rounded w-64">
-    <div class="fg-inverse">
+    <div class="text-inverse">
       <%= t(".description") %>
     </div>
   </div>

--- a/app/views/investments/_value_tooltip.html.erb
+++ b/app/views/investments/_value_tooltip.html.erb
@@ -3,14 +3,14 @@
 <div data-controller="tooltip" data-tooltip-placement-value="right" data-tooltip-offset-value=10 data-tooltip-cross-axis-value=50>
   <%= icon("info", size: "sm") %>
   <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-700 text-sm p-2 rounded w-64">
-    <div class="fg-inverse">
+    <div class="text-inverse">
       <%= t(".total_value_tooltip") %>
     </div>
     <div class="flex pt-3">
       <div class="text-gray-300">
         <%= t(".cash") %>
       </div>
-      <div class="fg-inverse ml-auto">
+      <div class="text-inverse ml-auto">
         <%= tag.p format_money(cash, precision: 0) %>
       </div>
     </div>
@@ -18,7 +18,7 @@
       <div class="text-gray-300">
         <%= t(".holdings") %>
       </div>
-      <div class="fg-inverse ml-auto">
+      <div class="text-inverse ml-auto">
         <%= tag.p format_money(holdings, precision: 0) %>
       </div>
     </div>
@@ -29,7 +29,7 @@
       <div class="text-gray-300">
         <%= t(".total") %>
       </div>
-      <div class="fg-inverse font-bold ml-auto">
+      <div class="text-inverse font-bold ml-auto">
         <%= tag.p format_money(balance, precision: 0) %>
       </div>
     </div>

--- a/app/views/investments/_value_tooltip.html.erb
+++ b/app/views/investments/_value_tooltip.html.erb
@@ -7,7 +7,7 @@
       <%= t(".total_value_tooltip") %>
     </div>
     <div class="flex pt-3">
-      <div class="text-inverse/70">
+      <div class="text-inverse opacity-70">
         <%= t(".cash") %>
       </div>
       <div class="text-inverse ml-auto">
@@ -15,7 +15,7 @@
       </div>
     </div>
     <div class="flex">
-      <div class="text-inverse/70">
+      <div class="text-inverse opacity-70">
         <%= t(".holdings") %>
       </div>
       <div class="text-inverse ml-auto">
@@ -26,7 +26,7 @@
     <hr class="my-2 border-inverse">
 
     <div class="flex">
-      <div class="text-inverse/70">
+      <div class="text-inverse opacity-70">
         <%= t(".total") %>
       </div>
       <div class="text-inverse font-bold ml-auto">

--- a/app/views/investments/_value_tooltip.html.erb
+++ b/app/views/investments/_value_tooltip.html.erb
@@ -2,12 +2,12 @@
 
 <div data-controller="tooltip" data-tooltip-placement-value="right" data-tooltip-offset-value=10 data-tooltip-cross-axis-value=50>
   <%= icon("info", size: "sm") %>
-  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-700 text-sm p-2 rounded w-64">
+  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-2 rounded w-64">
     <div class="text-inverse">
       <%= t(".total_value_tooltip") %>
     </div>
     <div class="flex pt-3">
-      <div class="text-gray-300">
+      <div class="text-inverse/70">
         <%= t(".cash") %>
       </div>
       <div class="text-inverse ml-auto">
@@ -15,7 +15,7 @@
       </div>
     </div>
     <div class="flex">
-      <div class="text-gray-300">
+      <div class="text-inverse/70">
         <%= t(".holdings") %>
       </div>
       <div class="text-inverse ml-auto">
@@ -23,10 +23,10 @@
       </div>
     </div>
 
-    <hr class="my-2 border-secondary">
+    <hr class="my-2 border-inverse">
 
     <div class="flex">
-      <div class="text-gray-300">
+      <div class="text-inverse/70">
         <%= t(".total") %>
       </div>
       <div class="text-inverse font-bold ml-auto">

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -18,7 +18,7 @@
         { label: t(".role_label") } %>
 
       <div class="w-full">
-        <%= form.submit t(".submit"), class: "bg-inverse fg-inverse rounded-lg px-4 py-2 w-full" %>
+        <%= form.submit t(".submit"), class: "bg-inverse text-inverse rounded-lg px-4 py-2 w-full" %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/layouts/lookbooks.html.erb
+++ b/app/views/layouts/lookbooks.html.erb
@@ -8,7 +8,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="p-4 h-full bg-container <%= params.dig(:lookbook, :display, :container_classes) %>">
+  <body class="p-4 h-full bg-container text-primary <%= params.dig(:lookbook, :display, :container_classes) %>">
     <%= yield %>
   </body>
 </html>

--- a/app/views/pages/changelog.html.erb
+++ b/app/views/pages/changelog.html.erb
@@ -5,7 +5,7 @@
     <div class="w-full md:w-1/3">
       <div class="md:px-3 flex items-center gap-3">
         <% if @release_notes[:avatar].present? %>
-          <div class="fg-inverse shrink-0 w-9 h-9">
+          <div class="text-inverse shrink-0 w-9 h-9">
             <%= image_tag @release_notes[:avatar], class: "rounded-full w-full h-full object-cover" %>
           </div>
         <% else %>

--- a/app/views/settings/hostings/_assistant_settings.html.erb
+++ b/app/views/settings/hostings/_assistant_settings.html.erb
@@ -54,12 +54,12 @@
         <%= button_to t(".disconnect_button"),
               disconnect_external_assistant_settings_hosting_path,
               method: :delete,
-              class: "bg-red-600 fg-inverse text-sm font-medium rounded-lg px-4 py-2 whitespace-nowrap",
+              class: "bg-red-600 text-inverse text-sm font-medium rounded-lg px-4 py-2 whitespace-nowrap",
               data: { turbo_confirm: {
                 title: t(".confirm_disconnect.title"),
                 body: t(".confirm_disconnect.body"),
                 accept: t(".disconnect_button"),
-                acceptClass: "w-full bg-red-600 fg-inverse rounded-xl text-center p-[10px] border mb-2"
+                acceptClass: "w-full bg-red-600 text-inverse rounded-xl text-center p-[10px] border mb-2"
               }} %>
       </div>
     <% end %>

--- a/app/views/settings/hostings/_danger_zone_settings.html.erb
+++ b/app/views/settings/hostings/_danger_zone_settings.html.erb
@@ -7,12 +7,12 @@
       </div>
       <%=
             button_to t("settings.hostings.show.clear_cache"), clear_cache_settings_hosting_path, method: :delete,
-              class: "w-full md:w-auto bg-yellow-600 fg-inverse text-sm font-medium rounded-lg px-4 py-2",
+              class: "w-full md:w-auto bg-yellow-600 text-inverse text-sm font-medium rounded-lg px-4 py-2",
               data: { turbo_confirm: {
                 title: t("settings.hostings.show.confirm_clear_cache.title"),
                 body: t("settings.hostings.show.confirm_clear_cache.body"),
                 accept: t("settings.hostings.show.clear_cache"),
-                acceptClass: "w-full bg-yellow-600 fg-inverse rounded-xl text-center p-[10px] border mb-2"
+                acceptClass: "w-full bg-yellow-600 text-inverse rounded-xl text-center p-[10px] border mb-2"
               }}
       %>
     </div>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -70,7 +70,7 @@
             <div class="flex gap-2 items-center justify-between bg-container p-4 border border-alpha-black-25 rounded-lg">
               <div class="flex gap-2 items-center">
                 <div class="w-9 h-9 shrink-0">
-                  <div class="fg-inverse w-full h-full bg-surface-inset rounded-full flex items-center justify-center text-lg uppercase"><%= invitation.email[0] %></div>
+                  <div class="text-inverse w-full h-full bg-surface-inset rounded-full flex items-center justify-center text-lg uppercase"><%= invitation.email[0] %></div>
                 </div>
                 <div class="flex">
                   <p class="text-primary font-medium text-sm"><%= invitation.email %></p>

--- a/app/views/shared/_money_field.html.erb
+++ b/app/views/shared/_money_field.html.erb
@@ -22,7 +22,7 @@
       <div class="form-field__actions">
         <div data-controller="tooltip">
           <%= icon "help-circle", size: "sm", color: "default", class: "cursor-help" %>
-          <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-700 text-sm p-2 rounded w-64 text-white">
+          <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-inverse text-sm p-2 rounded w-64">
             <%= options[:label_tooltip] %>
           </div>
         </div>

--- a/app/views/shared/_text_tooltip.erb
+++ b/app/views/shared/_text_tooltip.erb
@@ -1,4 +1,4 @@
-<div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-700 text-sm px-1.5 py-1 rounded-md">
+<div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm px-1.5 py-1 rounded-md">
   <div class="text-inverse font-normal max-w-[200px]">
     <%= tooltip_text %>
   </div>

--- a/app/views/shared/_text_tooltip.erb
+++ b/app/views/shared/_text_tooltip.erb
@@ -1,5 +1,5 @@
 <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-700 text-sm px-1.5 py-1 rounded-md">
-  <div class="fg-inverse font-normal max-w-[200px]">
+  <div class="text-inverse font-normal max-w-[200px]">
     <%= tooltip_text %>
   </div>
 </div>

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -3,7 +3,7 @@
 <div id="cta">
   <%= tag.div class: "relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs", data: { controller: "element-removal" } do %>
     <div class="h-5 w-5 shrink-0 p-px text-primary">
-      <div class="flex h-full items-center justify-center rounded-full bg-success fg-inverse">
+      <div class="flex h-full items-center justify-center rounded-full bg-success text-inverse">
         <%= icon "check", size: "xs", color: "current" %>
       </div>
     </div>

--- a/design/tokens/README.md
+++ b/design/tokens/README.md
@@ -100,7 +100,7 @@ The same syntax appears inside composite values like `shadow.xs.$value`: `"0px 1
 - `utility.border-divider`: the value is a plain class string (`border-tertiary`) instead of a `{ref}`. The build treats values without `{}` as raw `@apply` arguments.
 - `utility.bg-overlay`: uses `sure.utility.raw: "background-color"` because it needs alpha rendering instead of `@apply`.
 - `utility.bg-loader`: uses `sure.compose` to apply two utilities together (`bg-surface-inset animate-pulse`).
-- `utility.button-bg-ghost-hover`: its dark value is a multi-class string (`bg-gray-800 fg-inverse`), not a single ref. The build accepts both forms.
+- `utility.button-bg-ghost-hover`: its dark value is a multi-class string (`bg-gray-800 text-inverse`), not a single ref. The build accepts both forms.
 
 ## Consumers
 

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://design-tokens.github.io/community-group/format/",
-  "$version": "1.0.0",
+  "$version": "2.0.0",
   "$description": "Sure design tokens. Single source of truth. Hand-edit; run `npm run tokens:build` to regenerate CSS. Template syntax in $value strings: `{path.to.token}` resolves to `var(--path-to-token)`; `{path|N%}` becomes `--alpha(var(--path) / N%)`. Utility tokens whose value lacks `{}` are treated as raw Tailwind class lists for @apply.",
 
   "font": {
@@ -275,15 +275,6 @@
       "$extensions": { "sure.compose": ["bg-surface-inset", "animate-pulse"] }
     },
 
-    "fg-gray":              { "$type": "utility", "$value": "{color.gray.500}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.400}" } },
-    "fg-contrast":          { "$type": "utility", "$value": "{color.gray.400}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.500}" } },
-    "fg-inverse":           { "$type": "utility", "$value": "{color.white}",    "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.900}" } },
-    "fg-primary":           { "$type": "utility", "$value": "{color.gray.900}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.white}" } },
-    "fg-primary-variant":   { "$type": "utility", "$value": "{color.gray.800}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.50}" } },
-    "fg-secondary":         { "$type": "utility", "$value": "{color.gray.50}",  "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.400}" } },
-    "fg-secondary-variant": { "$type": "utility", "$value": "{color.gray.100}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.500}" } },
-    "fg-subdued":           { "$type": "utility", "$value": "{color.gray.400}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.500}" } },
-
     "text-primary":   { "$type": "utility", "$value": "{color.gray.900}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.white}" } },
     "text-inverse":   { "$type": "utility", "$value": "{color.white}",    "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.900}" } },
     "text-secondary": { "$type": "utility", "$value": "{color.gray.500}", "$extensions": { "sure.utility": { "prefix": "text" }, "sure.dark": "{color.gray.300}" } },
@@ -346,7 +337,7 @@
     "button-bg-disabled":          { "$type": "utility", "$value": "{color.gray.50}",  "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.700}" } },
     "button-bg-destructive":       { "$type": "utility", "$value": "{color.red.500}",  "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.red.400}" } },
     "button-bg-destructive-hover": { "$type": "utility", "$value": "{color.red.600}",  "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.red.500}" } },
-    "button-bg-ghost-hover":       { "$type": "utility", "$value": "{color.gray.50}",  "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "bg-gray-800 fg-inverse" } },
+    "button-bg-ghost-hover":       { "$type": "utility", "$value": "{color.gray.50}",  "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "bg-gray-800 text-inverse" } },
     "button-bg-outline-hover":     { "$type": "utility", "$value": "{color.gray.100}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.700}" } },
 
     "tab-item-active":  { "$type": "utility", "$value": "{color.white}",     "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.700}" } },

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -21,7 +21,7 @@
     "success":     { "$value": "{color.green.600}",  "$type": "color", "$extensions": { "sure.dark": "{color.green.500}" } },
     "warning":     { "$value": "{color.yellow.600}", "$type": "color", "$extensions": { "sure.dark": "{color.yellow.400}" } },
     "destructive": { "$value": "{color.red.600}",    "$type": "color", "$extensions": { "sure.dark": "{color.red.400}" } },
-    "shadow":      { "$value": "{color.black|6%}",   "$type": "color", "$extensions": { "sure.dark": "{color.black|25%}" } },
+    "shadow":      { "$value": "{color.black|6%}",   "$type": "color", "$extensions": { "sure.dark": "{color.white|8%}" } },
 
     "gray": {
       "25":  { "$value": "#FAFAFA", "$type": "color" },
@@ -240,11 +240,11 @@
   },
 
   "shadow": {
-    "xs": { "$value": "0px 1px 2px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 2px 0px {color.black|25%}" } },
-    "sm": { "$value": "0px 1px 6px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 6px 0px {color.black|30%}" } },
-    "md": { "$value": "0px 4px 8px -2px {color.black|6%}",  "$type": "shadow", "$extensions": { "sure.dark": "0px 4px 8px -2px {color.black|35%}" } },
-    "lg": { "$value": "0px 12px 16px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 12px 16px -4px {color.black|40%}" } },
-    "xl": { "$value": "0px 20px 24px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 20px 24px -4px {color.black|50%}" } }
+    "xs": { "$value": "0px 1px 2px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 2px 0px {color.white|8%}" } },
+    "sm": { "$value": "0px 1px 6px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 6px 0px {color.white|8%}" } },
+    "md": { "$value": "0px 4px 8px -2px {color.black|6%}",  "$type": "shadow", "$extensions": { "sure.dark": "0px 4px 8px -2px {color.white|8%}" } },
+    "lg": { "$value": "0px 12px 16px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 12px 16px -4px {color.white|8%}" } },
+    "xl": { "$value": "0px 20px 24px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 20px 24px -4px {color.white|8%}" } }
   },
 
   "animate": {

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -21,7 +21,7 @@
     "success":     { "$value": "{color.green.600}",  "$type": "color", "$extensions": { "sure.dark": "{color.green.500}" } },
     "warning":     { "$value": "{color.yellow.600}", "$type": "color", "$extensions": { "sure.dark": "{color.yellow.400}" } },
     "destructive": { "$value": "{color.red.600}",    "$type": "color", "$extensions": { "sure.dark": "{color.red.400}" } },
-    "shadow":      { "$value": "{color.black|6%}",   "$type": "color", "$extensions": { "sure.dark": "{color.white|8%}" } },
+    "shadow":      { "$value": "{color.black|6%}",   "$type": "color", "$extensions": { "sure.dark": "{color.black|25%}" } },
 
     "gray": {
       "25":  { "$value": "#FAFAFA", "$type": "color" },
@@ -240,11 +240,11 @@
   },
 
   "shadow": {
-    "xs": { "$value": "0px 1px 2px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 2px 0px {color.white|8%}" } },
-    "sm": { "$value": "0px 1px 6px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 6px 0px {color.white|8%}" } },
-    "md": { "$value": "0px 4px 8px -2px {color.black|6%}",  "$type": "shadow", "$extensions": { "sure.dark": "0px 4px 8px -2px {color.white|8%}" } },
-    "lg": { "$value": "0px 12px 16px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 12px 16px -4px {color.white|8%}" } },
-    "xl": { "$value": "0px 20px 24px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 20px 24px -4px {color.white|8%}" } }
+    "xs": { "$value": "0px 1px 2px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 2px 0px {color.black|25%}" } },
+    "sm": { "$value": "0px 1px 6px 0px {color.black|6%}",   "$type": "shadow", "$extensions": { "sure.dark": "0px 1px 6px 0px {color.black|30%}" } },
+    "md": { "$value": "0px 4px 8px -2px {color.black|6%}",  "$type": "shadow", "$extensions": { "sure.dark": "0px 4px 8px -2px {color.black|35%}" } },
+    "lg": { "$value": "0px 12px 16px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 12px 16px -4px {color.black|40%}" } },
+    "xl": { "$value": "0px 20px 24px -4px {color.black|6%}","$type": "shadow", "$extensions": { "sure.dark": "0px 20px 24px -4px {color.black|50%}" } }
   },
 
   "animate": {

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -329,6 +329,7 @@
     "border-subdued":     { "$type": "utility", "$value": "{color.alpha-black.50}",  "$extensions": { "sure.utility": { "prefix": "border" }, "sure.dark": "{color.alpha-white.100}" } },
     "border-solid":       { "$type": "utility", "$value": "{color.black}",           "$extensions": { "sure.utility": { "prefix": "border" }, "sure.dark": "{color.white}" } },
     "border-destructive": { "$type": "utility", "$value": "{color.red.500}",         "$extensions": { "sure.utility": { "prefix": "border" }, "sure.dark": "{color.red.400}" } },
+    "border-inverse":     { "$type": "utility", "$value": "{color.alpha-white.200}", "$extensions": { "sure.utility": { "prefix": "border" }, "sure.dark": "{color.alpha-black.300}" } },
 
     "button-bg-primary":           { "$type": "utility", "$value": "{color.gray.900}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.white}" } },
     "button-bg-primary-hover":     { "$type": "utility", "$value": "{color.gray.800}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.50}" } },

--- a/test/components/previews/design_tokens_preview.rb
+++ b/test/components/previews/design_tokens_preview.rb
@@ -48,10 +48,7 @@ class DesignTokensPreview < ViewComponent::Preview
   end
 
   def text
-    render_with_template(locals: {
-      text_utilities: collect_utilities { |name| name.start_with?("text-") },
-      fg_utilities:   collect_utilities { |name| name.start_with?("fg-") }
-    })
+    render_with_template(locals: { utilities: collect_utilities { |name| name.start_with?("text-") } })
   end
 
   def borders

--- a/test/components/previews/design_tokens_preview/effects.html.erb
+++ b/test/components/previews/design_tokens_preview/effects.html.erb
@@ -14,7 +14,7 @@
     <div class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
       <% shadows.each do |s| %>
         <div class="<%= card %>">
-          <div class="h-16 w-full rounded-md bg-container" style="box-shadow: <%= s[:light_resolved] %>"></div>
+          <div class="h-16 w-full rounded-md bg-container" style="box-shadow: var(<%= s[:var] %>)"></div>
           <p class="<%= label %>"><%= s[:var] %></p>
           <p class="<%= meta %> truncate"><%= s[:light_raw] %></p>
           <% if s[:dark_raw] %>

--- a/test/components/previews/design_tokens_preview/text.html.erb
+++ b/test/components/previews/design_tokens_preview/text.html.erb
@@ -3,59 +3,34 @@
   meta        = "text-xs text-secondary font-mono"
   light_ctx   = "rounded p-3 bg-surface"
   dark_ctx    = "rounded p-3 bg-gray-900"
-
-  render_group = ->(items) {
-    capture do
-      content_tag(:div, class: "grid gap-3 grid-cols-1 lg:grid-cols-2") do
-        safe_join(items.map do |u|
-          content_tag(:div, class: card) do
-            safe_join([
-              content_tag(:div, class: "grid grid-cols-2 gap-2") do
-                safe_join([
-                  content_tag(:div, class: light_ctx) do
-                    content_tag(:p, "Quick brown fox", class: "text-sm font-medium #{u[:name]}")
-                  end,
-                  content_tag(:div, class: dark_ctx) do
-                    content_tag(:p, "Quick brown fox", class: "text-sm font-medium #{u[:name]}")
-                  end
-                ])
-              end,
-              content_tag(:div, class: "space-y-0.5") do
-                safe_join([
-                  content_tag(:p, u[:name], class: "text-xs font-medium text-primary"),
-                  content_tag(:p, u[:light_resolved] || u[:light_value], class: "#{meta} truncate"),
-                  (u[:dark_value] ? content_tag(:p, "dark: #{u[:dark_resolved] || u[:dark_value]}", class: "#{meta} truncate text-subdued") : nil)
-                ].compact)
-              end
-            ])
-          end
-        end)
-      end
-    end
-  }
 %>
-<div class="bg-surface min-h-screen p-6 space-y-10">
+<div class="bg-surface min-h-screen p-6 space-y-6">
   <header>
     <h2 class="text-2xl font-semibold text-primary">Text &amp; foregrounds</h2>
     <p class="text-sm text-secondary">
-      Each example renders the literal class on a light <em>and</em> a dark surface so utilities meant for inverse contexts show their intended state.
+      <code class="font-mono">text-*</code> utilities. Each example renders the literal class on a light <em>and</em> a dark surface so utilities meant for inverse contexts show their intended state.
     </p>
   </header>
 
-  <section class="space-y-3">
-    <header class="space-y-1">
-      <h3 class="text-lg font-medium text-primary"><code class="font-mono">text-*</code> <span class="text-xs text-secondary font-normal">(canonical, ~2,000 uses across the codebase)</span></h3>
-    </header>
-    <%= render_group.call(text_utilities) %>
-  </section>
-
-  <section class="space-y-3">
-    <header class="space-y-1">
-      <h3 class="text-lg font-medium text-primary"><code class="font-mono">fg-*</code> <span class="text-xs text-warning font-normal">(legacy — prefer <code class="font-mono">text-*</code>)</span></h3>
-      <p class="text-sm text-secondary">
-        Older namespace, ~40 uses left in the codebase. Most are 1:1 duplicates of a <code class="font-mono">text-*</code> equivalent. Tracked for migration; no new code should reference these.
-      </p>
-    </header>
-    <%= render_group.call(fg_utilities) %>
-  </section>
+  <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+    <% utilities.each do |u| %>
+      <div class="<%= card %>">
+        <div class="grid grid-cols-2 gap-2">
+          <div class="<%= light_ctx %>">
+            <p class="text-sm font-medium <%= u[:name] %>">Quick brown fox</p>
+          </div>
+          <div class="<%= dark_ctx %>">
+            <p class="text-sm font-medium <%= u[:name] %>">Quick brown fox</p>
+          </div>
+        </div>
+        <div class="space-y-0.5">
+          <p class="text-xs font-medium text-primary"><%= u[:name] %></p>
+          <p class="<%= meta %> truncate"><%= u[:light_resolved] || u[:light_value] %></p>
+          <% if u[:dark_value] %>
+            <p class="<%= meta %> truncate text-subdued">dark: <%= u[:dark_resolved] || u[:dark_value] %></p>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/test/components/previews/menu_component_preview.rb
+++ b/test/components/previews/menu_component_preview.rb
@@ -22,7 +22,7 @@ class MenuComponentPreview < ViewComponent::Preview
     def menu_contents(menu)
       menu.with_header do
         content_tag(:div, class: "p-3") do
-          content_tag(:h3, "Menu header", class: "font-medium text-gray-900")
+          content_tag(:h3, "Menu header", class: "font-medium text-primary")
         end
       end
 
@@ -35,8 +35,8 @@ class MenuComponentPreview < ViewComponent::Preview
       menu.with_custom_content do
         content_tag(:div, class: "p-4") do
           safe_join([
-            content_tag(:h3, "Custom content header", class: "font-medium text-gray-900"),
-            content_tag(:p, "Some custom content", class: "text-sm text-gray-500")
+            content_tag(:h3, "Custom content header", class: "font-medium text-primary"),
+            content_tag(:p, "Some custom content", class: "text-sm text-secondary")
           ])
         end
       end


### PR DESCRIPTION
## Summary

The design system has two parallel namespaces for foreground colors: `text-*` (canonical, ~2,000 usages) and `fg-*` (32 usages). Most `fg-*` tokens are 1:1 duplicates of their `text-*` counterpart; `fg-gray` is the only one with a real visual delta against the closest equivalent (one shade lighter in dark mode).

This PR migrates the 32 `fg-*` usages to `text-*` and drops the `fg-*` block from the design tokens. Closes #1606.

## Mapping

| From | To | Count | Visual delta |
|---|---|---:|---|
| `fg-inverse` | `text-inverse` | 20 | none (identical) |
| `fg-gray` | `text-secondary` | 7 | dark only — gray-300 vs gray-400 |
| `fg-primary` | `text-primary` | 3 | none |
| `fg-subdued` | `text-subdued` | 2 | none |

Four other `fg-*` tokens (`fg-contrast`, `fg-primary-variant`, `fg-secondary`, `fg-secondary-variant`) had zero usages and are removed without replacement.

## Token JSON

- `$version` bumps `1.0.0` → `2.0.0` per the policy in #1620 (removing tokens is a breaking schema change).
- `button-bg-ghost-hover`'s dark value internally referenced `fg-inverse`; rewritten to `"bg-gray-800 text-inverse"`.
- New `border-inverse` utility, used by the value-tooltip `<hr>` divider (see polish section).
- `_generated.css` regenerated: 50 → 43 `@utility` blocks.

## Dark-mode polish (rolled in)

Reviewing Lookbook previews to validate the migration surfaced six pre-existing dark-mode bugs. Bundled here since they share a visual-review surface.

- **Tooltips.** Raw `bg-gray-700` paired with `text-inverse` produced dark-on-dark in dark mode. Swapped to `bg-inverse` across `DS::Tooltip` and four partials. Muted labels in `_value_tooltip` use `text-inverse opacity-70` — custom `@utility` blocks aren't modifier-aware, so `text-inverse/70` produced no class at all (caught by CodeRabbit + Codex, fixed in 0027c238).
- **`border-inverse`.** New utility for the value tooltip's `<hr>`; `border-secondary` would have gone invisible on the white pill in dark mode.
- **Lookbook layout body.** Added `text-primary`. Without it, child text fell through to browser-default black in dark mode and the Tabs preview content disappeared.
- **`<dialog>` element.** Browser UA stylesheets apply `color: black` directly to `<dialog>`, beating ancestor inheritance. Added `text-primary` to the element itself. Affects every modal and drawer in the real app, not just previews.
- **Menu preview.** Lookbook-only swap from raw `text-gray-900`/`500` to semantic tokens. The real `_user_menu.html.erb` was already correct.
- **Effects preview.** Shadow swatches piped resolved light-mode values into inline `style="box-shadow: ..."`, so the demo never updated when the theme toggled. Switched to `var(--shadow-X)`.

## Where to look in dark mode

App pages — the `fg-gray → text-secondary` swap is the only fg-* migration with a visible delta. Mostly affects default-color icons (`application_helper#icon` with `color: "default"`) which now render one shade lighter in dark mode:
- Sidebar nav icons and icon-only buttons throughout the app.
- Account list, transaction list (icon-heavy).
- Dashboard + account-detail charts (axis labels via `time_series_chart_controller.js`).

Lookbook — touched by the rolled-in polish:
- `DS / Tooltip`, `DS / Menu`, `DS / Tabs`, `DS / Dialog` (modal + drawer), `Design tokens / Effects`.

The 25 fg-* swaps with identical values shouldn't show change. Quick eyeball still worth it on: hosting settings buttons, profile invite avatars, account add flow, AI consent / family export / invitation forms.

## Test plan

- [x] `npm run tokens:build` produces no diff against `_generated.css`.
- [x] `bundle exec rails tailwindcss:build` succeeds.
- [x] `bin/rubocop -f github` clean.
- [ ] CI green.
- [ ] `bin/rails test` passes.
- [ ] Visual eyeball, app + Lookbook, light + dark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced legacy fg-* text utilities with new text-* equivalents and added a border-inverse utility.
  * Updated UI styling across components and templates: buttons, icons, dialogs, tooltips, charts, forms, avatars, and previews now use text-* and inverse-themed classes.
  * Design token and preview pages updated to reflect the new text-* utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
