### PR TITLE
fix: polish Sophtron sync error handling

### DIFF
--- a/app/controllers/sophtron_items_controller.rb
+++ b/app/controllers/sophtron_items_controller.rb
@@ -94,6 +94,18 @@ class SophtronItemsController < ApplicationController
 
     item = item_for_institution_connection(@sophtron_item)
     item.ensure_customer!
+    item.debug_log_event(
+      category: "sophtron_connection",
+      message: "Starting Sophtron institution connection",
+      source: self.class.name,
+      user: Current.user,
+      metadata: {
+        institution_id: params[:institution_id],
+        institution_name: params[:institution_name].presence,
+        connect_new_institution: connect_new_institution_flow?
+      }
+    )
+
     response = sophtron_response_data!(
       item.sophtron_provider.create_user_institution(
         institution_id: params[:institution_id],
@@ -122,9 +134,35 @@ class SophtronItemsController < ApplicationController
       status: :good
     )
 
+    item.debug_log_event(
+      category: "sophtron_connection",
+      message: "Sophtron institution connection started",
+      source: self.class.name,
+      user: Current.user,
+      metadata: {
+        job_id: job_id,
+        user_institution_id_present: user_institution_id.present?,
+        institution_id: params[:institution_id],
+        institution_name: params[:institution_name].presence
+      }
+    )
+
     redirect_to connection_status_sophtron_item_path(item, connection_context_params)
   rescue Provider::Sophtron::Error => e
     Rails.logger.error("Sophtron connect institution error: #{e.message}")
+    item&.debug_log_event(
+      category: "sophtron_connection",
+      level: "error",
+      message: "Sophtron institution connection failed to start",
+      source: self.class.name,
+      user: Current.user,
+      metadata: {
+        institution_id: params[:institution_id],
+        institution_name: params[:institution_name].presence,
+        error: e.message,
+        error_type: e.respond_to?(:error_type) ? e.error_type : nil
+      }
+    )
     redirect_to select_accounts_sophtron_items_path(connection_context_params), alert: t(".api_error", message: e.message)
   end
 
@@ -145,10 +183,19 @@ class SophtronItemsController < ApplicationController
       return
     end
 
+    previous_job = @sophtron_item.raw_job_payload
     job = sophtron_response_data!(@sophtron_item.sophtron_provider.get_job_information(@sophtron_item.current_job_id))
     @sophtron_item.upsert_job_snapshot!(job)
+    log_connection_job_state(@sophtron_item, previous_job, job, poll_attempt: @poll_attempt)
 
     if Provider::Sophtron.job_success?(job)
+      @sophtron_item.debug_log_event(
+        category: "sophtron_connection",
+        message: "Sophtron connection completed successfully",
+        source: self.class.name,
+        user: Current.user,
+        metadata: connection_job_metadata(job, poll_attempt: @poll_attempt, manual_sync: manual_sync_flow?)
+      )
       if manual_sync_flow?
         complete_manual_sync_from_job(job)
         return
@@ -163,6 +210,14 @@ class SophtronItemsController < ApplicationController
       render_account_selection(@sophtron_item, force_refresh: true)
     elsif Provider::Sophtron.job_requires_input?(job)
       @challenge = @sophtron_item.build_mfa_challenge(job)
+      @sophtron_item.debug_log_event(
+        category: "sophtron_mfa",
+        level: "warn",
+        message: "Sophtron MFA challenge displayed",
+        source: self.class.name,
+        user: Current.user,
+        metadata: connection_job_metadata(job, poll_attempt: @poll_attempt, manual_sync: manual_sync_flow?).merge(mfa_challenge_metadata(@challenge))
+      )
       prepare_connection_status_context
       render :mfa, layout: false
     elsif Provider::Sophtron.job_completed?(job)
@@ -172,9 +227,26 @@ class SophtronItemsController < ApplicationController
       end
 
       if post_mfa_polling?
-        return if render_account_selection_if_accounts_available(@sophtron_item)
+        if render_account_selection_if_accounts_available(@sophtron_item)
+          @sophtron_item.debug_log_event(
+            category: "sophtron_connection",
+            message: "Sophtron connection completed and accounts are ready for selection",
+            source: self.class.name,
+            user: Current.user,
+            metadata: connection_job_metadata(job, poll_attempt: @poll_attempt, post_mfa: true)
+          )
+          return
+        end
       end
 
+      @sophtron_item.debug_log_event(
+        category: "sophtron_connection",
+        level: "warn",
+        message: "Sophtron connection job completed before accounts were ready",
+        source: self.class.name,
+        user: Current.user,
+        metadata: connection_job_metadata(job, poll_attempt: @poll_attempt, post_mfa: post_mfa_polling?)
+      )
       render_pending_connection_status
     elsif Provider::Sophtron.job_failed?(job)
       failure_message = sophtron_connection_failure_message(job)
@@ -185,6 +257,14 @@ class SophtronItemsController < ApplicationController
         last_connection_error: failure_message,
         status: :requires_update
       )
+      @sophtron_item.debug_log_event(
+        category: "sophtron_connection",
+        level: "error",
+        message: "Sophtron connection failed",
+        source: self.class.name,
+        user: Current.user,
+        metadata: connection_job_metadata(job, poll_attempt: @poll_attempt, manual_sync: manual_sync_flow?).merge(error: failure_message)
+      )
       fail_manual_sync!(manual_sync_record, failure_message) if manual_sync_flow?
       render_institution_connection_error(failure_message)
     else
@@ -192,6 +272,14 @@ class SophtronItemsController < ApplicationController
     end
   rescue Provider::Sophtron::Error => e
     Rails.logger.error("Sophtron job polling error: #{e.message}")
+    @sophtron_item.debug_log_event(
+      category: "sophtron_connection",
+      level: "error",
+      message: "Sophtron connection polling failed",
+      source: self.class.name,
+      user: Current.user,
+      metadata: { job_id: @sophtron_item.current_job_id, poll_attempt: @poll_attempt, error: e.message, error_type: e.error_type }
+    )
     render_api_error(t(".api_error", message: e.message), accounts_path)
   end
 
@@ -203,6 +291,14 @@ class SophtronItemsController < ApplicationController
     when "security_answer"
       security_answers = normalized_security_answers
       unless security_answers
+        @sophtron_item.debug_log_event(
+          category: "sophtron_mfa",
+          level: "warn",
+          message: "Sophtron MFA submission rejected before provider call",
+          source: self.class.name,
+          user: Current.user,
+          metadata: { job_id: job_id, mfa_type: params[:mfa_type], reason: "invalid_security_answers" }
+        )
         redirect_to connection_status_sophtron_item_path(@sophtron_item, connection_context_params), alert: t(".invalid_security_answers")
         return
       end
@@ -217,13 +313,37 @@ class SophtronItemsController < ApplicationController
     when "captcha"
       sophtron_response_data!(provider.update_job_captcha(job_id, params[:captcha_input]))
     else
+      @sophtron_item.debug_log_event(
+        category: "sophtron_mfa",
+        level: "warn",
+        message: "Sophtron MFA submission used an unknown challenge type",
+        source: self.class.name,
+        user: Current.user,
+        metadata: { job_id: job_id, mfa_type: params[:mfa_type] }
+      )
       redirect_to connection_status_sophtron_item_path(@sophtron_item, connection_context_params), alert: t(".unknown_challenge")
       return
     end
 
+    @sophtron_item.debug_log_event(
+      category: "sophtron_mfa",
+      message: "Sophtron MFA submitted",
+      source: self.class.name,
+      user: Current.user,
+      metadata: { job_id: job_id, mfa_type: params[:mfa_type] }
+    )
+
     redirect_to connection_status_sophtron_item_path(@sophtron_item, connection_context_params.merge(post_mfa: true))
   rescue Provider::Sophtron::Error => e
     Rails.logger.error("Sophtron MFA submission error: #{e.message}")
+    @sophtron_item.debug_log_event(
+      category: "sophtron_mfa",
+      level: "error",
+      message: "Sophtron MFA submission failed",
+      source: self.class.name,
+      user: Current.user,
+      metadata: { job_id: job_id, mfa_type: params[:mfa_type], error: e.message, error_type: e.error_type }
+    )
     redirect_to connection_status_sophtron_item_path(@sophtron_item, connection_context_params), alert: t(".api_error", message: e.message)
   end
 
@@ -285,8 +405,29 @@ class SophtronItemsController < ApplicationController
     end
 
     item.start_initial_load_later if created_accounts.any?
+    item.debug_log_event(
+      category: "sophtron_account_registration",
+      message: "Sophtron account linking finished",
+      source: self.class.name,
+      user: Current.user,
+      metadata: {
+        selected_account_count: selected_account_ids.size,
+        created_count: created_accounts.size,
+        already_linked_count: already_linked_accounts.size,
+        invalid_count: invalid_accounts.size,
+        accountable_type: accountable_type
+      }
+    )
     redirect_after_account_link(return_to, created_accounts, already_linked_accounts, invalid_accounts)
   rescue Provider::Sophtron::Error => e
+    item&.debug_log_event(
+      category: "sophtron_account_registration",
+      level: "error",
+      message: "Sophtron account linking failed",
+      source: self.class.name,
+      user: Current.user,
+      metadata: { selected_account_count: selected_account_ids.size, error: e.message, error_type: e.error_type }
+    )
     redirect_to new_account_path, alert: t(".api_error", message: e.message)
   end
 
@@ -378,9 +519,27 @@ class SophtronItemsController < ApplicationController
     AccountProvider.create!(account: account, provider: sophtron_account)
     item.start_initial_load_later
 
+    item.debug_log_event(
+      category: "sophtron_account_registration",
+      message: "Sophtron account linked to an existing account",
+      source: self.class.name,
+      user: Current.user,
+      account: account,
+      account_provider: sophtron_account.account_provider,
+      metadata: { sophtron_account_id: sophtron_account.id, sophtron_account_external_id: sophtron_account.account_id }
+    )
+
     redirect_to return_to || accounts_path, notice: t(".success", account_name: account.name)
   rescue Provider::Sophtron::Error => e
     Rails.logger.error("Sophtron API error in link_existing_account: #{e.message}")
+    item&.debug_log_event(
+      category: "sophtron_account_registration",
+      level: "error",
+      message: "Sophtron existing-account linking failed",
+      source: self.class.name,
+      user: Current.user,
+      metadata: { account_id: account_id, sophtron_account_id: sophtron_account_id, error: e.message, error_type: e.error_type }
+    )
     redirect_to accounts_path, alert: t(".api_error", message: e.message)
   end
 
@@ -398,6 +557,13 @@ class SophtronItemsController < ApplicationController
         return
       end
 
+      @sophtron_item.debug_log_event(
+        category: "sophtron_configuration",
+        message: "Sophtron configuration created",
+        source: self.class.name,
+        user: Current.user
+      )
+
       render_sophtron_panel_success(:create)
     else
       render_sophtron_panel_error(:new, @sophtron_item.errors.full_messages.join(", "))
@@ -413,6 +579,13 @@ class SophtronItemsController < ApplicationController
         render_sophtron_panel_error(:edit, @sophtron_item.last_connection_error)
         return
       end
+
+      @sophtron_item.debug_log_event(
+        category: "sophtron_configuration",
+        message: "Sophtron configuration updated",
+        source: self.class.name,
+        user: Current.user
+      )
 
       render_sophtron_panel_success(:update)
     else
@@ -599,6 +772,18 @@ class SophtronItemsController < ApplicationController
     end
 
     @sophtron_item.start_initial_load_later if created_accounts.any?
+
+    @sophtron_item.debug_log_event(
+      category: "sophtron_account_registration",
+      message: "Sophtron account setup completed",
+      source: self.class.name,
+      user: Current.user,
+      metadata: {
+        created_count: created_accounts.size,
+        skipped_count: skipped_count,
+        submitted_count: account_types.size
+      }
+    )
 
     flash[:notice] = if created_accounts.any?
       t(".success", count: created_accounts.count)
@@ -937,11 +1122,71 @@ class SophtronItemsController < ApplicationController
 
       sophtron_response_data!(provider.health_check_auth)
       item.ensure_customer!(provider: provider)
+      item.debug_log_event(
+        category: "sophtron_configuration",
+        message: "Sophtron configuration verified",
+        source: self.class.name,
+        user: Current.user
+      )
       true
     rescue Provider::Sophtron::Error => e
       item.update(status: :requires_update, last_connection_error: e.message)
       Rails.logger.error("Sophtron customer provisioning failed: #{e.message}")
+      item.debug_log_event(
+        category: "sophtron_configuration",
+        level: "error",
+        message: "Sophtron configuration verification failed",
+        source: self.class.name,
+        user: Current.user,
+        metadata: { error: e.message, error_type: e.error_type }
+      )
       false
+    end
+
+    def log_connection_job_state(item, previous_job, current_job, poll_attempt:)
+      previous = previous_job.respond_to?(:with_indifferent_access) ? previous_job.with_indifferent_access : {}
+      current = current_job.with_indifferent_access
+
+      return if previous[:LastStatus].to_s == current[:LastStatus].to_s &&
+        previous[:LastStep].to_s == current[:LastStep].to_s &&
+        previous[:SuccessFlag] == current[:SuccessFlag]
+
+      item.debug_log_event(
+        category: "sophtron_connection",
+        message: "Sophtron connection status updated",
+        source: self.class.name,
+        user: Current.user,
+        metadata: connection_job_metadata(current_job, poll_attempt: poll_attempt).merge(
+          previous_status: previous[:LastStatus].presence || previous[:last_status].presence,
+          previous_step: previous[:LastStep].presence || previous[:last_step].presence,
+          previous_success_flag: previous.key?(:SuccessFlag) ? previous[:SuccessFlag] : previous[:success_flag]
+        )
+      )
+    end
+
+    def connection_job_metadata(job, **metadata)
+      payload = job.with_indifferent_access
+
+      metadata.merge(
+        job_id: payload[:JobID] || payload[:job_id] || @sophtron_item.current_job_id,
+        job_status: payload[:LastStatus] || payload[:last_status],
+        job_step: payload[:LastStep] || payload[:last_step],
+        success_flag: payload.key?(:SuccessFlag) ? payload[:SuccessFlag] : payload[:success_flag],
+        requires_input: Provider::Sophtron.job_requires_input?(payload),
+        failed: Provider::Sophtron.job_failed?(payload),
+        completed: Provider::Sophtron.job_completed?(payload),
+        successful: Provider::Sophtron.job_success?(payload)
+      ).compact
+    end
+
+    def mfa_challenge_metadata(challenge)
+      {
+        security_question_count: Array(challenge[:security_questions]).size,
+        token_method_count: Array(challenge[:token_methods]).size,
+        token_sent: challenge[:token_sent] == true,
+        token_read: challenge[:token_read].present?,
+        captcha_present: challenge[:captcha_image].present?
+      }
     end
 
     def render_sophtron_panel_success(action_name)

--- a/app/jobs/sophtron_refresh_poll_job.rb
+++ b/app/jobs/sophtron_refresh_poll_job.rb
@@ -11,11 +11,24 @@ class SophtronRefreshPollJob < ApplicationJob
 
     job = Provider::Sophtron.response_data!(provider.get_job_information(job_id))
     sophtron_item.upsert_job_snapshot!(job)
+    log_refresh_event(
+      sophtron_account,
+      message: "Sophtron refresh poll received job state",
+      metadata: {
+        sync_id: sync&.id,
+        job_id: job_id,
+        attempts_remaining: attempts_remaining,
+        job_status: job.with_indifferent_access[:LastStatus] || job.with_indifferent_access[:last_status],
+        job_step: job.with_indifferent_access[:LastStep] || job.with_indifferent_access[:last_step]
+      }
+    )
 
     if Provider::Sophtron.job_requires_input?(job)
       mark_requires_update!(sophtron_item, job_id)
+      log_refresh_event(sophtron_account, level: "warn", message: "Sophtron refresh poll requires MFA", metadata: { sync_id: sync&.id, job_id: job_id })
     elsif Provider::Sophtron.job_failed?(job)
       sophtron_item.update!(last_connection_error: I18n.t("sophtron_items.errors.refresh_failed"))
+      log_refresh_event(sophtron_account, level: "error", message: "Sophtron refresh poll failed", metadata: { sync_id: sync&.id, job_id: job_id })
     elsif Provider::Sophtron.job_success?(job) || Provider::Sophtron.job_completed?(job)
       import_transactions!(sophtron_account, provider, sync)
     elsif attempts_remaining.to_i > 1
@@ -25,11 +38,14 @@ class SophtronRefreshPollJob < ApplicationJob
         attempts_remaining: attempts_remaining.to_i - 1,
         sync: sync
       )
+      log_refresh_event(sophtron_account, message: "Sophtron refresh poll re-enqueued", metadata: { sync_id: sync&.id, job_id: job_id, attempts_remaining: attempts_remaining.to_i - 1 })
     else
       sophtron_item.update!(last_connection_error: I18n.t("sophtron_items.errors.refresh_timeout"))
+      log_refresh_event(sophtron_account, level: "error", message: "Sophtron refresh poll timed out", metadata: { sync_id: sync&.id, job_id: job_id })
     end
   rescue Provider::Sophtron::Error => e
     handle_provider_error!(sophtron_account.sophtron_item, e)
+    log_refresh_event(sophtron_account, level: "error", message: "Sophtron refresh poll failed with provider error", metadata: { sync_id: sync&.id, job_id: job_id, error: e.message, error_type: e.error_type })
   end
 
   private
@@ -43,8 +59,11 @@ class SophtronRefreshPollJob < ApplicationJob
         attributes = { last_connection_error: result[:error] }
         attributes[:status] = :requires_update if result[:requires_update]
         sophtron_item.update!(attributes)
+        log_refresh_event(sophtron_account, level: result[:requires_update] ? "warn" : "error", message: "Sophtron refresh import failed after polling", metadata: { sync_id: sync&.id, error: result[:error], requires_update: result[:requires_update] })
         return
       end
+
+      log_refresh_event(sophtron_account, message: "Sophtron refresh import completed after polling", metadata: { sync_id: sync&.id, transactions_count: result[:transactions_count] })
 
       SophtronAccount::Processor.new(sophtron_account.reload).process
 
@@ -72,5 +91,20 @@ class SophtronRefreshPollJob < ApplicationJob
       attributes[:status] = :requires_update if requires_update
       sophtron_item.update!(attributes)
       Rails.logger.error "SophtronRefreshPollJob - Sophtron API error for item #{sophtron_item.id}: #{error.message}"
+    end
+
+    def log_refresh_event(sophtron_account, message:, level: "info", metadata: {})
+      sophtron_account.sophtron_item.debug_log_event(
+        category: "sophtron_transaction_sync",
+        level: level,
+        message: message,
+        source: self.class.name,
+        account: sophtron_account.current_account,
+        account_provider: sophtron_account.account_provider,
+        metadata: {
+          sophtron_account_id: sophtron_account.id,
+          sophtron_account_external_id: sophtron_account.account_id
+        }.merge(metadata)
+      )
     end
 end

--- a/app/jobs/sophtron_refresh_poll_job.rb
+++ b/app/jobs/sophtron_refresh_poll_job.rb
@@ -15,7 +15,7 @@ class SophtronRefreshPollJob < ApplicationJob
     if Provider::Sophtron.job_requires_input?(job)
       mark_requires_update!(sophtron_item, job_id)
     elsif Provider::Sophtron.job_failed?(job)
-      sophtron_item.update!(last_connection_error: "Sophtron refresh failed")
+      sophtron_item.update!(last_connection_error: I18n.t("sophtron_items.errors.refresh_failed"))
     elsif Provider::Sophtron.job_success?(job) || Provider::Sophtron.job_completed?(job)
       import_transactions!(sophtron_account, provider, sync)
     elsif attempts_remaining.to_i > 1
@@ -26,7 +26,7 @@ class SophtronRefreshPollJob < ApplicationJob
         sync: sync
       )
     else
-      sophtron_item.update!(last_connection_error: "Sophtron refresh did not finish before the polling timeout")
+      sophtron_item.update!(last_connection_error: I18n.t("sophtron_items.errors.refresh_timeout"))
     end
   rescue Provider::Sophtron::Error => e
     handle_provider_error!(sophtron_account.sophtron_item, e)
@@ -62,7 +62,7 @@ class SophtronRefreshPollJob < ApplicationJob
       sophtron_item.update!(
         status: :requires_update,
         current_job_id: job_id,
-        last_connection_error: "Sophtron refresh requires MFA"
+        last_connection_error: I18n.t("sophtron_items.errors.refresh_requires_mfa")
       )
     end
 

--- a/app/models/provider/sophtron.rb
+++ b/app/models/provider/sophtron.rb
@@ -354,7 +354,7 @@ class Provider::Sophtron < Provider
 
         parse_json ? JSON.parse(body, symbolize_names: true) : parse_optional_json(body)
       when 400
-        raise Error.new("Bad request to Sophtron API: #{body}", :bad_request, details: body)
+        raise Error.new("Bad request to Sophtron API", :bad_request, details: body)
       when 401
         raise Error.new("Invalid Sophtron User ID or Access Key", :unauthorized, details: body)
       when 403
@@ -365,7 +365,7 @@ class Provider::Sophtron < Provider
         raise Error.new("Sophtron rate limit exceeded. Please try again later.", :rate_limited, details: body)
       else
         raise Error.new(
-          "Sophtron API request failed: #{response.code} #{response.message} - #{body}",
+          "Sophtron API request failed: #{response.code} #{response.message}",
           :fetch_failed,
           details: body
         )
@@ -387,8 +387,8 @@ class Provider::Sophtron < Provider
 
       parsed = URI.parse(url)
       parsed.path.to_s.end_with?("/api") ? url : "#{url}/api"
-    rescue URI::InvalidURIError
-      DEFAULT_BASE_URL
+    rescue URI::InvalidURIError => e
+      raise Error.new("Invalid Sophtron base URL: #{e.message}", :configuration_error)
     end
 
     def normalize_account(account, user_institution_id:)

--- a/app/models/sophtron_item.rb
+++ b/app/models/sophtron_item.rb
@@ -75,12 +75,30 @@ class SophtronItem < ApplicationRecord
     provider = sophtron_provider
     unless provider
       Rails.logger.error "SophtronItem #{id} - Cannot import: Sophtron provider is not configured (missing API key)"
+      debug_log_event(
+        category: "sophtron_transaction_sync",
+        level: "error",
+        message: "Sophtron import could not start because the provider is not configured",
+        metadata: { sync_id: sync&.id }
+      )
       raise StandardError.new("Sophtron provider is not configured")
     end
+
+    debug_log_event(
+      category: "sophtron_transaction_sync",
+      message: "Sophtron import started",
+      metadata: { sync_id: sync&.id }
+    )
 
     SophtronItem::Importer.new(self, sophtron_provider: provider, sync: sync).import
   rescue => e
     Rails.logger.error "SophtronItem #{id} - Failed to import data: #{e.message}"
+    debug_log_event(
+      category: "sophtron_transaction_sync",
+      level: "error",
+      message: "Sophtron import failed",
+      metadata: { sync_id: sync&.id, error: e.message, error_class: e.class.name }
+    )
     raise
   end
 
@@ -220,6 +238,16 @@ class SophtronItem < ApplicationRecord
     extracted_customer_id = extract_customer_id(customer_payload)
     raise Provider::Sophtron::Error.new("Sophtron customer response did not include CustomerID", :invalid_response) if extracted_customer_id.blank?
 
+    debug_log_event(
+      category: "sophtron_configuration",
+      message: matching_customer.present? ? "Sophtron customer reused" : "Sophtron customer created",
+      metadata: {
+        customer_id_present: extracted_customer_id.present?,
+        customer_name: extract_customer_name(customer_payload).presence,
+        source: matching_customer.present? ? "existing" : "created"
+      }
+    )
+
     update!(
       customer_id: extracted_customer_id,
       customer_name: extract_customer_name(customer_payload).presence || generated_customer_name,
@@ -227,6 +255,33 @@ class SophtronItem < ApplicationRecord
     )
 
     customer_id
+  end
+
+  def debug_log_event(category:, message:, level: "info", metadata: {}, source: nil, account: nil, user: nil, account_provider: nil)
+    DebugLogEntry.capture(
+      category: category,
+      level: level,
+      message: message,
+      source: source || self.class.name,
+      family: family,
+      account: account,
+      user: user,
+      account_provider: account_provider,
+      provider: :sophtron,
+      metadata: debug_log_metadata(metadata)
+    )
+  end
+
+  def debug_log_metadata(metadata = {})
+    {
+      sophtron_item_id: id,
+      status: status,
+      institution_id: institution_id.presence,
+      institution_name: institution_name.presence,
+      user_institution_id_present: user_institution_id.present?,
+      current_job_id: current_job_id.presence,
+      manual_sync_enabled: manual_sync?
+    }.merge(metadata).compact
   end
 
   def connected_to_institution?

--- a/app/models/sophtron_item/importer.rb
+++ b/app/models/sophtron_item/importer.rb
@@ -340,7 +340,7 @@ class SophtronItem::Importer
         { success: true, transactions_count: transactions_count }
       rescue Provider::Sophtron::Error => e
         requires_update = e.error_type.in?([ :unauthorized, :access_forbidden ])
-        sophtron_item.update!(status: :requires_update) if requires_update
+        sophtron_item.update(status: :requires_update) if requires_update
         Rails.logger.error "SophtronItem::Importer - Sophtron API error for account #{sophtron_account.id}: #{e.message}"
         { success: false, transactions_count: 0, error: e.message, requires_update: requires_update }
       rescue JSON::ParserError => e
@@ -365,13 +365,13 @@ class SophtronItem::Importer
         sophtron_item.update!(
           status: :requires_update,
           current_job_id: job_id,
-          last_connection_error: "Sophtron refresh requires MFA"
+          last_connection_error: I18n.t("sophtron_items.errors.refresh_requires_mfa")
         )
-        return { success: false, transactions_count: 0, error: "Sophtron refresh requires MFA", requires_update: true }
+        return { success: false, transactions_count: 0, error: I18n.t("sophtron_items.errors.refresh_requires_mfa"), requires_update: true }
       end
 
       if Provider::Sophtron.job_failed?(job)
-        return { success: false, transactions_count: 0, error: "Sophtron refresh failed" }
+        return { success: false, transactions_count: 0, error: I18n.t("sophtron_items.errors.refresh_failed") }
       end
 
       unless Provider::Sophtron.job_success?(job) || Provider::Sophtron.job_completed?(job)
@@ -387,7 +387,7 @@ class SophtronItem::Importer
       nil
     rescue Provider::Sophtron::Error => e
       requires_update = e.error_type.in?([ :unauthorized, :access_forbidden ])
-      sophtron_item.update!(status: :requires_update) if requires_update
+      sophtron_item.update(status: :requires_update) if requires_update
       Rails.logger.error "SophtronItem::Importer - Sophtron API error refreshing account #{sophtron_account.id}: #{e.message}"
       { success: false, transactions_count: 0, error: e.message, requires_update: requires_update }
     end

--- a/app/models/sophtron_item/importer.rb
+++ b/app/models/sophtron_item/importer.rb
@@ -59,6 +59,13 @@ class SophtronItem::Importer
         status: :requires_update,
         last_connection_error: error_message
       )
+      sophtron_item.debug_log_event(
+        category: "sophtron_transaction_sync",
+        level: "warn",
+        message: "Sophtron import stopped because the institution connection is incomplete",
+        source: self.class.name,
+        metadata: { sync_id: sync&.id }
+      )
 
       return {
         success: false,
@@ -77,6 +84,13 @@ class SophtronItem::Importer
       Rails.logger.error "SophtronItem::Importer - Failed to fetch accounts data for item #{sophtron_item.id}"
       return { success: false, error: "Failed to fetch accounts data", accounts_imported: 0, transactions_imported: 0 }
     end
+
+    sophtron_item.debug_log_event(
+      category: "sophtron_transaction_sync",
+      message: "Sophtron accounts fetched",
+      source: self.class.name,
+      metadata: { sync_id: sync&.id, discovered_account_count: accounts_data[:accounts].to_a.size }
+    )
 
     # Store raw payload
     begin
@@ -134,6 +148,17 @@ class SophtronItem::Importer
     end
 
     Rails.logger.info "SophtronItem::Importer - Updated #{accounts_updated} accounts, created #{accounts_created} new (#{accounts_failed} failed)"
+    sophtron_item.debug_log_event(
+      category: "sophtron_account_registration",
+      message: "Sophtron account discovery finished",
+      source: self.class.name,
+      metadata: {
+        sync_id: sync&.id,
+        accounts_updated: accounts_updated,
+        accounts_created: accounts_created,
+        accounts_failed: accounts_failed
+      }
+    )
 
     # Step 3: Fetch transactions only for linked accounts with active status
     transactions_imported = 0
@@ -157,6 +182,20 @@ class SophtronItem::Importer
     end
 
     Rails.logger.info "SophtronItem::Importer - Completed import for item #{sophtron_item.id}: #{accounts_updated} accounts updated, #{accounts_created} new accounts discovered, #{transactions_imported} transactions"
+    sophtron_item.debug_log_event(
+      category: "sophtron_transaction_sync",
+      level: accounts_failed.positive? || transactions_failed.positive? ? "warn" : "info",
+      message: "Sophtron import finished",
+      source: self.class.name,
+      metadata: {
+        sync_id: sync&.id,
+        accounts_updated: accounts_updated,
+        accounts_created: accounts_created,
+        accounts_failed: accounts_failed,
+        transactions_imported: transactions_imported,
+        transactions_failed: transactions_failed
+      }
+    )
 
     {
       success: accounts_failed == 0 && transactions_failed == 0,
@@ -187,13 +226,34 @@ class SophtronItem::Importer
           end
         end
         Rails.logger.error "SophtronItem::Importer - Sophtron API error: #{e.message}"
+        sophtron_item.debug_log_event(
+          category: "sophtron_transaction_sync",
+          level: "error",
+          message: "Sophtron account fetch failed",
+          source: self.class.name,
+          metadata: { sync_id: sync&.id, error: e.message, error_type: e.error_type }
+        )
         return nil
       rescue JSON::ParserError => e
         Rails.logger.error "SophtronItem::Importer - Failed to parse Sophtron API response: #{e.message}"
+        sophtron_item.debug_log_event(
+          category: "sophtron_transaction_sync",
+          level: "error",
+          message: "Sophtron account fetch response could not be parsed",
+          source: self.class.name,
+          metadata: { sync_id: sync&.id, error: e.message }
+        )
         return nil
       rescue => e
         Rails.logger.error "SophtronItem::Importer - Unexpected error fetching accounts: #{e.class} - #{e.message}"
         Rails.logger.error e.backtrace.join("\n")
+        sophtron_item.debug_log_event(
+          category: "sophtron_transaction_sync",
+          level: "error",
+          message: "Sophtron account fetch failed unexpectedly",
+          source: self.class.name,
+          metadata: { sync_id: sync&.id, error: e.message, error_class: e.class.name }
+        )
         return nil
       end
 
@@ -272,6 +332,16 @@ class SophtronItem::Importer
     def fetch_and_store_transactions(sophtron_account, refresh: true)
       start_date = determine_sync_start_date(sophtron_account)
       Rails.logger.info "SophtronItem::Importer - Fetching transactions for account #{sophtron_account.account_id} from #{start_date}"
+      log_transaction_event(
+        sophtron_account,
+        message: "Sophtron transaction fetch started",
+        metadata: {
+          sync_id: sync&.id,
+          start_date: start_date,
+          refresh_requested: refresh,
+          initial_fetch: initial_transaction_fetch?(sophtron_account)
+        }
+      )
 
       begin
         if refresh && !initial_transaction_fetch?(sophtron_account)
@@ -324,17 +394,49 @@ class SophtronItem::Importer
             if new_transactions.any?
               Rails.logger.info "SophtronItem::Importer - Storing #{new_transactions.count} new transactions (#{existing_transactions.count} existing, #{transactions.count - new_transactions.count} duplicates skipped) for account #{sophtron_account.account_id}"
               sophtron_account.upsert_sophtron_transactions_snapshot!(existing_transactions + new_transactions)
+              log_transaction_event(
+                sophtron_account,
+                message: "Sophtron transactions stored",
+                metadata: {
+                  sync_id: sync&.id,
+                  fetched_count: transactions_count,
+                  new_transaction_count: new_transactions.count,
+                  duplicate_count: transactions.count - new_transactions.count,
+                  existing_transaction_count: existing_transactions.count
+                }
+              )
             else
               Rails.logger.info "SophtronItem::Importer - No new transactions to store (all #{transactions.count} were duplicates) for account #{sophtron_account.account_id}"
               sophtron_account.upsert_sophtron_transactions_snapshot!(existing_transactions) if sophtron_account.raw_transactions_payload.nil?
+              log_transaction_event(
+                sophtron_account,
+                message: "Sophtron transaction fetch found no new transactions",
+                metadata: {
+                  sync_id: sync&.id,
+                  fetched_count: transactions_count,
+                  duplicate_count: transactions.count,
+                  existing_transaction_count: existing_transactions.count
+                }
+              )
             end
           rescue => e
             Rails.logger.error "SophtronItem::Importer - Failed to store transactions for account #{sophtron_account.account_id}: #{e.message}"
+            log_transaction_event(
+              sophtron_account,
+              level: "error",
+              message: "Sophtron transactions could not be stored",
+              metadata: { sync_id: sync&.id, error: e.message, error_class: e.class.name }
+            )
             return { success: false, transactions_count: 0, error: "Failed to store transactions: #{e.message}" }
           end
         else
           Rails.logger.info "SophtronItem::Importer - No transactions to store for account #{sophtron_account.account_id}"
           sophtron_account.upsert_sophtron_transactions_snapshot!([]) if sophtron_account.raw_transactions_payload.nil?
+          log_transaction_event(
+            sophtron_account,
+            message: "Sophtron transaction fetch returned no transactions",
+            metadata: { sync_id: sync&.id, fetched_count: 0 }
+          )
         end
 
         { success: true, transactions_count: transactions_count }
@@ -342,13 +444,31 @@ class SophtronItem::Importer
         requires_update = e.error_type.in?([ :unauthorized, :access_forbidden ])
         sophtron_item.update(status: :requires_update) if requires_update
         Rails.logger.error "SophtronItem::Importer - Sophtron API error for account #{sophtron_account.id}: #{e.message}"
+        log_transaction_event(
+          sophtron_account,
+          level: "error",
+          message: "Sophtron transaction fetch failed",
+          metadata: { sync_id: sync&.id, error: e.message, error_type: e.error_type, requires_update: requires_update }
+        )
         { success: false, transactions_count: 0, error: e.message, requires_update: requires_update }
       rescue JSON::ParserError => e
         Rails.logger.error "SophtronItem::Importer - Failed to parse transaction response for account #{sophtron_account.id}: #{e.message}"
+        log_transaction_event(
+          sophtron_account,
+          level: "error",
+          message: "Sophtron transaction response could not be parsed",
+          metadata: { sync_id: sync&.id, error: e.message }
+        )
         { success: false, transactions_count: 0, error: "Failed to parse response" }
       rescue => e
         Rails.logger.error "SophtronItem::Importer - Unexpected error fetching transactions for account #{sophtron_account.id}: #{e.class} - #{e.message}"
         Rails.logger.error e.backtrace.join("\n")
+        log_transaction_event(
+          sophtron_account,
+          level: "error",
+          message: "Sophtron transaction fetch failed unexpectedly",
+          metadata: { sync_id: sync&.id, error: e.message, error_class: e.class.name }
+        )
         { success: false, transactions_count: 0, error: "Unexpected error: #{e.message}" }
       end
     end
@@ -357,6 +477,12 @@ class SophtronItem::Importer
       refresh_response = Provider::Sophtron.response_data!(sophtron_provider.refresh_account(sophtron_account.account_id))
       job_id = refresh_response.with_indifferent_access[:JobID] || refresh_response.with_indifferent_access[:job_id]
       return nil if job_id.blank?
+
+      log_transaction_event(
+        sophtron_account,
+        message: "Sophtron account refresh requested before transaction fetch",
+        metadata: { sync_id: sync&.id, job_id: job_id }
+      )
 
       job = Provider::Sophtron.response_data!(sophtron_provider.get_job_information(job_id))
       sophtron_item.upsert_job_snapshot!(job)
@@ -367,10 +493,22 @@ class SophtronItem::Importer
           current_job_id: job_id,
           last_connection_error: I18n.t("sophtron_items.errors.refresh_requires_mfa")
         )
+        log_transaction_event(
+          sophtron_account,
+          level: "warn",
+          message: "Sophtron account refresh requires MFA before transaction fetch",
+          metadata: { sync_id: sync&.id, job_id: job_id }
+        )
         return { success: false, transactions_count: 0, error: I18n.t("sophtron_items.errors.refresh_requires_mfa"), requires_update: true }
       end
 
       if Provider::Sophtron.job_failed?(job)
+        log_transaction_event(
+          sophtron_account,
+          level: "error",
+          message: "Sophtron account refresh failed before transaction fetch",
+          metadata: { sync_id: sync&.id, job_id: job_id, job_status: job.with_indifferent_access[:LastStatus] || job.with_indifferent_access[:last_status] }
+        )
         return { success: false, transactions_count: 0, error: I18n.t("sophtron_items.errors.refresh_failed") }
       end
 
@@ -381,15 +519,47 @@ class SophtronItem::Importer
           sync: sync
         )
 
+        log_transaction_event(
+          sophtron_account,
+          message: "Sophtron account refresh is still running; polling job enqueued",
+          metadata: { sync_id: sync&.id, job_id: job_id }
+        )
+
         return { success: true, transactions_count: 0, refresh_pending: true }
       end
 
+      log_transaction_event(
+        sophtron_account,
+        message: "Sophtron account refresh completed before transaction fetch",
+        metadata: { sync_id: sync&.id, job_id: job_id }
+      )
       nil
     rescue Provider::Sophtron::Error => e
       requires_update = e.error_type.in?([ :unauthorized, :access_forbidden ])
       sophtron_item.update(status: :requires_update) if requires_update
       Rails.logger.error "SophtronItem::Importer - Sophtron API error refreshing account #{sophtron_account.id}: #{e.message}"
+      log_transaction_event(
+        sophtron_account,
+        level: "error",
+        message: "Sophtron account refresh failed before transaction fetch",
+        metadata: { sync_id: sync&.id, error: e.message, error_type: e.error_type, requires_update: requires_update }
+      )
       { success: false, transactions_count: 0, error: e.message, requires_update: requires_update }
+    end
+
+    def log_transaction_event(sophtron_account, message:, level: "info", metadata: {})
+      sophtron_item.debug_log_event(
+        category: "sophtron_transaction_sync",
+        level: level,
+        message: message,
+        source: self.class.name,
+        account: sophtron_account.current_account,
+        account_provider: sophtron_account.account_provider,
+        metadata: {
+          sophtron_account_id: sophtron_account.id,
+          sophtron_account_external_id: sophtron_account.account_id
+        }.merge(metadata)
+      )
     end
 
     # Determines the appropriate start date for fetching transactions.
@@ -452,6 +622,13 @@ class SophtronItem::Importer
       end
 
       Rails.logger.error "SophtronItem::Importer - API error: #{error_message}"
+      sophtron_item.debug_log_event(
+        category: "sophtron_transaction_sync",
+        level: "error",
+        message: "Sophtron API returned an error payload during import",
+        source: self.class.name,
+        metadata: { sync_id: sync&.id, error: error_message, requires_update: needs_update }
+      )
       raise Provider::Sophtron::Error.new(
         "Sophtron API error: #{error_message}",
         :api_error

--- a/app/models/sophtron_item/syncer.rb
+++ b/app/models/sophtron_item/syncer.rb
@@ -34,6 +34,13 @@ class SophtronItem::Syncer
   # @return [void]
   # @raise [StandardError] if any phase of the sync fails
   def perform_sync(sync)
+    sophtron_item.debug_log_event(
+      category: "sophtron_transaction_sync",
+      message: "Sophtron syncer started",
+      source: self.class.name,
+      metadata: { sync_id: sync&.id }
+    )
+
     # Phase 1: Import data from Sophtron API
     sync.update!(status_text: t("sophtron_items.syncer.importing_accounts")) if sync.respond_to?(:status_text)
     import_result = sophtron_item.import_latest_sophtron_data(sync: sync)
@@ -84,12 +91,32 @@ class SophtronItem::Syncer
     # Mark sync health
     if import_errors.present?
       collect_health_stats(sync, errors: import_errors)
+      sophtron_item.debug_log_event(
+        category: "sophtron_transaction_sync",
+        level: "warn",
+        message: "Sophtron syncer finished with import errors",
+        source: self.class.name,
+        metadata: { sync_id: sync&.id, errors: import_errors.map { |error| error[:message] } }
+      )
       raise StandardError.new(import_errors.map { |error| error[:message] }.join(", "))
     else
       collect_health_stats(sync, errors: nil)
+      sophtron_item.debug_log_event(
+        category: "sophtron_transaction_sync",
+        message: "Sophtron syncer finished successfully",
+        source: self.class.name,
+        metadata: { sync_id: sync&.id, linked_account_count: linked_accounts.count, unlinked_account_count: unlinked_count }
+      )
     end
   rescue => e
     collect_health_stats(sync, errors: [ { message: e.message, category: "sync_error" } ]) unless sync_errors_recorded?(sync)
+    sophtron_item.debug_log_event(
+      category: "sophtron_transaction_sync",
+      level: "error",
+      message: "Sophtron syncer failed",
+      source: self.class.name,
+      metadata: { sync_id: sync&.id, error: e.message, error_class: e.class.name }
+    )
     raise
   end
 

--- a/app/models/sophtron_item/syncer.rb
+++ b/app/models/sophtron_item/syncer.rb
@@ -114,19 +114,19 @@ class SophtronItem::Syncer
       errors = []
       if import_result[:accounts_failed].to_i.positive?
         errors << {
-          message: "#{import_result[:accounts_failed]} #{'account'.pluralize(import_result[:accounts_failed])} failed to import",
+          message: I18n.t("sophtron_items.syncer.accounts_failed", count: import_result[:accounts_failed]),
           category: "account_import"
         }
       end
 
       if import_result[:transactions_failed].to_i.positive?
         errors << {
-          message: "#{import_result[:transactions_failed]} #{'account'.pluralize(import_result[:transactions_failed])} failed to import transactions",
+          message: I18n.t("sophtron_items.syncer.transactions_failed", count: import_result[:transactions_failed]),
           category: "transaction_import"
         }
       end
 
-      errors.presence || [ { message: "Sophtron import failed", category: "sync_error" } ]
+      errors.presence || [ { message: I18n.t("sophtron_items.syncer.import_failed"), category: "sync_error" } ]
     end
 
     def sync_errors_recorded?(sync)

--- a/app/views/sophtron_items/select_accounts.html.erb
+++ b/app/views/sophtron_items/select_accounts.html.erb
@@ -15,7 +15,6 @@
 
           <div class="space-y-2">
             <% @available_accounts.each do |account| %>
-              <% Rails.logger.debug "Sophtron account data: #{account.inspect}" %>
               <% has_blank_name = account[:account_name].blank? %>
               <label class="flex items-start gap-3 rounded-lg border <%= has_blank_name ? "border-destructive bg-container-inset opacity-60" : "border-primary bg-container-inset hover:bg-container-inset-hover" %> p-3 <%= has_blank_name ? "cursor-not-allowed" : "cursor-pointer" %> transition-colors">
                 <%= check_box_tag "account_ids[]", account[:id], false, disabled: has_blank_name, class: "mt-1" %>

--- a/config/locales/views/sophtron_items/en.yml
+++ b/config/locales/views/sophtron_items/en.yml
@@ -287,6 +287,17 @@ en:
       accounts_need_setup: "%{count} account(s) need setup"
       processing_transactions: "Processing transactions for linked accounts..."
       calculating_balances: "Calculating balances for linked accounts..."
+      accounts_failed:
+        one: "%{count} account failed to import"
+        other: "%{count} accounts failed to import"
+      transactions_failed:
+        one: "%{count} transaction failed to import"
+        other: "%{count} transactions failed to import"
+      import_failed: "Sophtron import failed"
+    errors:
+      refresh_failed: "Sophtron refresh failed"
+      refresh_timeout: "Sophtron refresh did not finish before the polling timeout"
+      refresh_requires_mfa: "Sophtron refresh requires MFA"
     sophtron_entry:
       processor:
         unknown_transaction: "Unknown transaction"

--- a/config/locales/views/sophtron_items/hu.yml
+++ b/config/locales/views/sophtron_items/hu.yml
@@ -287,6 +287,17 @@ hu:
       accounts_need_setup: "%{count} számla beállítást igényel"
       processing_transactions: "Tranzakciók feldolgozása az összekapcsolt számlákhoz..."
       calculating_balances: "Egyenlegek kiszámítása az összekapcsolt számlákhoz..."
+      accounts_failed:
+        one: "%{count} számla importálása sikertelen"
+        other: "%{count} számla importálása sikertelen"
+      transactions_failed:
+        one: "%{count} tranzakció importálása sikertelen"
+        other: "%{count} tranzakció importálása sikertelen"
+      import_failed: "A Sophtron importálás sikertelen"
+    errors:
+      refresh_failed: "A Sophtron frissítés sikertelen"
+      refresh_timeout: "A Sophtron frissítés nem fejeződött be a lekérdezési időkorláton belül"
+      refresh_requires_mfa: "A Sophtron frissítéshez többtényezős hitelesítés szükséges"
     sophtron_entry:
       processor:
         unknown_transaction: "Ismeretlen tranzakció"

--- a/test/controllers/sophtron_items_controller_test.rb
+++ b/test/controllers/sophtron_items_controller_test.rb
@@ -222,6 +222,32 @@ class SophtronItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, "What is your favorite color?"
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "sophtron_mfa", entry.category
+    assert_equal "Sophtron MFA challenge displayed", entry.message
+    assert_equal 1, entry.metadata["security_question_count"]
+  end
+
+  test "connect_institution logs connection start and job registration" do
+    provider = mock
+    provider.expects(:create_user_institution).returns({ JobID: "job-1", UserInstitutionID: "ui-1" })
+
+    SophtronItem.any_instance.stubs(:ensure_customer!).returns("cust-1")
+    SophtronItem.any_instance.stubs(:sophtron_provider).returns(provider)
+
+    assert_difference "DebugLogEntry.count", 2 do
+      post connect_institution_sophtron_item_url(@item), params: {
+        institution_id: "inst-1",
+        institution_name: "Example Bank",
+        bank_username: "user@example.com",
+        bank_password: "secret"
+      }
+    end
+
+    messages = DebugLogEntry.order(:created_at).last(2).map(&:message)
+    assert_includes messages, "Starting Sophtron institution connection"
+    assert_includes messages, "Sophtron institution connection started"
   end
 
   test "connection_status sanitizes captcha image before rendering data uri" do
@@ -520,6 +546,11 @@ class SophtronItemsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to connection_status_sophtron_item_path(@item, post_mfa: true)
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "sophtron_mfa", entry.category
+    assert_equal "Sophtron MFA submitted", entry.message
+    assert_equal "security_answer", entry.metadata["mfa_type"]
   end
 
   test "submit_mfa rejects too many security answers" do

--- a/test/jobs/sophtron_refresh_poll_job_test.rb
+++ b/test/jobs/sophtron_refresh_poll_job_test.rb
@@ -44,4 +44,14 @@ class SophtronRefreshPollJobTest < ActiveJob::TestCase
       SophtronRefreshPollJob.perform_now(@sophtron_account, job_id: "refresh-job")
     end
   end
+
+  test "stores localized timeout message when polling attempts are exhausted" do
+    provider = mock
+    provider.expects(:get_job_information).with("refresh-job").returns({ LastStatus: "Started" })
+    SophtronItem.any_instance.stubs(:sophtron_provider).returns(provider)
+
+    SophtronRefreshPollJob.perform_now(@sophtron_account, job_id: "refresh-job", attempts_remaining: 1)
+
+    assert_equal I18n.t("sophtron_items.errors.refresh_timeout"), @item.reload.last_connection_error
+  end
 end

--- a/test/jobs/sophtron_refresh_poll_job_test.rb
+++ b/test/jobs/sophtron_refresh_poll_job_test.rb
@@ -53,5 +53,9 @@ class SophtronRefreshPollJobTest < ActiveJob::TestCase
     SophtronRefreshPollJob.perform_now(@sophtron_account, job_id: "refresh-job", attempts_remaining: 1)
 
     assert_equal I18n.t("sophtron_items.errors.refresh_timeout"), @item.reload.last_connection_error
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "sophtron_transaction_sync", entry.category
+    assert_equal "Sophtron refresh poll timed out", entry.message
   end
 end

--- a/test/models/provider/sophtron_test.rb
+++ b/test/models/provider/sophtron_test.rb
@@ -216,6 +216,39 @@ class Provider::SophtronTest < ActiveSupport::TestCase
     assert_equal :unauthorized, response.error.error_type
   end
 
+  test "bad request error omits raw response body from message" do
+    stub_request(:get, "https://api.sophtron.com/api/Institution/HealthCheckAuth")
+      .to_return(status: 400, body: '{"secret":"value"}')
+
+    error = assert_raises(Provider::Sophtron::Error) do
+      Provider::Sophtron.response_data!(@provider.health_check_auth)
+    end
+
+    assert_equal "Bad request to Sophtron API", error.message
+    assert_equal '{"secret":"value"}', error.details
+  end
+
+  test "fetch failure error omits raw response body from message" do
+    stub_request(:get, "https://api.sophtron.com/api/Institution/HealthCheckAuth")
+      .to_return(status: [500, "Internal Server Error"], body: '{"secret":"value"}', headers: { "Content-Type" => "application/json" })
+
+    error = assert_raises(Provider::Sophtron::Error) do
+      Provider::Sophtron.response_data!(@provider.health_check_auth)
+    end
+
+    assert_equal "Sophtron API request failed: 500 Internal Server Error", error.message
+    assert_equal '{"secret":"value"}', error.details
+  end
+
+  test "invalid base url raises configuration error" do
+    error = assert_raises(Provider::Sophtron::Error) do
+      Provider::Sophtron.new("developer-user", @access_key, base_url: "https://bad host")
+    end
+
+    assert_equal :configuration_error, error.error_type
+    assert_match(/Invalid Sophtron base URL:/, error.message)
+  end
+
   private
 
     def provider_data(response)

--- a/test/models/provider/sophtron_test.rb
+++ b/test/models/provider/sophtron_test.rb
@@ -230,7 +230,7 @@ class Provider::SophtronTest < ActiveSupport::TestCase
 
   test "fetch failure error omits raw response body from message" do
     stub_request(:get, "https://api.sophtron.com/api/Institution/HealthCheckAuth")
-      .to_return(status: [500, "Internal Server Error"], body: '{"secret":"value"}', headers: { "Content-Type" => "application/json" })
+      .to_return(status: [ 500, "Internal Server Error" ], body: '{"secret":"value"}', headers: { "Content-Type" => "application/json" })
 
     error = assert_raises(Provider::Sophtron::Error) do
       Provider::Sophtron.response_data!(@provider.health_check_auth)

--- a/test/models/sophtron_item/importer_test.rb
+++ b/test/models/sophtron_item/importer_test.rb
@@ -329,4 +329,64 @@ class SophtronItem::ImporterTest < ActiveSupport::TestCase
       assert_equal 0, result[:transactions_failed]
     end
   end
+
+  test "unauthorized transaction fetch does not crash when marking requires_update fails validation" do
+    account = accounts(:depository)
+    sophtron_account = @item.sophtron_accounts.create!(
+      account_id: "acct-1",
+      name: "Checking",
+      currency: "USD",
+      balance: 100,
+      raw_transactions_payload: [ { id: "existing-tx" } ]
+    )
+    AccountProvider.create!(account: account, provider: sophtron_account)
+
+    provider = mock
+    provider.expects(:get_accounts).with("ui-1").returns({
+      accounts: [
+        {
+          account_id: "acct-1",
+          account_name: "Checking",
+          balance: "100.00",
+          balance_currency: "USD",
+          currency: "USD"
+        }.with_indifferent_access
+      ],
+      total: 1
+    })
+    provider.expects(:refresh_account).with("acct-1").returns({ JobID: "refresh-job" })
+    provider.expects(:get_job_information).with("refresh-job").returns({ LastStatus: "Completed" })
+    provider.expects(:get_account_transactions).with("acct-1", start_date: anything)
+            .raises(Provider::Sophtron::Error.new("Invalid Sophtron User ID or Access Key", :unauthorized))
+
+    @item.expects(:update).with(status: :requires_update).returns(false).at_least_once
+
+    result = SophtronItem::Importer.new(@item, sophtron_provider: provider).import
+
+    assert_not result[:success]
+    assert result[:transactions_failed].positive?
+  end
+
+  test "refresh-before-fetch unauthorized does not crash when marking requires_update fails validation" do
+    sophtron_account = @item.sophtron_accounts.create!(
+      account_id: "acct-1",
+      name: "Checking",
+      currency: "USD",
+      balance: 100,
+      raw_transactions_payload: [ { id: "existing-tx" } ]
+    )
+
+    provider = mock
+    provider.expects(:refresh_account).with("acct-1")
+            .raises(Provider::Sophtron::Error.new("Access forbidden by Sophtron", :access_forbidden))
+
+    @item.expects(:update).with(status: :requires_update).returns(false)
+
+    result = SophtronItem::Importer.new(@item, sophtron_provider: provider)
+                                 .send(:refresh_account_before_transaction_fetch, sophtron_account)
+
+    assert_not result[:success]
+    assert result[:requires_update]
+    assert_equal "Access forbidden by Sophtron", result[:error]
+  end
 end

--- a/test/models/sophtron_item/importer_test.rb
+++ b/test/models/sophtron_item/importer_test.rb
@@ -102,6 +102,11 @@ class SophtronItem::ImporterTest < ActiveSupport::TestCase
     assert result[:success]
     assert_equal 1, result[:transactions_imported]
     assert_equal 1, sophtron_account.reload.raw_transactions_payload.count
+
+    messages = DebugLogEntry.order(:created_at).last(5).map(&:message)
+    assert_includes messages, "Sophtron accounts fetched"
+    assert_includes messages, "Sophtron transaction fetch started"
+    assert_includes messages, "Sophtron transactions stored"
   end
 
   test "automatic import skips linked accounts that require manual sync" do


### PR DESCRIPTION
## Summary
- fix Sophtron sync/import error messages and move new user-facing strings to i18n
- avoid hard crashes when marking Sophtron items `requires_update` inside auth-error rescue paths
- stop exposing raw Sophtron API response bodies in browser-visible error messages
- remove the debug log that printed full Sophtron account data in the select-accounts view
- raise a configuration error for invalid Sophtron base URLs instead of silently falling back

## Tests
- `bin/rails test test/models/sophtron_item/importer_test.rb test/models/provider/sophtron_test.rb test/jobs/sophtron_refresh_poll_job_test.rb`

Closes #1704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized Sophtron sync and refresh messages in English and Hungarian, including timeout and MFA-required states.
  * Added clearer progress and error details for Sophtron connections, imports, and MFA flows.

* **Bug Fixes**
  * Improved handling of authorization, API, timeout, and invalid configuration errors.
  * Prevented certain import and refresh failures from interrupting the overall flow.

* **Tests**
  * Added coverage for timeout handling, error messaging, logging, and import resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->