### PR TITLE
Fix SSO icon rendering for mixed-case provider icons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -195,8 +195,8 @@ module ApplicationHelper
     def safe_lucide_icon(key, **opts)
       lucide_icon(key, **opts)
     rescue StandardError => e
-      Rails.logger.warn("[ApplicationHelper] Falling back to help-circle for unknown icon #{key.inspect}: #{e.message}")
-      lucide_icon("help-circle", **opts)
+      Rails.logger.warn("[ApplicationHelper] Falling back to key for unknown icon #{key.inspect}: #{e.message}")
+      lucide_icon("key", **opts)
     end
 
     def normalize_icon_key(key)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,12 +26,14 @@ module ApplicationHelper
       extra_classes
     )
 
+    resolved_key = normalize_icon_key(key)
+
     if custom
-      inline_svg_tag("#{key}.svg", class: icon_classes, **opts)
+      inline_svg_tag("#{resolved_key}.svg", class: icon_classes, **opts)
     elsif as_button
-      render DS::Button.new(variant: "icon", class: extra_classes, icon: key, size: size, type: "button", **opts)
+      render DS::Button.new(variant: "icon", class: extra_classes, icon: resolved_key, size: size, type: "button", **opts)
     else
-      lucide_icon(key, class: icon_classes, **opts)
+      safe_lucide_icon(resolved_key, class: icon_classes, **opts)
     end
   end
 
@@ -190,6 +192,20 @@ module ApplicationHelper
   end
 
   private
+    def safe_lucide_icon(key, **opts)
+      lucide_icon(key, **opts)
+    rescue StandardError => e
+      Rails.logger.warn("[ApplicationHelper] Falling back to help-circle for unknown icon #{key.inspect}: #{e.message}")
+      lucide_icon("help-circle", **opts)
+    end
+
+    def normalize_icon_key(key)
+      normalized = key.to_s.strip
+      return normalized if normalized.blank?
+
+      normalized.downcase
+    end
+
     def calculate_total(item, money_method, negate)
       # Filter out transfer-type transactions from entries
       # Only Entry objects have entryable transactions, Account objects don't

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -28,7 +28,7 @@ class ApplicationHelperTest < ActionView::TestCase
 
     result = icon("not-a-real-icon")
 
-    assert_equal [ "not-a-real-icon", "help-circle" ], calls
+    assert_equal [ "not-a-real-icon", "key" ], calls
     assert_equal "<svg></svg>", result
   ensure
     singleton_class.send(:remove_method, :lucide_icon) if singleton_class.method_defined?(:lucide_icon)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,6 +1,39 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
+  test "#icon normalizes icon names to lowercase" do
+    capture = []
+
+    singleton_class.send(:define_method, :lucide_icon) do |key, **opts|
+      capture << [ key, opts ]
+      "<svg></svg>".html_safe
+    end
+
+    icon("Key")
+
+    assert_equal "key", capture.first.first
+  ensure
+    singleton_class.send(:remove_method, :lucide_icon) if singleton_class.method_defined?(:lucide_icon)
+  end
+
+  test "#icon falls back when lucide icon is unknown" do
+    calls = []
+
+    singleton_class.send(:define_method, :lucide_icon) do |key, **_opts|
+      calls << key
+      raise ArgumentError, "Unknown icon #{key}" if key == "not-a-real-icon"
+
+      "<svg></svg>".html_safe
+    end
+
+    result = icon("not-a-real-icon")
+
+    assert_equal [ "not-a-real-icon", "help-circle" ], calls
+    assert_equal "<svg></svg>", result
+  ensure
+    singleton_class.send(:remove_method, :lucide_icon) if singleton_class.method_defined?(:lucide_icon)
+  end
+
   test "#title(page_title)" do
     title("Test Title")
     assert_equal "Test Title", content_for(:title)


### PR DESCRIPTION
## Summary
- normalize icon names before Lucide lookup so persisted values like `Key` render as `key`
- fail gracefully with `help-circle` instead of crashing the SSO admin page on unknown icons
- add helper regression coverage for mixed-case icons and unknown icon fallback

## Root cause
The recent SSO admin UI renders stored provider icons through `lucide_icon(...)`. Lucide lookups are case-sensitive, so persisted values like `Key` raise `Unknown icon Key` even though `key` is valid.

## Notes
- I verified from the installed `lucide-rails 0.7.3` icon set that `key.svg` and `key-round.svg` exist, while `Key.svg` does not.
- This keeps the fix focused on the actual regression: case normalization plus graceful fallback.

cc Juanjo, cc Ninwhendo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Icon rendering now gracefully handles errors with automatic fallback to a default icon, improving system reliability.
  * Icon keys are now case-insensitive, preventing errors from inconsistent character casing.
  * Enhanced error logging for icon rendering issues to facilitate troubleshooting and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->