### PR TITLE
fix(design-system): DS::Link a11y — distinguishable default, icon-only label, external-link hardening

### DIFF
--- a/app/components/DS/link.html.erb
+++ b/app/components/DS/link.html.erb
@@ -10,4 +10,8 @@
   <% if icon && icon_position == "right" %>
     <%= helpers.icon(icon, size: size, color: icon_color) %>
   <% end %>
+
+  <% if opens_in_new_tab? %>
+    <span class="sr-only"><%= t("ds.link.opens_in_new_tab", default: "(opens in new tab)") %></span>
+  <% end %>
 <% end %>

--- a/app/components/DS/link.rb
+++ b/app/components/DS/link.rb
@@ -6,11 +6,12 @@ class DS::Link < DS::Buttonish
   VARIANTS = VARIANTS.reverse_merge(
     default: {
       # Underline + `text-link` so the link is distinguishable by more
-      # than color alone (WCAG 1.4.1). Focus ring lands on the page
-      # chrome via `outline-offset`, visible regardless of theme.
+      # than color alone (WCAG 1.4.1). Focus ring uses the established
+      # alpha-ring DS pattern (also used by DS::Toggle, DS::Tooltip,
+      # provider_card, form-field) so theming stays centralized.
       container_classes: "text-link underline underline-offset-2 hover:no-underline " \
-                         "focus-visible:outline-2 focus-visible:outline-offset-2 " \
-                         "focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white",
+                         "focus-visible:ring-2 focus-visible:ring-alpha-black-300 " \
+                         "theme-dark:focus-visible:ring-alpha-white-300",
       icon_classes: "text-secondary"
     }
   ).freeze

--- a/app/components/DS/link.rb
+++ b/app/components/DS/link.rb
@@ -5,7 +5,12 @@ class DS::Link < DS::Buttonish
 
   VARIANTS = VARIANTS.reverse_merge(
     default: {
-      container_classes: "",
+      # Underline + `text-link` so the link is distinguishable by more
+      # than color alone (WCAG 1.4.1). Focus ring lands on the page
+      # chrome via `outline-offset`, visible regardless of theme.
+      container_classes: "text-link underline underline-offset-2 hover:no-underline " \
+                         "focus-visible:outline-2 focus-visible:outline-offset-2 " \
+                         "focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white",
       icon_classes: "text-secondary"
     }
   ).freeze
@@ -18,10 +23,37 @@ class DS::Link < DS::Buttonish
       data = data.merge(turbo_frame: frame)
     end
 
+    # External link hardening: `target="_blank"` without `rel="noopener"`
+    # exposes window.opener to the new tab (reverse-tabnabbing). Always
+    # set `noopener noreferrer` when we send the user off-tab. Authors
+    # can override by passing `rel:` explicitly.
+    if merged_opts[:target].to_s == "_blank"
+      merged_opts[:rel] ||= "noopener noreferrer"
+    end
+
+    # Icon-only links have no visible text node, so screen readers fall
+    # back to announcing the href. Derive a humanized fallback from the
+    # icon key so AT users hear *something* meaningful; explicit
+    # `aria: { label: }` on the caller still wins. Mirrors DS::Button.
+    if icon_only? && icon.present?
+      aria = (merged_opts[:aria] || {}).symbolize_keys
+      if aria[:label].blank? && merged_opts[:"aria-label"].blank?
+        aria[:label] = icon.to_s.tr("-_", " ").capitalize
+        merged_opts[:aria] = aria
+      end
+    end
+
     merged_opts.merge(
       class: class_names(container_classes, extra_classes),
       data: data
     )
+  end
+
+  # Render an sr-only suffix when the link opens in a new tab so AT
+  # users hear "(opens in new tab)" — visual is a separate concern
+  # (callers can render a `external-link` icon if they want a glyph).
+  def opens_in_new_tab?
+    opts[:target].to_s == "_blank"
   end
 
   private

--- a/app/components/DS/link.rb
+++ b/app/components/DS/link.rb
@@ -35,10 +35,19 @@ class DS::Link < DS::Buttonish
     # back to announcing the href. Derive a humanized fallback from the
     # icon key so AT users hear *something* meaningful; explicit
     # `aria: { label: }` on the caller still wins. Mirrors DS::Button.
+    #
+    # When the link also opens in a new tab, fold the cue into the
+    # generated `aria-label` itself — `aria-label` overrides the
+    # descendant accessible name, so the sr-only "(opens in new tab)"
+    # span in the template would otherwise be masked.
     if icon_only? && icon.present?
       aria = (merged_opts[:aria] || {}).symbolize_keys
       if aria[:label].blank? && merged_opts[:"aria-label"].blank?
-        aria[:label] = icon.to_s.tr("-_", " ").capitalize
+        label = icon.to_s.tr("-_", " ").humanize
+        if merged_opts[:target].to_s == "_blank"
+          label = "#{label} #{I18n.t("ds.link.opens_in_new_tab", default: "(opens in new tab)")}"
+        end
+        aria[:label] = label
         merged_opts[:aria] = aria
       end
     end

--- a/config/locales/views/components/en.yml
+++ b/config/locales/views/components/en.yml
@@ -22,6 +22,8 @@ en:
       default_label: Beta
     dialog:
       close: Close
+    link:
+      opens_in_new_tab: (opens in new tab)
   provider_sync_summary:
     title: Sync summary
     last_sync: "Last sync: %{time_ago} ago"


### PR DESCRIPTION
## Summary

Five a11y fixes on `DS::Link` — three on the `:default` variant (the bare inline link), two on the link element shared by every variant. Closes #1739.

DS::Link extends DS::Buttonish, so the button-styled variants (`:primary`, `:secondary`, `:icon`, `:ghost`, etc.) inherit container styling from the base. The `:default` variant is the only one without a button shell.

## Fixes

### 1. Color-only differentiation (WCAG 1.4.1)

```diff
  default: {
-   container_classes: "",
+   container_classes: "text-link underline underline-offset-2 hover:no-underline \
+                       focus-visible:outline-2 focus-visible:outline-offset-2 \
+                       focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white",
    icon_classes: "text-secondary"
  }
```

The default variant rendered as plain-color text with no underline, weight change, or other distinguishing mark. Colorblind / low-vision users couldn't pick links out of body copy. Adding `text-link underline underline-offset-2` matches the marketing-page convention used elsewhere in the codebase (e.g. `_lunchflow_panel.html.erb`).

### 2. Focus ring on `<a>`

`base.css` only applies `focus-visible:outline` to `<button>`. `<a>` falls back to the (minimal) browser default. Adding `focus-visible:outline-2 outline-offset-2 outline-gray-900 theme-dark:outline-white` directly on the default variant mirrors the DS::Button ring from #1738. The Buttonish-derived variants render as buttons visually but as `<a>` — out of scope; their explicit focus styling lives in their own variant strings.

### 3. Icon-only accessible name

Mirror the DS::Button fix from #1738. Derive a humanized `aria-label` from the icon key when the caller doesn't provide one:

```ruby
if icon_only? && icon.present?
  aria = (merged_opts[:aria] || {}).symbolize_keys
  if aria[:label].blank? && merged_opts[:"aria-label"].blank?
    aria[:label] = icon.to_s.tr("-_", " ").capitalize
    merged_opts[:aria] = aria
  end
end
```

Soft fallback only — explicit `aria: { label: }` wins. Without it, an icon-only link would otherwise announce the raw URL.

### 4. External-link hardening — `rel="noopener noreferrer"`

`target="_blank"` without `rel="noopener"` exposes `window.opener` to the destination tab (reverse-tabnabbing — destination can redirect the source via `window.opener.location`). Set `rel="noopener noreferrer"` automatically when `target="_blank"`:

```ruby
if merged_opts[:target].to_s == "_blank"
  merged_opts[:rel] ||= "noopener noreferrer"
end
```

Explicit `rel:` from the caller wins.

### 5. sr-only "(opens in new tab)" hint

```erb
<% if opens_in_new_tab? %>
  <span class="sr-only"><%= t("ds.link.opens_in_new_tab", default: "(opens in new tab)") %></span>
<% end %>
```

AT users hear *"Mercury, link, opens in new tab"* instead of being silently shoved into a new context. Visual indicator (external-link glyph) stays at the caller's discretion.

Locale key: `ds.link.opens_in_new_tab` (en only — other locales handled in the i18n PR cadence per `feat/i18n-*` pattern).

## Diff

3 files, 39 insertions, 1 deletion.

- `app/components/DS/link.rb` — `default` variant classes; `merged_opts` adds rel + aria-label; new `opens_in_new_tab?` predicate.
- `app/components/DS/link.html.erb` — sr-only span suffix.
- `config/locales/views/components/en.yml` — new `ds.link.opens_in_new_tab` key.

## Compatibility

No existing DS::Link callsites use `target="_blank"` or are icon-only on `main`, so the new behavior doesn't change any rendered output today. The new defaults only kick in for future callers (and for any existing `:default`-variant caller, who picks up the underline + ring).

## Out of scope

- **Adding rel="noopener" / sr-only hint to non-DS `link_to` calls** across the codebase (~10 callsites in `_lunchflow_panel.html.erb`, `_simplefin_panel.html.erb`, `_enable_banking_panel.html.erb`, etc. — most already pass `rel:` correctly; the sr-only hint is a clean follow-up).
- **External-link glyph helper** (`<%= icon "external-link", class: "..." %>`) for the visual side — caller's job today; could become a `external: true` kwarg later.
- **Buttonish-variant focus rings** — `:icon`, `:icon_inverse`, `:secondary`, etc. variants on `DS::Link` render as `<a>` but inherit button styling. Their focus styling cascades from the `:focus-visible` rule on `<button>` in base.css, which won't match `<a>`. Out of scope here; will be a separate sweep alongside #1738 / future button-state work.

## Test plan

- [x] `bin/rubocop` clean.
- [x] `bundle exec erb_lint` clean.
- [x] `bin/rails tailwindcss:build` — new utilities compile.
- [x] `bin/rails test` — pending.
- [ ] Render `<%= render DS::Link.new(text: "Read the docs", href: "/docs", variant: :default) %>` in Lookbook, confirm underline + `text-link` color in both modes.
- [ ] Tab onto the link, confirm a 2px ring appears outside.
- [ ] Render `<%= render DS::Link.new(text: "Mercury", href: "https://mercury.com", target: "_blank") %>`, inspect markup: `rel="noopener noreferrer"` is present, an `sr-only` span follows the text.
- [ ] VoiceOver/NVDA: confirm announcement is *"Mercury, link, opens in new tab"*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links now include screen-reader text when they open in a new tab; localized cue added.

* **Bug Fixes**
  * Icon-only links receive auto-generated accessible labels (includes new-tab cue when applicable).
  * Improved focus-visible outline for better keyboard navigation.
  * External links opened in a new tab now include protective rel attributes for security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->