### PR TITLE
feat(api): expose securities and price history

### DIFF
--- a/app/controllers/api/v1/securities_controller.rb
+++ b/app/controllers/api/v1/securities_controller.rb
@@ -82,12 +82,9 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
     def safe_per_page_param
       per_page = params[:per_page].to_i
 
-      case per_page
-      when 1..100
-        per_page
-      else
-        25
-      end
+      return 25 if per_page < 1
+
+      [ per_page, 100 ].min
     end
 
     def render_validation_error(message)

--- a/app/controllers/api/v1/securities_controller.rb
+++ b/app/controllers/api/v1/securities_controller.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class Api::V1::SecuritiesController < Api::V1::BaseController
+  include Pagy::Backend
+
+  InvalidFilterError = Class.new(StandardError)
+
+  before_action :ensure_read_scope
+  before_action :set_security, only: :show
+
+  def index
+    securities_query = apply_filters(securities_scope).order(:ticker, :exchange_operating_mic, :name)
+    @per_page = safe_per_page_param
+
+    @pagy, @securities = pagy(
+      securities_query,
+      page: safe_page_param,
+      limit: @per_page
+    )
+
+    render :index
+  rescue InvalidFilterError => e
+    render_validation_error(e.message)
+  end
+
+  def show
+    render :show
+  end
+
+  private
+
+    def set_security
+      raise ActiveRecord::RecordNotFound, "Security not found" unless valid_uuid?(params[:id])
+
+      @security = securities_scope.find(params[:id])
+    end
+
+    def ensure_read_scope
+      authorize_scope!(:read)
+    end
+
+    def securities_scope
+      Security
+        .where(id: holding_security_ids)
+        .or(Security.where(id: trade_security_ids))
+        .distinct
+    end
+
+    def holding_security_ids
+      Holding.where(account_id: accessible_account_ids).select(:security_id)
+    end
+
+    def trade_security_ids
+      Trade.joins(:entry).where(entries: { account_id: accessible_account_ids }).select(:security_id)
+    end
+
+    def accessible_account_ids
+      @accessible_account_ids ||= current_resource_owner.family.accounts.visible.accessible_by(current_resource_owner).select(:id)
+    end
+
+    def apply_filters(query)
+      query = query.where("securities.ticker ILIKE ?", params[:ticker].to_s.strip) if params[:ticker].present?
+      query = query.where(exchange_operating_mic: params[:exchange_operating_mic].to_s.upcase) if params[:exchange_operating_mic].present?
+      if params[:kind].present?
+        raise InvalidFilterError, "kind must be one of: #{Security::KINDS.join(', ')}" unless Security::KINDS.include?(params[:kind])
+
+        query = query.where(kind: params[:kind])
+      end
+      query = query.where(offline: ActiveModel::Type::Boolean.new.cast(params[:offline])) if params.key?(:offline)
+      query
+    end
+
+    def valid_uuid?(value)
+      value.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i)
+    end
+
+    def safe_page_param
+      page = params[:page].to_i
+      page > 0 ? page : 1
+    end
+
+    def safe_per_page_param
+      per_page = params[:per_page].to_i
+
+      case per_page
+      when 1..100
+        per_page
+      else
+        25
+      end
+    end
+
+    def render_validation_error(message)
+      render json: {
+        error: "validation_failed",
+        message: message,
+        errors: [ message ]
+      }, status: :unprocessable_entity
+    end
+end

--- a/app/controllers/api/v1/securities_controller.rb
+++ b/app/controllers/api/v1/securities_controller.rb
@@ -82,7 +82,7 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
     def parse_boolean_filter_param(key)
       normalized_value = params[key].to_s.strip.downcase
 
-      return nil if normalized_value.blank?
+      raise InvalidFilterError, "#{key} must be true or false" if normalized_value.blank?
       return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
 
       raise InvalidFilterError, "#{key} must be true or false"

--- a/app/controllers/api/v1/securities_controller.rb
+++ b/app/controllers/api/v1/securities_controller.rb
@@ -66,7 +66,7 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
 
     def apply_filters(query)
       query = query.where("securities.ticker ILIKE ?", params[:ticker].to_s.strip) if params[:ticker].present?
-      query = query.where(exchange_operating_mic: params[:exchange_operating_mic].to_s.upcase) if params[:exchange_operating_mic].present?
+      query = query.where(exchange_operating_mic: params[:exchange_operating_mic].to_s.strip.upcase) if params[:exchange_operating_mic].present?
       if params[:kind].present?
         raise InvalidFilterError, "kind must be one of: #{Security::KINDS.join(', ')}" unless Security::KINDS.include?(params[:kind])
 

--- a/app/controllers/api/v1/securities_controller.rb
+++ b/app/controllers/api/v1/securities_controller.rb
@@ -2,14 +2,9 @@
 
 class Api::V1::SecuritiesController < Api::V1::BaseController
   include Pagy::Backend
+  include Api::V1::SecurityResourceFiltering
 
   InvalidFilterError = Class.new(StandardError)
-  BOOLEAN_FILTERS = {
-    "true" => true,
-    "1" => true,
-    "false" => false,
-    "0" => false
-  }.freeze
 
   before_action :ensure_read_scope
   before_action :set_security, only: :show
@@ -47,25 +42,11 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
 
     def securities_scope
       Security
-        .where(id: holding_security_ids)
-        .or(Security.where(id: trade_security_ids))
-        .distinct
-    end
-
-    def holding_security_ids
-      Holding.where(account_id: accessible_account_ids).select(:security_id)
-    end
-
-    def trade_security_ids
-      Trade.joins(:entry).where(entries: { account_id: accessible_account_ids }).select(:security_id)
-    end
-
-    def accessible_account_ids
-      @accessible_account_ids ||= current_resource_owner.family.accounts.visible.accessible_by(current_resource_owner).select(:id)
+        .where(id: scoped_security_ids)
     end
 
     def apply_filters(query)
-      query = query.where("securities.ticker ILIKE ?", params[:ticker].to_s.strip) if params[:ticker].present?
+      query = query.where("LOWER(securities.ticker) = ?", params[:ticker].to_s.strip.downcase) if params[:ticker].present?
       query = query.where(exchange_operating_mic: params[:exchange_operating_mic].to_s.strip.upcase) if params[:exchange_operating_mic].present?
       if params[:kind].present?
         raise InvalidFilterError, "kind must be one of: #{Security::KINDS.join(', ')}" unless Security::KINDS.include?(params[:kind])
@@ -74,42 +55,8 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
       end
       if params.key?(:offline)
         offline = parse_boolean_filter_param(:offline)
-        query = query.where(offline: offline) unless offline.nil?
+        query = query.where(offline: offline)
       end
       query
-    end
-
-    def parse_boolean_filter_param(key)
-      normalized_value = params[key].to_s.strip.downcase
-
-      raise InvalidFilterError, "#{key} must be true or false" if normalized_value.blank?
-      return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
-
-      raise InvalidFilterError, "#{key} must be true or false"
-    end
-
-    def valid_uuid?(value)
-      value.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i)
-    end
-
-    def safe_page_param
-      page = params[:page].to_i
-      page > 0 ? page : 1
-    end
-
-    def safe_per_page_param
-      per_page = params[:per_page].to_i
-
-      return 25 if per_page < 1
-
-      [ per_page, 100 ].min
-    end
-
-    def render_validation_error(message)
-      render json: {
-        error: "validation_failed",
-        message: message,
-        errors: [ message ]
-      }, status: :unprocessable_entity
     end
 end

--- a/app/controllers/api/v1/securities_controller.rb
+++ b/app/controllers/api/v1/securities_controller.rb
@@ -4,8 +4,6 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
   include Pagy::Backend
   include Api::V1::SecurityResourceFiltering
 
-  InvalidFilterError = Class.new(StandardError)
-
   before_action :ensure_read_scope
   before_action :set_security, only: :show
 
@@ -20,7 +18,7 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
     )
 
     render :index
-  rescue InvalidFilterError => e
+  rescue Api::V1::SecurityResourceFiltering::InvalidFilterError => e
     render_validation_error(e.message)
   end
 
@@ -49,7 +47,7 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
       query = query.where("LOWER(securities.ticker) = ?", params[:ticker].to_s.strip.downcase) if params[:ticker].present?
       query = query.where(exchange_operating_mic: params[:exchange_operating_mic].to_s.strip.upcase) if params[:exchange_operating_mic].present?
       if params[:kind].present?
-        raise InvalidFilterError, "kind must be one of: #{Security::KINDS.join(', ')}" unless Security::KINDS.include?(params[:kind])
+        invalid_filter!("kind must be one of: #{Security::KINDS.join(', ')}") unless Security::KINDS.include?(params[:kind])
 
         query = query.where(kind: params[:kind])
       end

--- a/app/controllers/api/v1/securities_controller.rb
+++ b/app/controllers/api/v1/securities_controller.rb
@@ -4,6 +4,12 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
   include Pagy::Backend
 
   InvalidFilterError = Class.new(StandardError)
+  BOOLEAN_FILTERS = {
+    "true" => true,
+    "1" => true,
+    "false" => false,
+    "0" => false
+  }.freeze
 
   before_action :ensure_read_scope
   before_action :set_security, only: :show
@@ -66,8 +72,20 @@ class Api::V1::SecuritiesController < Api::V1::BaseController
 
         query = query.where(kind: params[:kind])
       end
-      query = query.where(offline: ActiveModel::Type::Boolean.new.cast(params[:offline])) if params.key?(:offline)
+      if params.key?(:offline)
+        offline = parse_boolean_filter_param(:offline)
+        query = query.where(offline: offline) unless offline.nil?
+      end
       query
+    end
+
+    def parse_boolean_filter_param(key)
+      normalized_value = params[key].to_s.strip.downcase
+
+      return nil if normalized_value.blank?
+      return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
+
+      raise InvalidFilterError, "#{key} must be true or false"
     end
 
     def valid_uuid?(value)

--- a/app/controllers/api/v1/security_prices_controller.rb
+++ b/app/controllers/api/v1/security_prices_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
       query = query.where(currency: params[:currency].to_s.upcase) if params[:currency].present?
       query = query.where("security_prices.date >= ?", parse_date_param(:start_date)) if params[:start_date].present?
       query = query.where("security_prices.date <= ?", parse_date_param(:end_date)) if params[:end_date].present?
-      query = query.where(provisional: ActiveModel::Type::Boolean.new.cast(params[:provisional])) if params.key?(:provisional)
+      query = query.where(provisional: ActiveModel::Type::Boolean.new.cast(params[:provisional])) if params[:provisional].present?
       query
     end
 

--- a/app/controllers/api/v1/security_prices_controller.rb
+++ b/app/controllers/api/v1/security_prices_controller.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+class Api::V1::SecurityPricesController < Api::V1::BaseController
+  include Pagy::Backend
+
+  InvalidFilterError = Class.new(StandardError)
+
+  before_action :ensure_read_scope
+  before_action :set_security_price, only: :show
+
+  def index
+    security_prices_query = apply_filters(security_prices_scope).order(date: :desc, created_at: :desc)
+    @per_page = safe_per_page_param
+
+    @pagy, @security_prices = pagy(
+      security_prices_query,
+      page: safe_page_param,
+      limit: @per_page
+    )
+
+    render :index
+  rescue InvalidFilterError => e
+    render_validation_error(e.message)
+  end
+
+  def show
+    render :show
+  end
+
+  private
+
+    def set_security_price
+      raise ActiveRecord::RecordNotFound, "Security price not found" unless valid_uuid?(params[:id])
+
+      @security_price = security_prices_scope.find(params[:id])
+    end
+
+    def ensure_read_scope
+      authorize_scope!(:read)
+    end
+
+    def security_prices_scope
+      Security::Price
+        .where(security_id: scoped_security_ids)
+        .includes(:security)
+    end
+
+    def scoped_security_ids
+      Security
+        .where(id: holding_security_ids)
+        .or(Security.where(id: trade_security_ids))
+        .select(:id)
+    end
+
+    def holding_security_ids
+      Holding.where(account_id: accessible_account_ids).select(:security_id)
+    end
+
+    def trade_security_ids
+      Trade.joins(:entry).where(entries: { account_id: accessible_account_ids }).select(:security_id)
+    end
+
+    def accessible_account_ids
+      @accessible_account_ids ||= current_resource_owner.family.accounts.visible.accessible_by(current_resource_owner).select(:id)
+    end
+
+    def apply_filters(query)
+      if params[:security_id].present?
+        raise InvalidFilterError, "security_id must be a valid UUID" unless valid_uuid?(params[:security_id])
+
+        query = query.where(security_id: params[:security_id])
+      end
+
+      query = query.where(currency: params[:currency].to_s.upcase) if params[:currency].present?
+      query = query.where("security_prices.date >= ?", parse_date_param(:start_date)) if params[:start_date].present?
+      query = query.where("security_prices.date <= ?", parse_date_param(:end_date)) if params[:end_date].present?
+      query = query.where(provisional: ActiveModel::Type::Boolean.new.cast(params[:provisional])) if params.key?(:provisional)
+      query
+    end
+
+    def parse_date_param(key)
+      Date.iso8601(params[key].to_s)
+    rescue ArgumentError
+      raise InvalidFilterError, "#{key} must be an ISO 8601 date"
+    end
+
+    def valid_uuid?(value)
+      value.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i)
+    end
+
+    def safe_page_param
+      page = params[:page].to_i
+      page > 0 ? page : 1
+    end
+
+    def safe_per_page_param
+      per_page = params[:per_page].to_i
+
+      case per_page
+      when 1..100
+        per_page
+      else
+        25
+      end
+    end
+
+    def render_validation_error(message)
+      render json: {
+        error: "validation_failed",
+        message: message,
+        errors: [ message ]
+      }, status: :unprocessable_entity
+    end
+end

--- a/app/controllers/api/v1/security_prices_controller.rb
+++ b/app/controllers/api/v1/security_prices_controller.rb
@@ -2,14 +2,9 @@
 
 class Api::V1::SecurityPricesController < Api::V1::BaseController
   include Pagy::Backend
+  include Api::V1::SecurityResourceFiltering
 
   InvalidFilterError = Class.new(StandardError)
-  BOOLEAN_FILTERS = {
-    "true" => true,
-    "1" => true,
-    "false" => false,
-    "0" => false
-  }.freeze
 
   before_action :ensure_read_scope
   before_action :set_security_price, only: :show
@@ -51,25 +46,6 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
         .includes(:security)
     end
 
-    def scoped_security_ids
-      Security
-        .where(id: holding_security_ids)
-        .or(Security.where(id: trade_security_ids))
-        .select(:id)
-    end
-
-    def holding_security_ids
-      Holding.where(account_id: accessible_account_ids).select(:security_id)
-    end
-
-    def trade_security_ids
-      Trade.joins(:entry).where(entries: { account_id: accessible_account_ids }).select(:security_id)
-    end
-
-    def accessible_account_ids
-      @accessible_account_ids ||= current_resource_owner.family.accounts.visible.accessible_by(current_resource_owner).select(:id)
-    end
-
     def apply_filters(query)
       if params[:security_id].present?
         raise InvalidFilterError, "security_id must be a valid UUID" unless valid_uuid?(params[:security_id])
@@ -77,53 +53,13 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
         query = query.where(security_id: params[:security_id])
       end
 
-      query = query.where(currency: params[:currency].to_s.upcase) if params[:currency].present?
+      query = query.where(currency: params[:currency].to_s.strip.upcase) if params[:currency].present?
       query = query.where("security_prices.date >= ?", parse_date_param(:start_date)) if params[:start_date].present?
       query = query.where("security_prices.date <= ?", parse_date_param(:end_date)) if params[:end_date].present?
       if params.key?(:provisional)
-        provisional = parse_boolean_filter_param(:provisional)
+        provisional = parse_boolean_filter_param(:provisional, allow_blank: true)
         query = query.where(provisional: provisional) unless provisional.nil?
       end
       query
-    end
-
-    def parse_boolean_filter_param(key)
-      normalized_value = params[key].to_s.strip.downcase
-
-      raise InvalidFilterError, "#{key} must be true or false" if normalized_value.blank?
-      return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
-
-      raise InvalidFilterError, "#{key} must be true or false"
-    end
-
-    def parse_date_param(key)
-      Date.iso8601(params[key].to_s)
-    rescue ArgumentError
-      raise InvalidFilterError, "#{key} must be an ISO 8601 date"
-    end
-
-    def valid_uuid?(value)
-      value.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i)
-    end
-
-    def safe_page_param
-      page = params[:page].to_i
-      page > 0 ? page : 1
-    end
-
-    def safe_per_page_param
-      per_page = params[:per_page].to_i
-
-      return 25 if per_page < 1
-
-      [ per_page, 100 ].min
-    end
-
-    def render_validation_error(message)
-      render json: {
-        error: "validation_failed",
-        message: message,
-        errors: [ message ]
-      }, status: :unprocessable_entity
     end
 end

--- a/app/controllers/api/v1/security_prices_controller.rb
+++ b/app/controllers/api/v1/security_prices_controller.rb
@@ -90,7 +90,7 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
     def parse_boolean_filter_param(key)
       normalized_value = params[key].to_s.strip.downcase
 
-      return nil if normalized_value.blank?
+      raise InvalidFilterError, "#{key} must be true or false" if normalized_value.blank?
       return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
 
       raise InvalidFilterError, "#{key} must be true or false"

--- a/app/controllers/api/v1/security_prices_controller.rb
+++ b/app/controllers/api/v1/security_prices_controller.rb
@@ -4,8 +4,6 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
   include Pagy::Backend
   include Api::V1::SecurityResourceFiltering
 
-  InvalidFilterError = Class.new(StandardError)
-
   before_action :ensure_read_scope
   before_action :set_security_price, only: :show
 
@@ -20,7 +18,7 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
     )
 
     render :index
-  rescue InvalidFilterError => e
+  rescue Api::V1::SecurityResourceFiltering::InvalidFilterError => e
     render_validation_error(e.message)
   end
 
@@ -48,7 +46,7 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
 
     def apply_filters(query)
       if params[:security_id].present?
-        raise InvalidFilterError, "security_id must be a valid UUID" unless valid_uuid?(params[:security_id])
+        invalid_filter!("security_id must be a valid UUID") unless valid_uuid?(params[:security_id])
 
         query = query.where(security_id: params[:security_id])
       end
@@ -57,8 +55,8 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
       query = query.where("security_prices.date >= ?", parse_date_param(:start_date)) if params[:start_date].present?
       query = query.where("security_prices.date <= ?", parse_date_param(:end_date)) if params[:end_date].present?
       if params.key?(:provisional)
-        provisional = parse_boolean_filter_param(:provisional, allow_blank: true)
-        query = query.where(provisional: provisional) unless provisional.nil?
+        provisional = parse_boolean_filter_param(:provisional)
+        query = query.where(provisional: provisional)
       end
       query
     end

--- a/app/controllers/api/v1/security_prices_controller.rb
+++ b/app/controllers/api/v1/security_prices_controller.rb
@@ -96,12 +96,9 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
     def safe_per_page_param
       per_page = params[:per_page].to_i
 
-      case per_page
-      when 1..100
-        per_page
-      else
-        25
-      end
+      return 25 if per_page < 1
+
+      [ per_page, 100 ].min
     end
 
     def render_validation_error(message)

--- a/app/controllers/api/v1/security_prices_controller.rb
+++ b/app/controllers/api/v1/security_prices_controller.rb
@@ -4,6 +4,12 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
   include Pagy::Backend
 
   InvalidFilterError = Class.new(StandardError)
+  BOOLEAN_FILTERS = {
+    "true" => true,
+    "1" => true,
+    "false" => false,
+    "0" => false
+  }.freeze
 
   before_action :ensure_read_scope
   before_action :set_security_price, only: :show
@@ -74,8 +80,20 @@ class Api::V1::SecurityPricesController < Api::V1::BaseController
       query = query.where(currency: params[:currency].to_s.upcase) if params[:currency].present?
       query = query.where("security_prices.date >= ?", parse_date_param(:start_date)) if params[:start_date].present?
       query = query.where("security_prices.date <= ?", parse_date_param(:end_date)) if params[:end_date].present?
-      query = query.where(provisional: ActiveModel::Type::Boolean.new.cast(params[:provisional])) if params[:provisional].present?
+      if params.key?(:provisional)
+        provisional = parse_boolean_filter_param(:provisional)
+        query = query.where(provisional: provisional) unless provisional.nil?
+      end
       query
+    end
+
+    def parse_boolean_filter_param(key)
+      normalized_value = params[key].to_s.strip.downcase
+
+      return nil if normalized_value.blank?
+      return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
+
+      raise InvalidFilterError, "#{key} must be true or false"
     end
 
     def parse_date_param(key)

--- a/app/controllers/concerns/api/v1/security_resource_filtering.rb
+++ b/app/controllers/concerns/api/v1/security_resource_filtering.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Api::V1::SecurityResourceFiltering
+  class InvalidFilterError < StandardError; end
+
   BOOLEAN_FILTERS = {
     "true" => true,
     "1" => true,
@@ -30,44 +32,22 @@ module Api::V1::SecurityResourceFiltering
       @accessible_account_ids ||= current_resource_owner.family.accounts.visible.accessible_by(current_resource_owner).select(:id)
     end
 
-    def parse_boolean_filter_param(key, allow_blank: false)
+    def parse_boolean_filter_param(key)
       normalized_value = params[key].to_s.strip.downcase
 
-      return nil if allow_blank && normalized_value.blank?
-      raise invalid_filter!("#{key} must be true or false") if normalized_value.blank?
+      invalid_filter!("#{key} must be true or false") if normalized_value.blank?
       return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
 
-      raise invalid_filter!("#{key} must be true or false")
+      invalid_filter!("#{key} must be true or false")
     end
 
     def parse_date_param(key)
       Date.iso8601(params[key].to_s)
     rescue ArgumentError
-      raise invalid_filter!("#{key} must be an ISO 8601 date")
-    end
-
-    def safe_page_param
-      page = params[:page].to_i
-      page > 0 ? page : 1
-    end
-
-    def safe_per_page_param
-      per_page = params[:per_page].to_i
-
-      return 25 if per_page < 1
-
-      [ per_page, 100 ].min
-    end
-
-    def render_validation_error(message)
-      render_json({
-        error: "validation_failed",
-        message: message,
-        errors: [ message ]
-      }, status: :unprocessable_entity)
+      invalid_filter!("#{key} must be an ISO 8601 date")
     end
 
     def invalid_filter!(message)
-      self.class::InvalidFilterError.new(message)
+      raise InvalidFilterError, message
     end
 end

--- a/app/controllers/concerns/api/v1/security_resource_filtering.rb
+++ b/app/controllers/concerns/api/v1/security_resource_filtering.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Api::V1::SecurityResourceFiltering
+  BOOLEAN_FILTERS = {
+    "true" => true,
+    "1" => true,
+    "false" => false,
+    "0" => false
+  }.freeze
+
+  private
+
+    def scoped_security_ids
+      Security
+        .where(id: holding_security_ids)
+        .or(Security.where(id: trade_security_ids))
+        .distinct
+        .select(:id)
+    end
+
+    def holding_security_ids
+      Holding.where(account_id: accessible_account_ids).select(:security_id)
+    end
+
+    def trade_security_ids
+      Trade.joins(:entry).where(entries: { account_id: accessible_account_ids }).select(:security_id)
+    end
+
+    def accessible_account_ids
+      @accessible_account_ids ||= current_resource_owner.family.accounts.visible.accessible_by(current_resource_owner).select(:id)
+    end
+
+    def parse_boolean_filter_param(key, allow_blank: false)
+      normalized_value = params[key].to_s.strip.downcase
+
+      return nil if allow_blank && normalized_value.blank?
+      raise invalid_filter!("#{key} must be true or false") if normalized_value.blank?
+      return BOOLEAN_FILTERS.fetch(normalized_value) if BOOLEAN_FILTERS.key?(normalized_value)
+
+      raise invalid_filter!("#{key} must be true or false")
+    end
+
+    def parse_date_param(key)
+      Date.iso8601(params[key].to_s)
+    rescue ArgumentError
+      raise invalid_filter!("#{key} must be an ISO 8601 date")
+    end
+
+    def safe_page_param
+      page = params[:page].to_i
+      page > 0 ? page : 1
+    end
+
+    def safe_per_page_param
+      per_page = params[:per_page].to_i
+
+      return 25 if per_page < 1
+
+      [ per_page, 100 ].min
+    end
+
+    def render_validation_error(message)
+      render_json({
+        error: "validation_failed",
+        message: message,
+        errors: [ message ]
+      }, status: :unprocessable_entity)
+    end
+
+    def invalid_filter!(message)
+      self.class::InvalidFilterError.new(message)
+    end
+end

--- a/app/views/api/v1/securities/_security.json.jbuilder
+++ b/app/views/api/v1/securities/_security.json.jbuilder
@@ -9,7 +9,6 @@ json.exchange_mic security.exchange_mic
 json.exchange_acronym security.exchange_acronym
 json.exchange_operating_mic security.exchange_operating_mic
 json.exchange_name security.exchange_name
-json.price_provider security.price_provider
 json.offline security.offline
 json.offline_reason security.offline_reason
 json.website_url security.website_url

--- a/app/views/api/v1/securities/_security.json.jbuilder
+++ b/app/views/api/v1/securities/_security.json.jbuilder
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+json.id security.id
+json.ticker security.ticker
+json.name security.name
+json.kind security.kind
+json.country_code security.country_code
+json.exchange_mic security.exchange_mic
+json.exchange_acronym security.exchange_acronym
+json.exchange_operating_mic security.exchange_operating_mic
+json.exchange_name security.exchange_name
+json.price_provider security.price_provider
+json.offline security.offline
+json.offline_reason security.offline_reason
+json.website_url security.website_url
+json.logo_url security.display_logo_url
+json.first_provider_price_on security.first_provider_price_on
+json.created_at security.created_at.iso8601
+json.updated_at security.updated_at.iso8601

--- a/app/views/api/v1/securities/index.json.jbuilder
+++ b/app/views/api/v1/securities/index.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+json.securities @securities do |security|
+  json.partial! "security", security: security
+end
+
+json.pagination do
+  json.page @pagy.page
+  json.per_page @per_page
+  json.total_count @pagy.count
+  json.total_pages @pagy.pages
+end

--- a/app/views/api/v1/securities/show.json.jbuilder
+++ b/app/views/api/v1/securities/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "security", security: @security

--- a/app/views/api/v1/security_prices/_security_price.json.jbuilder
+++ b/app/views/api/v1/security_prices/_security_price.json.jbuilder
@@ -3,7 +3,7 @@
 json.id security_price.id
 json.date security_price.date
 json.price Money.new(security_price.price, security_price.currency).format
-json.price_amount security_price.price.to_d.to_s("F")
+json.price_amount format("%.4f", security_price.price.to_d)
 json.currency security_price.currency
 json.provisional security_price.provisional
 

--- a/app/views/api/v1/security_prices/_security_price.json.jbuilder
+++ b/app/views/api/v1/security_prices/_security_price.json.jbuilder
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+json.id security_price.id
+json.date security_price.date
+json.price Money.new(security_price.price, security_price.currency).format
+json.price_amount security_price.price.to_s
+json.currency security_price.currency
+json.provisional security_price.provisional
+
+json.security do
+  json.id security_price.security.id
+  json.ticker security_price.security.ticker
+  json.name security_price.security.name
+  json.exchange_operating_mic security_price.security.exchange_operating_mic
+end
+
+json.created_at security_price.created_at.iso8601
+json.updated_at security_price.updated_at.iso8601

--- a/app/views/api/v1/security_prices/_security_price.json.jbuilder
+++ b/app/views/api/v1/security_prices/_security_price.json.jbuilder
@@ -3,7 +3,7 @@
 json.id security_price.id
 json.date security_price.date
 json.price Money.new(security_price.price, security_price.currency).format
-json.price_amount security_price.price.to_s
+json.price_amount security_price.price.to_d.to_s("F")
 json.currency security_price.currency
 json.provisional security_price.provisional
 

--- a/app/views/api/v1/security_prices/index.json.jbuilder
+++ b/app/views/api/v1/security_prices/index.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+json.security_prices @security_prices do |security_price|
+  json.partial! "security_price", security_price: security_price
+end
+
+json.pagination do
+  json.page @pagy.page
+  json.per_page @per_page
+  json.total_count @pagy.count
+  json.total_pages @pagy.pages
+end

--- a/app/views/api/v1/security_prices/show.json.jbuilder
+++ b/app/views/api/v1/security_prices/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "security_price", security_price: @security_price

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -429,6 +429,8 @@ Rails.application.routes.draw do
       resources :merchants, only: %i[index show]
       resources :rules, only: [ :index, :show ]
       resources :rule_runs, only: [ :index, :show ]
+      resources :securities, only: [ :index, :show ]
+      resources :security_prices, only: [ :index, :show ]
       resources :tags, only: %i[index show create update destroy]
 
       resources :transactions, only: [ :index, :show, :create, :update, :destroy ]

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1504,9 +1504,6 @@ components:
         exchange_name:
           type: string
           nullable: true
-        price_provider:
-          type: string
-          nullable: true
         offline:
           type: boolean
         offline_reason:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3898,6 +3898,7 @@ paths:
       description: Security ID
       schema:
         type: string
+        format: uuid
     get:
       summary: Retrieve a security referenced by family investment data
       tags:
@@ -4016,6 +4017,7 @@ paths:
       description: Security price ID
       schema:
         type: string
+        format: uuid
     get:
       summary: Retrieve a security price referenced by family investment data
       tags:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3862,7 +3862,7 @@ paths:
       - name: offline
         in: query
         required: false
-        description: Filter by offline status (true or false)
+        description: Filter by offline status. When supplied, must be true or false.
         schema:
           type: boolean
       responses:
@@ -3979,7 +3979,8 @@ paths:
       - name: provisional
         in: query
         required: false
-        description: Filter by provisional price status (true or false)
+        description: Filter by provisional price status. When supplied, must be true
+          or false.
         schema:
           type: boolean
       responses:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1466,6 +1466,144 @@ components:
             "$ref": "#/components/schemas/Holding"
         pagination:
           "$ref": "#/components/schemas/Pagination"
+    Security:
+      type: object
+      required:
+      - id
+      - ticker
+      - kind
+      - offline
+      - created_at
+      - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        ticker:
+          type: string
+        name:
+          type: string
+          nullable: true
+        kind:
+          type: string
+          enum:
+          - standard
+          - cash
+        country_code:
+          type: string
+          nullable: true
+        exchange_mic:
+          type: string
+          nullable: true
+        exchange_acronym:
+          type: string
+          nullable: true
+        exchange_operating_mic:
+          type: string
+          nullable: true
+        exchange_name:
+          type: string
+          nullable: true
+        price_provider:
+          type: string
+          nullable: true
+        offline:
+          type: boolean
+        offline_reason:
+          type: string
+          nullable: true
+        website_url:
+          type: string
+          nullable: true
+        logo_url:
+          type: string
+          nullable: true
+        first_provider_price_on:
+          type: string
+          format: date
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SecurityCollection:
+      type: object
+      required:
+      - securities
+      - pagination
+      properties:
+        securities:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Security"
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+    SecurityPrice:
+      type: object
+      required:
+      - id
+      - date
+      - price
+      - price_amount
+      - currency
+      - provisional
+      - security
+      - created_at
+      - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        price:
+          type: string
+          description: Formatted security price
+        price_amount:
+          type: string
+          description: Exact decimal security price
+        currency:
+          type: string
+        provisional:
+          type: boolean
+        security:
+          type: object
+          required:
+          - id
+          - ticker
+          properties:
+            id:
+              type: string
+              format: uuid
+            ticker:
+              type: string
+            name:
+              type: string
+              nullable: true
+            exchange_operating_mic:
+              type: string
+              nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SecurityPriceCollection:
+      type: object
+      required:
+      - security_prices
+      - pagination
+      properties:
+        security_prices:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SecurityPrice"
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
     Money:
       type: object
       required:
@@ -3679,6 +3817,234 @@ paths:
                 "$ref": "#/components/schemas/ErrorResponse"
         '404':
           description: rule not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/securities":
+    get:
+      summary: List securities referenced by family investment data
+      tags:
+      - Securities
+      security:
+      - apiKeyAuth: []
+      parameters:
+      - name: page
+        in: query
+        required: false
+        description: 'Page number (default: 1)'
+        schema:
+          type: integer
+      - name: per_page
+        in: query
+        required: false
+        description: 'Items per page (default: 25, max: 100)'
+        schema:
+          type: integer
+      - name: ticker
+        in: query
+        required: false
+        description: Filter by ticker symbol
+        schema:
+          type: string
+      - name: exchange_operating_mic
+        in: query
+        required: false
+        description: Filter by exchange operating MIC
+        schema:
+          type: string
+      - name: kind
+        in: query
+        required: false
+        description: Filter by security kind
+        schema:
+          type: string
+          enum:
+          - standard
+          - cash
+      - name: offline
+        in: query
+        required: false
+        description: Filter by offline status
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: securities listed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityCollection"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: invalid kind filter
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/securities/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      description: Security ID
+      schema:
+        type: string
+    get:
+      summary: Retrieve a security referenced by family investment data
+      tags:
+      - Securities
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: security retrieved
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Security"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '404':
+          description: security not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/security_prices":
+    get:
+      summary: List security price history referenced by family investment data
+      tags:
+      - Security Prices
+      security:
+      - apiKeyAuth: []
+      parameters:
+      - name: page
+        in: query
+        required: false
+        description: 'Page number (default: 1)'
+        schema:
+          type: integer
+      - name: per_page
+        in: query
+        required: false
+        description: 'Items per page (default: 25, max: 100)'
+        schema:
+          type: integer
+      - name: security_id
+        in: query
+        required: false
+        description: Filter by security ID
+        schema:
+          type: string
+          format: uuid
+      - name: currency
+        in: query
+        required: false
+        description: Filter by currency code
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        required: false
+        description: Filter prices from this date
+        schema:
+          type: string
+          format: date
+      - name: end_date
+        in: query
+        required: false
+        description: Filter prices until this date
+        schema:
+          type: string
+          format: date
+      - name: provisional
+        in: query
+        required: false
+        description: Filter by provisional price status
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: security prices listed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityPriceCollection"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: invalid date filter
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/security_prices/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      description: Security price ID
+      schema:
+        type: string
+    get:
+      summary: Retrieve a security price referenced by family investment data
+      tags:
+      - Security Prices
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: security price retrieved
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityPrice"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '404':
+          description: security price not found
           content:
             application/json:
               schema:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3865,7 +3865,7 @@ paths:
       - name: offline
         in: query
         required: false
-        description: Filter by offline status
+        description: Filter by offline status (true or false)
         schema:
           type: boolean
       responses:
@@ -3888,7 +3888,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
         '422':
-          description: invalid kind filter
+          description: invalid filter
           content:
             application/json:
               schema:
@@ -3982,7 +3982,7 @@ paths:
       - name: provisional
         in: query
         required: false
-        description: Filter by provisional price status
+        description: Filter by provisional price status (true or false)
         schema:
           type: boolean
       responses:
@@ -4005,7 +4005,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
         '422':
-          description: invalid date filter
+          description: invalid filter
           content:
             application/json:
               schema:

--- a/spec/requests/api/v1/securities_spec.rb
+++ b/spec/requests/api/v1/securities_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'API V1 Securities', type: :request do
+  let(:family) do
+    Family.create!(
+      name: 'API Family',
+      currency: 'USD',
+      locale: 'en',
+      date_format: '%m-%d-%Y'
+    )
+  end
+
+  let(:user) do
+    family.users.create!(
+      email: 'api-user@example.com',
+      password: 'password123',
+      password_confirmation: 'password123'
+    )
+  end
+
+  let(:api_key) do
+    key = ApiKey.generate_secure_key
+    ApiKey.create!(
+      user: user,
+      name: 'API Docs Key',
+      key: key,
+      scopes: %w[read_write],
+      source: 'web'
+    )
+  end
+
+  let(:api_key_without_read_scope) do
+    key = ApiKey.generate_secure_key
+    ApiKey.new(
+      user: user,
+      name: 'No Read Docs Key',
+      key: key,
+      scopes: %w[write],
+      source: 'web'
+    ).tap { |api_key| api_key.save!(validate: false) }
+  end
+
+  let(:'X-Api-Key') { api_key.plain_key }
+
+  let(:account) do
+    Account.create!(
+      family: family,
+      name: 'Investment Account',
+      balance: 50_000,
+      currency: 'USD',
+      accountable: Investment.create!
+    )
+  end
+
+  let!(:security) do
+    Security.create!(
+      ticker: 'VTI',
+      name: 'Vanguard Total Stock Market ETF',
+      country_code: 'US',
+      exchange_operating_mic: 'ARCX'
+    )
+  end
+
+  let!(:holding) do
+    Holding.create!(
+      account: account,
+      security: security,
+      date: Date.current,
+      qty: 100,
+      price: 250.50,
+      amount: 25_050,
+      currency: 'USD'
+    )
+  end
+
+  path '/api/v1/securities' do
+    get 'List securities referenced by family investment data' do
+      tags 'Securities'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+      parameter name: :page, in: :query, type: :integer, required: false,
+                description: 'Page number (default: 1)'
+      parameter name: :per_page, in: :query, type: :integer, required: false,
+                description: 'Items per page (default: 25, max: 100)'
+      parameter name: :ticker, in: :query, required: false,
+                description: 'Filter by ticker symbol',
+                schema: { type: :string }
+      parameter name: :exchange_operating_mic, in: :query, required: false,
+                description: 'Filter by exchange operating MIC',
+                schema: { type: :string }
+      parameter name: :kind, in: :query, required: false,
+                description: 'Filter by security kind',
+                schema: { type: :string, enum: %w[standard cash] }
+      parameter name: :offline, in: :query, required: false,
+                description: 'Filter by offline status',
+                schema: { type: :boolean }
+
+      response '200', 'securities listed' do
+        schema '$ref' => '#/components/schemas/SecurityCollection'
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { nil }
+
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { api_key_without_read_scope.plain_key }
+
+        run_test!
+      end
+
+      response '422', 'invalid kind filter' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:kind) { 'unsupported' }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/securities/{id}' do
+    parameter name: :id, in: :path, type: :string, required: true, description: 'Security ID'
+
+    get 'Retrieve a security referenced by family investment data' do
+      tags 'Securities'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+
+      let(:id) { security.id }
+
+      response '200', 'security retrieved' do
+        schema '$ref' => '#/components/schemas/Security'
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { nil }
+
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { api_key_without_read_scope.plain_key }
+
+        run_test!
+      end
+
+      response '404', 'security not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/securities_spec.rb
+++ b/spec/requests/api/v1/securities_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'API V1 Securities', type: :request do
                 description: 'Filter by security kind',
                 schema: { type: :string, enum: %w[standard cash] }
       parameter name: :offline, in: :query, required: false,
-                description: 'Filter by offline status (true or false)',
+                description: 'Filter by offline status. When supplied, must be true or false.',
                 schema: { type: :boolean }
 
       response '200', 'securities listed' do

--- a/spec/requests/api/v1/securities_spec.rb
+++ b/spec/requests/api/v1/securities_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'API V1 Securities', type: :request do
                 description: 'Filter by security kind',
                 schema: { type: :string, enum: %w[standard cash] }
       parameter name: :offline, in: :query, required: false,
-                description: 'Filter by offline status',
+                description: 'Filter by offline status (true or false)',
                 schema: { type: :boolean }
 
       response '200', 'securities listed' do
@@ -119,7 +119,7 @@ RSpec.describe 'API V1 Securities', type: :request do
         run_test!
       end
 
-      response '422', 'invalid kind filter' do
+      response '422', 'invalid filter' do
         schema '$ref' => '#/components/schemas/ErrorResponse'
 
         let(:kind) { 'unsupported' }

--- a/spec/requests/api/v1/securities_spec.rb
+++ b/spec/requests/api/v1/securities_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'API V1 Securities', type: :request do
       user: user,
       name: 'API Docs Key',
       key: key,
+      display_key: key,
       scopes: %w[read_write],
       source: 'web'
     )
@@ -37,6 +38,7 @@ RSpec.describe 'API V1 Securities', type: :request do
       user: user,
       name: 'No Read Docs Key',
       key: key,
+      display_key: key,
       scopes: %w[write],
       source: 'web'
     ).tap { |api_key| api_key.save!(validate: false) }

--- a/spec/requests/api/v1/securities_spec.rb
+++ b/spec/requests/api/v1/securities_spec.rb
@@ -34,12 +34,13 @@ RSpec.describe 'API V1 Securities', type: :request do
 
   let(:api_key_without_read_scope) do
     key = ApiKey.generate_secure_key
+    # Persist an invalid key shape intentionally so rswag can document 403.
     ApiKey.new(
       user: user,
       name: 'No Read Docs Key',
       key: key,
       display_key: key,
-      scopes: %w[write],
+      scopes: [],
       source: 'web'
     ).tap { |api_key| api_key.save!(validate: false) }
   end
@@ -132,7 +133,8 @@ RSpec.describe 'API V1 Securities', type: :request do
   end
 
   path '/api/v1/securities/{id}' do
-    parameter name: :id, in: :path, type: :string, required: true, description: 'Security ID'
+    parameter name: :id, in: :path, required: true, description: 'Security ID',
+              schema: { type: :string, format: :uuid }
 
     get 'Retrieve a security referenced by family investment data' do
       tags 'Securities'

--- a/spec/requests/api/v1/security_prices_spec.rb
+++ b/spec/requests/api/v1/security_prices_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'API V1 Security Prices', type: :request do
+  let(:family) do
+    Family.create!(
+      name: 'API Family',
+      currency: 'USD',
+      locale: 'en',
+      date_format: '%m-%d-%Y'
+    )
+  end
+
+  let(:user) do
+    family.users.create!(
+      email: 'api-user@example.com',
+      password: 'password123',
+      password_confirmation: 'password123'
+    )
+  end
+
+  let(:api_key) do
+    key = ApiKey.generate_secure_key
+    ApiKey.create!(
+      user: user,
+      name: 'API Docs Key',
+      key: key,
+      scopes: %w[read_write],
+      source: 'web'
+    )
+  end
+
+  let(:api_key_without_read_scope) do
+    key = ApiKey.generate_secure_key
+    ApiKey.new(
+      user: user,
+      name: 'No Read Docs Key',
+      key: key,
+      scopes: %w[write],
+      source: 'web'
+    ).tap { |api_key| api_key.save!(validate: false) }
+  end
+
+  let(:'X-Api-Key') { api_key.plain_key }
+
+  let(:account) do
+    Account.create!(
+      family: family,
+      name: 'Investment Account',
+      balance: 50_000,
+      currency: 'USD',
+      accountable: Investment.create!
+    )
+  end
+
+  let!(:security) do
+    Security.create!(
+      ticker: 'VTI',
+      name: 'Vanguard Total Stock Market ETF',
+      country_code: 'US',
+      exchange_operating_mic: 'ARCX'
+    )
+  end
+
+  let!(:holding) do
+    Holding.create!(
+      account: account,
+      security: security,
+      date: Date.current,
+      qty: 100,
+      price: 250.50,
+      amount: 25_050,
+      currency: 'USD'
+    )
+  end
+
+  let!(:security_price) do
+    Security::Price.create!(
+      security: security,
+      date: Date.current,
+      price: 250.1234,
+      currency: 'USD'
+    )
+  end
+
+  path '/api/v1/security_prices' do
+    get 'List security price history referenced by family investment data' do
+      tags 'Security Prices'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+      parameter name: :page, in: :query, type: :integer, required: false,
+                description: 'Page number (default: 1)'
+      parameter name: :per_page, in: :query, type: :integer, required: false,
+                description: 'Items per page (default: 25, max: 100)'
+      parameter name: :security_id, in: :query, required: false,
+                description: 'Filter by security ID',
+                schema: { type: :string, format: :uuid }
+      parameter name: :currency, in: :query, required: false,
+                description: 'Filter by currency code',
+                schema: { type: :string }
+      parameter name: :start_date, in: :query, required: false,
+                description: 'Filter prices from this date',
+                schema: { type: :string, format: :date }
+      parameter name: :end_date, in: :query, required: false,
+                description: 'Filter prices until this date',
+                schema: { type: :string, format: :date }
+      parameter name: :provisional, in: :query, required: false,
+                description: 'Filter by provisional price status',
+                schema: { type: :boolean }
+
+      response '200', 'security prices listed' do
+        schema '$ref' => '#/components/schemas/SecurityPriceCollection'
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { nil }
+
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { api_key_without_read_scope.plain_key }
+
+        run_test!
+      end
+
+      response '422', 'invalid security filter' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:security_id) { 'not-a-uuid' }
+
+        run_test!
+      end
+
+      response '422', 'invalid date filter' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:start_date) { 'not-a-date' }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/security_prices/{id}' do
+    parameter name: :id, in: :path, type: :string, required: true, description: 'Security price ID'
+
+    get 'Retrieve a security price referenced by family investment data' do
+      tags 'Security Prices'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+
+      let(:id) { security_price.id }
+
+      response '200', 'security price retrieved' do
+        schema '$ref' => '#/components/schemas/SecurityPrice'
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { nil }
+
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { api_key_without_read_scope.plain_key }
+
+        run_test!
+      end
+
+      response '404', 'security price not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/security_prices_spec.rb
+++ b/spec/requests/api/v1/security_prices_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'API V1 Security Prices', type: :request do
                 description: 'Filter prices until this date',
                 schema: { type: :string, format: :date }
       parameter name: :provisional, in: :query, required: false,
-                description: 'Filter by provisional price status (true or false)',
+                description: 'Filter by provisional price status. When supplied, must be true or false.',
                 schema: { type: :boolean }
 
       response '200', 'security prices listed' do

--- a/spec/requests/api/v1/security_prices_spec.rb
+++ b/spec/requests/api/v1/security_prices_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'API V1 Security Prices', type: :request do
                 description: 'Filter prices until this date',
                 schema: { type: :string, format: :date }
       parameter name: :provisional, in: :query, required: false,
-                description: 'Filter by provisional price status',
+                description: 'Filter by provisional price status (true or false)',
                 schema: { type: :boolean }
 
       response '200', 'security prices listed' do
@@ -131,18 +131,10 @@ RSpec.describe 'API V1 Security Prices', type: :request do
         run_test!
       end
 
-      response '422', 'invalid security filter' do
+      response '422', 'invalid filter' do
         schema '$ref' => '#/components/schemas/ErrorResponse'
 
         let(:security_id) { 'not-a-uuid' }
-
-        run_test!
-      end
-
-      response '422', 'invalid date filter' do
-        schema '$ref' => '#/components/schemas/ErrorResponse'
-
-        let(:start_date) { 'not-a-date' }
 
         run_test!
       end

--- a/spec/requests/api/v1/security_prices_spec.rb
+++ b/spec/requests/api/v1/security_prices_spec.rb
@@ -34,12 +34,13 @@ RSpec.describe 'API V1 Security Prices', type: :request do
 
   let(:api_key_without_read_scope) do
     key = ApiKey.generate_secure_key
+    # Persist an invalid key shape intentionally so rswag can document 403.
     ApiKey.new(
       user: user,
       name: 'No Read Docs Key',
       key: key,
       display_key: key,
-      scopes: %w[write],
+      scopes: [],
       source: 'web'
     ).tap { |api_key| api_key.save!(validate: false) }
   end
@@ -144,7 +145,8 @@ RSpec.describe 'API V1 Security Prices', type: :request do
   end
 
   path '/api/v1/security_prices/{id}' do
-    parameter name: :id, in: :path, type: :string, required: true, description: 'Security price ID'
+    parameter name: :id, in: :path, required: true, description: 'Security price ID',
+              schema: { type: :string, format: :uuid }
 
     get 'Retrieve a security price referenced by family investment data' do
       tags 'Security Prices'

--- a/spec/requests/api/v1/security_prices_spec.rb
+++ b/spec/requests/api/v1/security_prices_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'API V1 Security Prices', type: :request do
       user: user,
       name: 'API Docs Key',
       key: key,
+      display_key: key,
       scopes: %w[read_write],
       source: 'web'
     )
@@ -37,6 +38,7 @@ RSpec.describe 'API V1 Security Prices', type: :request do
       user: user,
       name: 'No Read Docs Key',
       key: key,
+      display_key: key,
       scopes: %w[write],
       source: 'web'
     ).tap { |api_key| api_key.save!(validate: false) }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -839,7 +839,6 @@ RSpec.configure do |config|
               exchange_acronym: { type: :string, nullable: true },
               exchange_operating_mic: { type: :string, nullable: true },
               exchange_name: { type: :string, nullable: true },
-              price_provider: { type: :string, nullable: true },
               offline: { type: :boolean },
               offline_reason: { type: :string, nullable: true },
               website_url: { type: :string, nullable: true },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -826,6 +826,75 @@ RSpec.configure do |config|
               pagination: { '$ref' => '#/components/schemas/Pagination' }
             }
           },
+          Security: {
+            type: :object,
+            required: %w[id ticker kind offline created_at updated_at],
+            properties: {
+              id: { type: :string, format: :uuid },
+              ticker: { type: :string },
+              name: { type: :string, nullable: true },
+              kind: { type: :string, enum: %w[standard cash] },
+              country_code: { type: :string, nullable: true },
+              exchange_mic: { type: :string, nullable: true },
+              exchange_acronym: { type: :string, nullable: true },
+              exchange_operating_mic: { type: :string, nullable: true },
+              exchange_name: { type: :string, nullable: true },
+              price_provider: { type: :string, nullable: true },
+              offline: { type: :boolean },
+              offline_reason: { type: :string, nullable: true },
+              website_url: { type: :string, nullable: true },
+              logo_url: { type: :string, nullable: true },
+              first_provider_price_on: { type: :string, format: :date, nullable: true },
+              created_at: { type: :string, format: :'date-time' },
+              updated_at: { type: :string, format: :'date-time' }
+            }
+          },
+          SecurityCollection: {
+            type: :object,
+            required: %w[securities pagination],
+            properties: {
+              securities: {
+                type: :array,
+                items: { '$ref' => '#/components/schemas/Security' }
+              },
+              pagination: { '$ref' => '#/components/schemas/Pagination' }
+            }
+          },
+          SecurityPrice: {
+            type: :object,
+            required: %w[id date price price_amount currency provisional security created_at updated_at],
+            properties: {
+              id: { type: :string, format: :uuid },
+              date: { type: :string, format: :date },
+              price: { type: :string, description: 'Formatted security price' },
+              price_amount: { type: :string, description: 'Exact decimal security price' },
+              currency: { type: :string },
+              provisional: { type: :boolean },
+              security: {
+                type: :object,
+                required: %w[id ticker],
+                properties: {
+                  id: { type: :string, format: :uuid },
+                  ticker: { type: :string },
+                  name: { type: :string, nullable: true },
+                  exchange_operating_mic: { type: :string, nullable: true }
+                }
+              },
+              created_at: { type: :string, format: :'date-time' },
+              updated_at: { type: :string, format: :'date-time' }
+            }
+          },
+          SecurityPriceCollection: {
+            type: :object,
+            required: %w[security_prices pagination],
+            properties: {
+              security_prices: {
+                type: :array,
+                items: { '$ref' => '#/components/schemas/SecurityPrice' }
+              },
+              pagination: { '$ref' => '#/components/schemas/Pagination' }
+            }
+          },
           Money: {
             type: :object,
             required: %w[amount currency formatted],

--- a/test/controllers/api/v1/securities_controller_test.rb
+++ b/test/controllers/api/v1/securities_controller_test.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @user.api_keys.active.destroy_all
+
+    @api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Read Key",
+      scopes: [ "read" ],
+      source: "web",
+      display_key: "test_read_#{SecureRandom.hex(8)}"
+    )
+
+    @account = @family.accounts.create!(
+      name: "Investment Account",
+      accountable: Investment.new,
+      balance: 25_000,
+      currency: "USD"
+    )
+
+    @holding_ticker = "VTI#{SecureRandom.hex(4).upcase}"
+    @trade_ticker = "AAPL#{SecureRandom.hex(4).upcase}"
+
+    @holding_security = Security.create!(
+      ticker: @holding_ticker,
+      name: "Vanguard Total Stock Market ETF",
+      country_code: "US",
+      exchange_operating_mic: "ARCX"
+    )
+    @account.holdings.create!(
+      security: @holding_security,
+      date: Date.parse("2024-01-15"),
+      qty: 100,
+      price: 250,
+      amount: 25_000,
+      currency: "USD"
+    )
+
+    @trade_security = Security.create!(
+      ticker: @trade_ticker,
+      name: "Apple Inc.",
+      country_code: "US",
+      exchange_operating_mic: "XNAS"
+    )
+    @account.entries.create!(
+      name: "Buy AAPL",
+      date: Date.parse("2024-01-16"),
+      amount: 1800,
+      currency: "USD",
+      entryable: Trade.new(
+        security: @trade_security,
+        qty: 10,
+        price: 180,
+        currency: "USD"
+      )
+    )
+
+    @unreferenced_security = Security.create!(ticker: "MSFT#{SecureRandom.hex(4).upcase}", name: "Microsoft Corp.", country_code: "US")
+
+    other_account = families(:empty).accounts.create!(
+      name: "Other Investment Account",
+      accountable: Investment.new,
+      balance: 1000,
+      currency: "USD"
+    )
+    @other_security = Security.create!(ticker: "GOOG#{SecureRandom.hex(4).upcase}", name: "Alphabet Inc.", country_code: "US")
+    other_account.holdings.create!(
+      security: @other_security,
+      date: Date.parse("2024-01-15"),
+      qty: 1,
+      price: 100,
+      amount: 100,
+      currency: "USD"
+    )
+  end
+
+  test "lists securities referenced by accessible family investment data" do
+    get api_v1_securities_url, headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    security_ids = response_data["securities"].map { |security| security["id"] }
+
+    assert_includes security_ids, @holding_security.id
+    assert_includes security_ids, @trade_security.id
+    assert_not_includes security_ids, @unreferenced_security.id
+    assert_not_includes security_ids, @other_security.id
+    assert response_data.key?("pagination")
+  end
+
+  test "shows a scoped security" do
+    get api_v1_security_url(@holding_security), headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+
+    assert_equal @holding_security.id, response_data["id"]
+    assert_equal @holding_ticker, response_data["ticker"]
+    assert_equal "ARCX", response_data["exchange_operating_mic"]
+    assert_equal "standard", response_data["kind"]
+  end
+
+  test "returns not found for another family's security" do
+    get api_v1_security_url(@other_security), headers: api_headers(@api_key)
+
+    assert_response :not_found
+    response_data = JSON.parse(response.body)
+    assert_equal "record_not_found", response_data["error"]
+  end
+
+  test "returns not found for malformed security id" do
+    get api_v1_security_url("not-a-uuid"), headers: api_headers(@api_key)
+
+    assert_response :not_found
+    response_data = JSON.parse(response.body)
+    assert_equal "record_not_found", response_data["error"]
+  end
+
+  test "filters securities by ticker" do
+    get api_v1_securities_url, params: { ticker: @trade_ticker }, headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_equal [ @trade_security.id ], response_data["securities"].map { |security| security["id"] }
+  end
+
+  test "filters securities by exchange operating mic" do
+    get api_v1_securities_url, params: { exchange_operating_mic: "arcx" }, headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_equal [ @holding_security.id ], response_data["securities"].map { |security| security["id"] }
+  end
+
+  test "rejects invalid kind filter" do
+    get api_v1_securities_url, params: { kind: "unsupported" }, headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+    response_data = JSON.parse(response.body)
+    assert_equal "validation_failed", response_data["error"]
+  end
+
+  test "requires authentication" do
+    get api_v1_securities_url
+
+    assert_response :unauthorized
+  end
+
+  test "requires read scope" do
+    api_key_without_read = ApiKey.new(
+      user: @user,
+      name: "No Read Key",
+      scopes: [],
+      source: "web",
+      display_key: "no_read_#{SecureRandom.hex(8)}"
+    )
+    api_key_without_read.save!(validate: false)
+
+    get api_v1_securities_url, headers: api_headers(api_key_without_read)
+
+    assert_response :forbidden
+  ensure
+    api_key_without_read&.destroy
+  end
+
+  private
+
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.plain_key }
+    end
+end

--- a/test/controllers/api/v1/securities_controller_test.rb
+++ b/test/controllers/api/v1/securities_controller_test.rb
@@ -161,6 +161,15 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response_data["errors"], "offline must be true or false"
   end
 
+  test "rejects blank offline filter" do
+    get api_v1_securities_url, params: { offline: "" }, headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+    response_data = JSON.parse(response.body)
+    assert_equal "validation_failed", response_data["error"]
+    assert_includes response_data["errors"], "offline must be true or false"
+  end
+
   test "requires authentication" do
     get api_v1_securities_url
 
@@ -187,6 +196,6 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
   private
 
     def api_headers(api_key)
-      { "X-Api-Key" => api_key.plain_key }
+      { "X-Api-Key" => api_key.display_key }
     end
 end

--- a/test/controllers/api/v1/securities_controller_test.rb
+++ b/test/controllers/api/v1/securities_controller_test.rb
@@ -152,6 +152,15 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "validation_failed", response_data["error"]
   end
 
+  test "rejects malformed offline filter" do
+    get api_v1_securities_url, params: { offline: "maybe" }, headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+    response_data = JSON.parse(response.body)
+    assert_equal "validation_failed", response_data["error"]
+    assert_includes response_data["errors"], "offline must be true or false"
+  end
+
   test "requires authentication" do
     get api_v1_securities_url
 

--- a/test/controllers/api/v1/securities_controller_test.rb
+++ b/test/controllers/api/v1/securities_controller_test.rb
@@ -130,7 +130,7 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "filters securities by exchange operating mic" do
-    get api_v1_securities_url, params: { exchange_operating_mic: "arcx" }, headers: api_headers(@api_key)
+    get api_v1_securities_url, params: { exchange_operating_mic: " arcx " }, headers: api_headers(@api_key)
 
     assert_response :success
     response_data = JSON.parse(response.body)

--- a/test/controllers/api/v1/securities_controller_test.rb
+++ b/test/controllers/api/v1/securities_controller_test.rb
@@ -137,6 +137,13 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ @holding_security.id ], response_data["securities"].map { |security| security["id"] }
   end
 
+  test "caps per_page at documented maximum" do
+    get api_v1_securities_url, params: { per_page: 250 }, headers: api_headers(@api_key)
+
+    assert_response :success
+    assert_equal 100, JSON.parse(response.body).dig("pagination", "per_page")
+  end
+
   test "rejects invalid kind filter" do
     get api_v1_securities_url, params: { kind: "unsupported" }, headers: api_headers(@api_key)
 

--- a/test/controllers/api/v1/securities_controller_test.rb
+++ b/test/controllers/api/v1/securities_controller_test.rb
@@ -16,30 +16,10 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
       display_key: "test_read_#{SecureRandom.hex(8)}"
     )
 
-    @account = @family.accounts.create!(
-      name: "Investment Account",
-      accountable: Investment.new,
-      balance: 25_000,
-      currency: "USD"
-    )
-
-    @holding_ticker = "VTI#{SecureRandom.hex(4).upcase}"
+    @account = accounts(:investment)
+    @holding_security = securities(:aapl)
+    @holding_ticker = @holding_security.ticker
     @trade_ticker = "AAPL#{SecureRandom.hex(4).upcase}"
-
-    @holding_security = Security.create!(
-      ticker: @holding_ticker,
-      name: "Vanguard Total Stock Market ETF",
-      country_code: "US",
-      exchange_operating_mic: "ARCX"
-    )
-    @account.holdings.create!(
-      security: @holding_security,
-      date: Date.parse("2024-01-15"),
-      qty: 100,
-      price: 250,
-      amount: 25_000,
-      currency: "USD"
-    )
 
     @trade_security = Security.create!(
       ticker: @trade_ticker,
@@ -101,8 +81,9 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal @holding_security.id, response_data["id"]
     assert_equal @holding_ticker, response_data["ticker"]
-    assert_equal "ARCX", response_data["exchange_operating_mic"]
+    assert_equal @holding_security.exchange_operating_mic, response_data["exchange_operating_mic"]
     assert_equal "standard", response_data["kind"]
+    assert_not response_data.key?("price_provider")
   end
 
   test "returns not found for another family's security" do
@@ -122,7 +103,7 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "filters securities by ticker" do
-    get api_v1_securities_url, params: { ticker: @trade_ticker }, headers: api_headers(@api_key)
+    get api_v1_securities_url, params: { ticker: @trade_ticker.downcase }, headers: api_headers(@api_key)
 
     assert_response :success
     response_data = JSON.parse(response.body)
@@ -130,11 +111,11 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "filters securities by exchange operating mic" do
-    get api_v1_securities_url, params: { exchange_operating_mic: " arcx " }, headers: api_headers(@api_key)
+    get api_v1_securities_url, params: { exchange_operating_mic: " xnas " }, headers: api_headers(@api_key)
 
     assert_response :success
     response_data = JSON.parse(response.body)
-    assert_equal [ @holding_security.id ], response_data["securities"].map { |security| security["id"] }
+    assert_equal [ @holding_security.id, @trade_security.id ], response_data["securities"].map { |security| security["id"] }
   end
 
   test "caps per_page at documented maximum" do
@@ -196,6 +177,6 @@ class Api::V1::SecuritiesControllerTest < ActionDispatch::IntegrationTest
   private
 
     def api_headers(api_key)
-      { "X-Api-Key" => api_key.display_key }
+      { "X-Api-Key" => api_key.plain_key }
     end
 end

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -16,35 +16,15 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
       display_key: "test_read_#{SecureRandom.hex(8)}"
     )
 
-    @account = @family.accounts.create!(
-      name: "Investment Account",
-      accountable: Investment.new,
-      balance: 25_000,
-      currency: "USD"
-    )
-
-    @ticker = "VTI#{SecureRandom.hex(4).upcase}"
-
-    @security = Security.create!(
-      ticker: @ticker,
-      name: "Vanguard Total Stock Market ETF",
-      country_code: "US",
-      exchange_operating_mic: "ARCX"
-    )
-    @account.holdings.create!(
+    @account = accounts(:investment)
+    @security = securities(:aapl)
+    @ticker = @security.ticker
+    @security_price = security_prices(:one)
+    @eur_price = Security::Price.create!(
       security: @security,
-      date: Date.parse("2024-01-15"),
-      qty: 100,
-      price: 250,
-      amount: 25_000,
-      currency: "USD"
-    )
-    @security_price = Security::Price.create!(
-      security: @security,
-      date: Date.parse("2024-01-15"),
+      date: @security_price.date,
       price: BigDecimal("250.5000"),
-      currency: "USD",
-      provisional: true
+      currency: "EUR"
     )
 
     other_account = families(:empty).accounts.create!(
@@ -89,8 +69,8 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     response_data = JSON.parse(response.body)
 
     assert_equal @security_price.id, response_data["id"]
-    assert_equal "2024-01-15", response_data["date"]
-    assert_equal "250.5000", response_data["price_amount"]
+    assert_equal @security_price.date.iso8601, response_data["date"]
+    assert_equal "215.0000", response_data["price_amount"]
     assert_equal @security.id, response_data.dig("security", "id")
   end
 
@@ -115,12 +95,13 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     response_data = JSON.parse(response.body)
-    assert_equal [ @security_price.id ], response_data["security_prices"].map { |price| price["id"] }
+    assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
+    assert response_data["security_prices"].all? { |price| price.dig("security", "id") == @security.id }
   end
 
   test "filters security prices by date range and provisional status" do
     get api_v1_security_prices_url,
-        params: { start_date: "2024-01-15", end_date: "2024-01-15", provisional: true },
+        params: { start_date: @security_price.date.iso8601, end_date: @security_price.date.iso8601, currency: "USD", provisional: false },
         headers: api_headers(@api_key)
 
     assert_response :success
@@ -128,15 +109,25 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ @security_price.id ], response_data["security_prices"].map { |price| price["id"] }
   end
 
-  test "rejects blank provisional filter" do
+  test "ignores blank provisional filter" do
     get api_v1_security_prices_url,
         params: { provisional: "" },
         headers: api_headers(@api_key)
 
-    assert_response :unprocessable_entity
+    assert_response :success
     response_data = JSON.parse(response.body)
-    assert_equal "validation_failed", response_data["error"]
-    assert_includes response_data["errors"], "provisional must be true or false"
+    assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
+  end
+
+  test "filters security prices by currency" do
+    get api_v1_security_prices_url,
+        params: { currency: " usd " },
+        headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
+    assert_not_includes response_data["security_prices"].map { |price| price["id"] }, @eur_price.id
   end
 
   test "rejects malformed provisional filter" do
@@ -199,6 +190,6 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
   private
 
     def api_headers(api_key)
-      { "X-Api-Key" => api_key.display_key }
+      { "X-Api-Key" => api_key.plain_key }
     end
 end

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -138,6 +138,17 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
   end
 
+  test "rejects malformed provisional filter" do
+    get api_v1_security_prices_url,
+        params: { provisional: "maybe" },
+        headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+    response_data = JSON.parse(response.body)
+    assert_equal "validation_failed", response_data["error"]
+    assert_includes response_data["errors"], "provisional must be true or false"
+  end
+
   test "caps per_page at documented maximum" do
     get api_v1_security_prices_url, params: { per_page: 250 }, headers: api_headers(@api_key)
 

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -138,6 +138,13 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
   end
 
+  test "caps per_page at documented maximum" do
+    get api_v1_security_prices_url, params: { per_page: 250 }, headers: api_headers(@api_key)
+
+    assert_response :success
+    assert_equal 100, JSON.parse(response.body).dig("pagination", "per_page")
+  end
+
   test "rejects malformed security_id filter" do
     get api_v1_security_prices_url, params: { security_id: "not-a-uuid" }, headers: api_headers(@api_key)
 

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -42,7 +42,7 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     @security_price = Security::Price.create!(
       security: @security,
       date: Date.parse("2024-01-15"),
-      price: BigDecimal("0.0001"),
+      price: BigDecimal("250.5000"),
       currency: "USD",
       provisional: true
     )
@@ -90,7 +90,7 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal @security_price.id, response_data["id"]
     assert_equal "2024-01-15", response_data["date"]
-    assert_equal "0.0001", response_data["price_amount"]
+    assert_equal "250.5000", response_data["price_amount"]
     assert_equal @security.id, response_data.dig("security", "id")
   end
 

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -109,14 +109,15 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ @security_price.id ], response_data["security_prices"].map { |price| price["id"] }
   end
 
-  test "ignores blank provisional filter" do
+  test "rejects blank provisional filter" do
     get api_v1_security_prices_url,
         params: { provisional: "" },
         headers: api_headers(@api_key)
 
-    assert_response :success
+    assert_response :unprocessable_entity
     response_data = JSON.parse(response.body)
-    assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
+    assert_equal "validation_failed", response_data["error"]
+    assert_includes response_data["errors"], "provisional must be true or false"
   end
 
   test "filters security prices by currency" do

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @user.api_keys.active.destroy_all
+
+    @api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Read Key",
+      scopes: [ "read" ],
+      source: "web",
+      display_key: "test_read_#{SecureRandom.hex(8)}"
+    )
+
+    @account = @family.accounts.create!(
+      name: "Investment Account",
+      accountable: Investment.new,
+      balance: 25_000,
+      currency: "USD"
+    )
+
+    @ticker = "VTI#{SecureRandom.hex(4).upcase}"
+
+    @security = Security.create!(
+      ticker: @ticker,
+      name: "Vanguard Total Stock Market ETF",
+      country_code: "US",
+      exchange_operating_mic: "ARCX"
+    )
+    @account.holdings.create!(
+      security: @security,
+      date: Date.parse("2024-01-15"),
+      qty: 100,
+      price: 250,
+      amount: 25_000,
+      currency: "USD"
+    )
+    @security_price = Security::Price.create!(
+      security: @security,
+      date: Date.parse("2024-01-15"),
+      price: 250.1234,
+      currency: "USD",
+      provisional: true
+    )
+
+    other_account = families(:empty).accounts.create!(
+      name: "Other Investment Account",
+      accountable: Investment.new,
+      balance: 1000,
+      currency: "USD"
+    )
+    @other_security = Security.create!(ticker: "GOOG#{SecureRandom.hex(4).upcase}", name: "Alphabet Inc.", country_code: "US")
+    other_account.holdings.create!(
+      security: @other_security,
+      date: Date.parse("2024-01-15"),
+      qty: 1,
+      price: 100,
+      amount: 100,
+      currency: "USD"
+    )
+    @other_price = Security::Price.create!(
+      security: @other_security,
+      date: Date.parse("2024-01-15"),
+      price: 100,
+      currency: "USD"
+    )
+  end
+
+  test "lists prices for securities referenced by accessible family investment data" do
+    get api_v1_security_prices_url, headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    price_ids = response_data["security_prices"].map { |price| price["id"] }
+
+    assert_includes price_ids, @security_price.id
+    assert_not_includes price_ids, @other_price.id
+    assert response_data.key?("pagination")
+  end
+
+  test "shows a scoped security price" do
+    get api_v1_security_price_url(@security_price), headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+
+    assert_equal @security_price.id, response_data["id"]
+    assert_equal "2024-01-15", response_data["date"]
+    assert_equal "250.1234", response_data["price_amount"]
+    assert_equal @security.id, response_data.dig("security", "id")
+  end
+
+  test "returns not found for another family's security price" do
+    get api_v1_security_price_url(@other_price), headers: api_headers(@api_key)
+
+    assert_response :not_found
+    response_data = JSON.parse(response.body)
+    assert_equal "record_not_found", response_data["error"]
+  end
+
+  test "returns not found for malformed security price id" do
+    get api_v1_security_price_url("not-a-uuid"), headers: api_headers(@api_key)
+
+    assert_response :not_found
+    response_data = JSON.parse(response.body)
+    assert_equal "record_not_found", response_data["error"]
+  end
+
+  test "filters security prices by security_id" do
+    get api_v1_security_prices_url, params: { security_id: @security.id }, headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_equal [ @security_price.id ], response_data["security_prices"].map { |price| price["id"] }
+  end
+
+  test "filters security prices by date range and provisional status" do
+    get api_v1_security_prices_url,
+        params: { start_date: "2024-01-15", end_date: "2024-01-15", provisional: true },
+        headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_equal [ @security_price.id ], response_data["security_prices"].map { |price| price["id"] }
+  end
+
+  test "rejects malformed security_id filter" do
+    get api_v1_security_prices_url, params: { security_id: "not-a-uuid" }, headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+    response_data = JSON.parse(response.body)
+    assert_equal "validation_failed", response_data["error"]
+  end
+
+  test "rejects invalid date filters" do
+    get api_v1_security_prices_url, params: { start_date: "01/15/2024" }, headers: api_headers(@api_key)
+
+    assert_response :unprocessable_entity
+    response_data = JSON.parse(response.body)
+    assert_equal "validation_failed", response_data["error"]
+  end
+
+  test "requires authentication" do
+    get api_v1_security_prices_url
+
+    assert_response :unauthorized
+  end
+
+  test "requires read scope" do
+    api_key_without_read = ApiKey.new(
+      user: @user,
+      name: "No Read Key",
+      scopes: [],
+      source: "web",
+      display_key: "no_read_#{SecureRandom.hex(8)}"
+    )
+    api_key_without_read.save!(validate: false)
+
+    get api_v1_security_prices_url, headers: api_headers(api_key_without_read)
+
+    assert_response :forbidden
+  ensure
+    api_key_without_read&.destroy
+  end
+
+  private
+
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.plain_key }
+    end
+end

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -42,7 +42,7 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     @security_price = Security::Price.create!(
       security: @security,
       date: Date.parse("2024-01-15"),
-      price: 250.1234,
+      price: BigDecimal("0.0001"),
       currency: "USD",
       provisional: true
     )
@@ -90,7 +90,7 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal @security_price.id, response_data["id"]
     assert_equal "2024-01-15", response_data["date"]
-    assert_equal "250.1234", response_data["price_amount"]
+    assert_equal "0.0001", response_data["price_amount"]
     assert_equal @security.id, response_data.dig("security", "id")
   end
 
@@ -126,6 +126,16 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     response_data = JSON.parse(response.body)
     assert_equal [ @security_price.id ], response_data["security_prices"].map { |price| price["id"] }
+  end
+
+  test "ignores blank provisional filter" do
+    get api_v1_security_prices_url,
+        params: { provisional: "" },
+        headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
   end
 
   test "rejects malformed security_id filter" do

--- a/test/controllers/api/v1/security_prices_controller_test.rb
+++ b/test/controllers/api/v1/security_prices_controller_test.rb
@@ -128,14 +128,15 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ @security_price.id ], response_data["security_prices"].map { |price| price["id"] }
   end
 
-  test "ignores blank provisional filter" do
+  test "rejects blank provisional filter" do
     get api_v1_security_prices_url,
         params: { provisional: "" },
         headers: api_headers(@api_key)
 
-    assert_response :success
+    assert_response :unprocessable_entity
     response_data = JSON.parse(response.body)
-    assert_includes response_data["security_prices"].map { |price| price["id"] }, @security_price.id
+    assert_equal "validation_failed", response_data["error"]
+    assert_includes response_data["errors"], "provisional must be true or false"
   end
 
   test "rejects malformed provisional filter" do
@@ -198,6 +199,6 @@ class Api::V1::SecurityPricesControllerTest < ActionDispatch::IntegrationTest
   private
 
     def api_headers(api_key)
-      { "X-Api-Key" => api_key.plain_key }
+      { "X-Api-Key" => api_key.display_key }
     end
 end


### PR DESCRIPTION
## Summary
- Add read-only API access to securities referenced by a family's investment data.
- Add read-only API access to security price history for those scoped securities.

## What changed
- Added `GET /api/v1/securities` and `GET /api/v1/securities/:id`.
- Added `GET /api/v1/security_prices` and `GET /api/v1/security_prices/:id`.
- Scoped the global security catalog through the current user's accessible visible accounts, holdings, and trades.
- Added filters for ticker, exchange MIC, kind, offline status, security, currency, date range, and provisional status.
- Added Jbuilder serializers, Minitest behavior coverage, docs-only rswag specs, and regenerated `docs/api/openapi.yaml`.

## Why
- API clients and self-hosted operators need a stable way to verify portfolio securities and price history without scraping investment views or inferring catalog state from holdings alone.

## Validation
- `docker exec -w /workspace devcontainer-app-1 bin/rails test test/controllers/api/v1/securities_controller_test.rb test/controllers/api/v1/security_prices_controller_test.rb`
- `docker exec -w /workspace devcontainer-app-1 env RAILS_ENV=test bundle exec rake rswag:specs:swaggerize`
- `docker exec -w /workspace devcontainer-app-1 bundle exec rubocop app/controllers/api/v1/securities_controller.rb app/controllers/api/v1/security_prices_controller.rb app/views/api/v1/securities/_security.json.jbuilder app/views/api/v1/security_prices/_security_price.json.jbuilder test/controllers/api/v1/securities_controller_test.rb test/controllers/api/v1/security_prices_controller_test.rb spec/requests/api/v1/securities_spec.rb spec/requests/api/v1/security_prices_spec.rb spec/swagger_helper.rb`
- `git diff --check`

## Notes
- Draft for maintainer review.
- Endpoints are read-only and do not expose provider credentials or raw provider payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Securities and Security Prices APIs (index + show) with filtering, UUID/date validation, ordering, paginated JSON responses, detailed resource fields (identifiers, exchange/provider info, offline status, price data, timestamps), auth/authorization enforcement, and 422 validation errors for invalid filters.

* **Documentation**
  * OpenAPI docs updated with schemas and endpoint specs for securities and security prices.

* **Tests**
  * Added request and integration tests covering success, auth, filters, pagination, and validation/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->