### PR TITLE
Reject revoked OAuth tokens in API v1 authentication

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -56,7 +56,7 @@ class Api::V1::BaseController < ApplicationController
       # Check token validity and scope (read_write includes read access)
       has_sufficient_scope = access_token&.scopes&.include?("read") || access_token&.scopes&.include?("read_write")
 
-      unless access_token && !access_token.expired? && has_sufficient_scope
+      unless access_token&.accessible? && has_sufficient_scope
         render_json({ error: "unauthorized", message: "Access token is invalid, expired, or missing required scope" }, status: :unauthorized)
         return false
       end

--- a/test/controllers/api/v1/base_controller_test.rb
+++ b/test/controllers/api/v1/base_controller_test.rb
@@ -60,6 +60,23 @@ class Api::V1::BaseControllerTest < ActionDispatch::IntegrationTest
     assert_equal @user.email, response_body["user"]
   end
 
+  test "should reject revoked access token" do
+    access_token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read"
+    )
+    access_token.revoke
+
+    get "/api/v1/test", params: {}, headers: {
+      "Authorization" => "Bearer #{access_token.token}"
+    }
+
+    assert_response :unauthorized
+    response_body = JSON.parse(response.body)
+    assert_equal "unauthorized", response_body["error"]
+  end
+
   test "should reject invalid access token" do
     get "/api/v1/test", params: {}, headers: {
       "Authorization" => "Bearer invalid_token"


### PR DESCRIPTION
### Motivation
- Fix a security gap in API v1 where manually validated Doorkeeper access tokens were accepted even after revocation because the custom check only tested expiry and scope.
- Restore Doorkeeper revocation semantics so revoked tokens cannot be used to access API endpoints.

### Description
- Replace the manual expiry check with `access_token&.accessible?` in `Api::V1::BaseController#authenticate_oauth` so revocation (`revoked_at`) is honored.
- Add an integration test `test "should reject revoked access token"` in `test/controllers/api/v1/base_controller_test.rb` that creates, revokes, and asserts a revoked token returns `401 unauthorized`.
- Modified files: `app/controllers/api/v1/base_controller.rb` and `test/controllers/api/v1/base_controller_test.rb`.

### Testing
- Ran the focused test suite with `bin/rails test test/controllers/api/v1/base_controller_test.rb` and observed all tests passed: `27 runs, 240 assertions, 0 failures, 0 errors, 1 skips`.
- The new regression test verifies that revoked OAuth tokens now receive a `401 unauthorized` response.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b378cda0cc83328c38862e79a44fa1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth access token validation has been enhanced to properly identify and reject revoked access tokens. The authentication system now uses improved token validation logic to ensure only valid, active tokens are accepted for API requests. This change strengthens security and prevents unauthorized access through previously-revoked credentials that may have remained in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->