### PR TITLE
fix(design-system): DS::Disclosure focus ring + motion-safe chevron rotation

### DIFF
--- a/app/components/DS/disclosure.html.erb
+++ b/app/components/DS/disclosure.html.erb
@@ -1,13 +1,14 @@
 <details class="group" <%= "open" if open %>>
   <%= tag.summary class: class_names(
-    "px-3 py-2 rounded-xl cursor-pointer flex items-center justify-between bg-surface"
+    "px-3 py-2 rounded-xl cursor-pointer flex items-center justify-between bg-surface",
+    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white"
   ) do %>
     <% if summary_content? %>
       <%= summary_content %>
     <% else %>
       <div class="flex items-center gap-3">
         <% if align == :left %>
-          <%= helpers.icon "chevron-right", class: "group-open:transform group-open:rotate-90" %>
+          <%= helpers.icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
         <% end %>
 
         <%= tag.span class: class_names("font-medium", align == :left ? "text-sm text-primary" : "text-xs uppercase text-secondary") do %>
@@ -16,7 +17,7 @@
       </div>
 
       <% if align == :right %>
-        <%= helpers.icon "chevron-down", class: "group-open:transform group-open:rotate-180" %>
+        <%= helpers.icon "chevron-down", class: "group-open:rotate-180 motion-safe:transition-transform motion-safe:duration-150" %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Summary

Two small a11y polishes on the native `<details>` / `<summary>` primitive wrapped by `DS::Disclosure`. Native semantics are already correct (no role/aria scaffolding needed); this PR fills in the two universal-checklist gaps from #1737. Closes #1741.

## Fixes

### Focus-visible ring on `<summary>` (WCAG 2.4.7)

`<summary>` is a focusable interactive element, but it previously relied entirely on the browser-default outline — thin, inconsistent across engines, and easy to miss against the disclosure's tinted surface. Match the new ring pattern landing in #1738:

```diff
  <%= tag.summary class: class_names(
-   "px-3 py-2 rounded-xl cursor-pointer flex items-center justify-between bg-surface"
+   "px-3 py-2 rounded-xl cursor-pointer flex items-center justify-between bg-surface",
+   "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white"
  ) do %>
```

`outline-offset-2` places the ring outside the summary so it lands on the surrounding page chrome (light surface in light mode, dark in dark mode), where a 2px dark-or-white outline gets a clean contrast lock regardless of the `bg-surface` tint underneath.

### Chevron rotation gated on `prefers-reduced-motion` (WCAG 2.3.3 AAA)

The chevron jumped between closed/open states with no transition — visually fine but a missed opportunity for the motion-allowed audience. Add a 150ms transform transition gated on `motion-safe:` so reduced-motion users still get the instant snap:

```diff
- <%= helpers.icon "chevron-right", class: "group-open:transform group-open:rotate-90" %>
+ <%= helpers.icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
…
- <%= helpers.icon "chevron-down",  class: "group-open:transform group-open:rotate-180" %>
+ <%= helpers.icon "chevron-down",  class: "group-open:rotate-180 motion-safe:transition-transform motion-safe:duration-150" %>
```

The `transform` utility was a Tailwind v3 holdover — v4 applies `rotate-*` on its own without the explicit `transform` modifier. Dropping it; the rotation continues to work.

## Diff

1 file, 4 insertions, 3 deletions. `app/components/DS/disclosure.html.erb` only.

## Out of scope

- Summary content slot contract (`renders_one :summary_content`) docs — could grow in a follow-up alongside the broader DS docs polish from #1715.
- Touch-target audit on summary — current `px-3 py-2 text-sm` ≈ 30px tall, below the 44×44 enhanced threshold. The issue body for #1741 explicitly scoped the audit to focus-ring + reduced-motion, so leaving for a follow-up.
- The 6 known disclosure callsites (`trades/_header.html.erb`, `transactions/_form.html.erb`, `transactions/bulk_updates/new.html.erb`, `accounts/_accountable_group.html.erb`, the wrapper rendered from `DS::Dialog` for confirm dialogs) all inherit the new ring + transition automatically — no migration work needed.

## Test plan

- [x] `bundle exec erb_lint app/components/DS/disclosure.html.erb` — clean.
- [x] `bin/rails tailwindcss:build` — `motion-safe:transition-transform` / `motion-safe:duration-150` resolve into the built CSS.
- [x] `bin/rails test` — 4304 pass, 1 pre-existing libvips env error (unrelated).
- [ ] Open `/transactions` or `/trades/:id`, Tab to a disclosure summary, confirm a 2px ring appears outside the summary in both modes.
- [ ] Toggle a disclosure, confirm the chevron animates over ~150ms.
- [ ] System pref → enable Reduce Motion, toggle a disclosure again, confirm the chevron snap-rotates instantly with no transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved focus visibility for the disclosure component with enhanced outline styling to boost accessibility.
  * Refined chevron icon styling and transitions with better support for motion preferences, ensuring smoother animations while respecting user settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->