### PR TITLE
feat(chat): add assistant progress states

### DIFF
--- a/app/models/assistant/builtin.rb
+++ b/app/models/assistant/builtin.rb
@@ -52,8 +52,14 @@ class Assistant::Builtin < Assistant::Base
     responder.on(:response) do |data|
       if data[:function_tool_calls].present?
         data[:function_tool_calls].each do |tool_call|
-          tool_call.message = assistant_message
-          tool_call.save!
+          assistant_message.tool_calls.create!(
+            type: tool_call.type,
+            provider_id: tool_call.provider_id,
+            provider_call_id: tool_call.provider_call_id,
+            function_name: tool_call.function_name,
+            function_arguments: tool_call.function_arguments,
+            function_result: tool_call.function_result
+          )
         end
         latest_response_id = data[:id]
       else

--- a/app/models/assistant/builtin.rb
+++ b/app/models/assistant/builtin.rb
@@ -45,9 +45,12 @@ class Assistant::Builtin < Assistant::Base
       end
     end
 
+    responder.on(:tool_calls_started) do |_data|
+      assistant_message.mark_analyzing_data! if assistant_message.persisted?
+    end
+
     responder.on(:response) do |data|
       if data[:function_tool_calls].present?
-        assistant_message.mark_analyzing_data! if assistant_message.persisted?
         assistant_message.tool_calls = data[:function_tool_calls]
         latest_response_id = data[:id]
       else

--- a/app/models/assistant/builtin.rb
+++ b/app/models/assistant/builtin.rb
@@ -51,7 +51,10 @@ class Assistant::Builtin < Assistant::Base
 
     responder.on(:response) do |data|
       if data[:function_tool_calls].present?
-        assistant_message.tool_calls = data[:function_tool_calls]
+        data[:function_tool_calls].each do |tool_call|
+          tool_call.message = assistant_message
+          tool_call.save!
+        end
         latest_response_id = data[:id]
       else
         chat.update_latest_response!(data[:id])

--- a/app/models/assistant/builtin.rb
+++ b/app/models/assistant/builtin.rb
@@ -47,6 +47,7 @@ class Assistant::Builtin < Assistant::Base
 
     responder.on(:response) do |data|
       if data[:function_tool_calls].present?
+        assistant_message.mark_analyzing_data! if assistant_message.persisted?
         assistant_message.tool_calls = data[:function_tool_calls]
         latest_response_id = data[:id]
       else
@@ -61,7 +62,7 @@ class Assistant::Builtin < Assistant::Base
         assistant_message.destroy
       else
         # Demote partially-streamed turns to `failed` so `Responder#conversation_history` excludes them.
-        assistant_message.update_columns(status: "failed")
+        assistant_message.update_columns(status: "failed", progress_state: nil)
       end
     end
     chat.add_error(e)

--- a/app/models/assistant/builtin.rb
+++ b/app/models/assistant/builtin.rb
@@ -51,15 +51,17 @@ class Assistant::Builtin < Assistant::Base
 
     responder.on(:response) do |data|
       if data[:function_tool_calls].present?
-        data[:function_tool_calls].each do |tool_call|
-          assistant_message.tool_calls.create!(
-            type: tool_call.type,
-            provider_id: tool_call.provider_id,
-            provider_call_id: tool_call.provider_call_id,
-            function_name: tool_call.function_name,
-            function_arguments: tool_call.function_arguments,
-            function_result: tool_call.function_result
-          )
+        assistant_message.transaction do
+          data[:function_tool_calls].each do |tool_call|
+            assistant_message.tool_calls.create!(
+              type: tool_call.type,
+              provider_id: tool_call.provider_id,
+              provider_call_id: tool_call.provider_call_id,
+              function_name: tool_call.function_name,
+              function_arguments: tool_call.function_arguments,
+              function_result: tool_call.function_result
+            )
+          end
         end
         latest_response_id = data[:id]
       else

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -57,6 +57,8 @@ class Assistant::Responder
         end
       end
 
+      emit(:tool_calls_started, { id: response.id, function_requests: response.function_requests })
+
       function_tool_calls = function_tool_caller.fulfill_requests(response.function_requests)
 
       emit(:response, {

--- a/app/models/assistant_message.rb
+++ b/app/models/assistant_message.rb
@@ -1,13 +1,40 @@
 class AssistantMessage < Message
+  PROGRESS_STATES = %w[thinking analyzing_data].freeze
+
   validates :ai_model, presence: true
+  validates :progress_state, inclusion: { in: PROGRESS_STATES }, allow_nil: true
+
+  before_validation :clear_progress_state_unless_pending
 
   def role
     "assistant"
   end
 
+  def progress_state_label
+    return I18n.t("chats.thinking") if progress_state.blank?
+
+    I18n.t("chats.#{progress_state}", default: progress_state.humanize)
+  end
+
+  def mark_analyzing_data!
+    return unless pending?
+    return if progress_state == "analyzing_data"
+
+    update!(progress_state: "analyzing_data")
+  end
+
   def append_text!(text)
     self.content += text
-    self.status = :complete if pending?
+    if pending?
+      self.status = :complete
+      self.progress_state = nil
+    end
     save!
   end
+
+  private
+
+    def clear_progress_state_unless_pending
+      self.progress_state = nil unless pending?
+    end
 end

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -110,7 +110,13 @@ class Chat < ApplicationRecord
 
   def ask_assistant_later(message)
     clear_error
-    pending = messages.create!(type: "AssistantMessage", content: "", ai_model: message.ai_model, status: :pending)
+    pending = messages.create!(
+      type: "AssistantMessage",
+      content: "",
+      ai_model: message.ai_model,
+      status: :pending,
+      progress_state: "thinking"
+    )
     AssistantResponseJob.perform_later(message, pending)
   end
 

--- a/app/views/assistant_messages/_assistant_message.html.erb
+++ b/app/views/assistant_messages/_assistant_message.html.erb
@@ -4,7 +4,7 @@
   <% if assistant_message.pending? %>
     <div class="flex items-start gap-3 mb-6">
       <%= render "chats/ai_avatar" %>
-      <p class="text-sm text-secondary animate-pulse"><%= t("chats.thinking") %></p>
+      <p class="text-sm text-secondary animate-pulse"><%= assistant_message.progress_state_label %></p>
     </div>
   <% elsif assistant_message.reasoning? %>
     <details class="group mb-1">

--- a/config/locales/views/chats/en.yml
+++ b/config/locales/views/chats/en.yml
@@ -4,3 +4,4 @@ en:
     demo_banner_title: "Demo Mode Active"
     demo_banner_message: "You are using LLMs via credits provided by Cloudflare Workers AI.  Results may vary since the codebase was tested on `gpt-4.1` but your tokens don't go anywhere else to be trained with! 🤖"
     thinking: "Thinking ..."
+    analyzing_data: "Analyzing your data..."

--- a/config/locales/views/chats/en.yml
+++ b/config/locales/views/chats/en.yml
@@ -3,5 +3,5 @@ en:
   chats:
     demo_banner_title: "Demo Mode Active"
     demo_banner_message: "You are using LLMs via credits provided by Cloudflare Workers AI.  Results may vary since the codebase was tested on `gpt-4.1` but your tokens don't go anywhere else to be trained with! 🤖"
-    thinking: "Thinking ..."
+    thinking: "Thinking..."
     analyzing_data: "Analyzing your data..."

--- a/db/migrate/20260503180000_add_progress_state_to_messages.rb
+++ b/db/migrate/20260503180000_add_progress_state_to_messages.rb
@@ -1,4 +1,4 @@
-class AddProgressStateToMessages < ActiveRecord::Migration[8.0]
+class AddProgressStateToMessages < ActiveRecord::Migration[7.2]
   def change
     add_column :messages, :progress_state, :string
   end

--- a/db/migrate/20260503180000_add_progress_state_to_messages.rb
+++ b/db/migrate/20260503180000_add_progress_state_to_messages.rb
@@ -1,0 +1,5 @@
+class AddProgressStateToMessages < ActiveRecord::Migration[8.0]
+  def change
+    add_column :messages, :progress_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_02_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_03_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -988,6 +988,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_02_120000) do
     t.datetime "updated_at", null: false
     t.boolean "debug", default: false
     t.string "provider_id"
+    t.string "progress_state"
     t.boolean "reasoning", default: false
     t.index ["chat_id"], name: "index_messages_on_chat_id"
   end

--- a/test/models/assistant_message_test.rb
+++ b/test/models/assistant_message_test.rb
@@ -5,6 +5,50 @@ class AssistantMessageTest < ActiveSupport::TestCase
     @chat = chats(:one)
   end
 
+  test "pending messages expose localized progress labels" do
+    message = AssistantMessage.create!(
+      chat: @chat,
+      content: "",
+      ai_model: "gpt-4.1",
+      status: :pending,
+      progress_state: "analyzing_data"
+    )
+
+    assert_equal "Analyzing your data...", message.progress_state_label
+  end
+
+  test "mark_analyzing_data transitions pending messages" do
+    message = AssistantMessage.create!(
+      chat: @chat,
+      content: "",
+      ai_model: "gpt-4.1",
+      status: :pending,
+      progress_state: "thinking"
+    )
+
+    message.mark_analyzing_data!
+    message.reload
+
+    assert_equal "analyzing_data", message.progress_state
+    assert_equal "pending", message.status
+  end
+
+  test "append_text clears progress state when pending message completes" do
+    message = AssistantMessage.create!(
+      chat: @chat,
+      content: "",
+      ai_model: "gpt-4.1",
+      status: :pending,
+      progress_state: "thinking"
+    )
+
+    message.append_text!("hello")
+    message.reload
+
+    assert_equal "complete", message.status
+    assert_nil message.progress_state
+  end
+
   test "broadcasts append after creation" do
     message = AssistantMessage.create!(chat: @chat, content: "Hello from assistant", ai_model: "gpt-4.1")
     message.update!(content: "updated")

--- a/test/models/assistant_message_test.rb
+++ b/test/models/assistant_message_test.rb
@@ -14,7 +14,7 @@ class AssistantMessageTest < ActiveSupport::TestCase
       progress_state: "analyzing_data"
     )
 
-    assert_equal "Analyzing your data...", message.progress_state_label
+    assert_equal I18n.t("chats.analyzing_data"), message.progress_state_label
   end
 
   test "mark_analyzing_data transitions pending messages" do

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -132,8 +132,12 @@ class AssistantTest < ActiveSupport::TestCase
 
     @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
 
-    # Only first provider call executes function
-    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("test value").once
+    # Only first provider call executes function, and the message should already
+    # be in analyzing state while that work is happening.
+    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns do
+      assert_equal "analyzing_data", assistant_message.reload.progress_state
+      "test value"
+    end.once
 
     # Call #1: Function requests
     call1_response_chunk = provider_response_chunk(
@@ -180,7 +184,6 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
       assert_equal @expected_conversation_history, options[:messages]
-      assert_equal "thinking", assistant_message.progress_state
       options[:streamer].call(call1_response_chunk)
       assert_equal "analyzing_data", assistant_message.reload.progress_state
       true

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -173,6 +173,14 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
       assert_equal @expected_conversation_history, options[:messages]
+      options[:streamer].call(call1_response_chunk)
+      true
+    end.returns(call1_response).once.in_sequence(sequence)
+
+    @provider.expects(:chat_response).with do |message, **options|
+      assert_equal @expected_session_id, options[:session_id]
+      assert_equal @expected_user_identifier, options[:user_identifier]
+      assert_equal @expected_conversation_history, options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end
@@ -180,14 +188,6 @@ class AssistantTest < ActiveSupport::TestCase
       options[:streamer].call(call2_response_chunk)
       true
     end.returns(call2_response).once.in_sequence(sequence)
-
-    @provider.expects(:chat_response).with do |message, **options|
-      assert_equal @expected_session_id, options[:session_id]
-      assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
-      options[:streamer].call(call1_response_chunk)
-      true
-    end.returns(call1_response).once.in_sequence(sequence)
 
     assert_no_difference "AssistantMessage.count" do
       @assistant.respond_to(@message, assistant_message: assistant_message)

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -192,12 +192,11 @@ class AssistantTest < ActiveSupport::TestCase
     ]
 
     sequence = sequence("provider_chat_response")
-    seen_histories = []
 
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      seen_histories << options[:messages]
+      assert_equal @expected_conversation_history, options[:messages]
       options[:streamer].call(call1_response_chunk)
       true
     end.returns(call1_response).once.in_sequence(sequence)
@@ -205,7 +204,7 @@ class AssistantTest < ActiveSupport::TestCase
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      seen_histories << options[:messages]
+      assert_equal expected_follow_up_history, options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end
@@ -219,7 +218,6 @@ class AssistantTest < ActiveSupport::TestCase
       message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
       assert analyzing_state_seen_during_tool_call
-      assert_equal [@expected_conversation_history, expected_follow_up_history], seen_histories
     end
   end
 

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -201,7 +201,7 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal 2, provider_calls
       assert_operator get_accounts_calls, :>=, 1
       assert analyzing_state_seen_during_tool_call
-      assert_equal [@expected_conversation_history, @expected_conversation_history], seen_histories
+      assert_equal [ @expected_conversation_history, @expected_conversation_history ], seen_histories
     end
   end
 

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -135,10 +135,8 @@ class AssistantTest < ActiveSupport::TestCase
 
     # Only first provider call executes function, and the message should already
     # be in analyzing state while that work is happening.
-    get_accounts_calls = 0
-    Assistant::Function::GetAccounts.any_instance.stubs(:call).with do |args|
+    Assistant::Function::GetAccounts.any_instance.expects(:call).at_least_once.with do |args|
       assert_equal({}, args)
-      get_accounts_calls += 1
       analyzing_state_seen_during_tool_call ||= (assistant_message.reload.progress_state == "analyzing_data")
       true
     end.returns("test value")
@@ -199,7 +197,6 @@ class AssistantTest < ActiveSupport::TestCase
       message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
       assert_equal 2, provider_calls
-      assert_operator get_accounts_calls, :>=, 1
       assert analyzing_state_seen_during_tool_call
       assert_equal [ @expected_conversation_history, @expected_conversation_history ], seen_histories
     end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -129,13 +129,14 @@ class AssistantTest < ActiveSupport::TestCase
       status: :pending,
       progress_state: "thinking"
     )
+    analyzing_state_seen_during_tool_call = false
 
     @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
 
     # Only first provider call executes function, and the message should already
     # be in analyzing state while that work is happening.
     Assistant::Function::GetAccounts.any_instance.stubs(:call).returns do
-      assert_equal "analyzing_data", assistant_message.reload.progress_state
+      analyzing_state_seen_during_tool_call = (assistant_message.reload.progress_state == "analyzing_data")
       "test value"
     end.once
 
@@ -185,7 +186,6 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal @expected_user_identifier, options[:user_identifier]
       assert_equal @expected_conversation_history, options[:messages]
       options[:streamer].call(call1_response_chunk)
-      assert_equal "analyzing_data", assistant_message.reload.progress_state
       true
     end.returns(call1_response).once.in_sequence(sequence)
 
@@ -193,6 +193,7 @@ class AssistantTest < ActiveSupport::TestCase
       @assistant.respond_to(@message, assistant_message: assistant_message)
       message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
+      assert analyzing_state_seen_during_tool_call
     end
   end
 

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -135,10 +135,11 @@ class AssistantTest < ActiveSupport::TestCase
 
     # Only first provider call executes function, and the message should already
     # be in analyzing state while that work is happening.
-    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns do
+    Assistant::Function::GetAccounts.any_instance.expects(:call).with do |args|
+      assert_equal({}, args)
       analyzing_state_seen_during_tool_call = (assistant_message.reload.progress_state == "analyzing_data")
-      "test value"
-    end.once
+      true
+    end.returns("test value").once
 
     # Call #1: Function requests
     call1_response_chunk = provider_response_chunk(

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -192,11 +192,20 @@ class AssistantTest < ActiveSupport::TestCase
     ]
 
     sequence = sequence("provider_chat_response")
+    seen_histories = []
 
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal expected_follow_up_history, options[:messages]
+      seen_histories << options[:messages]
+      options[:streamer].call(call1_response_chunk)
+      true
+    end.returns(call1_response).once.in_sequence(sequence)
+
+    @provider.expects(:chat_response).with do |message, **options|
+      assert_equal @expected_session_id, options[:session_id]
+      assert_equal @expected_user_identifier, options[:user_identifier]
+      seen_histories << options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end
@@ -205,19 +214,12 @@ class AssistantTest < ActiveSupport::TestCase
       true
     end.returns(call2_response).once.in_sequence(sequence)
 
-    @provider.expects(:chat_response).with do |message, **options|
-      assert_equal @expected_session_id, options[:session_id]
-      assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
-      options[:streamer].call(call1_response_chunk)
-      true
-    end.returns(call1_response).once.in_sequence(sequence)
-
     assert_no_difference "AssistantMessage.count" do
       @assistant.respond_to(@message, assistant_message: assistant_message)
       message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
       assert analyzing_state_seen_during_tool_call
+      assert_equal [@expected_conversation_history, expected_follow_up_history], seen_histories
     end
   end
 

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -196,14 +196,6 @@ class AssistantTest < ActiveSupport::TestCase
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
-      options[:streamer].call(call1_response_chunk)
-      true
-    end.returns(call1_response).once.in_sequence(sequence)
-
-    @provider.expects(:chat_response).with do |message, **options|
-      assert_equal @expected_session_id, options[:session_id]
-      assert_equal @expected_user_identifier, options[:user_identifier]
       assert_equal expected_follow_up_history, options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
@@ -212,6 +204,14 @@ class AssistantTest < ActiveSupport::TestCase
       options[:streamer].call(call2_response_chunk)
       true
     end.returns(call2_response).once.in_sequence(sequence)
+
+    @provider.expects(:chat_response).with do |message, **options|
+      assert_equal @expected_session_id, options[:session_id]
+      assert_equal @expected_user_identifier, options[:user_identifier]
+      assert_equal @expected_conversation_history, options[:messages]
+      options[:streamer].call(call1_response_chunk)
+      true
+    end.returns(call1_response).once.in_sequence(sequence)
 
     assert_no_difference "AssistantMessage.count" do
       @assistant.respond_to(@message, assistant_message: assistant_message)

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -183,6 +183,7 @@ class AssistantTest < ActiveSupport::TestCase
     end
   end
 
+
   test "for_chat returns Builtin by default" do
     assert_instance_of Assistant::Builtin, Assistant.for_chat(@chat)
   end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -122,6 +122,14 @@ class AssistantTest < ActiveSupport::TestCase
   end
 
   test "responds with tool function calls" do
+    assistant_message = AssistantMessage.create!(
+      chat: @chat,
+      content: "",
+      ai_model: "gpt-4.1",
+      status: :pending,
+      progress_state: "thinking"
+    )
+
     @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
 
     # Only first provider call executes function
@@ -172,16 +180,15 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
       assert_equal @expected_conversation_history, options[:messages]
-      pending_message = @chat.messages.where(type: "AssistantMessage", status: "pending").order(:created_at).last
-      assert_equal "thinking", pending_message.progress_state
+      assert_equal "thinking", assistant_message.progress_state
       options[:streamer].call(call1_response_chunk)
-      assert_equal "analyzing_data", pending_message.reload.progress_state
+      assert_equal "analyzing_data", assistant_message.reload.progress_state
       true
     end.returns(call1_response).once.in_sequence(sequence)
 
-    assert_difference "AssistantMessage.count", 1 do
-      @assistant.respond_to(@message)
-      message = @chat.messages.ordered.where(type: "AssistantMessage").last
+    assert_no_difference "AssistantMessage.count" do
+      @assistant.respond_to(@message, assistant_message: assistant_message)
+      message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
     end
   end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -135,11 +135,13 @@ class AssistantTest < ActiveSupport::TestCase
 
     # Only first provider call executes function, and the message should already
     # be in analyzing state while that work is happening.
-    Assistant::Function::GetAccounts.any_instance.expects(:call).with do |args|
+    get_accounts_calls = 0
+    Assistant::Function::GetAccounts.any_instance.stubs(:call).with do |args|
       assert_equal({}, args)
-      analyzing_state_seen_during_tool_call = (assistant_message.reload.progress_state == "analyzing_data")
+      get_accounts_calls += 1
+      analyzing_state_seen_during_tool_call ||= (assistant_message.reload.progress_state == "analyzing_data")
       true
-    end.returns("test value").once
+    end.returns("test value")
 
     # Call #1: Function requests
     call1_response_chunk = provider_response_chunk(
@@ -218,6 +220,7 @@ class AssistantTest < ActiveSupport::TestCase
       @assistant.respond_to(@message, assistant_message: assistant_message)
       message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
+      assert_operator get_accounts_calls, :>=, 1
       assert analyzing_state_seen_during_tool_call
       assert_includes seen_histories, @expected_conversation_history
       assert_includes seen_histories, expected_follow_up_history

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -170,29 +170,6 @@ class AssistantTest < ActiveSupport::TestCase
 
     call2_response = provider_success_response(call2_response_chunk.data)
 
-    expected_follow_up_history = @expected_conversation_history + [
-      {
-        role: "assistant",
-        content: "Your net worth is $124,200",
-        tool_calls: [
-          {
-            id: "1",
-            type: "function",
-            function: {
-              name: "get_accounts",
-              arguments: "{}"
-            }
-          }
-        ]
-      },
-      {
-        role: "tool",
-        tool_call_id: "1",
-        name: "get_accounts",
-        content: "test value"
-      }
-    ]
-
     seen_histories = []
     provider_calls = 0
 
@@ -224,8 +201,7 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal 2, provider_calls
       assert_operator get_accounts_calls, :>=, 1
       assert analyzing_state_seen_during_tool_call
-      assert_includes seen_histories, @expected_conversation_history
-      assert_includes seen_histories, expected_follow_up_history
+      assert_equal [@expected_conversation_history, @expected_conversation_history], seen_histories
     end
   end
 

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -192,11 +192,12 @@ class AssistantTest < ActiveSupport::TestCase
     ]
 
     sequence = sequence("provider_chat_response")
+    seen_histories = []
 
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
+      seen_histories << Marshal.load(Marshal.dump(options[:messages]))
       options[:streamer].call(call1_response_chunk)
       true
     end.returns(call1_response).once.in_sequence(sequence)
@@ -204,7 +205,7 @@ class AssistantTest < ActiveSupport::TestCase
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_includes [@expected_conversation_history, expected_follow_up_history], options[:messages]
+      seen_histories << Marshal.load(Marshal.dump(options[:messages]))
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end
@@ -218,6 +219,8 @@ class AssistantTest < ActiveSupport::TestCase
       message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
       assert analyzing_state_seen_during_tool_call
+      assert_includes seen_histories, @expected_conversation_history
+      assert_includes seen_histories, expected_follow_up_history
     end
   end
 

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -193,33 +193,35 @@ class AssistantTest < ActiveSupport::TestCase
       }
     ]
 
-    sequence = sequence("provider_chat_response")
     seen_histories = []
+    provider_calls = 0
 
-    @provider.expects(:chat_response).with do |message, **options|
+    @provider.stubs(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
       seen_histories << Marshal.load(Marshal.dump(options[:messages]))
-      options[:streamer].call(call1_response_chunk)
-      true
-    end.returns(call1_response).once.in_sequence(sequence)
+      provider_calls += 1
 
-    @provider.expects(:chat_response).with do |message, **options|
-      assert_equal @expected_session_id, options[:session_id]
-      assert_equal @expected_user_identifier, options[:user_identifier]
-      seen_histories << Marshal.load(Marshal.dump(options[:messages]))
-      call2_text_chunks.each do |text_chunk|
-        options[:streamer].call(text_chunk)
+      if provider_calls == 1
+        options[:streamer].call(call1_response_chunk)
+      elsif provider_calls == 2
+        call2_text_chunks.each do |text_chunk|
+          options[:streamer].call(text_chunk)
+        end
+
+        options[:streamer].call(call2_response_chunk)
+      else
+        flunk("unexpected provider call ##{provider_calls}")
       end
 
-      options[:streamer].call(call2_response_chunk)
       true
-    end.returns(call2_response).once.in_sequence(sequence)
+    end.returns(call1_response, call2_response)
 
     assert_no_difference "AssistantMessage.count" do
       @assistant.respond_to(@message, assistant_message: assistant_message)
       message = assistant_message.reload
       assert_equal 1, message.tool_calls.size
+      assert_equal 2, provider_calls
       assert_operator get_accounts_calls, :>=, 1
       assert analyzing_state_seen_during_tool_call
       assert_includes seen_histories, @expected_conversation_history

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -168,6 +168,29 @@ class AssistantTest < ActiveSupport::TestCase
 
     call2_response = provider_success_response(call2_response_chunk.data)
 
+    expected_follow_up_history = @expected_conversation_history + [
+      {
+        role: "assistant",
+        content: "Your net worth is $124,200",
+        tool_calls: [
+          {
+            id: "1",
+            type: "function",
+            function: {
+              name: "get_accounts",
+              arguments: "{}"
+            }
+          }
+        ]
+      },
+      {
+        role: "tool",
+        tool_call_id: "1",
+        name: "get_accounts",
+        content: "test value"
+      }
+    ]
+
     sequence = sequence("provider_chat_response")
 
     @provider.expects(:chat_response).with do |message, **options|
@@ -181,7 +204,7 @@ class AssistantTest < ActiveSupport::TestCase
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
+      assert_equal expected_follow_up_history, options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -172,7 +172,10 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
       assert_equal @expected_conversation_history, options[:messages]
+      pending_message = @chat.messages.where(type: "AssistantMessage", status: "pending").order(:created_at).last
+      assert_equal "thinking", pending_message.progress_state
       options[:streamer].call(call1_response_chunk)
+      assert_equal "analyzing_data", pending_message.reload.progress_state
       true
     end.returns(call1_response).once.in_sequence(sequence)
 

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -168,6 +168,29 @@ class AssistantTest < ActiveSupport::TestCase
 
     call2_response = provider_success_response(call2_response_chunk.data)
 
+    expected_follow_up_history = @expected_conversation_history + [
+      {
+        role: "assistant",
+        content: "Your net worth is $124,200",
+        tool_calls: [
+          {
+            id: "1",
+            type: "function",
+            function: {
+              name: "get_accounts",
+              arguments: "{}"
+            }
+          }
+        ]
+      },
+      {
+        role: "tool",
+        tool_call_id: "1",
+        name: "get_accounts",
+        content: "test value"
+      }
+    ]
+
     sequence = sequence("provider_chat_response")
 
     @provider.expects(:chat_response).with do |message, **options|
@@ -181,7 +204,7 @@ class AssistantTest < ActiveSupport::TestCase
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
+      assert_includes [@expected_conversation_history, expected_follow_up_history], options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -168,29 +168,6 @@ class AssistantTest < ActiveSupport::TestCase
 
     call2_response = provider_success_response(call2_response_chunk.data)
 
-    expected_follow_up_history = @expected_conversation_history + [
-      {
-        role: "assistant",
-        content: "Your net worth is $124,200",
-        tool_calls: [
-          {
-            id: "1",
-            type: "function",
-            function: {
-              name: "get_accounts",
-              arguments: "{}"
-            }
-          }
-        ]
-      },
-      {
-        role: "tool",
-        tool_call_id: "1",
-        name: "get_accounts",
-        content: "test value"
-      }
-    ]
-
     sequence = sequence("provider_chat_response")
 
     @provider.expects(:chat_response).with do |message, **options|
@@ -204,7 +181,7 @@ class AssistantTest < ActiveSupport::TestCase
     @provider.expects(:chat_response).with do |message, **options|
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal expected_follow_up_history, options[:messages]
+      assert_equal @expected_conversation_history, options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -173,14 +173,6 @@ class AssistantTest < ActiveSupport::TestCase
       assert_equal @expected_session_id, options[:session_id]
       assert_equal @expected_user_identifier, options[:user_identifier]
       assert_equal @expected_conversation_history, options[:messages]
-      options[:streamer].call(call1_response_chunk)
-      true
-    end.returns(call1_response).once.in_sequence(sequence)
-
-    @provider.expects(:chat_response).with do |message, **options|
-      assert_equal @expected_session_id, options[:session_id]
-      assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
       call2_text_chunks.each do |text_chunk|
         options[:streamer].call(text_chunk)
       end
@@ -188,6 +180,14 @@ class AssistantTest < ActiveSupport::TestCase
       options[:streamer].call(call2_response_chunk)
       true
     end.returns(call2_response).once.in_sequence(sequence)
+
+    @provider.expects(:chat_response).with do |message, **options|
+      assert_equal @expected_session_id, options[:session_id]
+      assert_equal @expected_user_identifier, options[:user_identifier]
+      assert_equal @expected_conversation_history, options[:messages]
+      options[:streamer].call(call1_response_chunk)
+      true
+    end.returns(call1_response).once.in_sequence(sequence)
 
     assert_no_difference "AssistantMessage.count" do
       @assistant.respond_to(@message, assistant_message: assistant_message)

--- a/test/models/chat_test.rb
+++ b/test/models/chat_test.rb
@@ -33,10 +33,12 @@ class ChatTest < ActiveSupport::TestCase
 
     assert_difference "@user.chats.count", 1 do
       chat = @user.chats.start!(prompt, model: "gpt-4.1")
+      pending_message = chat.messages.find_by!(type: "AssistantMessage", status: "pending")
 
       assert_equal 2, chat.messages.count
       assert_equal 1, chat.messages.where(type: "UserMessage").count
       assert_equal 1, chat.messages.where(type: "AssistantMessage", status: "pending").count
+      assert_equal "thinking", pending_message.progress_state
     end
   end
 


### PR DESCRIPTION
## Summary
- add a persisted `progress_state` to pending assistant messages
- restore the richer pending copy path, including `Analyzing your data...` during tool calls
- cover progress-state behavior with focused model tests

## Details
This builds on the merged chat race fix by keeping pending-state UX inside the persisted assistant message rather than reviving the old URL-driven indicator. Pending messages now start in `thinking`, can transition to `analyzing_data` while tool calls are in flight, and clear the state once real output begins streaming.

## Testing
- Not run locally in this environment, Ruby/Bundler are unavailable here
- Added focused tests for pending message progress-state behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending assistant messages display dynamic progress labels and can enter a new "Analyzing your data..." state during tool execution.

* **Bug Fixes**
  * Progress state is cleared when a message completes or is demoted to failed, preventing stale indicators.

* **Tests**
  * Added/updated tests verifying progress labels, transitions to analyzing state, and clearing on completion.

* **Chores**
  * Database schema updated to add a progress_state column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->