### PR TITLE
Add assurance vie to investment subtypes

### DIFF
--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -50,6 +50,7 @@ class Investment < ApplicationRecord
     "smsf" => { short: "SMSF", long: "Self-Managed Super Fund", region: "au", tax_treatment: :tax_deferred },
 
     # === Europe ===
+    "assurance_vie" => { short: "AV", long: "Assurance Vie", region: "eu", tax_treatment: :tax_advantaged },
     "pea" => { short: "PEA", long: "Plan d'Épargne en Actions", region: "eu", tax_treatment: :tax_advantaged },
     "pillar_3a" => { short: "Pillar 3a", long: "Private Pension (Pillar 3a)", region: "eu", tax_treatment: :tax_deferred },
     "riester" => { short: "Riester", long: "Riester-Rente", region: "eu", tax_treatment: :tax_deferred },

--- a/test/models/investment_test.rb
+++ b/test/models/investment_test.rb
@@ -99,6 +99,10 @@ class InvestmentTest < ActiveSupport::TestCase
     assert_equal :tax_advantaged, investment.tax_treatment
   end
 
+  test "tax_treatment returns tax_advantaged for French AV" do
+    investment = Investment.new(subtype: "assurance_vie")
+    assert_equal :tax_advantaged, investment.tax_treatment
+  end
   # Generic account types
 
   test "tax_treatment returns tax_deferred for generic pension and retirement" do


### PR DESCRIPTION
## Summary

Add `assurance_vie` as a new investment subtype for the European region, covering the French "Assurance Vie" product which benefits from a specific advantageous tax treatment after 8 years of holding.

## Changes

- Added `assurance_vie` subtype in `Investment::SUBTYPES` under the Europe region with `tax_treatment: :tax_advantaged`
- Added unit test to verify `tax_treatment` returns `:tax_advantaged` for `assurance_vie` subtype


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Assurance Vie investment accounts, a French tax-advantaged investment product now available in the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->