### PR TITLE
refactor(design-system): extend DS::Alert and migrate 9 inline alert blocks

### DIFF
--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -12,6 +12,7 @@
   --color-success: var(--color-green-600);
   --color-warning: var(--color-yellow-600);
   --color-destructive: var(--color-red-600);
+  --color-info: var(--color-blue-600);
   --color-shadow: --alpha(var(--color-black) / 6%);
   --color-gray-25: #FAFAFA;
   --color-gray-50: #F7F7F7;
@@ -199,6 +200,7 @@
     --color-success: var(--color-green-500);
     --color-warning: var(--color-yellow-400);
     --color-destructive: var(--color-red-400);
+    --color-info: var(--color-blue-500);
     --color-shadow: --alpha(var(--color-white) / 8%);
     --budget-unused-fill: var(--color-gray-500);
     --budget-unallocated-fill: var(--color-gray-700);

--- a/app/components/DS/alert.html.erb
+++ b/app/components/DS/alert.html.erb
@@ -1,7 +1,15 @@
 <div class="<%= container_classes %>">
   <%= helpers.icon icon_name, size: "sm", color: icon_color, class: "shrink-0" %>
 
-  <div class="flex-1 text-sm">
-    <%= message %>
+  <div class="flex-1 text-sm text-primary space-y-1">
+    <% if title.present? %>
+      <p class="font-medium text-primary"><%= title %></p>
+    <% end %>
+
+    <% if content.present? %>
+      <%= content %>
+    <% elsif message.present? %>
+      <%= message %>
+    <% end %>
   </div>
 </div>

--- a/app/components/DS/alert.rb
+++ b/app/components/DS/alert.rb
@@ -1,24 +1,27 @@
 class DS::Alert < DesignSystemComponent
-  def initialize(message:, variant: :info)
+  VARIANTS = %i[info success warning error destructive].freeze
+
+  def initialize(message: nil, title: nil, variant: :info)
     @message = message
+    @title = title
     @variant = variant
   end
 
   private
-    attr_reader :message, :variant
+    attr_reader :message, :title, :variant
 
     def container_classes
       base_classes = "flex items-start gap-3 p-4 rounded-lg border"
 
       variant_classes = case variant
       when :info
-        "bg-blue-50 text-blue-700 border-blue-200 theme-dark:bg-blue-900/20 theme-dark:text-blue-400 theme-dark:border-blue-800"
+        "bg-info/10 border-info/20"
       when :success
-        "bg-green-50 text-green-700 border-green-200 theme-dark:bg-green-900/20 theme-dark:text-green-400 theme-dark:border-green-800"
+        "bg-success/10 border-success/20"
       when :warning
-        "bg-yellow-50 text-yellow-700 border-yellow-200 theme-dark:bg-yellow-900/20 theme-dark:text-yellow-400 theme-dark:border-yellow-800"
+        "bg-warning/10 border-warning/20"
       when :error, :destructive
-        "bg-red-50 text-red-700 border-red-200 theme-dark:bg-red-900/20 theme-dark:text-red-400 theme-dark:border-red-800"
+        "bg-destructive/10 border-destructive/20"
       end
 
       "#{base_classes} #{variant_classes}"
@@ -46,7 +49,7 @@ class DS::Alert < DesignSystemComponent
       when :error, :destructive
         "destructive"
       else
-        "blue-600"
+        "info"
       end
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,7 @@ module ApplicationHelper
   def icon(key, size: "md", color: "default", custom: false, as_button: false, **opts)
     extra_classes = opts.delete(:class)
     sizes = { xs: "w-3 h-3", sm: "w-4 h-4", md: "w-5 h-5", lg: "w-6 h-6", xl: "w-7 h-7", "2xl": "w-8 h-8" }
-    colors = { default: "text-secondary", white: "text-inverse", success: "text-success", warning: "text-warning", destructive: "text-destructive", current: "text-current" }
+    colors = { default: "text-secondary", white: "text-inverse", success: "text-success", warning: "text-warning", destructive: "text-destructive", info: "text-info", current: "text-current" }
 
     icon_classes = class_names(
       "shrink-0",

--- a/app/views/lunchflow_items/_api_error.html.erb
+++ b/app/views/lunchflow_items/_api_error.html.erb
@@ -4,13 +4,11 @@
     <% dialog.with_header(title: "Lunch Flow Connection Error") %>
     <% dialog.with_body do %>
       <div class="space-y-4">
-        <div class="flex items-start gap-3">
-          <%= icon("alert-circle", class: "text-destructive w-5 h-5 shrink-0 mt-0.5") %>
-          <div class="text-sm">
-            <p class="font-medium text-primary mb-2">Unable to connect to Lunch Flow</p>
-            <p class="text-secondary"><%= error_message %></p>
-          </div>
-        </div>
+        <%= render DS::Alert.new(
+          title: "Unable to connect to Lunch Flow",
+          message: error_message,
+          variant: :error
+        ) %>
 
         <div class="bg-surface rounded-lg p-4 space-y-2 text-sm">
           <p class="font-medium text-primary">Common Issues:</p>

--- a/app/views/lunchflow_items/_setup_required.html.erb
+++ b/app/views/lunchflow_items/_setup_required.html.erb
@@ -3,13 +3,11 @@
     <% dialog.with_header(title: "Lunch Flow Setup Required") %>
     <% dialog.with_body do %>
       <div class="space-y-4">
-        <div class="flex items-start gap-3">
-          <%= icon("alert-circle", class: "text-warning w-5 h-5 shrink-0 mt-0.5") %>
-          <div class="text-sm text-secondary">
-            <p class="font-medium text-primary mb-2">API Key Not Configured</p>
-            <p>Before you can link Lunch Flow accounts, you need to configure your Lunch Flow API key.</p>
-          </div>
-        </div>
+        <%= render DS::Alert.new(
+          title: "API Key Not Configured",
+          message: "Before you can link Lunch Flow accounts, you need to configure your Lunch Flow API key.",
+          variant: :warning
+        ) %>
 
         <div class="bg-surface rounded-lg p-4 space-y-2 text-sm">
           <p class="font-medium text-primary">Setup Steps:</p>

--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -62,18 +62,12 @@
       </div>
     </div>
 
-    <div class="bg-warning-50 border border-warning-200 rounded-xl p-4">
-      <div class="flex items-start gap-2">
-        <%= icon("alert-triangle", class: "w-5 h-5 text-warning-600 mt-0.5") %>
-        <div>
-          <h4 class="font-medium text-warning-800 text-sm">Important Security Note</h4>
-          <p class="text-warning-700 text-sm mt-1">
-            This is the only time your API key will be displayed. Make sure to copy it now and store it securely.
-            If you lose this key, you'll need to generate a new one.
-          </p>
-        </div>
-      </div>
-    </div>
+    <%= render DS::Alert.new(title: "Important Security Note", variant: :warning) do %>
+      <p>
+        This is the only time your API key will be displayed. Make sure to copy it now and store it securely.
+        If you lose this key, you'll need to generate a new one.
+      </p>
+    <% end %>
 
     <div class="bg-surface-inset rounded-xl p-4">
       <h4 class="font-medium text-primary mb-3">How to use your API key</h4>

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -67,18 +67,12 @@
             </div>
           </div>
 
-          <div class="bg-warning-50 border border-warning-200 rounded-xl p-4">
-            <div class="flex items-start gap-2">
-              <%= icon("alert-triangle", class: "w-5 h-5 text-warning-600 mt-0.5") %>
-              <div>
-                <h4 class="font-medium text-warning-800 text-sm">Important Security Note</h4>
-                <p class="text-warning-700 text-sm mt-1">
-                  This is the only time your API key will be displayed. Make sure to copy it now and store it securely.
-                  If you lose this key, you'll need to generate a new one.
-                </p>
-              </div>
-            </div>
-          </div>
+          <%= render DS::Alert.new(title: "Important Security Note", variant: :warning) do %>
+            <p>
+              This is the only time your API key will be displayed. Make sure to copy it now and store it securely.
+              If you lose this key, you'll need to generate a new one.
+            </p>
+          <% end %>
 
           <div class="bg-surface-inset rounded-xl p-4">
             <h4 class="font-medium text-primary mb-3">How to use your API key</h4>

--- a/app/views/settings/api_keys/new.html.erb
+++ b/app/views/settings/api_keys/new.html.erb
@@ -30,18 +30,12 @@
       </div>
     </div>
 
-    <div class="bg-warning-50 border border-warning-200 rounded-xl p-4">
-      <div class="flex items-start gap-2">
-        <%= icon("alert-triangle", class: "w-5 h-5 text-warning-600 mt-0.5") %>
-        <div>
-          <h4 class="font-medium text-warning-800 text-sm">Security Warning</h4>
-          <p class="text-warning-700 text-sm mt-1">
-            Your API key will be displayed only once after creation. Make sure to copy and store it securely.
-            Anyone with access to this key can access your data according to the permissions you select.
-          </p>
-        </div>
-      </div>
-    </div>
+    <%= render DS::Alert.new(title: "Security Warning", variant: :warning) do %>
+      <p>
+        Your API key will be displayed only once after creation. Make sure to copy and store it securely.
+        Anyone with access to this key can access your data according to the permissions you select.
+      </p>
+    <% end %>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-primary">
       <%= render DS::Link.new(

--- a/app/views/settings/hostings/_alpha_vantage_settings.html.erb
+++ b/app/views/settings/hostings/_alpha_vantage_settings.html.erb
@@ -34,13 +34,8 @@
                         data: { "auto-submit-form-target": "auto" } %>
   <% end %>
 
-  <div class="bg-amber-50 border border-amber-200 rounded-lg p-3">
-    <div class="flex items-start gap-2">
-      <%= icon("alert-triangle", size: "sm", class: "text-amber-600 mt-0.5") %>
-      <div class="text-sm text-amber-700">
-        <p><%= t(".rate_limit_warning") %></p>
-        <p class="mt-1"><%= t(".no_health_check_note") %></p>
-      </div>
-    </div>
-  </div>
+  <%= render DS::Alert.new(variant: :warning) do %>
+    <p><%= t(".rate_limit_warning") %></p>
+    <p><%= t(".no_health_check_note") %></p>
+  <% end %>
 </div>

--- a/app/views/settings/hostings/_eodhd_settings.html.erb
+++ b/app/views/settings/hostings/_eodhd_settings.html.erb
@@ -35,12 +35,5 @@
                         data: { "auto-submit-form-target": "auto" } %>
   <% end %>
 
-  <div class="bg-amber-50 border border-amber-200 rounded-lg p-3">
-    <div class="flex items-start gap-2">
-      <%= icon("alert-triangle", size: "sm", class: "text-amber-600 mt-0.5") %>
-      <p class="text-sm text-amber-700">
-        <%= t(".rate_limit_warning") %>
-      </p>
-    </div>
-  </div>
+  <%= render DS::Alert.new(message: t(".rate_limit_warning"), variant: :warning) %>
 </div>

--- a/app/views/settings/hostings/_provider_selection.html.erb
+++ b/app/views/settings/hostings/_provider_selection.html.erb
@@ -71,13 +71,6 @@
   </div>
 
   <% if ENV["EXCHANGE_RATE_PROVIDER"].present? || ENV["SECURITIES_PROVIDERS"].present? || ENV["SECURITIES_PROVIDER"].present? %>
-    <div class="bg-amber-50 border border-amber-200 rounded-lg p-3">
-      <div class="flex items-start gap-2">
-        <%= icon("alert-triangle", size: "sm", class: "text-amber-600 mt-0.5 shrink-0") %>
-        <p class="text-sm text-amber-700">
-          <%= t(".env_configured_message") %>
-        </p>
-      </div>
-    </div>
+    <%= render DS::Alert.new(message: t(".env_configured_message"), variant: :warning) %>
   <% end %>
 </div>

--- a/app/views/settings/hostings/_twelve_data_settings.html.erb
+++ b/app/views/settings/hostings/_twelve_data_settings.html.erb
@@ -57,30 +57,26 @@
       </div>
 
       <% if @plan_restricted_securities.present? %>
-        <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 mt-4">
-          <div class="flex items-start gap-2">
-            <%= icon("alert-triangle", size: "sm", class: "text-amber-600 mt-0.5") %>
-            <div class="text-sm">
-              <p class="font-medium text-amber-800"><%= t(".plan_upgrade_warning_title") %></p>
-              <p class="text-amber-700 mt-1"><%= t(".plan_upgrade_warning_description") %></p>
-              <ul class="mt-2 space-y-1">
-                <% @plan_restricted_securities.each do |security| %>
-                  <li class="text-amber-700">
-                    <span class="font-medium"><%= security[:ticker] %></span>
-                    <% if security[:name].present? %>
-                      <span class="text-amber-600">(<%= security[:name] %>)</span>
-                    <% end %>
-                    <span class="text-amber-600">— <%= t(".requires_plan", plan: security[:required_plan]) %></span>
-                  </li>
-                <% end %>
-              </ul>
-              <p class="mt-2">
-                <a href="https://twelvedata.com/pricing" target="_blank" rel="noopener noreferrer" class="text-amber-800 underline font-medium">
-                  <%= t(".view_pricing") %>
-                </a>
-              </p>
-            </div>
-          </div>
+        <div class="mt-4">
+          <%= render DS::Alert.new(title: t(".plan_upgrade_warning_title"), variant: :warning) do %>
+            <p><%= t(".plan_upgrade_warning_description") %></p>
+            <ul class="space-y-1">
+              <% @plan_restricted_securities.each do |security| %>
+                <li>
+                  <span class="font-medium text-primary"><%= security[:ticker] %></span>
+                  <% if security[:name].present? %>
+                    <span class="text-secondary">(<%= security[:name] %>)</span>
+                  <% end %>
+                  <span class="text-secondary">— <%= t(".requires_plan", plan: security[:required_plan]) %></span>
+                </li>
+              <% end %>
+            </ul>
+            <p>
+              <a href="https://twelvedata.com/pricing" target="_blank" rel="noopener noreferrer" class="text-link underline font-medium">
+                <%= t(".view_pricing") %>
+              </a>
+            </p>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/settings/hostings/_yahoo_finance_settings.html.erb
+++ b/app/views/settings/hostings/_yahoo_finance_settings.html.erb
@@ -20,15 +20,11 @@
           <%= t(".status_inactive") %>
         </p>
       </div>
-      <div class="bg-amber-50 border border-amber-200 rounded-lg p-3">
-        <div class="flex items-start gap-2">
-          <%= icon("alert-triangle", size: "sm", class: "text-amber-600 mt-0.5 shrink-0") %>
-          <div>
-            <h3 class="text-sm font-medium text-amber-700"><%= t(".connection_failed") %></h3>
-            <p class="text-sm text-amber-700 mt-1"><%= t(".troubleshooting") %></p>
-          </div>
-        </div>
-      </div>
+      <%= render DS::Alert.new(
+        title: t(".connection_failed"),
+        message: t(".troubleshooting"),
+        variant: :warning
+      ) %>
     </div>
   <% end %>
 </div>

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -21,6 +21,7 @@
     "success":     { "$value": "{color.green.600}",  "$type": "color", "$extensions": { "sure.dark": "{color.green.500}" } },
     "warning":     { "$value": "{color.yellow.600}", "$type": "color", "$extensions": { "sure.dark": "{color.yellow.400}" } },
     "destructive": { "$value": "{color.red.600}",    "$type": "color", "$extensions": { "sure.dark": "{color.red.400}" } },
+    "info":        { "$value": "{color.blue.600}",   "$type": "color", "$extensions": { "sure.dark": "{color.blue.500}" } },
     "shadow":      { "$value": "{color.black|6%}",   "$type": "color", "$extensions": { "sure.dark": "{color.white|8%}" } },
 
     "gray": {

--- a/test/components/previews/alert_component_preview.rb
+++ b/test/components/previews/alert_component_preview.rb
@@ -1,7 +1,34 @@
 class AlertComponentPreview < Lookbook::Preview
   # @param message text
+  # @param title text
   # @param variant select [info, success, warning, error]
-  def default(message: "This is an alert message.", variant: :info)
-    render DS::Alert.new(message: message, variant: variant.to_sym)
+  def default(message: "This is an alert message.", title: nil, variant: :info)
+    render DS::Alert.new(message: message, title: title.presence, variant: variant.to_sym)
+  end
+
+  # @param variant select [info, success, warning, error]
+  def with_title(variant: :warning)
+    render DS::Alert.new(
+      message: "Heads up — this account hasn't synced in 7 days.",
+      title: "Stale connection",
+      variant: variant.to_sym
+    )
+  end
+
+  # @param variant select [info, success, warning, error]
+  def with_body_slot(variant: :error)
+    render DS::Alert.new(title: "We couldn't process this request", variant: variant.to_sym) do
+      tag.div do
+        safe_join([
+          tag.p("Verify the values you submitted and try again. If the issue persists, contact support.", class: "text-secondary"),
+          tag.ul(class: "list-disc list-inside text-secondary") do
+            safe_join([
+              tag.li("Check that all required fields are populated."),
+              tag.li("Confirm the dates fall within an open period.")
+            ])
+          end
+        ])
+      end
+    end
   end
 end


### PR DESCRIPTION
First sub-PR of #1715. Extends the existing `DS::Alert` primitive so it can carry rich content, swaps its raw Tailwind palette for semantic tokens, and migrates the three densest duplicate clusters (API keys warnings, settings/hostings amber blocks, lunchflow modal headers) onto it.

## What this changes

**`DS::Alert` API**
- New optional `title:` kwarg renders a bold leading line above the message/body.
- Component now accepts a content block. Block content takes precedence over `message:`. Existing `DS::Alert.new(message:, variant:)` callers are untouched.
- Container surface migrated from `bg-{blue,green,yellow,red}-50 ... border-{...}-200 text-{...}-700` to `bg-{info,success,warning,destructive}/10 border-{...}/20`. The body uses `text-primary` and the icon carries the variant signal — matches the convention already in place across `pending_duplicate_merges`, `simplefin_items`, `settings/providers/*` etc.
- `icon_color` no longer returns the literal `"blue-600"` for `:info` (which the icon helper silently dropped on the floor); it returns `:info`, backed by a new `text-info` entry in the helper colour map.

**Token addition**
- New `--color-info` semantic colour, mirroring the `success / warning / destructive` shape (blue-600 in light mode, blue-500 in dark). Generated by `npm run tokens:build` from `design/tokens/sure.tokens.json`. Unblocks `bg-info/N`, `text-info`, `border-info/N` modifier-aware utilities.

**Lookbook**
- `AlertComponentPreview` gains `with_title` and `with_body_slot` examples alongside the existing default preview.

**Migrations (9 callsites)**
- `app/views/settings/api_keys/{new,created,created.turbo_stream}.html.erb` — three near-identical "Security Warning" / "Important Security Note" boxes (×3).
- `app/views/settings/hostings/_alpha_vantage_settings.html.erb`, `_eodhd_settings.html.erb`, `_yahoo_finance_settings.html.erb`, `_provider_selection.html.erb`, `_twelve_data_settings.html.erb` — five amber-50 warning blocks covering rate-limit notes, health-check failures, env-configured override messaging, and the plan-restricted-securities list (×5).
- `app/views/lunchflow_items/_api_error.html.erb`, `_setup_required.html.erb` — two modal alert headers (×2).

The remaining ~36 inline alert sites enumerated in #1715 stay for follow-up sub-PRs so this one stays bisect-friendly and easy to review.

## Why this shape

#1715 flagged that `DS::Alert` was the outlier in the codebase: its template only rendered `message:`, so every alert with even a title-and-body shape ended up as a hand-rolled `flex items-start gap-3` div, and its variant classes had drifted to raw Tailwind palette where the rest of the app had already moved to semantic tokens. Swapping the surface and adding a slot is the smallest change that lets the existing primitive absorb the duplication.

Picked alpha-modifier surfaces (`bg-warning/10` etc.) over hypothetical `bg-warning-50` palette-family tokens because:
1. The latter doesn't exist in `sure.tokens.json` today and would require a much bigger token-system change. `bg-warning-50` is in fact silently broken in the current codebase (no theme key `--color-warning-50` is generated) — see #1653.
2. Alpha-modifier on theme colours already works in Tailwind v4 and matches the convention used by `pending_duplicate_merges`, `simplefin_items`, `settings/providers/*` etc.

## Commits (bisect-friendly)

1. `feat(design-system): add info semantic color token` — token + regenerated CSS only.
2. `refactor(design-system): adopt semantic tokens and add body slot in DS::Alert` — primitive + helper + lookbook.
3. `refactor(views): migrate api_keys, hostings, lunchflow alerts to DS::Alert` — call-site migrations.

## Tests

`bin/rubocop` and `bundle exec erb_lint` clean on touched files. `bin/brakeman --no-pager` clean. `bin/rails test` was not run locally — my dev container's Postgres wasn't reachable at the moment of writing this PR, so I'm leaning on CI for the full suite. There are no behavioural changes (no models / controllers / routes touched), so the risk surface is `app/components/DS/alert.rb` plus the nine view files.

## Test plan

- [x] CI green (`bin/rails test`).
- [x] Visit `/lookbook` and confirm the three `AlertComponentPreview` examples render in light and dark mode.
- [x] `/settings/api_keys/new`, `/settings/api_keys/<id>` after creating one, and the create-via-Turbo flow — the security-warning box renders identical to the previous shape, with the icon carrying the warning colour.
- [x] `/settings/hostings` for each of Alpha Vantage / EODHD / Yahoo Finance / Twelve Data / Provider Selection — confirm each amber block now renders as a `DS::Alert` warning. For Twelve Data, hit the plan-restricted-securities path so the body-slot list is exercised.
- [x] Lunch Flow: open the connect-modal in the API-error path and the setup-required path; confirm the alert renders correctly above the existing 'common issues' / 'setup steps' card and the action button.

## What this PR does NOT do

Out of scope for this sub-PR; landing as separate sub-PRs of #1715:

- The remaining ~36 inline alert sites enumerated in the issue (settings/sso_providers, transactions/show duplicate-warning, accounts/confirm_unlink, etc.).
- Badge / disclosure / search-input / segmented-control consolidation work.
- The Tailwind v4 `@utility` modifier-suffix limitation tracked in #1653 — this PR sidesteps it by using theme-color alpha modifiers on `--color-{info,success,warning,destructive}`, but does not resolve the underlying issue for the `text-inverse/N` family.


## Visual changes

Captured with Playwright on `upstream/main` (before) and `feature/ds-alert-extension` (after) against a self-hosted `bin/rails server` with seeded demo data. Each PNG is a DOM-element-level crop of the alert (not a full-page screenshot). Source branch hosting the captures: [`screenshots/ds-alert-1731`](https://github.com/we-promise/sure/tree/screenshots/ds-alert-1731).

### Lookbook — base variants (component-isolated)

#### Light

| Variant | Before | After |
|---|---|---|
| `info` | ![info-before-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/light/lookbook-default-info.png) | ![info-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/lookbook-default-info.png) |
| `success` | ![success-before-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/light/lookbook-default-success.png) | ![success-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/lookbook-default-success.png) |
| `warning` | ![warning-before-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/light/lookbook-default-warning.png) | ![warning-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/lookbook-default-warning.png) |
| `error` | ![error-before-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/light/lookbook-default-error.png) | ![error-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/lookbook-default-error.png) |

#### Dark

| Variant | Before | After |
|---|---|---|
| `info` | ![info-before-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/dark/lookbook-default-info.png) | ![info-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/lookbook-default-info.png) |
| `success` | ![success-before-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/dark/lookbook-default-success.png) | ![success-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/lookbook-default-success.png) |
| `warning` | ![warning-before-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/dark/lookbook-default-warning.png) | ![warning-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/lookbook-default-warning.png) |
| `error` | ![error-before-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/dark/lookbook-default-error.png) | ![error-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/lookbook-default-error.png) |

### New shapes (after only — these didn't exist before)

`with_title` (light → dark):

![with-title-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/lookbook-with-title.png)
![with-title-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/lookbook-with-title.png)

`with_body_slot` (light → dark):

![with-body-slot-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/lookbook-with-body-slot.png)
![with-body-slot-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/lookbook-with-body-slot.png)

### In-context callsites

#### `settings/api_keys/new.html.erb` — Security Warning (warning, title + body)

| Theme | Before | After |
|---|---|---|
| Light | ![api-key-new-before-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/light/api-key-new.png) | ![api-key-new-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/api-key-new.png) |
| Dark | ![api-key-new-before-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/dark/api-key-new.png) | ![api-key-new-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/api-key-new.png) |

This is the most dramatic pair. The before state has no surface tint at all because `bg-warning-50` / `text-warning-700` / `border-warning-200` are not generated by Tailwind v4 — there's no `--color-warning-50` etc. theme colour, just `--color-warning`. The PR moves to `bg-warning/10` / `text-primary` / `border-warning/20` which all resolve through theme tokens.

#### `settings/hostings/_eodhd_settings.html.erb` — rate-limit warning

| Theme | Before | After |
|---|---|---|
| Light | ![eodhd-before-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/light/hostings-eodhd.png) | ![eodhd-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/hostings-eodhd.png) |
| Dark | ![eodhd-before-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/dark/hostings-eodhd.png) | ![eodhd-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/hostings-eodhd.png) |

#### `settings/hostings/_alpha_vantage_settings.html.erb` — rate limit + no-health-check note

| Theme | Before | After |
|---|---|---|
| Light | ![av-before-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/light/hostings-alpha-vantage.png) | ![av-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/hostings-alpha-vantage.png) |
| Dark | ![av-before-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/before/dark/hostings-alpha-vantage.png) | ![av-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/hostings-alpha-vantage.png) |

The hostings alerts use `bg-amber-50` raw palette in the before state, which **does** compile (amber is in Tailwind's default palette), so the surface tint is present. The after pair shifts the tone slightly — warning maps to yellow-600 in this DS, where amber-500 sits a touch warmer — and moves the body text from `text-amber-700` (variant-tinted) to `text-primary` (high-contrast) so the icon and (when present) title carry the variant signal alone.

#### `settings/hostings/_yahoo_finance_settings.html.erb` — connection-failed (after only)

The before run happened to land while the upstream Yahoo Finance endpoint was healthy, so the conditional alert didn't render and the pair is missing. The before-state chrome is the same `bg-amber-50` shape as the eodhd / alpha_vantage pairs above.

| Theme | After |
|---|---|
| Light | ![yahoo-after-light](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/light/hostings-yahoo-finance.png) |
| Dark | ![yahoo-after-dark](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/screenshots/after/dark/hostings-yahoo-finance.png) |

### Verification notes

- Both themes render correctly across every variant. Dark mode uses the same `bg-{variant}/10` / `border-{variant}/20` tokens as light and flips automatically through `--color-*` theme overrides.
- Spacing, padding (`p-4 rounded-lg`), and icon alignment are preserved — no layout shift between before and after.
- The icon helper now accepts `color: :info` (backed by the new `--color-info` token), eliminating the `"blue-600"` literal that the helper's colour map was silently dropping.
- The plan-restriction Twelve Data alert and the lunchflow modal alerts share the same primitive and tokens; they're not in this matrix only because their conditional state is harder to trigger reliably during automated capture. Their visual chrome is identical to the warning / error variants in the lookbook + callsite gallery above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert component now supports optional titles alongside messages.
  * Added new "info" color token to the design system.

* **Improvements**
  * Standardized alert styling across the application for a more consistent user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1731)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
