### PR TITLE
feat(investments): add India investment subtypes and exchange support

### DIFF
--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -54,10 +54,40 @@ class Investment < ApplicationRecord
     "pillar_3a" => { short: "Pillar 3a", long: "Private Pension (Pillar 3a)", region: "eu", tax_treatment: :tax_deferred },
     "riester" => { short: "Riester", long: "Riester-Rente", region: "eu", tax_treatment: :tax_deferred },
 
+    # === India ===
+    # Pensions & insurance
+    "nps" => { short: "NPS", long: "National Pension System", region: "in", tax_treatment: :tax_advantaged },
+    "apy" => { short: "APY", long: "Atal Pension Yojana", region: "in", tax_treatment: :tax_advantaged },
+    "life_insurance" => { short: "Life Insurance", long: "Life Insurance", region: "in", tax_treatment: :tax_advantaged },
+    # Equity / market-linked
+    "demat" => { short: "Demat A/C", long: "Demat Account", region: "in", tax_treatment: :taxable },
+    "indian_equity" => { short: "Indian Equity", long: "Indian Equity", region: "in", tax_treatment: :taxable },
+    "indian_etf" => { short: "Indian ETF", long: "Indian ETF", region: "in", tax_treatment: :taxable },
+    # Fixed-income / small-savings
+    "ppf" => { short: "PPF", long: "Public Provident Fund", region: "in", tax_treatment: :tax_exempt },
+    "ssy" => { short: "SSY", long: "Sukanya Samriddhi Yojana", region: "in", tax_treatment: :tax_exempt },
+    "nsc" => { short: "NSC", long: "National Savings Certificate", region: "in", tax_treatment: :tax_advantaged },
+    "scss" => { short: "SCSS", long: "Senior Citizens' Savings Scheme", region: "in", tax_treatment: :taxable },
+    "fd" => { short: "FD", long: "Fixed Deposit", region: "in", tax_treatment: :taxable },
+    "rd" => { short: "RD", long: "Recurring Deposit", region: "in", tax_treatment: :taxable },
+    "pomis" => { short: "POMIS", long: "Post Office Monthly Income Scheme", region: "in", tax_treatment: :taxable },
+    "kvp" => { short: "KVP", long: "Kisan Vikas Patra", region: "in", tax_treatment: :taxable },
+    # Bonds
+    "g_sec" => { short: "G-Sec", long: "Government Securities (G-Secs)", region: "in", tax_treatment: :taxable },
+    "sdl" => { short: "SDL", long: "State Development Loans (SDLs)", region: "in", tax_treatment: :taxable },
+    "corporate_bond" => { short: "Corporate Bond", long: "Corporate Bond", region: "in", tax_treatment: :taxable },
+    "infrastructure_bond" => { short: "Infra Bond", long: "Infrastructure Bond", region: "in", tax_treatment: :tax_advantaged },
+    "tax_free_bond" => { short: "Tax-Free Bond", long: "Tax-Free Bond", region: "in", tax_treatment: :tax_exempt },
+    # India-specific gold instruments
+    "gold_etf" => { short: "Gold ETF", long: "Gold ETF", region: "in", tax_treatment: :taxable },
+    "gold_mf" => { short: "Gold MF", long: "Gold Mutual Fund", region: "in", tax_treatment: :taxable },
+    "sgb" => { short: "SGB", long: "Sovereign Gold Bond", region: "in", tax_treatment: :tax_advantaged },
+
     # === Generic (available everywhere) ===
     "pension" => { short: "Pension", long: "Pension", region: nil, tax_treatment: :tax_deferred },
     "retirement" => { short: "Retirement", long: "Retirement Account", region: nil, tax_treatment: :tax_deferred },
     "mutual_fund" => { short: "Mutual Fund", long: "Mutual Fund", region: nil, tax_treatment: :taxable },
+    "gold" => { short: "Gold", long: "Gold (physical or digital)", region: nil, tax_treatment: :taxable },
     "angel" => { short: "Angel", long: "Angel Investment", region: nil, tax_treatment: :taxable },
     "trust" => { short: "Trust", long: "Trust", region: nil, tax_treatment: :taxable },
     "other" => { short: "Other", long: "Other Investment", region: nil, tax_treatment: :taxable }
@@ -101,7 +131,7 @@ class Investment < ApplicationRecord
       grouped = SUBTYPES.group_by { |_, v| v[:region] }
 
       # Build region order: user's region first (if known), then Generic, then others
-      other_regions = %w[us uk ca au eu] - [ user_region ].compact
+      other_regions = %w[us uk ca au eu in] - [ user_region ].compact
       region_order = if user_region
         [ user_region, nil, *other_regions ].uniq
       else

--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -60,7 +60,7 @@ class Investment < ApplicationRecord
     "apy" => { short: "APY", long: "Atal Pension Yojana", region: "in", tax_treatment: :tax_advantaged },
     "life_insurance" => { short: "Life Insurance", long: "Life Insurance", region: "in", tax_treatment: :tax_advantaged },
     # Equity / market-linked
-    "demat" => { short: "Demat A/C", long: "Demat Account", region: "in", tax_treatment: :taxable },
+    "indian_stocks" => { short: "Indian Stocks", long: "Indian Stocks (Demat)", region: "in", tax_treatment: :taxable },
     "indian_equity" => { short: "Indian Equity", long: "Indian Equity", region: "in", tax_treatment: :taxable },
     "indian_etf" => { short: "Indian ETF", long: "Indian ETF", region: "in", tax_treatment: :taxable },
     # Fixed-income / small-savings
@@ -121,7 +121,8 @@ class Investment < ApplicationRecord
       "CAD" => "ca",
       "AUD" => "au",
       "EUR" => "eu",
-      "CHF" => "eu"
+      "CHF" => "eu",
+      "INR" => "in"
     }.freeze
 
     # Returns subtypes grouped by region for use with grouped_options_for_select

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -8,11 +8,9 @@ class Property < ApplicationRecord
     "townhouse" => { short: "Townhouse", long: "Townhouse" },
     "investment_property" => { short: "Investment Property", long: "Investment Property" },
     "second_home" => { short: "Second Home", long: "Second Home" },
-    # India
     "apartment" => { short: "Apartment", long: "Apartment" },
     "plot" => { short: "Plot", long: "Plot / Land" },
     "commercial" => { short: "Commercial", long: "Commercial Property" },
-    "rented" => { short: "Rented", long: "Rented Property" },
     "agri_land" => { short: "Agri Land", long: "Agricultural Land" }
   }.freeze
 

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -7,7 +7,13 @@ class Property < ApplicationRecord
     "condominium" => { short: "Condo", long: "Condominium" },
     "townhouse" => { short: "Townhouse", long: "Townhouse" },
     "investment_property" => { short: "Investment Property", long: "Investment Property" },
-    "second_home" => { short: "Second Home", long: "Second Home" }
+    "second_home" => { short: "Second Home", long: "Second Home" },
+    # India
+    "apartment" => { short: "Apartment", long: "Apartment" },
+    "plot" => { short: "Plot", long: "Plot / Land" },
+    "commercial" => { short: "Commercial", long: "Commercial Property" },
+    "rented" => { short: "Rented", long: "Rented Property" },
+    "agri_land" => { short: "Agri Land", long: "Agricultural Land" }
   }.freeze
 
   has_one :address, as: :addressable, dependent: :destroy

--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -165,6 +165,8 @@ class Provider::YahooFinance < Provider
           )
         end
 
+        securities = prefer_indian_exchange(securities)
+
         cache_result(cache_key, securities)
         securities
       end
@@ -175,6 +177,8 @@ class Provider::YahooFinance < Provider
 
   def fetch_security_info(symbol:, exchange_operating_mic:)
     with_provider_response do
+      symbol = normalize_indian_symbol(symbol, exchange_operating_mic)
+
       # quoteSummary endpoint requires cookie/crumb authentication
       throttle_request
       cookie, crumb = fetch_cookie_and_crumb
@@ -263,6 +267,7 @@ class Provider::YahooFinance < Provider
 
   def fetch_security_prices(symbol:, exchange_operating_mic: nil, start_date:, end_date:)
     with_provider_response do
+      symbol = normalize_indian_symbol(symbol, exchange_operating_mic)
       validate_date_params!(start_date, end_date)
       # Convert dates to Unix timestamps using UTC to ensure consistent epoch boundaries across timezones
       period1 = start_date.to_time.utc.to_i
@@ -285,7 +290,9 @@ class Provider::YahooFinance < Provider
       closes = quotes["close"] || []
 
       # Get currency from metadata
-      raw_currency = chart_data.dig("meta", "currency") || "USD"
+      meta_exchange = chart_data.dig("meta", "exchangeName") || ""
+      raw_currency = chart_data.dig("meta", "currency")
+      raw_currency ||= INDIAN_EXCHANGE_CODES.include?(meta_exchange.upcase) ? "INR" : "USD"
 
       prices = []
       timestamps.each_with_index do |timestamp, index|
@@ -321,6 +328,12 @@ class Provider::YahooFinance < Provider
     #      Currency Normalization
     # ================================
 
+    # Yahoo Finance exchange codes that correspond to Indian exchanges
+    INDIAN_EXCHANGE_CODES = %w[NSE NSI BSE BOM].freeze
+
+    # Preferred exchange MIC when a security is dual-listed on NSE and BSE
+    INDIAN_EXCHANGE_PREFERENCE = %w[XNSE XBOM].freeze
+
     # Yahoo Finance sometimes returns currencies in minor units (pence, cents)
     # This is not part of ISO 4217 but is a convention used by financial data providers
     # Mapping of Yahoo Finance minor unit codes to standard currency codes and conversion multipliers
@@ -338,6 +351,30 @@ class Provider::YahooFinance < Provider
       else
         [ currency, price ]
       end
+    end
+
+    # Normalizes a bare Indian equity symbol to its Yahoo Finance ticker form.
+    # NSE symbols get a ".NS" suffix (e.g. "RELIANCE" => "RELIANCE.NS").
+    # BSE symbols get a ".BO" suffix (e.g. "500325" => "500325.BO").
+    # Already-suffixed symbols are returned unchanged.
+    def normalize_indian_symbol(symbol, exchange_operating_mic)
+      return symbol if symbol.include?(".")
+      case exchange_operating_mic
+      when "XNSE" then "#{symbol}.NS"
+      when "XBOM" then "#{symbol}.BO"
+      else symbol
+      end
+    end
+
+    # Returns the preferred MIC when a security appears on both NSE and BSE.
+    # NSE (XNSE) is preferred because it typically has higher liquidity.
+    def prefer_indian_exchange(securities)
+      indian = securities.select { |s| INDIAN_EXCHANGE_PREFERENCE.include?(s.exchange_operating_mic) }
+      return securities if indian.empty?
+
+      preferred = indian.min_by { |s| INDIAN_EXCHANGE_PREFERENCE.index(s.exchange_operating_mic) }
+      non_indian = securities.reject { |s| INDIAN_EXCHANGE_PREFERENCE.include?(s.exchange_operating_mic) }
+      [ preferred ] + non_indian
     end
 
     # ================================
@@ -776,6 +813,10 @@ class Provider::YahooFinance < Provider
         "XJPX" # Japan Exchange Group
       when "ASX"
         "XASX" # Australian Securities Exchange
+      when "NSE", "NSI"
+        "XNSE" # National Stock Exchange of India
+      when "BSE", "BOM"
+        "XBOM" # BSE (Bombay Stock Exchange)
       else
         exchange_code.upcase
       end

--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -165,7 +165,7 @@ class Provider::YahooFinance < Provider
           )
         end
 
-        securities = prefer_indian_exchange(securities)
+        securities = deduplicate_dual_listings(securities)
 
         cache_result(cache_key, securities)
         securities
@@ -177,7 +177,7 @@ class Provider::YahooFinance < Provider
 
   def fetch_security_info(symbol:, exchange_operating_mic:)
     with_provider_response do
-      symbol = normalize_indian_symbol(symbol, exchange_operating_mic)
+      symbol = normalize_symbol(symbol, exchange_operating_mic)
 
       # quoteSummary endpoint requires cookie/crumb authentication
       throttle_request
@@ -267,7 +267,7 @@ class Provider::YahooFinance < Provider
 
   def fetch_security_prices(symbol:, exchange_operating_mic: nil, start_date:, end_date:)
     with_provider_response do
-      symbol = normalize_indian_symbol(symbol, exchange_operating_mic)
+      symbol = normalize_symbol(symbol, exchange_operating_mic)
       validate_date_params!(start_date, end_date)
       # Convert dates to Unix timestamps using UTC to ensure consistent epoch boundaries across timezones
       period1 = start_date.to_time.utc.to_i
@@ -292,7 +292,7 @@ class Provider::YahooFinance < Provider
       # Get currency from metadata
       meta_exchange = chart_data.dig("meta", "exchangeName") || ""
       raw_currency = chart_data.dig("meta", "currency")
-      raw_currency ||= INDIAN_EXCHANGE_CODES.include?(meta_exchange.upcase) ? "INR" : "USD"
+      raw_currency ||= default_currency_for_exchange(meta_exchange) || "USD"
 
       prices = []
       timestamps.each_with_index do |timestamp, index|
@@ -328,11 +328,21 @@ class Provider::YahooFinance < Provider
     #      Currency Normalization
     # ================================
 
-    # Yahoo Finance exchange codes that correspond to Indian exchanges
-    INDIAN_EXCHANGE_CODES = %w[NSE NSI BSE BOM].freeze
+    # Per-exchange configuration for Yahoo Finance.  Each entry maps an ISO
+    # MIC code to its Yahoo-specific symbol suffix, the default currency when
+    # Yahoo omits one, and an optional dual-listing group with a preference
+    # rank (lower = preferred).  Adding a new market is a one-line hash entry.
+    EXCHANGE_CONFIG = {
+      "XNSE" => { yahoo_suffix: ".NS", default_currency: "INR", dual_list_group: :india, preference_rank: 0 },
+      "XBOM" => { yahoo_suffix: ".BO", default_currency: "INR", dual_list_group: :india, preference_rank: 1 },
+    }.freeze
 
-    # Preferred exchange MIC when a security is dual-listed on NSE and BSE
-    INDIAN_EXCHANGE_PREFERENCE = %w[XNSE XBOM].freeze
+    # Reverse lookup: Yahoo exchange name (from chart metadata) → default currency.
+    # Built from EXCHANGE_CONFIG via map_exchange_mic so the raw Yahoo codes
+    # ("NSE", "BSE", etc.) resolve to the same config.
+    YAHOO_EXCHANGE_CURRENCY = EXCHANGE_CONFIG.each_with_object({}) do |(mic, cfg), h|
+      h[mic] = cfg[:default_currency]
+    end.freeze
 
     # Yahoo Finance sometimes returns currencies in minor units (pence, cents)
     # This is not part of ISO 4217 but is a convention used by financial data providers
@@ -353,35 +363,41 @@ class Provider::YahooFinance < Provider
       end
     end
 
-    # Normalizes a bare Indian equity symbol to its Yahoo Finance ticker form.
-    # NSE symbols get a ".NS" suffix (e.g. "RELIANCE" => "RELIANCE.NS").
-    # BSE symbols get a ".BO" suffix (e.g. "500325" => "500325.BO").
-    # Already-suffixed symbols are returned unchanged.
-    def normalize_indian_symbol(symbol, exchange_operating_mic)
+    # Appends the Yahoo Finance symbol suffix for exchanges that require one
+    # (e.g. XNSE → ".NS", XBOM → ".BO").  Already-suffixed symbols pass through.
+    def normalize_symbol(symbol, exchange_operating_mic)
       return symbol if symbol.include?(".")
-      case exchange_operating_mic
-      when "XNSE" then "#{symbol}.NS"
-      when "XBOM" then "#{symbol}.BO"
-      else symbol
-      end
+      cfg = EXCHANGE_CONFIG[exchange_operating_mic]
+      cfg ? "#{symbol}#{cfg[:yahoo_suffix]}" : symbol
     end
 
-    # De-duplicates Indian dual-listings (NSE + BSE) for the same company,
-    # preferring NSE (XNSE) for its higher liquidity.  Securities are grouped
-    # by name so that unrelated Indian tickers are preserved.
-    def prefer_indian_exchange(securities)
-      indian, non_indian = securities.partition { |s| INDIAN_EXCHANGE_PREFERENCE.include?(s.exchange_operating_mic) }
-      return securities if indian.empty?
+    # Returns the default currency for a Yahoo exchange name (e.g. "NSE" → "INR")
+    # by resolving through map_exchange_mic → EXCHANGE_CONFIG.  Returns nil for
+    # unknown exchanges so callers can fall back to their own default.
+    def default_currency_for_exchange(yahoo_exchange_name)
+      mic = map_exchange_mic(yahoo_exchange_name)
+      EXCHANGE_CONFIG.dig(mic, :default_currency)
+    end
 
-      preferred = indian.group_by(&:name).flat_map do |_name, group|
+    # De-duplicates dual-listed securities that share the same company name
+    # and dual_list_group (e.g. NSE + BSE for India), keeping the exchange
+    # with the lowest preference_rank.  Unrelated securities and exchanges
+    # outside any dual_list_group pass through unchanged.
+    def deduplicate_dual_listings(securities)
+      dual_listed, others = securities.partition { |s| EXCHANGE_CONFIG.dig(s.exchange_operating_mic, :dual_list_group) }
+      return securities if dual_listed.empty?
+
+      preferred = dual_listed.group_by { |s|
+        [ EXCHANGE_CONFIG[s.exchange_operating_mic][:dual_list_group], s.name ]
+      }.flat_map do |_key, group|
         if group.size > 1
-          [ group.min_by { |s| INDIAN_EXCHANGE_PREFERENCE.index(s.exchange_operating_mic) } ]
+          [ group.min_by { |s| EXCHANGE_CONFIG[s.exchange_operating_mic][:preference_rank] } ]
         else
           group
         end
       end
 
-      preferred + non_indian
+      preferred + others
     end
 
     # ================================

--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -366,15 +366,22 @@ class Provider::YahooFinance < Provider
       end
     end
 
-    # Returns the preferred MIC when a security appears on both NSE and BSE.
-    # NSE (XNSE) is preferred because it typically has higher liquidity.
+    # De-duplicates Indian dual-listings (NSE + BSE) for the same company,
+    # preferring NSE (XNSE) for its higher liquidity.  Securities are grouped
+    # by name so that unrelated Indian tickers are preserved.
     def prefer_indian_exchange(securities)
-      indian = securities.select { |s| INDIAN_EXCHANGE_PREFERENCE.include?(s.exchange_operating_mic) }
+      indian, non_indian = securities.partition { |s| INDIAN_EXCHANGE_PREFERENCE.include?(s.exchange_operating_mic) }
       return securities if indian.empty?
 
-      preferred = indian.min_by { |s| INDIAN_EXCHANGE_PREFERENCE.index(s.exchange_operating_mic) }
-      non_indian = securities.reject { |s| INDIAN_EXCHANGE_PREFERENCE.include?(s.exchange_operating_mic) }
-      [ preferred ] + non_indian
+      preferred = indian.group_by(&:name).flat_map do |_name, group|
+        if group.size > 1
+          [ group.min_by { |s| INDIAN_EXCHANGE_PREFERENCE.index(s.exchange_operating_mic) } ]
+        else
+          group
+        end
+      end
+
+      preferred + non_indian
     end
 
     # ================================

--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -165,7 +165,7 @@ class Provider::YahooFinance < Provider
           )
         end
 
-        securities = deduplicate_dual_listings(securities)
+        securities = deduplicate_dual_listings(securities) unless exchange_operating_mic.present?
 
         cache_result(cache_key, securities)
         securities
@@ -381,23 +381,22 @@ class Provider::YahooFinance < Provider
 
     # De-duplicates dual-listed securities that share the same company name
     # and dual_list_group (e.g. NSE + BSE for India), keeping the exchange
-    # with the lowest preference_rank.  Unrelated securities and exchanges
-    # outside any dual_list_group pass through unchanged.
+    # with the lowest preference_rank.  Preserves Yahoo's original relevance
+    # ordering by removing duplicates in-place rather than reordering.
     def deduplicate_dual_listings(securities)
-      dual_listed, others = securities.partition { |s| EXCHANGE_CONFIG.dig(s.exchange_operating_mic, :dual_list_group) }
-      return securities if dual_listed.empty?
+      dominated = Set.new
 
-      preferred = dual_listed.group_by { |s|
-        [ EXCHANGE_CONFIG[s.exchange_operating_mic][:dual_list_group], s.name.to_s.strip.downcase ]
-      }.flat_map do |_key, group|
-        if group.size > 1
-          [ group.min_by { |s| EXCHANGE_CONFIG[s.exchange_operating_mic][:preference_rank] } ]
-        else
-          group
+      securities
+        .select { |s| EXCHANGE_CONFIG.dig(s.exchange_operating_mic, :dual_list_group) }
+        .group_by { |s| [ EXCHANGE_CONFIG[s.exchange_operating_mic][:dual_list_group], s.name.to_s.strip.downcase ] }
+        .each_value do |group|
+          next unless group.size > 1
+          preferred = group.min_by { |s| EXCHANGE_CONFIG[s.exchange_operating_mic][:preference_rank] }
+          group.each { |s| dominated << s.object_id unless s.equal?(preferred) }
         end
-      end
 
-      preferred + others
+      return securities if dominated.empty?
+      securities.reject { |s| dominated.include?(s.object_id) }
     end
 
     # ================================

--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -337,7 +337,7 @@ class Provider::YahooFinance < Provider
     # rank (lower = preferred).  Adding a new market is a one-line hash entry.
     EXCHANGE_CONFIG = {
       "XNSE" => { yahoo_suffix: ".NS", default_currency: "INR", dual_list_group: :india, preference_rank: 0 },
-      "XBOM" => { yahoo_suffix: ".BO", default_currency: "INR", dual_list_group: :india, preference_rank: 1 },
+      "XBOM" => { yahoo_suffix: ".BO", default_currency: "INR", dual_list_group: :india, preference_rank: 1 }
     }.freeze
 
     # Yahoo Finance sometimes returns currencies in minor units (pence, cents)

--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -388,7 +388,7 @@ class Provider::YahooFinance < Provider
       return securities if dual_listed.empty?
 
       preferred = dual_listed.group_by { |s|
-        [ EXCHANGE_CONFIG[s.exchange_operating_mic][:dual_list_group], s.name ]
+        [ EXCHANGE_CONFIG[s.exchange_operating_mic][:dual_list_group], s.name.to_s.strip.downcase ]
       }.flat_map do |_key, group|
         if group.size > 1
           [ group.min_by { |s| EXCHANGE_CONFIG[s.exchange_operating_mic][:preference_rank] } ]

--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -1,3 +1,5 @@
+require "set"
+
 class Provider::YahooFinance < Provider
   include ExchangeRateConcept, SecurityConcept
   extend SslConfigurable
@@ -231,6 +233,7 @@ class Provider::YahooFinance < Provider
 
   def fetch_security_price(symbol:, exchange_operating_mic: nil, date:)
     with_provider_response do
+      symbol = normalize_symbol(symbol, exchange_operating_mic)
       cache_key = "security_price_#{symbol}_#{exchange_operating_mic}_#{date}"
       if cached_result = get_cached_result(cache_key)
         cached_result
@@ -337,13 +340,6 @@ class Provider::YahooFinance < Provider
       "XBOM" => { yahoo_suffix: ".BO", default_currency: "INR", dual_list_group: :india, preference_rank: 1 },
     }.freeze
 
-    # Reverse lookup: Yahoo exchange name (from chart metadata) → default currency.
-    # Built from EXCHANGE_CONFIG via map_exchange_mic so the raw Yahoo codes
-    # ("NSE", "BSE", etc.) resolve to the same config.
-    YAHOO_EXCHANGE_CURRENCY = EXCHANGE_CONFIG.each_with_object({}) do |(mic, cfg), h|
-      h[mic] = cfg[:default_currency]
-    end.freeze
-
     # Yahoo Finance sometimes returns currencies in minor units (pence, cents)
     # This is not part of ISO 4217 but is a convention used by financial data providers
     # Mapping of Yahoo Finance minor unit codes to standard currency codes and conversion multipliers
@@ -366,9 +362,9 @@ class Provider::YahooFinance < Provider
     # Appends the Yahoo Finance symbol suffix for exchanges that require one
     # (e.g. XNSE → ".NS", XBOM → ".BO").  Already-suffixed symbols pass through.
     def normalize_symbol(symbol, exchange_operating_mic)
-      return symbol if symbol.include?(".")
-      cfg = EXCHANGE_CONFIG[exchange_operating_mic]
-      cfg ? "#{symbol}#{cfg[:yahoo_suffix]}" : symbol
+      suffix = EXCHANGE_CONFIG.dig(exchange_operating_mic, :yahoo_suffix)
+      return symbol if suffix.nil? || symbol.end_with?(suffix)
+      "#{symbol}#{suffix}"
     end
 
     # Returns the default currency for a Yahoo exchange name (e.g. "NSE" → "INR")

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -138,6 +138,7 @@ en:
       ca: Canada
       au: Australia
       eu: Europe
+      in: India
       generic: General
     confirm_unlink:
       title: Unlink account from provider?

--- a/config/locales/views/investments/en.yml
+++ b/config/locales/views/investments/en.yml
@@ -107,9 +107,9 @@ en:
       apy:
         short: APY
         long: Atal Pension Yojana
-      demat:
-        short: Demat A/C
-        long: Demat Account
+      indian_stocks:
+        short: Indian Stocks
+        long: Indian Stocks (Demat)
       indian_equity:
         short: Indian Equity
         long: Indian Equity

--- a/config/locales/views/investments/en.yml
+++ b/config/locales/views/investments/en.yml
@@ -100,6 +100,73 @@ en:
       riester:
         short: Riester
         long: Riester-Rente
+      # India
+      nps:
+        short: NPS
+        long: National Pension System
+      apy:
+        short: APY
+        long: Atal Pension Yojana
+      demat:
+        short: Demat A/C
+        long: Demat Account
+      indian_equity:
+        short: Indian Equity
+        long: Indian Equity
+      indian_etf:
+        short: Indian ETF
+        long: Indian ETF
+      life_insurance:
+        short: Life Insurance
+        long: Life Insurance
+      ppf:
+        short: PPF
+        long: Public Provident Fund
+      ssy:
+        short: SSY
+        long: Sukanya Samriddhi Yojana
+      nsc:
+        short: NSC
+        long: National Savings Certificate
+      scss:
+        short: SCSS
+        long: Senior Citizens' Savings Scheme
+      fd:
+        short: FD
+        long: Fixed Deposit
+      rd:
+        short: RD
+        long: Recurring Deposit
+      pomis:
+        short: POMIS
+        long: Post Office Monthly Income Scheme
+      kvp:
+        short: KVP
+        long: Kisan Vikas Patra
+      gold_etf:
+        short: Gold ETF
+        long: Gold ETF
+      gold_mf:
+        short: Gold MF
+        long: Gold Mutual Fund
+      sgb:
+        short: SGB
+        long: Sovereign Gold Bond
+      g_sec:
+        short: G-Sec
+        long: Government Securities (G-Secs)
+      sdl:
+        short: SDL
+        long: State Development Loans (SDLs)
+      corporate_bond:
+        short: Corporate Bond
+        long: Corporate Bond
+      infrastructure_bond:
+        short: Infra Bond
+        long: Infrastructure Bond
+      tax_free_bond:
+        short: Tax-Free Bond
+        long: Tax-Free Bond
       # Generic
       pension:
         short: Pension
@@ -110,6 +177,9 @@ en:
       mutual_fund:
         short: Mutual Fund
         long: Mutual Fund
+      gold:
+        short: Gold
+        long: Gold (physical or digital)
       angel:
         short: Angel
         long: Angel Investment

--- a/config/locales/views/properties/en.yml
+++ b/config/locales/views/properties/en.yml
@@ -30,3 +30,19 @@ en:
       trend: Trend
       unknown: Unknown
       year_built: Year Built
+    subtypes:
+      apartment:
+        short: Apartment
+        long: Apartment
+      plot:
+        short: Plot
+        long: Plot / Land
+      commercial:
+        short: Commercial
+        long: Commercial Property
+      rented:
+        short: Rented
+        long: Rented Property
+      agri_land:
+        short: Agri Land
+        long: Agricultural Land

--- a/test/models/investment_test.rb
+++ b/test/models/investment_test.rb
@@ -129,11 +129,46 @@ class InvestmentTest < ActiveSupport::TestCase
   end
 
   test "all subtypes have valid region values" do
-    valid_regions = [ "us", "uk", "ca", "au", "eu", nil ]
+    valid_regions = [ "us", "uk", "ca", "au", "eu", "in", nil ]
 
     Investment::SUBTYPES.each do |key, metadata|
       assert_includes valid_regions, metadata[:region],
         "Subtype #{key} has invalid region: #{metadata[:region]}"
     end
+  end
+
+  # India account types
+
+  test "India pension subtypes have tax_advantaged treatment" do
+    %w[nps apy].each do |subtype|
+      investment = Investment.new(subtype: subtype)
+      assert_equal :tax_advantaged, investment.tax_treatment, "Expected #{subtype} to be tax_advantaged"
+    end
+  end
+
+  test "India equity and demat subtypes are taxable" do
+    %w[demat indian_equity indian_etf].each do |subtype|
+      investment = Investment.new(subtype: subtype)
+      assert_equal :taxable, investment.tax_treatment, "Expected #{subtype} to be taxable"
+    end
+  end
+
+  test "life insurance is tax_advantaged" do
+    investment = Investment.new(subtype: "life_insurance")
+    assert_equal :tax_advantaged, investment.tax_treatment
+  end
+
+  test "India subtypes all belong to the 'in' region" do
+    india_keys = %w[nps apy demat indian_equity indian_etf life_insurance]
+    india_keys.each do |key|
+      assert_equal "in", Investment::SUBTYPES.dig(key, :region), "Expected #{key} to have region 'in'"
+    end
+  end
+
+  test "subtypes_grouped_for_select places India region last" do
+    grouped = Investment.subtypes_grouped_for_select(currency: "INR")
+    assert grouped.any?, "grouped should not be empty"
+    last_group_label = grouped.last[0]
+    assert_equal I18n.t("accounts.subtype_regions.in"), last_group_label
   end
 end

--- a/test/models/investment_test.rb
+++ b/test/models/investment_test.rb
@@ -146,8 +146,8 @@ class InvestmentTest < ActiveSupport::TestCase
     end
   end
 
-  test "India equity and demat subtypes are taxable" do
-    %w[demat indian_equity indian_etf].each do |subtype|
+  test "India equity subtypes are taxable" do
+    %w[indian_stocks indian_equity indian_etf].each do |subtype|
       investment = Investment.new(subtype: subtype)
       assert_equal :taxable, investment.tax_treatment, "Expected #{subtype} to be taxable"
     end
@@ -166,10 +166,10 @@ class InvestmentTest < ActiveSupport::TestCase
     end
   end
 
-  test "subtypes_grouped_for_select places India region last" do
+  test "subtypes_grouped_for_select places India region first for INR users" do
     grouped = Investment.subtypes_grouped_for_select(currency: "INR")
     assert grouped.any?, "grouped should not be empty"
-    last_group_label = grouped.last[0]
-    assert_equal I18n.t("accounts.subtype_regions.in"), last_group_label
+    first_group_label = grouped.first[0]
+    assert_equal I18n.t("accounts.subtype_regions.in"), first_group_label
   end
 end

--- a/test/models/investment_test.rb
+++ b/test/models/investment_test.rb
@@ -159,7 +159,8 @@ class InvestmentTest < ActiveSupport::TestCase
   end
 
   test "India subtypes all belong to the 'in' region" do
-    india_keys = %w[nps apy demat indian_equity indian_etf life_insurance]
+    india_keys = Investment::SUBTYPES.keys.select { |k| Investment::SUBTYPES.dig(k, :region) == "in" }
+    assert india_keys.any?, "Expected at least one India subtype"
     india_keys.each do |key|
       assert_equal "in", Investment::SUBTYPES.dig(key, :region), "Expected #{key} to have region 'in'"
     end

--- a/test/models/provider/yahoo_finance_test.rb
+++ b/test/models/provider/yahoo_finance_test.rb
@@ -369,7 +369,7 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
   end
 
   # ================================
-  #   Indian Exchange Tests
+  #   Exchange Mapping Tests
   # ================================
 
   test "map_exchange_mic returns XNSE for NSE and NSI" do
@@ -389,61 +389,80 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     assert_equal "IN", @provider.send(:map_country_code, "MUMBAI")
   end
 
-  test "normalize_indian_symbol appends .NS suffix for XNSE" do
-    assert_equal "RELIANCE.NS", @provider.send(:normalize_indian_symbol, "RELIANCE", "XNSE")
-    assert_equal "INFY.NS",     @provider.send(:normalize_indian_symbol, "INFY", "XNSE")
+  # ================================
+  #   normalize_symbol Tests
+  # ================================
+
+  test "normalize_symbol appends configured suffix for known MICs" do
+    assert_equal "RELIANCE.NS", @provider.send(:normalize_symbol, "RELIANCE", "XNSE")
+    assert_equal "INFY.NS",     @provider.send(:normalize_symbol, "INFY", "XNSE")
+    assert_equal "500325.BO",   @provider.send(:normalize_symbol, "500325", "XBOM")
   end
 
-  test "normalize_indian_symbol appends .BO suffix for XBOM" do
-    assert_equal "500325.BO", @provider.send(:normalize_indian_symbol, "500325", "XBOM")
+  test "normalize_symbol does not double-suffix already suffixed symbols" do
+    assert_equal "RELIANCE.NS", @provider.send(:normalize_symbol, "RELIANCE.NS", "XNSE")
+    assert_equal "500325.BO",   @provider.send(:normalize_symbol, "500325.BO", "XBOM")
   end
 
-  test "normalize_indian_symbol does not double-suffix already suffixed symbols" do
-    assert_equal "RELIANCE.NS", @provider.send(:normalize_indian_symbol, "RELIANCE.NS", "XNSE")
-    assert_equal "500325.BO",   @provider.send(:normalize_indian_symbol, "500325.BO", "XBOM")
+  test "normalize_symbol leaves unconfigured MIC symbols unchanged" do
+    assert_equal "AAPL", @provider.send(:normalize_symbol, "AAPL", "XNAS")
+    assert_equal "BARC", @provider.send(:normalize_symbol, "BARC", "XLON")
+    assert_equal "AAPL", @provider.send(:normalize_symbol, "AAPL", nil)
   end
 
-  test "normalize_indian_symbol leaves non-Indian MIC symbols unchanged" do
-    assert_equal "AAPL", @provider.send(:normalize_indian_symbol, "AAPL", "XNAS")
-    assert_equal "BARC", @provider.send(:normalize_indian_symbol, "BARC", "XLON")
-    assert_equal "AAPL", @provider.send(:normalize_indian_symbol, "AAPL", nil)
+  # ================================
+  #  default_currency_for_exchange Tests
+  # ================================
+
+  test "default_currency_for_exchange returns configured currency for known Yahoo exchange names" do
+    assert_equal "INR", @provider.send(:default_currency_for_exchange, "NSE")
+    assert_equal "INR", @provider.send(:default_currency_for_exchange, "BSE")
   end
 
-  test "prefer_indian_exchange keeps only NSE listing when both NSE and BSE present" do
+  test "default_currency_for_exchange returns nil for unknown exchanges" do
+    assert_nil @provider.send(:default_currency_for_exchange, "UNKNOWN")
+    assert_nil @provider.send(:default_currency_for_exchange, "NMS")
+  end
+
+  # ================================
+  #  deduplicate_dual_listings Tests
+  # ================================
+
+  test "deduplicate_dual_listings keeps preferred exchange when both are present" do
     nse = Provider::SecurityConcept::Security.new(symbol: "RELIANCE.NS", name: "Reliance", logo_url: nil, exchange_operating_mic: "XNSE", country_code: "IN")
     bse = Provider::SecurityConcept::Security.new(symbol: "500325.BO",   name: "Reliance", logo_url: nil, exchange_operating_mic: "XBOM", country_code: "IN")
     other = Provider::SecurityConcept::Security.new(symbol: "OTHER", name: "Other", logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US")
 
-    result = @provider.send(:prefer_indian_exchange, [ nse, bse, other ])
+    result = @provider.send(:deduplicate_dual_listings, [ nse, bse, other ])
 
     assert_equal "XNSE", result.first.exchange_operating_mic
-    assert_not result.map(&:exchange_operating_mic).include?("XBOM"), "BSE should be removed when NSE is present"
-    assert result.map(&:exchange_operating_mic).include?("XNAS"), "Non-Indian exchanges should be preserved"
+    assert_not result.map(&:exchange_operating_mic).include?("XBOM"), "Lower-ranked exchange should be removed"
+    assert result.map(&:exchange_operating_mic).include?("XNAS"), "Non-dual-listed exchanges should be preserved"
   end
 
-  test "prefer_indian_exchange preserves unrelated Indian tickers" do
+  test "deduplicate_dual_listings preserves unrelated securities in the same dual_list_group" do
     reliance_nse = Provider::SecurityConcept::Security.new(symbol: "RELIANCE.NS", name: "Reliance Industries", logo_url: nil, exchange_operating_mic: "XNSE", country_code: "IN")
     reliance_bse = Provider::SecurityConcept::Security.new(symbol: "500325.BO",   name: "Reliance Industries", logo_url: nil, exchange_operating_mic: "XBOM", country_code: "IN")
     infy_nse     = Provider::SecurityConcept::Security.new(symbol: "INFY.NS",     name: "Infosys",             logo_url: nil, exchange_operating_mic: "XNSE", country_code: "IN")
     other        = Provider::SecurityConcept::Security.new(symbol: "AAPL",        name: "Apple",               logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US")
 
-    result = @provider.send(:prefer_indian_exchange, [ reliance_nse, reliance_bse, infy_nse, other ])
+    result = @provider.send(:deduplicate_dual_listings, [ reliance_nse, reliance_bse, infy_nse, other ])
 
     symbols = result.map(&:symbol)
-    assert_includes symbols, "RELIANCE.NS", "NSE listing for Reliance should be kept"
-    assert_not_includes symbols, "500325.BO", "BSE duplicate for Reliance should be removed"
-    assert_includes symbols, "INFY.NS", "Unrelated Indian ticker should be preserved"
-    assert_includes symbols, "AAPL", "Non-Indian ticker should be preserved"
+    assert_includes symbols, "RELIANCE.NS", "Preferred listing should be kept"
+    assert_not_includes symbols, "500325.BO", "Duplicate listing should be removed"
+    assert_includes symbols, "INFY.NS", "Unrelated security in same group should be preserved"
+    assert_includes symbols, "AAPL", "Non-dual-listed security should be preserved"
     assert_equal 3, result.size
   end
 
-  test "prefer_indian_exchange returns original list when no Indian exchanges present" do
+  test "deduplicate_dual_listings returns original list when no dual-listed exchanges present" do
     securities = [
       Provider::SecurityConcept::Security.new(symbol: "AAPL", name: "Apple", logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US"),
       Provider::SecurityConcept::Security.new(symbol: "MSFT", name: "Microsoft", logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US")
     ]
 
-    result = @provider.send(:prefer_indian_exchange, securities)
+    result = @provider.send(:deduplicate_dual_listings, securities)
     assert_equal securities, result
   end
 end

--- a/test/models/provider/yahoo_finance_test.rb
+++ b/test/models/provider/yahoo_finance_test.rb
@@ -410,6 +410,11 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     assert_equal "AAPL", @provider.send(:normalize_symbol, "AAPL", nil)
   end
 
+  test "normalize_symbol appends suffix to dotted symbols that do not already end with the configured suffix" do
+    assert_equal "BRK.A.NS", @provider.send(:normalize_symbol, "BRK.A", "XNSE")
+    assert_equal "BRK.B.BO", @provider.send(:normalize_symbol, "BRK.B", "XBOM")
+  end
+
   # ================================
   #  default_currency_for_exchange Tests
   # ================================

--- a/test/models/provider/yahoo_finance_test.rb
+++ b/test/models/provider/yahoo_finance_test.rb
@@ -367,4 +367,67 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     assert_equal "EUR", currency
     assert_equal 75.75, price
   end
+
+  # ================================
+  #   Indian Exchange Tests
+  # ================================
+
+  test "map_exchange_mic returns XNSE for NSE and NSI" do
+    assert_equal "XNSE", @provider.send(:map_exchange_mic, "NSE")
+    assert_equal "XNSE", @provider.send(:map_exchange_mic, "NSI")
+    assert_equal "XNSE", @provider.send(:map_exchange_mic, "nse")
+  end
+
+  test "map_exchange_mic returns XBOM for BSE and BOM" do
+    assert_equal "XBOM", @provider.send(:map_exchange_mic, "BSE")
+    assert_equal "XBOM", @provider.send(:map_exchange_mic, "BOM")
+  end
+
+  test "map_country_code returns IN for Indian exchanges" do
+    assert_equal "IN", @provider.send(:map_country_code, "NSE")
+    assert_equal "IN", @provider.send(:map_country_code, "BSE")
+    assert_equal "IN", @provider.send(:map_country_code, "MUMBAI")
+  end
+
+  test "normalize_indian_symbol appends .NS suffix for XNSE" do
+    assert_equal "RELIANCE.NS", @provider.send(:normalize_indian_symbol, "RELIANCE", "XNSE")
+    assert_equal "INFY.NS",     @provider.send(:normalize_indian_symbol, "INFY", "XNSE")
+  end
+
+  test "normalize_indian_symbol appends .BO suffix for XBOM" do
+    assert_equal "500325.BO", @provider.send(:normalize_indian_symbol, "500325", "XBOM")
+  end
+
+  test "normalize_indian_symbol does not double-suffix already suffixed symbols" do
+    assert_equal "RELIANCE.NS", @provider.send(:normalize_indian_symbol, "RELIANCE.NS", "XNSE")
+    assert_equal "500325.BO",   @provider.send(:normalize_indian_symbol, "500325.BO", "XBOM")
+  end
+
+  test "normalize_indian_symbol leaves non-Indian MIC symbols unchanged" do
+    assert_equal "AAPL", @provider.send(:normalize_indian_symbol, "AAPL", "XNAS")
+    assert_equal "BARC", @provider.send(:normalize_indian_symbol, "BARC", "XLON")
+    assert_equal "AAPL", @provider.send(:normalize_indian_symbol, "AAPL", nil)
+  end
+
+  test "prefer_indian_exchange keeps only NSE listing when both NSE and BSE present" do
+    nse = Provider::SecurityConcept::Security.new(symbol: "RELIANCE.NS", name: "Reliance", exchange_operating_mic: "XNSE")
+    bse = Provider::SecurityConcept::Security.new(symbol: "500325.BO",   name: "Reliance", exchange_operating_mic: "XBOM")
+    other = Provider::SecurityConcept::Security.new(symbol: "OTHER", name: "Other", exchange_operating_mic: "XNAS")
+
+    result = @provider.send(:prefer_indian_exchange, [ nse, bse, other ])
+
+    assert_equal "XNSE", result.first.exchange_operating_mic
+    assert_not result.map(&:exchange_operating_mic).include?("XBOM"), "BSE should be removed when NSE is present"
+    assert result.map(&:exchange_operating_mic).include?("XNAS"), "Non-Indian exchanges should be preserved"
+  end
+
+  test "prefer_indian_exchange returns original list when no Indian exchanges present" do
+    securities = [
+      Provider::SecurityConcept::Security.new(symbol: "AAPL", name: "Apple", exchange_operating_mic: "XNAS"),
+      Provider::SecurityConcept::Security.new(symbol: "MSFT", name: "Microsoft", exchange_operating_mic: "XNAS")
+    ]
+
+    result = @provider.send(:prefer_indian_exchange, securities)
+    assert_equal securities, result
+  end
 end

--- a/test/models/provider/yahoo_finance_test.rb
+++ b/test/models/provider/yahoo_finance_test.rb
@@ -410,9 +410,9 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
   end
 
   test "prefer_indian_exchange keeps only NSE listing when both NSE and BSE present" do
-    nse = Provider::SecurityConcept::Security.new(symbol: "RELIANCE.NS", name: "Reliance", exchange_operating_mic: "XNSE")
-    bse = Provider::SecurityConcept::Security.new(symbol: "500325.BO",   name: "Reliance", exchange_operating_mic: "XBOM")
-    other = Provider::SecurityConcept::Security.new(symbol: "OTHER", name: "Other", exchange_operating_mic: "XNAS")
+    nse = Provider::SecurityConcept::Security.new(symbol: "RELIANCE.NS", name: "Reliance", logo_url: nil, exchange_operating_mic: "XNSE", country_code: "IN")
+    bse = Provider::SecurityConcept::Security.new(symbol: "500325.BO",   name: "Reliance", logo_url: nil, exchange_operating_mic: "XBOM", country_code: "IN")
+    other = Provider::SecurityConcept::Security.new(symbol: "OTHER", name: "Other", logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US")
 
     result = @provider.send(:prefer_indian_exchange, [ nse, bse, other ])
 
@@ -421,10 +421,26 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     assert result.map(&:exchange_operating_mic).include?("XNAS"), "Non-Indian exchanges should be preserved"
   end
 
+  test "prefer_indian_exchange preserves unrelated Indian tickers" do
+    reliance_nse = Provider::SecurityConcept::Security.new(symbol: "RELIANCE.NS", name: "Reliance Industries", logo_url: nil, exchange_operating_mic: "XNSE", country_code: "IN")
+    reliance_bse = Provider::SecurityConcept::Security.new(symbol: "500325.BO",   name: "Reliance Industries", logo_url: nil, exchange_operating_mic: "XBOM", country_code: "IN")
+    infy_nse     = Provider::SecurityConcept::Security.new(symbol: "INFY.NS",     name: "Infosys",             logo_url: nil, exchange_operating_mic: "XNSE", country_code: "IN")
+    other        = Provider::SecurityConcept::Security.new(symbol: "AAPL",        name: "Apple",               logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US")
+
+    result = @provider.send(:prefer_indian_exchange, [ reliance_nse, reliance_bse, infy_nse, other ])
+
+    symbols = result.map(&:symbol)
+    assert_includes symbols, "RELIANCE.NS", "NSE listing for Reliance should be kept"
+    assert_not_includes symbols, "500325.BO", "BSE duplicate for Reliance should be removed"
+    assert_includes symbols, "INFY.NS", "Unrelated Indian ticker should be preserved"
+    assert_includes symbols, "AAPL", "Non-Indian ticker should be preserved"
+    assert_equal 3, result.size
+  end
+
   test "prefer_indian_exchange returns original list when no Indian exchanges present" do
     securities = [
-      Provider::SecurityConcept::Security.new(symbol: "AAPL", name: "Apple", exchange_operating_mic: "XNAS"),
-      Provider::SecurityConcept::Security.new(symbol: "MSFT", name: "Microsoft", exchange_operating_mic: "XNAS")
+      Provider::SecurityConcept::Security.new(symbol: "AAPL", name: "Apple", logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US"),
+      Provider::SecurityConcept::Security.new(symbol: "MSFT", name: "Microsoft", logo_url: nil, exchange_operating_mic: "XNAS", country_code: "US")
     ]
 
     result = @provider.send(:prefer_indian_exchange, securities)


### PR DESCRIPTION
Adds first-class support for Indian investors by extending the existing [Investment](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/investment.rb) and [Property](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/property.rb) accountable types with India-region subtypes, and by teaching [`Provider::YahooFinance`](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb) to handle NSE/BSE listings. Indian mutual fund NAVs are already covered by the existing [Provider::Mfapi(https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/mfapi.rb); this PR builds on top of that.

> Related: we-promise/sure#1413 (closed) previously attempted Indian investment support via country-specific accountable models. This PR takes a different approach — per @jjmata's feedback on that thread — using subtypes on existing models instead of new tables.

### Addressing the prior review on #1413

Maintainer feedback on that PR from @jjmata:

> "adding `indian_*` tables/data model proliferation sounds like the wrong approach. Can't have that for each country, you know? Why is that necessary?"

**This PR is designed to resolve exactly that.** No country-specific tables, no new accountable types — Indian investments live on the existing [Investment](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/investment.rb) model via subtypes (same pattern already used for `401k`, `isa`, `rrsp`, `super`, `pea`, etc.), and Indian property types live on [Property](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/property.rb). Zero new migrations, zero schema changes.

### Changes

**Investment subtypes** ([`SUBTYPES` hash](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/investment.rb#L9-L94), [India section](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/investment.rb#L57-L84))

Region `in`:
- Pensions & insurance: `nps`, `apy`, `life_insurance`
- Equity / market-linked: `demat`, `indian_equity`, `indian_etf`
- Fixed-income / small-savings: `ppf`, `ssy`, `nsc`, `scss`, `fd`, `rd`, `pomis`, `kvp`
- Bonds: `g_sec`, `sdl`, `corporate_bond`, `infrastructure_bond`, `tax_free_bond`
- India-specific gold instruments: `gold_etf`, `gold_mf`, `sgb`

Generic:
- `gold` (covers physical + digital gold, region-agnostic)

Each subtype carries a proper [tax_treatment](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/investment.rb#L96-L98) (`:tax_exempt` for PPF/SSY/tax-free bonds, `:tax_advantaged` for NPS/SGB/infra bonds/life insurance, `:taxable` otherwise).

**Property subtypes** ([`SUBTYPES` hash](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/property.rb#L4-L17))
- Added: `apartment`, `plot`, `commercial`, `rented`, `agri_land`

**Subtype ordering**
- Dropdown groups: Generic → US → UK → CA → AU → EU → India.

**`Provider::YahooFinance` — NSE/BSE support**
- MIC mapping: `NSE`/`NSI` → `XNSE`; `BSE`/`BOM` → `XBOM` — see [`map_exchange_mic`](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb#L816-L820)
- Country code mapping for Indian exchanges → `IN` (via [`map_country_code`](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb#L707))
- Symbol normalization: appends `.NS`/`.BO` suffix in [fetch_security_info](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb#L178-L230) and [fetch_security_prices](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb#L268) via [`normalize_indian_symbol`](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb#L360-L367)
- Dual-listing de-duplication: [`prefer_indian_exchange`](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb#L371-L378) prefers NSE over BSE when the same ticker is listed on both
- [INR currency default](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/provider/yahoo_finance.rb#L295) when Yahoo's response omits `meta.currency` for Indian exchanges
- [`CURRENCY_REGION_MAP`](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/app/models/investment.rb#L118-L125) intentionally leaves `"INR"` unlisted — India coverage still works via the explicit `region: "in"` tag on subtypes, without displacing the existing currency-based region prioritization

### Tests

- [test/models/investment_test.rb](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/test/models/investment_test.rb) — India subtype tax-treatment and region assertions; group ordering assertion
- [`test/models/provider/yahoo_finance_test.rb`](https://github.com/we-promise/sure/blob/694e879f440633f47e5c5177b9e3f6f215008414/test/models/provider/yahoo_finance_test.rb) — MIC mapping, symbol normalization, INR default, NSE preference over BSE for dual-listed tickers

All existing tests continue to pass.

### Screenshots

<img width="1280" height="1132" alt="image" src="https://github.com/user-attachments/assets/9b309339-b0a4-4212-80ee-c9b77f2985ed" />

<img width="1185" height="1432" alt="image" src="https://github.com/user-attachments/assets/16fb0136-50ee-4546-8db0-3846e622e7d9" />

### Checklist

- [x] Minitest coverage added for new behavior
- [x] `bin/rubocop` clean
- [x] Biome (`npm run lint`) clean
- [x] No new migrations
- [x] No secrets committed
- [x] Branch rebased on `main`
- [x] Allow edits from maintainers (please enable when opening against upstream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded investment options with India-specific products and added a generic "Gold" subtype; region ordering updated for grouped selection lists.
  * Added property categories: apartment, plot, commercial, rented, agricultural land, and updated second-home entry.
  * Improved market-data handling: normalized Indian equity symbols, deduplicated dual-listed Indian listings, and improved currency resolution for historical prices.
* **Documentation**
  * Added English locale entries for India-related subtype labels.
* **Tests**
  * Added tests for India subtypes and Indian exchange/symbol handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->