### PR TITLE
fix(i18n): align import mapping product placeholder on stable

### DIFF
--- a/config/locales/views/imports/de.yml
+++ b/config/locales/views/imports/de.yml
@@ -61,13 +61,13 @@ de:
         rows_label: Zeilen
         unassigned_account: Neues Konto für nicht zugewiesene Zeilen erstellen?
       show:
-        account_mapping_description: Weise alle Konten aus deiner importierten Datei den bestehenden Konten in %{product_name} zu. Du kannst auch neue Konten hinzufügen oder sie ohne Kategorie lassen.
+        account_mapping_description: Weise alle Konten aus deiner importierten Datei den bestehenden Konten in %{product} zu. Du kannst auch neue Konten hinzufügen oder sie ohne Kategorie lassen.
         account_mapping_title: Konten zuweisen
-        account_type_mapping_description: Weise alle Kontotypen aus deiner importierten Datei den Kontotypen in %{product_name} zu.
+        account_type_mapping_description: Weise alle Kontotypen aus deiner importierten Datei den Kontotypen in %{product} zu.
         account_type_mapping_title: Kontotypen zuweisen
-        category_mapping_description: Weise alle Kategorien aus deiner importierten Datei den bestehenden Kategorien in %{product_name} zu. Du kannst auch neue Kategorien hinzufügen oder sie ohne Kategorie lassen.
+        category_mapping_description: Weise alle Kategorien aus deiner importierten Datei den bestehenden Kategorien in %{product} zu. Du kannst auch neue Kategorien hinzufügen oder sie ohne Kategorie lassen.
         category_mapping_title: Kategorien zuweisen
-        tag_mapping_description: Weise alle Tags aus deiner importierten Datei den bestehenden Tags in %{product_name} zu. Du kannst auch neue Tags hinzufügen oder sie ohne Kategorie lassen.
+        tag_mapping_description: Weise alle Tags aus deiner importierten Datei den bestehenden Tags in %{product} zu. Du kannst auch neue Tags hinzufügen oder sie ohne Kategorie lassen.
         tag_mapping_title: Tags zuweisen
     uploads:
       show:

--- a/config/locales/views/imports/nl.yml
+++ b/config/locales/views/imports/nl.yml
@@ -37,13 +37,13 @@ nl:
         rows_label: Rijen
         unassigned_account: Moet u een nieuw account aanmaken voor niet-toegewezen rijen?
       show:
-        account_mapping_description: Wijs alle accounts van uw geïmporteerde bestand toe aan bestaande %{product_name} accounts. U kunt ook nieuwe accounts toevoegen of ze ongecategoriseerd laten.
+        account_mapping_description: Wijs alle accounts van uw geïmporteerde bestand toe aan bestaande %{product} accounts. U kunt ook nieuwe accounts toevoegen of ze ongecategoriseerd laten.
         account_mapping_title: Uw accounts toewijzen
-        account_type_mapping_description: Wijs alle accounttypen van uw geïmporteerde bestand toe aan %{product_name} accounttypen
+        account_type_mapping_description: Wijs alle accounttypen van uw geïmporteerde bestand toe aan %{product} accounttypen
         account_type_mapping_title: Uw accounttypen toewijzen
-        category_mapping_description: Wijs alle categorieën van uw geïmporteerde bestand toe aan bestaande %{product_name} categorieën. U kunt ook nieuwe categorieën toevoegen of ze ongecategoriseerd laten.
+        category_mapping_description: Wijs alle categorieën van uw geïmporteerde bestand toe aan bestaande %{product} categorieën. U kunt ook nieuwe categorieën toevoegen of ze ongecategoriseerd laten.
         category_mapping_title: Uw categorieën toewijzen
-        tag_mapping_description: Wijs alle tags van uw geïmporteerde bestand toe aan bestaande %{product_name} tags. U kunt ook nieuwe tags toevoegen of ze ongecategoriseerd laten.
+        tag_mapping_description: Wijs alle tags van uw geïmporteerde bestand toe aan bestaande %{product} tags. U kunt ook nieuwe tags toevoegen of ze ongecategoriseerd laten.
         tag_mapping_title: Uw tags toewijzen
     uploads:
       show:

--- a/config/locales/views/imports/pt-BR.yml
+++ b/config/locales/views/imports/pt-BR.yml
@@ -36,18 +36,18 @@ pt-BR:
         unassigned_account: Precisa criar uma nova conta para linhas não atribuídas?
       show:
         account_mapping_description: Atribua todas as contas do seu arquivo importado às
-          contas existentes no %{product_name}. Você também pode adicionar novas contas ou deixá-las
+          contas existentes no %{product}. Você também pode adicionar novas contas ou deixá-las
           sem categoria.
         account_mapping_title: Atribuir suas contas
         account_type_mapping_description: Atribuir todos os tipos de conta do seu arquivo importado aos
-          do %{product_name}
+          do %{product}
         account_type_mapping_title: Atribuir seus tipos de conta
         category_mapping_description: Atribua todas as categorias do seu arquivo importado às
-          categorias existentes no %{product_name}. Você também pode adicionar novas categorias ou deixá-las
+          categorias existentes no %{product}. Você também pode adicionar novas categorias ou deixá-las
           sem categoria.
         category_mapping_title: Atribuir suas categorias
         tag_mapping_description: Atribua todas as tags do seu arquivo importado às 
-          tags existentes no %{product_name}. Você também pode adicionar novas tags ou deixá-las
+          tags existentes no %{product}. Você também pode adicionar novas tags ou deixá-las
           sem categoria.
         tag_mapping_title: Atribuir suas tags
     uploads:

--- a/config/locales/views/imports/tr.yml
+++ b/config/locales/views/imports/tr.yml
@@ -26,13 +26,13 @@ tr:
         rows_label: Satırlar
         unassigned_account: Atanmamış satırlar için yeni bir hesap oluşturmak ister misiniz?
       show:
-        account_mapping_description: "İçe aktardığınız dosyadaki tüm hesapları %{product_name}'deki mevcut hesaplara eşleyin. Ayrıca yeni hesaplar ekleyebilir veya kategorize etmeden bırakabilirsiniz."
+        account_mapping_description: "İçe aktardığınız dosyadaki tüm hesapları %{product}'deki mevcut hesaplara eşleyin. Ayrıca yeni hesaplar ekleyebilir veya kategorize etmeden bırakabilirsiniz."
         account_mapping_title: Hesaplarınızı eşleyin
-        account_type_mapping_description: "İçe aktardığınız dosyadaki tüm hesap türlerini %{product_name}'deki hesap türlerine eşleyin."
+        account_type_mapping_description: "İçe aktardığınız dosyadaki tüm hesap türlerini %{product}'deki hesap türlerine eşleyin."
         account_type_mapping_title: Hesap türlerinizi eşleyin
-        category_mapping_description: "İçe aktardığınız dosyadaki tüm kategorileri %{product_name}'deki mevcut kategorilere eşleyin. Ayrıca yeni kategoriler ekleyebilir veya kategorize etmeden bırakabilirsiniz."
+        category_mapping_description: "İçe aktardığınız dosyadaki tüm kategorileri %{product}'deki mevcut kategorilere eşleyin. Ayrıca yeni kategoriler ekleyebilir veya kategorize etmeden bırakabilirsiniz."
         category_mapping_title: Kategorilerinizi eşleyin
-        tag_mapping_description: "İçe aktardığınız dosyadaki tüm etiketleri %{product_name}'deki mevcut etiketlere eşleyin. Ayrıca yeni etiketler ekleyebilir veya kategorize etmeden bırakabilirsiniz."
+        tag_mapping_description: "İçe aktardığınız dosyadaki tüm etiketleri %{product}'deki mevcut etiketlere eşleyin. Ayrıca yeni etiketler ekleyebilir veya kategorize etmeden bırakabilirsiniz."
         tag_mapping_title: Etiketlerinizi eşleyin
     uploads:
       show:

--- a/config/locales/views/imports/zh-CN.yml
+++ b/config/locales/views/imports/zh-CN.yml
@@ -34,13 +34,13 @@ zh-CN:
         sure_mapping_label: "%{product_name} 中的 %{mapping}"
         unassigned_account: 需要为未分配行创建新账户？
       show:
-        account_mapping_description: 将导入文件中的所有账户分配到 %{product_name} 的现有账户。您也可以新建账户或保留为未分类。
+        account_mapping_description: 将导入文件中的所有账户分配到 %{product} 的现有账户。您也可以新建账户或保留为未分类。
         account_mapping_title: 分配账户
-        account_type_mapping_description: 将导入文件中的所有账户类型分配到 %{product_name} 的账户类型
+        account_type_mapping_description: 将导入文件中的所有账户类型分配到 %{product} 的账户类型
         account_type_mapping_title: 分配账户类型
-        category_mapping_description: 将导入文件中的所有分类分配到 %{product_name} 的现有分类。您也可以新建分类或保留为未分类。
+        category_mapping_description: 将导入文件中的所有分类分配到 %{product} 的现有分类。您也可以新建分类或保留为未分类。
         category_mapping_title: 分配分类
-        tag_mapping_description: 将导入文件中的所有标签分配到 %{product_name} 的现有标签。您也可以新建标签或保留为未分类。
+        tag_mapping_description: 将导入文件中的所有标签分配到 %{product} 的现有标签。您也可以新建标签或保留为未分类。
         tag_mapping_title: 分配标签
     uploads:
       show:


### PR DESCRIPTION
## Summary
- cherry-pick the import mapping i18n placeholder fix onto the v0.7.0 stable branch
- replace `%{product_name}` with `%{product}` in affected import mapping locale strings
- fix CSV import confirmation crashes seen on stable self-hosted installs

## Testing
- inspected the affected locale files after cherry-pick
- verified the branch contains only the hotfix commit on top of v0.7.0-release-branch

## Context
Self-hosted stable users can hit `missing interpolation argument :product_name` during CSV import confirmation because the view passes `product` while these locale strings still expected `product_name`.
