### PR TITLE
fix(preview): delete stale container app before redeploy

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -82,6 +82,28 @@ jobs:
           sed -i "s/\${PR_NUMBER}/${{ github.event.pull_request.number }}/g" src/index.ts
           cat wrangler.toml
 
+      - name: Delete existing preview container app before redeploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: workers/preview
+        run: |
+          CONTAINER_NAME="sure-preview-${{ github.event.pull_request.number }}-railscontainer"
+          echo "Looking for stale preview container app: $CONTAINER_NAME"
+
+          CONTAINER_ID=$(npx wrangler containers list --json | jq -r --arg NAME "$CONTAINER_NAME" '
+            map(select((.name // .application_name // .app_name // "") == $NAME))
+            | first
+            | (.id // .container_id // .application_id // empty)
+          ')
+
+          if [ -n "$CONTAINER_ID" ]; then
+            echo "Deleting stale preview container app $CONTAINER_NAME ($CONTAINER_ID)"
+            npx wrangler containers delete "$CONTAINER_ID"
+          else
+            echo "No stale preview container app found; continuing"
+          fi
+
       - name: Delete existing preview Worker before redeploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- delete the stale Cloudflare container application before redeploying a PR preview
- keep the existing worker cleanup step from #1819
- ensure new commits can fully replace previews when the prior container app is tied to an older durable object namespace

## Why
The previous fix cleaned up the Worker service, but redeploys can still fail with:

> There is already an application with the name sure-preview-<PR>-railscontainer deployed that is associated with a different durable object namespace

That means the stale object is the Cloudflare container application itself. This change explicitly lists and deletes that app before deploying the fresh preview.

## Testing
- `git diff --check`
- cherry-picked onto `feat/goals-v2-architecture` in a fresh worktree
