### PR TITLE
fix(a11y): add skip-link and aria-current="page" to application layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,9 @@ end %>
     data-app-layout-expanded-sidebar-class="<%= expanded_sidebar_class %>"
     data-app-layout-collapsed-sidebar-class="<%= collapsed_sidebar_class %>"
     data-app-layout-user-id-value="<%= Current.user.id %>">
+    <%= link_to t("layouts.application.skip_to_main"), "#main",
+        class: "sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-2 focus:rounded-lg focus:bg-container focus:text-primary focus:shadow-border-xs" %>
+
     <div
       class="hidden fixed inset-0 bg-surface z-20 h-full w-full pt-[calc(env(safe-area-inset-top)+0.75rem)] pr-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pl-3 overflow-y-auto transition-all duration-300"
       data-app-layout-target="mobileSidebar">
@@ -139,7 +142,7 @@ end %>
     <% end %>
 
     <%# SHARED - Main content %>
-    <%= tag.main class: class_names("grow overflow-y-auto px-3 lg:px-10 w-full mx-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-0"), data: { app_layout_target: "content", viewport_target: "content" } do %>
+    <%= tag.main id: "main", class: class_names("grow overflow-y-auto px-3 lg:px-10 w-full mx-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-0"), data: { app_layout_target: "content", viewport_target: "content" } do %>
       <% unless intro_mode %>
         <div class="hidden lg:flex gap-2 items-center justify-between mb-6 sticky top-0 z-10 -mx-3 lg:-mx-10 px-3 lg:px-10 py-4 bg-surface border-b border-tertiary">
           <div class="flex items-center gap-2">

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -1,12 +1,15 @@
 <%= render "layouts/shared/htmldoc" do %>
   <div class="flex flex-col md:flex-row h-full bg-surface pt-[env(safe-area-inset-top)]">
+    <%= link_to t("layouts.application.skip_to_main"), "#main",
+        class: "sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-2 focus:rounded-lg focus:bg-container focus:text-primary focus:shadow-border-xs" %>
+
     <div class="w-full md:w-auto md:min-w-64 shrink-0 md:h-full md:overflow-y-auto border-divider md:border-r">
       <div class="p-4">
         <%= render "settings/settings_nav" %>
       </div>
     </div>
 
-    <main class="grow flex h-full">
+    <main id="main" class="grow flex h-full">
       <div class="relative max-w-4xl mx-auto flex flex-col w-full h-full">
         <div class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]">
           <div class="sticky top-0 z-10 px-3 md:px-10 pt-1.5 md:pt-3 pb-3 bg-surface border-b border-tertiary shrink-0">

--- a/app/views/layouts/shared/_nav_item.html.erb
+++ b/app/views/layouts/shared/_nav_item.html.erb
@@ -1,6 +1,6 @@
 <%# locals:(name:, path:, icon:, icon_custom:, active:, mobile_only: false) %>
 
-<%= link_to path, class: "space-y-1 group block relative pb-1" do %>
+<%= link_to path, class: "space-y-1 group block relative pb-1", aria: { current: ("page" if active) } do %>
   <div class="grow flex flex-col lg:flex-row gap-1 items-center">
     <%= tag.div class: class_names("w-4 h-1 lg:w-1 lg:h-4 rounded-bl-sm rounded-br-sm lg:rounded-tr-sm lg:rounded-br-sm lg:rounded-bl-none", "bg-nav-indicator" => active) %>
 

--- a/config/locales/views/layout/ca.yml
+++ b/config/locales/views/layout/ca.yml
@@ -3,6 +3,7 @@ ca:
   layouts:
     application:
       privacy_mode: Alternar mode de privadesa
+      skip_to_main: Saltar al contingut principal
       nav:
         assistant: Assistent
         budgets: Pressupostos

--- a/config/locales/views/layout/de.yml
+++ b/config/locales/views/layout/de.yml
@@ -3,6 +3,7 @@ de:
   layouts:
     application:
       privacy_mode: Datenschutzmodus umschalten
+      skip_to_main: Zum Hauptinhalt springen
       nav:
         assistant: Assistent
         budgets: Budgets

--- a/config/locales/views/layout/en.yml
+++ b/config/locales/views/layout/en.yml
@@ -3,6 +3,7 @@ en:
   layouts:
     application:
       privacy_mode: Toggle privacy mode
+      skip_to_main: Skip to main content
       nav:
         assistant: Assistant
         budgets: Budgets

--- a/config/locales/views/layout/es.yml
+++ b/config/locales/views/layout/es.yml
@@ -3,6 +3,7 @@ es:
   layouts:
     application:
       privacy_mode: Alternar modo de privacidad
+      skip_to_main: Saltar al contenido principal
       nav:
         assistant: Asistente
         budgets: Presupuestos

--- a/config/locales/views/layout/fr.yml
+++ b/config/locales/views/layout/fr.yml
@@ -3,6 +3,7 @@ fr:
   layouts:
     application:
       privacy_mode: Activer/désactiver le mode confidentialité
+      skip_to_main: Aller au contenu principal
       nav:
         assistant: Assistant
         budgets: Budgets

--- a/config/locales/views/layout/hu.yml
+++ b/config/locales/views/layout/hu.yml
@@ -3,6 +3,7 @@ hu:
   layouts:
     application:
       privacy_mode: Adatvédelmi mód váltása
+      skip_to_main: Ugrás a fő tartalomhoz
       nav:
         assistant: Asszisztens
         budgets: Költségvetések

--- a/config/locales/views/layout/nb.yml
+++ b/config/locales/views/layout/nb.yml
@@ -3,6 +3,7 @@ nb:
   layouts:
     application:
       privacy_mode: Veksle personvernmodus
+      skip_to_main: Hopp til hovedinnhold
       nav:
         assistant: Assistent
         budgets: Budsjett

--- a/config/locales/views/layout/nl.yml
+++ b/config/locales/views/layout/nl.yml
@@ -3,6 +3,7 @@ nl:
   layouts:
     application:
       privacy_mode: Privacymodus in-/uitschakelen
+      skip_to_main: Ga naar hoofdinhoud
       nav:
         assistant: Assistent
         budgets: Budgetten

--- a/config/locales/views/layout/pl.yml
+++ b/config/locales/views/layout/pl.yml
@@ -3,6 +3,7 @@ pl:
   layouts:
     application:
       privacy_mode: Przełącz tryb prywatności
+      skip_to_main: Przejdź do głównej treści
       nav:
         assistant: Asystent
         budgets: Budżety

--- a/config/locales/views/layout/pt-BR.yml
+++ b/config/locales/views/layout/pt-BR.yml
@@ -3,6 +3,7 @@ pt-BR:
   layouts:
     application:
       privacy_mode: Alternar modo de privacidade
+      skip_to_main: Pular para o conteúdo principal
       nav:
         assistant: Assistente
         budgets: Orçamentos

--- a/config/locales/views/layout/ro.yml
+++ b/config/locales/views/layout/ro.yml
@@ -3,6 +3,7 @@ ro:
   layouts:
     application:
       privacy_mode: Comutare mod confidențialitate
+      skip_to_main: Sari la conținutul principal
       nav:
         assistant: Asistent
         budgets: Bugete

--- a/config/locales/views/layout/tr.yml
+++ b/config/locales/views/layout/tr.yml
@@ -3,6 +3,7 @@ tr:
   layouts:
     application:
       privacy_mode: Gizlilik modunu değiştir
+      skip_to_main: Ana içeriğe atla
       nav:
         assistant: Asistan
         budgets: Bütçeler

--- a/config/locales/views/layout/zh-CN.yml
+++ b/config/locales/views/layout/zh-CN.yml
@@ -4,6 +4,7 @@ zh-CN:
   layouts:
     application:
       privacy_mode: 切换隐私模式
+      skip_to_main: 跳到主要内容
       nav:
         assistant: 智能助手
         budgets: 预算管理

--- a/config/locales/views/layout/zh-TW.yml
+++ b/config/locales/views/layout/zh-TW.yml
@@ -3,6 +3,7 @@ zh-TW:
   layouts:
     application:
       privacy_mode: 切換隱私模式
+      skip_to_main: 跳至主要內容
       nav:
         assistant: 助手
         budgets: 預算

--- a/test/integration/layout_accessibility_test.rb
+++ b/test/integration/layout_accessibility_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class LayoutAccessibilityTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+  end
+
+  test "application layout renders skip-link pointing at #main and a <main> with id=\"main\"" do
+    get root_path
+    assert_response :ok
+
+    skip_text = I18n.t("layouts.application.skip_to_main")
+
+    assert_select "a[href=\"#main\"]", text: skip_text
+    assert_select "main#main"
+  end
+end

--- a/test/integration/layout_accessibility_test.rb
+++ b/test/integration/layout_accessibility_test.rb
@@ -14,4 +14,14 @@ class LayoutAccessibilityTest < ActionDispatch::IntegrationTest
     assert_select "a[href=\"#main\"]", text: skip_text
     assert_select "main#main"
   end
+
+  test "settings layout renders skip-link pointing at #main and a <main> with id=\"main\"" do
+    get settings_profile_path
+    assert_response :ok
+
+    skip_text = I18n.t("layouts.application.skip_to_main")
+
+    assert_select "a[href=\"#main\"]", text: skip_text
+    assert_select "main#main"
+  end
 end

--- a/test/views/layouts/shared/nav_item_view_test.rb
+++ b/test/views/layouts/shared/nav_item_view_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class NavItemViewTest < ActionView::TestCase
+  test "active nav item carries aria-current=\"page\"" do
+    html = render(partial: "layouts/shared/nav_item", locals: {
+      name: "Transactions",
+      path: "/transactions",
+      icon: "credit-card",
+      icon_custom: false,
+      active: true
+    })
+
+    assert_includes html, "aria-current=\"page\""
+  end
+
+  test "inactive nav item omits aria-current" do
+    html = render(partial: "layouts/shared/nav_item", locals: {
+      name: "Transactions",
+      path: "/transactions",
+      icon: "credit-card",
+      icon_custom: false,
+      active: false
+    })
+
+    assert_not_includes html, "aria-current"
+  end
+end


### PR DESCRIPTION
# Summary
- Add a focus-visible "Skip to main content" link as the first focusable element of the application layout, anchored to the now-`id="main"` `<main>` element.
- Emit `aria-current="page"` on the active link in the shared nav-item partial — applies to both the desktop primary nav and the mobile bottom nav.
- Add the new `layouts.application.skip_to_main` i18n key across all 14 supported locales.

# Root Cause
- **WCAG 2.4.1 Bypass Blocks**: the application layout exposed no skip-link, so keyboard-only users had to Tab through the top mobile nav, logo, ~6 primary nav items, and the account sidebar before reaching content.
- **WCAG 1.3.1 / 4.1.2 Info & Relationships / Name, Role, Value**: the shared nav-item partial rendered the active state with a visual indicator only (`bg-nav-indicator` bar + `text-primary`). Assistive technology had no way to announce the current location because `aria-current` was never written to the `<a>`.

# Changes Made
- [`app/views/layouts/application.html.erb`](app/views/layouts/application.html.erb) — Added a `sr-only` / `focus:not-sr-only` skip-link as the first child of the outer wrapper, and `id: "main"` on the existing `tag.main` call so the anchor resolves.
- [`app/views/layouts/shared/_nav_item.html.erb`](app/views/layouts/shared/_nav_item.html.erb) — Added `aria: { current: ("page" if active) }` to the existing `link_to`, reusing the partial's already-passed `active` local. Mirrors the existing pattern in `app/views/settings/_settings_nav_item.html.erb:6`.
- `config/locales/views/layout/{ca,de,en,es,fr,hu,nb,nl,pl,pt-BR,ro,tr,zh-CN,zh-TW}.yml` — Added `skip_to_main` under `layouts.application` (14 locales).
- `test/views/layouts/shared/nav_item_view_test.rb` (new) — `ActionView::TestCase` render test asserting `aria-current="page"` is present when `active: true` and absent when `active: false`.

# Review Feedback Addressed
- **Test-runner environment** — *resolved.* Built the project's `.devcontainer/Dockerfile` (Ruby 3.4.7) and provisioned a Postgres 16 instance, then ran the tests for real. The new test file originally used `class Layouts::Shared::NavItemViewTest`, which failed at load time with `NameError: uninitialized constant Layouts` because no `Layouts::Shared` module exists in this autoload graph. Renamed the test class to top-level `NavItemViewTest` (matches the in-repo `Transactions::MergedBadgeViewTest` style after that namespace is dropped).
- **Green evidence** — *resolved.* Concrete output captured in the **Testing Evidence** section below.
- **`/llm/list` behavioral assertion for new OpenAI IDs** — *not actioned.* This PR is a pure accessibility change with zero LLM/OpenAI code. The repo has no `/llm/list` endpoint (`grep -rn 'llm/list\|llms#index\|resources :llms' app config` is empty; the only LLM-adjacent route is `resource :llm_usage, only: :show`). Adding an assertion against a non-existent endpoint would violate the scope of this PR and produce a guaranteed-broken test. Suspected misrouted feedback — please confirm or withdraw.

# Testing Evidence
Executed inside `sure-dev:test` (built from `.devcontainer/Dockerfile`, Ruby 3.4.7) against Postgres 16:

- **Focused partial test** — `bundle exec rails test test/views/layouts/shared/nav_item_view_test.rb`
  ```
  Run options: --seed 60095
  # Running:
  ..
  Finished in 2.526769s, 0.7915 runs/s, 1.5830 assertions/s.
  2 runs, 4 assertions, 0 failures, 0 errors, 0 skips
  ```
- **Broader sweep** — `bundle exec rails test test/views/ test/helpers/application_helper_test.rb test/controllers/pages_controller_test.rb test/i18n_test.rb`
  ```
  Run options: --seed 44012
  # Running:
  ...............SSSS..
  Finished in 6.493687s, 3.2339 runs/s, 5.0819 assertions/s.
  21 runs, 33 assertions, 0 failures, 0 errors, 4 skips
  ```
  *(The 4 skips are pre-existing in `test/i18n_test.rb` and are unrelated to this change.)*
- **Pages controller (renders the modified application layout)** —
  ```
  Run options: --seed 55574
  # Running:
  .......
  Finished in 6.342300s, 1.1037 runs/s, 2.3651 assertions/s.
  7 runs, 15 assertions, 0 failures, 0 errors, 0 skips
  ```
- **Linting**
  - `bundle exec rubocop test/views/layouts/shared/nav_item_view_test.rb` → `1 file inspected, no offenses detected`
  - `bundle exec erb_lint app/views/layouts/application.html.erb app/views/layouts/shared/_nav_item.html.erb` → `Linting 2 files with 16 linters... No errors were found in ERB files`

# Risks / Limitations
- `<main>` is not natively focusable. Modern browsers move focus on `:target` activation, but some screen-reader/browser combinations do not announce focus on a non-tabbable element. Optional follow-up: add `tabindex="-1"` to `tag.main`. Out of scope per issue body.
- Skip-link `focus:top-2` sits in the same vertical zone as the notification tray (`top-6 / md:top-4`). Overlap is brief (only while the link is focused) and resolves on Enter activation, but happy to switch to `focus:top-12` if preferred.
- Other layouts (`settings.html.erb`, `wizard.html.erb`, `imports.html.erb`) each render their own `<main>` without an id and have no skip-link. Out of scope here — worth tracking as a follow-up so the audit is eventually app-wide.
- **System tests not run** in this environment (selenium not provisioned for the focused remediation pass). CI should run `DISABLE_PARALLELIZATION=true bin/rails test:system` as the final gate.

# Notes
- Pattern reused from `app/views/settings/_settings_nav_item.html.erb:6` — same `aria: { current: ("page" if ...) }` idiom.
- `scroll_on_connect_controller.js` already keys off `[aria-current="page"]`. The primary nav containers do not opt into that controller today, so behavior is purely additive; no existing call sites are affected.
- **Merge gate pending reviewer response** on the `/llm/list` item flagged under "Review Feedback Addressed". Once that item is withdrawn or clarified as out-of-scope for #1765, this PR is ready.
- Closes #1765


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Skip to main content" link for quick keyboard navigation and focus.

* **Accessibility**
  * Navigation links now include aria-current when active for better screen-reader feedback.
  * Layouts include a main region with an explicit id so the skip link reliably targets content.

* **Localization**
  * Added localized labels for the skip-to-main control across multiple languages.

* **Tests**
  * Added view and integration tests verifying skip-link behavior and aria-current handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1781)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->