### PR TITLE
chore(preview): run Cloudflare PR previews on basic instances

### DIFF
--- a/workers/preview/wrangler.toml
+++ b/workers/preview/wrangler.toml
@@ -17,6 +17,7 @@ enabled = true
 [[containers]]
 class_name = "RailsContainer"
 image = "../../Dockerfile.preview"
+instance_type = "basic"
 max_instances = 1
 
 # Durable Object binding for the container


### PR DESCRIPTION
## Summary
- switch Cloudflare PR preview containers from lite to basic
- raise preview resources from 256 MiB / 1/16 vCPU to 1 GiB / 1/4 vCPU
- keep the rest of the preview container configuration unchanged

## Why
Preview deploys are frequently reporting success before the app is actually usable, and recent investigations showed the current preview containers are running on Cloudflares tiny lite instance type. Moving to basic gives the preview app materially more headroom for image pull, Rails boot, Postgres, and Redis startup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview deployment container configuration to specify basic instance type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->