### PR TITLE
fix(sso): preserve user-edited name across OIDC logins

### DIFF
--- a/app/models/oidc_identity.rb
+++ b/app/models/oidc_identity.rb
@@ -25,10 +25,13 @@ class OidcIdentity < ApplicationRecord
       groups: groups
     })
 
-    # Sync name to user if provided (keep existing if IdP doesn't provide)
+    # Sync name to user only when Sure has nothing on file (first link, or an
+    # admin blanked the field). Edits made inside Sure must survive subsequent
+    # SSO logins — previously the IdP value won unconditionally and clobbered
+    # any manually-edited name on every login (#1103).
     user.update!(
-      first_name: auth.info&.first_name.presence || user.first_name,
-      last_name: auth.info&.last_name.presence || user.last_name
+      first_name: user.first_name.presence || auth.info&.first_name.presence,
+      last_name: user.last_name.presence || auth.info&.last_name.presence
     )
 
     # Apply role mapping based on group membership

--- a/test/models/oidc_identity_test.rb
+++ b/test/models/oidc_identity_test.rb
@@ -57,6 +57,41 @@ class OidcIdentityTest < ActiveSupport::TestCase
     end
   end
 
+  test "sync_user_attributes! preserves user-edited first and last name" do
+    # Regression for #1103: every SSO login used to overwrite user.first_name
+    # with the IdP value, clobbering edits the user made inside Sure.
+    @user.update!(first_name: "Adam", last_name: "Smith")
+    auth = OmniAuth::AuthHash.new(
+      provider: @oidc_identity.provider,
+      uid: @oidc_identity.uid,
+      info: { email: @user.email, first_name: "Ben", last_name: "Jones" }
+    )
+
+    @oidc_identity.sync_user_attributes!(auth)
+
+    @user.reload
+    assert_equal "Adam", @user.first_name
+    assert_equal "Smith", @user.last_name
+    # Identity record itself still mirrors the IdP for audit / debugging.
+    assert_equal "Ben",   @oidc_identity.info["first_name"]
+    assert_equal "Jones", @oidc_identity.info["last_name"]
+  end
+
+  test "sync_user_attributes! fills blank user names from the IdP" do
+    @user.update!(first_name: nil, last_name: nil)
+    auth = OmniAuth::AuthHash.new(
+      provider: @oidc_identity.provider,
+      uid: @oidc_identity.uid,
+      info: { email: @user.email, first_name: "Ben", last_name: "Jones" }
+    )
+
+    @oidc_identity.sync_user_attributes!(auth)
+
+    @user.reload
+    assert_equal "Ben", @user.first_name
+    assert_equal "Jones", @user.last_name
+  end
+
   test "creates from omniauth hash" do
     auth = OmniAuth::AuthHash.new({
       provider: "google_oauth2",


### PR DESCRIPTION
**Description**
Closes #1103.

## Bug

`OidcIdentity#sync_user_attributes!` runs on every SSO sign-in. Its
precedence at [oidc_identity.rb:29-32](app/models/oidc_identity.rb#L29-L32)
was

```ruby
user.update!(
  first_name: auth.info&.first_name.presence || user.first_name,
  last_name:  auth.info&.last_name.presence  || user.last_name
)
```

i.e. the IdP value won whenever it was present. A user who edited
"Adam" inside Sure had it reset to the IdP value "Ben" on the very
next login. The reporter noticed `last_name` "stuck" — that was only
because their IdP didn't return a `last_name`, so the fallback to the
user's value kicked in by accident.

## Fix

Swap the precedence to

```ruby
user.update!(
  first_name: user.first_name.presence || auth.info&.first_name.presence,
  last_name:  user.last_name.presence  || auth.info&.last_name.presence
)
```

The IdP now fills the user's name **only** when Sure has nothing on
file — i.e. first time the identity is linked, or after an admin
blanked the field. Subsequent edits in Sure survive every login.

The audit copy on `OidcIdentity#info` (lines 20-26) is untouched — the
IdP-reported name remains available for debugging / display.

## Verification

Reproduced and verified with the reporter's exact scenario (Sure
"Adam/Smith", IdP "Ben/Jones") and three adjacent cases:

| Scenario                                             | Before    | After     |
| ---------------------------------------------------- | --------- | --------- |
| A — user edited in Sure, IdP also sends names (#1103)| Ben/Smith | **Adam/Smith** |
| B — fresh link, user has no name, IdP sends names    | Ben/Jones | Ben/Jones |
| C — user kept first name only, IdP sends both        | Ben/Jones | Adam/Jones |
| D — user blanked names, IdP sends nothing            | nil/nil   | nil/nil   |

## Test plan

- [x] Added regression test asserting `Adam/Smith` survives a sync
      with IdP `Ben/Jones`.
- [x] Added test asserting blank user names are filled from the IdP
      on first link.
- [x] `rubocop` clean
- [ ] Reviewer with a configured OIDC provider edits their name in
      Profile, logs out, logs back in via SSO, confirms the edited
      name is still there.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-edited first and last names are now preserved during SSO authentication. Names populate from the identity provider only when profile fields are blank.

* **Tests**
  * Added regression tests for name synchronization behavior during SSO authentication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1777)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->