### PR TITLE
Constrain Lunchflow base URL to trusted endpoint

### DIFF
--- a/app/models/lunchflow_item.rb
+++ b/app/models/lunchflow_item.rb
@@ -1,6 +1,8 @@
 class LunchflowItem < ApplicationRecord
   include Syncable, Provided, Unlinking, Encryptable
 
+  DEFAULT_BASE_URL = "https://lunchflow.app/api/v1".freeze
+
   enum :status, { good: "good", requires_update: "requires_update" }, default: :good
 
   # Encrypt sensitive credentials and raw payloads if ActiveRecord encryption is configured
@@ -154,6 +156,17 @@ class LunchflowItem < ApplicationRecord
   end
 
   def effective_base_url
-    base_url.presence || "https://lunchflow.app/api/v1"
+    return DEFAULT_BASE_URL if base_url.blank?
+
+    uri = URI.parse(base_url)
+    return DEFAULT_BASE_URL unless uri.is_a?(URI::HTTPS)
+    return DEFAULT_BASE_URL unless uri.host == "lunchflow.app"
+    return DEFAULT_BASE_URL unless ["", "/", "/api/v1", "/api/v1/"].include?(uri.path)
+    return DEFAULT_BASE_URL unless uri.query.blank?
+    return DEFAULT_BASE_URL unless uri.fragment.blank?
+
+    DEFAULT_BASE_URL
+  rescue URI::InvalidURIError
+    DEFAULT_BASE_URL
   end
 end

--- a/app/models/lunchflow_item.rb
+++ b/app/models/lunchflow_item.rb
@@ -161,7 +161,7 @@ class LunchflowItem < ApplicationRecord
     uri = URI.parse(base_url)
     return DEFAULT_BASE_URL unless uri.is_a?(URI::HTTPS)
     return DEFAULT_BASE_URL unless uri.host == "lunchflow.app"
-    return DEFAULT_BASE_URL unless ["", "/", "/api/v1", "/api/v1/"].include?(uri.path)
+    return DEFAULT_BASE_URL unless [ "", "/", "/api/v1", "/api/v1/" ].include?(uri.path)
     return DEFAULT_BASE_URL unless uri.query.blank?
     return DEFAULT_BASE_URL unless uri.fragment.blank?
 

--- a/test/models/lunchflow_item_test.rb
+++ b/test/models/lunchflow_item_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class LunchflowItemTest < ActiveSupport::TestCase
+  def setup
+    @lunchflow_item = lunchflow_items(:one)
+  end
+
+  test "effective_base_url returns default when base_url blank" do
+    @lunchflow_item.base_url = nil
+
+    assert_equal LunchflowItem::DEFAULT_BASE_URL, @lunchflow_item.effective_base_url
+  end
+
+  test "effective_base_url returns default for non-lunchflow host" do
+    @lunchflow_item.base_url = "https://169.254.169.254/latest/meta-data"
+
+    assert_equal LunchflowItem::DEFAULT_BASE_URL, @lunchflow_item.effective_base_url
+  end
+
+  test "effective_base_url returns default for non-https scheme" do
+    @lunchflow_item.base_url = "http://lunchflow.app/api/v1"
+
+    assert_equal LunchflowItem::DEFAULT_BASE_URL, @lunchflow_item.effective_base_url
+  end
+
+  test "effective_base_url returns canonical default for valid lunchflow url" do
+    @lunchflow_item.base_url = "https://lunchflow.app/api/v1/"
+
+    assert_equal LunchflowItem::DEFAULT_BASE_URL, @lunchflow_item.effective_base_url
+  end
+end


### PR DESCRIPTION
### Motivation
- Prevent SSRF introduced by allowing user-controlled `base_url` for Lunchflow connections by ensuring outbound requests use a trusted canonical endpoint.

### Description
- Add `DEFAULT_BASE_URL` and tighten `LunchflowItem#effective_base_url` to validate `base_url` and only accept the canonical `https://lunchflow.app/api/v1` form, otherwise fall back to the safe default.
- Normalize and reject untrusted or malformed inputs by checking scheme, host, path, query, and fragment and rescuing `URI::InvalidURIError`.
- Preserve existing behavior for valid canonical Lunchflow URLs while removing the ability for authenticated users to direct backend requests to arbitrary hosts.
- Add focused unit tests in `test/models/lunchflow_item_test.rb` covering blank, non-Lunchflow host, non-HTTPS scheme, and canonical URL cases.

### Testing
- Ran `bin/rails test test/models/lunchflow_item_test.rb` and all tests passed (`4 runs, 4 assertions, 0 failures`).
- Inspected `app/controllers/lunchflow_items_controller.rb`, `app/models/lunchflow_item.rb`, and `app/models/provider/lunchflow.rb` to confirm the vulnerability path and that the fix centralizes validation in the model.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b34be8162083329a0979d08fa6e32a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of API base URLs to require secure HTTPS and the official host; invalid or non-HTTPS values now fall back to the default service endpoint for safety and reliability.

* **Tests**
  * Added unit tests covering URL validation and fallback scenarios to ensure consistent behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1768)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->