### PR TITLE
i18n(es): fill high-value locale gaps

### DIFF
--- a/config/locales/breadcrumbs/es.yml
+++ b/config/locales/breadcrumbs/es.yml
@@ -1,6 +1,8 @@
 ---
 es:
   breadcrumbs:
+    categorize: Categorizar
     exports: Exportaciones
     home: Inicio
     imports: Importaciones
+    transactions: Transacciones

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -153,6 +153,8 @@ es:
   helpers:
     select:
       prompt: Por favor seleccione
+      search_placeholder: Buscar
+      default_label: Seleccionar...
     submit:
       create: Crear %{model}
       submit: Guardar %{model}

--- a/config/locales/models/chat/es.yml
+++ b/config/locales/models/chat/es.yml
@@ -1,0 +1,8 @@
+---
+es:
+  chat:
+    errors:
+      rate_limited: "El proveedor de IA está limitado por tasa en este momento. Vuelve a intentarlo en unos minutos."
+      temporarily_unavailable: "El proveedor de IA no está disponible temporalmente en este momento. Vuelve a intentarlo en unos minutos."
+      misconfigured: "El proveedor de IA no está configurado correctamente. Ponte en contacto con tu administrador."
+      default: "No se pudo generar una respuesta. Inténtalo de nuevo."

--- a/config/locales/models/chat/es.yml
+++ b/config/locales/models/chat/es.yml
@@ -2,7 +2,7 @@
 es:
   chat:
     errors:
-      rate_limited: "El proveedor de IA está limitado por tasa en este momento. Vuelve a intentarlo en unos minutos."
-      temporarily_unavailable: "El proveedor de IA no está disponible temporalmente en este momento. Vuelve a intentarlo en unos minutos."
+      rate_limited: "El proveedor de IA está limitando acceso a su API. Vuelve a intentarlo en unos minutos."
+      temporarily_unavailable: "El proveedor de IA no está disponible temporalmente. Vuelve a intentarlo en unos minutos."
       misconfigured: "El proveedor de IA no está configurado correctamente. Ponte en contacto con tu administrador."
       default: "No se pudo generar una respuesta. Inténtalo de nuevo."

--- a/config/locales/models/transaction/es.yml
+++ b/config/locales/models/transaction/es.yml
@@ -1,0 +1,11 @@
+---
+es:
+  activerecord:
+    errors:
+      models:
+        transaction:
+          attributes:
+            attachments:
+              too_many: "no puede superar %{max} archivos por transacción"
+              too_large: "el archivo %{index} es demasiado grande (máximo %{max_mb} MB)"
+              invalid_format: "el archivo %{index} tiene un formato no compatible (%{file_format})"

--- a/config/locales/views/accounts/es.yml
+++ b/config/locales/views/accounts/es.yml
@@ -1,11 +1,13 @@
 ---
 es:
   accounts:
+    not_authorized: No tienes permiso para gestionar esta cuenta
     account:
       edit: Editar
       link_lunchflow: Vincular con Lunch Flow
       link_provider: Vincular con proveedor
       unlink_provider: Desvincular de proveedor
+      change_simplefin_account: Cambiar cuenta de SimpleFIN
       troubleshoot: Solucionar problemas
       enable: Activar cuenta
       disable: Desactivar cuenta
@@ -13,6 +15,7 @@ es:
       remove_default: Quitar predeterminada
       default_label: Predeterminada
       delete: Eliminar cuenta
+      sharing: Compartir
     chart:
       data_not_available: Datos no disponibles para el período seleccionado
     create:
@@ -22,12 +25,14 @@ es:
     destroy:
       success: "Cuenta %{type} programada para eliminación"
       cannot_delete_linked: "No se puede eliminar una cuenta vinculada. Por favor, desvincúlela primero."
+      failed: "No se pudo eliminar el recurso. Inténtalo de nuevo más tarde."
     empty:
       empty_message: Añade una cuenta mediante conexión, importación o introducción manual.
       new_account: Nueva cuenta
       no_accounts: Aún no hay cuentas
     form:
       balance: Saldo actual
+      opening_balance_date_label: Fecha del saldo inicial
       name_label: Nombre de la cuenta
       name_placeholder: Ejemplo de nombre de cuenta
       additional_details: Detalles adicionales
@@ -56,6 +61,7 @@ es:
         title: ¿Cómo te gustaría añadirla?
       title: ¿Qué te gustaría añadir?
     show:
+      limited_fx_history_warning: "El historial de tipos de cambio solo está disponible desde %{date}. Las transacciones anteriores a esa fecha usan conversiones de divisa aproximadas; esto puede ocurrir cuando el proveedor de tipos de cambio solo ofrece una ventana histórica limitada."
       activity:
         amount: Cantidad
         balance: Saldo
@@ -128,6 +134,7 @@ es:
       ca: Canadá
       au: Australia
       eu: Europa
+      in: India
       generic: General
     confirm_unlink:
       title: ¿Desvincular cuenta del proveedor?

--- a/config/locales/views/loans/es.yml
+++ b/config/locales/views/loans/es.yml
@@ -10,6 +10,8 @@ es:
       rate_type: Tipo de interés
       term_months: Plazo (meses)
       term_months_placeholder: '360'
+      subtype_prompt: Selecciona el tipo de préstamo
+      subtype_none: Ninguno
     new:
       title: Introduce los detalles del préstamo
     overview:

--- a/config/locales/views/mfa/es.yml
+++ b/config/locales/views/mfa/es.yml
@@ -31,8 +31,15 @@ es:
       verify_title: 2. Ingresa el Código de Verificación
     verify:
       description: Ingresa el código de tu aplicación de autenticación para continuar
+      or: o
       page_title: Verificar la Autenticación de Dos Factores
       title: Autenticación de Dos Factores
       verify_button: Verificar
+      webauthn_button: Usar passkey o llave de seguridad
+      webauthn_unsupported: Este navegador no admite passkeys ni llaves de seguridad.
     verify_code:
       invalid_code: Código de autenticación inválido. Por favor, inténtalo de nuevo.
+    verify_webauthn:
+      invalid_credential: No se pudo verificar esa passkey o llave de seguridad. Inténtalo de nuevo.
+    webauthn_options:
+      unavailable: No hay passkeys ni llaves de seguridad disponibles para esta cuenta.

--- a/config/locales/views/settings/securities/es.yml
+++ b/config/locales/views/settings/securities/es.yml
@@ -8,3 +8,20 @@ es:
         enable_mfa: Habilitar 2FA
         mfa_description: Agrega una capa adicional de seguridad a tu cuenta al requerir un código de tu aplicación de autenticación al iniciar sesión
         mfa_title: Autenticación de 2FA
+        webauthn_add: Añadir passkey o llave de seguridad
+        webauthn_added: Añadida el %{date}
+        webauthn_description: Usa una passkey, Touch ID, Windows Hello o una llave de seguridad física como segundo factor al iniciar sesión.
+        webauthn_empty: Aún no hay passkeys ni llaves de seguridad registradas.
+        webauthn_last_used: Último uso hace %{time_ago}
+        webauthn_name_label: Nombre de la llave
+        webauthn_name_placeholder: Touch ID del MacBook, YubiKey, etc.
+        webauthn_remove: Eliminar
+        webauthn_remove_confirm: ¿Seguro que quieres eliminar esta passkey o llave de seguridad?
+        webauthn_remove_confirm_body: Tendrás que volver a registrar esta passkey o llave de seguridad antes de poder usarla para verificar el inicio de sesión.
+        webauthn_title: Passkeys y llaves de seguridad
+        webauthn_unsupported: Este navegador no admite passkeys ni llaves de seguridad.
+  webauthn_credentials:
+    default_name: Llave de seguridad
+    failure: No se pudo guardar esa passkey o llave de seguridad. Inténtalo de nuevo.
+    mfa_required: Activa la autenticación de dos factores antes de añadir una passkey o llave de seguridad.
+    success: Se eliminó la passkey o llave de seguridad.

--- a/config/locales/views/transfer_matches/es.yml
+++ b/config/locales/views/transfer_matches/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  transfer_matches:
+    new:
+      header:
+        title: Vincular transferencia o pago
+        subtitle: Vincula la transacción correspondiente en otra cuenta o crea una si no existe.

--- a/config/locales/views/valuations/es.yml
+++ b/config/locales/views/valuations/es.yml
@@ -1,6 +1,8 @@
 ---
 es:
   valuations:
+    errors:
+      amount_required: El importe es obligatorio
     form:
       amount: Importe
       submit: Añadir actualización de saldo


### PR DESCRIPTION
## Summary

This kicks off the Spanish (`es`) cleanup with a deliberately scoped first pass instead of trying to fix the full current backlog in one PR.

Included here:
- fills smaller, high-value missing `es` strings in active user-facing areas
- adds missing Spanish locale files for chat errors, transaction attachment validations, and transfer-match headers
- covers recent auth/security copy for MFA + passkeys/security keys

## Files covered

- `config/locales/breadcrumbs/es.yml`
- `config/locales/defaults/es.yml`
- `config/locales/models/chat/es.yml`
- `config/locales/models/transaction/es.yml`
- `config/locales/views/accounts/es.yml`
- `config/locales/views/loans/es.yml`
- `config/locales/views/mfa/es.yml`
- `config/locales/views/settings/securities/es.yml`
- `config/locales/views/transfer_matches/es.yml`
- `config/locales/views/valuations/es.yml`

## Notes

I originally tried to reproduce the exact old `9 files / 11 strings missing` report, but the current `main` branch has moved on quite a bit and the local Ruby/i18n task environment is broken in this runner (`psych`/`libyaml` issue), so this PR is based on a direct locale-file audit instead.

There is still a much larger `es` backlog remaining in provider-heavy areas (for example Sophtron, Binance, Mercury, imports, and others). I kept those out of this starter PR on purpose so review stays manageable.

Happy to follow with a second PR for the larger remaining chunks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added comprehensive Spanish language translations across the application, including breadcrumb navigation, form labels, error messages, and WebAuthn/passkey features.
  * Extended Spanish support for account management, loan forms, MFA verification, security settings, transfer matching, and validation messages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1733)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->