### PR TITLE
fix(preview): run preview container in development

### DIFF
--- a/workers/preview/src/index.ts
+++ b/workers/preview/src/index.ts
@@ -65,7 +65,7 @@ export class RailsContainer extends Container {
   pingEndpoint = "container/up";
   entrypoint = ["/rails/bin/preview-entrypoint", "bundle", "exec", "puma", "-C", "config/puma.rb"];
   envVars = {
-    RAILS_ENV: "production",
+    RAILS_ENV: "development",
     RAILS_LOG_TO_STDOUT: "true",
     RAILS_SERVE_STATIC_FILES: "true",
     SECRET_KEY_BASE: "preview-secret-key-base-for-pr-${PR_NUMBER}",


### PR DESCRIPTION
## Summary
- run the Cloudflare preview container with `RAILS_ENV=development`
- align the container runtime with `workers/preview/wrangler.toml` and `Dockerfile.preview`
- keep the existing self-contained preview boot flow unchanged otherwise

## Root cause
The preview container diagnostics show:
- `rails db:prepare` completes
- Puma starts, but never opens port 3000
- the process reports `puma 6.6.0 (tcp://0.0.0.0:3000)` with `rails-socket-state: no-listener`

At the same time, preview config was internally inconsistent:
- `workers/preview/wrangler.toml` declares `RAILS_ENV = "development"`
- `Dockerfile.preview` is documented and built as a self-contained development preview image
- but `workers/preview/src/index.ts` hardcoded container `envVars.RAILS_ENV = "production"`

That means the deployed preview runtime was booting in production despite the preview image/template being designed around development-style startup. This patch removes that mismatch.

## Testing
- `git diff --check`
- inspected live preview diagnostics at `/_container_status`
