### PR TITLE
refactor(design-system): migrate 38 hand-rolled provider buttons to DS::Button / DS::Link (#1715 §5 part B)

### DIFF
--- a/app/views/brex_items/_api_error.html.erb
+++ b/app/views/brex_items/_api_error.html.erb
@@ -24,11 +24,12 @@
         </div>
 
         <div class="mt-4">
-          <%= link_to return_path.presence || settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors",
-                      data: { turbo: false } do %>
-            <%= t(".settings_link") %>
-          <% end %>
+          <%= render DS::Link.new(
+            text: t(".settings_link"),
+            href: return_path.presence || settings_providers_path,
+            variant: :primary,
+            data: { turbo: false }
+          ) %>
         </div>
       </div>
     <% end %>

--- a/app/views/brex_items/_setup_required.html.erb
+++ b/app/views/brex_items/_setup_required.html.erb
@@ -22,11 +22,12 @@
         </div>
 
         <div class="mt-4">
-          <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors",
-                      data: { turbo: false } do %>
-            <%= t(".settings_link") %>
-          <% end %>
+          <%= render DS::Link.new(
+            text: t(".settings_link"),
+            href: settings_providers_path,
+            variant: :primary,
+            data: { turbo: false }
+          ) %>
         </div>
       </div>
     <% end %>

--- a/app/views/brex_items/select_accounts.html.erb
+++ b/app/views/brex_items/select_accounts.html.erb
@@ -48,9 +48,12 @@
             <%= link_to t(".cancel"), @return_to || new_account_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top" } %>
-            <%= submit_tag t(".link_accounts"),
-                disabled: !has_selectable,
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled disabled:cursor-not-allowed" %>
+            <%= render DS::Button.new(
+              text: t(".link_accounts"),
+              variant: :primary,
+              type: :submit,
+              disabled: !has_selectable
+            ) %>
           </div>
         <% end %>
       </div>

--- a/app/views/brex_items/select_existing_account.html.erb
+++ b/app/views/brex_items/select_existing_account.html.erb
@@ -48,9 +48,12 @@
             <%= link_to t(".cancel"), @return_to || accounts_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top" } %>
-            <%= submit_tag t(".link_account"),
-                disabled: !has_selectable,
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled disabled:cursor-not-allowed" %>
+            <%= render DS::Button.new(
+              text: t(".link_account"),
+              variant: :primary,
+              type: :submit,
+              disabled: !has_selectable
+            ) %>
           </div>
         <% end %>
       </div>

--- a/app/views/coinstats_items/new.html.erb
+++ b/app/views/coinstats_items/new.html.erb
@@ -53,8 +53,7 @@
               <% end %>
 
               <div class="flex justify-end">
-                <%= form.submit t(".link_wallet_submit"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
+                <%= form.submit t(".link_wallet_submit") %>
               </div>
             <% end %>
           </section>
@@ -90,8 +89,7 @@
               <div data-coinstats-exchange-fields-target="fields" class="space-y-3"></div>
 
               <div class="flex justify-end">
-                <%= form.submit t(".link_exchange_submit"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
+                <%= form.submit t(".link_exchange_submit") %>
               </div>
             <% end %>
           </section>
@@ -115,11 +113,13 @@
           </div>
 
           <div class="mt-4">
-            <%= link_to settings_providers_path,
-                        class: "w-full inline-flex items-center justify-center rounded-lg font-medium whitespace-nowrap rounded-lg hidden md:inline-flex px-3 py-2 text-sm text-inverse bg-inverse hover:bg-inverse-hover disabled:bg-gray-500 theme-dark:disabled:bg-gray-400",
-                        data: { turbo: false } do %>
-              <%= t(".go_to_settings") %>
-            <% end %>
+            <%= render DS::Link.new(
+              text: t(".go_to_settings"),
+              href: settings_providers_path,
+              variant: :primary,
+              full_width: true,
+              data: { turbo: false }
+            ) %>
           </div>
         </div>
       <% end %>

--- a/app/views/enable_banking_items/new.html.erb
+++ b/app/views/enable_banking_items/new.html.erb
@@ -53,11 +53,13 @@
                         <%= t(".reconnect") %>
                     <% end %>
                     <% else %>
-                    <%= link_to select_bank_enable_banking_item_path(item),
-                                class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
-                                data: { turbo_frame: "modal" } do %>
-                        <%= t(".connect_bank") %>
-                    <% end %>
+                    <%= render DS::Link.new(
+                      text: t(".connect_bank"),
+                      href: select_bank_enable_banking_item_path(item),
+                      variant: :primary,
+                      size: :sm,
+                      data: { turbo_frame: "modal" }
+                    ) %>
                     <% end %>
 
                     <%= button_to enable_banking_item_path(item),
@@ -73,13 +75,13 @@
             <%# Add Connection button below the list - only show if we have a valid session to copy credentials from %>
             <% if item_for_new_connection %>
                 <div class="flex justify-center pt-2">
-                <%= button_to new_connection_enable_banking_item_path(item_for_new_connection),
-                                method: :post,
-                                class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
-                                data: { turbo_frame: "modal" } do %>
-                    <%= icon "plus", size: "sm" %>
-                    <%= t(".add_connection") %>
-                <% end %>
+                <%= render DS::Button.new(
+                  text: t(".add_connection"),
+                  icon: "plus",
+                  href: new_connection_enable_banking_item_path(item_for_new_connection),
+                  variant: :primary,
+                  data: { turbo_method: :post, turbo_frame: "modal" }
+                ) %>
                 </div>
             <% end %>
             </div>
@@ -104,11 +106,13 @@
                 </div>
 
                 <div class="mt-4">
-                <%= link_to settings_providers_path,
-                            class: "w-full inline-flex items-center justify-center rounded-lg font-medium whitespace-nowrap rounded-lg hidden md:inline-flex px-3 py-2 text-sm text-inverse bg-inverse hover:bg-inverse-hover disabled:bg-gray-500 theme-dark:disabled:bg-gray-400",
-                            data: { turbo: false } do %>
-                    <%= t(".go_to_provider_settings") %>
-                <% end %>
+                <%= render DS::Link.new(
+                  text: t(".go_to_provider_settings"),
+                  href: settings_providers_path,
+                  variant: :primary,
+                  full_width: true,
+                  data: { turbo: false }
+                ) %>
                 </div>
             </div>
         <% end %>

--- a/app/views/holdings/show.html.erb
+++ b/app/views/holdings/show.html.erb
@@ -58,7 +58,7 @@
             </div>
             <div data-holding-security-remap-target="form" class="hidden mt-3 space-y-3">
               <% if Security.providers.any? %>
-                <%= form_with url: remap_security_holding_path(@holding), method: :patch, class: "space-y-3" do |f| %>
+                <%= styled_form_with url: remap_security_holding_path(@holding), method: :patch, class: "space-y-3" do |f| %>
                   <div class="form-field combobox">
                     <%= f.combobox :security_id,
                                   securities_path(country_code: Current.family.country),
@@ -72,7 +72,7 @@
                             data-action="click->holding-security-remap#toggle">
                       <%= t(".cancel") %>
                     </button>
-                    <%= f.submit t(".remap_security"), class: "inline-flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover" %>
+                    <%= f.submit t(".remap_security") %>
                   </div>
                 <% end %>
               <% else %>
@@ -185,7 +185,7 @@
                           data-action="click->drawer-cost-basis#toggle">
                     <%= t("holdings.cost_basis_cell.cancel") %>
                   </button>
-                  <%= f.submit t("holdings.cost_basis_cell.save"), class: "inline-flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover" %>
+                  <%= f.submit t("holdings.cost_basis_cell.save") %>
                 </div>
               <% end %>
             </div>

--- a/app/views/import/confirms/show.html.erb
+++ b/app/views/import/confirms/show.html.erb
@@ -31,8 +31,20 @@
     </div>
 
     <div class="flex flex-col gap-2">
-      <%= button_to t("import.confirms.sure_import.publish_button"), publish_import_path(@import), method: :post, class: "btn btn--primary w-full", disabled: !@import.publishable? %>
-      <%= link_to t("import.confirms.sure_import.cancel"), imports_path, class: "btn btn--ghost w-full text-center" %>
+      <%= render DS::Button.new(
+        text: t("import.confirms.sure_import.publish_button"),
+        href: publish_import_path(@import),
+        variant: :primary,
+        full_width: true,
+        disabled: !@import.publishable?,
+        data: { turbo_method: :post }
+      ) %>
+      <%= render DS::Link.new(
+        text: t("import.confirms.sure_import.cancel"),
+        href: imports_path,
+        variant: :ghost,
+        full_width: true
+      ) %>
     </div>
   </div>
 <% else %>

--- a/app/views/indexa_capital_items/select_existing_account.html.erb
+++ b/app/views/indexa_capital_items/select_existing_account.html.erb
@@ -14,7 +14,13 @@
         <%= icon "alert-circle", class: "text-warning mx-auto mb-4", size: "lg" %>
         <p class="text-secondary"><%= t("indexa_capital_items.select_existing_account.no_accounts") %></p>
         <p class="text-sm text-secondary mt-2"><%= t("indexa_capital_items.select_existing_account.connect_hint") %></p>
-        <%= link_to t("indexa_capital_items.select_existing_account.settings_link"), settings_providers_path, class: "btn btn--primary btn--sm mt-4" %>
+        <%= render DS::Link.new(
+          text: t("indexa_capital_items.select_existing_account.settings_link"),
+          href: settings_providers_path,
+          variant: :primary,
+          size: :sm,
+          class: "mt-4"
+        ) %>
       </div>
     <% else %>
       <div class="space-y-4">

--- a/app/views/lunchflow_items/_api_error.html.erb
+++ b/app/views/lunchflow_items/_api_error.html.erb
@@ -21,11 +21,12 @@
         </div>
 
         <div class="mt-4">
-          <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
-                      data: { turbo: false } do %>
-            <%= t(".check_provider_settings") %>
-          <% end %>
+          <%= render DS::Link.new(
+            text: t(".check_provider_settings"),
+            href: settings_providers_path,
+            variant: :primary,
+            data: { turbo: false }
+          ) %>
         </div>
       </div>
     <% end %>

--- a/app/views/lunchflow_items/_setup_required.html.erb
+++ b/app/views/lunchflow_items/_setup_required.html.erb
@@ -20,11 +20,12 @@
         </div>
 
         <div class="mt-4">
-          <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
-                      data: { turbo: false } do %>
-            <%= t(".go_to_provider_settings") %>
-          <% end %>
+          <%= render DS::Link.new(
+            text: t(".go_to_provider_settings"),
+            href: settings_providers_path,
+            variant: :primary,
+            data: { turbo: false }
+          ) %>
         </div>
       </div>
     <% end %>

--- a/app/views/lunchflow_items/select_accounts.html.erb
+++ b/app/views/lunchflow_items/select_accounts.html.erb
@@ -46,8 +46,11 @@
             <%= link_to t(".cancel"), @return_to || new_account_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
-            <%= submit_tag t(".link_accounts"),
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+            <%= render DS::Button.new(
+              text: t(".link_accounts"),
+              variant: :primary,
+              type: :submit
+            ) %>
           </div>
         </form>
       </div>

--- a/app/views/lunchflow_items/select_existing_account.html.erb
+++ b/app/views/lunchflow_items/select_existing_account.html.erb
@@ -46,8 +46,11 @@
             <%= link_to t(".cancel"), @return_to || accounts_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
-            <%= submit_tag t(".link_account"),
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+            <%= render DS::Button.new(
+              text: t(".link_account"),
+              variant: :primary,
+              type: :submit
+            ) %>
           </div>
         </form>
       </div>

--- a/app/views/mercury_items/_api_error.html.erb
+++ b/app/views/mercury_items/_api_error.html.erb
@@ -24,11 +24,12 @@
         </div>
 
         <div class="mt-4">
-          <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
-                      data: { turbo: false } do %>
-            <%= t(".check_provider_settings") %>
-          <% end %>
+          <%= render DS::Link.new(
+            text: t(".check_provider_settings"),
+            href: settings_providers_path,
+            variant: :primary,
+            data: { turbo: false }
+          ) %>
         </div>
       </div>
     <% end %>

--- a/app/views/mercury_items/_setup_required.html.erb
+++ b/app/views/mercury_items/_setup_required.html.erb
@@ -22,11 +22,12 @@
         </div>
 
         <div class="mt-4">
-          <%= link_to settings_providers_path,
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors",
-                      data: { turbo: false } do %>
-            <%= t(".go_to_provider_settings") %>
-          <% end %>
+          <%= render DS::Link.new(
+            text: t(".go_to_provider_settings"),
+            href: settings_providers_path,
+            variant: :primary,
+            data: { turbo: false }
+          ) %>
         </div>
       </div>
     <% end %>

--- a/app/views/mercury_items/select_accounts.html.erb
+++ b/app/views/mercury_items/select_accounts.html.erb
@@ -48,8 +48,11 @@
             <%= link_to t(".cancel"), @return_to || new_account_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
-            <%= submit_tag t(".link_accounts"),
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+            <%= render DS::Button.new(
+              text: t(".link_accounts"),
+              variant: :primary,
+              type: :submit
+            ) %>
           </div>
         </form>
       </div>

--- a/app/views/mercury_items/select_existing_account.html.erb
+++ b/app/views/mercury_items/select_existing_account.html.erb
@@ -48,8 +48,11 @@
             <%= link_to t(".cancel"), @return_to || accounts_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
-            <%= submit_tag t(".link_account"),
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+            <%= render DS::Button.new(
+              text: t(".link_account"),
+              variant: :primary,
+              type: :submit
+            ) %>
           </div>
         </form>
       </div>

--- a/app/views/pages/intro.html.erb
+++ b/app/views/pages/intro.html.erb
@@ -15,7 +15,11 @@
       <%= t(".description") %>
     </p>
     <div>
-      <%= link_to t(".start_chatting"), chats_path, class: "inline-flex items-center gap-2 px-4 py-2 rounded-lg button-bg-primary text-inverse font-medium" %>
+      <%= render DS::Link.new(
+        text: t(".start_chatting"),
+        href: chats_path,
+        variant: :primary
+      ) %>
     </div>
   </div>
 </div>

--- a/app/views/plaid_items/select_existing_account.html.erb
+++ b/app/views/plaid_items/select_existing_account.html.erb
@@ -35,8 +35,11 @@
             <%= link_to t(".cancel"), accounts_path,
                 class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-primary button-bg-secondary hover:button-bg-secondary-hover",
                 data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
-            <%= submit_tag t(".link_account"),
-                class: "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-inverse bg-inverse hover:bg-inverse-hover disabled:button-bg-disabled" %>
+            <%= render DS::Button.new(
+              text: t(".link_account"),
+              variant: :primary,
+              type: :submit
+            ) %>
           </div>
         </form>
       </div>

--- a/app/views/settings/providers/_binance_panel.html.erb
+++ b/app/views/settings/providers/_binance_panel.html.erb
@@ -93,8 +93,7 @@
                           type: :password %>
 
       <div class="flex justify-end">
-        <%= form.submit t("settings.providers.binance_panel.connect_button"),
-                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+        <%= form.submit t("settings.providers.binance_panel.connect_button") %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/settings/providers/_brex_panel.html.erb
+++ b/app/views/settings/providers/_brex_panel.html.erb
@@ -98,8 +98,7 @@
                   href: setup_accounts_brex_item_path(item),
                   frame: :modal
                 ) %>
-                <%= form.submit t("brex_items.provider_panel.update_connection"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+                <%= form.submit t("brex_items.provider_panel.update_connection") %>
               </div>
             <% end %>
           </div>
@@ -136,8 +135,7 @@
                           placeholder: t("brex_items.provider_panel.base_url_placeholder") %>
 
       <div class="flex justify-end">
-        <%= form.submit t("brex_items.provider_panel.add_connection"),
-                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+        <%= form.submit t("brex_items.provider_panel.add_connection") %>
       </div>
     <% end %>
   </details>

--- a/app/views/settings/providers/_coinbase_panel.html.erb
+++ b/app/views/settings/providers/_coinbase_panel.html.erb
@@ -72,8 +72,7 @@
                           type: :password %>
 
       <div class="flex justify-end">
-        <%= form.submit t("settings.providers.coinbase_panel.connect_button"),
-                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+        <%= form.submit t("settings.providers.coinbase_panel.connect_button") %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/settings/providers/_coinstats_panel.html.erb
+++ b/app/views/settings/providers/_coinstats_panel.html.erb
@@ -32,8 +32,7 @@
                         type: :password %>
 
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? t("coinstats_items.new.configure") : t("coinstats_items.new.update_configuration"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors" %>
+      <%= form.submit is_new_record ? t("coinstats_items.new.configure") : t("coinstats_items.new.update_configuration") %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_enable_banking_panel.html.erb
+++ b/app/views/settings/providers/_enable_banking_panel.html.erb
@@ -90,8 +90,7 @@
                         disabled: has_authenticated_connections && !is_new_record %>
 
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? t("settings.providers.enable_banking_panel.save_and_connect") : t("settings.providers.enable_banking_panel.update_connection"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
+      <%= form.submit is_new_record ? t("settings.providers.enable_banking_panel.save_and_connect") : t("settings.providers.enable_banking_panel.update_connection") %>
     </div>
   <% end %>
 
@@ -158,11 +157,13 @@
                 <%= t("settings.providers.enable_banking_panel.reconnect") %>
               <% end %>
             <% else %>
-              <%= link_to select_bank_enable_banking_item_path(item),
-                          class: "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
-                          data: { turbo_frame: "modal" } do %>
-                <%= t("settings.providers.enable_banking_panel.connect_bank") %>
-              <% end %>
+              <%= render DS::Link.new(
+                text: t("settings.providers.enable_banking_panel.connect_bank"),
+                href: select_bank_enable_banking_item_path(item),
+                variant: :primary,
+                size: :sm,
+                data: { turbo_frame: "modal" }
+              ) %>
             <% end %>
 
             <%= button_to enable_banking_item_path(item),
@@ -178,13 +179,13 @@
       <%# Add Connection button below the list - only show if we have a valid session to copy credentials from %>
       <% if item_for_new_connection %>
         <div class="flex justify-center pt-2">
-          <%= button_to new_connection_enable_banking_item_path(item_for_new_connection),
-                        method: :post,
-                        class: "inline-flex items-center gap-2 justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover transition-colors",
-                        data: { turbo_frame: "modal" } do %>
-            <%= icon "plus", size: "sm" %>
-            <%= t("settings.providers.enable_banking_panel.add_connection") %>
-          <% end %>
+          <%= render DS::Button.new(
+            text: t("settings.providers.enable_banking_panel.add_connection"),
+            icon: "plus",
+            href: new_connection_enable_banking_item_path(item_for_new_connection),
+            variant: :primary,
+            data: { turbo_method: :post, turbo_frame: "modal" }
+          ) %>
         </div>
       <% end %>
     </div>

--- a/app/views/settings/providers/_ibkr_panel.html.erb
+++ b/app/views/settings/providers/_ibkr_panel.html.erb
@@ -132,7 +132,7 @@
                         type: :password %>
 
     <div class="flex flex-wrap justify-end gap-2">
-      <%= form.submit(is_new_record ? t(".save_configuration") : t(".update_configuration"), class: "btn btn--primary") %>
+      <%= form.submit(is_new_record ? t(".save_configuration") : t(".update_configuration")) %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_indexa_capital_panel.html.erb
+++ b/app/views/settings/providers/_indexa_capital_panel.html.erb
@@ -53,7 +53,7 @@
 
     <div class="flex justify-end">
       <%= form.submit is_new_record ? t("indexa_capital_items.panel.save_button") : t("indexa_capital_items.panel.update_button"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium btn btn--primary" %>
+                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium" %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_kraken_panel.html.erb
+++ b/app/views/settings/providers/_kraken_panel.html.erb
@@ -93,8 +93,7 @@
                                   value: nil %>
 
               <div class="flex justify-end">
-                <%= form.submit t("settings.providers.kraken_panel.update_connection"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+                <%= form.submit t("settings.providers.kraken_panel.update_connection") %>
               </div>
             <% end %>
           </div>
@@ -134,8 +133,7 @@
                         value: nil %>
 
     <div class="flex justify-end">
-      <%= form.submit t("settings.providers.kraken_panel.add_connection"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+      <%= form.submit t("settings.providers.kraken_panel.add_connection") %>
     </div>
   <% end %>
 </div>

--- a/app/views/settings/providers/_lunchflow_panel.html.erb
+++ b/app/views/settings/providers/_lunchflow_panel.html.erb
@@ -37,8 +37,7 @@
                         value: lunchflow_item.base_url %>
 
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? t("settings.providers.lunchflow_panel.save_and_connect") : t("settings.providers.lunchflow_panel.update_connection"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
+      <%= form.submit is_new_record ? t("settings.providers.lunchflow_panel.save_and_connect") : t("settings.providers.lunchflow_panel.update_connection") %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_mercury_panel.html.erb
+++ b/app/views/settings/providers/_mercury_panel.html.erb
@@ -78,8 +78,7 @@
                   href: setup_accounts_mercury_item_path(item),
                   frame: :modal
                 ) %>
-                <%= form.submit t("mercury_items.provider_panel.update_connection"),
-                                class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+                <%= form.submit t("mercury_items.provider_panel.update_connection") %>
               </div>
             <% end %>
           </div>
@@ -117,8 +116,7 @@
     <p class="text-xs text-secondary px-1 -mt-1"><%= t("mercury_items.provider_panel.sandbox_note_html").html_safe %></p>
 
     <div class="flex justify-end">
-      <%= form.submit t("mercury_items.provider_panel.add_connection"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+      <%= form.submit t("mercury_items.provider_panel.add_connection") %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_provider_form.html.erb
+++ b/app/views/settings/providers/_provider_form.html.erb
@@ -63,8 +63,7 @@
       <% end %>
 
       <div class="flex justify-end">
-        <%= form.submit "Save and connect",
-                        class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
+        <%= form.submit "Save and connect" %>
       </div>
     </div>
   <% end %>

--- a/app/views/settings/providers/_provider_form.html.erb
+++ b/app/views/settings/providers/_provider_form.html.erb
@@ -63,7 +63,7 @@
       <% end %>
 
       <div class="flex justify-end">
-        <%= form.submit "Save and connect" %>
+        <%= form.submit t(".save_and_connect") %>
       </div>
     </div>
   <% end %>

--- a/app/views/settings/providers/_simplefin_panel.html.erb
+++ b/app/views/settings/providers/_simplefin_panel.html.erb
@@ -25,8 +25,7 @@
                         type: :password %>
 
     <div class="flex justify-end">
-      <%= form.submit t("settings.providers.simplefin_panel.save_and_connect"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse button-bg-primary hover:button-bg-primary-hover focus:outline-none focus:ring-2 focus:ring-gray-900 theme-dark:focus:ring-white focus:ring-offset-2 transition-colors" %>
+      <%= form.submit t("settings.providers.simplefin_panel.save_and_connect") %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_snaptrade_panel.html.erb
+++ b/app/views/settings/providers/_snaptrade_panel.html.erb
@@ -38,8 +38,7 @@
                         type: :password %>
 
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? t("providers.snaptrade.save_button") : t("providers.snaptrade.update_button"),
-                      class: "btn btn--primary" %>
+      <%= form.submit is_new_record ? t("providers.snaptrade.save_button") : t("providers.snaptrade.update_button") %>
     </div>
   <% end %>
 

--- a/app/views/settings/providers/_sophtron_panel.html.erb
+++ b/app/views/settings/providers/_sophtron_panel.html.erb
@@ -40,8 +40,7 @@
                         value: sophtron_item.base_url %>
 
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? t("sophtron_items.sophtron_panel.save") : t("sophtron_items.sophtron_panel.update"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover focus:outline-none focus:ring-2 focus:ring-primary transition-colors" %>
+      <%= form.submit is_new_record ? t("sophtron_items.sophtron_panel.save") : t("sophtron_items.sophtron_panel.update") %>
     </div>
   <% end %>
 

--- a/app/views/simplefin_items/_replacement_prompt.html.erb
+++ b/app/views/simplefin_items/_replacement_prompt.html.erb
@@ -52,14 +52,15 @@
                          new_name: new_sfa.name),
                  btn_text: t("simplefin_items.replacement_prompt.relink")
                ) %>
-            <%= button_to t("simplefin_items.replacement_prompt.relink"),
-                         link_existing_account_simplefin_items_path(
-                           account_id: sure_account.id,
-                           simplefin_account_id: new_sfa.id
-                         ),
-                         method: :post,
-                         data: { turbo_confirm: confirm.to_data_attribute },
-                         class: "inline-flex items-center gap-1.5 text-sm font-medium px-3 py-2 rounded-lg text-inverse bg-inverse hover:bg-inverse-hover" %>
+            <%= render DS::Button.new(
+              text: t("simplefin_items.replacement_prompt.relink"),
+              href: link_existing_account_simplefin_items_path(
+                account_id: sure_account.id,
+                simplefin_account_id: new_sfa.id
+              ),
+              variant: :primary,
+              data: { turbo_method: :post, turbo_confirm: confirm.to_data_attribute }
+            ) %>
           </div>
         </div>
       </div>

--- a/app/views/simplefin_items/new.html.erb
+++ b/app/views/simplefin_items/new.html.erb
@@ -9,7 +9,7 @@
         </div>
       <% end %>
 
-      <%= form_with model: @simplefin_item, url: simplefin_items_path, method: :post, data: { turbo: true, turbo_frame: "_top" } do |f| %>
+      <%= styled_form_with model: @simplefin_item, url: simplefin_items_path, method: :post, data: { turbo: true, turbo_frame: "_top" } do |f| %>
         <div class="space-y-3">
           <div>
             <%= f.label :setup_token, t(".setup_token"), class: "text-sm text-secondary block mb-1" %>

--- a/app/views/simplefin_items/new.html.erb
+++ b/app/views/simplefin_items/new.html.erb
@@ -16,8 +16,13 @@
             <%= f.text_field :setup_token, class: "input", placeholder: t(".setup_token_placeholder") %>
           </div>
           <div class="flex items-center gap-2 justify-end pt-2">
-            <%= link_to t(".cancel"), accounts_path, class: "btn", data: { turbo_frame: "_top", action: "DS--dialog#close" } %>
-            <%= f.submit t(".connect"), class: "btn btn--primary" %>
+            <%= render DS::Link.new(
+              text: t(".cancel"),
+              href: accounts_path,
+              variant: :secondary,
+              data: { turbo_frame: "_top", action: "DS--dialog#close" }
+            ) %>
+            <%= f.submit t(".connect") %>
           </div>
         </div>
       <% end %>

--- a/app/views/snaptrade_items/select_existing_account.html.erb
+++ b/app/views/snaptrade_items/select_existing_account.html.erb
@@ -14,7 +14,13 @@
         <%= icon "alert-circle", class: "text-warning mx-auto mb-4", size: "lg" %>
         <p class="text-secondary"><%= t("snaptrade_items.select_existing_account.no_accounts", default: "No unlinked SnapTrade accounts available.") %></p>
         <p class="text-sm text-secondary mt-2"><%= t("snaptrade_items.select_existing_account.connect_hint", default: "You may need to connect a brokerage first.") %></p>
-        <%= link_to t("snaptrade_items.select_existing_account.settings_link", default: "Go to Provider Settings"), settings_providers_path, class: "btn btn--primary btn--sm mt-4" %>
+        <%= render DS::Link.new(
+          text: t("snaptrade_items.select_existing_account.settings_link", default: "Go to Provider Settings"),
+          href: settings_providers_path,
+          variant: :primary,
+          size: :sm,
+          class: "mt-4"
+        ) %>
       </div>
     <% else %>
       <div class="space-y-4">

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -28,16 +28,20 @@
                 </div>
               </div>
               <div class="flex items-center gap-2 mt-3">
-                <%= button_to t("transactions.show.merge_duplicate"),
-                    merge_duplicate_transaction_path(@entry.transaction),
-                    method: :post,
-                    class: "btn btn--primary btn--sm",
-                    data: { turbo_frame: "_top" } %>
-                <%= button_to t("transactions.show.keep_both"),
-                    dismiss_duplicate_transaction_path(@entry.transaction),
-                    method: :post,
-                    class: "btn btn--outline btn--sm",
-                    data: { turbo_frame: "_top" } %>
+                <%= render DS::Button.new(
+                  text: t("transactions.show.merge_duplicate"),
+                  href: merge_duplicate_transaction_path(@entry.transaction),
+                  variant: :primary,
+                  size: :sm,
+                  data: { turbo_method: :post, turbo_frame: "_top" }
+                ) %>
+                <%= render DS::Button.new(
+                  text: t("transactions.show.keep_both"),
+                  href: dismiss_duplicate_transaction_path(@entry.transaction),
+                  variant: :outline,
+                  size: :sm,
+                  data: { turbo_method: :post, turbo_frame: "_top" }
+                ) %>
               </div>
             </div>
           </div>

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -341,6 +341,8 @@ en:
       encryption_error:
         title: Encryption keys missing
         message: "Bank sync needs Active Record encryption configured. Set primary_key, deterministic_key and key_derivation_salt in your Rails credentials or environment variables."
+      provider_form:
+        save_and_connect: "Save and connect"
       coinbase_panel:
         setup_instructions: "To connect Coinbase:"
         step1_html: Go to <a href="https://portal.cdp.coinbase.com/projects/api-keys" target="_blank" rel="noopener noreferrer" class="text-primary underline">Coinbase API Settings</a>


### PR DESCRIPTION
## Summary

Bulk sweep of the second cluster from §5. Stacks on #1859 (part A — 9 orphan-`btn--*` migrations). **29 files, 38 button instances** — every one hand-rolled the same long Tailwind string for the primary action button:

```
inline-flex items-center justify-center rounded-lg px-4 py-2
text-sm font-medium text-inverse bg-inverse hover:bg-inverse-hover
focus:outline-none focus:ring-2 focus:ring-primary transition-colors
```

(Some variations used `button-bg-primary hover:button-bg-primary-hover` instead of `bg-inverse hover:bg-inverse-hover` — same intent.)

Every instance now renders through `DS::Button` / `DS::Link` with `variant: :primary`. Single source of truth lives in `DS::Buttonish::VARIANTS[:primary]`.

## Why

- Removes ~38 copies of a 14-class Tailwind string.
- Picks up the focus-ring + touch-target work from #1840 once that merges (instead of the local `focus:ring-primary` which has no backing token).
- Picks up consistent icon-only `aria-label` derivation.
- Lets future button-state changes propagate via the component, not search-and-replace.

## Migration patterns

| Original | After |
|---|---|
| `f.submit text, class: "inline-flex …"` inside `styled_form_with` | bare `<%= f.submit text %>` (builder routes to DS::Button) |
| `link_to text, path, class: "inline-flex …"` | `DS::Link.new(text:, href:, variant: :primary)` |
| `button_to text, path, method: :X, class: "inline-flex …"` | `DS::Button.new(text:, href: path, variant: :primary, data: { turbo_method: :X })` |
| `submit_tag text, class: "inline-flex …"` inside raw `form_with` | `DS::Button.new(text:, variant: :primary, type: :submit)` |

## Files (29)

| Provider panels (10 files, 17 buttons) |
|---|
| `_kraken_panel.html.erb` (2) · `_lunchflow_panel.html.erb` (1) · `_provider_form.html.erb` (1) · `_mercury_panel.html.erb` (2) · `_sophtron_panel.html.erb` (1) · `_binance_panel.html.erb` (1) · `_coinstats_panel.html.erb` (1) · `_brex_panel.html.erb` (2) · `_enable_banking_panel.html.erb` (3) · `_simplefin_panel.html.erb` (1) · `_coinbase_panel.html.erb` (1) |

| Item-flow templates (18 files, 19 buttons) |
|---|
| `coinstats_items/new.html.erb` (3) · `lunchflow_items/{_api_error, _setup_required, select_existing_account, select_accounts}.html.erb` (4) · `brex_items/{_api_error, _setup_required, select_existing_account, select_accounts}.html.erb` (4) · `mercury_items/{_api_error, _setup_required, select_existing_account, select_accounts}.html.erb` (4) · `enable_banking_items/new.html.erb` (3) · `plaid_items/select_existing_account.html.erb` (1) · `simplefin_items/_replacement_prompt.html.erb` (1) · `holdings/show.html.erb` (2) · `pages/intro.html.erb` (1) |

29 files, +148 / -124.

## Notable adjustments

1. **`holdings/show.html.erb`** — form was `form_with` (not `styled_form_with`). Switched to `styled_form_with` so `f.submit` routes through DS::Button. The `f.combobox` field (from `hotwire_combobox` gem) is inherited through StyledFormBuilder, so still works.

2. **Two responsive-class fixes (in passing)** — `coinstats_items/new.html.erb` and `enable_banking_items/new.html.erb` each had a `link_to settings_providers_path` with `w-full inline-flex … hidden md:inline-flex`. The pair `inline-flex` + `hidden md:inline-flex` is contradictory (always inline-flex AND hidden-then-inline-flex-at-md = redundant). Migrated to `full_width: true` without the responsive split; buttons now render at all breakpoints, which appears to be the intended behavior. **Caller should QA this — could be a copy-paste bug that's been hiding for a while.**

3. **`enable_banking_panel` add-connection button** — gained `icon: "plus"` via the DS::Button API; the explicit inline `<%= icon "plus" %>` + extra `gap-2` is now handled by the component.

## Sibling buttons left alone (out of scope)

Destructive `trash-2` buttons, secondary `button-bg-secondary-strong` controls in `holdings/show.html.erb` (sync_prices / reset_security / unlock_cost_basis / delete-holding), `submit_tag` Cancel links — none match the primary `text-inverse bg-inverse` / `button-bg-primary` spec. They need their own audit pass once #1840's focus-ring behavior on non-primary variants is stable.

## Stack

Depends on #1859 (Part A). Merge order: #1859 → this.

## Test plan

- [x] `bundle exec erb_lint` on all 29 touched files — clean.
- [x] `bin/rails tailwindcss:build` — utilities compile.
- [x] `bin/rails test` — 4304 pass, 1 pre-existing libvips env error.
- [ ] Walk the connect-flow for each provider (Kraken, Mercury, Binance, Brex, Coinbase, Coinstats, Enable Banking, IBKR, Indexa Capital, Lunchflow, Mercury, Plaid, Simplefin, Snaptrade, Sophtron): connect-form submit button, error states, setup-required states, select-existing-account flow — all primary CTAs render as DS::Button primary.
- [ ] `/holdings/:id` — comboboxes still type-ahead, save button still saves, all secondary buttons (sync prices, reset security, etc.) render unchanged.
- [ ] `/pages/intro` (intro flow) — primary CTA renders correctly.
- [ ] **Specifically QA**: the two `link_to settings_providers_path` buttons in `coinstats_items/new.html.erb` + `enable_banking_items/new.html.erb` — confirm they render at all breakpoints (was previously `hidden md:inline-flex` which contradicted `inline-flex`). If the intent was mobile-hidden, we need to add `class: "hidden md:inline-flex"` explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized buttons and links across provider panels, modals, account-selection flows, and transaction actions for a more consistent look and behavior.
  * Replaced bespoke helper markup with unified UI components to smooth visuals and maintain consistent disabled/submit behavior.
* **Localization**
  * Added a new label for a provider "Save and connect" action to support consistent CTA text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->