### PR TITLE
feat(credit_card): add validation for expiration date and update form to prevent past dates

### DIFF
--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -5,6 +5,8 @@ class CreditCard < ApplicationRecord
     "credit_card" => { short: "Credit Card", long: "Credit Card" }
   }.freeze
 
+  validate :expiration_date_not_in_past
+
   class << self
     def color
       "#F13636"
@@ -30,4 +32,13 @@ class CreditCard < ApplicationRecord
   def annual_fee_money
     annual_fee ? Money.new(annual_fee, account.currency) : nil
   end
+
+  private
+
+    def expiration_date_not_in_past
+      return if expiration_date.blank?
+      return if expiration_date >= Date.current
+
+      errors.add(:expiration_date, :greater_than_or_equal_to, count: Date.current)
+    end
 end

--- a/app/views/credit_cards/_form.html.erb
+++ b/app/views/credit_cards/_form.html.erb
@@ -27,7 +27,8 @@
 
       <div class="flex items-center gap-2">
         <%= credit_card_form.date_field :expiration_date,
-                                      label: t("credit_cards.form.expiration_date") %>
+                                      label: t("credit_cards.form.expiration_date"),
+                                      min: Date.current %>
         <%= credit_card_form.number_field :annual_fee,
                                         label: t("credit_cards.form.annual_fee"),
                                         placeholder: t("credit_cards.form.annual_fee_placeholder"),

--- a/test/models/credit_card_test.rb
+++ b/test/models/credit_card_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class CreditCardTest < ActiveSupport::TestCase
+  test "is invalid when expiration date is in the past" do
+    card = credit_cards(:one)
+    card.expiration_date = Date.yesterday
+
+    assert_not card.valid?
+    assert_includes card.errors[:expiration_date], "must be greater than or equal to #{Date.current}"
+  end
+
+  test "is valid when expiration date is today or later" do
+    card = credit_cards(:one)
+    card.expiration_date = Date.current
+
+    assert card.valid?
+  end
+end

--- a/test/models/credit_card_test.rb
+++ b/test/models/credit_card_test.rb
@@ -6,7 +6,7 @@ class CreditCardTest < ActiveSupport::TestCase
     card.expiration_date = Date.yesterday
 
     assert_not card.valid?
-    assert_includes card.errors[:expiration_date], "must be greater than or equal to #{Date.current}"
+    assert_includes card.errors.details[:expiration_date].map { |error| error[:error] }, :greater_than_or_equal_to
   end
 
   test "is valid when expiration date is today or later" do


### PR DESCRIPTION
- Implemented a validation method to ensure the expiration date of credit cards is not in the past.
- Updated the credit card form to set a minimum date for the expiration date field, preventing users from selecting past dates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users can no longer submit credit cards with past expiration dates; the form now prevents selecting dates before today and server-side validation rejects expired dates.

* **Tests**
  * Added tests verifying cards with past expiration dates are invalid and that today-or-later dates are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->