### PR TITLE
feat(filters): add reusable empty-state for list filter search

### DIFF
--- a/app/javascript/controllers/list_filter_controller.js
+++ b/app/javascript/controllers/list_filter_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
   }
 
   filter() {
-    const filterValue = this.inputTarget.value.toLowerCase();
+    const filterValue = this.inputTarget.value.trim().toLowerCase();
     const items = this.listTarget.querySelectorAll(".filterable-item");
     let noMatchFound = true;
 

--- a/app/javascript/controllers/list_filter_controller.js
+++ b/app/javascript/controllers/list_filter_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
     let noMatchFound = true;
 
     if (this.hasEmptyMessageTarget) {
+      this.emptyMessageTarget.textContent = "";
       this.emptyMessageTarget.classList.add("hidden");
     }
 
@@ -30,7 +31,9 @@ export default class extends Controller {
     });
 
     if (noMatchFound && this.hasEmptyMessageTarget) {
+      const msg = this.emptyMessageTarget.dataset.emptyMessage ?? "";
       this.emptyMessageTarget.classList.remove("hidden");
+      this.emptyMessageTarget.textContent = msg;
     }
 
     this.highlightedIndex = -1;

--- a/app/views/category/dropdowns/show.html.erb
+++ b/app/views/category/dropdowns/show.html.erb
@@ -17,9 +17,9 @@
         </div>
       </div>
       <div data-list-filter-target="list" role="listbox" class="flex flex-col gap-0.5 p-1.5 mt-0.5 mr-2 max-h-64 overflow-y-scroll scrollbar">
-        <div class="pb-2 pl-4 mr-2 text-secondary hidden" data-list-filter-target="emptyMessage">
-          <%= t(".no_categories") %>
-        </div>
+        <%= render "shared/list_filter_empty_state",
+                   message: t(".no_categories"),
+                   classes: "mr-2 pb-2 pl-4 text-sm text-secondary" %>
         <% if @categories.any? %>
           <% Category::Group.for(@categories).each do |group| %>
             <%= render "category/dropdowns/row", category: group.category %>

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -140,9 +140,9 @@
                 </div>
               </div>
               <div data-list-filter-target="list" class="max-h-80 overflow-auto rounded-xl border border-secondary divide-y divide-alpha-black-100 theme-dark:divide-alpha-white-100">
-                <p class="hidden px-4 py-3 text-sm text-secondary" data-list-filter-target="emptyMessage">
-                  <%= t(".no_matching_currencies") %>
-                </p>
+                <%= render "shared/list_filter_empty_state",
+                           message: t(".no_matching_currencies"),
+                           classes: "px-4 py-3 text-sm text-secondary" %>
                 <% currency_rows.each do |currency| %>
                   <% checked = selected_currency_codes.include?(currency.iso_code) %>
                   <% base_currency = currency.iso_code == primary_currency_code %>

--- a/app/views/shared/_list_filter_empty_state.html.erb
+++ b/app/views/shared/_list_filter_empty_state.html.erb
@@ -1,5 +1,5 @@
 <%#
-  Reusable empty line for Stimulus list-filter when all .filterable-item rows are hidden.
+  Reusable empty state for Stimulus list-filter when all .filterable-item rows are hidden.
   Pass message (required for non-default copy) and optional classes for layout context.
 
   Body stays empty at rest: list_filter fills text from data-empty-message after reveal so

--- a/app/views/shared/_list_filter_empty_state.html.erb
+++ b/app/views/shared/_list_filter_empty_state.html.erb
@@ -1,12 +1,4 @@
-<%#
-  Reusable empty state for Stimulus list-filter when all .filterable-item rows are hidden.
-  Pass message (required for non-default copy) and optional classes for layout context.
-
-  Body stays empty at rest: list_filter fills text from data-empty-message after reveal so
-  role="status" / aria-live announces reliably (toggle hidden alone does not notify AT).
-
-  Default copy/styles suit the transactions filter menu; override classes where the list layout differs.
-%>
+<%# Reusable list-filter empty state; text is populated on reveal for aria-live. %>
 <% message = local_assigns.fetch(:message, t("transactions.searches.filters.list_filter_empty_state.no_matches")) %>
 <% classes = local_assigns.fetch(:classes, "py-3 w-full text-center text-sm text-secondary") %>
 <%= tag.p(

--- a/app/views/shared/_list_filter_empty_state.html.erb
+++ b/app/views/shared/_list_filter_empty_state.html.erb
@@ -2,12 +2,20 @@
   Reusable empty line for Stimulus list-filter when all .filterable-item rows are hidden.
   Pass message (required for non-default copy) and optional classes for layout context.
 
+  Body stays empty at rest: list_filter fills text from data-empty-message after reveal so
+  role="status" / aria-live announces reliably (toggle hidden alone does not notify AT).
+
   Default copy/styles suit the transactions filter menu; override classes where the list layout differs.
 %>
 <% message = local_assigns.fetch(:message, t("transactions.searches.filters.list_filter_empty_state.no_matches")) %>
 <% classes = local_assigns.fetch(:classes, "py-3 w-full text-center text-sm text-secondary") %>
-<p class="hidden <%= classes %>"
-   data-list-filter-target="emptyMessage"
-   role="status"
-   aria-live="polite"
-   aria-atomic="true"><%= message %></p>
+<%= tag.p(
+      nil,
+      class: "#{classes} hidden",
+      data: {
+        list_filter_target: "emptyMessage",
+        empty_message: message.to_s,
+      },
+      role: "status",
+      aria: { live: "polite", atomic: "true" },
+    ) %>

--- a/app/views/shared/_list_filter_empty_state.html.erb
+++ b/app/views/shared/_list_filter_empty_state.html.erb
@@ -1,0 +1,13 @@
+<%#
+  Reusable empty line for Stimulus list-filter when all .filterable-item rows are hidden.
+  Pass message (required for non-default copy) and optional classes for layout context.
+
+  Default copy/styles suit the transactions filter menu; override classes where the list layout differs.
+%>
+<% message = local_assigns.fetch(:message, t("transactions.searches.filters.list_filter_empty_state.no_matches")) %>
+<% classes = local_assigns.fetch(:classes, "py-3 w-full text-center text-sm text-secondary") %>
+<p class="hidden <%= classes %>"
+   data-list-filter-target="emptyMessage"
+   role="status"
+   aria-live="polite"
+   aria-atomic="true"><%= message %></p>

--- a/app/views/transactions/categorizes/show.html.erb
+++ b/app/views/transactions/categorizes/show.html.erb
@@ -117,9 +117,9 @@
             <div data-list-filter-target="list" data-categorize-target="list"
                  data-action="click->categorize#clearFilter"
                  class="flex flex-wrap gap-2">
-              <p class="hidden text-sm text-secondary w-full py-2" data-list-filter-target="emptyMessage">
-                <%= t(".no_categories") %>
-              </p>
+              <%= render "shared/list_filter_empty_state",
+                         message: t(".no_categories"),
+                         classes: "w-full py-2 text-sm text-secondary" %>
               <% @categories.each do |category| %>
                 <button type="submit"
                         name="category_id"

--- a/app/views/transactions/searches/filters/_account_filter.html.erb
+++ b/app/views/transactions/searches/filters/_account_filter.html.erb
@@ -5,6 +5,7 @@
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
+    <%= render "shared/list_filter_empty_state" %>
     <% Current.user.accessible_accounts.alphabetically.each do |account| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= account.name %>">
         <%= form.check_box :accounts,

--- a/app/views/transactions/searches/filters/_category_filter.html.erb
+++ b/app/views/transactions/searches/filters/_category_filter.html.erb
@@ -5,6 +5,7 @@
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
+    <%= render "shared/list_filter_empty_state" %>
     <% family_categories.each do |category| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= category.name %>">
         <%= form.check_box :categories,

--- a/app/views/transactions/searches/filters/_merchant_filter.html.erb
+++ b/app/views/transactions/searches/filters/_merchant_filter.html.erb
@@ -5,6 +5,7 @@
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
+    <%= render "shared/list_filter_empty_state" %>
     <% Current.family.assigned_merchants_for(Current.user).alphabetically.each do |merchant| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= merchant.name %>">
         <%= form.check_box :merchants,

--- a/app/views/transactions/searches/filters/_tag_filter.html.erb
+++ b/app/views/transactions/searches/filters/_tag_filter.html.erb
@@ -5,6 +5,7 @@
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
+    <%= render "shared/list_filter_empty_state" %>
     <% Current.family.tags.alphabetically.each do |tag| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= tag.name %>">
         <%= form.check_box :tags,

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -225,6 +225,8 @@ en:
         unexpected_error: "Unexpected error during conversion: %{error}"
     searches:
       filters:
+        list_filter_empty_state:
+          no_matches: No matching results
         amount_filter:
           equal_to: Equal to
           greater_than: Greater than


### PR DESCRIPTION
## Summary

This PR extracts a reusable empty-state partial for list-filter search results, improving UX by displaying a clear message when no matches are found instead of an empty list.

## Context

Follows up on #1679 by isolating the empty-state logic based on review feedback, aligning with ongoing Design System cleanup efforts.

## What changed

- Introduced a shared partial: `shared/list_filter_empty_state`
- Integrated with existing Stimulus `list-filter` controller via the `emptyMessage` target
- Displays a “No matches found” message when client-side filtering yields zero items
- Applied across transaction filter dropdowns (Account, Category, Tag, Merchant)
- Extended to related list-filter UIs (categorize flow, category dropdown, currency preferences)

## Reusability

- Supports configurable message and optional classes via `local_assigns.fetch`
- Avoids duplication of markup across list-filter implementations
- Includes accessibility attributes:
  - `role="status"`
  - `aria-live="polite"`
  - `aria-atomic="true"`

## Design System Alignment

- Uses existing design tokens only (`text-sm`, `text-secondary`)
- Introduces no new styles or CSS
- Keeps behavior scoped outside DS (presentation-only reuse)

## Additional improvements

- Trimmed input in `list_filter_controller.js` to prevent whitespace-only queries from hiding all results unintentionally

## i18n

- Added: `transactions.searches.filters.list_filter_empty_state.no_matches` (English only; other locales follow project conventions)

## Why

- Eliminates confusing blank states during filtering
- Improves accessibility and clarity of search interactions
- Extracts a reusable pattern from #1679, avoiding the need for cherry-picking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized, reusable empty-state component for all list filters with localization and consistent styling.
  * Empty states now display a localized "no matches" message when filters return no results and expose accessible status updates.

* **Bug Fixes**
  * Filter input trims whitespace before matching.
  * Starting a filter run reliably clears or updates the empty-state so users see correct feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->