### PR TITLE
fix(preview): surface demo data failure logs

### DIFF
--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -84,6 +84,22 @@ emit_status() {
   fi
 }
 
+summarize_log_tail() {
+  local file="$1"
+  local label="$2"
+
+  if [ ! -f "$file" ]; then
+    printf '%s log unavailable' "$label"
+    return 0
+  fi
+
+  tail -n 80 "$file" 2>&1 |
+    sed 's/"/'"'"'/g' |
+    tr '\n' ' ' |
+    sed 's/  */ /g' |
+    cut -c 1-1600
+}
+
 trap 'emit_status failed "preview-entrypoint failed on line ${LINENO}"' ERR
 emit_status boot "preview-entrypoint started"
 
@@ -217,7 +233,7 @@ for i in {1..180}; do
           '
         ) > /tmp/demo-data.log 2>&1 && \
           emit_status demo-data-ready "default demo dataset loaded in background" || \
-          emit_status demo-data-failed "background demo dataset load failed"
+          emit_status demo-data-failed "background demo dataset load failed: $(summarize_log_tail /tmp/demo-data.log demo-data)"
       ) &
     fi
 


### PR DESCRIPTION
## Summary
- include a sanitized tail of `/tmp/demo-data.log` in `demo-data-failed` status events
- keep the failure payload compact enough for preview diagnostics

## Why
Preview demo-data failures are currently reduced to a generic marker, which blocks root-cause investigation in PR previews.