### PR TITLE
ci: publish Helm chart to GHCR as OCI

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   prepare_release:
@@ -71,6 +72,7 @@ jobs:
     with:
       chart_version: ${{ needs.prepare_release.outputs.chart_version }}
       app_version: ${{ needs.prepare_release.outputs.app_version }}
+      publish_oci: true
       update_gh_pages: true
     secrets: inherit
 

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -16,9 +16,15 @@ on:
         required: false
         type: boolean
         default: true
+      publish_oci:
+        description: Whether to publish packaged chart to the OCI registry
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:
@@ -95,6 +101,25 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
+
+      - name: Log in to GHCR for Helm OCI publish
+        if: ${{ inputs.publish_oci }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push chart to GHCR as OCI artifact
+        if: ${{ inputs.publish_oci }}
+        run: |
+          set -euo pipefail
+          CHART_PACKAGE=$(find .cr-release-packages -maxdepth 1 -name '*.tgz' | head -n 1)
+          if [ -z "$CHART_PACKAGE" ]; then
+            echo "::error::No packaged chart found to publish"
+            exit 1
+          fi
+
+          helm push "$CHART_PACKAGE" oci://ghcr.io/we-promise/charts
 
       - name: Checkout gh-pages
         if: ${{ inputs.update_gh_pages }}

--- a/charts/sure/README.md
+++ b/charts/sure/README.md
@@ -23,6 +23,10 @@ Official Helm chart for deploying the Sure Rails application on Kubernetes. It s
 
 - Kubernetes >= 1.25
 - Helm >= 3.10
+- OCI install (published to GHCR):
+  ```sh
+  helm install sure oci://ghcr.io/we-promise/charts/sure --version <chart-version> -n sure --create-namespace
+  ```
 - For subcharts: add repositories first
   ```sh
   helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
@@ -40,13 +44,24 @@ Important: For production stability, use immutable image tags (for example, set 
 # Namespace
 kubectl create ns sure || true
 
-# Install chart (example: provide SECRET_KEY_BASE and pin an immutable image tag)
+# Install from OCI (recommended)
+helm upgrade --install sure oci://ghcr.io/we-promise/charts/sure \
+  --version <chart-version> \
+  -n sure \
+  --create-namespace \
+  --set image.tag=v1.2.3 \
+  --set rails.secret.enabled=true \
+  --set rails.secret.values.SECRET_KEY_BASE=$(openssl rand -hex 32)
+
+# Or install from a local checkout while developing the chart
 helm upgrade --install sure charts/sure \
   -n sure \
   --set image.tag=v1.2.3 \
   --set rails.secret.enabled=true \
   --set rails.secret.values.SECRET_KEY_BASE=$(openssl rand -hex 32)
 ```
+
+If you still prefer the legacy Helm repository flow, the chart also remains available via `https://we-promise.github.io/sure`.
 
 Expose the app via an Ingress (see values) or `kubectl port-forward svc/sure 8080:80 -n sure`.
 


### PR DESCRIPTION
## Summary
- publish the Helm chart to GHCR as an OCI artifact during chart releases
- keep the existing `gh-pages` Helm repo publish path for backward compatibility
- document the OCI install path in the chart README

## What changed
- adds `publish_oci` support to the reusable Helm publish workflow
- logs Helm into `ghcr.io` with `GITHUB_TOKEN` and pushes the packaged chart to `oci://ghcr.io/we-promise/charts`
- grants `packages: write` to the chart release workflow so OCI publishing can succeed
- updates README examples to show OCI installs as the recommended path

## Expected OCI reference
```sh
helm install sure oci://ghcr.io/we-promise/charts/sure --version <chart-version>
```

## Notes
- I intentionally left `gh-pages` publishing enabled so existing users of `https://we-promise.github.io/sure` do not break.
- I could not run Helm locally in this workspace because `helm` is not installed here, so validation was limited to workflow/doc review plus `git diff --check`.

cc @cook1e_mr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm charts now available via OCI registry (GitHub Container Registry), enabling container-native installation workflows.

* **Documentation**
  * Installation guide updated with OCI-based installation as the recommended method, including quickstart examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1793)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->