### PR TITLE
docs(agents): add Design System Hygiene checklist for UI PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,17 @@ When adding or modifying API endpoints in `app/controllers/api/v1/`, you **MUST*
 ### Post-commit API consistency (LLM checklist)
 After every API endpoint commit, ensure: (1) **Minitest** behavioral coverage in `test/controllers/api/v1/{resource}_controller_test.rb` (no behavioral assertions in rswag); (2) **rswag** remains docs-only (no `expect`/`assert_*` in `spec/requests/api/v1/`); (3) **rswag auth** uses the same API key pattern everywhere (`X-Api-Key`, not OAuth/Bearer). Full checklist: [.cursor/rules/api-endpoint-consistency.mdc](.cursor/rules/api-endpoint-consistency.mdc).
 
+## Design System Hygiene (UI PRs)
+
+When a PR touches `.erb`, view components, or `.css`:
+
+1. **Tokens, not palette.** Use functional tokens from `app/assets/tailwind/sure-design-system.css` (`bg-warning/10`, `text-destructive`, `bg-container`, `text-primary`, `border-primary`). No raw Tailwind palette (`bg-blue-50`, `text-red-500`, hex literals).
+2. **Reach for `DS::*` first.** Check `app/components/DS/` (`DS::Alert`, `DS::Button`, `DS::Disclosure`, `DS::Dialog`, `DS::Menu`, etc.) before writing an alert, badge, button, disclosure, dialog, or input shape.
+3. **Two copies → lift to DS.** Same hand-rolled shape ≥2× in a diff with no DS equivalent → propose a new `DS::*` primitive before the second copy lands.
+4. **Conventions.** Use the `icon` helper (never `lucide_icon` directly), no raw SVG outside DS primitives, user-facing strings via `t()`, avoid arbitrary `*-[Npx]` values when a scale token fits.
+
+Reviewers escalate violations of (2)–(3) to close/rewrite; (1) and (4) are request-changes.
+
 ## Securities Providers
 
 If you need to add a new securities price provider (Tiingo, EODHD, Binance-style crypto, etc.), see [adding-a-securities-provider.md](./docs/llm-guides/adding-a-securities-provider.md) for the full walkthrough — provider class, registry wiring, MIC handling, settings UI, locales, and tests.


### PR DESCRIPTION
Adds a short Design-System-Hygiene block to `AGENTS.md` so review agents and human reviewers have a citable rule for the patterns that #1715 keeps catching one PR at a time.

## Why

`AGENTS.md` already nails API-endpoint consistency for backend work. UI PRs have no equivalent: contributor PRs keep introducing raw Tailwind palette where a semantic token exists, and hand-rolled alert / button / disclosure / dialog shapes when `DS::*` already covers them. Each one gets re-discovered in review.

This is the smallest version of \"write the rule down once.\" It mirrors the weight of the existing API section — four short numbered points plus a one-line escalation rule — and links the DS-consolidation umbrella issue (#1715) so reviewers and agents have a single thread to track.

## What it covers

1. **Tokens, not palette** — use functional tokens (`bg-warning/10`, `text-destructive`, `text-primary`, `border-primary`); no raw `bg-blue-50` / `text-red-500` / hex literals.
2. **Reach for `DS::*` first** — check `app/components/DS/` before writing an alert / badge / button / disclosure / dialog / input shape.
3. **Two copies → lift to DS** — same hand-rolled shape ≥2× in a diff with no DS equivalent → propose a new `DS::*`.
4. **Conventions** — `icon` helper not `lucide_icon`, no raw SVG outside DS primitives, `t()` for user strings, no arbitrary `*-[Npx]` values where a scale token fits.

Plus a one-line escalation rule for reviewers: violations of (2)–(3) are close/rewrite, (1) and (4) are request-changes. The DS-consolidation umbrella (#1715) is named so future contributors land in the right thread.

## Out of scope

- Doesn't touch `.cursor/rules/ui-ux-design-guidelines.mdc` — that rule already exists; this is the AGENTS.md companion that human reviewers and review agents are more likely to consult.
- Doesn't introduce automation. The intent is a written rule that reviewers cite, not a hook or lint gate (those would belong in a separate PR).

## Tests

Docs-only. No CI surface beyond the markdown render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design system contribution guidelines for UI pull requests to establish standards for component consistency, styling practices, and accessibility conventions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1732)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->