### PR TITLE
Scope SnapTrade orphan cleanup to current family

### DIFF
--- a/app/models/snaptrade_item/provided.rb
+++ b/app/models/snaptrade_item/provided.rb
@@ -160,13 +160,14 @@ module SnaptradeItem::Provided
     return [] unless credentials_configured? && user_registered?
 
     all_users = list_all_users
-    all_users.reject { |uid| uid == snaptrade_user_id }
+    all_users.select { |uid| uid != snaptrade_user_id && uid.start_with?("family_#{family_id}_") }
   end
 
   # Delete an orphaned SnapTrade user and all their connections
   def delete_orphaned_user(user_id)
     return false unless credentials_configured?
     return false if user_id == snaptrade_user_id # Don't delete current user
+    return false unless user_id.start_with?("family_#{family_id}_")
 
     snaptrade_provider.delete_user(user_id: user_id)
     true

--- a/test/models/snaptrade_item_test.rb
+++ b/test/models/snaptrade_item_test.rb
@@ -93,7 +93,7 @@ class SnaptradeItemTest < ActiveSupport::TestCase
       "legacy_user_444"
     ])
 
-    assert_equal(["family_#{@family.id}_222"], item.orphaned_users)
+    assert_equal([ "family_#{@family.id}_222" ], item.orphaned_users)
   end
 
   test "delete_orphaned_user rejects users outside the current family namespace" do

--- a/test/models/snaptrade_item_test.rb
+++ b/test/models/snaptrade_item_test.rb
@@ -93,7 +93,7 @@ class SnaptradeItemTest < ActiveSupport::TestCase
       "legacy_user_444"
     ])
 
-    assert_equal ["family_#{@family.id}_222"], item.orphaned_users
+    assert_equal [ "family_#{`@family.id`}_222" ], item.orphaned_users
   end
 
   test "delete_orphaned_user rejects users outside the current family namespace" do

--- a/test/models/snaptrade_item_test.rb
+++ b/test/models/snaptrade_item_test.rb
@@ -75,4 +75,42 @@ class SnaptradeItemTest < ActiveSupport::TestCase
     provider = item.snaptrade_provider
     assert_instance_of Provider::Snaptrade, provider
   end
+
+  test "orphaned_users only includes users for the same family" do
+    item = SnaptradeItem.new(
+      family: @family,
+      name: "Test",
+      client_id: "test",
+      consumer_key: "test",
+      snaptrade_user_id: "family_#{@family.id}_111",
+      snaptrade_user_secret: "secret"
+    )
+
+    item.stubs(:list_all_users).returns([
+      "family_#{@family.id}_111",
+      "family_#{@family.id}_222",
+      "family_999_333",
+      "legacy_user_444"
+    ])
+
+    assert_equal ["family_#{@family.id}_222"], item.orphaned_users
+  end
+
+  test "delete_orphaned_user rejects users outside the current family namespace" do
+    item = SnaptradeItem.new(
+      family: @family,
+      name: "Test",
+      client_id: "test",
+      consumer_key: "test",
+      snaptrade_user_id: "family_#{@family.id}_111",
+      snaptrade_user_secret: "secret"
+    )
+
+    provider = mock
+    provider.expects(:delete_user).never
+    item.stubs(:snaptrade_provider).returns(provider)
+
+    assert_not item.delete_orphaned_user("family_999_222")
+    assert_not item.delete_orphaned_user("legacy_user_333")
+  end
 end

--- a/test/models/snaptrade_item_test.rb
+++ b/test/models/snaptrade_item_test.rb
@@ -93,7 +93,7 @@ class SnaptradeItemTest < ActiveSupport::TestCase
       "legacy_user_444"
     ])
 
-    assert_equal [ "family_#{`@family.id`}_222" ], item.orphaned_users
+    assert_equal(["family_#{@family.id}_222"], item.orphaned_users)
   end
 
   test "delete_orphaned_user rejects users outside the current family namespace" do


### PR DESCRIPTION
### Motivation

- Prevent cross-tenant enumeration and deletion of SnapTrade users when SnapTrade client credentials are shared by limiting orphan handling to the current family namespace.

### Description

- Restrict `SnaptradeItem#orphaned_users` to only return IDs that start with `family_#{family_id}_` and exclude the current user ID.
- Add a server-side guard in `SnaptradeItem#delete_orphaned_user` that rejects deletion requests for user IDs not in the current family namespace.
- Add model tests in `test/models/snaptrade_item_test.rb` to assert that `orphaned_users` only includes same-family IDs and that deletion rejects out-of-scope IDs.

### Testing

- Ran `bin/rails test test/models/snaptrade_item_test.rb` and the model tests passed (all green).
- Running `bin/rails test test/models/snaptrade_item_test.rb test/controllers/snaptrade_items_controller_test.rb` triggered controller view rendering errors due to missing asset `tailwind.css` in the test environment, causing two test errors unrelated to the model change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b3188748bc8332930e55b700955812)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened orphaned-account removal so only accounts within the current family namespace are considered, and added an extra safety guard to refuse deletion of IDs not matching the family prefix (still excluding the configured user).

* **Tests**
  * Added coverage to verify family-scoped filtering and that deletion is never attempted for IDs outside the current family.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1769)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->