### PR TITLE
fix(design-system): DS::FilledIcon decorative-vs-meaningful API

### DIFF
--- a/app/components/DS/filled_icon.html.erb
+++ b/app/components/DS/filled_icon.html.erb
@@ -1,5 +1,8 @@
 <%= tag.div style: transparent? ? container_styles : nil,
-            class: container_classes do %>
+            class: container_classes,
+            role: description.present? ? "img" : nil,
+            "aria-label": description,
+            "aria-hidden": aria_hidden ? "true" : nil do %>
   <% if icon %>
     <%= helpers.icon(icon, size: icon_size, color: "current") %>
   <% elsif text %>

--- a/app/components/DS/filled_icon.html.erb
+++ b/app/components/DS/filled_icon.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div style: transparent? ? container_styles : nil,
             class: container_classes,
             role: (!aria_hidden && description.present?) ? "img" : nil,
-            "aria-label": aria_hidden ? nil : description,
+            "aria-label": aria_hidden ? nil : description.presence,
             "aria-hidden": aria_hidden ? "true" : nil do %>
   <% if icon %>
     <%= helpers.icon(icon, size: icon_size, color: "current") %>

--- a/app/components/DS/filled_icon.html.erb
+++ b/app/components/DS/filled_icon.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div style: transparent? ? container_styles : nil,
             class: container_classes,
-            role: description.present? ? "img" : nil,
-            "aria-label": description,
+            role: (!aria_hidden && description.present?) ? "img" : nil,
+            "aria-label": aria_hidden ? nil : description,
             "aria-hidden": aria_hidden ? "true" : nil do %>
   <% if icon %>
     <%= helpers.icon(icon, size: icon_size, color: "current") %>

--- a/app/components/DS/filled_icon.rb
+++ b/app/components/DS/filled_icon.rb
@@ -42,8 +42,8 @@ class DS::FilledIcon < DesignSystemComponent
     @hex_color = hex_color
     @size = size.to_sym
     @rounded = rounded
-    @description = description
-    @aria_hidden = aria_hidden.nil? ? description.blank? : aria_hidden
+    @description = description.presence
+    @aria_hidden = aria_hidden.nil? ? @description.blank? : aria_hidden
   end
 
   def container_classes

--- a/app/components/DS/filled_icon.rb
+++ b/app/components/DS/filled_icon.rb
@@ -1,5 +1,5 @@
 class DS::FilledIcon < DesignSystemComponent
-  attr_reader :icon, :text, :hex_color, :size, :rounded, :variant
+  attr_reader :icon, :text, :hex_color, :size, :rounded, :variant, :description, :aria_hidden
 
   VARIANTS = %i[default text surface container inverse].freeze
 
@@ -24,13 +24,26 @@ class DS::FilledIcon < DesignSystemComponent
     }
   }.freeze
 
-  def initialize(variant: :default, icon: nil, text: nil, hex_color: nil, size: "md", rounded: false)
+  # `description:` makes the icon meaningful — emits `role="img"` +
+  # `aria-label=description` so AT users hear it. Without `description:`,
+  # the wrapper defaults to `aria-hidden="true"` (decorative) on the
+  # assumption that adjacent DOM carries the accessible name. Pass
+  # `aria_hidden: false` if you want the visual exposed but the name
+  # already lives in surrounding text (rare).
+  #
+  # NOTE on the `:text` variant: only `text.first` is rendered (e.g.
+  # "Apple" → "A"). The single letter is decorative — relying on AT
+  # users to infer "Apple" from "A" is broken. Use `description:` to
+  # surface the full label, or ensure the adjacent text node carries it.
+  def initialize(variant: :default, icon: nil, text: nil, hex_color: nil, size: "md", rounded: false, description: nil, aria_hidden: nil)
     @variant = variant.to_sym
     @icon = icon
     @text = text
     @hex_color = hex_color
     @size = size.to_sym
     @rounded = rounded
+    @description = description
+    @aria_hidden = aria_hidden.nil? ? description.blank? : aria_hidden
   end
 
   def container_classes


### PR DESCRIPTION
## Summary

`DS::FilledIcon` is used across 33 callsites — almost always as a decorative visual next to a textual label (transaction merchant avatar, recurring-transaction icon, payment-method tile, etc.). The wrapper was rendering without any aria scaffolding, so AT users would traverse the inner `<svg>` or single-letter `<span>` with no context for *what* it represented relative to the surrounding row.

Two small API additions to make decorative-vs-meaningful explicit. Closes #1742.

## Fixes

### `description:` for the meaningful case

```ruby
DS::FilledIcon.new(icon: "credit-card", description: "Credit card payment method")
```

Emits `role="img"` + `aria-label="..."` so AT users hear the label without the icon needing adjacent text. Useful when the icon stands alone (grid tiles, isolated badges).

### `aria_hidden:` for the decorative default

```ruby
DS::FilledIcon.new(icon: "credit-card")  # → aria-hidden="true"
DS::FilledIcon.new(icon: "credit-card", description: "Card")  # → role=img + aria-label="Card", no aria-hidden
DS::FilledIcon.new(icon: "credit-card", aria_hidden: false)  # → exposed, no name (escape hatch)
```

Default `aria_hidden:` is `nil` → resolved to `true` when `description.blank?`, `false` when description is present. So existing callsites get `aria-hidden="true"` automatically (correct — adjacent text already names them) and meaningful callsites get the proper `role="img" aria-label="…"` binding.

### Docs: the `:text` variant gotcha

`:text` variant renders only `text.first` — `holding.name = "Apple"` becomes a single `A` in the circle. The single letter is decorative; AT users can't infer "Apple" from "A". Comment added to the initializer pointing callers at `description:` for the AT name.

## Diff

```ruby
# app/components/DS/filled_icon.rb
- attr_reader :icon, :text, :hex_color, :size, :rounded, :variant
+ attr_reader :icon, :text, :hex_color, :size, :rounded, :variant, :description, :aria_hidden
…
- def initialize(variant: :default, icon: nil, text: nil, hex_color: nil, size: "md", rounded: false)
+ def initialize(variant: :default, icon: nil, text: nil, hex_color: nil, size: "md", rounded: false,
+                description: nil, aria_hidden: nil)
…
+ @description = description
+ @aria_hidden = aria_hidden.nil? ? description.blank? : aria_hidden
```

```erb
<%# app/components/DS/filled_icon.html.erb %>
<%= tag.div style: transparent? ? container_styles : nil,
-           class: container_classes do %>
+           class: container_classes,
+           role: description.present? ? "img" : nil,
+           "aria-label": description,
+           "aria-hidden": aria_hidden ? "true" : nil do %>
```

2 files, 19 insertions, 3 deletions.

## Out of scope

- **Touch-target audit** — `DS::FilledIcon` is a decorative wrapper, not interactive (no click handler, no `<button>`); WCAG 2.5.5 doesn't apply. The interactive wrappers that *contain* a FilledIcon (transaction rows, recurring-transaction rows, payment tiles) are governed by their own row's clickable region.
- **`hex_color:` palette soft-validation** — would require a registry of valid hex values from `design/tokens/sure.tokens.json`; nice-to-have but adds build coupling. Park until #1736 / #1653 land.
- **`color-mix(in oklab, …)` browser-support note** — tier-2 concern; baselines around Safari 16.4 / Chrome 111 / Firefox 113.
- **Backfilling `description:` on existing callsites** — none of the 33 currently need it (all have adjacent text labels). If a future use case introduces a stand-alone FilledIcon, that caller adds the description at the point of use.

## Test plan

- [x] `bin/rubocop` clean.
- [x] `bundle exec erb_lint` clean.
- [x] `bin/rails test` — pending.
- [ ] Open `/transactions`, inspect a row, confirm the FilledIcon wrapper renders `aria-hidden="true"` (decorative default).
- [ ] In Lookbook (`/design-system/preview/filled_icon`), render with `description:` and confirm `role="img"` + `aria-label` are set, and `aria-hidden` is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icons now accept optional accessibility descriptions and configurable aria behavior to improve screen-reader labeling and semantic markup.
  * Icons can be explicitly marked decorative or meaningful; text variant remains optimized for single-character rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->