### PR TITLE
Add startup warning for remote_user_header when trusted proxies are unset

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -58,7 +58,7 @@ module Authentication
         user.email = user_email
         user.password = SecureRandom.base58(50)
         user.family = Family.new
-        user.role = :admin
+        user.role = User.role_for_new_family_creator(fallback_role: :admin)
         user.save!
         user
       rescue ActiveRecord::RecordNotUnique

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -54,9 +54,11 @@ module Authentication
 
     def find_or_create_remote_header_user(user_email)
       User.find_by(email: user_email) || begin
+        # Leave password_digest nil so the user can't fall back to local
+        # password login or password reset; the proxy is the only path in.
         user = User.new
         user.email = user_email
-        user.password = SecureRandom.base58(50)
+        user.skip_password_validation = true
         user.family = Family.new
         user.role = User.role_for_new_family_creator(fallback_role: :admin)
         user.save!

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,6 +1,8 @@
 module Authentication
   extend ActiveSupport::Concern
 
+  REMOTE_HEADER_SSO_PROVIDER = "remote_user_header"
+
   included do
     before_action :set_request_details
     before_action :authenticate_user!
@@ -47,13 +49,27 @@ module Authentication
 
     def create_session_by_remote_header
       if user_email = request.headers[Rails.application.config.remote_user_header_email]
-        user = find_or_create_remote_header_user(user_email)
+        user, created = find_or_create_remote_header_user(user_email)
+        if created
+          SsoAuditLog.log_jit_account_created!(
+            user: user,
+            provider: REMOTE_HEADER_SSO_PROVIDER,
+            request: request
+          )
+        end
+        SsoAuditLog.log_login!(
+          user: user,
+          provider: REMOTE_HEADER_SSO_PROVIDER,
+          request: request
+        )
         create_session_for(user)
       end
     end
 
     def find_or_create_remote_header_user(user_email)
-      User.find_by(email: user_email) || begin
+      if user = User.find_by(email: user_email)
+        [ user, false ]
+      else
         # Leave password_digest nil so the user can't fall back to local
         # password login or password reset; the proxy is the only path in.
         user = User.new
@@ -61,10 +77,12 @@ module Authentication
         user.skip_password_validation = true
         user.family = Family.new
         user.role = User.role_for_new_family_creator(fallback_role: :admin)
-        user.save!
-        user
-      rescue ActiveRecord::RecordNotUnique
-        User.find_by!(email: user_email)
+        begin
+          user.save!
+          [ user, true ]
+        rescue ActiveRecord::RecordNotUnique
+          [ User.find_by!(email: user_email), false ]
+        end
       end
     end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -16,8 +16,16 @@ module Authentication
 
   private
     def authenticate_user!
-      if session_record = find_session_by_cookie
-        Current.session = session_record
+      cookie_session = find_session_by_cookie
+
+      if cookie_session && cookie_session_disagrees_with_header?(cookie_session)
+        cookie_session.destroy
+        cookies.delete(:session_token)
+        cookie_session = nil
+      end
+
+      if cookie_session
+        Current.session = cookie_session
       elsif session_record = create_session_by_remote_header
         Current.session = session_record
       else
@@ -27,6 +35,14 @@ module Authentication
           redirect_to new_session_url
         end
       end
+    end
+
+    def cookie_session_disagrees_with_header?(session)
+      header_name = Rails.application.config.remote_user_header_email
+      return false if header_name.blank?
+
+      header_email = request.headers[header_name]&.strip&.downcase
+      header_email.present? && session.user.email != header_email
     end
 
     def create_session_by_remote_header

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -18,12 +18,29 @@ module Authentication
     def authenticate_user!
       if session_record = find_session_by_cookie
         Current.session = session_record
+      elsif session_record = create_session_by_remote_header
+        Current.session = session_record
       else
         if self_hosted_first_login?
           redirect_to new_registration_url
         else
           redirect_to new_session_url
         end
+      end
+    end
+
+    def create_session_by_remote_header
+      if user_email = request.headers[Rails.application.config.remote_user_header_email]
+        unless user = User.find_by(email: user_email)
+          user = User.new
+          user.email = user_email
+          user.password = SecureRandom.base58(50)
+          family = Family.new
+          user.family = family
+          user.role = :admin
+          user.save
+        end
+        create_session_for(user)
       end
     end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -38,7 +38,7 @@ module Authentication
           family = Family.new
           user.family = family
           user.role = :admin
-          user.save
+          user.save!
         end
         create_session_for(user)
       end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -48,7 +48,11 @@ module Authentication
     end
 
     def create_session_by_remote_header
-      if user_email = request.headers[Rails.application.config.remote_user_header_email]
+      header_name = Rails.application.config.remote_user_header_email
+      return if header_name.blank?
+
+      user_email = request.headers[header_name]&.strip&.downcase
+      if user_email.present? && URI::MailTo::EMAIL_REGEXP.match?(user_email)
         user, created = find_or_create_remote_header_user(user_email)
         if created
           SsoAuditLog.log_jit_account_created!(

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -31,16 +31,22 @@ module Authentication
 
     def create_session_by_remote_header
       if user_email = request.headers[Rails.application.config.remote_user_header_email]
-        unless user = User.find_by(email: user_email)
-          user = User.new
-          user.email = user_email
-          user.password = SecureRandom.base58(50)
-          family = Family.new
-          user.family = family
-          user.role = :admin
-          user.save!
-        end
+        user = find_or_create_remote_header_user(user_email)
         create_session_for(user)
+      end
+    end
+
+    def find_or_create_remote_header_user(user_email)
+      User.find_by(email: user_email) || begin
+        user = User.new
+        user.email = user_email
+        user.password = SecureRandom.base58(50)
+        user.family = Family.new
+        user.role = :admin
+        user.save!
+        user
+      rescue ActiveRecord::RecordNotUnique
+        User.find_by!(email: user_email)
       end
     end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -40,34 +40,52 @@ module Authentication
     end
 
     def cookie_session_disagrees_with_header?(session)
-      header_name = Rails.application.config.remote_user_header_email
-      return false if header_name.blank?
-
-      header_email = request.headers[header_name]&.strip&.downcase
-      header_email.present? && session.user.email != header_email
+      email = trusted_remote_user_email
+      email.present? && session.user.email != email
     end
 
     def create_session_by_remote_header
-      header_name = Rails.application.config.remote_user_header_email
-      return if header_name.blank?
+      return unless user_email = trusted_remote_user_email
 
-      user_email = request.headers[header_name]&.strip&.downcase
-      if user_email.present? && URI::MailTo::EMAIL_REGEXP.match?(user_email)
-        user, created = find_or_create_remote_header_user(user_email)
-        if created
-          SsoAuditLog.log_jit_account_created!(
-            user: user,
-            provider: REMOTE_HEADER_SSO_PROVIDER,
-            request: request
-          )
-        end
-        SsoAuditLog.log_login!(
+      user, created = find_or_create_remote_header_user(user_email)
+      if created
+        SsoAuditLog.log_jit_account_created!(
           user: user,
           provider: REMOTE_HEADER_SSO_PROVIDER,
           request: request
         )
-        create_session_for(user)
       end
+      SsoAuditLog.log_login!(
+        user: user,
+        provider: REMOTE_HEADER_SSO_PROVIDER,
+        request: request
+      )
+      create_session_for(user)
+    end
+
+    # Returns the email asserted by the upstream proxy, but only when the
+    # request passes all configured trust gates: header set, source IP in
+    # the trusted-proxies allowlist (if any), and email shape is valid.
+    def trusted_remote_user_email
+      header_name = Rails.application.config.remote_user_header_email
+      return nil if header_name.blank?
+      return nil unless remote_user_proxy_trusted?
+
+      email = request.headers[header_name]&.strip&.downcase
+      return nil if email.blank?
+      return nil unless URI::MailTo::EMAIL_REGEXP.match?(email)
+
+      email
+    end
+
+    def remote_user_proxy_trusted?
+      trusted = Rails.application.config.remote_user_trusted_proxies
+      return true if trusted.blank?
+
+      client_ip = IPAddr.new(request.remote_ip)
+      trusted.any? { |range| range.include?(client_ip) }
+    rescue IPAddr::Error
+      false
     end
 
     def find_or_create_remote_header_user(user_email)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -80,10 +80,10 @@ module Authentication
 
     def remote_user_proxy_trusted?
       trusted = Rails.application.config.remote_user_trusted_proxies
-      return true if trusted.blank?
+      return true if trusted.nil?
 
-      client_ip = IPAddr.new(request.remote_ip)
-      trusted.any? { |range| range.include?(client_ip) }
+      peer_ip = IPAddr.new(request.env["REMOTE_ADDR"])
+      trusted.any? { |range| range.include?(peer_ip) }
     rescue IPAddr::Error
       false
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,8 @@ module Sure
 
     config.app_mode = (ENV["SELF_HOSTED"] == "true" || ENV["SELF_HOSTING_ENABLED"] == "true" ? "self_hosted" : "managed").inquiry
 
+    config.remote_user_header_email = ENV["REMOTE_USER_HEADER_EMAIL"]
+
     # Self hosters can optionally set their own encryption keys if they want to use ActiveRecord encryption.
     if Rails.application.credentials.active_record_encryption.present?
       config.active_record.encryption = Rails.application.credentials.active_record_encryption

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,11 @@ module Sure
     config.app_mode = (ENV["SELF_HOSTED"] == "true" || ENV["SELF_HOSTING_ENABLED"] == "true" ? "self_hosted" : "managed").inquiry
 
     config.remote_user_header_email = ENV["REMOTE_USER_HEADER_EMAIL"]
+    config.remote_user_trusted_proxies = ENV["REMOTE_USER_TRUSTED_PROXIES"]
+      &.split(",")
+      &.map(&:strip)
+      &.reject(&:empty?)
+      &.filter_map { |s| IPAddr.new(s) rescue nil }
 
     # Self hosters can optionally set their own encryption keys if they want to use ActiveRecord encryption.
     if Rails.application.credentials.active_record_encryption.present?

--- a/config/initializers/remote_user_header.rb
+++ b/config/initializers/remote_user_header.rb
@@ -1,0 +1,11 @@
+Rails.application.config.after_initialize do
+  if Rails.application.config.remote_user_header_email.present? &&
+     Rails.application.config.remote_user_trusted_proxies.nil?
+    Rails.logger.warn(
+      "[remote_user_header] REMOTE_USER_HEADER_EMAIL is set but " \
+      "REMOTE_USER_TRUSTED_PROXIES is unset; the header will be trusted " \
+      "from ANY source IP. Ensure Sure is not reachable except via your " \
+      "authenticating reverse proxy, or set REMOTE_USER_TRUSTED_PROXIES."
+    )
+  end
+end

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -316,3 +316,16 @@ docker compose exec db psql -U sure_user -d sure_development -c "SELECT 1;" # Th
 ### Slow `.csv` import (processing rows taking longer than expected)
 
 Importing comma-separated-value file(s) requires the `sure-worker` container to communicate with Redis. Check your worker logs for any unexpected errors, such as connection timeouts or Redis communication failures.
+
+## Reverse-proxy authentication
+
+Sure can be configured to trust a request header set by an upstream reverse proxy and use it to log a user in automatically (passwordless). This is intended to be used in conjunction with separate authorization software running in front of Sure.
+
+For more information and examples, see https://doc.traefik.io/traefik/middlewares/http/forwardauth/ or similar documentation for your HTTP proxy and authentication software.
+
+Configure the Sure environment with the name of the header that carries the authenticated user's email:
+```
+REMOTE_USER_HEADER_EMAIL="Remote-Email"
+```
+
+ !! NOTE!! this allows unchallenged (passwordless) login via simple HTTP headers. Only use this method if you have a proxy in front of Sure that is applying the authentication challenge, *AND THE SURE HTTP SERVER IS NOT ACCESSIBLE DIRECTLY*.

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -324,7 +324,7 @@ Sure can be configured to trust a request header set by an upstream reverse prox
 For more information and examples, see https://doc.traefik.io/traefik/middlewares/http/forwardauth/ or similar documentation for your HTTP proxy and authentication software.
 
 Configure the Sure environment with the name of the header that carries the authenticated user's email:
-```
+```txt
 REMOTE_USER_HEADER_EMAIL="Remote-Email"
 ```
 
@@ -332,7 +332,7 @@ REMOTE_USER_HEADER_EMAIL="Remote-Email"
 
 ### Restrict by source IP (recommended)
 
-Only honor the header when the request comes from a known proxy address. When unset, the gate is skipped; when set, requests from any other IP are treated as if the header weren't present. Accepts a comma-separated list of IPs or CIDRs:
-```
+Only honor the header when the immediate peer (`REMOTE_ADDR`) is in this list. Leave the variable unset to disable the gate (the default, every request is honored). Set it to a comma-separated list of IPs or CIDRs to enable. A set-but-empty or unparseable value fails closed — every request is treated as outside the allowlist and the header is ignored.
+```txt
 REMOTE_USER_TRUSTED_PROXIES="10.0.0.5,172.18.0.0/16"
 ```

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -329,3 +329,10 @@ REMOTE_USER_HEADER_EMAIL="Remote-Email"
 ```
 
  !! NOTE!! this allows unchallenged (passwordless) login via simple HTTP headers. Only use this method if you have a proxy in front of Sure that is applying the authentication challenge, *AND THE SURE HTTP SERVER IS NOT ACCESSIBLE DIRECTLY*.
+
+### Restrict by source IP (recommended)
+
+Only honor the header when the request comes from a known proxy address. When unset, the gate is skipped; when set, requests from any other IP are treated as if the header weren't present. Accepts a comma-separated list of IPs or CIDRs:
+```
+REMOTE_USER_TRUSTED_PROXIES="10.0.0.5,172.18.0.0/16"
+```

--- a/test/integration/remote_user_header_authentication_test.rb
+++ b/test/integration/remote_user_header_authentication_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+
+class RemoteUserHeaderAuthenticationTest < ActionDispatch::IntegrationTest
+  HEADER_NAME = "Remote-Email"
+  JIT_EMAIL = "headerjit@test.example"
+
+  setup do
+    Rails.application.config.stubs(:remote_user_header_email).returns(HEADER_NAME)
+  end
+
+  test "feature is opt-in: with config unset, the header is ignored" do
+    Rails.application.config.stubs(:remote_user_header_email).returns(nil)
+
+    assert_no_difference -> { User.count } do
+      get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+    end
+    assert_redirected_to new_session_url
+  end
+
+  test "JIT user has password_digest = nil and a created family" do
+    get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+
+    user = User.find_by(email: JIT_EMAIL)
+    assert_not_nil user, "JIT user should be created"
+    assert_nil user.password_digest, "JIT users must not have a local password"
+    assert_not_nil user.family, "JIT users must have an associated family"
+  end
+
+  test "JIT delegates role assignment to User.role_for_new_family_creator" do
+    User.expects(:role_for_new_family_creator)
+        .with(fallback_role: :admin)
+        .returns(:super_admin)
+
+    get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+
+    assert_equal "super_admin", User.find_by!(email: JIT_EMAIL).role
+  end
+
+  test "writes SsoAuditLog: jit_account_created once, login on every header-driven session" do
+    assert_difference -> { SsoAuditLog.count }, 2 do
+      get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+    end
+
+    user = User.find_by!(email: JIT_EMAIL)
+
+    reset! # drop cookies so the next request goes through the header path again
+
+    assert_difference -> { SsoAuditLog.count }, 1 do
+      get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+    end
+
+    events = SsoAuditLog.where(user: user).order(:created_at).pluck(:event_type, :provider)
+    assert_equal [
+      [ "jit_account_created", "remote_user_header" ],
+      [ "login",               "remote_user_header" ],
+      [ "login",               "remote_user_header" ]
+    ], events
+  end
+
+  test "cookie session for a different user is invalidated when the header asserts another identity" do
+    user_a = users(:family_admin)
+    sign_in(user_a)
+    cookie_session = user_a.sessions.order(:created_at).last
+    assert_not_nil cookie_session, "sign_in should have created a session"
+
+    get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+
+    refute Session.exists?(id: cookie_session.id), "cookie session should be destroyed when header asserts a different user"
+    assert_not_nil User.find_by(email: JIT_EMAIL), "header-asserted user should be JIT'd"
+  end
+
+  test "IP allowlist: request from a non-allowlisted IP is ignored" do
+    Rails.application.config.stubs(:remote_user_trusted_proxies)
+                            .returns([ IPAddr.new("10.0.0.0/24") ])
+
+    assert_no_difference -> { User.count } do
+      get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+    end
+    assert_redirected_to new_session_url
+  end
+
+  test "IP allowlist: request from an allowlisted CIDR is honored" do
+    Rails.application.config.stubs(:remote_user_trusted_proxies)
+                            .returns([ IPAddr.new("127.0.0.0/8") ])
+
+    assert_difference -> { User.count }, 1 do
+      get root_url, headers: { HEADER_NAME => JIT_EMAIL }
+    end
+  end
+
+  test "malformed email value fails closed without raising" do
+    [ "not an email", "", "  ", "@", "foo@" ].each do |bad|
+      assert_no_difference -> { User.count }, "header value #{bad.inspect} should not JIT" do
+        get root_url, headers: { HEADER_NAME => bad }
+      end
+      assert_redirected_to new_session_url
+    end
+  end
+end

--- a/test/integration/remote_user_header_authentication_test.rb
+++ b/test/integration/remote_user_header_authentication_test.rb
@@ -6,6 +6,7 @@ class RemoteUserHeaderAuthenticationTest < ActionDispatch::IntegrationTest
 
   setup do
     Rails.application.config.stubs(:remote_user_header_email).returns(HEADER_NAME)
+    Rails.application.config.stubs(:remote_user_trusted_proxies).returns(nil)
   end
 
   test "feature is opt-in: with config unset, the header is ignored" do


### PR DESCRIPTION
This adds a startup warning when REMOTE_USER_HEADER_EMAIL is set but REMOTE_USER_TRUSTED_PROXIES is unset, to avoid silently trusting the header from any source IP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote-header based SSO authentication for single sign-on through reverse proxies
  * Automatic Just-In-Time account provisioning using proxy-provided credentials
  * IP allowlisting for validating trusted proxy sources
  * Enhanced session management with proxy header identity validation

* **Documentation**
  * Added reverse-proxy authentication configuration guide with security recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->