### PR TITLE
Exclude `investment_contribution` from budget expense calculations

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -81,7 +81,7 @@ class Transaction < ApplicationRecord
   # Kinds excluded from budget/income-statement analytics.
   # loan_payment and investment_contribution are intentionally NOT here —
   # they represent real cash outflow from a budgeting perspective.
-  BUDGET_EXCLUDED_KINDS = %w[funds_movement one_time cc_payment].freeze
+  BUDGET_EXCLUDED_KINDS = %w[funds_movement one_time cc_payment investment_contribution].freeze
 
   # All valid investment activity labels (for UI dropdown)
   ACTIVITY_LABELS = [


### PR DESCRIPTION
Adds `investment_contribution` to `BUDGET_EXCLUDED_KINDS` so transfers 
to investment accounts are excluded from expense calculations in 
Reports and Budget, consistent with other transfer types.

Fixes #1313.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Investment contributions are now properly excluded from budget and income-statement analytics, ensuring more accurate financial summaries and providing clearer visibility into your actual spending and income patterns separate from investment activities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1770)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->