### PR TITLE
feat(accounts): Highlight matching activity search text in entry names

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -15,6 +15,7 @@ module AccountsHelper
     search = query.to_s.strip
     return name if search.blank?
 
-    highlight(name, search, highlighter: ACTIVITY_HIGHLIGHT_MARKUP)
+    escaped_name = ERB::Util.html_escape(name.to_s)
+    highlight(escaped_name, search, highlighter: ACTIVITY_HIGHLIGHT_MARKUP, sanitize: false)
   end
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,4 +1,6 @@
 module AccountsHelper
+  ACTIVITY_HIGHLIGHT_MARKUP = '<span class="text-warning/80 font-medium underline decoration-warning/60 underline-offset-2">\1</span>'.freeze
+
   def summary_card(title:, &block)
     content = capture(&block)
     render "accounts/summary_card", title: title, content: content
@@ -7,5 +9,12 @@ module AccountsHelper
   def sync_path_for(account)
     # Always use the account sync path, which handles syncing all providers
     sync_account_path(account)
+  end
+
+  def highlight_activity_entry_name(name, query = params.dig(:q, :search))
+    search = query.to_s.strip
+    return name if search.blank?
+
+    highlight(name, search, highlighter: ACTIVITY_HIGHLIGHT_MARKUP)
   end
 end

--- a/app/views/trades/_trade.html.erb
+++ b/app/views/trades/_trade.html.erb
@@ -32,10 +32,10 @@
             </div>
 
             <div class="truncate flex-shrink">
-              <%= link_to entry.name,
+              <%= link_to(highlight_activity_entry_name(entry.name),
                         entry_path(entry),
                         data: { turbo_frame: "drawer", turbo_prefetch: false },
-                        class: "hover:underline" %>
+                        class: "hover:underline") %>
             </div>
           <% end %>
         </div>

--- a/app/views/transactions/_split_parent_row.html.erb
+++ b/app/views/transactions/_split_parent_row.html.erb
@@ -29,10 +29,10 @@
           <div class="space-y-0.5">
             <div class="flex items-center gap-1 min-w-0">
               <div class="truncate flex-shrink">
-                <%= link_to entry.name,
+                <%= link_to(highlight_activity_entry_name(entry.name),
                     entry_path(entry),
                     data: { turbo_frame: "drawer", turbo_prefetch: false },
-                    class: "hover:underline" %>
+                    class: "hover:underline") %>
               </div>
 
               <div class="flex items-center gap-1 flex-shrink-0">
@@ -51,7 +51,7 @@
                 <%= link_to entry.account.name,
                     account_path(entry.account, tab: "transactions"),
                     data: { turbo_frame: "_top" },
-                    class: "hover:underline" %>
+                    class: "hover:underline") %>
               </span>
             </div>
           </div>

--- a/app/views/transactions/_split_parent_row.html.erb
+++ b/app/views/transactions/_split_parent_row.html.erb
@@ -51,7 +51,7 @@
                 <%= link_to entry.account.name,
                     account_path(entry.account, tab: "transactions"),
                     data: { turbo_frame: "_top" },
-                    class: "hover:underline") %>
+                    class: "hover:underline" %>
               </span>
             </div>
           </div>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -59,7 +59,7 @@
                   <div class="truncate flex-shrink">
                     <% if transaction.transfer? %>
                       <%= link_to(
-                            entry.name,
+                            highlight_activity_entry_name(entry.name),
                             transaction.transfer.present? ? transfer_path(transaction.transfer) : entry_path(entry),
                             data: {
                               turbo_frame: "drawer",
@@ -69,7 +69,7 @@
                           ) %>
                     <% else %>
                       <%= link_to(
-                            entry.name,
+                            highlight_activity_entry_name(entry.name),
                             entry_path(entry),
                             data: {
                               turbo_frame: "drawer",

--- a/app/views/valuations/_valuation.html.erb
+++ b/app/views/valuations/_valuation.html.erb
@@ -17,10 +17,10 @@
           <%= render DS::FilledIcon.new(icon: icon, size: "md", hex_color: color, rounded: true) %>
 
           <div class="truncate text-primary">
-            <%= link_to entry.name,
+            <%= link_to(highlight_activity_entry_name(entry.name),
                         entry_path(entry),
                         data: { turbo_frame: "drawer", turbo_prefetch: false },
-                        class: "hover:underline" %>
+                        class: "hover:underline") %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Add subtle match highlighting to activity search results in the Account Activity feed.

Matched text within entry names is highlighted using a text color change and underline (no background), ensuring clear visibility while preserving dark-mode readability.

## Why

Improves scan efficiency by making matched terms immediately identifiable, without introducing visual noise from background highlights.

## Scope

- `app/helpers/accounts_helper.rb`
- `app/views/transactions/_transaction.html.erb`
- `app/views/trades/_trade.html.erb`
- `app/views/valuations/_valuation.html.erb`
- `app/views/transactions/_split_parent_row.html.erb`

## Test Plan

- Search partial terms (e.g., `balan`)
- Verify matched text is underlined and color-highlighted
- Confirm no background highlight is applied
- Validate behavior across all activity row types
- Ensure no UI or interaction regressions

## Screenshot

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/4f08f950-596d-4e45-ad80-f1ff4beef79d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now highlight matching text in activity entry names, improving scannability across trades, transactions (including split-parent rows), and valuations.
  * Highlighting preserves existing link behavior and navigation while making matched terms easier to spot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->