### PR TITLE
fix(ds/dialog): use existing i18n namespace for close button label

### DIFF
--- a/app/components/DS/dialog.rb
+++ b/app/components/DS/dialog.rb
@@ -133,8 +133,8 @@ class DS::Dialog < DesignSystemComponent
       variant: "icon",
       class: classes,
       icon: "x",
-      title: I18n.t("common.close"),
-      aria_label: I18n.t("common.close"),
+      title: I18n.t("ds.dialog.close"),
+      aria_label: I18n.t("ds.dialog.close"),
       data: { action: "DS--dialog#close" }
     )
   end

--- a/config/locales/views/components/en.yml
+++ b/config/locales/views/components/en.yml
@@ -8,6 +8,8 @@ en:
         warning: Warning
         error: Error
         destructive: Error
+    dialog:
+      close: Close
   provider_sync_summary:
     title: Sync summary
     last_sync: "Last sync: %{time_ago} ago"


### PR DESCRIPTION
**Description**

Closes #1763.

## Bug

`DS::Dialog#close_button` calls `I18n.t("common.close")`, but no
`common.close` key exists in any locale file under `config/locales/`.
With `raise_on_missing_translations` off in production, Rails falls
back to the literal string `"Translation missing: en.common.close"`,
which the component wires into both the `title` and `aria-label` of
the X close button on every modal rendered through `DS::Dialog`.

Visible in the DOM on every modal X button:

```html
<button ... title="Translation missing: en.common.close"
              aria-label="Translation missing: en.common.close" ...>
```

The string is read aloud by screen readers and surfaces as the OS-level
hover tooltip.

## Fix

- Switch the lookup in `app/components/DS/dialog.rb` from
  `common.close` (which doesn't exist) to `ds.dialog.close`, mirroring
  the existing `ds.alert.*` namespace already defined in
  `config/locales/views/components/en.yml`.
- Add the English string `ds.dialog.close: "Close"`. Other locales fall
  back to English via `config.i18n.fallbacks = true`
  (`config/application.rb:28`) until translators provide a localized
  string.

## Verification

Toggled the running container between the original (broken) file and
the patched file, captured the rendered DOM for the same modal's X
close button.

| State  | `title` / `aria-label`                       |
| ------ | -------------------------------------------- |
| Before | `Translation missing: en.common.close`       |
| After  | `Close`                                      |

Console sanity-check:

```
> I18n.t("common.close")
=> "Translation missing: en.common.close"
> I18n.t("ds.dialog.close")
=> "Close"
```

## Test plan

- [x] Manual DOM inspection of a modal X button in dev
- [x] `I18n.t("ds.dialog.close")` returns `"Close"` in console
- [ ] Reviewer hits any page that opens a modal (e.g. "New transaction"
      on an account, "New API key" in settings) and confirms the X
      button's `aria-label` reads `Close`


Before
<img width="1255" height="746" alt="1180_before" src="https://github.com/user-attachments/assets/109d7866-8709-48d6-8a71-739586951eec" />
After
<img width="1255" height="746" alt="1180_after" src="https://github.com/user-attachments/assets/7a770614-d7d5-453a-9efe-5d82caa8444c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized translation infrastructure for dialog components to align with design system standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1776)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->