### PR TITLE
fix(design-system): bump --color-success for WCAG 1.4.11 contrast

### DIFF
--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -9,7 +9,7 @@
   --font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --color-white: #ffffff;
   --color-black: #0B0B0B;
-  --color-success: var(--color-green-600);
+  --color-success: var(--color-green-700);
   --color-warning: var(--color-yellow-600);
   --color-destructive: var(--color-red-600);
   --color-info: var(--color-blue-600);
@@ -197,7 +197,7 @@
 
 @layer base {
   [data-theme="dark"] {
-    --color-success: var(--color-green-500);
+    --color-success: var(--color-green-400);
     --color-warning: var(--color-yellow-400);
     --color-destructive: var(--color-red-400);
     --color-info: var(--color-blue-500);

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -18,7 +18,7 @@
     "white": { "$value": "#ffffff", "$type": "color" },
     "black": { "$value": "#0B0B0B", "$type": "color" },
 
-    "success":     { "$value": "{color.green.600}",  "$type": "color", "$extensions": { "sure.dark": "{color.green.500}" } },
+    "success":     { "$value": "{color.green.700}",  "$type": "color", "$extensions": { "sure.dark": "{color.green.400}" } },
     "warning":     { "$value": "{color.yellow.600}", "$type": "color", "$extensions": { "sure.dark": "{color.yellow.400}" } },
     "destructive": { "$value": "{color.red.600}",    "$type": "color", "$extensions": { "sure.dark": "{color.red.400}" } },
     "info":        { "$value": "{color.blue.600}",   "$type": "color", "$extensions": { "sure.dark": "{color.blue.500}" } },


### PR DESCRIPTION
## Summary

Bump `--color-success` so that `text-success` clears WCAG 1.4.11's 3:1 non-text contrast minimum on the `bg-success/10` tinted surface used throughout the app (DS::Alert, provider sync indicators, status pills, import success states, etc.).

- **Light:** `green-600` (`#10A861`) → `green-700` (`#078C52`)
- **Dark:** `green-500` (`#12B76A`) → `green-400` (`#32D583`)

Surfaced while measuring contrast for #1734 and explicitly deferred there for a token-level follow-up. Closes #1735, resolves child #4 of #1736.

## Numerical contrast (WCAG)

Foreground `text-success` against alpha-blended `bg-success/10` over `bg-container`:

| Mode | Foreground | Surface | Ratio | WCAG 1.4.11 |
|---|---|---|---|---|
| Light, before | green-600 `#10A861` | `#E7F6EF` | **2.77** | ❌ fails |
| Light, after  | green-700 `#078C52` | `#E6F3ED` | **3.77** | ✅ AA-large / non-text |
| Dark, before  | green-500 `#12B76A` | `#17271F` | 5.95 | ✅ AA |
| Dark, after   | green-400 `#32D583` | `#1A2A22` | **7.90** | ✅ AAA |

## Visual

Light mode, `bg-success/10` surface, success icon — from `/design-system/preview/alert/default?variant=success`:

| Before (`green-600`, 2.77:1) | After (`green-700`, 3.77:1) |
|---|---|
| ![light-before](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/issue-color-success-bump/light-before.png) | ![light-after](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/issue-color-success-bump/light-after.png) |

Dark mode (was already passing — gets more headroom):

| Before (`green-500`, 5.95:1) | After (`green-400`, 7.90:1) |
|---|---|
| ![dark-before](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/issue-color-success-bump/dark-before.png) | ![dark-after](https://github.com/we-promise/sure/raw/screenshots/ds-alert-1731/issue-color-success-bump/dark-after.png) |

## Diff

Two-file change. `design/tokens/sure.tokens.json` is the source; `_generated.css` is the regenerated output (`npm run tokens:build`).

```diff
- "success":     { "\$value": "{color.green.600}",  "\$type": "color", "\$extensions": { "sure.dark": "{color.green.500}" } },
+ "success":     { "\$value": "{color.green.700}",  "\$type": "color", "\$extensions": { "sure.dark": "{color.green.400}" } },
```

```diff
- --color-success: var(--color-green-600);
+ --color-success: var(--color-green-700);
…
- --color-success: var(--color-green-500);
+ --color-success: var(--color-green-400);
```

## Knock-on review (visual only)

`text-success` / `bg-success` / `border-success` callsites that shift tone slightly. All still semantic; no API change. Spot-checked:

- `app/components/DS/alert.rb` — success variant icon + border
- `app/views/settings/providers/_health_strip.html.erb`, `_ibkr_panel.html.erb`, `_brex_panel.html.erb`, `_enable_banking_panel.html.erb`
- `app/views/lunchflow_items/setup_accounts.html.erb`, `coinstats_items/_coinstats_item.html.erb`, `snaptrade_items/_snaptrade_item.html.erb`, `snaptrade_items/setup_accounts.html.erb`
- `app/views/imports/_pdf_import.html.erb`
- `app/views/shared/notifications/_cta.html.erb`, `_notice.html.erb`
- `app/views/doorkeeper/authorizations/{show,new}.html.erb`
- `app/views/recurring_transactions/index.html.erb`, `_projected_transaction.html.erb`
- `app/views/settings/api_keys/show.html.erb`, `_assistant_settings.html.erb`, `_yahoo_finance_settings.html.erb`
- `app/components/provider_sync_summary.html.erb`

## Out of scope / not changed

- `app/javascript/controllers/sankey_chart_controller.js:23` keeps its `var(--color-success) → #10A861` fallback (used only for d3 opacity manipulation in the cash-flow sankey, a data-viz surface explicitly carved out of WCAG 1.4.11). Cleaner long-term fix is `getComputedStyle().getPropertyValue("--color-success")` at runtime — separate refactor, not gated by this PR.
- `bg-success-surface` / `text-success-foreground` utility references in `doorkeeper/authorizations/show.html.erb` and `settings/api_keys/show.html.erb` are pre-existing dead utilities (no backing token); unrelated to this PR.
- The other children of #1736 (`text-subdued` rename, `text-secondary` lift, `text-link` bump, white-on-light button regression, Lookbook palette hygiene) each get their own PRs.

## Test plan

- [ ] `npm run tokens:check` — clean (verified locally).
- [ ] `bin/rails tailwindcss:build` — rebuilds compiled CSS with the new token (verified locally).
- [ ] `bin/rails test` — green (one unrelated `LoadError: libvips.42` on local env, not introduced here).
- [ ] Visit `/design-system/preview/alert/default?variant=success` in light + dark, confirm the success icon is visibly darker / brighter (respectively) on the tinted surface.
- [ ] Visit `/settings/providers` and confirm the green sync-OK dots and "no errors" copy still read clean against the surrounding chrome.
- [ ] Visit `/recurring_transactions` and confirm the green "negative amount = income" rows still render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined success state colors across light and dark themes for improved visual consistency and accessibility in the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->