### PR TITLE
i18n(en): hardcode 'One error' in sso_providers errors_title singular form

### DIFF
--- a/config/locales/views/admin/sso_providers/en.yml
+++ b/config/locales/views/admin/sso_providers/en.yml
@@ -94,7 +94,7 @@ en:
         create_provider: "Create Provider"
         update_provider: "Update Provider"
         errors_title:
-          one: "%{count} error prohibited this provider from being saved:"
+          one: "One error prohibited this provider from being saved:"
           other: "%{count} errors prohibited this provider from being saved:"
         provisioning_title: "User Provisioning"
         default_role_label: "Default Role for New Users"

--- a/config/locales/views/admin/sso_providers/en.yml
+++ b/config/locales/views/admin/sso_providers/en.yml
@@ -94,7 +94,7 @@ en:
         create_provider: "Create Provider"
         update_provider: "Update Provider"
         errors_title:
-          one: "One error prohibited this provider from being saved:"
+          one: "An error prohibited this provider from being saved:"
           other: "%{count} errors prohibited this provider from being saved:"
         provisioning_title: "User Provisioning"
         default_role_label: "Default Role for New Users"


### PR DESCRIPTION
## Summary

Per [@jjmata review feedback on #1830](https://github.com/we-promise/sure/pull/1830) (merged): the `one:` branch of `admin.sso_providers.form.errors_title` should hardcode `"One error prohibited..."` instead of interpolating `%{count}`. Reads more naturally in prose than `"1 error prohibited..."`.

```yaml
errors_title:
  one: "One error prohibited this provider from being saved:"   # was: "%{count} error prohibited..."
  other: "%{count} errors prohibited this provider from being saved:"
```

`other:` keeps `%{count}` — "2 errors...", "3 errors..." etc still interpolate.

Scope: EN only. Other locales (`ca`, `es`, `fr`, `de`, `nl`, `pl`, `hu`) currently use flat strings with `%{count}` and are unchanged — style call for each locale's reviewer.

## Test plan

- [ ] Trigger an SSO provider form validation error with exactly 1 error → message reads "One error prohibited this provider from being saved:"
- [ ] Trigger 2+ errors → message reads "N errors prohibited this provider from being saved:"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSO provider form validation messages now show a clear singular message when only one error occurs, improving clarity and readability for users. Plural messaging for multiple errors remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->