### PR TITLE
fix(preview): use Rails health endpoint for container ping

### DIFF
--- a/workers/preview/src/index.ts
+++ b/workers/preview/src/index.ts
@@ -62,7 +62,7 @@ const WAITING_MESSAGES: Record<string, string> = {
 
 export class RailsContainer extends Container {
   defaultPort = 3000;
-  pingEndpoint = "container/up";
+  pingEndpoint = "up";
   entrypoint = ["/rails/bin/preview-entrypoint", "bundle", "exec", "puma", "-C", "config/puma.rb"];
   envVars = {
     RAILS_ENV: "production",

--- a/workers/preview/src/index.ts
+++ b/workers/preview/src/index.ts
@@ -62,7 +62,7 @@ const WAITING_MESSAGES: Record<string, string> = {
 
 export class RailsContainer extends Container {
   defaultPort = 3000;
-  pingEndpoint = "up";
+  pingEndpoint = "localhost/up";
   entrypoint = ["/rails/bin/preview-entrypoint", "bundle", "exec", "puma", "-C", "config/puma.rb"];
   envVars = {
     RAILS_ENV: "production",


### PR DESCRIPTION
## Summary
- point the preview container ping endpoint at Rails' actual health route (`/up`)
- stop using `container/up`, which is not defined in the app

## Why
- preview cold starts are currently flaky and sometimes take a very long time to be marked healthy
- the active preview container config still used `pingEndpoint = "container/up"`
- the Rails app exposes `GET /up` via `rails/health#show`
- this should align container health checks with the real app readiness endpoint while the larger cold-start sequencing work continues
