### PR TITLE
fix(mobile): respect system navigation bar inset on chat screen

### DIFF
--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -374,7 +374,12 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
 
               // Message input
               Container(
-                padding: const EdgeInsets.all(16),
+                padding: EdgeInsets.fromLTRB(
+                  16,
+                  16,
+                  16,
+                  16 + MediaQuery.paddingOf(context).bottom,
+                ),
                 decoration: BoxDecoration(
                   color: colorScheme.surface,
                   boxShadow: [


### PR DESCRIPTION
## Summary

- On Android devices with the 3-button navigation bar, and on Android 15+ where edge-to-edge is forced, the system navigation bar was overlapping the message input bar in the chat conversation screen
- The message input container's bottom padding now adds `MediaQuery.paddingOf(context).bottom` so the input row clears the system nav bar
- In non-edge-to-edge mode this value is 0, so existing behaviour on older devices is unchanged
- The `colorScheme.surface` background of the input container naturally extends to the screen edge, giving a clean visual fill behind the nav bar

## Test plan

- [ ] Open a chat conversation on an Android device/emulator with the 3-button navigation bar — input row should be fully visible above the nav bar
- [ ] Confirm the empty state (suggested questions) is fully visible
- [ ] Confirm the keyboard still correctly pushes the input up
- [ ] Test with gesture navigation — no extra dead space at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing and padding handling in the chat message input area on mobile devices. The input field now properly accommodates device safe areas, notches, and keyboard overlays, ensuring consistent visual appearance and enhanced usability when composing messages across all mobile devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1784)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->