### PR TITLE
Add per-account toggle to disable automatic transaction categorization

### DIFF
--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -112,6 +112,7 @@ module AccountableResource
         :name, :balance, :subtype, :currency, :accountable_type, :return_to,
         :opening_balance_date,
         :institution_name, :institution_domain, :notes, :exclude_from_reports,
+        :enable_category_matcher,
         accountable_attributes: self.class.permitted_accountable_attributes
       )
     end

--- a/app/models/plaid_entry/processor.rb
+++ b/app/models/plaid_entry/processor.rb
@@ -69,6 +69,7 @@ class PlaidEntry::Processor
 
     def matched_category
       return nil unless detailed_category
+      return nil unless account&.enable_category_matcher?
       @matched_category ||= category_matcher.match(detailed_category)
     end
 

--- a/app/models/simplefin_account/transactions/processor.rb
+++ b/app/models/simplefin_account/transactions/processor.rb
@@ -52,6 +52,9 @@ class SimplefinAccount::Transactions::Processor
 
   private
 
+    # TODO: When SimpleFIN category matching is wired up (SimplefinAccount::Transactions::CategoryMatcher
+    # does not exist yet and this method is currently unused), apply the same
+    # `account&.enable_category_matcher?` guard used in PlaidEntry::Processor#matched_category.
     def category_matcher
       @category_matcher ||= SimplefinAccount::Transactions::CategoryMatcher.new(family_categories)
     end

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -24,6 +24,16 @@
 
     <%= yield form %>
 
+    <% if account.linked? && account.persisted? %>
+      <div class="flex items-center justify-between gap-3 py-2">
+        <div class="space-y-1">
+          <p class="text-sm text-primary"><%= t(".enable_category_matcher_label") %></p>
+          <p class="text-secondary text-sm"><%= t(".enable_category_matcher_hint") %></p>
+        </div>
+        <%= form.toggle :enable_category_matcher %>
+      </div>
+    <% end %>
+
     <details class="group">
       <summary class="cursor-pointer text-sm text-secondary hover:text-primary flex items-center gap-1 py-2">
         <%= icon "chevron-right", size: "sm", class: "group-open:rotate-90 transition-transform" %>

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -51,6 +51,8 @@ en:
       notes_label: Notes
       notes_placeholder: Store additional information like account numbers, sort codes, IBAN, routing numbers, etc.
       exclude_from_reports: Exclude from all reports
+      enable_category_matcher_label: Enable category matcher
+      enable_category_matcher_hint: When enabled, the provider's suggested category is applied to imported transactions. Disable to leave new transactions uncategorized.
     index:
       accounts: Accounts
       manual_accounts:

--- a/db/migrate/20260708000000_add_enable_category_matcher_to_accounts.rb
+++ b/db/migrate/20260708000000_add_enable_category_matcher_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddEnableCategoryMatcherToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :enable_category_matcher, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_28_200000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_08_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -120,6 +120,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_28_200000) do
     t.datetime "disabled_at"
     t.boolean "exclude_from_reports", default: false, null: false
     t.integer "account_providers_count", default: 0, null: false
+    t.boolean "enable_category_matcher", default: true, null: false
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"

--- a/test/models/plaid_entry/processor_test.rb
+++ b/test/models/plaid_entry/processor_test.rb
@@ -89,4 +89,35 @@ class PlaidEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal "Amazon", entry.name
     assert_equal categories(:food_and_drink).id, entry.transaction.category_id
   end
+
+  test "skips category matcher when account.enable_category_matcher is false" do
+    @plaid_account.current_account.update!(enable_category_matcher: false)
+
+    plaid_transaction = {
+      "transaction_id" => "456",
+      "merchant_name" => "Amazon",
+      "amount" => 100,
+      "date" => Date.current,
+      "iso_currency_code" => "USD",
+      "personal_finance_category" => {
+        "detailed" => "Food"
+      },
+      "merchant_entity_id" => "456"
+    }
+
+    @category_matcher.expects(:match).never
+
+    processor = PlaidEntry::Processor.new(
+      plaid_transaction,
+      plaid_account: @plaid_account,
+      category_matcher: @category_matcher
+    )
+
+    assert_difference [ "Entry.count", "Transaction.count" ], 1 do
+      processor.process
+    end
+
+    entry = Entry.order(created_at: :desc).first
+    assert_nil entry.transaction.category_id
+  end
 end


### PR DESCRIPTION
This PR comes out of a discussion on Discord. I'd like to have transactions imported from Plaid not use the category matcher and just leave them uncategorized.

This PR (writted by Claude with me guiding and testing), adds a new toggle to disable this functionality on a per-account basis.

## Summary

- Adds `enable_category_matcher` boolean column to accounts (default `true`, preserving existing behavior) so users can opt out of Plaid's automatic category suggestions on a per-account basis
- When disabled, newly synced transactions arrive uncategorized — leaving categories to rules or manual assignment
- Toggle appears in the account edit modal (three-dot menu → Edit) for linked accounts only, saves via the normal "Update Account" submit button.

<img width="572" height="407" alt="image" src="https://github.com/user-attachments/assets/c955fbb7-2101-456b-9a4f-ea9b8e2c0d2e" />

## Details

The Plaid integration maps `personal_finance_category.detailed` to user-defined categories via `PlaidEntry::Processor`. This is unconditional today — the initial category assignment can't be prevented even if the user prefers to categorize manually. A per-account toggle is more flexible than a per-family setting since users may want auto-categorization on one account but not another.

The `enable_category_matcher` name is intentionally generic so it future-proofs for other providers (e.g. SimpleFIN) that may wire up category matching later.

**What is not changing:**
- Existing categorized transactions are untouched — the toggle only affects future syncs
- Rules, AI categorization, and merchant enrichment are unaffected
- SimpleFIN's category matcher (currently dead code in its processor) is not modified

## Test plan

- [ ] Visit `/accounts` → three-dot menu → Edit on a Plaid-linked account → confirm toggle renders defaulting to on
- [ ] Toggle off → click "Update Account" → reopen modal → confirm toggle is still off
- [ ] Confirm toggle does **not** appear for manual (unlinked) accounts
- [ ] `bin/rails test test/models/plaid_entry/processor_test.rb` passes
- [ ] `bin/rails test` passes
- [ ] `bin/rubocop -f github -a` clean
- [ ] `bundle exec erb_lint ./app/**/*.erb -a` clean
- [ ] `bin/brakeman --no-pager` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added category matcher toggle for linked accounts—users can now enable or disable automatic transaction categorization directly from account settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->