### PR TITLE
fix(design-system): drop dividers in manage-currencies modal

### DIFF
--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -139,7 +139,7 @@
                   <%= icon("search", class: "text-secondary") %>
                 </div>
               </div>
-              <div data-list-filter-target="list" class="max-h-80 overflow-auto rounded-xl border border-secondary divide-y divide-secondary/60">
+              <div data-list-filter-target="list" class="max-h-80 overflow-auto rounded-xl border border-secondary">
                 <p class="hidden px-4 py-3 text-sm text-secondary" data-list-filter-target="emptyMessage">
                   <%= t(".no_matching_currencies") %>
                 </p>


### PR DESCRIPTION
## Summary

The currency list inside the Manage currencies modal (`/settings/preferences` → Manage currencies → expanded list) renders harsh, near-white separator lines between rows in dark mode. Spotted during visual sign-off of the design-system sweep.

### Screenshot of the problem

Bright white lines between every currency row (BMD / BTN / BTC / BOB / BAM in the screenshot below).

<img width="967" height="954" alt="Captura de pantalla 2026-05-04 202609" src="https://github.com/user-attachments/assets/48f597ef-b31b-49af-b1d1-01565036f2f7" />

## Root cause

`app/views/settings/preferences/show.html.erb:142` had:

```erb
<div data-list-filter-target="list" class="max-h-80 overflow-auto rounded-xl border border-secondary divide-y divide-secondary/60">
```

The `divide-y` width utility correctly applies `border-top-width: 1px` to each child row. But `divide-secondary/60` silently emits no CSS — `divide-secondary` is a custom `@utility` name, not a theme color, so Tailwind v4's `divide-{name}` resolution can't find a `--color-secondary` and falls back to `currentColor`. The row's text color is `text-primary` (white in dark mode), so the divider renders nearly white.

This is the same class of bug being addressed in #1660 (which would swap the divider to `divide-alpha-black-100 theme-dark:divide-alpha-white-100`, making the lines a 8% white tint — much subtler, no longer "shouty"). This PR goes a step further and drops the dividers entirely.

## Why drop instead of subtle-alpha

For dense scrollable selection lists, dividers add visual weight without functional benefit:

- The wrapping `border border-secondary rounded-xl` already provides list containment
- Each row's `px-4 py-3` padding creates natural rhythm
- The per-row hover state (becomes properly themed once #1660 lands) provides scanning affordance
- 179 currency rows on a `max-h-80 overflow-auto` viewport means dividers add line-density rather than help orientation

Lines up with how modern settings panels (macOS Settings currency picker, GitHub repo preferences) handle dense list selection — clean rows, no separators, hover-driven feedback.

## Scope

One-line change. Single file. No new tokens, no controller changes.

## Testing

- [ ] `/settings/preferences` → "Manage currencies" → expand list. Dark mode: no bright lines. Light mode: rows still readable, list still feels contained.
- [ ] Hover any non-base row → subtle bg highlight reads (will improve further once #1660 merges and the `hover:bg-surface-inset/30` undefined modifier becomes `hover:bg-surface-inset`).
- [ ] Scroll the list → row alignment still scannable.
- [ ] Type in search filter → filtered rows still visible, empty-state message still styled.