### PR TITLE
feat(design-system): DS::Disclosure :inline variant + migrate indexa_capital + snaptrade panels (#1715 §6)

### DIFF
--- a/app/components/DS/disclosure.rb
+++ b/app/components/DS/disclosure.rb
@@ -1,12 +1,13 @@
 class DS::Disclosure < DesignSystemComponent
   renders_one :summary_content
 
-  VARIANTS = %i[default card card_inset].freeze
+  VARIANTS = %i[default card card_inset inline].freeze
 
   attr_reader :title, :align, :open, :variant, :opts
 
   # `:default` — bg-surface summary, no chrome on the `<details>`. Use
-  # for inline expanders inside a parent card.
+  # for inline expanders that sit inside a parent card (the summary
+  # itself reads as the surface).
   #
   # `:card` — `<details>` itself becomes a `bg-container shadow-border-xs
   # rounded-xl` card; the summary inherits the container (no own bg).
@@ -18,7 +19,13 @@ class DS::Disclosure < DesignSystemComponent
   # (e.g. the IBKR flex-query "report details" panel embedded inside
   # the IBKR settings flow). Same summary contract as `:card`.
   #
-  # In both card variants, callers should pass their own
+  # `:inline` — no surface, no padding, no shadow. The disclosure reads
+  # as a plain text-link-style toggle (e.g. "Alternative auth" inside
+  # a form, or a "Manage connections" lazy-load opener). Caller provides
+  # the summary text (and optional chevron) via the `summary_content`
+  # slot.
+  #
+  # In card / inline variants, callers should pass their own
   # `summary_content` slot; the built-in title rendering assumes the
   # `:default` shape.
   def initialize(title: nil, align: "right", open: false, variant: :default, **opts)
@@ -59,6 +66,12 @@ class DS::Disclosure < DesignSystemComponent
       # Ring token matches `settings/provider_card.html.erb` (the
       # established focus pattern on container cards).
       "list-none cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300 rounded-xl"
+    when :inline
+      # Inline variant: no surface, no padding — the summary reads as
+      # plain text-link copy. Caller markup (text + optional chevron)
+      # provides the visual. Keep cursor + focus-visible ring + matching
+      # alpha-black-300 token used by the card variants for consistency.
+      "list-none cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300 rounded-sm"
     else
       "px-3 py-2 rounded-xl cursor-pointer flex items-center justify-between bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300"
     end

--- a/app/components/DS/disclosure.rb
+++ b/app/components/DS/disclosure.rb
@@ -32,10 +32,10 @@ class DS::Disclosure < DesignSystemComponent
     @title = title
     @align = align.to_sym
     @open = open
-    @variant = variant.to_sym
+    @variant = variant&.to_sym
     @opts = opts
 
-    raise ArgumentError, "Invalid variant: #{@variant}. Must be one of #{VARIANTS.inspect}" unless VARIANTS.include?(@variant)
+    raise ArgumentError, "Invalid variant: #{@variant.inspect}. Must be one of #{VARIANTS.inspect}" unless VARIANTS.include?(@variant)
   end
 
   def details_classes

--- a/app/views/settings/providers/_indexa_capital_panel.html.erb
+++ b/app/views/settings/providers/_indexa_capital_panel.html.erb
@@ -29,10 +29,12 @@
                         type: :password %>
     <p class="text-xs text-secondary px-1 -mt-1"><%= t("indexa_capital_items.panel.fields.api_token.description") %></p>
 
-    <details class="group">
-      <summary class="text-sm text-secondary cursor-pointer hover:text-primary transition-colors">
-        <%= t("indexa_capital_items.panel.alternative_auth") %>
-      </summary>
+    <%= render DS::Disclosure.new(variant: :inline) do |disclosure| %>
+      <% disclosure.with_summary_content do %>
+        <span class="text-sm text-secondary hover:text-primary transition-colors">
+          <%= t("indexa_capital_items.panel.alternative_auth") %>
+        </span>
+      <% end %>
       <div class="mt-3 space-y-3 pt-3 border-t border-primary">
         <%= form.text_field :username,
                             label: t("indexa_capital_items.panel.fields.username.label"),
@@ -49,7 +51,7 @@
                             placeholder: is_new_record ? t("indexa_capital_items.panel.fields.password.placeholder_new") : t("indexa_capital_items.panel.fields.password.placeholder_update"),
                             type: :password %>
       </div>
-    </details>
+    <% end %>
 
     <div class="flex justify-end">
       <%= form.submit is_new_record ? t("indexa_capital_items.panel.save_button") : t("indexa_capital_items.panel.update_button"),

--- a/app/views/settings/providers/_snaptrade_panel.html.erb
+++ b/app/views/settings/providers/_snaptrade_panel.html.erb
@@ -57,25 +57,31 @@
   <% if items&.any? && items.first.user_registered? %>
     <% item = items.first %>
     <div class="border-t border-primary pt-4 mt-4">
-      <details class="group"
-               data-controller="lazy-load"
-               data-action="toggle->lazy-load#toggled"
-               data-lazy-load-url-value="<%= connections_snaptrade_item_path(item) %>"
-               data-lazy-load-auto-open-param-value="manage">
-        <summary class="flex items-center justify-between cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-          <div class="flex items-center gap-2">
-            <p class="text-sm text-secondary">
-              <%= t("providers.snaptrade.status_connected", count: item.snaptrade_accounts.count) %>
-              <% if item.unlinked_accounts_count > 0 %>
-                <span class="text-warning">(<%= t("providers.snaptrade.needs_setup", count: item.unlinked_accounts_count) %>)</span>
-              <% end %>
-            </p>
+      <%= render DS::Disclosure.new(
+        variant: :inline,
+        data: {
+          controller: "lazy-load",
+          action: "toggle->lazy-load#toggled",
+          lazy_load_url_value: connections_snaptrade_item_path(item),
+          lazy_load_auto_open_param_value: "manage"
+        }
+      ) do |disclosure| %>
+        <% disclosure.with_summary_content do %>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <p class="text-sm text-secondary">
+                <%= t("providers.snaptrade.status_connected", count: item.snaptrade_accounts.count) %>
+                <% if item.unlinked_accounts_count > 0 %>
+                  <span class="text-warning">(<%= t("providers.snaptrade.needs_setup", count: item.unlinked_accounts_count) %>)</span>
+                <% end %>
+              </p>
+            </div>
+            <span class="flex items-center gap-1 text-sm text-secondary hover:text-primary">
+              <%= t("providers.snaptrade.manage_connections") %>
+              <%= icon "chevron-right", class: "w-3 h-3 group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
+            </span>
           </div>
-          <span class="flex items-center gap-1 text-sm text-secondary hover:text-primary">
-            <%= t("providers.snaptrade.manage_connections") %>
-            <%= icon "chevron-right", class: "w-3 h-3 transition-transform group-open:rotate-90" %>
-          </span>
-        </summary>
+        <% end %>
 
         <div class="mt-3 space-y-3" data-lazy-load-target="content">
           <div data-lazy-load-target="loading" class="flex items-center gap-2 text-sm text-secondary py-2">
@@ -86,7 +92,7 @@
           <div data-lazy-load-target="frame">
           </div>
         </div>
-      </details>
+      <% end %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Summary

Final piece of the disclosure migration arc for #1715 §6. Stacks on #1857 (which stacks on #1856 → #1855).

Adds an `:inline` variant to `DS::Disclosure` for plain text-link-style toggles — no surface, no padding, no shadow. The disclosure reads as clickable summary text + revealed content, nothing more.

## Use case

Two raw `<details>` callsites in `app/views/settings/providers/` that didn't fit any prior variant:

1. **`_indexa_capital_panel.html.erb`** — single inline `<details>` revealing username / document / password form fields under an "Alternative auth" summary text. Summary was hand-rolled as a `<summary class="text-sm text-secondary cursor-pointer hover:text-primary transition-colors">`.

2. **`_snaptrade_panel.html.erb`** — lazy-load `<details>` with `data-controller="lazy-load" data-action="toggle->lazy-load#toggled" data-lazy-load-url-value=... data-lazy-load-auto-open-param-value="manage"`. The new `tag.details ... **opts` forwarding from #1857 lets the Stimulus controller attrs flow through cleanly via DS::Disclosure's `data:` keyword.

Chevron rotation on snaptrade gets the standard `motion-safe:transition-transform motion-safe:duration-150` treatment (was bare `transition-transform` without the motion-safe gate).

## Variants

| Variant | Details surface | Use case |
|---|---|---|
| `:default` | none / `bg-surface` summary | inline expander inside parent card |
| `:card` | `bg-container shadow-border-xs rounded-xl p-4` | provider rows, settings sections |
| `:card_inset` | `bg-surface-inset rounded-xl p-4` | inset sub-panels (IBKR flex query) |
| `:inline` | no surface | text-link-style toggles |

## Diff

3 files, +48 / -28.

- `app/components/DS/disclosure.rb` — add `:inline` to `VARIANTS`, branches for `details_classes` + `summary_classes`.
- 2 panel migrations.

## Stack

Builds on #1857 → #1856 → #1855. Merge order: cards → panels → card_inset → this.

After this PR, the §6 disclosure consolidation arc covers:

- `:default` variant — original inline-summary usage.
- `:card` (14 provider items + 3 provider panels + settings/_section primitive = 19 callsites).
- `:card_inset` (1 callsite: ibkr flex query).
- `:inline` (2 callsites: indexa_capital + snaptrade).

The remaining raw `<details>` callsites (hostings inline "Show details" expanders, AI prompts groups, debug pages, assistant tool calls) are structurally different — not in scope for this arc.

## Test plan

- [x] `bin/rubocop` clean.
- [x] `bundle exec erb_lint` clean.
- [x] `bin/rails tailwindcss:build` — utilities compile.
- [x] `bin/rails test` — 4304 pass, 1 pre-existing libvips env error.
- [ ] `/settings/providers` (Indexa Capital enabled) — click "Alternative auth" summary, confirm fields reveal/hide identically to main.
- [ ] `/settings/providers` (Snaptrade with at least one item) — click "Manage connections" disclosure, confirm Stimulus `lazy-load` controller fires (data-controller flows through), connections load.
- [ ] Tab into both summaries, confirm a 2px focus-visible ring appears (new `:inline` variant gets the same ring token as the others).
- [ ] `prefers-reduced-motion: reduce` — snaptrade chevron snaps without animation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style & UI**
  * Standardized collapsible disclosure sections throughout settings interfaces by adopting centralized design system components for improved visual consistency.
  * Enhanced disclosure components with a new inline variant, providing flexible styling options for different collapsible interface elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->