### PR TITLE
Clamp Enable Banking sync window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,3 @@ scripts/
 .claude_settings.json
 .security-key
 logs/security/
-
-# Added by codex
-.codex
-.playwright-cli/

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ logs/security/
 
 # Added by codex
 .codex
+.playwright-cli/

--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -274,6 +274,14 @@
   }
 }
 
+@utility bg-destructive-surface {
+  @apply bg-red-tint-5;
+
+  @variant theme-dark {
+    @apply bg-red-tint-10;
+  }
+}
+
 @utility bg-inverse {
   @apply bg-gray-800;
 

--- a/app/components/DS/dialog.rb
+++ b/app/components/DS/dialog.rb
@@ -133,8 +133,8 @@ class DS::Dialog < DesignSystemComponent
       variant: "icon",
       class: classes,
       icon: "x",
-      title: I18n.t("common.close"),
-      aria_label: I18n.t("common.close"),
+      title: I18n.t("defaults.common.close"),
+      aria_label: I18n.t("defaults.common.close"),
       data: { action: "DS--dialog#close" }
     )
   end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -17,6 +17,7 @@ class AccountsController < ApplicationController
     @enable_banking_items = visible_provider_items(family.enable_banking_items.ordered.includes(:syncs))
     @coinstats_items = visible_provider_items(family.coinstats_items.ordered.includes(:coinstats_accounts, :accounts, :syncs))
     @mercury_items = visible_provider_items(family.mercury_items.ordered.includes(:syncs, :mercury_accounts))
+    @brex_items = visible_provider_items(family.brex_items.ordered.includes(:syncs, :brex_accounts))
     @coinbase_items = visible_provider_items(family.coinbase_items.ordered.includes(:coinbase_accounts, :accounts, :syncs))
     @snaptrade_items = visible_provider_items(family.snaptrade_items.ordered.includes(:syncs, :snaptrade_accounts))
     @indexa_capital_items = visible_provider_items(family.indexa_capital_items.ordered.includes(:syncs, :indexa_capital_accounts))
@@ -312,6 +313,13 @@ class AccountsController < ApplicationController
       @mercury_items.each do |item|
         latest_sync = item.syncs.ordered.first
         @mercury_sync_stats_map[item.id] = latest_sync&.sync_stats || {}
+      end
+
+      # Brex sync stats
+      @brex_sync_stats_map = {}
+      @brex_items.each do |item|
+        latest_sync = item.syncs.ordered.first
+        @brex_sync_stats_map[item.id] = latest_sync&.sync_stats || {}
       end
 
       # Coinbase sync stats

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -17,7 +17,7 @@ class AccountsController < ApplicationController
     @enable_banking_items = visible_provider_items(family.enable_banking_items.ordered.includes(:syncs))
     @coinstats_items = visible_provider_items(family.coinstats_items.ordered.includes(:coinstats_accounts, :accounts, :syncs))
     @mercury_items = visible_provider_items(family.mercury_items.ordered.includes(:syncs, :mercury_accounts))
-    @brex_items = visible_provider_items(family.brex_items.ordered.includes(:syncs, :brex_accounts))
+    @brex_items = visible_provider_items(family.brex_items.ordered.includes(:accounts, :syncs, brex_accounts: :account_provider))
     @coinbase_items = visible_provider_items(family.coinbase_items.ordered.includes(:coinbase_accounts, :accounts, :syncs))
     @snaptrade_items = visible_provider_items(family.snaptrade_items.ordered.includes(:syncs, :snaptrade_accounts))
     @indexa_capital_items = visible_provider_items(family.indexa_capital_items.ordered.includes(:syncs, :indexa_capital_accounts))
@@ -317,9 +317,23 @@ class AccountsController < ApplicationController
 
       # Brex sync stats
       @brex_sync_stats_map = {}
+      @brex_account_counts_map = {}
+      @brex_institutions_count_map = {}
       @brex_items.each do |item|
         latest_sync = item.syncs.ordered.first
         @brex_sync_stats_map[item.id] = latest_sync&.sync_stats || {}
+        brex_accounts = item.brex_accounts.to_a
+        linked_count = brex_accounts.count { |brex_account| brex_account.account_provider.present? }
+        total_count = brex_accounts.count
+        @brex_account_counts_map[item.id] = {
+          linked: linked_count,
+          unlinked: total_count - linked_count,
+          total: total_count
+        }
+        @brex_institutions_count_map[item.id] = brex_accounts
+          .filter_map(&:institution_metadata)
+          .uniq { |institution| institution["name"] || institution["institution_name"] }
+          .count
       end
 
       # Coinbase sync stats

--- a/app/controllers/brex_items/account_flows_controller.rb
+++ b/app/controllers/brex_items/account_flows_controller.rb
@@ -30,7 +30,9 @@ class BrexItems::AccountFlowsController < ApplicationController
   def select_existing_account
     return redirect_to accounts_path, alert: t("brex_items.select_existing_account.no_account_specified") if params[:account_id].blank?
 
-    @account = Current.family.accounts.find(params[:account_id])
+    @account = Current.family.accounts.find_by(id: params[:account_id])
+    return redirect_to accounts_path, alert: t("brex_items.select_existing_account.no_account_specified") unless @account
+
     result = brex_account_flow.select_existing_account_result(account: @account)
 
     return handle_brex_selection_result(result, empty_path: accounts_path, api_return_path: accounts_path) unless result.success?
@@ -45,7 +47,9 @@ class BrexItems::AccountFlowsController < ApplicationController
   def link_existing_account
     return redirect_to accounts_path, alert: t("brex_items.link_existing_account.no_account_specified") if params[:account_id].blank?
 
-    account = Current.family.accounts.find(params[:account_id])
+    account = Current.family.accounts.find_by(id: params[:account_id])
+    return redirect_to accounts_path, alert: t("brex_items.link_existing_account.no_account_specified") unless account
+
     result = brex_account_flow.link_existing_account_result(
       account: account,
       brex_account_id: params[:brex_account_id]
@@ -105,6 +109,7 @@ class BrexItems::AccountFlowsController < ApplicationController
       return nil if second_character.blank?
       return nil if second_character == "/" || second_character == "\\"
       return nil if second_character.match?(/[[:space:][:cntrl:]]/)
+      return nil if encoded_path_separator?(return_to)
 
       uri = URI.parse(return_to)
 
@@ -113,5 +118,15 @@ class BrexItems::AccountFlowsController < ApplicationController
       return_to
     rescue URI::InvalidURIError
       nil
+    end
+
+    def encoded_path_separator?(return_to)
+      encoded_second_character = return_to[1, 3]
+      return false unless encoded_second_character&.start_with?("%")
+
+      decoded = URI.decode_www_form_component(encoded_second_character)
+      decoded == "/" || decoded == "\\"
+    rescue ArgumentError
+      false
     end
 end

--- a/app/controllers/brex_items/account_flows_controller.rb
+++ b/app/controllers/brex_items/account_flows_controller.rb
@@ -1,0 +1,112 @@
+class BrexItems::AccountFlowsController < ApplicationController
+  before_action :require_admin!
+
+  def preload_accounts
+    render json: brex_account_flow.preload_payload
+  end
+
+  def select_accounts
+    @accountable_type = params[:accountable_type] || "Depository"
+    @return_to = safe_return_to_path
+    result = brex_account_flow.select_accounts_result(accountable_type: @accountable_type)
+
+    return handle_brex_selection_result(result, empty_path: new_account_path, api_return_path: @return_to) unless result.success?
+
+    @brex_item = result.brex_item
+    @available_accounts = result.available_accounts
+
+    render "brex_items/select_accounts", layout: false
+  end
+
+  def link_accounts
+    result = brex_account_flow.link_new_accounts_result(
+      account_ids: params[:account_ids] || [],
+      accountable_type: params[:accountable_type] || "Depository"
+    )
+
+    redirect_with_navigation(result, return_to: safe_return_to_path)
+  end
+
+  def select_existing_account
+    return redirect_to accounts_path, alert: t("brex_items.select_existing_account.no_account_specified") if params[:account_id].blank?
+
+    @account = Current.family.accounts.find(params[:account_id])
+    result = brex_account_flow.select_existing_account_result(account: @account)
+
+    return handle_brex_selection_result(result, empty_path: accounts_path, api_return_path: accounts_path) unless result.success?
+
+    @brex_item = result.brex_item
+    @available_accounts = result.available_accounts
+    @return_to = safe_return_to_path
+
+    render "brex_items/select_existing_account", layout: false
+  end
+
+  def link_existing_account
+    return redirect_to accounts_path, alert: t("brex_items.link_existing_account.no_account_specified") if params[:account_id].blank?
+
+    account = Current.family.accounts.find(params[:account_id])
+    result = brex_account_flow.link_existing_account_result(
+      account: account,
+      brex_account_id: params[:brex_account_id]
+    )
+
+    redirect_with_navigation(result, return_to: safe_return_to_path)
+  end
+
+  private
+
+    def brex_account_flow
+      @brex_account_flow ||= BrexItem::AccountFlow.new(family: Current.family, brex_item_id: params[:brex_item_id])
+    end
+
+    def handle_brex_selection_result(result, empty_path:, api_return_path:)
+      case result.status
+      when :empty, :account_already_linked
+        redirect_to empty_path, alert: result.message
+      when :no_api_token, :select_connection
+        redirect_to settings_providers_path, alert: result.message
+      when :setup_required
+        if turbo_frame_request?
+          render partial: "brex_items/setup_required", layout: false
+        else
+          redirect_to settings_providers_path, alert: result.message
+        end
+      when :api_error, :unexpected_error
+        render_api_error_partial(result.message, api_return_path)
+      else
+        redirect_to settings_providers_path, alert: result.message
+      end
+    end
+
+    def redirect_with_navigation(result, return_to:)
+      redirect_to navigation_path_for(result.target, return_to: return_to), result.flash_type => result.message
+    end
+
+    def navigation_path_for(target, return_to:)
+      {
+        new_account: new_account_path,
+        settings_providers: settings_providers_path,
+        return_to_or_accounts: return_to || accounts_path
+      }.fetch(target, accounts_path)
+    end
+
+    def render_api_error_partial(error_message, return_path)
+      render partial: "brex_items/api_error", locals: { error_message: error_message, return_path: return_path }, layout: false
+    end
+
+    def safe_return_to_path
+      return nil if params[:return_to].blank?
+
+      return_to = params[:return_to].to_s
+      uri = URI.parse(return_to)
+
+      return nil if uri.scheme.present? || uri.host.present?
+      return nil if return_to.start_with?("//")
+      return nil unless return_to.start_with?("/")
+
+      return_to
+    rescue URI::InvalidURIError
+      nil
+    end
+end

--- a/app/controllers/brex_items/account_flows_controller.rb
+++ b/app/controllers/brex_items/account_flows_controller.rb
@@ -98,12 +98,17 @@ class BrexItems::AccountFlowsController < ApplicationController
     def safe_return_to_path
       return nil if params[:return_to].blank?
 
-      return_to = params[:return_to].to_s
+      return_to = params[:return_to].to_s.strip
+      return nil unless return_to.start_with?("/")
+
+      second_character = return_to[1]
+      return nil if second_character.blank?
+      return nil if second_character == "/" || second_character == "\\"
+      return nil if second_character.match?(/[[:space:][:cntrl:]]/)
+
       uri = URI.parse(return_to)
 
       return nil if uri.scheme.present? || uri.host.present?
-      return nil if return_to.start_with?("//")
-      return nil unless return_to.start_with?("/")
 
       return_to
     rescue URI::InvalidURIError

--- a/app/controllers/brex_items/account_setups_controller.rb
+++ b/app/controllers/brex_items/account_setups_controller.rb
@@ -14,8 +14,8 @@ class BrexItems::AccountSetupsController < ApplicationController
 
   def complete_account_setup
     result = brex_account_flow.complete_setup_result(
-      account_types: params[:account_types] || {},
-      account_subtypes: params[:account_subtypes] || {}
+      account_types: sanitized_account_types,
+      account_subtypes: sanitized_account_subtypes
     )
 
     unless result.success?
@@ -61,8 +61,40 @@ class BrexItems::AccountSetupsController < ApplicationController
         turbo_stream.replace(
           ActionView::RecordIdentifier.dom_id(@brex_item),
           partial: "brex_items/brex_item",
-          locals: { brex_item: @brex_item }
+          locals: view_context.brex_item_render_locals(@brex_item)
         )
       ] + Array(flash_notification_stream_items)
+    end
+
+    def sanitized_account_types
+      allowed_account_ids = @brex_item.brex_accounts.pluck(:id).map(&:to_s)
+      allowed_types = Provider::BrexAdapter.supported_account_types + [ "skip" ]
+
+      setup_param_hash(:account_types).each_with_object({}) do |(account_id, selected_type), sanitized|
+        next unless allowed_account_ids.include?(account_id.to_s)
+        next unless allowed_types.include?(selected_type.to_s)
+
+        sanitized[account_id.to_s] = selected_type.to_s
+      end
+    end
+
+    def sanitized_account_subtypes
+      allowed_account_ids = @brex_item.brex_accounts.pluck(:id).map(&:to_s)
+      allowed_subtypes = (Depository::SUBTYPES.keys + CreditCard::SUBTYPES.keys).map(&:to_s)
+
+      setup_param_hash(:account_subtypes).each_with_object({}) do |(account_id, selected_subtype), sanitized|
+        next unless allowed_account_ids.include?(account_id.to_s)
+        next if selected_subtype.blank?
+        next unless allowed_subtypes.include?(selected_subtype.to_s)
+
+        sanitized[account_id.to_s] = selected_subtype.to_s
+      end
+    end
+
+    def setup_param_hash(key)
+      raw_params = params.fetch(key, {})
+      return {} if raw_params.blank?
+
+      raw_params.respond_to?(:to_unsafe_h) ? raw_params.to_unsafe_h : raw_params.to_h
     end
 end

--- a/app/controllers/brex_items/account_setups_controller.rb
+++ b/app/controllers/brex_items/account_setups_controller.rb
@@ -1,0 +1,68 @@
+class BrexItems::AccountSetupsController < ApplicationController
+  before_action :set_brex_item
+  before_action :require_admin!
+
+  def setup_accounts
+    flow = brex_account_flow
+    @api_error = flow.import_accounts_error_message
+    @brex_accounts = flow.unlinked_brex_accounts
+    @account_type_options = flow.account_type_options
+    @subtype_options = flow.subtype_options
+
+    render "brex_items/setup_accounts"
+  end
+
+  def complete_account_setup
+    result = brex_account_flow.complete_setup_result(
+      account_types: params[:account_types] || {},
+      account_subtypes: params[:account_subtypes] || {}
+    )
+
+    unless result.success?
+      redirect_to accounts_path, alert: result.message, status: :see_other
+      return
+    end
+
+    flash[:notice] = result.message
+
+    if turbo_frame_request?
+      render_accounts_update_after_setup
+    else
+      redirect_to accounts_path, status: :see_other
+    end
+  end
+
+  private
+
+    def set_brex_item
+      @brex_item = Current.family.brex_items.find(params[:id])
+    end
+
+    def brex_account_flow
+      @brex_account_flow ||= BrexItem::AccountFlow.new(family: Current.family, brex_item: @brex_item)
+    end
+
+    def render_accounts_update_after_setup
+      @manual_accounts = Account.uncached { Current.family.accounts.visible_manual.order(:name).to_a }
+      @brex_items = Current.family.brex_items.ordered
+
+      manual_accounts_stream = if @manual_accounts.any?
+        turbo_stream.update(
+          "manual-accounts",
+          partial: "accounts/index/manual_accounts",
+          locals: { accounts: @manual_accounts }
+        )
+      else
+        turbo_stream.replace("manual-accounts", view_context.tag.div(id: "manual-accounts"))
+      end
+
+      render turbo_stream: [
+        manual_accounts_stream,
+        turbo_stream.replace(
+          ActionView::RecordIdentifier.dom_id(@brex_item),
+          partial: "brex_items/brex_item",
+          locals: { brex_item: @brex_item }
+        )
+      ] + Array(flash_notification_stream_items)
+    end
+end

--- a/app/controllers/brex_items/account_setups_controller.rb
+++ b/app/controllers/brex_items/account_setups_controller.rb
@@ -1,10 +1,10 @@
 class BrexItems::AccountSetupsController < ApplicationController
-  before_action :set_brex_item
   before_action :require_admin!
+  before_action :set_brex_item
 
   def setup_accounts
     flow = brex_account_flow
-    @api_error = flow.import_accounts_error_message
+    @api_error = flow.import_accounts_with_user_facing_error
     @brex_accounts = flow.unlinked_brex_accounts
     @account_type_options = flow.account_type_options
     @subtype_options = flow.subtype_options
@@ -61,20 +61,20 @@ class BrexItems::AccountSetupsController < ApplicationController
         turbo_stream.replace(
           ActionView::RecordIdentifier.dom_id(@brex_item),
           partial: "brex_items/brex_item",
-          locals: view_context.brex_item_render_locals(@brex_item)
+          locals: { brex_item: @brex_item }
         )
       ] + Array(flash_notification_stream_items)
     end
 
     def sanitized_account_types
       allowed_account_ids = @brex_item.brex_accounts.pluck(:id).map(&:to_s)
-      allowed_types = Provider::BrexAdapter.supported_account_types + [ "skip" ]
+      supported_types = Provider::BrexAdapter.supported_account_types
 
       setup_param_hash(:account_types).each_with_object({}) do |(account_id, selected_type), sanitized|
         next unless allowed_account_ids.include?(account_id.to_s)
-        next unless allowed_types.include?(selected_type.to_s)
 
-        sanitized[account_id.to_s] = selected_type.to_s
+        normalized_type = selected_type.to_s
+        sanitized[account_id.to_s] = supported_types.include?(normalized_type) ? normalized_type : "skip"
       end
     end
 

--- a/app/controllers/brex_items_controller.rb
+++ b/app/controllers/brex_items_controller.rb
@@ -10,120 +10,52 @@ class BrexItemsController < ApplicationController
   def show
   end
 
-  # Preload Brex accounts in background (async, non-blocking)
   def preload_accounts
-    begin
-      account_flow = brex_item_account_flow_context
-      brex_item = account_flow[:brex_item]
-      unless brex_item
-        render json: brex_item_selection_error_payload(account_flow[:credentialed_items])
-        return
-      end
-
-      unless brex_item.credentials_configured?
-        render json: { success: false, error: "no_credentials", has_accounts: false }
-        return
-      end
-
-      cache_key = brex_accounts_cache_key(brex_item)
-
-      # Check if already cached
-      cached_accounts = Rails.cache.read(cache_key)
-
-      if cached_accounts.present?
-        render json: { success: true, has_accounts: cached_accounts.any?, cached: true }
-        return
-      end
-
-      brex_provider = brex_item.brex_provider
-
-      unless brex_provider.present?
-        render json: { success: false, error: "no_api_token", has_accounts: false }
-        return
-      end
-
-      accounts_data = brex_provider.get_accounts
-      available_accounts = accounts_data[:accounts] || []
-
-      # Cache the accounts for 5 minutes
-      Rails.cache.write(cache_key, available_accounts, expires_in: 5.minutes)
-
-      render json: { success: true, has_accounts: available_accounts.any?, cached: false }
-    rescue Provider::Brex::BrexError => e
-      Rails.logger.error("Brex preload error: #{e.message}")
-      # API error (bad token, network issue, etc) - keep button visible, show error when clicked
-      render json: { success: false, error: "api_error", error_message: e.message, has_accounts: nil }
-    rescue StandardError => e
-      Rails.logger.error("Unexpected error preloading Brex accounts: #{e.class}: #{e.message}")
-      # Unexpected error - keep button visible, show error when clicked
-      render json: { success: false, error: "unexpected_error", error_message: t("brex_items.errors.unexpected_error"), has_accounts: nil }
+    flow = brex_account_flow
+    unless flow.selected?
+      render json: brex_item_selection_error_payload(flow)
+      return
     end
+
+    render json: flow.preload_payload
+  rescue BrexItem::AccountFlow::NoApiTokenError
+    render json: { success: false, error: "no_api_token", has_accounts: false }
+  rescue Provider::Brex::BrexError => e
+    Rails.logger.error("Brex preload error: #{e.message}")
+    render json: { success: false, error: "api_error", error_message: e.message, has_accounts: nil }
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error preloading Brex accounts: #{e.class}: #{e.message}")
+    render json: { success: false, error: "unexpected_error", error_message: t("brex_items.errors.unexpected_error"), has_accounts: nil }
   end
 
-  # Fetch available accounts from Brex API and show selection UI
   def select_accounts
-    begin
-      account_flow = brex_item_account_flow_context
-      @brex_item = account_flow[:brex_item]
-      unless @brex_item
-        render_brex_item_selection_failure(credentialed_items: account_flow[:credentialed_items])
-        return
-      end
-
-      cache_key = brex_accounts_cache_key(@brex_item)
-
-      # Try to get cached accounts first
-      @available_accounts = Rails.cache.read(cache_key)
-
-      # If not cached, fetch from API
-      if @available_accounts.nil?
-        brex_provider = @brex_item.brex_provider
-
-        unless brex_provider.present?
-          redirect_to settings_providers_path, alert: t(".no_api_token",
-                                                        default: "Brex API token not found. Please configure it in Provider Settings.")
-          return
-        end
-
-        accounts_data = brex_provider.get_accounts
-
-        @available_accounts = accounts_data[:accounts] || []
-
-        # Cache the accounts for 5 minutes
-        Rails.cache.write(cache_key, @available_accounts, expires_in: 5.minutes)
-      end
-
-      linked_account_ids = @brex_item.brex_accounts.joins(:account_provider).pluck(:account_id)
-      @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
-
-      @accountable_type = params[:accountable_type] || "Depository"
-      @available_accounts = filtered_available_accounts(@available_accounts, @accountable_type)
-      @return_to = safe_return_to_path
-
-      if @available_accounts.empty?
-        redirect_to new_account_path, alert: t(".no_accounts_found")
-        return
-      end
-
-      render layout: false
-    rescue Provider::Brex::BrexError => e
-      Rails.logger.error("Brex API error in select_accounts: #{e.message}")
-      @error_message = e.message
-      @return_path = safe_return_to_path
-      render partial: "brex_items/api_error",
-             locals: { error_message: @error_message, return_path: @return_path },
-             layout: false
-    rescue StandardError => e
-      Rails.logger.error("Unexpected error in select_accounts: #{e.class}: #{e.message}")
-      @error_message = t(".unexpected_error")
-      @return_path = safe_return_to_path
-      render partial: "brex_items/api_error",
-             locals: { error_message: @error_message, return_path: @return_path },
-             layout: false
+    flow = brex_account_flow
+    unless flow.selected?
+      render_brex_item_selection_failure(flow)
+      return
     end
+
+    @brex_item = flow.brex_item
+    @accountable_type = params[:accountable_type] || "Depository"
+    @available_accounts = flow.available_accounts(accountable_type: @accountable_type)
+    @return_to = safe_return_to_path
+
+    if @available_accounts.empty?
+      redirect_to new_account_path, alert: t(".no_accounts_found")
+      return
+    end
+
+    render layout: false
+  rescue BrexItem::AccountFlow::NoApiTokenError
+    redirect_to settings_providers_path, alert: t(".no_api_token")
+  rescue Provider::Brex::BrexError => e
+    Rails.logger.error("Brex API error in select_accounts: #{e.message}")
+    render_api_error_partial(e.message, safe_return_to_path)
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error in select_accounts: #{e.class}: #{e.message}")
+    render_api_error_partial(t(".unexpected_error"), safe_return_to_path)
   end
 
-  # Create accounts from selected Brex accounts
   def link_accounts
     selected_account_ids = params[:account_ids] || []
     accountable_type = params[:accountable_type] || "Depository"
@@ -134,112 +66,24 @@ class BrexItemsController < ApplicationController
       return
     end
 
-    account_flow = brex_item_account_flow_context
-    brex_item = account_flow[:brex_item]
-
-    unless brex_item
-      redirect_to settings_providers_path, alert: t(".select_connection", default: "Choose a Brex connection before linking accounts.")
+    flow = brex_account_flow
+    unless flow.selected?
+      redirect_to settings_providers_path, alert: t(".select_connection")
       return
     end
 
-    # Fetch account details from API
-    brex_provider = brex_item.brex_provider
-    unless brex_provider.present?
-      redirect_to new_account_path, alert: t(".no_api_token")
-      return
-    end
+    result = flow.link_new_accounts!(
+      account_ids: selected_account_ids,
+      accountable_type: accountable_type
+    )
 
-    accounts_data = brex_provider.get_accounts
-
-    created_accounts = []
-    already_linked_accounts = []
-    invalid_accounts = []
-
-    selected_account_ids.each do |account_id|
-      # Find the account data from API response
-      account_data = accounts_data[:accounts].find { |acc| acc[:id].to_s == account_id.to_s }
-      next unless account_data
-
-      account_name = brex_account_name(account_data)
-
-      # Validate account name is not blank (required by Account model)
-      if account_name.blank?
-        invalid_accounts << account_id
-        Rails.logger.warn "BrexItemsController - Skipping account #{account_id} with blank name"
-        next
-      end
-
-      # Create or find brex_account
-      brex_account = brex_item.brex_accounts.find_or_initialize_by(
-        account_id: account_id.to_s
-      )
-      brex_account.upsert_brex_snapshot!(account_data)
-      brex_account.save!
-
-      # Check if this brex_account is already linked
-      if brex_account.account_provider.present?
-        already_linked_accounts << account_name
-        next
-      end
-
-      # Create the internal Account with proper balance initialization
-      account = Account.create_and_sync(
-        {
-          family: Current.family,
-          name: account_name,
-          balance: 0, # Initial balance will be set during sync
-          currency: brex_account_currency(account_data),
-          accountable_type: accountable_type,
-          accountable_attributes: default_accountable_attributes(accountable_type)
-        },
-        skip_initial_sync: true
-      )
-
-      # Link account to brex_account via account_providers join table
-      AccountProvider.create!(
-        account: account,
-        provider: brex_account
-      )
-
-      created_accounts << account
-    end
-
-    # Trigger sync to fetch transactions if any accounts were created
-    brex_item.sync_later if created_accounts.any?
-
-    # Build appropriate flash message
-    if invalid_accounts.any? && created_accounts.empty? && already_linked_accounts.empty?
-      # All selected accounts were invalid (blank names)
-      redirect_to new_account_path, alert: t(".invalid_account_names", count: invalid_accounts.count)
-    elsif invalid_accounts.any? && (created_accounts.any? || already_linked_accounts.any?)
-      # Some accounts were created/already linked, but some had invalid names
-      redirect_to return_to || accounts_path,
-                  alert: t(".partial_invalid",
-                           created_count: created_accounts.count,
-                           already_linked_count: already_linked_accounts.count,
-                           invalid_count: invalid_accounts.count)
-    elsif created_accounts.any? && already_linked_accounts.any?
-      redirect_to return_to || accounts_path,
-                  notice: t(".partial_success",
-                           created_count: created_accounts.count,
-                           already_linked_count: already_linked_accounts.count,
-                           already_linked_names: already_linked_accounts.join(", "))
-    elsif created_accounts.any?
-      redirect_to return_to || accounts_path,
-                  notice: t(".success", count: created_accounts.count)
-    elsif already_linked_accounts.any?
-      redirect_to return_to || accounts_path,
-                  alert: t(".all_already_linked",
-                          count: already_linked_accounts.count,
-                          names: already_linked_accounts.join(", "))
-    else
-      redirect_to new_account_path, alert: t(".link_failed")
-    end
+    redirect_after_link_accounts(result, return_to: return_to)
+  rescue BrexItem::AccountFlow::NoApiTokenError
+    redirect_to new_account_path, alert: t(".no_api_token")
   rescue Provider::Brex::BrexError => e
     redirect_to new_account_path, alert: t(".api_error", message: e.message)
   end
 
-  # Fetch available Brex accounts to link with an existing account
   def select_existing_account
     account_id = params[:account_id]
 
@@ -250,76 +94,37 @@ class BrexItemsController < ApplicationController
 
     @account = Current.family.accounts.find(account_id)
 
-    # Check if account is already linked
     if @account.account_providers.exists?
       redirect_to accounts_path, alert: t(".account_already_linked")
       return
     end
 
-    account_flow = brex_item_account_flow_context
-    @brex_item = account_flow[:brex_item]
-    unless @brex_item
-      render_brex_item_selection_failure(credentialed_items: account_flow[:credentialed_items])
+    flow = brex_account_flow
+    unless flow.selected?
+      render_brex_item_selection_failure(flow)
       return
     end
 
-    begin
-      cache_key = brex_accounts_cache_key(@brex_item)
+    @brex_item = flow.brex_item
+    @available_accounts = flow.available_accounts_for_existing(account: @account)
 
-      # Try to get cached accounts first
-      @available_accounts = Rails.cache.read(cache_key)
-
-      # If not cached, fetch from API
-      if @available_accounts.nil?
-        brex_provider = @brex_item.brex_provider
-
-        unless brex_provider.present?
-          redirect_to settings_providers_path, alert: t(".no_api_token",
-                                                        default: "Brex API token not found. Please configure it in Provider Settings.")
-          return
-        end
-
-        accounts_data = brex_provider.get_accounts
-
-        @available_accounts = accounts_data[:accounts] || []
-
-        # Cache the accounts for 5 minutes
-        Rails.cache.write(cache_key, @available_accounts, expires_in: 5.minutes)
-      end
-
-      if @available_accounts.empty?
-        redirect_to accounts_path, alert: t(".no_accounts_found")
-        return
-      end
-
-      linked_account_ids = @brex_item.brex_accounts.joins(:account_provider).pluck(:account_id)
-      @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
-      @available_accounts = filtered_available_accounts(@available_accounts, @account.accountable_type)
-
-      if @available_accounts.empty?
-        redirect_to accounts_path, alert: t(".all_accounts_already_linked")
-        return
-      end
-
-      @return_to = safe_return_to_path
-
-      render layout: false
-    rescue Provider::Brex::BrexError => e
-      Rails.logger.error("Brex API error in select_existing_account: #{e.message}")
-      @error_message = e.message
-      render partial: "brex_items/api_error",
-             locals: { error_message: @error_message, return_path: accounts_path },
-             layout: false
-    rescue StandardError => e
-      Rails.logger.error("Unexpected error in select_existing_account: #{e.class}: #{e.message}")
-      @error_message = t(".unexpected_error")
-      render partial: "brex_items/api_error",
-             locals: { error_message: @error_message, return_path: accounts_path },
-             layout: false
+    if @available_accounts.empty?
+      redirect_to accounts_path, alert: t(".all_accounts_already_linked")
+      return
     end
+
+    @return_to = safe_return_to_path
+    render layout: false
+  rescue BrexItem::AccountFlow::NoApiTokenError
+    redirect_to settings_providers_path, alert: t(".no_api_token")
+  rescue Provider::Brex::BrexError => e
+    Rails.logger.error("Brex API error in select_existing_account: #{e.message}")
+    render_api_error_partial(e.message, accounts_path)
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error in select_existing_account: #{e.class}: #{e.message}")
+    render_api_error_partial(t(".unexpected_error"), accounts_path)
   end
 
-  # Link a selected Brex account to an existing account
   def link_existing_account
     account_id = params[:account_id]
     brex_account_id = params[:brex_account_id]
@@ -330,70 +135,31 @@ class BrexItemsController < ApplicationController
       return
     end
 
-    account_flow = brex_item_account_flow_context
-    brex_item = account_flow[:brex_item]
-
     @account = Current.family.accounts.find(account_id)
 
-    # Check if account is already linked
     if @account.account_providers.exists?
       redirect_to accounts_path, alert: t(".account_already_linked")
       return
     end
 
-    unless brex_item
-      redirect_to settings_providers_path, alert: t(".select_connection", default: "Choose a Brex connection before linking accounts.")
+    flow = brex_account_flow
+    unless flow.selected?
+      redirect_to settings_providers_path, alert: t(".select_connection")
       return
     end
 
-    # Fetch account details from API
-    brex_provider = brex_item.brex_provider
-    unless brex_provider.present?
-      redirect_to accounts_path, alert: t(".no_api_token")
-      return
-    end
-
-    accounts_data = brex_provider.get_accounts
-
-    # Find the selected Brex account data
-    account_data = accounts_data[:accounts].find { |acc| acc[:id].to_s == brex_account_id.to_s }
-    unless account_data
-      redirect_to accounts_path, alert: t(".brex_account_not_found")
-      return
-    end
-
-    account_name = brex_account_name(account_data)
-
-    # Validate account name is not blank (required by Account model)
-    if account_name.blank?
-      redirect_to accounts_path, alert: t(".invalid_account_name")
-      return
-    end
-
-    # Create or find brex_account
-    brex_account = brex_item.brex_accounts.find_or_initialize_by(
-      account_id: brex_account_id.to_s
-    )
-    brex_account.upsert_brex_snapshot!(account_data)
-    brex_account.save!
-
-    # Check if this brex_account is already linked to another account
-    if brex_account.account_provider.present?
-      redirect_to accounts_path, alert: t(".brex_account_already_linked")
-      return
-    end
-
-    # Link account to brex_account via account_providers join table
-    AccountProvider.create!(
-      account: @account,
-      provider: brex_account
-    )
-
-    # Trigger sync to fetch transactions
-    brex_item.sync_later
+    flow.link_existing_account!(account: @account, brex_account_id: brex_account_id)
 
     redirect_to return_to || accounts_path,
                 notice: t(".success", account_name: @account.name)
+  rescue BrexItem::AccountFlow::NoApiTokenError
+    redirect_to accounts_path, alert: t(".no_api_token")
+  rescue BrexItem::AccountFlow::AccountNotFoundError
+    redirect_to accounts_path, alert: t(".brex_account_not_found")
+  rescue BrexItem::AccountFlow::InvalidAccountNameError
+    redirect_to accounts_path, alert: t(".invalid_account_name")
+  rescue BrexItem::AccountFlow::AccountAlreadyLinkedError
+    redirect_to accounts_path, alert: t(".brex_account_already_linked")
   rescue Provider::Brex::BrexError => e
     redirect_to accounts_path, alert: t(".api_error", message: e.message)
   end
@@ -407,35 +173,10 @@ class BrexItemsController < ApplicationController
     @brex_item.name ||= "Brex Connection"
 
     if @brex_item.save
-      # Trigger initial sync to fetch accounts
       @brex_item.sync_later
-
-      if turbo_frame_request?
-        flash.now[:notice] = t(".success")
-        @brex_items = Current.family.brex_items.active.ordered.includes(:syncs, :brex_accounts)
-        render turbo_stream: [
-          turbo_stream.replace(
-            "brex-providers-panel",
-            partial: "settings/providers/brex_panel",
-            locals: { brex_items: @brex_items }
-          ),
-          *flash_notification_stream_items
-        ]
-      else
-        redirect_to accounts_path, notice: t(".success"), status: :see_other
-      end
+      render_provider_panel_success(t(".success"))
     else
-      @error_message = @brex_item.errors.full_messages.join(", ")
-
-      if turbo_frame_request?
-        render turbo_stream: turbo_stream.replace(
-          "brex-providers-panel",
-          partial: "settings/providers/brex_panel",
-          locals: { error_message: @error_message }
-        ), status: :unprocessable_entity
-      else
-        redirect_to settings_providers_path, alert: @error_message, status: :see_other
-      end
+      render_provider_panel_error
     end
   end
 
@@ -444,13 +185,79 @@ class BrexItemsController < ApplicationController
 
   def update
     permitted_params = brex_item_params
-    expire_accounts_cache = brex_accounts_cache_sensitive_update?(permitted_params)
+    expire_accounts_cache = BrexItem::AccountFlow.cache_sensitive_update?(permitted_params)
 
     if @brex_item.update(permitted_params)
-      Rails.cache.delete(brex_accounts_cache_key(@brex_item)) if expire_accounts_cache
+      Rails.cache.delete(BrexItem::AccountFlow.cache_key(Current.family, @brex_item)) if expire_accounts_cache
+      render_provider_panel_success(t(".success"))
+    else
+      render_provider_panel_error
+    end
+  end
 
+  def destroy
+    safely_unlink_brex_item
+    @brex_item.destroy_later
+    redirect_to accounts_path, notice: t(".success")
+  end
+
+  def sync
+    @brex_item.sync_later unless @brex_item.syncing?
+
+    respond_to do |format|
+      format.html { redirect_back_or_to accounts_path }
+      format.json { head :ok }
+    end
+  end
+
+  def setup_accounts
+    flow = brex_account_flow_for_item
+    @api_error = import_accounts_for_setup(flow)
+    @brex_accounts = flow.unlinked_brex_accounts
+    @account_type_options = flow.account_type_options
+    @subtype_options = flow.subtype_options
+  end
+
+  def complete_account_setup
+    flow = brex_account_flow_for_item
+    result = flow.complete_setup!(
+      account_types: params[:account_types] || {},
+      account_subtypes: params[:account_subtypes] || {}
+    )
+
+    flash[:notice] = account_setup_notice(result)
+
+    if turbo_frame_request?
+      render_accounts_update_after_setup
+    else
+      redirect_to accounts_path, status: :see_other
+    end
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    Rails.logger.error("Brex account setup failed: #{e.class} - #{e.message}")
+    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
+    redirect_to accounts_path, alert: t(".creation_failed", error: e.message), status: :see_other
+  rescue StandardError => e
+    Rails.logger.error("Brex account setup failed unexpectedly: #{e.class} - #{e.message}")
+    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
+    redirect_to accounts_path, alert: t(".creation_failed", error: t(".unexpected_error")), status: :see_other
+  end
+
+  private
+
+    def brex_account_flow
+      @brex_account_flow ||= BrexItem::AccountFlow.new(
+        family: Current.family,
+        brex_item_id: params[:brex_item_id]
+      )
+    end
+
+    def brex_account_flow_for_item
+      BrexItem::AccountFlow.new(family: Current.family, brex_item: @brex_item)
+    end
+
+    def render_provider_panel_success(message)
       if turbo_frame_request?
-        flash.now[:notice] = t(".success")
+        flash.now[:notice] = message
         @brex_items = Current.family.brex_items.active.ordered.includes(:syncs, :brex_accounts)
         render turbo_stream: [
           turbo_stream.replace(
@@ -461,9 +268,11 @@ class BrexItemsController < ApplicationController
           *flash_notification_stream_items
         ]
       else
-        redirect_to accounts_path, notice: t(".success"), status: :see_other
+        redirect_to accounts_path, notice: message, status: :see_other
       end
-    else
+    end
+
+    def render_provider_panel_error
       @error_message = @brex_item.errors.full_messages.join(", ")
 
       if turbo_frame_request?
@@ -476,190 +285,58 @@ class BrexItemsController < ApplicationController
         redirect_to settings_providers_path, alert: @error_message, status: :see_other
       end
     end
-  end
 
-  def destroy
-    # Ensure we detach provider links before scheduling deletion
-    begin
-      @brex_item.unlink_all!(dry_run: false)
-    rescue => e
-      Rails.logger.warn("Brex unlink during destroy failed: #{e.class} - #{e.message}")
-    end
-    @brex_item.destroy_later
-    redirect_to accounts_path, notice: t(".success")
-  end
-
-  def sync
-    unless @brex_item.syncing?
-      @brex_item.sync_later
-    end
-
-    respond_to do |format|
-      format.html { redirect_back_or_to accounts_path }
-      format.json { head :ok }
-    end
-  end
-
-  # Show unlinked Brex accounts for setup
-  def setup_accounts
-    # First, ensure we have the latest accounts from the API
-    @api_error = fetch_brex_accounts_from_api
-
-    # Get Brex accounts that are not linked (no AccountProvider)
-    @brex_accounts = @brex_item.brex_accounts
-      .left_joins(:account_provider)
-      .where(account_providers: { id: nil })
-
-    # Get supported account types from the adapter
-    supported_types = Provider::BrexAdapter.supported_account_types
-
-    # Map of account type keys to their internal values
-    account_type_keys = {
-      "depository" => "Depository",
-      "credit_card" => "CreditCard",
-      "investment" => "Investment",
-      "loan" => "Loan",
-      "other_asset" => "OtherAsset"
-    }
-
-    # Build account type options using i18n, filtering to supported types
-    all_account_type_options = account_type_keys.filter_map do |key, type|
-      next unless supported_types.include?(type)
-      [ t(".account_types.#{key}"), type ]
-    end
-
-    # Add "Skip" option at the beginning
-    @account_type_options = [ [ t(".account_types.skip"), "skip" ] ] + all_account_type_options
-
-    # Helper to translate subtype options
-    translate_subtypes = ->(type_key, subtypes_hash) {
-      subtypes_hash.map { |k, v| [ t(".subtypes.#{type_key}.#{k}", default: v[:long] || k.humanize), k ] }
-    }
-
-    # Subtype options for each account type (only include supported types)
-    all_subtype_options = {
-      "Depository" => {
-        label: t(".subtype_labels.depository"),
-        options: translate_subtypes.call("depository", Depository::SUBTYPES)
-      },
-      "CreditCard" => {
-        label: t(".subtype_labels.credit_card"),
-        options: [],
-        message: t(".subtype_messages.credit_card")
-      },
-      "Investment" => {
-        label: t(".subtype_labels.investment"),
-        options: translate_subtypes.call("investment", Investment::SUBTYPES)
-      },
-      "Loan" => {
-        label: t(".subtype_labels.loan"),
-        options: translate_subtypes.call("loan", Loan::SUBTYPES)
-      },
-      "OtherAsset" => {
-        label: t(".subtype_labels.other_asset").presence,
-        options: [],
-        message: t(".subtype_messages.other_asset")
-      }
-    }
-
-    @subtype_options = all_subtype_options.slice(*supported_types)
-  end
-
-  def complete_account_setup
-    account_types = params[:account_types] || {}
-    account_subtypes = params[:account_subtypes] || {}
-
-    # Valid account types for this provider
-    valid_types = Provider::BrexAdapter.supported_account_types
-
-    created_accounts = []
-    skipped_count = 0
-
-    begin
-      ActiveRecord::Base.transaction do
-        account_types.each do |brex_account_id, selected_type|
-          # Skip accounts marked as "skip"
-          if selected_type == "skip" || selected_type.blank?
-            skipped_count += 1
-            next
-          end
-
-          # Validate account type is supported
-          unless valid_types.include?(selected_type)
-            Rails.logger.warn("Invalid account type '#{selected_type}' submitted for Brex account #{brex_account_id}")
-            next
-          end
-
-          # Find account - scoped to this item to prevent cross-item manipulation
-          brex_account = @brex_item.brex_accounts.find_by(id: brex_account_id)
-          unless brex_account
-            Rails.logger.warn("Brex account #{brex_account_id} not found for item #{@brex_item.id}")
-            next
-          end
-
-          # Skip if already linked (race condition protection)
-          if brex_account.account_provider.present?
-            Rails.logger.info("Brex account #{brex_account_id} already linked, skipping")
-            next
-          end
-
-          selected_subtype = account_subtypes[brex_account_id]
-
-          # Default subtype for CreditCard since it only has one option
-          selected_subtype = "credit_card" if selected_type == "CreditCard" && selected_subtype.blank?
-          selected_subtype = "checking" if selected_type == "Depository" && selected_subtype.blank?
-
-          # Create account with user-selected type and subtype (raises on failure)
-          # Skip initial sync - provider sync will handle balance creation with correct currency
-          account = Account.create_and_sync(
-            {
-              family: Current.family,
-              name: brex_account.name,
-              balance: brex_account.current_balance || 0,
-              currency: brex_account.currency.presence || Current.family.currency,
-              accountable_type: selected_type,
-              accountable_attributes: selected_subtype.present? ? { subtype: selected_subtype } : {}
-            },
-            skip_initial_sync: true
-          )
-
-          # Link account to brex_account via account_providers join table (raises on failure)
-          AccountProvider.create!(
-            account: account,
-            provider: brex_account
-          )
-
-          created_accounts << account
-        end
+    def redirect_after_link_accounts(result, return_to:)
+      if result.invalid_count.positive? && result.created_count.zero? && result.already_linked_count.zero?
+        redirect_to new_account_path, alert: t(".invalid_account_names", count: result.invalid_count)
+      elsif result.invalid_count.positive? && (result.created_count.positive? || result.already_linked_count.positive?)
+        redirect_to return_to || accounts_path,
+                    alert: t(".partial_invalid",
+                             created_count: result.created_count,
+                             already_linked_count: result.already_linked_count,
+                             invalid_count: result.invalid_count)
+      elsif result.created_count.positive? && result.already_linked_count.positive?
+        redirect_to return_to || accounts_path,
+                    notice: t(".partial_success",
+                              created_count: result.created_count,
+                              already_linked_count: result.already_linked_count,
+                              already_linked_names: result.already_linked_names.join(", "))
+      elsif result.created_count.positive?
+        redirect_to return_to || accounts_path,
+                    notice: t(".success", count: result.created_count)
+      elsif result.already_linked_count.positive?
+        redirect_to return_to || accounts_path,
+                    alert: t(".all_already_linked",
+                             count: result.already_linked_count,
+                             names: result.already_linked_names.join(", "))
+      else
+        redirect_to new_account_path, alert: t(".link_failed")
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
-      Rails.logger.error("Brex account setup failed: #{e.class} - #{e.message}")
-      Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
-      flash[:alert] = t(".creation_failed", error: e.message)
-      redirect_to accounts_path, status: :see_other
-      return
+    end
+
+    def import_accounts_for_setup(flow)
+      flow.import_accounts_from_api_if_needed
+    rescue BrexItem::AccountFlow::NoApiTokenError
+      t("brex_items.setup_accounts.no_api_token")
+    rescue Provider::Brex::BrexError => e
+      Rails.logger.error("Brex API error: #{e.message}")
+      t("brex_items.setup_accounts.api_error", message: e.message)
     rescue StandardError => e
-      Rails.logger.error("Brex account setup failed unexpectedly: #{e.class} - #{e.message}")
-      Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
-      flash[:alert] = t(".creation_failed", error: t(".unexpected_error"))
-      redirect_to accounts_path, status: :see_other
-      return
+      Rails.logger.error("Unexpected error fetching Brex accounts: #{e.class}: #{e.message}")
+      t("brex_items.setup_accounts.api_error", message: t("brex_items.errors.unexpected_error"))
     end
 
-    # Trigger a sync to process transactions
-    @brex_item.sync_later if created_accounts.any?
-
-    # Set appropriate flash message
-    if created_accounts.any?
-      flash[:notice] = t(".success", count: created_accounts.count)
-    elsif skipped_count > 0
-      flash[:notice] = t(".all_skipped")
-    else
-      flash[:notice] = t(".no_accounts")
+    def account_setup_notice(result)
+      if result.created_count.positive?
+        t(".success", count: result.created_count)
+      elsif result.skipped_count.positive?
+        t(".all_skipped")
+      else
+        t(".no_accounts")
+      end
     end
 
-    if turbo_frame_request?
-      # Recompute data needed by Accounts#index partials
+    def render_accounts_update_after_setup
       @manual_accounts = Account.uncached {
         Current.family.accounts
           .visible_manual
@@ -686,108 +363,18 @@ class BrexItemsController < ApplicationController
           locals: { brex_item: @brex_item }
         )
       ] + Array(flash_notification_stream_items)
-    else
-      redirect_to accounts_path, status: :see_other
-    end
-  end
-
-  private
-
-    # Fetch Brex accounts from the API and store them locally
-    # Returns nil on success, or an error message string on failure
-    def fetch_brex_accounts_from_api
-      # Skip if we already have accounts cached
-      return nil unless @brex_item.brex_accounts.empty?
-
-      # Validate API token is configured
-      unless @brex_item.credentials_configured?
-        return t("brex_items.setup_accounts.no_api_token")
-      end
-
-      # Use the specific brex_item's provider (scoped to this family's item)
-      brex_provider = @brex_item.brex_provider
-      unless brex_provider.present?
-        return t("brex_items.setup_accounts.no_api_token")
-      end
-
-      begin
-        accounts_data = brex_provider.get_accounts
-        available_accounts = accounts_data[:accounts] || []
-
-        if available_accounts.empty?
-          Rails.logger.info("Brex API returned no accounts for item #{@brex_item.id}")
-          return nil
-        end
-
-        available_accounts.each do |account_data|
-          account_name = brex_account_name(account_data)
-          next if account_name.blank?
-
-          brex_account = @brex_item.brex_accounts.find_or_initialize_by(
-            account_id: account_data[:id].to_s
-          )
-          brex_account.upsert_brex_snapshot!(account_data)
-          brex_account.save!
-        end
-
-        nil # Success
-      rescue Provider::Brex::BrexError => e
-        Rails.logger.error("Brex API error: #{e.message}")
-        t("brex_items.setup_accounts.api_error", message: e.message)
-      rescue StandardError => e
-        Rails.logger.error("Unexpected error fetching Brex accounts: #{e.class}: #{e.message}")
-        t("brex_items.setup_accounts.api_error", message: t("brex_items.errors.unexpected_error"))
-      end
     end
 
-    def filtered_available_accounts(accounts, accountable_type)
-      return [] unless Provider::BrexAdapter.supported_account_types.include?(accountable_type)
-
-      accounts.select do |account|
-        case accountable_type
-        when "CreditCard"
-          brex_account_kind(account) == "card"
-        when "Depository"
-          brex_account_kind(account) == "cash"
-        else
-          true
-        end
-      end
+    def render_api_error_partial(error_message, return_path)
+      render partial: "brex_items/api_error",
+             locals: { error_message: error_message, return_path: return_path },
+             layout: false
     end
 
-    def brex_account_name(account_data)
-      data = account_data.with_indifferent_access
-      return data[:name].presence || "Brex Card" if brex_account_kind(data) == "card"
-
-      data[:name].presence || data[:display_name].presence || "Brex Cash #{data[:id]}"
-    end
-
-    def brex_account_kind(account_data)
-      return account_data.account_kind if account_data.respond_to?(:account_kind)
-
-      data = account_data.with_indifferent_access
-      kind = data[:account_kind].presence || data[:kind].presence || "cash"
-      kind.to_s == "credit_card" ? "card" : kind.to_s
-    end
-
-    def brex_account_currency(account_data)
-      data = account_data.with_indifferent_access
-      BrexAccount.currency_code_from_money(data[:current_balance] || data[:available_balance] || data[:account_limit])
-    end
-
-    def default_account_type_for_brex_account(brex_account)
-      brex_account_kind(brex_account) == "card" ? "CreditCard" : "Depository"
-    end
-
-    def default_accountable_attributes(accountable_type)
-      case accountable_type
-      when "CreditCard"
-        { subtype: "credit_card" }
-      when "Depository"
-        { subtype: "checking" }
-      else
-        {}
-      end
+    def safely_unlink_brex_item
+      @brex_item.unlink_all!(dry_run: false)
+    rescue => e
+      Rails.logger.warn("Brex unlink during destroy failed: #{e.class} - #{e.message}")
     end
 
     def set_brex_item
@@ -805,36 +392,8 @@ class BrexItemsController < ApplicationController
       permitted
     end
 
-    def brex_items_with_credentials
-      Current.family.brex_items.active.ordered.select(&:credentials_configured?)
-    end
-
-    def brex_item_account_flow_context
-      credentialed_items = brex_items_with_credentials
-      brex_item = nil
-
-      if params[:brex_item_id].present?
-        brex_item = credentialed_items.find { |item| item.id.to_s == params[:brex_item_id].to_s }
-      elsif credentialed_items.one?
-        brex_item = credentialed_items.first
-      end
-
-      {
-        brex_item: brex_item,
-        credentialed_items: credentialed_items
-      }
-    end
-
-    def brex_accounts_cache_key(brex_item)
-      "brex_accounts_#{Current.family.id}_#{brex_item.id}"
-    end
-
-    def brex_accounts_cache_sensitive_update?(permitted_params)
-      permitted_params.key?(:token) || permitted_params.key?(:base_url)
-    end
-
-    def brex_item_selection_error_payload(credentialed_items)
-      if brex_item_selection_required?(credentialed_items)
+    def brex_item_selection_error_payload(flow)
+      if flow.selection_required?
         {
           success: false,
           error: "select_connection",
@@ -846,8 +405,8 @@ class BrexItemsController < ApplicationController
       end
     end
 
-    def render_brex_item_selection_failure(credentialed_items:)
-      if brex_item_selection_required?(credentialed_items)
+    def render_brex_item_selection_failure(flow)
+      if flow.selection_required?
         redirect_to settings_providers_path,
                     alert: t(".select_connection", default: "Choose a Brex connection in Provider Settings.")
       elsif turbo_frame_request?
@@ -859,33 +418,18 @@ class BrexItemsController < ApplicationController
       end
     end
 
-    def brex_item_selection_required?(credentialed_items)
-      credentialed_items.count > 1 && params[:brex_item_id].blank?
-    end
-
-    # Sanitize return_to parameter to prevent XSS attacks
-    # Only allow internal paths, reject external URLs and javascript: URIs
     def safe_return_to_path
       return nil if params[:return_to].blank?
 
       return_to = params[:return_to].to_s
+      uri = URI.parse(return_to)
 
-      # Parse the URL to check if it's external
-      begin
-        uri = URI.parse(return_to)
+      return nil if uri.scheme.present? || uri.host.present?
+      return nil if return_to.start_with?("//")
+      return nil unless return_to.start_with?("/")
 
-        # Reject absolute URLs with schemes (http:, https:, javascript:, etc.)
-        # Only allow relative paths
-        return nil if uri.scheme.present? || uri.host.present?
-        return nil if return_to.start_with?("//")
-
-        # Ensure the path starts with / (is a relative path)
-        return nil unless return_to.start_with?("/")
-
-        return_to
-      rescue URI::InvalidURIError
-        # If the URI is invalid, reject it
-        nil
-      end
+      return_to
+    rescue URI::InvalidURIError
+      nil
     end
 end

--- a/app/controllers/brex_items_controller.rb
+++ b/app/controllers/brex_items_controller.rb
@@ -11,157 +11,54 @@ class BrexItemsController < ApplicationController
   end
 
   def preload_accounts
-    flow = brex_account_flow
-    unless flow.selected?
-      render json: brex_item_selection_error_payload(flow)
-      return
-    end
-
-    render json: flow.preload_payload
-  rescue BrexItem::AccountFlow::NoApiTokenError
-    render json: { success: false, error: "no_api_token", has_accounts: false }
-  rescue Provider::Brex::BrexError => e
-    Rails.logger.error("Brex preload error: #{e.message}")
-    render json: { success: false, error: "api_error", error_message: e.message, has_accounts: nil }
-  rescue StandardError => e
-    Rails.logger.error("Unexpected error preloading Brex accounts: #{e.class}: #{e.message}")
-    render json: { success: false, error: "unexpected_error", error_message: t("brex_items.errors.unexpected_error"), has_accounts: nil }
+    render json: brex_account_flow.preload_payload
   end
 
   def select_accounts
-    flow = brex_account_flow
-    unless flow.selected?
-      render_brex_item_selection_failure(flow)
-      return
-    end
-
-    @brex_item = flow.brex_item
     @accountable_type = params[:accountable_type] || "Depository"
-    @available_accounts = flow.available_accounts(accountable_type: @accountable_type)
     @return_to = safe_return_to_path
+    result = brex_account_flow.select_accounts_result(accountable_type: @accountable_type)
 
-    if @available_accounts.empty?
-      redirect_to new_account_path, alert: t(".no_accounts_found")
-      return
-    end
+    return handle_brex_selection_result(result, empty_path: new_account_path, api_return_path: @return_to) unless result.success?
+
+    @brex_item = result.brex_item
+    @available_accounts = result.available_accounts
 
     render layout: false
-  rescue BrexItem::AccountFlow::NoApiTokenError
-    redirect_to settings_providers_path, alert: t(".no_api_token")
-  rescue Provider::Brex::BrexError => e
-    Rails.logger.error("Brex API error in select_accounts: #{e.message}")
-    render_api_error_partial(e.message, safe_return_to_path)
-  rescue StandardError => e
-    Rails.logger.error("Unexpected error in select_accounts: #{e.class}: #{e.message}")
-    render_api_error_partial(t(".unexpected_error"), safe_return_to_path)
   end
 
   def link_accounts
-    selected_account_ids = params[:account_ids] || []
-    accountable_type = params[:accountable_type] || "Depository"
-    return_to = safe_return_to_path
-
-    if selected_account_ids.empty?
-      redirect_to new_account_path, alert: t(".no_accounts_selected")
-      return
-    end
-
-    flow = brex_account_flow
-    unless flow.selected?
-      redirect_to settings_providers_path, alert: t(".select_connection")
-      return
-    end
-
-    result = flow.link_new_accounts!(
-      account_ids: selected_account_ids,
-      accountable_type: accountable_type
+    result = brex_account_flow.link_new_accounts_result(
+      account_ids: params[:account_ids] || [],
+      accountable_type: params[:accountable_type] || "Depository"
     )
 
-    redirect_after_link_accounts(result, return_to: return_to)
-  rescue BrexItem::AccountFlow::NoApiTokenError
-    redirect_to new_account_path, alert: t(".no_api_token")
-  rescue Provider::Brex::BrexError => e
-    redirect_to new_account_path, alert: t(".api_error", message: e.message)
+    redirect_with_navigation(result, return_to: safe_return_to_path)
   end
 
   def select_existing_account
-    account_id = params[:account_id]
+    return redirect_to accounts_path, alert: t(".no_account_specified") if params[:account_id].blank?
 
-    unless account_id.present?
-      redirect_to accounts_path, alert: t(".no_account_specified")
-      return
-    end
+    @account = Current.family.accounts.find(params[:account_id])
+    result = brex_account_flow.select_existing_account_result(account: @account)
 
-    @account = Current.family.accounts.find(account_id)
+    return handle_brex_selection_result(result, empty_path: accounts_path, api_return_path: accounts_path) unless result.success?
 
-    if @account.account_providers.exists?
-      redirect_to accounts_path, alert: t(".account_already_linked")
-      return
-    end
-
-    flow = brex_account_flow
-    unless flow.selected?
-      render_brex_item_selection_failure(flow)
-      return
-    end
-
-    @brex_item = flow.brex_item
-    @available_accounts = flow.available_accounts_for_existing(account: @account)
-
-    if @available_accounts.empty?
-      redirect_to accounts_path, alert: t(".all_accounts_already_linked")
-      return
-    end
-
+    @brex_item = result.brex_item
+    @available_accounts = result.available_accounts
     @return_to = safe_return_to_path
+
     render layout: false
-  rescue BrexItem::AccountFlow::NoApiTokenError
-    redirect_to settings_providers_path, alert: t(".no_api_token")
-  rescue Provider::Brex::BrexError => e
-    Rails.logger.error("Brex API error in select_existing_account: #{e.message}")
-    render_api_error_partial(e.message, accounts_path)
-  rescue StandardError => e
-    Rails.logger.error("Unexpected error in select_existing_account: #{e.class}: #{e.message}")
-    render_api_error_partial(t(".unexpected_error"), accounts_path)
   end
 
   def link_existing_account
-    account_id = params[:account_id]
-    brex_account_id = params[:brex_account_id]
-    return_to = safe_return_to_path
+    account = Current.family.accounts.find(params[:account_id]) if params[:account_id].present?
+    result = brex_account_flow.link_existing_account_result(
+      account: account,
+      brex_account_id: params[:brex_account_id]
+    )
 
-    unless account_id.present? && brex_account_id.present?
-      redirect_to accounts_path, alert: t(".missing_parameters")
-      return
-    end
-
-    @account = Current.family.accounts.find(account_id)
-
-    if @account.account_providers.exists?
-      redirect_to accounts_path, alert: t(".account_already_linked")
-      return
-    end
-
-    flow = brex_account_flow
-    unless flow.selected?
-      redirect_to settings_providers_path, alert: t(".select_connection")
-      return
-    end
-
-    flow.link_existing_account!(account: @account, brex_account_id: brex_account_id)
-
-    redirect_to return_to || accounts_path,
-                notice: t(".success", account_name: @account.name)
-  rescue BrexItem::AccountFlow::NoApiTokenError
-    redirect_to accounts_path, alert: t(".no_api_token")
-  rescue BrexItem::AccountFlow::AccountNotFoundError
-    redirect_to accounts_path, alert: t(".brex_account_not_found")
-  rescue BrexItem::AccountFlow::InvalidAccountNameError
-    redirect_to accounts_path, alert: t(".invalid_account_name")
-  rescue BrexItem::AccountFlow::AccountAlreadyLinkedError
-    redirect_to accounts_path, alert: t(".brex_account_already_linked")
-  rescue Provider::Brex::BrexError => e
-    redirect_to accounts_path, alert: t(".api_error", message: e.message)
+    redirect_with_navigation(result, return_to: safe_return_to_path)
   end
 
   def new
@@ -184,11 +81,7 @@ class BrexItemsController < ApplicationController
   end
 
   def update
-    permitted_params = brex_item_params
-    expire_accounts_cache = BrexItem::AccountFlow.cache_sensitive_update?(permitted_params)
-
-    if @brex_item.update(permitted_params)
-      Rails.cache.delete(BrexItem::AccountFlow.cache_key(Current.family, @brex_item)) if expire_accounts_cache
+    if BrexItem::AccountFlow.update_item_with_cache_expiration(@brex_item, family: Current.family, attributes: brex_item_params)
       render_provider_panel_success(t(".success"))
     else
       render_provider_panel_error
@@ -212,7 +105,7 @@ class BrexItemsController < ApplicationController
 
   def setup_accounts
     flow = brex_account_flow_for_item
-    @api_error = import_accounts_for_setup(flow)
+    @api_error = flow.import_accounts_error_message
     @brex_accounts = flow.unlinked_brex_accounts
     @account_type_options = flow.account_type_options
     @subtype_options = flow.subtype_options
@@ -220,35 +113,29 @@ class BrexItemsController < ApplicationController
 
   def complete_account_setup
     flow = brex_account_flow_for_item
-    result = flow.complete_setup!(
+    result = flow.complete_setup_result(
       account_types: params[:account_types] || {},
       account_subtypes: params[:account_subtypes] || {}
     )
 
-    flash[:notice] = account_setup_notice(result)
+    unless result.success?
+      redirect_to accounts_path, alert: result.message, status: :see_other
+      return
+    end
+
+    flash[:notice] = result.message
 
     if turbo_frame_request?
       render_accounts_update_after_setup
     else
       redirect_to accounts_path, status: :see_other
     end
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
-    Rails.logger.error("Brex account setup failed: #{e.class} - #{e.message}")
-    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
-    redirect_to accounts_path, alert: t(".creation_failed", error: e.message), status: :see_other
-  rescue StandardError => e
-    Rails.logger.error("Brex account setup failed unexpectedly: #{e.class} - #{e.message}")
-    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
-    redirect_to accounts_path, alert: t(".creation_failed", error: t(".unexpected_error")), status: :see_other
   end
 
   private
 
     def brex_account_flow
-      @brex_account_flow ||= BrexItem::AccountFlow.new(
-        family: Current.family,
-        brex_item_id: params[:brex_item_id]
-      )
+      @brex_account_flow ||= BrexItem::AccountFlow.new(family: Current.family, brex_item_id: params[:brex_item_id])
     end
 
     def brex_account_flow_for_item
@@ -256,93 +143,34 @@ class BrexItemsController < ApplicationController
     end
 
     def render_provider_panel_success(message)
-      if turbo_frame_request?
-        flash.now[:notice] = message
-        @brex_items = Current.family.brex_items.active.ordered.includes(:syncs, :brex_accounts)
-        render turbo_stream: [
-          turbo_stream.replace(
-            "brex-providers-panel",
-            partial: "settings/providers/brex_panel",
-            locals: { brex_items: @brex_items }
-          ),
-          *flash_notification_stream_items
-        ]
-      else
-        redirect_to accounts_path, notice: message, status: :see_other
-      end
+      return redirect_to accounts_path, notice: message, status: :see_other unless turbo_frame_request?
+
+      flash.now[:notice] = message
+      @brex_items = Current.family.brex_items.active.ordered.includes(:syncs, :brex_accounts)
+      render_brex_provider_panel(locals: { brex_items: @brex_items }, include_flash: true)
     end
 
     def render_provider_panel_error
       @error_message = @brex_item.errors.full_messages.join(", ")
+      return redirect_to settings_providers_path, alert: @error_message, status: :see_other unless turbo_frame_request?
 
-      if turbo_frame_request?
-        render turbo_stream: turbo_stream.replace(
+      render_brex_provider_panel(locals: { error_message: @error_message }, status: :unprocessable_entity)
+    end
+
+    def render_brex_provider_panel(locals:, status: :ok, include_flash: false)
+      streams = [
+        turbo_stream.replace(
           "brex-providers-panel",
           partial: "settings/providers/brex_panel",
-          locals: { error_message: @error_message }
-        ), status: :unprocessable_entity
-      else
-        redirect_to settings_providers_path, alert: @error_message, status: :see_other
-      end
-    end
-
-    def redirect_after_link_accounts(result, return_to:)
-      if result.invalid_count.positive? && result.created_count.zero? && result.already_linked_count.zero?
-        redirect_to new_account_path, alert: t(".invalid_account_names", count: result.invalid_count)
-      elsif result.invalid_count.positive? && (result.created_count.positive? || result.already_linked_count.positive?)
-        redirect_to return_to || accounts_path,
-                    alert: t(".partial_invalid",
-                             created_count: result.created_count,
-                             already_linked_count: result.already_linked_count,
-                             invalid_count: result.invalid_count)
-      elsif result.created_count.positive? && result.already_linked_count.positive?
-        redirect_to return_to || accounts_path,
-                    notice: t(".partial_success",
-                              created_count: result.created_count,
-                              already_linked_count: result.already_linked_count,
-                              already_linked_names: result.already_linked_names.join(", "))
-      elsif result.created_count.positive?
-        redirect_to return_to || accounts_path,
-                    notice: t(".success", count: result.created_count)
-      elsif result.already_linked_count.positive?
-        redirect_to return_to || accounts_path,
-                    alert: t(".all_already_linked",
-                             count: result.already_linked_count,
-                             names: result.already_linked_names.join(", "))
-      else
-        redirect_to new_account_path, alert: t(".link_failed")
-      end
-    end
-
-    def import_accounts_for_setup(flow)
-      flow.import_accounts_from_api_if_needed
-    rescue BrexItem::AccountFlow::NoApiTokenError
-      t("brex_items.setup_accounts.no_api_token")
-    rescue Provider::Brex::BrexError => e
-      Rails.logger.error("Brex API error: #{e.message}")
-      t("brex_items.setup_accounts.api_error", message: e.message)
-    rescue StandardError => e
-      Rails.logger.error("Unexpected error fetching Brex accounts: #{e.class}: #{e.message}")
-      t("brex_items.setup_accounts.api_error", message: t("brex_items.errors.unexpected_error"))
-    end
-
-    def account_setup_notice(result)
-      if result.created_count.positive?
-        t(".success", count: result.created_count)
-      elsif result.skipped_count.positive?
-        t(".all_skipped")
-      else
-        t(".no_accounts")
-      end
+          locals: locals
+        )
+      ]
+      streams += flash_notification_stream_items if include_flash
+      render turbo_stream: streams, status: status
     end
 
     def render_accounts_update_after_setup
-      @manual_accounts = Account.uncached {
-        Current.family.accounts
-          .visible_manual
-          .order(:name)
-          .to_a
-      }
+      @manual_accounts = Account.uncached { Current.family.accounts.visible_manual.order(:name).to_a }
       @brex_items = Current.family.brex_items.ordered
 
       manual_accounts_stream = if @manual_accounts.any?
@@ -366,9 +194,7 @@ class BrexItemsController < ApplicationController
     end
 
     def render_api_error_partial(error_message, return_path)
-      render partial: "brex_items/api_error",
-             locals: { error_message: error_message, return_path: return_path },
-             layout: false
+      render partial: "brex_items/api_error", locals: { error_message: error_message, return_path: return_path }, layout: false
     end
 
     def safely_unlink_brex_item
@@ -392,30 +218,35 @@ class BrexItemsController < ApplicationController
       permitted
     end
 
-    def brex_item_selection_error_payload(flow)
-      if flow.selection_required?
-        {
-          success: false,
-          error: "select_connection",
-          error_message: t(".select_connection", default: "Choose a Brex connection before loading accounts."),
-          has_accounts: nil
-        }
+    def handle_brex_selection_result(result, empty_path:, api_return_path:)
+      case result.status
+      when :empty, :account_already_linked
+        redirect_to empty_path, alert: result.message
+      when :no_api_token, :select_connection
+        redirect_to settings_providers_path, alert: result.message
+      when :setup_required
+        if turbo_frame_request?
+          render partial: "brex_items/setup_required", layout: false
+        else
+          redirect_to settings_providers_path, alert: result.message
+        end
+      when :api_error, :unexpected_error
+        render_api_error_partial(result.message, api_return_path)
       else
-        { success: false, error: "no_credentials", has_accounts: false }
+        redirect_to settings_providers_path, alert: result.message
       end
     end
 
-    def render_brex_item_selection_failure(flow)
-      if flow.selection_required?
-        redirect_to settings_providers_path,
-                    alert: t(".select_connection", default: "Choose a Brex connection in Provider Settings.")
-      elsif turbo_frame_request?
-        render partial: "brex_items/setup_required", layout: false
-      else
-        redirect_to settings_providers_path,
-                    alert: t(".no_credentials_configured",
-                             default: "Please configure your Brex API token first in Provider Settings.")
-      end
+    def redirect_with_navigation(result, return_to:)
+      redirect_to navigation_path_for(result.target, return_to: return_to), result.flash_type => result.message
+    end
+
+    def navigation_path_for(target, return_to:)
+      {
+        new_account: new_account_path,
+        settings_providers: settings_providers_path,
+        return_to_or_accounts: return_to || accounts_path
+      }.fetch(target, accounts_path)
     end
 
     def safe_return_to_path

--- a/app/controllers/brex_items_controller.rb
+++ b/app/controllers/brex_items_controller.rb
@@ -52,7 +52,9 @@ class BrexItemsController < ApplicationController
   end
 
   def link_existing_account
-    account = Current.family.accounts.find(params[:account_id]) if params[:account_id].present?
+    return redirect_to accounts_path, alert: t(".no_account_specified") if params[:account_id].blank?
+
+    account = Current.family.accounts.find(params[:account_id])
     result = brex_account_flow.link_existing_account_result(
       account: account,
       brex_account_id: params[:brex_account_id]

--- a/app/controllers/brex_items_controller.rb
+++ b/app/controllers/brex_items_controller.rb
@@ -56,7 +56,7 @@ class BrexItemsController < ApplicationController
     rescue StandardError => e
       Rails.logger.error("Unexpected error preloading Brex accounts: #{e.class}: #{e.message}")
       # Unexpected error - keep button visible, show error when clicked
-      render json: { success: false, error: "unexpected_error", error_message: e.message, has_accounts: nil }
+      render json: { success: false, error: "unexpected_error", error_message: t("brex_items.errors.unexpected_error"), has_accounts: nil }
     end
   end
 
@@ -737,7 +737,7 @@ class BrexItemsController < ApplicationController
         t("brex_items.setup_accounts.api_error", message: e.message)
       rescue StandardError => e
         Rails.logger.error("Unexpected error fetching Brex accounts: #{e.class}: #{e.message}")
-        t("brex_items.setup_accounts.api_error", message: e.message)
+        t("brex_items.setup_accounts.api_error", message: t("brex_items.errors.unexpected_error"))
       end
     end
 

--- a/app/controllers/brex_items_controller.rb
+++ b/app/controllers/brex_items_controller.rb
@@ -1,0 +1,889 @@
+class BrexItemsController < ApplicationController
+  before_action :set_brex_item, only: [ :show, :edit, :update, :destroy, :sync, :setup_accounts, :complete_account_setup ]
+  before_action :require_admin!, only: [ :new, :create, :preload_accounts, :select_accounts, :link_accounts, :select_existing_account, :link_existing_account, :edit, :update, :destroy, :sync, :setup_accounts, :complete_account_setup ]
+
+  def index
+    @brex_items = Current.family.brex_items.active.ordered
+    render layout: "settings"
+  end
+
+  def show
+  end
+
+  # Preload Brex accounts in background (async, non-blocking)
+  def preload_accounts
+    begin
+      account_flow = brex_item_account_flow_context
+      brex_item = account_flow[:brex_item]
+      unless brex_item
+        render json: brex_item_selection_error_payload(account_flow[:credentialed_items])
+        return
+      end
+
+      unless brex_item.credentials_configured?
+        render json: { success: false, error: "no_credentials", has_accounts: false }
+        return
+      end
+
+      cache_key = brex_accounts_cache_key(brex_item)
+
+      # Check if already cached
+      cached_accounts = Rails.cache.read(cache_key)
+
+      if cached_accounts.present?
+        render json: { success: true, has_accounts: cached_accounts.any?, cached: true }
+        return
+      end
+
+      brex_provider = brex_item.brex_provider
+
+      unless brex_provider.present?
+        render json: { success: false, error: "no_api_token", has_accounts: false }
+        return
+      end
+
+      accounts_data = brex_provider.get_accounts
+      available_accounts = accounts_data[:accounts] || []
+
+      # Cache the accounts for 5 minutes
+      Rails.cache.write(cache_key, available_accounts, expires_in: 5.minutes)
+
+      render json: { success: true, has_accounts: available_accounts.any?, cached: false }
+    rescue Provider::Brex::BrexError => e
+      Rails.logger.error("Brex preload error: #{e.message}")
+      # API error (bad token, network issue, etc) - keep button visible, show error when clicked
+      render json: { success: false, error: "api_error", error_message: e.message, has_accounts: nil }
+    rescue StandardError => e
+      Rails.logger.error("Unexpected error preloading Brex accounts: #{e.class}: #{e.message}")
+      # Unexpected error - keep button visible, show error when clicked
+      render json: { success: false, error: "unexpected_error", error_message: e.message, has_accounts: nil }
+    end
+  end
+
+  # Fetch available accounts from Brex API and show selection UI
+  def select_accounts
+    begin
+      account_flow = brex_item_account_flow_context
+      @brex_item = account_flow[:brex_item]
+      unless @brex_item
+        render_brex_item_selection_failure(credentialed_items: account_flow[:credentialed_items])
+        return
+      end
+
+      cache_key = brex_accounts_cache_key(@brex_item)
+
+      # Try to get cached accounts first
+      @available_accounts = Rails.cache.read(cache_key)
+
+      # If not cached, fetch from API
+      if @available_accounts.nil?
+        brex_provider = @brex_item.brex_provider
+
+        unless brex_provider.present?
+          redirect_to settings_providers_path, alert: t(".no_api_token",
+                                                        default: "Brex API token not found. Please configure it in Provider Settings.")
+          return
+        end
+
+        accounts_data = brex_provider.get_accounts
+
+        @available_accounts = accounts_data[:accounts] || []
+
+        # Cache the accounts for 5 minutes
+        Rails.cache.write(cache_key, @available_accounts, expires_in: 5.minutes)
+      end
+
+      linked_account_ids = @brex_item.brex_accounts.joins(:account_provider).pluck(:account_id)
+      @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
+
+      @accountable_type = params[:accountable_type] || "Depository"
+      @available_accounts = filtered_available_accounts(@available_accounts, @accountable_type)
+      @return_to = safe_return_to_path
+
+      if @available_accounts.empty?
+        redirect_to new_account_path, alert: t(".no_accounts_found")
+        return
+      end
+
+      render layout: false
+    rescue Provider::Brex::BrexError => e
+      Rails.logger.error("Brex API error in select_accounts: #{e.message}")
+      @error_message = e.message
+      @return_path = safe_return_to_path
+      render partial: "brex_items/api_error",
+             locals: { error_message: @error_message, return_path: @return_path },
+             layout: false
+    rescue StandardError => e
+      Rails.logger.error("Unexpected error in select_accounts: #{e.class}: #{e.message}")
+      @error_message = t(".unexpected_error")
+      @return_path = safe_return_to_path
+      render partial: "brex_items/api_error",
+             locals: { error_message: @error_message, return_path: @return_path },
+             layout: false
+    end
+  end
+
+  # Create accounts from selected Brex accounts
+  def link_accounts
+    selected_account_ids = params[:account_ids] || []
+    accountable_type = params[:accountable_type] || "Depository"
+    return_to = safe_return_to_path
+
+    if selected_account_ids.empty?
+      redirect_to new_account_path, alert: t(".no_accounts_selected")
+      return
+    end
+
+    account_flow = brex_item_account_flow_context
+    brex_item = account_flow[:brex_item]
+
+    unless brex_item
+      redirect_to settings_providers_path, alert: t(".select_connection", default: "Choose a Brex connection before linking accounts.")
+      return
+    end
+
+    # Fetch account details from API
+    brex_provider = brex_item.brex_provider
+    unless brex_provider.present?
+      redirect_to new_account_path, alert: t(".no_api_token")
+      return
+    end
+
+    accounts_data = brex_provider.get_accounts
+
+    created_accounts = []
+    already_linked_accounts = []
+    invalid_accounts = []
+
+    selected_account_ids.each do |account_id|
+      # Find the account data from API response
+      account_data = accounts_data[:accounts].find { |acc| acc[:id].to_s == account_id.to_s }
+      next unless account_data
+
+      account_name = brex_account_name(account_data)
+
+      # Validate account name is not blank (required by Account model)
+      if account_name.blank?
+        invalid_accounts << account_id
+        Rails.logger.warn "BrexItemsController - Skipping account #{account_id} with blank name"
+        next
+      end
+
+      # Create or find brex_account
+      brex_account = brex_item.brex_accounts.find_or_initialize_by(
+        account_id: account_id.to_s
+      )
+      brex_account.upsert_brex_snapshot!(account_data)
+      brex_account.save!
+
+      # Check if this brex_account is already linked
+      if brex_account.account_provider.present?
+        already_linked_accounts << account_name
+        next
+      end
+
+      # Create the internal Account with proper balance initialization
+      account = Account.create_and_sync(
+        {
+          family: Current.family,
+          name: account_name,
+          balance: 0, # Initial balance will be set during sync
+          currency: brex_account_currency(account_data),
+          accountable_type: accountable_type,
+          accountable_attributes: default_accountable_attributes(accountable_type)
+        },
+        skip_initial_sync: true
+      )
+
+      # Link account to brex_account via account_providers join table
+      AccountProvider.create!(
+        account: account,
+        provider: brex_account
+      )
+
+      created_accounts << account
+    end
+
+    # Trigger sync to fetch transactions if any accounts were created
+    brex_item.sync_later if created_accounts.any?
+
+    # Build appropriate flash message
+    if invalid_accounts.any? && created_accounts.empty? && already_linked_accounts.empty?
+      # All selected accounts were invalid (blank names)
+      redirect_to new_account_path, alert: t(".invalid_account_names", count: invalid_accounts.count)
+    elsif invalid_accounts.any? && (created_accounts.any? || already_linked_accounts.any?)
+      # Some accounts were created/already linked, but some had invalid names
+      redirect_to return_to || accounts_path,
+                  alert: t(".partial_invalid",
+                           created_count: created_accounts.count,
+                           already_linked_count: already_linked_accounts.count,
+                           invalid_count: invalid_accounts.count)
+    elsif created_accounts.any? && already_linked_accounts.any?
+      redirect_to return_to || accounts_path,
+                  notice: t(".partial_success",
+                           created_count: created_accounts.count,
+                           already_linked_count: already_linked_accounts.count,
+                           already_linked_names: already_linked_accounts.join(", "))
+    elsif created_accounts.any?
+      redirect_to return_to || accounts_path,
+                  notice: t(".success", count: created_accounts.count)
+    elsif already_linked_accounts.any?
+      redirect_to return_to || accounts_path,
+                  alert: t(".all_already_linked",
+                          count: already_linked_accounts.count,
+                          names: already_linked_accounts.join(", "))
+    else
+      redirect_to new_account_path, alert: t(".link_failed")
+    end
+  rescue Provider::Brex::BrexError => e
+    redirect_to new_account_path, alert: t(".api_error", message: e.message)
+  end
+
+  # Fetch available Brex accounts to link with an existing account
+  def select_existing_account
+    account_id = params[:account_id]
+
+    unless account_id.present?
+      redirect_to accounts_path, alert: t(".no_account_specified")
+      return
+    end
+
+    @account = Current.family.accounts.find(account_id)
+
+    # Check if account is already linked
+    if @account.account_providers.exists?
+      redirect_to accounts_path, alert: t(".account_already_linked")
+      return
+    end
+
+    account_flow = brex_item_account_flow_context
+    @brex_item = account_flow[:brex_item]
+    unless @brex_item
+      render_brex_item_selection_failure(credentialed_items: account_flow[:credentialed_items])
+      return
+    end
+
+    begin
+      cache_key = brex_accounts_cache_key(@brex_item)
+
+      # Try to get cached accounts first
+      @available_accounts = Rails.cache.read(cache_key)
+
+      # If not cached, fetch from API
+      if @available_accounts.nil?
+        brex_provider = @brex_item.brex_provider
+
+        unless brex_provider.present?
+          redirect_to settings_providers_path, alert: t(".no_api_token",
+                                                        default: "Brex API token not found. Please configure it in Provider Settings.")
+          return
+        end
+
+        accounts_data = brex_provider.get_accounts
+
+        @available_accounts = accounts_data[:accounts] || []
+
+        # Cache the accounts for 5 minutes
+        Rails.cache.write(cache_key, @available_accounts, expires_in: 5.minutes)
+      end
+
+      if @available_accounts.empty?
+        redirect_to accounts_path, alert: t(".no_accounts_found")
+        return
+      end
+
+      linked_account_ids = @brex_item.brex_accounts.joins(:account_provider).pluck(:account_id)
+      @available_accounts = @available_accounts.reject { |acc| linked_account_ids.include?(acc[:id].to_s) }
+      @available_accounts = filtered_available_accounts(@available_accounts, @account.accountable_type)
+
+      if @available_accounts.empty?
+        redirect_to accounts_path, alert: t(".all_accounts_already_linked")
+        return
+      end
+
+      @return_to = safe_return_to_path
+
+      render layout: false
+    rescue Provider::Brex::BrexError => e
+      Rails.logger.error("Brex API error in select_existing_account: #{e.message}")
+      @error_message = e.message
+      render partial: "brex_items/api_error",
+             locals: { error_message: @error_message, return_path: accounts_path },
+             layout: false
+    rescue StandardError => e
+      Rails.logger.error("Unexpected error in select_existing_account: #{e.class}: #{e.message}")
+      @error_message = t(".unexpected_error")
+      render partial: "brex_items/api_error",
+             locals: { error_message: @error_message, return_path: accounts_path },
+             layout: false
+    end
+  end
+
+  # Link a selected Brex account to an existing account
+  def link_existing_account
+    account_id = params[:account_id]
+    brex_account_id = params[:brex_account_id]
+    return_to = safe_return_to_path
+
+    unless account_id.present? && brex_account_id.present?
+      redirect_to accounts_path, alert: t(".missing_parameters")
+      return
+    end
+
+    account_flow = brex_item_account_flow_context
+    brex_item = account_flow[:brex_item]
+
+    @account = Current.family.accounts.find(account_id)
+
+    # Check if account is already linked
+    if @account.account_providers.exists?
+      redirect_to accounts_path, alert: t(".account_already_linked")
+      return
+    end
+
+    unless brex_item
+      redirect_to settings_providers_path, alert: t(".select_connection", default: "Choose a Brex connection before linking accounts.")
+      return
+    end
+
+    # Fetch account details from API
+    brex_provider = brex_item.brex_provider
+    unless brex_provider.present?
+      redirect_to accounts_path, alert: t(".no_api_token")
+      return
+    end
+
+    accounts_data = brex_provider.get_accounts
+
+    # Find the selected Brex account data
+    account_data = accounts_data[:accounts].find { |acc| acc[:id].to_s == brex_account_id.to_s }
+    unless account_data
+      redirect_to accounts_path, alert: t(".brex_account_not_found")
+      return
+    end
+
+    account_name = brex_account_name(account_data)
+
+    # Validate account name is not blank (required by Account model)
+    if account_name.blank?
+      redirect_to accounts_path, alert: t(".invalid_account_name")
+      return
+    end
+
+    # Create or find brex_account
+    brex_account = brex_item.brex_accounts.find_or_initialize_by(
+      account_id: brex_account_id.to_s
+    )
+    brex_account.upsert_brex_snapshot!(account_data)
+    brex_account.save!
+
+    # Check if this brex_account is already linked to another account
+    if brex_account.account_provider.present?
+      redirect_to accounts_path, alert: t(".brex_account_already_linked")
+      return
+    end
+
+    # Link account to brex_account via account_providers join table
+    AccountProvider.create!(
+      account: @account,
+      provider: brex_account
+    )
+
+    # Trigger sync to fetch transactions
+    brex_item.sync_later
+
+    redirect_to return_to || accounts_path,
+                notice: t(".success", account_name: @account.name)
+  rescue Provider::Brex::BrexError => e
+    redirect_to accounts_path, alert: t(".api_error", message: e.message)
+  end
+
+  def new
+    @brex_item = Current.family.brex_items.build
+  end
+
+  def create
+    @brex_item = Current.family.brex_items.build(brex_item_params)
+    @brex_item.name ||= "Brex Connection"
+
+    if @brex_item.save
+      # Trigger initial sync to fetch accounts
+      @brex_item.sync_later
+
+      if turbo_frame_request?
+        flash.now[:notice] = t(".success")
+        @brex_items = Current.family.brex_items.active.ordered.includes(:syncs, :brex_accounts)
+        render turbo_stream: [
+          turbo_stream.replace(
+            "brex-providers-panel",
+            partial: "settings/providers/brex_panel",
+            locals: { brex_items: @brex_items }
+          ),
+          *flash_notification_stream_items
+        ]
+      else
+        redirect_to accounts_path, notice: t(".success"), status: :see_other
+      end
+    else
+      @error_message = @brex_item.errors.full_messages.join(", ")
+
+      if turbo_frame_request?
+        render turbo_stream: turbo_stream.replace(
+          "brex-providers-panel",
+          partial: "settings/providers/brex_panel",
+          locals: { error_message: @error_message }
+        ), status: :unprocessable_entity
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    permitted_params = brex_item_params
+    expire_accounts_cache = brex_accounts_cache_sensitive_update?(permitted_params)
+
+    if @brex_item.update(permitted_params)
+      Rails.cache.delete(brex_accounts_cache_key(@brex_item)) if expire_accounts_cache
+
+      if turbo_frame_request?
+        flash.now[:notice] = t(".success")
+        @brex_items = Current.family.brex_items.active.ordered.includes(:syncs, :brex_accounts)
+        render turbo_stream: [
+          turbo_stream.replace(
+            "brex-providers-panel",
+            partial: "settings/providers/brex_panel",
+            locals: { brex_items: @brex_items }
+          ),
+          *flash_notification_stream_items
+        ]
+      else
+        redirect_to accounts_path, notice: t(".success"), status: :see_other
+      end
+    else
+      @error_message = @brex_item.errors.full_messages.join(", ")
+
+      if turbo_frame_request?
+        render turbo_stream: turbo_stream.replace(
+          "brex-providers-panel",
+          partial: "settings/providers/brex_panel",
+          locals: { error_message: @error_message }
+        ), status: :unprocessable_entity
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+  end
+
+  def destroy
+    # Ensure we detach provider links before scheduling deletion
+    begin
+      @brex_item.unlink_all!(dry_run: false)
+    rescue => e
+      Rails.logger.warn("Brex unlink during destroy failed: #{e.class} - #{e.message}")
+    end
+    @brex_item.destroy_later
+    redirect_to accounts_path, notice: t(".success")
+  end
+
+  def sync
+    unless @brex_item.syncing?
+      @brex_item.sync_later
+    end
+
+    respond_to do |format|
+      format.html { redirect_back_or_to accounts_path }
+      format.json { head :ok }
+    end
+  end
+
+  # Show unlinked Brex accounts for setup
+  def setup_accounts
+    # First, ensure we have the latest accounts from the API
+    @api_error = fetch_brex_accounts_from_api
+
+    # Get Brex accounts that are not linked (no AccountProvider)
+    @brex_accounts = @brex_item.brex_accounts
+      .left_joins(:account_provider)
+      .where(account_providers: { id: nil })
+
+    # Get supported account types from the adapter
+    supported_types = Provider::BrexAdapter.supported_account_types
+
+    # Map of account type keys to their internal values
+    account_type_keys = {
+      "depository" => "Depository",
+      "credit_card" => "CreditCard",
+      "investment" => "Investment",
+      "loan" => "Loan",
+      "other_asset" => "OtherAsset"
+    }
+
+    # Build account type options using i18n, filtering to supported types
+    all_account_type_options = account_type_keys.filter_map do |key, type|
+      next unless supported_types.include?(type)
+      [ t(".account_types.#{key}"), type ]
+    end
+
+    # Add "Skip" option at the beginning
+    @account_type_options = [ [ t(".account_types.skip"), "skip" ] ] + all_account_type_options
+
+    # Helper to translate subtype options
+    translate_subtypes = ->(type_key, subtypes_hash) {
+      subtypes_hash.map { |k, v| [ t(".subtypes.#{type_key}.#{k}", default: v[:long] || k.humanize), k ] }
+    }
+
+    # Subtype options for each account type (only include supported types)
+    all_subtype_options = {
+      "Depository" => {
+        label: t(".subtype_labels.depository"),
+        options: translate_subtypes.call("depository", Depository::SUBTYPES)
+      },
+      "CreditCard" => {
+        label: t(".subtype_labels.credit_card"),
+        options: [],
+        message: t(".subtype_messages.credit_card")
+      },
+      "Investment" => {
+        label: t(".subtype_labels.investment"),
+        options: translate_subtypes.call("investment", Investment::SUBTYPES)
+      },
+      "Loan" => {
+        label: t(".subtype_labels.loan"),
+        options: translate_subtypes.call("loan", Loan::SUBTYPES)
+      },
+      "OtherAsset" => {
+        label: t(".subtype_labels.other_asset").presence,
+        options: [],
+        message: t(".subtype_messages.other_asset")
+      }
+    }
+
+    @subtype_options = all_subtype_options.slice(*supported_types)
+  end
+
+  def complete_account_setup
+    account_types = params[:account_types] || {}
+    account_subtypes = params[:account_subtypes] || {}
+
+    # Valid account types for this provider
+    valid_types = Provider::BrexAdapter.supported_account_types
+
+    created_accounts = []
+    skipped_count = 0
+
+    begin
+      ActiveRecord::Base.transaction do
+        account_types.each do |brex_account_id, selected_type|
+          # Skip accounts marked as "skip"
+          if selected_type == "skip" || selected_type.blank?
+            skipped_count += 1
+            next
+          end
+
+          # Validate account type is supported
+          unless valid_types.include?(selected_type)
+            Rails.logger.warn("Invalid account type '#{selected_type}' submitted for Brex account #{brex_account_id}")
+            next
+          end
+
+          # Find account - scoped to this item to prevent cross-item manipulation
+          brex_account = @brex_item.brex_accounts.find_by(id: brex_account_id)
+          unless brex_account
+            Rails.logger.warn("Brex account #{brex_account_id} not found for item #{@brex_item.id}")
+            next
+          end
+
+          # Skip if already linked (race condition protection)
+          if brex_account.account_provider.present?
+            Rails.logger.info("Brex account #{brex_account_id} already linked, skipping")
+            next
+          end
+
+          selected_subtype = account_subtypes[brex_account_id]
+          selected_type = default_account_type_for_brex_account(brex_account) if selected_type == "skip" || selected_type.blank?
+
+          # Default subtype for CreditCard since it only has one option
+          selected_subtype = "credit_card" if selected_type == "CreditCard" && selected_subtype.blank?
+          selected_subtype = "checking" if selected_type == "Depository" && selected_subtype.blank?
+
+          # Create account with user-selected type and subtype (raises on failure)
+          # Skip initial sync - provider sync will handle balance creation with correct currency
+          account = Account.create_and_sync(
+            {
+              family: Current.family,
+              name: brex_account.name,
+              balance: brex_account.current_balance || 0,
+              currency: brex_account.currency.presence || Current.family.currency,
+              accountable_type: selected_type,
+              accountable_attributes: selected_subtype.present? ? { subtype: selected_subtype } : {}
+            },
+            skip_initial_sync: true
+          )
+
+          # Link account to brex_account via account_providers join table (raises on failure)
+          AccountProvider.create!(
+            account: account,
+            provider: brex_account
+          )
+
+          created_accounts << account
+        end
+      end
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+      Rails.logger.error("Brex account setup failed: #{e.class} - #{e.message}")
+      Rails.logger.error(e.backtrace.first(10).join("\n"))
+      flash[:alert] = t(".creation_failed", error: e.message)
+      redirect_to accounts_path, status: :see_other
+      return
+    rescue StandardError => e
+      Rails.logger.error("Brex account setup failed unexpectedly: #{e.class} - #{e.message}")
+      Rails.logger.error(e.backtrace.first(10).join("\n"))
+      flash[:alert] = t(".creation_failed", error: t(".unexpected_error"))
+      redirect_to accounts_path, status: :see_other
+      return
+    end
+
+    # Trigger a sync to process transactions
+    @brex_item.sync_later if created_accounts.any?
+
+    # Set appropriate flash message
+    if created_accounts.any?
+      flash[:notice] = t(".success", count: created_accounts.count)
+    elsif skipped_count > 0
+      flash[:notice] = t(".all_skipped")
+    else
+      flash[:notice] = t(".no_accounts")
+    end
+
+    if turbo_frame_request?
+      # Recompute data needed by Accounts#index partials
+      @manual_accounts = Account.uncached {
+        Current.family.accounts
+          .visible_manual
+          .order(:name)
+          .to_a
+      }
+      @brex_items = Current.family.brex_items.ordered
+
+      manual_accounts_stream = if @manual_accounts.any?
+        turbo_stream.update(
+          "manual-accounts",
+          partial: "accounts/index/manual_accounts",
+          locals: { accounts: @manual_accounts }
+        )
+      else
+        turbo_stream.replace("manual-accounts", view_context.tag.div(id: "manual-accounts"))
+      end
+
+      render turbo_stream: [
+        manual_accounts_stream,
+        turbo_stream.replace(
+          ActionView::RecordIdentifier.dom_id(@brex_item),
+          partial: "brex_items/brex_item",
+          locals: { brex_item: @brex_item }
+        )
+      ] + Array(flash_notification_stream_items)
+    else
+      redirect_to accounts_path, status: :see_other
+    end
+  end
+
+  private
+
+    # Fetch Brex accounts from the API and store them locally
+    # Returns nil on success, or an error message string on failure
+    def fetch_brex_accounts_from_api
+      # Skip if we already have accounts cached
+      return nil unless @brex_item.brex_accounts.empty?
+
+      # Validate API token is configured
+      unless @brex_item.credentials_configured?
+        return t("brex_items.setup_accounts.no_api_token")
+      end
+
+      # Use the specific brex_item's provider (scoped to this family's item)
+      brex_provider = @brex_item.brex_provider
+      unless brex_provider.present?
+        return t("brex_items.setup_accounts.no_api_token")
+      end
+
+      begin
+        accounts_data = brex_provider.get_accounts
+        available_accounts = accounts_data[:accounts] || []
+
+        if available_accounts.empty?
+          Rails.logger.info("Brex API returned no accounts for item #{@brex_item.id}")
+          return nil
+        end
+
+        available_accounts.each do |account_data|
+          account_name = brex_account_name(account_data)
+          next if account_name.blank?
+
+          brex_account = @brex_item.brex_accounts.find_or_initialize_by(
+            account_id: account_data[:id].to_s
+          )
+          brex_account.upsert_brex_snapshot!(account_data)
+          brex_account.save!
+        end
+
+        nil # Success
+      rescue Provider::Brex::BrexError => e
+        Rails.logger.error("Brex API error: #{e.message}")
+        t("brex_items.setup_accounts.api_error", message: e.message)
+      rescue StandardError => e
+        Rails.logger.error("Unexpected error fetching Brex accounts: #{e.class}: #{e.message}")
+        t("brex_items.setup_accounts.api_error", message: e.message)
+      end
+    end
+
+    def filtered_available_accounts(accounts, accountable_type)
+      accounts.select do |account|
+        case accountable_type
+        when "CreditCard"
+          brex_account_kind(account) == "card"
+        when "Depository"
+          brex_account_kind(account) == "cash"
+        else
+          Provider::BrexAdapter.supported_account_types.include?(accountable_type)
+        end
+      end
+    end
+
+    def brex_account_name(account_data)
+      data = account_data.with_indifferent_access
+      return data[:name].presence || "Brex Card" if brex_account_kind(data) == "card"
+
+      data[:name].presence || data[:display_name].presence || "Brex Cash #{data[:id]}"
+    end
+
+    def brex_account_kind(account_data)
+      return account_data.account_kind if account_data.respond_to?(:account_kind)
+
+      data = account_data.with_indifferent_access
+      kind = data[:account_kind].presence || data[:kind].presence || "cash"
+      kind.to_s == "credit_card" ? "card" : kind.to_s
+    end
+
+    def brex_account_currency(account_data)
+      data = account_data.with_indifferent_access
+      BrexAccount.currency_code_from_money(data[:current_balance] || data[:available_balance] || data[:account_limit])
+    end
+
+    def default_account_type_for_brex_account(brex_account)
+      brex_account_kind(brex_account) == "card" ? "CreditCard" : "Depository"
+    end
+
+    def default_accountable_attributes(accountable_type)
+      case accountable_type
+      when "CreditCard"
+        { subtype: "credit_card" }
+      when "Depository"
+        { subtype: "checking" }
+      else
+        {}
+      end
+    end
+
+    def set_brex_item
+      @brex_item = Current.family.brex_items.find(params[:id])
+    end
+
+    def brex_item_params
+      permitted = params.require(:brex_item).permit(:name, :sync_start_date, :token, :base_url)
+      permitted.delete(:token) if @brex_item&.persisted? && permitted[:token].blank?
+      permitted[:token] = permitted[:token].to_s.strip if permitted[:token].present?
+      if permitted.key?(:base_url)
+        permitted[:base_url] = permitted[:base_url].to_s.strip
+        permitted[:base_url] = nil if permitted[:base_url].blank?
+      end
+      permitted
+    end
+
+    def brex_items_with_credentials
+      Current.family.brex_items.active.ordered.select(&:credentials_configured?)
+    end
+
+    def brex_item_account_flow_context
+      credentialed_items = brex_items_with_credentials
+      brex_item = nil
+
+      if params[:brex_item_id].present?
+        brex_item = credentialed_items.find { |item| item.id.to_s == params[:brex_item_id].to_s }
+      elsif credentialed_items.one?
+        brex_item = credentialed_items.first
+      end
+
+      {
+        brex_item: brex_item,
+        credentialed_items: credentialed_items
+      }
+    end
+
+    def brex_accounts_cache_key(brex_item)
+      "brex_accounts_#{Current.family.id}_#{brex_item.id}"
+    end
+
+    def brex_accounts_cache_sensitive_update?(permitted_params)
+      permitted_params.key?(:token) || permitted_params.key?(:base_url)
+    end
+
+    def brex_item_selection_error_payload(credentialed_items)
+      if brex_item_selection_required?(credentialed_items)
+        {
+          success: false,
+          error: "select_connection",
+          error_message: t(".select_connection", default: "Choose a Brex connection before loading accounts."),
+          has_accounts: nil
+        }
+      else
+        { success: false, error: "no_credentials", has_accounts: false }
+      end
+    end
+
+    def render_brex_item_selection_failure(credentialed_items:)
+      if brex_item_selection_required?(credentialed_items)
+        redirect_to settings_providers_path,
+                    alert: t(".select_connection", default: "Choose a Brex connection in Provider Settings.")
+      elsif turbo_frame_request?
+        render partial: "brex_items/setup_required", layout: false
+      else
+        redirect_to settings_providers_path,
+                    alert: t(".no_credentials_configured",
+                             default: "Please configure your Brex API token first in Provider Settings.")
+      end
+    end
+
+    def brex_item_selection_required?(credentialed_items)
+      credentialed_items.count > 1 && params[:brex_item_id].blank?
+    end
+
+    # Sanitize return_to parameter to prevent XSS attacks
+    # Only allow internal paths, reject external URLs and javascript: URIs
+    def safe_return_to_path
+      return nil if params[:return_to].blank?
+
+      return_to = params[:return_to].to_s
+
+      # Parse the URL to check if it's external
+      begin
+        uri = URI.parse(return_to)
+
+        # Reject absolute URLs with schemes (http:, https:, javascript:, etc.)
+        # Only allow relative paths
+        return nil if uri.scheme.present?
+
+        # Ensure the path starts with / (is a relative path)
+        return nil unless return_to.start_with?("/")
+
+        return_to
+      rescue URI::InvalidURIError
+        # If the URI is invalid, reject it
+        nil
+      end
+    end
+end

--- a/app/controllers/brex_items_controller.rb
+++ b/app/controllers/brex_items_controller.rb
@@ -1,6 +1,6 @@
 class BrexItemsController < ApplicationController
-  before_action :set_brex_item, only: [ :show, :edit, :update, :destroy, :sync, :setup_accounts, :complete_account_setup ]
-  before_action :require_admin!, only: [ :new, :create, :preload_accounts, :select_accounts, :link_accounts, :select_existing_account, :link_existing_account, :edit, :update, :destroy, :sync, :setup_accounts, :complete_account_setup ]
+  before_action :set_brex_item, only: [ :show, :edit, :update, :destroy, :sync ]
+  before_action :require_admin!, only: [ :new, :create, :edit, :update, :destroy, :sync ]
 
   def index
     @brex_items = Current.family.brex_items.active.ordered
@@ -8,59 +8,6 @@ class BrexItemsController < ApplicationController
   end
 
   def show
-  end
-
-  def preload_accounts
-    render json: brex_account_flow.preload_payload
-  end
-
-  def select_accounts
-    @accountable_type = params[:accountable_type] || "Depository"
-    @return_to = safe_return_to_path
-    result = brex_account_flow.select_accounts_result(accountable_type: @accountable_type)
-
-    return handle_brex_selection_result(result, empty_path: new_account_path, api_return_path: @return_to) unless result.success?
-
-    @brex_item = result.brex_item
-    @available_accounts = result.available_accounts
-
-    render layout: false
-  end
-
-  def link_accounts
-    result = brex_account_flow.link_new_accounts_result(
-      account_ids: params[:account_ids] || [],
-      accountable_type: params[:accountable_type] || "Depository"
-    )
-
-    redirect_with_navigation(result, return_to: safe_return_to_path)
-  end
-
-  def select_existing_account
-    return redirect_to accounts_path, alert: t(".no_account_specified") if params[:account_id].blank?
-
-    @account = Current.family.accounts.find(params[:account_id])
-    result = brex_account_flow.select_existing_account_result(account: @account)
-
-    return handle_brex_selection_result(result, empty_path: accounts_path, api_return_path: accounts_path) unless result.success?
-
-    @brex_item = result.brex_item
-    @available_accounts = result.available_accounts
-    @return_to = safe_return_to_path
-
-    render layout: false
-  end
-
-  def link_existing_account
-    return redirect_to accounts_path, alert: t(".no_account_specified") if params[:account_id].blank?
-
-    account = Current.family.accounts.find(params[:account_id])
-    result = brex_account_flow.link_existing_account_result(
-      account: account,
-      brex_account_id: params[:brex_account_id]
-    )
-
-    redirect_with_navigation(result, return_to: safe_return_to_path)
   end
 
   def new
@@ -91,7 +38,7 @@ class BrexItemsController < ApplicationController
   end
 
   def destroy
-    safely_unlink_brex_item
+    @brex_item.unlink_all!(dry_run: false)
     @brex_item.destroy_later
     redirect_to accounts_path, notice: t(".success")
   end
@@ -105,44 +52,7 @@ class BrexItemsController < ApplicationController
     end
   end
 
-  def setup_accounts
-    flow = brex_account_flow_for_item
-    @api_error = flow.import_accounts_error_message
-    @brex_accounts = flow.unlinked_brex_accounts
-    @account_type_options = flow.account_type_options
-    @subtype_options = flow.subtype_options
-  end
-
-  def complete_account_setup
-    flow = brex_account_flow_for_item
-    result = flow.complete_setup_result(
-      account_types: params[:account_types] || {},
-      account_subtypes: params[:account_subtypes] || {}
-    )
-
-    unless result.success?
-      redirect_to accounts_path, alert: result.message, status: :see_other
-      return
-    end
-
-    flash[:notice] = result.message
-
-    if turbo_frame_request?
-      render_accounts_update_after_setup
-    else
-      redirect_to accounts_path, status: :see_other
-    end
-  end
-
   private
-
-    def brex_account_flow
-      @brex_account_flow ||= BrexItem::AccountFlow.new(family: Current.family, brex_item_id: params[:brex_item_id])
-    end
-
-    def brex_account_flow_for_item
-      BrexItem::AccountFlow.new(family: Current.family, brex_item: @brex_item)
-    end
 
     def render_provider_panel_success(message)
       return redirect_to accounts_path, notice: message, status: :see_other unless turbo_frame_request?
@@ -171,40 +81,6 @@ class BrexItemsController < ApplicationController
       render turbo_stream: streams, status: status
     end
 
-    def render_accounts_update_after_setup
-      @manual_accounts = Account.uncached { Current.family.accounts.visible_manual.order(:name).to_a }
-      @brex_items = Current.family.brex_items.ordered
-
-      manual_accounts_stream = if @manual_accounts.any?
-        turbo_stream.update(
-          "manual-accounts",
-          partial: "accounts/index/manual_accounts",
-          locals: { accounts: @manual_accounts }
-        )
-      else
-        turbo_stream.replace("manual-accounts", view_context.tag.div(id: "manual-accounts"))
-      end
-
-      render turbo_stream: [
-        manual_accounts_stream,
-        turbo_stream.replace(
-          ActionView::RecordIdentifier.dom_id(@brex_item),
-          partial: "brex_items/brex_item",
-          locals: { brex_item: @brex_item }
-        )
-      ] + Array(flash_notification_stream_items)
-    end
-
-    def render_api_error_partial(error_message, return_path)
-      render partial: "brex_items/api_error", locals: { error_message: error_message, return_path: return_path }, layout: false
-    end
-
-    def safely_unlink_brex_item
-      @brex_item.unlink_all!(dry_run: false)
-    rescue => e
-      Rails.logger.warn("Brex unlink during destroy failed: #{e.class} - #{e.message}")
-    end
-
     def set_brex_item
       @brex_item = Current.family.brex_items.find(params[:id])
     end
@@ -218,51 +94,5 @@ class BrexItemsController < ApplicationController
         permitted[:base_url] = nil if permitted[:base_url].blank?
       end
       permitted
-    end
-
-    def handle_brex_selection_result(result, empty_path:, api_return_path:)
-      case result.status
-      when :empty, :account_already_linked
-        redirect_to empty_path, alert: result.message
-      when :no_api_token, :select_connection
-        redirect_to settings_providers_path, alert: result.message
-      when :setup_required
-        if turbo_frame_request?
-          render partial: "brex_items/setup_required", layout: false
-        else
-          redirect_to settings_providers_path, alert: result.message
-        end
-      when :api_error, :unexpected_error
-        render_api_error_partial(result.message, api_return_path)
-      else
-        redirect_to settings_providers_path, alert: result.message
-      end
-    end
-
-    def redirect_with_navigation(result, return_to:)
-      redirect_to navigation_path_for(result.target, return_to: return_to), result.flash_type => result.message
-    end
-
-    def navigation_path_for(target, return_to:)
-      {
-        new_account: new_account_path,
-        settings_providers: settings_providers_path,
-        return_to_or_accounts: return_to || accounts_path
-      }.fetch(target, accounts_path)
-    end
-
-    def safe_return_to_path
-      return nil if params[:return_to].blank?
-
-      return_to = params[:return_to].to_s
-      uri = URI.parse(return_to)
-
-      return nil if uri.scheme.present? || uri.host.present?
-      return nil if return_to.start_with?("//")
-      return nil unless return_to.start_with?("/")
-
-      return_to
-    rescue URI::InvalidURIError
-      nil
     end
 end

--- a/app/controllers/brex_items_controller.rb
+++ b/app/controllers/brex_items_controller.rb
@@ -434,7 +434,7 @@ class BrexItemsController < ApplicationController
           locals: { error_message: @error_message }
         ), status: :unprocessable_entity
       else
-        render :new, status: :unprocessable_entity
+        redirect_to settings_providers_path, alert: @error_message, status: :see_other
       end
     end
   end
@@ -473,7 +473,7 @@ class BrexItemsController < ApplicationController
           locals: { error_message: @error_message }
         ), status: :unprocessable_entity
       else
-        render :edit, status: :unprocessable_entity
+        redirect_to settings_providers_path, alert: @error_message, status: :see_other
       end
     end
   end
@@ -604,7 +604,6 @@ class BrexItemsController < ApplicationController
           end
 
           selected_subtype = account_subtypes[brex_account_id]
-          selected_type = default_account_type_for_brex_account(brex_account) if selected_type == "skip" || selected_type.blank?
 
           # Default subtype for CreditCard since it only has one option
           selected_subtype = "credit_card" if selected_type == "CreditCard" && selected_subtype.blank?
@@ -635,13 +634,13 @@ class BrexItemsController < ApplicationController
       end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
       Rails.logger.error("Brex account setup failed: #{e.class} - #{e.message}")
-      Rails.logger.error(e.backtrace.first(10).join("\n"))
+      Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
       flash[:alert] = t(".creation_failed", error: e.message)
       redirect_to accounts_path, status: :see_other
       return
     rescue StandardError => e
       Rails.logger.error("Brex account setup failed unexpectedly: #{e.class} - #{e.message}")
-      Rails.logger.error(e.backtrace.first(10).join("\n"))
+      Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
       flash[:alert] = t(".creation_failed", error: t(".unexpected_error"))
       redirect_to accounts_path, status: :see_other
       return
@@ -742,6 +741,8 @@ class BrexItemsController < ApplicationController
     end
 
     def filtered_available_accounts(accounts, accountable_type)
+      return [] unless Provider::BrexAdapter.supported_account_types.include?(accountable_type)
+
       accounts.select do |account|
         case accountable_type
         when "CreditCard"
@@ -749,7 +750,7 @@ class BrexItemsController < ApplicationController
         when "Depository"
           brex_account_kind(account) == "cash"
         else
-          Provider::BrexAdapter.supported_account_types.include?(accountable_type)
+          true
         end
       end
     end
@@ -875,7 +876,8 @@ class BrexItemsController < ApplicationController
 
         # Reject absolute URLs with schemes (http:, https:, javascript:, etc.)
         # Only allow relative paths
-        return nil if uri.scheme.present?
+        return nil if uri.scheme.present? || uri.host.present?
+        return nil if return_to.start_with?("//")
 
         # Ensure the path starts with / (is a relative path)
         return nil unless return_to.start_with?("/")

--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -129,6 +129,7 @@ class Settings::ProvidersController < ApplicationController
         config.provider_key.to_s.casecmp("sophtron").zero? || \
         config.provider_key.to_s.casecmp("coinstats").zero? || \
         config.provider_key.to_s.casecmp("mercury").zero? || \
+        config.provider_key.to_s.casecmp("brex").zero? || \
         config.provider_key.to_s.casecmp("coinbase").zero? || \
         config.provider_key.to_s.casecmp("snaptrade").zero? || \
         config.provider_key.to_s.casecmp("indexa_capital").zero?
@@ -142,6 +143,7 @@ class Settings::ProvidersController < ApplicationController
       @sophtron_items = Current.family.sophtron_items.where.not(user_id: [ nil, "" ], access_key: [ nil, "" ]).ordered.select(:id)
       @coinstats_items = Current.family.coinstats_items.ordered # CoinStats panel needs account info for status display
       @mercury_items = Current.family.mercury_items.active.ordered.includes(:syncs, :mercury_accounts)
+      @brex_items = Current.family.brex_items.active.ordered.includes(:syncs, :brex_accounts)
       @coinbase_items = Current.family.coinbase_items.ordered # Coinbase panel needs name and sync info for status display
       @snaptrade_items = Current.family.snaptrade_items.includes(:snaptrade_accounts).ordered
       @indexa_capital_items = Current.family.indexa_capital_items.ordered.select(:id)

--- a/app/helpers/brex_items_helper.rb
+++ b/app/helpers/brex_items_helper.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module BrexItemsHelper
+  BrexAccountDisplay = Struct.new(
+    :id,
+    :name,
+    :kind,
+    :currency,
+    :status,
+    :blank_name,
+    keyword_init: true
+  ) do
+    alias_method :blank_name?, :blank_name
+  end
+
+  def brex_account_display(account)
+    data = account.with_indifferent_access
+    kind = normalized_brex_account_kind(data)
+    name = brex_account_display_name(data, kind)
+
+    BrexAccountDisplay.new(
+      id: data[:id],
+      name: name,
+      kind: kind,
+      currency: BrexAccount.currency_code_from_money(data[:current_balance] || data[:available_balance] || data[:account_limit]),
+      status: data[:status],
+      blank_name: name.blank?
+    )
+  end
+
+  def brex_account_metadata(display)
+    parts = [
+      t("brex_items.account_metadata.provider"),
+      display.currency,
+      display.kind.to_s.titleize,
+      display.status.presence&.to_s&.titleize
+    ].compact
+
+    parts.join(t("brex_items.account_metadata.separator"))
+  end
+
+  def default_brex_depository_subtype(account_name)
+    normalized_name = account_name.to_s.downcase
+
+    if normalized_name.match?(/\bchecking\b|\bchequing\b|\bck\b|demand\s+deposit/)
+      "checking"
+    elsif normalized_name.match?(/\bsavings\b|\bsv\b/)
+      "savings"
+    elsif normalized_name.match?(/money\s+market|\bmm\b/)
+      "money_market"
+    else
+      "checking"
+    end
+  end
+
+  private
+
+    def normalized_brex_account_kind(data)
+      kind = data[:account_kind].presence || data[:kind].presence || "cash"
+      kind.to_s == "credit_card" ? "card" : kind.to_s
+    end
+
+    def brex_account_display_name(data, kind)
+      return data[:name].presence || t("brex_items.default_card_name") if kind == "card"
+
+      data[:name].presence || data[:display_name].presence || t("brex_items.default_cash_name", id: data[:id])
+    end
+end

--- a/app/helpers/brex_items_helper.rb
+++ b/app/helpers/brex_items_helper.rb
@@ -39,6 +39,19 @@ module BrexItemsHelper
     parts.join(t("brex_items.account_metadata.separator"))
   end
 
+  def brex_item_render_locals(brex_item, sync_stats_map: nil, account_counts_map: nil, institutions_count_map: nil)
+    counts = (account_counts_map || {})[brex_item.id] || {}
+
+    {
+      brex_item: brex_item,
+      stats: (sync_stats_map || {})[brex_item.id] || brex_item.syncs.ordered.first&.sync_stats || {},
+      unlinked_count: counts[:unlinked] || brex_item.unlinked_accounts_count,
+      linked_count: counts[:linked] || brex_item.linked_accounts_count,
+      total_count: counts[:total] || brex_item.total_accounts_count,
+      institutions_count: (institutions_count_map || {})[brex_item.id] || brex_item.connected_institutions.size
+    }
+  end
+
   def default_brex_depository_subtype(account_name)
     normalized_name = account_name.to_s.downcase
 

--- a/app/helpers/brex_items_helper.rb
+++ b/app/helpers/brex_items_helper.rb
@@ -15,8 +15,8 @@ module BrexItemsHelper
 
   def brex_account_display(account)
     data = account.with_indifferent_access
-    kind = normalized_brex_account_kind(data)
-    name = brex_account_display_name(data, kind)
+    kind = BrexAccount.kind_for(data)
+    name = BrexAccount.name_for(data)
 
     BrexAccountDisplay.new(
       id: data[:id],
@@ -52,17 +52,4 @@ module BrexItemsHelper
       "checking"
     end
   end
-
-  private
-
-    def normalized_brex_account_kind(data)
-      kind = data[:account_kind].presence || data[:kind].presence || "cash"
-      kind.to_s == "credit_card" ? "card" : kind.to_s
-    end
-
-    def brex_account_display_name(data, kind)
-      return data[:name].presence || t("brex_items.default_card_name") if kind == "card"
-
-      data[:name].presence || data[:display_name].presence || t("brex_items.default_cash_name", id: data[:id])
-    end
 end

--- a/app/models/brex_account.rb
+++ b/app/models/brex_account.rb
@@ -116,7 +116,7 @@ class BrexAccount < ApplicationRecord
       account_status: snapshot[:status],
       account_type: snapshot[:type],
       provider: "brex",
-      institution_metadata: institution_metadata(snapshot, kind),
+      institution_metadata: build_institution_metadata(snapshot, kind),
       raw_payload: self.class.sanitize_payload(account_snapshot)
     )
   end
@@ -140,6 +140,7 @@ class BrexAccount < ApplicationRecord
         normalized_key.include?("secret") ||
         normalized_key.in?(%w[api_key access_key authorization cvc cvv security_code])
     end
+    private_class_method :sensitive_number_key?, :sensitive_secret_key?
 
     def brex_account_name(snapshot, kind)
       return snapshot[:name].presence || "Brex Card" if kind == "card"
@@ -147,7 +148,7 @@ class BrexAccount < ApplicationRecord
       snapshot[:name].presence || snapshot[:display_name].presence || "Brex Cash #{snapshot[:id]}"
     end
 
-    def institution_metadata(snapshot, kind)
+    def build_institution_metadata(snapshot, kind)
       {
         name: "Brex",
         domain: "brex.com",

--- a/app/models/brex_account.rb
+++ b/app/models/brex_account.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 class BrexAccount < ApplicationRecord
-  include CurrencyNormalizable, Encryptable
+  include CurrencyNormalizable
 
   CARD_PRIMARY_ACCOUNT_ID = "card_primary"
 
-  if encryption_ready?
-    encrypts :raw_payload
-    encrypts :raw_transactions_payload
-  end
+  encrypts :raw_payload
+  encrypts :raw_transactions_payload
 
   belongs_to :brex_item
 
@@ -55,9 +53,9 @@ class BrexAccount < ApplicationRecord
   def self.default_accountable_attributes(accountable_type)
     case accountable_type
     when "CreditCard"
-      { subtype: "credit_card" }
+      { subtype: CreditCard::DEFAULT_SUBTYPE }
     when "Depository"
-      { subtype: "checking" }
+      { subtype: Depository::DEFAULT_SUBTYPE }
     else
       {}
     end

--- a/app/models/brex_account.rb
+++ b/app/models/brex_account.rb
@@ -12,7 +12,6 @@ class BrexAccount < ApplicationRecord
 
   has_one :account_provider, as: :provider, dependent: :destroy
   has_one :account, through: :account_provider, source: :account
-  has_one :linked_account, through: :account_provider, source: :account
 
   validates :name, :currency, presence: true
   validates :account_id, uniqueness: { scope: :brex_item_id }
@@ -73,7 +72,12 @@ class BrexAccount < ApplicationRecord
     BigDecimal(amount.to_s) / BigDecimal(divisor.to_s)
   rescue Money::Currency::UnknownCurrencyError, ArgumentError
     Rails.logger.warn("Invalid Brex money payload #{money_payload.inspect}, defaulting conversion to USD")
-    BigDecimal(payload[:amount].to_s) / BigDecimal(Money::Currency.new("USD").minor_unit_conversion.to_s)
+    begin
+      safe_amount = BigDecimal(payload[:amount].to_s)
+      safe_amount / BigDecimal(Money::Currency.new("USD").minor_unit_conversion.to_s)
+    rescue ArgumentError, TypeError
+      BigDecimal("0")
+    end
   end
 
   def self.currency_code_from_money(money_payload)
@@ -129,6 +133,10 @@ class BrexAccount < ApplicationRecord
     account
   end
 
+  def linked_account
+    account
+  end
+
   def cash?
     account_kind == "cash"
   end
@@ -159,11 +167,9 @@ class BrexAccount < ApplicationRecord
   end
 
   def upsert_brex_transactions_snapshot!(transactions_snapshot)
-    assign_attributes(
+    update!(
       raw_transactions_payload: self.class.sanitize_payload(transactions_snapshot)
     )
-
-    save!
   end
 
   private

--- a/app/models/brex_account.rb
+++ b/app/models/brex_account.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+class BrexAccount < ApplicationRecord
+  include CurrencyNormalizable, Encryptable
+
+  CARD_PRIMARY_ACCOUNT_ID = "card_primary"
+
+  if encryption_ready?
+    encrypts :raw_payload
+    encrypts :raw_transactions_payload
+  end
+
+  belongs_to :brex_item
+
+  has_one :account_provider, as: :provider, dependent: :destroy
+  has_one :account, through: :account_provider, source: :account
+  has_one :linked_account, through: :account_provider, source: :account
+
+  validates :name, :currency, presence: true
+  validates :account_id, uniqueness: { scope: :brex_item_id }
+  validates :account_kind, inclusion: { in: %w[cash card] }
+
+  def self.card_account_id
+    CARD_PRIMARY_ACCOUNT_ID
+  end
+
+  def self.money_to_decimal(money_payload)
+    return nil if money_payload.blank?
+
+    payload = money_payload.is_a?(Hash) ? money_payload.with_indifferent_access : { amount: money_payload, currency: "USD" }
+    amount = payload[:amount]
+    return nil if amount.nil?
+
+    currency = currency_code_from_money(payload)
+    divisor = Money::Currency.new(currency).minor_unit_conversion
+    BigDecimal(amount.to_s) / BigDecimal(divisor.to_s)
+  rescue Money::Currency::UnknownCurrencyError, ArgumentError
+    Rails.logger.warn("Invalid Brex money payload #{money_payload.inspect}, defaulting conversion to USD")
+    BigDecimal(payload[:amount].to_s) / BigDecimal(Money::Currency.new("USD").minor_unit_conversion.to_s)
+  end
+
+  def self.currency_code_from_money(money_payload)
+    payload = money_payload.is_a?(Hash) ? money_payload.with_indifferent_access : {}
+    currency = payload[:currency].presence || "USD"
+    Money::Currency.new(currency).iso_code
+  rescue Money::Currency::UnknownCurrencyError
+    "USD"
+  end
+
+  def self.sanitize_payload(payload)
+    case payload
+    when Array
+      payload.map { |value| sanitize_payload(value) }
+    when Hash
+      payload.each_with_object({}) do |(key, value), sanitized|
+        key_string = key.to_s
+        normalized_key = key_string.downcase
+
+        if sensitive_number_key?(normalized_key)
+          sanitized["#{key_string}_last4"] = last_four(value)
+        elsif normalized_key == "card_metadata"
+          sanitized[key_string] = sanitize_card_metadata(value)
+        elsif sensitive_secret_key?(normalized_key)
+          sanitized[key_string] = "[FILTERED]"
+        else
+          sanitized[key_string] = sanitize_payload(value)
+        end
+      end
+    else
+      payload
+    end
+  end
+
+  def self.last_four(value)
+    digits = value.to_s.gsub(/\D/, "")
+    digits.last(4) if digits.present?
+  end
+
+  def self.sanitize_card_metadata(value)
+    return nil unless value.is_a?(Hash)
+
+    metadata = value.with_indifferent_access
+    {
+      "card_id" => metadata[:card_id].presence || metadata[:id].presence,
+      "card_name" => metadata[:card_name].presence || metadata[:name].presence,
+      "card_type" => metadata[:card_type].presence || metadata[:type].presence,
+      "last_four" => metadata[:last_four].presence || metadata[:last4].presence || metadata[:card_last_four].presence
+    }.compact
+  end
+
+  def current_account
+    account
+  end
+
+  def cash?
+    account_kind == "cash"
+  end
+
+  def card?
+    account_kind == "card"
+  end
+
+  def upsert_brex_snapshot!(account_snapshot)
+    snapshot = account_snapshot.with_indifferent_access
+    kind = snapshot[:account_kind].presence || snapshot[:kind].presence || "cash"
+    kind = "card" if kind.to_s == "credit_card"
+
+    update!(
+      current_balance: self.class.money_to_decimal(snapshot[:current_balance]),
+      available_balance: self.class.money_to_decimal(snapshot[:available_balance]),
+      account_limit: self.class.money_to_decimal(snapshot[:account_limit]),
+      currency: self.class.currency_code_from_money(snapshot[:current_balance] || snapshot[:available_balance] || snapshot[:account_limit]),
+      name: brex_account_name(snapshot, kind),
+      account_id: snapshot[:id]&.to_s,
+      account_kind: kind,
+      account_status: snapshot[:status],
+      account_type: snapshot[:type],
+      provider: "brex",
+      institution_metadata: institution_metadata(snapshot, kind),
+      raw_payload: self.class.sanitize_payload(account_snapshot)
+    )
+  end
+
+  def upsert_brex_transactions_snapshot!(transactions_snapshot)
+    assign_attributes(
+      raw_transactions_payload: self.class.sanitize_payload(transactions_snapshot)
+    )
+
+    save!
+  end
+
+  private
+
+    def self.sensitive_number_key?(normalized_key)
+      normalized_key.in?(%w[account_number routing_number pan primary_account_number card_number])
+    end
+
+    def self.sensitive_secret_key?(normalized_key)
+      normalized_key.include?("token") ||
+        normalized_key.include?("secret") ||
+        normalized_key.in?(%w[api_key access_key authorization cvc cvv security_code])
+    end
+
+    def brex_account_name(snapshot, kind)
+      return snapshot[:name].presence || "Brex Card" if kind == "card"
+
+      snapshot[:name].presence || snapshot[:display_name].presence || "Brex Cash #{snapshot[:id]}"
+    end
+
+    def institution_metadata(snapshot, kind)
+      {
+        name: "Brex",
+        domain: "brex.com",
+        url: "https://brex.com",
+        account_kind: kind,
+        account_type: snapshot[:type],
+        primary: snapshot[:primary],
+        account_number_last4: self.class.last_four(snapshot[:account_number]),
+        routing_number_last4: self.class.last_four(snapshot[:routing_number]),
+        status: snapshot[:status],
+        current_statement_period: self.class.sanitize_payload(snapshot[:current_statement_period])
+      }.compact
+    end
+end

--- a/app/models/brex_account.rb
+++ b/app/models/brex_account.rb
@@ -24,6 +24,45 @@ class BrexAccount < ApplicationRecord
     CARD_PRIMARY_ACCOUNT_ID
   end
 
+  def self.kind_for(account_data)
+    return account_data.account_kind if account_data.respond_to?(:account_kind)
+
+    data = account_data.with_indifferent_access
+    kind = data[:account_kind].presence || data[:kind].presence || "cash"
+    kind.to_s == "credit_card" ? "card" : kind.to_s
+  end
+
+  def self.name_for(account_data)
+    data = account_data.with_indifferent_access
+    kind = kind_for(data)
+
+    if kind == "card"
+      data[:name].presence || I18n.t("brex_items.default_card_name", default: "Brex Card")
+    else
+      data[:name].presence || data[:display_name].presence || I18n.t("brex_items.default_cash_name", id: data[:id], default: "Brex Cash #{data[:id]}")
+    end
+  end
+
+  def self.currency_for(account_data)
+    data = account_data.with_indifferent_access
+    currency_code_from_money(data[:current_balance] || data[:available_balance] || data[:account_limit])
+  end
+
+  def self.default_account_type_for(account_data)
+    kind_for(account_data) == "card" ? "CreditCard" : "Depository"
+  end
+
+  def self.default_accountable_attributes(accountable_type)
+    case accountable_type
+    when "CreditCard"
+      { subtype: "credit_card" }
+    when "Depository"
+      { subtype: "checking" }
+    else
+      {}
+    end
+  end
+
   def self.money_to_decimal(money_payload)
     return nil if money_payload.blank?
 
@@ -110,7 +149,7 @@ class BrexAccount < ApplicationRecord
       available_balance: self.class.money_to_decimal(snapshot[:available_balance]),
       account_limit: self.class.money_to_decimal(snapshot[:account_limit]),
       currency: self.class.currency_code_from_money(snapshot[:current_balance] || snapshot[:available_balance] || snapshot[:account_limit]),
-      name: brex_account_name(snapshot, kind),
+      name: self.class.name_for(snapshot.merge(account_kind: kind)),
       account_id: snapshot[:id]&.to_s,
       account_kind: kind,
       account_status: snapshot[:status],
@@ -141,12 +180,6 @@ class BrexAccount < ApplicationRecord
         normalized_key.in?(%w[api_key access_key authorization cvc cvv security_code])
     end
     private_class_method :sensitive_number_key?, :sensitive_secret_key?
-
-    def brex_account_name(snapshot, kind)
-      return snapshot[:name].presence || "Brex Card" if kind == "card"
-
-      snapshot[:name].presence || snapshot[:display_name].presence || "Brex Cash #{snapshot[:id]}"
-    end
 
     def build_institution_metadata(snapshot, kind)
       {

--- a/app/models/brex_account/processor.rb
+++ b/app/models/brex_account/processor.rb
@@ -27,8 +27,18 @@ class BrexAccount::Processor
 
     def process_account!
       account = brex_account.current_account
-      balance = brex_account.current_balance || 0
-      currency = parse_currency(brex_account.currency) || "USD"
+      balance = brex_account.current_balance
+      currency = parse_currency(brex_account.currency)
+
+      if balance.nil?
+        Rails.logger.warn "BrexAccount::Processor - current_balance is nil for brex_account #{brex_account.id}, defaulting to 0"
+        balance = 0
+      end
+
+      if currency.nil?
+        Rails.logger.warn "BrexAccount::Processor - currency parse failed for brex_account #{brex_account.id}: #{brex_account.currency.inspect}, defaulting to USD"
+        currency = "USD"
+      end
 
       account.update!(
         balance: balance,

--- a/app/models/brex_account/processor.rb
+++ b/app/models/brex_account/processor.rb
@@ -51,9 +51,12 @@ class BrexAccount::Processor
       end
     end
 
+    # Transaction import errors are logged and swallowed so balance sync can continue.
     def process_transactions
       BrexAccount::Transactions::Processor.new(brex_account).process
-    rescue => e
+    rescue StandardError => e
+      Rails.logger.error "BrexAccount::Processor - Failed to process transactions for brex_account #{brex_account.id}: #{e.message}"
+      Rails.logger.error Array(e.backtrace).first(10).join("\n")
       report_exception(e, "transactions")
     end
 

--- a/app/models/brex_account/processor.rb
+++ b/app/models/brex_account/processor.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class BrexAccount::Processor
+  include CurrencyNormalizable
+
+  attr_reader :brex_account
+
+  def initialize(brex_account)
+    @brex_account = brex_account
+  end
+
+  def process
+    unless brex_account.current_account.present?
+      Rails.logger.info "BrexAccount::Processor - No linked account for brex_account #{brex_account.id}, skipping processing"
+      return
+    end
+
+    process_account!
+    process_transactions
+  rescue StandardError => e
+    Rails.logger.error "BrexAccount::Processor - Failed to process account #{brex_account.id}: #{e.message}"
+    report_exception(e, "account")
+    raise
+  end
+
+  private
+
+    def process_account!
+      account = brex_account.current_account
+      balance = brex_account.current_balance || 0
+      currency = parse_currency(brex_account.currency) || "USD"
+
+      account.update!(
+        balance: balance,
+        cash_balance: balance,
+        currency: currency
+      )
+
+      if account.accountable_type == "CreditCard" && brex_account.available_balance.present?
+        account.accountable.update!(available_credit: brex_account.available_balance)
+      end
+    end
+
+    def process_transactions
+      BrexAccount::Transactions::Processor.new(brex_account).process
+    rescue => e
+      report_exception(e, "transactions")
+    end
+
+    def report_exception(error, context)
+      Sentry.capture_exception(error) do |scope|
+        scope.set_tags(
+          brex_account_id: brex_account.id,
+          context: context
+        )
+      end
+    end
+end

--- a/app/models/brex_account/processor.rb
+++ b/app/models/brex_account/processor.rb
@@ -37,6 +37,13 @@ class BrexAccount::Processor
 
       if currency.nil?
         Rails.logger.warn "BrexAccount::Processor - currency parse failed for brex_account #{brex_account.id}: #{brex_account.currency.inspect}, defaulting to USD"
+        Sentry.capture_message("BrexAccount currency parse failed", level: :warning) do |scope|
+          scope.set_tags(brex_account_id: brex_account.id)
+          scope.set_context("brex_account", {
+            id: brex_account.id,
+            currency: brex_account.currency
+          })
+        end
         currency = "USD"
       end
 

--- a/app/models/brex_account/transactions/processor.rb
+++ b/app/models/brex_account/transactions/processor.rb
@@ -1,0 +1,71 @@
+class BrexAccount::Transactions::Processor
+  attr_reader :brex_account
+
+  def initialize(brex_account)
+    @brex_account = brex_account
+  end
+
+  def process
+    unless brex_account.raw_transactions_payload.present?
+      Rails.logger.info "BrexAccount::Transactions::Processor - No transactions in raw_transactions_payload for brex_account #{brex_account.id}"
+      return { success: true, total: 0, imported: 0, failed: 0, errors: [] }
+    end
+
+    total_count = brex_account.raw_transactions_payload.count
+    Rails.logger.info "BrexAccount::Transactions::Processor - Processing #{total_count} transactions for brex_account #{brex_account.id}"
+
+    imported_count = 0
+    failed_count = 0
+    errors = []
+
+    # Each entry is processed inside a transaction, but to avoid locking up the DB when
+    # there are hundreds or thousands of transactions, we process them individually.
+    brex_account.raw_transactions_payload.each_with_index do |transaction_data, index|
+      begin
+        result = BrexEntry::Processor.new(
+          transaction_data,
+          brex_account: brex_account
+        ).process
+
+        if result.nil?
+          # Transaction was skipped (e.g., no linked account)
+          failed_count += 1
+          errors << { index: index, transaction_id: transaction_data[:id], error: "No linked account" }
+        else
+          imported_count += 1
+        end
+      rescue ArgumentError => e
+        # Validation error - log and continue
+        failed_count += 1
+        transaction_id = transaction_data.try(:[], :id) || transaction_data.try(:[], "id") || "unknown"
+        error_message = "Validation error: #{e.message}"
+        Rails.logger.error "BrexAccount::Transactions::Processor - #{error_message} (transaction #{transaction_id})"
+        errors << { index: index, transaction_id: transaction_id, error: error_message }
+      rescue => e
+        # Unexpected error - log with full context and continue
+        failed_count += 1
+        transaction_id = transaction_data.try(:[], :id) || transaction_data.try(:[], "id") || "unknown"
+        error_message = "#{e.class}: #{e.message}"
+        Rails.logger.error "BrexAccount::Transactions::Processor - Error processing transaction #{transaction_id}: #{error_message}"
+        Rails.logger.error e.backtrace.join("\n")
+        errors << { index: index, transaction_id: transaction_id, error: error_message }
+      end
+    end
+
+    result = {
+      success: failed_count == 0,
+      total: total_count,
+      imported: imported_count,
+      failed: failed_count,
+      errors: errors
+    }
+
+    if failed_count > 0
+      Rails.logger.warn "BrexAccount::Transactions::Processor - Completed with #{failed_count} failures out of #{total_count} transactions"
+    else
+      Rails.logger.info "BrexAccount::Transactions::Processor - Successfully processed #{imported_count} transactions"
+    end
+
+    result
+  end
+end

--- a/app/models/brex_account/transactions/processor.rb
+++ b/app/models/brex_account/transactions/processor.rb
@@ -72,6 +72,6 @@ class BrexAccount::Transactions::Processor
   private
 
     def transaction_id_for(transaction_data)
-      transaction_data.try(:[], :id) || transaction_data.try(:[], "id") || "unknown"
+      transaction_data&.dig(:id) || transaction_data&.dig("id") || "unknown"
     end
 end

--- a/app/models/brex_account/transactions/processor.rb
+++ b/app/models/brex_account/transactions/processor.rb
@@ -8,7 +8,7 @@ class BrexAccount::Transactions::Processor
   def process
     unless brex_account.raw_transactions_payload.present?
       Rails.logger.info "BrexAccount::Transactions::Processor - No transactions in raw_transactions_payload for brex_account #{brex_account.id}"
-      return { success: true, total: 0, imported: 0, failed: 0, errors: [] }
+      return { success: true, total: 0, imported: 0, skipped: 0, failed: 0, errors: [], skipped_transactions: [] }
     end
 
     total_count = brex_account.raw_transactions_payload.count
@@ -16,7 +16,9 @@ class BrexAccount::Transactions::Processor
 
     imported_count = 0
     failed_count = 0
+    skipped_count = 0
     errors = []
+    skipped = []
 
     # Each entry is processed inside a transaction, but to avoid locking up the DB when
     # there are hundreds or thousands of transactions, we process them individually.
@@ -27,10 +29,12 @@ class BrexAccount::Transactions::Processor
           brex_account: brex_account
         ).process
 
-        if result.nil?
-          # Transaction was skipped (e.g., no linked account)
+        if result == :skipped
+          skipped_count += 1
+          skipped << { index: index, transaction_id: transaction_id_for(transaction_data), reason: "No linked account" }
+        elsif result.nil?
           failed_count += 1
-          errors << { index: index, transaction_id: transaction_id_for(transaction_data), error: "No linked account" }
+          errors << { index: index, transaction_id: transaction_id_for(transaction_data), error: "No transaction imported" }
         else
           imported_count += 1
         end
@@ -47,7 +51,7 @@ class BrexAccount::Transactions::Processor
         transaction_id = transaction_id_for(transaction_data)
         error_message = "#{e.class}: #{e.message}"
         Rails.logger.error "BrexAccount::Transactions::Processor - Error processing transaction #{transaction_id}: #{error_message}"
-        Rails.logger.error Array(e.backtrace).join("\n")
+        Rails.logger.error Array(e.backtrace).first(10).join("\n")
         errors << { index: index, transaction_id: transaction_id, error: error_message }
       end
     end
@@ -56,8 +60,10 @@ class BrexAccount::Transactions::Processor
       success: failed_count == 0,
       total: total_count,
       imported: imported_count,
+      skipped: skipped_count,
       failed: failed_count,
-      errors: errors
+      errors: errors,
+      skipped_transactions: skipped
     }
 
     if failed_count > 0

--- a/app/models/brex_account/transactions/processor.rb
+++ b/app/models/brex_account/transactions/processor.rb
@@ -30,24 +30,24 @@ class BrexAccount::Transactions::Processor
         if result.nil?
           # Transaction was skipped (e.g., no linked account)
           failed_count += 1
-          errors << { index: index, transaction_id: transaction_data[:id], error: "No linked account" }
+          errors << { index: index, transaction_id: transaction_id_for(transaction_data), error: "No linked account" }
         else
           imported_count += 1
         end
       rescue ArgumentError => e
         # Validation error - log and continue
         failed_count += 1
-        transaction_id = transaction_data.try(:[], :id) || transaction_data.try(:[], "id") || "unknown"
+        transaction_id = transaction_id_for(transaction_data)
         error_message = "Validation error: #{e.message}"
         Rails.logger.error "BrexAccount::Transactions::Processor - #{error_message} (transaction #{transaction_id})"
         errors << { index: index, transaction_id: transaction_id, error: error_message }
       rescue => e
         # Unexpected error - log with full context and continue
         failed_count += 1
-        transaction_id = transaction_data.try(:[], :id) || transaction_data.try(:[], "id") || "unknown"
+        transaction_id = transaction_id_for(transaction_data)
         error_message = "#{e.class}: #{e.message}"
         Rails.logger.error "BrexAccount::Transactions::Processor - Error processing transaction #{transaction_id}: #{error_message}"
-        Rails.logger.error e.backtrace.join("\n")
+        Rails.logger.error Array(e.backtrace).join("\n")
         errors << { index: index, transaction_id: transaction_id, error: error_message }
       end
     end
@@ -68,4 +68,10 @@ class BrexAccount::Transactions::Processor
 
     result
   end
+
+  private
+
+    def transaction_id_for(transaction_data)
+      transaction_data.try(:[], :id) || transaction_data.try(:[], "id") || "unknown"
+    end
 end

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "digest/md5"
+
+class BrexEntry::Processor
+  include CurrencyNormalizable
+
+  def initialize(brex_transaction, brex_account:)
+    @brex_transaction = brex_transaction
+    @brex_account = brex_account
+  end
+
+  def process
+    unless account.present?
+      Rails.logger.warn "BrexEntry::Processor - No linked account for brex_account #{brex_account.id}, skipping transaction #{external_id}"
+      return nil
+    end
+
+    import_adapter.import_transaction(
+      external_id: external_id,
+      amount: amount,
+      currency: currency,
+      date: date,
+      name: name,
+      source: "brex",
+      merchant: merchant,
+      notes: notes,
+      extra: extra
+    )
+  rescue ArgumentError => e
+    Rails.logger.error "BrexEntry::Processor - Validation error for transaction #{external_id}: #{e.message}"
+    raise
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    Rails.logger.error "BrexEntry::Processor - Failed to save transaction #{external_id}: #{e.message}"
+    raise StandardError.new("Failed to import transaction: #{e.message}")
+  rescue => e
+    Rails.logger.error "BrexEntry::Processor - Unexpected error processing transaction #{external_id}: #{e.class} - #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    raise StandardError.new("Unexpected error importing transaction: #{e.message}")
+  end
+
+  private
+    attr_reader :brex_transaction, :brex_account
+
+    def import_adapter
+      @import_adapter ||= Account::ProviderImportAdapter.new(account)
+    end
+
+    def account
+      @account ||= brex_account.current_account
+    end
+
+    def data
+      @data ||= brex_transaction.with_indifferent_access
+    end
+
+    def external_id
+      id = data[:id].presence
+      raise ArgumentError, "Brex transaction missing required field 'id'" unless id
+
+      "brex_#{id}"
+    end
+
+    def name
+      data[:description].presence ||
+        merchant_payload[:raw_descriptor].presence ||
+        merchant_payload[:name].presence ||
+        "Brex transaction"
+    end
+
+    def notes
+      note_parts = []
+      note_parts << data[:type] if data[:type].present?
+      note_parts << data[:expense_id] if data[:expense_id].present?
+      note_parts.any? ? note_parts.join(" - ") : nil
+    end
+
+    def merchant
+      merchant_name = merchant_payload[:raw_descriptor].presence || merchant_payload[:name].presence
+      return nil if merchant_name.blank?
+
+      merchant_name = merchant_name.to_s.strip
+      return nil if merchant_name.blank?
+
+      merchant_id = Digest::MD5.hexdigest(merchant_name.downcase)
+
+      @merchant ||= import_adapter.find_or_create_merchant(
+        provider_merchant_id: "brex_merchant_#{merchant_id}",
+        name: merchant_name,
+        source: "brex"
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error "BrexEntry::Processor - Failed to create merchant '#{merchant_name}': #{e.message}"
+      nil
+    end
+
+    def merchant_payload
+      @merchant_payload ||= begin
+        payload = data[:merchant]
+        payload.is_a?(Hash) ? payload.with_indifferent_access : {}
+      end
+    end
+
+    def amount
+      BrexAccount.money_to_decimal(data[:amount]) || BigDecimal("0")
+    rescue ArgumentError => e
+      Rails.logger.error "Failed to parse Brex transaction amount: #{data[:amount].inspect} - #{e.message}"
+      raise
+    end
+
+    def currency
+      parse_currency(BrexAccount.currency_code_from_money(data[:amount])) ||
+        parse_currency(brex_account.currency) ||
+        "USD"
+    end
+
+    def date
+      date_value = data[:posted_at_date].presence || data[:initiated_at_date].presence
+
+      case date_value
+      when String
+        Date.parse(date_value)
+      when Integer, Float
+        Time.at(date_value).to_date
+      when Time, DateTime
+        date_value.to_date
+      when Date
+        date_value
+      else
+        raise ArgumentError, "Invalid date format: #{date_value.inspect}"
+      end
+    rescue ArgumentError, TypeError => e
+      Rails.logger.error("Failed to parse Brex transaction date '#{date_value}': #{e.message}")
+      raise ArgumentError, "Unable to parse transaction date: #{date_value.inspect}"
+    end
+
+    def extra
+      {
+        brex: {
+          transaction_id: data[:id],
+          account_kind: brex_account.account_kind,
+          type: data[:type],
+          card_id: data[:card_id],
+          transfer_id: data[:transfer_id],
+          expense_id: data[:expense_id],
+          card_transaction_operation_reference_id: data[:card_transaction_operation_reference_id],
+          initiated_at_date: data[:initiated_at_date],
+          posted_at_date: data[:posted_at_date],
+          merchant: BrexAccount.sanitize_payload(data[:merchant])
+        }.compact
+      }
+    end
+end

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -35,7 +35,7 @@ class BrexEntry::Processor
     raise StandardError.new("Failed to import transaction: #{e.message}")
   rescue => e
     Rails.logger.error "BrexEntry::Processor - Unexpected error processing transaction #{external_id}: #{e.class} - #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
+    Rails.logger.error Array(e.backtrace).join("\n")
     raise StandardError.new("Unexpected error importing transaction: #{e.message}")
   end
 
@@ -77,21 +77,22 @@ class BrexEntry::Processor
 
     def merchant
       merchant_name = merchant_payload[:raw_descriptor].presence || merchant_payload[:name].presence
-      return nil if merchant_name.blank?
+      return @merchant if instance_variable_defined?(:@merchant)
+      return @merchant = nil if merchant_name.blank?
 
       merchant_name = merchant_name.to_s.strip
-      return nil if merchant_name.blank?
+      return @merchant = nil if merchant_name.blank?
 
       merchant_id = Digest::MD5.hexdigest(merchant_name.downcase)
 
-      @merchant ||= import_adapter.find_or_create_merchant(
+      @merchant = import_adapter.find_or_create_merchant(
         provider_merchant_id: "brex_merchant_#{merchant_id}",
         name: merchant_name,
         source: "brex"
       )
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error "BrexEntry::Processor - Failed to create merchant '#{merchant_name}': #{e.message}"
-      nil
+      @merchant = nil
     end
 
     def merchant_payload

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -11,13 +11,16 @@ class BrexEntry::Processor
   end
 
   def process
+    cached_external_id = nil
+    cached_external_id = external_id
+
     unless account.present?
-      Rails.logger.warn "BrexEntry::Processor - No linked account for brex_account #{brex_account.id}, skipping transaction #{external_id}"
+      Rails.logger.warn "BrexEntry::Processor - No linked account for brex_account #{brex_account.id}, skipping transaction #{cached_external_id}"
       return :skipped
     end
 
     import_adapter.import_transaction(
-      external_id: external_id,
+      external_id: cached_external_id,
       amount: amount,
       currency: currency,
       date: date,
@@ -28,13 +31,13 @@ class BrexEntry::Processor
       extra: extra
     )
   rescue ArgumentError => e
-    Rails.logger.error "BrexEntry::Processor - Validation error for transaction #{external_id}: #{e.message}"
+    Rails.logger.error "BrexEntry::Processor - Validation error for transaction #{cached_external_id || safe_external_id}: #{e.message}"
     raise
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
-    Rails.logger.error "BrexEntry::Processor - Failed to save transaction #{external_id}: #{e.message}"
+    Rails.logger.error "BrexEntry::Processor - Failed to save transaction #{cached_external_id || safe_external_id}: #{e.message}"
     raise StandardError.new("Failed to import transaction: #{e.message}")
   rescue => e
-    Rails.logger.error "BrexEntry::Processor - Unexpected error processing transaction #{external_id}: #{e.class} - #{e.message}"
+    Rails.logger.error "BrexEntry::Processor - Unexpected error processing transaction #{cached_external_id || safe_external_id}: #{e.class} - #{e.message}"
     Rails.logger.error Array(e.backtrace).join("\n")
     raise StandardError.new("Unexpected error importing transaction: #{e.message}")
   end
@@ -61,11 +64,17 @@ class BrexEntry::Processor
       "brex_#{id}"
     end
 
+    def safe_external_id
+      external_id
+    rescue ArgumentError
+      "brex_unknown"
+    end
+
     def name
       data[:description].presence ||
         merchant_payload[:raw_descriptor].presence ||
         merchant_payload[:name].presence ||
-        "Brex transaction"
+        I18n.t("brex_items.entries.default_name")
     end
 
     def notes

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -13,7 +13,7 @@ class BrexEntry::Processor
   def process
     unless account.present?
       Rails.logger.warn "BrexEntry::Processor - No linked account for brex_account #{brex_account.id}, skipping transaction #{external_id}"
-      return nil
+      return :skipped
     end
 
     import_adapter.import_transaction(
@@ -110,9 +110,26 @@ class BrexEntry::Processor
     end
 
     def currency
-      parse_currency(BrexAccount.currency_code_from_money(data[:amount])) ||
+      amount_currency = transaction_amount_currency
+      log_invalid_currency(amount_currency) if amount_currency.blank? && data[:amount].present?
+
+      parse_currency(amount_currency) ||
         parse_currency(brex_account.currency) ||
         "USD"
+    end
+
+    def transaction_amount_currency
+      amount_payload = data[:amount]
+      return nil unless amount_payload.is_a?(Hash)
+
+      amount_payload.with_indifferent_access[:currency]
+    end
+
+    def log_invalid_currency(currency_value)
+      Rails.logger.warn(
+        "Invalid Brex currency #{currency_value.inspect} for transaction #{data[:id].presence || 'unknown'} " \
+        "on brex_account #{brex_account.id} amount=#{data[:amount].inspect} account_currency=#{brex_account.currency.inspect}; defaulting to fallback"
+      )
     end
 
     def date

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -12,6 +12,7 @@ class BrexItem < ApplicationRecord
   validates :name, presence: true
   validates :token, presence: true, on: :create
   validate :base_url_must_be_official_brex_url
+  before_validation :normalize_token
   before_validation :normalize_base_url
 
   belongs_to :family
@@ -83,11 +84,7 @@ class BrexItem < ApplicationRecord
   end
 
   def upsert_brex_snapshot!(accounts_snapshot)
-    assign_attributes(
-      raw_payload: BrexAccount.sanitize_payload(accounts_snapshot)
-    )
-
-    save!
+    update!(raw_payload: BrexAccount.sanitize_payload(accounts_snapshot))
   end
 
   def has_completed_initial_setup?
@@ -126,10 +123,10 @@ class BrexItem < ApplicationRecord
   end
 
   def connected_institutions
-    brex_accounts.includes(:account)
-                  .where.not(institution_metadata: nil)
-                  .map { |acc| acc.institution_metadata }
-                  .uniq { |inst| inst["name"] || inst["institution_name"] }
+    brex_accounts.where.not(institution_metadata: nil)
+                 .pluck(:institution_metadata)
+                 .compact
+                 .uniq { |inst| inst["name"] || inst["institution_name"] }
   end
 
   def institution_summary
@@ -158,6 +155,10 @@ class BrexItem < ApplicationRecord
   end
 
   private
+    def normalize_token
+      self.token = token&.strip
+    end
+
     def normalize_base_url
       stripped = base_url.to_s.strip
       if stripped.blank?

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -24,6 +24,7 @@ class BrexItem < ApplicationRecord
   scope :syncable, -> { active }
   scope :ordered, -> { order(created_at: :desc) }
   scope :needs_update, -> { where(status: :requires_update) }
+  scope :with_credentials, -> { where.not(token: [ nil, "" ]) }
 
   def destroy_later
     update!(scheduled_for_deletion: true)
@@ -34,7 +35,7 @@ class BrexItem < ApplicationRecord
     provider = brex_provider
     unless provider
       Rails.logger.error "BrexItem #{id} - Cannot import: provider is not configured"
-      raise StandardError.new("Brex provider is not configured")
+      raise Provider::Brex::BrexError.new("Brex provider is not configured", :not_configured)
     end
 
     BrexItem::Importer.new(self, brex_provider: provider, sync_start_date: sync_start_date).import
@@ -47,7 +48,7 @@ class BrexItem < ApplicationRecord
     return [] if brex_accounts.empty?
 
     results = []
-    brex_accounts.joins(:account).merge(Account.visible).each do |brex_account|
+    brex_accounts.joins(:account).includes(:account).merge(Account.visible).each do |brex_account|
       begin
         result = BrexAccount::Processor.new(brex_account).process
         results << { brex_account_id: brex_account.id, success: true, result: result }

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -1,0 +1,159 @@
+class BrexItem < ApplicationRecord
+  include Syncable, Provided, Unlinking
+
+  enum :status, { good: "good", requires_update: "requires_update" }, default: :good
+
+  # Helper to detect if ActiveRecord Encryption is configured for this app
+  def self.encryption_ready?
+    creds_ready = Rails.application.credentials.active_record_encryption.present?
+    env_ready = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"].present? &&
+                ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"].present? &&
+                ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"].present?
+    creds_ready || env_ready
+  end
+
+  # Encrypt sensitive credentials if ActiveRecord encryption is configured
+  if encryption_ready?
+    encrypts :token, deterministic: true
+  end
+
+  validates :name, presence: true
+  validates :token, presence: true, on: :create
+
+  belongs_to :family
+  has_one_attached :logo, dependent: :purge_later
+
+  has_many :brex_accounts, dependent: :destroy
+  has_many :accounts, through: :brex_accounts
+
+  scope :active, -> { where(scheduled_for_deletion: false) }
+  scope :syncable, -> { active }
+  scope :ordered, -> { order(created_at: :desc) }
+  scope :needs_update, -> { where(status: :requires_update) }
+
+  def destroy_later
+    update!(scheduled_for_deletion: true)
+    DestroyJob.perform_later(self)
+  end
+
+  def import_latest_brex_data
+    provider = brex_provider
+    unless provider
+      Rails.logger.error "BrexItem #{id} - Cannot import: provider is not configured"
+      raise StandardError.new("Brex provider is not configured")
+    end
+
+    BrexItem::Importer.new(self, brex_provider: provider).import
+  rescue => e
+    Rails.logger.error "BrexItem #{id} - Failed to import data: #{e.message}"
+    raise
+  end
+
+  def process_accounts
+    return [] if brex_accounts.empty?
+
+    results = []
+    brex_accounts.joins(:account).merge(Account.visible).each do |brex_account|
+      begin
+        result = BrexAccount::Processor.new(brex_account).process
+        results << { brex_account_id: brex_account.id, success: true, result: result }
+      rescue => e
+        Rails.logger.error "BrexItem #{id} - Failed to process account #{brex_account.id}: #{e.message}"
+        results << { brex_account_id: brex_account.id, success: false, error: e.message }
+      end
+    end
+
+    results
+  end
+
+  def schedule_account_syncs(parent_sync: nil, window_start_date: nil, window_end_date: nil)
+    return [] if accounts.empty?
+
+    results = []
+    accounts.visible.each do |account|
+      begin
+        account.sync_later(
+          parent_sync: parent_sync,
+          window_start_date: window_start_date,
+          window_end_date: window_end_date
+        )
+        results << { account_id: account.id, success: true }
+      rescue => e
+        Rails.logger.error "BrexItem #{id} - Failed to schedule sync for account #{account.id}: #{e.message}"
+        results << { account_id: account.id, success: false, error: e.message }
+      end
+    end
+
+    results
+  end
+
+  def upsert_brex_snapshot!(accounts_snapshot)
+    assign_attributes(
+      raw_payload: BrexAccount.sanitize_payload(accounts_snapshot)
+    )
+
+    save!
+  end
+
+  def has_completed_initial_setup?
+    # Setup is complete if we have any linked accounts
+    accounts.any?
+  end
+
+  def sync_status_summary
+    total_accounts = total_accounts_count
+    linked_count = linked_accounts_count
+    unlinked_count = unlinked_accounts_count
+
+    if total_accounts == 0
+      "No accounts found"
+    elsif unlinked_count == 0
+      "#{linked_count} #{'account'.pluralize(linked_count)} synced"
+    else
+      "#{linked_count} synced, #{unlinked_count} need setup"
+    end
+  end
+
+  def linked_accounts_count
+    brex_accounts.joins(:account_provider).count
+  end
+
+  def unlinked_accounts_count
+    brex_accounts.left_joins(:account_provider).where(account_providers: { id: nil }).count
+  end
+
+  def total_accounts_count
+    brex_accounts.count
+  end
+
+  def institution_display_name
+    institution_name.presence || institution_domain.presence || name
+  end
+
+  def connected_institutions
+    brex_accounts.includes(:account)
+                  .where.not(institution_metadata: nil)
+                  .map { |acc| acc.institution_metadata }
+                  .uniq { |inst| inst["name"] || inst["institution_name"] }
+  end
+
+  def institution_summary
+    institutions = connected_institutions
+    case institutions.count
+    when 0
+      "No institutions connected"
+    when 1
+      institutions.first["name"] || institutions.first["institution_name"] || "1 institution"
+    else
+      "#{institutions.count} institutions"
+    end
+  end
+
+  def credentials_configured?
+    token.to_s.strip.present?
+  end
+
+  def effective_base_url
+    base_url.presence || "https://api.brex.com"
+  end
+end

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -4,6 +4,7 @@ class BrexItem < ApplicationRecord
   enum :status, { good: "good", requires_update: "requires_update" }, default: :good
 
   encrypts :token, deterministic: true
+  encrypts :raw_payload
 
   def self.encryption_ready?
     ActiveRecordEncryptionConfig.ready?

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -13,6 +13,7 @@ class BrexItem < ApplicationRecord
   validates :name, presence: true
   validates :token, presence: true, on: :create
   validate :base_url_must_be_official_brex_url
+  validate :token_cannot_be_blank_when_changed
   before_validation :normalize_token
   before_validation :normalize_base_url
 
@@ -158,6 +159,12 @@ class BrexItem < ApplicationRecord
   private
     def normalize_token
       self.token = token&.strip
+    end
+
+    def token_cannot_be_blank_when_changed
+      return unless persisted? && will_save_change_to_token? && token.blank?
+
+      errors.add(:token, :blank)
     end
 
     def normalize_base_url

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -19,6 +19,8 @@ class BrexItem < ApplicationRecord
 
   validates :name, presence: true
   validates :token, presence: true, on: :create
+  validate :base_url_must_be_official_brex_url
+  before_validation :normalize_base_url
 
   belongs_to :family
   has_one_attached :logo, dependent: :purge_later
@@ -154,6 +156,26 @@ class BrexItem < ApplicationRecord
   end
 
   def effective_base_url
-    base_url.presence || "https://api.brex.com"
+    return Provider::Brex::DEFAULT_BASE_URL if base_url.blank?
+
+    Provider::Brex.normalize_base_url(base_url)
   end
+
+  private
+    def normalize_base_url
+      stripped = base_url.to_s.strip
+      if stripped.blank?
+        self.base_url = nil
+        return
+      end
+
+      normalized = Provider::Brex.normalize_base_url(stripped)
+      self.base_url = normalized if normalized.present?
+    end
+
+    def base_url_must_be_official_brex_url
+      return if base_url.blank? || Provider::Brex.allowed_base_url?(base_url)
+
+      errors.add(:base_url, :official_hosts_only)
+    end
 end

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -3,18 +3,10 @@ class BrexItem < ApplicationRecord
 
   enum :status, { good: "good", requires_update: "requires_update" }, default: :good
 
-  # Helper to detect if ActiveRecord Encryption is configured for this app
-  def self.encryption_ready?
-    creds_ready = Rails.application.credentials.active_record_encryption.present?
-    env_ready = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"].present? &&
-                ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"].present? &&
-                ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"].present?
-    creds_ready || env_ready
-  end
+  encrypts :token, deterministic: true
 
-  # Encrypt sensitive credentials if ActiveRecord encryption is configured
-  if encryption_ready?
-    encrypts :token, deterministic: true
+  def self.encryption_ready?
+    ActiveRecordEncryptionConfig.ready?
   end
 
   validates :name, presence: true
@@ -38,14 +30,14 @@ class BrexItem < ApplicationRecord
     DestroyJob.perform_later(self)
   end
 
-  def import_latest_brex_data
+  def import_latest_brex_data(sync_start_date: nil)
     provider = brex_provider
     unless provider
       Rails.logger.error "BrexItem #{id} - Cannot import: provider is not configured"
       raise StandardError.new("Brex provider is not configured")
     end
 
-    BrexItem::Importer.new(self, brex_provider: provider).import
+    BrexItem::Importer.new(self, brex_provider: provider, sync_start_date: sync_start_date).import
   rescue => e
     Rails.logger.error "BrexItem #{id} - Failed to import data: #{e.message}"
     raise

--- a/app/models/brex_item.rb
+++ b/app/models/brex_item.rb
@@ -100,11 +100,11 @@ class BrexItem < ApplicationRecord
     unlinked_count = unlinked_accounts_count
 
     if total_accounts == 0
-      "No accounts found"
+      I18n.t("brex_items.sync_status.no_accounts")
     elsif unlinked_count == 0
-      "#{linked_count} #{'account'.pluralize(linked_count)} synced"
+      I18n.t("brex_items.sync_status.all_synced", count: linked_count)
     else
-      "#{linked_count} synced, #{unlinked_count} need setup"
+      I18n.t("brex_items.sync_status.partial_setup", synced: linked_count, pending: unlinked_count)
     end
   end
 
@@ -135,11 +135,14 @@ class BrexItem < ApplicationRecord
     institutions = connected_institutions
     case institutions.count
     when 0
-      "No institutions connected"
+      I18n.t("brex_items.institution_summary.none")
     when 1
-      institutions.first["name"] || institutions.first["institution_name"] || "1 institution"
+      name = institutions.first["name"] ||
+             institutions.first["institution_name"] ||
+             I18n.t("brex_items.institution_summary.count", count: 1)
+      I18n.t("brex_items.institution_summary.one", name: name)
     else
-      "#{institutions.count} institutions"
+      I18n.t("brex_items.institution_summary.count", count: institutions.count)
     end
   end
 

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -113,6 +113,10 @@ class BrexItem::AccountFlow
     navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.no_api_token"))
   rescue Provider::Brex::BrexError => e
     navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.api_error", message: e.message))
+  rescue StandardError => e
+    Rails.logger.error("Brex account linking failed: #{e.class} - #{e.message}")
+    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
+    navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.api_error", message: e.message))
   end
 
   def link_existing_account_result(account:, brex_account_id:)
@@ -132,6 +136,10 @@ class BrexItem::AccountFlow
   rescue AccountAlreadyLinkedError
     navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.brex_account_already_linked"))
   rescue Provider::Brex::BrexError => e
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.api_error", message: e.message))
+  rescue StandardError => e
+    Rails.logger.error("Brex existing account linking failed: #{e.class} - #{e.message}")
+    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
     navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.api_error", message: e.message))
   end
 
@@ -294,6 +302,11 @@ class BrexItem::AccountFlow
 
     failed_count = 0
 
+    submitted_brex_accounts = brex_item.brex_accounts
+                                    .where(id: account_types.keys)
+                                    .includes(:account_provider)
+                                    .index_by { |brex_account| brex_account.id.to_s }
+
     account_types.each do |brex_account_id, selected_type|
       if selected_type == "skip" || selected_type.blank?
         skipped_count += 1
@@ -306,7 +319,7 @@ class BrexItem::AccountFlow
         next
       end
 
-      brex_account = brex_item.brex_accounts.find_by(id: brex_account_id)
+      brex_account = submitted_brex_accounts[brex_account_id.to_s]
       unless brex_account
         Rails.logger.warn("Brex account #{brex_account_id} not found for item #{brex_item.id}")
         next

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -104,6 +104,7 @@ class BrexItem::AccountFlow
 
   def link_new_accounts_result(account_ids:, accountable_type:)
     return navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.no_accounts_selected")) if account_ids.blank?
+    return navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.invalid_account_type")) unless supported_account_type?(accountable_type)
     return navigation(:settings_providers, :alert, I18n.t("brex_items.link_accounts.select_connection")) unless selected?
 
     link_navigation_result(link_new_accounts!(account_ids: account_ids, accountable_type: accountable_type))
@@ -134,6 +135,8 @@ class BrexItem::AccountFlow
   end
 
   def link_new_accounts!(account_ids:, accountable_type:)
+    raise ArgumentError, "Unsupported Brex account type: #{accountable_type}" unless supported_account_type?(accountable_type)
+
     created_accounts = []
     already_linked_names = []
     invalid_account_ids = []
@@ -192,10 +195,15 @@ class BrexItem::AccountFlow
     account_name = BrexAccount.name_for(account_data)
     raise InvalidAccountNameError if account_name.blank?
 
-    brex_account = upsert_brex_account!(brex_account_id, account_data)
-    raise AccountAlreadyLinkedError if brex_account.account_provider.present?
+    brex_account = nil
 
-    AccountProvider.create!(account: account, provider: brex_account)
+    ActiveRecord::Base.transaction do
+      brex_account = upsert_brex_account!(brex_account_id, account_data)
+      raise AccountAlreadyLinkedError if brex_account.account_provider.present?
+
+      AccountProvider.create!(account: account, provider: brex_account)
+    end
+
     brex_item.sync_later
 
     brex_account
@@ -293,6 +301,7 @@ class BrexItem::AccountFlow
 
       unless valid_types.include?(selected_type)
         Rails.logger.warn("Invalid account type '#{selected_type}' submitted for Brex account #{brex_account_id}")
+        skipped_count += 1
         next
       end
 
@@ -341,7 +350,7 @@ class BrexItem::AccountFlow
     SetupResult.new(created_accounts: created_accounts, skipped_count: skipped_count, failed_count: failed_count)
   end
 
-  def import_accounts_error_message
+  def import_accounts_with_user_facing_error
     import_accounts_from_api_if_needed
   rescue NoApiTokenError
     I18n.t("brex_items.setup_accounts.no_api_token")
@@ -509,6 +518,8 @@ class BrexItem::AccountFlow
     def setup_notice(result)
       if result.failed_count.positive? && result.created_count.positive?
         I18n.t("brex_items.complete_account_setup.partial_success", created_count: result.created_count, failed_count: result.failed_count)
+      elsif result.skipped_count.positive? && result.created_count.positive?
+        I18n.t("brex_items.complete_account_setup.partial_skipped", created_count: result.created_count, skipped_count: result.skipped_count)
       elsif result.failed_count.positive?
         I18n.t("brex_items.complete_account_setup.creation_failed_count", count: result.failed_count)
       elsif result.created_count.positive?
@@ -582,8 +593,11 @@ class BrexItem::AccountFlow
     def upsert_brex_account!(account_id, account_data)
       brex_account = brex_item.brex_accounts.find_or_initialize_by(account_id: account_id.to_s)
       brex_account.upsert_brex_snapshot!(account_data)
-      brex_account.save!
       brex_account
+    end
+
+    def supported_account_type?(accountable_type)
+      Provider::BrexAdapter.supported_account_types.include?(accountable_type)
     end
 
     def brex_account_snapshot_changed?(brex_account, account_data)

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -69,7 +69,7 @@ class BrexItem::AccountFlow
     return { success: false, error: "no_credentials", has_accounts: false } unless brex_item&.credentials_configured?
 
     cached_accounts = Rails.cache.read(cache_key)
-    return { success: true, has_accounts: cached_accounts.any?, cached: true } if cached_accounts.present?
+    return { success: true, has_accounts: cached_accounts.any?, cached: true } unless cached_accounts.nil?
 
     available_accounts = fetch_accounts
     Rails.cache.write(cache_key, available_accounts, expires_in: CACHE_TTL)
@@ -221,39 +221,41 @@ class BrexItem::AccountFlow
     invalid_account_ids = []
     accounts_by_id = indexed_accounts
 
-    account_ids.each do |account_id|
-      account_data = accounts_by_id[account_id.to_s]
-      next unless account_data
+    ActiveRecord::Base.transaction do
+      account_ids.each do |account_id|
+        account_data = accounts_by_id[account_id.to_s]
+        next unless account_data
 
-      account_name = BrexAccount.name_for(account_data)
+        account_name = BrexAccount.name_for(account_data)
 
-      if account_name.blank?
-        invalid_account_ids << account_id
-        Rails.logger.warn "BrexItem::AccountFlow - Skipping account #{account_id} with blank name"
-        next
+        if account_name.blank?
+          invalid_account_ids << account_id
+          Rails.logger.warn "BrexItem::AccountFlow - Skipping account #{account_id} with blank name"
+          next
+        end
+
+        brex_account = upsert_brex_account!(account_id, account_data)
+
+        if brex_account.account_provider.present?
+          already_linked_names << account_name
+          next
+        end
+
+        account = Account.create_and_sync(
+          {
+            family: family,
+            name: account_name,
+            balance: 0,
+            currency: BrexAccount.currency_for(account_data),
+            accountable_type: accountable_type,
+            accountable_attributes: BrexAccount.default_accountable_attributes(accountable_type)
+          },
+          skip_initial_sync: true
+        )
+
+        AccountProvider.create!(account: account, provider: brex_account)
+        created_accounts << account
       end
-
-      brex_account = upsert_brex_account!(account_id, account_data)
-
-      if brex_account.account_provider.present?
-        already_linked_names << account_name
-        next
-      end
-
-      account = Account.create_and_sync(
-        {
-          family: family,
-          name: account_name,
-          balance: 0,
-          currency: BrexAccount.currency_for(account_data),
-          accountable_type: accountable_type,
-          accountable_attributes: BrexAccount.default_accountable_attributes(accountable_type)
-        },
-        skip_initial_sync: true
-      )
-
-      AccountProvider.create!(account: account, provider: brex_account)
-      created_accounts << account
     end
 
     brex_item.sync_later if created_accounts.any?
@@ -575,7 +577,10 @@ class BrexItem::AccountFlow
     end
 
     def unlinked_available_accounts
-      linked_account_ids = brex_item.brex_accounts.joins(:account_provider).pluck(:account_id).map(&:to_s)
+      linked_account_ids = brex_item.brex_accounts
+                                   .joins(:account_provider)
+                                   .pluck("#{BrexAccount.table_name}.account_id")
+                                   .map(&:to_s)
       accounts.reject { |account| linked_account_ids.include?(account.with_indifferent_access[:id].to_s) }
     end
 

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -68,8 +68,9 @@ class BrexItem::AccountFlow
     return selection_error_payload if !selected?
     return { success: false, error: "no_credentials", has_accounts: false } unless brex_item&.credentials_configured?
 
-    cached = Rails.cache.exist?(cache_key)
-    available_accounts = accounts
+    cached_accounts = Rails.cache.read(cache_key)
+    cached = !cached_accounts.nil?
+    available_accounts = cached ? cached_accounts : fetch_and_cache_accounts
 
     { success: true, has_accounts: available_accounts.any?, cached: cached }
   rescue NoApiTokenError
@@ -558,6 +559,10 @@ class BrexItem::AccountFlow
       cached_accounts = Rails.cache.read(cache_key)
       return cached_accounts unless cached_accounts.nil?
 
+      fetch_and_cache_accounts
+    end
+
+    def fetch_and_cache_accounts
       available_accounts = fetch_accounts
       Rails.cache.write(cache_key, available_accounts, expires_in: CACHE_TTL)
       available_accounts

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -1,0 +1,339 @@
+# frozen_string_literal: true
+
+class BrexItem::AccountFlow
+  CACHE_TTL = 5.minutes
+
+  class NoApiTokenError < StandardError; end
+  class AccountNotFoundError < StandardError; end
+  class InvalidAccountNameError < StandardError; end
+  class AccountAlreadyLinkedError < StandardError; end
+
+  LinkAccountsResult = Data.define(:created_accounts, :already_linked_names, :invalid_account_ids) do
+    def created_count = created_accounts.count
+    def already_linked_count = already_linked_names.count
+    def invalid_count = invalid_account_ids.count
+  end
+
+  SetupResult = Data.define(:created_accounts, :skipped_count) do
+    def created_count = created_accounts.count
+  end
+
+  attr_reader :family, :brex_item_id, :brex_item, :credentialed_items
+
+  def initialize(family:, brex_item_id: nil, brex_item: nil)
+    @family = family
+    @brex_item_id = brex_item_id
+    @credentialed_items = family.brex_items.active.ordered.select(&:credentials_configured?)
+    @brex_item = brex_item || resolve_brex_item
+  end
+
+  def self.cache_key(family, brex_item)
+    "brex_accounts_#{family.id}_#{brex_item.id}"
+  end
+
+  def self.cache_sensitive_update?(permitted_params)
+    permitted_params.key?(:token) || permitted_params.key?(:base_url)
+  end
+
+  def selected?
+    brex_item.present?
+  end
+
+  def selection_required?
+    credentialed_items.count > 1 && brex_item_id.blank?
+  end
+
+  def preload_payload
+    return { success: false, error: "no_credentials", has_accounts: false } unless brex_item&.credentials_configured?
+
+    cached_accounts = Rails.cache.read(cache_key)
+    return { success: true, has_accounts: cached_accounts.any?, cached: true } if cached_accounts.present?
+
+    available_accounts = fetch_accounts
+    Rails.cache.write(cache_key, available_accounts, expires_in: CACHE_TTL)
+
+    { success: true, has_accounts: available_accounts.any?, cached: false }
+  end
+
+  def available_accounts(accountable_type:)
+    filter_accounts(unlinked_available_accounts, accountable_type)
+  end
+
+  def available_accounts_for_existing(account:)
+    filter_accounts(unlinked_available_accounts, account.accountable_type)
+  end
+
+  def link_new_accounts!(account_ids:, accountable_type:)
+    created_accounts = []
+    already_linked_names = []
+    invalid_account_ids = []
+    accounts_by_id = indexed_accounts
+
+    account_ids.each do |account_id|
+      account_data = accounts_by_id[account_id.to_s]
+      next unless account_data
+
+      account_name = BrexAccount.name_for(account_data)
+
+      if account_name.blank?
+        invalid_account_ids << account_id
+        Rails.logger.warn "BrexItem::AccountFlow - Skipping account #{account_id} with blank name"
+        next
+      end
+
+      brex_account = upsert_brex_account!(account_id, account_data)
+
+      if brex_account.account_provider.present?
+        already_linked_names << account_name
+        next
+      end
+
+      account = Account.create_and_sync(
+        {
+          family: family,
+          name: account_name,
+          balance: 0,
+          currency: BrexAccount.currency_for(account_data),
+          accountable_type: accountable_type,
+          accountable_attributes: BrexAccount.default_accountable_attributes(accountable_type)
+        },
+        skip_initial_sync: true
+      )
+
+      AccountProvider.create!(account: account, provider: brex_account)
+      created_accounts << account
+    end
+
+    brex_item.sync_later if created_accounts.any?
+
+    LinkAccountsResult.new(
+      created_accounts: created_accounts,
+      already_linked_names: already_linked_names,
+      invalid_account_ids: invalid_account_ids
+    )
+  end
+
+  def link_existing_account!(account:, brex_account_id:)
+    account_data = indexed_accounts[brex_account_id.to_s]
+    raise AccountNotFoundError unless account_data
+
+    account_name = BrexAccount.name_for(account_data)
+    raise InvalidAccountNameError if account_name.blank?
+
+    brex_account = upsert_brex_account!(brex_account_id, account_data)
+    raise AccountAlreadyLinkedError if brex_account.account_provider.present?
+
+    AccountProvider.create!(account: account, provider: brex_account)
+    brex_item.sync_later
+
+    brex_account
+  end
+
+  def import_accounts_from_api_if_needed
+    return nil unless brex_item.brex_accounts.empty?
+    raise NoApiTokenError unless brex_item.credentials_configured?
+
+    available_accounts = fetch_accounts
+    return nil if available_accounts.empty?
+
+    available_accounts.each do |account_data|
+      account_name = BrexAccount.name_for(account_data)
+      next if account_name.blank?
+
+      upsert_brex_account!(account_data.with_indifferent_access[:id], account_data)
+    end
+
+    nil
+  end
+
+  def unlinked_brex_accounts
+    brex_item.brex_accounts
+             .left_joins(:account_provider)
+             .where(account_providers: { id: nil })
+  end
+
+  def account_type_options
+    supported_types = Provider::BrexAdapter.supported_account_types
+    account_type_keys = {
+      "depository" => "Depository",
+      "credit_card" => "CreditCard",
+      "investment" => "Investment",
+      "loan" => "Loan",
+      "other_asset" => "OtherAsset"
+    }
+
+    options = account_type_keys.filter_map do |key, type|
+      next unless supported_types.include?(type)
+
+      [ I18n.t("brex_items.setup_accounts.account_types.#{key}"), type ]
+    end
+
+    [ [ I18n.t("brex_items.setup_accounts.account_types.skip"), "skip" ] ] + options
+  end
+
+  def subtype_options
+    supported_types = Provider::BrexAdapter.supported_account_types
+    all_subtype_options = {
+      "Depository" => {
+        label: I18n.t("brex_items.setup_accounts.subtype_labels.depository"),
+        options: translate_subtypes("depository", Depository::SUBTYPES)
+      },
+      "CreditCard" => {
+        label: I18n.t("brex_items.setup_accounts.subtype_labels.credit_card"),
+        options: [],
+        message: I18n.t("brex_items.setup_accounts.subtype_messages.credit_card")
+      },
+      "Investment" => {
+        label: I18n.t("brex_items.setup_accounts.subtype_labels.investment"),
+        options: translate_subtypes("investment", Investment::SUBTYPES)
+      },
+      "Loan" => {
+        label: I18n.t("brex_items.setup_accounts.subtype_labels.loan"),
+        options: translate_subtypes("loan", Loan::SUBTYPES)
+      },
+      "OtherAsset" => {
+        label: I18n.t("brex_items.setup_accounts.subtype_labels.other_asset").presence,
+        options: [],
+        message: I18n.t("brex_items.setup_accounts.subtype_messages.other_asset")
+      }
+    }
+
+    all_subtype_options.slice(*supported_types)
+  end
+
+  def complete_setup!(account_types:, account_subtypes:)
+    created_accounts = []
+    skipped_count = 0
+    valid_types = Provider::BrexAdapter.supported_account_types
+
+    ActiveRecord::Base.transaction do
+      account_types.each do |brex_account_id, selected_type|
+        if selected_type == "skip" || selected_type.blank?
+          skipped_count += 1
+          next
+        end
+
+        unless valid_types.include?(selected_type)
+          Rails.logger.warn("Invalid account type '#{selected_type}' submitted for Brex account #{brex_account_id}")
+          next
+        end
+
+        brex_account = brex_item.brex_accounts.find_by(id: brex_account_id)
+        unless brex_account
+          Rails.logger.warn("Brex account #{brex_account_id} not found for item #{brex_item.id}")
+          next
+        end
+
+        if brex_account.account_provider.present?
+          Rails.logger.info("Brex account #{brex_account_id} already linked, skipping")
+          next
+        end
+
+        selected_subtype = selected_subtype_for(
+          selected_type: selected_type,
+          submitted_subtype: account_subtypes[brex_account_id]
+        )
+
+        account = Account.create_and_sync(
+          {
+            family: family,
+            name: brex_account.name,
+            balance: brex_account.current_balance || 0,
+            currency: brex_account.currency.presence || family.currency,
+            accountable_type: selected_type,
+            accountable_attributes: selected_subtype.present? ? { subtype: selected_subtype } : {}
+          },
+          skip_initial_sync: true
+        )
+
+        AccountProvider.create!(account: account, provider: brex_account)
+        created_accounts << account
+      end
+    end
+
+    brex_item.sync_later if created_accounts.any?
+
+    SetupResult.new(created_accounts: created_accounts, skipped_count: skipped_count)
+  end
+
+  private
+
+    def resolve_brex_item
+      if brex_item_id.present?
+        item = family.brex_items.active.find_by(id: brex_item_id)
+        return item if item&.credentials_configured?
+
+        return nil
+      end
+
+      credentialed_items.first if credentialed_items.one?
+    end
+
+    def cache_key
+      self.class.cache_key(family, brex_item)
+    end
+
+    def fetch_accounts
+      provider = brex_item&.brex_provider
+      raise NoApiTokenError unless provider.present?
+
+      accounts_data = provider.get_accounts
+      accounts_data[:accounts] || []
+    end
+
+    def accounts
+      cached_accounts = Rails.cache.read(cache_key)
+      return cached_accounts unless cached_accounts.nil?
+
+      available_accounts = fetch_accounts
+      Rails.cache.write(cache_key, available_accounts, expires_in: CACHE_TTL)
+      available_accounts
+    end
+
+    def unlinked_available_accounts
+      linked_account_ids = brex_item.brex_accounts.joins(:account_provider).pluck(:account_id).map(&:to_s)
+      accounts.reject { |account| linked_account_ids.include?(account.with_indifferent_access[:id].to_s) }
+    end
+
+    def filter_accounts(accounts, accountable_type)
+      return [] unless Provider::BrexAdapter.supported_account_types.include?(accountable_type)
+
+      accounts.select do |account|
+        case accountable_type
+        when "CreditCard"
+          BrexAccount.kind_for(account) == "card"
+        when "Depository"
+          BrexAccount.kind_for(account) == "cash"
+        else
+          true
+        end
+      end
+    end
+
+    def indexed_accounts
+      accounts.index_by { |account| account.with_indifferent_access[:id].to_s }
+    end
+
+    def upsert_brex_account!(account_id, account_data)
+      brex_account = brex_item.brex_accounts.find_or_initialize_by(account_id: account_id.to_s)
+      brex_account.upsert_brex_snapshot!(account_data)
+      brex_account.save!
+      brex_account
+    end
+
+    def translate_subtypes(type_key, subtypes_hash)
+      subtypes_hash.map do |key, value|
+        [
+          I18n.t("brex_items.setup_accounts.subtypes.#{type_key}.#{key}", default: value[:long] || key.to_s.humanize),
+          key
+        ]
+      end
+    end
+
+    def selected_subtype_for(selected_type:, submitted_subtype:)
+      return "credit_card" if selected_type == "CreditCard" && submitted_subtype.blank?
+      return "checking" if selected_type == "Depository" && submitted_subtype.blank?
+
+      submitted_subtype
+    end
+end

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -22,7 +22,7 @@ class BrexItem::AccountFlow
     def invalid_count = invalid_account_ids.count
   end
 
-  SetupResult = Data.define(:created_accounts, :skipped_count) do
+  SetupResult = Data.define(:created_accounts, :skipped_count, :failed_count) do
     def created_count = created_accounts.count
   end
 
@@ -35,7 +35,7 @@ class BrexItem::AccountFlow
   def initialize(family:, brex_item_id: nil, brex_item: nil)
     @family = family
     @brex_item_id = brex_item_id
-    @credentialed_items = family.brex_items.active.ordered.select(&:credentials_configured?)
+    @credentialed_items = family.brex_items.active.with_credentials.ordered.select(&:credentials_configured?)
     @brex_item = brex_item || resolve_brex_item
   end
 
@@ -68,13 +68,10 @@ class BrexItem::AccountFlow
     return selection_error_payload if !selected?
     return { success: false, error: "no_credentials", has_accounts: false } unless brex_item&.credentials_configured?
 
-    cached_accounts = Rails.cache.read(cache_key)
-    return { success: true, has_accounts: cached_accounts.any?, cached: true } unless cached_accounts.nil?
+    cached = Rails.cache.exist?(cache_key)
+    available_accounts = accounts
 
-    available_accounts = fetch_accounts
-    Rails.cache.write(cache_key, available_accounts, expires_in: CACHE_TTL)
-
-    { success: true, has_accounts: available_accounts.any?, cached: false }
+    { success: true, has_accounts: available_accounts.any?, cached: cached }
   rescue NoApiTokenError
     { success: false, error: "no_api_token", has_accounts: false }
   rescue Provider::Brex::BrexError => e
@@ -86,101 +83,22 @@ class BrexItem::AccountFlow
   end
 
   def select_accounts_result(accountable_type:)
-    return selection_failure_result("brex_items.select_accounts") unless selected?
-
-    accounts = filter_accounts(unlinked_available_accounts, accountable_type)
-    if accounts.empty?
-      return SelectionResult.new(
-        status: :empty,
-        brex_item: brex_item,
-        available_accounts: [],
-        accountable_type: accountable_type,
-        message: I18n.t("brex_items.select_accounts.no_accounts_found")
-      )
-    end
-
-    SelectionResult.new(
-      status: :success,
-      brex_item: brex_item,
-      available_accounts: accounts,
+    selection_result_for(
+      scope: "brex_items.select_accounts",
       accountable_type: accountable_type,
-      message: nil
-    )
-  rescue NoApiTokenError
-    SelectionResult.new(
-      status: :no_api_token,
-      brex_item: brex_item,
-      available_accounts: [],
-      accountable_type: accountable_type,
-      message: I18n.t("brex_items.select_accounts.no_api_token")
-    )
-  rescue Provider::Brex::BrexError => e
-    Rails.logger.error("Brex API error in select_accounts: #{e.message}")
-    SelectionResult.new(
-      status: :api_error,
-      brex_item: brex_item,
-      available_accounts: [],
-      accountable_type: accountable_type,
-      message: e.message
-    )
-  rescue StandardError => e
-    Rails.logger.error("Unexpected error in select_accounts: #{e.class}: #{e.message}")
-    SelectionResult.new(
-      status: :unexpected_error,
-      brex_item: brex_item,
-      available_accounts: [],
-      accountable_type: accountable_type,
-      message: I18n.t("brex_items.select_accounts.unexpected_error")
+      empty_message_key: "no_accounts_found",
+      log_context: "select_accounts"
     )
   end
 
   def select_existing_account_result(account:)
     return linked_account_result if account.account_providers.exists?
-    return selection_failure_result("brex_items.select_existing_account", accountable_type: account.accountable_type) unless selected?
 
-    accounts = filter_accounts(unlinked_available_accounts, account.accountable_type)
-    if accounts.empty?
-      return SelectionResult.new(
-        status: :empty,
-        brex_item: brex_item,
-        available_accounts: [],
-        accountable_type: account.accountable_type,
-        message: I18n.t("brex_items.select_existing_account.all_accounts_already_linked")
-      )
-    end
-
-    SelectionResult.new(
-      status: :success,
-      brex_item: brex_item,
-      available_accounts: accounts,
+    selection_result_for(
+      scope: "brex_items.select_existing_account",
       accountable_type: account.accountable_type,
-      message: nil
-    )
-  rescue NoApiTokenError
-    SelectionResult.new(
-      status: :no_api_token,
-      brex_item: brex_item,
-      available_accounts: [],
-      accountable_type: account.accountable_type,
-      message: I18n.t("brex_items.select_existing_account.no_api_token")
-    )
-  rescue Provider::Brex::BrexError => e
-    Rails.logger.error("Brex API error in select_existing_account: #{e.message}")
-    SelectionResult.new(
-      status: :api_error,
-      brex_item: brex_item,
-      available_accounts: [],
-      accountable_type: account.accountable_type,
-      message: e.message
-    )
-  rescue StandardError => e
-    Rails.logger.error("Unexpected error in select_existing_account: #{e.class}: #{e.message}")
-    SelectionResult.new(
-      status: :unexpected_error,
-      brex_item: brex_item,
-      available_accounts: [],
-      accountable_type: account.accountable_type,
-      message: I18n.t("brex_items.select_existing_account.unexpected_error")
+      empty_message_key: "all_accounts_already_linked",
+      log_context: "select_existing_account"
     )
   end
 
@@ -284,17 +202,22 @@ class BrexItem::AccountFlow
   end
 
   def import_accounts_from_api_if_needed
-    return nil unless brex_item.brex_accounts.empty?
     raise NoApiTokenError unless brex_item.credentials_configured?
 
     available_accounts = fetch_accounts
     return nil if available_accounts.empty?
 
-    available_accounts.each do |account_data|
-      account_name = BrexAccount.name_for(account_data)
-      next if account_name.blank?
+    existing_accounts = brex_item.brex_accounts.index_by(&:account_id)
 
-      upsert_brex_account!(account_data.with_indifferent_access[:id], account_data)
+    available_accounts.each do |account_data|
+      account_id = account_data.with_indifferent_access[:id].to_s
+      account_name = BrexAccount.name_for(account_data)
+      next if account_id.blank? || account_name.blank?
+
+      brex_account = existing_accounts[account_id]
+      next if brex_account.present? && !brex_account_snapshot_changed?(brex_account, account_data)
+
+      upsert_brex_account!(account_id, account_data)
     end
 
     nil
@@ -360,54 +283,62 @@ class BrexItem::AccountFlow
     skipped_count = 0
     valid_types = Provider::BrexAdapter.supported_account_types
 
-    ActiveRecord::Base.transaction do
-      account_types.each do |brex_account_id, selected_type|
-        if selected_type == "skip" || selected_type.blank?
-          skipped_count += 1
-          next
+    failed_count = 0
+
+    account_types.each do |brex_account_id, selected_type|
+      if selected_type == "skip" || selected_type.blank?
+        skipped_count += 1
+        next
+      end
+
+      unless valid_types.include?(selected_type)
+        Rails.logger.warn("Invalid account type '#{selected_type}' submitted for Brex account #{brex_account_id}")
+        next
+      end
+
+      brex_account = brex_item.brex_accounts.find_by(id: brex_account_id)
+      unless brex_account
+        Rails.logger.warn("Brex account #{brex_account_id} not found for item #{brex_item.id}")
+        next
+      end
+
+      if brex_account.account_provider.present?
+        Rails.logger.info("Brex account #{brex_account_id} already linked, skipping")
+        next
+      end
+
+      selected_subtype = selected_subtype_for(
+        selected_type: selected_type,
+        submitted_subtype: account_subtypes[brex_account_id]
+      )
+
+      begin
+        ActiveRecord::Base.transaction do
+          account = Account.create_and_sync(
+            {
+              family: family,
+              name: brex_account.name,
+              balance: brex_account.current_balance || 0,
+              currency: brex_account.currency.presence || family.currency,
+              accountable_type: selected_type,
+              accountable_attributes: selected_subtype.present? ? { subtype: selected_subtype } : {}
+            },
+            skip_initial_sync: true
+          )
+
+          AccountProvider.create!(account: account, provider: brex_account)
+          created_accounts << account
         end
-
-        unless valid_types.include?(selected_type)
-          Rails.logger.warn("Invalid account type '#{selected_type}' submitted for Brex account #{brex_account_id}")
-          next
-        end
-
-        brex_account = brex_item.brex_accounts.find_by(id: brex_account_id)
-        unless brex_account
-          Rails.logger.warn("Brex account #{brex_account_id} not found for item #{brex_item.id}")
-          next
-        end
-
-        if brex_account.account_provider.present?
-          Rails.logger.info("Brex account #{brex_account_id} already linked, skipping")
-          next
-        end
-
-        selected_subtype = selected_subtype_for(
-          selected_type: selected_type,
-          submitted_subtype: account_subtypes[brex_account_id]
-        )
-
-        account = Account.create_and_sync(
-          {
-            family: family,
-            name: brex_account.name,
-            balance: brex_account.current_balance || 0,
-            currency: brex_account.currency.presence || family.currency,
-            accountable_type: selected_type,
-            accountable_attributes: selected_subtype.present? ? { subtype: selected_subtype } : {}
-          },
-          skip_initial_sync: true
-        )
-
-        AccountProvider.create!(account: account, provider: brex_account)
-        created_accounts << account
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+        failed_count += 1
+        Rails.logger.error("Brex account setup failed for #{brex_account_id}: #{e.class} - #{e.message}")
+        Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
       end
     end
 
     brex_item.sync_later if created_accounts.any?
 
-    SetupResult.new(created_accounts: created_accounts, skipped_count: skipped_count)
+    SetupResult.new(created_accounts: created_accounts, skipped_count: skipped_count, failed_count: failed_count)
   end
 
   def import_accounts_error_message
@@ -425,7 +356,7 @@ class BrexItem::AccountFlow
   def complete_setup_result(account_types:, account_subtypes:)
     result = complete_setup!(account_types: account_types, account_subtypes: account_subtypes)
 
-    SetupCompletion.new(success: true, message: setup_notice(result))
+    SetupCompletion.new(success: result.failed_count.zero? || result.created_count.positive?, message: setup_notice(result))
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
     Rails.logger.error("Brex account setup failed: #{e.class} - #{e.message}")
     Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
@@ -476,6 +407,47 @@ class BrexItem::AccountFlow
           message: I18n.t("#{scope}.no_credentials_configured")
         )
       end
+    end
+
+    def selection_result_for(scope:, accountable_type:, empty_message_key:, log_context:)
+      return selection_failure_result(scope, accountable_type: accountable_type) unless selected?
+
+      available_accounts = filter_accounts(unlinked_available_accounts, accountable_type)
+      if available_accounts.empty?
+        return selection_result(
+          status: :empty,
+          accountable_type: accountable_type,
+          message: I18n.t("#{scope}.#{empty_message_key}")
+        )
+      end
+
+      selection_result(status: :success, accountable_type: accountable_type, available_accounts: available_accounts)
+    rescue NoApiTokenError
+      selection_result(
+        status: :no_api_token,
+        accountable_type: accountable_type,
+        message: I18n.t("#{scope}.no_api_token")
+      )
+    rescue Provider::Brex::BrexError => e
+      Rails.logger.error("Brex API error in #{log_context}: #{e.message}")
+      selection_result(status: :api_error, accountable_type: accountable_type, message: e.message)
+    rescue StandardError => e
+      Rails.logger.error("Unexpected error in #{log_context}: #{e.class}: #{e.message}")
+      selection_result(
+        status: :unexpected_error,
+        accountable_type: accountable_type,
+        message: I18n.t("#{scope}.unexpected_error")
+      )
+    end
+
+    def selection_result(status:, accountable_type:, available_accounts: [], message: nil)
+      SelectionResult.new(
+        status: status,
+        brex_item: brex_item,
+        available_accounts: available_accounts,
+        accountable_type: accountable_type,
+        message: message
+      )
     end
 
     def linked_account_result
@@ -535,7 +507,11 @@ class BrexItem::AccountFlow
     end
 
     def setup_notice(result)
-      if result.created_count.positive?
+      if result.failed_count.positive? && result.created_count.positive?
+        I18n.t("brex_items.complete_account_setup.partial_success", created_count: result.created_count, failed_count: result.failed_count)
+      elsif result.failed_count.positive?
+        I18n.t("brex_items.complete_account_setup.creation_failed_count", count: result.failed_count)
+      elsif result.created_count.positive?
         I18n.t("brex_items.complete_account_setup.success", count: result.created_count)
       elsif result.skipped_count.positive?
         I18n.t("brex_items.complete_account_setup.all_skipped")
@@ -610,6 +586,25 @@ class BrexItem::AccountFlow
       brex_account
     end
 
+    def brex_account_snapshot_changed?(brex_account, account_data)
+      snapshot = account_data.with_indifferent_access
+      balances = snapshot.slice(:current_balance, :available_balance, :account_limit)
+
+      expected = {
+        account_kind: BrexAccount.kind_for(snapshot),
+        account_status: snapshot[:status],
+        account_type: snapshot[:type],
+        available_balance: BrexAccount.money_to_decimal(balances[:available_balance]),
+        current_balance: BrexAccount.money_to_decimal(balances[:current_balance]),
+        account_limit: BrexAccount.money_to_decimal(balances[:account_limit]),
+        currency: BrexAccount.currency_code_from_money(balances[:current_balance] || balances[:available_balance] || balances[:account_limit]),
+        name: BrexAccount.name_for(snapshot),
+        raw_payload: BrexAccount.sanitize_payload(account_data)
+      }
+
+      expected.any? { |attribute, value| brex_account.public_send(attribute) != value }
+    end
+
     def translate_subtypes(type_key, subtypes_hash)
       subtypes_hash.map do |key, value|
         [
@@ -620,8 +615,8 @@ class BrexItem::AccountFlow
     end
 
     def selected_subtype_for(selected_type:, submitted_subtype:)
-      return "credit_card" if selected_type == "CreditCard" && submitted_subtype.blank?
-      return "checking" if selected_type == "Depository" && submitted_subtype.blank?
+      return CreditCard::DEFAULT_SUBTYPE if selected_type == "CreditCard" && submitted_subtype.blank?
+      return Depository::DEFAULT_SUBTYPE if selected_type == "Depository" && submitted_subtype.blank?
 
       submitted_subtype
     end

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -116,7 +116,7 @@ class BrexItem::AccountFlow
   rescue StandardError => e
     Rails.logger.error("Brex account linking failed: #{e.class} - #{e.message}")
     Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
-    navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.api_error", message: e.message))
+    navigation(:new_account, :alert, I18n.t("brex_items.errors.unexpected_error"))
   end
 
   def link_existing_account_result(account:, brex_account_id:)
@@ -130,17 +130,17 @@ class BrexItem::AccountFlow
   rescue NoApiTokenError
     navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.no_api_token"))
   rescue AccountNotFoundError
-    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.brex_account_not_found"))
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.provider_account_not_found"))
   rescue InvalidAccountNameError
     navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.invalid_account_name"))
   rescue AccountAlreadyLinkedError
-    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.brex_account_already_linked"))
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.provider_account_already_linked"))
   rescue Provider::Brex::BrexError => e
     navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.api_error", message: e.message))
   rescue StandardError => e
     Rails.logger.error("Brex existing account linking failed: #{e.class} - #{e.message}")
     Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
-    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.api_error", message: e.message))
+    navigation(:accounts, :alert, I18n.t("brex_items.errors.unexpected_error"))
   end
 
   def link_new_accounts!(account_ids:, accountable_type:)

--- a/app/models/brex_item/account_flow.rb
+++ b/app/models/brex_item/account_flow.rb
@@ -8,6 +8,14 @@ class BrexItem::AccountFlow
   class InvalidAccountNameError < StandardError; end
   class AccountAlreadyLinkedError < StandardError; end
 
+  NavigationResult = Data.define(:target, :flash_type, :message)
+
+  SelectionResult = Data.define(:status, :brex_item, :available_accounts, :accountable_type, :message) do
+    def success? = status == :success
+    def setup_required? = status == :setup_required
+    def provider_error? = status.in?([ :api_error, :unexpected_error ])
+  end
+
   LinkAccountsResult = Data.define(:created_accounts, :already_linked_names, :invalid_account_ids) do
     def created_count = created_accounts.count
     def already_linked_count = already_linked_names.count
@@ -16,6 +24,10 @@ class BrexItem::AccountFlow
 
   SetupResult = Data.define(:created_accounts, :skipped_count) do
     def created_count = created_accounts.count
+  end
+
+  SetupCompletion = Data.define(:success, :message) do
+    def success? = success
   end
 
   attr_reader :family, :brex_item_id, :brex_item, :credentialed_items
@@ -35,6 +47,15 @@ class BrexItem::AccountFlow
     permitted_params.key?(:token) || permitted_params.key?(:base_url)
   end
 
+  def self.update_item_with_cache_expiration(brex_item, family:, attributes:)
+    expire_accounts_cache = cache_sensitive_update?(attributes)
+    updated = brex_item.update(attributes)
+
+    Rails.cache.delete(cache_key(family, brex_item)) if updated && expire_accounts_cache
+
+    updated
+  end
+
   def selected?
     brex_item.present?
   end
@@ -44,6 +65,7 @@ class BrexItem::AccountFlow
   end
 
   def preload_payload
+    return selection_error_payload if !selected?
     return { success: false, error: "no_credentials", has_accounts: false } unless brex_item&.credentials_configured?
 
     cached_accounts = Rails.cache.read(cache_key)
@@ -53,14 +75,144 @@ class BrexItem::AccountFlow
     Rails.cache.write(cache_key, available_accounts, expires_in: CACHE_TTL)
 
     { success: true, has_accounts: available_accounts.any?, cached: false }
+  rescue NoApiTokenError
+    { success: false, error: "no_api_token", has_accounts: false }
+  rescue Provider::Brex::BrexError => e
+    Rails.logger.error("Brex preload error: #{e.message}")
+    { success: false, error: "api_error", error_message: e.message, has_accounts: nil }
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error preloading Brex accounts: #{e.class}: #{e.message}")
+    { success: false, error: "unexpected_error", error_message: I18n.t("brex_items.errors.unexpected_error"), has_accounts: nil }
   end
 
-  def available_accounts(accountable_type:)
-    filter_accounts(unlinked_available_accounts, accountable_type)
+  def select_accounts_result(accountable_type:)
+    return selection_failure_result("brex_items.select_accounts") unless selected?
+
+    accounts = filter_accounts(unlinked_available_accounts, accountable_type)
+    if accounts.empty?
+      return SelectionResult.new(
+        status: :empty,
+        brex_item: brex_item,
+        available_accounts: [],
+        accountable_type: accountable_type,
+        message: I18n.t("brex_items.select_accounts.no_accounts_found")
+      )
+    end
+
+    SelectionResult.new(
+      status: :success,
+      brex_item: brex_item,
+      available_accounts: accounts,
+      accountable_type: accountable_type,
+      message: nil
+    )
+  rescue NoApiTokenError
+    SelectionResult.new(
+      status: :no_api_token,
+      brex_item: brex_item,
+      available_accounts: [],
+      accountable_type: accountable_type,
+      message: I18n.t("brex_items.select_accounts.no_api_token")
+    )
+  rescue Provider::Brex::BrexError => e
+    Rails.logger.error("Brex API error in select_accounts: #{e.message}")
+    SelectionResult.new(
+      status: :api_error,
+      brex_item: brex_item,
+      available_accounts: [],
+      accountable_type: accountable_type,
+      message: e.message
+    )
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error in select_accounts: #{e.class}: #{e.message}")
+    SelectionResult.new(
+      status: :unexpected_error,
+      brex_item: brex_item,
+      available_accounts: [],
+      accountable_type: accountable_type,
+      message: I18n.t("brex_items.select_accounts.unexpected_error")
+    )
   end
 
-  def available_accounts_for_existing(account:)
-    filter_accounts(unlinked_available_accounts, account.accountable_type)
+  def select_existing_account_result(account:)
+    return linked_account_result if account.account_providers.exists?
+    return selection_failure_result("brex_items.select_existing_account", accountable_type: account.accountable_type) unless selected?
+
+    accounts = filter_accounts(unlinked_available_accounts, account.accountable_type)
+    if accounts.empty?
+      return SelectionResult.new(
+        status: :empty,
+        brex_item: brex_item,
+        available_accounts: [],
+        accountable_type: account.accountable_type,
+        message: I18n.t("brex_items.select_existing_account.all_accounts_already_linked")
+      )
+    end
+
+    SelectionResult.new(
+      status: :success,
+      brex_item: brex_item,
+      available_accounts: accounts,
+      accountable_type: account.accountable_type,
+      message: nil
+    )
+  rescue NoApiTokenError
+    SelectionResult.new(
+      status: :no_api_token,
+      brex_item: brex_item,
+      available_accounts: [],
+      accountable_type: account.accountable_type,
+      message: I18n.t("brex_items.select_existing_account.no_api_token")
+    )
+  rescue Provider::Brex::BrexError => e
+    Rails.logger.error("Brex API error in select_existing_account: #{e.message}")
+    SelectionResult.new(
+      status: :api_error,
+      brex_item: brex_item,
+      available_accounts: [],
+      accountable_type: account.accountable_type,
+      message: e.message
+    )
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error in select_existing_account: #{e.class}: #{e.message}")
+    SelectionResult.new(
+      status: :unexpected_error,
+      brex_item: brex_item,
+      available_accounts: [],
+      accountable_type: account.accountable_type,
+      message: I18n.t("brex_items.select_existing_account.unexpected_error")
+    )
+  end
+
+  def link_new_accounts_result(account_ids:, accountable_type:)
+    return navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.no_accounts_selected")) if account_ids.blank?
+    return navigation(:settings_providers, :alert, I18n.t("brex_items.link_accounts.select_connection")) unless selected?
+
+    link_navigation_result(link_new_accounts!(account_ids: account_ids, accountable_type: accountable_type))
+  rescue NoApiTokenError
+    navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.no_api_token"))
+  rescue Provider::Brex::BrexError => e
+    navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.api_error", message: e.message))
+  end
+
+  def link_existing_account_result(account:, brex_account_id:)
+    return navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.missing_parameters")) if account.blank? || brex_account_id.blank?
+    return navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.account_already_linked")) if account.account_providers.exists?
+    return navigation(:settings_providers, :alert, I18n.t("brex_items.link_existing_account.select_connection")) unless selected?
+
+    link_existing_account!(account: account, brex_account_id: brex_account_id)
+
+    navigation(:return_to_or_accounts, :notice, I18n.t("brex_items.link_existing_account.success", account_name: account.name))
+  rescue NoApiTokenError
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.no_api_token"))
+  rescue AccountNotFoundError
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.brex_account_not_found"))
+  rescue InvalidAccountNameError
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.invalid_account_name"))
+  rescue AccountAlreadyLinkedError
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.brex_account_already_linked"))
+  rescue Provider::Brex::BrexError => e
+    navigation(:accounts, :alert, I18n.t("brex_items.link_existing_account.api_error", message: e.message))
   end
 
   def link_new_accounts!(account_ids:, accountable_type:)
@@ -256,7 +408,139 @@ class BrexItem::AccountFlow
     SetupResult.new(created_accounts: created_accounts, skipped_count: skipped_count)
   end
 
+  def import_accounts_error_message
+    import_accounts_from_api_if_needed
+  rescue NoApiTokenError
+    I18n.t("brex_items.setup_accounts.no_api_token")
+  rescue Provider::Brex::BrexError => e
+    Rails.logger.error("Brex API error: #{e.message}")
+    I18n.t("brex_items.setup_accounts.api_error", message: e.message)
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error fetching Brex accounts: #{e.class}: #{e.message}")
+    I18n.t("brex_items.setup_accounts.api_error", message: I18n.t("brex_items.errors.unexpected_error"))
+  end
+
+  def complete_setup_result(account_types:, account_subtypes:)
+    result = complete_setup!(account_types: account_types, account_subtypes: account_subtypes)
+
+    SetupCompletion.new(success: true, message: setup_notice(result))
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    Rails.logger.error("Brex account setup failed: #{e.class} - #{e.message}")
+    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
+    SetupCompletion.new(
+      success: false,
+      message: I18n.t("brex_items.complete_account_setup.creation_failed", error: e.message)
+    )
+  rescue StandardError => e
+    Rails.logger.error("Brex account setup failed unexpectedly: #{e.class} - #{e.message}")
+    Rails.logger.error(Array(e.backtrace).first(10).join("\n"))
+    SetupCompletion.new(
+      success: false,
+      message: I18n.t(
+        "brex_items.complete_account_setup.creation_failed",
+        error: I18n.t("brex_items.complete_account_setup.unexpected_error")
+      )
+    )
+  end
+
   private
+
+    def selection_error_payload
+      return { success: false, error: "no_credentials", has_accounts: false } unless selection_required?
+
+      {
+        success: false,
+        error: "select_connection",
+        error_message: I18n.t("brex_items.select_accounts.select_connection"),
+        has_accounts: nil
+      }
+    end
+
+    def selection_failure_result(scope, accountable_type: nil)
+      if selection_required?
+        SelectionResult.new(
+          status: :select_connection,
+          brex_item: nil,
+          available_accounts: [],
+          accountable_type: accountable_type,
+          message: I18n.t("#{scope}.select_connection")
+        )
+      else
+        SelectionResult.new(
+          status: :setup_required,
+          brex_item: nil,
+          available_accounts: [],
+          accountable_type: accountable_type,
+          message: I18n.t("#{scope}.no_credentials_configured")
+        )
+      end
+    end
+
+    def linked_account_result
+      SelectionResult.new(
+        status: :account_already_linked,
+        brex_item: brex_item,
+        available_accounts: [],
+        accountable_type: nil,
+        message: I18n.t("brex_items.select_existing_account.account_already_linked")
+      )
+    end
+
+    def link_navigation_result(result)
+      if result.invalid_count.positive? && result.created_count.zero? && result.already_linked_count.zero?
+        navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.invalid_account_names", count: result.invalid_count))
+      elsif result.invalid_count.positive? && (result.created_count.positive? || result.already_linked_count.positive?)
+        navigation(
+          :return_to_or_accounts,
+          :alert,
+          I18n.t(
+            "brex_items.link_accounts.partial_invalid",
+            created_count: result.created_count,
+            already_linked_count: result.already_linked_count,
+            invalid_count: result.invalid_count
+          )
+        )
+      elsif result.created_count.positive? && result.already_linked_count.positive?
+        navigation(
+          :return_to_or_accounts,
+          :notice,
+          I18n.t(
+            "brex_items.link_accounts.partial_success",
+            created_count: result.created_count,
+            already_linked_count: result.already_linked_count,
+            already_linked_names: result.already_linked_names.join(", ")
+          )
+        )
+      elsif result.created_count.positive?
+        navigation(:return_to_or_accounts, :notice, I18n.t("brex_items.link_accounts.success", count: result.created_count))
+      elsif result.already_linked_count.positive?
+        navigation(
+          :return_to_or_accounts,
+          :alert,
+          I18n.t(
+            "brex_items.link_accounts.all_already_linked",
+            count: result.already_linked_count,
+            names: result.already_linked_names.join(", ")
+          )
+        )
+      else
+        navigation(:new_account, :alert, I18n.t("brex_items.link_accounts.link_failed"))
+      end
+    end
+
+    def navigation(target, flash_type, message)
+      NavigationResult.new(target: target, flash_type: flash_type, message: message)
+    end
+
+    def setup_notice(result)
+      if result.created_count.positive?
+        I18n.t("brex_items.complete_account_setup.success", count: result.created_count)
+      elsif result.skipped_count.positive?
+        I18n.t("brex_items.complete_account_setup.all_skipped")
+      else
+        I18n.t("brex_items.complete_account_setup.no_accounts")
+      end
+    end
 
     def resolve_brex_item
       if brex_item_id.present?

--- a/app/models/brex_item/importer.rb
+++ b/app/models/brex_item/importer.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+class BrexItem::Importer
+  attr_reader :brex_item, :brex_provider
+
+  def initialize(brex_item, brex_provider:)
+    @brex_item = brex_item
+    @brex_provider = brex_provider
+  end
+
+  def import
+    Rails.logger.info "BrexItem::Importer - Starting import for item #{brex_item.id}"
+
+    accounts_data = fetch_accounts_data
+    return failed_result("Failed to fetch accounts data") unless accounts_data
+
+    store_item_snapshot(accounts_data)
+
+    account_result = import_accounts(accounts_data[:accounts].to_a)
+    transaction_result = import_transactions
+
+    brex_item.update!(status: :good) if account_result[:accounts_failed].zero? && transaction_result[:transactions_failed].zero?
+
+    {
+      success: account_result[:accounts_failed].zero? && transaction_result[:transactions_failed].zero?,
+      **account_result,
+      **transaction_result
+    }
+  end
+
+  private
+
+    def fetch_accounts_data
+      accounts_data = brex_provider.get_accounts
+
+      unless accounts_data.is_a?(Hash)
+        Rails.logger.error "BrexItem::Importer - Invalid accounts_data format: expected Hash, got #{accounts_data.class}"
+        return nil
+      end
+
+      accounts_data
+    rescue Provider::Brex::BrexError => e
+      mark_requires_update_if_credentials_error(e)
+      Rails.logger.error "BrexItem::Importer - Brex API error: #{e.message} trace_id=#{e.trace_id}"
+      nil
+    rescue JSON::ParserError => e
+      Rails.logger.error "BrexItem::Importer - Failed to parse Brex API response: #{e.message}"
+      nil
+    rescue => e
+      Rails.logger.error "BrexItem::Importer - Unexpected error fetching accounts: #{e.class} - #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      nil
+    end
+
+    def store_item_snapshot(accounts_data)
+      brex_item.upsert_brex_snapshot!(accounts_data)
+    rescue => e
+      Rails.logger.error "BrexItem::Importer - Failed to store accounts snapshot: #{e.message}"
+    end
+
+    def import_accounts(accounts)
+      accounts_updated = 0
+      accounts_created = 0
+      accounts_failed = 0
+
+      linked_account_ids = brex_item.brex_accounts
+                                   .joins(:account_provider)
+                                   .pluck(:account_id)
+                                   .map(&:to_s)
+      all_existing_ids = brex_item.brex_accounts.pluck(:account_id).map(&:to_s)
+
+      accounts.each do |account_data|
+        snapshot = account_data.with_indifferent_access
+        account_id = snapshot[:id].to_s
+        account_name = brex_account_name(snapshot)
+        next if account_id.blank? || account_name.blank?
+
+        if linked_account_ids.include?(account_id)
+          import_account(snapshot)
+          accounts_updated += 1
+        elsif !all_existing_ids.include?(account_id)
+          import_account(snapshot)
+          accounts_created += 1
+          all_existing_ids << account_id
+        end
+      rescue => e
+        accounts_failed += 1
+        Rails.logger.error "BrexItem::Importer - Failed to import account #{account_id.presence || 'unknown'}: #{e.message}"
+      end
+
+      {
+        accounts_updated: accounts_updated,
+        accounts_created: accounts_created,
+        accounts_failed: accounts_failed
+      }
+    end
+
+    def import_account(account_data)
+      account_id = account_data[:id].to_s
+      raise ArgumentError, "Account ID is required" if account_id.blank?
+
+      brex_account = brex_item.brex_accounts.find_or_initialize_by(account_id: account_id)
+      brex_account.name ||= brex_account_name(account_data)
+      brex_account.currency ||= BrexAccount.currency_code_from_money(account_data[:current_balance] || account_data[:available_balance] || account_data[:account_limit])
+      brex_account.upsert_brex_snapshot!(account_data)
+      brex_account
+    end
+
+    def import_transactions
+      transactions_imported = 0
+      transactions_failed = 0
+
+      brex_item.brex_accounts.joins(:account).merge(Account.visible).find_each do |brex_account|
+        result = fetch_and_store_transactions(brex_account)
+        if result[:success]
+          transactions_imported += result[:transactions_count]
+        else
+          transactions_failed += 1
+        end
+      rescue => e
+        transactions_failed += 1
+        Rails.logger.error "BrexItem::Importer - Failed to fetch/store transactions for account #{brex_account.account_id}: #{e.message}"
+      end
+
+      {
+        transactions_imported: transactions_imported,
+        transactions_failed: transactions_failed
+      }
+    end
+
+    def fetch_and_store_transactions(brex_account)
+      start_date = determine_sync_start_date(brex_account)
+      Rails.logger.info "BrexItem::Importer - Fetching #{brex_account.account_kind} transactions for account #{brex_account.account_id} from #{start_date}"
+
+      transactions_data = if brex_account.card?
+        brex_provider.get_primary_card_transactions(start_date: start_date)
+      else
+        brex_provider.get_cash_transactions(brex_account.account_id, start_date: start_date)
+      end
+
+      unless transactions_data.is_a?(Hash)
+        Rails.logger.error "BrexItem::Importer - Invalid transactions_data format for account #{brex_account.account_id}"
+        return { success: false, transactions_count: 0, error: "Invalid response format" }
+      end
+
+      transactions = transactions_data[:transactions].to_a
+      store_new_transactions(brex_account, transactions)
+
+      { success: true, transactions_count: transactions.count }
+    rescue Provider::Brex::BrexError => e
+      mark_requires_update_if_credentials_error(e)
+      Rails.logger.error "BrexItem::Importer - Brex API error for account #{brex_account.id}: #{e.message} trace_id=#{e.trace_id}"
+      { success: false, transactions_count: 0, error: e.message }
+    rescue JSON::ParserError => e
+      Rails.logger.error "BrexItem::Importer - Failed to parse transaction response for account #{brex_account.id}: #{e.message}"
+      { success: false, transactions_count: 0, error: "Failed to parse response" }
+    rescue => e
+      Rails.logger.error "BrexItem::Importer - Unexpected error fetching transactions for account #{brex_account.id}: #{e.class} - #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      { success: false, transactions_count: 0, error: "Unexpected error: #{e.message}" }
+    end
+
+    def store_new_transactions(brex_account, transactions)
+      return if transactions.empty?
+
+      existing_transactions = brex_account.raw_transactions_payload.to_a
+      existing_ids = existing_transactions.map { |tx| tx.with_indifferent_access[:id] }.to_set
+
+      new_transactions = transactions.select do |tx|
+        tx_id = tx.with_indifferent_access[:id]
+        tx_id.present? && !existing_ids.include?(tx_id)
+      end
+
+      return if new_transactions.empty?
+
+      brex_account.upsert_brex_transactions_snapshot!(existing_transactions + new_transactions)
+    end
+
+    def determine_sync_start_date(brex_account)
+      if brex_account.raw_transactions_payload.to_a.any?
+        brex_item.last_synced_at ? brex_item.last_synced_at - 7.days : 90.days.ago
+      else
+        account_baseline = brex_account.created_at || Time.current
+        [ account_baseline - 7.days, 90.days.ago ].max
+      end
+    end
+
+    def brex_account_name(account_data)
+      return "Brex Card" if account_data[:account_kind].to_s == "card"
+
+      account_data[:name].presence || "Brex Cash #{account_data[:id]}"
+    end
+
+    def mark_requires_update_if_credentials_error(error)
+      return unless error.error_type.in?([ :unauthorized, :access_forbidden ])
+
+      brex_item.update!(status: :requires_update)
+    rescue => update_error
+      Rails.logger.error "BrexItem::Importer - Failed to update item status: #{update_error.message}"
+    end
+
+    def failed_result(error)
+      {
+        success: false,
+        error: error,
+        accounts_updated: 0,
+        accounts_created: 0,
+        accounts_failed: 0,
+        transactions_imported: 0,
+        transactions_failed: 0
+      }
+    end
+end

--- a/app/models/brex_item/importer.rb
+++ b/app/models/brex_item/importer.rb
@@ -57,6 +57,14 @@ class BrexItem::Importer
       brex_item.upsert_brex_snapshot!(accounts_data)
     rescue => e
       Rails.logger.error "BrexItem::Importer - Failed to store accounts snapshot: #{e.message}"
+      Sentry.capture_exception(e) do |scope|
+        scope.set_tags(brex_item_id: brex_item.id)
+        scope.set_context("brex_item_snapshot", {
+          brex_item_id: brex_item.id,
+          accounts_data: BrexAccount.sanitize_payload(accounts_data)
+        })
+      end
+      raise
     end
 
     def import_accounts(accounts)
@@ -66,9 +74,9 @@ class BrexItem::Importer
 
       linked_account_ids = brex_item.brex_accounts
                                    .joins(:account_provider)
-                                   .pluck(:account_id)
+                                   .pluck("#{BrexAccount.table_name}.account_id")
                                    .map(&:to_s)
-      all_existing_ids = brex_item.brex_accounts.pluck(:account_id).map(&:to_s)
+      all_existing_ids = brex_item.brex_accounts.pluck("#{BrexAccount.table_name}.account_id").map(&:to_s)
 
       accounts.each do |account_data|
         snapshot = account_data.with_indifferent_access
@@ -145,7 +153,7 @@ class BrexItem::Importer
       end
 
       transactions = transactions_data[:transactions].to_a
-      created_count = store_new_transactions(brex_account, transactions)
+      created_count = store_new_transactions(brex_account, transactions, window_start_date: start_date)
 
       { success: true, transactions_count: created_count }
     rescue Provider::Brex::BrexError => e
@@ -161,21 +169,51 @@ class BrexItem::Importer
       { success: false, transactions_count: 0, error: "Unexpected error: #{e.message}" }
     end
 
-    def store_new_transactions(brex_account, transactions)
-      return 0 if transactions.empty?
-
-      existing_transactions = brex_account.raw_transactions_payload.to_a
+    def store_new_transactions(brex_account, transactions, window_start_date:)
+      existing_payload = brex_account.raw_transactions_payload.to_a
+      existing_transactions = transactions_in_window(existing_payload, window_start_date)
       existing_ids = existing_transactions.map { |tx| tx.with_indifferent_access[:id] }.to_set
 
       new_transactions = transactions.select do |tx|
         tx_id = tx.with_indifferent_access[:id]
-        tx_id.present? && !existing_ids.include?(tx_id)
+        tx_id.present? && !existing_ids.include?(tx_id) && transaction_in_window?(tx, window_start_date)
       end
 
-      return 0 if new_transactions.empty?
+      return 0 if new_transactions.empty? && existing_transactions.count == existing_payload.count
 
       brex_account.upsert_brex_transactions_snapshot!(existing_transactions + new_transactions)
       new_transactions.count
+    end
+
+    def transactions_in_window(transactions, window_start_date)
+      transactions.select { |transaction| transaction_in_window?(transaction, window_start_date) }
+    end
+
+    def transaction_in_window?(transaction, window_start_date)
+      return true if window_start_date.blank?
+
+      transaction_date = transaction_date_for(transaction)
+      return true if transaction_date.blank?
+
+      transaction_date >= window_start_date.to_date
+    end
+
+    def transaction_date_for(transaction)
+      data = transaction.with_indifferent_access
+      date_value = data[:posted_at_date].presence || data[:initiated_at_date].presence || data[:posted_at].presence || data[:created_at].presence
+
+      case date_value
+      when Date
+        date_value
+      when Time, DateTime
+        date_value.to_date
+      when String
+        Date.parse(date_value)
+      else
+        nil
+      end
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def determine_sync_start_date(brex_account)

--- a/app/models/brex_item/importer.rb
+++ b/app/models/brex_item/importer.rb
@@ -48,7 +48,7 @@ class BrexItem::Importer
       nil
     rescue => e
       Rails.logger.error "BrexItem::Importer - Unexpected error fetching accounts: #{e.class} - #{e.message}"
-      Rails.logger.error e.backtrace.join("\n")
+      Rails.logger.error Array(e.backtrace).join("\n")
       nil
     end
 
@@ -144,9 +144,9 @@ class BrexItem::Importer
       end
 
       transactions = transactions_data[:transactions].to_a
-      store_new_transactions(brex_account, transactions)
+      created_count = store_new_transactions(brex_account, transactions)
 
-      { success: true, transactions_count: transactions.count }
+      { success: true, transactions_count: created_count }
     rescue Provider::Brex::BrexError => e
       mark_requires_update_if_credentials_error(e)
       Rails.logger.error "BrexItem::Importer - Brex API error for account #{brex_account.id}: #{e.message} trace_id=#{e.trace_id}"
@@ -156,12 +156,12 @@ class BrexItem::Importer
       { success: false, transactions_count: 0, error: "Failed to parse response" }
     rescue => e
       Rails.logger.error "BrexItem::Importer - Unexpected error fetching transactions for account #{brex_account.id}: #{e.class} - #{e.message}"
-      Rails.logger.error e.backtrace.join("\n")
+      Rails.logger.error Array(e.backtrace).join("\n")
       { success: false, transactions_count: 0, error: "Unexpected error: #{e.message}" }
     end
 
     def store_new_transactions(brex_account, transactions)
-      return if transactions.empty?
+      return 0 if transactions.empty?
 
       existing_transactions = brex_account.raw_transactions_payload.to_a
       existing_ids = existing_transactions.map { |tx| tx.with_indifferent_access[:id] }.to_set
@@ -171,9 +171,10 @@ class BrexItem::Importer
         tx_id.present? && !existing_ids.include?(tx_id)
       end
 
-      return if new_transactions.empty?
+      return 0 if new_transactions.empty?
 
       brex_account.upsert_brex_transactions_snapshot!(existing_transactions + new_transactions)
+      new_transactions.count
     end
 
     def determine_sync_start_date(brex_account)

--- a/app/models/brex_item/importer.rb
+++ b/app/models/brex_item/importer.rb
@@ -72,7 +72,7 @@ class BrexItem::Importer
       accounts.each do |account_data|
         snapshot = account_data.with_indifferent_access
         account_id = snapshot[:id].to_s
-        account_name = brex_account_name(snapshot)
+        account_name = BrexAccount.name_for(snapshot)
         next if account_id.blank? || account_name.blank?
 
         if linked_account_ids.include?(account_id)
@@ -100,7 +100,7 @@ class BrexItem::Importer
       raise ArgumentError, "Account ID is required" if account_id.blank?
 
       brex_account = brex_item.brex_accounts.find_or_initialize_by(account_id: account_id)
-      brex_account.name ||= brex_account_name(account_data)
+      brex_account.name ||= BrexAccount.name_for(account_data)
       brex_account.currency ||= BrexAccount.currency_code_from_money(account_data[:current_balance] || account_data[:available_balance] || account_data[:account_limit])
       brex_account.upsert_brex_snapshot!(account_data)
       brex_account
@@ -184,12 +184,6 @@ class BrexItem::Importer
         account_baseline = brex_account.created_at || Time.current
         [ account_baseline - 7.days, 90.days.ago ].max
       end
-    end
-
-    def brex_account_name(account_data)
-      return "Brex Card" if account_data[:account_kind].to_s == "card"
-
-      account_data[:name].presence || "Brex Cash #{account_data[:id]}"
     end
 
     def mark_requires_update_if_credentials_error(error)

--- a/app/models/brex_item/importer.rb
+++ b/app/models/brex_item/importer.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class BrexItem::Importer
-  attr_reader :brex_item, :brex_provider
+  attr_reader :brex_item, :brex_provider, :sync_start_date
 
-  def initialize(brex_item, brex_provider:)
+  def initialize(brex_item, brex_provider:, sync_start_date: nil)
     @brex_item = brex_item
     @brex_provider = brex_provider
+    @sync_start_date = sync_start_date
   end
 
   def import
@@ -178,6 +179,8 @@ class BrexItem::Importer
     end
 
     def determine_sync_start_date(brex_account)
+      return sync_start_date if sync_start_date.present?
+
       if brex_account.raw_transactions_payload.to_a.any?
         brex_item.last_synced_at ? brex_item.last_synced_at - 7.days : 90.days.ago
       else

--- a/app/models/brex_item/importer.rb
+++ b/app/models/brex_item/importer.rb
@@ -150,13 +150,13 @@ class BrexItem::Importer
       { success: true, transactions_count: created_count }
     rescue Provider::Brex::BrexError => e
       mark_requires_update_if_credentials_error(e)
-      Rails.logger.error "BrexItem::Importer - Brex API error for account #{brex_account.id}: #{e.message} trace_id=#{e.trace_id}"
+      Rails.logger.error "BrexItem::Importer - Brex API error for account #{brex_account.account_id}: #{e.message} trace_id=#{e.trace_id}"
       { success: false, transactions_count: 0, error: e.message }
     rescue JSON::ParserError => e
-      Rails.logger.error "BrexItem::Importer - Failed to parse transaction response for account #{brex_account.id}: #{e.message}"
+      Rails.logger.error "BrexItem::Importer - Failed to parse transaction response for account #{brex_account.account_id}: #{e.message}"
       { success: false, transactions_count: 0, error: "Failed to parse response" }
     rescue => e
-      Rails.logger.error "BrexItem::Importer - Unexpected error fetching transactions for account #{brex_account.id}: #{e.class} - #{e.message}"
+      Rails.logger.error "BrexItem::Importer - Unexpected error fetching transactions for account #{brex_account.account_id}: #{e.class} - #{e.message}"
       Rails.logger.error Array(e.backtrace).join("\n")
       { success: false, transactions_count: 0, error: "Unexpected error: #{e.message}" }
     end

--- a/app/models/brex_item/provided.rb
+++ b/app/models/brex_item/provided.rb
@@ -1,0 +1,13 @@
+module BrexItem::Provided
+  extend ActiveSupport::Concern
+
+  def brex_provider
+    return nil unless credentials_configured?
+
+    Provider::Brex.new(token.to_s.strip, base_url: effective_base_url)
+  end
+
+  def syncer
+    BrexItem::Syncer.new(self)
+  end
+end

--- a/app/models/brex_item/provided.rb
+++ b/app/models/brex_item/provided.rb
@@ -4,7 +4,10 @@ module BrexItem::Provided
   def brex_provider
     return nil unless credentials_configured?
 
-    Provider::Brex.new(token.to_s.strip, base_url: effective_base_url)
+    base_url = effective_base_url
+    return nil unless base_url.present?
+
+    Provider::Brex.new(token.to_s.strip, base_url: base_url)
   end
 
   def syncer

--- a/app/models/brex_item/syncer.rb
+++ b/app/models/brex_item/syncer.rb
@@ -10,7 +10,7 @@ class BrexItem::Syncer
   def perform_sync(sync)
     # Phase 1: Import data from Brex API
     sync.update!(status_text: "Importing accounts from Brex...") if sync.respond_to?(:status_text)
-    brex_item.import_latest_brex_data
+    brex_item.import_latest_brex_data(sync_start_date: sync.window_start_date)
 
     # Phase 2: Collect setup statistics using shared concern
     sync.update!(status_text: "Checking account configuration...") if sync.respond_to?(:status_text)

--- a/app/models/brex_item/syncer.rb
+++ b/app/models/brex_item/syncer.rb
@@ -1,0 +1,64 @@
+class BrexItem::Syncer
+  include SyncStats::Collector
+
+  attr_reader :brex_item
+
+  def initialize(brex_item)
+    @brex_item = brex_item
+  end
+
+  def perform_sync(sync)
+    # Phase 1: Import data from Brex API
+    sync.update!(status_text: "Importing accounts from Brex...") if sync.respond_to?(:status_text)
+    brex_item.import_latest_brex_data
+
+    # Phase 2: Collect setup statistics using shared concern
+    sync.update!(status_text: "Checking account configuration...") if sync.respond_to?(:status_text)
+    collect_setup_stats(sync, provider_accounts: brex_item.brex_accounts)
+
+    # Check for unlinked accounts
+    linked_accounts = brex_item.brex_accounts.joins(:account_provider)
+    unlinked_accounts = brex_item.brex_accounts.left_joins(:account_provider).where(account_providers: { id: nil })
+
+    # Set pending_account_setup if there are unlinked accounts
+    if unlinked_accounts.any?
+      brex_item.update!(pending_account_setup: true)
+      sync.update!(status_text: "#{unlinked_accounts.count} accounts need setup...") if sync.respond_to?(:status_text)
+    else
+      brex_item.update!(pending_account_setup: false)
+    end
+
+    # Phase 3: Process transactions for linked accounts only
+    if linked_accounts.any?
+      sync.update!(status_text: "Processing transactions...") if sync.respond_to?(:status_text)
+      mark_import_started(sync)
+      Rails.logger.info "BrexItem::Syncer - Processing #{linked_accounts.count} linked accounts"
+      brex_item.process_accounts
+      Rails.logger.info "BrexItem::Syncer - Finished processing accounts"
+
+      # Phase 4: Schedule balance calculations for linked accounts
+      sync.update!(status_text: "Calculating balances...") if sync.respond_to?(:status_text)
+      brex_item.schedule_account_syncs(
+        parent_sync: sync,
+        window_start_date: sync.window_start_date,
+        window_end_date: sync.window_end_date
+      )
+
+      # Phase 5: Collect transaction statistics
+      account_ids = linked_accounts.includes(:account_provider).filter_map { |ma| ma.current_account&.id }
+      collect_transaction_stats(sync, account_ids: account_ids, source: "brex")
+    else
+      Rails.logger.info "BrexItem::Syncer - No linked accounts to process"
+    end
+
+    # Mark sync health
+    collect_health_stats(sync, errors: nil)
+  rescue => e
+    collect_health_stats(sync, errors: [ { message: e.message, category: "sync_error" } ])
+    raise
+  end
+
+  def perform_post_sync
+    # no-op
+  end
+end

--- a/app/models/brex_item/syncer.rb
+++ b/app/models/brex_item/syncer.rb
@@ -10,9 +10,12 @@ class BrexItem::Syncer
   end
 
   def perform_sync(sync)
+    sync_errors = []
+
     # Phase 1: Import data from Brex API
     update_status(sync, :importing_accounts)
-    brex_item.import_latest_brex_data(sync_start_date: sync.window_start_date)
+    import_result = brex_item.import_latest_brex_data(sync_start_date: sync.window_start_date)
+    sync_errors.concat(import_result_errors(import_result))
 
     # Phase 2: Collect setup statistics
     update_status(sync, :checking_account_configuration)
@@ -44,16 +47,18 @@ class BrexItem::Syncer
       update_status(sync, :processing_transactions)
       mark_import_started(sync)
       Rails.logger.info "BrexItem::Syncer - Processing #{linked_count} linked accounts"
-      brex_item.process_accounts
+      process_results = brex_item.process_accounts
+      sync_errors.concat(result_failure_errors(process_results, category: :account_processing_error, message_key: :account_processing_failed))
       Rails.logger.info "BrexItem::Syncer - Finished processing accounts"
 
       # Phase 4: Schedule balance calculations for linked accounts
       update_status(sync, :calculating_balances)
-      brex_item.schedule_account_syncs(
+      schedule_results = brex_item.schedule_account_syncs(
         parent_sync: sync,
         window_start_date: sync.window_start_date,
         window_end_date: sync.window_end_date
       )
+      sync_errors.concat(result_failure_errors(schedule_results, category: :account_sync_error, message_key: :account_sync_failed))
 
       # Phase 5: Collect transaction statistics
       account_ids = linked_accounts
@@ -65,7 +70,7 @@ class BrexItem::Syncer
     end
 
     # Mark sync health
-    collect_health_stats(sync, errors: nil)
+    collect_health_stats(sync, errors: sync_errors.presence)
   rescue => e
     safe_message = user_safe_error_message(e)
     Rails.logger.error "BrexItem::Syncer - sync failed for Brex item #{brex_item.id}: #{e.class} - #{e.message}"
@@ -100,6 +105,37 @@ class BrexItem::Syncer
 
       merge_sync_stats(sync, setup_stats)
       setup_stats
+    end
+
+    def import_result_errors(result)
+      return [] if result.is_a?(Hash) && result[:success]
+
+      unless result.is_a?(Hash)
+        return [ sync_error(:import_error, :import_failed) ]
+      end
+
+      errors = []
+      accounts_failed = result[:accounts_failed].to_i
+      transactions_failed = result[:transactions_failed].to_i
+
+      errors << sync_error(:account_import_error, :accounts_failed, count: accounts_failed) if accounts_failed.positive?
+      errors << sync_error(:transaction_import_error, :transactions_failed, count: transactions_failed) if transactions_failed.positive?
+      errors << sync_error(:import_error, :import_failed) if errors.empty?
+      errors
+    end
+
+    def result_failure_errors(results, category:, message_key:)
+      failed_count = Array(results).count { |result| result.is_a?(Hash) && result[:success] == false }
+      return [] unless failed_count.positive?
+
+      [ sync_error(category, message_key, count: failed_count) ]
+    end
+
+    def sync_error(category, message_key, **options)
+      {
+        message: I18n.t("brex_items.syncer.#{message_key}", **options),
+        category: category.to_s
+      }
     end
 
     def user_safe_error_message(error)

--- a/app/models/brex_item/syncer.rb
+++ b/app/models/brex_item/syncer.rb
@@ -1,6 +1,8 @@
 class BrexItem::Syncer
   include SyncStats::Collector
 
+  SafeSyncError = Class.new(StandardError)
+
   attr_reader :brex_item
 
   def initialize(brex_item)
@@ -54,11 +56,27 @@ class BrexItem::Syncer
     # Mark sync health
     collect_health_stats(sync, errors: nil)
   rescue => e
-    collect_health_stats(sync, errors: [ { message: e.message, category: "sync_error" } ])
-    raise
+    safe_message = user_safe_error_message(e)
+    Rails.logger.error "BrexItem::Syncer - sync failed for Brex item #{brex_item.id}: #{e.class} - #{e.message}"
+    Rails.logger.error Array(e.backtrace).first(10).join("\n")
+    Sentry.capture_exception(e) do |scope|
+      scope.set_tags(brex_item_id: brex_item.id)
+    end
+    collect_health_stats(sync, errors: [ { message: safe_message, category: "sync_error" } ])
+    raise SafeSyncError, safe_message
   end
 
   def perform_post_sync
     # no-op
   end
+
+  private
+
+    def user_safe_error_message(error)
+      if error.is_a?(Provider::Brex::BrexError) && error.error_type.in?([ :unauthorized, :access_forbidden ])
+        I18n.t("brex_items.syncer.credentials_invalid")
+      else
+        I18n.t("brex_items.syncer.failed")
+      end
+    end
 end

--- a/app/models/brex_item/syncer.rb
+++ b/app/models/brex_item/syncer.rb
@@ -11,35 +11,44 @@ class BrexItem::Syncer
 
   def perform_sync(sync)
     # Phase 1: Import data from Brex API
-    sync.update!(status_text: "Importing accounts from Brex...") if sync.respond_to?(:status_text)
+    update_status(sync, :importing_accounts)
     brex_item.import_latest_brex_data(sync_start_date: sync.window_start_date)
 
-    # Phase 2: Collect setup statistics using shared concern
-    sync.update!(status_text: "Checking account configuration...") if sync.respond_to?(:status_text)
-    collect_setup_stats(sync, provider_accounts: brex_item.brex_accounts)
+    # Phase 2: Collect setup statistics
+    update_status(sync, :checking_account_configuration)
 
-    # Check for unlinked accounts
-    linked_accounts = brex_item.brex_accounts.joins(:account_provider)
-    unlinked_accounts = brex_item.brex_accounts.left_joins(:account_provider).where(account_providers: { id: nil })
+    linked_count = brex_item.brex_accounts.joins(:account_provider).count
+    unlinked_count = brex_item.brex_accounts
+                             .left_joins(:account_provider)
+                             .where(account_providers: { id: nil })
+                             .count
+    total_count = linked_count + unlinked_count
+    collect_brex_setup_stats(
+      sync,
+      total_count: total_count,
+      linked_count: linked_count,
+      unlinked_count: unlinked_count
+    )
 
     # Set pending_account_setup if there are unlinked accounts
-    if unlinked_accounts.any?
+    if unlinked_count.positive?
       brex_item.update!(pending_account_setup: true)
-      sync.update!(status_text: "#{unlinked_accounts.count} accounts need setup...") if sync.respond_to?(:status_text)
+      update_status(sync, :accounts_need_setup, count: unlinked_count)
     else
       brex_item.update!(pending_account_setup: false)
     end
 
     # Phase 3: Process transactions for linked accounts only
-    if linked_accounts.any?
-      sync.update!(status_text: "Processing transactions...") if sync.respond_to?(:status_text)
+    if linked_count.positive?
+      linked_accounts = brex_item.brex_accounts.joins(:account_provider)
+      update_status(sync, :processing_transactions)
       mark_import_started(sync)
-      Rails.logger.info "BrexItem::Syncer - Processing #{linked_accounts.count} linked accounts"
+      Rails.logger.info "BrexItem::Syncer - Processing #{linked_count} linked accounts"
       brex_item.process_accounts
       Rails.logger.info "BrexItem::Syncer - Finished processing accounts"
 
       # Phase 4: Schedule balance calculations for linked accounts
-      sync.update!(status_text: "Calculating balances...") if sync.respond_to?(:status_text)
+      update_status(sync, :calculating_balances)
       brex_item.schedule_account_syncs(
         parent_sync: sync,
         window_start_date: sync.window_start_date,
@@ -47,7 +56,9 @@ class BrexItem::Syncer
       )
 
       # Phase 5: Collect transaction statistics
-      account_ids = linked_accounts.includes(:account_provider).filter_map { |ma| ma.current_account&.id }
+      account_ids = linked_accounts
+                    .includes(account_provider: :account)
+                    .filter_map { |ma| ma.current_account&.id }
       collect_transaction_stats(sync, account_ids: account_ids, source: "brex")
     else
       Rails.logger.info "BrexItem::Syncer - No linked accounts to process"
@@ -71,6 +82,25 @@ class BrexItem::Syncer
   end
 
   private
+
+    def update_status(sync, key, **options)
+      return unless sync.respond_to?(:status_text)
+
+      sync.update!(status_text: I18n.t("brex_items.syncer.#{key}", **options))
+    end
+
+    def collect_brex_setup_stats(sync, total_count:, linked_count:, unlinked_count:)
+      return {} unless sync.respond_to?(:sync_stats)
+
+      setup_stats = {
+        "total_accounts" => total_count,
+        "linked_accounts" => linked_count,
+        "unlinked_accounts" => unlinked_count
+      }
+
+      merge_sync_stats(sync, setup_stats)
+      setup_stats
+    end
 
     def user_safe_error_message(error)
       if error.is_a?(Provider::Brex::BrexError) && error.error_type.in?([ :unauthorized, :access_forbidden ])

--- a/app/models/brex_item/unlinking.rb
+++ b/app/models/brex_item/unlinking.rb
@@ -12,8 +12,7 @@ module BrexItem::Unlinking
     results = []
 
     brex_accounts.find_each do |provider_account|
-      links = AccountProvider.where(provider_type: "BrexAccount", provider_id: provider_account.id).to_a
-      link_ids = links.map(&:id)
+      link_ids = AccountProvider.where(provider_type: "BrexAccount", provider_id: provider_account.id).ids
       result = {
         provider_account_id: provider_account.id,
         name: provider_account.name,
@@ -25,6 +24,10 @@ module BrexItem::Unlinking
 
       begin
         ActiveRecord::Base.transaction do
+          links = AccountProvider.where(provider_type: "BrexAccount", provider_id: provider_account.id).to_a
+          link_ids = links.map(&:id)
+          result[:provider_link_ids] = link_ids
+
           # Detach holdings for any provider links found
           if link_ids.any?
             Holding.where(account_provider_id: link_ids).update_all(account_provider_id: nil)

--- a/app/models/brex_item/unlinking.rb
+++ b/app/models/brex_item/unlinking.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module BrexItem::Unlinking
+  # Concern that encapsulates unlinking logic for a Brex item.
+  extend ActiveSupport::Concern
+
+  # Idempotently remove all connections between this Brex item and local accounts.
+  # - Detaches any AccountProvider links for each BrexAccount
+  # - Detaches Holdings that point at the AccountProvider links
+  # Returns a per-account result payload for observability
+  def unlink_all!(dry_run: false)
+    results = []
+
+    brex_accounts.find_each do |provider_account|
+      links = AccountProvider.where(provider_type: "BrexAccount", provider_id: provider_account.id).to_a
+      link_ids = links.map(&:id)
+      result = {
+        provider_account_id: provider_account.id,
+        name: provider_account.name,
+        provider_link_ids: link_ids
+      }
+      results << result
+
+      next if dry_run
+
+      begin
+        ActiveRecord::Base.transaction do
+          # Detach holdings for any provider links found
+          if link_ids.any?
+            Holding.where(account_provider_id: link_ids).update_all(account_provider_id: nil)
+          end
+
+          # Destroy all provider links
+          links.each do |ap|
+            ap.destroy!
+          end
+        end
+      rescue StandardError => e
+        Rails.logger.warn(
+          "BrexItem Unlinker: failed to fully unlink provider account ##{provider_account.id} (links=#{link_ids.inspect}): #{e.class} - #{e.message}"
+        )
+        # Record error for observability; continue with other accounts
+        result[:error] = e.message
+      end
+    end
+
+    results
+  end
+end

--- a/app/models/concerns/encryptable.rb
+++ b/app/models/concerns/encryptable.rb
@@ -6,11 +6,7 @@ module Encryptable
     # This allows encryption to be optional - if not configured, sensitive fields
     # are stored in plaintext (useful for development or legacy deployments).
     def encryption_ready?
-      creds_ready = Rails.application.credentials.active_record_encryption.present?
-      env_ready = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"].present? &&
-                  ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"].present? &&
-                  ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"].present?
-      creds_ready || env_ready
+      ActiveRecordEncryptionConfig.explicitly_configured?
     end
   end
 end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -1,6 +1,8 @@
 class CreditCard < ApplicationRecord
   include Accountable
 
+  DEFAULT_SUBTYPE = "credit_card"
+
   SUBTYPES = {
     "credit_card" => { short: "Credit Card", long: "Credit Card" }
   }.freeze

--- a/app/models/data_enrichment.rb
+++ b/app/models/data_enrichment.rb
@@ -1,5 +1,5 @@
 class DataEnrichment < ApplicationRecord
   belongs_to :enrichable, polymorphic: true
 
-  enum :source, { rule: "rule", plaid: "plaid", simplefin: "simplefin", lunchflow: "lunchflow", synth: "synth", ai: "ai", enable_banking: "enable_banking", coinstats: "coinstats", mercury: "mercury", indexa_capital: "indexa_capital", sophtron: "sophtron" }
+  enum :source, { rule: "rule", plaid: "plaid", simplefin: "simplefin", lunchflow: "lunchflow", synth: "synth", ai: "ai", enable_banking: "enable_banking", coinstats: "coinstats", mercury: "mercury", brex: "brex", indexa_capital: "indexa_capital", sophtron: "sophtron" }
 end

--- a/app/models/depository.rb
+++ b/app/models/depository.rb
@@ -1,6 +1,8 @@
 class Depository < ApplicationRecord
   include Accountable
 
+  DEFAULT_SUBTYPE = "checking"
+
   SUBTYPES = {
     "checking" => { short: "Checking", long: "Checking" },
     "savings" => { short: "Savings", long: "Savings" },

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -2,6 +2,8 @@ class EnableBankingItem::Importer
   # Maximum number of pagination requests to prevent infinite loops
   # Enable Banking typically returns ~100 transactions per page, so 100 pages = ~10,000 transactions
   MAX_PAGINATION_PAGES = 100
+  MAX_SYNC_LOOKBACK_DAYS = 120
+  INCREMENTAL_SYNC_BUFFER_DAYS = 7
 
   NETWORK_ERRORS = [
     ::SocketError,
@@ -512,17 +514,21 @@ class EnableBankingItem::Importer
 
       # Use user-configured sync_start_date if set, otherwise default
       user_start_date = enable_banking_item.sync_start_date
+      minimum_allowed_start_date = MAX_SYNC_LOOKBACK_DAYS.days.ago.to_date
 
-      if has_stored_transactions
-        # For incremental syncs, get transactions from 7 days before last sync
+      start_date = if has_stored_transactions
+        # For incremental syncs, get transactions from a small buffer before the
+        # last successful sync to catch late-settling transactions.
         if enable_banking_item.last_synced_at
-          enable_banking_item.last_synced_at.to_date - 7.days
+          enable_banking_item.last_synced_at.to_date - INCREMENTAL_SYNC_BUFFER_DAYS.days
         else
           30.days.ago.to_date
         end
       else
-        # Initial sync: use user's configured date or default to 3 months
+        # Initial sync: use user's configured date or default to 3 months.
         user_start_date || 3.months.ago.to_date
       end
+
+      [ start_date, minimum_allowed_start_date ].compact.max
     end
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1,7 +1,7 @@
 class Family < ApplicationRecord
   include Syncable, AutoTransferMatchable, Subscribeable, VectorSearchable
   include PlaidConnectable, SimplefinConnectable, LunchflowConnectable, EnableBankingConnectable
-  include CoinbaseConnectable, BinanceConnectable, CoinstatsConnectable, SnaptradeConnectable, MercuryConnectable, SophtronConnectable
+  include CoinbaseConnectable, BinanceConnectable, CoinstatsConnectable, SnaptradeConnectable, MercuryConnectable, BrexConnectable, SophtronConnectable
   include IndexaCapitalConnectable
 
   DATE_FORMATS = [

--- a/app/models/family/brex_connectable.rb
+++ b/app/models/family/brex_connectable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Family::BrexConnectable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :brex_items, dependent: :destroy
+  end
+
+  def can_connect_brex?
+    true
+  end
+
+  def create_brex_item!(token:, base_url: nil, item_name: nil)
+    brex_item = brex_items.create!(
+      name: item_name || "Brex Connection",
+      token: token,
+      base_url: base_url
+    )
+
+    brex_item.sync_later
+
+    brex_item
+  end
+
+  def has_brex_credentials?
+    brex_items.active.any?(&:credentials_configured?)
+  end
+end

--- a/app/models/family/brex_connectable.rb
+++ b/app/models/family/brex_connectable.rb
@@ -24,6 +24,6 @@ module Family::BrexConnectable
   end
 
   def has_brex_credentials?
-    brex_items.active.any?(&:credentials_configured?)
+    brex_items.active.with_credentials.any?(&:credentials_configured?)
   end
 end

--- a/app/models/family/syncer.rb
+++ b/app/models/family/syncer.rb
@@ -17,6 +17,7 @@ class Family::Syncer
     coinbase_items
     coinstats_items
     mercury_items
+    brex_items
     snaptrade_items
     sophtron_items
   ].freeze

--- a/app/models/provider/brex.rb
+++ b/app/models/provider/brex.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+class Provider::Brex
+  include HTTParty
+  extend SslConfigurable
+
+  DEFAULT_BASE_URL = "https://api.brex.com"
+  DEFAULT_LIMIT = 1000
+  MAX_PAGES = 250
+
+  headers "User-Agent" => "Sure Finance Brex Client"
+  default_options.merge!({ timeout: 120 }.merge(httparty_ssl_options))
+
+  attr_reader :token, :base_url
+
+  def initialize(token, base_url: DEFAULT_BASE_URL)
+    @token = token.to_s.strip
+    @base_url = base_url.to_s.presence || DEFAULT_BASE_URL
+    @base_url = @base_url.chomp("/")
+  end
+
+  def get_accounts
+    cash_accounts = get_cash_accounts
+    card_accounts = get_card_accounts
+
+    accounts = cash_accounts.map { |account| account.merge(account_kind: "cash") }
+    accounts << aggregate_card_account(card_accounts) if card_accounts.any?
+
+    {
+      accounts: accounts,
+      cash_accounts: cash_accounts,
+      card_accounts: card_accounts
+    }
+  end
+
+  def get_cash_accounts
+    get_paginated("/v2/accounts/cash").map { |account| account.with_indifferent_access.merge(account_kind: "cash") }
+  end
+
+  def get_card_accounts
+    get_paginated("/v2/accounts/card").map { |account| account.with_indifferent_access.merge(account_kind: "card") }
+  end
+
+  def get_cash_transactions(account_id, start_date: nil)
+    path = "/v2/transactions/cash/#{ERB::Util.url_encode(account_id.to_s)}"
+    {
+      transactions: get_paginated(path, params: posted_at_start_params(start_date))
+    }
+  end
+
+  def get_primary_card_transactions(start_date: nil)
+    {
+      transactions: get_paginated("/v2/transactions/card/primary", params: posted_at_start_params(start_date))
+    }
+  end
+
+  private
+
+    def aggregate_card_account(card_accounts)
+      totals = %i[current_balance available_balance account_limit].index_with do |field|
+        sum_money(card_accounts.filter_map { |account| account.with_indifferent_access[field] })
+      end
+
+      {
+        id: BrexAccount.card_account_id,
+        name: "Brex Card",
+        account_kind: "card",
+        status: card_accounts.map { |account| account.with_indifferent_access[:status] }.compact.first,
+        card_accounts_count: card_accounts.count,
+        current_balance: totals[:current_balance],
+        available_balance: totals[:available_balance],
+        account_limit: totals[:account_limit],
+        raw_card_accounts: BrexAccount.sanitize_payload(card_accounts)
+      }.compact
+    end
+
+    def sum_money(money_values)
+      normalized = money_values.compact
+      return nil if normalized.empty?
+
+      currency = BrexAccount.currency_code_from_money(normalized.first)
+      total = normalized.sum do |money|
+        money.with_indifferent_access[:amount].to_i
+      end
+
+      { amount: total, currency: currency }
+    end
+
+    def posted_at_start_params(start_date)
+      return {} if start_date.blank?
+
+      { posted_at_start: start_date.to_date.to_s }
+    end
+
+    def get_paginated(path, params: {})
+      records = []
+      cursor = nil
+      seen_cursors = Set.new
+      page_count = 0
+
+      loop do
+        page_count += 1
+        raise BrexError.new("Brex pagination exceeded #{MAX_PAGES} pages", :pagination_error) if page_count > MAX_PAGES
+
+        page_params = params.compact.merge(limit: DEFAULT_LIMIT)
+        page_params[:cursor] = cursor if cursor.present?
+
+        response_payload = get_json(path, params: page_params)
+        if response_payload.is_a?(Array)
+          records.concat(response_payload)
+          break
+        end
+
+        page_records = extract_records(response_payload)
+        records.concat(page_records)
+
+        next_cursor = response_payload.with_indifferent_access[:next_cursor]
+        break if next_cursor.blank?
+
+        if seen_cursors.include?(next_cursor)
+          raise BrexError.new("Brex pagination returned a repeated cursor", :pagination_error)
+        end
+
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+      end
+
+      records
+    end
+
+    def get_json(path, params: {})
+      query = params.present? ? "?#{URI.encode_www_form(params)}" : ""
+      request_path = "#{path}#{query}"
+
+      response = self.class.get(
+        "#{base_url}#{request_path}",
+        headers: auth_headers
+      )
+
+      handle_response(response, path: path)
+    rescue BrexError
+      raise
+    rescue SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+      Rails.logger.error "Brex API: GET #{path} failed: #{e.class}: #{e.message}"
+      raise BrexError.new("Exception during GET request: #{e.message}", :request_failed)
+    rescue JSON::ParserError => e
+      Rails.logger.error "Brex API: invalid JSON for GET #{path}: #{e.message}"
+      raise BrexError.new("Invalid response from Brex API", :invalid_response)
+    rescue => e
+      Rails.logger.error "Brex API: Unexpected error during GET #{path}: #{e.class}: #{e.message}"
+      raise BrexError.new("Exception during GET request: #{e.message}", :request_failed)
+    end
+
+    def extract_records(response_payload)
+      payload = response_payload.with_indifferent_access
+      payload[:items] ||
+        payload[:data] ||
+        payload[:accounts] ||
+        payload[:transactions] ||
+        []
+    end
+
+    def auth_headers
+      {
+        "Authorization" => "Bearer #{token}",
+        "Content-Type" => "application/json",
+        "Accept" => "application/json"
+      }
+    end
+
+    def handle_response(response, path:)
+      trace_id = brex_trace_id(response)
+
+      case response.code
+      when 200
+        parse_json(response.body)
+      when 400
+        Rails.logger.error "Brex API: bad request for #{path} trace_id=#{trace_id}"
+        raise BrexError.new(safe_error_message(response.body, fallback: "Bad request to Brex API"), :bad_request, http_status: 400, trace_id: trace_id)
+      when 401
+        Rails.logger.warn "Brex API: unauthorized for #{path} trace_id=#{trace_id}"
+        raise BrexError.new(safe_error_message(response.body, fallback: "Invalid Brex API token"), :unauthorized, http_status: 401, trace_id: trace_id)
+      when 403
+        Rails.logger.warn "Brex API: access forbidden for #{path} trace_id=#{trace_id}"
+        raise BrexError.new("Access forbidden - check Brex API token scopes", :access_forbidden, http_status: 403, trace_id: trace_id)
+      when 404
+        Rails.logger.warn "Brex API: resource not found for #{path} trace_id=#{trace_id}"
+        raise BrexError.new("Brex resource not found", :not_found, http_status: 404, trace_id: trace_id)
+      when 429
+        Rails.logger.warn "Brex API: rate limited for #{path} trace_id=#{trace_id}"
+        raise BrexError.new("Brex rate limit exceeded. Please try again later.", :rate_limited, http_status: 429, trace_id: trace_id)
+      else
+        Rails.logger.error "Brex API: unexpected response code=#{response.code} path=#{path} trace_id=#{trace_id}"
+        raise BrexError.new("Failed to fetch data from Brex API: HTTP #{response.code}", :fetch_failed, http_status: response.code, trace_id: trace_id)
+      end
+    end
+
+    def parse_json(body)
+      return {} if body.blank?
+
+      JSON.parse(body, symbolize_names: true)
+    end
+
+    def safe_error_message(body, fallback:)
+      payload = parse_json(body)
+      payload = payload.with_indifferent_access
+      message = payload[:message].presence ||
+                payload.dig(:error, :message).presence ||
+                payload.dig(:errors, 0, :message).presence
+      message.presence || fallback
+    rescue JSON::ParserError
+      fallback
+    end
+
+    def brex_trace_id(response)
+      headers = response.respond_to?(:headers) ? response.headers : {}
+      headers["X-Brex-Trace-Id"].presence ||
+        headers["x-brex-trace-id"].presence
+    end
+
+    class BrexError < StandardError
+      attr_reader :error_type, :http_status, :trace_id
+
+      def initialize(message, error_type = :unknown, http_status: nil, trace_id: nil)
+        super(message)
+        @error_type = error_type
+        @http_status = http_status
+        @trace_id = trace_id
+      end
+    end
+end

--- a/app/models/provider/brex.rb
+++ b/app/models/provider/brex.rb
@@ -30,7 +30,9 @@ class Provider::Brex
     return nil if uri.userinfo.present?
     return nil if uri.query.present? || uri.fragment.present?
     return nil unless uri.path.blank? || uri.path == "/"
+    return nil unless uri.port == 443
 
+    # This exact allowlist is the SSRF boundary; arbitrary Brex-like hosts are never accepted.
     normalized = "#{uri.scheme.downcase}://#{uri.host.to_s.downcase}"
     ALLOWED_BASE_URLS.include?(normalized) ? normalized : nil
   rescue URI::InvalidURIError

--- a/app/models/provider/brex.rb
+++ b/app/models/provider/brex.rb
@@ -5,6 +5,8 @@ class Provider::Brex
   extend SslConfigurable
 
   DEFAULT_BASE_URL = "https://api.brex.com"
+  STAGING_BASE_URL = "https://api-staging.brex.com"
+  ALLOWED_BASE_URLS = [ DEFAULT_BASE_URL, STAGING_BASE_URL ].freeze
   DEFAULT_LIMIT = 1000
   MAX_PAGES = 250
 
@@ -15,8 +17,28 @@ class Provider::Brex
 
   def initialize(token, base_url: DEFAULT_BASE_URL)
     @token = token.to_s.strip
-    @base_url = base_url.to_s.presence || DEFAULT_BASE_URL
-    @base_url = @base_url.chomp("/")
+    @base_url = self.class.normalize_base_url(base_url)
+    raise ArgumentError, "Brex base URL must be blank or one of: #{ALLOWED_BASE_URLS.join(', ')}" unless @base_url.present?
+  end
+
+  def self.normalize_base_url(value)
+    stripped = value.to_s.strip
+    return DEFAULT_BASE_URL if stripped.blank?
+
+    uri = URI.parse(stripped)
+    return nil unless uri.is_a?(URI::HTTPS)
+    return nil if uri.userinfo.present?
+    return nil if uri.query.present? || uri.fragment.present?
+    return nil unless uri.path.blank? || uri.path == "/"
+
+    normalized = "#{uri.scheme.downcase}://#{uri.host.to_s.downcase}"
+    ALLOWED_BASE_URLS.include?(normalized) ? normalized : nil
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def self.allowed_base_url?(value)
+    normalize_base_url(value).present?
   end
 
   def get_accounts
@@ -80,7 +102,13 @@ class Provider::Brex
       normalized = money_values.compact
       return nil if normalized.empty?
 
-      currency = BrexAccount.currency_code_from_money(normalized.first)
+      currencies = normalized.map { |money| BrexAccount.currency_code_from_money(money) }.uniq
+      if currencies.many?
+        Rails.logger.warn "Brex API: Cannot aggregate card balances with mixed currencies: #{currencies.join(', ')}"
+        return nil
+      end
+
+      currency = currencies.first
       total = normalized.sum do |money|
         money.with_indifferent_access[:amount].to_i
       end
@@ -217,6 +245,8 @@ class Provider::Brex
         else
           Time.zone.parse(start_date.to_s)
         end
+
+      raise ArgumentError, "Invalid start_date: #{start_date.inspect}" if time.nil?
 
       time.utc.iso8601
     end

--- a/app/models/provider/brex.rb
+++ b/app/models/provider/brex.rb
@@ -38,7 +38,9 @@ class Provider::Brex
   end
 
   def get_card_accounts
-    get_paginated("/v2/accounts/card").map { |account| account.with_indifferent_access.merge(account_kind: "card") }
+    response_payload = get_json("/v2/accounts/card")
+
+    extract_records(response_payload).map { |account| account.with_indifferent_access.merge(account_kind: "card") }
   end
 
   def get_cash_transactions(account_id, start_date: nil)
@@ -89,7 +91,7 @@ class Provider::Brex
     def posted_at_start_params(start_date)
       return {} if start_date.blank?
 
-      { posted_at_start: start_date.to_date.to_s }
+      { posted_at_start: rfc3339_start_date(start_date) }
     end
 
     def get_paginated(path, params: {})
@@ -152,6 +154,8 @@ class Provider::Brex
     end
 
     def extract_records(response_payload)
+      return response_payload if response_payload.is_a?(Array)
+
       payload = response_payload.with_indifferent_access
       payload[:items] ||
         payload[:data] ||
@@ -176,10 +180,10 @@ class Provider::Brex
         parse_json(response.body)
       when 400
         Rails.logger.error "Brex API: bad request for #{path} trace_id=#{trace_id}"
-        raise BrexError.new(safe_error_message(response.body, fallback: "Bad request to Brex API"), :bad_request, http_status: 400, trace_id: trace_id)
+        raise BrexError.new("Bad request to Brex API", :bad_request, http_status: 400, trace_id: trace_id)
       when 401
         Rails.logger.warn "Brex API: unauthorized for #{path} trace_id=#{trace_id}"
-        raise BrexError.new(safe_error_message(response.body, fallback: "Invalid Brex API token"), :unauthorized, http_status: 401, trace_id: trace_id)
+        raise BrexError.new("Invalid Brex API token or account permissions", :unauthorized, http_status: 401, trace_id: trace_id)
       when 403
         Rails.logger.warn "Brex API: access forbidden for #{path} trace_id=#{trace_id}"
         raise BrexError.new("Access forbidden - check Brex API token scopes", :access_forbidden, http_status: 403, trace_id: trace_id)
@@ -201,15 +205,20 @@ class Provider::Brex
       JSON.parse(body, symbolize_names: true)
     end
 
-    def safe_error_message(body, fallback:)
-      payload = parse_json(body)
-      payload = payload.with_indifferent_access
-      message = payload[:message].presence ||
-                payload.dig(:error, :message).presence ||
-                payload.dig(:errors, 0, :message).presence
-      message.presence || fallback
-    rescue JSON::ParserError
-      fallback
+    def rfc3339_start_date(start_date)
+      time =
+        case start_date
+        when Time
+          start_date
+        when DateTime
+          start_date.to_time
+        when Date
+          start_date.to_time(:utc)
+        else
+          Time.zone.parse(start_date.to_s)
+        end
+
+      time.utc.iso8601
     end
 
     def brex_trace_id(response)

--- a/app/models/provider/brex.rb
+++ b/app/models/provider/brex.rb
@@ -62,9 +62,7 @@ class Provider::Brex
   end
 
   def get_card_accounts
-    response_payload = get_json("/v2/accounts/card")
-
-    extract_records(response_payload).map { |account| account.with_indifferent_access.merge(account_kind: "card") }
+    get_paginated("/v2/accounts/card").map { |account| account.with_indifferent_access.merge(account_kind: "card") }
   end
 
   def get_cash_transactions(account_id, start_date: nil)

--- a/app/models/provider/brex_adapter.rb
+++ b/app/models/provider/brex_adapter.rb
@@ -13,7 +13,7 @@ class Provider::BrexAdapter < Provider::Base
   def self.connection_configs(family:)
     return [] unless family.can_connect_brex?
 
-    brex_items = family.brex_items.active.ordered.select(&:credentials_configured?)
+    brex_items = family.brex_items.active.with_credentials.ordered.select(&:credentials_configured?)
 
     return [ connection_config_for(nil) ] if brex_items.empty?
 
@@ -74,7 +74,7 @@ class Provider::BrexAdapter < Provider::Base
       return nil
     end
 
-    credentialed_items = family.brex_items.active.ordered.select(&:credentials_configured?)
+    credentialed_items = family.brex_items.active.with_credentials.ordered.select(&:credentials_configured?)
     return credentialed_items.first if credentialed_items.one?
 
     nil

--- a/app/models/provider/brex_adapter.rb
+++ b/app/models/provider/brex_adapter.rb
@@ -114,19 +114,19 @@ class Provider::BrexAdapter < Provider::Base
 
   def institution_name
     metadata = provider_account.institution_metadata
-    return nil unless metadata.present?
 
-    metadata["name"] || item&.institution_name
+    metadata&.[]("name") || item&.institution_name
   end
 
   def institution_url
     metadata = provider_account.institution_metadata
-    return nil unless metadata.present?
 
-    metadata["url"] || item&.institution_url
+    metadata&.[]("url") || item&.institution_url
   end
 
   def institution_color
-    item&.institution_color
+    metadata = provider_account.institution_metadata
+
+    metadata&.[]("color") || item&.institution_color
   end
 end

--- a/app/models/provider/brex_adapter.rb
+++ b/app/models/provider/brex_adapter.rb
@@ -1,0 +1,129 @@
+class Provider::BrexAdapter < Provider::Base
+  include Provider::Syncable
+  include Provider::InstitutionMetadata
+
+  # Register this adapter with the factory
+  Provider::Factory.register("BrexAccount", self)
+
+  def self.supported_account_types
+    %w[Depository CreditCard]
+  end
+
+  # Returns connection configurations for this provider
+  def self.connection_configs(family:)
+    return [] unless family.can_connect_brex?
+
+    brex_items = family.brex_items.active.ordered.select(&:credentials_configured?)
+
+    return [ connection_config_for(nil) ] if brex_items.empty?
+
+    brex_items.map { |brex_item| connection_config_for(brex_item) }
+  end
+
+  def provider_name
+    "brex"
+  end
+
+  # Build a Brex provider instance with family-specific credentials
+  # @param family [Family] The family to get credentials for (required)
+  # @return [Provider::Brex, nil] Returns nil if credentials are not configured
+  def self.build_provider(family: nil, brex_item_id: nil)
+    return nil unless family.present?
+
+    brex_item = resolve_brex_item(family, brex_item_id)
+    return nil unless brex_item&.credentials_configured?
+
+    Provider::Brex.new(
+      brex_item.token.to_s.strip,
+      base_url: brex_item.effective_base_url
+    )
+  end
+
+  def self.connection_config_for(brex_item)
+    path_params = ->(extra = {}) do
+      brex_item.present? ? extra.merge(brex_item_id: brex_item.id) : extra
+    end
+
+    {
+      key: brex_item.present? ? "brex_#{brex_item.id}" : "brex",
+      name: brex_item.present? ? I18n.t("brex_items.provider_connection.name", name: brex_item.name) : I18n.t("brex_items.provider_connection.default_name"),
+      description: brex_item.present? ? I18n.t("brex_items.provider_connection.description", name: brex_item.name) : I18n.t("brex_items.provider_connection.default_description"),
+      can_connect: true,
+      new_account_path: ->(accountable_type, return_to) {
+        Rails.application.routes.url_helpers.select_accounts_brex_items_path(
+          path_params.call(accountable_type: accountable_type, return_to: return_to)
+        )
+      },
+      existing_account_path: ->(account_id) {
+        Rails.application.routes.url_helpers.select_existing_account_brex_items_path(
+          path_params.call(account_id: account_id)
+        )
+      }
+    }
+  end
+  private_class_method :connection_config_for
+
+  def self.resolve_brex_item(family, brex_item_id)
+    if brex_item_id.present?
+      item = family.brex_items.active.find_by(id: brex_item_id)
+      return item if item&.credentials_configured?
+
+      return nil
+    end
+
+    credentialed_items = family.brex_items.active.ordered.select(&:credentials_configured?)
+    return credentialed_items.first if credentialed_items.one?
+
+    nil
+  end
+  private_class_method :resolve_brex_item
+
+  def sync_path
+    Rails.application.routes.url_helpers.sync_brex_item_path(item)
+  end
+
+  def item
+    provider_account.brex_item
+  end
+
+  def can_delete_holdings?
+    false
+  end
+
+  def institution_domain
+    metadata = provider_account.institution_metadata
+    return nil unless metadata.present?
+
+    domain = metadata["domain"]
+    url = metadata["url"]
+
+    # Derive domain from URL if missing
+    if domain.blank? && url.present?
+      begin
+        domain = URI.parse(url).host&.gsub(/^www\./, "")
+      rescue URI::InvalidURIError
+        Rails.logger.warn("Invalid institution URL for Brex account #{provider_account.id}: #{url}")
+      end
+    end
+
+    domain
+  end
+
+  def institution_name
+    metadata = provider_account.institution_metadata
+    return nil unless metadata.present?
+
+    metadata["name"] || item&.institution_name
+  end
+
+  def institution_url
+    metadata = provider_account.institution_metadata
+    return nil unless metadata.present?
+
+    metadata["url"] || item&.institution_url
+  end
+
+  def institution_color
+    item&.institution_color
+  end
+end

--- a/app/models/provider/brex_adapter.rb
+++ b/app/models/provider/brex_adapter.rb
@@ -115,18 +115,18 @@ class Provider::BrexAdapter < Provider::Base
   def institution_name
     metadata = provider_account.institution_metadata
 
-    metadata&.[]("name") || item&.institution_name
+    metadata&.dig("name") || item&.institution_name
   end
 
   def institution_url
     metadata = provider_account.institution_metadata
 
-    metadata&.[]("url") || item&.institution_url
+    metadata&.dig("url") || item&.institution_url
   end
 
   def institution_color
     metadata = provider_account.institution_metadata
 
-    metadata&.[]("color") || item&.institution_color
+    metadata&.dig("color") || item&.institution_color
   end
 end

--- a/app/models/provider/brex_adapter.rb
+++ b/app/models/provider/brex_adapter.rb
@@ -33,9 +33,12 @@ class Provider::BrexAdapter < Provider::Base
     brex_item = resolve_brex_item(family, brex_item_id)
     return nil unless brex_item&.credentials_configured?
 
+    base_url = brex_item.effective_base_url
+    return nil unless base_url.present?
+
     Provider::Brex.new(
       brex_item.token.to_s.strip,
-      base_url: brex_item.effective_base_url
+      base_url: base_url
     )
   end
 

--- a/app/models/provider_merchant.rb
+++ b/app/models/provider_merchant.rb
@@ -1,5 +1,5 @@
 class ProviderMerchant < Merchant
-  enum :source, { plaid: "plaid", simplefin: "simplefin", lunchflow: "lunchflow", synth: "synth", ai: "ai", enable_banking: "enable_banking", coinstats: "coinstats", mercury: "mercury", indexa_capital: "indexa_capital", sophtron: "sophtron" }
+  enum :source, { plaid: "plaid", simplefin: "simplefin", lunchflow: "lunchflow", synth: "synth", ai: "ai", enable_banking: "enable_banking", coinstats: "coinstats", mercury: "mercury", brex: "brex", indexa_capital: "indexa_capital", sophtron: "sophtron" }
 
   validates :name, uniqueness: { scope: [ :source ] }
   validates :source, presence: true

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -17,7 +17,7 @@
   ) %>
 <% end %>
 
-<% if @manual_accounts.empty? && @plaid_items.empty? && @simplefin_items.empty? && @lunchflow_items.empty? && @enable_banking_items.empty? && @coinstats_items.empty? && @coinbase_items.empty? && @mercury_items.empty? && @snaptrade_items.empty? && @indexa_capital_items.empty? && @sophtron_items.empty? %>
+<% if @manual_accounts.empty? && @plaid_items.empty? && @simplefin_items.empty? && @lunchflow_items.empty? && @enable_banking_items.empty? && @coinstats_items.empty? && @coinbase_items.empty? && @mercury_items.empty? && @brex_items.empty? && @snaptrade_items.empty? && @indexa_capital_items.empty? && @sophtron_items.empty? %>
   <%= render "empty" %>
 <% else %>
   <div class="space-y-2">
@@ -47,6 +47,10 @@
 
     <% if @mercury_items.any? %>
       <%= render @mercury_items.sort_by(&:created_at) %>
+    <% end %>
+
+    <% if @brex_items.any? %>
+      <%= render @brex_items.sort_by(&:created_at) %>
     <% end %>
 
     <% if @coinbase_items.any? %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -50,7 +50,15 @@
     <% end %>
 
     <% if @brex_items.any? %>
-      <%= render @brex_items.sort_by(&:created_at) %>
+      <% @brex_items.sort_by(&:created_at).each do |brex_item| %>
+        <%= render partial: "brex_items/brex_item",
+                   locals: brex_item_render_locals(
+                     brex_item,
+                     sync_stats_map: @brex_sync_stats_map,
+                     account_counts_map: @brex_account_counts_map,
+                     institutions_count_map: @brex_institutions_count_map
+                   ) %>
+      <% end %>
     <% end %>
 
     <% if @coinbase_items.any? %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -50,15 +50,7 @@
     <% end %>
 
     <% if @brex_items.any? %>
-      <% @brex_items.sort_by(&:created_at).each do |brex_item| %>
-        <%= render partial: "brex_items/brex_item",
-                   locals: brex_item_render_locals(
-                     brex_item,
-                     sync_stats_map: @brex_sync_stats_map,
-                     account_counts_map: @brex_account_counts_map,
-                     institutions_count_map: @brex_institutions_count_map
-                   ) %>
-      <% end %>
+      <%= render @brex_items.sort_by(&:created_at) %>
     <% end %>
 
     <% if @coinbase_items.any? %>

--- a/app/views/brex_items/_api_error.html.erb
+++ b/app/views/brex_items/_api_error.html.erb
@@ -24,7 +24,7 @@
         </div>
 
         <div class="mt-4">
-          <%= link_to settings_providers_path,
+          <%= link_to return_path.presence || settings_providers_path,
                       class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors",
                       data: { turbo: false } do %>
             <%= t(".settings_link") %>

--- a/app/views/brex_items/_api_error.html.erb
+++ b/app/views/brex_items/_api_error.html.erb
@@ -1,0 +1,36 @@
+<%# locals: (error_message:, return_path:) %>
+<%= turbo_frame_tag "modal" do %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t(".title")) %>
+    <% dialog.with_body do %>
+      <div class="space-y-4">
+        <div class="flex items-start gap-3">
+          <%= icon("alert-circle", class: "text-destructive w-5 h-5 shrink-0 mt-0.5") %>
+          <div class="text-sm">
+            <p class="font-medium text-primary mb-2"><%= t(".heading") %></p>
+            <p class="text-secondary"><%= error_message %></p>
+          </div>
+        </div>
+
+        <div class="bg-surface rounded-lg p-4 space-y-2 text-sm">
+          <p class="font-medium text-primary"><%= t(".common_issues") %></p>
+          <ul class="list-disc list-inside space-y-1 text-secondary">
+            <li><strong><%= t(".invalid_token_label") %></strong> <%= t(".invalid_token") %></li>
+            <li><strong><%= t(".expired_credentials_label") %></strong> <%= t(".expired_credentials") %></li>
+            <li><strong><%= t(".permissions_label") %></strong> <%= t(".permissions") %></li>
+            <li><strong><%= t(".network_label") %></strong> <%= t(".network") %></li>
+            <li><strong><%= t(".service_label") %></strong> <%= t(".service") %></li>
+          </ul>
+        </div>
+
+        <div class="mt-4">
+          <%= link_to settings_providers_path,
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors",
+                      data: { turbo: false } do %>
+            <%= t(".settings_link") %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/brex_items/_brex_item.html.erb
+++ b/app/views/brex_items/_brex_item.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (brex_item:) %>
+<%# locals: (brex_item:, stats:, unlinked_count:, linked_count:, total_count:, institutions_count:) %>
 
 <%= tag.div id: dom_id(brex_item) do %>
   <details open class="group bg-container p-4 shadow-border-xs rounded-xl">
@@ -84,22 +84,11 @@
           <%= render "accounts/index/account_groups", accounts: brex_item.accounts %>
         <% end %>
 
-        <%# Sync summary (collapsible) - using shared ProviderSyncSummary component %>
-        <% stats = if defined?(@brex_sync_stats_map) && @brex_sync_stats_map
-             @brex_sync_stats_map[brex_item.id] || {}
-           else
-             brex_item.syncs.ordered.first&.sync_stats || {}
-           end %>
         <%= render ProviderSyncSummary.new(
           stats: stats,
           provider_item: brex_item,
-          institutions_count: brex_item.connected_institutions.size
+          institutions_count: institutions_count
         ) %>
-
-        <%# Use model methods for consistent counts %>
-        <% unlinked_count = brex_item.unlinked_accounts_count %>
-        <% linked_count = brex_item.linked_accounts_count %>
-        <% total_count = brex_item.total_accounts_count %>
 
         <% if unlinked_count > 0 %>
           <div class="p-4 flex flex-col gap-3 items-center justify-center">

--- a/app/views/brex_items/_brex_item.html.erb
+++ b/app/views/brex_items/_brex_item.html.erb
@@ -1,0 +1,132 @@
+<%# locals: (brex_item:) %>
+
+<%= tag.div id: dom_id(brex_item) do %>
+  <details open class="group bg-container p-4 shadow-border-xs rounded-xl">
+    <summary class="flex items-center justify-between gap-2">
+      <div class="flex items-center gap-2">
+        <%= icon "chevron-right", class: "group-open:transform group-open:rotate-90" %>
+
+        <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
+          <% if brex_item.logo.attached? %>
+            <%= image_tag brex_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
+          <% else %>
+            <div class="flex items-center justify-center">
+              <%= tag.p brex_item.name.first.upcase, class: "text-primary text-xs font-medium" %>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="pl-1 text-sm">
+          <div class="flex items-center gap-2">
+            <%= tag.p brex_item.name, class: "font-medium text-primary" %>
+            <% if brex_item.scheduled_for_deletion? %>
+              <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
+            <% end %>
+          </div>
+          <% if brex_item.accounts.any? %>
+            <p class="text-xs text-secondary">
+              <%= brex_item.institution_summary %>
+            </p>
+          <% end %>
+          <% if brex_item.syncing? %>
+            <div class="text-secondary flex items-center gap-1">
+              <%= icon "loader", size: "sm", class: "animate-spin" %>
+              <%= tag.span t(".syncing") %>
+            </div>
+          <% elsif brex_item.sync_error.present? %>
+            <div class="text-secondary flex items-center gap-1">
+              <%= render DS::Tooltip.new(text: brex_item.sync_error, icon: "alert-circle", size: "sm", color: "destructive") %>
+              <%= tag.span t(".error"), class: "text-destructive" %>
+            </div>
+          <% else %>
+            <p class="text-secondary">
+              <% if brex_item.last_synced_at %>
+                <% if brex_item.sync_status_summary %>
+                  <%= t(".status_with_summary", timestamp: time_ago_in_words(brex_item.last_synced_at), summary: brex_item.sync_status_summary) %>
+                <% else %>
+                  <%= t(".status", timestamp: time_ago_in_words(brex_item.last_synced_at)) %>
+                <% end %>
+              <% else %>
+                <%= t(".status_never") %>
+              <% end %>
+            </p>
+          <% end %>
+        </div>
+      </div>
+
+      <% if Current.user&.admin? %>
+        <div class="flex items-center gap-2">
+          <% if Rails.env.development? %>
+            <%= icon(
+              "refresh-cw",
+              as_button: true,
+              href: sync_brex_item_path(brex_item)
+            ) %>
+          <% end %>
+
+          <%= render DS::Menu.new do |menu| %>
+            <% menu.with_item(
+              variant: "button",
+              text: t(".delete"),
+              icon: "trash-2",
+              href: brex_item_path(brex_item),
+              method: :delete,
+              confirm: CustomConfirm.for_resource_deletion(brex_item.name, high_severity: true)
+            ) %>
+          <% end %>
+        </div>
+      <% end %>
+    </summary>
+
+    <% unless brex_item.scheduled_for_deletion? %>
+      <div class="space-y-4 mt-4">
+        <% if brex_item.accounts.any? %>
+          <%= render "accounts/index/account_groups", accounts: brex_item.accounts %>
+        <% end %>
+
+        <%# Sync summary (collapsible) - using shared ProviderSyncSummary component %>
+        <% stats = if defined?(@brex_sync_stats_map) && @brex_sync_stats_map
+             @brex_sync_stats_map[brex_item.id] || {}
+           else
+             brex_item.syncs.ordered.first&.sync_stats || {}
+           end %>
+        <%= render ProviderSyncSummary.new(
+          stats: stats,
+          provider_item: brex_item,
+          institutions_count: brex_item.connected_institutions.size
+        ) %>
+
+        <%# Use model methods for consistent counts %>
+        <% unlinked_count = brex_item.unlinked_accounts_count %>
+        <% linked_count = brex_item.linked_accounts_count %>
+        <% total_count = brex_item.total_accounts_count %>
+
+        <% if unlinked_count > 0 %>
+          <div class="p-4 flex flex-col gap-3 items-center justify-center">
+            <p class="text-primary font-medium text-sm"><%= t(".setup_needed") %></p>
+            <p class="text-secondary text-sm"><%= t(".setup_description", linked: linked_count, total: total_count) %></p>
+            <%= render DS::Link.new(
+              text: t(".setup_action"),
+              icon: "settings",
+              variant: "primary",
+              href: setup_accounts_brex_item_path(brex_item),
+              frame: :modal
+            ) %>
+          </div>
+        <% elsif brex_item.accounts.empty? && total_count == 0 %>
+          <div class="p-4 flex flex-col gap-3 items-center justify-center">
+            <p class="text-primary font-medium text-sm"><%= t(".no_accounts_title") %></p>
+            <p class="text-secondary text-sm"><%= t(".no_accounts_description") %></p>
+            <%= render DS::Link.new(
+              text: t(".setup_action"),
+              icon: "settings",
+              variant: "primary",
+              href: setup_accounts_brex_item_path(brex_item),
+              frame: :modal
+            ) %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </details>
+<% end %>

--- a/app/views/brex_items/_brex_item.html.erb
+++ b/app/views/brex_items/_brex_item.html.erb
@@ -1,4 +1,15 @@
-<%# locals: (brex_item:, stats:, unlinked_count:, linked_count:, total_count:, institutions_count:) %>
+<%# locals: (brex_item:) %>
+<% render_locals = brex_item_render_locals(
+     brex_item,
+     sync_stats_map: @brex_sync_stats_map,
+     account_counts_map: @brex_account_counts_map,
+     institutions_count_map: @brex_institutions_count_map
+   ) %>
+<% stats = render_locals[:stats] %>
+<% unlinked_count = render_locals[:unlinked_count] %>
+<% linked_count = render_locals[:linked_count] %>
+<% total_count = render_locals[:total_count] %>
+<% institutions_count = render_locals[:institutions_count] %>
 
 <%= tag.div id: dom_id(brex_item) do %>
   <details open class="group bg-container p-4 shadow-border-xs rounded-xl">
@@ -20,7 +31,7 @@
           <div class="flex items-center gap-2">
             <%= tag.p brex_item.name, class: "font-medium text-primary" %>
             <% if brex_item.scheduled_for_deletion? %>
-              <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
+              <%= tag.p t(".deletion_in_progress"), class: "text-destructive text-sm animate-pulse" %>
             <% end %>
           </div>
           <% if brex_item.accounts.any? %>

--- a/app/views/brex_items/_setup_required.html.erb
+++ b/app/views/brex_items/_setup_required.html.erb
@@ -1,0 +1,34 @@
+<%= turbo_frame_tag "modal" do %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t(".title")) %>
+    <% dialog.with_body do %>
+      <div class="space-y-4">
+        <div class="flex items-start gap-3">
+          <%= icon("alert-circle", class: "text-warning w-5 h-5 shrink-0 mt-0.5") %>
+          <div class="text-sm text-secondary">
+            <p class="font-medium text-primary mb-2"><%= t(".heading") %></p>
+            <p><%= t(".description") %></p>
+          </div>
+        </div>
+
+        <div class="bg-surface rounded-lg p-4 space-y-2 text-sm">
+          <p class="font-medium text-primary"><%= t(".setup_steps") %></p>
+          <ol class="list-decimal list-inside space-y-1 text-secondary">
+            <li><%= t(".steps.open_settings_html") %></li>
+            <li><%= t(".steps.find_section_html") %></li>
+            <li><%= t(".steps.enter_token") %></li>
+            <li><%= t(".steps.return_to_link") %></li>
+          </ol>
+        </div>
+
+        <div class="mt-4">
+          <%= link_to settings_providers_path,
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors",
+                      data: { turbo: false } do %>
+            <%= t(".settings_link") %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/brex_items/_subtype_select.html.erb
+++ b/app/views/brex_items/_subtype_select.html.erb
@@ -1,0 +1,25 @@
+<div class="subtype-select" data-type="<%= account_type %>" style="display: none;">
+  <% if subtype_config[:options].present? %>
+    <%= label_tag "account_subtypes[#{brex_account.id}]", subtype_config[:label],
+                 class: "block text-sm font-medium text-primary mb-2" %>
+    <% selected_value = "" %>
+    <% if account_type == "Depository" %>
+      <% n = brex_account.name.to_s.downcase %>
+      <% selected_value = "" %>
+      <% if n =~ /\bchecking\b|\bchequing\b|\bck\b|demand\s+deposit/ %>
+        <% selected_value = "checking" %>
+      <% elsif n =~ /\bsavings\b|\bsv\b/ %>
+        <% selected_value = "savings" %>
+      <% elsif n =~ /money\s+market|\bmm\b/ %>
+        <% selected_value = "money_market" %>
+      <% else %>
+        <% selected_value = "checking" %>
+      <% end %>
+    <% end %>
+    <%= select_tag "account_subtypes[#{brex_account.id}]",
+                  options_for_select([["Select #{account_type == 'Depository' ? 'subtype' : 'type'}", ""]] + subtype_config[:options], selected_value),
+                  { class: "appearance-none bg-container border border-primary rounded-md px-3 py-2 text-sm leading-6 text-primary focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none w-full" } %>
+  <% else %>
+    <p class="text-sm text-secondary"><%= subtype_config[:message] %></p>
+  <% end %>
+</div>

--- a/app/views/brex_items/_subtype_select.html.erb
+++ b/app/views/brex_items/_subtype_select.html.erb
@@ -4,20 +4,11 @@
                  class: "block text-sm font-medium text-primary mb-2" %>
     <% selected_value = "" %>
     <% if account_type == "Depository" %>
-      <% n = brex_account.name.to_s.downcase %>
-      <% selected_value = "" %>
-      <% if n =~ /\bchecking\b|\bchequing\b|\bck\b|demand\s+deposit/ %>
-        <% selected_value = "checking" %>
-      <% elsif n =~ /\bsavings\b|\bsv\b/ %>
-        <% selected_value = "savings" %>
-      <% elsif n =~ /money\s+market|\bmm\b/ %>
-        <% selected_value = "money_market" %>
-      <% else %>
-        <% selected_value = "checking" %>
-      <% end %>
+      <% selected_value = default_brex_depository_subtype(brex_account.name) %>
     <% end %>
+    <% prompt_key = account_type == "Depository" ? "subtype" : "type" %>
     <%= select_tag "account_subtypes[#{brex_account.id}]",
-                  options_for_select([["Select #{account_type == 'Depository' ? 'subtype' : 'type'}", ""]] + subtype_config[:options], selected_value),
+                  options_for_select([[t("brex_items.subtype_select.placeholder.#{prompt_key}"), ""]] + subtype_config[:options], selected_value),
                   { class: "appearance-none bg-container border border-primary rounded-md px-3 py-2 text-sm leading-6 text-primary focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none w-full" } %>
   <% else %>
     <p class="text-sm text-secondary"><%= subtype_config[:message] %></p>

--- a/app/views/brex_items/select_accounts.html.erb
+++ b/app/views/brex_items/select_accounts.html.erb
@@ -8,8 +8,10 @@
           <%= t(".description", product_name: product_name) %>
         </p>
 
-        <form action="<%= link_accounts_brex_items_path %>" method="post" class="space-y-4" data-turbo-frame="_top">
-          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+        <%= form_with url: link_accounts_brex_items_path,
+                      method: :post,
+                      data: { turbo_frame: "_top" },
+                      class: "space-y-4" do %>
           <%= hidden_field_tag :brex_item_id, @brex_item.id %>
           <%= hidden_field_tag :accountable_type, @accountable_type %>
           <%= hidden_field_tag :return_to, @return_to %>
@@ -47,7 +49,7 @@
             <%= submit_tag t(".link_accounts"),
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
           </div>
-        </form>
+        <% end %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/brex_items/select_accounts.html.erb
+++ b/app/views/brex_items/select_accounts.html.erb
@@ -1,0 +1,61 @@
+<%= turbo_frame_tag "modal" do %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t(".title")) %>
+
+    <% dialog.with_body do %>
+      <div class="space-y-4">
+        <p class="text-sm text-secondary">
+          <%= t(".description", product_name: product_name) %>
+        </p>
+
+        <form action="<%= link_accounts_brex_items_path %>" method="post" class="space-y-4" data-turbo-frame="_top">
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= hidden_field_tag :brex_item_id, @brex_item.id %>
+          <%= hidden_field_tag :accountable_type, @accountable_type %>
+          <%= hidden_field_tag :return_to, @return_to %>
+
+          <div class="space-y-2">
+            <% @available_accounts.each do |account| %>
+              <% account_data = account.with_indifferent_access %>
+              <% account_kind = account_data[:account_kind].presence || account_data[:kind].presence || "cash" %>
+              <% account_name = account_kind.to_s == "card" ? account_data[:name].presence || "Brex Card" : account_data[:name].presence || "Brex Cash #{account_data[:id]}" %>
+              <% account_currency = BrexAccount.currency_code_from_money(account_data[:current_balance] || account_data[:available_balance] || account_data[:account_limit]) %>
+              <% has_blank_name = account_name.blank? %>
+              <label class="flex items-start gap-3 p-3 border <%= has_blank_name ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= has_blank_name ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+                <%= check_box_tag "account_ids[]", account_data[:id], false, disabled: has_blank_name, class: "mt-1" %>
+                <div class="flex-1">
+                  <div class="font-medium text-sm <%= has_blank_name ? "text-error" : "text-primary" %>">
+                    <% if has_blank_name %>
+                      <%= t(".no_name_placeholder") %>
+                    <% else %>
+                      <%= account_name %>
+                    <% end %>
+                  </div>
+                  <div class="text-xs text-secondary mt-1">
+                    Brex • <%= account_currency %> • <%= account_kind.to_s.titleize %>
+                    <% if account_data[:status].present? %>
+                      • <%= account_data[:status].to_s.titleize %>
+                    <% end %>
+                  </div>
+                  <% if has_blank_name %>
+                    <div class="text-xs text-error mt-1">
+                      <%= t(".configure_name_in_brex") %>
+                    </div>
+                  <% end %>
+                </div>
+              </label>
+            <% end %>
+          </div>
+
+          <div class="flex gap-2 justify-end pt-4">
+            <%= link_to t(".cancel"), @return_to || new_account_path,
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
+                data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
+            <%= submit_tag t(".link_accounts"),
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+          </div>
+        </form>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/brex_items/select_accounts.html.erb
+++ b/app/views/brex_items/select_accounts.html.erb
@@ -16,28 +16,21 @@
 
           <div class="space-y-2">
             <% @available_accounts.each do |account| %>
-              <% account_data = account.with_indifferent_access %>
-              <% account_kind = account_data[:account_kind].presence || account_data[:kind].presence || "cash" %>
-              <% account_name = account_kind.to_s == "card" ? account_data[:name].presence || "Brex Card" : account_data[:name].presence || "Brex Cash #{account_data[:id]}" %>
-              <% account_currency = BrexAccount.currency_code_from_money(account_data[:current_balance] || account_data[:available_balance] || account_data[:account_limit]) %>
-              <% has_blank_name = account_name.blank? %>
-              <label class="flex items-start gap-3 p-3 border <%= has_blank_name ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= has_blank_name ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
-                <%= check_box_tag "account_ids[]", account_data[:id], false, disabled: has_blank_name, class: "mt-1" %>
+              <% account_display = brex_account_display(account) %>
+              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+                <%= check_box_tag "account_ids[]", account_display.id, false, disabled: account_display.blank_name?, class: "mt-1" %>
                 <div class="flex-1">
-                  <div class="font-medium text-sm <%= has_blank_name ? "text-error" : "text-primary" %>">
-                    <% if has_blank_name %>
+                  <div class="font-medium text-sm <%= account_display.blank_name? ? "text-error" : "text-primary" %>">
+                    <% if account_display.blank_name? %>
                       <%= t(".no_name_placeholder") %>
                     <% else %>
-                      <%= account_name %>
+                      <%= account_display.name %>
                     <% end %>
                   </div>
                   <div class="text-xs text-secondary mt-1">
-                    Brex • <%= account_currency %> • <%= account_kind.to_s.titleize %>
-                    <% if account_data[:status].present? %>
-                      • <%= account_data[:status].to_s.titleize %>
-                    <% end %>
+                    <%= brex_account_metadata(account_display) %>
                   </div>
-                  <% if has_blank_name %>
+                  <% if account_display.blank_name? %>
                     <div class="text-xs text-error mt-1">
                       <%= t(".configure_name_in_brex") %>
                     </div>
@@ -50,7 +43,7 @@
           <div class="flex gap-2 justify-end pt-4">
             <%= link_to t(".cancel"), @return_to || new_account_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
-                data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
+                data: { turbo_frame: "_top" } %>
             <%= submit_tag t(".link_accounts"),
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
           </div>

--- a/app/views/brex_items/select_accounts.html.erb
+++ b/app/views/brex_items/select_accounts.html.erb
@@ -16,13 +16,15 @@
           <%= hidden_field_tag :accountable_type, @accountable_type %>
           <%= hidden_field_tag :return_to, @return_to %>
 
+          <% account_displays = @available_accounts.map { |account| brex_account_display(account) } %>
+          <% has_selectable = account_displays.any? { |account_display| !account_display.blank_name? } %>
+
           <div class="space-y-2">
-            <% @available_accounts.each do |account| %>
-              <% account_display = brex_account_display(account) %>
-              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+            <% account_displays.each do |account_display| %>
+              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-destructive bg-red-tint-5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
                 <%= check_box_tag "account_ids[]", account_display.id, false, disabled: account_display.blank_name?, class: "mt-1" %>
                 <div class="flex-1">
-                  <div class="font-medium text-sm <%= account_display.blank_name? ? "text-error" : "text-primary" %>">
+                  <div class="font-medium text-sm <%= account_display.blank_name? ? "text-destructive" : "text-primary" %>">
                     <% if account_display.blank_name? %>
                       <%= t(".no_name_placeholder") %>
                     <% else %>
@@ -33,7 +35,7 @@
                     <%= brex_account_metadata(account_display) %>
                   </div>
                   <% if account_display.blank_name? %>
-                    <div class="text-xs text-error mt-1">
+                    <div class="text-xs text-destructive mt-1">
                       <%= t(".configure_name_in_brex") %>
                     </div>
                   <% end %>
@@ -47,7 +49,8 @@
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top" } %>
             <%= submit_tag t(".link_accounts"),
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+                disabled: !has_selectable,
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled disabled:cursor-not-allowed" %>
           </div>
         <% end %>
       </div>

--- a/app/views/brex_items/select_accounts.html.erb
+++ b/app/views/brex_items/select_accounts.html.erb
@@ -21,7 +21,7 @@
 
           <div class="space-y-2">
             <% account_displays.each do |account_display| %>
-              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-destructive bg-red-tint-5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-destructive bg-destructive-surface" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
                 <%= check_box_tag "account_ids[]", account_display.id, false, disabled: account_display.blank_name?, class: "mt-1" %>
                 <div class="flex-1">
                   <div class="font-medium text-sm <%= account_display.blank_name? ? "text-destructive" : "text-primary" %>">

--- a/app/views/brex_items/select_existing_account.html.erb
+++ b/app/views/brex_items/select_existing_account.html.erb
@@ -21,7 +21,7 @@
 
           <div class="space-y-2">
             <% account_displays.each do |account_display| %>
-              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-destructive bg-red-tint-5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-destructive bg-destructive-surface" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
                 <%= radio_button_tag "brex_account_id", account_display.id, false, disabled: account_display.blank_name?, class: "mt-1" %>
                 <div class="flex-1">
                   <div class="font-medium text-sm <%= account_display.blank_name? ? "text-destructive" : "text-primary" %>">

--- a/app/views/brex_items/select_existing_account.html.erb
+++ b/app/views/brex_items/select_existing_account.html.erb
@@ -1,0 +1,61 @@
+<%= turbo_frame_tag "modal" do %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t(".title", account_name: @account.name)) %>
+
+    <% dialog.with_body do %>
+      <div class="space-y-4">
+        <p class="text-sm text-secondary">
+          <%= t(".description") %>
+        </p>
+
+        <form action="<%= link_existing_account_brex_items_path %>" method="post" class="space-y-4" data-turbo-frame="_top">
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= hidden_field_tag :brex_item_id, @brex_item.id %>
+          <%= hidden_field_tag :account_id, @account.id %>
+          <%= hidden_field_tag :return_to, @return_to %>
+
+          <div class="space-y-2">
+            <% @available_accounts.each do |account| %>
+              <% account_data = account.with_indifferent_access %>
+              <% account_kind = account_data[:account_kind].presence || account_data[:kind].presence || "cash" %>
+              <% account_name = account_kind.to_s == "card" ? account_data[:name].presence || "Brex Card" : account_data[:name].presence || "Brex Cash #{account_data[:id]}" %>
+              <% account_currency = BrexAccount.currency_code_from_money(account_data[:current_balance] || account_data[:available_balance] || account_data[:account_limit]) %>
+              <% has_blank_name = account_name.blank? %>
+              <label class="flex items-start gap-3 p-3 border <%= has_blank_name ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= has_blank_name ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+                <%= radio_button_tag "brex_account_id", account_data[:id], false, disabled: has_blank_name, class: "mt-1" %>
+                <div class="flex-1">
+                  <div class="font-medium text-sm <%= has_blank_name ? "text-error" : "text-primary" %>">
+                    <% if has_blank_name %>
+                      <%= t(".no_name_placeholder") %>
+                    <% else %>
+                      <%= account_name %>
+                    <% end %>
+                  </div>
+                  <div class="text-xs text-secondary mt-1">
+                    Brex • <%= account_currency %> • <%= account_kind.to_s.titleize %>
+                    <% if account_data[:status].present? %>
+                      • <%= account_data[:status].to_s.titleize %>
+                    <% end %>
+                  </div>
+                  <% if has_blank_name %>
+                    <div class="text-xs text-error mt-1">
+                      <%= t(".configure_name_in_brex") %>
+                    </div>
+                  <% end %>
+                </div>
+              </label>
+            <% end %>
+          </div>
+
+          <div class="flex gap-2 justify-end pt-4">
+            <%= link_to t(".cancel"), @return_to || accounts_path,
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
+                data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
+            <%= submit_tag t(".link_account"),
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+          </div>
+        </form>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/brex_items/select_existing_account.html.erb
+++ b/app/views/brex_items/select_existing_account.html.erb
@@ -8,19 +8,23 @@
           <%= t(".description") %>
         </p>
 
-        <form action="<%= link_existing_account_brex_items_path %>" method="post" class="space-y-4" data-turbo-frame="_top">
-          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+        <%= form_with url: link_existing_account_brex_items_path,
+                      method: :post,
+                      data: { turbo_frame: "_top" },
+                      class: "space-y-4" do %>
           <%= hidden_field_tag :brex_item_id, @brex_item.id %>
           <%= hidden_field_tag :account_id, @account.id %>
           <%= hidden_field_tag :return_to, @return_to %>
 
+          <% account_displays = @available_accounts.map { |account| brex_account_display(account) } %>
+          <% has_selectable = account_displays.any? { |account_display| !account_display.blank_name? } %>
+
           <div class="space-y-2">
-            <% @available_accounts.each do |account| %>
-              <% account_display = brex_account_display(account) %>
-              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+            <% account_displays.each do |account_display| %>
+              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-destructive bg-red-tint-5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
                 <%= radio_button_tag "brex_account_id", account_display.id, false, disabled: account_display.blank_name?, class: "mt-1" %>
                 <div class="flex-1">
-                  <div class="font-medium text-sm <%= account_display.blank_name? ? "text-error" : "text-primary" %>">
+                  <div class="font-medium text-sm <%= account_display.blank_name? ? "text-destructive" : "text-primary" %>">
                     <% if account_display.blank_name? %>
                       <%= t(".no_name_placeholder") %>
                     <% else %>
@@ -31,7 +35,7 @@
                     <%= brex_account_metadata(account_display) %>
                   </div>
                   <% if account_display.blank_name? %>
-                    <div class="text-xs text-error mt-1">
+                    <div class="text-xs text-destructive mt-1">
                       <%= t(".configure_name_in_brex") %>
                     </div>
                   <% end %>
@@ -45,9 +49,10 @@
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top" } %>
             <%= submit_tag t(".link_account"),
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+                disabled: !has_selectable,
+                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled disabled:cursor-not-allowed" %>
           </div>
-        </form>
+        <% end %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/brex_items/select_existing_account.html.erb
+++ b/app/views/brex_items/select_existing_account.html.erb
@@ -16,28 +16,21 @@
 
           <div class="space-y-2">
             <% @available_accounts.each do |account| %>
-              <% account_data = account.with_indifferent_access %>
-              <% account_kind = account_data[:account_kind].presence || account_data[:kind].presence || "cash" %>
-              <% account_name = account_kind.to_s == "card" ? account_data[:name].presence || "Brex Card" : account_data[:name].presence || "Brex Cash #{account_data[:id]}" %>
-              <% account_currency = BrexAccount.currency_code_from_money(account_data[:current_balance] || account_data[:available_balance] || account_data[:account_limit]) %>
-              <% has_blank_name = account_name.blank? %>
-              <label class="flex items-start gap-3 p-3 border <%= has_blank_name ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= has_blank_name ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
-                <%= radio_button_tag "brex_account_id", account_data[:id], false, disabled: has_blank_name, class: "mt-1" %>
+              <% account_display = brex_account_display(account) %>
+              <label class="flex items-start gap-3 p-3 border <%= account_display.blank_name? ? "border-error bg-error/5" : "border-primary" %> rounded-lg <%= account_display.blank_name? ? "cursor-not-allowed opacity-60" : "hover:bg-subtle cursor-pointer" %> transition-colors">
+                <%= radio_button_tag "brex_account_id", account_display.id, false, disabled: account_display.blank_name?, class: "mt-1" %>
                 <div class="flex-1">
-                  <div class="font-medium text-sm <%= has_blank_name ? "text-error" : "text-primary" %>">
-                    <% if has_blank_name %>
+                  <div class="font-medium text-sm <%= account_display.blank_name? ? "text-error" : "text-primary" %>">
+                    <% if account_display.blank_name? %>
                       <%= t(".no_name_placeholder") %>
                     <% else %>
-                      <%= account_name %>
+                      <%= account_display.name %>
                     <% end %>
                   </div>
                   <div class="text-xs text-secondary mt-1">
-                    Brex • <%= account_currency %> • <%= account_kind.to_s.titleize %>
-                    <% if account_data[:status].present? %>
-                      • <%= account_data[:status].to_s.titleize %>
-                    <% end %>
+                    <%= brex_account_metadata(account_display) %>
                   </div>
-                  <% if has_blank_name %>
+                  <% if account_display.blank_name? %>
                     <div class="text-xs text-error mt-1">
                       <%= t(".configure_name_in_brex") %>
                     </div>
@@ -50,7 +43,7 @@
           <div class="flex gap-2 justify-end pt-4">
             <%= link_to t(".cancel"), @return_to || accounts_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
-                data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
+                data: { turbo_frame: "_top" } %>
             <%= submit_tag t(".link_account"),
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
           </div>

--- a/app/views/brex_items/setup_accounts.html.erb
+++ b/app/views/brex_items/setup_accounts.html.erb
@@ -1,0 +1,106 @@
+<% content_for :title, t(".title") %>
+
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_header(title: t(".title")) do %>
+    <div class="flex items-center gap-2">
+      <%= icon "building-2", class: "text-primary" %>
+      <span class="text-primary"><%= t(".subtitle") %></span>
+    </div>
+  <% end %>
+
+  <% dialog.with_body do %>
+    <%= form_with url: complete_account_setup_brex_item_path(@brex_item),
+                  method: :post,
+                  local: true,
+                  data: {
+                    controller: "loading-button",
+                    action: "submit->loading-button#showLoading",
+                    loading_button_loading_text_value: t(".creating_accounts"),
+                    turbo_frame: "_top"
+                  },
+                  class: "space-y-6" do |form| %>
+
+      <div class="space-y-4">
+        <% if @api_error.present? %>
+          <div class="p-8 flex flex-col gap-3 items-center justify-center text-center">
+            <%= icon "alert-circle", size: "lg", class: "text-destructive" %>
+            <p class="text-primary font-medium"><%= t(".fetch_failed") %></p>
+            <p class="text-destructive text-sm"><%= @api_error %></p>
+          </div>
+        <% elsif @brex_accounts.empty? %>
+          <div class="p-8 flex flex-col gap-3 items-center justify-center text-center">
+            <%= icon "check-circle", size: "lg", class: "text-success" %>
+            <p class="text-primary font-medium"><%= t(".no_accounts_to_setup") %></p>
+            <p class="text-secondary text-sm"><%= t(".all_accounts_linked") %></p>
+          </div>
+        <% else %>
+          <div class="bg-surface border border-primary p-4 rounded-lg">
+            <div class="flex items-start gap-3">
+              <%= icon "info", size: "sm", class: "text-primary mt-0.5 flex-shrink-0" %>
+              <div>
+                <p class="text-sm text-primary mb-2">
+                  <strong><%= t(".choose_account_type") %></strong>
+                </p>
+                <ul class="text-xs text-secondary space-y-1 list-disc list-inside">
+                  <% @account_type_options.reject { |_, type| type == "skip" }.each do |label, type| %>
+                    <li><strong><%= label %></strong></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <% @brex_accounts.each do |brex_account| %>
+          <div class="border border-primary rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <div>
+                <h3 class="font-medium text-primary">
+                  <%= brex_account.name %>
+                </h3>
+              </div>
+            </div>
+
+            <div class="space-y-3" data-controller="account-type-selector" data-account-type-selector-account-id-value="<%= brex_account.id %>">
+              <div>
+                <%= label_tag "account_types[#{brex_account.id}]", t(".account_type_label"),
+                             class: "block text-sm font-medium text-primary mb-2" %>
+                <% default_account_type = brex_account.card? ? "CreditCard" : "Depository" %>
+                <%= select_tag "account_types[#{brex_account.id}]",
+                              options_for_select(@account_type_options, default_account_type),
+                              { class: "appearance-none bg-container border border-primary rounded-md px-3 py-2 text-sm leading-6 text-primary focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none w-full",
+                                data: {
+                                  action: "change->account-type-selector#updateSubtype"
+                                } } %>
+              </div>
+
+              <!-- Subtype dropdowns (shown/hidden based on account type) -->
+              <div data-account-type-selector-target="subtypeContainer">
+                <% @subtype_options.each do |account_type, subtype_config| %>
+                  <%= render "brex_items/subtype_select", account_type: account_type, subtype_config: subtype_config, brex_account: brex_account %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div class="flex gap-3">
+        <%= render DS::Button.new(
+          text: t(".create_accounts"),
+          variant: "primary",
+          icon: "plus",
+          type: "submit",
+          class: "flex-1",
+          disabled: @api_error.present? || @brex_accounts.empty?,
+          data: { loading_button_target: "button" }
+        ) %>
+        <%= render DS::Link.new(
+          text: t(".cancel"),
+          variant: "secondary",
+          href: accounts_path
+        ) %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/settings/providers/_brex_panel.html.erb
+++ b/app/views/settings/providers/_brex_panel.html.erb
@@ -63,6 +63,7 @@
               <%= button_to brex_item_path(item),
                             method: :delete,
                             class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 rounded-lg",
+                            aria: { label: t("brex_items.provider_panel.disconnect_label", name: item.name) },
                             data: { turbo_confirm: t("brex_items.provider_panel.disconnect_confirm", name: item.name) } do %>
                 <%= icon "trash-2", size: "sm" %>
               <% end %>

--- a/app/views/settings/providers/_brex_panel.html.erb
+++ b/app/views/settings/providers/_brex_panel.html.erb
@@ -16,6 +16,18 @@
     </p>
   </div>
 
+  <% unless BrexItem.encryption_ready? %>
+    <div class="p-3 rounded-md bg-warning/10 text-warning text-sm">
+      <div class="flex items-start gap-2">
+        <%= icon "shield-alert", size: "sm", class: "mt-0.5 shrink-0" %>
+        <div>
+          <p class="font-medium"><%= t("brex_items.provider_panel.encryption_warning.title") %></p>
+          <p class="mt-1"><%= t("brex_items.provider_panel.encryption_warning.message") %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <% error_msg = local_assigns[:error_message] || @error_message %>
   <% if error_msg.present? %>
     <div class="p-2 rounded-md bg-destructive/10 text-destructive text-sm overflow-hidden">

--- a/app/views/settings/providers/_brex_panel.html.erb
+++ b/app/views/settings/providers/_brex_panel.html.erb
@@ -1,0 +1,141 @@
+<div id="brex-providers-panel" class="space-y-4">
+  <% active_items = local_assigns[:brex_items] || @brex_items || Current.family.brex_items.active.ordered %>
+  <% credentialed_items = active_items.select(&:credentials_configured?) %>
+
+  <div class="prose prose-sm text-secondary">
+    <p class="text-primary font-medium"><%= t("brex_items.provider_panel.setup_title") %></p>
+    <ol>
+      <li><%= t("brex_items.provider_panel.instructions.sign_in_html", link: link_to("Brex", "https://brex.com", target: "_blank", rel: "noopener noreferrer", class: "link")) %></li>
+      <li><%= t("brex_items.provider_panel.instructions.open_tokens") %></li>
+      <li><%= t("brex_items.provider_panel.instructions.create_token") %></li>
+      <li><%= t("brex_items.provider_panel.instructions.copy_token_html") %></li>
+    </ol>
+
+    <p class="text-sm text-subdued mt-2">
+      <%= t("brex_items.provider_panel.sandbox_note_html") %>
+    </p>
+  </div>
+
+  <% error_msg = local_assigns[:error_message] || @error_message %>
+  <% if error_msg.present? %>
+    <div class="p-2 rounded-md bg-destructive/10 text-destructive text-sm overflow-hidden">
+      <p class="line-clamp-3" title="<%= error_msg %>"><%= error_msg %></p>
+    </div>
+  <% end %>
+
+  <% if active_items.any? %>
+    <div class="space-y-3">
+      <% active_items.each do |item| %>
+        <details class="group bg-container p-4 shadow-border-xs rounded-xl">
+          <summary class="flex items-center justify-between gap-2">
+            <div class="flex items-center gap-3">
+              <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
+                <p class="text-primary text-xs font-medium"><%= item.name.to_s.first.to_s.upcase %></p>
+              </div>
+              <div>
+                <p class="font-medium text-primary"><%= item.name %></p>
+                <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>
+              </div>
+            </div>
+          </summary>
+
+          <div class="mt-4 space-y-4">
+            <div class="flex items-center gap-2">
+              <%= button_to sync_brex_item_path(item),
+                            method: :post,
+                            class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-secondary hover:text-primary border border-secondary rounded-lg hover:border-primary",
+                            disabled: item.syncing? do %>
+                <%= icon "refresh-cw", size: "sm" %>
+                <%= t("brex_items.provider_panel.sync") %>
+              <% end %>
+              <%= button_to brex_item_path(item),
+                            method: :delete,
+                            class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 rounded-lg",
+                            data: { turbo_confirm: t("brex_items.provider_panel.disconnect_confirm", name: item.name) } do %>
+                <%= icon "trash-2", size: "sm" %>
+              <% end %>
+            </div>
+
+            <%= styled_form_with model: item,
+                                 url: brex_item_path(item),
+                                 scope: :brex_item,
+                                 method: :patch,
+                                 data: { turbo: true },
+                                 class: "space-y-3" do |form| %>
+              <%= form.text_field :name,
+                                  label: t("brex_items.provider_panel.connection_name_label"),
+                                  placeholder: t("brex_items.provider_panel.connection_name_placeholder") %>
+
+              <%= form.text_field :token,
+                                  label: t("brex_items.provider_panel.token_label"),
+                                  placeholder: t("brex_items.provider_panel.keep_token_placeholder"),
+                                  type: :password,
+                                  value: nil %>
+
+              <%= form.text_field :base_url,
+                                  label: t("brex_items.provider_panel.base_url_label"),
+                                  placeholder: t("brex_items.provider_panel.base_url_placeholder"),
+                                  value: item.base_url %>
+
+              <div class="flex flex-wrap justify-end gap-2">
+                <%= render DS::Link.new(
+                  text: t("brex_items.provider_panel.setup_accounts"),
+                  icon: "settings",
+                  variant: "secondary",
+                  href: setup_accounts_brex_item_path(item),
+                  frame: :modal
+                ) %>
+                <%= form.submit t("brex_items.provider_panel.update_connection"),
+                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+              </div>
+            <% end %>
+          </div>
+        </details>
+      <% end %>
+    </div>
+  <% end %>
+
+  <details <%= "open" unless active_items.any? %> class="group bg-container p-4 shadow-border-xs rounded-xl">
+    <summary class="flex items-center gap-2 text-sm font-medium text-primary">
+      <%= icon "plus" %>
+      <%= t("brex_items.provider_panel.add_connection") %>
+    </summary>
+
+    <% brex_item = Current.family.brex_items.build(name: t("brex_items.provider_panel.default_connection_name")) %>
+    <%= styled_form_with model: brex_item,
+                         url: brex_items_path,
+                         scope: :brex_item,
+                         method: :post,
+                         data: { turbo: true },
+                         class: "space-y-3 mt-4" do |form| %>
+      <%= form.text_field :name,
+                          label: t("brex_items.provider_panel.connection_name_label"),
+                          placeholder: t("brex_items.provider_panel.connection_name_placeholder") %>
+
+      <%= form.text_field :token,
+                          label: t("brex_items.provider_panel.token_label"),
+                          placeholder: t("brex_items.provider_panel.token_placeholder"),
+                          type: :password,
+                          value: nil %>
+
+      <%= form.text_field :base_url,
+                          label: t("brex_items.provider_panel.base_url_label"),
+                          placeholder: t("brex_items.provider_panel.base_url_placeholder") %>
+
+      <div class="flex justify-end">
+        <%= form.submit t("brex_items.provider_panel.add_connection"),
+                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+      </div>
+    <% end %>
+  </details>
+
+  <div class="flex items-center gap-2">
+    <% if credentialed_items.any? %>
+      <div class="w-2 h-2 bg-success rounded-full"></div>
+      <p class="text-sm text-secondary"><%= t("brex_items.provider_panel.configured_html", accounts_link: link_to(t("brex_items.provider_panel.accounts_link"), accounts_path, class: "link")) %></p>
+    <% else %>
+      <div class="w-2 h-2 bg-surface-inset rounded-full"></div>
+      <p class="text-sm text-secondary"><%= t("brex_items.provider_panel.not_configured") %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/settings/providers/show.html.erb
+++ b/app/views/settings/providers/show.html.erb
@@ -61,7 +61,7 @@
       </turbo-frame>
     <% end %>
 
-    <%= settings_section title: "Brex (beta)", collapsible: true, open: false do %>
+    <%= settings_section title: t("settings.providers.show.brex_title"), collapsible: true, open: false do %>
       <turbo-frame id="brex-providers-panel">
         <%= render "settings/providers/brex_panel" %>
       </turbo-frame>

--- a/app/views/settings/providers/show.html.erb
+++ b/app/views/settings/providers/show.html.erb
@@ -61,6 +61,12 @@
       </turbo-frame>
     <% end %>
 
+    <%= settings_section title: "Brex (beta)", collapsible: true, open: false do %>
+      <turbo-frame id="brex-providers-panel">
+        <%= render "settings/providers/brex_panel" %>
+      </turbo-frame>
+    <% end %>
+
     <%= settings_section title: "Coinbase (beta)", collapsible: true, open: false do %>
       <turbo-frame id="coinbase-providers-panel">
         <%= render "settings/providers/coinbase_panel" %>

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -1,3 +1,5 @@
+require Rails.root.join("lib/active_record_encryption_config").to_s
+
 # Configure Active Record encryption keys
 # Priority order:
 # 1. Environment variables (works for both managed and self-hosted modes)
@@ -9,8 +11,12 @@ primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
 deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
 key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
 
+if ActiveRecordEncryptionConfig.partial_env?
+  raise ActiveRecordEncryptionConfig.partial_env_message
+end
+
 # If all environment variables are present, use them (works for both managed and self-hosted)
-if primary_key.present? && deterministic_key.present? && key_derivation_salt.present?
+if ActiveRecordEncryptionConfig.complete_env?
   Rails.application.config.active_record.encryption.primary_key = primary_key
   Rails.application.config.active_record.encryption.deterministic_key = deterministic_key
   Rails.application.config.active_record.encryption.key_derivation_salt = key_derivation_salt

--- a/config/locales/common/en.yml
+++ b/config/locales/common/en.yml
@@ -1,4 +1,0 @@
----
-en:
-  common:
-    close: Close

--- a/config/locales/common/en.yml
+++ b/config/locales/common/en.yml
@@ -1,0 +1,4 @@
+---
+en:
+  common:
+    close: Close

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -3,6 +3,8 @@ en:
   defaults:
     brand_name: "%{brand_name}"
     product_name: "%{product_name}"
+  common:
+    close: "Close"
   global:
     expand: "Expand"
   activerecord:

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -3,8 +3,8 @@ en:
   defaults:
     brand_name: "%{brand_name}"
     product_name: "%{product_name}"
-  common:
-    close: "Close"
+    common:
+      close: "Close"
   global:
     expand: "Expand"
   activerecord:

--- a/config/locales/models/brex_item/en.yml
+++ b/config/locales/models/brex_item/en.yml
@@ -1,0 +1,14 @@
+---
+en:
+  activerecord:
+    attributes:
+      brex_item:
+        base_url: Base URL
+        name: Connection name
+        token: Token
+    errors:
+      models:
+        brex_item:
+          attributes:
+            base_url:
+              official_hosts_only: must be blank, https://api.brex.com, or https://api-staging.brex.com

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -58,7 +58,7 @@ en:
       link_failed: Failed to link accounts
       no_accounts_selected: Please select at least one account
       no_api_token: Brex API token not found. Please configure it in Provider Settings.
-      partial_invalid: "Successfully linked %{created_count} account(s), %{already_linked_count} were already linked, %{invalid_count} account(s) had invalid names"
+      partial_invalid: "Successfully linked %{created_count} account(s), %{already_linked_count} account(s) were already linked, %{invalid_count} account(s) had invalid names"
       partial_success: "Successfully linked %{created_count} account(s). %{already_linked_count} account(s) were already linked: %{already_linked_names}"
       select_connection: Choose a Brex connection before linking accounts.
       success:
@@ -109,7 +109,7 @@ en:
       token_placeholder: Paste token here
       update_connection: Update connection
     provider_connection:
-      default_description: Connect to your bank via Brex
+      default_description: Connect to your Brex account
       default_name: Brex
       description: "Connect using %{name}"
       name: "Brex - %{name}"
@@ -162,11 +162,11 @@ en:
       account_already_linked: This account is already linked to a provider
       api_error: "API error: %{message}"
       invalid_account_name: Cannot link account with blank name
-      brex_account_already_linked: This Brex account is already linked to another account
-      brex_account_not_found: Brex account not found
       missing_parameters: Missing required parameters
       no_account_specified: No account specified
       no_api_token: Brex API token not found. Please configure it in Provider Settings.
+      provider_account_already_linked: This Brex account is already linked to another account
+      provider_account_not_found: Brex account not found
       select_connection: Choose a Brex connection before linking accounts.
       success: "Successfully linked %{account_name} with Brex"
     setup_accounts:

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -76,8 +76,8 @@ en:
       default_connection_name: Brex Connection
       disconnect_confirm: "Disconnect %{name}?"
       encryption_warning:
-        title: Brex tokens are stored without database encryption
-        message: Configure Active Record encryption keys before adding Brex tokens in a self-hosted install. Without those keys, Sure stores provider credentials in plaintext in the database.
+        title: Brex tokens require database encryption
+        message: Configure Active Record encryption keys before adding Brex tokens. Sure will not store Brex provider credentials unless encryption is configured.
       instructions:
         copy_token_html: "Copy the token and add it as a named connection below. Sure stores the token only for syncing this family."
         create_token: "Create an API token with these read-only scopes: accounts.cash.readonly, accounts.card.readonly, transactions.cash.readonly, transactions.card.readonly"

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -1,8 +1,13 @@
 ---
 en:
   brex_items:
+    account_metadata:
+      provider: Brex
+      separator: " • "
     create:
       success: Brex connection created successfully
+    default_card_name: Brex Card
+    default_cash_name: "Brex Cash %{id}"
     destroy:
       success: Brex connection removed
     index:
@@ -64,7 +69,7 @@ en:
       accounts_link: Accounts
       add_connection: Add Brex connection
       base_url_label: Base URL (optional)
-      base_url_placeholder: https://api.brex.com (default)
+      base_url_placeholder: https://api.brex.com
       configured_html: "Configured and ready to use. Visit the %{accounts_link} tab to manage and set up accounts."
       connection_name_label: Connection name
       connection_name_placeholder: Business checking
@@ -77,7 +82,7 @@ en:
         sign_in_html: "Visit %{link} and log in to the account you want to connect"
       keep_token_placeholder: Leave blank to keep the current token
       not_configured: Not configured
-      sandbox_note_html: "Use a separate named connection for each Brex company/API token you want to sync. Leave Base URL blank for production, or enter a Brex-provided staging base URL if Brex grants one."
+      sandbox_note_html: "Use a separate named connection for each Brex company/API token you want to sync. Leave Base URL blank for production. Staging is limited to Brex-approved testing and does not work with customer tokens."
       setup_accounts: Set up accounts
       setup_title: "Setup instructions:"
       sync: Sync
@@ -130,6 +135,10 @@ en:
         open_settings_html: "Go to <strong>Settings > Providers</strong>"
         return_to_link: Return here to link your accounts
       title: Brex Setup Required
+    subtype_select:
+      placeholder:
+        subtype: Select subtype
+        type: Select type
     link_existing_account:
       account_already_linked: This account is already linked to a provider
       api_error: "API error: %{message}"

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -12,6 +12,18 @@ en:
       success: Brex connection removed
     index:
       title: Brex Connections
+    institution_summary:
+      none: No institutions connected
+      one: "%{name}"
+      count:
+        one: "%{count} institution"
+        other: "%{count} institutions"
+    sync_status:
+      no_accounts: No accounts found
+      all_synced:
+        one: "%{count} account synced"
+        other: "%{count} accounts synced"
+      partial_setup: "%{synced} synced, %{pending} need setup"
     api_error:
       common_issues: "Common issues:"
       expired_credentials: Generate a new API token from Brex.
@@ -149,6 +161,7 @@ en:
       brex_account_already_linked: This Brex account is already linked to another account
       brex_account_not_found: Brex account not found
       missing_parameters: Missing required parameters
+      no_account_specified: No account specified
       no_api_token: Brex API token not found. Please configure it in Provider Settings.
       select_connection: Choose a Brex connection before linking accounts.
       success: "Successfully linked %{account_name} with Brex"

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -1,0 +1,209 @@
+---
+en:
+  brex_items:
+    create:
+      success: Brex connection created successfully
+    destroy:
+      success: Brex connection removed
+    index:
+      title: Brex Connections
+    api_error:
+      common_issues: "Common issues:"
+      expired_credentials: Generate a new API token from Brex.
+      expired_credentials_label: "Expired credentials:"
+      heading: Unable to connect to Brex
+      invalid_token: Check your API token in Provider Settings.
+      invalid_token_label: "Invalid API token:"
+      network: Check your internet connection.
+      network_label: "Network issue:"
+      permissions: Ensure your token has the required read-only account and transaction scopes.
+      permissions_label: "Insufficient permissions:"
+      service: Brex API may be temporarily unavailable.
+      service_label: "Service down:"
+      settings_link: Check Provider Settings
+      title: Brex Connection Error
+    loading:
+      loading_message: Loading Brex accounts...
+      loading_title: Loading
+    link_accounts:
+      all_already_linked:
+        one: "The selected account (%{names}) is already linked"
+        other: "All %{count} selected accounts are already linked: %{names}"
+      api_error: "API error: %{message}"
+      invalid_account_names:
+        one: "Cannot link account with blank name"
+        other: "Cannot link %{count} accounts with blank names"
+      link_failed: Failed to link accounts
+      no_accounts_selected: Please select at least one account
+      no_api_token: Brex API token not found. Please configure it in Provider Settings.
+      partial_invalid: "Successfully linked %{created_count} account(s), %{already_linked_count} were already linked, %{invalid_count} account(s) had invalid names"
+      partial_success: "Successfully linked %{created_count} account(s). %{already_linked_count} account(s) were already linked: %{already_linked_names}"
+      select_connection: Choose a Brex connection before linking accounts.
+      success:
+        one: "Successfully linked %{count} account"
+        other: "Successfully linked %{count} accounts"
+    brex_item:
+      accounts_need_setup: Accounts need setup
+      delete: Delete connection
+      deletion_in_progress: deletion in progress...
+      error: Error
+      no_accounts_description: This connection has no linked accounts yet.
+      no_accounts_title: No accounts
+      setup_action: Set Up New Accounts
+      setup_description: "%{linked} of %{total} accounts linked. Choose account types for your newly imported Brex accounts."
+      setup_needed: New accounts ready to set up
+      status: "Synced %{timestamp} ago"
+      status_never: Never synced
+      status_with_summary: "Last synced %{timestamp} ago - %{summary}"
+      syncing: Syncing...
+      total: Total
+      unlinked: Unlinked
+    provider_panel:
+      accounts_link: Accounts
+      add_connection: Add Brex connection
+      base_url_label: Base URL (optional)
+      base_url_placeholder: https://api.brex.com (default)
+      configured_html: "Configured and ready to use. Visit the %{accounts_link} tab to manage and set up accounts."
+      connection_name_label: Connection name
+      connection_name_placeholder: Business checking
+      default_connection_name: Brex Connection
+      disconnect_confirm: "Disconnect %{name}?"
+      instructions:
+        copy_token_html: "Copy the token and add it as a named connection below. Sure stores the token only for syncing this family."
+        create_token: "Create an API token with these read-only scopes: accounts.cash.readonly, accounts.card.readonly, transactions.cash.readonly, transactions.card.readonly"
+        open_tokens: Go to the Brex developer/API token settings for the company you want to connect
+        sign_in_html: "Visit %{link} and log in to the account you want to connect"
+      keep_token_placeholder: Leave blank to keep the current token
+      not_configured: Not configured
+      sandbox_note_html: "Use a separate named connection for each Brex company/API token you want to sync. Leave Base URL blank for production, or enter a Brex-provided staging base URL if Brex grants one."
+      setup_accounts: Set up accounts
+      setup_title: "Setup instructions:"
+      sync: Sync
+      token_label: Token
+      token_placeholder: Paste token here
+      update_connection: Update connection
+    provider_connection:
+      default_description: Connect to your bank via Brex
+      default_name: Brex
+      description: "Connect using %{name}"
+      name: "Brex - %{name}"
+    select_accounts:
+      accounts_selected: accounts selected
+      api_error: "API error: %{message}"
+      cancel: Cancel
+      configure_name_in_brex: Cannot import - please configure account name in Brex
+      description: Select the accounts you want to link to your %{product_name} account.
+      link_accounts: Link selected accounts
+      no_accounts_found: No accounts found. Please check your API token configuration.
+      no_api_token: Brex API token is not configured. Please configure it in Settings.
+      no_credentials_configured: Please configure your Brex API token first in Provider Settings.
+      no_name_placeholder: "(No name)"
+      select_connection: Choose a Brex connection in Provider Settings.
+      title: Select Brex Accounts
+      unexpected_error: An unexpected error occurred. Please try again later.
+    select_existing_account:
+      account_already_linked: This account is already linked to a provider
+      all_accounts_already_linked: All Brex accounts are already linked
+      api_error: "API error: %{message}"
+      cancel: Cancel
+      configure_name_in_brex: Cannot import - please configure account name in Brex
+      description: Select a Brex account to link with this account. Transactions will be synced and deduplicated automatically.
+      link_account: Link account
+      no_account_specified: No account specified
+      no_accounts_found: No Brex accounts found. Please check your API token configuration.
+      no_api_token: Brex API token is not configured. Please configure it in Settings.
+      no_credentials_configured: Please configure your Brex API token first in Provider Settings.
+      no_name_placeholder: "(No name)"
+      select_connection: Choose a Brex connection in Provider Settings.
+      title: "Link %{account_name} with Brex"
+      unexpected_error: An unexpected error occurred. Please try again later.
+    setup_required:
+      description: Before you can link Brex accounts, you need to configure your Brex API token.
+      heading: API Token Not Configured
+      settings_link: Go to Provider Settings
+      setup_steps: "Setup steps:"
+      steps:
+        enter_token: Enter your Brex API token
+        find_section_html: "Find the <strong>Brex</strong> section"
+        open_settings_html: "Go to <strong>Settings > Providers</strong>"
+        return_to_link: Return here to link your accounts
+      title: Brex Setup Required
+    link_existing_account:
+      account_already_linked: This account is already linked to a provider
+      api_error: "API error: %{message}"
+      invalid_account_name: Cannot link account with blank name
+      brex_account_already_linked: This Brex account is already linked to another account
+      brex_account_not_found: Brex account not found
+      missing_parameters: Missing required parameters
+      no_api_token: Brex API token not found. Please configure it in Provider Settings.
+      select_connection: Choose a Brex connection before linking accounts.
+      success: "Successfully linked %{account_name} with Brex"
+    setup_accounts:
+      account_type_label: "Account Type:"
+      all_accounts_linked: "All your Brex accounts have already been set up."
+      api_error: "API error: %{message}"
+      fetch_failed: "Failed to Fetch Accounts"
+      no_accounts_to_setup: "No Accounts to Set Up"
+      no_api_token: "Brex API token is not configured. Please check your connection settings."
+      account_types:
+        skip: Skip this account
+        depository: Checking or Savings Account
+        credit_card: Credit Card
+        investment: Investment Account
+        loan: Loan or Mortgage
+        other_asset: Other Asset
+      subtype_labels:
+        depository: "Account Subtype:"
+        credit_card: ""
+        investment: "Investment Type:"
+        loan: "Loan Type:"
+        other_asset: ""
+      subtype_messages:
+        credit_card: "Credit cards will be automatically set up as credit card accounts."
+        other_asset: "No additional options needed for Other Assets."
+      subtypes:
+        depository:
+          checking: Checking
+          savings: Savings
+          hsa: Health Savings Account
+          cd: Certificate of Deposit
+          money_market: Money Market
+        investment:
+          brokerage: Brokerage
+          pension: Pension
+          retirement: Retirement
+          "401k": "401(k)"
+          roth_401k: "Roth 401(k)"
+          "403b": "403(b)"
+          tsp: Thrift Savings Plan
+          "529_plan": "529 Plan"
+          hsa: Health Savings Account
+          mutual_fund: Mutual Fund
+          ira: Traditional IRA
+          roth_ira: Roth IRA
+          angel: Angel
+        loan:
+          mortgage: Mortgage
+          student: Student Loan
+          auto: Auto Loan
+          other: Other Loan
+      balance: Balance
+      cancel: Cancel
+      choose_account_type: "Choose the correct account type for each Brex account:"
+      create_accounts: Create Accounts
+      creating_accounts: Creating Accounts...
+      historical_data_range: "Historical Data Range:"
+      subtitle: Choose the correct account types for your imported accounts
+      sync_start_date_help: Select how far back you want to sync transaction history. Maximum 3 years of history available.
+      sync_start_date_label: "Start syncing transactions from:"
+      title: Set Up Your Brex Accounts
+    complete_account_setup:
+      all_skipped: "All accounts were skipped. No accounts were created."
+      creation_failed: "Failed to create accounts: %{error}"
+      no_accounts: "No accounts to set up."
+      success: "Successfully created %{count} account(s)."
+      unexpected_error: An unexpected error occurred.
+    sync:
+      success: Sync started
+    update:
+      success: Brex connection updated

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -240,7 +240,14 @@ en:
     sync:
       success: Sync started
     syncer:
+      accounts_need_setup:
+        one: "%{count} account needs setup..."
+        other: "%{count} accounts need setup..."
+      calculating_balances: Calculating balances...
+      checking_account_configuration: Checking account configuration...
       credentials_invalid: Invalid Brex API token or account permissions
       failed: Sync failed. Please try again or contact support.
+      importing_accounts: Importing accounts from Brex...
+      processing_transactions: Processing transactions...
     update:
       success: Brex connection updated

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -41,6 +41,8 @@ en:
       title: Brex Connection Error
     errors:
       unexpected_error: An unexpected error occurred. Please try again later.
+    entries:
+      default_name: Brex transaction
     loading:
       loading_message: Loading Brex accounts...
       loading_title: Loading
@@ -52,6 +54,7 @@ en:
       invalid_account_names:
         one: "Cannot link account with blank name"
         other: "Cannot link %{count} accounts with blank names"
+      invalid_account_type: Unsupported Brex account type
       link_failed: Failed to link accounts
       no_accounts_selected: Please select at least one account
       no_api_token: Brex API token not found. Please configure it in Provider Settings.
@@ -230,10 +233,14 @@ en:
       creation_failed: "Failed to create accounts: %{error}"
       creation_failed_count: "Failed to create %{count} account(s)."
       no_accounts: "No accounts to set up."
+      partial_skipped: "Successfully created %{created_count} account(s); %{skipped_count} account(s) were skipped."
       partial_success: "Successfully created %{created_count} account(s), but %{failed_count} account(s) failed."
       success: "Successfully created %{count} account(s)."
       unexpected_error: An unexpected error occurred.
     sync:
       success: Sync started
+    syncer:
+      credentials_invalid: Invalid Brex API token or account permissions
+      failed: Sync failed. Please try again or contact support.
     update:
       success: Brex connection updated

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -86,6 +86,7 @@ en:
       connection_name_label: Connection name
       connection_name_placeholder: Business checking
       default_connection_name: Brex Connection
+      disconnect_label: "Disconnect %{name}"
       disconnect_confirm: "Disconnect %{name}?"
       encryption_warning:
         title: Brex tokens require database encryption
@@ -227,7 +228,9 @@ en:
     complete_account_setup:
       all_skipped: "All accounts were skipped. No accounts were created."
       creation_failed: "Failed to create accounts: %{error}"
+      creation_failed_count: "Failed to create %{count} account(s)."
       no_accounts: "No accounts to set up."
+      partial_success: "Successfully created %{created_count} account(s), but %{failed_count} account(s) failed."
       success: "Successfully created %{count} account(s)."
       unexpected_error: An unexpected error occurred.
     sync:

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -22,6 +22,8 @@ en:
       service_label: "Service down:"
       settings_link: Check Provider Settings
       title: Brex Connection Error
+    errors:
+      unexpected_error: An unexpected error occurred. Please try again later.
     loading:
       loading_message: Loading Brex accounts...
       loading_title: Loading

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -75,6 +75,9 @@ en:
       connection_name_placeholder: Business checking
       default_connection_name: Brex Connection
       disconnect_confirm: "Disconnect %{name}?"
+      encryption_warning:
+        title: Brex tokens are stored without database encryption
+        message: Configure Active Record encryption keys before adding Brex tokens in a self-hosted install. Without those keys, Sure stores provider credentials in plaintext in the database.
       instructions:
         copy_token_html: "Copy the token and add it as a named connection below. Sure stores the token only for syncing this family."
         create_token: "Create an API token with these read-only scopes: accounts.cash.readonly, accounts.card.readonly, transactions.cash.readonly, transactions.card.readonly"

--- a/config/locales/views/brex_items/en.yml
+++ b/config/locales/views/brex_items/en.yml
@@ -240,14 +240,27 @@ en:
     sync:
       success: Sync started
     syncer:
+      account_processing_failed:
+        one: "%{count} Brex account failed while processing."
+        other: "%{count} Brex accounts failed while processing."
+      account_sync_failed:
+        one: "%{count} Brex account sync could not be scheduled."
+        other: "%{count} Brex account syncs could not be scheduled."
       accounts_need_setup:
         one: "%{count} account needs setup..."
         other: "%{count} accounts need setup..."
+      accounts_failed:
+        one: "%{count} Brex account failed to import."
+        other: "%{count} Brex accounts failed to import."
       calculating_balances: Calculating balances...
       checking_account_configuration: Checking account configuration...
       credentials_invalid: Invalid Brex API token or account permissions
       failed: Sync failed. Please try again or contact support.
+      import_failed: Brex import failed.
       importing_accounts: Importing accounts from Brex...
       processing_transactions: Processing transactions...
+      transactions_failed:
+        one: "%{count} Brex account had transaction import failures."
+        other: "%{count} Brex accounts had transaction import failures."
     update:
       success: Brex connection updated

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -187,6 +187,7 @@ en:
       change: Change photo
     providers:
       show:
+        brex_title: Brex (beta)
         coinbase_title: Coinbase
       encryption_error:
         title: Encryption Configuration Required

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,17 +35,17 @@ Rails.application.routes.draw do
 
   resources :brex_items, only: %i[index new create show edit update destroy] do
     collection do
-      get :preload_accounts
-      get :select_accounts
-      post :link_accounts
-      get :select_existing_account
-      post :link_existing_account
+      get :preload_accounts, to: "brex_items/account_flows#preload_accounts"
+      get :select_accounts, to: "brex_items/account_flows#select_accounts"
+      post :link_accounts, to: "brex_items/account_flows#link_accounts"
+      get :select_existing_account, to: "brex_items/account_flows#select_existing_account"
+      post :link_existing_account, to: "brex_items/account_flows#link_existing_account"
     end
 
     member do
       post :sync
-      get :setup_accounts
-      post :complete_account_setup
+      get :setup_accounts, to: "brex_items/account_setups#setup_accounts"
+      post :complete_account_setup, to: "brex_items/account_setups#complete_account_setup"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,22 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :brex_items, only: %i[index new create show edit update destroy] do
+    collection do
+      get :preload_accounts
+      get :select_accounts
+      post :link_accounts
+      get :select_existing_account
+      post :link_existing_account
+    end
+
+    member do
+      post :sync
+      get :setup_accounts
+      post :complete_account_setup
+    end
+  end
+
   resources :coinbase_items, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     collection do
       get :preload_accounts

--- a/db/migrate/20260505010000_create_brex_items_and_accounts.rb
+++ b/db/migrate/20260505010000_create_brex_items_and_accounts.rb
@@ -12,9 +12,9 @@ class CreateBrexItemsAndAccounts < ActiveRecord::Migration[7.2]
       t.string :institution_url
       t.string :institution_color
 
-      t.string :status, default: "good"
-      t.boolean :scheduled_for_deletion, default: false
-      t.boolean :pending_account_setup, default: false
+      t.string :status, null: false, default: "good"
+      t.boolean :scheduled_for_deletion, null: false, default: false
+      t.boolean :pending_account_setup, null: false, default: false
 
       t.datetime :sync_start_date
 

--- a/db/migrate/20260505010000_create_brex_items_and_accounts.rb
+++ b/db/migrate/20260505010000_create_brex_items_and_accounts.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class CreateBrexItemsAndAccounts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :brex_items, id: :uuid do |t|
+      t.references :family, null: false, foreign_key: true, type: :uuid
+      t.string :name
+
+      t.string :institution_id
+      t.string :institution_name
+      t.string :institution_domain
+      t.string :institution_url
+      t.string :institution_color
+
+      t.string :status, default: "good"
+      t.boolean :scheduled_for_deletion, default: false
+      t.boolean :pending_account_setup, default: false
+
+      t.datetime :sync_start_date
+
+      t.jsonb :raw_payload
+      t.jsonb :raw_institution_payload
+
+      t.text :token
+      t.string :base_url
+
+      t.timestamps
+    end
+
+    add_index :brex_items, :status
+
+    create_table :brex_accounts, id: :uuid do |t|
+      t.references :brex_item, null: false, foreign_key: true, type: :uuid
+
+      t.string :name
+      t.string :account_id, null: false
+      t.string :account_kind, null: false, default: "cash"
+
+      t.string :currency
+      t.decimal :current_balance, precision: 19, scale: 4
+      t.decimal :available_balance, precision: 19, scale: 4
+      t.decimal :account_limit, precision: 19, scale: 4
+      t.string :account_status
+      t.string :account_type
+      t.string :provider
+
+      t.jsonb :institution_metadata
+      t.jsonb :raw_payload
+      t.jsonb :raw_transactions_payload
+
+      t.timestamps
+    end
+
+    add_index :brex_accounts,
+              [ :brex_item_id, :account_id ],
+              unique: true,
+              name: "index_brex_accounts_on_item_and_account_id"
+  end
+end

--- a/db/migrate/20260505010000_create_brex_items_and_accounts.rb
+++ b/db/migrate/20260505010000_create_brex_items_and_accounts.rb
@@ -4,7 +4,7 @@ class CreateBrexItemsAndAccounts < ActiveRecord::Migration[7.2]
   def change
     create_table :brex_items, id: :uuid do |t|
       t.references :family, null: false, foreign_key: true, type: :uuid
-      t.string :name
+      t.string :name, null: false
 
       t.string :institution_id
       t.string :institution_name
@@ -21,7 +21,7 @@ class CreateBrexItemsAndAccounts < ActiveRecord::Migration[7.2]
       t.jsonb :raw_payload
       t.jsonb :raw_institution_payload
 
-      t.text :token
+      t.text :token, null: false
       t.string :base_url
 
       t.timestamps

--- a/db/migrate/20260505010000_create_brex_items_and_accounts.rb
+++ b/db/migrate/20260505010000_create_brex_items_and_accounts.rb
@@ -36,7 +36,7 @@ class CreateBrexItemsAndAccounts < ActiveRecord::Migration[7.2]
       t.string :account_id, null: false
       t.string :account_kind, null: false, default: "cash"
 
-      t.string :currency
+      t.string :currency, null: false, default: "USD"
       t.decimal :current_balance, precision: 19, scale: 4
       t.decimal :available_balance, precision: 19, scale: 4
       t.decimal :account_limit, precision: 19, scale: 4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -237,7 +237,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_010000) do
 
   create_table "brex_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "family_id", null: false
-    t.string "name"
+    t.string "name", null: false
     t.string "institution_id"
     t.string "institution_name"
     t.string "institution_domain"
@@ -249,7 +249,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_010000) do
     t.datetime "sync_start_date"
     t.jsonb "raw_payload"
     t.jsonb "raw_institution_payload"
-    t.text "token"
+    t.text "token", null: false
     t.string "base_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,9 +243,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_010000) do
     t.string "institution_domain"
     t.string "institution_url"
     t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
+    t.string "status", default: "good", null: false
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.boolean "pending_account_setup", default: false, null: false
     t.datetime "sync_start_date"
     t.jsonb "raw_payload"
     t.jsonb "raw_institution_payload"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -219,7 +219,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_010000) do
     t.string "name"
     t.string "account_id", null: false
     t.string "account_kind", default: "cash", null: false
-    t.string "currency"
+    t.string "currency", default: "USD", null: false
     t.decimal "current_balance", precision: 19, scale: 4
     t.decimal "available_balance", precision: 19, scale: 4
     t.decimal "account_limit", precision: 19, scale: 4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_03_180000) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_05_010000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -212,6 +212,49 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_03_180000) do
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_binance_items_on_family_id"
     t.index ["status"], name: "index_binance_items_on_status"
+  end
+
+  create_table "brex_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "brex_item_id", null: false
+    t.string "name"
+    t.string "account_id", null: false
+    t.string "account_kind", default: "cash", null: false
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
+    t.decimal "available_balance", precision: 19, scale: 4
+    t.decimal "account_limit", precision: 19, scale: 4
+    t.string "account_status"
+    t.string "account_type"
+    t.string "provider"
+    t.jsonb "institution_metadata"
+    t.jsonb "raw_payload"
+    t.jsonb "raw_transactions_payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["brex_item_id", "account_id"], name: "index_brex_accounts_on_item_and_account_id", unique: true
+    t.index ["brex_item_id"], name: "index_brex_accounts_on_brex_item_id"
+  end
+
+  create_table "brex_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "family_id", null: false
+    t.string "name"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_domain"
+    t.string "institution_url"
+    t.string "institution_color"
+    t.string "status", default: "good"
+    t.boolean "scheduled_for_deletion", default: false
+    t.boolean "pending_account_setup", default: false
+    t.datetime "sync_start_date"
+    t.jsonb "raw_payload"
+    t.jsonb "raw_institution_payload"
+    t.text "token"
+    t.string "base_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_id"], name: "index_brex_items_on_family_id"
+    t.index ["status"], name: "index_brex_items_on_status"
   end
 
   create_table "budget_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1674,6 +1717,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_03_180000) do
   add_foreign_key "chats", "users"
   add_foreign_key "coinbase_accounts", "coinbase_items"
   add_foreign_key "coinbase_items", "families"
+  add_foreign_key "brex_accounts", "brex_items"
+  add_foreign_key "brex_items", "families"
   add_foreign_key "coinstats_accounts", "coinstats_items"
   add_foreign_key "coinstats_items", "families"
   add_foreign_key "enable_banking_accounts", "enable_banking_items"

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://design-tokens.github.io/community-group/format/",
-  "$version": "2.1.0",
+  "$version": "2.2.0",
   "$description": "Sure design tokens. Single source of truth. Hand-edit; run `npm run tokens:build` to regenerate CSS. Template syntax in $value strings: `{path.to.token}` resolves to `var(--path-to-token)`; `{path|N%}` becomes `--alpha(var(--path) / N%)`. Utility tokens whose value lacks `{}` are treated as raw Tailwind class lists for @apply.",
 
   "font": {
@@ -260,6 +260,7 @@
     "bg-container-hover":     { "$type": "utility", "$value": "{color.gray.50}",  "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.800}" } },
     "bg-container-inset":     { "$type": "utility", "$value": "{color.gray.50}",  "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.800}" } },
     "bg-container-inset-hover":{ "$type": "utility","$value": "{color.gray.100}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.700}" } },
+    "bg-destructive-surface": { "$type": "utility", "$value": "{color.red.tint-5}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.red.tint-10}" } },
     "bg-inverse":             { "$type": "utility", "$value": "{color.gray.800}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.white}" } },
     "bg-inverse-hover":       { "$type": "utility", "$value": "{color.gray.700}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.100}" } },
     "bg-overlay": {

--- a/lib/active_record_encryption_config.rb
+++ b/lib/active_record_encryption_config.rb
@@ -15,44 +15,44 @@ module ActiveRecordEncryptionConfig
 
   module_function
 
-    def complete_env?(env = ENV)
-      ENV_KEYS.all? { |key| env_value_present?(env, key) }
-    end
+  def complete_env?(env = ENV)
+    ENV_KEYS.all? { |key| env_value_present?(env, key) }
+  end
 
-    def partial_env?(env = ENV)
-      present_count = ENV_KEYS.count { |key| env_value_present?(env, key) }
-      present_count.positive? && present_count < ENV_KEYS.count
-    end
+  def partial_env?(env = ENV)
+    present_count = ENV_KEYS.count { |key| env_value_present?(env, key) }
+    present_count.positive? && present_count < ENV_KEYS.count
+  end
 
-    def missing_env_keys(env = ENV)
-      ENV_KEYS.reject { |key| env_value_present?(env, key) }
-    end
+  def missing_env_keys(env = ENV)
+    ENV_KEYS.reject { |key| env_value_present?(env, key) }
+  end
 
-    def partial_env_message(env = ENV)
-      "Active Record encryption environment variables are partially configured. Missing: #{missing_env_keys(env).join(', ')}"
-    end
+  def partial_env_message(env = ENV)
+    "Active Record encryption environment variables are partially configured. Missing: #{missing_env_keys(env).join(', ')}"
+  end
 
-    def credentials_configured?(credentials = Rails.application.credentials)
-      credentials.active_record_encryption.present?
-    rescue NoMethodError
-      false
-    end
+  def credentials_configured?(credentials = Rails.application.credentials)
+    credentials.active_record_encryption.present?
+  rescue NoMethodError
+    false
+  end
 
-    def runtime_configured?(config = Rails.application.config.active_record.encryption)
-      CONFIG_KEYS.all? { |key| config.public_send(key).present? }
-    rescue NoMethodError
-      false
-    end
+  def runtime_configured?(config = Rails.application.config.active_record.encryption)
+    CONFIG_KEYS.all? { |key| config.public_send(key).present? }
+  rescue NoMethodError
+    false
+  end
 
-    def explicitly_configured?
-      complete_env? || credentials_configured?
-    end
+  def explicitly_configured?
+    complete_env? || credentials_configured?
+  end
 
-    def ready?
-      explicitly_configured? || runtime_configured?
-    end
+  def ready?
+    explicitly_configured? || runtime_configured?
+  end
 
-    def env_value_present?(env, key)
-      env[key].present?
-    end
+  def env_value_present?(env, key)
+    env[key].present?
+  end
 end

--- a/lib/active_record_encryption_config.rb
+++ b/lib/active_record_encryption_config.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ActiveRecordEncryptionConfig
+  ENV_KEYS = %w[
+    ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+    ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+    ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+  ].freeze
+
+  CONFIG_KEYS = %i[
+    primary_key
+    deterministic_key
+    key_derivation_salt
+  ].freeze
+
+  module_function
+
+    def complete_env?(env = ENV)
+      ENV_KEYS.all? { |key| env_value_present?(env, key) }
+    end
+
+    def partial_env?(env = ENV)
+      present_count = ENV_KEYS.count { |key| env_value_present?(env, key) }
+      present_count.positive? && present_count < ENV_KEYS.count
+    end
+
+    def missing_env_keys(env = ENV)
+      ENV_KEYS.reject { |key| env_value_present?(env, key) }
+    end
+
+    def partial_env_message(env = ENV)
+      "Active Record encryption environment variables are partially configured. Missing: #{missing_env_keys(env).join(', ')}"
+    end
+
+    def credentials_configured?(credentials = Rails.application.credentials)
+      credentials.active_record_encryption.present?
+    rescue NoMethodError
+      false
+    end
+
+    def runtime_configured?(config = Rails.application.config.active_record.encryption)
+      CONFIG_KEYS.all? { |key| config.public_send(key).present? }
+    rescue NoMethodError
+      false
+    end
+
+    def explicitly_configured?
+      complete_env? || credentials_configured?
+    end
+
+    def ready?
+      explicitly_configured? || runtime_configured?
+    end
+
+    def env_value_present?(env, key)
+      env[key].present?
+    end
+end

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -265,6 +265,18 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Choose a Brex connection before linking accounts.", flash[:alert]
   end
 
+  test "link existing account requires account id" do
+    assert_no_difference "AccountProvider.count" do
+      post link_existing_account_brex_items_url, params: {
+        brex_item_id: @second_item.id,
+        brex_account_id: "shared_brex_account"
+      }
+    end
+
+    assert_redirected_to accounts_path
+    assert_equal "No account specified", flash[:alert]
+  end
+
   test "sync only queues a sync for the selected brex item" do
     assert_difference -> { Sync.where(syncable: @second_item).count }, 1 do
       assert_no_difference -> { Sync.where(syncable: @existing_item).count } do

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -139,7 +139,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     get select_accounts_brex_items_url, params: { accountable_type: "Depository" }
 
     assert_redirected_to settings_providers_path
-    assert_equal "Choose a Brex connection in Provider Settings.", flash[:alert]
+    assert_equal I18n.t("brex_items.select_accounts.select_connection"), flash[:alert]
   end
 
   test "select accounts renders the selected brex item id" do
@@ -265,7 +265,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to accounts_path
-    assert_equal "No account specified", flash[:alert]
+    assert_equal I18n.t("brex_items.select_existing_account.no_account_specified"), flash[:alert]
   end
 
   test "select existing account renders the selected brex item id" do
@@ -334,7 +334,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to settings_providers_path
-    assert_equal "Choose a Brex connection before linking accounts.", flash[:alert]
+    assert_equal I18n.t("brex_items.link_accounts.select_connection"), flash[:alert]
   end
 
   test "link existing account does not silently use the first connection when multiple items exist" do
@@ -355,7 +355,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to settings_providers_path
-    assert_equal "Choose a Brex connection before linking accounts.", flash[:alert]
+    assert_equal I18n.t("brex_items.link_existing_account.select_connection"), flash[:alert]
   end
 
   test "link existing account requires account id" do
@@ -367,7 +367,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to accounts_path
-    assert_equal "No account specified", flash[:alert]
+    assert_equal I18n.t("brex_items.link_existing_account.no_account_specified"), flash[:alert]
   end
 
   test "link existing account redirects when account id is invalid" do
@@ -380,7 +380,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to accounts_path
-    assert_equal "No account specified", flash[:alert]
+    assert_equal I18n.t("brex_items.link_existing_account.no_account_specified"), flash[:alert]
   end
 
   test "sync only queues a sync for the selected brex item" do

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -118,7 +118,6 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "preload accounts uses selected brex item cache key" do
-    Rails.cache.expects(:exist?).with(brex_cache_key(@second_item)).returns(false)
     Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(nil)
     Rails.cache.expects(:write).with(brex_cache_key(@second_item), brex_accounts_payload, expires_in: 5.minutes)
 
@@ -200,6 +199,63 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
         assert fields.first["value"].blank?
       end
     end
+  end
+
+  test "select existing account rejects unsafe return paths" do
+    account = @family.accounts.create!(
+      name: "Manual Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    [
+      "//evil.example/accounts",
+      "\\evil.example/accounts",
+      "/\\evil.example/accounts",
+      "/%2fevil.example/accounts",
+      "/%2Fevil.example/accounts",
+      "/%5cevil.example/accounts",
+      "/%5Cevil.example/accounts",
+      "/\naccounts",
+      "/ accounts",
+      "   ",
+      "/"
+    ].each do |return_to|
+      Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(brex_accounts_payload)
+
+      get select_existing_account_brex_items_url, params: {
+        brex_item_id: @second_item.id,
+        account_id: account.id,
+        return_to: return_to
+      }
+
+      assert_response :success
+      assert_select %(input[name="return_to"]) do |fields|
+        assert fields.first["value"].blank?
+      end
+    end
+  end
+
+  test "select existing account preserves safe local return path" do
+    account = @family.accounts.create!(
+      name: "Manual Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    return_to = "/accounts?tab=manual"
+
+    Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(brex_accounts_payload)
+
+    get select_existing_account_brex_items_url, params: {
+      brex_item_id: @second_item.id,
+      account_id: account.id,
+      return_to: return_to
+    }
+
+    assert_response :success
+    assert_select %(input[name="return_to"][value="#{return_to}"])
   end
 
   test "select existing account redirects when account id is invalid" do

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -446,7 +446,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     def brex_cache_key(brex_item)
-      "brex_accounts_#{@family.id}_#{brex_item.id}"
+      BrexItem::AccountFlow.cache_key(@family, brex_item)
     end
 
     def clear_brex_cache_entries

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -5,10 +5,10 @@ require "test_helper"
 class BrexItemsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in users(:family_admin)
-    Rails.cache.clear
     SyncJob.stubs(:perform_later)
 
     @family = families(:dylan_family)
+    clear_brex_cache_entries
     @existing_item = brex_items(:one)
     @second_item = BrexItem.create!(
       family: @family,
@@ -19,7 +19,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    Rails.cache.clear
+    clear_brex_cache_entries
   end
 
   test "create adds a new brex connection without overwriting existing credentials" do
@@ -118,6 +118,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "preload accounts uses selected brex item cache key" do
+    Rails.cache.expects(:exist?).with(brex_cache_key(@second_item)).returns(false)
     Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(nil)
     Rails.cache.expects(:write).with(brex_cache_key(@second_item), brex_accounts_payload, expires_in: 5.minutes)
 
@@ -173,6 +174,28 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     refute_includes @response.body, "//evil.example/accounts"
+  end
+
+  test "select accounts rejects backslash and unsafe local return paths" do
+    [
+      "/\\evil.example/accounts",
+      "/\naccounts",
+      "/ accounts",
+      "/"
+    ].each do |return_to|
+      Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(brex_accounts_payload)
+
+      get select_accounts_brex_items_url, params: {
+        brex_item_id: @second_item.id,
+        accountable_type: "Depository",
+        return_to: return_to
+      }
+
+      assert_response :success
+      assert_select %(input[name="return_to"]) do |fields|
+        assert fields.first["value"].blank?
+      end
+    end
   end
 
   test "select existing account renders the selected brex item id" do
@@ -287,6 +310,42 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test "complete account setup ignores unsupported account type and subtype params" do
+    valid_brex_account = @second_item.brex_accounts.create!(
+      account_id: "setup_valid",
+      account_kind: "cash",
+      name: "Setup Valid",
+      currency: "USD",
+      current_balance: 100
+    )
+    unsupported_brex_account = @second_item.brex_accounts.create!(
+      account_id: "setup_unsupported",
+      account_kind: "cash",
+      name: "Setup Unsupported",
+      currency: "USD",
+      current_balance: 100
+    )
+
+    assert_difference "AccountProvider.count", 1 do
+      post complete_account_setup_brex_item_url(@second_item), params: {
+        account_types: {
+          valid_brex_account.id => "Depository",
+          unsupported_brex_account.id => "Investment",
+          "not-a-brex-account" => "Depository"
+        },
+        account_subtypes: {
+          valid_brex_account.id => "savings",
+          unsupported_brex_account.id => "brokerage",
+          "not-a-brex-account" => "checking"
+        }
+      }
+    end
+
+    assert_redirected_to accounts_path
+    assert_equal "savings", valid_brex_account.reload.account.accountable.subtype
+    assert_nil unsupported_brex_account.reload.account_provider
+  end
+
   private
 
     def brex_accounts_payload
@@ -304,5 +363,15 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
 
     def brex_cache_key(brex_item)
       "brex_accounts_#{@family.id}_#{brex_item.id}"
+    end
+
+    def clear_brex_cache_entries
+      return unless defined?(@family) && @family.present?
+      return unless Rails.cache.respond_to?(:delete_matched)
+
+      Rails.cache.delete_matched("brex_accounts_#{@family.id}_*")
+    rescue NotImplementedError
+      # Some test cache stores do not implement delete_matched; tests that depend
+      # on cache state stub exact Brex cache keys instead of relying on globals.
     end
 end

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -179,6 +179,10 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
   test "select accounts rejects backslash and unsafe local return paths" do
     [
       "/\\evil.example/accounts",
+      "/%2fevil.example/accounts",
+      "/%2Fevil.example/accounts",
+      "/%5cevil.example/accounts",
+      "/%5Cevil.example/accounts",
       "/\naccounts",
       "/ accounts",
       "/"
@@ -196,6 +200,16 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
         assert fields.first["value"].blank?
       end
     end
+  end
+
+  test "select existing account redirects when account id is invalid" do
+    get select_existing_account_brex_items_url, params: {
+      brex_item_id: @second_item.id,
+      account_id: SecureRandom.uuid
+    }
+
+    assert_redirected_to accounts_path
+    assert_equal "No account specified", flash[:alert]
   end
 
   test "select existing account renders the selected brex item id" do
@@ -300,6 +314,19 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "No account specified", flash[:alert]
   end
 
+  test "link existing account redirects when account id is invalid" do
+    assert_no_difference "AccountProvider.count" do
+      post link_existing_account_brex_items_url, params: {
+        brex_item_id: @second_item.id,
+        account_id: SecureRandom.uuid,
+        brex_account_id: "shared_brex_account"
+      }
+    end
+
+    assert_redirected_to accounts_path
+    assert_equal "No account specified", flash[:alert]
+  end
+
   test "sync only queues a sync for the selected brex item" do
     assert_difference -> { Sync.where(syncable: @second_item).count }, 1 do
       assert_no_difference -> { Sync.where(syncable: @existing_item).count } do
@@ -344,6 +371,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to accounts_path
     assert_equal "savings", valid_brex_account.reload.account.accountable.subtype
     assert_nil unsupported_brex_account.reload.account_provider
+    assert_match(/skipped/i, flash[:notice])
   end
 
   private

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -47,7 +47,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
       brex_item: {
         name: "Renamed Business Brex",
         token: "updated_second_token",
-        base_url: "https://staging.example.test"
+        base_url: "https://api-staging.brex.com"
       }
     }
 
@@ -55,7 +55,22 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal existing_token, @existing_item.reload.token
     assert_equal "Renamed Business Brex", @second_item.reload.name
     assert_equal "updated_second_token", @second_item.token
-    assert_equal "https://staging.example.test", @second_item.base_url
+    assert_equal "https://api-staging.brex.com", @second_item.base_url
+  end
+
+  test "update rejects arbitrary brex base url" do
+    patch brex_item_url(@second_item), params: {
+      brex_item: {
+        name: "Renamed Business Brex",
+        token: "updated_second_token",
+        base_url: "https://evil.example.test"
+      }
+    }
+
+    assert_redirected_to settings_providers_path
+    assert_includes flash[:alert], "https://api.brex.com"
+    assert_equal "https://api.brex.com", @second_item.reload.base_url
+    assert_equal "second_brex_token", @second_item.token
   end
 
   test "blank token update preserves the selected brex token" do
@@ -82,7 +97,7 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
       brex_item: {
         name: "Renamed Business Brex",
         token: "updated_second_token",
-        base_url: "https://staging.example.test"
+        base_url: "https://api-staging.brex.com"
       }
     }
 
@@ -145,6 +160,19 @@ class BrexItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes @response.body, %(name="brex_item_id")
     assert_includes @response.body, %(value="#{@second_item.id}")
+  end
+
+  test "select accounts rejects protocol relative return paths" do
+    Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(brex_accounts_payload)
+
+    get select_accounts_brex_items_url, params: {
+      brex_item_id: @second_item.id,
+      accountable_type: "Depository",
+      return_to: "//evil.example/accounts"
+    }
+
+    assert_response :success
+    refute_includes @response.body, "//evil.example/accounts"
   end
 
   test "select existing account renders the selected brex item id" do

--- a/test/controllers/brex_items_controller_test.rb
+++ b/test/controllers/brex_items_controller_test.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BrexItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    Rails.cache.clear
+    SyncJob.stubs(:perform_later)
+
+    @family = families(:dylan_family)
+    @existing_item = brex_items(:one)
+    @second_item = BrexItem.create!(
+      family: @family,
+      name: "Business Brex",
+      token: "second_brex_token",
+      base_url: "https://api.brex.com"
+    )
+  end
+
+  teardown do
+    Rails.cache.clear
+  end
+
+  test "create adds a new brex connection without overwriting existing credentials" do
+    existing_token = @existing_item.token
+
+    assert_difference "BrexItem.count", 1 do
+      post brex_items_url, params: {
+        brex_item: {
+          name: "Joint Brex",
+          token: "joint_brex_token",
+          base_url: "https://api.brex.com"
+        }
+      }
+    end
+
+    assert_redirected_to accounts_path
+    assert_equal existing_token, @existing_item.reload.token
+    assert_equal "joint_brex_token", @family.brex_items.find_by!(name: "Joint Brex").token
+  end
+
+  test "update changes only the selected brex connection" do
+    existing_token = @existing_item.token
+
+    patch brex_item_url(@second_item), params: {
+      brex_item: {
+        name: "Renamed Business Brex",
+        token: "updated_second_token",
+        base_url: "https://staging.example.test"
+      }
+    }
+
+    assert_redirected_to accounts_path
+    assert_equal existing_token, @existing_item.reload.token
+    assert_equal "Renamed Business Brex", @second_item.reload.name
+    assert_equal "updated_second_token", @second_item.token
+    assert_equal "https://staging.example.test", @second_item.base_url
+  end
+
+  test "blank token update preserves the selected brex token" do
+    original_token = @second_item.token
+
+    patch brex_item_url(@second_item), params: {
+      brex_item: {
+        name: "Renamed Business Brex",
+        token: "",
+        base_url: "https://api.brex.com"
+      }
+    }
+
+    assert_redirected_to accounts_path
+    assert_equal "Renamed Business Brex", @second_item.reload.name
+    assert_equal original_token, @second_item.token
+  end
+
+  test "update expires selected brex account cache when credentials change" do
+    Rails.cache.expects(:delete).with(brex_cache_key(@existing_item)).never
+    Rails.cache.expects(:delete).with(brex_cache_key(@second_item)).once
+
+    patch brex_item_url(@second_item), params: {
+      brex_item: {
+        name: "Renamed Business Brex",
+        token: "updated_second_token",
+        base_url: "https://staging.example.test"
+      }
+    }
+
+    assert_redirected_to accounts_path
+  end
+
+  test "update does not expire selected brex account cache for name-only changes" do
+    Rails.cache.expects(:delete).never
+
+    patch brex_item_url(@second_item), params: {
+      brex_item: {
+        name: "Renamed Business Brex"
+      }
+    }
+
+    assert_redirected_to accounts_path
+    assert_equal "Renamed Business Brex", @second_item.reload.name
+  end
+
+  test "preload accounts uses selected brex item cache key" do
+    Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(nil)
+    Rails.cache.expects(:write).with(brex_cache_key(@second_item), brex_accounts_payload, expires_in: 5.minutes)
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: brex_accounts_payload)
+    Provider::Brex.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    get preload_accounts_brex_items_url, params: { brex_item_id: @second_item.id }, as: :json
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal true, response["success"]
+    assert_equal true, response["has_accounts"]
+  end
+
+  test "select accounts requires an explicit connection when multiple brex items exist" do
+    get select_accounts_brex_items_url, params: { accountable_type: "Depository" }
+
+    assert_redirected_to settings_providers_path
+    assert_equal "Choose a Brex connection in Provider Settings.", flash[:alert]
+  end
+
+  test "select accounts renders the selected brex item id" do
+    Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(nil)
+    Rails.cache.expects(:write).with(brex_cache_key(@second_item), brex_accounts_payload, expires_in: 5.minutes)
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: brex_accounts_payload)
+    Provider::Brex.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    get select_accounts_brex_items_url, params: {
+      brex_item_id: @second_item.id,
+      accountable_type: "Depository"
+    }
+
+    assert_response :success
+    assert_includes @response.body, %(name="brex_item_id")
+    assert_includes @response.body, %(value="#{@second_item.id}")
+  end
+
+  test "select existing account renders the selected brex item id" do
+    account = @family.accounts.create!(
+      name: "Manual Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    Rails.cache.expects(:read).with(brex_cache_key(@second_item)).returns(nil)
+    Rails.cache.expects(:write).with(brex_cache_key(@second_item), brex_accounts_payload, expires_in: 5.minutes)
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: brex_accounts_payload)
+    Provider::Brex.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    get select_existing_account_brex_items_url, params: {
+      brex_item_id: @second_item.id,
+      account_id: account.id
+    }
+
+    assert_response :success
+    assert_includes @response.body, %(name="brex_item_id")
+    assert_includes @response.body, %(value="#{@second_item.id}")
+  end
+
+  test "link accounts uses selected brex item and allows duplicate upstream ids across items" do
+    @existing_item.brex_accounts.create!(
+      account_id: "shared_brex_account",
+      name: "Shared Checking",
+      currency: "USD",
+      current_balance: 1000
+    )
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: brex_accounts_payload)
+    Provider::Brex.expects(:new)
+      .with(@second_item.token, base_url: @second_item.effective_base_url)
+      .returns(provider)
+
+    assert_difference -> { @second_item.brex_accounts.where(account_id: "shared_brex_account").count }, 1 do
+      assert_difference "AccountProvider.count", 1 do
+        post link_accounts_brex_items_url, params: {
+          brex_item_id: @second_item.id,
+          account_ids: [ "shared_brex_account" ],
+          accountable_type: "Depository"
+        }
+      end
+    end
+
+    assert_redirected_to accounts_path
+    assert_equal 1, @existing_item.brex_accounts.where(account_id: "shared_brex_account").count
+  end
+
+  test "link accounts does not silently use the first connection when multiple items exist" do
+    assert_no_difference "BrexAccount.count" do
+      assert_no_difference "Account.count" do
+        post link_accounts_brex_items_url, params: {
+          account_ids: [ "shared_brex_account" ],
+          accountable_type: "Depository"
+        }
+      end
+    end
+
+    assert_redirected_to settings_providers_path
+    assert_equal "Choose a Brex connection before linking accounts.", flash[:alert]
+  end
+
+  test "link existing account does not silently use the first connection when multiple items exist" do
+    account = @family.accounts.create!(
+      name: "Manual Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    assert_no_difference "BrexAccount.count" do
+      assert_no_difference "AccountProvider.count" do
+        post link_existing_account_brex_items_url, params: {
+          account_id: account.id,
+          brex_account_id: "shared_brex_account"
+        }
+      end
+    end
+
+    assert_redirected_to settings_providers_path
+    assert_equal "Choose a Brex connection before linking accounts.", flash[:alert]
+  end
+
+  test "sync only queues a sync for the selected brex item" do
+    assert_difference -> { Sync.where(syncable: @second_item).count }, 1 do
+      assert_no_difference -> { Sync.where(syncable: @existing_item).count } do
+        post sync_brex_item_url(@second_item)
+      end
+    end
+
+    assert_response :redirect
+  end
+
+  private
+
+    def brex_accounts_payload
+      [
+        {
+          id: "shared_brex_account",
+          name: "Shared Checking",
+          account_kind: "cash",
+          status: "active",
+          current_balance: { amount: 100_000, currency: "USD" },
+          available_balance: { amount: 95_000, currency: "USD" }
+        }
+      ]
+    end
+
+    def brex_cache_key(brex_item)
+      "brex_accounts_#{@family.id}_#{brex_item.id}"
+    end
+end

--- a/test/fixtures/brex_accounts.yml
+++ b/test/fixtures/brex_accounts.yml
@@ -1,0 +1,7 @@
+checking_account:
+  brex_item: one
+  account_id: "cash_acc_checking_1"
+  account_kind: cash
+  name: "Brex Checking"
+  currency: USD
+  current_balance: 10000.00

--- a/test/fixtures/brex_items.yml
+++ b/test/fixtures/brex_items.yml
@@ -1,0 +1,7 @@
+one:
+  family: dylan_family
+
+  name: "Test Brex Connection"
+  token: "test_brex_token_123"
+  base_url: "https://staging.example.test"
+  status: good

--- a/test/fixtures/brex_items.yml
+++ b/test/fixtures/brex_items.yml
@@ -3,5 +3,5 @@ one:
 
   name: "Test Brex Connection"
   token: "test_brex_token_123"
-  base_url: "https://staging.example.test"
+  base_url: "https://api-staging.brex.com"
   status: good

--- a/test/lib/active_record_encryption_config_test.rb
+++ b/test/lib/active_record_encryption_config_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveRecordEncryptionConfigTest < ActiveSupport::TestCase
+  test "detects complete encryption environment" do
+    env = {
+      "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY" => "primary",
+      "ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY" => "deterministic",
+      "ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT" => "salt"
+    }
+
+    assert ActiveRecordEncryptionConfig.complete_env?(env)
+    refute ActiveRecordEncryptionConfig.partial_env?(env)
+    assert_empty ActiveRecordEncryptionConfig.missing_env_keys(env)
+  end
+
+  test "detects partially configured encryption environment" do
+    env = {
+      "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY" => "primary",
+      "ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY" => nil,
+      "ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT" => "salt"
+    }
+
+    refute ActiveRecordEncryptionConfig.complete_env?(env)
+    assert ActiveRecordEncryptionConfig.partial_env?(env)
+    assert_equal [ "ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY" ], ActiveRecordEncryptionConfig.missing_env_keys(env)
+    assert_includes ActiveRecordEncryptionConfig.partial_env_message(env), "ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"
+  end
+
+  test "does not treat absent encryption environment as partial" do
+    env = {
+      "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY" => nil,
+      "ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY" => nil,
+      "ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT" => nil
+    }
+
+    refute ActiveRecordEncryptionConfig.complete_env?(env)
+    refute ActiveRecordEncryptionConfig.partial_env?(env)
+  end
+
+  test "detects runtime encryption configuration" do
+    config = Struct.new(:primary_key, :deterministic_key, :key_derivation_salt).new("primary", "deterministic", "salt")
+
+    assert ActiveRecordEncryptionConfig.runtime_configured?(config)
+  end
+
+  test "explicit configuration excludes runtime generated config" do
+    ActiveRecordEncryptionConfig.stubs(:complete_env?).returns(false)
+    ActiveRecordEncryptionConfig.stubs(:credentials_configured?).returns(false)
+    ActiveRecordEncryptionConfig.stubs(:runtime_configured?).returns(true)
+
+    refute ActiveRecordEncryptionConfig.explicitly_configured?
+    assert ActiveRecordEncryptionConfig.ready?
+  end
+end

--- a/test/models/brex_account/transactions/processor_test.rb
+++ b/test/models/brex_account/transactions/processor_test.rb
@@ -32,4 +32,61 @@ class BrexAccount::Transactions::ProcessorTest < ActiveSupport::TestCase
     assert_equal "No linked account", result[:skipped_transactions].first[:reason]
     assert_empty result[:errors]
   end
+
+  test "imports linked transactions successfully" do
+    link_brex_account!
+
+    result = BrexAccount::Transactions::Processor.new(@brex_account).process
+
+    assert result[:success]
+    assert_equal 1, result[:total]
+    assert_equal 1, result[:imported]
+    assert_equal 0, result[:skipped]
+    assert_equal 0, result[:failed]
+    assert_empty result[:skipped_transactions]
+    assert_empty result[:errors]
+  end
+
+  test "aggregates partial transaction failures" do
+    link_brex_account!
+    @brex_account.update!(
+      raw_transactions_payload: [
+        {
+          id: "tx_success",
+          amount: { amount: 1_00, currency: "USD" },
+          description: "Successful transaction",
+          posted_at_date: "2026-01-02"
+        },
+        {
+          id: "tx_failure",
+          amount: { amount: 2_00, currency: "USD" },
+          description: "Failed transaction",
+          posted_at_date: "not-a-date"
+        }
+      ]
+    )
+
+    result = BrexAccount::Transactions::Processor.new(@brex_account).process
+
+    assert_not result[:success]
+    assert_equal 2, result[:total]
+    assert_equal 1, result[:imported]
+    assert_equal 0, result[:skipped]
+    assert_equal 1, result[:failed]
+    assert_empty result[:skipped_transactions]
+    assert_equal "tx_failure", result[:errors].first[:transaction_id]
+    assert_match(/Unable to parse transaction date/, result[:errors].first[:error])
+  end
+
+  private
+
+    def link_brex_account!
+      account = @brex_item.family.accounts.create!(
+        name: "Linked Cash",
+        balance: 0,
+        currency: "USD",
+        accountable: Depository.new
+      )
+      AccountProvider.create!(account: account, provider: @brex_account)
+    end
 end

--- a/test/models/brex_account/transactions/processor_test.rb
+++ b/test/models/brex_account/transactions/processor_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BrexAccount::Transactions::ProcessorTest < ActiveSupport::TestCase
+  setup do
+    @brex_item = brex_items(:one)
+    @brex_account = @brex_item.brex_accounts.create!(
+      account_id: "cash_unlinked",
+      account_kind: "cash",
+      name: "Unlinked Cash",
+      currency: "USD",
+      raw_transactions_payload: [
+        {
+          id: "tx_skipped",
+          amount: { amount: 1_00, currency: "USD" },
+          description: "Skipped transaction",
+          posted_at_date: "2026-01-02"
+        }
+      ]
+    )
+  end
+
+  test "counts intentionally skipped transactions separately from failures" do
+    result = BrexAccount::Transactions::Processor.new(@brex_account).process
+
+    assert result[:success]
+    assert_equal 1, result[:total]
+    assert_equal 0, result[:imported]
+    assert_equal 1, result[:skipped]
+    assert_equal 0, result[:failed]
+    assert_equal "No linked account", result[:skipped_transactions].first[:reason]
+    assert_empty result[:errors]
+  end
+end

--- a/test/models/brex_account_test.rb
+++ b/test/models/brex_account_test.rb
@@ -9,7 +9,7 @@ class BrexAccountTest < ActiveSupport::TestCase
       family: @family_a,
       name: "Family A Brex",
       token: "token_a",
-      base_url: "https://staging.example.test",
+      base_url: "https://api-staging.brex.com",
       status: "good"
     )
 
@@ -17,7 +17,7 @@ class BrexAccountTest < ActiveSupport::TestCase
       family: @family_b,
       name: "Family B Brex",
       token: "token_b",
-      base_url: "https://staging.example.test",
+      base_url: "https://api-staging.brex.com",
       status: "good"
     )
   end
@@ -49,7 +49,7 @@ class BrexAccountTest < ActiveSupport::TestCase
       family: @family_a,
       name: "Family A Second Brex",
       token: "token_a_2",
-      base_url: "https://staging.example.test",
+      base_url: "https://api-staging.brex.com",
       status: "good"
     )
 

--- a/test/models/brex_account_test.rb
+++ b/test/models/brex_account_test.rb
@@ -131,6 +131,10 @@ class BrexAccountTest < ActiveSupport::TestCase
     assert_equal BigDecimal("1200.0"), brex_account.available_balance
   end
 
+  test "invalid Brex money amount falls back to zero" do
+    assert_equal BigDecimal("0"), BrexAccount.money_to_decimal(amount: "not-a-number", currency: "USD")
+  end
+
   test "snapshot sanitizes full account and routing numbers" do
     brex_account = @item_a.brex_accounts.create!(
       account_id: "cash_2",
@@ -175,5 +179,23 @@ class BrexAccountTest < ActiveSupport::TestCase
     assert_equal({ "card_id" => "card_1", "last_four" => "1111" }, sanitized["card_metadata"])
     refute_includes sanitized.to_s, "test-pan-placeholder"
     refute_includes sanitized.to_s, "private"
+  end
+
+  test "linked_account uses the cached account association" do
+    brex_account = @item_a.brex_accounts.create!(
+      account_id: "cash_linked_alias",
+      name: "Linked Alias",
+      currency: "USD",
+      account_kind: "cash"
+    )
+    account = @family_a.accounts.create!(
+      name: "Linked Alias",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    AccountProvider.create!(account: account, provider: brex_account)
+
+    assert_equal brex_account.account, brex_account.linked_account
   end
 end

--- a/test/models/brex_account_test.rb
+++ b/test/models/brex_account_test.rb
@@ -44,6 +44,13 @@ class BrexAccountTest < ActiveSupport::TestCase
     end
   end
 
+  test "declares raw Brex payloads as encrypted" do
+    encrypted_attributes = BrexAccount.encrypted_attributes.map(&:to_s)
+
+    assert_includes encrypted_attributes, "raw_payload"
+    assert_includes encrypted_attributes, "raw_transactions_payload"
+  end
+
   test "same account_id can be linked under different brex_items in the same family" do
     item_a_2 = BrexItem.create!(
       family: @family_a,

--- a/test/models/brex_account_test.rb
+++ b/test/models/brex_account_test.rb
@@ -1,0 +1,172 @@
+require "test_helper"
+
+class BrexAccountTest < ActiveSupport::TestCase
+  setup do
+    @family_a = families(:dylan_family)
+    @family_b = families(:empty)
+
+    @item_a = BrexItem.create!(
+      family: @family_a,
+      name: "Family A Brex",
+      token: "token_a",
+      base_url: "https://staging.example.test",
+      status: "good"
+    )
+
+    @item_b = BrexItem.create!(
+      family: @family_b,
+      name: "Family B Brex",
+      token: "token_b",
+      base_url: "https://staging.example.test",
+      status: "good"
+    )
+  end
+
+  test "same account_id can be linked under different brex_items" do
+    BrexAccount.create!(
+      brex_item: @item_a,
+      account_id: "shared_brex_acc_1",
+      name: "Checking",
+      currency: "USD",
+      current_balance: 5000
+    )
+
+    # A second family connecting the same Brex account must succeed and produce
+    # an independent ledger (separate BrexAccount row, separate Account).
+    assert_difference "BrexAccount.count", 1 do
+      BrexAccount.create!(
+        brex_item: @item_b,
+        account_id: "shared_brex_acc_1",
+        name: "Checking",
+        currency: "USD",
+        current_balance: 5000
+      )
+    end
+  end
+
+  test "same account_id can be linked under different brex_items in the same family" do
+    item_a_2 = BrexItem.create!(
+      family: @family_a,
+      name: "Family A Second Brex",
+      token: "token_a_2",
+      base_url: "https://staging.example.test",
+      status: "good"
+    )
+
+    BrexAccount.create!(
+      brex_item: @item_a,
+      account_id: "shared_brex_acc_1",
+      name: "Checking",
+      currency: "USD",
+      current_balance: 5000
+    )
+
+    assert_difference "BrexAccount.count", 1 do
+      BrexAccount.create!(
+        brex_item: item_a_2,
+        account_id: "shared_brex_acc_1",
+        name: "Checking",
+        currency: "USD",
+        current_balance: 5000
+      )
+    end
+  end
+
+  test "same account_id cannot appear twice under the same brex_item" do
+    BrexAccount.create!(
+      brex_item: @item_a,
+      account_id: "duplicate_acc",
+      name: "Checking",
+      currency: "USD",
+      current_balance: 1000
+    )
+
+    duplicate = BrexAccount.new(
+      brex_item: @item_a,
+      account_id: "duplicate_acc",
+      name: "Checking",
+      currency: "USD",
+      current_balance: 1000
+    )
+    refute duplicate.valid?
+    assert_includes duplicate.errors[:account_id], "has already been taken"
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      BrexAccount.create!(
+        brex_item: @item_a,
+        account_id: "duplicate_acc",
+        name: "Checking",
+        currency: "USD",
+        current_balance: 1000
+      )
+    end
+  end
+
+  test "minor-unit money converts to decimal account balances" do
+    brex_account = @item_a.brex_accounts.create!(
+      account_id: "cash_1",
+      name: "Operating",
+      currency: "USD",
+      account_kind: "cash"
+    )
+
+    brex_account.upsert_brex_snapshot!(
+      {
+        id: "cash_1",
+        name: "Operating",
+        account_kind: "cash",
+        current_balance: { amount: 123_456, currency: "USD" },
+        available_balance: { amount: 120_000, currency: "USD" }
+      }
+    )
+
+    assert_equal BigDecimal("1234.56"), brex_account.current_balance
+    assert_equal BigDecimal("1200.0"), brex_account.available_balance
+  end
+
+  test "snapshot sanitizes full account and routing numbers" do
+    brex_account = @item_a.brex_accounts.create!(
+      account_id: "cash_2",
+      name: "Operating",
+      currency: "USD",
+      account_kind: "cash"
+    )
+
+    brex_account.upsert_brex_snapshot!(
+      {
+        id: "cash_2",
+        name: "Operating",
+        account_kind: "cash",
+        current_balance: { amount: 100, currency: "USD" },
+        account_number: "123456789012",
+        routing_number: "021000021",
+        token: "secret"
+      }
+    )
+
+    payload = brex_account.raw_payload
+    refute_includes payload.values.compact.map(&:to_s).join(" "), "123456789012"
+    refute_includes payload.values.compact.map(&:to_s).join(" "), "021000021"
+    assert_equal "9012", payload["account_number_last4"]
+    assert_equal "0021", payload["routing_number_last4"]
+    assert_equal "[FILTERED]", payload["token"]
+  end
+
+  test "transaction payload sanitizer drops arbitrary card metadata" do
+    sanitized = BrexAccount.sanitize_payload(
+      {
+        id: "tx_1",
+        card_metadata: {
+          card_id: "card_1",
+          pan: "4111111111111111",
+          secret_note: "private",
+          last_four: "1111"
+        }
+      }
+    )
+
+    assert_equal({ "card_id" => "card_1", "last_four" => "1111" }, sanitized["card_metadata"])
+    refute_includes sanitized.to_s, "4111111111111111"
+    refute_includes sanitized.to_s, "private"
+  end
+end

--- a/test/models/brex_account_test.rb
+++ b/test/models/brex_account_test.rb
@@ -138,15 +138,15 @@ class BrexAccountTest < ActiveSupport::TestCase
         name: "Operating",
         account_kind: "cash",
         current_balance: { amount: 100, currency: "USD" },
-        account_number: "123456789012",
-        routing_number: "021000021",
-        token: "secret"
+        account_number: "account-last4-9012",
+        routing_number: "routing-last4-0021",
+        token: "test-token-placeholder"
       }
     )
 
     payload = brex_account.raw_payload
-    refute_includes payload.values.compact.map(&:to_s).join(" "), "123456789012"
-    refute_includes payload.values.compact.map(&:to_s).join(" "), "021000021"
+    refute_includes payload.values.compact.map(&:to_s).join(" "), "account-last4-9012"
+    refute_includes payload.values.compact.map(&:to_s).join(" "), "routing-last4-0021"
     assert_equal "9012", payload["account_number_last4"]
     assert_equal "0021", payload["routing_number_last4"]
     assert_equal "[FILTERED]", payload["token"]
@@ -158,15 +158,15 @@ class BrexAccountTest < ActiveSupport::TestCase
         id: "tx_1",
         card_metadata: {
           card_id: "card_1",
-          pan: "4111111111111111",
-          secret_note: "private",
+          pan: "test-pan-placeholder",
+          private_note: "private",
           last_four: "1111"
         }
       }
     )
 
     assert_equal({ "card_id" => "card_1", "last_four" => "1111" }, sanitized["card_metadata"])
-    refute_includes sanitized.to_s, "4111111111111111"
+    refute_includes sanitized.to_s, "test-pan-placeholder"
     refute_includes sanitized.to_s, "private"
   end
 end

--- a/test/models/brex_entry/processor_test.rb
+++ b/test/models/brex_entry/processor_test.rb
@@ -69,6 +69,35 @@ class BrexEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal "NEW_BREX_TYPE", entry.transaction.extra.dig("brex", "type")
   end
 
+  test "uses localized default transaction name" do
+    transaction = card_transaction(id: "tx_default_name", amount: 12_34)
+    transaction.delete(:description)
+    transaction.delete(:merchant)
+
+    entry = BrexEntry::Processor.new(transaction, brex_account: @brex_account).process
+
+    assert_equal I18n.t("brex_items.entries.default_name"), entry.name
+  end
+
+  test "logs validation failure without re-reading missing external id" do
+    Rails.logger.expects(:error).with(regexp_matches(/Validation error for transaction brex_unknown/)).once
+
+    assert_raises(ArgumentError) do
+      BrexEntry::Processor.new(card_transaction(id: nil, amount: 12_34), brex_account: @brex_account).process
+    end
+  end
+
+  test "logs save failure with cached external id" do
+    Account::ProviderImportAdapter.any_instance
+                                  .expects(:import_transaction)
+                                  .raises(ActiveRecord::RecordInvalid.new(Entry.new))
+    Rails.logger.expects(:error).with(regexp_matches(/Failed to save transaction brex_tx_save_failure/)).once
+
+    assert_raises(StandardError) do
+      BrexEntry::Processor.new(card_transaction(id: "tx_save_failure", amount: 12_34), brex_account: @brex_account).process
+    end
+  end
+
   test "logs missing transaction currency before using account fallback" do
     Rails.logger.expects(:warn).with(regexp_matches(/Invalid Brex currency nil for transaction tx_missing_currency/)).once
 

--- a/test/models/brex_entry/processor_test.rb
+++ b/test/models/brex_entry/processor_test.rb
@@ -80,7 +80,7 @@ class BrexEntry::ProcessorTest < ActiveSupport::TestCase
         merchant: {
           raw_descriptor: "STAPLES",
           card_metadata: {
-            pan: "4111111111111111"
+            pan: "test-pan-placeholder"
           }
         }
       }

--- a/test/models/brex_entry/processor_test.rb
+++ b/test/models/brex_entry/processor_test.rb
@@ -31,6 +31,9 @@ class BrexEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal Date.new(2026, 1, 2), entry.date
     assert_equal "STAPLES", entry.transaction.merchant.name
     assert_equal "card_1", entry.transaction.extra.dig("brex", "card_id")
+    assert_equal "STAPLES", entry.transaction.extra.dig("brex", "merchant", "raw_descriptor")
+    refute_includes entry.transaction.extra.dig("brex", "merchant").to_s, "test-pan-placeholder"
+    refute_includes entry.transaction.extra.dig("brex", "merchant").to_s, "pan"
   end
 
   test "imports card payment as negative amount" do
@@ -64,6 +67,17 @@ class BrexEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal BigDecimal("0"), entry.amount
     assert_equal "Cash movement", entry.name
     assert_equal "NEW_BREX_TYPE", entry.transaction.extra.dig("brex", "type")
+  end
+
+  test "logs missing transaction currency before using account fallback" do
+    Rails.logger.expects(:warn).with(regexp_matches(/Invalid Brex currency nil for transaction tx_missing_currency/)).once
+
+    entry = BrexEntry::Processor.new(
+      card_transaction(id: "tx_missing_currency", amount: 12_34).tap { |transaction| transaction[:amount].delete(:currency) },
+      brex_account: @brex_account
+    ).process
+
+    assert_equal "USD", entry.currency
   end
 
   private

--- a/test/models/brex_entry/processor_test.rb
+++ b/test/models/brex_entry/processor_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BrexEntry::ProcessorTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @brex_item = brex_items(:one)
+    @account = @family.accounts.create!(
+      name: "Brex Card",
+      balance: 0,
+      currency: "USD",
+      accountable: CreditCard.new
+    )
+    @brex_account = @brex_item.brex_accounts.create!(
+      account_id: BrexAccount.card_account_id,
+      account_kind: "card",
+      name: "Brex Card",
+      currency: "USD",
+      current_balance: 0
+    )
+    AccountProvider.create!(account: @account, provider: @brex_account)
+  end
+
+  test "imports card purchase with Brex signed amount preserved" do
+    entry = BrexEntry::Processor.new(card_transaction(amount: 12_34), brex_account: @brex_account).process
+
+    assert_equal BigDecimal("12.34"), entry.amount
+    assert_equal "USD", entry.currency
+    assert_equal "brex", entry.source
+    assert_equal Date.new(2026, 1, 2), entry.date
+    assert_equal "STAPLES", entry.transaction.merchant.name
+    assert_equal "card_1", entry.transaction.extra.dig("brex", "card_id")
+  end
+
+  test "imports card payment as negative amount" do
+    entry = BrexEntry::Processor.new(card_transaction(id: "tx_payment", amount: -50_00, type: "COLLECTION"), brex_account: @brex_account).process
+
+    assert_equal BigDecimal("-50.0"), entry.amount
+    assert_equal "cc_payment", entry.transaction.kind
+  end
+
+  test "is idempotent by external id and source" do
+    transaction = card_transaction(id: "tx_duplicate", amount: 12_34)
+
+    assert_difference -> { @account.entries.where(source: "brex", external_id: "brex_tx_duplicate").count }, 1 do
+      BrexEntry::Processor.new(transaction, brex_account: @brex_account).process
+      BrexEntry::Processor.new(transaction, brex_account: @brex_account).process
+    end
+  end
+
+  test "tolerates nullable Brex fields and unknown types" do
+    transaction = {
+      id: "tx_nullable",
+      amount: nil,
+      description: "Cash movement",
+      posted_at_date: "2026-01-03",
+      initiated_at_date: "2026-01-02",
+      type: "NEW_BREX_TYPE"
+    }
+
+    entry = BrexEntry::Processor.new(transaction, brex_account: @brex_account).process
+
+    assert_equal BigDecimal("0"), entry.amount
+    assert_equal "Cash movement", entry.name
+    assert_equal "NEW_BREX_TYPE", entry.transaction.extra.dig("brex", "type")
+  end
+
+  private
+
+    def card_transaction(id: "tx_1", amount:, type: "CARD_EXPENSE")
+      {
+        id: id,
+        amount: { amount: amount, currency: "USD" },
+        description: "Office supplies",
+        posted_at_date: "2026-01-02",
+        initiated_at_date: "2026-01-01",
+        type: type,
+        card_id: "card_1",
+        merchant: {
+          raw_descriptor: "STAPLES",
+          card_metadata: {
+            pan: "4111111111111111"
+          }
+        }
+      }
+    end
+end

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -40,6 +40,7 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
 
   test "preload payload treats cached empty accounts as a cache hit" do
     cache_key = BrexItem::AccountFlow.cache_key(@family, @brex_item)
+    Rails.cache.expects(:exist?).with(cache_key).returns(true)
     Rails.cache.expects(:read).with(cache_key).returns([])
     Rails.cache.expects(:write).never
     @brex_item.expects(:brex_provider).never
@@ -103,6 +104,45 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     refute_includes brex_account.raw_payload.to_s, "account-last4-3456"
   end
 
+  test "refreshes existing provider accounts during setup discovery" do
+    brex_item = BrexItem.create!(
+      family: @family,
+      name: "Refresh Brex",
+      token: "refresh_brex_token",
+      base_url: "https://api.brex.com"
+    )
+    brex_item.brex_accounts.create!(
+      account_id: "cash_import_1",
+      name: "Old Cash",
+      currency: "USD",
+      account_kind: "cash",
+      current_balance: 1
+    )
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(
+      accounts: [
+        {
+          id: "cash_import_1",
+          name: "Updated Cash",
+          account_kind: "cash",
+          current_balance: { amount: 12_345, currency: "USD" }
+        }
+      ]
+    )
+    brex_item.expects(:brex_provider).returns(provider)
+
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: brex_item)
+
+    assert_no_difference -> { brex_item.brex_accounts.count } do
+      assert_nil flow.import_accounts_from_api_if_needed
+    end
+
+    brex_account = brex_item.brex_accounts.find_by!(account_id: "cash_import_1")
+    assert_equal "Updated Cash", brex_account.name
+    assert_equal BigDecimal("123.45"), brex_account.current_balance
+  end
+
   test "complete setup creates account links with default subtype" do
     brex_account = @brex_item.brex_accounts.create!(
       account_id: "setup_cash_1",
@@ -126,7 +166,38 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
 
     account = brex_account.reload.account
     assert_equal "Setup Cash", account.name
-    assert_equal "checking", account.accountable.subtype
+    assert_equal Depository::DEFAULT_SUBTYPE, account.accountable.subtype
+  end
+
+  test "complete setup keeps prior accounts when one account creation fails" do
+    first_brex_account = @brex_item.brex_accounts.create!(
+      account_id: "setup_partial_1",
+      account_kind: "cash",
+      name: "Setup Partial One",
+      currency: "USD",
+      current_balance: 100
+    )
+    second_brex_account = @brex_item.brex_accounts.create!(
+      account_id: "setup_partial_2",
+      account_kind: "cash",
+      name: "Setup Partial Two",
+      currency: "USD",
+      current_balance: 100
+    )
+    second_brex_account.update_column(:name, nil)
+
+    result = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item).complete_setup!(
+      account_types: {
+        first_brex_account.id => "Depository",
+        second_brex_account.id => "Depository"
+      },
+      account_subtypes: {}
+    )
+
+    assert_equal 1, result.created_count
+    assert_equal 1, result.failed_count
+    assert first_brex_account.reload.account_provider.present?
+    assert_nil second_brex_account.reload.account_provider
   end
 
   test "link new accounts rolls back account creation when provider link fails" do

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -96,7 +96,7 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
 
     assert_equal :new_account, result.target
     assert_equal :alert, result.flash_type
-    assert_equal I18n.t("brex_items.link_accounts.api_error", message: "link failure"), result.message
+    assert_equal I18n.t("brex_items.errors.unexpected_error"), result.message
   end
 
   test "link existing account converts unexpected errors into navigation alerts" do
@@ -113,7 +113,7 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
 
     assert_equal :accounts, result.target
     assert_equal :alert, result.flash_type
-    assert_equal I18n.t("brex_items.link_existing_account.api_error", message: "link existing failure"), result.message
+    assert_equal I18n.t("brex_items.errors.unexpected_error"), result.message
   end
 
   test "imports provider accounts into the selected item" do

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -40,7 +40,6 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
 
   test "preload payload treats cached empty accounts as a cache hit" do
     cache_key = BrexItem::AccountFlow.cache_key(@family, @brex_item)
-    Rails.cache.expects(:exist?).with(cache_key).returns(true)
     Rails.cache.expects(:read).with(cache_key).returns([])
     Rails.cache.expects(:write).never
     @brex_item.expects(:brex_provider).never

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -85,6 +85,37 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     end
   end
 
+  test "link new accounts converts unexpected errors into navigation alerts" do
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item)
+    flow.expects(:link_new_accounts!).raises(StandardError, "link failure")
+
+    result = flow.link_new_accounts_result(
+      account_ids: [ "cash_import_1" ],
+      accountable_type: "Depository"
+    )
+
+    assert_equal :new_account, result.target
+    assert_equal :alert, result.flash_type
+    assert_equal I18n.t("brex_items.link_accounts.api_error", message: "link failure"), result.message
+  end
+
+  test "link existing account converts unexpected errors into navigation alerts" do
+    account = @family.accounts.create!(
+      name: "Manual Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item)
+    flow.expects(:link_existing_account!).raises(StandardError, "link existing failure")
+
+    result = flow.link_existing_account_result(account: account, brex_account_id: "cash_import_1")
+
+    assert_equal :accounts, result.target
+    assert_equal :alert, result.flash_type
+    assert_equal I18n.t("brex_items.link_existing_account.api_error", message: "link existing failure"), result.message
+  end
+
   test "imports provider accounts into the selected item" do
     brex_item = BrexItem.create!(
       family: @family,

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BrexItem::AccountFlowTest < ActiveSupport::TestCase
+  setup do
+    SyncJob.stubs(:perform_later)
+    @family = families(:dylan_family)
+    @brex_item = brex_items(:one)
+  end
+
+  test "requires explicit item when multiple credentialed connections exist" do
+    BrexItem.create!(
+      family: @family,
+      name: "Second Brex",
+      token: "second_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    flow = BrexItem::AccountFlow.new(family: @family)
+
+    assert_not flow.selected?
+    assert flow.selection_required?
+  end
+
+  test "imports provider accounts into the selected item" do
+    brex_item = BrexItem.create!(
+      family: @family,
+      name: "Import Brex",
+      token: "import_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(
+      accounts: [
+        {
+          id: "cash_import_1",
+          name: "Imported Cash",
+          account_kind: "cash",
+          current_balance: { amount: 12_345, currency: "USD" },
+          account_number: "account-last4-3456"
+        }
+      ]
+    )
+    brex_item.expects(:brex_provider).returns(provider)
+
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: brex_item)
+
+    assert_difference -> { brex_item.brex_accounts.count }, 1 do
+      assert_nil flow.import_accounts_from_api_if_needed
+    end
+
+    brex_account = brex_item.brex_accounts.find_by!(account_id: "cash_import_1")
+    assert_equal "Imported Cash", brex_account.name
+    assert_equal "3456", brex_account.raw_payload["account_number_last4"]
+    refute_includes brex_account.raw_payload.to_s, "account-last4-3456"
+  end
+
+  test "complete setup creates account links with default subtype" do
+    brex_account = @brex_item.brex_accounts.create!(
+      account_id: "setup_cash_1",
+      account_kind: "cash",
+      name: "Setup Cash",
+      currency: "USD",
+      current_balance: 100
+    )
+
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item)
+
+    assert_difference "AccountProvider.count", 1 do
+      result = flow.complete_setup!(
+        account_types: { brex_account.id => "Depository" },
+        account_subtypes: {}
+      )
+
+      assert_equal 1, result.created_count
+      assert_equal 0, result.skipped_count
+    end
+
+    account = brex_account.reload.account
+    assert_equal "Setup Cash", account.name
+    assert_equal "checking", account.accountable.subtype
+  end
+end

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -23,6 +23,39 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     assert flow.selection_required?
   end
 
+  test "preload payload returns explicit selection error when multiple connections exist" do
+    BrexItem.create!(
+      family: @family,
+      name: "Second Brex",
+      token: "second_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    payload = BrexItem::AccountFlow.new(family: @family).preload_payload
+
+    assert_equal false, payload[:success]
+    assert_equal "select_connection", payload[:error]
+    assert_nil payload[:has_accounts]
+  end
+
+  test "link result returns navigation instead of raising expected selection errors" do
+    BrexItem.create!(
+      family: @family,
+      name: "Second Brex",
+      token: "second_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    result = BrexItem::AccountFlow.new(family: @family).link_new_accounts_result(
+      account_ids: [ "cash_import_1" ],
+      accountable_type: "Depository"
+    )
+
+    assert_equal :settings_providers, result.target
+    assert_equal :alert, result.flash_type
+    assert_equal I18n.t("brex_items.link_accounts.select_connection"), result.message
+  end
+
   test "imports provider accounts into the selected item" do
     brex_item = BrexItem.create!(
       family: @family,
@@ -81,5 +114,23 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     account = brex_account.reload.account
     assert_equal "Setup Cash", account.name
     assert_equal "checking", account.accountable.subtype
+  end
+
+  test "complete setup result returns localized notice" do
+    brex_account = @brex_item.brex_accounts.create!(
+      account_id: "setup_result_cash_1",
+      account_kind: "cash",
+      name: "Setup Result Cash",
+      currency: "USD",
+      current_balance: 100
+    )
+
+    result = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item).complete_setup_result(
+      account_types: { brex_account.id => "Depository" },
+      account_subtypes: {}
+    )
+
+    assert result.success?
+    assert_equal I18n.t("brex_items.complete_account_setup.success", count: 1), result.message
   end
 end

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -70,6 +70,22 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     assert_equal I18n.t("brex_items.link_accounts.select_connection"), result.message
   end
 
+  test "link new accounts rejects unsupported account type before creating accounts" do
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item)
+    @brex_item.expects(:brex_provider).never
+
+    assert_no_difference [ "Account.count", "BrexAccount.count", "AccountProvider.count" ] do
+      result = flow.link_new_accounts_result(
+        account_ids: [ "cash_import_1" ],
+        accountable_type: "Investment"
+      )
+
+      assert_equal :new_account, result.target
+      assert_equal :alert, result.flash_type
+      assert_equal I18n.t("brex_items.link_accounts.invalid_account_type"), result.message
+    end
+  end
+
   test "imports provider accounts into the selected item" do
     brex_item = BrexItem.create!(
       family: @family,
@@ -220,6 +236,36 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     assert_no_difference [ "Account.count", "BrexAccount.count", "AccountProvider.count" ] do
       assert_raises(ActiveRecord::RecordInvalid) do
         flow.link_new_accounts!(account_ids: [ "rollback_cash_1" ], accountable_type: "Depository")
+      end
+    end
+  end
+
+  test "link existing account rolls back provider account when link creation fails" do
+    account = @family.accounts.create!(
+      name: "Existing Cash",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(
+      accounts: [
+        {
+          id: "rollback_existing_cash_1",
+          name: "Rollback Existing Cash",
+          account_kind: "cash",
+          current_balance: { amount: 12_345, currency: "USD" }
+        }
+      ]
+    )
+    @brex_item.expects(:brex_provider).returns(provider)
+    AccountProvider.expects(:create!).raises(ActiveRecord::RecordInvalid.new(AccountProvider.new))
+
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item)
+
+    assert_no_difference [ "BrexAccount.count", "AccountProvider.count" ] do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        flow.link_existing_account!(account: account, brex_account_id: "rollback_existing_cash_1")
       end
     end
   end

--- a/test/models/brex_item/account_flow_test.rb
+++ b/test/models/brex_item/account_flow_test.rb
@@ -38,6 +38,19 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     assert_nil payload[:has_accounts]
   end
 
+  test "preload payload treats cached empty accounts as a cache hit" do
+    cache_key = BrexItem::AccountFlow.cache_key(@family, @brex_item)
+    Rails.cache.expects(:read).with(cache_key).returns([])
+    Rails.cache.expects(:write).never
+    @brex_item.expects(:brex_provider).never
+
+    payload = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item).preload_payload
+
+    assert payload[:success]
+    assert_equal false, payload[:has_accounts]
+    assert_equal true, payload[:cached]
+  end
+
   test "link result returns navigation instead of raising expected selection errors" do
     BrexItem.create!(
       family: @family,
@@ -114,6 +127,30 @@ class BrexItem::AccountFlowTest < ActiveSupport::TestCase
     account = brex_account.reload.account
     assert_equal "Setup Cash", account.name
     assert_equal "checking", account.accountable.subtype
+  end
+
+  test "link new accounts rolls back account creation when provider link fails" do
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(
+      accounts: [
+        {
+          id: "rollback_cash_1",
+          name: "Rollback Cash",
+          account_kind: "cash",
+          current_balance: { amount: 12_345, currency: "USD" }
+        }
+      ]
+    )
+    @brex_item.expects(:brex_provider).returns(provider)
+    AccountProvider.expects(:create!).raises(ActiveRecord::RecordInvalid.new(AccountProvider.new))
+
+    flow = BrexItem::AccountFlow.new(family: @family, brex_item: @brex_item)
+
+    assert_no_difference [ "Account.count", "BrexAccount.count", "AccountProvider.count" ] do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        flow.link_new_accounts!(account_ids: [ "rollback_cash_1" ], accountable_type: "Depository")
+      end
+    end
   end
 
   test "complete setup result returns localized notice" do

--- a/test/models/brex_item/importer_test.rb
+++ b/test/models/brex_item/importer_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BrexItem::ImporterTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @brex_item = brex_items(:one)
+    @account = @family.accounts.create!(
+      name: "Operating Cash",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new(subtype: "checking")
+    )
+    @brex_account = @brex_item.brex_accounts.create!(
+      account_id: "cash_1",
+      account_kind: "cash",
+      name: "Operating Cash",
+      currency: "USD",
+      current_balance: 0
+    )
+    AccountProvider.create!(account: @account, provider: @brex_account)
+  end
+
+  test "imports account discovery and fetches transactions only for linked accounts" do
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: [ cash_account_payload, card_account_payload ])
+    provider.expects(:get_cash_transactions).with("cash_1", start_date: anything).returns(
+      transactions: [
+        {
+          id: "cash_tx_1",
+          amount: { amount: 12_34, currency: "USD" },
+          description: "Wire fee",
+          posted_at_date: "2026-01-02"
+        }
+      ]
+    )
+    provider.expects(:get_primary_card_transactions).never
+
+    result = BrexItem::Importer.new(@brex_item, brex_provider: provider).import
+
+    assert result[:success]
+    assert_equal 1, result[:accounts_updated]
+    assert_equal 1, result[:accounts_created]
+    assert_equal [ "cash_tx_1" ], @brex_account.reload.raw_transactions_payload.map { |tx| tx["id"] }
+    assert_equal "card", @brex_item.brex_accounts.find_by!(account_id: BrexAccount.card_account_id).account_kind
+  end
+
+  test "marks item as requiring update on authorization errors" do
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).raises(
+      Provider::Brex::BrexError.new("Access forbidden", :access_forbidden, http_status: 403, trace_id: "trace_123")
+    )
+
+    result = BrexItem::Importer.new(@brex_item, brex_provider: provider).import
+
+    refute result[:success]
+    assert @brex_item.reload.requires_update?
+  end
+
+  private
+
+    def cash_account_payload
+      {
+        id: "cash_1",
+        name: "Operating Cash",
+        account_kind: "cash",
+        status: "ACTIVE",
+        current_balance: { amount: 120_000, currency: "USD" },
+        available_balance: { amount: 110_000, currency: "USD" },
+        account_number: "123456789012",
+        routing_number: "021000021"
+      }
+    end
+
+    def card_account_payload
+      {
+        id: BrexAccount.card_account_id,
+        name: "Brex Card",
+        account_kind: "card",
+        status: "ACTIVE",
+        current_balance: { amount: 1_234, currency: "USD" },
+        available_balance: { amount: 100_000, currency: "USD" },
+        account_limit: { amount: 150_000, currency: "USD" },
+        raw_card_accounts: [
+          {
+            id: "card_account_1",
+            card_metadata: {
+              pan: "4111111111111111"
+            }
+          }
+        ]
+      }
+    end
+end

--- a/test/models/brex_item/importer_test.rb
+++ b/test/models/brex_item/importer_test.rb
@@ -46,6 +46,44 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
     assert_equal "card", @brex_item.brex_accounts.find_by!(account_id: BrexAccount.card_account_id).account_kind
   end
 
+  test "counts only newly stored transactions as imported" do
+    @brex_account.update!(
+      raw_transactions_payload: [
+        {
+          id: "cash_tx_1",
+          amount: { amount: 12_34, currency: "USD" },
+          description: "Existing wire fee",
+          posted_at_date: "2026-01-02"
+        }
+      ]
+    )
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: [ cash_account_payload ])
+    provider.expects(:get_cash_transactions).with("cash_1", start_date: anything).returns(
+      transactions: [
+        {
+          id: "cash_tx_1",
+          amount: { amount: 12_34, currency: "USD" },
+          description: "Existing wire fee",
+          posted_at_date: "2026-01-02"
+        },
+        {
+          id: "cash_tx_2",
+          amount: { amount: 56_78, currency: "USD" },
+          description: "New wire fee",
+          posted_at_date: "2026-01-03"
+        }
+      ]
+    )
+
+    result = BrexItem::Importer.new(@brex_item, brex_provider: provider).import
+
+    assert result[:success]
+    assert_equal 1, result[:transactions_imported]
+    assert_equal [ "cash_tx_1", "cash_tx_2" ], @brex_account.reload.raw_transactions_payload.map { |tx| tx["id"] }
+  end
+
   test "marks item as requiring update on authorization errors" do
     provider = mock("brex_provider")
     provider.expects(:get_accounts).raises(

--- a/test/models/brex_item/importer_test.rb
+++ b/test/models/brex_item/importer_test.rb
@@ -37,7 +37,7 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
     )
     provider.expects(:get_primary_card_transactions).never
 
-    result = BrexItem::Importer.new(@brex_item, brex_provider: provider).import
+    result = BrexItem::Importer.new(@brex_item, brex_provider: provider, sync_start_date: Date.new(2026, 1, 1)).import
 
     assert result[:success]
     assert_equal 1, result[:accounts_updated]
@@ -77,11 +77,56 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
       ]
     )
 
-    result = BrexItem::Importer.new(@brex_item, brex_provider: provider).import
+    result = BrexItem::Importer.new(@brex_item, brex_provider: provider, sync_start_date: Date.new(2026, 1, 1)).import
 
     assert result[:success]
     assert_equal 1, result[:transactions_imported]
     assert_equal [ "cash_tx_1", "cash_tx_2" ], @brex_account.reload.raw_transactions_payload.map { |tx| tx["id"] }
+  end
+
+  test "keeps raw transaction snapshots bounded to the sync window" do
+    @brex_account.update!(
+      raw_transactions_payload: [
+        {
+          id: "old_cash_tx",
+          amount: { amount: 12_34, currency: "USD" },
+          description: "Old wire fee",
+          posted_at_date: "2025-12-01"
+        },
+        {
+          id: "recent_cash_tx",
+          amount: { amount: 56_78, currency: "USD" },
+          description: "Recent wire fee",
+          posted_at_date: "2026-01-02"
+        }
+      ]
+    )
+
+    sync_start_date = Date.new(2026, 1, 1)
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: [ cash_account_payload ])
+    provider.expects(:get_cash_transactions).with("cash_1", start_date: sync_start_date).returns(
+      transactions: [
+        {
+          id: "ignored_before_window",
+          amount: { amount: 1_00, currency: "USD" },
+          description: "Ignored old transaction",
+          posted_at_date: "2025-12-31"
+        },
+        {
+          id: "new_cash_tx",
+          amount: { amount: 2_00, currency: "USD" },
+          description: "New transaction",
+          posted_at_date: "2026-01-03"
+        }
+      ]
+    )
+
+    result = BrexItem::Importer.new(@brex_item, brex_provider: provider, sync_start_date: sync_start_date).import
+
+    assert result[:success]
+    assert_equal 1, result[:transactions_imported]
+    assert_equal [ "recent_cash_tx", "new_cash_tx" ], @brex_account.reload.raw_transactions_payload.map { |tx| tx["id"] }
   end
 
   test "uses explicit sync start date for cash and card transaction fetches" do
@@ -115,6 +160,18 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
     assert result[:success]
   end
 
+  test "raises and reports snapshot persistence failures" do
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: [ cash_account_payload ])
+    @brex_item.expects(:upsert_brex_snapshot!).raises(StandardError.new("snapshot failed"))
+
+    error = assert_raises StandardError do
+      BrexItem::Importer.new(@brex_item, brex_provider: provider).import
+    end
+
+    assert_equal "snapshot failed", error.message
+  end
+
   test "marks item as requiring update on authorization errors" do
     provider = mock("brex_provider")
     provider.expects(:get_accounts).raises(
@@ -125,6 +182,19 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
 
     refute result[:success]
     assert @brex_item.reload.requires_update?
+  end
+
+  test "clears requires update after a clean import" do
+    @brex_item.update!(status: :requires_update)
+
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: [ cash_account_payload ])
+    provider.expects(:get_cash_transactions).with("cash_1", start_date: anything).returns(transactions: [])
+
+    result = BrexItem::Importer.new(@brex_item, brex_provider: provider).import
+
+    assert result[:success]
+    assert @brex_item.reload.good?
   end
 
   private

--- a/test/models/brex_item/importer_test.rb
+++ b/test/models/brex_item/importer_test.rb
@@ -84,6 +84,37 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
     assert_equal [ "cash_tx_1", "cash_tx_2" ], @brex_account.reload.raw_transactions_payload.map { |tx| tx["id"] }
   end
 
+  test "uses explicit sync start date for cash and card transaction fetches" do
+    card_account = @family.accounts.create!(
+      name: "Brex Card",
+      balance: 0,
+      currency: "USD",
+      accountable: CreditCard.new
+    )
+    brex_card_account = @brex_item.brex_accounts.create!(
+      account_id: BrexAccount.card_account_id,
+      account_kind: "card",
+      name: "Brex Card",
+      currency: "USD",
+      current_balance: 0
+    )
+    AccountProvider.create!(account: card_account, provider: brex_card_account)
+
+    sync_start_date = Date.new(2026, 2, 1)
+    provider = mock("brex_provider")
+    provider.expects(:get_accounts).returns(accounts: [ cash_account_payload, card_account_payload ])
+    provider.expects(:get_cash_transactions).with("cash_1", start_date: sync_start_date).returns(transactions: [])
+    provider.expects(:get_primary_card_transactions).with(start_date: sync_start_date).returns(transactions: [])
+
+    result = BrexItem::Importer.new(
+      @brex_item,
+      brex_provider: provider,
+      sync_start_date: sync_start_date
+    ).import
+
+    assert result[:success]
+  end
+
   test "marks item as requiring update on authorization errors" do
     provider = mock("brex_provider")
     provider.expects(:get_accounts).raises(

--- a/test/models/brex_item/importer_test.rb
+++ b/test/models/brex_item/importer_test.rb
@@ -106,8 +106,8 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
         status: "ACTIVE",
         current_balance: { amount: 120_000, currency: "USD" },
         available_balance: { amount: 110_000, currency: "USD" },
-        account_number: "123456789012",
-        routing_number: "021000021"
+        account_number: "account-last4-9012",
+        routing_number: "routing-last4-0021"
       }
     end
 
@@ -124,7 +124,7 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
           {
             id: "card_account_1",
             card_metadata: {
-              pan: "4111111111111111"
+              pan: "test-pan-placeholder"
             }
           }
         ]

--- a/test/models/brex_item/importer_test.rb
+++ b/test/models/brex_item/importer_test.rb
@@ -25,7 +25,7 @@ class BrexItem::ImporterTest < ActiveSupport::TestCase
   test "imports account discovery and fetches transactions only for linked accounts" do
     provider = mock("brex_provider")
     provider.expects(:get_accounts).returns(accounts: [ cash_account_payload, card_account_payload ])
-    provider.expects(:get_cash_transactions).with("cash_1", start_date: anything).returns(
+    provider.expects(:get_cash_transactions).with("cash_1", start_date: Date.new(2026, 1, 1)).returns(
       transactions: [
         {
           id: "cash_tx_1",

--- a/test/models/brex_item/syncer_test.rb
+++ b/test/models/brex_item/syncer_test.rb
@@ -36,6 +36,55 @@ class BrexItem::SyncerTest < ActiveSupport::TestCase
     assert_equal 1, sync.sync_stats["unlinked_accounts"]
   end
 
+  test "records importer failure counts in health stats" do
+    sync = recording_sync(window_start_date: Date.new(2026, 2, 1))
+    @brex_item.expects(:import_latest_brex_data).returns(
+      success: false,
+      accounts_failed: 2,
+      transactions_failed: 1
+    )
+
+    @syncer.perform_sync(sync)
+
+    assert_equal 2, sync.sync_stats["total_errors"]
+    assert_equal [
+      I18n.t("brex_items.syncer.accounts_failed", count: 2),
+      I18n.t("brex_items.syncer.transactions_failed", count: 1)
+    ], sync.sync_stats["errors"].map { |error| error["message"] }
+  end
+
+  test "records account processing and scheduling failures in health stats" do
+    account = @brex_item.family.accounts.create!(
+      name: "Linked Brex Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    brex_account = @brex_item.brex_accounts.first
+    AccountProvider.create!(account: account, provider: brex_account)
+
+    sync = recording_sync(window_start_date: Date.new(2026, 2, 1))
+    @brex_item.expects(:import_latest_brex_data).returns(
+      success: true,
+      accounts_failed: 0,
+      transactions_failed: 0
+    )
+    @brex_item.expects(:process_accounts).returns([
+      { brex_account_id: brex_account.id, success: false, error: "processing failure" }
+    ])
+    @brex_item.expects(:schedule_account_syncs).returns([
+      { account_id: account.id, success: false, error: "scheduling failure" }
+    ])
+
+    @syncer.perform_sync(sync)
+
+    assert_equal 2, sync.sync_stats["total_errors"]
+    assert_equal [
+      I18n.t("brex_items.syncer.account_processing_failed", count: 1),
+      I18n.t("brex_items.syncer.account_sync_failed", count: 1)
+    ], sync.sync_stats["errors"].map { |error| error["message"] }
+  end
+
   test "raises user safe credential error for Brex auth failures" do
     sync = mock_sync(window_start_date: Date.new(2026, 2, 1))
     @brex_item.expects(:import_latest_brex_data)
@@ -70,11 +119,12 @@ class BrexItem::SyncerTest < ActiveSupport::TestCase
         define_method(:initialize) do |start_date|
           @window_start_date = start_date
           @window_end_date = nil
+          @created_at = Time.current
           @sync_stats = {}
           @updates = []
         end
 
-        attr_reader :window_start_date, :window_end_date
+        attr_reader :window_start_date, :window_end_date, :created_at
 
         def update!(attributes)
           @updates << attributes

--- a/test/models/brex_item/syncer_test.rb
+++ b/test/models/brex_item/syncer_test.rb
@@ -17,6 +17,19 @@ class BrexItem::SyncerTest < ActiveSupport::TestCase
     @syncer.perform_sync(sync)
   end
 
+  test "raises user safe credential error for Brex auth failures" do
+    sync = mock_sync(window_start_date: Date.new(2026, 2, 1))
+    @brex_item.expects(:import_latest_brex_data)
+              .raises(Provider::Brex::BrexError.new("raw upstream auth body", :unauthorized, http_status: 401))
+    Sentry.expects(:capture_exception)
+
+    error = assert_raises(BrexItem::Syncer::SafeSyncError) do
+      @syncer.perform_sync(sync)
+    end
+
+    assert_equal I18n.t("brex_items.syncer.credentials_invalid"), error.message
+  end
+
   private
 
     def mock_sync(window_start_date:)

--- a/test/models/brex_item/syncer_test.rb
+++ b/test/models/brex_item/syncer_test.rb
@@ -17,6 +17,25 @@ class BrexItem::SyncerTest < ActiveSupport::TestCase
     @syncer.perform_sync(sync)
   end
 
+  test "records localized setup status text and counts" do
+    window_start_date = Date.new(2026, 2, 1)
+    sync = recording_sync(window_start_date: window_start_date)
+
+    @brex_item.expects(:import_latest_brex_data).with(sync_start_date: window_start_date).once
+
+    @syncer.perform_sync(sync)
+
+    assert_equal [
+      I18n.t("brex_items.syncer.importing_accounts"),
+      I18n.t("brex_items.syncer.checking_account_configuration"),
+      I18n.t("brex_items.syncer.accounts_need_setup", count: 1)
+    ], sync.updates.filter_map { |attrs| attrs[:status_text] }
+
+    assert_equal 1, sync.sync_stats["total_accounts"]
+    assert_equal 0, sync.sync_stats["linked_accounts"]
+    assert_equal 1, sync.sync_stats["unlinked_accounts"]
+  end
+
   test "raises user safe credential error for Brex auth failures" do
     sync = mock_sync(window_start_date: Date.new(2026, 2, 1))
     @brex_item.expects(:import_latest_brex_data)
@@ -41,5 +60,27 @@ class BrexItem::SyncerTest < ActiveSupport::TestCase
       sync.stubs(:window_end_date).returns(nil)
       sync.stubs(:update!)
       sync
+    end
+
+    def recording_sync(window_start_date:)
+      Class.new do
+        attr_accessor :sync_stats, :status_text
+        attr_reader :updates
+
+        define_method(:initialize) do |start_date|
+          @window_start_date = start_date
+          @window_end_date = nil
+          @sync_stats = {}
+          @updates = []
+        end
+
+        attr_reader :window_start_date, :window_end_date
+
+        def update!(attributes)
+          @updates << attributes
+          self.sync_stats = attributes[:sync_stats] if attributes.key?(:sync_stats)
+          self.status_text = attributes[:status_text] if attributes.key?(:status_text)
+        end
+      end.new(window_start_date)
     end
 end

--- a/test/models/brex_item/syncer_test.rb
+++ b/test/models/brex_item/syncer_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BrexItem::SyncerTest < ActiveSupport::TestCase
+  setup do
+    @brex_item = brex_items(:one)
+    @syncer = BrexItem::Syncer.new(@brex_item)
+  end
+
+  test "passes sync window start date to importer" do
+    window_start_date = Date.new(2026, 2, 1)
+    sync = mock_sync(window_start_date: window_start_date)
+
+    @brex_item.expects(:import_latest_brex_data).with(sync_start_date: window_start_date).once
+
+    @syncer.perform_sync(sync)
+  end
+
+  private
+
+    def mock_sync(window_start_date:)
+      sync = mock("sync")
+      sync.stubs(:respond_to?).with(:status_text).returns(true)
+      sync.stubs(:respond_to?).with(:sync_stats).returns(true)
+      sync.stubs(:sync_stats).returns({})
+      sync.stubs(:window_start_date).returns(window_start_date)
+      sync.stubs(:window_end_date).returns(nil)
+      sync.stubs(:update!)
+      sync
+    end
+end

--- a/test/models/brex_item_test.rb
+++ b/test/models/brex_item_test.rb
@@ -52,6 +52,17 @@ class BrexItemTest < ActiveSupport::TestCase
     assert_equal "https://api.brex.com", item.base_url
   end
 
+  test "token is stripped before validation and save" do
+    item = BrexItem.create!(
+      family: families(:empty),
+      name: "Token Normalized Brex",
+      token: "  normalized_token  ",
+      base_url: "https://api.brex.com"
+    )
+
+    assert_equal "normalized_token", item.token
+  end
+
   test "base_url rejects non-Brex hosts and endpoint paths" do
     [
       "http://api.brex.com",

--- a/test/models/brex_item_test.rb
+++ b/test/models/brex_item_test.rb
@@ -90,8 +90,16 @@ class BrexItemTest < ActiveSupport::TestCase
     assert_equal @brex_item.token, provider.token
   end
 
-  test "declares brex token as encrypted" do
+  test "declares Brex token and raw payload as encrypted" do
     assert_includes BrexItem.encrypted_attributes.map(&:to_s), "token"
+    assert_includes BrexItem.encrypted_attributes.map(&:to_s), "raw_payload"
+  end
+
+  test "schema requires name and token" do
+    columns = BrexItem.columns.index_by(&:name)
+
+    assert_equal false, columns["name"].null
+    assert_equal false, columns["token"].null
   end
 
   test "brex_provider returns nil when credentials not configured" do

--- a/test/models/brex_item_test.rb
+++ b/test/models/brex_item_test.rb
@@ -57,7 +57,7 @@ class BrexItemTest < ActiveSupport::TestCase
       "http://api.brex.com",
       "https://evil.example.test",
       "https://api.brex.com/v2",
-      "https://api.brex.com?token=leak",
+      "https://api.brex.com?debug=true",
       "//api.brex.com"
     ].each do |base_url|
       item = BrexItem.new(family: families(:empty), name: "Invalid Brex", token: "token", base_url: base_url)

--- a/test/models/brex_item_test.rb
+++ b/test/models/brex_item_test.rb
@@ -28,12 +28,43 @@ class BrexItemTest < ActiveSupport::TestCase
   end
 
   test "effective_base_url returns custom url when set" do
-    assert_equal "https://staging.example.test", @brex_item.effective_base_url
+    assert_equal "https://api-staging.brex.com", @brex_item.effective_base_url
   end
 
   test "effective_base_url returns default when base_url blank" do
     @brex_item.base_url = nil
     assert_equal "https://api.brex.com", @brex_item.effective_base_url
+  end
+
+  test "base_url accepts official Brex API roots" do
+    assert BrexItem.new(family: families(:empty), name: "Production", token: "token", base_url: "https://api.brex.com").valid?
+    assert BrexItem.new(family: families(:empty), name: "Staging", token: "token", base_url: "https://api-staging.brex.com").valid?
+  end
+
+  test "base_url normalizes official URL case and trailing slash" do
+    item = BrexItem.create!(
+      family: families(:empty),
+      name: "Normalized Brex",
+      token: "token",
+      base_url: " HTTPS://API.BREX.COM/ "
+    )
+
+    assert_equal "https://api.brex.com", item.base_url
+  end
+
+  test "base_url rejects non-Brex hosts and endpoint paths" do
+    [
+      "http://api.brex.com",
+      "https://evil.example.test",
+      "https://api.brex.com/v2",
+      "https://api.brex.com?token=leak",
+      "//api.brex.com"
+    ].each do |base_url|
+      item = BrexItem.new(family: families(:empty), name: "Invalid Brex", token: "token", base_url: base_url)
+
+      refute item.valid?, "Expected #{base_url.inspect} to be invalid"
+      assert_includes item.errors[:base_url], I18n.t("activerecord.errors.models.brex_item.attributes.base_url.official_hosts_only")
+    end
   end
 
   test "brex_provider returns Provider::Brex instance" do
@@ -47,13 +78,19 @@ class BrexItemTest < ActiveSupport::TestCase
     assert_nil @brex_item.brex_provider
   end
 
+  test "brex_provider returns nil when persisted base_url is not allowed" do
+    @brex_item.update_column(:base_url, "https://evil.example.test")
+
+    assert_nil @brex_item.reload.brex_provider
+  end
+
   test "family credential check ignores blank and scheduled for deletion items" do
     family = families(:empty)
     blank_item = BrexItem.create!(
       family: family,
       name: "Blank Brex",
       token: "temporary_token",
-      base_url: "https://staging.example.test"
+      base_url: "https://api-staging.brex.com"
     )
     blank_item.update_column(:token, "")
 
@@ -61,7 +98,7 @@ class BrexItemTest < ActiveSupport::TestCase
       family: family,
       name: "Whitespace Brex",
       token: "temporary_token",
-      base_url: "https://staging.example.test"
+      base_url: "https://api-staging.brex.com"
     )
     whitespace_item.update_column(:token, "   ")
 
@@ -69,7 +106,7 @@ class BrexItemTest < ActiveSupport::TestCase
       family: family,
       name: "Deleted Brex",
       token: "deleted_token",
-      base_url: "https://staging.example.test",
+      base_url: "https://api-staging.brex.com",
       scheduled_for_deletion: true
     )
 

--- a/test/models/brex_item_test.rb
+++ b/test/models/brex_item_test.rb
@@ -56,6 +56,12 @@ class BrexItemTest < ActiveSupport::TestCase
     [
       "http://api.brex.com",
       "https://evil.example.test",
+      "https://localhost",
+      "https://127.0.0.1",
+      "https://10.0.0.1",
+      "https://api.brex.com.evil.example",
+      "https://api.brex.com@127.0.0.1",
+      "https://api.brex.com:444",
       "https://api.brex.com/v2",
       "https://api.brex.com?debug=true",
       "//api.brex.com"
@@ -71,6 +77,10 @@ class BrexItemTest < ActiveSupport::TestCase
     provider = @brex_item.brex_provider
     assert_instance_of Provider::Brex, provider
     assert_equal @brex_item.token, provider.token
+  end
+
+  test "declares brex token as encrypted" do
+    assert_includes BrexItem.encrypted_attributes.map(&:to_s), "token"
   end
 
   test "brex_provider returns nil when credentials not configured" do

--- a/test/models/brex_item_test.rb
+++ b/test/models/brex_item_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class BrexItemTest < ActiveSupport::TestCase
+  def setup
+    @brex_item = brex_items(:one)
+  end
+
+  test "fixture is valid" do
+    assert @brex_item.valid?
+  end
+
+  test "belongs to family" do
+    assert_equal families(:dylan_family), @brex_item.family
+  end
+
+  test "credentials_configured returns true when token present" do
+    assert @brex_item.credentials_configured?
+  end
+
+  test "credentials_configured returns false when token blank" do
+    @brex_item.token = nil
+    assert_not @brex_item.credentials_configured?
+  end
+
+  test "credentials_configured returns false when token is whitespace" do
+    @brex_item.token = "   "
+    assert_not @brex_item.credentials_configured?
+  end
+
+  test "effective_base_url returns custom url when set" do
+    assert_equal "https://staging.example.test", @brex_item.effective_base_url
+  end
+
+  test "effective_base_url returns default when base_url blank" do
+    @brex_item.base_url = nil
+    assert_equal "https://api.brex.com", @brex_item.effective_base_url
+  end
+
+  test "brex_provider returns Provider::Brex instance" do
+    provider = @brex_item.brex_provider
+    assert_instance_of Provider::Brex, provider
+    assert_equal @brex_item.token, provider.token
+  end
+
+  test "brex_provider returns nil when credentials not configured" do
+    @brex_item.token = nil
+    assert_nil @brex_item.brex_provider
+  end
+
+  test "family credential check ignores blank and scheduled for deletion items" do
+    family = families(:empty)
+    blank_item = BrexItem.create!(
+      family: family,
+      name: "Blank Brex",
+      token: "temporary_token",
+      base_url: "https://staging.example.test"
+    )
+    blank_item.update_column(:token, "")
+
+    whitespace_item = BrexItem.create!(
+      family: family,
+      name: "Whitespace Brex",
+      token: "temporary_token",
+      base_url: "https://staging.example.test"
+    )
+    whitespace_item.update_column(:token, "   ")
+
+    deleted_item = BrexItem.create!(
+      family: family,
+      name: "Deleted Brex",
+      token: "deleted_token",
+      base_url: "https://staging.example.test",
+      scheduled_for_deletion: true
+    )
+
+    refute family.has_brex_credentials?
+
+    whitespace_item.update_column(:token, "configured_token")
+    assert family.has_brex_credentials?
+
+    whitespace_item.update_column(:token, "   ")
+    deleted_item.update!(scheduled_for_deletion: false)
+    assert family.has_brex_credentials?
+  end
+
+  test "syncer returns BrexItem::Syncer instance" do
+    syncer = @brex_item.send(:syncer)
+    assert_instance_of BrexItem::Syncer, syncer
+  end
+end

--- a/test/models/brex_item_test.rb
+++ b/test/models/brex_item_test.rb
@@ -63,6 +63,17 @@ class BrexItemTest < ActiveSupport::TestCase
     assert_equal "normalized_token", item.token
   end
 
+  test "token cannot be blanked on update" do
+    original_token = @brex_item.token
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      @brex_item.update!(token: "   ")
+    end
+
+    assert_equal original_token, @brex_item.reload.token
+    assert_includes @brex_item.errors[:token], "can't be blank"
+  end
+
   test "base_url rejects non-Brex hosts and endpoint paths" do
     [
       "http://api.brex.com",

--- a/test/models/enable_banking_item/importer_start_date_test.rb
+++ b/test/models/enable_banking_item/importer_start_date_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class EnableBankingItem::ImporterStartDateTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    @family = families(:dylan_family)
+
+    @enable_banking_item = EnableBankingItem.create!(
+      family: @family,
+      name: "Test EB",
+      country_code: "FR",
+      application_id: "test_app_id",
+      client_certificate: "test_cert",
+      session_id: "test_session",
+      session_expires_at: 1.day.from_now
+    )
+
+    @enable_banking_account = EnableBankingAccount.create!(
+      enable_banking_item: @enable_banking_item,
+      name: "Compte courant",
+      uid: "hash_abc123",
+      account_id: "uuid-1234-5678-abcd",
+      currency: "EUR"
+    )
+
+    @importer = EnableBankingItem::Importer.new(@enable_banking_item, enable_banking_provider: mock())
+  end
+
+  test "initial sync clamps old user-configured start date to 120 days" do
+    travel_to Time.zone.local(2026, 5, 16, 12, 0, 0) do
+      @enable_banking_item.update!(sync_start_date: Date.new(2025, 1, 1))
+
+      start_date = @importer.send(:determine_sync_start_date, @enable_banking_account)
+
+      assert_equal Date.new(2026, 1, 16), start_date
+    end
+  end
+
+  test "incremental sync clamps stale last sync lookback to 120 days" do
+    travel_to Time.zone.local(2026, 5, 16, 12, 0, 0) do
+      @enable_banking_account.update!(raw_transactions_payload: [ { transaction_id: "tx_1" } ])
+
+      old_sync = @enable_banking_item.syncs.create!(created_at: 200.days.ago)
+      old_sync.update!(status: :completed, completed_at: 180.days.ago)
+
+      start_date = @importer.send(:determine_sync_start_date, @enable_banking_account)
+
+      assert_equal Date.new(2026, 1, 16), start_date
+    end
+  end
+
+  test "incremental sync still uses 7-day buffer when within allowed window" do
+    travel_to Time.zone.local(2026, 5, 16, 12, 0, 0) do
+      @enable_banking_account.update!(raw_transactions_payload: [ { transaction_id: "tx_1" } ])
+
+      recent_sync = @enable_banking_item.syncs.create!(created_at: 10.days.ago)
+      recent_sync.update!(status: :completed, completed_at: 3.days.ago)
+
+      start_date = @importer.send(:determine_sync_start_date, @enable_banking_account)
+
+      assert_equal Date.new(2026, 5, 6), start_date
+    end
+  end
+end

--- a/test/models/provider/brex_adapter_test.rb
+++ b/test/models/provider/brex_adapter_test.rb
@@ -1,0 +1,153 @@
+require "uri"
+
+require "test_helper"
+
+class Provider::BrexAdapterTest < ActiveSupport::TestCase
+  test "supports Depository accounts" do
+    assert_includes Provider::BrexAdapter.supported_account_types, "Depository"
+  end
+
+  test "supports CreditCard accounts" do
+    assert_includes Provider::BrexAdapter.supported_account_types, "CreditCard"
+  end
+
+  test "does not support Investment accounts" do
+    assert_not_includes Provider::BrexAdapter.supported_account_types, "Investment"
+  end
+
+  test "returns fallback connection config when no credentials exist yet" do
+    # Brex is a per-family provider - any family can connect
+    family = families(:empty)
+    configs = Provider::BrexAdapter.connection_configs(family: family)
+
+    assert_equal 1, configs.length
+    assert_equal "brex", configs.first[:key]
+    assert_equal I18n.t("brex_items.provider_connection.default_name"), configs.first[:name]
+    assert configs.first[:can_connect]
+  end
+
+  test "returns one connection config per credentialed brex item" do
+    family = families(:dylan_family)
+    first_item = brex_items(:one)
+    second_item = BrexItem.create!(
+      family: family,
+      name: "Business Brex",
+      token: "second_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    configs = Provider::BrexAdapter.connection_configs(family: family)
+
+    assert_equal 2, configs.length
+    assert_equal [ "brex_#{second_item.id}", "brex_#{first_item.id}" ], configs.map { |config| config[:key] }
+    assert_equal [
+      I18n.t("brex_items.provider_connection.name", name: second_item.name),
+      I18n.t("brex_items.provider_connection.name", name: first_item.name)
+    ], configs.map { |config| config[:name] }
+
+    new_account_uri = URI.parse(configs.first[:new_account_path].call("Depository", "/accounts"))
+    assert_equal "/brex_items/select_accounts", new_account_uri.path
+    assert_includes new_account_uri.query, "brex_item_id=#{second_item.id}"
+
+    existing_account_uri = URI.parse(configs.first[:existing_account_path].call(accounts(:depository).id))
+    assert_equal "/brex_items/select_existing_account", existing_account_uri.path
+    assert_includes existing_account_uri.query, "brex_item_id=#{second_item.id}"
+  end
+
+  test "connection configs ignore items with whitespace-only tokens" do
+    family = families(:dylan_family)
+    BrexItem.create!(
+      family: family,
+      name: "Blank Brex",
+      token: "temporary_token",
+      base_url: "https://api.brex.com"
+    ).update_column(:token, "   ")
+
+    configs = Provider::BrexAdapter.connection_configs(family: family)
+
+    assert_equal [ "brex_#{brex_items(:one).id}" ], configs.map { |config| config[:key] }
+  end
+
+  test "build_provider returns nil when family is nil" do
+    assert_nil Provider::BrexAdapter.build_provider(family: nil)
+  end
+
+  test "build_provider returns nil when family has no brex items" do
+    family = families(:empty)
+    assert_nil Provider::BrexAdapter.build_provider(family: family)
+  end
+
+  test "build_provider returns Brex provider when credentials configured" do
+    family = families(:dylan_family)
+    provider = Provider::BrexAdapter.build_provider(family: family)
+
+    assert_instance_of Provider::Brex, provider
+  end
+
+  test "build_provider uses explicit brex item credentials" do
+    family = families(:dylan_family)
+    second_item = BrexItem.create!(
+      family: family,
+      name: "Business Brex",
+      token: "second_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    provider = Provider::BrexAdapter.build_provider(family: family, brex_item_id: second_item.id)
+
+    assert_instance_of Provider::Brex, provider
+    assert_equal "second_brex_token", provider.token
+    assert_equal "https://api.brex.com", provider.base_url
+  end
+
+  test "build_provider does not pick the first connection when multiple credentials exist" do
+    family = families(:dylan_family)
+    BrexItem.create!(
+      family: family,
+      name: "Business Brex",
+      token: "second_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    assert_nil Provider::BrexAdapter.build_provider(family: family)
+  end
+
+  test "build_provider strips surrounding token whitespace" do
+    family = families(:dylan_family)
+    second_item = BrexItem.create!(
+      family: family,
+      name: "Business Brex",
+      token: " second_brex_token \n",
+      base_url: "https://api.brex.com"
+    )
+
+    provider = Provider::BrexAdapter.build_provider(family: family, brex_item_id: second_item.id)
+
+    assert_equal "second_brex_token", provider.token
+  end
+
+  test "build_provider refuses brex items outside the family" do
+    family = families(:dylan_family)
+    other_item = BrexItem.create!(
+      family: families(:empty),
+      name: "Other Brex",
+      token: "other_brex_token",
+      base_url: "https://api.brex.com"
+    )
+
+    assert_nil Provider::BrexAdapter.build_provider(family: family, brex_item_id: other_item.id)
+  end
+
+  test "build_provider refuses explicit brex item without usable credentials" do
+    family = families(:dylan_family)
+    blank_item = BrexItem.create!(
+      family: family,
+      name: "Blank Brex",
+      token: "temporary_token",
+      base_url: "https://api.brex.com"
+    )
+    blank_item.update_column(:token, "   ")
+
+    assert_nil Provider::BrexAdapter.build_provider(family: family, brex_item_id: blank_item.id)
+  end
+end

--- a/test/models/provider/brex_adapter_test.rb
+++ b/test/models/provider/brex_adapter_test.rb
@@ -150,4 +150,38 @@ class Provider::BrexAdapterTest < ActiveSupport::TestCase
 
     assert_nil Provider::BrexAdapter.build_provider(family: family, brex_item_id: blank_item.id)
   end
+
+  test "build_provider refuses explicit brex item with invalid persisted base_url" do
+    family = families(:dylan_family)
+    item = BrexItem.create!(
+      family: family,
+      name: "Invalid URL Brex",
+      token: "token",
+      base_url: "https://api.brex.com"
+    )
+    item.update_column(:base_url, "https://evil.example.test")
+
+    assert_nil Provider::BrexAdapter.build_provider(family: family, brex_item_id: item.id)
+  end
+
+  test "reads institution metadata from brex account column" do
+    brex_account = brex_items(:one).brex_accounts.create!(
+      account_id: "metadata_cash",
+      account_kind: "cash",
+      name: "Metadata Cash",
+      currency: "USD",
+      institution_metadata: {
+        "name" => "Brex",
+        "domain" => "brex.com",
+        "url" => "https://brex.com"
+      }
+    )
+
+    adapter = Provider::BrexAdapter.new(brex_account)
+
+    assert_equal "brex.com", brex_account.institution_metadata["domain"]
+    assert_equal "brex.com", adapter.institution_domain
+    assert_equal "Brex", adapter.institution_name
+    assert_equal "https://brex.com", adapter.institution_url
+  end
 end

--- a/test/models/provider/brex_adapter_test.rb
+++ b/test/models/provider/brex_adapter_test.rb
@@ -184,4 +184,25 @@ class Provider::BrexAdapterTest < ActiveSupport::TestCase
     assert_equal "Brex", adapter.institution_name
     assert_equal "https://brex.com", adapter.institution_url
   end
+
+  test "falls back to brex item institution metadata" do
+    brex_item = brex_items(:one)
+    brex_item.update!(
+      institution_name: "Brex Item Name",
+      institution_url: "https://brex.com/item",
+      institution_color: "#123456"
+    )
+    brex_account = brex_item.brex_accounts.create!(
+      account_id: "metadata_fallback_cash",
+      account_kind: "cash",
+      name: "Metadata Fallback Cash",
+      currency: "USD"
+    )
+
+    adapter = Provider::BrexAdapter.new(brex_account)
+
+    assert_equal "Brex Item Name", adapter.institution_name
+    assert_equal "https://brex.com/item", adapter.institution_url
+    assert_equal "#123456", adapter.institution_color
+  end
 end

--- a/test/models/provider/brex_test.rb
+++ b/test/models/provider/brex_test.rb
@@ -33,6 +33,12 @@ class Provider::BrexTest < ActiveSupport::TestCase
     [
       "http://api.brex.com",
       "https://evil.example.test",
+      "https://localhost",
+      "https://127.0.0.1",
+      "https://10.0.0.1",
+      "https://api.brex.com.evil.example",
+      "https://api.brex.com@127.0.0.1",
+      "https://api.brex.com:444",
       "https://api.brex.com/v1",
       "https://api.brex.com?host=evil.example.test",
       "//api.brex.com"

--- a/test/models/provider/brex_test.rb
+++ b/test/models/provider/brex_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Provider::BrexTest < ActiveSupport::TestCase
   def setup
-    @provider = Provider::Brex.new("test_token", base_url: "https://staging.example.test")
+    @provider = Provider::Brex.new("test_token", base_url: "https://api-staging.brex.com")
   end
 
   test "initializes with token and default base_url" do
@@ -13,7 +13,7 @@ class Provider::BrexTest < ActiveSupport::TestCase
 
   test "initializes with custom base_url" do
     assert_equal "test_token", @provider.token
-    assert_equal "https://staging.example.test", @provider.base_url
+    assert_equal "https://api-staging.brex.com", @provider.base_url
   end
 
   test "initializes with stripped token and removes trailing base url slash" do
@@ -21,6 +21,26 @@ class Provider::BrexTest < ActiveSupport::TestCase
 
     assert_equal "test_token", provider.token
     assert_equal "https://api.brex.com", provider.base_url
+  end
+
+  test "initializes with official staging base url" do
+    provider = Provider::Brex.new("test_token", base_url: "https://api-staging.brex.com/")
+
+    assert_equal "https://api-staging.brex.com", provider.base_url
+  end
+
+  test "rejects arbitrary base urls" do
+    [
+      "http://api.brex.com",
+      "https://evil.example.test",
+      "https://api.brex.com/v1",
+      "https://api.brex.com?host=evil.example.test",
+      "//api.brex.com"
+    ].each do |base_url|
+      assert_raises ArgumentError do
+        Provider::Brex.new("test_token", base_url: base_url)
+      end
+    end
   end
 
   test "BrexError includes error_type" do
@@ -115,6 +135,34 @@ class Provider::BrexTest < ActiveSupport::TestCase
     assert_equal 1, accounts_data[:accounts].first[:card_accounts_count]
   end
 
+  test "does not aggregate mixed currency card balances" do
+    cash_response = OpenStruct.new(
+      code: 200,
+      body: { items: [] }.to_json,
+      headers: {}
+    )
+    card_response = OpenStruct.new(
+      code: 200,
+      body: [
+        {
+          id: "card_account_1",
+          current_balance: { amount: 12_345, currency: "USD" }
+        },
+        {
+          id: "card_account_2",
+          current_balance: { amount: 6_789, currency: "EUR" }
+        }
+      ].to_json,
+      headers: {}
+    )
+
+    Provider::Brex.stubs(:get).returns(cash_response, card_response)
+
+    accounts_data = Provider::Brex.new("test_token").get_accounts
+
+    assert_nil accounts_data[:accounts].first[:current_balance]
+  end
+
   test "guards repeated pagination cursors" do
     first_response = OpenStruct.new(
       code: 200,
@@ -174,6 +222,14 @@ class Provider::BrexTest < ActiveSupport::TestCase
       .returns(response)
 
     Provider::Brex.new("test_token").get_primary_card_transactions(start_date: Date.new(2026, 1, 2))
+  end
+
+  test "raises clear error for invalid start date" do
+    error = assert_raises ArgumentError do
+      Provider::Brex.new("test_token").get_primary_card_transactions(start_date: "not-a-date")
+    end
+
+    assert_includes error.message, "Invalid start_date"
   end
 
   test "maps rate limits and exposes trace id without leaking body" do

--- a/test/models/provider/brex_test.rb
+++ b/test/models/provider/brex_test.rb
@@ -1,0 +1,132 @@
+require "test_helper"
+
+class Provider::BrexTest < ActiveSupport::TestCase
+  def setup
+    @provider = Provider::Brex.new("test_token", base_url: "https://staging.example.test")
+  end
+
+  test "initializes with token and default base_url" do
+    provider = Provider::Brex.new("my_token")
+    assert_equal "my_token", provider.token
+    assert_equal "https://api.brex.com", provider.base_url
+  end
+
+  test "initializes with custom base_url" do
+    assert_equal "test_token", @provider.token
+    assert_equal "https://staging.example.test", @provider.base_url
+  end
+
+  test "initializes with stripped token and removes trailing base url slash" do
+    provider = Provider::Brex.new(" test_token \n", base_url: "https://api.brex.com/")
+
+    assert_equal "test_token", provider.token
+    assert_equal "https://api.brex.com", provider.base_url
+  end
+
+  test "BrexError includes error_type" do
+    error = Provider::Brex::BrexError.new("Test error", :unauthorized)
+    assert_equal "Test error", error.message
+    assert_equal :unauthorized, error.error_type
+  end
+
+  test "BrexError defaults error_type to unknown" do
+    error = Provider::Brex::BrexError.new("Test error")
+    assert_equal :unknown, error.error_type
+  end
+
+  test "fetches cash accounts from the v2 endpoint with bearer auth" do
+    response = OpenStruct.new(
+      code: 200,
+      body: { items: [ { id: "cash_1", name: "Operating" } ] }.to_json,
+      headers: {}
+    )
+
+    Provider::Brex.expects(:get)
+      .with(
+        "https://api.brex.com/v2/accounts/cash?limit=1000",
+        headers: {
+          "Authorization" => "Bearer test_token",
+          "Content-Type" => "application/json",
+          "Accept" => "application/json"
+        }
+      )
+      .returns(response)
+
+    accounts = Provider::Brex.new(" test_token ").get_cash_accounts
+
+    assert_equal 1, accounts.length
+    assert_equal "cash_1", accounts.first[:id]
+    assert_equal "cash", accounts.first[:account_kind]
+  end
+
+  test "aggregates card accounts into one provider account" do
+    cash_response = OpenStruct.new(
+      code: 200,
+      body: { items: [] }.to_json,
+      headers: {}
+    )
+    card_response = OpenStruct.new(
+      code: 200,
+      body: {
+        items: [
+          {
+            id: "card_account_1",
+            status: "ACTIVE",
+            current_balance: { amount: 12_345, currency: "USD" },
+            available_balance: { amount: 100_000, currency: "USD" },
+            account_limit: { amount: 250_000, currency: "USD" }
+          }
+        ]
+      }.to_json,
+      headers: {}
+    )
+
+    Provider::Brex.stubs(:get).returns(cash_response, card_response)
+
+    accounts_data = Provider::Brex.new("test_token").get_accounts
+
+    assert_equal [ "card_primary" ], accounts_data[:accounts].map { |account| account[:id] }
+    assert_equal "card", accounts_data[:accounts].first[:account_kind]
+    assert_equal 1, accounts_data[:accounts].first[:card_accounts_count]
+  end
+
+  test "guards repeated pagination cursors" do
+    first_response = OpenStruct.new(
+      code: 200,
+      body: { items: [ { id: "tx_1" } ], next_cursor: "cursor_1" }.to_json,
+      headers: {}
+    )
+    second_response = OpenStruct.new(
+      code: 200,
+      body: { items: [ { id: "tx_2" } ], next_cursor: "cursor_1" }.to_json,
+      headers: {}
+    )
+
+    Provider::Brex.stubs(:get).returns(first_response, second_response)
+
+    error = assert_raises Provider::Brex::BrexError do
+      Provider::Brex.new("test_token").get_primary_card_transactions
+    end
+
+    assert_equal :pagination_error, error.error_type
+  end
+
+  test "maps rate limits and exposes trace id without leaking body" do
+    response = OpenStruct.new(
+      code: 429,
+      body: { message: "secret raw provider body" }.to_json,
+      headers: { "x-brex-trace-id" => "trace_123" }
+    )
+
+    Provider::Brex.stubs(:get).returns(response)
+
+    error = assert_raises Provider::Brex::BrexError do
+      Provider::Brex.new("test_token").get_cash_accounts
+    end
+
+    assert_equal :rate_limited, error.error_type
+    assert_equal 429, error.http_status
+    assert_equal "trace_123", error.trace_id
+    refute_includes error.message, "secret raw provider body"
+  end
+end

--- a/test/models/provider/brex_test.rb
+++ b/test/models/provider/brex_test.rb
@@ -59,6 +59,31 @@ class Provider::BrexTest < ActiveSupport::TestCase
     assert_equal "cash", accounts.first[:account_kind]
   end
 
+  test "fetches card accounts without pagination params because endpoint returns an array" do
+    response = OpenStruct.new(
+      code: 200,
+      body: [ { id: "card_account_1", status: "ACTIVE" } ].to_json,
+      headers: {}
+    )
+
+    Provider::Brex.expects(:get)
+      .with(
+        "https://api.brex.com/v2/accounts/card",
+        headers: {
+          "Authorization" => "Bearer test_token",
+          "Content-Type" => "application/json",
+          "Accept" => "application/json"
+        }
+      )
+      .returns(response)
+
+    accounts = Provider::Brex.new("test_token").get_card_accounts
+
+    assert_equal 1, accounts.length
+    assert_equal "card_account_1", accounts.first[:id]
+    assert_equal "card", accounts.first[:account_kind]
+  end
+
   test "aggregates card accounts into one provider account" do
     cash_response = OpenStruct.new(
       code: 200,
@@ -111,6 +136,46 @@ class Provider::BrexTest < ActiveSupport::TestCase
     assert_equal :pagination_error, error.error_type
   end
 
+  test "guards pagination page cap" do
+    responses = (1..251).map do |page|
+      OpenStruct.new(
+        code: 200,
+        body: { items: [ { id: "tx_#{page}" } ], next_cursor: "cursor_#{page}" }.to_json,
+        headers: {}
+      )
+    end
+
+    Provider::Brex.stubs(:get).returns(*responses)
+
+    error = assert_raises Provider::Brex::BrexError do
+      Provider::Brex.new("test_token").get_primary_card_transactions
+    end
+
+    assert_equal :pagination_error, error.error_type
+    assert_includes error.message, "exceeded"
+  end
+
+  test "sends posted_at_start as RFC3339 date time" do
+    response = OpenStruct.new(
+      code: 200,
+      body: { items: [] }.to_json,
+      headers: {}
+    )
+
+    Provider::Brex.expects(:get)
+      .with(
+        "https://api.brex.com/v2/transactions/card/primary?posted_at_start=2026-01-02T00%3A00%3A00Z&limit=1000",
+        headers: {
+          "Authorization" => "Bearer test_token",
+          "Content-Type" => "application/json",
+          "Accept" => "application/json"
+        }
+      )
+      .returns(response)
+
+    Provider::Brex.new("test_token").get_primary_card_transactions(start_date: Date.new(2026, 1, 2))
+  end
+
   test "maps rate limits and exposes trace id without leaking body" do
     response = OpenStruct.new(
       code: 429,
@@ -128,5 +193,35 @@ class Provider::BrexTest < ActiveSupport::TestCase
     assert_equal 429, error.http_status
     assert_equal "trace_123", error.trace_id
     refute_includes error.message, "secret raw provider body"
+  end
+
+  test "maps non-success responses without exposing provider body" do
+    expectations = {
+      400 => [ :bad_request, "Bad request to Brex API" ],
+      401 => [ :unauthorized, "Invalid Brex API token or account permissions" ],
+      403 => [ :access_forbidden, "Access forbidden - check Brex API token scopes" ],
+      404 => [ :not_found, "Brex resource not found" ],
+      500 => [ :fetch_failed, "Failed to fetch data from Brex API: HTTP 500" ]
+    }
+
+    expectations.each do |status, (error_type, message)|
+      response = OpenStruct.new(
+        code: status,
+        body: { message: "secret provider body #{status}" }.to_json,
+        headers: { "X-Brex-Trace-Id" => "trace_#{status}" }
+      )
+
+      Provider::Brex.stubs(:get).returns(response)
+
+      error = assert_raises Provider::Brex::BrexError do
+        Provider::Brex.new("test_token").get_cash_accounts
+      end
+
+      assert_equal error_type, error.error_type
+      assert_equal status, error.http_status
+      assert_equal "trace_#{status}", error.trace_id
+      assert_equal message, error.message
+      refute_includes error.message, "secret provider body"
+    end
   end
 end

--- a/test/models/provider/brex_test.rb
+++ b/test/models/provider/brex_test.rb
@@ -85,7 +85,7 @@ class Provider::BrexTest < ActiveSupport::TestCase
     assert_equal "cash", accounts.first[:account_kind]
   end
 
-  test "fetches card accounts without pagination params because endpoint returns an array" do
+  test "fetches card accounts from the paginated v2 endpoint" do
     response = OpenStruct.new(
       code: 200,
       body: [ { id: "card_account_1", status: "ACTIVE" } ].to_json,
@@ -94,7 +94,7 @@ class Provider::BrexTest < ActiveSupport::TestCase
 
     Provider::Brex.expects(:get)
       .with(
-        "https://api.brex.com/v2/accounts/card",
+        "https://api.brex.com/v2/accounts/card?limit=1000",
         headers: {
           "Authorization" => "Bearer test_token",
           "Content-Type" => "application/json",


### PR DESCRIPTION
## Summary
- clamp Enable Banking transaction sync start dates to the provider's 120-day window
- keep the 7-day overlap buffer for normal incremental syncs
- add importer tests covering stale and in-range sync windows

## Testing
- `ruby -c app/models/enable_banking_item/importer.rb`
- `ruby -c test/models/enable_banking_item/importer_start_date_test.rb`
- full Rails test run currently blocked in this environment by missing `libyaml-0.so.2` for Ruby psych


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Brex integration to connect and manage Brex business accounts
  * Enabled account linking and setup flows for Brex connections
  * Added account synchronization to fetch balances and transaction data
  * Introduced Brex provider panel in settings for managing connections

* **Chores**
  * Updated design tokens and styling for new UI components
  * Added localization strings for Brex-related features
  * Enhanced encryption configuration infrastructure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->