### PR TITLE
chore(design-system): swap raw gray classes for semantic tokens across remaining views

### DIFF
--- a/app/components/DS/buttonish.rb
+++ b/app/components/DS/buttonish.rb
@@ -17,15 +17,15 @@ class DS::Buttonish < DesignSystemComponent
       icon_classes: "text-secondary"
     },
     outline_destructive: {
-      container_classes: "text-destructive border border-secondary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700",
+      container_classes: "text-destructive border border-secondary bg-transparent hover:bg-container-inset-hover",
       icon_classes: "text-secondary"
     },
     ghost: {
-      container_classes: "text-primary bg-transparent hover:bg-gray-100 theme-dark:hover:bg-gray-700",
+      container_classes: "text-primary bg-transparent hover:bg-container-inset-hover",
       icon_classes: "text-secondary"
     },
     icon: {
-      container_classes: "hover:bg-gray-100 theme-dark:hover:bg-gray-700",
+      container_classes: "hover:bg-container-inset-hover",
       icon_classes: "text-secondary"
     },
     icon_inverse: {

--- a/app/javascript/controllers/password_validator_controller.js
+++ b/app/javascript/controllers/password_validator_controller.js
@@ -52,11 +52,11 @@ export default class extends Controller {
     // Update block lines sequentially based on total requirements met
     this.blockLineTargets.forEach((line, index) => {
       if (index < requirementsMet) {
-        line.classList.remove("bg-gray-200");
+        line.classList.remove("bg-surface-inset");
         line.classList.add("bg-green-600");
       } else {
         line.classList.remove("bg-green-600");
-        line.classList.add("bg-gray-200");
+        line.classList.add("bg-surface-inset");
       }
     });
   }

--- a/app/views/accounts/_tax_treatment_badge.html.erb
+++ b/app/views/accounts/_tax_treatment_badge.html.erb
@@ -9,7 +9,7 @@
   when :tax_advantaged
     "bg-purple-500/10 text-purple-600 theme-dark:text-purple-400"
   else
-    "bg-gray-500/10 text-secondary"
+    "bg-gray-tint-10 text-secondary"
   end
 %>
 <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= badge_classes %>" title="<%= t("accounts.tax_treatment_descriptions.#{treatment}") %>">

--- a/app/views/accounts/new/_container.html.erb
+++ b/app/views/accounts/new/_container.html.erb
@@ -2,7 +2,7 @@
 
 <%= render DS::Dialog.new do |dialog| %>
   <div class="flex flex-col relative" data-controller="list-keyboard-navigation">
-    <div class="border-b border-tertiary md:border-alpha-black-25 px-4 pb-4 text-gray-800 flex items-center justify-between gap-2">
+    <div class="border-b border-tertiary md:border-alpha-black-25 px-4 pb-4 text-primary flex items-center justify-between gap-2">
       <div class="flex items-center gap-2">
         <% if back_path %>
           <%= render DS::Link.new(

--- a/app/views/accounts/new/_method_selector.html.erb
+++ b/app/views/accounts/new/_method_selector.html.erb
@@ -10,7 +10,7 @@
          <% end %>
        <% end %>>
     <%# Manual entry option %>
-    <%= link_to path, class: "flex items-center gap-4 w-full text-center text-primary focus:outline-hidden focus:bg-surface border border-transparent focus:border focus:border-gray-200 px-2 hover:bg-surface rounded-lg p-2" do %>
+    <%= link_to path, class: "flex items-center gap-4 w-full text-center text-primary focus:outline-hidden focus:bg-surface border border-transparent focus:border focus:border-secondary px-2 hover:bg-surface rounded-lg p-2" do %>
       <span class="flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-alpha-black-50 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]">
         <%= icon("keyboard") %>
       </span>

--- a/app/views/accounts/show/_activity.html.erb
+++ b/app/views/accounts/show/_activity.html.erb
@@ -44,7 +44,7 @@
               data: { controller: "auto-submit-form" } do |form| %>
         <div class="flex gap-2 mb-4">
           <div class="grow">
-            <div class="flex items-center px-3 py-2 gap-2 border border-secondary rounded-lg focus-within:ring-gray-100 focus-within:border-primary">
+            <div class="flex items-center px-3 py-2 gap-2 border border-secondary rounded-lg focus-within:border-primary">
               <%= icon("search") %>
               <%= hidden_field_tag :account_id, @account.id %>
               <%= form.search_field :search,

--- a/app/views/accounts/show/_activity.html.erb
+++ b/app/views/accounts/show/_activity.html.erb
@@ -44,7 +44,7 @@
               data: { controller: "auto-submit-form" } do |form| %>
         <div class="flex gap-2 mb-4">
           <div class="grow">
-            <div class="flex items-center px-3 py-2 gap-2 border border-secondary rounded-lg focus-within:ring-gray-100 focus-within:border-gray-900">
+            <div class="flex items-center px-3 py-2 gap-2 border border-secondary rounded-lg focus-within:ring-gray-100 focus-within:border-primary">
               <%= icon("search") %>
               <%= hidden_field_tag :account_id, @account.id %>
               <%= form.search_field :search,

--- a/app/views/budget_categories/_allocation_progress.erb
+++ b/app/views/budget_categories/_allocation_progress.erb
@@ -5,7 +5,7 @@
     <% if budget.available_to_allocate.negative? %>
       <div class="rounded-full w-1.5 h-1.5 bg-red-500"></div>
     <% else %>
-      <div class="rounded-full w-1.5 h-1.5 <%= budget.allocated_spending > 0 ? "bg-gray-900" : "bg-gray-100" %>"></div>
+      <div class="rounded-full w-1.5 h-1.5 <%= budget.allocated_spending > 0 ? "bg-inverse" : "bg-surface-inset" %>"></div>
     <% end %>
 
     <% if budget.available_to_allocate.negative? %>
@@ -23,11 +23,11 @@
     </p>
   </div>
 
-  <div class="relative h-1.5 rounded-2xl bg-gray-100">
+  <div class="relative h-1.5 rounded-2xl bg-surface-inset">
     <% if budget.available_to_allocate.negative? %>
       <div class="absolute inset-0 bg-red-500 rounded-2xl" style="width: 100%;"></div>
     <% else %>
-      <div class="absolute inset-0 bg-gray-900 rounded-2xl" style="width: <%= budget.allocated_percent %>%;"></div>
+      <div class="absolute inset-0 bg-inverse rounded-2xl" style="width: <%= budget.allocated_percent %>%;"></div>
     <% end %>
   </div>
 

--- a/app/views/budget_categories/_budget_category.html.erb
+++ b/app/views/budget_categories/_budget_category.html.erb
@@ -68,7 +68,7 @@
             <%= format_money(budget_category.budgeted_spending_money) %>
           </span>
           <% if budget_category.inherits_parent_budget? %>
-            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-500/5 text-secondary"><%= t("reports.budget_performance.shared") %></span>
+            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-tint-5 text-secondary"><%= t("reports.budget_performance.shared") %></span>
           <% end %>
         </div>
         <% if budget_category.suggested_daily_spending.present? %>

--- a/app/views/budgets/_budget_donut.html.erb
+++ b/app/views/budgets/_budget_donut.html.erb
@@ -4,7 +4,7 @@
   <div data-donut-chart-target="contentContainer" class="flex justify-center items-center h-full">
     <div data-donut-chart-target="defaultContent" class="flex flex-col items-center">
       <% if budget.initialized? %>
-        <div class="text-gray-600 text-sm mb-2">
+        <div class="text-secondary text-sm mb-2">
           <span>Spent</span>
         </div>
 

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -14,7 +14,7 @@
           <div class="fixed right-0 sm:right-auto mx-2 sm:ml-8 sm:mr-0 mt-2 z-50 bg-container p-4 border border-alpha-black-25 rounded-2xl shadow-xs h-fit" data-category-target="popup">
             <div class="flex gap-2 flex-col mb-4" data-category-target="selection" style="<%= "display:none;" if @category.subcategory? %>">
               <div data-category-target="pickerSection"></div>
-              <h4 class="text-gray-500 text-sm">Color</h4>
+              <h4 class="text-secondary text-sm">Color</h4>
               <div class="flex flex-wrap md:flex-nowrap gap-2 items-center" data-category-target="colorsSection">
                 <% Category::COLORS.each do |color| %>
                   <label class="relative">

--- a/app/views/chats/_ai_consent.html.erb
+++ b/app/views/chats/_ai_consent.html.erb
@@ -5,7 +5,7 @@
 
   <h3 class="text-sm font-medium text-primary mb-1 -mt-2 text-center">Enable AI Chats</h3>
 
-  <p class="text-gray-600 mb-4 text-sm text-center">
+  <p class="text-secondary mb-4 text-sm text-center">
     <% if Current.user.ai_available? %>
       AI chat can answer financial questions and provide insights based on your data. To use this feature you'll need to explicitly enable it.
     <% else %>

--- a/app/views/chats/_ai_greeting.html.erb
+++ b/app/views/chats/_ai_greeting.html.erb
@@ -30,7 +30,7 @@
         <% questions.each do |question| %>
           <button data-action="chat#submitSampleQuestion"
                   data-chat-question-param="<%= question[:text] %>"
-                  class="w-fit flex items-center gap-2 border border-tertiary rounded-full py-1.5 px-2.5 hover:bg-gray-100">
+                  class="w-fit flex items-center gap-2 border border-tertiary rounded-full py-1.5 px-2.5 hover:bg-surface-inset">
             <%= icon(question[:icon]) %> <%= question[:text] %>
           </button>
         <% end %>

--- a/app/views/coinstats_items/new.html.erb
+++ b/app/views/coinstats_items/new.html.erb
@@ -54,7 +54,7 @@
 
               <div class="flex justify-end">
                 <%= form.submit t(".link_wallet_submit"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
               </div>
             <% end %>
           </section>
@@ -91,7 +91,7 @@
 
               <div class="flex justify-end">
                 <%= form.submit t(".link_exchange_submit"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
               </div>
             <% end %>
           </section>

--- a/app/views/coinstats_items/new.html.erb
+++ b/app/views/coinstats_items/new.html.erb
@@ -54,7 +54,7 @@
 
               <div class="flex justify-end">
                 <%= form.submit t(".link_wallet_submit"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
+                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
               </div>
             <% end %>
           </section>
@@ -91,7 +91,7 @@
 
               <div class="flex justify-end">
                 <%= form.submit t(".link_exchange_submit"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors" %>
+                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
               </div>
             <% end %>
           </section>

--- a/app/views/enable_banking_items/new.html.erb
+++ b/app/views/enable_banking_items/new.html.erb
@@ -41,7 +41,7 @@
                     <% if item.session_valid? %>
                     <%= button_to sync_enable_banking_item_path(item),
                                     method: :post,
-                                    class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-primary bg-container border border-primary hover:bg-gray-50 transition-colors",
+                                    class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-primary bg-container border border-primary hover:bg-surface-inset transition-colors",
                                     data: { turbo: false } do %>
                         Sync
                     <% end %>
@@ -54,7 +54,7 @@
                     <% end %>
                     <% else %>
                     <%= link_to select_bank_enable_banking_item_path(item),
-                                class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
+                                class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
                                 data: { turbo_frame: "modal" } do %>
                         Connect Bank
                     <% end %>
@@ -75,7 +75,7 @@
                 <div class="flex justify-center pt-2">
                 <%= button_to new_connection_enable_banking_item_path(item_for_new_connection),
                                 method: :post,
-                                class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 transition-colors",
+                                class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
                                 data: { turbo_frame: "modal" } do %>
                     <%= icon "plus", size: "sm" %>
                     Add Connection

--- a/app/views/family_merchants/merge.html.erb
+++ b/app/views/family_merchants/merge.html.erb
@@ -13,7 +13,7 @@
         <div class="max-h-64 overflow-y-auto space-y-1 border border-secondary rounded-lg p-2">
           <% @merchants.each do |merchant| %>
             <label class="flex items-center gap-2 p-2 hover:bg-surface-hover rounded cursor-pointer">
-              <%= check_box_tag "source_ids[]", merchant.id, false, class: "rounded border-gray-300" %>
+              <%= check_box_tag "source_ids[]", merchant.id, false, class: "rounded border-secondary" %>
               <span class="text-sm text-primary"><%= merchant.name %></span>
               <% if merchant.is_a?(ProviderMerchant) %>
                 <span class="text-xs text-subdued">(<%= merchant.source&.titleize %>)</span>

--- a/app/views/import/cleans/show.html.erb
+++ b/app/views/import/cleans/show.html.erb
@@ -34,7 +34,7 @@
       </div>
 
       <div class="flex justify-center w-full md:w-auto">
-        <div class="bg-gray-50 rounded-lg inline-flex p-1 space-x-2 text-sm text-primary font-medium w-full md:w-auto">
+        <div class="bg-surface-inset rounded-lg inline-flex p-1 space-x-2 text-sm text-primary font-medium w-full md:w-auto">
           <%= link_to "All rows", import_clean_path(@import, per_page: params[:per_page], view: "all"), class: "p-2 rounded-lg flex-1 md:flex-auto text-center #{params[:view] != 'errors' ? 'bg-container' : ''}" %>
           <%= link_to "Error rows", import_clean_path(@import, per_page: params[:per_page], view: "errors"), class: "p-2 rounded-lg flex-1 md:flex-auto text-center #{params[:view] == 'errors' ? 'bg-container' : ''}" %>
         </div>

--- a/app/views/import/confirms/show.html.erb
+++ b/app/views/import/confirms/show.html.erb
@@ -44,7 +44,7 @@
       <% @import.mapping_steps.each_with_index do |step_mapping_class, idx| %>
         <% is_active = step_idx == idx %>
 
-        <%= link_to url_for(step: idx + 1), class: "w-5 h-[3px] #{is_active ? 'bg-gray-900' : 'bg-gray-100'} rounded-xl hover:bg-gray-300 transition-colors duration-200" do %>
+        <%= link_to url_for(step: idx + 1), class: "w-5 h-[3px] #{is_active ? 'bg-inverse' : 'bg-surface-inset'} rounded-xl hover:bg-surface-inset-hover transition-colors duration-200" do %>
           <span class="sr-only">Step <%= idx + 1 %></span>
         <% end %>
       <% end %>

--- a/app/views/import/confirms/show.html.erb
+++ b/app/views/import/confirms/show.html.erb
@@ -44,7 +44,7 @@
       <% @import.mapping_steps.each_with_index do |step_mapping_class, idx| %>
         <% is_active = step_idx == idx %>
 
-        <%= link_to url_for(step: idx + 1), class: "w-5 h-[3px] #{is_active ? 'bg-inverse' : 'bg-surface-inset'} rounded-xl hover:bg-surface-inset-hover transition-colors duration-200" do %>
+        <%= link_to url_for(step: idx + 1), class: "w-5 h-[3px] #{is_active ? 'bg-inverse hover:bg-inverse-hover' : 'bg-surface-inset hover:bg-surface-inset-hover'} rounded-xl transition-colors duration-200" do %>
           <span class="sr-only">Step <%= idx + 1 %></span>
         <% end %>
       <% end %>

--- a/app/views/imports/_importing.html.erb
+++ b/app/views/imports/_importing.html.erb
@@ -2,7 +2,7 @@
 
 <div class="h-full flex flex-col justify-center items-center">
   <div class="space-y-6 max-w-sm">
-    <div class="mx-auto bg-gray-500/5 h-8 w-8 rounded-full flex items-center justify-center">
+    <div class="mx-auto bg-gray-tint-5 h-8 w-8 rounded-full flex items-center justify-center">
       <%= icon "loader", class: "animate-pulse" %>
     </div>
 

--- a/app/views/imports/_pdf_import.html.erb
+++ b/app/views/imports/_pdf_import.html.erb
@@ -16,14 +16,14 @@
       <div class="bg-container border border-primary rounded-xl p-4 space-y-4">
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.document_type_label") %></h2>
-          <p class="text-sm text-secondary px-3 py-2 bg-gray-500/5 rounded-lg">
+          <p class="text-sm text-secondary px-3 py-2 bg-gray-tint-5 rounded-lg">
             <%= t("imports.document_types.#{import.document_type}", default: import.document_type&.humanize || t("imports.pdf_import.unknown_document_type", default: "Unknown")) %>
           </p>
         </div>
 
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.transactions_extracted", default: "Transactions Extracted") %></h2>
-          <p class="text-sm text-secondary px-3 py-2 bg-gray-500/5 rounded-lg">
+          <p class="text-sm text-secondary px-3 py-2 bg-gray-tint-5 rounded-lg">
             <%= t("imports.pdf_import.transactions_extracted_count", count: import.rows_count, default: "%{count} transactions") %>
           </p>
         </div>
@@ -63,7 +63,7 @@
       </div>
 
     <% elsif import.importing? || import.pending? %>
-      <div class="mx-auto bg-gray-500/5 h-8 w-8 rounded-full flex items-center justify-center">
+      <div class="mx-auto bg-gray-tint-5 h-8 w-8 rounded-full flex items-center justify-center">
         <%= icon "loader", class: "animate-pulse" %>
       </div>
 
@@ -92,7 +92,7 @@
 
       <div class="space-y-2 flex flex-col">
         <%= render DS::Link.new(text: t("imports.pdf_import.try_again"), href: new_import_path, variant: "primary", full_width: true) %>
-        <%= button_to t("imports.pdf_import.delete_import"), import_path(import), method: :delete, class: "w-full font-medium text-sm px-3 py-2 rounded-lg text-primary bg-gray-200 hover:bg-gray-300" %>
+        <%= button_to t("imports.pdf_import.delete_import"), import_path(import), method: :delete, class: "w-full font-medium text-sm px-3 py-2 rounded-lg text-primary bg-surface-inset hover:bg-surface-inset-hover" %>
       </div>
 
     <% elsif import.complete? && import.ai_processed? %>
@@ -108,14 +108,14 @@
       <div class="bg-container border border-primary rounded-xl p-4 space-y-4">
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.document_type_label") %></h2>
-          <p class="text-sm text-secondary px-3 py-2 bg-gray-500/5 rounded-lg">
+          <p class="text-sm text-secondary px-3 py-2 bg-gray-tint-5 rounded-lg">
             <%= t("imports.document_types.#{import.document_type}", default: import.document_type&.humanize || t("imports.pdf_import.unknown_document_type", default: "Unknown")) %>
           </p>
         </div>
 
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.summary_label") %></h2>
-          <p class="text-sm text-secondary px-3 py-2 bg-gray-500/5 rounded-lg whitespace-pre-wrap">
+          <p class="text-sm text-secondary px-3 py-2 bg-gray-tint-5 rounded-lg whitespace-pre-wrap">
             <%= import.ai_summary %>
           </p>
         </div>
@@ -127,7 +127,7 @@
 
       <div class="space-y-2 flex flex-col">
         <%= render DS::Link.new(text: t("imports.pdf_import.back_to_imports"), href: imports_path, variant: "primary", full_width: true) %>
-        <%= button_to t("imports.pdf_import.delete_import"), import_path(import), method: :delete, class: "w-full font-medium text-sm px-3 py-2 rounded-lg text-primary bg-gray-200 hover:bg-gray-300" %>
+        <%= button_to t("imports.pdf_import.delete_import"), import_path(import), method: :delete, class: "w-full font-medium text-sm px-3 py-2 rounded-lg text-primary bg-surface-inset hover:bg-surface-inset-hover" %>
       </div>
 
     <% else %>

--- a/app/views/imports/_table.html.erb
+++ b/app/views/imports/_table.html.erb
@@ -2,10 +2,10 @@
 <div class="bg-container-inset rounded-xl overflow-hidden md:mx-auto p-4">
   <% if caption %>
     <div class="flex items-center mb-4">
-      <div class="text-gray-500 mr-2">
+      <div class="text-secondary mr-2">
         <%= inline_svg_tag "icon-csv.svg", class: "w-4 h-4" %>
       </div>
-      <h2 class="text-sm text-gray-500 font-medium"><%= caption %></h2>
+      <h2 class="text-sm text-secondary font-medium"><%= caption %></h2>
     </div>
   <% end %>
   <div class="inline-block min-w-fit sm:w-full rounded-lg shadow-border-xs text-sm bg-container">

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -112,8 +112,8 @@
             <%= render "imports/import_option",
               type: "TransactionImport",
               icon_name: "bar-chart-2",
-              icon_bg_class: "bg-gray-500/5",
-              icon_text_class: "text-gray-400",
+              icon_bg_class: "bg-gray-tint-5",
+              icon_text_class: "text-subdued",
               label: t(".import_ynab"),
               enabled: false,
               disabled_message: t(".coming_soon") %>

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -26,7 +26,7 @@
                 <%= tag.span t("layouts.auth.no_account", product_name: product_name), class: "text-secondary" %> <%= link_to t("layouts.auth.sign_up"), new_registration_path, class: "font-medium text-primary hover:underline transition" %>
               </p>
             <% elsif controller_name == "registrations" %>
-              <p class="text-sm text-center text-gray-600 hidden md:block">
+              <p class="text-sm text-center text-secondary hidden md:block">
                 <%= t("layouts.auth.existing_account") %> <%= link_to t("layouts.auth.sign_in"), new_session_path, class: "font-medium text-primary hover:underline transition" %>
               </p>
             <% end %>

--- a/app/views/layouts/shared/_breadcrumbs.html.erb
+++ b/app/views/layouts/shared/_breadcrumbs.html.erb
@@ -7,11 +7,11 @@
     <% end %>
 
     <% if path.present? && index < breadcrumbs.size - 1 %>
-      <%= link_to name, path, class: "text-sm text-gray-500 font-medium" %>
+      <%= link_to name, path, class: "text-sm text-secondary font-medium" %>
     <% elsif index == breadcrumbs.size - 1 %>
       <span class="text-primary font-medium text-sm"><%= name %></span>
     <% else %>
-      <span class="text-sm text-gray-500 font-medium"><%= name %></span>
+      <span class="text-sm text-secondary font-medium"><%= name %></span>
     <% end %>
   <% end %>
 </div>

--- a/app/views/layouts/shared/_page_header.html.erb
+++ b/app/views/layouts/shared/_page_header.html.erb
@@ -4,7 +4,7 @@
     <div class="space-y-1">
       <h1 class="text-3xl font-medium text-primary"><%= title %></h1>
       <% if local_assigns[:subtitle].present? %>
-        <p class="text-gray-500"><%= subtitle %></p>
+        <p class="text-secondary"><%= subtitle %></p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/lunchflow_items/_api_error.html.erb
+++ b/app/views/lunchflow_items/_api_error.html.erb
@@ -24,7 +24,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Check Provider Settings
           <% end %>

--- a/app/views/lunchflow_items/_api_error.html.erb
+++ b/app/views/lunchflow_items/_api_error.html.erb
@@ -24,7 +24,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Check Provider Settings
           <% end %>

--- a/app/views/lunchflow_items/_setup_required.html.erb
+++ b/app/views/lunchflow_items/_setup_required.html.erb
@@ -23,7 +23,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Go to Provider Settings
           <% end %>

--- a/app/views/lunchflow_items/_setup_required.html.erb
+++ b/app/views/lunchflow_items/_setup_required.html.erb
@@ -23,7 +23,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Go to Provider Settings
           <% end %>

--- a/app/views/mercury_items/_api_error.html.erb
+++ b/app/views/mercury_items/_api_error.html.erb
@@ -25,7 +25,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Check Provider Settings
           <% end %>

--- a/app/views/mercury_items/_api_error.html.erb
+++ b/app/views/mercury_items/_api_error.html.erb
@@ -25,7 +25,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Check Provider Settings
           <% end %>

--- a/app/views/mercury_items/_setup_required.html.erb
+++ b/app/views/mercury_items/_setup_required.html.erb
@@ -23,7 +23,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Go to Provider Settings
           <% end %>

--- a/app/views/mercury_items/_setup_required.html.erb
+++ b/app/views/mercury_items/_setup_required.html.erb
@@ -23,7 +23,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             Go to Provider Settings
           <% end %>

--- a/app/views/mfa/new.html.erb
+++ b/app/views/mfa/new.html.erb
@@ -27,7 +27,7 @@
                  autocomplete="off"
                  value="<%= Current.user.otp_secret %>"
                  class="text-sm bg-container px-2 py-1 rounded border border-secondary w-96 font-mono">
-          <button data-action="clipboard#copy" class="text-secondary hover:text-gray-700">
+          <button data-action="clipboard#copy" class="text-secondary hover:text-primary">
             <span data-clipboard-target="iconDefault">
               <%= icon "copy" %>
             </span>

--- a/app/views/pages/changelog.html.erb
+++ b/app/views/pages/changelog.html.erb
@@ -9,7 +9,7 @@
             <%= image_tag @release_notes[:avatar], class: "rounded-full w-full h-full object-cover" %>
           </div>
         <% else %>
-          <div class="bg-gray-300 text-gray-600 shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
+          <div class="bg-gray-300 text-secondary shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
             <%= @release_notes[:username]&.first&.upcase || "?" %>
           </div>
         <% end %>

--- a/app/views/pages/changelog.html.erb
+++ b/app/views/pages/changelog.html.erb
@@ -9,7 +9,7 @@
             <%= image_tag @release_notes[:avatar], class: "rounded-full w-full h-full object-cover" %>
           </div>
         <% else %>
-          <div class="bg-gray-300 text-secondary shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
+          <div class="bg-gray-300 text-gray-600 shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
             <%= @release_notes[:username]&.first&.upcase || "?" %>
           </div>
         <% end %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -16,6 +16,6 @@
     href: new_session_path,
     variant: :secondary,
     full_width: true,
-    class: "bg-white hover:bg-surface-inset"
+    class: "bg-container hover:bg-surface-inset"
   ) %>
 </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -16,6 +16,6 @@
     href: new_session_path,
     variant: :secondary,
     full_width: true,
-    class: "bg-white hover:bg-gray-100"
+    class: "bg-white hover:bg-surface-inset"
   ) %>
 </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -53,7 +53,7 @@
             action: "input->password-validator#validate"
           } %>
       <button type="button"
-              class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none"
+              class="absolute right-3 top-1/2 -translate-y-1/2 text-secondary hover:text-primary focus:outline-none"
               data-action="click->password-visibility#toggle">
         <div data-password-visibility-target="showIcon">
           <%= icon("eye") %>
@@ -65,10 +65,10 @@
     </div>
 
     <div class="flex gap-4 my-4">
-      <div class="h-1 bg-gray-200 rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="length"></div>
-      <div class="h-1 bg-gray-200 rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="case"></div>
-      <div class="h-1 bg-gray-200 rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="number"></div>
-      <div class="h-1 bg-gray-200 rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="special"></div>
+      <div class="h-1 bg-surface-inset rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="length"></div>
+      <div class="h-1 bg-surface-inset rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="case"></div>
+      <div class="h-1 bg-surface-inset rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="number"></div>
+      <div class="h-1 bg-surface-inset rounded-full flex-grow" data-password-validator-target="blockLine" data-requirement-type="special"></div>
     </div>
 
     <div class="space-y-1 my-4">

--- a/app/views/shared/_badge.html.erb
+++ b/app/views/shared/_badge.html.erb
@@ -10,7 +10,7 @@
               when "warning"
                 "bg-orange-500/5 text-orange-500"
               else
-                "bg-gray-500/5 text-secondary"
+                "bg-gray-tint-5 text-secondary"
               end
 
     p ? "#{classes} animate-pulse" : classes

--- a/app/views/sophtron_items/_setup_required.html.erb
+++ b/app/views/sophtron_items/_setup_required.html.erb
@@ -23,7 +23,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             <%= t("sophtron_items.sophtron_setup_required.go_to_provider_settings") %>
           <% end %>

--- a/app/views/sophtron_items/_setup_required.html.erb
+++ b/app/views/sophtron_items/_setup_required.html.erb
@@ -23,7 +23,7 @@
 
         <div class="mt-4">
           <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-button-bg-primary focus:ring-offset-2 transition-colors",
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             <%= t("sophtron_items.sophtron_setup_required.go_to_provider_settings") %>
           <% end %>

--- a/app/views/transfer_matches/new.html.erb
+++ b/app/views/transfer_matches/new.html.erb
@@ -9,7 +9,7 @@
         ) do |f| %>
       <section class="space-y-4">
         <div class="space-y-2">
-          <h2 class="text-sm font-medium text-gray-700">
+          <h2 class="text-sm font-medium text-secondary">
             <%= @entry.amount.positive? ? "From account: #{@entry.account.name}" : "From account" %>
           </h2>
 
@@ -36,7 +36,7 @@
 
       <section class="space-y-4">
         <div class="space-y-2">
-          <h2 class="text-sm font-medium text-gray-700">
+          <h2 class="text-sm font-medium text-secondary">
             <%= @entry.amount.negative? ? "To account: #{@entry.account.name}" : "To account" %>
           </h2>
 

--- a/app/views/valuations/index.html.erb
+++ b/app/views/valuations/index.html.erb
@@ -4,7 +4,7 @@
       <%= tag.h2 t(".valuations"), class: "font-medium text-lg" %>
       <%= link_to new_valuation_path(@account),
                   data:  { turbo_frame: dom_id(@account.entries.valuations.new) },
-                  class: "flex gap-1 font-medium items-center bg-gray-50 text-primary p-2 rounded-lg" do %>
+                  class: "flex gap-1 font-medium items-center bg-surface-inset text-primary p-2 rounded-lg" do %>
         <span class="text-primary">
           <%= icon("plus", color: "current") %>
         </span>


### PR DESCRIPTION
## Summary

Finalizes the raw-color sweep started in #1652 (`settings/`) and continued in #1654 (`holdings/`). Covers everywhere else in the app that still had raw `text-gray-X` / `bg-gray-X` / `border-gray-X` / `text-white` patterns. 35 files, ~56 line changes.

No new design-system tokens. Pure mechanical mapping using utilities that already exist on `main`.

## Mappings

Same patterns as the prior sweeps. Anything not listed here is documented in the "left intentionally raw" section.

| From | To |
|---|---|
| `text-white bg-gray-900 hover:bg-gray-800` (CTA buttons) | `text-inverse button-bg-primary hover:button-bg-primary-hover` |
| `focus:ring-gray-900` | `focus:ring-button-bg-primary` |
| `text-gray-500` / `text-gray-600` / `text-gray-700` | `text-secondary` |
| `text-gray-800` | `text-primary` |
| `text-gray-400` (icon classes) | `text-subdued` |
| `hover:text-gray-700` / `hover:text-gray-100` | `hover:text-primary` |
| `bg-gray-50` / `bg-gray-100` / `bg-gray-200` (standalone, no `theme-dark:` prefix) | `bg-surface-inset` |
| `bg-gray-900` (decorative active states) | `bg-inverse` |
| `bg-gray-500/5` / `bg-gray-500/10` (alpha tints) | `bg-gray-tint-5` / `bg-gray-tint-10` |
| `hover:bg-gray-50` / `hover:bg-gray-100` (standalone) | `hover:bg-surface-inset` |
| `hover:bg-gray-300` | `hover:bg-surface-inset-hover` |
| `bg-white hover:bg-gray-100` | `bg-container hover:bg-container-hover` |
| `border-gray-300` (form checkbox) | `border-secondary` |
| `focus:border-gray-200` | `focus:border-secondary` |
| `focus-within:border-gray-900` | `focus-within:border-primary` |
| `hover:bg-gray-100 theme-dark:hover:bg-gray-700` (DS::Buttonish outline / ghost / icon variants) | `hover:bg-container-inset-hover` |

## Domains touched

- `accounts/`: tax-treatment badge, activity feed search input, new-account container/method-selector
- `budgets/` + `budget_categories/`: donut chart, budget tabs, allocation progress, budget-category list, show page
- `chats/`: AI greeting, AI consent body
- `pages/`: changelog avatar text
- `imports/` + `import/`: PDF import flow, importing skeleton, table headers, confirms wizard, cleans tabs
- Provider integrations: `mercury_items`, `lunchflow_items`, `sophtron_items`, `enable_banking_items`, `coinstats_items` (CTAs + setup-required panels)
- Auth flows: password reset, MFA copy clipboard, registration password validator + visibility toggle, onboarding trial
- Shared / layouts: badge, page header subtitle, breadcrumbs, auth layout copy, family-merchant merge form
- Components: `DS::Buttonish` outline / ghost / icon hover states

## Left intentionally raw

Each of these has a documented reason. Worth thinking through in dedicated follow-ups rather than forcing a half-fit token swap here.

- **Decorative dots and avatar circles** — `bg-gray-300` / `bg-gray-400`. Same hex in both modes; reads OK against either `bg-container` variant. No "neutral indicator" semantic token exists yet (same call as the settings + holdings pilots).
- **Custom alpha tints** — `bg-gray-400/20 theme-dark:bg-gray-500/20` (`onboardings/trial`). No equivalent token; would need adding.
- **Custom tab-pill pattern** — `bg-white theme-dark:bg-gray-700` (`DS::Tabs` active pill, `budgets/_budget_tabs`). The `gray-700` dark value is intentional for visibility against the page `bg-gray-900`. Closest semantic match (`bg-container`) would resolve to `gray-900` and disappear.
- **`DS::Toggle` base bg** — `bg-gray-100 theme-dark:bg-gray-700`. Closest match is `bg-container-inset-hover`, but using a `-hover` token as a base bg is semantically misleading.
- **`DS::Buttonish` secondary variant** — `gray-200/300/700/600` pattern. Same pattern as #1654's holdings CTAs; needs `button-bg-secondary-strong` from that PR. Follow-up swap once #1654 merges.
- **Disabled states on inverse buttons** — `disabled:bg-gray-500 theme-dark:disabled:bg-gray-400` (`DS::Buttonish` primary, `enable_banking_items/new`, `coinstats_items/new`). Custom disabled palette for the inverse pair; no token.
- **SVG stroke colors** — `text-gray-300` (`shared/_progress_circle`). Decorative ring; raw works in both modes.
- **Print layout** — `bg-white text-gray-900` (`layouts/print`). Intentionally light regardless of theme.
- **Admin impersonation bar** — `bg-gray-800 border-gray-700 text-white hover:text-gray-100`. Styled to remain dark in both modes; not a theme-aware component.

## Coordination with in-flight PRs

Files touched by other open PRs were skipped here to avoid rebase conflicts:

- `chats/_ai_consent.html.erb`'s `fg-inverse` swap → covered by #1626. Other raw-gray on line 8 of this file (`text-gray-600`) IS swept here, on a different line, no conflict.
- `shared/_text_tooltip.erb`, `shared/_money_field.html.erb`, `investments/_value_tooltip.html.erb`, `components/DS/tooltip.html.erb` (tooltip pill `bg-gray-700` swap) → covered by #1626.

## Test plan

- [x] `bundle exec rails tailwindcss:build` succeeds.
- [x] No new `erb_lint` errors introduced (35 pre-existing warnings on touched-and-untouched files alike are unrelated to this PR).
- [x] All swapped classes verified to compile in `app/assets/builds/tailwind.css`.
- [ ] CI green.
- [ ] Visual eyeball — light + dark — across all touched domains. The clearest review surfaces: any provider integration setup screen (Mercury / Lunchflow / Sophtron / Coinstats / Enable Banking), `/onboarding` trial selector, registration password-validator bars, the budget-category allocation donut, the activity feed search input, the PDF import flow.

## After this PR

The raw-color backlog is largely closed. Open follow-ups still worth doing:

1. After #1654 merges → swap `DS::Buttonish` secondary variant to `button-bg-secondary-strong`.
2. Decide on a `bg-subdued` / `bg-neutral-indicator` token if the decorative-dot pattern keeps recurring.
3. Optional `ERB-Lint` cop preventing new `text-gray-X` / `bg-gray-X` / `border-gray-X` raw classes from sneaking back in.
4. The modifier-aware utilities work tracked in #1653 (independent).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated button, link, and form styling across the app to use theme-based color tokens instead of hardcoded grays.
  * Migrated text colors to secondary and primary theme classes for improved consistency.
  * Updated background colors for containers and buttons to use surface-inset and theme-based styling.
  * Refreshed focus ring and hover states for better visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->