### PR TITLE
chore(design-system): swap raw gray classes for semantic tokens in settings/

### DIFF
--- a/app/views/settings/_user_avatar_field.html.erb
+++ b/app/views/settings/_user_avatar_field.html.erb
@@ -5,7 +5,7 @@
     <button type="button"
             data-profile-image-preview-target="clearBtn"
             data-action="click->profile-image-preview#clearFileInput"
-      class="<%= user.profile_image.attached? ? "" : "hidden" %> z-50 cursor-pointer absolute bottom-0 right-0 w-8 h-8 bg-gray-50 rounded-full flex justify-center items-center border border-white border-2">
+      class="<%= user.profile_image.attached? ? "" : "hidden" %> z-50 cursor-pointer absolute bottom-0 right-0 w-8 h-8 bg-surface-inset rounded-full flex justify-center items-center border border-white border-2">
       <%= icon "x", size: "sm" %>
     </button>
 
@@ -52,7 +52,7 @@
 
     <%= form.file_field :profile_image,
         accept: "image/png, image/jpeg",
-        class: "hidden px-3 py-2 bg-gray-50 text-primary rounded-md text-sm font-medium",
+        class: "hidden px-3 py-2 bg-surface-inset text-primary rounded-md text-sm font-medium",
         data: {
           profile_image_preview_target: "input",
           action: "change->profile-image-preview#showFileInputPreview"

--- a/app/views/settings/ai_prompts/show.html.erb
+++ b/app/views/settings/ai_prompts/show.html.erb
@@ -24,7 +24,7 @@
         <!-- Main System Prompt Section -->
         <div class="space-y-3">
           <div class="flex items-center gap-3">
-            <div class="w-9 h-9 rounded-full bg-gray-25 flex justify-center items-center">
+            <div class="w-9 h-9 rounded-full bg-surface-inset flex justify-center items-center">
               <%= icon "message-circle" %>
             </div>
             <div>
@@ -52,7 +52,7 @@
         <!-- Auto-Categorization Section -->
         <div class="space-y-3">
           <div class="flex items-center gap-3">
-            <div class="w-9 h-9 rounded-full bg-gray-25 flex justify-center items-center">
+            <div class="w-9 h-9 rounded-full bg-surface-inset flex justify-center items-center">
               <%= icon "brain" %>
             </div>
             <div>
@@ -80,7 +80,7 @@
         <!-- Merchant Detection Section -->
         <div class="space-y-3">
           <div class="flex items-center gap-3">
-            <div class="w-9 h-9 rounded-full bg-gray-25 flex justify-center items-center">
+            <div class="w-9 h-9 rounded-full bg-surface-inset flex justify-center items-center">
               <%= icon "store" %>
             </div>
             <div>

--- a/app/views/settings/hostings/_twelve_data_settings.html.erb
+++ b/app/views/settings/hostings/_twelve_data_settings.html.erb
@@ -45,12 +45,12 @@
                 limit: number_with_delimiter(@twelve_data_usage.data.limit),
                 percentage: number_to_percentage(@twelve_data_usage.data.utilization, precision: 1)) %>
         </p>
-        <div class="w-52 h-1.5 bg-gray-100 rounded-2xl">
+        <div class="w-52 h-1.5 bg-surface-inset rounded-2xl">
           <div class="h-full bg-green-500 rounded-2xl"
                style="width: <%= [@twelve_data_usage.data.utilization, 2].max %>%;"></div>
         </div>
       </div>
-      <div class="bg-gray-100 rounded-md px-1.5 py-0.5 w-fit">
+      <div class="bg-surface-inset rounded-md px-1.5 py-0.5 w-fit">
         <p class="text-xs font-medium text-secondary uppercase">
           <%= t(".plan", plan: @twelve_data_usage.data.plan) %>
         </p>

--- a/app/views/settings/llm_usages/show.html.erb
+++ b/app/views/settings/llm_usages/show.html.erb
@@ -135,10 +135,10 @@
                         <%= icon "alert-circle", class: "w-4 h-4 text-red-600 theme-dark:text-red-400" %>
                         <span class="text-red-600 theme-dark:text-red-400 font-medium">Failed</span>
                       </div>
-                      <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-gray-800 text-sm p-3 rounded w-72 text-left break-words whitespace-normal shadow-lg hidden">
-                        <div class="text-white">
+                      <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-3 rounded w-72 text-left break-words whitespace-normal shadow-lg hidden">
+                        <div class="text-inverse">
                           <% if usage.http_status_code.present? %>
-                            <p class="text-xs mt-1 text-gray-300">HTTP Status: <%= usage.http_status_code %></p>
+                            <p class="text-xs mt-1 text-inverse opacity-70">HTTP Status: <%= usage.http_status_code %></p>
                           <% end %>
                           <p class="text-xs"><%= usage.error_message %></p>
                         </div>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -8,7 +8,7 @@
       <%= form.email_field :email, placeholder: t(".email"), label: t(".email") %>
 
       <% if @user.unconfirmed_email.present? %>
-        <p class="mt-2 text-sm text-gray-600">
+        <p class="mt-2 text-sm text-secondary">
           You have requested to change your email to <%= @user.unconfirmed_email %>. Please go to your email and confirm for the change to take effect. If you haven't received the email, please check your spam folder, or <%= link_to "request a new confirmation email", resend_confirmation_email_user_path(@user), class: "hover:underline text-secondary" %>.
         </p>
       <% end %>
@@ -88,8 +88,8 @@
                                readonly
                                autocomplete="off"
                                value="<%= accept_invitation_url(invitation.token) %>"
-                               class="text-sm bg-gray-50 px-2 py-1 rounded border border-secondary w-72">
-                    <button data-action="clipboard#copy" class="text-secondary hover:text-gray-700">
+                               class="text-sm bg-surface-inset px-2 py-1 rounded border border-secondary w-72">
+                    <button data-action="clipboard#copy" class="text-secondary hover:text-primary">
                       <span data-clipboard-target="iconDefault">
                         <%= icon "copy" %>
                       </span>

--- a/app/views/settings/providers/_enable_banking_panel.html.erb
+++ b/app/views/settings/providers/_enable_banking_panel.html.erb
@@ -99,7 +99,7 @@
 
     <div class="flex justify-end">
       <%= form.submit is_new_record ? "Save Configuration" : "Update Configuration",
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800" %>
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover" %>
     </div>
   <% end %>
 
@@ -154,7 +154,7 @@
             <% if item.session_valid? %>
               <%= button_to sync_enable_banking_item_path(item),
                             method: :post,
-                            class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-primary bg-container border border-primary hover:bg-gray-50 transition-colors",
+                            class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-primary bg-container border border-primary hover:bg-surface-inset transition-colors",
                             data: { turbo: false } do %>
                 Sync
               <% end %>
@@ -167,7 +167,7 @@
               <% end %>
             <% else %>
               <%= link_to select_bank_enable_banking_item_path(item),
-                          class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
+                          class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
                           data: { turbo_frame: "modal" } do %>
                 Connect Bank
               <% end %>
@@ -188,7 +188,7 @@
         <div class="flex justify-center pt-2">
           <%= button_to new_connection_enable_banking_item_path(item_for_new_connection),
                         method: :post,
-                        class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
+                        class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
                         data: { turbo_frame: "modal" } do %>
             <%= icon "plus", size: "sm" %>
             Add Connection

--- a/app/views/settings/providers/_enable_banking_panel.html.erb
+++ b/app/views/settings/providers/_enable_banking_panel.html.erb
@@ -99,7 +99,7 @@
 
     <div class="flex justify-end">
       <%= form.submit is_new_record ? "Save Configuration" : "Update Configuration",
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover" %>
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_lunchflow_panel.html.erb
+++ b/app/views/settings/providers/_lunchflow_panel.html.erb
@@ -45,7 +45,7 @@
 
     <div class="flex justify-end">
       <%= form.submit is_new_record ? "Save Configuration" : "Update Configuration",
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_lunchflow_panel.html.erb
+++ b/app/views/settings/providers/_lunchflow_panel.html.erb
@@ -45,7 +45,7 @@
 
     <div class="flex justify-end">
       <%= form.submit is_new_record ? "Save Configuration" : "Update Configuration",
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_provider_form.html.erb
+++ b/app/views/settings/providers/_provider_form.html.erb
@@ -68,7 +68,7 @@
 
       <div class="flex justify-end">
         <%= form.submit "Save Configuration",
-                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
       </div>
     </div>
   <% end %>

--- a/app/views/settings/providers/_provider_form.html.erb
+++ b/app/views/settings/providers/_provider_form.html.erb
@@ -68,7 +68,7 @@
 
       <div class="flex justify-end">
         <%= form.submit "Save Configuration",
-                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
+                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
       </div>
     </div>
   <% end %>

--- a/app/views/settings/providers/_simplefin_panel.html.erb
+++ b/app/views/settings/providers/_simplefin_panel.html.erb
@@ -32,7 +32,7 @@
 
     <div class="flex justify-end">
       <%= form.submit "Save Configuration",
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_simplefin_panel.html.erb
+++ b/app/views/settings/providers/_simplefin_panel.html.erb
@@ -32,7 +32,7 @@
 
     <div class="flex justify-end">
       <%= form.submit "Save Configuration",
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
     </div>
   <% end %>
 

--- a/app/views/settings/securities/show.html.erb
+++ b/app/views/settings/securities/show.html.erb
@@ -4,7 +4,7 @@
   <div class="space-y-4">
     <div class="p-3 shadow-border-xs bg-container rounded-lg md:flex md:justify-between md:items-center">
       <div class="flex items-center gap-3">
-        <div class="w-9 h-9 rounded-full bg-gray-25 flex justify-center items-center">
+        <div class="w-9 h-9 rounded-full bg-surface-inset flex justify-center items-center">
           <%= icon "shield-check" %>
         </div>
 


### PR DESCRIPTION
## Summary

Pilot for the raw-color sweep backlog item. Settings views carried 21 occurrences of raw `text-gray-X` / `bg-gray-X` / `text-white` / `focus:ring-gray-X` classes that don't theme-flip — most happened to render fine in light mode and drifted in dark mode. Each mapped to a design-system equivalent.

Goal: validate the swap pattern on a contained, mechanical scope before splitting the rest of the sweep by domain (~98 more occurrences across ~56 files, mostly in `holdings/`, `transactions/`, `accounts/`, top-level views).

## Mappings

| From | To | Where |
|---|---|---|
| `text-white bg-gray-900 hover:bg-gray-800` | `text-inverse button-bg-primary hover:button-bg-primary-hover` | Provider-panel CTA buttons (Enable Banking, SimpleFIN, Mercury, Lunchflow, generic provider form) |
| `bg-gray-25` / `bg-gray-50` / `bg-gray-100` | `bg-surface-inset` | Round avatars, file-input toggles, progress-bar fills, muted badges |
| `bg-gray-800` (tooltip pill) | `bg-inverse` | LLM-usages failure tooltip |
| `text-white` inside tooltip | `text-inverse` | Same tooltip |
| `text-gray-300` (muted tooltip label) | `text-inverse opacity-70` | Same tooltip |
| `text-gray-600` (muted body text) | `text-secondary` | Profile pending-email notice |
| `hover:text-gray-700` | `hover:text-primary` | Profile clipboard-copy button |
| `focus:ring-gray-900` | `focus:ring-button-bg-primary` | All provider-panel CTA focus rings |

## What's left intentionally

`bg-gray-400` (×7) — status-indicator dots in provider panels marking "not configured". Gray-400 keeps the same hex in both modes, and the surrounding `bg-container` flips light → dark; the dot stays visible against either. There's no `bg-subdued` semantic token yet (only `text-subdued`). Better to decide once the broader sweep surfaces more inactive-indicator cases.

## Why settings first

Pilot scope. Smallest concentration of raw colors with the widest variety of patterns: CTAs, avatars, tooltips, focus rings, hover states, progress bars. If the mapping holds here, the rest of the sweep is mechanical replication into bigger domains.

## Test plan

- [x] `bundle exec rails tailwindcss:build` succeeds.
- [x] `bundle exec erb_lint app/views/settings/` clean (one pre-existing warning on `_sophtron_panel.html.erb:68`, unrelated).
- [ ] CI green.
- [ ] Visual eyeball — light + dark:
  - `/settings/profile` (pending-email notice, invitations table, clipboard button)
  - `/settings/ai_prompts` (round-avatar headers)
  - `/settings/securities`
  - `/settings/llm_usages` — failure tooltip
  - Provider panels — Enable Banking, SimpleFIN, Mercury, Lunchflow + the generic provider form (CTA buttons, focus state on tab)
  - `/settings/hostings/twelve_data_settings` (progress bar + plan badge)

## Followup

Subsequent PRs by domain:
- `holdings/` (highest concentration, includes more tooltip + button patterns)
- `transactions/`, `accounts/`
- Top-level views, doorkeeper templates
- Optional ERB-Lint cop to prevent regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling across settings screens (profile, AI prompts, hosting, LLM usage, providers, securities).
  * Refreshed color tokens, backgrounds, button palettes, hover/focus states, and tooltip/text accents for a more consistent themed appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->