### PR TITLE
feat(ui): render money values in Geist Mono with tabular numerals

### DIFF
--- a/app/components/UI/account/activity_date.html.erb
+++ b/app/components/UI/account/activity_date.html.erb
@@ -20,7 +20,7 @@
 
         <div class="flex items-center gap-4">
           <div class="flex items-center gap-2">
-            <span class="font-medium privacy-sensitive"><%= end_balance_money.format %></span>
+            <span class="font-medium privacy-sensitive"><%= helpers.format_money(end_balance_money) %></span>
             <%= render DS::Tooltip.new(text: "The end of day balance, after all transactions and adjustments", placement: "left", size: "sm") %>
           </div>
           <%= helpers.icon "chevron-down", class: "group-open:rotate-180" %>

--- a/app/components/UI/account/balance_reconciliation.html.erb
+++ b/app/components/UI/account/balance_reconciliation.html.erb
@@ -11,7 +11,7 @@
       </dt>
       <hr class="grow border-dashed <%= item[:style] == :final ? "border-primary" : "border-secondary" %>">
       <dd class="<%= item[:style] == :start || item[:style] == :final ? "font-bold" : item[:style] == :subtotal ? "font-medium" : "" %>">
-        <%= item[:value].format %>
+        <%= helpers.format_money(item[:value]) %>
       </dd>
     </dl>
 

--- a/app/components/UI/account/chart.html.erb
+++ b/app/components/UI/account/chart.html.erb
@@ -9,10 +9,10 @@
         <% end %>
       </div>
       <div class="flex flex-row gap-2 items-baseline">
-        <%= tag.p view_balance_money.format, class: "text-primary text-3xl font-medium truncate privacy-sensitive" %>
+        <%= tag.p helpers.format_money(view_balance_money), class: "text-primary text-3xl font-medium truncate privacy-sensitive" %>
 
         <% if converted_balance_money %>
-          <%= tag.p converted_balance_money.format, class: "text-sm font-medium text-secondary privacy-sensitive" %>
+          <%= tag.p helpers.format_money(converted_balance_money), class: "text-sm font-medium text-secondary privacy-sensitive" %>
         <% end %>
       </div>
     </div>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,17 +89,31 @@ module ApplicationHelper
     family_moniker_plural.downcase
   end
 
+  # Renders a money value. By default, wraps the formatted string in a
+  # `<span class="font-mono tabular-nums">` so monetary numbers display in
+  # Geist Mono with tabular figures across the UI.
+  #
+  # Pass `html: false` when the return value must be a plain string (JSON
+  # payloads, HTML attribute values, translation interpolations, etc.).
   def format_money(number_or_money, options = {})
     return nil unless number_or_money
 
-    Money.new(number_or_money).format(options)
+    html_output = options.delete(:html)
+    html_output = true if html_output.nil?
+
+    formatted = Money.new(number_or_money).format(options)
+
+    return formatted unless html_output
+
+    content_tag(:span, formatted, class: "font-mono tabular-nums")
   end
 
   def totals_by_currency(collection:, money_method:, separator: " | ", negate: false)
-    collection.group_by(&:currency)
-              .transform_values { |item| calculate_total(item, money_method, negate) }
-              .map { |_currency, money| format_money(money) }
-              .join(separator)
+    formatted = collection.group_by(&:currency)
+                          .transform_values { |item| calculate_total(item, money_method, negate) }
+                          .map { |_currency, money| format_money(money) }
+
+    safe_join(formatted, separator)
   end
 
   def currency_picker_options_for_family(family = Current.family, extra: [])

--- a/app/javascript/controllers/sankey_chart_controller.js
+++ b/app/javascript/controllers/sankey_chart_controller.js
@@ -233,7 +233,7 @@ export default class extends Controller {
         textEl.append("tspan")
           .attr("x", textEl.attr("x"))
           .attr("dy", "1.2em")
-          .attr("class", "font-mono text-secondary")
+          .attr("class", "font-mono tabular-nums text-secondary")
           .style("font-size", "0.65rem")
           .text(controller.#formatCurrency(d.value));
       });
@@ -357,9 +357,10 @@ export default class extends Controller {
   #showTooltip(event, value, percentage, title = null) {
     if (!this.tooltip) this.#createTooltip();
 
+    const formattedValue = `<span class="font-mono tabular-nums">${this.#formatCurrency(value)}</span>`;
     const content = title
-      ? `${title}<br/>${this.#formatCurrency(value)} (${percentage || 0}%)`
-      : `${this.#formatCurrency(value)} (${percentage || 0}%)`;
+      ? `${title}<br/>${formattedValue} (${percentage || 0}%)`
+      : `${formattedValue} (${percentage || 0}%)`;
 
     const isInDialog = !!this.element.closest("dialog");
     const x = isInDialog ? event.clientX : event.pageX;

--- a/app/javascript/controllers/time_series_chart_controller.js
+++ b/app/javascript/controllers/time_series_chart_controller.js
@@ -394,14 +394,14 @@ export default class extends Controller {
           <div class="flex items-center justify-center h-4 w-4">
             ${this._getTrendIcon(datum)}
           </div>
-          ${this._extractFormattedValue(datum.trend.current)}
+          <span class="font-mono tabular-nums">${this._extractFormattedValue(datum.trend.current)}</span>
         </div>
 
         ${
           datum.trend.value === 0
             ? `<span class="w-20"></span>`
             : `
-          <span style="color: ${datum.trend.color};">
+          <span class="font-mono tabular-nums" style="color: ${datum.trend.color};">
             ${this._extractFormattedValue(datum.trend.value)} (${datum.trend.percent_formatted})
           </span>
         `

--- a/app/views/budget_categories/_budget_category.html.erb
+++ b/app/views/budget_categories/_budget_category.html.erb
@@ -76,8 +76,7 @@
           <div class="w-full sm:w-auto text-xs text-subdued">
             <%= t("reports.budget_performance.suggested_daily",
               amount: daily_info[:amount].format,
-              days: daily_info[:days_remaining])
-            %>
+              days: daily_info[:days_remaining]) %>
           </div>
         <% end %>
         <% end %>
@@ -116,7 +115,7 @@
         <div class="min-w-0 flex-1">
           <p class="text-sm font-medium text-primary truncate"><%= budget_category.category.name %></p>
           <p class="text-sm text-secondary font-medium privacy-sensitive">
-            <%= budget_category.median_monthly_expense_money.format %> avg
+            <%= format_money(budget_category.median_monthly_expense_money) %> avg
           </p>
         </div>
 

--- a/app/views/budget_categories/_budget_category_form.html.erb
+++ b/app/views/budget_categories/_budget_category_form.html.erb
@@ -8,7 +8,7 @@
   <div class="text-sm mr-3">
     <p class="text-primary font-medium mb-0.5"><%= budget_category.category.name %></p>
 
-    <p class="text-secondary privacy-sensitive"><%= budget_category.median_monthly_expense_money.format(precision: 0) %>/m avg</p>
+    <p class="text-secondary privacy-sensitive"><%= format_money(budget_category.median_monthly_expense_money, precision: 0) %>/m avg</p>
   </div>
 
   <div class="ml-auto">

--- a/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
+++ b/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
@@ -7,7 +7,7 @@
 
   <div class="text-sm mr-3">
     <p class="text-primary font-medium mb-0.5"><%= budget_category.category.name %></p>
-    <p class="text-secondary privacy-sensitive"><%= budget_category.avg_monthly_expense_money.format(precision: 0) %>/m avg</p>
+    <p class="text-secondary privacy-sensitive"><%= format_money(budget_category.avg_monthly_expense_money, precision: 0) %>/m avg</p>
   </div>
 
   <div class="ml-auto">

--- a/app/views/budget_categories/show.html.erb
+++ b/app/views/budget_categories/show.html.erb
@@ -73,14 +73,14 @@
           <div class="flex items-center justify-between text-sm">
             <dt class="text-secondary">Monthly average spending</dt>
             <dd class="text-primary font-medium privacy-sensitive">
-              <%= @budget_category.avg_monthly_expense_money.format %>
+              <%= format_money(@budget_category.avg_monthly_expense_money) %>
             </dd>
           </div>
 
           <div class="flex items-center justify-between text-sm">
             <dt class="text-secondary">Monthly median spending</dt>
             <dd class="text-primary font-medium privacy-sensitive">
-              <%= @budget_category.median_monthly_expense_money.format %>
+              <%= format_money(@budget_category.median_monthly_expense_money) %>
             </dd>
           </div>
         </dl>

--- a/app/views/budgets/_actuals_summary.html.erb
+++ b/app/views/budgets/_actuals_summary.html.erb
@@ -5,7 +5,7 @@
     <h3 class="text-sm text-secondary mb-2">Income</h3>
 
     <span class="inline-block mb-2 text-xl font-medium text-primary privacy-sensitive">
-      <%= budget.actual_income_money.format %>
+      <%= format_money(budget.actual_income_money) %>
     </span>
 
     <% if budget.income_category_totals.any? %>
@@ -32,7 +32,7 @@
   <div class="p-4">
     <h3 class="text-sm text-secondary mb-2">Expenses</h3>
 
-    <span class="inline-block mb-2 text-xl font-medium text-primary privacy-sensitive"><%= budget.actual_spending_money.format %></span>
+    <span class="inline-block mb-2 text-xl font-medium text-primary privacy-sensitive"><%= format_money(budget.actual_spending_money) %></span>
 
     <% if budget.expense_category_totals.any? %>
       <div>

--- a/app/views/budgets/_budget_donut.html.erb
+++ b/app/views/budgets/_budget_donut.html.erb
@@ -13,7 +13,7 @@
         </div>
 
         <%= render DS::Link.new(
-          text: "of #{budget.budgeted_spending_money.format}",
+          text: "of #{format_money(budget.budgeted_spending_money, html: false)}",
           variant: "secondary",
           icon: "pencil",
           icon_position: "right",
@@ -47,7 +47,7 @@
           </p>
 
           <%= render DS::Link.new(
-            text: "of #{bc.budgeted_spending_money.format(precision: 0)}",
+            text: "of #{format_money(bc.budgeted_spending_money, precision: 0, html: false)}",
             variant: "secondary",
             icon: "pencil",
             icon_position: "right",

--- a/app/views/enable_banking_items/select_existing_account.html.erb
+++ b/app/views/enable_banking_items/select_existing_account.html.erb
@@ -22,7 +22,7 @@
                 <div class="flex flex-col">
                   <span class="text-sm text-primary font-medium"><%= eba.name.presence || eba.account_id %></span>
                   <span class="text-xs text-secondary">
-                    <%= eba.currency %> • Balance: <%= number_to_currency((eba.current_balance || 0), unit: eba.currency) %>
+                    <%= eba.currency %> • Balance: <span class="font-mono tabular-nums"><%= number_to_currency((eba.current_balance || 0), unit: eba.currency) %></span>
                   </span>
                 </div>
               </label>

--- a/app/views/enable_banking_items/setup_accounts.html.erb
+++ b/app/views/enable_banking_items/setup_accounts.html.erb
@@ -81,7 +81,7 @@
                     <p><%= enable_banking_account.account_type_display %></p>
                   <% end %>
                   <% if enable_banking_account.current_balance.present? %>
-                    <p>Balance: <%= number_to_currency(enable_banking_account.current_balance, unit: enable_banking_account.currency) %></p>
+                    <p>Balance: <span class="font-mono tabular-nums"><%= number_to_currency(enable_banking_account.current_balance, unit: enable_banking_account.currency) %></span></p>
                   <% end %>
                 </div>
               </div>

--- a/app/views/ibkr_items/select_existing_account.html.erb
+++ b/app/views/ibkr_items/select_existing_account.html.erb
@@ -21,7 +21,7 @@
                 <div class="flex flex-col">
                   <span class="text-sm text-primary font-medium"><%= ibkr_account.name.presence || ibkr_account.ibkr_account_id %></span>
                   <span class="text-xs text-secondary">
-                    <%= ibkr_account.currency %> • Balance: <%= number_to_currency((ibkr_account.current_balance || 0), unit: Money::Currency.new(ibkr_account.currency || "USD").symbol) %>
+                    <%= ibkr_account.currency %> • Balance: <span class="font-mono tabular-nums"><%= number_to_currency((ibkr_account.current_balance || 0), unit: Money::Currency.new(ibkr_account.currency || "USD").symbol) %></span>
                   </span>
                 </div>
               </label>

--- a/app/views/indexa_capital_items/select_accounts.html.erb
+++ b/app/views/indexa_capital_items/select_accounts.html.erb
@@ -50,7 +50,7 @@
                     <% if indexa_capital_account.account_type.present? %>
                       <%= indexa_capital_account.account_type.titleize %> &middot;
                     <% end %>
-                    <%= number_to_currency(indexa_capital_account.current_balance || 0, unit: Money::Currency.new(indexa_capital_account.currency || "EUR").symbol) %>
+                    <span class="font-mono tabular-nums"><%= number_to_currency(indexa_capital_account.current_balance || 0, unit: Money::Currency.new(indexa_capital_account.currency || "EUR").symbol) %></span>
                   </p>
                 </label>
               </div>

--- a/app/views/indexa_capital_items/select_existing_account.html.erb
+++ b/app/views/indexa_capital_items/select_existing_account.html.erb
@@ -41,7 +41,7 @@
                     <%= indexa_capital_account.account_type.titleize %> &middot;
                   <% end %>
                   <%= t("indexa_capital_items.select_existing_account.balance_label") %>
-                  <%= number_to_currency(indexa_capital_account.current_balance || 0, unit: Money::Currency.new(indexa_capital_account.currency || "EUR").symbol) %>
+                  <span class="font-mono tabular-nums"><%= number_to_currency(indexa_capital_account.current_balance || 0, unit: Money::Currency.new(indexa_capital_account.currency || "EUR").symbol) %></span>
                 </p>
               </div>
               <%= render DS::Button.new(

--- a/app/views/indexa_capital_items/setup_accounts.html.erb
+++ b/app/views/indexa_capital_items/setup_accounts.html.erb
@@ -50,7 +50,7 @@
                         <%= indexa_capital_account.account_type.titleize %> &middot;
                       <% end %>
                       <%= t("indexa_capital_items.setup_accounts.balance") %>:
-                      <%= number_to_currency(indexa_capital_account.current_balance || 0, unit: Money::Currency.new(indexa_capital_account.currency || "EUR").symbol) %>
+                      <span class="font-mono tabular-nums"><%= number_to_currency(indexa_capital_account.current_balance || 0, unit: Money::Currency.new(indexa_capital_account.currency || "EUR").symbol) %></span>
                     </p>
                     <% if indexa_capital_account.account_number.present? %>
                       <p class="text-xs text-secondary"><%= indexa_capital_account.account_number %></p>

--- a/app/views/pages/dashboard/_balance_sheet.html.erb
+++ b/app/views/pages/dashboard/_balance_sheet.html.erb
@@ -11,7 +11,7 @@
 
           <% if classification_group.account_groups.any? %>
             <span class="text-secondary">&middot;</span>
-            <span class="text-secondary font-medium text-lg privacy-sensitive"><%= classification_group.total_money.format(precision: 0) %></span>
+            <span class="text-secondary font-medium text-lg privacy-sensitive"><%= format_money(classification_group.total_money, precision: 0) %></span>
           <% end %>
         </h2>
       </div>

--- a/app/views/pages/dashboard/_net_worth_chart.html.erb
+++ b/app/views/pages/dashboard/_net_worth_chart.html.erb
@@ -6,7 +6,7 @@
     <div class="space-y-2">
       <% if series.trend.present? %>
         <p class="text-primary -space-x-0.5 text-3xl font-medium privacy-sensitive <%= "animate-pulse" if balance_sheet.syncing? %>">
-          <%= series.trend.current.format %>
+          <%= format_money(series.trend.current) %>
         </p>
         <%= render partial: "shared/trend_change", locals: { trend: series.trend, comparison_label: period.comparison_label } %>
       <% else %>

--- a/app/views/pending_duplicate_merges/new.html.erb
+++ b/app/views/pending_duplicate_merges/new.html.erb
@@ -28,7 +28,7 @@
                 <p class="text-xs text-secondary">
                   <%= @transaction.entry.account.name %>
                   • <%= I18n.l(@transaction.entry.date, format: :long) %>
-                  • <%= number_to_currency(@transaction.entry.amount.abs, unit: Money::Currency.new(@transaction.entry.currency).symbol) %>
+                  • <span class="font-mono tabular-nums"><%= number_to_currency(@transaction.entry.amount.abs, unit: Money::Currency.new(@transaction.entry.currency).symbol) %></span>
                 </p>
               </div>
             </div>
@@ -53,7 +53,7 @@
                       <div class="font-medium text-primary"><%= entry.name %></div>
                       <div class="text-xs text-secondary">
                         <%= I18n.l(entry.date, format: :short) %> •
-                        <%= number_to_currency(entry.amount.abs, unit: Money::Currency.new(entry.currency).symbol) %>
+                        <span class="font-mono tabular-nums"><%= number_to_currency(entry.amount.abs, unit: Money::Currency.new(entry.currency).symbol) %></span>
                       </div>
                     </div>
                   </label>

--- a/app/views/recurring_transactions/index.html.erb
+++ b/app/views/recurring_transactions/index.html.erb
@@ -135,7 +135,7 @@
                 <% else %>
                   <td class="py-3 px-2 text-sm font-medium privacy-sensitive <%= recurring_transaction.amount.negative? ? "text-success" : "text-primary" %>">
                     <% if recurring_transaction.manual? && recurring_transaction.has_amount_variance? %>
-                      <div class="inline-flex items-center gap-1 cursor-help group" title="<%= t("recurring_transactions.amount_range", min: format_money(-recurring_transaction.expected_amount_min_money), max: format_money(-recurring_transaction.expected_amount_max_money)) %>">
+                      <div class="inline-flex items-center gap-1 cursor-help group" title="<%= t("recurring_transactions.amount_range", min: format_money(-recurring_transaction.expected_amount_min_money, html: false), max: format_money(-recurring_transaction.expected_amount_max_money, html: false)) %>">
                         <span class="text-xs text-secondary group-hover:text-primary transition-colors">~</span>
                         <span class="border-b border-dashed border-subdued group-hover:border-primary transition-colors privacy-sensitive"><%= format_money(-recurring_transaction.expected_amount_avg_money) %></span>
                       </div>

--- a/app/views/reports/_breakdown_table.html.erb
+++ b/app/views/reports/_breakdown_table.html.erb
@@ -11,7 +11,7 @@
   <div class="text-large mb-4 flex items-center gap-2 text-lg">
     <%= icon(icon_name, class: "w-5 h-5") %>
     <span><%= t(title_key) %>:</span>
-    <span class="font-medium text-secondary <%= color_class %> privacy-sensitive"> <%= Money.new(total, Current.family.currency).format %></span>
+    <span class="font-medium text-secondary <%= color_class %> privacy-sensitive"> <%= format_money(Money.new(total, Current.family.currency)) %></span>
   </div>
 
   <div class="bg-container-inset rounded-xl p-1 overflow-x-auto">

--- a/app/views/reports/_budget_performance.html.erb
+++ b/app/views/reports/_budget_performance.html.erb
@@ -64,13 +64,13 @@
               <div>
                 <span class="text-subdued"><%= t("reports.budget_performance.spent") %>:</span>
                 <span class="font-medium text-primary privacy-sensitive">
-                  <%= Money.new(budget_item[:actual], Current.family.currency).format %>
+                  <%= format_money(Money.new(budget_item[:actual], Current.family.currency)) %>
                 </span>
               </div>
               <div>
                 <span class="text-subdued"><%= t("reports.budget_performance.budgeted") %>:</span>
                 <span class="font-medium text-secondary privacy-sensitive">
-                  <%= Money.new(budget_item[:budgeted], Current.family.currency).format %>
+                  <%= format_money(Money.new(budget_item[:budgeted], Current.family.currency)) %>
                 </span>
               </div>
             </div>
@@ -79,12 +79,12 @@
               <% if budget_item[:remaining] >= 0 %>
                 <span class="text-subdued"><%= t("reports.budget_performance.remaining") %>:</span>
                 <span class="font-medium text-success privacy-sensitive">
-                  <%= Money.new(budget_item[:remaining], Current.family.currency).format %>
+                  <%= format_money(Money.new(budget_item[:remaining], Current.family.currency)) %>
                 </span>
               <% else %>
                 <span class="text-subdued"><%= t("reports.budget_performance.over_by") %>:</span>
                 <span class="font-medium text-destructive privacy-sensitive">
-                  <%= Money.new(budget_item[:remaining].abs, Current.family.currency).format %>
+                  <%= format_money(Money.new(budget_item[:remaining].abs, Current.family.currency)) %>
                 </span>
               <% end %>
             </div>
@@ -97,7 +97,7 @@
               <div class="mt-3 pt-3 border-t border-tertiary">
                 <p class="text-xs text-subdued">
                   <%= t("reports.budget_performance.suggested_daily",
-                        amount: Money.new((budget_item[:remaining] / days_remaining), Current.family.currency).format,
+                        amount: format_money(Money.new((budget_item[:remaining] / days_remaining), Current.family.currency), html: false),
                         days: days_remaining) %>
                 </p>
               </div>

--- a/app/views/reports/_category_row.html.erb
+++ b/app/views/reports/_category_row.html.erb
@@ -41,7 +41,7 @@
 
   <td class="py-3 px-4 lg:px-6 text-right">
     <span class="text-sm <%= color_class %> privacy-sensitive">
-      <%= Money.new(item[:total], Current.family.currency).format %>
+      <%= format_money(Money.new(item[:total], Current.family.currency)) %>
     </span>
   </td>
 

--- a/app/views/reports/_net_worth.html.erb
+++ b/app/views/reports/_net_worth.html.erb
@@ -5,7 +5,7 @@
     <div class="p-4 bg-surface-inset rounded-lg">
       <p class="text-sm text-secondary mb-2"><%= t("reports.net_worth.current_net_worth") %></p>
       <p class="text-2xl font-semibold privacy-sensitive <%= net_worth_metrics[:current_net_worth] >= 0 ? "text-success" : "text-destructive" %>">
-        <%= net_worth_metrics[:current_net_worth].format %>
+        <%= format_money(net_worth_metrics[:current_net_worth]) %>
       </p>
     </div>
 
@@ -15,7 +15,7 @@
       <% if net_worth_metrics[:trend] %>
         <% trend = net_worth_metrics[:trend] %>
         <p class="text-2xl font-semibold mb-1 privacy-sensitive" style="color: <%= trend.color %>">
-          <%= trend.value.format(signify_positive: true) %>
+          <%= format_money(trend.value, signify_positive: true) %>
         </p>
         <p class="text-xs" style="color: <%= trend.color %>">
           <%= trend.value >= 0 ? "+" : "" %><%= trend.percent_formatted %>
@@ -29,9 +29,9 @@
     <div class="p-4 bg-surface-inset rounded-lg">
       <p class="text-sm text-secondary mb-2"><%= t("reports.net_worth.assets_vs_liabilities") %></p>
       <div class="flex items-baseline gap-2 flex-wrap">
-        <span class="text-lg font-semibold text-success break-words privacy-sensitive"><%= net_worth_metrics[:total_assets].format %></span>
+        <span class="text-lg font-semibold text-success break-words privacy-sensitive"><%= format_money(net_worth_metrics[:total_assets]) %></span>
         <span class="text-xs text-subdued shrink-0">-</span>
-        <span class="text-lg font-semibold text-destructive break-words privacy-sensitive"><%= net_worth_metrics[:total_liabilities].format %></span>
+        <span class="text-lg font-semibold text-destructive break-words privacy-sensitive"><%= format_money(net_worth_metrics[:total_liabilities]) %></span>
       </div>
     </div>
   </div>
@@ -52,7 +52,7 @@
           <% net_worth_metrics[:asset_groups].each_with_index do |group, idx| %>
             <tr class="<%= idx < net_worth_metrics[:asset_groups].size - 1 ? "table-divider" : "" %>">
               <td class="py-3 px-4 lg:px-6 text-sm font-medium text-secondary"><%= group[:name] %></td>
-              <td class="py-3 px-4 lg:px-6 text-sm font-medium text-right text-success privacy-sensitive"><%= group[:total].format %></td>
+              <td class="py-3 px-4 lg:px-6 text-sm font-medium text-right text-success privacy-sensitive"><%= format_money(group[:total]) %></td>
             </tr>
           <% end %>
           <% if net_worth_metrics[:asset_groups].empty? %>
@@ -79,7 +79,7 @@
           <% net_worth_metrics[:liability_groups].each_with_index do |group, idx| %>
             <tr class="<%= idx < net_worth_metrics[:liability_groups].size - 1 ? "table-divider" : "" %>">
               <td class="py-3 px-4 lg:px-6 text-sm font-medium text-secondary"><%= group[:name] %></td>
-              <td class="py-3 px-4 lg:px-6 text-sm font-medium text-right text-destructive privacy-sensitive"><%= group[:total].format %></td>
+              <td class="py-3 px-4 lg:px-6 text-sm font-medium text-right text-destructive privacy-sensitive"><%= format_money(group[:total]) %></td>
             </tr>
           <% end %>
           <% if net_worth_metrics[:liability_groups].empty? %>

--- a/app/views/reports/_summary_dashboard.html.erb
+++ b/app/views/reports/_summary_dashboard.html.erb
@@ -12,7 +12,7 @@
 
     <div class="space-y-2">
       <p class="text-2xl font-semibold text-primary privacy-sensitive">
-        <%= metrics[:current_income].format %>
+        <%= format_money(metrics[:current_income]) %>
       </p>
 
       <% if metrics[:income_change] %>
@@ -49,7 +49,7 @@
 
     <div class="space-y-2">
       <p class="text-2xl font-semibold text-primary privacy-sensitive">
-        <%= metrics[:current_expenses].format %>
+        <%= format_money(metrics[:current_expenses]) %>
       </p>
 
       <% if metrics[:expense_change] %>
@@ -86,7 +86,7 @@
 
     <div class="space-y-2">
       <p class="text-2xl font-semibold privacy-sensitive <%= metrics[:net_savings] >= 0 ? "text-success" : "text-destructive" %>">
-        <%= metrics[:net_savings].format %>
+        <%= format_money(metrics[:net_savings]) %>
       </p>
 
       <p class="text-sm text-subdued">

--- a/app/views/reports/_trends_insights.html.erb
+++ b/app/views/reports/_trends_insights.html.erb
@@ -31,13 +31,13 @@
                     </span>
                   </td>
                   <td class="py-3 px-4 lg:px-6 text-right privacy-sensitive">
-                    <%= Money.new(trend[:income], Current.family.currency).format %>
+                    <%= format_money(Money.new(trend[:income], Current.family.currency)) %>
                   </td>
                   <td class="py-3 px-4 lg:px-6 text-right privacy-sensitive">
-                    <%= Money.new(trend[:expenses], Current.family.currency).format %>
+                    <%= format_money(Money.new(trend[:expenses], Current.family.currency)) %>
                   </td>
                   <td class="py-3 px-4 lg:px-6 text-right privacy-sensitive <%= trend[:net] >= 0 ? "text-success" : "text-destructive" %>">
-                    <%= Money.new(trend[:net], Current.family.currency).format %>
+                    <%= format_money(Money.new(trend[:net], Current.family.currency)) %>
                   </td>
                   <td class="py-3 px-4 lg:px-6 text-right <%= trend[:net] >= 0 ? "text-success" : "text-destructive" %>">
                     <% savings_rate = trend[:income] > 0 ? ((trend[:net].to_f / trend[:income].to_f) * 100).round(1) : 0 %>
@@ -60,21 +60,21 @@
           <div class="p-4 bg-surface-inset rounded-lg">
             <p class="text-sm text-secondary mb-1"><%= t("reports.trends.avg_monthly_income") %></p>
             <p class="text-lg font-semibold text-success privacy-sensitive">
-              <%= Money.new(avg_income, Current.family.currency).format %>
+              <%= format_money(Money.new(avg_income, Current.family.currency)) %>
             </p>
           </div>
 
           <div class="p-4 bg-surface-inset rounded-lg">
             <p class="text-sm text-secondary mb-1"><%= t("reports.trends.avg_monthly_expenses") %></p>
             <p class="text-lg font-semibold text-destructive privacy-sensitive">
-              <%= Money.new(avg_expenses, Current.family.currency).format %>
+              <%= format_money(Money.new(avg_expenses, Current.family.currency)) %>
             </p>
           </div>
 
           <div class="p-4 bg-surface-inset rounded-lg">
             <p class="text-sm text-secondary mb-1"><%= t("reports.trends.avg_monthly_savings") %></p>
             <p class="text-lg font-semibold privacy-sensitive <%= avg_net >= 0 ? "text-success" : "text-destructive" %>">
-              <%= Money.new(avg_net, Current.family.currency).format %>
+              <%= format_money(Money.new(avg_net, Current.family.currency)) %>
             </p>
           </div>
         </div>

--- a/app/views/reports/print.html.erb
+++ b/app/views/reports/print.html.erb
@@ -16,7 +16,7 @@
     <div class="tufte-metric-row">
       <div class="tufte-metric-card tufte-metric-card-sm">
         <span class="tufte-metric-card-label"><%= t("reports.print.summary.income") %></span>
-        <span class="tufte-metric-card-value tufte-income"><%= @summary_metrics[:current_income].format %></span>
+        <span class="tufte-metric-card-value tufte-income"><%= format_money(@summary_metrics[:current_income]) %></span>
         <% if @summary_metrics[:income_change] && @summary_metrics[:income_change] != 0 %>
           <span class="tufte-metric-card-change <%= @summary_metrics[:income_change] >= 0 ? "tufte-up" : "tufte-down" %>">
             <%= t("reports.print.summary.vs_prior", percent: (@summary_metrics[:income_change] >= 0 ? "+#{@summary_metrics[:income_change]}" : @summary_metrics[:income_change].to_s)) %>
@@ -31,7 +31,7 @@
 
       <div class="tufte-metric-card tufte-metric-card-sm">
         <span class="tufte-metric-card-label"><%= t("reports.print.summary.expenses") %></span>
-        <span class="tufte-metric-card-value tufte-expense"><%= @summary_metrics[:current_expenses].format %></span>
+        <span class="tufte-metric-card-value tufte-expense"><%= format_money(@summary_metrics[:current_expenses]) %></span>
         <% if @summary_metrics[:expense_change] && @summary_metrics[:expense_change] != 0 %>
           <span class="tufte-metric-card-change <%= @summary_metrics[:expense_change] >= 0 ? "tufte-down" : "tufte-up" %>">
             <%= t("reports.print.summary.vs_prior", percent: (@summary_metrics[:expense_change] >= 0 ? "+#{@summary_metrics[:expense_change]}" : @summary_metrics[:expense_change].to_s)) %>
@@ -46,7 +46,7 @@
 
       <div class="tufte-metric-card tufte-metric-card-sm">
         <span class="tufte-metric-card-label"><%= t("reports.print.summary.net_savings") %></span>
-        <span class="tufte-metric-card-value <%= @summary_metrics[:net_savings] >= 0 ? "tufte-income" : "tufte-expense" %>"><%= @summary_metrics[:net_savings].format %></span>
+        <span class="tufte-metric-card-value <%= @summary_metrics[:net_savings] >= 0 ? "tufte-income" : "tufte-expense" %>"><%= format_money(@summary_metrics[:net_savings]) %></span>
         <%
           # Calculate savings rate
           savings_rate = @summary_metrics[:current_income].amount > 0 ? ((@summary_metrics[:net_savings].amount / @summary_metrics[:current_income].amount) * 100).round(0) : 0
@@ -79,11 +79,11 @@
         <div class="tufte-metric-card">
           <span class="tufte-metric-card-label"><%= t("reports.print.net_worth.current_balance") %></span>
           <span class="tufte-metric-card-value <%= @net_worth_metrics[:current_net_worth] >= 0 ? "tufte-income" : "tufte-expense" %>">
-            <%= @net_worth_metrics[:current_net_worth].format %>
+            <%= format_money(@net_worth_metrics[:current_net_worth]) %>
           </span>
           <% if @net_worth_metrics[:trend] %>
             <span class="tufte-metric-card-change" style="color: <%= @net_worth_metrics[:trend].color %>">
-              <%= @net_worth_metrics[:trend].value >= 0 ? "+" : "" %><%= @net_worth_metrics[:trend].value.format %> (<%= @net_worth_metrics[:trend].percent_formatted %>) <%= t("reports.print.net_worth.this_period") %>
+              <%= @net_worth_metrics[:trend].value >= 0 ? "+" : "" %><%= format_money(@net_worth_metrics[:trend].value) %> (<%= @net_worth_metrics[:trend].percent_formatted %>) <%= t("reports.print.net_worth.this_period") %>
             </span>
           <% end %>
           <% if has_sparkline_data?(@trends_data) %>
@@ -96,14 +96,14 @@
 
       <div class="tufte-two-col">
         <div>
-          <h3 class="tufte-subsection"><%= t("reports.print.net_worth.assets") %> <span class="tufte-income"><%= @net_worth_metrics[:total_assets].format %></span></h3>
+          <h3 class="tufte-subsection"><%= t("reports.print.net_worth.assets") %> <span class="tufte-income"><%= format_money(@net_worth_metrics[:total_assets]) %></span></h3>
           <% if @net_worth_metrics[:asset_groups].any? %>
             <table class="tufte-table tufte-compact">
               <tbody>
                 <% @net_worth_metrics[:asset_groups].each do |group| %>
                   <tr>
                     <td><%= group[:name] %></td>
-                    <td class="tufte-right"><%= group[:total].format %></td>
+                    <td class="tufte-right"><%= format_money(group[:total]) %></td>
                   </tr>
                 <% end %>
               </tbody>
@@ -111,14 +111,14 @@
           <% end %>
         </div>
         <div>
-          <h3 class="tufte-subsection"><%= t("reports.print.net_worth.liabilities") %> <span class="tufte-expense"><%= @net_worth_metrics[:total_liabilities].format %></span></h3>
+          <h3 class="tufte-subsection"><%= t("reports.print.net_worth.liabilities") %> <span class="tufte-expense"><%= format_money(@net_worth_metrics[:total_liabilities]) %></span></h3>
           <% if @net_worth_metrics[:liability_groups].any? %>
             <table class="tufte-table tufte-compact">
               <tbody>
                 <% @net_worth_metrics[:liability_groups].each do |group| %>
                   <tr>
                     <td><%= group[:name] %></td>
-                    <td class="tufte-right"><%= group[:total].format %></td>
+                    <td class="tufte-right"><%= format_money(group[:total]) %></td>
                   </tr>
                 <% end %>
               </tbody>
@@ -149,9 +149,9 @@
           <% @trends_data.each do |trend| %>
             <tr class="<%= trend[:is_current_month] ? "tufte-highlight" : "" %>">
               <td><%= trend[:month] %><%= trend[:is_current_month] ? " *" : "" %></td>
-              <td class="tufte-right tufte-income"><%= Money.new(trend[:income], Current.family.currency).format %></td>
-              <td class="tufte-right tufte-expense"><%= Money.new(trend[:expenses], Current.family.currency).format %></td>
-              <td class="tufte-right <%= trend[:net] >= 0 ? "tufte-income" : "tufte-expense" %>"><%= Money.new(trend[:net], Current.family.currency).format %></td>
+              <td class="tufte-right tufte-income"><%= format_money(Money.new(trend[:income], Current.family.currency)) %></td>
+              <td class="tufte-right tufte-expense"><%= format_money(Money.new(trend[:expenses], Current.family.currency)) %></td>
+              <td class="tufte-right <%= trend[:net] >= 0 ? "tufte-income" : "tufte-expense" %>"><%= format_money(Money.new(trend[:net], Current.family.currency)) %></td>
               <td class="tufte-right">
                 <% month_savings_rate = trend[:income] > 0 ? ((trend[:net].to_f / trend[:income].to_f) * 100).round(0) : 0 %>
                 <%= month_savings_rate %>%
@@ -172,9 +172,9 @@
           %>
           <tr>
             <td><%= t("reports.print.trends.average") %></td>
-            <td class="tufte-right tufte-income"><%= Money.new(avg_income, Current.family.currency).format %></td>
-            <td class="tufte-right tufte-expense"><%= Money.new(avg_expenses, Current.family.currency).format %></td>
-            <td class="tufte-right <%= avg_net >= 0 ? "tufte-income" : "tufte-expense" %>"><%= Money.new(avg_net, Current.family.currency).format %></td>
+            <td class="tufte-right tufte-income"><%= format_money(Money.new(avg_income, Current.family.currency)) %></td>
+            <td class="tufte-right tufte-expense"><%= format_money(Money.new(avg_expenses, Current.family.currency)) %></td>
+            <td class="tufte-right <%= avg_net >= 0 ? "tufte-income" : "tufte-expense" %>"><%= format_money(Money.new(avg_net, Current.family.currency)) %></td>
             <td class="tufte-right"><%= overall_savings_rate %>%</td>
           </tr>
         </tfoot>
@@ -268,7 +268,7 @@
       <div class="tufte-two-col">
         <% if income_groups.any? %>
           <div>
-            <h3 class="tufte-subsection"><%= t("reports.print.spending.income") %> <span class="tufte-income"><%= Money.new(income_total, Current.family.currency).format %></span></h3>
+            <h3 class="tufte-subsection"><%= t("reports.print.spending.income") %> <span class="tufte-income"><%= format_money(Money.new(income_total, Current.family.currency)) %></span></h3>
             <table class="tufte-table tufte-compact">
               <thead>
                 <tr>
@@ -285,7 +285,7 @@
                       <span class="tufte-dot" style="background: <%= group[:category_color] %>"></span>
                       <%= group[:category_name] %>
                     </td>
-                    <td class="tufte-right"><%= Money.new(group[:total], Current.family.currency).format %></td>
+                    <td class="tufte-right"><%= format_money(Money.new(group[:total], Current.family.currency)) %></td>
                     <td class="tufte-right tufte-muted"><%= percentage %>%</td>
                   </tr>
                 <% end %>
@@ -303,7 +303,7 @@
 
         <% if expense_groups.any? %>
           <div>
-            <h3 class="tufte-subsection"><%= t("reports.print.spending.expenses") %> <span class="tufte-expense"><%= Money.new(expense_total, Current.family.currency).format %></span></h3>
+            <h3 class="tufte-subsection"><%= t("reports.print.spending.expenses") %> <span class="tufte-expense"><%= format_money(Money.new(expense_total, Current.family.currency)) %></span></h3>
             <table class="tufte-table tufte-compact">
               <thead>
                 <tr>
@@ -320,7 +320,7 @@
                       <span class="tufte-dot" style="background: <%= group[:category_color] %>"></span>
                       <%= group[:category_name] %>
                     </td>
-                    <td class="tufte-right"><%= Money.new(group[:total], Current.family.currency).format %></td>
+                    <td class="tufte-right"><%= format_money(Money.new(group[:total], Current.family.currency)) %></td>
                     <td class="tufte-right tufte-muted"><%= percentage %>%</td>
                   </tr>
                 <% end %>

--- a/app/views/simplefin_items/_stale_account_row.html.erb
+++ b/app/views/simplefin_items/_stale_account_row.html.erb
@@ -13,7 +13,7 @@
         <% end %>
       </h3>
       <p class="text-sm text-secondary">
-        <%= number_to_currency(simplefin_account.current_balance || 0, unit: simplefin_account.currency || "USD") %>
+        <span class="font-mono tabular-nums"><%= number_to_currency(simplefin_account.current_balance || 0, unit: simplefin_account.currency || "USD") %></span>
         <span class="mx-1">•</span>
         <%= t("simplefin_items.setup_accounts.stale_accounts.transaction_count", count: transaction_count) %>
       </p>

--- a/app/views/simplefin_items/select_existing_account.html.erb
+++ b/app/views/simplefin_items/select_existing_account.html.erb
@@ -22,7 +22,7 @@
                 <div class="flex flex-col">
                   <span class="text-sm text-primary font-medium"><%= sfa.name.presence || sfa.account_id %></span>
                   <span class="text-xs text-secondary">
-                    <%= sfa.currency %> • Balance: <%= number_to_currency((sfa.current_balance || sfa.available_balance || 0), unit: sfa.currency) %>
+                    <%= sfa.currency %> • Balance: <span class="font-mono tabular-nums"><%= number_to_currency((sfa.current_balance || sfa.available_balance || 0), unit: sfa.currency) %></span>
                   </span>
                   <% if sfa.current_account.present? %>
                     <span class="text-xs text-secondary"><%= t("simplefin_items.select_existing_account.currently_linked_to", account_name: sfa.current_account.name) %></span>

--- a/app/views/simplefin_items/setup_accounts.html.erb
+++ b/app/views/simplefin_items/setup_accounts.html.erb
@@ -92,7 +92,7 @@
                   <% end %>
                 </h3>
                 <p class="text-sm text-secondary">
-                  <%= t(".account_card.balance") %>: <%= number_to_currency(simplefin_account.current_balance || 0, unit: simplefin_account.currency) %>
+                  <%= t(".account_card.balance") %>: <span class="font-mono tabular-nums"><%= number_to_currency(simplefin_account.current_balance || 0, unit: simplefin_account.currency) %></span>
                 </p>
                 <%= render "activity_badge", activity: activity, likely_closed: likely_closed %>
               </div>

--- a/app/views/snaptrade_items/select_existing_account.html.erb
+++ b/app/views/snaptrade_items/select_existing_account.html.erb
@@ -41,7 +41,7 @@
                     <%= snaptrade_account.brokerage_name %> •
                   <% end %>
                   <%= t("snaptrade_items.select_existing_account.balance_label", default: "Balance:") %>
-                  <%= number_to_currency(snaptrade_account.current_balance || 0, unit: Money::Currency.new(snaptrade_account.currency || "USD").symbol) %>
+                  <span class="font-mono tabular-nums"><%= number_to_currency(snaptrade_account.current_balance || 0, unit: Money::Currency.new(snaptrade_account.currency || "USD").symbol) %></span>
                 </p>
               </div>
               <%= render DS::Button.new(

--- a/app/views/snaptrade_items/setup_accounts.html.erb
+++ b/app/views/snaptrade_items/setup_accounts.html.erb
@@ -116,7 +116,7 @@
                           <%= snaptrade_account.account_type.titleize %> •
                         <% end %>
                         <%= t("snaptrade_items.setup_accounts.balance_label", default: "Balance:") %>
-                        <%= number_to_currency(snaptrade_account.current_balance || 0, unit: Money::Currency.new(snaptrade_account.currency || "USD").symbol) %>
+                        <span class="font-mono tabular-nums"><%= number_to_currency(snaptrade_account.current_balance || 0, unit: Money::Currency.new(snaptrade_account.currency || "USD").symbol) %></span>
                       </p>
                       <% if snaptrade_account.account_number.present? %>
                         <p class="text-xs text-secondary"><%= t("snaptrade_items.setup_accounts.account_number", default: "Account:") %> •••<%= snaptrade_account.account_number.last(4) %></p>

--- a/app/views/transactions/_summary.html.erb
+++ b/app/views/transactions/_summary.html.erb
@@ -14,12 +14,12 @@
     <% if show_transfers %>
       <p class="text-sm text-secondary"><%= t("transactions.summary.inflow") %></p>
       <p class="text-primary font-medium text-xl privacy-sensitive" id="total-income">
-        <%= (totals.income_money + totals.transfer_inflow_money).format %>
+        <%= format_money(totals.income_money + totals.transfer_inflow_money) %>
       </p>
     <% else %>
       <p class="text-sm text-secondary"><%= t("transactions.summary.income") %></p>
       <p class="text-primary font-medium text-xl privacy-sensitive" id="total-income">
-        <%= totals.income_money.format %>
+        <%= format_money(totals.income_money) %>
       </p>
     <% end %>
   </div>
@@ -27,12 +27,12 @@
     <% if show_transfers %>
       <p class="text-sm text-secondary"><%= t("transactions.summary.outflow") %></p>
       <p class="text-primary font-medium text-xl privacy-sensitive" id="total-expense">
-        <%= (totals.expense_money + totals.transfer_outflow_money).format %>
+        <%= format_money(totals.expense_money + totals.transfer_outflow_money) %>
       </p>
     <% else %>
       <p class="text-sm text-secondary"><%= t("transactions.summary.expenses") %></p>
       <p class="text-primary font-medium text-xl privacy-sensitive" id="total-expense">
-        <%= totals.expense_money.format %>
+        <%= format_money(totals.expense_money) %>
       </p>
     <% end %>
   </div>

--- a/app/views/valuations/_confirmation_contents.html.erb
+++ b/app/views/valuations/_confirmation_contents.html.erb
@@ -10,15 +10,15 @@
     <div class="bg-container rounded-lg p-4 space-y-2 border border-primary">
       <div class="flex justify-between">
         <span>Total account value</span>
-        <span class="font-medium text-primary"><%= Money.new(reconciliation_dry_run.new_balance, account.currency).format %></span>
+        <span class="font-medium text-primary"><%= format_money(Money.new(reconciliation_dry_run.new_balance, account.currency)) %></span>
       </div>
       <div class="flex justify-between text-xs">
         <span>Holdings value</span>
-        <span><%= Money.new(holdings_value, account.currency).format %></span>
+        <span><%= format_money(Money.new(holdings_value, account.currency)) %></span>
       </div>
       <div class="flex justify-between text-xs">
         <span>Brokerage cash</span>
-        <span class="<%= brokerage_cash.negative? ? "text-red-500" : "text-green-500" %>"><%= Money.new(brokerage_cash, account.currency).format %></span>
+        <span class="<%= brokerage_cash.negative? ? "text-red-500" : "text-green-500" %>"><%= format_money(Money.new(brokerage_cash, account.currency)) %></span>
       </div>
     </div>
   <% else %>
@@ -43,7 +43,7 @@
         balance
       <% end %>
       on <span class="font-medium text-primary"><%= entry.date.strftime("%B %d, %Y") %></span> to
-      <span class="font-medium text-primary"><%= entry.amount_money.format %></span>.
+      <span class="font-medium text-primary"><%= format_money(entry.amount_money) %></span>.
     </p>
   <% end %>
 

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -21,7 +21,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
 
   test "account activity marks trade amounts as privacy-sensitive" do
     trade_entry = entries(:trade)
-    expected_amount = ApplicationController.helpers.format_money(-trade_entry.amount_money)
+    expected_amount = ApplicationController.helpers.format_money(-trade_entry.amount_money, html: false)
 
     get account_url(accounts(:investment))
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -51,11 +51,29 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test "#totals_by_currency(collection: collection, money_method: money_method)" do
-    assert_equal "$3.00", totals_by_currency(collection: [ @account1, @account2 ], money_method: :balance_money)
-    assert_equal "$3.00 | -€7.00", totals_by_currency(collection: [ @account1, @account2, @account3 ], money_method: :balance_money)
+    mono = ->(amount) { %(<span class="font-mono tabular-nums">#{amount}</span>) }
+
+    assert_equal mono.call("$3.00"), totals_by_currency(collection: [ @account1, @account2 ], money_method: :balance_money)
+    assert_equal "#{mono.call('$3.00')} | #{mono.call('-€7.00')}", totals_by_currency(collection: [ @account1, @account2, @account3 ], money_method: :balance_money)
     assert_equal "", totals_by_currency(collection: [], money_method: :balance_money)
-    assert_equal "$0.00", totals_by_currency(collection: [ Account.new(currency: "USD", balance: 0) ], money_method: :balance_money)
-    assert_equal "-$3.00 | €7.00", totals_by_currency(collection: [ @account1, @account2, @account3 ], money_method: :balance_money, negate: true)
+    assert_equal mono.call("$0.00"), totals_by_currency(collection: [ Account.new(currency: "USD", balance: 0) ], money_method: :balance_money)
+    assert_equal "#{mono.call('-$3.00')} | #{mono.call('€7.00')}", totals_by_currency(collection: [ @account1, @account2, @account3 ], money_method: :balance_money, negate: true)
+  end
+
+  test "#format_money wraps output in mono span by default" do
+    assert_equal %(<span class="font-mono tabular-nums">$1.00</span>), format_money(Money.new(1, "USD"))
+    assert format_money(Money.new(1, "USD")).html_safe?
+  end
+
+  test "#format_money returns a plain string when html: false" do
+    result = format_money(Money.new(1, "USD"), html: false)
+    assert_equal "$1.00", result
+    refute_includes result, "<span"
+  end
+
+  test "#format_money returns nil for nil input" do
+    assert_nil format_money(nil)
+    assert_nil format_money(nil, html: false)
   end
 
   test "#currency_picker_options_for_family returns enabled family currencies" do


### PR DESCRIPTION
## Summary
- Money number displays now render in Geist Mono with `tabular-nums` everywhere they appear standalone (balance cards, totals, KPIs, report tables, chart labels/tooltips, provider setup pages, etc.) so they line up vertically and read as numeric data rather than running prose.
- The `format_money` helper does the heavy lifting: it now wraps its formatted string in `<span class="font-mono tabular-nums">…</span>` by default. Pass `html: false` for plain output (used by the `title` attribute on the recurring transactions row).
- Direct `Money#format` calls in ERB were rewritten to `format_money(...)` so the wrap applies uniformly. Provider setup pages using `number_to_currency` got an inline `font-mono tabular-nums` wrapper.
- The Sankey chart's SVG node label + tooltip and the time-series chart tooltip now mono-format their currency values.
- `helpers.format_money(...)` used inside ViewComponents because ApplicationHelper isn't auto-mixed there.
- `Money#format` itself is untouched, so plain-string callers (other API jbuilders that don't go through the helper) stay byte-identical.

## Screenshots

> Captured against current dev data on `feat/savings-goals` with this PR's templates applied locally. Hosted on the `screenshots/money-mono` branch in this repo.

### Dashboard — sidebar balances + Sankey labels
![Dashboard](https://raw.githubusercontent.com/we-promise/sure/screenshots/money-mono/money-mono-01-dashboard.png)

### Transactions list — KPI cards, row amounts, date totals
![Transactions](https://raw.githubusercontent.com/we-promise/sure/screenshots/money-mono/money-mono-02-transactions.png)

### Budgets — donut center, expected vs actual, category rows
![Budgets](https://raw.githubusercontent.com/we-promise/sure/screenshots/money-mono/money-mono-03-budgets.png)

### Reports — KPI cards + monthly breakdown table
![Reports](https://raw.githubusercontent.com/we-promise/sure/screenshots/money-mono/money-mono-04-reports.png)

### Account detail — balance + chart
![Account detail](https://raw.githubusercontent.com/we-promise/sure/screenshots/money-mono/money-mono-05-account-detail.png)

### Time-series chart tooltip
![Chart tooltip](https://raw.githubusercontent.com/we-promise/sure/screenshots/money-mono/money-mono-06-chart-tooltip.png)

### Sankey link tooltip
![Sankey tooltip](https://raw.githubusercontent.com/we-promise/sure/screenshots/money-mono/money-mono-07-sankey.png)

## What's deliberately *not* mono
- Money interpolated mid-sentence in `t(...)` strings (e.g. `"Catch-up: $500 over your monthly average"`). Mono mid-prose reads broken, so the formatted amount stays in body sans there.
- Money form inputs (`number_field`). User asked for displays, not entry.
- Donut chart's `"of $X"` sub-label below the main value — the `"of"` prefix is plain text and can't be wrapped without restructuring the `DS::Link` component.

## Mechanics
The change is concentrated in one helper:

```ruby
def format_money(number_or_money, options = {})
  return nil unless number_or_money

  html_output = options.delete(:html)
  html_output = true if html_output.nil?

  formatted = Money.new(number_or_money).format(options)

  return formatted unless html_output

  content_tag(:span, formatted, class: "font-mono tabular-nums")
end
```

`--font-mono` is already wired in `app/assets/tailwind/sure-design-system/_generated.css` (`@theme { --font-mono: 'Geist Mono', ... }`) and `tabular-nums` is a standard Tailwind utility, so no new CSS or font files are needed — Tailwind picks up the new class strings on the next build.

## Test plan
- [x] `bin/rubocop` clean on changed files
- [x] `bundle exec erb_lint --autocorrect` clean on changed templates
- [x] `bin/brakeman` clean
- [x] `bin/rails test` — 3999 runs, 0 failures from this change (1 pre-existing libvips error in Active Storage, unrelated)
- [x] Visually verified dashboard, account detail, transactions list, budgets, reports, Sankey + time-series tooltips
- [ ] Confirm balances API response still returns plain strings (controller defines its own `format_money` shadow that returns plain `money&.format`)
- [ ] Print report (`/reports/print`) renders mono cleanly in the Tufte layout

## Open questions
- Should we eventually pull the controller-local `format_money` shadow in `Api::V1::BalancesController` and have it call `format_money(money, html: false)` instead? Right now there are two definitions doing similar work.
- The `donut-chart` `"of $X"` label could become consistent if `DS::Link` accepted HTML text — separate refactor.