### PR TITLE
feat(mobile): add mass delete for chats

### DIFF
--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -321,6 +321,42 @@ class ChatProvider with ChangeNotifier {
     }
   }
 
+  /// Delete multiple chats
+  Future<bool> deleteMultipleChats({
+    required String accessToken,
+    required List<String> chatIds,
+  }) async {
+    try {
+      final result = await _chatService.deleteMultipleChats(
+        accessToken: accessToken,
+        chatIds: chatIds,
+      );
+
+      final deletedCount = result['deletedCount'] as int;
+      if (result['success'] == true || deletedCount > 0) {
+        final failedIds = (result['failedIds'] as List).cast<String>().toSet();
+        final deleted = chatIds.toSet().difference(failedIds);
+        _chats.removeWhere((c) => deleted.contains(c.id));
+
+        if (_currentChat != null && deleted.contains(_currentChat!.id)) {
+          _currentChat = null;
+        }
+
+        notifyListeners();
+        return true;
+      }
+
+      _errorMessage = 'Failed to delete chats';
+      notifyListeners();
+      return false;
+    } catch (e) {
+      debugPrint('deleteMultipleChats error: $e');
+      _errorMessage = 'Something went wrong. Please try again.';
+      notifyListeners();
+      return false;
+    }
+  }
+
   /// Start polling for new messages (AI responses)
   void _startPolling(String accessToken, String chatId) {
     _pollingTimer?.cancel();

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -332,9 +332,9 @@ class ChatProvider with ChangeNotifier {
         chatIds: chatIds,
       );
 
-      final deletedCount = result['deletedCount'] as int;
+      final deletedCount = (result['deletedCount'] as int?) ?? 0;
       if (result['success'] == true || deletedCount > 0) {
-        final failedIds = (result['failedIds'] as List).cast<String>().toSet();
+        final failedIds = ((result['failedIds'] as List?) ?? []).cast<String>().toSet();
         final deleted = chatIds.toSet().difference(failedIds);
         _chats.removeWhere((c) => deleted.contains(c.id));
 

--- a/mobile/lib/screens/chat_list_screen.dart
+++ b/mobile/lib/screens/chat_list_screen.dart
@@ -12,6 +12,9 @@ class ChatListScreen extends StatefulWidget {
 }
 
 class _ChatListScreenState extends State<ChatListScreen> {
+  bool _isSelectionMode = false;
+  final Set<String> _selectedChatIds = {};
+
   @override
   void initState() {
     super.initState();
@@ -33,6 +36,89 @@ class _ChatListScreenState extends State<ChatListScreen> {
 
   Future<void> _handleRefresh() async {
     await _loadChats();
+  }
+
+  void _toggleSelectionMode() {
+    setState(() {
+      _isSelectionMode = !_isSelectionMode;
+      _selectedChatIds.clear();
+    });
+  }
+
+  void _toggleSelectAll(List<String> allIds) {
+    setState(() {
+      if (_selectedChatIds.length == allIds.length) {
+        _selectedChatIds.clear();
+      } else {
+        _selectedChatIds
+          ..clear()
+          ..addAll(allIds);
+      }
+    });
+  }
+
+  void _toggleChatSelection(String id) {
+    setState(() {
+      if (_selectedChatIds.contains(id)) {
+        _selectedChatIds.remove(id);
+      } else {
+        _selectedChatIds.add(id);
+      }
+    });
+  }
+
+  Future<void> _deleteSelectedChats() async {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    final chatProvider = Provider.of<ChatProvider>(context, listen: false);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Chats'),
+        content: Text(
+          'Delete ${_selectedChatIds.length} chat(s)? This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Delete', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    final accessToken = await authProvider.getValidAccessToken();
+    if (accessToken == null) {
+      await authProvider.logout();
+      return;
+    }
+
+    final success = await chatProvider.deleteMultipleChats(
+      accessToken: accessToken,
+      chatIds: _selectedChatIds.toList(),
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _isSelectionMode = false;
+      _selectedChatIds.clear();
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          success ? 'Chats deleted' : 'Some chats could not be deleted',
+        ),
+        backgroundColor: success ? Colors.green : Colors.red,
+      ),
+    );
   }
 
   Future<void> _openNewChat() async {
@@ -74,17 +160,38 @@ class _ChatListScreenState extends State<ChatListScreen> {
         title: const Text('Chats'),
         centerTitle: false,
         actions: [
-          Padding(
-            padding: const EdgeInsets.only(top: 12, right: 12),
-            child: InkWell(
-              onTap: _handleRefresh,
-              child: const SizedBox(
-                width: 36,
-                height: 36,
-                child: Icon(Icons.refresh),
+          if (_isSelectionMode) ...[
+            IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: _selectedChatIds.isNotEmpty ? _deleteSelectedChats : null,
+            ),
+            IconButton(
+              icon: const Icon(Icons.select_all),
+              onPressed: () {
+                final allIds = Provider.of<ChatProvider>(context, listen: false)
+                    .chats
+                    .map((c) => c.id)
+                    .toList();
+                _toggleSelectAll(allIds);
+              },
+            ),
+            IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: _toggleSelectionMode,
+            ),
+          ] else ...[
+            Padding(
+              padding: const EdgeInsets.only(top: 12, right: 12),
+              child: InkWell(
+                onTap: _handleRefresh,
+                child: const SizedBox(
+                  width: 36,
+                  height: 36,
+                  child: Icon(Icons.refresh),
+                ),
               ),
             ),
-          ),
+          ],
         ],
       ),
       body: Consumer<ChatProvider>(
@@ -166,9 +273,12 @@ class _ChatListScreenState extends State<ChatListScreen> {
               itemCount: chatProvider.chats.length,
               itemBuilder: (context, index) {
                 final chat = chatProvider.chats[index];
+                final isSelected = _selectedChatIds.contains(chat.id);
                 return Dismissible(
                   key: Key(chat.id),
-                  direction: DismissDirection.endToStart,
+                  direction: _isSelectionMode
+                      ? DismissDirection.none
+                      : DismissDirection.endToStart,
                   background: Container(
                     color: Colors.red,
                     alignment: Alignment.centerRight,
@@ -208,13 +318,18 @@ class _ChatListScreenState extends State<ChatListScreen> {
                     }
                   },
                   child: ListTile(
-                    leading: CircleAvatar(
-                      backgroundColor: colorScheme.primaryContainer,
-                      child: Icon(
-                        Icons.chat,
-                        color: colorScheme.onPrimaryContainer,
-                      ),
-                    ),
+                    leading: _isSelectionMode
+                        ? Checkbox(
+                            value: isSelected,
+                            onChanged: (_) => _toggleChatSelection(chat.id),
+                          )
+                        : CircleAvatar(
+                            backgroundColor: colorScheme.primaryContainer,
+                            child: Icon(
+                              Icons.chat,
+                              color: colorScheme.onPrimaryContainer,
+                            ),
+                          ),
                     title: Text(
                       chat.title,
                       maxLines: 1,
@@ -223,7 +338,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
                     subtitle: chat.lastMessageAt != null
                         ? Text(_formatDateTime(chat.lastMessageAt!))
                         : null,
-                    trailing: chat.messageCount != null
+                    trailing: chat.messageCount != null && !_isSelectionMode
                         ? Container(
                             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                             decoration: BoxDecoration(
@@ -241,6 +356,10 @@ class _ChatListScreenState extends State<ChatListScreen> {
                           )
                         : null,
                     onTap: () async {
+                      if (_isSelectionMode) {
+                        _toggleChatSelection(chat.id);
+                        return;
+                      }
                       await Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -249,6 +368,14 @@ class _ChatListScreenState extends State<ChatListScreen> {
                       );
                       _loadChats();
                     },
+                    onLongPress: _isSelectionMode
+                        ? null
+                        : () {
+                            setState(() {
+                              _isSelectionMode = true;
+                              _selectedChatIds.add(chat.id);
+                            });
+                          },
                   ),
                 );
               },

--- a/mobile/lib/screens/chat_list_screen.dart
+++ b/mobile/lib/screens/chat_list_screen.dart
@@ -114,7 +114,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(
-          success ? 'Chats deleted' : 'Some chats could not be deleted',
+          success ? 'Chats deleted' : 'Failed to delete chats',
         ),
         backgroundColor: success ? Colors.green : Colors.red,
       ),

--- a/mobile/lib/services/chat_service.dart
+++ b/mobile/lib/services/chat_service.dart
@@ -331,6 +331,27 @@ class ChatService {
     }
   }
 
+  /// Delete multiple chats in parallel
+  Future<Map<String, dynamic>> deleteMultipleChats({
+    required String accessToken,
+    required List<String> chatIds,
+  }) async {
+    final results = await Future.wait(
+      chatIds.map((id) => deleteChat(accessToken: accessToken, chatId: id)),
+    );
+    final failedIds = chatIds
+        .asMap()
+        .entries
+        .where((e) => results[e.key]['success'] != true)
+        .map((e) => e.value)
+        .toList();
+    return {
+      'success': failedIds.isEmpty,
+      'deletedCount': chatIds.length - failedIds.length,
+      'failedIds': failedIds,
+    };
+  }
+
   /// Retry the last assistant response in a chat
   Future<Map<String, dynamic>> retryMessage({
     required String accessToken,

--- a/mobile/lib/services/chat_service.dart
+++ b/mobile/lib/services/chat_service.dart
@@ -337,7 +337,14 @@ class ChatService {
     required List<String> chatIds,
   }) async {
     final results = await Future.wait(
-      chatIds.map((id) => deleteChat(accessToken: accessToken, chatId: id)),
+      chatIds.map((id) async {
+        try {
+          return await deleteChat(accessToken: accessToken, chatId: id);
+        } catch (_) {
+          return {'success': false};
+        }
+      }),
+      eagerError: false,
     );
     final failedIds = chatIds
         .asMap()


### PR DESCRIPTION
## Summary

- Long-press any chat to enter selection mode — that chat is pre-selected
- Tap individual chats to toggle selection, or use **Select All** to toggle all at once
- Delete icon in the AppBar is disabled until at least one chat is selected
- Confirmation dialog shows the count before deleting
- Deletions fire in parallel via `Future.wait()` against the existing `DELETE /api/v1/chats/{id}` endpoint — no backend changes needed
- Tap **✕** to exit selection mode without deleting
- Swipe-to-delete on individual chats continues to work outside selection mode

## Test plan

- [ ] Long-press a chat → selection mode activates, that chat is pre-selected
- [ ] Tap other chats to add/remove from selection
- [ ] Tap Select All → all chats selected; tap again → all deselected
- [ ] Delete icon disabled when no chats selected, enabled when ≥1 selected
- [ ] Confirm delete → selected chats removed, success snackbar shown
- [ ] Cancel delete → nothing deleted, selection mode remains
- [ ] Tap ✕ → exits selection mode, no deletions
- [ ] Swipe-to-delete still works outside selection mode
- [ ] Deleting all chats shows the empty state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select chats: long-press to enter selection mode, tap to toggle, select-all/close controls, and bulk-delete with confirmation.

* **Improvements**
  * Bulk delete now reports partial failures and updates the list accordingly.
  * UI adjusts in selection mode (checkboxes, disables swipe-to-delete, hides message count, app bar shows selection actions).
  * Shows success/error snackbars; missing session will trigger sign-out.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1779)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->