### PR TITLE
fix(enable-banking): fix pending→posted auto-claim producing badge, duplicate, and wrong date

### DIFF
--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -109,8 +109,27 @@ class Account::ProviderImportAdapter
         end
 
         if pending_match
+          old_pending_external_id = pending_match.external_id
           entry = pending_match
           entry.assign_attributes(external_id: external_id)
+
+          # Clear the pending flag so this entry no longer shows as pending after being claimed
+          # by a booked transaction. Also record the old external_id so the sync engine can
+          # exclude it from re-import (preventing the old pending from being recreated on the
+          # next sync when the stored raw payload still contains the pending transaction data).
+          if entry.entryable.is_a?(Transaction)
+            ex = (entry.transaction.extra || {}).deep_dup
+            Transaction::PENDING_PROVIDERS.each do |provider|
+              next unless ex.key?(provider)
+              ex[provider].delete("pending")
+              ex.delete(provider) if ex[provider].empty?
+            end
+            if old_pending_external_id.present?
+              existing_claims = Array.wrap(ex["auto_claimed_pending_ids"])
+              ex["auto_claimed_pending_ids"] = (existing_claims + [ old_pending_external_id ]).uniq
+            end
+            entry.transaction.extra = ex
+          end
         end
       end
 

--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -110,6 +110,7 @@ class Account::ProviderImportAdapter
 
         if pending_match
           old_pending_external_id = pending_match.external_id
+          pending_entry_date      = pending_match.date
           entry = pending_match
           entry.assign_attributes(external_id: external_id)
 
@@ -139,7 +140,7 @@ class Account::ProviderImportAdapter
       entry.assign_attributes(
         amount: amount,
         currency: currency,
-        date: date
+        date: pending_entry_date || date
       )
 
       # Use enrichment pattern to respect user overrides

--- a/app/models/enable_banking_account/transactions/processor.rb
+++ b/app/models/enable_banking_account/transactions/processor.rb
@@ -23,29 +23,51 @@ class EnableBankingAccount::Transactions::Processor
       Account::ProviderImportAdapter.new(enable_banking_account.current_account)
     end
 
-    # Pre-fetch external_ids that were manually merged and must not be re-imported.
-    # One query per sync; O(1) Set lookup per transaction — avoids N+1.
-    # Uses a lateral jsonb_array_elements join to extract only the ID strings in SQL,
-    # avoiding loading full extra blobs into Ruby. Handles both Array (current) and
-    # Hash (legacy) formats via jsonb_typeof.
+    # Pre-fetch external_ids that must not be re-imported.
+    # One query per category per sync; O(1) Set lookup per transaction — avoids N+1.
     excluded_ids = if enable_banking_account.current_account
-      Transaction.joins(:entry)
-                 .where(entries: { account_id: enable_banking_account.current_account.id })
-                 .where("transactions.extra ? 'manual_merge'")
-                 .joins(
-                   Arel.sql(<<~SQL.squish)
-                     CROSS JOIN LATERAL jsonb_array_elements(
-                       CASE jsonb_typeof(transactions.extra->'manual_merge')
-                       WHEN 'array'  THEN transactions.extra->'manual_merge'
-                       WHEN 'object' THEN jsonb_build_array(transactions.extra->'manual_merge')
-                       ELSE '[]'::jsonb
-                       END
-                     ) AS merge_elem
-                   SQL
-                 )
-                 .pluck(Arel.sql("merge_elem->>'merged_from_external_id'"))
-                 .compact
-                 .to_set
+      account_id = enable_banking_account.current_account.id
+
+      # 1. Manually merged: pending entries the user explicitly merged into a posted transaction.
+      #    Uses a lateral join to extract merged_from_external_id from the manual_merge JSON
+      #    (handles both Array current format and legacy Hash format via jsonb_typeof).
+      manually_merged_ids = Transaction.joins(:entry)
+                                       .where(entries: { account_id: account_id })
+                                       .where("transactions.extra ? 'manual_merge'")
+                                       .joins(
+                                         Arel.sql(<<~SQL.squish)
+                                           CROSS JOIN LATERAL jsonb_array_elements(
+                                             CASE jsonb_typeof(transactions.extra->'manual_merge')
+                                             WHEN 'array'  THEN transactions.extra->'manual_merge'
+                                             WHEN 'object' THEN jsonb_build_array(transactions.extra->'manual_merge')
+                                             ELSE '[]'::jsonb
+                                             END
+                                           ) AS merge_elem
+                                         SQL
+                                       )
+                                       .pluck(Arel.sql("merge_elem->>'merged_from_external_id'"))
+                                       .compact
+                                       .to_set
+
+      # 2. Auto-claimed: pending entries that were automatically matched to a booked transaction
+      #    by the amount/date heuristic. Their old external_ids are stored in
+      #    extra["auto_claimed_pending_ids"] so they are not re-imported as new pending entries
+      #    on subsequent syncs (the stored raw payload still contains the old pending data).
+      auto_claimed_ids = Transaction.joins(:entry)
+                                    .where(entries: { account_id: account_id })
+                                    .where("transactions.extra ? 'auto_claimed_pending_ids'")
+                                    .joins(
+                                      Arel.sql(<<~SQL.squish)
+                                        CROSS JOIN LATERAL jsonb_array_elements_text(
+                                          transactions.extra->'auto_claimed_pending_ids'
+                                        ) AS claimed_id
+                                      SQL
+                                    )
+                                    .pluck(Arel.sql("claimed_id"))
+                                    .compact
+                                    .to_set
+
+      manually_merged_ids | auto_claimed_ids
     else
       Set.new
     end

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -881,14 +881,15 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
     end
   end
 
-  test "clears pending flag and records old external_id when claiming pending entry with nil extra" do
+  test "clears pending flag, preserves pending date, and records old external_id when claiming pending entry with nil extra" do
     # Enable Banking booked transactions often have nil extra (no FX, no MCC).
     # The deep_merge path is skipped, so we must clear the pending flag explicitly.
+    pending_date = Date.today - 2.days
     pending_entry = @adapter.import_transaction(
       external_id: "eb_pending_nil_extra",
       amount: 42.00,
       currency: "EUR",
-      date: Date.today - 1.day,
+      date: pending_date,
       name: "Supermarket",
       source: "enable_banking",
       extra: { "enable_banking" => { "pending" => true } }
@@ -901,7 +902,7 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
         external_id: "eb_booked_nil_extra",
         amount: 42.00,
         currency: "EUR",
-        date: Date.today,
+        date: Date.today,   # booked date is later than pending date
         name: "Supermarket Posted",
         source: "enable_banking",
         extra: nil  # typical for simple Enable Banking booked transactions
@@ -910,9 +911,13 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
       assert_equal pending_entry.id, posted_entry.id, "should claim the pending entry"
       assert_equal "eb_booked_nil_extra", posted_entry.external_id
 
-      # Pending flag must be cleared so the entry no longer shows a pending badge
       posted_entry.reload
+
+      # Pending flag must be cleared so the entry no longer shows a pending badge
       assert_not posted_entry.transaction.pending?, "pending flag should be cleared after claim"
+
+      # Date must be the original pending date, not the later booked date
+      assert_equal pending_date, posted_entry.date, "pending date should be preserved, not overwritten with booked date"
 
       # Old pending external_id must be stored so the sync engine can skip re-importing it
       claimed_ids = posted_entry.transaction.extra&.dig("auto_claimed_pending_ids") || []

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -881,6 +881,46 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
     end
   end
 
+  test "clears pending flag and records old external_id when claiming pending entry with nil extra" do
+    # Enable Banking booked transactions often have nil extra (no FX, no MCC).
+    # The deep_merge path is skipped, so we must clear the pending flag explicitly.
+    pending_entry = @adapter.import_transaction(
+      external_id: "eb_pending_nil_extra",
+      amount: 42.00,
+      currency: "EUR",
+      date: Date.today - 1.day,
+      name: "Supermarket",
+      source: "enable_banking",
+      extra: { "enable_banking" => { "pending" => true } }
+    )
+
+    assert pending_entry.transaction.pending?, "should be pending before claim"
+
+    assert_no_difference "@account.entries.count" do
+      posted_entry = @adapter.import_transaction(
+        external_id: "eb_booked_nil_extra",
+        amount: 42.00,
+        currency: "EUR",
+        date: Date.today,
+        name: "Supermarket Posted",
+        source: "enable_banking",
+        extra: nil  # typical for simple Enable Banking booked transactions
+      )
+
+      assert_equal pending_entry.id, posted_entry.id, "should claim the pending entry"
+      assert_equal "eb_booked_nil_extra", posted_entry.external_id
+
+      # Pending flag must be cleared so the entry no longer shows a pending badge
+      posted_entry.reload
+      assert_not posted_entry.transaction.pending?, "pending flag should be cleared after claim"
+
+      # Old pending external_id must be stored so the sync engine can skip re-importing it
+      claimed_ids = posted_entry.transaction.extra&.dig("auto_claimed_pending_ids") || []
+      assert_includes claimed_ids, "eb_pending_nil_extra",
+        "auto_claimed_pending_ids should record the old pending external_id"
+    end
+  end
+
   test "does not reconcile when posted transaction has same external_id as pending" do
     # When external_id matches, normal dedup should handle it
     pending_entry = @adapter.import_transaction(

--- a/test/models/enable_banking_account/transactions/processor_test.rb
+++ b/test/models/enable_banking_account/transactions/processor_test.rb
@@ -186,6 +186,89 @@ class EnableBankingAccount::Transactions::ProcessorTest < ActiveSupport::TestCas
     result = EnableBankingAccount::Transactions::Processor.new(@enable_banking_account).process
 
     assert_equal 0, result[:failed]
+  end
+
+  test "does not re-import a pending transaction whose external_id was auto-claimed" do
+    # When a pending entry is automatically matched to a booked transaction by the
+    # amount/date heuristic (find_pending_transaction), the old pending external_id
+    # is stored in auto_claimed_pending_ids so subsequent syncs don't recreate it.
+    pending_ext_id = "enable_banking_PDNG_AUTO_CLAIMED"
+
+    booked_entry = create_transaction(
+      account:     @account,
+      name:        "Grocery Store",
+      date:        1.day.ago.to_date,
+      amount:      55,
+      currency:    "EUR",
+      external_id: "enable_banking_BOOK_SETTLED",
+      source:      "enable_banking"
+    )
+    booked_entry.transaction.update!(
+      extra: {
+        "auto_claimed_pending_ids" => [ pending_ext_id ]
+      }
+    )
+
+    @enable_banking_account.update!(
+      raw_transactions_payload: [
+        raw_pending_transaction(transaction_id: "PDNG_AUTO_CLAIMED")
+      ]
+    )
+
+    assert_no_difference "@account.entries.count" do
+      EnableBankingAccount::Transactions::Processor.new(@enable_banking_account).process
+    end
+  end
+
+  test "does not re-import when both manual_merge and auto_claimed_pending_ids exclusions are present" do
+    manually_merged_ext_id  = "enable_banking_PDNG_MANUAL"
+    auto_claimed_ext_id     = "enable_banking_PDNG_AUTO"
+
+    manual_entry = create_transaction(
+      account:     @account,
+      name:        "Manual Merge Entry",
+      date:        2.days.ago.to_date,
+      amount:      20,
+      currency:    "EUR",
+      external_id: "enable_banking_BOOK_MANUAL",
+      source:      "enable_banking"
+    )
+    manual_entry.transaction.update!(
+      extra: {
+        "manual_merge" => {
+          "merged_from_external_id" => manually_merged_ext_id,
+          "merged_at"               => Time.current.iso8601,
+          "source"                  => "enable_banking"
+        }
+      }
+    )
+
+    auto_entry = create_transaction(
+      account:     @account,
+      name:        "Auto Claimed Entry",
+      date:        1.day.ago.to_date,
+      amount:      30,
+      currency:    "EUR",
+      external_id: "enable_banking_BOOK_AUTO",
+      source:      "enable_banking"
+    )
+    auto_entry.transaction.update!(
+      extra: { "auto_claimed_pending_ids" => [ auto_claimed_ext_id ] }
+    )
+
+    @enable_banking_account.update!(
+      raw_transactions_payload: [
+        raw_pending_transaction(transaction_id: "PDNG_MANUAL"),         # excluded via manual_merge
+        raw_pending_transaction(transaction_id: "PDNG_AUTO"),           # excluded via auto_claimed_pending_ids
+        raw_pending_transaction(transaction_id: "PDNG_BRAND_NEW_XXXX")  # new — should import
+      ]
+    )
+
+    result = nil
+    assert_difference "@account.entries.count", 1 do
+      result = EnableBankingAccount::Transactions::Processor.new(@enable_banking_account).process
+    end
+    assert_equal 2, result[:skipped]
     assert_equal 1, result[:imported]
   end
 


### PR DESCRIPTION
## Problem

When Enable Banking syncs a booked transaction that matches an existing pending entry by amount/date (the auto-claim path in `find_pending_transaction`), three things went wrong:

**1. Pending badge on the booked entry**
The `extra["enable_banking"]["pending"] = true` flag was never cleared on the claimed entry. For simple transactions (no FX, no MCC) the incoming `extra` is `nil`, so the deep-merge block is skipped entirely — the badge persisted forever.

**2. The original pending entry reappeared after the next sync**
After the claim, the old pending `external_id` (e.g. `PDNG_123`) stayed in the stored `raw_transactions_payload`. Enable Banking issues completely different IDs for pending vs. booked transactions, so the importer's C4 filter — which only matches by `transaction_id` equality — never pruned it. On the next sync, `find_or_initialize_by(external_id: "PDNG_123")` couldn't find the claimed entry (now keyed as `BOOK_456`) and created a fresh pending duplicate with no category.

**3. Wrong date on the claimed entry**
The pending date (when the transaction was initiated) was silently overwritten with the booked/settlement date — inconsistent with how the manual `merge_with_duplicate!` path already handles this.

The result visible to users: a booked transaction showing a pending badge, the user-assigned category, and a later date; plus the original pending transaction reappearing alongside it with no category and the correct earlier date.

## Solution

**`ProviderImportAdapter#import_transaction`**
- Capture `pending_entry_date` and `old_pending_external_id` before claiming.
- Use `pending_entry_date || date` when assigning attributes so the pending date is preserved.
- Clear the `pending` key from all providers in `extra` in-memory (persisted by the existing save path).
- Store `old_pending_external_id` in `extra["auto_claimed_pending_ids"]` so the Processor knows to skip it.

**`EnableBankingAccount::Transactions::Processor#process`**
- Add a second LATERAL query alongside the existing `manual_merge` exclusion to also collect all `auto_claimed_pending_ids`, then union both into `excluded_ids`. This prevents the old pending `external_id` from being re-imported on every subsequent sync.

## Testing

- `provider_import_adapter_test.rb`: new test covers nil-extra auto-claim — asserts pending flag cleared, date preserved, and `auto_claimed_pending_ids` populated.
- `processor_test.rb`: two new tests — one for `auto_claimed_pending_ids` exclusion alone, one for both exclusion types together in the same batch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction date preservation: when pending transactions are matched with posted entries during reconciliation, the original pending date is now correctly retained
  * Enhanced duplicate prevention: the system now maintains comprehensive tracking of auto-reconciled pending transactions to prevent unintended re-imports
  * Refined reconciliation logic: strengthened detection of previously auto-matched transactions to ensure they are excluded from future import cycles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1783)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->