### PR TITLE
fix(mercury): support named multiple API connections

### DIFF
--- a/app/controllers/mercury_items_controller.rb
+++ b/app/controllers/mercury_items_controller.rb
@@ -13,13 +13,18 @@ class MercuryItemsController < ApplicationController
   # Preload Mercury accounts in background (async, non-blocking)
   def preload_accounts
     begin
-      # Check if family has credentials
-      unless Current.family.has_mercury_credentials?
+      mercury_item = mercury_item_for_account_flow
+      unless mercury_item
+        render json: mercury_item_selection_error_payload
+        return
+      end
+
+      unless mercury_item.credentials_configured?
         render json: { success: false, error: "no_credentials", has_accounts: false }
         return
       end
 
-      cache_key = "mercury_accounts_#{Current.family.id}"
+      cache_key = mercury_accounts_cache_key(mercury_item)
 
       # Check if already cached
       cached_accounts = Rails.cache.read(cache_key)
@@ -29,8 +34,7 @@ class MercuryItemsController < ApplicationController
         return
       end
 
-      # Fetch from API
-      mercury_provider = Provider::MercuryAdapter.build_provider(family: Current.family)
+      mercury_provider = mercury_item.mercury_provider
 
       unless mercury_provider.present?
         render json: { success: false, error: "no_api_token", has_accounts: false }
@@ -58,28 +62,20 @@ class MercuryItemsController < ApplicationController
   # Fetch available accounts from Mercury API and show selection UI
   def select_accounts
     begin
-      # Check if family has Mercury credentials configured
-      unless Current.family.has_mercury_credentials?
-        if turbo_frame_request?
-          # Render setup modal for turbo frame requests
-          render partial: "mercury_items/setup_required", layout: false
-        else
-          # Redirect for regular requests
-          redirect_to settings_providers_path,
-                     alert: t(".no_credentials_configured",
-                            default: "Please configure your Mercury API token first in Provider Settings.")
-        end
+      @mercury_item = mercury_item_for_account_flow
+      unless @mercury_item
+        render_mercury_item_selection_failure(".no_credentials_configured")
         return
       end
 
-      cache_key = "mercury_accounts_#{Current.family.id}"
+      cache_key = mercury_accounts_cache_key(@mercury_item)
 
       # Try to get cached accounts first
       @available_accounts = Rails.cache.read(cache_key)
 
       # If not cached, fetch from API
       if @available_accounts.nil?
-        mercury_provider = Provider::MercuryAdapter.build_provider(family: Current.family)
+        mercury_provider = @mercury_item.mercury_provider
 
         unless mercury_provider.present?
           redirect_to settings_providers_path, alert: t(".no_api_token",
@@ -95,12 +91,8 @@ class MercuryItemsController < ApplicationController
         Rails.cache.write(cache_key, @available_accounts, expires_in: 5.minutes)
       end
 
-      # Filter out already linked accounts
-      mercury_item = Current.family.mercury_items.first
-      if mercury_item
-        linked_account_ids = mercury_item.mercury_accounts.joins(:account_provider).pluck(:account_id)
-        @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
-      end
+      linked_account_ids = @mercury_item.mercury_accounts.joins(:account_provider).pluck(:account_id)
+      @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
 
       @accountable_type = params[:accountable_type] || "Depository"
       @return_to = safe_return_to_path
@@ -133,19 +125,20 @@ class MercuryItemsController < ApplicationController
     selected_account_ids = params[:account_ids] || []
     accountable_type = params[:accountable_type] || "Depository"
     return_to = safe_return_to_path
+    mercury_item = mercury_item_for_account_flow
 
     if selected_account_ids.empty?
       redirect_to new_account_path, alert: t(".no_accounts_selected")
       return
     end
 
-    # Create or find mercury_item for this family
-    mercury_item = Current.family.mercury_items.first_or_create!(
-      name: "Mercury Connection"
-    )
+    unless mercury_item
+      redirect_to settings_providers_path, alert: t(".select_connection", default: "Choose a Mercury connection before linking accounts.")
+      return
+    end
 
     # Fetch account details from API
-    mercury_provider = Provider::MercuryAdapter.build_provider(family: Current.family)
+    mercury_provider = mercury_item.mercury_provider
     unless mercury_provider.present?
       redirect_to new_account_path, alert: t(".no_api_token")
       return
@@ -259,29 +252,21 @@ class MercuryItemsController < ApplicationController
       return
     end
 
-    # Check if family has Mercury credentials configured
-    unless Current.family.has_mercury_credentials?
-      if turbo_frame_request?
-        # Render setup modal for turbo frame requests
-        render partial: "mercury_items/setup_required", layout: false
-      else
-        # Redirect for regular requests
-        redirect_to settings_providers_path,
-                   alert: t(".no_credentials_configured",
-                          default: "Please configure your Mercury API token first in Provider Settings.")
-      end
+    @mercury_item = mercury_item_for_account_flow
+    unless @mercury_item
+      render_mercury_item_selection_failure(".no_credentials_configured")
       return
     end
 
     begin
-      cache_key = "mercury_accounts_#{Current.family.id}"
+      cache_key = mercury_accounts_cache_key(@mercury_item)
 
       # Try to get cached accounts first
       @available_accounts = Rails.cache.read(cache_key)
 
       # If not cached, fetch from API
       if @available_accounts.nil?
-        mercury_provider = Provider::MercuryAdapter.build_provider(family: Current.family)
+        mercury_provider = @mercury_item.mercury_provider
 
         unless mercury_provider.present?
           redirect_to settings_providers_path, alert: t(".no_api_token",
@@ -302,12 +287,8 @@ class MercuryItemsController < ApplicationController
         return
       end
 
-      # Filter out already linked accounts
-      mercury_item = Current.family.mercury_items.first
-      if mercury_item
-        linked_account_ids = mercury_item.mercury_accounts.joins(:account_provider).pluck(:account_id)
-        @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
-      end
+      linked_account_ids = @mercury_item.mercury_accounts.joins(:account_provider).pluck(:account_id)
+      @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
 
       if @available_accounts.empty?
         redirect_to accounts_path, alert: t(".all_accounts_already_linked")
@@ -337,6 +318,7 @@ class MercuryItemsController < ApplicationController
     account_id = params[:account_id]
     mercury_account_id = params[:mercury_account_id]
     return_to = safe_return_to_path
+    mercury_item = mercury_item_for_account_flow
 
     unless account_id.present? && mercury_account_id.present?
       redirect_to accounts_path, alert: t(".missing_parameters")
@@ -351,13 +333,13 @@ class MercuryItemsController < ApplicationController
       return
     end
 
-    # Create or find mercury_item for this family
-    mercury_item = Current.family.mercury_items.first_or_create!(
-      name: "Mercury Connection"
-    )
+    unless mercury_item
+      redirect_to settings_providers_path, alert: t(".select_connection", default: "Choose a Mercury connection before linking accounts.")
+      return
+    end
 
     # Fetch account details from API
-    mercury_provider = Provider::MercuryAdapter.build_provider(family: Current.family)
+    mercury_provider = mercury_item.mercury_provider
     unless mercury_provider.present?
       redirect_to accounts_path, alert: t(".no_api_token")
       return
@@ -423,7 +405,7 @@ class MercuryItemsController < ApplicationController
 
       if turbo_frame_request?
         flash.now[:notice] = t(".success")
-        @mercury_items = Current.family.mercury_items.ordered
+        @mercury_items = Current.family.mercury_items.active.ordered.includes(:syncs, :mercury_accounts)
         render turbo_stream: [
           turbo_stream.replace(
             "mercury-providers-panel",
@@ -457,7 +439,7 @@ class MercuryItemsController < ApplicationController
     if @mercury_item.update(mercury_item_params)
       if turbo_frame_request?
         flash.now[:notice] = t(".success")
-        @mercury_items = Current.family.mercury_items.ordered
+        @mercury_items = Current.family.mercury_items.active.ordered.includes(:syncs, :mercury_accounts)
         render turbo_stream: [
           turbo_stream.replace(
             "mercury-providers-panel",
@@ -750,7 +732,52 @@ class MercuryItemsController < ApplicationController
     end
 
     def mercury_item_params
-      params.require(:mercury_item).permit(:name, :sync_start_date, :token, :base_url)
+      permitted = params.require(:mercury_item).permit(:name, :sync_start_date, :token, :base_url)
+      permitted.delete(:token) if @mercury_item&.persisted? && permitted[:token].blank?
+      permitted
+    end
+
+    def mercury_items_with_credentials
+      Current.family.mercury_items.active.where.not(token: [ nil, "" ])
+    end
+
+    def mercury_item_for_account_flow
+      if params[:mercury_item_id].present?
+        return mercury_items_with_credentials.find_by(id: params[:mercury_item_id])
+      end
+
+      items = mercury_items_with_credentials.to_a
+      items.one? ? items.first : nil
+    end
+
+    def mercury_accounts_cache_key(mercury_item)
+      "mercury_accounts_#{Current.family.id}_#{mercury_item.id}"
+    end
+
+    def mercury_item_selection_error_payload
+      if mercury_items_with_credentials.count > 1 && params[:mercury_item_id].blank?
+        {
+          success: false,
+          error: "select_connection",
+          error_message: t(".select_connection", default: "Choose a Mercury connection before loading accounts."),
+          has_accounts: nil
+        }
+      else
+        { success: false, error: "no_credentials", has_accounts: false }
+      end
+    end
+
+    def render_mercury_item_selection_failure(translation_key)
+      if mercury_items_with_credentials.count > 1 && params[:mercury_item_id].blank?
+        redirect_to settings_providers_path,
+                    alert: t(".select_connection", default: "Choose a Mercury connection in Provider Settings.")
+      elsif turbo_frame_request?
+        render partial: "mercury_items/setup_required", layout: false
+      else
+        redirect_to settings_providers_path,
+                    alert: t(translation_key,
+                             default: "Please configure your Mercury API token first in Provider Settings.")
+      end
     end
 
     # Sanitize return_to parameter to prevent XSS attacks

--- a/app/controllers/mercury_items_controller.rb
+++ b/app/controllers/mercury_items_controller.rb
@@ -13,9 +13,10 @@ class MercuryItemsController < ApplicationController
   # Preload Mercury accounts in background (async, non-blocking)
   def preload_accounts
     begin
-      mercury_item = mercury_item_for_account_flow
+      account_flow = mercury_item_account_flow_context
+      mercury_item = account_flow[:mercury_item]
       unless mercury_item
-        render json: mercury_item_selection_error_payload
+        render json: mercury_item_selection_error_payload(account_flow[:credentialed_items])
         return
       end
 
@@ -62,9 +63,10 @@ class MercuryItemsController < ApplicationController
   # Fetch available accounts from Mercury API and show selection UI
   def select_accounts
     begin
-      @mercury_item = mercury_item_for_account_flow
+      account_flow = mercury_item_account_flow_context
+      @mercury_item = account_flow[:mercury_item]
       unless @mercury_item
-        render_mercury_item_selection_failure(".no_credentials_configured")
+        render_mercury_item_selection_failure(".no_credentials_configured", credentialed_items: account_flow[:credentialed_items])
         return
       end
 
@@ -125,12 +127,14 @@ class MercuryItemsController < ApplicationController
     selected_account_ids = params[:account_ids] || []
     accountable_type = params[:accountable_type] || "Depository"
     return_to = safe_return_to_path
-    mercury_item = mercury_item_for_account_flow
 
     if selected_account_ids.empty?
       redirect_to new_account_path, alert: t(".no_accounts_selected")
       return
     end
+
+    account_flow = mercury_item_account_flow_context
+    mercury_item = account_flow[:mercury_item]
 
     unless mercury_item
       redirect_to settings_providers_path, alert: t(".select_connection", default: "Choose a Mercury connection before linking accounts.")
@@ -252,9 +256,10 @@ class MercuryItemsController < ApplicationController
       return
     end
 
-    @mercury_item = mercury_item_for_account_flow
+    account_flow = mercury_item_account_flow_context
+    @mercury_item = account_flow[:mercury_item]
     unless @mercury_item
-      render_mercury_item_selection_failure(".no_credentials_configured")
+      render_mercury_item_selection_failure(".no_credentials_configured", credentialed_items: account_flow[:credentialed_items])
       return
     end
 
@@ -318,12 +323,14 @@ class MercuryItemsController < ApplicationController
     account_id = params[:account_id]
     mercury_account_id = params[:mercury_account_id]
     return_to = safe_return_to_path
-    mercury_item = mercury_item_for_account_flow
 
     unless account_id.present? && mercury_account_id.present?
       redirect_to accounts_path, alert: t(".missing_parameters")
       return
     end
+
+    account_flow = mercury_item_account_flow_context
+    mercury_item = account_flow[:mercury_item]
 
     @account = Current.family.accounts.find(account_id)
 
@@ -746,14 +753,20 @@ class MercuryItemsController < ApplicationController
       Current.family.mercury_items.active.ordered.select(&:credentials_configured?)
     end
 
-    def mercury_item_for_account_flow
+    def mercury_item_account_flow_context
       credentialed_items = mercury_items_with_credentials
+      mercury_item = nil
 
       if params[:mercury_item_id].present?
-        return credentialed_items.find { |item| item.id.to_s == params[:mercury_item_id].to_s }
+        mercury_item = credentialed_items.find { |item| item.id.to_s == params[:mercury_item_id].to_s }
+      elsif credentialed_items.one?
+        mercury_item = credentialed_items.first
       end
 
-      credentialed_items.one? ? credentialed_items.first : nil
+      {
+        mercury_item: mercury_item,
+        credentialed_items: credentialed_items
+      }
     end
 
     def mercury_accounts_cache_key(mercury_item)
@@ -764,8 +777,8 @@ class MercuryItemsController < ApplicationController
       permitted_params.key?(:token) || permitted_params.key?(:base_url)
     end
 
-    def mercury_item_selection_error_payload
-      if mercury_items_with_credentials.count > 1 && params[:mercury_item_id].blank?
+    def mercury_item_selection_error_payload(credentialed_items)
+      if mercury_item_selection_required?(credentialed_items)
         {
           success: false,
           error: "select_connection",
@@ -777,17 +790,21 @@ class MercuryItemsController < ApplicationController
       end
     end
 
-    def render_mercury_item_selection_failure(translation_key)
-      if mercury_items_with_credentials.count > 1 && params[:mercury_item_id].blank?
+    def render_mercury_item_selection_failure(fallback_translation_key, credentialed_items:)
+      if mercury_item_selection_required?(credentialed_items)
         redirect_to settings_providers_path,
                     alert: t(".select_connection", default: "Choose a Mercury connection in Provider Settings.")
       elsif turbo_frame_request?
         render partial: "mercury_items/setup_required", layout: false
       else
         redirect_to settings_providers_path,
-                    alert: t(translation_key,
+                    alert: t(fallback_translation_key,
                              default: "Please configure your Mercury API token first in Provider Settings.")
       end
+    end
+
+    def mercury_item_selection_required?(credentialed_items)
+      credentialed_items.count > 1 && params[:mercury_item_id].blank?
     end
 
     # Sanitize return_to parameter to prevent XSS attacks

--- a/app/controllers/mercury_items_controller.rb
+++ b/app/controllers/mercury_items_controller.rb
@@ -436,7 +436,12 @@ class MercuryItemsController < ApplicationController
   end
 
   def update
-    if @mercury_item.update(mercury_item_params)
+    permitted_params = mercury_item_params
+    expire_accounts_cache = mercury_accounts_cache_sensitive_update?(permitted_params)
+
+    if @mercury_item.update(permitted_params)
+      Rails.cache.delete(mercury_accounts_cache_key(@mercury_item)) if expire_accounts_cache
+
       if turbo_frame_request?
         flash.now[:notice] = t(".success")
         @mercury_items = Current.family.mercury_items.active.ordered.includes(:syncs, :mercury_accounts)
@@ -738,20 +743,25 @@ class MercuryItemsController < ApplicationController
     end
 
     def mercury_items_with_credentials
-      Current.family.mercury_items.active.where.not(token: [ nil, "" ])
+      Current.family.mercury_items.active.ordered.select(&:credentials_configured?)
     end
 
     def mercury_item_for_account_flow
+      credentialed_items = mercury_items_with_credentials
+
       if params[:mercury_item_id].present?
-        return mercury_items_with_credentials.find_by(id: params[:mercury_item_id])
+        return credentialed_items.find { |item| item.id.to_s == params[:mercury_item_id].to_s }
       end
 
-      items = mercury_items_with_credentials.to_a
-      items.one? ? items.first : nil
+      credentialed_items.one? ? credentialed_items.first : nil
     end
 
     def mercury_accounts_cache_key(mercury_item)
       "mercury_accounts_#{Current.family.id}_#{mercury_item.id}"
+    end
+
+    def mercury_accounts_cache_sensitive_update?(permitted_params)
+      permitted_params.key?(:token) || permitted_params.key?(:base_url)
     end
 
     def mercury_item_selection_error_payload

--- a/app/controllers/mercury_items_controller.rb
+++ b/app/controllers/mercury_items_controller.rb
@@ -66,7 +66,7 @@ class MercuryItemsController < ApplicationController
       account_flow = mercury_item_account_flow_context
       @mercury_item = account_flow[:mercury_item]
       unless @mercury_item
-        render_mercury_item_selection_failure(".no_credentials_configured", credentialed_items: account_flow[:credentialed_items])
+        render_mercury_item_selection_failure(credentialed_items: account_flow[:credentialed_items])
         return
       end
 
@@ -259,7 +259,7 @@ class MercuryItemsController < ApplicationController
     account_flow = mercury_item_account_flow_context
     @mercury_item = account_flow[:mercury_item]
     unless @mercury_item
-      render_mercury_item_selection_failure(".no_credentials_configured", credentialed_items: account_flow[:credentialed_items])
+      render_mercury_item_selection_failure(credentialed_items: account_flow[:credentialed_items])
       return
     end
 
@@ -790,7 +790,7 @@ class MercuryItemsController < ApplicationController
       end
     end
 
-    def render_mercury_item_selection_failure(fallback_translation_key, credentialed_items:)
+    def render_mercury_item_selection_failure(credentialed_items:)
       if mercury_item_selection_required?(credentialed_items)
         redirect_to settings_providers_path,
                     alert: t(".select_connection", default: "Choose a Mercury connection in Provider Settings.")
@@ -798,7 +798,7 @@ class MercuryItemsController < ApplicationController
         render partial: "mercury_items/setup_required", layout: false
       else
         redirect_to settings_providers_path,
-                    alert: t(fallback_translation_key,
+                    alert: t(".no_credentials_configured",
                              default: "Please configure your Mercury API token first in Provider Settings.")
       end
     end

--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -141,7 +141,7 @@ class Settings::ProvidersController < ApplicationController
       # Providers page only needs to know whether any Sophtron connections exist with valid credentials
       @sophtron_items = Current.family.sophtron_items.where.not(user_id: [ nil, "" ], access_key: [ nil, "" ]).ordered.select(:id)
       @coinstats_items = Current.family.coinstats_items.ordered # CoinStats panel needs account info for status display
-      @mercury_items = Current.family.mercury_items.ordered.select(:id)
+      @mercury_items = Current.family.mercury_items.active.ordered.includes(:syncs, :mercury_accounts)
       @coinbase_items = Current.family.coinbase_items.ordered # Coinbase panel needs name and sync info for status display
       @snaptrade_items = Current.family.snaptrade_items.includes(:snaptrade_accounts).ordered
       @indexa_capital_items = Current.family.indexa_capital_items.ordered.select(:id)

--- a/app/models/family/mercury_connectable.rb
+++ b/app/models/family/mercury_connectable.rb
@@ -23,6 +23,6 @@ module Family::MercuryConnectable
   end
 
   def has_mercury_credentials?
-    mercury_items.where.not(token: nil).exists?
+    mercury_items.active.where.not(token: [ nil, "" ]).exists?
   end
 end

--- a/app/models/family/mercury_connectable.rb
+++ b/app/models/family/mercury_connectable.rb
@@ -23,6 +23,6 @@ module Family::MercuryConnectable
   end
 
   def has_mercury_credentials?
-    mercury_items.active.where.not(token: [ nil, "" ]).exists?
+    mercury_items.active.any?(&:credentials_configured?)
   end
 end

--- a/app/models/mercury_item.rb
+++ b/app/models/mercury_item.rb
@@ -168,7 +168,7 @@ class MercuryItem < ApplicationRecord
   end
 
   def credentials_configured?
-    token.present?
+    token.to_s.strip.present?
   end
 
   def effective_base_url

--- a/app/models/provider/mercury_adapter.rb
+++ b/app/models/provider/mercury_adapter.rb
@@ -48,8 +48,8 @@ class Provider::MercuryAdapter < Provider::Base
 
     {
       key: mercury_item.present? ? "mercury_#{mercury_item.id}" : "mercury",
-      name: mercury_item.present? ? "Mercury - #{mercury_item.name}" : "Mercury",
-      description: mercury_item.present? ? "Connect using #{mercury_item.name}" : "Connect to your bank via Mercury",
+      name: mercury_item.present? ? I18n.t("mercury_items.provider_connection.name", name: mercury_item.name) : I18n.t("mercury_items.provider_connection.default_name"),
+      description: mercury_item.present? ? I18n.t("mercury_items.provider_connection.description", name: mercury_item.name) : I18n.t("mercury_items.provider_connection.default_description"),
       can_connect: true,
       new_account_path: ->(accountable_type, return_to) {
         Rails.application.routes.url_helpers.select_accounts_mercury_items_path(

--- a/app/models/provider/mercury_adapter.rb
+++ b/app/models/provider/mercury_adapter.rb
@@ -36,7 +36,7 @@ class Provider::MercuryAdapter < Provider::Base
     return nil unless mercury_item&.credentials_configured?
 
     Provider::Mercury.new(
-      mercury_item.token,
+      mercury_item.token.to_s.strip,
       base_url: mercury_item.effective_base_url
     )
   end

--- a/app/models/provider/mercury_adapter.rb
+++ b/app/models/provider/mercury_adapter.rb
@@ -15,7 +15,7 @@ class Provider::MercuryAdapter < Provider::Base
   def self.connection_configs(family:)
     return [] unless family.can_connect_mercury?
 
-    mercury_items = family.mercury_items.active.where.not(token: [ nil, "" ]).ordered
+    mercury_items = family.mercury_items.active.ordered.select(&:credentials_configured?)
 
     return [ connection_config_for(nil) ] if mercury_items.empty?
 
@@ -68,10 +68,13 @@ class Provider::MercuryAdapter < Provider::Base
   def self.resolve_mercury_item(family, mercury_item)
     if mercury_item.present?
       mercury_item_id = mercury_item.respond_to?(:id) ? mercury_item.id : mercury_item
-      return family.mercury_items.active.find_by(id: mercury_item_id)
+      item = family.mercury_items.active.find_by(id: mercury_item_id)
+      return item if item&.credentials_configured?
+
+      return nil
     end
 
-    family.mercury_items.active.where.not(token: [ nil, "" ]).ordered.first
+    family.mercury_items.active.ordered.find(&:credentials_configured?)
   end
   private_class_method :resolve_mercury_item
 

--- a/app/models/provider/mercury_adapter.rb
+++ b/app/models/provider/mercury_adapter.rb
@@ -29,10 +29,10 @@ class Provider::MercuryAdapter < Provider::Base
   # Build a Mercury provider instance with family-specific credentials
   # @param family [Family] The family to get credentials for (required)
   # @return [Provider::Mercury, nil] Returns nil if credentials are not configured
-  def self.build_provider(family: nil, mercury_item: nil)
+  def self.build_provider(family: nil, mercury_item_id: nil)
     return nil unless family.present?
 
-    mercury_item = resolve_mercury_item(family, mercury_item)
+    mercury_item = resolve_mercury_item(family, mercury_item_id)
     return nil unless mercury_item&.credentials_configured?
 
     Provider::Mercury.new(
@@ -65,9 +65,8 @@ class Provider::MercuryAdapter < Provider::Base
   end
   private_class_method :connection_config_for
 
-  def self.resolve_mercury_item(family, mercury_item)
-    if mercury_item.present?
-      mercury_item_id = mercury_item.respond_to?(:id) ? mercury_item.id : mercury_item
+  def self.resolve_mercury_item(family, mercury_item_id)
+    if mercury_item_id.present?
       item = family.mercury_items.active.find_by(id: mercury_item_id)
       return item if item&.credentials_configured?
 

--- a/app/models/provider/mercury_adapter.rb
+++ b/app/models/provider/mercury_adapter.rb
@@ -15,23 +15,11 @@ class Provider::MercuryAdapter < Provider::Base
   def self.connection_configs(family:)
     return [] unless family.can_connect_mercury?
 
-    [ {
-      key: "mercury",
-      name: "Mercury",
-      description: "Connect to your bank via Mercury",
-      can_connect: true,
-      new_account_path: ->(accountable_type, return_to) {
-        Rails.application.routes.url_helpers.select_accounts_mercury_items_path(
-          accountable_type: accountable_type,
-          return_to: return_to
-        )
-      },
-      existing_account_path: ->(account_id) {
-        Rails.application.routes.url_helpers.select_existing_account_mercury_items_path(
-          account_id: account_id
-        )
-      }
-    } ]
+    mercury_items = family.mercury_items.active.where.not(token: [ nil, "" ]).ordered
+
+    return [ connection_config_for(nil) ] if mercury_items.empty?
+
+    mercury_items.map { |mercury_item| connection_config_for(mercury_item) }
   end
 
   def provider_name
@@ -41,11 +29,10 @@ class Provider::MercuryAdapter < Provider::Base
   # Build a Mercury provider instance with family-specific credentials
   # @param family [Family] The family to get credentials for (required)
   # @return [Provider::Mercury, nil] Returns nil if credentials are not configured
-  def self.build_provider(family: nil)
+  def self.build_provider(family: nil, mercury_item: nil)
     return nil unless family.present?
 
-    # Get family-specific credentials
-    mercury_item = family.mercury_items.where.not(token: nil).first
+    mercury_item = resolve_mercury_item(family, mercury_item)
     return nil unless mercury_item&.credentials_configured?
 
     Provider::Mercury.new(
@@ -53,6 +40,40 @@ class Provider::MercuryAdapter < Provider::Base
       base_url: mercury_item.effective_base_url
     )
   end
+
+  def self.connection_config_for(mercury_item)
+    path_params = ->(extra = {}) do
+      mercury_item.present? ? extra.merge(mercury_item_id: mercury_item.id) : extra
+    end
+
+    {
+      key: mercury_item.present? ? "mercury_#{mercury_item.id}" : "mercury",
+      name: mercury_item.present? ? "Mercury - #{mercury_item.name}" : "Mercury",
+      description: mercury_item.present? ? "Connect using #{mercury_item.name}" : "Connect to your bank via Mercury",
+      can_connect: true,
+      new_account_path: ->(accountable_type, return_to) {
+        Rails.application.routes.url_helpers.select_accounts_mercury_items_path(
+          path_params.call(accountable_type: accountable_type, return_to: return_to)
+        )
+      },
+      existing_account_path: ->(account_id) {
+        Rails.application.routes.url_helpers.select_existing_account_mercury_items_path(
+          path_params.call(account_id: account_id)
+        )
+      }
+    }
+  end
+  private_class_method :connection_config_for
+
+  def self.resolve_mercury_item(family, mercury_item)
+    if mercury_item.present?
+      mercury_item_id = mercury_item.respond_to?(:id) ? mercury_item.id : mercury_item
+      return family.mercury_items.active.find_by(id: mercury_item_id)
+    end
+
+    family.mercury_items.active.where.not(token: [ nil, "" ]).ordered.first
+  end
+  private_class_method :resolve_mercury_item
 
   def sync_path
     Rails.application.routes.url_helpers.sync_mercury_item_path(item)

--- a/app/views/mercury_items/select_accounts.html.erb
+++ b/app/views/mercury_items/select_accounts.html.erb
@@ -10,6 +10,7 @@
 
         <form action="<%= link_accounts_mercury_items_path %>" method="post" class="space-y-4" data-turbo-frame="_top">
           <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= hidden_field_tag :mercury_item_id, @mercury_item.id %>
           <%= hidden_field_tag :accountable_type, @accountable_type %>
           <%= hidden_field_tag :return_to, @return_to %>
 

--- a/app/views/mercury_items/select_existing_account.html.erb
+++ b/app/views/mercury_items/select_existing_account.html.erb
@@ -10,6 +10,7 @@
 
         <form action="<%= link_existing_account_mercury_items_path %>" method="post" class="space-y-4" data-turbo-frame="_top">
           <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= hidden_field_tag :mercury_item_id, @mercury_item.id %>
           <%= hidden_field_tag :account_id, @account.id %>
           <%= hidden_field_tag :return_to, @return_to %>
 

--- a/app/views/settings/providers/_mercury_panel.html.erb
+++ b/app/views/settings/providers/_mercury_panel.html.erb
@@ -1,6 +1,6 @@
 <div id="mercury-providers-panel" class="space-y-4">
-  <% items = local_assigns[:mercury_items] || @mercury_items || Current.family.mercury_items.active.ordered %>
-  <% credentialed_items = items.select(&:credentials_configured?) %>
+  <% active_items = local_assigns[:mercury_items] || @mercury_items || Current.family.mercury_items.active.ordered %>
+  <% credentialed_items = active_items.select(&:credentials_configured?) %>
 
   <div class="prose prose-sm text-secondary">
     <p class="text-primary font-medium"><%= t("mercury_items.provider_panel.setup_title") %></p>
@@ -24,9 +24,9 @@
     </div>
   <% end %>
 
-  <% if items.any? %>
+  <% if active_items.any? %>
     <div class="space-y-3">
-      <% items.each do |item| %>
+      <% active_items.each do |item| %>
         <details class="group bg-container p-4 shadow-border-xs rounded-xl">
           <summary class="flex items-center justify-between gap-2">
             <div class="flex items-center gap-3">
@@ -96,7 +96,7 @@
     </div>
   <% end %>
 
-  <details <%= "open" unless items.any? %> class="group bg-container p-4 shadow-border-xs rounded-xl">
+  <details <%= "open" unless active_items.any? %> class="group bg-container p-4 shadow-border-xs rounded-xl">
     <summary class="flex items-center gap-2 text-sm font-medium text-primary">
       <%= icon "plus" %>
       <%= t("mercury_items.provider_panel.add_connection") %>

--- a/app/views/settings/providers/_mercury_panel.html.erb
+++ b/app/views/settings/providers/_mercury_panel.html.erb
@@ -1,20 +1,19 @@
 <div id="mercury-providers-panel" class="space-y-4">
   <% items = local_assigns[:mercury_items] || @mercury_items || Current.family.mercury_items.active.ordered %>
+  <% credentialed_items = items.select(&:credentials_configured?) %>
 
   <div class="prose prose-sm text-secondary">
-    <p class="text-primary font-medium">Setup instructions:</p>
+    <p class="text-primary font-medium"><%= t("mercury_items.provider_panel.setup_title") %></p>
     <ol>
-      <li>Visit <a href="https://mercury.com" target="_blank" rel="noopener noreferrer" class="link">Mercury</a> and log in to the account you want to connect</li>
-      <li>Go to Settings > Developer > API Tokens</li>
-      <li>Create a new API token with "Read Only" access</li>
-      <li><strong>Important:</strong> Add your server's IP address to the token's whitelist</li>
-      <li>Copy the <strong>full token</strong> (including the <code>secret-token:</code> prefix) and add it as a named connection below</li>
+      <li><%= t("mercury_items.provider_panel.instructions.sign_in_html", link: link_to("Mercury", "https://mercury.com", target: "_blank", rel: "noopener noreferrer", class: "link")) %></li>
+      <li><%= t("mercury_items.provider_panel.instructions.open_tokens") %></li>
+      <li><%= t("mercury_items.provider_panel.instructions.create_token") %></li>
+      <li><%= t("mercury_items.provider_panel.instructions.whitelist_ip_html") %></li>
+      <li><%= t("mercury_items.provider_panel.instructions.copy_token_html") %></li>
     </ol>
 
     <p class="text-sm text-subdued mt-2">
-      Use a separate named connection for each Mercury login/API token you want to sync.
-      For sandbox testing, use <code>https://api-sandbox.mercury.com/api/v1</code> as the Base URL.
-      Mercury requires IP whitelisting - make sure to add your IP in the Mercury dashboard.
+      <%= t("mercury_items.provider_panel.sandbox_note_html") %>
     </p>
   </div>
 
@@ -32,32 +31,32 @@
           <summary class="flex items-center justify-between gap-2">
             <div class="flex items-center gap-3">
               <div class="flex items-center justify-center h-8 w-8 bg-blue-600/10 rounded-full">
-                <p class="text-blue-600 text-xs font-medium"><%= item.name.first.upcase %></p>
+                <p class="text-blue-600 text-xs font-medium"><%= item.name.to_s.first.to_s.upcase %></p>
               </div>
               <div>
                 <p class="font-medium text-primary"><%= item.name %></p>
                 <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>
               </div>
             </div>
+          </summary>
 
+          <div class="mt-4 space-y-4">
             <div class="flex items-center gap-2">
               <%= button_to sync_mercury_item_path(item),
                             method: :post,
                             class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-secondary hover:text-primary border border-secondary rounded-lg hover:border-primary",
                             disabled: item.syncing? do %>
                 <%= icon "refresh-cw", size: "sm" %>
-                Sync
+                <%= t("mercury_items.provider_panel.sync") %>
               <% end %>
               <%= button_to mercury_item_path(item),
                             method: :delete,
                             class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 rounded-lg",
-                            data: { turbo_confirm: "Disconnect #{item.name}?" } do %>
+                            data: { turbo_confirm: t("mercury_items.provider_panel.disconnect_confirm", name: item.name) } do %>
                 <%= icon "trash-2", size: "sm" %>
               <% end %>
             </div>
-          </summary>
 
-          <div class="mt-4 space-y-4">
             <%= styled_form_with model: item,
                                  url: mercury_item_path(item),
                                  scope: :mercury_item,
@@ -65,29 +64,29 @@
                                  data: { turbo: true },
                                  class: "space-y-3" do |form| %>
               <%= form.text_field :name,
-                                  label: "Connection name",
-                                  placeholder: "Business checking" %>
+                                  label: t("mercury_items.provider_panel.connection_name_label"),
+                                  placeholder: t("mercury_items.provider_panel.connection_name_placeholder") %>
 
               <%= form.text_field :token,
-                                  label: "Token",
-                                  placeholder: "Leave blank to keep the current token",
+                                  label: t("mercury_items.provider_panel.token_label"),
+                                  placeholder: t("mercury_items.provider_panel.keep_token_placeholder"),
                                   type: :password,
                                   value: nil %>
 
               <%= form.text_field :base_url,
-                                  label: "Base URL (optional)",
-                                  placeholder: "https://api.mercury.com/api/v1 (default)",
+                                  label: t("mercury_items.provider_panel.base_url_label"),
+                                  placeholder: t("mercury_items.provider_panel.base_url_placeholder"),
                                   value: item.base_url %>
 
               <div class="flex flex-wrap justify-end gap-2">
                 <%= render DS::Link.new(
-                  text: "Set up accounts",
+                  text: t("mercury_items.provider_panel.setup_accounts"),
                   icon: "settings",
                   variant: "secondary",
                   href: setup_accounts_mercury_item_path(item),
                   frame: :modal
                 ) %>
-                <%= form.submit "Update connection",
+                <%= form.submit t("mercury_items.provider_panel.update_connection"),
                                 class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
               </div>
             <% end %>
@@ -100,10 +99,10 @@
   <details <%= "open" unless items.any? %> class="group bg-container p-4 shadow-border-xs rounded-xl">
     <summary class="flex items-center gap-2 text-sm font-medium text-primary">
       <%= icon "plus" %>
-      Add Mercury connection
+      <%= t("mercury_items.provider_panel.add_connection") %>
     </summary>
 
-    <% mercury_item = Current.family.mercury_items.build(name: "Mercury Connection") %>
+    <% mercury_item = Current.family.mercury_items.build(name: t("mercury_items.provider_panel.default_connection_name")) %>
     <%= styled_form_with model: mercury_item,
                          url: mercury_items_path,
                          scope: :mercury_item,
@@ -111,33 +110,33 @@
                          data: { turbo: true },
                          class: "space-y-3 mt-4" do |form| %>
       <%= form.text_field :name,
-                          label: "Connection name",
-                          placeholder: "Business checking" %>
+                          label: t("mercury_items.provider_panel.connection_name_label"),
+                          placeholder: t("mercury_items.provider_panel.connection_name_placeholder") %>
 
       <%= form.text_field :token,
-                          label: "Token",
-                          placeholder: "Paste token here",
+                          label: t("mercury_items.provider_panel.token_label"),
+                          placeholder: t("mercury_items.provider_panel.token_placeholder"),
                           type: :password,
                           value: nil %>
 
       <%= form.text_field :base_url,
-                          label: "Base URL (optional)",
-                          placeholder: "https://api.mercury.com/api/v1 (default)" %>
+                          label: t("mercury_items.provider_panel.base_url_label"),
+                          placeholder: t("mercury_items.provider_panel.base_url_placeholder") %>
 
       <div class="flex justify-end">
-        <%= form.submit "Add connection",
+        <%= form.submit t("mercury_items.provider_panel.add_connection"),
                         class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
       </div>
     <% end %>
   </details>
 
   <div class="flex items-center gap-2">
-    <% if items.any? %>
+    <% if credentialed_items.any? %>
       <div class="w-2 h-2 bg-success rounded-full"></div>
-      <p class="text-sm text-secondary">Configured and ready to use. Visit the <a href="<%= accounts_path %>" class="link">Accounts</a> tab to manage and set up accounts.</p>
+      <p class="text-sm text-secondary"><%= t("mercury_items.provider_panel.configured_html", accounts_link: link_to(t("mercury_items.provider_panel.accounts_link"), accounts_path, class: "link")) %></p>
     <% else %>
       <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
-      <p class="text-sm text-secondary">Not configured</p>
+      <p class="text-sm text-secondary"><%= t("mercury_items.provider_panel.not_configured") %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/providers/_mercury_panel.html.erb
+++ b/app/views/settings/providers/_mercury_panel.html.erb
@@ -1,23 +1,19 @@
-<div class="space-y-4">
+<div id="mercury-providers-panel" class="space-y-4">
+  <% items = local_assigns[:mercury_items] || @mercury_items || Current.family.mercury_items.active.ordered %>
+
   <div class="prose prose-sm text-secondary">
     <p class="text-primary font-medium">Setup instructions:</p>
     <ol>
-      <li>Visit <a href="https://mercury.com" target="_blank" rel="noopener noreferrer" class="link">Mercury</a> and log in to your account</li>
+      <li>Visit <a href="https://mercury.com" target="_blank" rel="noopener noreferrer" class="link">Mercury</a> and log in to the account you want to connect</li>
       <li>Go to Settings > Developer > API Tokens</li>
       <li>Create a new API token with "Read Only" access</li>
       <li><strong>Important:</strong> Add your server's IP address to the token's whitelist</li>
-      <li>Copy the <strong>full token</strong> (including the <code>secret-token:</code> prefix) and paste it below</li>
-      <li>After a successful connection, go to the Accounts tab to set up new accounts</li>
+      <li>Copy the <strong>full token</strong> (including the <code>secret-token:</code> prefix) and add it as a named connection below</li>
     </ol>
 
-    <p class="text-primary font-medium">Field descriptions:</p>
-    <ul>
-      <li><strong>API Token:</strong> Your full Mercury API token including the <code>secret-token:</code> prefix (required)</li>
-      <li><strong>Base URL:</strong> Mercury API URL (optional, defaults to https://api.mercury.com/api/v1)</li>
-    </ul>
-
     <p class="text-sm text-subdued mt-2">
-      <strong>Note:</strong> For sandbox testing, use <code>https://api-sandbox.mercury.com/api/v1</code> as the Base URL.
+      Use a separate named connection for each Mercury login/API token you want to sync.
+      For sandbox testing, use <code>https://api-sandbox.mercury.com/api/v1</code> as the Base URL.
       Mercury requires IP whitelisting - make sure to add your IP in the Mercury dashboard.
     </p>
   </div>
@@ -29,40 +25,114 @@
     </div>
   <% end %>
 
-  <%
-    # Get or initialize a mercury_item for this family
-    # - If family has an item WITH credentials, use it (for updates)
-    # - If family has an item WITHOUT credentials, use it (to add credentials)
-    # - If family has no items at all, create a new one
-    mercury_item = Current.family.mercury_items.first_or_initialize(name: "Mercury Connection")
-    is_new_record = mercury_item.new_record?
-  %>
+  <% if items.any? %>
+    <div class="space-y-3">
+      <% items.each do |item| %>
+        <details class="group bg-container p-4 shadow-border-xs rounded-xl">
+          <summary class="flex items-center justify-between gap-2">
+            <div class="flex items-center gap-3">
+              <div class="flex items-center justify-center h-8 w-8 bg-blue-600/10 rounded-full">
+                <p class="text-blue-600 text-xs font-medium"><%= item.name.first.upcase %></p>
+              </div>
+              <div>
+                <p class="font-medium text-primary"><%= item.name %></p>
+                <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>
+              </div>
+            </div>
 
-  <%= styled_form_with model: mercury_item,
-                       url: is_new_record ? mercury_items_path : mercury_item_path(mercury_item),
-                       scope: :mercury_item,
-                       method: is_new_record ? :post : :patch,
-                       data: { turbo: true },
-                       class: "space-y-3" do |form| %>
-    <%= form.text_field :token,
-                        label: "Token",
-                        placeholder: is_new_record ? "Paste token here" : "Enter new token to update",
-                        type: :password %>
+            <div class="flex items-center gap-2">
+              <%= button_to sync_mercury_item_path(item),
+                            method: :post,
+                            class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-secondary hover:text-primary border border-secondary rounded-lg hover:border-primary",
+                            disabled: item.syncing? do %>
+                <%= icon "refresh-cw", size: "sm" %>
+                Sync
+              <% end %>
+              <%= button_to mercury_item_path(item),
+                            method: :delete,
+                            class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 rounded-lg",
+                            data: { turbo_confirm: "Disconnect #{item.name}?" } do %>
+                <%= icon "trash-2", size: "sm" %>
+              <% end %>
+            </div>
+          </summary>
 
-    <%= form.text_field :base_url,
-                        label: "Base Url (Optional)",
-                        placeholder: "https://api.mercury.com/api/v1 (default)",
-                        value: mercury_item.base_url %>
+          <div class="mt-4 space-y-4">
+            <%= styled_form_with model: item,
+                                 url: mercury_item_path(item),
+                                 scope: :mercury_item,
+                                 method: :patch,
+                                 data: { turbo: true },
+                                 class: "space-y-3" do |form| %>
+              <%= form.text_field :name,
+                                  label: "Connection name",
+                                  placeholder: "Business checking" %>
 
-    <div class="flex justify-end">
-      <%= form.submit is_new_record ? "Save Configuration" : "Update Configuration",
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+              <%= form.text_field :token,
+                                  label: "Token",
+                                  placeholder: "Leave blank to keep the current token",
+                                  type: :password,
+                                  value: nil %>
+
+              <%= form.text_field :base_url,
+                                  label: "Base URL (optional)",
+                                  placeholder: "https://api.mercury.com/api/v1 (default)",
+                                  value: item.base_url %>
+
+              <div class="flex flex-wrap justify-end gap-2">
+                <%= render DS::Link.new(
+                  text: "Set up accounts",
+                  icon: "settings",
+                  variant: "secondary",
+                  href: setup_accounts_mercury_item_path(item),
+                  frame: :modal
+                ) %>
+                <%= form.submit "Update connection",
+                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+              </div>
+            <% end %>
+          </div>
+        </details>
+      <% end %>
     </div>
   <% end %>
 
-  <% items = local_assigns[:mercury_items] || @mercury_items || Current.family.mercury_items.where.not(token: [nil, ""]) %>
+  <details <%= "open" unless items.any? %> class="group bg-container p-4 shadow-border-xs rounded-xl">
+    <summary class="flex items-center gap-2 text-sm font-medium text-primary">
+      <%= icon "plus" %>
+      Add Mercury connection
+    </summary>
+
+    <% mercury_item = Current.family.mercury_items.build(name: "Mercury Connection") %>
+    <%= styled_form_with model: mercury_item,
+                         url: mercury_items_path,
+                         scope: :mercury_item,
+                         method: :post,
+                         data: { turbo: true },
+                         class: "space-y-3 mt-4" do |form| %>
+      <%= form.text_field :name,
+                          label: "Connection name",
+                          placeholder: "Business checking" %>
+
+      <%= form.text_field :token,
+                          label: "Token",
+                          placeholder: "Paste token here",
+                          type: :password,
+                          value: nil %>
+
+      <%= form.text_field :base_url,
+                          label: "Base URL (optional)",
+                          placeholder: "https://api.mercury.com/api/v1 (default)" %>
+
+      <div class="flex justify-end">
+        <%= form.submit "Add connection",
+                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+      </div>
+    <% end %>
+  </details>
+
   <div class="flex items-center gap-2">
-    <% if items&.any? %>
+    <% if items.any? %>
       <div class="w-2 h-2 bg-success rounded-full"></div>
       <p class="text-sm text-secondary">Configured and ready to use. Visit the <a href="<%= accounts_path %>" class="link">Accounts</a> tab to manage and set up accounts.</p>
     <% else %>

--- a/config/locales/views/mercury_items/en.yml
+++ b/config/locales/views/mercury_items/en.yml
@@ -43,6 +43,31 @@ en:
       syncing: Syncing...
       total: Total
       unlinked: Unlinked
+    provider_panel:
+      accounts_link: Accounts
+      add_connection: Add Mercury connection
+      base_url_label: Base URL (optional)
+      base_url_placeholder: https://api.mercury.com/api/v1 (default)
+      configured_html: "Configured and ready to use. Visit the %{accounts_link} tab to manage and set up accounts."
+      connection_name_label: Connection name
+      connection_name_placeholder: Business checking
+      default_connection_name: Mercury Connection
+      disconnect_confirm: "Disconnect %{name}?"
+      instructions:
+        copy_token_html: "Copy the <strong>full token</strong> (including the <code>secret-token:</code> prefix) and add it as a named connection below"
+        create_token: Create a new API token with "Read Only" access
+        open_tokens: Go to Settings > Developer > API Tokens
+        sign_in_html: "Visit %{link} and log in to the account you want to connect"
+        whitelist_ip_html: "<strong>Important:</strong> Add your server's IP address to the token's whitelist"
+      keep_token_placeholder: Leave blank to keep the current token
+      not_configured: Not configured
+      sandbox_note_html: "Use a separate named connection for each Mercury login/API token you want to sync. For sandbox testing, use <code>https://api-sandbox.mercury.com/api/v1</code> as the Base URL. Mercury requires IP whitelisting - make sure to add your IP in the Mercury dashboard."
+      setup_accounts: Set up accounts
+      setup_title: "Setup instructions:"
+      sync: Sync
+      token_label: Token
+      token_placeholder: Paste token here
+      update_connection: Update connection
     select_accounts:
       accounts_selected: accounts selected
       api_error: "API error: %{message}"

--- a/config/locales/views/mercury_items/en.yml
+++ b/config/locales/views/mercury_items/en.yml
@@ -23,6 +23,7 @@ en:
       no_api_token: Mercury API token not found. Please configure it in Provider Settings.
       partial_invalid: "Successfully linked %{created_count} account(s), %{already_linked_count} were already linked, %{invalid_count} account(s) had invalid names"
       partial_success: "Successfully linked %{created_count} account(s). %{already_linked_count} account(s) were already linked: %{already_linked_names}"
+      select_connection: Choose a Mercury connection before linking accounts.
       success:
         one: "Successfully linked %{count} account"
         other: "Successfully linked %{count} accounts"
@@ -53,6 +54,7 @@ en:
       no_api_token: Mercury API token is not configured. Please configure it in Settings.
       no_credentials_configured: Please configure your Mercury API token first in Provider Settings.
       no_name_placeholder: "(No name)"
+      select_connection: Choose a Mercury connection in Provider Settings.
       title: Select Mercury Accounts
     select_existing_account:
       account_already_linked: This account is already linked to a provider
@@ -67,6 +69,7 @@ en:
       no_api_token: Mercury API token is not configured. Please configure it in Settings.
       no_credentials_configured: Please configure your Mercury API token first in Provider Settings.
       no_name_placeholder: "(No name)"
+      select_connection: Choose a Mercury connection in Provider Settings.
       title: "Link %{account_name} with Mercury"
     link_existing_account:
       account_already_linked: This account is already linked to a provider
@@ -76,6 +79,7 @@ en:
       mercury_account_not_found: Mercury account not found
       missing_parameters: Missing required parameters
       no_api_token: Mercury API token not found. Please configure it in Provider Settings.
+      select_connection: Choose a Mercury connection before linking accounts.
       success: "Successfully linked %{account_name} with Mercury"
     setup_accounts:
       account_type_label: "Account Type:"

--- a/config/locales/views/mercury_items/en.yml
+++ b/config/locales/views/mercury_items/en.yml
@@ -68,6 +68,11 @@ en:
       token_label: Token
       token_placeholder: Paste token here
       update_connection: Update connection
+    provider_connection:
+      default_description: Connect to your bank via Mercury
+      default_name: Mercury
+      description: "Connect using %{name}"
+      name: "Mercury - %{name}"
     select_accounts:
       accounts_selected: accounts selected
       api_error: "API error: %{message}"

--- a/test/controllers/mercury_items_controller_test.rb
+++ b/test/controllers/mercury_items_controller_test.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    Rails.cache.clear
+    SyncJob.stubs(:perform_later)
+
+    @family = families(:dylan_family)
+    @existing_item = mercury_items(:one)
+    @second_item = MercuryItem.create!(
+      family: @family,
+      name: "Business Mercury",
+      token: "second_mercury_token",
+      base_url: "https://api.mercury.com/api/v1"
+    )
+  end
+
+  teardown do
+    Rails.cache.clear
+  end
+
+  test "create adds a new mercury connection without overwriting existing credentials" do
+    existing_token = @existing_item.token
+
+    assert_difference "MercuryItem.count", 1 do
+      post mercury_items_url, params: {
+        mercury_item: {
+          name: "Joint Mercury",
+          token: "joint_mercury_token",
+          base_url: "https://api.mercury.com/api/v1"
+        }
+      }
+    end
+
+    assert_redirected_to accounts_path
+    assert_equal existing_token, @existing_item.reload.token
+    assert_equal "joint_mercury_token", @family.mercury_items.find_by!(name: "Joint Mercury").token
+  end
+
+  test "update changes only the selected mercury connection" do
+    existing_token = @existing_item.token
+
+    patch mercury_item_url(@second_item), params: {
+      mercury_item: {
+        name: "Renamed Business Mercury",
+        token: "updated_second_token",
+        base_url: "https://api-sandbox.mercury.com/api/v1"
+      }
+    }
+
+    assert_redirected_to accounts_path
+    assert_equal existing_token, @existing_item.reload.token
+    assert_equal "Renamed Business Mercury", @second_item.reload.name
+    assert_equal "updated_second_token", @second_item.token
+    assert_equal "https://api-sandbox.mercury.com/api/v1", @second_item.base_url
+  end
+
+  test "blank token update preserves the selected mercury token" do
+    original_token = @second_item.token
+
+    patch mercury_item_url(@second_item), params: {
+      mercury_item: {
+        name: "Renamed Business Mercury",
+        token: "",
+        base_url: "https://api.mercury.com/api/v1"
+      }
+    }
+
+    assert_redirected_to accounts_path
+    assert_equal "Renamed Business Mercury", @second_item.reload.name
+    assert_equal original_token, @second_item.token
+  end
+
+  test "preload accounts uses selected mercury item cache key" do
+    Rails.cache.expects(:read).with(mercury_cache_key(@second_item)).returns(nil)
+    Rails.cache.expects(:write).with(mercury_cache_key(@second_item), mercury_accounts_payload, expires_in: 5.minutes)
+
+    provider = mock("mercury_provider")
+    provider.expects(:get_accounts).returns(accounts: mercury_accounts_payload)
+    Provider::Mercury.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    get preload_accounts_mercury_items_url, params: { mercury_item_id: @second_item.id }, as: :json
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal true, response["success"]
+    assert_equal true, response["has_accounts"]
+  end
+
+  test "select accounts requires an explicit connection when multiple mercury items exist" do
+    get select_accounts_mercury_items_url, params: { accountable_type: "Depository" }
+
+    assert_redirected_to settings_providers_path
+    assert_equal "Choose a Mercury connection in Provider Settings.", flash[:alert]
+  end
+
+  test "select accounts renders the selected mercury item id" do
+    Rails.cache.expects(:read).with(mercury_cache_key(@second_item)).returns(nil)
+    Rails.cache.expects(:write).with(mercury_cache_key(@second_item), mercury_accounts_payload, expires_in: 5.minutes)
+
+    provider = mock("mercury_provider")
+    provider.expects(:get_accounts).returns(accounts: mercury_accounts_payload)
+    Provider::Mercury.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    get select_accounts_mercury_items_url, params: {
+      mercury_item_id: @second_item.id,
+      accountable_type: "Depository"
+    }
+
+    assert_response :success
+    assert_includes @response.body, %(name="mercury_item_id")
+    assert_includes @response.body, %(value="#{@second_item.id}")
+  end
+
+  test "link accounts uses selected mercury item and allows duplicate upstream ids across items" do
+    @existing_item.mercury_accounts.create!(
+      account_id: "shared_mercury_account",
+      name: "Shared Checking",
+      currency: "USD",
+      current_balance: 1000
+    )
+
+    provider = mock("mercury_provider")
+    provider.expects(:get_accounts).returns(accounts: mercury_accounts_payload)
+    Provider::Mercury.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    assert_difference -> { @second_item.mercury_accounts.where(account_id: "shared_mercury_account").count }, 1 do
+      assert_difference "AccountProvider.count", 1 do
+        post link_accounts_mercury_items_url, params: {
+          mercury_item_id: @second_item.id,
+          account_ids: [ "shared_mercury_account" ],
+          accountable_type: "Depository"
+        }
+      end
+    end
+
+    assert_redirected_to accounts_path
+    assert_equal 1, @existing_item.mercury_accounts.where(account_id: "shared_mercury_account").count
+  end
+
+  test "link accounts does not silently use the first connection when multiple items exist" do
+    assert_no_difference "MercuryAccount.count" do
+      assert_no_difference "Account.count" do
+        post link_accounts_mercury_items_url, params: {
+          account_ids: [ "shared_mercury_account" ],
+          accountable_type: "Depository"
+        }
+      end
+    end
+
+    assert_redirected_to settings_providers_path
+    assert_equal "Choose a Mercury connection before linking accounts.", flash[:alert]
+  end
+
+  test "sync only queues a sync for the selected mercury item" do
+    assert_difference -> { Sync.where(syncable: @second_item).count }, 1 do
+      assert_no_difference -> { Sync.where(syncable: @existing_item).count } do
+        post sync_mercury_item_url(@second_item)
+      end
+    end
+
+    assert_response :redirect
+  end
+
+  private
+
+    def mercury_accounts_payload
+      [
+        {
+          id: "shared_mercury_account",
+          nickname: "Shared Checking",
+          name: "Shared Checking",
+          status: "active",
+          type: "checking",
+          currentBalance: 1000
+        }
+      ]
+    end
+
+    def mercury_cache_key(mercury_item)
+      "mercury_accounts_#{@family.id}_#{mercury_item.id}"
+    end
+end

--- a/test/controllers/mercury_items_controller_test.rb
+++ b/test/controllers/mercury_items_controller_test.rb
@@ -75,7 +75,8 @@ class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update expires selected mercury account cache when credentials change" do
-    Rails.cache.write(mercury_cache_key(@second_item), mercury_accounts_payload)
+    Rails.cache.expects(:delete).with(mercury_cache_key(@existing_item)).never
+    Rails.cache.expects(:delete).with(mercury_cache_key(@second_item)).once
 
     patch mercury_item_url(@second_item), params: {
       mercury_item: {
@@ -86,7 +87,6 @@ class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to accounts_path
-    assert_nil Rails.cache.read(mercury_cache_key(@second_item))
   end
 
   test "preload accounts uses selected mercury item cache key" do

--- a/test/controllers/mercury_items_controller_test.rb
+++ b/test/controllers/mercury_items_controller_test.rb
@@ -74,6 +74,21 @@ class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal original_token, @second_item.token
   end
 
+  test "update expires selected mercury account cache when credentials change" do
+    Rails.cache.write(mercury_cache_key(@second_item), mercury_accounts_payload)
+
+    patch mercury_item_url(@second_item), params: {
+      mercury_item: {
+        name: "Renamed Business Mercury",
+        token: "updated_second_token",
+        base_url: "https://api-sandbox.mercury.com/api/v1"
+      }
+    }
+
+    assert_redirected_to accounts_path
+    assert_nil Rails.cache.read(mercury_cache_key(@second_item))
+  end
+
   test "preload accounts uses selected mercury item cache key" do
     Rails.cache.expects(:read).with(mercury_cache_key(@second_item)).returns(nil)
     Rails.cache.expects(:write).with(mercury_cache_key(@second_item), mercury_accounts_payload, expires_in: 5.minutes)

--- a/test/controllers/mercury_items_controller_test.rb
+++ b/test/controllers/mercury_items_controller_test.rb
@@ -89,6 +89,19 @@ class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to accounts_path
   end
 
+  test "update does not expire selected mercury account cache for name-only changes" do
+    Rails.cache.expects(:delete).never
+
+    patch mercury_item_url(@second_item), params: {
+      mercury_item: {
+        name: "Renamed Business Mercury"
+      }
+    }
+
+    assert_redirected_to accounts_path
+    assert_equal "Renamed Business Mercury", @second_item.reload.name
+  end
+
   test "preload accounts uses selected mercury item cache key" do
     Rails.cache.expects(:read).with(mercury_cache_key(@second_item)).returns(nil)
     Rails.cache.expects(:write).with(mercury_cache_key(@second_item), mercury_accounts_payload, expires_in: 5.minutes)
@@ -134,6 +147,33 @@ class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, %(value="#{@second_item.id}")
   end
 
+  test "select existing account renders the selected mercury item id" do
+    account = @family.accounts.create!(
+      name: "Manual Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    Rails.cache.expects(:read).with(mercury_cache_key(@second_item)).returns(nil)
+    Rails.cache.expects(:write).with(mercury_cache_key(@second_item), mercury_accounts_payload, expires_in: 5.minutes)
+
+    provider = mock("mercury_provider")
+    provider.expects(:get_accounts).returns(accounts: mercury_accounts_payload)
+    Provider::Mercury.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    get select_existing_account_mercury_items_url, params: {
+      mercury_item_id: @second_item.id,
+      account_id: account.id
+    }
+
+    assert_response :success
+    assert_includes @response.body, %(name="mercury_item_id")
+    assert_includes @response.body, %(value="#{@second_item.id}")
+  end
+
   test "link accounts uses selected mercury item and allows duplicate upstream ids across items" do
     @existing_item.mercury_accounts.create!(
       account_id: "shared_mercury_account",
@@ -168,6 +208,27 @@ class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
         post link_accounts_mercury_items_url, params: {
           account_ids: [ "shared_mercury_account" ],
           accountable_type: "Depository"
+        }
+      end
+    end
+
+    assert_redirected_to settings_providers_path
+    assert_equal "Choose a Mercury connection before linking accounts.", flash[:alert]
+  end
+
+  test "link existing account does not silently use the first connection when multiple items exist" do
+    account = @family.accounts.create!(
+      name: "Manual Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    assert_no_difference "MercuryAccount.count" do
+      assert_no_difference "AccountProvider.count" do
+        post link_existing_account_mercury_items_url, params: {
+          account_id: account.id,
+          mercury_account_id: "shared_mercury_account"
         }
       end
     end

--- a/test/models/mercury_account_test.rb
+++ b/test/models/mercury_account_test.rb
@@ -44,6 +44,34 @@ class MercuryAccountTest < ActiveSupport::TestCase
     end
   end
 
+  test "same account_id can be linked under different mercury_items in the same family" do
+    item_a_2 = MercuryItem.create!(
+      family: @family_a,
+      name: "Family A Second Mercury",
+      token: "token_a_2",
+      base_url: "https://api-sandbox.mercury.com/api/v1",
+      status: "good"
+    )
+
+    MercuryAccount.create!(
+      mercury_item: @item_a,
+      account_id: "shared_merc_acc_1",
+      name: "Checking",
+      currency: "USD",
+      current_balance: 5000
+    )
+
+    assert_difference "MercuryAccount.count", 1 do
+      MercuryAccount.create!(
+        mercury_item: item_a_2,
+        account_id: "shared_merc_acc_1",
+        name: "Checking",
+        currency: "USD",
+        current_balance: 5000
+      )
+    end
+  end
+
   test "same account_id cannot appear twice under the same mercury_item" do
     MercuryAccount.create!(
       mercury_item: @item_a,

--- a/test/models/mercury_item_test.rb
+++ b/test/models/mercury_item_test.rb
@@ -22,6 +22,11 @@ class MercuryItemTest < ActiveSupport::TestCase
     assert_not @mercury_item.credentials_configured?
   end
 
+  test "credentials_configured returns false when token is whitespace" do
+    @mercury_item.token = "   "
+    assert_not @mercury_item.credentials_configured?
+  end
+
   test "effective_base_url returns custom url when set" do
     assert_equal "https://api-sandbox.mercury.com/api/v1", @mercury_item.effective_base_url
   end
@@ -52,6 +57,14 @@ class MercuryItemTest < ActiveSupport::TestCase
     )
     blank_item.update_column(:token, "")
 
+    whitespace_item = MercuryItem.create!(
+      family: family,
+      name: "Whitespace Mercury",
+      token: "temporary_token",
+      base_url: "https://api-sandbox.mercury.com/api/v1"
+    )
+    whitespace_item.update_column(:token, "   ")
+
     deleted_item = MercuryItem.create!(
       family: family,
       name: "Deleted Mercury",
@@ -62,6 +75,10 @@ class MercuryItemTest < ActiveSupport::TestCase
 
     refute family.has_mercury_credentials?
 
+    whitespace_item.update_column(:token, "configured_token")
+    assert family.has_mercury_credentials?
+
+    whitespace_item.update_column(:token, "   ")
     deleted_item.update!(scheduled_for_deletion: false)
     assert family.has_mercury_credentials?
   end

--- a/test/models/mercury_item_test.rb
+++ b/test/models/mercury_item_test.rb
@@ -42,6 +42,30 @@ class MercuryItemTest < ActiveSupport::TestCase
     assert_nil @mercury_item.mercury_provider
   end
 
+  test "family credential check ignores blank and scheduled for deletion items" do
+    family = families(:empty)
+    blank_item = MercuryItem.create!(
+      family: family,
+      name: "Blank Mercury",
+      token: "temporary_token",
+      base_url: "https://api-sandbox.mercury.com/api/v1"
+    )
+    blank_item.update_column(:token, "")
+
+    deleted_item = MercuryItem.create!(
+      family: family,
+      name: "Deleted Mercury",
+      token: "deleted_token",
+      base_url: "https://api-sandbox.mercury.com/api/v1",
+      scheduled_for_deletion: true
+    )
+
+    refute family.has_mercury_credentials?
+
+    deleted_item.update!(scheduled_for_deletion: false)
+    assert family.has_mercury_credentials?
+  end
+
   test "syncer returns MercuryItem::Syncer instance" do
     syncer = @mercury_item.send(:syncer)
     assert_instance_of MercuryItem::Syncer, syncer

--- a/test/models/provider/mercury_adapter_test.rb
+++ b/test/models/provider/mercury_adapter_test.rb
@@ -47,6 +47,20 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
     assert_includes existing_account_uri.query, "mercury_item_id=#{second_item.id}"
   end
 
+  test "connection configs ignore items with whitespace-only tokens" do
+    family = families(:dylan_family)
+    MercuryItem.create!(
+      family: family,
+      name: "Blank Mercury",
+      token: "temporary_token",
+      base_url: "https://api.mercury.com/api/v1"
+    ).update_column(:token, "   ")
+
+    configs = Provider::MercuryAdapter.connection_configs(family: family)
+
+    assert_equal [ "mercury_#{mercury_items(:one).id}" ], configs.map { |config| config[:key] }
+  end
+
   test "build_provider returns nil when family is nil" do
     assert_nil Provider::MercuryAdapter.build_provider(family: nil)
   end
@@ -89,5 +103,18 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
     )
 
     assert_nil Provider::MercuryAdapter.build_provider(family: family, mercury_item: other_item)
+  end
+
+  test "build_provider refuses explicit mercury item without usable credentials" do
+    family = families(:dylan_family)
+    blank_item = MercuryItem.create!(
+      family: family,
+      name: "Blank Mercury",
+      token: "temporary_token",
+      base_url: "https://api.mercury.com/api/v1"
+    )
+    blank_item.update_column(:token, "   ")
+
+    assert_nil Provider::MercuryAdapter.build_provider(family: family, mercury_item: blank_item)
   end
 end

--- a/test/models/provider/mercury_adapter_test.rb
+++ b/test/models/provider/mercury_adapter_test.rb
@@ -18,7 +18,7 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
 
     assert_equal 1, configs.length
     assert_equal "mercury", configs.first[:key]
-    assert_equal "Mercury", configs.first[:name]
+    assert_equal I18n.t("mercury_items.provider_connection.default_name"), configs.first[:name]
     assert configs.first[:can_connect]
   end
 
@@ -36,7 +36,10 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
 
     assert_equal 2, configs.length
     assert_equal [ "mercury_#{second_item.id}", "mercury_#{first_item.id}" ], configs.map { |config| config[:key] }
-    assert_equal [ "Mercury - Business Mercury", "Mercury - Test Mercury Connection" ], configs.map { |config| config[:name] }
+    assert_equal [
+      I18n.t("mercury_items.provider_connection.name", name: second_item.name),
+      I18n.t("mercury_items.provider_connection.name", name: first_item.name)
+    ], configs.map { |config| config[:name] }
 
     new_account_uri = URI.parse(configs.first[:new_account_path].call("Depository", "/accounts"))
     assert_equal "/mercury_items/select_accounts", new_account_uri.path

--- a/test/models/provider/mercury_adapter_test.rb
+++ b/test/models/provider/mercury_adapter_test.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 require "test_helper"
 
 class Provider::MercuryAdapterTest < ActiveSupport::TestCase
@@ -9,15 +11,40 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
     assert_not_includes Provider::MercuryAdapter.supported_account_types, "Investment"
   end
 
-  test "returns connection configs for any family" do
+  test "returns fallback connection config when no credentials exist yet" do
     # Mercury is a per-family provider - any family can connect
-    family = families(:dylan_family)
+    family = families(:empty)
     configs = Provider::MercuryAdapter.connection_configs(family: family)
 
     assert_equal 1, configs.length
     assert_equal "mercury", configs.first[:key]
     assert_equal "Mercury", configs.first[:name]
     assert configs.first[:can_connect]
+  end
+
+  test "returns one connection config per credentialed mercury item" do
+    family = families(:dylan_family)
+    first_item = mercury_items(:one)
+    second_item = MercuryItem.create!(
+      family: family,
+      name: "Business Mercury",
+      token: "second_mercury_token",
+      base_url: "https://api.mercury.com/api/v1"
+    )
+
+    configs = Provider::MercuryAdapter.connection_configs(family: family)
+
+    assert_equal 2, configs.length
+    assert_equal [ "mercury_#{second_item.id}", "mercury_#{first_item.id}" ], configs.map { |config| config[:key] }
+    assert_equal [ "Mercury - Business Mercury", "Mercury - Test Mercury Connection" ], configs.map { |config| config[:name] }
+
+    new_account_uri = URI.parse(configs.first[:new_account_path].call("Depository", "/accounts"))
+    assert_equal "/mercury_items/select_accounts", new_account_uri.path
+    assert_includes new_account_uri.query, "mercury_item_id=#{second_item.id}"
+
+    existing_account_uri = URI.parse(configs.first[:existing_account_path].call(accounts(:depository).id))
+    assert_equal "/mercury_items/select_existing_account", existing_account_uri.path
+    assert_includes existing_account_uri.query, "mercury_item_id=#{second_item.id}"
   end
 
   test "build_provider returns nil when family is nil" do
@@ -34,5 +61,33 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
     provider = Provider::MercuryAdapter.build_provider(family: family)
 
     assert_instance_of Provider::Mercury, provider
+  end
+
+  test "build_provider uses explicit mercury item credentials" do
+    family = families(:dylan_family)
+    second_item = MercuryItem.create!(
+      family: family,
+      name: "Business Mercury",
+      token: "second_mercury_token",
+      base_url: "https://api.mercury.com/api/v1"
+    )
+
+    provider = Provider::MercuryAdapter.build_provider(family: family, mercury_item: second_item)
+
+    assert_instance_of Provider::Mercury, provider
+    assert_equal "second_mercury_token", provider.token
+    assert_equal "https://api.mercury.com/api/v1", provider.base_url
+  end
+
+  test "build_provider refuses mercury items outside the family" do
+    family = families(:dylan_family)
+    other_item = MercuryItem.create!(
+      family: families(:empty),
+      name: "Other Mercury",
+      token: "other_mercury_token",
+      base_url: "https://api.mercury.com/api/v1"
+    )
+
+    assert_nil Provider::MercuryAdapter.build_provider(family: family, mercury_item: other_item)
   end
 end

--- a/test/models/provider/mercury_adapter_test.rb
+++ b/test/models/provider/mercury_adapter_test.rb
@@ -93,6 +93,20 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
     assert_equal "https://api.mercury.com/api/v1", provider.base_url
   end
 
+  test "build_provider strips surrounding token whitespace" do
+    family = families(:dylan_family)
+    second_item = MercuryItem.create!(
+      family: family,
+      name: "Business Mercury",
+      token: " second_mercury_token \n",
+      base_url: "https://api.mercury.com/api/v1"
+    )
+
+    provider = Provider::MercuryAdapter.build_provider(family: family, mercury_item: second_item)
+
+    assert_equal "second_mercury_token", provider.token
+  end
+
   test "build_provider refuses mercury items outside the family" do
     family = families(:dylan_family)
     other_item = MercuryItem.create!(

--- a/test/models/provider/mercury_adapter_test.rb
+++ b/test/models/provider/mercury_adapter_test.rb
@@ -89,7 +89,7 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
       base_url: "https://api.mercury.com/api/v1"
     )
 
-    provider = Provider::MercuryAdapter.build_provider(family: family, mercury_item: second_item)
+    provider = Provider::MercuryAdapter.build_provider(family: family, mercury_item_id: second_item.id)
 
     assert_instance_of Provider::Mercury, provider
     assert_equal "second_mercury_token", provider.token
@@ -105,7 +105,7 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
       base_url: "https://api.mercury.com/api/v1"
     )
 
-    provider = Provider::MercuryAdapter.build_provider(family: family, mercury_item: second_item)
+    provider = Provider::MercuryAdapter.build_provider(family: family, mercury_item_id: second_item.id)
 
     assert_equal "second_mercury_token", provider.token
   end
@@ -119,7 +119,7 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
       base_url: "https://api.mercury.com/api/v1"
     )
 
-    assert_nil Provider::MercuryAdapter.build_provider(family: family, mercury_item: other_item)
+    assert_nil Provider::MercuryAdapter.build_provider(family: family, mercury_item_id: other_item.id)
   end
 
   test "build_provider refuses explicit mercury item without usable credentials" do
@@ -132,6 +132,6 @@ class Provider::MercuryAdapterTest < ActiveSupport::TestCase
     )
     blank_item.update_column(:token, "   ")
 
-    assert_nil Provider::MercuryAdapter.build_provider(family: family, mercury_item: blank_item)
+    assert_nil Provider::MercuryAdapter.build_provider(family: family, mercury_item_id: blank_item.id)
   end
 end


### PR DESCRIPTION
## Summary
- Adds support for multiple named Mercury API connections per family.
- Preserves existing Mercury links while scoping discovery, account setup, cache behavior, and sync to the selected connection.

## What changed
- Removes hidden single-Mercury assumptions from the setup and sync flow.
- Keeps account discovery and linked account handling scoped to a specific Mercury item.
- Allows the same upstream Mercury account id to exist under different Mercury connections.

## Why
Some families need to connect more than one Mercury API credential. Treating Mercury as a single family-wide connection prevents complete syncing and makes credential updates risk overwriting an existing setup.

## Validation
- Draft-stage branch validation was run locally before opening this PR.
- Validation will be refreshed before this is marked ready for review.

## Notes
- Draft only; not ready for maintainer review yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage multiple Mercury connections per family with per-connection panels; sync, edit, disconnect, and add connections independently
  * Account linking and selection flows now require choosing a specific Mercury connection

* **Bug Fixes**
  * Ignore whitespace-only tokens when considering configured credentials
  * Allow the same upstream account ID to be linked under different Mercury connections in the same family
  * Cache and sync actions scoped to the selected connection

* **Localization**
  * Added UI copy for multi-connection flows and provider panel

* **Tests**
  * Expanded coverage for multi-connection flows, selection, cache/scoping, and credential handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->