### PR TITLE
Add period navigation arrows to Reports view

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -128,6 +128,9 @@ class ReportsController < ApplicationController
 
       # Flags for view rendering
       @has_accounts = accessible_accounts.any?
+
+      # Build navigation links for period switching
+      @nav = build_period_navigation
     end
 
     def preferences_params
@@ -1069,5 +1072,46 @@ class ReportsController < ApplicationController
       end
 
       true
+    end
+
+    def build_period_navigation
+      case @period_type
+      when :monthly
+        prev_start = @start_date.beginning_of_month - 1.month
+        prev_end   = prev_start.end_of_month
+        next_start = @start_date.beginning_of_month + 1.month
+        next_end   = next_start.end_of_month
+        at_latest  = @start_date.beginning_of_month >= Date.current.beginning_of_month
+      when :quarterly
+        prev_start = (@start_date.beginning_of_quarter - 1.day).beginning_of_quarter
+        prev_end   = prev_start.end_of_quarter
+        next_start = @end_date.end_of_quarter + 1.day
+        next_end   = next_start.end_of_quarter
+        at_latest  = @start_date.beginning_of_quarter >= Date.current.beginning_of_quarter
+      when :ytd
+        prev_year  = @start_date.year - 1
+        prev_start = Date.new(prev_year, 1, 1)
+        prev_end   = Date.new(prev_year, 12, 31)
+        next_year  = @start_date.year + 1
+        next_start = Date.new(next_year, 1, 1)
+        next_end   = next_year == Date.current.year ? Date.current : Date.new(next_year, 12, 31)
+        at_latest  = @start_date.year >= Date.current.year
+      when :last_6_months
+        prev_start = @start_date.beginning_of_month - 6.months
+        prev_end   = prev_start + 6.months - 1.day
+        candidate_start = @start_date.beginning_of_month + 6.months
+        if candidate_start + 6.months >= Date.current.beginning_of_month
+          next_end   = Date.current.end_of_month
+          next_start = (next_end + 1.day - 6.months).beginning_of_month
+        else
+          next_start = candidate_start
+          next_end   = next_start + 6.months - 1.day
+        end
+        at_latest  = @end_date >= Date.current.end_of_month
+      else
+        return nil
+      end
+
+      { prev_start: prev_start, prev_end: prev_end, next_start: next_start, next_end: next_end, at_latest: at_latest }
     end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -88,6 +88,15 @@ class ReportsController < ApplicationController
     # It will render *inside* the modal frame.
   end
 
+  def picker
+    @period_type = params[:period_type]&.to_sym || :monthly
+    @start_date = parse_date_param(:start_date) || Date.current.beginning_of_month
+    render partial: "reports/period_picker", locals: {
+      period_type: @period_type,
+      start_date: @start_date
+    }
+  end
+
   private
     def setup_report_data(show_flash: false)
       @period_type = params[:period_type]&.to_sym || :monthly
@@ -1112,6 +1121,19 @@ class ReportsController < ApplicationController
         return nil
       end
 
-      { prev_start: prev_start, prev_end: prev_end, next_start: next_start, next_end: next_end, at_latest: at_latest }
+      { prev_start: prev_start, prev_end: prev_end, next_start: next_start, next_end: next_end, at_latest: at_latest, label: period_label }
+    end
+
+    def period_label
+      case @period_type
+      when :monthly
+        @start_date.strftime("%B %Y")
+      when :quarterly
+        "Q#{(@start_date.month / 3.0).ceil} #{@start_date.year}"
+      when :ytd
+        @start_date.year == Date.current.year ? "YTD #{@start_date.year}" : @start_date.year.to_s
+      when :last_6_months
+        "#{@start_date.strftime("%b %Y")} – #{@end_date.strftime("%b %Y")}"
+      end
     end
 end

--- a/app/views/reports/_period_picker.html.erb
+++ b/app/views/reports/_period_picker.html.erb
@@ -1,0 +1,138 @@
+<%# locals: (period_type:, start_date:) %>
+
+<%= turbo_frame_tag "reports_picker" do %>
+  <div class="p-3 space-y-2">
+    <% case period_type %>
+    <% when :monthly %>
+      <div class="flex items-center gap-2 justify-between mb-2">
+        <%= link_to picker_reports_path(period_type: :monthly, start_date: start_date.beginning_of_year - 1.year),
+              data: { turbo_frame: "reports_picker" },
+              class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+          <%= icon "chevron-left" %>
+        <% end %>
+
+        <span class="w-40 text-center px-3 py-2 border border-tertiary rounded-md">
+          <%= start_date.year %>
+        </span>
+
+        <% next_year_start = Date.new(start_date.year + 1, 1, 1) %>
+        <% if next_year_start <= Date.current %>
+          <%= link_to picker_reports_path(period_type: :monthly, start_date: next_year_start),
+                data: { turbo_frame: "reports_picker" },
+                class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+            <%= icon "chevron-right" %>
+          <% end %>
+        <% else %>
+          <span class="p-2 flex items-center justify-center text-subdued rounded-md">
+            <%= icon "chevron-right", color: "current" %>
+          </span>
+        <% end %>
+      </div>
+
+      <div class="grid grid-cols-3 gap-2 text-sm text-center font-medium">
+        <% Date::ABBR_MONTHNAMES.compact.each_with_index do |month_name, i| %>
+          <% month = i + 1 %>
+          <% date = Date.new(start_date.year, month, 1) %>
+          <% if date <= Date.current %>
+            <%= render DS::Link.new(
+              variant: date.month == start_date.month ? "secondary" : "ghost",
+              text: month_name,
+              href: reports_path(period_type: :monthly, start_date: date, end_date: date.end_of_month),
+              full_width: true,
+              frame: :_top
+            ) %>
+          <% else %>
+            <span class="px-3 py-2 text-subdued rounded-md"><%= month_name %></span>
+          <% end %>
+        <% end %>
+      </div>
+
+    <% when :quarterly %>
+      <div class="flex items-center gap-2 justify-between mb-2">
+        <%= link_to picker_reports_path(period_type: :quarterly, start_date: Date.new(start_date.year - 1, 1, 1)),
+              data: { turbo_frame: "reports_picker" },
+              class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+          <%= icon "chevron-left" %>
+        <% end %>
+
+        <span class="w-40 text-center px-3 py-2 border border-tertiary rounded-md">
+          <%= start_date.year %>
+        </span>
+
+        <% next_year_start = Date.new(start_date.year + 1, 1, 1) %>
+        <% if next_year_start <= Date.current %>
+          <%= link_to picker_reports_path(period_type: :quarterly, start_date: next_year_start),
+                data: { turbo_frame: "reports_picker" },
+                class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+            <%= icon "chevron-right" %>
+          <% end %>
+        <% else %>
+          <span class="p-2 flex items-center justify-center text-subdued rounded-md">
+            <%= icon "chevron-right", color: "current" %>
+          </span>
+        <% end %>
+      </div>
+
+      <div class="grid grid-cols-2 gap-2 text-sm text-center font-medium">
+        <% (1..4).each do |q| %>
+          <% quarter_start = Date.new(start_date.year, (q - 1) * 3 + 1, 1) %>
+          <% quarter_end = quarter_start.end_of_quarter %>
+          <% if quarter_start <= Date.current %>
+            <%= render DS::Link.new(
+              variant: quarter_start.quarter == start_date.quarter && start_date.year == quarter_start.year ? "secondary" : "ghost",
+              text: "Q#{q} #{start_date.year}",
+              href: reports_path(period_type: :quarterly, start_date: quarter_start, end_date: quarter_end),
+              full_width: true,
+              frame: :_top
+            ) %>
+          <% else %>
+            <span class="px-3 py-2 text-subdued rounded-md">Q<%= q %> <%= start_date.year %></span>
+          <% end %>
+        <% end %>
+      </div>
+
+    <% when :ytd %>
+      <% decade_start = (start_date.year / 10) * 10 %>
+      <% decade_end = decade_start + 9 %>
+
+      <div class="flex items-center gap-2 justify-between mb-2">
+        <%= link_to picker_reports_path(period_type: :ytd, start_date: Date.new(decade_start - 1, 1, 1)),
+              data: { turbo_frame: "reports_picker" },
+              class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+          <%= icon "chevron-left" %>
+        <% end %>
+
+        <span class="w-40 text-center px-3 py-2 border border-tertiary rounded-md">
+          <%= decade_start %>–<%= decade_end %>
+        </span>
+
+        <% if decade_start + 10 <= Date.current.year %>
+          <%= link_to picker_reports_path(period_type: :ytd, start_date: Date.new(decade_start + 10, 1, 1)),
+                data: { turbo_frame: "reports_picker" },
+                class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+            <%= icon "chevron-right" %>
+          <% end %>
+        <% else %>
+          <span class="p-2 flex items-center justify-center text-subdued rounded-md">
+            <%= icon "chevron-right", color: "current" %>
+          </span>
+        <% end %>
+      </div>
+
+      <div class="grid grid-cols-2 gap-2 text-sm text-center font-medium">
+        <% (decade_start..decade_end).each do |year| %>
+          <% next if year > Date.current.year %>
+          <% year_start = Date.new(year, 1, 1) %>
+          <% year_end = year == Date.current.year ? Date.current : Date.new(year, 12, 31) %>
+          <%= render DS::Link.new(
+            variant: year == start_date.year ? "secondary" : "ghost",
+            text: year == Date.current.year ? "YTD #{year}" : year.to_s,
+            href: reports_path(period_type: :ytd, start_date: year_start, end_date: year_end),
+            full_width: true,
+            frame: :_top
+          ) %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -141,10 +141,16 @@
           </span>
 
           <% if [:monthly, :quarterly, :ytd, :last_6_months].include?(@period_type) %>
-            <%= link_to reports_path(period_type: @period_type, start_date: next_start, end_date: next_end),
-                  aria: { label: "Next period" },
-                  class: "#{ at_latest ? 'text-disabled pointer-events-none' : 'text-secondary hover:text-primary transition-colors' }" do %>
-              <%= icon("chevron-right", size: "sm") %>
+            <% if at_latest %>
+              <span class="text-disabled" aria-disabled="true">
+                <%= icon("chevron-right", size: "sm") %>
+              </span>
+            <% else %>
+              <%= link_to reports_path(period_type: @period_type, start_date: next_start, end_date: next_end),
+                    aria: { label: "Next period" },
+                    class: "text-secondary hover:text-primary transition-colors" do %>
+                <%= icon("chevron-right", size: "sm") %>
+              <% end %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -92,10 +92,26 @@
     <%# Period Display %>
       <% unless @period_type == :custom %>
         <div class="flex items-center gap-3 text-sm text-subdued">
-          <%= link_to reports_path(period_type: @period_type, start_date: @nav[:prev_start], end_date: @nav[:prev_end]),
-                aria: { label: t("reports.index.previous_period") },
-                class: "text-secondary hover:text-primary transition-colors" do %>
-            <%= icon("chevron-left", size: "sm") %>
+          <% if @nav %>
+            <div class="flex items-center gap-2">
+              <%= render DS::Link.new(
+                variant: "icon",
+                icon: "chevron-left",
+                href: reports_path(period_type: @period_type, start_date: @nav[:prev_start], end_date: @nav[:prev_end]),
+              ) %>
+
+              <% if @nav[:at_latest] %>
+                <span class="text-subdued" aria-label="<%= t('reports.index.next_period') %>" aria-disabled="true">
+                  <%= icon("chevron-right", color: "current") %>
+                </span>
+              <% else %>
+                <%= render DS::Link.new(
+                  variant: "icon",
+                  icon: "chevron-right",
+                  href: reports_path(period_type: @period_type, start_date: @nav[:next_start], end_date: @nav[:next_end]),
+                ) %>
+              <% end %>
+            </div>
           <% end %>
 
           <span>
@@ -103,18 +119,6 @@
                   start: @start_date.strftime("%b %-d, %Y"),
                   end: @end_date.strftime("%b %-d, %Y")) %>
           </span>
-
-          <% if @nav[:at_latest] %>
-            <span class="text-disabled" aria-disabled="true" aria-label="<%= t('reports.index.next_period') %>">
-              <%= icon("chevron-right", size: "sm") %>
-            </span>
-          <% else %>
-            <%= link_to reports_path(period_type: @period_type, start_date: @nav[:next_start], end_date: @nav[:next_end]),
-                  aria: { label: t("reports.index.next_period") },
-                  class: "text-secondary hover:text-primary transition-colors" do %>
-              <%= icon("chevron-right", size: "sm") %>
-            <% end %>
-          <% end %>
         </div>
       <% end %>
   </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -90,11 +90,65 @@
     <% end %>
 
     <%# Period Display %>
-    <div class="text-sm text-subdued">
-      <%= t("reports.index.showing_period",
-            start: @start_date.strftime("%b %-d, %Y"),
-            end: @end_date.strftime("%b %-d, %Y")) %>
-    </div>
+      <% unless @period_type == :custom %>
+        <div class="flex items-center gap-3 text-sm text-subdued">
+          <%# Calculate prev/next ranges based on period type %>
+          <% case @period_type
+            when :monthly
+              prev_start = @start_date.beginning_of_month - 1.month
+              prev_end   = prev_start.end_of_month
+              next_start = @start_date.beginning_of_month + 1.month
+              next_end   = next_start.end_of_month
+              at_latest  = @start_date.beginning_of_month >= Date.current.beginning_of_month
+            when :quarterly
+              prev_start = (@start_date.beginning_of_quarter - 1.day).beginning_of_quarter
+              prev_end   = prev_start.end_of_quarter
+              next_start = @end_date.end_of_quarter + 1.day
+              next_end   = next_start.end_of_quarter
+              at_latest  = @start_date.beginning_of_quarter >= Date.current.beginning_of_quarter
+            when :ytd
+              prev_year  = @start_date.year - 1
+              prev_start = Date.new(prev_year, 1, 1)
+              prev_end   = Date.new(prev_year, 12, 31)
+              next_year  = @start_date.year + 1
+              next_start = Date.new(next_year, 1, 1)
+              next_end   = next_year == Date.current.year ? Date.current : Date.new(next_year, 12, 31)
+              at_latest  = @start_date.year >= Date.current.year
+            when :last_6_months
+              prev_start = @start_date.beginning_of_month - 6.months
+              prev_end   = prev_start + 6.months - 1.day
+              next_start = @start_date.beginning_of_month + 6.months
+              next_end   = if next_start + 6.months >= Date.current.beginning_of_month
+                              Date.current.end_of_month
+                            else
+                              next_start + 6.months - 1.day
+                            end
+              at_latest  = @end_date >= Date.current.end_of_month
+            end %>
+
+          <% if [:monthly, :quarterly, :ytd, :last_6_months].include?(@period_type) %>
+            <%= link_to reports_path(period_type: @period_type, start_date: prev_start, end_date: prev_end),
+                  aria: { label: "Previous period" },
+                  class: "text-secondary hover:text-primary transition-colors" do %>
+              <%= icon("chevron-left", size: "sm") %>
+            <% end %>
+          <% end %>
+
+          <span>
+            <%= t("reports.index.showing_period",
+                  start: @start_date.strftime("%b %-d, %Y"),
+                  end: @end_date.strftime("%b %-d, %Y")) %>
+          </span>
+
+          <% if [:monthly, :quarterly, :ytd, :last_6_months].include?(@period_type) %>
+            <%= link_to reports_path(period_type: @period_type, start_date: next_start, end_date: next_end),
+                  aria: { label: "Next period" },
+                  class: "#{ at_latest ? 'text-disabled pointer-events-none' : 'text-secondary hover:text-primary transition-colors' }" do %>
+              <%= icon("chevron-right", size: "sm") %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
   </div>
 <% end %>
 

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -117,18 +117,20 @@
             when :last_6_months
               prev_start = @start_date.beginning_of_month - 6.months
               prev_end   = prev_start + 6.months - 1.day
-              next_start = @start_date.beginning_of_month + 6.months
-              next_end   = if next_start + 6.months >= Date.current.beginning_of_month
-                              Date.current.end_of_month
-                            else
-                              next_start + 6.months - 1.day
-                            end
+              raw_next_end = @start_date.beginning_of_month + 12.months - 1.day
+              if raw_next_end >= Date.current.end_of_month
+                next_end   = Date.current.end_of_month
+                next_start = next_end - 6.months + 1.day
+              else
+                next_start = @start_date.beginning_of_month + 6.months
+                next_end   = raw_next_end
+              end
               at_latest  = @end_date >= Date.current.end_of_month
             end %>
 
           <% if [:monthly, :quarterly, :ytd, :last_6_months].include?(@period_type) %>
             <%= link_to reports_path(period_type: @period_type, start_date: prev_start, end_date: prev_end),
-                  aria: { label: "Previous period" },
+                  aria: { label: t("reports.index.previous_period") },
                   class: "text-secondary hover:text-primary transition-colors" do %>
               <%= icon("chevron-left", size: "sm") %>
             <% end %>
@@ -147,7 +149,7 @@
               </span>
             <% else %>
               <%= link_to reports_path(period_type: @period_type, start_date: next_start, end_date: next_end),
-                    aria: { label: "Next period" },
+                    aria: { label: t("reports.index.next_period") },
                     class: "text-secondary hover:text-primary transition-colors" do %>
                 <%= icon("chevron-right", size: "sm") %>
               <% end %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -105,7 +105,7 @@
           </span>
 
           <% if @nav[:at_latest] %>
-            <span class="text-disabled" aria-disabled="true">
+            <span class="text-disabled" aria-disabled="true" aria-label="<%= t('reports.index.next_period') %>">
               <%= icon("chevron-right", size: "sm") %>
             </span>
           <% else %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -90,37 +90,52 @@
     <% end %>
 
     <%# Period Display %>
-      <% unless @period_type == :custom %>
-        <div class="flex items-center gap-3 text-sm text-subdued">
-          <% if @nav %>
-            <div class="flex items-center gap-2">
-              <%= render DS::Link.new(
-                variant: "icon",
-                icon: "chevron-left",
-                href: reports_path(period_type: @period_type, start_date: @nav[:prev_start], end_date: @nav[:prev_end]),
-              ) %>
+    <% if @nav %>
+      <div class="flex items-center gap-1 mb-4">
+        <div class="flex items-center gap-2">
+          <%= render DS::Link.new(
+            variant: "icon",
+            icon: "chevron-left",
+            href: reports_path(period_type: @period_type, start_date: @nav[:prev_start], end_date: @nav[:prev_end]),
+          ) %>
 
-              <% if @nav[:at_latest] %>
-                <span class="text-subdued" aria-label="<%= t('reports.index.next_period') %>" aria-disabled="true">
-                  <%= icon("chevron-right", color: "current") %>
-                </span>
-              <% else %>
-                <%= render DS::Link.new(
-                  variant: "icon",
-                  icon: "chevron-right",
-                  href: reports_path(period_type: @period_type, start_date: @nav[:next_start], end_date: @nav[:next_end]),
-                ) %>
-              <% end %>
-            </div>
+          <% if @nav[:at_latest] %>
+            <span class="text-subdued" aria-label="<%= t('reports.index.next_period') %>" aria-disabled="true">
+              <%= icon("chevron-right", color: "current") %>
+            </span>
+          <% else %>
+            <%= render DS::Link.new(
+              variant: "icon",
+              icon: "chevron-right",
+              href: reports_path(period_type: @period_type, start_date: @nav[:next_start], end_date: @nav[:next_end]),
+            ) %>
           <% end %>
-
-          <span>
-            <%= t("reports.index.showing_period",
-                  start: @start_date.strftime("%b %-d, %Y"),
-                  end: @end_date.strftime("%b %-d, %Y")) %>
-          </span>
         </div>
-      <% end %>
+
+        <% if [:monthly, :quarterly, :ytd].include?(@period_type) %>
+          <%= render DS::Menu.new(variant: "button") do |menu| %>
+            <% menu.with_button class: "flex items-center gap-1 hover:bg-alpha-black-25 cursor-pointer rounded-md p-2" do %>
+              <span class="text-primary font-medium text-lg lg:text-base"><%= @nav[:label] %></span>
+              <%= icon("chevron-down") %>
+            <% end %>
+
+            <% menu.with_custom_content do %>
+              <%= render "reports/period_picker", period_type: @period_type, start_date: @start_date %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <span class="text-primary font-medium text-lg lg:text-base"><%= @nav[:label] %></span>
+        <% end %>
+
+        <div class="ml-auto">
+          <%= render DS::Link.new(
+            text: t("reports.index.today"),
+            variant: "outline",
+            href: reports_path(period_type: @period_type),
+          ) %>
+        </div>
+      </div>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -92,48 +92,10 @@
     <%# Period Display %>
       <% unless @period_type == :custom %>
         <div class="flex items-center gap-3 text-sm text-subdued">
-          <%# Calculate prev/next ranges based on period type %>
-          <% case @period_type
-            when :monthly
-              prev_start = @start_date.beginning_of_month - 1.month
-              prev_end   = prev_start.end_of_month
-              next_start = @start_date.beginning_of_month + 1.month
-              next_end   = next_start.end_of_month
-              at_latest  = @start_date.beginning_of_month >= Date.current.beginning_of_month
-            when :quarterly
-              prev_start = (@start_date.beginning_of_quarter - 1.day).beginning_of_quarter
-              prev_end   = prev_start.end_of_quarter
-              next_start = @end_date.end_of_quarter + 1.day
-              next_end   = next_start.end_of_quarter
-              at_latest  = @start_date.beginning_of_quarter >= Date.current.beginning_of_quarter
-            when :ytd
-              prev_year  = @start_date.year - 1
-              prev_start = Date.new(prev_year, 1, 1)
-              prev_end   = Date.new(prev_year, 12, 31)
-              next_year  = @start_date.year + 1
-              next_start = Date.new(next_year, 1, 1)
-              next_end   = next_year == Date.current.year ? Date.current : Date.new(next_year, 12, 31)
-              at_latest  = @start_date.year >= Date.current.year
-            when :last_6_months
-              prev_start = @start_date.beginning_of_month - 6.months
-              prev_end   = prev_start + 6.months - 1.day
-              raw_next_end = @start_date.beginning_of_month + 12.months - 1.day
-              if raw_next_end >= Date.current.end_of_month
-                next_end   = Date.current.end_of_month
-                next_start = next_end - 6.months + 1.day
-              else
-                next_start = @start_date.beginning_of_month + 6.months
-                next_end   = raw_next_end
-              end
-              at_latest  = @end_date >= Date.current.end_of_month
-            end %>
-
-          <% if [:monthly, :quarterly, :ytd, :last_6_months].include?(@period_type) %>
-            <%= link_to reports_path(period_type: @period_type, start_date: prev_start, end_date: prev_end),
-                  aria: { label: t("reports.index.previous_period") },
-                  class: "text-secondary hover:text-primary transition-colors" do %>
-              <%= icon("chevron-left", size: "sm") %>
-            <% end %>
+          <%= link_to reports_path(period_type: @period_type, start_date: @nav[:prev_start], end_date: @nav[:prev_end]),
+                aria: { label: t("reports.index.previous_period") },
+                class: "text-secondary hover:text-primary transition-colors" do %>
+            <%= icon("chevron-left", size: "sm") %>
           <% end %>
 
           <span>
@@ -142,17 +104,15 @@
                   end: @end_date.strftime("%b %-d, %Y")) %>
           </span>
 
-          <% if [:monthly, :quarterly, :ytd, :last_6_months].include?(@period_type) %>
-            <% if at_latest %>
-              <span class="text-disabled" aria-disabled="true">
-                <%= icon("chevron-right", size: "sm") %>
-              </span>
-            <% else %>
-              <%= link_to reports_path(period_type: @period_type, start_date: next_start, end_date: next_end),
-                    aria: { label: t("reports.index.next_period") },
-                    class: "text-secondary hover:text-primary transition-colors" do %>
-                <%= icon("chevron-right", size: "sm") %>
-              <% end %>
+          <% if @nav[:at_latest] %>
+            <span class="text-disabled" aria-disabled="true">
+              <%= icon("chevron-right", size: "sm") %>
+            </span>
+          <% else %>
+            <%= link_to reports_path(period_type: @period_type, start_date: @nav[:next_start], end_date: @nav[:next_end]),
+                  aria: { label: t("reports.index.next_period") },
+                  class: "text-secondary hover:text-primary transition-colors" do %>
+              <%= icon("chevron-right", size: "sm") %>
             <% end %>
           <% end %>
         </div>

--- a/config/locales/views/reports/en.yml
+++ b/config/locales/views/reports/en.yml
@@ -20,6 +20,7 @@ en:
       showing_period: "Showing data from %{start} to %{end}"
       previous_period: "Previous period"
       next_period: "Next period"
+      today: "Today"
     invalid_date_range: "End date cannot be before start date. The dates have been swapped."
     summary:
       total_income: Total Income

--- a/config/locales/views/reports/en.yml
+++ b/config/locales/views/reports/en.yml
@@ -18,6 +18,8 @@ en:
         from: From
         to: To
       showing_period: "Showing data from %{start} to %{end}"
+      previous_period: "Previous period"
+      next_period: "Next period"
     invalid_date_range: "End date cannot be before start date. The dates have been swapped."
     summary:
       total_income: Total Income

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,6 +237,7 @@ Rails.application.routes.draw do
     get :export_transactions, on: :collection
     get :google_sheets_instructions, on: :collection
     get :print, on: :collection
+    get :picker, on: :collection
   end
 
   resources :budgets, only: %i[index show edit update], param: :month_year do

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -108,8 +108,8 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_equal I18n.t("reports.invalid_date_range"), flash[:alert]
-    assert_includes @response.body, end_date.strftime("%b")
-    assert_includes @response.body, start_date.strftime("%b")
+    assert_includes @response.body, end_date.strftime("%b %Y")
+    assert_includes @response.body, start_date.strftime("%b %Y")
   end
 
   test "spending patterns returns data when expense transactions exist" do
@@ -255,7 +255,7 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     get reports_path(period_type: :monthly)
     assert_response :ok
 
-    assert_select "span[aria-disabled=true]"
+    assert_select "span[aria-label=?][aria-disabled=true]", I18n.t("reports.index.next_period")
   end
 
   test "monthly period navigation shows next month link on past month" do
@@ -276,21 +276,35 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     get reports_path(period_type: :last_6_months, start_date: start_date, end_date: end_date)
     assert_response :ok
 
-    # Debug: print all hrefs containing last_6_months
-    hrefs = @response.body.scan(/href="([^"]*last_6_months[^"]*)"/).flatten
-    puts "Found hrefs: #{hrefs}"
+    candidate_start = start_date.beginning_of_month + 6.months
+    if candidate_start + 6.months >= Date.current.beginning_of_month
+      expected_next_end   = Date.current.end_of_month
+      expected_next_start = (expected_next_end + 1.day - 6.months).beginning_of_month
+    else
+      expected_next_start = candidate_start
+      expected_next_end   = expected_next_start + 6.months - 1.day
+    end
 
-    assert true # placeholder
+    assert_select "a[href=?]",
+      reports_path(period_type: :last_6_months, start_date: expected_next_start, end_date: expected_next_end)
   end
 
   test "quarterly period navigation shows previous and next quarter links" do
-    get reports_path(period_type: :quarterly)
-    assert_response :ok
+      get reports_path(period_type: :quarterly)
+      assert_response :ok
 
-    prev_start = (Date.current.beginning_of_quarter - 1.day).beginning_of_quarter
-    prev_end = prev_start.end_of_quarter
-    assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
-  end
+      prev_start = (Date.current.beginning_of_quarter - 1.day).beginning_of_quarter
+      prev_end = prev_start.end_of_quarter
+      assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
+
+      # Also verify a past quarter shows an enabled next-quarter link
+      get reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
+      assert_response :ok
+
+      next_start = prev_start.next_quarter.beginning_of_quarter
+      next_end   = next_start.end_of_quarter
+      assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: next_start, end_date: next_end)
+    end
 
   test "custom period hides period display" do
     get reports_path(

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -107,12 +107,9 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     )
 
     assert_response :ok
-    # Should show flash message about invalid date range
-    assert flash[:alert].present?, "Flash alert should be present"
-    assert_match /End date cannot be before start date/, flash[:alert]
-    # Verify the response body contains the swapped date range in the correct order
-    assert_includes @response.body, end_date.strftime("%b %-d, %Y")
-    assert_includes @response.body, start_date.strftime("%b %-d, %Y")
+    assert_equal I18n.t("reports.invalid_date_range"), flash[:alert]
+    assert_includes @response.body, end_date.strftime("%b")
+    assert_includes @response.body, start_date.strftime("%b")
   end
 
   test "spending patterns returns data when expense transactions exist" do
@@ -244,5 +241,65 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     # Subcategories
     assert_select "tr[data-category='category-#{subcategory_movies.id}']", text: /^Movies/
     assert_select "tr[data-category='category-#{subcategory_games.id}']", text: /^Games/
+  end
+  test "monthly period navigation shows previous month link" do
+    get reports_path(period_type: :monthly)
+    assert_response :ok
+
+    prev_start = Date.current.beginning_of_month - 1.month
+    prev_end = prev_start.end_of_month
+    assert_select "a[href=?]", reports_path(period_type: :monthly, start_date: prev_start, end_date: prev_end)
+  end
+
+  test "monthly period navigation disables next arrow on current month" do
+    get reports_path(period_type: :monthly)
+    assert_response :ok
+
+    assert_select "span[aria-disabled=true]"
+  end
+
+  test "monthly period navigation shows next month link on past month" do
+    past_start = Date.current.beginning_of_month - 2.months
+    past_end = past_start.end_of_month
+    get reports_path(period_type: :monthly, start_date: past_start, end_date: past_end)
+    assert_response :ok
+
+    next_start = past_start + 1.month
+    next_end = next_start.end_of_month
+    assert_select "a[href=?]", reports_path(period_type: :monthly, start_date: next_start, end_date: next_end)
+  end
+
+  test "last 6 months next window extends to current month end when crossing boundary" do
+    start_date = Date.current.beginning_of_month - 12.months
+    end_date = start_date + 6.months - 1.day
+
+    get reports_path(period_type: :last_6_months, start_date: start_date, end_date: end_date)
+    assert_response :ok
+
+    # Debug: print all hrefs containing last_6_months
+    hrefs = @response.body.scan(/href="([^"]*last_6_months[^"]*)"/).flatten
+    puts "Found hrefs: #{hrefs}"
+
+    assert true # placeholder
+  end
+
+  test "quarterly period navigation shows previous and next quarter links" do
+    get reports_path(period_type: :quarterly)
+    assert_response :ok
+
+    prev_start = (Date.current.beginning_of_quarter - 1.day).beginning_of_quarter
+    prev_end = prev_start.end_of_quarter
+    assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
+  end
+
+  test "custom period hides period display" do
+    get reports_path(
+      period_type: :custom,
+      start_date: 1.month.ago.to_date,
+      end_date: Date.current
+    )
+    assert_response :ok
+
+    assert_select "a[aria-label=?]", I18n.t("reports.index.previous_period"), count: 0
   end
 end

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -290,21 +290,21 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "quarterly period navigation shows previous and next quarter links" do
-      get reports_path(period_type: :quarterly)
-      assert_response :ok
+    get reports_path(period_type: :quarterly)
+    assert_response :ok
 
-      prev_start = (Date.current.beginning_of_quarter - 1.day).beginning_of_quarter
-      prev_end = prev_start.end_of_quarter
-      assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
+    prev_start = (Date.current.beginning_of_quarter - 1.day).beginning_of_quarter
+    prev_end = prev_start.end_of_quarter
+    assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
 
-      # Also verify a past quarter shows an enabled next-quarter link
-      get reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
-      assert_response :ok
+    # Also verify a past quarter shows an enabled next-quarter link
+    get reports_path(period_type: :quarterly, start_date: prev_start, end_date: prev_end)
+    assert_response :ok
 
-      next_start = prev_start.next_quarter.beginning_of_quarter
-      next_end   = next_start.end_of_quarter
-      assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: next_start, end_date: next_end)
-    end
+    next_start = prev_start.next_quarter.beginning_of_quarter
+    next_end   = next_start.end_of_quarter
+    assert_select "a[href=?]", reports_path(period_type: :quarterly, start_date: next_start, end_date: next_end)
+  end
 
   test "custom period hides period display" do
     get reports_path(
@@ -316,5 +316,21 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "a[aria-label=?]", I18n.t("reports.index.previous_period"), count: 0
     assert_select "[aria-label=?]", I18n.t("reports.index.next_period"), count: 0
+  end
+  test "ytd period navigation shows previous year link" do
+    get reports_path(period_type: :ytd)
+    assert_response :ok
+
+    prev_year  = Date.current.year - 1
+    prev_start = Date.new(prev_year, 1, 1)
+    prev_end   = Date.new(prev_year, 12, 31)
+    assert_select "a[href=?]", reports_path(period_type: :ytd, start_date: prev_start, end_date: prev_end)
+  end
+
+  test "ytd period navigation disables next arrow on current year" do
+    get reports_path(period_type: :ytd)
+    assert_response :ok
+
+    assert_select "span[aria-label=?][aria-disabled=true]", I18n.t("reports.index.next_period")
   end
 end

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -315,5 +315,6 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
 
     assert_select "a[aria-label=?]", I18n.t("reports.index.previous_period"), count: 0
+    assert_select "[aria-label=?]", I18n.t("reports.index.next_period"), count: 0
   end
 end


### PR DESCRIPTION
Closes https://github.com/we-promise/sure/discussions/1681
Adds previous/next navigation arrows to the period display in the Reports view, allowing users to move between periods without manually changing dates.
Changes:

Monthly: navigate one month at a time
Quarterly: navigate one quarter at a time
YTD: navigate one year at a time
Last 6 months: navigate 6 months at a time, correctly extending to current month end when the window reaches the present
Custom: period display hidden (date picker is sufficient)
Next arrow is disabled when already at the current period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Period navigation added to reports with previous/next chevrons for monthly, quarterly, YTD, and last‑6‑months; next chevron is disabled on the latest period. Custom period hides the period display and shows only the custom date picker.

* **Localization**
  * Added "Previous period" and "Next period" translation strings.

* **Tests**
  * Added/updated tests covering period navigation and date‑range swap behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1707)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->