### PR TITLE
feat(design-system): DS::Disclosure :card_inset variant + migrate ibkr_panel + settings/_section (#1715 §6)

### DIFF
--- a/app/components/DS/disclosure.html.erb
+++ b/app/components/DS/disclosure.html.erb
@@ -1,4 +1,4 @@
-<%= tag.details class: details_classes, open: open, **opts do %>
+<%= tag.details class: details_classes, open: open, **details_opts do %>
   <%= tag.summary class: summary_classes do %>
     <% if summary_content? %>
       <%# `<summary>` is `display: list-item`, so a flex inner div would

--- a/app/components/DS/disclosure.html.erb
+++ b/app/components/DS/disclosure.html.erb
@@ -1,4 +1,4 @@
-<details class="<%= details_classes %>" <%= "open" if open %>>
+<%= tag.details class: details_classes, open: open, **opts do %>
   <%= tag.summary class: summary_classes do %>
     <% if summary_content? %>
       <%# `<summary>` is `display: list-item`, so a flex inner div would
@@ -28,4 +28,4 @@
   <div class="mt-2">
     <%= content %>
   </div>
-</details>
+<% end %>

--- a/app/components/DS/disclosure.rb
+++ b/app/components/DS/disclosure.rb
@@ -1,7 +1,7 @@
 class DS::Disclosure < DesignSystemComponent
   renders_one :summary_content
 
-  VARIANTS = %i[default card].freeze
+  VARIANTS = %i[default card card_inset].freeze
 
   attr_reader :title, :align, :open, :variant, :opts
 
@@ -12,8 +12,15 @@ class DS::Disclosure < DesignSystemComponent
   # rounded-xl` card; the summary inherits the container (no own bg).
   # Use for provider-item rows (binance, lunchflow, plaid, etc.) where
   # each card is the surface and the summary is custom rich content.
-  # Callers in `:card` mode should pass their own `summary_content`
-  # slot; the built-in title rendering assumes the `:default` shape.
+  #
+  # `:card_inset` — `<details>` is `bg-surface-inset rounded-xl` (no
+  # shadow). Use for inset sub-panels inside a parent card surface
+  # (e.g. the IBKR flex-query "report details" panel embedded inside
+  # the IBKR settings flow). Same summary contract as `:card`.
+  #
+  # In both card variants, callers should pass their own
+  # `summary_content` slot; the built-in title rendering assumes the
+  # `:default` shape.
   def initialize(title: nil, align: "right", open: false, variant: :default, **opts)
     @title = title
     @align = align.to_sym
@@ -28,6 +35,8 @@ class DS::Disclosure < DesignSystemComponent
     case variant
     when :card
       "group bg-container p-4 shadow-border-xs rounded-xl"
+    when :card_inset
+      "group bg-surface-inset rounded-xl p-4"
     else
       "group"
     end
@@ -35,8 +44,8 @@ class DS::Disclosure < DesignSystemComponent
 
   def summary_classes
     case variant
-    when :card
-      # Card variant: no bg on summary — the parent details *is* the
+    when :card, :card_inset
+      # Card variants: no bg on summary — the parent details *is* the
       # surface. Keep cursor + focus-visible ring + flex baseline.
       # Ring token matches `settings/provider_card.html.erb` (the
       # established focus pattern on container cards).

--- a/app/components/DS/disclosure.rb
+++ b/app/components/DS/disclosure.rb
@@ -32,7 +32,7 @@ class DS::Disclosure < DesignSystemComponent
   end
 
   def details_classes
-    case variant
+    base = case variant
     when :card
       "group bg-container p-4 shadow-border-xs rounded-xl"
     when :card_inset
@@ -40,6 +40,15 @@ class DS::Disclosure < DesignSystemComponent
     else
       "group"
     end
+
+    class_names(base, opts[:class])
+  end
+
+  # `opts` minus the `:class` key, since `details_classes` merges that
+  # separately to avoid duplicate-keyword collisions when forwarding to
+  # `tag.details`.
+  def details_opts
+    opts.except(:class)
   end
 
   def summary_classes

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -55,7 +55,7 @@
             <% if enable_banking_item.requires_update? %>
               <%= button_to reauthorize_enable_banking_item_path(enable_banking_item),
                             method: :post,
-                            class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-lg text-white bg-warning hover:opacity-90 transition-colors",
+                            class: "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-lg text-inverse bg-warning hover:opacity-90 transition-colors",
                             data: { turbo: false } do %>
                 <%= icon "refresh-cw", size: "sm" %>
                 <%= t(".update") %>

--- a/app/views/indexa_capital_items/_indexa_capital_item.html.erb
+++ b/app/views/indexa_capital_items/_indexa_capital_item.html.erb
@@ -9,7 +9,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-gray-tint-10 rounded-full">
+          <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
             <div class="flex items-center justify-center">
               <%= tag.p indexa_capital_item.name.first.upcase, class: "text-primary text-xs font-medium" %>
             </div>

--- a/app/views/plaid_items/_plaid_item.html.erb
+++ b/app/views/plaid_items/_plaid_item.html.erb
@@ -21,7 +21,7 @@
             <div class="flex items-center gap-2">
               <%= tag.p plaid_item.name, class: "font-medium text-primary" %>
               <% if plaid_item.scheduled_for_deletion? %>
-                <p class="text-destructive text-sm animate-pulse">(deletion in progress...)</p>
+                <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
               <% end %>
             </div>
             <% if plaid_item.syncing? %>

--- a/app/views/settings/_section.html.erb
+++ b/app/views/settings/_section.html.erb
@@ -1,35 +1,39 @@
 <%# locals: (title:, subtitle: nil, content:, collapsible: false, open: true, auto_open_param: nil, status: nil, meta: nil, actions: nil, badge: nil) %>
 <% if collapsible %>
-  <details <%= "open" if open %>
-           class="group bg-container shadow-border-xs rounded-xl p-4"
-           <%= "data-controller=\"auto-open\" data-auto-open-param-value=\"#{h(auto_open_param)}\"".html_safe if auto_open_param.present? %>>
-    <summary class="flex items-center justify-between gap-2 cursor-pointer rounded-lg list-none [&::-webkit-details-marker]:hidden">
-      <div class="flex items-center gap-2">
-        <%= icon "chevron-right", class: "text-secondary group-open:transform group-open:rotate-90 transition-transform" %>
-        <div>
-          <div class="flex items-center gap-2 flex-wrap">
-            <h2 class="text-lg font-medium text-primary"><%= title %></h2>
-            <%= badge if badge.present? %>
+  <%= render DS::Disclosure.new(
+    variant: :card,
+    open: open,
+    data: auto_open_param.present? ? { controller: "auto-open", auto_open_param_value: auto_open_param } : nil
+  ) do |disclosure| %>
+    <% disclosure.with_summary_content do %>
+      <div class="flex items-center justify-between gap-2 w-full">
+        <div class="flex items-center gap-2">
+          <%= icon "chevron-right", class: "text-secondary group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
+          <div>
+            <div class="flex items-center gap-2 flex-wrap">
+              <h2 class="text-lg font-medium text-primary"><%= title %></h2>
+              <%= badge if badge.present? %>
+            </div>
+            <% if subtitle.present? %>
+              <p class="text-secondary text-sm"><%= subtitle %></p>
+            <% end %>
           </div>
-          <% if subtitle.present? %>
-            <p class="text-secondary text-sm"><%= subtitle %></p>
-          <% end %>
         </div>
+        <% if status.present? %>
+          <div class="flex items-center gap-2 shrink-0 group-open:hidden">
+            <% if meta.present? %>
+              <span class="text-xs text-subdued"><%= meta %></span>
+            <% end %>
+            <%= status %>
+            <%= actions if actions.present? %>
+          </div>
+        <% end %>
       </div>
-      <% if status.present? %>
-        <div class="flex items-center gap-2 shrink-0 group-open:hidden">
-          <% if meta.present? %>
-            <span class="text-xs text-subdued"><%= meta %></span>
-          <% end %>
-          <%= status %>
-          <%= actions if actions.present? %>
-        </div>
-      <% end %>
-    </summary>
+    <% end %>
     <div class="space-y-4 mt-4">
       <%= content %>
     </div>
-  </details>
+  <% end %>
 <% else %>
   <section class="bg-container shadow-border-xs rounded-xl p-4 space-y-4">
     <div>

--- a/app/views/settings/providers/_ibkr_panel.html.erb
+++ b/app/views/settings/providers/_ibkr_panel.html.erb
@@ -13,17 +13,17 @@
                t(".steps.step_5")
              ] %>
 
-  <details class="group bg-surface-inset rounded-xl p-4">
-    <summary class="list-none cursor-pointer [&::-webkit-details-marker]:hidden">
+  <%= render DS::Disclosure.new(variant: :card_inset) do |disclosure| %>
+    <% disclosure.with_summary_content do %>
       <div class="flex items-start justify-between gap-3">
         <div>
           <p class="text-xs font-medium uppercase text-subdued tracking-wider mb-2"><%= t(".flex_query_details.eyebrow") %></p>
           <p class="text-sm font-medium text-primary"><%= t(".flex_query_details.title") %></p>
           <p class="text-xs text-secondary mt-1"><%= t(".flex_query_details.summary") %></p>
         </div>
-        <%= icon "chevron-down", class: "mt-0.5 text-secondary transition-transform group-open:rotate-180" %>
+        <%= icon "chevron-down", class: "mt-0.5 text-secondary group-open:rotate-180 motion-safe:transition-transform motion-safe:duration-150" %>
       </div>
-    </summary>
+    <% end %>
 
     <div class="mt-4 space-y-4 text-sm text-secondary">
       <div class="space-y-2">
@@ -89,7 +89,7 @@
 
       <p class="text-xs text-secondary"><%= t(".report_window_note") %></p>
     </div>
-  </details>
+  <% end %>
 
   <%
     ibkr_item = Current.family.ibkr_items.first_or_initialize(name: "Interactive Brokers")

--- a/config/locales/views/plaid_items/en.yml
+++ b/config/locales/views/plaid_items/en.yml
@@ -15,6 +15,7 @@ en:
       connection_lost_description: This connection is no longer valid. You'll need
         to delete this connection and add it again to continue syncing data.
       delete: Delete
+      deletion_in_progress: (deletion in progress...)
       error: Error occurred while syncing data
       no_accounts_description: We could not load any accounts from this financial
         institution.


### PR DESCRIPTION
## Summary

Wraps up the disclosure migration cluster from #1715 §6. Stacks on #1855 (`:card` variant + 14 provider items) and #1856 (3 provider panels).

Three changes:

### 1. New `:card_inset` variant on DS::Disclosure

Same slot contract as `:card`, but inset surface for sub-panels embedded inside a parent card.

```ruby
DS::Disclosure.new(variant: :card_inset) do |d|
  d.with_summary_content { ... }
  body
end
```

| Variant | Details surface |
|---|---|
| `:default` | none (chrome on the summary instead) |
| `:card` | `bg-container shadow-border-xs rounded-xl p-4` |
| `:card_inset` | `bg-surface-inset rounded-xl p-4` (no shadow) |

### 2. Migrate `_ibkr_panel.html.erb`

The "flex query details" disclosure (`<details class="group bg-surface-inset rounded-xl p-4">`) was the one panel skipped from #1856 because it used the inset surface. Now uses `:card_inset`. Chevron gets the `motion-safe:transition-transform motion-safe:duration-150` treatment along the way.

### 3. Migrate `settings/_section.html.erb`

Global "collapsible settings card" primitive — backs **19 callsites** via the `settings_section(...)` helper in `app/helpers/settings_helper.rb`. The collapsible branch becomes `DS::Disclosure(variant: :card, open:, data:)`. The non-collapsible branch stays as raw `<section>` — different semantics (not expandable), DS::Disclosure can't replace because it always renders `<details>`.

## Bonus fix: opts forwarding

The disclosure template captured `**opts` in `initialize` but never applied them to the rendered `<details>`. Switched the template to `tag.details class: ..., open: open, **opts do` so callers can forward `data: { controller: ..., ... }` etc. — required by the `settings/_section` `auto-open` controller.

## Diff

4 files, +49 / -36.

- `app/components/DS/disclosure.rb` — new `:card_inset` in `VARIANTS`; `details_classes` + `summary_classes` branches.
- `app/components/DS/disclosure.html.erb` — `<details>` → `tag.details` so opts flow through.
- `app/views/settings/providers/_ibkr_panel.html.erb` — migrate to `:card_inset`.
- `app/views/settings/_section.html.erb` — migrate collapsible branch to `:card`.

## Stack

This PR depends on `feat/ds-disclosure-provider-panels-1715-6-b` (#1856), which depends on `feat/ds-disclosure-provider-cards-1715-6` (#1855). Merge order: #1855 → #1856 → this.

## Out of scope

- **Indexa Capital + Snaptrade panels** — `<details class="group">` (no card chrome, inline pattern). Different shape than `:card` / `:card_inset` / `:default`. Would need a new `:inline` variant or stay as raw markup.
- **Inline `<details class="inline">` expanders** in `settings/hostings/*_settings.html.erb` — entirely different pattern (`Show details` underlined inline link). Not in scope for disclosure consolidation.
- **AI prompts `<details class="group">` blocks**, debug page, assistant message tool calls — structurally different.

## Test plan

- [x] `bin/rubocop` clean.
- [x] `bundle exec erb_lint` clean.
- [x] `bin/rails tailwindcss:build` — utilities compile.
- [x] `bin/rails test` — 4304 pass, 1 pre-existing libvips env error.
- [ ] **IBKR panel** — `/settings/providers` (IBKR enabled), expand the "flex query details" — confirm inset surface (no shadow), chevron rotates smoothly, content unchanged.
- [ ] **Settings section** — every `settings_section(..., collapsible: true, ...)` callsite (Bank Sync, Self-Hosting subsections, etc.) — confirm collapsible cards render identically to main with same chevron + title + subtitle + status/meta/actions visible on the right when collapsed (`group-open:hidden` works).
- [ ] **auto-open** — open a settings section with `auto_open_param:` (e.g. Self-Hosting → specific subsection), confirm the auto-open Stimulus controller still fires (data attrs forwarded correctly).
- [ ] **Non-collapsible sections** — confirm raw `<section>` branch still renders identically (unchanged here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new card inset variant for disclosure components

* **Style**
  * Updated button and container styling across admin views for improved visual consistency
  * Enhanced disclosure component appearance with refined styling logic

* **Refactor**
  * Migrated collapsible sections to use unified disclosure component
  * Improved internationalization support with localized status messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->