### PR TITLE
fix(preview): replace PR preview cleanly on redeploy

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -82,6 +82,16 @@ jobs:
           sed -i "s/\${PR_NUMBER}/${{ github.event.pull_request.number }}/g" src/index.ts
           cat wrangler.toml
 
+      - name: Delete existing preview Worker before redeploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: workers/preview
+        run: |
+          WORKER_NAME="sure-preview-${{ github.event.pull_request.number }}"
+          echo "Ensuring fresh preview deployment for $WORKER_NAME"
+          npx wrangler delete --name "$WORKER_NAME" --force || echo "Existing preview not found; continuing"
+
       - name: Create GitHub Deployment
         id: deployment
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- delete any existing PR preview worker before deploying a fresh preview
- avoid Cloudflare container app / durable object namespace conflicts on later pushes
- keep preview replacement behavior deterministic for synchronize/redeploy events

## Why
Pushing a new commit to a PR can currently fail with:

> There is already an application with the name sure-preview-<PR>-railscontainer deployed that is associated with a different durable object namespace

That means preview deploys are not cleanly replaceable once the underlying container/durable-object wiring changes. Deleting the existing preview worker before redeploying gives each new commit a fresh Cloudflare preview.

## Testing
- `git diff --check`
- inspected the workflow change in a fresh worktree
