### PR TITLE
Fix avg_cost to return per-share cost basis

### DIFF
--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -51,8 +51,8 @@ class Holding < ApplicationRecord
     # - If locked (user-set), trust the value even if 0 (valid for airdrops)
     # - Otherwise require positive since providers sometimes return 0 when unknown
     if cost_basis.present?
-      if (cost_basis_locked? || cost_basis.positive?) && qty.to_f > 0
-        return Money.new(cost_basis / qty, currency)
+      if cost_basis_locked? || cost_basis.positive?
+        return Money.new(cost_basis, currency)
       end
     end
 

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -51,8 +51,8 @@ class Holding < ApplicationRecord
     # - If locked (user-set), trust the value even if 0 (valid for airdrops)
     # - Otherwise require positive since providers sometimes return 0 when unknown
     if cost_basis.present?
-      if cost_basis_locked? || cost_basis.positive?
-        return Money.new(cost_basis, currency)
+      if (cost_basis_locked? || cost_basis.positive?) && qty.to_f > 0
+        return Money.new(cost_basis / qty, currency)
       end
     end
 

--- a/app/models/simplefin_account/investments/holdings_processor.rb
+++ b/app/models/simplefin_account/investments/holdings_processor.rb
@@ -128,7 +128,9 @@ class SimplefinAccount::Investments::HoldingsProcessor
     def normalize_cost_basis(raw_cost_basis, qty, source_key)
       return nil if raw_cost_basis.nil?
 
-      if qty.to_d.positive? && %w[total_cost value].include?(source_key)
+      if %w[total_cost value].include?(source_key)
+        return nil unless qty.to_d.positive?
+
         raw_cost_basis / qty
       else
         raw_cost_basis

--- a/app/models/simplefin_account/investments/holdings_processor.rb
+++ b/app/models/simplefin_account/investments/holdings_processor.rb
@@ -47,7 +47,8 @@ class SimplefinAccount::Investments::HoldingsProcessor
         # which would cause the system to display average cost as current price. (GH #1182)
         qty = parse_decimal(any_of(simplefin_holding, %w[shares quantity qty units]))
         market_value = parse_decimal(any_of(simplefin_holding, %w[market_value current_value]))
-        cost_basis = parse_decimal(any_of(simplefin_holding, %w[cost_basis basis total_cost value]))
+        raw_cost_basis = parse_decimal(any_of(simplefin_holding, %w[cost_basis basis total_cost value]))
+        cost_basis = normalize_cost_basis(raw_cost_basis, qty, simplefin_holding)
 
         # Derive price from market_value when possible; otherwise fall back to any price field
         fallback_price = parse_decimal(any_of(simplefin_holding, %w[purchase_price price unit_price average_cost avg_cost]))
@@ -110,6 +111,19 @@ class SimplefinAccount::Investments::HoldingsProcessor
     def holdings_data
       # Use the dedicated raw_holdings_payload field
       simplefin_account.raw_holdings_payload || []
+    end
+
+    # Sure stores holding cost_basis as per-share average cost. Some SimpleFIN
+    # providers expose total position basis via total_cost/value, so normalize those
+    # fields before passing the holding to the provider import adapter.
+    def normalize_cost_basis(raw_cost_basis, qty, simplefin_holding)
+      return nil if raw_cost_basis.nil?
+
+      if qty.to_d.positive? && (simplefin_holding.key?("total_cost") || simplefin_holding.key?("value"))
+        raw_cost_basis / qty
+      else
+        raw_cost_basis
+      end
     end
 
     def resolve_security(symbol, description)

--- a/app/models/simplefin_account/investments/holdings_processor.rb
+++ b/app/models/simplefin_account/investments/holdings_processor.rb
@@ -115,8 +115,10 @@ class SimplefinAccount::Investments::HoldingsProcessor
 
     def cost_basis_from(simplefin_holding)
       %w[cost_basis basis total_cost value].each do |key|
-        value = parse_decimal(simplefin_holding[key])
-        return [ value, key ] if value.present?
+        raw = simplefin_holding[key]
+        next if raw.nil? || raw.to_s.strip.empty?
+
+        return [ parse_decimal(raw), key ]
       end
 
       [ nil, nil ]

--- a/app/models/simplefin_account/investments/holdings_processor.rb
+++ b/app/models/simplefin_account/investments/holdings_processor.rb
@@ -47,8 +47,8 @@ class SimplefinAccount::Investments::HoldingsProcessor
         # which would cause the system to display average cost as current price. (GH #1182)
         qty = parse_decimal(any_of(simplefin_holding, %w[shares quantity qty units]))
         market_value = parse_decimal(any_of(simplefin_holding, %w[market_value current_value]))
-        raw_cost_basis = parse_decimal(any_of(simplefin_holding, %w[cost_basis basis total_cost value]))
-        cost_basis = normalize_cost_basis(raw_cost_basis, qty, simplefin_holding)
+        raw_cost_basis, cost_basis_source_key = cost_basis_from(simplefin_holding)
+        cost_basis = normalize_cost_basis(raw_cost_basis, qty, cost_basis_source_key)
 
         # Derive price from market_value when possible; otherwise fall back to any price field
         fallback_price = parse_decimal(any_of(simplefin_holding, %w[purchase_price price unit_price average_cost avg_cost]))
@@ -113,13 +113,22 @@ class SimplefinAccount::Investments::HoldingsProcessor
       simplefin_account.raw_holdings_payload || []
     end
 
+    def cost_basis_from(simplefin_holding)
+      %w[cost_basis basis total_cost value].each do |key|
+        value = parse_decimal(simplefin_holding[key])
+        return [ value, key ] if value.present?
+      end
+
+      [ nil, nil ]
+    end
+
     # Sure stores holding cost_basis as per-share average cost. Some SimpleFIN
-    # providers expose total position basis via total_cost/value, so normalize those
-    # fields before passing the holding to the provider import adapter.
-    def normalize_cost_basis(raw_cost_basis, qty, simplefin_holding)
+    # providers expose total position basis via total_cost/value, so normalize only
+    # when the selected provider field is known to represent total position basis.
+    def normalize_cost_basis(raw_cost_basis, qty, source_key)
       return nil if raw_cost_basis.nil?
 
-      if qty.to_d.positive? && (simplefin_holding.key?("total_cost") || simplefin_holding.key?("value"))
+      if qty.to_d.positive? && %w[total_cost value].include?(source_key)
         raw_cost_basis / qty
       else
         raw_cost_basis

--- a/test/jobs/simplefin_holdings_apply_job_test.rb
+++ b/test/jobs/simplefin_holdings_apply_job_test.rb
@@ -124,7 +124,7 @@ class SimplefinHoldingsApplyJobTest < ActiveSupport::TestCase
     # Price derived from market_value
     assert_in_delta 500.0, holding.price.to_f, 0.01
 
-    # cost_basis should fall back to "value" field (45000)
-    assert_in_delta 45000.0, holding.cost_basis.to_f, 0.01
+    # cost_basis should fall back to "value" field and normalize total basis to per-share basis
+    assert_in_delta 450.0, holding.cost_basis.to_f, 0.01
   end
 end

--- a/test/models/simplefin_account/investments/holdings_processor_test.rb
+++ b/test/models/simplefin_account/investments/holdings_processor_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::TestCase
+  setup do
+    @simplefin_account = SimplefinAccount.create!(
+      name: "Schwab IRA",
+      provider_account_id: "simplefin-test-account",
+      currency: "USD",
+      balance: 10_108.17,
+      raw_payload: {},
+      raw_transactions_payload: [],
+      raw_holdings_payload: [],
+      account: accounts(:investment)
+    )
+
+    @processor = SimplefinAccount::Investments::HoldingsProcessor.new(@simplefin_account)
+  end
+
+  test "cost_basis source is used unchanged as per share basis" do
+    payload = {
+      "cost_basis" => "16.61",
+      "total_cost" => "9588.61",
+      "value" => "10108.16"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, BigDecimal("577.279"), source_key)
+
+    assert_equal BigDecimal("16.61"), cost_basis
+    assert_equal "cost_basis", source_key
+  end
+
+  test "basis source is used unchanged as per share basis" do
+    payload = {
+      "basis" => "16.61",
+      "total_cost" => "9588.61"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, BigDecimal("577.279"), source_key)
+
+    assert_equal BigDecimal("16.61"), cost_basis
+    assert_equal "basis", source_key
+  end
+
+  test "total_cost source is normalized to per share basis" do
+    payload = {
+      "total_cost" => "9588.61"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, BigDecimal("577.279"), source_key)
+
+    assert_equal BigDecimal("9588.61") / BigDecimal("577.279"), cost_basis
+    assert_equal "total_cost", source_key
+  end
+
+  test "value source is normalized to per share basis" do
+    payload = {
+      "value" => "9588.61"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, BigDecimal("577.279"), source_key)
+
+    assert_equal BigDecimal("9588.61") / BigDecimal("577.279"), cost_basis
+    assert_equal "value", source_key
+  end
+
+  test "total cost source with zero quantity does not divide" do
+    payload = {
+      "total_cost" => "9588.61"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, BigDecimal("0"), source_key)
+
+    assert_equal BigDecimal("9588.61"), cost_basis
+    assert_equal "total_cost", source_key
+  end
+
+  test "missing cost basis fields return nil" do
+    payload = {
+      "market_value" => "10108.16"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, BigDecimal("577.279"), source_key)
+
+    assert_nil raw_cost_basis
+    assert_nil source_key
+    assert_nil cost_basis
+  end
+end

--- a/test/models/simplefin_account/investments/holdings_processor_test.rb
+++ b/test/models/simplefin_account/investments/holdings_processor_test.rb
@@ -2,18 +2,7 @@ require "test_helper"
 
 class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::TestCase
   setup do
-    @simplefin_account = SimplefinAccount.create!(
-      name: "Schwab IRA",
-      provider_account_id: "simplefin-test-account",
-      currency: "USD",
-      balance: 10_108.17,
-      raw_payload: {},
-      raw_transactions_payload: [],
-      raw_holdings_payload: [],
-      account: accounts(:investment)
-    )
-
-    @processor = SimplefinAccount::Investments::HoldingsProcessor.new(@simplefin_account)
+    @processor = SimplefinAccount::Investments::HoldingsProcessor.new(nil)
   end
 
   test "cost_basis source is used unchanged as per share basis" do

--- a/test/models/simplefin_account/investments/holdings_processor_test.rb
+++ b/test/models/simplefin_account/investments/holdings_processor_test.rb
@@ -67,7 +67,7 @@ class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::Test
     assert_equal "value", source_key
   end
 
-  test "total cost source with zero quantity does not divide" do
+  test "total cost source with zero quantity returns nil" do
     payload = {
       "total_cost" => "9588.61"
     }
@@ -75,7 +75,19 @@ class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::Test
     raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
     cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, BigDecimal("0"), source_key)
 
-    assert_equal BigDecimal("9588.61"), cost_basis
+    assert_nil cost_basis
+    assert_equal "total_cost", source_key
+  end
+
+  test "total cost source with nil quantity returns nil" do
+    payload = {
+      "total_cost" => "9588.61"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(:normalize_cost_basis, raw_cost_basis, nil, source_key)
+
+    assert_nil cost_basis
     assert_equal "total_cost", source_key
   end
 


### PR DESCRIPTION
This fixes incorrect investment return calculations when `Holding.cost_basis` stores total position cost basis instead of per-share cost.

`Holding#avg_cost` is documented and used as average cost per share, but previously returned the raw `cost_basis` value directly.

This caused calculations such as:

```ruby
qty * avg_cost
```

to multiply quantity by total cost basis, producing massively incorrect return calculations.

Example:

* qty: 577.279
* total cost basis: 9588.61
* market value: 10108.16

Expected gain:

* 10108.16 - 9588.61 = 519.55

Previous behavior:

* 577.279 * 9588.61
* resulting in multi-million incorrect negative returns

This patch converts stored total cost basis into per-share average cost while safely handling zero quantities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved investment holdings cost-basis handling: accepts multiple provider fields, preserves per-share values, normalizes total-position values to per-share when quantity > 0, and yields blank when no cost data is present.

* **Tests**
  * Added unit tests verifying raw vs. normalized cost-basis, multiple provider field names, zero/absent quantity behavior, and missing-data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->