### PR TITLE
fix(simplefin): treat Vanguard/Fidelity cost_basis as total when needed

### DIFF
--- a/app/models/simplefin_account/investments/holdings_processor.rb
+++ b/app/models/simplefin_account/investments/holdings_processor.rb
@@ -48,7 +48,7 @@ class SimplefinAccount::Investments::HoldingsProcessor
         qty = parse_decimal(any_of(simplefin_holding, %w[shares quantity qty units]))
         market_value = parse_decimal(any_of(simplefin_holding, %w[market_value current_value]))
         raw_cost_basis, cost_basis_source_key = cost_basis_from(simplefin_holding)
-        cost_basis = normalize_cost_basis(raw_cost_basis, qty, cost_basis_source_key, market_value)
+        cost_basis = normalize_cost_basis(raw_cost_basis, qty, cost_basis_source_key, institution_reports_total_basis?)
 
         # Derive price from market_value when possible; otherwise fall back to any price field
         fallback_price = parse_decimal(any_of(simplefin_holding, %w[purchase_price price unit_price average_cost avg_cost]))
@@ -125,42 +125,49 @@ class SimplefinAccount::Investments::HoldingsProcessor
     end
 
     # Sure stores holding cost_basis as per-share average cost. SimpleFIN
-    # brokerages are inconsistent:
-    #   - total_cost / value: always total position cost (per the SimpleFIN
-    #     spec / observed payloads); divide unconditionally.
-    #   - cost_basis / basis: the spec calls this per-share, but Vanguard and
-    #     Fidelity (issue #1718, #1182) populate it with the total instead.
-    #     We can't trust the key name, so we compare the raw value against
-    #     the holding's market share price and pick the interpretation that
-    #     lands closer to a believable per-share number.
+    # brokerages are inconsistent about which field carries which shape:
     #
-    # Heuristic for cost_basis/basis: let share_price = market_value / qty.
-    # The geometric midpoint between "raw is per-share" (raw ≈ share_price)
-    # and "raw is total" (raw ≈ qty × share_price) is share_price × √qty.
-    # If raw is above the midpoint it's almost certainly a total, so divide
-    # by qty; otherwise keep as per-share. Falls back to "treat as per-share"
-    # when market_value or qty is missing — same as the pre-fix behavior, so
-    # we never make a confidently-correct read worse.
-    def normalize_cost_basis(raw_cost_basis, qty, source_key, market_value = nil)
+    #   - total_cost / value: always a total position cost per the SimpleFIN
+    #     spec and observed payloads; divide by qty unconditionally.
+    #   - cost_basis / basis: the spec calls this per-share, and most
+    #     brokerages comply. Keep these values unchanged by default.
+    #
+    # Exception: a small allowlist of brokerages (Vanguard, Fidelity) is
+    # known to populate cost_basis with the total position cost in violation
+    # of the spec (#1718, #1182). For those connections only, divide by qty.
+    #
+    # An earlier revision of this fix used a magnitude heuristic
+    # (share_price × √qty midpoint). It was withdrawn because a legitimate
+    # per-share basis on a holding with a large unrealized loss
+    # (e.g. 100 shares with basis $100 now worth $5) trips the midpoint and
+    # gets mis-divided to $1/share — corrupting compliant providers. The
+    # allowlist trades some manual maintenance for that safety.
+    def normalize_cost_basis(raw_cost_basis, qty, source_key, total_basis_institution = false)
       return nil if raw_cost_basis.nil?
 
-      if %w[total_cost value].include?(source_key)
+      if %w[total_cost value].include?(source_key) ||
+         (total_basis_institution && %w[cost_basis basis].include?(source_key))
         return nil unless qty.to_d.positive?
         return raw_cost_basis / qty
       end
 
-      return raw_cost_basis unless qty.to_d.positive?
-      return raw_cost_basis unless market_value && market_value.to_d.positive?
+      raw_cost_basis
+    end
 
-      qty_f         = qty.to_f
-      share_price_f = market_value.to_f / qty_f
-      midpoint_f    = share_price_f * Math.sqrt(qty_f)
+    # Institutions known to populate the SimpleFIN `cost_basis` / `basis`
+    # field with the total position cost rather than the per-share value the
+    # spec requires. Matched as case-insensitive substrings against the
+    # account's stored org name and domain.
+    TOTAL_BASIS_INSTITUTIONS = %w[vanguard fidelity].freeze
 
-      if raw_cost_basis.to_f > midpoint_f
-        raw_cost_basis / qty
-      else
-        raw_cost_basis
-      end
+    def institution_reports_total_basis?
+      org = simplefin_account.respond_to?(:org_data) ? simplefin_account.org_data : nil
+      return false if org.blank?
+
+      candidates = [ org["name"], org[:name], org["domain"], org[:domain] ].compact.map(&:to_s).map(&:downcase)
+      return false if candidates.empty?
+
+      TOTAL_BASIS_INSTITUTIONS.any? { |needle| candidates.any? { |c| c.include?(needle) } }
     end
 
     def resolve_security(symbol, description)

--- a/app/models/simplefin_account/investments/holdings_processor.rb
+++ b/app/models/simplefin_account/investments/holdings_processor.rb
@@ -48,7 +48,7 @@ class SimplefinAccount::Investments::HoldingsProcessor
         qty = parse_decimal(any_of(simplefin_holding, %w[shares quantity qty units]))
         market_value = parse_decimal(any_of(simplefin_holding, %w[market_value current_value]))
         raw_cost_basis, cost_basis_source_key = cost_basis_from(simplefin_holding)
-        cost_basis = normalize_cost_basis(raw_cost_basis, qty, cost_basis_source_key)
+        cost_basis = normalize_cost_basis(raw_cost_basis, qty, cost_basis_source_key, market_value)
 
         # Derive price from market_value when possible; otherwise fall back to any price field
         fallback_price = parse_decimal(any_of(simplefin_holding, %w[purchase_price price unit_price average_cost avg_cost]))
@@ -124,15 +124,39 @@ class SimplefinAccount::Investments::HoldingsProcessor
       [ nil, nil ]
     end
 
-    # Sure stores holding cost_basis as per-share average cost. Some SimpleFIN
-    # providers expose total position basis via total_cost/value, so normalize only
-    # when the selected provider field is known to represent total position basis.
-    def normalize_cost_basis(raw_cost_basis, qty, source_key)
+    # Sure stores holding cost_basis as per-share average cost. SimpleFIN
+    # brokerages are inconsistent:
+    #   - total_cost / value: always total position cost (per the SimpleFIN
+    #     spec / observed payloads); divide unconditionally.
+    #   - cost_basis / basis: the spec calls this per-share, but Vanguard and
+    #     Fidelity (issue #1718, #1182) populate it with the total instead.
+    #     We can't trust the key name, so we compare the raw value against
+    #     the holding's market share price and pick the interpretation that
+    #     lands closer to a believable per-share number.
+    #
+    # Heuristic for cost_basis/basis: let share_price = market_value / qty.
+    # The geometric midpoint between "raw is per-share" (raw ≈ share_price)
+    # and "raw is total" (raw ≈ qty × share_price) is share_price × √qty.
+    # If raw is above the midpoint it's almost certainly a total, so divide
+    # by qty; otherwise keep as per-share. Falls back to "treat as per-share"
+    # when market_value or qty is missing — same as the pre-fix behavior, so
+    # we never make a confidently-correct read worse.
+    def normalize_cost_basis(raw_cost_basis, qty, source_key, market_value = nil)
       return nil if raw_cost_basis.nil?
 
       if %w[total_cost value].include?(source_key)
         return nil unless qty.to_d.positive?
+        return raw_cost_basis / qty
+      end
 
+      return raw_cost_basis unless qty.to_d.positive?
+      return raw_cost_basis unless market_value && market_value.to_d.positive?
+
+      qty_f         = qty.to_f
+      share_price_f = market_value.to_f / qty_f
+      midpoint_f    = share_price_f * Math.sqrt(qty_f)
+
+      if raw_cost_basis.to_f > midpoint_f
         raw_cost_basis / qty
       else
         raw_cost_basis

--- a/test/models/simplefin_account/investments/holdings_processor_test.rb
+++ b/test/models/simplefin_account/investments/holdings_processor_test.rb
@@ -80,64 +80,67 @@ class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::Test
     assert_equal "total_cost", source_key
   end
 
-  test "cost_basis reported as a total (Vanguard / Fidelity) is divided when market_value disagrees" do
-    # Issue #1718 / #1182: Vanguard puts the total position cost in cost_basis.
-    # Raw 22004.40 is two orders of magnitude above the ~$162 share price,
-    # so the heuristic should recognize it as a total and divide by qty.
-    payload = {
-      "shares" => "139.00",
-      "cost_basis" => "22004.40",
-      "market_value" => "22626.42"
-    }
-
-    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+  test "cost_basis from a known total-basis institution is divided by qty" do
+    # Issue #1718 / #1182: Vanguard populates cost_basis with the total
+    # position cost. When the institution is on the allowlist we divide.
     cost_basis = @processor.send(
       :normalize_cost_basis,
-      raw_cost_basis,
+      BigDecimal("22004.40"),
       BigDecimal("139.00"),
-      source_key,
-      BigDecimal("22626.42")
+      "cost_basis",
+      true # institution_reports_total_basis?
     )
 
     assert_in_delta 158.30, cost_basis.to_f, 0.01
-    assert_equal "cost_basis", source_key
   end
 
-  test "cost_basis reported as per-share is kept when market_value agrees" do
-    # Brokerage correctly reports per-share basis ($45) for a $50 share price.
-    # Heuristic must NOT divide this — that would produce a $0.45 phantom basis.
-    payload = {
-      "shares" => "100",
-      "cost_basis" => "45.00",
-      "market_value" => "5000.00"
-    }
-
-    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+  test "basis from a known total-basis institution is divided by qty" do
     cost_basis = @processor.send(
       :normalize_cost_basis,
-      raw_cost_basis,
-      BigDecimal("100"),
-      source_key,
-      BigDecimal("5000.00")
+      BigDecimal("9000.00"),
+      BigDecimal("200"),
+      "basis",
+      true
     )
 
     assert_equal BigDecimal("45.00"), cost_basis
   end
 
-  test "cost_basis heuristic falls back to per-share when market_value missing" do
-    # No market_value → can't sanity-check. Preserve pre-fix behavior of
-    # trusting the spec (treat as per-share) so we never regress a known-good
-    # provider just because the market value happens to be absent.
-    raw_cost_basis = BigDecimal("22004.40")
+  test "cost_basis from a compliant institution is kept untouched (no false divide)" do
+    # Codex regression: a legitimate per-share basis on a holding with a
+    # large unrealized loss (e.g. $100/share basis now worth $5/share) must
+    # NOT be divided by qty. Per the SimpleFIN spec, cost_basis is per-share
+    # — only the institution allowlist should override that.
     cost_basis = @processor.send(
       :normalize_cost_basis,
-      raw_cost_basis,
-      BigDecimal("139.00"),
+      BigDecimal("100.00"),
+      BigDecimal("100"),
       "cost_basis",
-      nil
+      false
     )
 
-    assert_equal raw_cost_basis, cost_basis
+    assert_equal BigDecimal("100.00"), cost_basis
+  end
+
+  test "institution_reports_total_basis? matches Vanguard and Fidelity org metadata" do
+    cases = {
+      { "name" => "Vanguard" }                          => true,
+      { "name" => "VANGUARD BROKERAGE" }                => true,
+      { "name" => "Fidelity Investments" }              => true,
+      { "domain" => "vanguard.com" }                    => true,
+      { "domain" => "401k.fidelity.com" }               => true,
+      { "name" => "Charles Schwab", "domain" => "schwab.com" } => false,
+      { "name" => "Chase" }                             => false,
+      {}                                                => false
+    }
+
+    cases.each do |org, expected|
+      account = Struct.new(:org_data).new(org)
+      processor = SimplefinAccount::Investments::HoldingsProcessor.new(account)
+      assert_equal expected,
+        processor.send(:institution_reports_total_basis?),
+        "org_data #{org.inspect} expected #{expected}"
+    end
   end
 
   test "missing cost basis fields return nil" do

--- a/test/models/simplefin_account/investments/holdings_processor_test.rb
+++ b/test/models/simplefin_account/investments/holdings_processor_test.rb
@@ -80,6 +80,66 @@ class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::Test
     assert_equal "total_cost", source_key
   end
 
+  test "cost_basis reported as a total (Vanguard / Fidelity) is divided when market_value disagrees" do
+    # Issue #1718 / #1182: Vanguard puts the total position cost in cost_basis.
+    # Raw 22004.40 is two orders of magnitude above the ~$162 share price,
+    # so the heuristic should recognize it as a total and divide by qty.
+    payload = {
+      "shares" => "139.00",
+      "cost_basis" => "22004.40",
+      "market_value" => "22626.42"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(
+      :normalize_cost_basis,
+      raw_cost_basis,
+      BigDecimal("139.00"),
+      source_key,
+      BigDecimal("22626.42")
+    )
+
+    assert_in_delta 158.30, cost_basis.to_f, 0.01
+    assert_equal "cost_basis", source_key
+  end
+
+  test "cost_basis reported as per-share is kept when market_value agrees" do
+    # Brokerage correctly reports per-share basis ($45) for a $50 share price.
+    # Heuristic must NOT divide this — that would produce a $0.45 phantom basis.
+    payload = {
+      "shares" => "100",
+      "cost_basis" => "45.00",
+      "market_value" => "5000.00"
+    }
+
+    raw_cost_basis, source_key = @processor.send(:cost_basis_from, payload)
+    cost_basis = @processor.send(
+      :normalize_cost_basis,
+      raw_cost_basis,
+      BigDecimal("100"),
+      source_key,
+      BigDecimal("5000.00")
+    )
+
+    assert_equal BigDecimal("45.00"), cost_basis
+  end
+
+  test "cost_basis heuristic falls back to per-share when market_value missing" do
+    # No market_value → can't sanity-check. Preserve pre-fix behavior of
+    # trusting the spec (treat as per-share) so we never regress a known-good
+    # provider just because the market value happens to be absent.
+    raw_cost_basis = BigDecimal("22004.40")
+    cost_basis = @processor.send(
+      :normalize_cost_basis,
+      raw_cost_basis,
+      BigDecimal("139.00"),
+      "cost_basis",
+      nil
+    )
+
+    assert_equal raw_cost_basis, cost_basis
+  end
+
   test "missing cost basis fields return nil" do
     payload = {
       "market_value" => "10108.16"


### PR DESCRIPTION
Closes #1718. Refs #1182, #1692.

## Bug

After PR #1692, SimpleFIN holdings imported from Vanguard / Fidelity
render a phantom ~-99% return on the entire investment account. Those
brokerages populate the SimpleFIN `cost_basis` key with the **total**
position cost (the spec says per-share — they don't follow it; see the
payload in #1182). PR #1692 stored it unchanged, then
`Holding#calculate_trend` computed `previous = qty × avg_cost`, so the
"previous" value ended up inflated by a factor of qty and the trend
became roughly `-(1 - 1/qty)`.

## Fix

In `SimplefinAccount::Investments::HoldingsProcessor#normalize_cost_basis`,
sanity-check raw `cost_basis` / `basis` values against the holding's
market share price.

Let `share_price = market_value / qty`. The geometric midpoint between
"raw is per-share" (`raw ≈ share_price`) and "raw is total"
(`raw ≈ qty × share_price`) is `share_price × √qty`. Above the
midpoint → treat as total and divide by qty; below → keep as
per-share. Falls back to the pre-fix behaviour (trust the spec) when
`market_value` or `qty` is missing, so we never regress confidently-
correct readings.

The `total_cost` / `value` keys retain their unconditional-divide
behaviour from #1692.

## Verification

Reproduced and verified against the Vanguard payload from #1182:
`qty = 139`, `cost_basis = 22004.40`, `market_value = 22626.42`.

### Before

| Scenario                                  | key        | stored_cb | previous   | trend    |
| ----------------------------------------- | ---------- | --------- | ---------- | -------- |
| Vanguard total in `cost_basis` (#1182)    | cost_basis | 22004.40  | 3,058,612  | -99.26%  |
| Fidelity-style total in `basis`           | basis      | 9,000.00  | 1,800,000  | -99.33%  |
| Honest per-share basis ($45 on $50 share) | cost_basis | 45.00     | 4,500      | +11.11%  |
| `total_cost` key (already handled)        | total_cost | 45.00     | 4,500      | +11.11%  |

### After

| Scenario                                  | key        | stored_cb | previous | trend    |
| ----------------------------------------- | ---------- | --------- | -------- | -------- |
| Vanguard total in `cost_basis` (#1182)    | cost_basis | **158.31**| 22,004   | **+2.83%** |
| Fidelity-style total in `basis`           | basis      | **45.00** | 9,000    | **+33.33%** |
| Honest per-share basis ($45 on $50 share) | cost_basis | 45.00     | 4,500    | +11.11% _(unchanged)_ |
| `total_cost` key (already handled)        | total_cost | 45.00     | 4,500    | +11.11% _(unchanged)_ |

## Test plan

- [x] `rubocop` clean on touched files
- [x] Added unit tests covering: Vanguard-style total in `cost_basis`,
      honest per-share basis with `market_value`, missing `market_value`
      fallback. Existing `cost_basis` / `basis` / `total_cost` / `value`
      / zero-qty / nil-qty tests retained.
- [ ] `bin/rails test test/models/simplefin_account/investments/holdings_processor_test.rb`
- [ ] Reviewer with a Vanguard or Fidelity SimpleFIN connection re-syncs
      an investment account and confirms the portfolio return collapses
      from ~-99% to a realistic value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost-basis interpretation for investment holdings so provider-reported totals from certain brokerages are handled correctly, preventing incorrect per-share division and ensuring displayed holding values are accurate.

* **Tests**
  * Added test coverage validating cost-basis normalization and institutional detection for known broker variants and non-compliant cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1772)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->