### PR TITLE
Revert "feat(accounts): Highlight matching activity search text in entry names"

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,6 +1,4 @@
 module AccountsHelper
-  ACTIVITY_HIGHLIGHT_MARKUP = '<span class="text-warning/80 font-medium underline decoration-warning/60 underline-offset-2">\1</span>'.freeze
-
   def summary_card(title:, &block)
     content = capture(&block)
     render "accounts/summary_card", title: title, content: content
@@ -9,13 +7,5 @@ module AccountsHelper
   def sync_path_for(account)
     # Always use the account sync path, which handles syncing all providers
     sync_account_path(account)
-  end
-
-  def highlight_activity_entry_name(name, query = params.dig(:q, :search))
-    search = query.to_s.strip
-    return name if search.blank?
-
-    escaped_name = ERB::Util.html_escape(name.to_s)
-    highlight(escaped_name, search, highlighter: ACTIVITY_HIGHLIGHT_MARKUP, sanitize: false)
   end
 end

--- a/app/views/trades/_trade.html.erb
+++ b/app/views/trades/_trade.html.erb
@@ -32,10 +32,10 @@
             </div>
 
             <div class="truncate flex-shrink">
-              <%= link_to(highlight_activity_entry_name(entry.name),
+              <%= link_to entry.name,
                         entry_path(entry),
                         data: { turbo_frame: "drawer", turbo_prefetch: false },
-                        class: "hover:underline") %>
+                        class: "hover:underline" %>
             </div>
           <% end %>
         </div>

--- a/app/views/transactions/_split_parent_row.html.erb
+++ b/app/views/transactions/_split_parent_row.html.erb
@@ -29,10 +29,10 @@
           <div class="space-y-0.5">
             <div class="flex items-center gap-1 min-w-0">
               <div class="truncate flex-shrink">
-                <%= link_to(highlight_activity_entry_name(entry.name),
+                <%= link_to entry.name,
                     entry_path(entry),
                     data: { turbo_frame: "drawer", turbo_prefetch: false },
-                    class: "hover:underline") %>
+                    class: "hover:underline" %>
               </div>
 
               <div class="flex items-center gap-1 flex-shrink-0">

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -59,7 +59,7 @@
                   <div class="truncate flex-shrink">
                     <% if transaction.transfer? %>
                       <%= link_to(
-                            highlight_activity_entry_name(entry.name),
+                            entry.name,
                             transaction.transfer.present? ? transfer_path(transaction.transfer) : entry_path(entry),
                             data: {
                               turbo_frame: "drawer",
@@ -69,7 +69,7 @@
                           ) %>
                     <% else %>
                       <%= link_to(
-                            highlight_activity_entry_name(entry.name),
+                            entry.name,
                             entry_path(entry),
                             data: {
                               turbo_frame: "drawer",

--- a/app/views/valuations/_valuation.html.erb
+++ b/app/views/valuations/_valuation.html.erb
@@ -17,10 +17,10 @@
           <%= render DS::FilledIcon.new(icon: icon, size: "md", hex_color: color, rounded: true) %>
 
           <div class="truncate text-primary">
-            <%= link_to(highlight_activity_entry_name(entry.name),
+            <%= link_to entry.name,
                         entry_path(entry),
                         data: { turbo_frame: "drawer", turbo_prefetch: false },
-                        class: "hover:underline") %>
+                        class: "hover:underline" %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Reverts we-promise/sure#1671 as it skipped "human review" - not ready for those yet. :-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed special formatting from entry names displayed in trades, transactions, and valuations views. Entry names now appear in standard format throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->