### PR TITLE
fix: correct SnapTrade cash activity signs

### DIFF
--- a/app/models/snaptrade_account/activities_processor.rb
+++ b/app/models/snaptrade_account/activities_processor.rb
@@ -247,9 +247,9 @@ class SnaptradeAccount::ActivitiesProcessor
     def normalize_cash_amount(amount, activity_type)
       case activity_type
       when "WITHDRAWAL", "TRANSFER_OUT", "FEE", "TAX"
-        -amount.abs  # These should be negative (money out)
+        amount.abs   # Money out should be positive in Sure
       when "CONTRIBUTION", "TRANSFER_IN", "DIVIDEND", "DIV", "INTEREST", "CASH"
-        amount.abs   # These should be positive (money in)
+        -amount.abs  # Money in should be negative in Sure
       else
         amount
       end

--- a/test/models/snaptrade_account/activities_processor_test.rb
+++ b/test/models/snaptrade_account/activities_processor_test.rb
@@ -70,7 +70,7 @@ class SnaptradeAccount::ActivitiesProcessorTest < ActiveSupport::TestCase
     assert_equal "Sell", trade.investment_activity_label
   end
 
-  test "processes dividend cash activity" do
+  test "processes dividend cash activity as negative inflow" do
     @snaptrade_account.update!(raw_activities_payload: [
       build_cash_activity(
         id: "div_001",
@@ -89,10 +89,11 @@ class SnaptradeAccount::ActivitiesProcessorTest < ActiveSupport::TestCase
     assert entry.entryable.is_a?(Transaction), "Entry should be a Transaction"
 
     transaction = entry.entryable
+    assert_equal(-25.50, entry.amount.to_f)
     assert_equal "Dividend", transaction.investment_activity_label
   end
 
-  test "processes contribution with positive amount" do
+  test "processes contribution with negative inflow amount" do
     @snaptrade_account.update!(raw_activities_payload: [
       build_cash_activity(
         id: "contrib_001",
@@ -107,12 +108,11 @@ class SnaptradeAccount::ActivitiesProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by(external_id: "contrib_001", source: "snaptrade")
     assert_not_nil entry
-    # Amount is on entry, not transaction
-    assert_equal 500.00, entry.amount.to_f  # Positive for contributions
+    assert_equal(-500.00, entry.amount.to_f)
     assert_equal "Contribution", entry.entryable.investment_activity_label
   end
 
-  test "processes withdrawal with negative amount" do
+  test "processes withdrawal with positive outflow amount" do
     @snaptrade_account.update!(raw_activities_payload: [
       build_cash_activity(
         id: "withdraw_001",
@@ -127,8 +127,38 @@ class SnaptradeAccount::ActivitiesProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by(external_id: "withdraw_001", source: "snaptrade")
     assert_not_nil entry
-    assert_equal(-200.00, entry.amount.to_f)  # Negative for withdrawals
+    assert_equal 200.00, entry.amount.to_f
     assert_equal "Withdrawal", entry.entryable.investment_activity_label
+  end
+
+  test "processes transfers with Sure sign convention" do
+    @snaptrade_account.update!(raw_activities_payload: [
+      build_cash_activity(
+        id: "transfer_in_001",
+        type: "TRANSFER_IN",
+        amount: 300.00,
+        settlement_date: Date.current.to_s
+      ),
+      build_cash_activity(
+        id: "transfer_out_001",
+        type: "TRANSFER_OUT",
+        amount: 125.00,
+        settlement_date: Date.current.to_s
+      )
+    ])
+
+    processor = SnaptradeAccount::ActivitiesProcessor.new(@snaptrade_account)
+    processor.process
+
+    transfer_in = @account.entries.find_by(external_id: "transfer_in_001", source: "snaptrade")
+    transfer_out = @account.entries.find_by(external_id: "transfer_out_001", source: "snaptrade")
+
+    assert_not_nil transfer_in
+    assert_not_nil transfer_out
+    assert_equal(-300.00, transfer_in.amount.to_f)
+    assert_equal 125.00, transfer_out.amount.to_f
+    assert_equal "Transfer", transfer_in.entryable.investment_activity_label
+    assert_equal "Transfer", transfer_out.entryable.investment_activity_label
   end
 
   test "maps all known activity types correctly" do

--- a/test/models/snaptrade_account_processor_test.rb
+++ b/test/models/snaptrade_account_processor_test.rb
@@ -210,7 +210,7 @@ class SnaptradeAccountProcessorTest < ActiveSupport::TestCase
     assert_equal "Dividend", tx_entry.entryable.investment_activity_label
   end
 
-  test "activities processor normalizes withdrawal as negative amount" do
+  test "activities processor normalizes withdrawal as positive outflow amount" do
     @snaptrade_account.update!(
       raw_activities_payload: [
         {
@@ -228,7 +228,7 @@ class SnaptradeAccountProcessorTest < ActiveSupport::TestCase
 
     assert_equal 1, result[:transactions]
     tx_entry = @account.entries.find_by(external_id: "activity_withdraw_1")
-    assert tx_entry.amount.negative?
+    assert_equal 1000.00, tx_entry.amount.to_f
   end
 
   test "activities processor skips activities without external_id" do


### PR DESCRIPTION
## Summary
- fix SnapTrade cash activity sign normalization to match Sure conventions
- store inflows as negative amounts and outflows as positive amounts
- add coverage for dividends, contributions, withdrawals, and transfers

Closes #1242

## Details
Sure uses:
- negative amounts for inflows / income
- positive amounts for outflows / expenses

SnapTrade cash activity normalization was inverted for dividends and other cash movements. This patch corrects:
- `DIVIDEND`, `DIV`, `CONTRIBUTION`, `TRANSFER_IN`, `INTEREST`, `CASH` -> negative
- `WITHDRAWAL`, `TRANSFER_OUT`, `FEE`, `TAX` -> positive

## Testing
- not run locally in this OpenClaw container because Ruby is unavailable here
- CI should validate the updated SnapTrade activity processor tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cash transaction sign handling so deposits, withdrawals, dividends and contributions display with the correct positive/negative amounts for accurate balances.
  * Improved transfer processing so inbound/outbound transfers are recorded and labeled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->