### PR TITLE
Add Actual Budget CSV import flow

### DIFF
--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -71,7 +71,7 @@ module ImportsHelper
 
   private
     def permitted_import_types
-      %w[transaction_import trade_import account_import mint_import category_import rule_import]
+      %w[transaction_import trade_import account_import mint_import actual_import category_import rule_import]
     end
 
     DryRunResource = Struct.new(:label, :icon, :text_class, :bg_class, keyword_init: true)

--- a/app/models/actual_import.rb
+++ b/app/models/actual_import.rb
@@ -1,0 +1,103 @@
+class ActualImport < Import
+  after_create :set_mappings
+
+  DEFAULT_COLUMN_MAPPINGS = {
+    signage_convention: "inflows_positive",
+    date_col_label: "Date",
+    date_format: "%Y-%m-%d",
+    name_col_label: "Payee",
+    amount_col_label: "Amount",
+    account_col_label: "Account",
+    category_col_label: "Category",
+    notes_col_label: "Notes"
+  }.freeze
+
+  CATEGORY_GROUP_COLUMN = "Category_Group".freeze
+
+  def self.default_column_mappings
+    DEFAULT_COLUMN_MAPPINGS
+  end
+
+  def generate_rows_from_csv
+    rows.destroy_all
+
+    mapped_rows = csv_rows.map.with_index(1) do |row, index|
+      {
+        source_row_number: index,
+        account: row[account_col_label].to_s,
+        date: row[date_col_label].to_s,
+        amount: signed_csv_amount(row).to_s,
+        currency: default_currency.to_s,
+        name: row[name_col_label].to_s,
+        category: combined_category(row),
+        notes: row[notes_col_label].to_s
+      }
+    end
+
+    rows.insert_all!(mapped_rows)
+    update_column(:rows_count, rows.count)
+  end
+
+  def import!
+    transaction do
+      mappings.each(&:create_mappable!)
+
+      rows.each do |row|
+        account = mappings.accounts.mappable_for(row.account)
+        category = mappings.categories.mappable_for(row.category)
+
+        entry = account.entries.build \
+          date: row.date_iso,
+          amount: row.signed_amount,
+          name: row.name,
+          currency: account.currency.presence || family.currency,
+          notes: row.notes,
+          entryable: Transaction.new(category: category),
+          import: self
+
+        entry.save!
+      end
+    end
+  end
+
+  def mapping_steps
+    [ Import::CategoryMapping, Import::AccountMapping ]
+  end
+
+  def required_column_keys
+    %i[date amount]
+  end
+
+  def column_keys
+    %i[date amount name category account notes]
+  end
+
+  def csv_template
+    template = <<~CSV
+      Account,Date,Payee,Notes,Category_Group,Category,Amount,Split_Amount,Cleared
+      Checking Account,2024-01-01,Employer,Monthly salary,Income,Paycheck,2500.00,0,Reconciled
+      Credit Card,2024-01-03,Coffee Shop,Morning coffee,Food,Coffee,-4.25,0,Cleared
+    CSV
+
+    CSV.parse(template, headers: true)
+  end
+
+  def signed_csv_amount(csv_row)
+    csv_row[amount_col_label].to_d
+  end
+
+  private
+    def set_mappings
+      assign_attributes(self.class.default_column_mappings)
+      save!
+    end
+
+    def combined_category(row)
+      category = row[category_col_label].to_s.strip
+      category_group = row[CATEGORY_GROUP_COLUMN].to_s.strip
+
+      return category if category_group.blank? || category.blank?
+
+      "#{category_group}: #{category}"
+    end
+end

--- a/app/models/actual_import.rb
+++ b/app/models/actual_import.rb
@@ -96,7 +96,8 @@ class ActualImport < Import
       category = row[category_col_label].to_s.strip
       category_group = row[CATEGORY_GROUP_COLUMN].to_s.strip
 
-      return category if category_group.blank? || category.blank?
+      return category if category_group.blank?
+      return category_group if category.blank?
 
       "#{category_group}: #{category}"
     end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -10,7 +10,7 @@ class Import < ApplicationRecord
 
   DOCUMENT_TYPES = %w[bank_statement credit_card_statement investment_statement financial_document contract other].freeze
 
-  TYPES = %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport PdfImport QifImport SureImport].freeze
+  TYPES = %w[TransactionImport TradeImport AccountImport MintImport ActualImport CategoryImport RuleImport PdfImport QifImport SureImport].freeze
   SIGNAGE_CONVENTIONS = %w[inflows_positive inflows_negative]
   SEPARATORS = [ [ "Comma (,)", "," ], [ "Semicolon (;)", ";" ] ].freeze
 

--- a/app/models/import/preflight.rb
+++ b/app/models/import/preflight.rb
@@ -313,9 +313,9 @@ class Import::Preflight
     end
 
     def apply_import_defaults(import)
-      return unless import.is_a?(MintImport)
+      return unless import.class.respond_to?(:default_column_mappings)
 
-      MintImport.default_column_mappings.each do |attribute, value|
+      import.class.default_column_mappings.each do |attribute, value|
         import.public_send("#{attribute}=", value) if import.public_send(attribute).blank?
       end
     end

--- a/app/views/import/configurations/_actual_import.html.erb
+++ b/app/views/import/configurations/_actual_import.html.erb
@@ -1,27 +1,27 @@
 <%# locals: (import:) %>
 
-<div class="flex items-center justify-between border border-secondary rounded-lg bg-emerald-500/5 p-5 gap-4 mb-4">
-  <span class="text-emerald-500">
+<div class="flex items-center justify-between border border-secondary rounded-lg bg-success/5 p-5 gap-4 mb-4">
+  <span class="text-success">
     <%= icon("check-circle", color: "current") %>
   </span>
-  <p class="text-sm text-primary italic">We have pre-configured your Actual Budget import for you. Please proceed to the next step.</p>
+  <p class="text-sm text-primary italic"><%= t(".preconfigured_notice") %></p>
 </div>
 
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
   <div class="flex items-center gap-4">
-    <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
+    <%= form.select :date_col_label, import.csv_headers, { include_blank: t(".leave_empty"), label: t(".date_label") }, required: true, disabled: import.complete? %>
     <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label") }, label: true, required: true, disabled: import.complete? %>
   </div>
 
   <div class="flex items-center gap-4">
-    <%= form.select :amount_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Amount" }, required: true, disabled: import.complete? %>
-    <%= form.select :signage_convention, [["Incomes are negative", "inflows_negative"], ["Incomes are positive", "inflows_positive"]], { label: true }, disabled: import.complete? %>
+    <%= form.select :amount_col_label, import.csv_headers, { include_blank: t(".leave_empty"), label: t(".amount_label") }, required: true, disabled: import.complete? %>
+    <%= form.select :signage_convention, [[t(".incomes_are_negative"), "inflows_negative"], [t(".incomes_are_positive"), "inflows_positive"]], { label: t(".signage_convention_label") }, disabled: import.complete? %>
   </div>
 
-  <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
-  <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Payee (optional)" }, disabled: import.complete? %>
-  <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>
-  <%= form.select :notes_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Notes (optional)" }, disabled: import.complete? %>
+  <%= form.select :account_col_label, import.csv_headers, { include_blank: t(".leave_empty"), label: t(".account_label") }, disabled: import.complete? %>
+  <%= form.select :name_col_label, import.csv_headers, { include_blank: t(".leave_empty"), label: t(".name_label") }, disabled: import.complete? %>
+  <%= form.select :category_col_label, import.csv_headers, { include_blank: t(".leave_empty"), label: t(".category_label") }, disabled: import.complete? %>
+  <%= form.select :notes_col_label, import.csv_headers, { include_blank: t(".leave_empty"), label: t(".notes_label") }, disabled: import.complete? %>
 
-  <%= form.submit "Apply configuration", disabled: import.complete? %>
+  <%= form.submit t(".apply_configuration"), disabled: import.complete? %>
 <% end %>

--- a/app/views/import/configurations/_actual_import.html.erb
+++ b/app/views/import/configurations/_actual_import.html.erb
@@ -1,0 +1,27 @@
+<%# locals: (import:) %>
+
+<div class="flex items-center justify-between border border-secondary rounded-lg bg-emerald-500/5 p-5 gap-4 mb-4">
+  <span class="text-emerald-500">
+    <%= icon("check-circle", color: "current") %>
+  </span>
+  <p class="text-sm text-primary italic">We have pre-configured your Actual Budget import for you. Please proceed to the next step.</p>
+</div>
+
+<%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
+  <div class="flex items-center gap-4">
+    <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label") }, label: true, required: true, disabled: import.complete? %>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <%= form.select :amount_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Amount" }, required: true, disabled: import.complete? %>
+    <%= form.select :signage_convention, [["Incomes are negative", "inflows_negative"], ["Incomes are positive", "inflows_positive"]], { label: true }, disabled: import.complete? %>
+  </div>
+
+  <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
+  <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Payee (optional)" }, disabled: import.complete? %>
+  <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>
+  <%= form.select :notes_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Notes (optional)" }, disabled: import.complete? %>
+
+  <%= form.submit "Apply configuration", disabled: import.complete? %>
+<% end %>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -31,7 +31,7 @@
 
     <%
       import_type = params[:type].presence || @pending_import&.type
-      active_tab = import_type.present? && !import_type.in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) ? "raw_data" : "financial_tools"
+      active_tab = import_type.present? && !import_type.in?(%w[MintImport ActualImport QifImport SureImport DocumentImport PdfImport]) ? "raw_data" : "financial_tools"
     %>
     <%= render DS::Tabs.new(active_tab: active_tab) do |tabs| %>
       <% tabs.with_nav do |nav| %>
@@ -42,7 +42,7 @@
       <% tabs.with_panel(tab_id: "financial_tools") do %>
         <div class="rounded-xl bg-container-inset p-1">
           <ul class="bg-container shadow-border-xs rounded-lg">
-            <% if @pending_import.present? && params[:type].present? && params[:type].in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) %>
+            <% if @pending_import.present? && params[:type].present? && params[:type].in?(%w[MintImport ActualImport QifImport SureImport DocumentImport PdfImport]) %>
               <li>
                 <%= link_to import_path(@pending_import), class: "flex items-center justify-between p-4 group cursor-pointer", data: { turbo: false } do %>
                   <div class="flex items-center gap-2">
@@ -96,6 +96,16 @@
                 type: "MintImport",
                 image: "mint-logo.jpeg",
                 label: t(".import_mint"),
+                enabled: true %>
+            <% end %>
+
+            <% if params[:type].nil? || params[:type] == "ActualImport" || params[:type] == "TransactionImport" %>
+              <%= render "imports/import_option",
+                type: "ActualImport",
+                icon_name: "wallet",
+                icon_bg_class: "bg-emerald-500/5",
+                icon_text_class: "text-emerald-500",
+                label: t(".import_actual"),
                 enabled: true %>
             <% end %>
 
@@ -153,7 +163,7 @@
       <% tabs.with_panel(tab_id: "raw_data") do %>
         <div class="rounded-xl bg-container-inset p-1">
           <ul class="bg-container shadow-border-xs rounded-lg">
-            <% if @pending_import.present? && params[:type].present? && !params[:type].in?(%w[MintImport QifImport SureImport DocumentImport PdfImport]) %>
+            <% if @pending_import.present? && params[:type].present? && !params[:type].in?(%w[MintImport ActualImport QifImport SureImport DocumentImport PdfImport]) %>
               <li>
                 <%= link_to import_path(@pending_import), class: "flex items-center justify-between p-4 group cursor-pointer", data: { turbo: false } do %>
                   <div class="flex items-center gap-2">

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -99,7 +99,7 @@
                 enabled: true %>
             <% end %>
 
-            <% if params[:type].nil? || params[:type] == "ActualImport" || params[:type] == "TransactionImport" %>
+            <% if params[:type].nil? || params[:type] == "ActualImport" %>
               <%= render "imports/import_option",
                 type: "ActualImport",
                 icon_name: "wallet",

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -112,6 +112,8 @@ en:
         instructions: Select continue to parse your CSV and move on to the clean step.
       mint_import:
         date_format_label: Date format
+      actual_import:
+        date_format_label: Date format
       rule_import:
         description: Configure your rule import. Rules will be created or updated based
           on the CSV data.
@@ -261,6 +263,7 @@ en:
       trade_import: "Trade import"
       account_import: "Account import"
       mint_import: "Mint import"
+      actual_import: "Actual import"
       qif_import: "QIF import"
       category_import: "Category import"
       rule_import: "Rule import"
@@ -293,6 +296,7 @@ en:
           trade_import: "Trade"
           account_import: "Account"
           mint_import: "Mint"
+          actual_import: "Actual"
           qif_import: "QIF"
           category_import: "Category"
           rule_import: "Rule"
@@ -321,6 +325,7 @@ en:
       import_accounts: Import accounts
       import_categories: Import categories
       import_mint: Import from Mint
+      import_actual: Import from Actual Budget
       import_portfolio: Import investments
       import_rules: Import rules
       import_transactions: Import transactions

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -113,7 +113,19 @@ en:
       mint_import:
         date_format_label: Date format
       actual_import:
+        preconfigured_notice: We have pre-configured your Actual Budget import for you. Please proceed to the next step.
+        leave_empty: Leave empty
+        date_label: Date
         date_format_label: Date format
+        amount_label: Amount
+        signage_convention_label: Signage convention
+        incomes_are_negative: Incomes are negative
+        incomes_are_positive: Incomes are positive
+        account_label: Account (optional)
+        name_label: Payee (optional)
+        category_label: Category (optional)
+        notes_label: Notes (optional)
+        apply_configuration: Apply configuration
       rule_import:
         description: Configure your rule import. Rules will be created or updated based
           on the CSV data.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1802,6 +1802,7 @@ components:
           - TradeImport
           - AccountImport
           - MintImport
+          - ActualImport
           - CategoryImport
           - RuleImport
           - SureImport
@@ -1889,6 +1890,7 @@ components:
           - TradeImport
           - AccountImport
           - MintImport
+          - ActualImport
           - CategoryImport
           - RuleImport
           - SureImport
@@ -1941,6 +1943,7 @@ components:
           - TradeImport
           - AccountImport
           - MintImport
+          - ActualImport
           - CategoryImport
           - RuleImport
           - SureImport
@@ -4482,6 +4485,7 @@ paths:
           - TradeImport
           - AccountImport
           - MintImport
+          - ActualImport
           - CategoryImport
           - RuleImport
           - SureImport
@@ -4540,6 +4544,7 @@ paths:
                   - TradeImport
                   - AccountImport
                   - MintImport
+                  - ActualImport
                   - CategoryImport
                   - RuleImport
                   - SureImport
@@ -4646,6 +4651,7 @@ paths:
                   - TradeImport
                   - AccountImport
                   - MintImport
+                  - ActualImport
                   - CategoryImport
                   - RuleImport
                   - SureImport
@@ -4883,6 +4889,7 @@ paths:
                   - TradeImport
                   - AccountImport
                   - MintImport
+                  - ActualImport
                   - CategoryImport
                   - RuleImport
                   - SureImport
@@ -4993,6 +5000,7 @@ paths:
                   - TradeImport
                   - AccountImport
                   - MintImport
+                  - ActualImport
                   - CategoryImport
                   - RuleImport
                   - SureImport

--- a/spec/requests/api/v1/imports_spec.rb
+++ b/spec/requests/api/v1/imports_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'API V1 Imports', type: :request do
                 schema: { type: :string, enum: %w[pending complete importing reverting revert_failed failed] }
       parameter name: :type, in: :query, required: false,
                 description: 'Filter by import type',
-                schema: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport SureImport] }
+                schema: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport ActualImport CategoryImport RuleImport SureImport] }
 
       response '200', 'imports listed' do
         schema '$ref' => '#/components/schemas/ImportCollection'
@@ -138,7 +138,7 @@ RSpec.describe 'API V1 Imports', type: :request do
           },
           type: {
             type: :string,
-            enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport SureImport],
+            enum: %w[TransactionImport TradeImport AccountImport MintImport ActualImport CategoryImport RuleImport SureImport],
             description: 'Import type (defaults to TransactionImport)'
           },
           account_id: {
@@ -388,7 +388,7 @@ RSpec.describe 'API V1 Imports', type: :request do
           },
           type: {
             type: :string,
-            enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport SureImport],
+            enum: %w[TransactionImport TradeImport AccountImport MintImport ActualImport CategoryImport RuleImport SureImport],
             description: 'Import type to validate (defaults to TransactionImport)'
           },
           account_id: {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -999,7 +999,7 @@ RSpec.configure do |config|
             type: :object,
             required: %w[type valid content stats errors warnings],
             properties: {
-              type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport SureImport] },
+              type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport ActualImport CategoryImport RuleImport SureImport] },
               valid: { type: :boolean },
               content: { '$ref' => '#/components/schemas/ImportPreflightContent' },
               stats: { '$ref' => '#/components/schemas/ImportPreflightStats' },
@@ -1063,7 +1063,7 @@ RSpec.configure do |config|
             required: %w[id type status created_at updated_at status_detail],
             properties: {
               id: { type: :string, format: :uuid },
-              type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport SureImport] },
+              type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport ActualImport CategoryImport RuleImport SureImport] },
               status: { type: :string, enum: %w[pending complete importing reverting revert_failed failed] },
               created_at: { type: :string, format: :'date-time' },
               updated_at: { type: :string, format: :'date-time' },
@@ -1078,7 +1078,7 @@ RSpec.configure do |config|
             required: %w[id type status created_at updated_at status_detail configuration stats],
             properties: {
               id: { type: :string, format: :uuid },
-              type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport CategoryImport RuleImport SureImport] },
+              type: { type: :string, enum: %w[TransactionImport TradeImport AccountImport MintImport ActualImport CategoryImport RuleImport SureImport] },
               status: { type: :string, enum: %w[pending complete importing reverting revert_failed failed] },
               created_at: { type: :string, format: :'date-time' },
               updated_at: { type: :string, format: :'date-time' },

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -36,26 +36,35 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
     driven_by :selenium_remote_chrome, screen_size: [ 1400, 1400 ]
   else
-    local_browser = if ENV["E2E_BROWSER"].present?
-      ENV.fetch("E2E_BROWSER").to_sym
-    elsif ENV["DISPLAY"].present?
-      :chrome
-    else
-      :headless_chrome
+    requested_browser = ENV["E2E_BROWSER"].presence&.to_sym
+    local_browser = case requested_browser
+    when :headless_chrome then :chrome
+    when :headless_firefox then :firefox
+    else requested_browser || :chrome
     end
 
-    headless = ENV["CI"].present? || local_browser == :headless_chrome
+    headless = ENV["CI"].present? || requested_browser.in?([ :headless_chrome, :headless_firefox ]) || ENV["DISPLAY"].blank?
 
     Capybara.register_driver :selenium_local_chrome do |app|
-      options = Selenium::WebDriver::Chrome::Options.new
-      options.add_argument("--window-size=1400,1400")
-      options.add_argument("--headless=new") if headless
-      options.add_argument("--no-sandbox")
-      options.add_argument("--disable-dev-shm-usage")
+      options = case local_browser
+      when :firefox
+        Selenium::WebDriver::Firefox::Options.new.tap do |firefox_options|
+          firefox_options.add_argument("--width=1400")
+          firefox_options.add_argument("--height=1400")
+          firefox_options.add_argument("-headless") if headless
+        end
+      else
+        Selenium::WebDriver::Chrome::Options.new.tap do |chrome_options|
+          chrome_options.add_argument("--window-size=1400,1400")
+          chrome_options.add_argument("--headless=new") if headless
+          chrome_options.add_argument("--no-sandbox")
+          chrome_options.add_argument("--disable-dev-shm-usage")
+        end
+      end
 
       Capybara::Selenium::Driver.new(
         app,
-        browser: :chrome,
+        browser: local_browser,
         options: options
       )
     end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -36,7 +36,31 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
     driven_by :selenium_remote_chrome, screen_size: [ 1400, 1400 ]
   else
-    driven_by :selenium, using: ENV["CI"].present? ? :headless_chrome : ENV.fetch("E2E_BROWSER", :chrome).to_sym, screen_size: [ 1400, 1400 ]
+    local_browser = if ENV["E2E_BROWSER"].present?
+      ENV.fetch("E2E_BROWSER").to_sym
+    elsif ENV["DISPLAY"].present?
+      :chrome
+    else
+      :headless_chrome
+    end
+
+    headless = ENV["CI"].present? || local_browser == :headless_chrome
+
+    Capybara.register_driver :selenium_local_chrome do |app|
+      options = Selenium::WebDriver::Chrome::Options.new
+      options.add_argument("--window-size=1400,1400")
+      options.add_argument("--headless=new") if headless
+      options.add_argument("--no-sandbox")
+      options.add_argument("--disable-dev-shm-usage")
+
+      Capybara::Selenium::Driver.new(
+        app,
+        browser: :chrome,
+        options: options
+      )
+    end
+
+    driven_by :selenium_local_chrome, screen_size: [ 1400, 1400 ]
   end
 
   def teardown

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -988,6 +988,56 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_includes data["required_headers"], "Amount"
   end
 
+  test "should apply Actual defaults before preflight header validation" do
+    actual_content = [
+      "Account,Date,Payee,Notes,Category_Group,Category,Amount,Split_Amount,Cleared",
+      "Checking Account,2024-01-01,Coffee Shop,Morning coffee,Food,Coffee,-4.25,0,Cleared"
+    ].join("\n")
+
+    assert_no_difference("Import.count") do
+      post preflight_api_v1_imports_url,
+           params: {
+             type: "ActualImport",
+             raw_file_content: actual_content
+           },
+           headers: api_headers(@read_only_api_key)
+    end
+
+    assert_response :success
+    data = JSON.parse(response.body)["data"]
+
+    assert_equal "ActualImport", data["type"]
+    assert_equal true, data["valid"]
+    assert_empty data["missing_required_headers"]
+    assert_includes data["required_headers"], "Date"
+    assert_includes data["required_headers"], "Amount"
+  end
+
+  test "should not overwrite explicit Actual preflight column mappings with defaults" do
+    actual_content = [
+      "Booked On,Value,Payee",
+      "2024-01-01,-4.25,Coffee Shop"
+    ].join("\n")
+
+    assert_no_difference("Import.count") do
+      post preflight_api_v1_imports_url,
+           params: {
+             type: "ActualImport",
+             raw_file_content: actual_content,
+             date_col_label: "Booked On",
+             amount_col_label: "Value"
+           },
+           headers: api_headers(@read_only_api_key)
+    end
+
+    assert_response :success
+    data = JSON.parse(response.body)["data"]
+
+    assert_equal true, data["valid"]
+    assert_equal [ "Booked On", "Value" ], data["required_headers"]
+    assert_empty data["missing_required_headers"]
+  end
+
   test "should not overwrite explicit Mint preflight column mappings with defaults" do
     mint_content = [
       "Posted On,Value,Description",

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class ImportsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @user = users(:family_admin)
+    ensure_tailwind_build
   end
 
   test "gets index" do
@@ -33,6 +34,7 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "button", text: "Import transactions", count: 0
     assert_select "button", text: "Import investments", count: 0
     assert_select "button", text: "Import from Mint", count: 1
+    assert_select "button", text: "Import from Actual Budget", count: 1
     assert_select "button", text: "Import from Quicken (QIF)", count: 1
     assert_select "span", text: "Import accounts first to unlock this option.", count: 2
     assert_select "div[aria-disabled=true]", count: 3

--- a/test/fixtures/files/imports/actual.csv
+++ b/test/fixtures/files/imports/actual.csv
@@ -1,0 +1,5 @@
+Account,Date,Payee,Notes,Category_Group,Category,Amount,Split_Amount,Cleared
+Checking Account,2024-01-01,Landlord,January rent,Housing,Rent,-1500.00,0,Reconciled
+Credit Card,2024-01-02,Coffee Shop,Morning coffee,Food,Coffee,-4.25,0,Cleared
+Checking Account,2024-01-05,Employer,Monthly salary,Income,Paycheck,2500.00,0,Reconciled
+Checking Account,2024-01-06,Internal Transfer,Move to savings,,Transfer,-250.00,0,Not cleared

--- a/test/models/actual_import_test.rb
+++ b/test/models/actual_import_test.rb
@@ -38,4 +38,16 @@ class ActualImportTest < ActiveSupport::TestCase
     assert_equal "Income: Paycheck", import.rows.order(:source_row_number).third.category
     assert_equal "Transfer", import.rows.order(:source_row_number).fourth.category
   end
+
+  test "generated rows fall back to category group when category is blank" do
+    import = @family.imports.create!(
+      type: "ActualImport",
+      raw_file_str: file_fixture("imports/actual.csv").read.sub("Housing,Rent", "Housing,"),
+      col_sep: ","
+    )
+
+    import.generate_rows_from_csv
+
+    assert_equal "Housing", import.rows.order(:source_row_number).first.category
+  end
 end

--- a/test/models/actual_import_test.rb
+++ b/test/models/actual_import_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class ActualImportTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "default column mappings are applied after create" do
+    import = @family.imports.create!(type: "ActualImport")
+
+    ActualImport.default_column_mappings.each do |attribute, value|
+      assert_equal value, import.public_send(attribute)
+    end
+  end
+
+  test "generated rows preserve stable source row numbers" do
+    import = @family.imports.create!(
+      type: "ActualImport",
+      raw_file_str: file_fixture("imports/actual.csv").read,
+      col_sep: ","
+    )
+
+    import.generate_rows_from_csv
+
+    assert_equal (1..4).to_a, import.rows.order(:source_row_number).pluck(:source_row_number)
+  end
+
+  test "generated rows combine category group and category" do
+    import = @family.imports.create!(
+      type: "ActualImport",
+      raw_file_str: file_fixture("imports/actual.csv").read,
+      col_sep: ","
+    )
+
+    import.generate_rows_from_csv
+
+    assert_equal "Food: Coffee", import.rows.order(:source_row_number).second.category
+    assert_equal "Income: Paycheck", import.rows.order(:source_row_number).third.category
+    assert_equal "Transfer", import.rows.order(:source_row_number).fourth.category
+  end
+end

--- a/test/system/imports_test.rb
+++ b/test/system/imports_test.rb
@@ -22,9 +22,7 @@ class ImportsTest < ApplicationSystemTestCase
 
     fill_in "import[raw_file_str]", with: file_fixture("imports/transactions.csv").read
 
-    within "form" do
-      click_on "Upload CSV"
-    end
+    find_field("import[raw_file_str]").find(:xpath, "./ancestor::form").click_button("Upload CSV")
 
     select "Date", from: "import[date_col_label]"
     select "YYYY-MM-DD", from: "import[date_format]"
@@ -73,9 +71,7 @@ class ImportsTest < ApplicationSystemTestCase
 
     fill_in "import[raw_file_str]", with: file_fixture("imports/trades.csv").read
 
-    within "form" do
-      click_on "Upload CSV"
-    end
+    find_field("import[raw_file_str]").find(:xpath, "./ancestor::form").click_button("Upload CSV")
 
     select "date", from: "import[date_col_label]"
     select "YYYY-MM-DD", from: "import[date_format]"
@@ -116,9 +112,7 @@ class ImportsTest < ApplicationSystemTestCase
 
     fill_in "import[raw_file_str]", with: file_fixture("imports/accounts.csv").read
 
-    within "form" do
-      click_on "Upload CSV"
-    end
+    find_field("import[raw_file_str]").find(:xpath, "./ancestor::form").click_button("Upload CSV")
 
     select "type", from: "import[entity_type_col_label]"
     select "name", from: "import[name_col_label]"
@@ -166,9 +160,7 @@ class ImportsTest < ApplicationSystemTestCase
 
     fill_in "import[raw_file_str]", with: file_fixture("imports/mint.csv").read
 
-    within "form" do
-      click_on "Upload CSV"
-    end
+    find_field("import[raw_file_str]").find(:xpath, "./ancestor::form").click_button("Upload CSV")
 
     click_on "Apply configuration"
 
@@ -178,6 +170,44 @@ class ImportsTest < ApplicationSystemTestCase
     click_on "Next"
 
     assert_selector "h1", text: "Assign your tags"
+    click_on "Next"
+
+    assert_selector "h1", text: "Assign your accounts"
+    click_on "Next"
+
+    click_on "Publish import"
+
+    assert_text "Import in progress"
+
+    perform_enqueued_jobs
+
+    click_on "Check status"
+
+    assert_text "Import successful"
+
+    click_on "Back to dashboard"
+  end
+
+  test "actual import" do
+    visit new_import_path
+
+    # Pending CSV-style imports default the dialog to the Raw Data tab; Actual lives under Financial Tools.
+    click_on "Financial Tools"
+    click_on "Import from Actual Budget"
+
+    within_testid("import-tabs") do
+      click_on "Copy & Paste"
+    end
+
+    fill_in "import[raw_file_str]", with: file_fixture("imports/actual.csv").read
+
+    find_field("import[raw_file_str]").find(:xpath, "./ancestor::form").click_button("Upload CSV")
+
+    click_on "Apply configuration"
+
+    click_on "Next step"
+
+    assert_selector "h1", text: "Assign your categories"
     click_on "Next"
 
     assert_selector "h1", text: "Assign your accounts"


### PR DESCRIPTION
## Summary
- add a new `ActualImport` flow for Actual Budget transaction CSV exports
- preconfigure Actual CSV column mappings and reuse the existing import pipeline
- combine `Category_Group` + `Category` into hierarchical category labels during row generation
- add UI, API/docs, and automated coverage for the new import path

## Scope
This first pass is intentionally limited to Actual's **transaction CSV export** path.

Included:
- date, amount, payee, account, category, and notes mapping
- category creation through the existing category mapping flow
- system/controller/model coverage for the new flow

Explicitly not included:
- Actual ZIP / SQLite import
- split reconstruction
- cleared/reconciled state import

## Validation
- `bin/rails test test/models/actual_import_test.rb test/controllers/imports_controller_test.rb test/controllers/api/v1/imports_controller_test.rb test/system/imports_test.rb`
- 71 runs, 399 assertions, 0 failures, 0 errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Actual Budget import in Financial Tools with configurable CSV column mappings, date format, and signage options.
* **UI / Localization**
  * “Actual” import option and localized labels added to import screens and selection lists.
* **Preflight**
  * Preflight now applies Actual Budget default mappings to ease header validation.
* **Tests**
  * Added unit, controller, system, and API schema tests covering Actual imports and flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->