### PR TITLE
fix(auth): surface exact OIDC issuer mismatches

### DIFF
--- a/app/javascript/controllers/admin_sso_form_controller.js
+++ b/app/javascript/controllers/admin_sso_form_controller.js
@@ -111,10 +111,21 @@ export default class extends Controller {
       if (response.ok) {
         const data = await response.json()
         if (data.issuer) {
-          // Valid OIDC discovery endpoint
-          issuerInput.classList.remove('border-yellow-300', 'border-red-300')
-          issuerInput.classList.add('border-green-300')
-          this.showValidationMessage(issuerInput, 'Valid OIDC issuer', 'success')
+          if (data.issuer === issuer) {
+            issuerInput.classList.remove('border-yellow-300', 'border-red-300', 'border-amber-300')
+            issuerInput.classList.add('border-green-300')
+            this.showValidationMessage(issuerInput, 'Valid OIDC issuer', 'success')
+          } else {
+            issuerInput.classList.remove('border-yellow-300', 'border-green-300')
+            issuerInput.classList.add('border-amber-300')
+
+            const trailingSlashOnly = data.issuer.replace(/\/$/, '') === issuer.replace(/\/$/, '')
+            const message = trailingSlashOnly
+              ? `Issuer mismatch: discovery returned ${data.issuer}. This is usually a trailing slash mismatch, so copy the issuer exactly as returned.`
+              : `Issuer mismatch: discovery returned ${data.issuer}. Copy the issuer exactly as returned by the provider.`
+
+            this.showValidationMessage(issuerInput, message, 'warning')
+          }
         } else {
           throw new Error('Invalid discovery response')
         }

--- a/app/models/sso_provider_tester.rb
+++ b/app/models/sso_provider_tester.rb
@@ -63,11 +63,14 @@ class SsoProviderTester
           )
         end
 
-        # Check if issuer matches
-        if discovery["issuer"] != provider.issuer && discovery["issuer"] != provider.issuer.chomp("/")
+        # Check if issuer matches exactly. OIDC discovery requires the configured
+        # issuer string to be identical to the issuer returned by the provider.
+        if discovery["issuer"] != provider.issuer
+          hint = trailing_slash_hint(provider.issuer, discovery["issuer"])
+
           return Result.new(
             success?: false,
-            message: "Issuer mismatch: expected #{provider.issuer}, got #{discovery["issuer"]}",
+            message: ["Issuer mismatch: expected #{provider.issuer}, got #{discovery["issuer"]}", hint].compact.join(". "),
             details: { expected: provider.issuer, actual: discovery["issuer"] }
           )
         end
@@ -203,5 +206,11 @@ class SsoProviderTester
 
     def faraday_client
       @faraday_client ||= Faraday.new(ssl: self.class.faraday_ssl_options)
+    end
+
+    def trailing_slash_hint(expected, actual)
+      return unless expected.to_s.chomp("/") == actual.to_s.chomp("/")
+
+      "This usually means the issuer URL differs only by a trailing slash. Update the configured issuer to exactly match the discovery document"
     end
 end

--- a/app/models/sso_provider_tester.rb
+++ b/app/models/sso_provider_tester.rb
@@ -70,7 +70,7 @@ class SsoProviderTester
 
           return Result.new(
             success?: false,
-            message: ["Issuer mismatch: expected #{provider.issuer}, got #{discovery["issuer"]}", hint].compact.join(". "),
+            message: [ "Issuer mismatch: expected #{provider.issuer}, got #{discovery["issuer"]}", hint ].compact.join(". "),
             details: { expected: provider.issuer, actual: discovery["issuer"] }
           )
         end
@@ -211,6 +211,6 @@ class SsoProviderTester
     def trailing_slash_hint(expected, actual)
       return unless expected.to_s.chomp("/") == actual.to_s.chomp("/")
 
-      "This usually means the issuer URL differs only by a trailing slash. Update the configured issuer to exactly match the discovery document"
+      "trailing slash mismatch. This usually means the issuer URL differs only by a trailing slash. Update the configured issuer to exactly match the discovery document"
     end
 end

--- a/test/models/sso_provider_tester_test.rb
+++ b/test/models/sso_provider_tester_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class SsoProviderTesterTest < ActiveSupport::TestCase
+  test "oidc discovery requires exact issuer match" do
+    provider = SsoProvider.new(
+      strategy: "openid_connect",
+      name: "pocket_id",
+      label: "Pocket ID",
+      issuer: "https://pocketid.example.com/",
+      client_id: "client-id",
+      client_secret: "secret"
+    )
+
+    response = stub(status: 200, success?: true, body: {
+      issuer: "https://pocketid.example.com",
+      authorization_endpoint: "https://pocketid.example.com/authorize",
+      token_endpoint: "https://pocketid.example.com/api/oidc/token"
+    }.to_json)
+
+    client = stub
+    client.stubs(:get).returns(response)
+
+    tester = SsoProviderTester.new(provider)
+    tester.stubs(:faraday_client).returns(client)
+
+    result = tester.test!
+
+    assert_not result.success?
+    assert_includes result.message, "Issuer mismatch"
+    assert_includes result.message, "trailing slash mismatch"
+    assert_equal "https://pocketid.example.com/", result.details[:expected]
+    assert_equal "https://pocketid.example.com", result.details[:actual]
+  end
+end


### PR DESCRIPTION
## Summary
- require exact issuer matching during OIDC provider validation
- warn in the admin SSO form when discovery returns a different issuer string
- add a regression test for trailing-slash issuer mismatches

## Why
A provider can currently look valid in the admin UI and still fail at login if the configured issuer differs from the discovery document by something small, especially a trailing slash. Runtime OIDC validation is stricter than the current admin-side validation, so this makes the mismatch visible earlier.

This should help with Pocket ID setups like the one discussed in #1166.

## Testing
- Added `test/models/sso_provider_tester_test.rb`
- I could not run the Ruby test suite in the current OpenClaw container because `ruby`/`bundle` are unavailable here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC issuer validation now requires an exact match between the configured issuer and the discovery response.
  * Error messages explicitly call out issuer mismatches caused solely by a trailing slash.
  * Validation feedback improved to make SSO configuration issues easier to identify and resolve.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->