### PR TITLE
optimize net_category_totals() by using memoized cache

### DIFF
--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -96,7 +96,7 @@ class IncomeStatement
       CategoryTotal.new(category: r[:category], total: r[:total], currency: family.currency, weight: weight)
     end
 
-    NetCategoryTotals.new(
+    @net_category_totals_by_period[period_cache_key(period)] = NetCategoryTotals.new(
       net_expense_categories: net_expense_categories,
       net_income_categories: net_income_categories,
       total_net_expense: total_net_expense,

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -30,14 +30,23 @@ class IncomeStatement
   end
 
   def expense_totals(period: Period.current_month)
-    build_period_total(classification: "expense", period: period)
+    # Memoized per instance so callers that also invoke `net_category_totals`
+    @expense_totals_by_period ||= {}
+    @expense_totals_by_period[period_cache_key(period)] ||=
+      build_period_total(classification: "expense", period: period)
   end
 
   def income_totals(period: Period.current_month)
-    build_period_total(classification: "income", period: period)
+    @income_totals_by_period ||= {}
+    @income_totals_by_period[period_cache_key(period)] ||=
+      build_period_total(classification: "income", period: period)
   end
 
   def net_category_totals(period: Period.current_month)
+    @net_category_totals_by_period ||= {}
+    cached = @net_category_totals_by_period[period_cache_key(period)]
+    return cached if cached
+
     expense = expense_totals(period: period)
     income = income_totals(period: period)
 
@@ -124,6 +133,10 @@ class IncomeStatement
 
     def categories
       @categories ||= family.categories.all.to_a
+    end
+
+    def period_cache_key(period)
+      [ period.start_date, period.end_date ]
     end
 
     def build_period_total(classification:, period:)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved income statement performance by caching computed totals per period to avoid redundant recalculation.
  * Net category totals are now reused when available, reducing processing time for repeated period queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->