### PR TITLE
ci: split unit and system test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Lint/Format js code
         run: npm run lint
 
-  test:
+  test_unit:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -120,6 +120,52 @@ jobs:
 
       - name: Unit and integration tests
         run: bin/rails test
+
+  test_system:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      PLAID_CLIENT_ID: foo
+      PLAID_SECRET: bar
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432
+      REDIS_URL: redis://localhost:6379
+      RAILS_ENV: test
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libvips postgresql-client libpq-dev
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: DB setup and smoke test
+        run: |
+          bin/rails db:create
+          bin/rails db:schema:load
+          bin/rails db:seed
 
       - name: System tests
         run: DISABLE_PARALLELIZATION=true bin/rails test:system


### PR DESCRIPTION
## Summary
- split the current `test` job into `test_unit` and `test_system`
- keep both jobs otherwise identical so they can run in parallel immediately
- leave deeper `test_system` splitting for later

## Why
Recent PR CI measurements showed the single `test` job sitting right on the 10-minute cliff, with system tests as the main bottleneck. Splitting unit/integration and system tests into separate jobs reduces wall-clock PR time without changing coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD testing infrastructure to improve test execution pipeline.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development and testing processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1787)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->