### PR TITLE
feat(advanced-reports): add income vs expenses report (MK-16)

### DIFF
--- a/app/controllers/advanced_reports/base_controller.rb
+++ b/app/controllers/advanced_reports/base_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module AdvancedReports
+  class BaseController < ApplicationController
+    layout "advanced_reports"
+
+    before_action :set_account_scope
+
+    private
+      def set_account_scope
+        @accounts = Current.family.accounts.active
+      end
+  end
+end

--- a/app/controllers/advanced_reports/dashboard_controller.rb
+++ b/app/controllers/advanced_reports/dashboard_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AdvancedReports
+  class DashboardController < BaseController
+    def index
+      @breadcrumbs = [ [ t("advanced_reports.dashboard.index.breadcrumb_home"), root_path ],
+                       [ t("advanced_reports.dashboard.index.breadcrumb_reports"), reports_path ],
+                       [ t("advanced_reports.dashboard.index.title"), nil ] ]
+    end
+  end
+end

--- a/app/controllers/advanced_reports/income_expenses_controller.rb
+++ b/app/controllers/advanced_reports/income_expenses_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module AdvancedReports
+  class IncomeExpensesController < BaseController
+    before_action :set_filters
+
+    def index
+      @report = AdvancedReports::IncomeExpensesQuery.new(
+        Current.family,
+        date_range_filter: @date_range_filter,
+        account_ids: @selected_account_id
+      ).call
+
+      @breadcrumbs = [
+        [ t("advanced_reports.dashboard.index.breadcrumb_home"), root_path ],
+        [ t("advanced_reports.dashboard.index.breadcrumb_reports"), reports_path ],
+        [ t("advanced_reports.dashboard.index.title"), advanced_reports_dashboard_index_path ],
+        [ t("advanced_reports.income_expenses.index.title"), nil ]
+      ]
+    end
+
+    private
+
+      def set_filters
+        @preset = params[:preset].presence || "last_3_months"
+        @selected_account = @accounts.find_by(id: params[:account_id]) if params[:account_id].present?
+        @selected_account_id = @selected_account&.id
+
+        @date_range_filter = AdvancedReports::DateRangeFilter.new(
+          preset: @preset,
+          start_date: params[:start_date],
+          end_date: params[:end_date]
+        )
+
+        return if @date_range_filter.valid?
+
+        handle_invalid_filters
+      rescue ArgumentError
+        handle_invalid_filters
+      end
+
+      def handle_invalid_filters
+        @preset = "last_3_months"
+        @date_range_filter = AdvancedReports::DateRangeFilter.new(preset: @preset)
+        flash.now[:alert] = t("advanced_reports.income_expenses.index.invalid_date_range")
+      end
+  end
+end

--- a/app/javascript/controllers/income_expenses_chart_controller.js
+++ b/app/javascript/controllers/income_expenses_chart_controller.js
@@ -1,0 +1,197 @@
+import { Controller } from "@hotwired/stimulus";
+import * as d3 from "d3";
+
+export default class extends Controller {
+  static values = {
+    data: Object,
+  };
+
+  connect() {
+    this.render();
+    this.resizeObserver = new ResizeObserver(() => this.render());
+    this.resizeObserver.observe(this.element);
+  }
+
+  disconnect() {
+    this.resizeObserver?.disconnect();
+  }
+
+  render() {
+    const width = this.element.clientWidth;
+    const height = 320;
+
+    if (!width) return;
+
+    d3.select(this.element).selectAll("*").remove();
+
+    const data = this.dataValue.values || [];
+    if (!data.length) return;
+
+    const margin = { top: 20, right: 20, bottom: 48, left: 56 };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
+
+    const svg = d3
+      .select(this.element)
+      .append("svg")
+      .attr("viewBox", `0 0 ${width} ${height}`)
+      .attr("preserveAspectRatio", "xMidYMid meet")
+      .attr("class", "h-full w-full");
+
+    const chart = svg
+      .append("g")
+      .attr("transform", `translate(${margin.left}, ${margin.top})`);
+
+    const x0 = d3
+      .scaleBand()
+      .domain(data.map((d) => d.label))
+      .range([0, innerWidth])
+      .padding(0.24);
+
+    const x1 = d3
+      .scaleBand()
+      .domain(["income", "expense"])
+      .range([0, x0.bandwidth()])
+      .padding(0.18);
+
+    const maxValue = d3.max(data, (d) => Math.max(d.income, d.expense, d.net, 0)) || 0;
+    const minValue = d3.min(data, (d) => Math.min(d.net, 0)) || 0;
+
+    const y = d3
+      .scaleLinear()
+      .domain([minValue, maxValue])
+      .nice()
+      .range([innerHeight, 0]);
+
+    const line = d3
+      .line()
+      .x((d) => x0(d.label) + x0.bandwidth() / 2)
+      .y((d) => y(d.net))
+      .curve(d3.curveMonotoneX);
+
+    chart
+      .append("g")
+      .call(
+        d3.axisLeft(y)
+          .ticks(5)
+          .tickFormat((value) => this.#formatAxisValue(value)),
+      )
+      .call((g) => g.select(".domain").remove())
+      .call((g) => g.selectAll(".tick line").attr("stroke", "#d7dee7"))
+      .call((g) => g.selectAll(".tick text").attr("fill", "#6b7280").attr("font-size", 12));
+
+    chart
+      .append("line")
+      .attr("x1", 0)
+      .attr("x2", innerWidth)
+      .attr("y1", y(0))
+      .attr("y2", y(0))
+      .attr("stroke", "#cfd8e3");
+
+    const group = chart
+      .selectAll("g.bar-group")
+      .data(data)
+      .enter()
+      .append("g")
+      .attr("transform", (d) => `translate(${x0(d.label)}, 0)`);
+
+    group
+      .selectAll("rect")
+      .data((d) => [
+        { key: "income", value: d.income, color: "#16a34a" },
+        { key: "expense", value: d.expense, color: "#ef4444" },
+      ])
+      .enter()
+      .append("rect")
+      .attr("x", (d) => x1(d.key))
+      .attr("y", (d) => y(Math.max(d.value, 0)))
+      .attr("width", x1.bandwidth())
+      .attr("height", (d) => Math.abs(y(d.value) - y(0)))
+      .attr("rx", 6)
+      .attr("fill", (d) => d.color);
+
+    chart
+      .append("path")
+      .datum(data)
+      .attr("fill", "none")
+      .attr("stroke", "#0f172a")
+      .attr("stroke-width", 2.5)
+      .attr("d", line);
+
+    chart
+      .selectAll("circle.net-point")
+      .data(data)
+      .enter()
+      .append("circle")
+      .attr("cx", (d) => x0(d.label) + x0.bandwidth() / 2)
+      .attr("cy", (d) => y(d.net))
+      .attr("r", 3.5)
+      .attr("fill", "#0f172a");
+
+    chart
+      .append("g")
+      .attr("transform", `translate(0, ${innerHeight})`)
+      .call(
+        d3.axisBottom(x0)
+          .tickValues(this.#visibleTicks(data))
+          .tickSize(0),
+      )
+      .call((g) => g.select(".domain").remove())
+      .call((g) => g.selectAll("text").attr("fill", "#6b7280").attr("font-size", 12))
+      .call((g) => g.selectAll("text").attr("dy", "1.2em"));
+
+    const legend = svg
+      .append("g")
+      .attr("transform", `translate(${margin.left}, ${height - 12})`);
+
+    [
+      { label: "Income", color: "#16a34a" },
+      { label: "Expenses", color: "#ef4444" },
+      { label: "Net cash flow", color: "#0f172a", line: true },
+    ].forEach((item, index) => {
+      const entry = legend.append("g").attr("transform", `translate(${index * 132}, 0)`);
+
+      if (item.line) {
+        entry.append("line")
+          .attr("x1", 0)
+          .attr("x2", 18)
+          .attr("y1", -4)
+          .attr("y2", -4)
+          .attr("stroke", item.color)
+          .attr("stroke-width", 2.5);
+      } else {
+        entry.append("rect")
+          .attr("width", 18)
+          .attr("height", 10)
+          .attr("rx", 3)
+          .attr("y", -9)
+          .attr("fill", item.color);
+      }
+
+      entry.append("text")
+        .attr("x", 24)
+        .attr("y", 0)
+        .attr("fill", "#6b7280")
+        .attr("font-size", 12)
+        .text(item.label);
+    });
+  }
+
+  #visibleTicks(data) {
+    if (data.length <= 6) return data.map((d) => d.label);
+
+    return data
+      .filter((_, index) => index % 2 === 0 || index === data.length - 1)
+      .map((d) => d.label);
+  }
+
+  #formatAxisValue(value) {
+    const absolute = Math.abs(value);
+
+    if (absolute >= 1000) {
+      return `$${(value / 1000).toFixed(1)}k`;
+    }
+
+    return `$${value}`;
+  }
+}

--- a/app/javascript/controllers/income_expenses_chart_controller.js
+++ b/app/javascript/controllers/income_expenses_chart_controller.js
@@ -144,11 +144,14 @@ export default class extends Controller {
       .append("g")
       .attr("transform", `translate(${margin.left}, ${height - 12})`);
 
-    [
-      { label: "Income", color: "#16a34a" },
-      { label: "Expenses", color: "#ef4444" },
-      { label: "Net cash flow", color: "#0f172a", line: true },
-    ].forEach((item, index) => {
+    const legendPayload = this.dataValue.legend || {};
+    const legendItems = [
+      { label: legendPayload.income || "Income", color: "#16a34a" },
+      { label: legendPayload.expenses || "Expenses", color: "#ef4444" },
+      { label: legendPayload.net_cash_flow || "Net cash flow", color: "#0f172a", line: true }
+    ];
+
+    legendItems.forEach((item, index) => {
       const entry = legend.append("g").attr("transform", `translate(${index * 132}, 0)`);
 
       if (item.line) {

--- a/app/services/advanced_reports/base_query.rb
+++ b/app/services/advanced_reports/base_query.rb
@@ -1,17 +1,24 @@
 class AdvancedReports::BaseQuery
-  attr_reader :family, :date_range_filter
+  attr_reader :family, :date_range_filter, :account_ids
 
-  def initialize(family, date_range_filter:)
+  def initialize(family, date_range_filter:, account_ids: nil)
     @family = family
     @date_range_filter = date_range_filter
+    @account_ids = Array(account_ids).compact_blank
   end
 
   private
 
     def scoped_transactions
-      family.transactions
+      scope = family.transactions
         .visible
         .excluding_pending
         .in_period(date_range_filter)
+        .joins(:entry)
+        .where(entries: { excluded: false })
+
+      return scope if account_ids.empty?
+
+      scope.where(entries: { account_id: account_ids })
     end
 end

--- a/app/services/advanced_reports/base_query.rb
+++ b/app/services/advanced_reports/base_query.rb
@@ -1,0 +1,17 @@
+class AdvancedReports::BaseQuery
+  attr_reader :family, :date_range_filter
+
+  def initialize(family, date_range_filter:)
+    @family = family
+    @date_range_filter = date_range_filter
+  end
+
+  private
+
+    def scoped_transactions
+      family.transactions
+        .visible
+        .excluding_pending
+        .in_period(date_range_filter)
+    end
+end

--- a/app/services/advanced_reports/date_range_filter.rb
+++ b/app/services/advanced_reports/date_range_filter.rb
@@ -1,0 +1,48 @@
+class AdvancedReports::DateRangeFilter
+  PRESETS = %w[this_month last_3_months ytd last_year].freeze
+
+  attr_reader :preset, :start_date, :end_date
+
+  def initialize(preset: nil, start_date: nil, end_date: nil)
+    if preset.present? && preset.to_s != "custom"
+      @preset = preset.to_s
+      @start_date, @end_date = resolve_preset(@preset)
+    else
+      @preset = "custom"
+      @start_date = coerce_date(start_date)
+      @end_date = coerce_date(end_date)
+    end
+  end
+
+  def valid?
+    start_date.is_a?(Date) && end_date.is_a?(Date) && start_date <= end_date
+  end
+
+  def date_range
+    start_date..end_date
+  end
+
+  private
+
+    def resolve_preset(key)
+      case key
+      when "this_month"
+        [ Date.current.beginning_of_month, Date.current ]
+      when "last_3_months"
+        [ 3.months.ago.to_date.beginning_of_month, Date.current ]
+      when "ytd"
+        [ Date.current.beginning_of_year, Date.current ]
+      when "last_year"
+        [ 1.year.ago.to_date.beginning_of_year, 1.year.ago.to_date.end_of_year ]
+      else
+        raise ArgumentError, "Unknown preset: #{key}. Valid presets are: #{PRESETS.join(', ')}"
+      end
+    end
+
+    def coerce_date(value)
+      return value if value.is_a?(Date)
+      Date.parse(value.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+end

--- a/app/services/advanced_reports/income_expenses_query.rb
+++ b/app/services/advanced_reports/income_expenses_query.rb
@@ -1,0 +1,120 @@
+class AdvancedReports::IncomeExpensesQuery < AdvancedReports::BaseQuery
+  Result = Data.define(
+    :total_income,
+    :total_expense,
+    :net_cash_flow,
+    :savings_rate,
+    :currency,
+    :months
+  )
+
+  Month = Data.define(
+    :date,
+    :label,
+    :income,
+    :expense,
+    :net_cash_flow
+  )
+
+  def call
+    monthly_rows = grouped_monthly_rows.index_by { |row| row.fetch("month").to_date }
+    months = build_months(monthly_rows)
+
+    total_income = months.sum(&:income)
+    total_expense = months.sum(&:expense)
+    net_cash_flow = total_income - total_expense
+
+    Result.new(
+      total_income: total_income,
+      total_expense: total_expense,
+      net_cash_flow: net_cash_flow,
+      savings_rate: savings_rate(total_income, net_cash_flow),
+      currency: family.currency,
+      months: months
+    )
+  end
+
+  private
+
+    def grouped_monthly_rows
+      ActiveRecord::Base.connection.select_all(query_sql).to_a
+    end
+
+    def query_sql
+      transactions_scope = scoped_transactions.where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
+
+      <<~SQL.squish
+        SELECT
+          DATE_TRUNC('month', e.date)::date AS month,
+          SUM(#{income_sql}) AS total_income,
+          SUM(#{expense_sql}) AS total_expense
+        FROM (#{transactions_scope.to_sql}) t
+        INNER JOIN entries e
+          ON e.entryable_id = t.id
+         AND e.entryable_type = 'Transaction'
+        GROUP BY DATE_TRUNC('month', e.date)::date
+        ORDER BY DATE_TRUNC('month', e.date)::date ASC
+      SQL
+    end
+
+    def income_sql
+      <<~SQL.squish
+        CASE
+          WHEN t.kind IN ('investment_contribution', 'loan_payment') THEN 0
+          WHEN e.amount < 0 THEN ABS(e.amount)
+          ELSE 0
+        END
+      SQL
+    end
+
+    def expense_sql
+      <<~SQL.squish
+        CASE
+          WHEN t.kind IN ('investment_contribution', 'loan_payment') THEN ABS(e.amount)
+          WHEN e.amount > 0 THEN e.amount
+          ELSE 0
+        END
+      SQL
+    end
+
+    def build_months(monthly_rows)
+      each_month.map do |month_date|
+        row = monthly_rows[month_date] || {}
+        income = decimal_or_zero(row["total_income"])
+        expense = decimal_or_zero(row["total_expense"])
+
+        Month.new(
+          date: month_date,
+          label: month_date.strftime("%b %Y"),
+          income: income,
+          expense: expense,
+          net_cash_flow: income - expense
+        )
+      end
+    end
+
+    def each_month
+      start_month = date_range_filter.start_date.beginning_of_month
+      end_month = date_range_filter.end_date.beginning_of_month
+
+      current_month = start_month
+      months = []
+
+      while current_month <= end_month
+        months << current_month
+        current_month = current_month.next_month
+      end
+
+      months
+    end
+
+    def savings_rate(total_income, net_cash_flow)
+      return 0.to_d if total_income.zero?
+
+      ((net_cash_flow / total_income) * 100).round(2)
+    end
+
+    def decimal_or_zero(value)
+      value.present? ? value.to_d : 0.to_d
+    end
+end

--- a/app/services/advanced_reports/transaction_summary_query.rb
+++ b/app/services/advanced_reports/transaction_summary_query.rb
@@ -1,0 +1,43 @@
+class AdvancedReports::TransactionSummaryQuery < AdvancedReports::BaseQuery
+  Result = Data.define(:total_income, :total_expense, :net, :currency)
+
+  def call
+    transactions_scope = scoped_transactions
+      .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
+
+    row = ActiveRecord::Base.connection.select_one(
+      ActiveRecord::Base.sanitize_sql_array([ query_sql(transactions_scope), { excluded: false } ])
+    )
+
+    total_income = row["total_income"]&.to_d || 0
+    total_expense = row["total_expense"]&.to_d || 0
+
+    Result.new(
+      total_income: total_income,
+      total_expense: total_expense,
+      net: total_income - total_expense,
+      currency: family.currency
+    )
+  end
+
+  private
+
+    def query_sql(transactions_scope)
+      <<~SQL
+        SELECT
+          SUM(CASE
+            WHEN t.kind IN ('investment_contribution', 'loan_payment') THEN 0
+            WHEN e.amount < 0 THEN ABS(e.amount)
+            ELSE 0
+          END) AS total_income,
+          SUM(CASE
+            WHEN t.kind IN ('investment_contribution', 'loan_payment') THEN ABS(e.amount)
+            WHEN e.amount > 0 THEN e.amount
+            ELSE 0
+          END) AS total_expense
+        FROM (#{transactions_scope.to_sql}) t
+        JOIN entries e ON e.entryable_id = t.id AND e.entryable_type = 'Transaction'
+        WHERE e.excluded = :excluded
+      SQL
+    end
+end

--- a/app/views/advanced_reports/dashboard/index.html.erb
+++ b/app/views/advanced_reports/dashboard/index.html.erb
@@ -4,4 +4,22 @@
   <div class="rounded-xl border border-primary bg-container p-6">
     <p class="text-secondary text-sm"><%= t(".description") %></p>
   </div>
+
+  <div class="grid gap-4 md:grid-cols-2">
+    <%= link_to advanced_reports_income_expenses_path,
+                class: "rounded-xl border border-primary bg-container p-6 transition-colors hover:bg-surface-hover" do %>
+      <div class="flex items-start justify-between gap-4">
+        <div class="space-y-2">
+          <h2 class="text-lg font-medium text-primary">
+            <%= t(".income_expenses.title") %>
+          </h2>
+          <p class="text-sm text-secondary">
+            <%= t(".income_expenses.description") %>
+          </p>
+        </div>
+
+        <%= icon("arrow-right", size: "sm") %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/advanced_reports/dashboard/index.html.erb
+++ b/app/views/advanced_reports/dashboard/index.html.erb
@@ -1,0 +1,7 @@
+<% content_for :page_title, t(".title") %>
+
+<div class="space-y-6">
+  <div class="rounded-xl border border-primary bg-container p-6">
+    <p class="text-secondary text-sm"><%= t(".description") %></p>
+  </div>
+</div>

--- a/app/views/advanced_reports/income_expenses/_report.html.erb
+++ b/app/views/advanced_reports/income_expenses/_report.html.erb
@@ -6,7 +6,12 @@
       expense: month.expense.to_f,
       net: month.net_cash_flow.to_f
     }
-  end
+  end,
+  legend: {
+    income: t(".chart.legend.income"),
+    expenses: t(".chart.legend.expenses"),
+    net_cash_flow: t(".chart.legend.net_cash_flow")
+  }
 } %>
 
 <div class="space-y-6">
@@ -64,7 +69,7 @@
     <div
       class="mt-6 min-h-80 w-full"
       data-controller="income-expenses-chart"
-      data-income-expenses-chart-data-value="<%= chart_data.to_json %>"></div>
+      data-income-expenses-chart-data-value="<%= ERB::Util.json_escape(chart_data.to_json) %>"></div>
   </div>
 
   <div class="rounded-xl border border-primary bg-container overflow-hidden">

--- a/app/views/advanced_reports/income_expenses/_report.html.erb
+++ b/app/views/advanced_reports/income_expenses/_report.html.erb
@@ -1,0 +1,96 @@
+<% chart_data = {
+  values: report.months.map do |month|
+    {
+      label: month.label,
+      income: month.income.to_f,
+      expense: month.expense.to_f,
+      net: month.net_cash_flow.to_f
+    }
+  end
+} %>
+
+<div class="space-y-6">
+  <% if flash[:alert].present? %>
+    <div class="rounded-xl border border-destructive bg-destructive-surface px-4 py-3 text-sm text-destructive">
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
+
+  <div class="flex flex-col gap-1">
+    <p class="text-sm text-secondary">
+      <%= t(".showing_period",
+            start_date: l(@date_range_filter.start_date, format: :long),
+            end_date: l(@date_range_filter.end_date, format: :long)) %>
+    </p>
+    <p class="text-sm text-secondary">
+      <%= @selected_account.present? ? @selected_account.name : t(".all_accounts") %>
+    </p>
+  </div>
+
+  <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <div class="rounded-xl border border-primary bg-container p-4">
+      <p class="text-sm text-secondary"><%= t(".summary.total_income") %></p>
+      <p class="mt-2 text-2xl font-medium text-primary"><%= number_to_currency(report.total_income, unit: Money::Currency.new(report.currency).symbol) %></p>
+    </div>
+
+    <div class="rounded-xl border border-primary bg-container p-4">
+      <p class="text-sm text-secondary"><%= t(".summary.total_expenses") %></p>
+      <p class="mt-2 text-2xl font-medium text-primary"><%= number_to_currency(report.total_expense, unit: Money::Currency.new(report.currency).symbol) %></p>
+    </div>
+
+    <div class="rounded-xl border border-primary bg-container p-4">
+      <p class="text-sm text-secondary"><%= t(".summary.net_cash_flow") %></p>
+      <p class="mt-2 text-2xl font-medium <%= report.net_cash_flow.negative? ? "text-destructive" : "text-success" %>">
+        <%= number_to_currency(report.net_cash_flow, unit: Money::Currency.new(report.currency).symbol) %>
+      </p>
+    </div>
+
+    <div class="rounded-xl border border-primary bg-container p-4">
+      <p class="text-sm text-secondary"><%= t(".summary.savings_rate") %></p>
+      <p class="mt-2 text-2xl font-medium <%= report.savings_rate.negative? ? "text-destructive" : "text-primary" %>">
+        <%= number_to_percentage(report.savings_rate, precision: 2, strip_insignificant_zeros: true) %>
+      </p>
+    </div>
+  </div>
+
+  <div class="rounded-xl border border-primary bg-container p-4 md:p-6">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h2 class="text-lg font-medium text-primary"><%= t(".chart.title") %></h2>
+        <p class="text-sm text-secondary"><%= t(".chart.description") %></p>
+      </div>
+    </div>
+
+    <div
+      class="mt-6 min-h-80 w-full"
+      data-controller="income-expenses-chart"
+      data-income-expenses-chart-data-value="<%= chart_data.to_json %>"></div>
+  </div>
+
+  <div class="rounded-xl border border-primary bg-container overflow-hidden">
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-primary">
+        <thead class="bg-surface">
+          <tr class="text-left text-sm text-secondary">
+            <th class="px-4 py-3 font-medium"><%= t(".table.month") %></th>
+            <th class="px-4 py-3 font-medium"><%= t(".table.income") %></th>
+            <th class="px-4 py-3 font-medium"><%= t(".table.expenses") %></th>
+            <th class="px-4 py-3 font-medium"><%= t(".table.net_cash_flow") %></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-primary text-sm text-primary">
+          <% report.months.each do |month| %>
+            <tr>
+              <td class="px-4 py-3 font-medium"><%= month.label %></td>
+              <td class="px-4 py-3"><%= number_to_currency(month.income, unit: Money::Currency.new(report.currency).symbol) %></td>
+              <td class="px-4 py-3"><%= number_to_currency(month.expense, unit: Money::Currency.new(report.currency).symbol) %></td>
+              <td class="px-4 py-3 <%= month.net_cash_flow.negative? ? "text-destructive" : "text-success" %>">
+                <%= number_to_currency(month.net_cash_flow, unit: Money::Currency.new(report.currency).symbol) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/advanced_reports/income_expenses/index.html.erb
+++ b/app/views/advanced_reports/income_expenses/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :page_title, t(".title") %>
+
+<div class="space-y-6">
+  <div class="rounded-xl border border-primary bg-container p-4 md:p-6">
+    <%= form_with url: advanced_reports_income_expenses_path,
+                  method: :get,
+                  data: { controller: "auto-submit-form", turbo_frame: "income_expenses_report" },
+                  class: "grid gap-4 lg:grid-cols-4" do |form| %>
+      <div class="space-y-1">
+        <%= form.label :preset, t(".filters.date_range"), class: "text-sm font-medium text-secondary" %>
+        <%= form.select :preset,
+                        options_for_select(@date_range_filter.class::PRESETS.map { |preset| [t(".presets.#{preset}"), preset] } + [[t(".presets.custom"), "custom"]], @preset),
+                        {},
+                        data: { auto_submit_form_target: "auto" },
+                        class: "w-full rounded-lg border border-primary bg-surface px-3 py-2 text-sm text-primary" %>
+      </div>
+
+      <div class="space-y-1">
+        <%= form.label :account_id, t(".filters.account"), class: "text-sm font-medium text-secondary" %>
+        <%= form.select :account_id,
+                        options_for_select([[t(".filters.all_accounts"), nil]] + @accounts.map { |account| [account.name, account.id] }, @selected_account_id),
+                        {},
+                        data: { auto_submit_form_target: "auto" },
+                        class: "w-full rounded-lg border border-primary bg-surface px-3 py-2 text-sm text-primary" %>
+      </div>
+
+      <div class="space-y-1">
+        <%= form.label :start_date, t(".filters.start_date"), class: "text-sm font-medium text-secondary" %>
+        <%= form.date_field :start_date,
+                            value: @date_range_filter.start_date&.strftime("%Y-%m-%d"),
+                            data: { auto_submit_form_target: "auto" },
+                            class: "w-full rounded-lg border border-primary bg-surface px-3 py-2 text-sm text-primary" %>
+      </div>
+
+      <div class="space-y-1">
+        <%= form.label :end_date, t(".filters.end_date"), class: "text-sm font-medium text-secondary" %>
+        <%= form.date_field :end_date,
+                            value: @date_range_filter.end_date&.strftime("%Y-%m-%d"),
+                            data: { auto_submit_form_target: "auto" },
+                            class: "w-full rounded-lg border border-primary bg-surface px-3 py-2 text-sm text-primary" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= turbo_frame_tag "income_expenses_report" do %>
+    <%= render "report", report: @report %>
+  <% end %>
+</div>

--- a/app/views/advanced_reports/shared/_sub_nav.html.erb
+++ b/app/views/advanced_reports/shared/_sub_nav.html.erb
@@ -1,0 +1,11 @@
+<nav class="shrink-0 border-b border-primary bg-surface px-3 md:px-10">
+  <div class="max-w-6xl mx-auto flex items-center gap-1 py-2">
+    <span class="text-sm font-medium text-secondary mr-3">
+      <%= t("advanced_reports.shared.sub_nav.title") %>
+    </span>
+
+    <%= link_to t("advanced_reports.shared.sub_nav.dashboard"),
+                advanced_reports_dashboard_index_path,
+                class: "text-sm px-3 py-1.5 rounded-lg transition-colors #{ page_active?(advanced_reports_dashboard_index_path) ? "bg-container text-primary font-medium" : "text-secondary hover:text-primary hover:bg-container" }" %>
+  </div>
+</nav>

--- a/app/views/advanced_reports/shared/_sub_nav.html.erb
+++ b/app/views/advanced_reports/shared/_sub_nav.html.erb
@@ -7,5 +7,9 @@
     <%= link_to t("advanced_reports.shared.sub_nav.dashboard"),
                 advanced_reports_dashboard_index_path,
                 class: "text-sm px-3 py-1.5 rounded-lg transition-colors #{ page_active?(advanced_reports_dashboard_index_path) ? "bg-container text-primary font-medium" : "text-secondary hover:text-primary hover:bg-container" }" %>
+
+    <%= link_to t("advanced_reports.shared.sub_nav.income_expenses"),
+                advanced_reports_income_expenses_path,
+                class: "text-sm px-3 py-1.5 rounded-lg transition-colors #{ page_active?(advanced_reports_income_expenses_path) ? "bg-container text-primary font-medium" : "text-secondary hover:text-primary hover:bg-container" }" %>
   </div>
 </nav>

--- a/app/views/layouts/advanced_reports.html.erb
+++ b/app/views/layouts/advanced_reports.html.erb
@@ -1,0 +1,38 @@
+<%= render "layouts/shared/htmldoc" do %>
+  <div class="flex flex-col h-full bg-surface pt-[env(safe-area-inset-top)]">
+    <%= render "advanced_reports/shared/sub_nav" %>
+
+    <main class="grow flex h-full overflow-hidden">
+      <div class="relative max-w-6xl mx-auto flex flex-col w-full h-full">
+        <div class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]">
+          <div class="sticky top-0 z-10 px-3 md:px-10 pt-1.5 md:pt-3 pb-3 bg-surface border-b border-primary shrink-0">
+            <% if content_for?(:breadcrumbs) %>
+              <%= yield :breadcrumbs %>
+            <% else %>
+              <%= render "layouts/shared/breadcrumbs", breadcrumbs: @breadcrumbs %>
+            <% end %>
+
+            <div class="flex items-center justify-between gap-4 mt-1.5 min-h-9">
+              <% if content_for?(:page_title) %>
+                <h1 class="text-primary text-xl font-medium">
+                  <%= content_for :page_title %>
+                </h1>
+              <% else %>
+                <div></div>
+              <% end %>
+              <% if content_for?(:page_actions) %>
+                <div class="flex items-center gap-2 shrink-0">
+                  <%= yield :page_actions %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="grow px-3 md:px-10 pb-20 pt-6">
+            <%= yield %>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@ else
     { name: t(".nav.home"), path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
     { name: t(".nav.transactions"), path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
     { name: t(".nav.reports"), path: reports_path, icon: "chart-bar", icon_custom: false, active: page_active?(reports_path) },
+    { name: t(".nav.advanced_reports"), path: advanced_reports_dashboard_index_path, icon: "chart-bar-square", icon_custom: false, active: page_active?(advanced_reports_dashboard_index_path) },
     { name: t(".nav.budgets"), path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
     { name: t(".nav.assistant"), path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
   ]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@ else
     { name: t(".nav.home"), path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
     { name: t(".nav.transactions"), path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
     { name: t(".nav.reports"), path: reports_path, icon: "chart-bar", icon_custom: false, active: page_active?(reports_path) },
-    { name: t(".nav.advanced_reports"), path: advanced_reports_dashboard_index_path, icon: "chart-bar-square", icon_custom: false, active: page_active?(advanced_reports_dashboard_index_path) },
+    { name: t(".nav.advanced_reports"), path: advanced_reports_dashboard_index_path, icon: "trending-up", icon_custom: false, active: page_active?(advanced_reports_dashboard_index_path) },
     { name: t(".nav.budgets"), path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
     { name: t(".nav.assistant"), path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
   ]

--- a/config/locales/views/advanced_reports/en.yml
+++ b/config/locales/views/advanced_reports/en.yml
@@ -7,7 +7,43 @@ en:
         description: In-depth financial analysis and reporting.
         breadcrumb_home: Home
         breadcrumb_reports: Reports
+        income_expenses:
+          title: Income vs Expenses
+          description: Track income, expenses, and net cash flow month by month.
+    income_expenses:
+      report:
+        all_accounts: All accounts
+        showing_period: "Showing %{start_date} to %{end_date}"
+        summary:
+          total_income: Total Income
+          total_expenses: Total Expenses
+          net_cash_flow: Net Cash Flow
+          savings_rate: Savings Rate
+        chart:
+          title: Monthly cash flow
+          description: Grouped income and expense bars with net cash flow overlay.
+        table:
+          month: Month
+          income: Income
+          expenses: Expenses
+          net_cash_flow: Net Cash Flow
+      index:
+        title: Income vs Expenses
+        invalid_date_range: The selected date range is invalid. Showing the last 3 months instead.
+        filters:
+          date_range: Date range
+          account: Account
+          all_accounts: All accounts
+          start_date: Start date
+          end_date: End date
+        presets:
+          this_month: This month
+          last_3_months: Last 3 months
+          ytd: Year to date
+          last_year: Last year
+          custom: Custom
     shared:
       sub_nav:
         title: Advanced Reports
         dashboard: Dashboard
+        income_expenses: Income vs Expenses

--- a/config/locales/views/advanced_reports/en.yml
+++ b/config/locales/views/advanced_reports/en.yml
@@ -22,6 +22,10 @@ en:
         chart:
           title: Monthly cash flow
           description: Grouped income and expense bars with net cash flow overlay.
+          legend:
+            income: Income
+            expenses: Expenses
+            net_cash_flow: Net cash flow
         table:
           month: Month
           income: Income

--- a/config/locales/views/advanced_reports/en.yml
+++ b/config/locales/views/advanced_reports/en.yml
@@ -1,0 +1,13 @@
+---
+en:
+  advanced_reports:
+    dashboard:
+      index:
+        title: Advanced Reports
+        description: In-depth financial analysis and reporting.
+        breadcrumb_home: Home
+        breadcrumb_reports: Reports
+    shared:
+      sub_nav:
+        title: Advanced Reports
+        dashboard: Dashboard

--- a/config/locales/views/layout/en.yml
+++ b/config/locales/views/layout/en.yml
@@ -6,6 +6,7 @@ en:
       nav:
         assistant: Assistant
         budgets: Budgets
+        advanced_reports: Advanced Reports
         home: Home
         reports: Reports
         transactions: Transactions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -556,6 +556,11 @@ Rails.application.routes.draw do
   get "terms", to: terms_url ? redirect(terms_url) : "pages#terms"
   get "intro", to: "pages#intro"
 
+  # Advanced Reports namespace
+  namespace :advanced_reports do
+    resources :dashboard, only: :index
+  end
+
   # Admin namespace for super admin functionality
   namespace :admin do
     resources :sso_providers do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -558,6 +558,7 @@ Rails.application.routes.draw do
 
   # Advanced Reports namespace
   namespace :advanced_reports do
+    root to: "dashboard#index"
     resources :dashboard, only: :index
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -560,6 +560,7 @@ Rails.application.routes.draw do
   namespace :advanced_reports do
     root to: "dashboard#index"
     resources :dashboard, only: :index
+    resources :income_expenses, only: :index
   end
 
   # Admin namespace for super admin functionality

--- a/test/controllers/advanced_reports/income_expenses_controller_test.rb
+++ b/test/controllers/advanced_reports/income_expenses_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class AdvancedReports::IncomeExpensesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    @account = accounts(:depository)
+  end
+
+  test "index renders successfully" do
+    get advanced_reports_income_expenses_path
+
+    assert_response :ok
+    assert_select "h1", text: I18n.t("advanced_reports.income_expenses.index.title")
+    assert_select "h2", text: I18n.t("advanced_reports.income_expenses.report.chart.title")
+  end
+
+  test "index filters by selected account" do
+    get advanced_reports_income_expenses_path(account_id: @account.id)
+
+    assert_response :ok
+    assert_includes @response.body, @account.name
+  end
+
+  test "invalid custom range falls back gracefully" do
+    get advanced_reports_income_expenses_path(
+      preset: "custom",
+      start_date: "2026-05-10",
+      end_date: "2026-05-01"
+    )
+
+    assert_response :ok
+    assert_includes @response.body, I18n.t("advanced_reports.income_expenses.index.invalid_date_range")
+  end
+end

--- a/test/services/advanced_reports/base_query_test.rb
+++ b/test/services/advanced_reports/base_query_test.rb
@@ -16,6 +16,7 @@ class AdvancedReports::BaseQueryTest < ActiveSupport::TestCase
     other_family = families(:empty)
     other_account = other_family.accounts.create!(
       name: "Other Checking",
+      balance: 0,
       currency: "USD",
       accountable: Depository.create!,
       owner: users(:empty)
@@ -80,5 +81,46 @@ class AdvancedReports::BaseQueryTest < ActiveSupport::TestCase
     transaction_ids = query.send(:scoped_transactions).pluck(:id)
 
     assert_not_includes transaction_ids, pending_entry.entryable_id
+  end
+
+  test "excludes entries marked as excluded" do
+    excluded_entry = @account.entries.create!(
+      name: "Excluded expense",
+      date: TEST_DATE,
+      amount: 30,
+      currency: "USD",
+      excluded: true,
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    query = AdvancedReports::BaseQuery.new(@family, date_range_filter: @filter)
+    transaction_ids = query.send(:scoped_transactions).pluck(:id)
+
+    assert_not_includes transaction_ids, excluded_entry.entryable_id
+  end
+
+  test "filters transactions to the selected account ids" do
+    other_account = accounts(:connected)
+    other_entry = other_account.entries.create!(
+      name: "Other account expense",
+      date: TEST_DATE,
+      amount: 25,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    selected_entry = @account.entries.create!(
+      name: "Selected account expense",
+      date: TEST_DATE,
+      amount: 40,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    query = AdvancedReports::BaseQuery.new(@family, date_range_filter: @filter, account_ids: @account.id)
+    transaction_ids = query.send(:scoped_transactions).pluck(:id)
+
+    assert_includes transaction_ids, selected_entry.entryable_id
+    assert_not_includes transaction_ids, other_entry.entryable_id
   end
 end

--- a/test/services/advanced_reports/base_query_test.rb
+++ b/test/services/advanced_reports/base_query_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class AdvancedReports::BaseQueryTest < ActiveSupport::TestCase
+  TEST_DATE = Date.new(2020, 6, 15)
+
+  setup do
+    @family = families(:dylan_family)
+    @account = accounts(:depository)
+    @filter = AdvancedReports::DateRangeFilter.new(
+      start_date: TEST_DATE.beginning_of_month,
+      end_date: TEST_DATE.end_of_month
+    )
+  end
+
+  test "scopes transactions to the given family only" do
+    other_family = families(:empty)
+    other_account = other_family.accounts.create!(
+      name: "Other Checking",
+      currency: "USD",
+      accountable: Depository.create!,
+      owner: users(:empty)
+    )
+    other_entry = other_account.entries.create!(
+      name: "Other family expense",
+      date: TEST_DATE,
+      amount: 999,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    family_entry = @account.entries.create!(
+      name: "My expense",
+      date: TEST_DATE,
+      amount: 50,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    query = AdvancedReports::BaseQuery.new(@family, date_range_filter: @filter)
+    transaction_ids = query.send(:scoped_transactions).pluck(:id)
+
+    assert_includes transaction_ids, family_entry.entryable_id
+    assert_not_includes transaction_ids, other_entry.entryable_id
+  end
+
+  test "filters transactions to the given date range" do
+    in_range_entry = @account.entries.create!(
+      name: "In range",
+      date: TEST_DATE,
+      amount: 25,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    out_of_range_entry = @account.entries.create!(
+      name: "Out of range",
+      date: TEST_DATE - 6.months,
+      amount: 25,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    query = AdvancedReports::BaseQuery.new(@family, date_range_filter: @filter)
+    transaction_ids = query.send(:scoped_transactions).pluck(:id)
+
+    assert_includes transaction_ids, in_range_entry.entryable_id
+    assert_not_includes transaction_ids, out_of_range_entry.entryable_id
+  end
+
+  test "excludes pending transactions" do
+    pending_entry = @account.entries.create!(
+      name: "Pending charge",
+      date: TEST_DATE,
+      amount: 30,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard", extra: { "simplefin" => { "pending" => true } })
+    )
+
+    query = AdvancedReports::BaseQuery.new(@family, date_range_filter: @filter)
+    transaction_ids = query.send(:scoped_transactions).pluck(:id)
+
+    assert_not_includes transaction_ids, pending_entry.entryable_id
+  end
+end

--- a/test/services/advanced_reports/date_range_filter_test.rb
+++ b/test/services/advanced_reports/date_range_filter_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class AdvancedReports::DateRangeFilterTest < ActiveSupport::TestCase
+  test "this_month preset sets correct date range" do
+    filter = AdvancedReports::DateRangeFilter.new(preset: "this_month")
+
+    assert_equal Date.current.beginning_of_month, filter.start_date
+    assert_equal Date.current, filter.end_date
+    assert filter.valid?
+  end
+
+  test "last_3_months preset sets correct date range" do
+    filter = AdvancedReports::DateRangeFilter.new(preset: "last_3_months")
+
+    assert_equal 3.months.ago.to_date.beginning_of_month, filter.start_date
+    assert_equal Date.current, filter.end_date
+    assert filter.valid?
+  end
+
+  test "ytd preset sets correct date range" do
+    filter = AdvancedReports::DateRangeFilter.new(preset: "ytd")
+
+    assert_equal Date.current.beginning_of_year, filter.start_date
+    assert_equal Date.current, filter.end_date
+    assert filter.valid?
+  end
+
+  test "last_year preset sets correct date range" do
+    filter = AdvancedReports::DateRangeFilter.new(preset: "last_year")
+
+    assert_equal 1.year.ago.to_date.beginning_of_year, filter.start_date
+    assert_equal 1.year.ago.to_date.end_of_year, filter.end_date
+    assert filter.valid?
+  end
+
+  test "custom preset with valid dates" do
+    filter = AdvancedReports::DateRangeFilter.new(
+      preset: "custom",
+      start_date: "2025-01-01",
+      end_date: "2025-03-31"
+    )
+
+    assert_equal Date.new(2025, 1, 1), filter.start_date
+    assert_equal Date.new(2025, 3, 31), filter.end_date
+    assert_equal "custom", filter.preset
+    assert filter.valid?
+  end
+
+  test "custom preset with Date objects" do
+    start_date = Date.new(2025, 1, 1)
+    end_date = Date.new(2025, 12, 31)
+
+    filter = AdvancedReports::DateRangeFilter.new(start_date: start_date, end_date: end_date)
+
+    assert_equal start_date, filter.start_date
+    assert_equal end_date, filter.end_date
+    assert filter.valid?
+  end
+
+  test "invalid when start_date after end_date" do
+    filter = AdvancedReports::DateRangeFilter.new(
+      start_date: "2025-12-31",
+      end_date: "2025-01-01"
+    )
+
+    assert_not filter.valid?
+  end
+
+  test "invalid when custom dates are missing" do
+    filter = AdvancedReports::DateRangeFilter.new(preset: "custom")
+
+    assert_not filter.valid?
+  end
+
+  test "invalid when date strings are unparseable" do
+    filter = AdvancedReports::DateRangeFilter.new(start_date: "not-a-date", end_date: "2025-12-31")
+
+    assert_not filter.valid?
+  end
+
+  test "date_range returns a Range of start to end date" do
+    filter = AdvancedReports::DateRangeFilter.new(preset: "ytd")
+
+    assert_equal filter.start_date..filter.end_date, filter.date_range
+  end
+
+  test "unknown preset raises ArgumentError" do
+    assert_raises(ArgumentError) do
+      AdvancedReports::DateRangeFilter.new(preset: "last_decade")
+    end
+  end
+
+  test "nil preset defaults to custom" do
+    filter = AdvancedReports::DateRangeFilter.new(start_date: "2025-01-01", end_date: "2025-06-30")
+
+    assert_equal "custom", filter.preset
+  end
+end

--- a/test/services/advanced_reports/income_expenses_query_test.rb
+++ b/test/services/advanced_reports/income_expenses_query_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class AdvancedReports::IncomeExpensesQueryTest < ActiveSupport::TestCase
+  TEST_DATE = Date.new(2020, 6, 15)
+
+  setup do
+    @family = families(:dylan_family)
+    @account = accounts(:depository)
+    @other_account = accounts(:connected)
+    @filter = AdvancedReports::DateRangeFilter.new(
+      start_date: Date.new(2020, 4, 1),
+      end_date: Date.new(2020, 6, 30)
+    )
+  end
+
+  def create_entry(account:, amount:, date:, kind: "standard", **opts)
+    account.entries.create!(
+      name: "Test entry",
+      date: date,
+      amount: amount,
+      currency: "USD",
+      entryable: Transaction.new(kind: kind, **opts)
+    )
+  end
+
+  test "returns monthly income expense and net cash flow totals" do
+    create_entry(account: @account, amount: -3000, date: Date.new(2020, 4, 10))
+    create_entry(account: @account, amount: 1200, date: Date.new(2020, 4, 12))
+    create_entry(account: @account, amount: -2500, date: Date.new(2020, 5, 5))
+    create_entry(account: @account, amount: 1600, date: Date.new(2020, 5, 8))
+
+    result = AdvancedReports::IncomeExpensesQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 5500.to_d, result.total_income
+    assert_equal 2800.to_d, result.total_expense
+    assert_equal 2700.to_d, result.net_cash_flow
+    assert_equal 49.09.to_d, result.savings_rate
+
+    april = result.months.detect { |month| month.date == Date.new(2020, 4, 1) }
+    may = result.months.detect { |month| month.date == Date.new(2020, 5, 1) }
+
+    assert_equal 3000.to_d, april.income
+    assert_equal 1200.to_d, april.expense
+    assert_equal 1800.to_d, april.net_cash_flow
+
+    assert_equal 2500.to_d, may.income
+    assert_equal 1600.to_d, may.expense
+    assert_equal 900.to_d, may.net_cash_flow
+  end
+
+  test "fills in months with no transactions" do
+    create_entry(account: @account, amount: -3000, date: Date.new(2020, 4, 10))
+
+    result = AdvancedReports::IncomeExpensesQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal [ Date.new(2020, 4, 1), Date.new(2020, 5, 1), Date.new(2020, 6, 1) ], result.months.map(&:date)
+    june = result.months.detect { |month| month.date == Date.new(2020, 6, 1) }
+
+    assert_equal 0.to_d, june.income
+    assert_equal 0.to_d, june.expense
+    assert_equal 0.to_d, june.net_cash_flow
+  end
+
+  test "filters results to the selected account" do
+    create_entry(account: @account, amount: -3000, date: TEST_DATE)
+    create_entry(account: @other_account, amount: -5000, date: TEST_DATE)
+
+    result = AdvancedReports::IncomeExpensesQuery.new(
+      @family,
+      date_range_filter: @filter,
+      account_ids: @account.id
+    ).call
+
+    assert_equal 3000.to_d, result.total_income
+  end
+
+  test "returns zero savings rate when total income is zero" do
+    create_entry(account: @account, amount: 1200, date: TEST_DATE)
+
+    result = AdvancedReports::IncomeExpensesQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 0.to_d, result.total_income
+    assert_equal(-1200.to_d, result.net_cash_flow)
+    assert_equal 0.to_d, result.savings_rate
+  end
+
+  test "treats loan payments and investment contributions as expenses" do
+    create_entry(account: @account, amount: -500, date: TEST_DATE, kind: "loan_payment")
+    create_entry(account: @account, amount: -250, date: TEST_DATE, kind: "investment_contribution")
+
+    result = AdvancedReports::IncomeExpensesQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 0.to_d, result.total_income
+    assert_equal 750.to_d, result.total_expense
+  end
+end

--- a/test/services/advanced_reports/transaction_summary_query_test.rb
+++ b/test/services/advanced_reports/transaction_summary_query_test.rb
@@ -1,0 +1,141 @@
+require "test_helper"
+
+class AdvancedReports::TransactionSummaryQueryTest < ActiveSupport::TestCase
+  TEST_DATE = Date.new(2020, 6, 15)
+
+  setup do
+    @family = families(:dylan_family)
+    @account = accounts(:depository)
+    @filter = AdvancedReports::DateRangeFilter.new(
+      start_date: TEST_DATE.beginning_of_month,
+      end_date: TEST_DATE.end_of_month
+    )
+  end
+
+  def create_entry(amount:, kind: "standard", **opts)
+    @account.entries.create!(
+      name: "Test entry",
+      date: TEST_DATE,
+      amount: amount,
+      currency: "USD",
+      entryable: Transaction.new(kind: kind, **opts)
+    )
+  end
+
+  test "returns zero totals when no transactions exist in range" do
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 0, result.total_income
+    assert_equal 0, result.total_expense
+    assert_equal 0, result.net
+  end
+
+  test "calculates total expense from positive amounts" do
+    create_entry(amount: 100)
+    create_entry(amount: 50)
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 150.to_d, result.total_expense
+    assert_equal 0, result.total_income
+  end
+
+  test "calculates total income from negative amounts" do
+    create_entry(amount: -2000)
+    create_entry(amount: -500)
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 2500.to_d, result.total_income
+    assert_equal 0, result.total_expense
+  end
+
+  test "net equals income minus expense" do
+    create_entry(amount: -3000)
+    create_entry(amount: 1500)
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 3000.to_d, result.total_income
+    assert_equal 1500.to_d, result.total_expense
+    assert_equal 1500.to_d, result.net
+  end
+
+  test "excludes budget-excluded transaction kinds" do
+    Transaction::BUDGET_EXCLUDED_KINDS.each do |kind|
+      create_entry(amount: 500, kind: kind)
+    end
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 0, result.total_expense
+    assert_equal 0, result.total_income
+  end
+
+  test "classifies investment_contribution as expense regardless of sign" do
+    create_entry(amount: -500, kind: "investment_contribution")
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 500.to_d, result.total_expense
+    assert_equal 0, result.total_income
+  end
+
+  test "classifies loan_payment as expense regardless of sign" do
+    create_entry(amount: -1200, kind: "loan_payment")
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 1200.to_d, result.total_expense
+    assert_equal 0, result.total_income
+  end
+
+  test "excludes pending transactions from totals" do
+    create_entry(amount: 999, extra: { "plaid" => { "pending" => true } })
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 0, result.total_expense
+  end
+
+  test "excludes transactions outside the date range" do
+    @account.entries.create!(
+      name: "Out of range",
+      date: TEST_DATE - 2.months,
+      amount: 500,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 0, result.total_expense
+  end
+
+  test "result includes the family currency" do
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal @family.currency, result.currency
+  end
+
+  test "scopes to the correct family only" do
+    other_family = families(:empty)
+    other_account = other_family.accounts.create!(
+      name: "Other Checking",
+      currency: "USD",
+      accountable: Depository.create!,
+      owner: users(:empty)
+    )
+    other_account.entries.create!(
+      name: "Other family expense",
+      date: TEST_DATE,
+      amount: 500,
+      currency: "USD",
+      entryable: Transaction.new(kind: "standard")
+    )
+
+    result = AdvancedReports::TransactionSummaryQuery.new(@family, date_range_filter: @filter).call
+
+    assert_equal 0, result.total_expense
+  end
+end

--- a/test/services/advanced_reports/transaction_summary_query_test.rb
+++ b/test/services/advanced_reports/transaction_summary_query_test.rb
@@ -122,6 +122,7 @@ class AdvancedReports::TransactionSummaryQueryTest < ActiveSupport::TestCase
     other_family = families(:empty)
     other_account = other_family.accounts.create!(
       name: "Other Checking",
+      balance: 0,
       currency: "USD",
       accountable: Depository.create!,
       owner: users(:empty)


### PR DESCRIPTION
## Summary
- add the Advanced Reports Income vs Expenses page with date/account filters, KPI cards, monthly table, and a grouped bar chart with net cash flow overlay
- add `AdvancedReports::IncomeExpensesQuery` and extend the shared base query to support excluded-entry and account scoping
- surface the report from the Advanced Reports dashboard and sub-navigation

## Testing
- `bin/rails test test/services/advanced_reports/base_query_test.rb test/services/advanced_reports/date_range_filter_test.rb test/services/advanced_reports/transaction_summary_query_test.rb test/services/advanced_reports/income_expenses_query_test.rb test/controllers/advanced_reports/income_expenses_controller_test.rb`
- `bin/rubocop app/services/advanced_reports/base_query.rb app/services/advanced_reports/income_expenses_query.rb app/controllers/advanced_reports/income_expenses_controller.rb test/services/advanced_reports/base_query_test.rb test/services/advanced_reports/transaction_summary_query_test.rb test/services/advanced_reports/income_expenses_query_test.rb test/controllers/advanced_reports/income_expenses_controller_test.rb`
- `npm run lint -- app/javascript/controllers/income_expenses_chart_controller.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced Reports dashboard with navigation and breadcrumbs
  * Income vs. Expenses report: interactive chart, monthly table, and summary cards (income, expenses, net, savings rate)
  * Date-range presets and custom date selection with account filtering and graceful invalid-range alerts
  * New layout/sub-navigation and app nav entry for easy access; localized UI strings

* **Tests**
  * Added comprehensive tests covering filters, queries, and controller behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->