### PR TITLE
fix(migrations): scope admin-backfill to a MigrationUser model (#1716)

### DIFF
--- a/db/migrate/20240520074309_add_admin_role_to_current_users.rb
+++ b/db/migrate/20240520074309_add_admin_role_to_current_users.rb
@@ -1,5 +1,12 @@
 class AddAdminRoleToCurrentUsers < ActiveRecord::Migration[7.2]
+  # Scope to the migration so loading the production User model — which declares
+  # enums for columns added by later migrations (e.g. ui_layout) — does not
+  # abort a fresh `db:migrate` run on an empty database.
+  class MigrationUser < ApplicationRecord
+    self.table_name = "users"
+  end
+
   def up
-    User.update_all(role: "admin")
+    MigrationUser.update_all(role: "admin")
   end
 end

--- a/db/migrate/20240520074309_add_admin_role_to_current_users.rb
+++ b/db/migrate/20240520074309_add_admin_role_to_current_users.rb
@@ -1,8 +1,11 @@
 class AddAdminRoleToCurrentUsers < ActiveRecord::Migration[7.2]
   # Scope to the migration so loading the production User model — which declares
   # enums for columns added by later migrations (e.g. ui_layout) — does not
-  # abort a fresh `db:migrate` run on an empty database.
-  class MigrationUser < ApplicationRecord
+  # abort a fresh `db:migrate` run on an empty database. Inherit from
+  # ActiveRecord::Base (not ApplicationRecord) so any future concerns,
+  # callbacks, or default scopes added to ApplicationRecord cannot re-introduce
+  # the same loading problem this migration is meant to avoid.
+  class MigrationUser < ActiveRecord::Base
     self.table_name = "users"
   end
 


### PR DESCRIPTION
## Summary

`bin/rails db:migrate` on an empty database aborts at the May 2024 migration `20240520074309_add_admin_role_to_current_users.rb` because `User.update_all(role: "admin")` loads the production `User` class, which declares `enum :ui_layout` for a column added by `20251030140000_add_ui_layout_to_users` (Oct 2025). The enum macro raises `Undeclared attribute type for enum 'ui_layout' in User` and the entire migration chain skips, leaving the DB in a partial state.

Apply the same `MigrationUser` pattern that `AddUiLayoutToUsers` already uses — a migration-scoped subclass of `ApplicationRecord` with only the table name set, so it touches `users` directly without loading the production enum declarations.

This unblocks fresh `bin/rails db:create db:migrate` on an empty database.

## Closes

Closes #1716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability so role assignments complete on fresh or empty databases, preventing deployment failures caused by later code changes and ensuring consistent user role configuration during setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->