### PR TITLE
fix(helm): skip Redis/DB auto-wiring when extraEnv override is set

### DIFF
--- a/charts/sure/templates/_env.tpl
+++ b/charts/sure/templates/_env.tpl
@@ -48,7 +48,8 @@ The helper always injects:
       key: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
 {{- end }}
 {{- if $includeDatabase }}
-{{- $explicitDb := (index $ctx.Values.rails.extraEnv "DATABASE_URL") -}}
+{{- $railsExtraEnv := (default (dict) $ctx.Values.rails.extraEnv) -}}
+{{- $explicitDb := (index $railsExtraEnv "DATABASE_URL") -}}
 {{- $dburl := include "sure.databaseUrl" $ctx -}}
 {{- if and $dburl (not $explicitDb) }}
 - name: DB_PASSWORD
@@ -61,7 +62,8 @@ The helper always injects:
 {{- end }}
 {{- end }}
 {{- if $includeRedis }}
-{{- $explicitRedis := (index $ctx.Values.rails.extraEnv "REDIS_URL") -}}
+{{- $railsExtraEnv := (default (dict) $ctx.Values.rails.extraEnv) -}}
+{{- $explicitRedis := (index $railsExtraEnv "REDIS_URL") -}}
 {{- $redis := include "sure.redisUrl" $ctx -}}
 {{- if and $redis (not $explicitRedis) }}
 - name: REDIS_PASSWORD

--- a/charts/sure/templates/_env.tpl
+++ b/charts/sure/templates/_env.tpl
@@ -48,8 +48,9 @@ The helper always injects:
       key: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
 {{- end }}
 {{- if $includeDatabase }}
+{{- $explicitDb := (index $ctx.Values.rails.extraEnv "DATABASE_URL") -}}
 {{- $dburl := include "sure.databaseUrl" $ctx -}}
-{{- if $dburl }}
+{{- if and $dburl (not $explicitDb) }}
 - name: DB_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -60,8 +61,9 @@ The helper always injects:
 {{- end }}
 {{- end }}
 {{- if $includeRedis }}
+{{- $explicitRedis := (index $ctx.Values.rails.extraEnv "REDIS_URL") -}}
 {{- $redis := include "sure.redisUrl" $ctx -}}
-{{- if $redis }}
+{{- if and $redis (not $explicitRedis) }}
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/charts/sure/templates/_env.tpl
+++ b/charts/sure/templates/_env.tpl
@@ -49,7 +49,7 @@ The helper always injects:
 {{- end }}
 {{- if $includeDatabase }}
 {{- $railsExtraEnv := (default (dict) $ctx.Values.rails.extraEnv) -}}
-{{- $explicitDb := (index $railsExtraEnv "DATABASE_URL") -}}
+{{- $explicitDb := hasKey $railsExtraEnv "DATABASE_URL" -}}
 {{- $dburl := include "sure.databaseUrl" $ctx -}}
 {{- if and $dburl (not $explicitDb) }}
 - name: DB_PASSWORD
@@ -63,7 +63,7 @@ The helper always injects:
 {{- end }}
 {{- if $includeRedis }}
 {{- $railsExtraEnv := (default (dict) $ctx.Values.rails.extraEnv) -}}
-{{- $explicitRedis := (index $railsExtraEnv "REDIS_URL") -}}
+{{- $explicitRedis := hasKey $railsExtraEnv "REDIS_URL" -}}
 {{- $redis := include "sure.redisUrl" $ctx -}}
 {{- if and $redis (not $explicitRedis) }}
 - name: REDIS_PASSWORD


### PR DESCRIPTION
## Problem

Setting `rails.extraEnv.REDIS_URL` causes the chart to emit `REDIS_URL` twice. Server-side apply rejects the Deployment:

    .spec.template.spec.containers[name="web"].env: duplicate entries for key [name="REDIS_URL"]

The auto-wiring path also attaches `REDIS_PASSWORD` from a `redis-password` secret key, which external-Redis users typically don't have. Even after deduplicating the URL, pods then fail `CreateContainerConfigError`.

Same shape for `rails.extraEnv.DATABASE_URL` with external Postgres.

`charts/sure/README.md` documents this override path at lines 71, 228, 252, and 273.

## Fix

Gate the auto-emit block in `sure.env` on the absence of a user override. With `rails.extraEnv.{DATABASE,REDIS}_URL` set, the generic `extraEnv` loop emits the URL once and the chart no longer injects `*_PASSWORD`.

Chart-managed Redis/Postgres behavior is unchanged.

## Verify

    helm template sure ./charts/sure -f external-redis-values.yaml \
      | grep -E "name: (REDIS_URL|REDIS_PASSWORD)$" | sort | uniq -c

Before: two `REDIS_URL` per workload plus `REDIS_PASSWORD` valueFrom. After: one `REDIS_URL`, no `REDIS_PASSWORD`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Configuration now detects when users supply DATABASE_URL or REDIS_URL and avoids injecting automatic DB or Redis credentials in that case.
  * Computed database and Redis variables are emitted only when those services are included and no user-provided URL exists.
  * All other environment generation behavior remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->