### PR TITLE
fix(enable_banking): match bank list search against BIC, not just name

### DIFF
--- a/app/javascript/controllers/bank_search_controller.js
+++ b/app/javascript/controllers/bank_search_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     const query = this.inputTarget.value.toLocaleLowerCase().trim();
     let visibleCount = 0;
 
-    this.itemTargets.forEach(item => {
+    this.itemTargets.forEach((item) => {
       const haystack = (item.dataset.bankSearch ?? "").toLocaleLowerCase();
       const match = haystack.includes(query);
       item.style.display = match ? "" : "none";

--- a/app/javascript/controllers/bank_search_controller.js
+++ b/app/javascript/controllers/bank_search_controller.js
@@ -8,8 +8,8 @@ export default class extends Controller {
     let visibleCount = 0;
 
     this.itemTargets.forEach(item => {
-      const name = item.dataset.bankName?.toLocaleLowerCase() ?? "";
-      const match = name.includes(query);
+      const haystack = (item.dataset.bankSearch ?? "").toLocaleLowerCase();
+      const match = haystack.includes(query);
       item.style.display = match ? "" : "none";
       if (match) visibleCount++;
     });

--- a/app/views/enable_banking_items/select_bank.html.erb
+++ b/app/views/enable_banking_items/select_bank.html.erb
@@ -28,7 +28,7 @@
 
           <div class="space-y-2 max-h-80 overflow-y-auto">
             <% @aspsps.each do |aspsp| %>
-              <div data-bank-search-target="item" data-bank-name="<%= aspsp[:name].to_s.downcase(:fold) %>">
+              <div data-bank-search-target="item" data-bank-search="<%= [ aspsp[:name], aspsp[:bic] ].compact_blank.join(" ").downcase(:fold) %>">
                 <%= button_to authorize_enable_banking_item_path(@enable_banking_item),
                               method: :post,
                               params: { aspsp_name: aspsp[:name], new_connection: @new_connection },

--- a/test/controllers/enable_banking_items_controller_test.rb
+++ b/test/controllers/enable_banking_items_controller_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "openssl"
+
+class EnableBankingItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    @family = families(:dylan_family)
+    @item = @family.enable_banking_items.create!(
+      name: "Test Connection",
+      country_code: "DE",
+      application_id: "test_app_id",
+      client_certificate: OpenSSL::PKey::RSA.new(2048).to_pem
+    )
+  end
+
+  test "select_bank exposes ASPSP BIC in the searchable data attribute" do
+    Provider::EnableBanking.any_instance.stubs(:get_aspsps).returns(
+      aspsps: [
+        {
+          name: "ING-DiBa AG",
+          country: "DE",
+          bic: "INGDDEFF",
+          beta: false,
+          psu_types: [ "personal" ],
+          auth_methods: [ { approach: "REDIRECT" } ]
+        }
+      ]
+    )
+
+    get select_bank_enable_banking_item_url(@item)
+
+    assert_response :success
+    haystack = @response.body[/data-bank-search="([^"]*)"/, 1]
+    assert haystack, "Expected list items to render a data-bank-search attribute the client filter reads from"
+    assert_includes haystack, "ingddeff",
+      "Expected the searchable data attribute to include the BIC so users can find banks by BIC code"
+    assert_includes haystack, "ing-diba ag",
+      "Expected the searchable data attribute to still include the bank name (existing name-search behavior)"
+  end
+end


### PR DESCRIPTION
## Summary
- The Enable Banking bank-selection modal's client-side search only indexed `aspsp[:name]`, so users searching by BIC (e.g. `INGDDEFF`) got an empty result even when the bank was visibly rendered in the list. This change extends the search haystack to include the BIC alongside the name.

## Root Cause
[`app/views/enable_banking_items/select_bank.html.erb:31`](https://github.com/we-promise/sure/blob/main/app/views/enable_banking_items/select_bank.html.erb#L31) rendered each list row with `data-bank-name="<%= aspsp[:name].downcase(:fold) %>"`, and the Stimulus controller at [`app/javascript/controllers/bank_search_controller.js:11`](https://github.com/we-promise/sure/blob/main/app/javascript/controllers/bank_search_controller.js#L11) substring-matched the user's query against that single field. The BIC was shown in the row's body but was never part of what the filter looked at.

## Fix
- View renders a combined `data-bank-search="<name> <bic>"` (case-folded, blanks dropped) on each item.
- Stimulus controller reads from `dataset.bankSearch`.
- No backwards-compatibility shim — `data-bank-name` had exactly one consumer (this controller), renamed in lockstep.

## Scope note
Issue #1814 describes ING Germany as missing from the list entirely. The Sure code path does **not** filter ASPSPs — `provider.get_aspsps(country:)` results are passed through unmodified — so a bank being absent reflects what Enable Banking's `/aspsps?country=DE` returned for that application, not an app-side allowlist. This PR addresses one concrete UX gap the report calls out (BIC search returning no results) without claiming to make a truly-absent bank appear; the latter is an Enable Banking dashboard / upstream concern.

## Test plan
- [x] New regression test: `test/controllers/enable_banking_items_controller_test.rb` — mocks `Provider::EnableBanking#get_aspsps` to return ING-DiBa with BIC `INGDDEFF`, asserts the rendered list row's `data-bank-search` attribute contains both `ingddeff` and `ing-diba ag`.
- [x] Test fails before the fix, passes after:

  ```
  $ bin/rails test test/controllers/enable_banking_items_controller_test.rb
  Run options: --seed 2260

  # Running:

  .

  Finished in 1.428127s, 0.7002 runs/s, 4.2013 assertions/s.
  1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
  ```

- [x] `bin/rubocop -f github -a` clean on the new Ruby test file
- [x] `bundle exec erb_lint ./app/views/enable_banking_items/select_bank.html.erb -a` clean
- [x] `npm run lint` (biome) clean on the changed Stimulus controller
- [x] `bin/brakeman --no-pager` — 0 security warnings
- [ ] Manual UI smoke: open the Enable Banking bank-selection modal, type a BIC substring, confirm the matching bank stays visible

Refs #1814


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Bank search now matches against both bank name and BIC, improving discoverability via either term; search remains case-insensitive and tolerant of minor formatting.
* **Tests**
  * Added integration tests to verify bank selection/search behavior and ensure BIC and name are searchable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1319" height="692" alt="image" src="https://github.com/user-attachments/assets/812b8dfb-7d05-4df3-a2cb-fbc1679a34d7" />
