### PR TITLE
perf(accounts): kill sidebar/sparkline N+1s and cache the sidebar

### DIFF
--- a/app/controllers/accountable_sparklines_controller.rb
+++ b/app/controllers/accountable_sparklines_controller.rb
@@ -43,8 +43,12 @@ class AccountableSparklinesController < ApplicationController
       ).balance_series
     end
 
+    # balance_type is derived purely from accountable_type, so only Investment/Crypto
+    # can yield :investment. Short-circuit to avoid an N+1 `account.linked?` check
+    # on every account for non-investment accountable types (loan, credit_card, etc).
     def requires_normalized_aggregation?
-      accounts.any? { |account| account.linked? && account.balance_type == :investment }
+      return false unless %w[Investment Crypto].include?(@accountable.name)
+      accounts.joins(:account_providers).exists?
     end
 
     def aggregate_normalized_series

--- a/app/controllers/accountable_sparklines_controller.rb
+++ b/app/controllers/accountable_sparklines_controller.rb
@@ -46,17 +46,11 @@ class AccountableSparklinesController < ApplicationController
     # balance_type is derived purely from accountable_type, so only Investment/Crypto
     # can yield :investment. Short-circuit to avoid an N+1 `account.linked?` check
     # on every account for non-investment accountable types (loan, credit_card, etc).
-    # `Account#linked?` recognizes both new-style (account_providers) and legacy
-    # (plaid_account_id / simplefin_account_id) links, so the bulk check must too.
+    # The `Account.linked` scope is the SQL-level mirror of `Account#linked?`.
     def requires_normalized_aggregation?
       return false unless %w[Investment Crypto].include?(@accountable.name)
 
-      accounts
-        .left_outer_joins(:account_providers)
-        .where(
-          "account_providers.id IS NOT NULL OR accounts.plaid_account_id IS NOT NULL OR accounts.simplefin_account_id IS NOT NULL"
-        )
-        .exists?
+      accounts.linked.exists?
     end
 
     def aggregate_normalized_series

--- a/app/controllers/accountable_sparklines_controller.rb
+++ b/app/controllers/accountable_sparklines_controller.rb
@@ -46,9 +46,17 @@ class AccountableSparklinesController < ApplicationController
     # balance_type is derived purely from accountable_type, so only Investment/Crypto
     # can yield :investment. Short-circuit to avoid an N+1 `account.linked?` check
     # on every account for non-investment accountable types (loan, credit_card, etc).
+    # `Account#linked?` recognizes both new-style (account_providers) and legacy
+    # (plaid_account_id / simplefin_account_id) links, so the bulk check must too.
     def requires_normalized_aggregation?
       return false unless %w[Investment Crypto].include?(@accountable.name)
-      accounts.joins(:account_providers).exists?
+
+      accounts
+        .left_outer_joins(:account_providers)
+        .where(
+          "account_providers.id IS NOT NULL OR accounts.plaid_account_id IS NOT NULL OR accounts.simplefin_account_id IS NOT NULL"
+        )
+        .exists?
     end
 
     def aggregate_normalized_series

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -10,6 +10,7 @@ class AccountsController < ApplicationController
     @manual_accounts = family.accounts
           .listable_manual
           .where(id: @accessible_account_ids)
+          .includes(:accountable, :account_providers, :plaid_account, :simplefin_account)
           .order(:name)
     @plaid_items = visible_provider_items(family.plaid_items.ordered.includes(:syncs, :plaid_accounts))
     @simplefin_items = visible_provider_items(family.simplefin_items.ordered.includes(:syncs))

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -8,4 +8,39 @@ module AccountsHelper
     # Always use the account sync path, which handles syncing all providers
     sync_account_path(account)
   end
+
+  # Returns the account id segment from `/accounts/<id>(/...)?`, or nil.
+  # Used as a cache-key component so the sidebar's active-link styling is
+  # correct without busting the cache for every unrelated path change.
+  def sidebar_active_account_id
+    match = request.path.match(%r{\A/accounts/([\w-]+)})
+    match && match[1]
+  end
+
+  # Cache key for `accounts/_account_sidebar_tabs.html.erb`.
+  # Kept here (not in the ERB) so the partial stays render-only.
+  #
+  # `shares_version` includes both row count and `max(updated_at)` because
+  # deleting a non-most-recent share would not move `max(updated_at)` and
+  # could otherwise serve stale fragments to a user who lost access.
+  # Both are pulled in a single SQL round-trip.
+  def account_sidebar_tabs_cache_key(family:, active_tab:, mobile:)
+    shares_version =
+      if Current.user
+        count, max_at = AccountShare
+          .where(user_id: Current.user.id)
+          .pick(Arel.sql("count(*), max(updated_at)"))
+        "#{count}-#{max_at&.to_i}"
+      end
+
+    [
+      family.build_cache_key("account_sidebar_tabs_v1", invalidate_on_data_updates: true),
+      Current.user&.id,
+      shares_version,
+      active_tab,
+      mobile,
+      I18n.locale,
+      sidebar_active_account_id
+    ]
+  end
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -23,14 +23,16 @@ module AccountsHelper
   # `shares_version` includes both row count and `max(updated_at)` because
   # deleting a non-most-recent share would not move `max(updated_at)` and
   # could otherwise serve stale fragments to a user who lost access.
-  # Both are pulled in a single SQL round-trip.
+  # Both are pulled in a single SQL round-trip via `pick`. Note: Rails
+  # returns the values as Strings for raw SQL fragments — that's fine
+  # since they only feed into a cache key (concat-stable, never coerced).
   def account_sidebar_tabs_cache_key(family:, active_tab:, mobile:)
     shares_version =
       if Current.user
         count, max_at = AccountShare
           .where(user_id: Current.user.id)
-          .pick(Arel.sql("count(*), max(updated_at)"))
-        "#{count}-#{max_at&.to_i}"
+          .pick(Arel.sql("count(*)"), Arel.sql("max(updated_at)"))
+        "#{count}-#{max_at}"
       end
 
     [

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,6 +59,14 @@ module ApplicationHelper
     current_page?(path) || (request.path.start_with?(path) && path != "/")
   end
 
+  # Returns the account id segment from `/accounts/<id>(/...)?`, or nil.
+  # Used as a cache-key component so the sidebar's active-link styling is
+  # correct without busting the cache for every unrelated path change.
+  def sidebar_active_account_id
+    match = request.path.match(%r{\A/accounts/([\w-]+)})
+    match && match[1]
+  end
+
   # Wrapper around I18n.l to support custom date formats
   def format_date(object, format = :default, options = {})
     date = object.to_date

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,6 +67,30 @@ module ApplicationHelper
     match && match[1]
   end
 
+  # Cache key for `accounts/_account_sidebar_tabs.html.erb`.
+  # Kept here (not in the ERB) so the partial stays render-only.
+  #
+  # `shares_version` includes both `count` and `max(updated_at)` because
+  # deleting a non-most-recent share would not move `max(updated_at)` and
+  # could otherwise serve stale fragments to a user who lost access.
+  def account_sidebar_tabs_cache_key(family:, active_tab:, mobile:)
+    shares_version =
+      if Current.user
+        rel = AccountShare.where(user_id: Current.user.id)
+        "#{rel.count}-#{rel.maximum(:updated_at)&.to_i}"
+      end
+
+    [
+      family.build_cache_key("account_sidebar_tabs_v1", invalidate_on_data_updates: true),
+      Current.user&.id,
+      shares_version,
+      active_tab,
+      mobile,
+      I18n.locale,
+      sidebar_active_account_id
+    ]
+  end
+
   # Wrapper around I18n.l to support custom date formats
   def format_date(object, format = :default, options = {})
     date = object.to_date

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,38 +59,6 @@ module ApplicationHelper
     current_page?(path) || (request.path.start_with?(path) && path != "/")
   end
 
-  # Returns the account id segment from `/accounts/<id>(/...)?`, or nil.
-  # Used as a cache-key component so the sidebar's active-link styling is
-  # correct without busting the cache for every unrelated path change.
-  def sidebar_active_account_id
-    match = request.path.match(%r{\A/accounts/([\w-]+)})
-    match && match[1]
-  end
-
-  # Cache key for `accounts/_account_sidebar_tabs.html.erb`.
-  # Kept here (not in the ERB) so the partial stays render-only.
-  #
-  # `shares_version` includes both `count` and `max(updated_at)` because
-  # deleting a non-most-recent share would not move `max(updated_at)` and
-  # could otherwise serve stale fragments to a user who lost access.
-  def account_sidebar_tabs_cache_key(family:, active_tab:, mobile:)
-    shares_version =
-      if Current.user
-        rel = AccountShare.where(user_id: Current.user.id)
-        "#{rel.count}-#{rel.maximum(:updated_at)&.to_i}"
-      end
-
-    [
-      family.build_cache_key("account_sidebar_tabs_v1", invalidate_on_data_updates: true),
-      Current.user&.id,
-      shares_version,
-      active_tab,
-      mobile,
-      I18n.locale,
-      sidebar_active_account_id
-    ]
-  end
-
   # Wrapper around I18n.l to support custom date formats
   def format_date(object, format = :default, options = {})
     date = object.to_date

--- a/app/models/account/linkable.rb
+++ b/app/models/account/linkable.rb
@@ -8,6 +8,17 @@ module Account::Linkable
     # Legacy provider associations - kept for backward compatibility during migration
     belongs_to :plaid_account, optional: true
     belongs_to :simplefin_account, optional: true
+
+    # SQL-level mirror of `linked?`. Use this for set-based checks (e.g. bulk
+    # `EXISTS`) so both definitions stay in sync. If `linked?` adds a new
+    # provider source, update this scope too.
+    scope :linked, -> {
+      left_outer_joins(:account_providers)
+        .where(
+          "account_providers.id IS NOT NULL OR accounts.plaid_account_id IS NOT NULL OR accounts.simplefin_account_id IS NOT NULL"
+        )
+        .distinct
+    }
   end
 
   # A "linked" account gets transaction and balance data from a third party like Plaid or SimpleFin

--- a/app/models/balance_sheet/account_totals.rb
+++ b/app/models/balance_sheet/account_totals.rb
@@ -27,7 +27,14 @@ class BalanceSheet::AccountTotals
 
     def visible_accounts
       @visible_accounts ||= begin
-        scope = family.accounts.visible.with_attached_logo.includes(:account_shares)
+        scope = family.accounts.visible.with_attached_logo
+                  .includes(
+                    :account_shares,
+                    :accountable,
+                    :plaid_account,
+                    :simplefin_account,
+                    account_providers: :provider
+                  )
         scope = scope.accessible_by(user) if user
         scope
       end

--- a/app/views/accounts/_account_sidebar_tabs.html.erb
+++ b/app/views/accounts/_account_sidebar_tabs.html.erb
@@ -1,17 +1,6 @@
 <%# locals: (family:, active_tab:, mobile: false) %>
 
-<% shares_version = (Current.user && AccountShare.where(user_id: Current.user.id).maximum(:updated_at)&.to_i) %>
-<% cache_key = [
-     family.build_cache_key("account_sidebar_tabs_v1", invalidate_on_data_updates: true),
-     Current.user&.id,
-     shares_version,
-     active_tab,
-     mobile,
-     I18n.locale,
-     sidebar_active_account_id
-   ] %>
-
-<% cache cache_key, expires_in: 12.hours do %>
+<% cache account_sidebar_tabs_cache_key(family: family, active_tab: active_tab, mobile: mobile), expires_in: 12.hours do %>
 <div id="account-sidebar-tabs">
   <% if family.missing_data_provider? %>
     <details class="group bg-yellow-tint-10 rounded-lg p-2 text-yellow-600 mb-3 text-xs">

--- a/app/views/accounts/_account_sidebar_tabs.html.erb
+++ b/app/views/accounts/_account_sidebar_tabs.html.erb
@@ -1,5 +1,17 @@
 <%# locals: (family:, active_tab:, mobile: false) %>
 
+<% shares_version = (Current.user && AccountShare.where(user_id: Current.user.id).maximum(:updated_at)&.to_i) %>
+<% cache_key = [
+     family.build_cache_key("account_sidebar_tabs_v1", invalidate_on_data_updates: true),
+     Current.user&.id,
+     shares_version,
+     active_tab,
+     mobile,
+     I18n.locale,
+     sidebar_active_account_id
+   ] %>
+
+<% cache cache_key, expires_in: 12.hours do %>
 <div id="account-sidebar-tabs">
   <% if family.missing_data_provider? %>
     <details class="group bg-yellow-tint-10 rounded-lg p-2 text-yellow-600 mb-3 text-xs">
@@ -88,3 +100,4 @@
     <% end %>
   <% end %>
 </div>
+<% end %>

--- a/app/views/accounts/index/_account_groups.erb
+++ b/app/views/accounts/index/_account_groups.erb
@@ -1,6 +1,11 @@
 <%# locals: (accounts:) %>
 
-<% ActiveRecord::Associations::Preloader.new(records: accounts, associations: :account_shares).call if accounts.any? %>
+<% if accounts.any? %>
+  <% ActiveRecord::Associations::Preloader.new(
+       records: accounts,
+       associations: [ :account_shares, :accountable, :plaid_account, :simplefin_account, { account_providers: :provider } ]
+     ).call %>
+<% end %>
 <% accounts.group_by(&:accountable_type).sort_by { |group, _| group }.each do |group, accounts| %>
   <div class="bg-container-inset p-1 rounded-xl">
     <div class="flex items-center px-4 py-2 text-xs font-medium text-secondary">

--- a/test/models/account/linkable_test.rb
+++ b/test/models/account/linkable_test.rb
@@ -66,4 +66,45 @@ class Account::LinkableTest < ActiveSupport::TestCase
 
     assert @account.can_delete_holdings?
   end
+
+  # The `linked` scope mirrors `linked?` at the SQL level. These tests pin
+  # all three link types so a future schema or `linked?` change breaks the
+  # test instead of silently diverging (e.g. wrong sparkline aggregation).
+  test "linked scope matches accounts linked via account_providers" do
+    plaid_account = plaid_accounts(:one)
+    AccountProvider.create!(account: @account, provider: plaid_account)
+
+    assert_includes Account.linked, @account
+  end
+
+  test "linked scope matches accounts with legacy plaid_account_id" do
+    plaid_account = plaid_accounts(:one)
+    @account.update!(plaid_account: plaid_account)
+
+    assert_includes Account.linked, @account
+  end
+
+  test "linked scope matches accounts with legacy simplefin_account_id" do
+    simplefin_item = SimplefinItem.create!(
+      family: @family,
+      name: "Test SimpleFin",
+      access_url: "https://example.com/access_token"
+    )
+    simplefin_account = SimplefinAccount.create!(
+      simplefin_item: simplefin_item,
+      name: "Test Account",
+      account_id: "test-acct",
+      currency: "USD",
+      account_type: "checking",
+      current_balance: 0
+    )
+    @account.update!(simplefin_account: simplefin_account)
+
+    assert_includes Account.linked, @account
+  end
+
+  test "linked scope excludes manual accounts" do
+    assert @account.unlinked?
+    refute_includes Account.linked, @account
+  end
 end


### PR DESCRIPTION
## Summary

The dashboard was issuing hundreds of per-account ``SELECT 1`` and polymorphic ``accountable`` lookups on every page load. The sidebar partial alone hit the DB ~50–100× and was rendered twice per request (mobile drawer + desktop sidebar). This PR collapses those into batched preloads and adds a fragment cache for the sidebar.

### Changes

- **``AccountableSparklinesController``** — short-circuit ``requires_normalized_aggregation?`` to Investment/Crypto only and collapse the per-account ``linked?`` loop into a single ``EXISTS``. Kills the N+1 ``AccountProvider Exists?`` queries on every sparkline endpoint (5+ per dashboard load).
- **``BalanceSheet::AccountTotals#visible_accounts``** — preload ``:accountable``, ``:plaid_account``, ``:simplefin_account``, and ``account_providers: :provider`` so the sidebar's ``account.subtype`` / ``account.linked?`` / ``account.provider`` calls don't trigger per-row polymorphic loads.
- **``AccountsController#index``** — same preloads on ``@manual_accounts``.
- **``accounts/index/_account_groups.erb``** — extend the existing ``Preloader`` call to batch-load accountable + provider associations so the per-provider-item partials (Plaid, SimpleFIN, Coinbase, Coinstats, etc.) stop re-issuing N+1s when rendering account rows on ``/accounts``.
- **``accounts/_account_sidebar_tabs.html.erb``** — wrap the partial in a ``cache`` block keyed on the family's data-version, the current user, an ``AccountShare`` fingerprint, locale, mobile flag, active tab, and a path-derived "current account" component (new ``sidebar_active_account_id`` helper). The sidebar renders on every page, so most navigations now serve the cached fragment instead of re-walking accounts/balances.

### Local impact

Measured against my real data (1 family, 23 accounts, 6.1k transactions):

| Path | Before | After |
| --- | --- | --- |
| ``/`` (dashboard) | ~6.5s | ~1.95s |
| ``/accounts`` | ~2.7s | ~0.85s on warm cache |
| ``/accountable_sparklines/*`` (each) | ~1.1–1.3s | ~1.1s with N+1s gone |

The remaining sparkline cost is mostly request boilerplate (auth callbacks, ``Current.*`` setup, layout rendering in dev). The dashboard fans out 5 sparkline turbo frames in parallel; Puma's default 3 threads serialize them. Bumping ``RAILS_MAX_THREADS`` to 8 in dev recovers the parallelism — that's an env tweak rather than a code change so it isn't included here.

### Cache key correctness

- Different users in the same family see different account access → ``Current.user.id`` is in the key.
- ``AccountShare`` updates can change visibility without touching ``accounts.updated_at`` → ``shares_version`` is in the key.
- Active-link styling depends on the current path → ``sidebar_active_account_id`` (extracts ``<id>`` from ``/accounts/<id>(/...)?``) keeps it correct without invalidating on every unrelated navigation.
- Mobile vs desktop emit different DOM ids → separate entries.
- Family data updates / completed syncs invalidate via ``family.build_cache_key(..., invalidate_on_data_updates: true)``.
- 12-hour ``expires_in`` is the upper bound; bump the ``account_sidebar_tabs_v1`` suffix if a future template change needs a hard invalidation.

## Test plan

- [x] ``bin/rubocop`` clean on changed Ruby files
- [x] ``bundle exec erb_lint`` clean on changed ERB files
- [x] ``bin/rails test test/controllers/accountable_sparklines_controller_test.rb test/controllers/accounts_controller_test.rb test/controllers/pages_controller_test.rb test/models/balance_sheet_test.rb`` — 43 runs, 0 failures
- [x] Smoke-tested manually: dashboard, ``/accounts``, ``/transactions``, navigating between specific account pages
- [x] Verify sidebar still renders correctly on first visit (cache miss) and subsequent visits (cache hit) with ``bin/rails dev:cache`` enabled
- [x] Verify highlighted account link is correct when navigating to ``/accounts/:id``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster and more responsive accounts sidebar via improved caching.
  * Quicker account list rendering thanks to broader data preloading.
  * More efficient handling of linked accounts for improved account-related displays.
  * Adjusted series generation for sparklines to produce more consistent charts for investment/crypto accounts.

* **Tests**
  * Added tests covering account linking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->