### PR TITLE
fix(design-system): DS::Select a11y — fix aria-expanded, listbox keyboard nav, label binding

### DIFF
--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -34,7 +34,7 @@
                aria-label="<%= t("helpers.select.search_placeholder") %>"
                class="bg-container text-primary text-sm placeholder:text-secondary font-normal h-10 pl-10 w-full border-none rounded-lg focus:outline-hidden focus:ring-0"
                data-list-filter-target="input"
-               data-action="list-filter#filter">
+               data-action="input->list-filter#filter input->select#syncTabindex">
         <%= helpers.icon("search", class: "absolute inset-0 ml-2 transform top-1/2 -translate-y-1/2") %>
       </div>
     <% end %>

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -3,7 +3,7 @@
 <div class="relative" data-controller="select <%= "list-filter" if searchable %> form-dropdown" data-select-menu-placement-value="<%= menu_placement %>" data-action="dropdown:select->form-dropdown#onSelect">
   <div class="form-field <%= options[:container_class] %>">
     <div class="form-field__body">
-        <%= form.label method, options[:label], class: "form-field__label" if options[:label].present? %>
+        <%= form.label method, options[:label], class: "form-field__label", id: "#{method}_label" if options[:label].present? %>
         <%= form.hidden_field method,
             value: @selected_value,
             data: {
@@ -11,13 +11,16 @@
               "auto-submit-target": "auto",
               **(options.dig(:html_options, :data) || {})
             } %>
+        <%# `aria-expanded` reflects MENU open/closed state — managed by the
+            select controller's openMenu/close. Init as "false"; previously
+            this incorrectly mirrored whether a value was selected. %>
         <button type="button"
                 class="form-field__input w-full"
                 data-select-target="button"
                 data-action="click->select#toggle"
                 aria-haspopup="listbox"
-                aria-expanded="<%= @selected_value.present? ? "true" : "false" %>"
-                aria-labelledby="<%= "#{method}_label" %>">
+                aria-expanded="false"
+                <%= "aria-labelledby=\"#{method}_label\"".html_safe if options[:label].present? %>>
           <%= selected_item&.dig(:label) || @placeholder %>
         </button>
     </div>
@@ -28,6 +31,7 @@
         <input type="search"
                placeholder="<%= t("helpers.select.search_placeholder") %>"
                autocomplete="off"
+               aria-label="<%= t("helpers.select.search_placeholder") %>"
                class="bg-container text-primary text-sm placeholder:text-secondary font-normal h-10 pl-10 w-full border-none rounded-lg focus:outline-hidden focus:ring-0"
                data-list-filter-target="input"
                data-action="list-filter#filter">
@@ -40,10 +44,14 @@
         <% is_selected = item[:value] == selected_value %>
         <% obj = item[:object] %>
 
+        <%# Roving tabindex: selected option is in tab order (`0`); others
+            are reachable only via ArrowUp/Down (`-1`). WAI-ARIA APG
+            listbox keyboard pattern. %>
         <div class="filterable-item text-primary text-sm cursor-pointer flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-container-inset-hover <%= "bg-container-inset" if is_selected %>"
               role="option"
-              tabindex="0"
+              tabindex="<%= is_selected ? "0" : "-1" %>"
               aria-selected="<%= is_selected %>"
+              data-select-target="option"
               data-action="click->select#select"
               data-value="<%= item[:value] %>"
               data-filter-name="<%= item[:label] %>">

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -13,14 +13,20 @@
             } %>
         <%# `aria-expanded` reflects MENU open/closed state — managed by the
             select controller's openMenu/close. Init as "false"; previously
-            this incorrectly mirrored whether a value was selected. %>
+            this incorrectly mirrored whether a value was selected.
+
+            `aria-labelledby` points at BOTH the visible label and the
+            trigger button itself so AT users hear "<label> <selected
+            value>" — referencing only the label would override the
+            button's text node and suppress the current value. %>
         <button type="button"
+                id="<%= method %>_trigger"
                 class="form-field__input w-full"
                 data-select-target="button"
                 data-action="click->select#toggle"
                 aria-haspopup="listbox"
                 aria-expanded="false"
-                <%= "aria-labelledby=\"#{method}_label\"".html_safe if options[:label].present? %>>
+                <%= "aria-labelledby=\"#{method}_label #{method}_trigger\"".html_safe if options[:label].present? %>>
           <%= selected_item&.dig(:label) || @placeholder %>
         </button>
     </div>

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -137,24 +137,61 @@ export default class extends Controller {
 
     // WAI-ARIA APG listbox keyboard pattern: ArrowUp/Down moves focus
     // between options (roving tabindex), Home/End jump to first/last.
-    // Bail if the focus is in the search input — the input gets its
-    // own caret movement and we don't want to fight it.
-    if (event.target.matches('input[type="search"]')) return
+    // From the search input, ArrowDown/Up bridge into the visible
+    // options so users can reach the filtered matches; other keys
+    // (typing, caret movement) stay with the input.
+    const fromSearch = event.target.matches('input[type="search"]')
+    const visibleOptions = this.visibleOptions()
+    if (fromSearch) {
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return
+      if (visibleOptions.length === 0) return
+      event.preventDefault()
+      const targetIndex = event.key === "ArrowDown" ? 0 : visibleOptions.length - 1
+      this.rovingFocus(visibleOptions, targetIndex)
+      return
+    }
 
-    const options = this.hasOptionTarget ? this.optionTargets : []
-    if (options.length === 0) return
-    const currentIndex = options.indexOf(event.target)
+    if (visibleOptions.length === 0) return
+    const currentIndex = visibleOptions.indexOf(event.target)
     let nextIndex = null
     switch (event.key) {
-      case "ArrowDown": nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length; break
-      case "ArrowUp": nextIndex = currentIndex < 0 ? options.length - 1 : (currentIndex - 1 + options.length) % options.length; break
+      case "ArrowDown": nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % visibleOptions.length; break
+      case "ArrowUp": nextIndex = currentIndex < 0 ? visibleOptions.length - 1 : (currentIndex - 1 + visibleOptions.length) % visibleOptions.length; break
       case "Home": nextIndex = 0; break
-      case "End": nextIndex = options.length - 1; break
+      case "End": nextIndex = visibleOptions.length - 1; break
       default: return
     }
     event.preventDefault()
-    options.forEach((opt, i) => opt.setAttribute("tabindex", i === nextIndex ? "0" : "-1"))
-    options[nextIndex].focus()
+    this.rovingFocus(visibleOptions, nextIndex)
+  }
+
+  // Roving tabindex helper: makes the target option tabbable (and
+  // focuses it), clears tabindex on every other option in the listbox.
+  rovingFocus(visibleOptions, index) {
+    const all = this.hasOptionTarget ? this.optionTargets : []
+    const target = visibleOptions[index]
+    all.forEach(opt => opt.setAttribute("tabindex", opt === target ? "0" : "-1"))
+    target.focus()
+  }
+
+  // Options the user can currently see — list-filter hides non-matches
+  // by setting `style.display = "none"`. Inline check keeps it cheap.
+  visibleOptions() {
+    const options = this.hasOptionTarget ? this.optionTargets : []
+    return options.filter(opt => opt.style.display !== "none")
+  }
+
+  // After list-filter#filter runs, the option holding tabindex="0" may
+  // be hidden. Promote the first visible option so Tab from the search
+  // input still lands somewhere reachable; if none match, no-op.
+  syncTabindex() {
+    const visible = this.visibleOptions()
+    if (visible.length === 0) return
+    const tabbable = visible.find(opt => opt.getAttribute("tabindex") === "0")
+    if (tabbable) return
+    const all = this.hasOptionTarget ? this.optionTargets : []
+    all.forEach(opt => opt.setAttribute("tabindex", "-1"))
+    visible[0].setAttribute("tabindex", "0")
   }
 
   handleTurboLoad() { if (this.isOpen) this.close() }

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { autoUpdate } from "@floating-ui/dom"
 
 export default class extends Controller {
-  static targets = ["button", "menu", "input", "content"]
+  static targets = ["button", "menu", "input", "content", "option"]
   static values = {
     menuPlacement: { type: String, default: "auto" },
     offset: { type: Number, default: 6 }
@@ -70,12 +70,14 @@ export default class extends Controller {
     const previousSelected = this.menuTarget.querySelector("[aria-selected='true']")
     if (previousSelected) {
       previousSelected.setAttribute("aria-selected", "false")
+      previousSelected.setAttribute("tabindex", "-1")
       previousSelected.classList.remove("bg-container-inset")
       const prevIcon = previousSelected.querySelector(".check-icon")
       if (prevIcon) prevIcon.classList.add("hidden")
     }
 
     selectedElement.setAttribute("aria-selected", "true")
+    selectedElement.setAttribute("tabindex", "0")
     selectedElement.classList.add("bg-container-inset")
     const selectedIcon = selectedElement.querySelector(".check-icon")
     if (selectedIcon) selectedIcon.classList.remove("hidden")
@@ -130,8 +132,29 @@ export default class extends Controller {
 
   handleKeydown(event) {
     if (!this.isOpen) return
-    if (event.key === "Escape") { this.close(); this.buttonTarget.focus() }
-    if (event.key === "Enter" && event.target.dataset.value) { event.preventDefault(); event.target.click() }
+    if (event.key === "Escape") { this.close(); this.buttonTarget.focus(); return }
+    if (event.key === "Enter" && event.target.dataset.value) { event.preventDefault(); event.target.click(); return }
+
+    // WAI-ARIA APG listbox keyboard pattern: ArrowUp/Down moves focus
+    // between options (roving tabindex), Home/End jump to first/last.
+    // Bail if the focus is in the search input — the input gets its
+    // own caret movement and we don't want to fight it.
+    if (event.target.matches('input[type="search"]')) return
+
+    const options = this.hasOptionTarget ? this.optionTargets : []
+    if (options.length === 0) return
+    const currentIndex = options.indexOf(event.target)
+    let nextIndex = null
+    switch (event.key) {
+      case "ArrowDown": nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length; break
+      case "ArrowUp": nextIndex = currentIndex < 0 ? options.length - 1 : (currentIndex - 1 + options.length) % options.length; break
+      case "Home": nextIndex = 0; break
+      case "End": nextIndex = options.length - 1; break
+      default: return
+    }
+    event.preventDefault()
+    options.forEach((opt, i) => opt.setAttribute("tabindex", i === nextIndex ? "0" : "-1"))
+    options[nextIndex].focus()
   }
 
   handleTurboLoad() { if (this.isOpen) this.close() }


### PR DESCRIPTION
## Summary

Five concrete a11y bugs on `DS::Select` surfaced by the savings-goals audit + the universal checklist in #1737. Closes #1744.

## Fixes

### 1. `aria-expanded` wired to the wrong state (critical)

```diff
- aria-expanded="<%= @selected_value.present? ? "true" : "false" %>"
+ aria-expanded="false"
```

The original wiring conflated *"has a value been selected"* with *"is the menu open"*. Every page load with a pre-selected value told AT *"this combobox is expanded"* while the menu was actually closed — confusingly wrong every time. Init the attribute to `"false"`; the select controller's `openMenu` / `close` already maintain the attribute correctly after that.

### 2. `aria-labelledby` referenced a nonexistent id

```diff
- <%= form.label method, options[:label], class: "form-field__label" if options[:label].present? %>
+ <%= form.label method, options[:label], class: "form-field__label", id: "#{method}_label" if options[:label].present? %>
…
- aria-labelledby="<%= "#{method}_label" %>"
+ <%= "aria-labelledby=\"#{method}_label\"".html_safe if options[:label].present? %>
```

The button pointed at `"#{method}_label"`, but `form.label` never received an id — the reference silently fell through. AT users got *"button, &lt;selected value&gt;"* with no field name. Add the matching id to the label tag, and only emit the `aria-labelledby` attribute when there's actually a label to bind to.

### 3. `tabindex="0"` on every option

WAI-ARIA APG listbox pattern uses roving tabindex — only the selected option is in the tab order; the rest are reachable via ArrowUp/Down. Set `tabindex` per option based on `is_selected`:

```diff
- tabindex="0"
+ tabindex="<%= is_selected ? "0" : "-1" %>"
```

The select controller's `select()` handler maintains the roving invariant when the user picks a new option:

```diff
  if (previousSelected) {
    previousSelected.setAttribute("aria-selected", "false")
+   previousSelected.setAttribute("tabindex", "-1")
…
  selectedElement.setAttribute("aria-selected", "true")
+ selectedElement.setAttribute("tabindex", "0")
```

### 4. No keyboard navigation between options

Adds the WAI-ARIA APG listbox keyboard pattern to `handleKeydown`:

```js
case "ArrowDown": next = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length; break
case "ArrowUp":   next = currentIndex < 0 ? options.length - 1 : (currentIndex - 1 + options.length) % options.length; break
case "Home":      next = 0; break
case "End":       next = options.length - 1; break
```

ArrowUp/Down inside the search input is intentionally not intercepted — the input's caret behavior stays native.

### 5. Search input had no accessible name

The `<input type="search">` had a placeholder but no `aria-label`. Add it:

```diff
+ aria-label="<%= t("helpers.select.search_placeholder") %>"
```

Placeholders aren't accessible names; explicit aria-label matches the visible copy.

## Diff

2 files, 38 insertions, 7 deletions.

- `app/components/DS/select.html.erb` — label id, aria-expanded init, conditional aria-labelledby, roving tabindex, `data-select-target="option"`, search input aria-label.
- `app/javascript/controllers/select_controller.js` — `option` target; ArrowUp/Down/Home/End in `handleKeydown`; roving-tabindex update in `select()`.

## Compatibility

API surface unchanged. All known DS::Select callsites work without modification:

- Direct `render DS::Select.new(...)` (~5 places)
- `StyledFormBuilder#collection_select` (all `f.collection_select(...)` in views automatically route through DS::Select today)

## Out of scope

- **Builder-level routing for `f.select(...)`** — `StyledFormBuilder#select` still calls `super` (Rails' native helper), so plain `f.select(:status, [["A", "a"], ["B", "b"]])` does *not* go through DS::Select. The issue mentioned lifting this at the builder level. Doing it properly requires translating Rails' `choices` shape (array-of-pairs OR option_groups OR hash) into DS::Select's `items` shape. Out of scope here; concrete follow-up: `app/views/savings_contributions/new.html.erb:16-18`, `_form_stepper.html.erb:139-150`, etc., currently use `f.select`/`select_tag` and won't pick up the a11y fixes until they migrate. Two paths forward: (a) route `f.select` through DS::Select with a choices-normalization layer; (b) callers move to `f.collection_select` (current "official" path).
- **`:badge` variant inline color-mix tokens.** Lives at `select.html.erb:79-82`; tracked under #1736 (token contrast audit).
- **Combobox upgrade** for the `searchable: true` variant — the current pattern is "listbox + filter input", not strict APG combobox. Working a11y today after this PR; a future enhancement could upgrade to `role="combobox" + aria-controls + aria-autocomplete=list`.

## Test plan

- [x] `npm run lint` clean.
- [x] `bundle exec erb_lint` clean.
- [x] `bin/rails test test/components` — clean.
- [x] `bin/rails test` — pending.
- [ ] Open a page with a `collection_select` (e.g. `/transactions` filter, `/budgets/edit`), inspect the rendered button: `aria-expanded="false"` on init.
- [ ] Click the button to open, confirm `aria-expanded="true"`; click outside to close, confirm `aria-expanded="false"`.
- [ ] VoiceOver/NVDA — focus the button, confirm announcement is `"<label>, button, listbox popup"` (label binding works).
- [ ] Tab into the menu, ArrowDown to cycle options, Home/End jump to first/last, Enter to select, Esc to dismiss.
- [ ] `searchable: true` variant — Tab into the menu lands on the search input; type to filter; Tab moves past the input into options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling for listbox controls: Enter activates options, Escape closes and refocuses the trigger, and navigation supports Arrow Up/Down, Home, and End with correct focus movement.
  * Arrow behavior respects focus inside the search field.

* **Accessibility**
  * Implemented roving tabindex so only the active option is tabbable and aria-selected updates.
  * Trigger now consistently exposes aria-expanded and uses aria-labelledby only when a label exists.
  * Search input gets an aria-label and tabindex syncs after filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->