### PR TITLE
Add per-institution manual sync flow for Sophtron (manual MFA)

### DIFF
--- a/app/controllers/sophtron_items_controller.rb
+++ b/app/controllers/sophtron_items_controller.rb
@@ -8,13 +8,13 @@ class SophtronItemsController < ApplicationController
 
   before_action :set_sophtron_item, only: [
     :show, :edit, :update, :destroy, :connect_institution, :sync,
-    :connection_status, :submit_mfa,
+    :connection_status, :submit_mfa, :toggle_manual_sync,
     :setup_accounts, :complete_account_setup
   ]
   before_action :require_admin!, only: [
     :new, :create, :preload_accounts, :select_accounts, :link_accounts,
     :select_existing_account, :link_existing_account, :connect_institution,
-    :edit, :update, :destroy, :sync, :connection_status, :submit_mfa,
+    :edit, :update, :destroy, :sync, :connection_status, :submit_mfa, :toggle_manual_sync,
     :setup_accounts, :complete_account_setup
   ]
 
@@ -146,6 +146,11 @@ class SophtronItemsController < ApplicationController
     @sophtron_item.upsert_job_snapshot!(job)
 
     if Provider::Sophtron.job_success?(job)
+      if manual_sync_flow?
+        complete_manual_sync_from_job(job)
+        return
+      end
+
       @sophtron_item.update!(
         current_job_id: nil,
         last_connection_error: nil,
@@ -157,18 +162,27 @@ class SophtronItemsController < ApplicationController
       @challenge = @sophtron_item.build_mfa_challenge(job)
       prepare_connection_status_context
       render :mfa, layout: false
-    elsif post_mfa_polling? && Provider::Sophtron.job_completed?(job)
-      return if render_account_selection_if_accounts_available(@sophtron_item)
+    elsif Provider::Sophtron.job_completed?(job)
+      if manual_sync_flow?
+        complete_manual_sync_from_job(job)
+        return
+      end
+
+      if post_mfa_polling?
+        return if render_account_selection_if_accounts_available(@sophtron_item)
+      end
 
       render_pending_connection_status
     elsif Provider::Sophtron.job_failed?(job)
       failure_message = sophtron_connection_failure_message(job)
       @sophtron_item.update!(
         current_job_id: nil,
-        user_institution_id: nil,
+        current_job_sophtron_account_id: nil,
+        user_institution_id: (manual_sync_flow? ? @sophtron_item.user_institution_id : nil),
         last_connection_error: failure_message,
         status: :requires_update
       )
+      fail_manual_sync!(manual_sync_record, failure_message) if manual_sync_flow?
       render_institution_connection_error(failure_message)
     else
       render_pending_connection_status
@@ -415,11 +429,42 @@ class SophtronItemsController < ApplicationController
   end
 
   def sync
+    if manual_sync_flow?
+      start_manual_sync
+      return
+    end
+
     @sophtron_item.sync_later unless @sophtron_item.syncing?
 
     respond_to do |format|
       format.html { redirect_back_or_to accounts_path }
       format.json { head :ok }
+    end
+  end
+
+  def toggle_manual_sync
+    sophtron_account = selected_sophtron_account
+    unless sophtron_account
+      redirect_back_or_to accounts_path, alert: t(".missing_institution")
+      return
+    end
+
+    enabled = !@sophtron_item.manual_sync_for_institution?(sophtron_account)
+    @sophtron_item.set_manual_sync_for_institution!(sophtron_account, enabled)
+
+    respond_to do |format|
+      format.html { redirect_back_or_to accounts_path, notice: t(".success_#{enabled ? 'enabled' : 'disabled'}", institution: sophtron_account.institution_name) }
+      format.turbo_stream do
+        flash.now[:notice] = t(".success_#{enabled ? 'enabled' : 'disabled'}", institution: sophtron_account.institution_name)
+        render turbo_stream: [
+          turbo_stream.replace(
+            ActionView::RecordIdentifier.dom_id(@sophtron_item),
+            partial: "sophtron_items/sophtron_item",
+            locals: { sophtron_item: @sophtron_item }
+          ),
+          *flash_notification_stream_items
+        ]
+      end
     end
   end
 
@@ -579,6 +624,138 @@ class SophtronItemsController < ApplicationController
   end
 
   private
+
+    def start_manual_sync
+      sophtron_account = selected_sophtron_account || @sophtron_item.sophtron_accounts.manual_sync.joins(:account_provider).first
+
+      unless sophtron_account
+        redirect_back_or_to accounts_path, alert: t(".no_linked_accounts")
+        return
+      end
+
+      sync = @sophtron_item.syncs.visible.first || @sophtron_item.syncs.create!
+      sync.start! if sync.may_start?
+
+      provider = @sophtron_item.sophtron_provider
+      raise Provider::Sophtron::Error.new("Sophtron provider is not configured", :configuration_error) unless provider
+
+      refresh_response = sophtron_response_data!(provider.refresh_account(sophtron_account.account_id)).with_indifferent_access
+      job_id = refresh_response[:JobID] || refresh_response[:job_id]
+
+      if job_id.blank?
+        complete_manual_sync!(sophtron_account, provider, sync)
+        render :manual_sync_complete, layout: false
+        return
+      end
+
+      @sophtron_item.update!(
+        current_job_id: job_id,
+        current_job_sophtron_account_id: sophtron_account.id,
+        raw_job_payload: refresh_response,
+        job_status: nil,
+        last_connection_error: nil,
+        status: :good
+      )
+
+      job = sophtron_response_data!(provider.get_job_information(job_id))
+      @sophtron_item.upsert_job_snapshot!(job)
+
+      if Provider::Sophtron.job_requires_input?(job)
+        @challenge = @sophtron_item.build_mfa_challenge(job)
+        prepare_connection_status_context
+        render :mfa, layout: false
+      elsif Provider::Sophtron.job_failed?(job)
+        fail_manual_sync!(sync, t(".failed"))
+        redirect_back_or_to accounts_path, alert: t(".failed")
+      elsif Provider::Sophtron.job_success?(job) || Provider::Sophtron.job_completed?(job)
+        complete_manual_sync!(sophtron_account, provider, sync)
+        render :manual_sync_complete, layout: false
+      else
+        @poll_attempt = 1
+        render_pending_connection_status
+      end
+    rescue Provider::Sophtron::Error => e
+      fail_manual_sync!(sync, e.message) if defined?(sync) && sync.present?
+      Rails.logger.error("Sophtron manual sync error: #{e.message}")
+      redirect_back_or_to accounts_path, alert: t(".api_error", message: e.message)
+    end
+
+    def complete_manual_sync_from_job(job)
+      sophtron_account = @sophtron_item.current_job_sophtron_account || @sophtron_item.sophtron_accounts.joins(:account_provider).first
+      sync = manual_sync_record
+
+      unless sophtron_account && sync
+        @sophtron_item.update!(current_job_id: nil, current_job_sophtron_account_id: nil)
+        render_api_error(t("sophtron_items.sync.no_linked_accounts"), accounts_path)
+        return
+      end
+
+      complete_manual_sync!(sophtron_account, @sophtron_item.sophtron_provider, sync)
+      render :manual_sync_complete, layout: false
+    rescue Provider::Sophtron::Error => e
+      fail_manual_sync!(sync, e.message) if defined?(sync) && sync.present?
+      render_api_error(t("sophtron_items.sync.api_error", message: e.message), accounts_path)
+    end
+
+    def complete_manual_sync!(sophtron_account, provider, sync)
+      raise Provider::Sophtron::Error.new("Sophtron provider is not configured", :configuration_error) unless provider
+
+      synced_accounts = @sophtron_item.sophtron_accounts_for_institution(sophtron_account)
+                                     .manual_sync
+                                     .joins(:account)
+                                     .merge(Account.visible)
+      synced_accounts = SophtronAccount.where(id: sophtron_account.id) if synced_accounts.empty?
+
+      synced_accounts.each do |account_to_import|
+        result = SophtronItem::Importer.new(@sophtron_item, sophtron_provider: provider, sync: sync)
+                                      .import_transactions_after_refresh(account_to_import)
+
+        unless result[:success]
+          fail_manual_sync!(sync, result[:error])
+          @sophtron_item.update!(last_connection_error: result[:error], status: (result[:requires_update] ? :requires_update : @sophtron_item.status))
+          raise Provider::Sophtron::Error.new(result[:error] || t("sophtron_items.sync.failed"), :api_error)
+        end
+
+        SophtronAccount::Processor.new(account_to_import.reload).process
+
+        account_to_import.current_account&.sync_later(
+          parent_sync: sync,
+          window_start_date: sync.window_start_date,
+          window_end_date: sync.window_end_date
+        )
+      end
+
+      @sophtron_item.update!(
+        current_job_id: nil,
+        current_job_sophtron_account_id: nil,
+        last_connection_error: nil,
+        status: :good
+      )
+
+      sync.finalize_if_all_children_finalized if synced_accounts.none? { |account_to_import| account_to_import.current_account.present? }
+
+      @manual_sync_account = sophtron_account
+      @manual_sync = sync
+    end
+
+    def fail_manual_sync!(sync, message)
+      return unless sync
+
+      sync.start! if sync.may_start?
+      sync.fail! if sync.may_fail?
+      sync.update!(error: message)
+    end
+
+    def manual_sync_record
+      sync = @sophtron_item.syncs.find_by(id: params[:sync_id]) if params[:sync_id].present?
+      sync || @sophtron_item.syncs.visible.first
+    end
+
+    def selected_sophtron_account
+      return if params[:sophtron_account_id].blank?
+
+      @sophtron_item.sophtron_accounts.find_by(id: params[:sophtron_account_id])
+    end
 
     def configured_sophtron_item
       Current.family.configured_sophtron_item
@@ -746,6 +923,9 @@ class SophtronItemsController < ApplicationController
       @accountable_type = params[:accountable_type] || "Depository"
       @account_id = params[:account_id]
       @return_to = safe_return_to_path
+      @manual_sync_flow = manual_sync_flow?
+      @manual_sync_id = params[:sync_id] || @sophtron_item.syncs.visible.first&.id
+      @manual_sync_sophtron_account_id = params[:sophtron_account_id] || @sophtron_item.current_job_sophtron_account_id
       @poll_interval_ms = CONNECTION_STATUS_POLL_INTERVAL_MS
       @post_mfa_polling = post_mfa_polling?
       @max_poll_attempts = connection_status_max_polls
@@ -780,6 +960,10 @@ class SophtronItemsController < ApplicationController
 
     def post_mfa_polling?
       ActiveModel::Type::Boolean.new.cast(params[:post_mfa]) || post_mfa_job_payload?(@sophtron_item.raw_job_payload)
+    end
+
+    def manual_sync_flow?
+      ActiveModel::Type::Boolean.new.cast(params[:manual_sync]) || @sophtron_item.current_job_sophtron_account_id.present?
     end
 
     def post_mfa_job_payload?(job_payload)
@@ -888,7 +1072,7 @@ class SophtronItemsController < ApplicationController
     end
 
     def connection_context_params
-      params.permit(:accountable_type, :account_id, :return_to, :post_mfa, :connect_new_institution).to_h.compact
+      params.permit(:accountable_type, :account_id, :return_to, :post_mfa, :connect_new_institution, :manual_sync, :sync_id, :sophtron_account_id).to_h.compact
     end
 
     def connect_new_institution_flow?

--- a/app/models/sophtron_account.rb
+++ b/app/models/sophtron_account.rb
@@ -21,6 +21,9 @@ class SophtronAccount < ApplicationRecord
 
   belongs_to :sophtron_item
 
+  scope :manual_sync, -> { where(manual_sync: true) }
+  scope :automatic_sync, -> { where(manual_sync: false) }
+
   # Association to link this Sophtron account to a Maybe Account
   has_one :account_provider, as: :provider, dependent: :destroy
   has_one :account, through: :account_provider, source: :account
@@ -33,6 +36,19 @@ class SophtronAccount < ApplicationRecord
   # @return [Account, nil] The linked Maybe Account, or nil if not linked
   def current_account
     account
+  end
+
+
+  def institution_name
+    institution_metadata.to_h["name"].presence || institution_metadata.to_h["institution_name"].presence || sophtron_item&.institution_name
+  end
+
+  def institution_user_institution_id
+    institution_metadata.to_h["user_institution_id"].presence || institution_metadata.to_h["UserInstitutionID"].presence || sophtron_item&.user_institution_id
+  end
+
+  def same_institution_accounts
+    sophtron_item.sophtron_accounts_for_institution(self)
   end
 
   # Updates this SophtronAccount with fresh data from the Sophtron API.

--- a/app/models/sophtron_item.rb
+++ b/app/models/sophtron_item.rb
@@ -43,13 +43,18 @@ class SophtronItem < ApplicationRecord
   validates :access_key, presence: true, on: :create
 
   belongs_to :family
+  belongs_to :current_job_sophtron_account, class_name: "SophtronAccount", optional: true
   has_one_attached :logo
 
   has_many :sophtron_accounts, dependent: :destroy
   has_many :accounts, through: :sophtron_accounts
 
   scope :active, -> { where(scheduled_for_deletion: false) }
-  scope :syncable, -> { active }
+  scope :syncable, -> {
+    active.left_joins(sophtron_accounts: :account_provider)
+          .where("sophtron_accounts.id IS NULL OR sophtron_accounts.manual_sync = ? OR account_providers.id IS NULL", false)
+          .distinct
+  }
   scope :ordered, -> { order(created_at: :desc) }
   scope :needs_update, -> { where(status: :requires_update) }
 
@@ -83,12 +88,13 @@ class SophtronItem < ApplicationRecord
     raise
   end
 
-  def process_accounts
-    return [] if sophtron_accounts.empty?
+  def process_accounts(sophtron_accounts_scope: nil)
+    accounts_to_process = sophtron_accounts_scope || sophtron_accounts.automatic_sync.joins(:account).merge(Account.visible)
+    return [] if accounts_to_process.empty?
 
     results = []
     # Only process accounts that are linked and have active status
-    sophtron_accounts.joins(:account).merge(Account.visible).each do |sophtron_account|
+    accounts_to_process.each do |sophtron_account|
       begin
         result = SophtronAccount::Processor.new(sophtron_account).process
         results << { sophtron_account_id: sophtron_account.id, success: true, result: result }
@@ -102,12 +108,13 @@ class SophtronItem < ApplicationRecord
     results
   end
 
-  def schedule_account_syncs(parent_sync: nil, window_start_date: nil, window_end_date: nil)
-    return [] if accounts.empty?
+  def schedule_account_syncs(parent_sync: nil, window_start_date: nil, window_end_date: nil, accounts_scope: nil)
+    accounts_to_sync = accounts_scope || automatic_sync_accounts
+    return [] if accounts_to_sync.empty?
 
     results = []
     # Only schedule syncs for active accounts
-    accounts.visible.each do |account|
+    accounts_to_sync.each do |account|
       begin
         account.sync_later(
           parent_sync: parent_sync,
@@ -123,6 +130,29 @@ class SophtronItem < ApplicationRecord
     end
 
     results
+  end
+
+  def automatic_sync_accounts
+    manual_account_ids = sophtron_accounts.manual_sync.joins(:account_provider).select("account_providers.account_id")
+    accounts.visible.where.not(id: manual_account_ids)
+  end
+
+  def sophtron_accounts_for_institution(anchor_account)
+    user_institution_id = anchor_account.institution_user_institution_id
+    return sophtron_accounts.where("institution_metadata ->> 'user_institution_id' = ? OR institution_metadata ->> 'UserInstitutionID' = ?", user_institution_id, user_institution_id) if user_institution_id.present?
+
+    institution_name = anchor_account.institution_name
+    return sophtron_accounts.where("institution_metadata ->> 'name' = ? OR institution_metadata ->> 'institution_name' = ?", institution_name, institution_name) if institution_name.present?
+
+    sophtron_accounts.where(id: anchor_account.id)
+  end
+
+  def manual_sync_for_institution?(anchor_account)
+    sophtron_accounts_for_institution(anchor_account).where(manual_sync: true).exists?
+  end
+
+  def set_manual_sync_for_institution!(anchor_account, manual_sync)
+    sophtron_accounts_for_institution(anchor_account).update_all(manual_sync: manual_sync, updated_at: Time.current)
   end
 
   def start_initial_load_later

--- a/app/models/sophtron_item/importer.rb
+++ b/app/models/sophtron_item/importer.rb
@@ -139,7 +139,7 @@ class SophtronItem::Importer
     transactions_imported = 0
     transactions_failed = 0
 
-    linked_accounts = sophtron_item.sophtron_accounts.joins(:account).merge(Account.visible)
+    linked_accounts = sophtron_item.sophtron_accounts.automatic_sync.joins(:account).merge(Account.visible)
     linked_accounts.each do |sophtron_account|
       begin
         result = fetch_and_store_transactions(sophtron_account)

--- a/app/models/sophtron_item/syncer.rb
+++ b/app/models/sophtron_item/syncer.rb
@@ -44,7 +44,7 @@ class SophtronItem::Syncer
     collect_setup_stats(sync, provider_accounts: sophtron_item.sophtron_accounts)
 
     # Check for unlinked accounts
-    linked_accounts = sophtron_item.sophtron_accounts.joins(:account_provider)
+    linked_accounts = sophtron_item.sophtron_accounts.automatic_sync.joins(:account_provider)
     unlinked_accounts = sophtron_item.sophtron_accounts.left_joins(:account_provider).where(account_providers: { id: nil })
 
     # Set pending_account_setup if there are unlinked accounts
@@ -61,7 +61,7 @@ class SophtronItem::Syncer
       sync.update!(status_text: t("sophtron_items.syncer.processing_transactions")) if sync.respond_to?(:status_text)
       mark_import_started(sync)
       Rails.logger.info "SophtronItem::Syncer - Processing #{linked_accounts.count} linked accounts"
-      sophtron_item.process_accounts
+      sophtron_item.process_accounts(sophtron_accounts_scope: linked_accounts.joins(:account).merge(Account.visible))
       Rails.logger.info "SophtronItem::Syncer - Finished processing accounts"
 
       # Phase 4: Schedule balance calculations for linked accounts
@@ -69,7 +69,8 @@ class SophtronItem::Syncer
       sophtron_item.schedule_account_syncs(
         parent_sync: sync,
         window_start_date: sync.window_start_date,
-        window_end_date: sync.window_end_date
+        window_end_date: sync.window_end_date,
+        accounts_scope: sophtron_item.automatic_sync_accounts
       )
 
       # Phase 5: Collect transaction statistics

--- a/app/views/sophtron_items/_mfa_context_fields.html.erb
+++ b/app/views/sophtron_items/_mfa_context_fields.html.erb
@@ -1,0 +1,6 @@
+<%= hidden_field_tag :accountable_type, @accountable_type %>
+<%= hidden_field_tag :account_id, @account_id %>
+<%= hidden_field_tag :return_to, @return_to %>
+<%= hidden_field_tag :manual_sync, @manual_sync_flow if @manual_sync_flow %>
+<%= hidden_field_tag :sync_id, @manual_sync_id if @manual_sync_id.present? %>
+<%= hidden_field_tag :sophtron_account_id, @manual_sync_sophtron_account_id if @manual_sync_sophtron_account_id.present? %>

--- a/app/views/sophtron_items/_sophtron_item.html.erb
+++ b/app/views/sophtron_items/_sophtron_item.html.erb
@@ -57,10 +57,11 @@
 
       <div class="flex items-center gap-2">
         <% if Rails.env.development? %>
-          <%= icon(
-            "refresh-cw",
-            as_button: true,
-            href: sync_sophtron_item_path(sophtron_item)
+          <%= render DS::Button.new(
+            variant: :icon,
+            icon: "refresh-cw",
+            href: sync_sophtron_item_path(sophtron_item),
+            title: t(".sync_now")
           ) %>
         <% end %>
 
@@ -80,7 +81,48 @@
     <% unless sophtron_item.scheduled_for_deletion? %>
       <div class="space-y-4 mt-4">
         <% if sophtron_item.accounts.any? %>
-          <%= render "accounts/index/account_groups", accounts: sophtron_item.accounts %>
+          <% linked_sophtron_accounts = sophtron_item.sophtron_accounts.joins(:account).merge(Account.visible).includes(:account).to_a %>
+          <% linked_sophtron_accounts.group_by { |account| account.institution_user_institution_id.presence || account.institution_name.presence || account.id }.each_value do |institution_accounts| %>
+            <% institution_anchor = institution_accounts.first %>
+            <% institution_manual_sync = sophtron_item.manual_sync_for_institution?(institution_anchor) %>
+            <div class="space-y-2 rounded-xl border border-primary p-3">
+              <div class="flex items-center justify-between gap-2">
+                <div class="min-w-0">
+                  <div class="flex items-center gap-2">
+                    <p class="truncate text-sm font-medium text-primary"><%= institution_anchor.institution_name || t(".unknown_institution") %></p>
+                    <% if institution_manual_sync %>
+                      <span class="rounded-full bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning"><%= t(".manual_sync") %></span>
+                    <% end %>
+                  </div>
+                  <p class="text-xs text-secondary"><%= t(".institution_accounts", count: institution_accounts.count) %></p>
+                </div>
+
+                <div class="flex items-center gap-1">
+                  <% if institution_manual_sync || Rails.env.development? %>
+                    <%= render DS::Button.new(
+                      variant: :icon,
+                      icon: "refresh-cw",
+                      href: sync_sophtron_item_path(sophtron_item, manual_sync: institution_manual_sync, sophtron_account_id: institution_anchor.id),
+                      frame: (institution_manual_sync ? "modal" : nil),
+                      title: t(".sync_now")
+                    ) %>
+                  <% end %>
+
+                  <%= render DS::Menu.new(icon_vertical: true, mobile_fullwidth: false, max_width: "280px") do |menu| %>
+                    <% menu.with_item(
+                      variant: "button",
+                      text: t(institution_manual_sync ? ".automatic_sync" : ".manual_sync_action"),
+                      icon: institution_manual_sync ? "refresh-cw" : "pause-circle",
+                      href: toggle_manual_sync_sophtron_item_path(sophtron_item, sophtron_account_id: institution_anchor.id),
+                      method: :post
+                    ) %>
+                  <% end %>
+                </div>
+              </div>
+
+              <%= render "accounts/index/account_groups", accounts: institution_accounts.filter_map(&:current_account) %>
+            </div>
+          <% end %>
         <% end %>
 
         <%# Sync summary (collapsible) - using shared ProviderSyncSummary component %>

--- a/app/views/sophtron_items/connection_status.html.erb
+++ b/app/views/sophtron_items/connection_status.html.erb
@@ -4,7 +4,7 @@
      {
        controller: "polling",
        polling_frame_id_value: "modal",
-       polling_url_value: connection_status_sophtron_item_path(@sophtron_item, accountable_type: @accountable_type, account_id: @account_id, return_to: @return_to, poll_attempt: @next_poll_attempt, post_mfa: @post_mfa_polling),
+       polling_url_value: connection_status_sophtron_item_path(@sophtron_item, accountable_type: @accountable_type, account_id: @account_id, return_to: @return_to, poll_attempt: @next_poll_attempt, post_mfa: @post_mfa_polling, manual_sync: @manual_sync_flow, sync_id: @manual_sync_id, sophtron_account_id: @manual_sync_sophtron_account_id),
        polling_interval_value: @poll_interval_ms
      }
    end %>
@@ -39,7 +39,7 @@
           <div class="flex gap-2 justify-end">
             <%= render DS::Link.new(
                   text: t(".check_again"),
-                  href: connection_status_sophtron_item_path(@sophtron_item, accountable_type: @accountable_type, account_id: @account_id, return_to: @return_to, poll_attempt: check_again_attempt, post_mfa: @post_mfa_polling),
+                  href: connection_status_sophtron_item_path(@sophtron_item, accountable_type: @accountable_type, account_id: @account_id, return_to: @return_to, poll_attempt: check_again_attempt, post_mfa: @post_mfa_polling, manual_sync: @manual_sync_flow, sync_id: @manual_sync_id, sophtron_account_id: @manual_sync_sophtron_account_id),
                   variant: :primary,
                   data: { turbo_frame: "modal", turbo_prefetch: false }
                 ) %>

--- a/app/views/sophtron_items/manual_sync_complete.html.erb
+++ b/app/views/sophtron_items/manual_sync_complete.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag "modal" do %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t(".title")) %>
+
+    <% dialog.with_body do %>
+      <div class="space-y-4">
+        <div class="rounded-lg border border-primary bg-container-inset p-3">
+          <div class="flex items-start gap-3">
+            <%= icon "check-circle", size: "sm", color: "success", class: "mt-0.5" %>
+            <div class="space-y-1 text-sm">
+              <p class="font-medium text-primary"><%= t(".message") %></p>
+              <p class="text-xs text-secondary"><%= t(".description") %></p>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex justify-end">
+          <%= render DS::Link.new(text: t(".close"), href: accounts_path, variant: :primary, data: { turbo_frame: "_top" }) %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/sophtron_items/mfa.html.erb
+++ b/app/views/sophtron_items/mfa.html.erb
@@ -11,9 +11,7 @@
         <% if security_questions.any? %>
           <%= form_with url: submit_mfa_sophtron_item_path(@sophtron_item), method: :post, class: "space-y-3", data: { turbo_frame: "modal" } do %>
             <%= hidden_field_tag :mfa_type, "security_answer" %>
-            <%= hidden_field_tag :accountable_type, @accountable_type %>
-            <%= hidden_field_tag :account_id, @account_id %>
-            <%= hidden_field_tag :return_to, @return_to %>
+            <%= render "sophtron_items/mfa_context_fields" %>
 
             <% security_questions.each_with_index do |question, index| %>
               <% answer_field_id = "security_answer_#{index}" %>
@@ -35,9 +33,7 @@
               <%= form_with url: submit_mfa_sophtron_item_path(@sophtron_item), method: :post, data: { turbo_frame: "modal" } do %>
                 <%= hidden_field_tag :mfa_type, "token_choice" %>
                 <%= hidden_field_tag :token_choice, method %>
-                <%= hidden_field_tag :accountable_type, @accountable_type %>
-                <%= hidden_field_tag :account_id, @account_id %>
-                <%= hidden_field_tag :return_to, @return_to %>
+                <%= render "sophtron_items/mfa_context_fields" %>
                 <%= button_tag type: "submit", class: "w-full rounded-lg border border-primary bg-container-inset p-3 text-left text-sm text-primary transition-colors hover:bg-container-inset-hover" do %>
                   <span class="font-medium"><%= method %></span>
                 <% end %>
@@ -47,9 +43,7 @@
         <% elsif @challenge[:token_sent] %>
           <%= form_with url: submit_mfa_sophtron_item_path(@sophtron_item), method: :post, class: "space-y-3", data: { turbo_frame: "modal" } do %>
             <%= hidden_field_tag :mfa_type, "token_input" %>
-            <%= hidden_field_tag :accountable_type, @accountable_type %>
-            <%= hidden_field_tag :account_id, @account_id %>
-            <%= hidden_field_tag :return_to, @return_to %>
+            <%= render "sophtron_items/mfa_context_fields" %>
             <div class="form-field">
               <div class="form-field__body">
                 <%= label_tag :token_input, t(".token"), class: "form-field__label" %>
@@ -65,18 +59,14 @@
             <p class="rounded-lg border border-primary bg-container-inset p-3 text-sm text-primary"><%= @challenge[:token_read] %></p>
             <%= form_with url: submit_mfa_sophtron_item_path(@sophtron_item), method: :post, data: { turbo_frame: "modal" } do %>
               <%= hidden_field_tag :mfa_type, "verify_phone" %>
-              <%= hidden_field_tag :accountable_type, @accountable_type %>
-              <%= hidden_field_tag :account_id, @account_id %>
-              <%= hidden_field_tag :return_to, @return_to %>
+              <%= render "sophtron_items/mfa_context_fields" %>
               <%= render DS::Button.new(text: t(".phone_confirmed"), type: "submit") %>
             <% end %>
           </div>
         <% elsif safe_captcha_image.present? %>
           <%= form_with url: submit_mfa_sophtron_item_path(@sophtron_item), method: :post, class: "space-y-3", data: { turbo_frame: "modal" } do %>
             <%= hidden_field_tag :mfa_type, "captcha" %>
-            <%= hidden_field_tag :accountable_type, @accountable_type %>
-            <%= hidden_field_tag :account_id, @account_id %>
-            <%= hidden_field_tag :return_to, @return_to %>
+            <%= render "sophtron_items/mfa_context_fields" %>
             <div class="rounded-lg border border-primary bg-container-inset p-3">
               <%= image_tag "data:image/png;base64,#{safe_captcha_image}", alt: t(".captcha_alt"), class: "max-w-full rounded-md" %>
             </div>

--- a/config/locales/views/sophtron_items/en.yml
+++ b/config/locales/views/sophtron_items/en.yml
@@ -97,19 +97,27 @@ en:
       unknown_challenge: Unknown Sophtron verification step.
     sophtron_item:
       accounts_need_setup: Accounts need setup
+      automatic_sync: Use automatic sync
       delete: Delete connection
       deletion_in_progress: deletion in progress...
       error: Error
       no_accounts_description: This connection has no linked accounts yet.
       no_accounts_title: No accounts
+      manual_sync: Manual MFA
+      institution_accounts:
+        one: "1 linked account"
+        other: "%{count} linked accounts"
+      manual_sync_action: Require manual MFA
       setup_action: Set Up New Accounts
       setup_description: "%{linked} of %{total} accounts linked. Choose account types for your newly imported Sophtron accounts."
       setup_needed: New accounts ready to set up
       status: "Synced %{timestamp} ago"
       status_never: Never synced
       status_with_summary: "Last synced %{timestamp} ago • %{summary}"
+      sync_now: Sync now
       syncing: Syncing...
       total: Total
+      unknown_institution: Unknown institution
       unlinked: Unlinked
     preload_accounts:
       preload_accounts: preload accounts
@@ -203,7 +211,19 @@ en:
       no_accounts: "No accounts to set up."
       success: "Successfully created %{count} account(s)."
     sync:
+      api_error: "Sophtron manual sync failed: %{message}"
+      failed: Sophtron manual sync failed
+      no_linked_accounts: This Sophtron institution does not have any linked accounts to sync.
       success: Sync started
+    toggle_manual_sync:
+      missing_institution: Choose a Sophtron institution first.
+      success_disabled: "%{institution} will sync automatically."
+      success_enabled: "%{institution} now requires manual sync."
+    manual_sync_complete:
+      close: Close
+      description: Account balances will finish updating in the background.
+      message: Transactions were downloaded after Sophtron verification.
+      title: Sophtron Sync Started
     sophtron_setup_required:
       title: Sophtron Setup Required
       message: >

--- a/config/locales/views/sophtron_items/hu.yml
+++ b/config/locales/views/sophtron_items/hu.yml
@@ -61,19 +61,27 @@ hu:
       no_user_id: A Sophtron felhasználói azonosító nincs beállítva. Kérlek állítsd be a Beállításokban.
     sophtron_item:
       accounts_need_setup: Számlák beállítást igényelnek
+      automatic_sync: Automatikus szinkronizálás használata
       delete: Kapcsolat törlése
       deletion_in_progress: törlés folyamatban...
       error: Hiba
       no_accounts_description: Ehhez a kapcsolathoz még nincsenek összekapcsolt számlák.
       no_accounts_title: Nincsenek számlák
+      manual_sync: Kézi MFA
+      institution_accounts:
+        one: "1 összekapcsolt számla"
+        other: "%{count} összekapcsolt számla"
+      manual_sync_action: Kézi MFA megkövetelése
       setup_action: Új számlák beállítása
       setup_description: "%{linked} / %{total} számla összekapcsolva. Válaszd ki az újonnan importált Sophtron számlák típusait."
       setup_needed: Új számlák beállításra várnak
       status: "Szinkronizálva %{timestamp} ezelőtt"
       status_never: Még nem szinkronizált
       status_with_summary: "Utolsó szinkronizálás %{timestamp} ezelőtt • %{summary}"
+      sync_now: Szinkronizálás most
       syncing: Szinkronizálás...
       total: Összesen
+      unknown_institution: Ismeretlen intézmény
       unlinked: Nincs összekapcsolva
     preload_accounts:
       preload_accounts: számlák előzetes betöltése
@@ -163,7 +171,19 @@ hu:
       no_accounts: "Nincs beállítandó számla."
       success: "%{count} számla sikeresen létrehozva."
     sync:
+      api_error: "A Sophtron kézi szinkronizálása sikertelen: %{message}"
+      failed: A Sophtron kézi szinkronizálása sikertelen
+      no_linked_accounts: Ehhez a Sophtron intézményhez nincs szinkronizálható összekapcsolt számla.
       success: Szinkronizálás elindítva
+    toggle_manual_sync:
+      missing_institution: Előbb válassz Sophtron intézményt.
+      success_disabled: "%{institution} automatikusan fog szinkronizálni."
+      success_enabled: "%{institution} mostantól kézi szinkronizálást igényel."
+    manual_sync_complete:
+      close: Bezárás
+      description: A számlaegyenlegek frissítése a háttérben fejeződik be.
+      message: A tranzakciók letöltése elindult a Sophtron ellenőrzés után.
+      title: Sophtron szinkronizálás elindítva
     sophtron_setup_required:
       title: Sophtron beállítás szükséges
       message: >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -546,6 +546,7 @@ Rails.application.routes.draw do
     member do
       post :connect_institution
       post :sync
+      post :toggle_manual_sync
       post :balances
       get :connection_status
       post :submit_mfa

--- a/db/migrate/20260508120000_add_manual_sync_to_sophtron_items.rb
+++ b/db/migrate/20260508120000_add_manual_sync_to_sophtron_items.rb
@@ -1,0 +1,7 @@
+class AddManualSyncToSophtronItems < ActiveRecord::Migration[7.2]
+  def change
+    add_column :sophtron_accounts, :manual_sync, :boolean, null: false, default: false
+    add_column :sophtron_items, :current_job_sophtron_account_id, :uuid
+    add_index :sophtron_items, :current_job_sophtron_account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_07_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_08_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1403,6 +1403,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_120000) do
     t.string "customer_id"
     t.string "member_id"
     t.string "account_number_mask"
+    t.boolean "manual_sync", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_sophtron_accounts_on_account_id"
@@ -1437,6 +1438,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_120000) do
     t.text "last_connection_error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "current_job_sophtron_account_id"
+    t.index ["current_job_sophtron_account_id"], name: "index_sophtron_items_on_current_job_sophtron_account_id"
     t.index ["customer_id"], name: "index_sophtron_items_on_customer_id"
     t.index ["family_id"], name: "index_sophtron_items_on_family_id"
     t.index ["status"], name: "index_sophtron_items_on_status"

--- a/test/controllers/sophtron_items_controller_test.rb
+++ b/test/controllers/sophtron_items_controller_test.rb
@@ -569,6 +569,103 @@ class SophtronItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to connection_status_sophtron_item_path(@item, post_mfa: true)
   end
 
+  test "toggle_manual_sync enables manual mode for one Sophtron institution" do
+    sophtron_account = @item.sophtron_accounts.create!(
+      account_id: "acct-1",
+      name: "Sophtron Checking",
+      currency: "USD",
+      balance: 100,
+      institution_metadata: { name: "Example Bank", user_institution_id: "ui-1" }
+    )
+    sibling_account = @item.sophtron_accounts.create!(
+      account_id: "acct-2",
+      name: "Sophtron Savings",
+      currency: "USD",
+      balance: 200,
+      institution_metadata: { name: "Example Bank", user_institution_id: "ui-1" }
+    )
+    other_institution_account = @item.sophtron_accounts.create!(
+      account_id: "acct-3",
+      name: "Other Card",
+      currency: "USD",
+      balance: 300,
+      institution_metadata: { name: "Other Bank", user_institution_id: "ui-2" }
+    )
+
+    post toggle_manual_sync_sophtron_item_url(@item, sophtron_account_id: sophtron_account.id)
+
+    assert_redirected_to accounts_path
+    assert sophtron_account.reload.manual_sync?
+    assert sibling_account.reload.manual_sync?
+    assert_not other_institution_account.reload.manual_sync?
+    assert_equal "Example Bank now requires manual sync.", flash[:notice]
+  end
+
+  test "manual sync starts Sophtron refresh and renders MFA challenge" do
+    @item.update!(user_institution_id: "ui-1")
+    sophtron_account = @item.sophtron_accounts.create!(
+      account_id: "acct-1",
+      name: "Sophtron Checking",
+      currency: "USD",
+      balance: 100,
+      manual_sync: true,
+      institution_metadata: { name: "Example Bank", user_institution_id: "ui-1" }
+    )
+    AccountProvider.create!(account: accounts(:depository), provider: sophtron_account)
+
+    provider = mock
+    provider.expects(:refresh_account).with("acct-1").returns({ JobID: "job-1" })
+    provider.expects(:get_job_information).with("job-1").returns({
+      SecurityQuestion: [ "What is your favorite color?" ].to_json,
+      SuccessFlag: nil,
+      LastStatus: "Waiting"
+    })
+    SophtronItem.any_instance.stubs(:sophtron_provider).returns(provider)
+
+    assert_no_enqueued_jobs only: SyncJob do
+      assert_difference -> { @item.syncs.count }, 1 do
+        post sync_sophtron_item_url(@item, manual_sync: true, sophtron_account_id: sophtron_account.id)
+      end
+    end
+
+    assert_response :success
+    assert_includes response.body, "What is your favorite color?"
+    assert_equal "job-1", @item.reload.current_job_id
+    assert_equal sophtron_account.id, @item.current_job_sophtron_account_id
+    assert @item.syncs.ordered.first.syncing?
+  end
+
+  test "submit_mfa preserves manual sync context" do
+    @item.update!(user_institution_id: "ui-1", current_job_id: "job-1")
+    sync = @item.syncs.create!
+    sophtron_account = @item.sophtron_accounts.create!(
+      account_id: "acct-1",
+      name: "Sophtron Checking",
+      currency: "USD",
+      balance: 100
+    )
+    provider = mock
+    provider.expects(:update_job_token_input).with("job-1", token_input: "123456").returns({})
+    SophtronItem.any_instance.stubs(:sophtron_provider).returns(provider)
+
+    post submit_mfa_sophtron_item_url(@item), params: {
+      mfa_type: "token_input",
+      token_input: "123456",
+      manual_sync: true,
+      sync_id: sync.id,
+      sophtron_account_id: sophtron_account.id
+    }
+
+    assert_redirected_to connection_status_sophtron_item_path(
+      @item,
+      manual_sync: "true",
+      post_mfa: true,
+      sophtron_account_id: sophtron_account.id,
+      sync_id: sync.id
+    )
+  end
+
+
   test "link_existing_account links manual account to sophtron account" do
     @item.update!(user_institution_id: "ui-1")
     account = accounts(:depository)

--- a/test/models/sophtron_item_test.rb
+++ b/test/models/sophtron_item_test.rb
@@ -162,4 +162,51 @@ class SophtronItemTest < ActiveSupport::TestCase
       end
     end
   end
+  test "manual Sophtron institution settings are account scoped" do
+    first_account = @item.sophtron_accounts.create!(
+      account_id: "acct-1",
+      name: "Sophtron Checking",
+      currency: "USD",
+      balance: 100,
+      institution_metadata: { name: "Example Bank", user_institution_id: "ui-1" }
+    )
+    sibling_account = @item.sophtron_accounts.create!(
+      account_id: "acct-2",
+      name: "Sophtron Savings",
+      currency: "USD",
+      balance: 200,
+      institution_metadata: { name: "Example Bank", user_institution_id: "ui-1" }
+    )
+    other_account = @item.sophtron_accounts.create!(
+      account_id: "acct-3",
+      name: "Other Card",
+      currency: "USD",
+      balance: 300,
+      institution_metadata: { name: "Other Bank", user_institution_id: "ui-2" }
+    )
+
+    @item.set_manual_sync_for_institution!(first_account, true)
+
+    assert first_account.reload.manual_sync?
+    assert sibling_account.reload.manual_sync?
+    assert_not other_account.reload.manual_sync?
+    assert_includes SophtronItem.syncable, @item
+
+    all_manual_item = @family.sophtron_items.create!(
+      name: "All Manual Sophtron",
+      user_id: "manual-user",
+      access_key: Base64.strict_encode64("secret-key")
+    )
+    all_manual_account = all_manual_item.sophtron_accounts.create!(
+      account_id: "manual-acct-1",
+      name: "Manual Checking",
+      currency: "USD",
+      balance: 100,
+      manual_sync: true,
+      institution_metadata: { name: "Manual Bank", user_institution_id: "manual-ui-1" }
+    )
+    AccountProvider.create!(account: accounts(:credit_card), provider: all_manual_account)
+
+    assert_not_includes SophtronItem.syncable, all_manual_item
+  end
 end


### PR DESCRIPTION
### Motivation
- Provide a way to require and run manual (MFA-driven) syncs for individual Sophtron institutions/accounts rather than always performing automatic refreshes. 
- Preserve MFA connection context across polling and challenge flows so manual sync interactions behave consistently with existing connection flows.

### Description
- Added per-account manual sync support by adding `manual_sync` to `sophtron_accounts` and a `current_job_sophtron_account_id` association on `sophtron_items`, plus a migration and schema update. 
- Implemented controller-level manual sync flow: `toggle_manual_sync` to enable/disable manual mode per institution, `sync` now delegates to `start_manual_sync` when `manual_sync` is requested, `connection_status` and `submit_mfa` preserve manual sync context and call `complete_manual_sync_from_job` when appropriate, and helper methods to manage manual sync lifecycle (`start_manual_sync`, `complete_manual_sync!`, `fail_manual_sync!`, `manual_sync_record`, `selected_sophtron_account`).
- Models updated to support scoping and processing rules: `SophtronAccount` gains `manual_sync`/`automatic_sync` scopes and helpers for institution identification, `SophtronItem` gains `current_job_sophtron_account` association, `syncable` scope updated to exclude items that only contain manual-only linked accounts, processing/scheduling methods accept scopes (`process_accounts`, `schedule_account_syncs`), and new helpers `automatic_sync_accounts`, `sophtron_accounts_for_institution`, `manual_sync_for_institution?`, and `set_manual_sync_for_institution!`.
- Importer and Syncer updated to only fetch/process transactions and schedule syncs for automatic-sync linked accounts by default, while manual-sync accounts are imported/processed only during an explicit manual refresh.
- Views and locales added/updated to surface manual sync controls and preserve manual sync context in MFA and connection polling UI (`_mfa_context_fields`, `manual_sync_complete`, changes to `_sophtron_item`, `mfa.html.erb`, `connection_status.html.erb`), plus a new button/menu item and Turbo responses for toggling state.
- Routing: added `toggle_manual_sync` member route for `sophtron_items`.

### Testing
- Added and updated controller tests in `test/controllers/sophtron_items_controller_test.rb` covering `toggle_manual_sync`, starting a manual sync that triggers an MFA challenge, and preserving manual sync context through `submit_mfa`, and all tests passed. 
- Added and updated model tests in `test/models/sophtron_item_test.rb` validating account-scoped manual settings, `syncable` behavior, and initial-load behavior, and these tests passed. 
- Ran the modified test files (`sophtron_items_controller_test` and `sophtron_item_test`) as part of the suite and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcd8ebed08332a5d80037aa4d492c)