### PR TITLE
fix(accounts): honor stored return path after subtype create

### DIFF
--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -48,7 +48,8 @@ module AccountableResource
       @account.lock_saved_attributes!
     end
 
-    redirect_to account_params[:return_to].presence || @account, notice: t("accounts.create.success", type: accountable_type.name.underscore.humanize)
+    redirect_to stored_return_to_or(account_path(@account), explicit_return_to: account_params[:return_to]),
+                notice: t("accounts.create.success", type: accountable_type.name.underscore.humanize)
   end
 
   def update

--- a/app/controllers/concerns/store_location.rb
+++ b/app/controllers/concerns/store_location.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 module StoreLocation
   extend ActiveSupport::Concern
 
@@ -10,10 +12,19 @@ module StoreLocation
   end
 
   def previous_path
-    session[:return_to] || fallback_path
+    safe_return_path(session[:return_to]) || fallback_path
   end
 
 private
+  def stored_return_to_or(fallback_path, explicit_return_to: nil)
+    if explicit_return_to.present?
+      session.delete(:return_to)
+      return safe_return_path(explicit_return_to) || fallback_path
+    end
+
+    safe_return_path(session.delete(:return_to)) || fallback_path
+  end
+
   def handle_not_found
     if request.fullpath == session[:return_to]
       session.delete(:return_to)
@@ -24,8 +35,12 @@ private
   end
 
   def store_return_to
-    if params[:return_to].present?
-      session[:return_to] = params[:return_to]
+    return if params[:return_to].blank?
+
+    if (return_path = safe_return_path(params[:return_to]))
+      session[:return_to] = return_path
+    else
+      session.delete(:return_to)
     end
   end
 
@@ -37,5 +52,20 @@ private
 
   def fallback_path
     root_path
+  end
+
+  def safe_return_path(value)
+    return nil if value.blank?
+
+    path = value.to_s
+    return nil unless path.start_with?("/")
+    return nil if path.start_with?("//")
+
+    uri = URI.parse(path)
+    return nil if uri.scheme.present? || uri.host.present?
+
+    path
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/app/controllers/concerns/store_location.rb
+++ b/app/controllers/concerns/store_location.rb
@@ -18,8 +18,10 @@ module StoreLocation
 private
   def stored_return_to_or(fallback_path, explicit_return_to: nil)
     if explicit_return_to.present?
-      session.delete(:return_to)
-      return safe_return_path(explicit_return_to) || fallback_path
+      if (return_path = safe_return_path(explicit_return_to))
+        session.delete(:return_to)
+        return return_path
+      end
     end
 
     safe_return_path(session.delete(:return_to)) || fallback_path
@@ -39,8 +41,6 @@ private
 
     if (return_path = safe_return_path(params[:return_to]))
       session[:return_to] = return_path
-    else
-      session.delete(:return_to)
     end
   end
 
@@ -60,12 +60,20 @@ private
     path = value.to_s
     return nil unless path.start_with?("/")
     return nil if path.start_with?("//")
+    return nil if path.start_with?("/\\")
 
     uri = URI.parse(path)
     return nil if uri.scheme.present? || uri.host.present?
+    return nil if unsafe_decoded_path?(uri.path)
 
     path
-  rescue URI::InvalidURIError
+  rescue URI::InvalidURIError, ArgumentError
     nil
+  end
+
+  def unsafe_decoded_path?(path)
+    decoded_path = URI.decode_www_form_component(path.to_s)
+
+    decoded_path.start_with?("//", "/\\") || decoded_path.split("/").include?("..")
   end
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -76,8 +76,8 @@ class PropertiesController < ApplicationController
         @account.activate!
 
         respond_to do |format|
-          format.html { redirect_to account_path(@account) }
-          format.turbo_stream { stream_redirect_to account_path(@account) }
+          format.html { redirect_to stored_return_to_or(account_path(@account)) }
+          format.turbo_stream { stream_redirect_to stored_return_to_or(account_path(@account)) }
         end
       else
         @success_message = "Address updated successfully."

--- a/test/controllers/depositories_controller_test.rb
+++ b/test/controllers/depositories_controller_test.rb
@@ -69,26 +69,66 @@ class DepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to account_path(created_account)
   end
 
-  test "create falls back to created account with unsafe stored return_to" do
+  test "create uses stored safe return_to when account return_to is unsafe" do
+    get new_depository_path(return_to: accounts_path)
+
     assert_difference -> { Account.count } => 1 do
-      post depositories_path,
-           params: {
-             account: {
-               name: "New Money Market",
-               balance: 3000,
-               currency: "USD",
-               accountable_type: "Depository",
-               accountable_attributes: {
-                 subtype: "money_market"
-               }
-             }
-           },
-           env: {
-             "rack.session" => { return_to: "//evil.example/accounts" }
-           }
+      post depositories_path, params: {
+        account: {
+          name: "New Brokerage",
+          balance: 5000,
+          currency: "USD",
+          accountable_type: "Depository",
+          return_to: "//evil.example/accounts",
+          accountable_attributes: {
+            subtype: "checking"
+          }
+        }
+      }
     end
 
-    created_account = Account.find_by!(name: "New Money Market")
-    assert_redirected_to account_path(created_account)
+    assert_redirected_to accounts_path
+  end
+
+  test "create uses stored safe return_to when account return_to contains path traversal" do
+    get new_depository_path(return_to: accounts_path)
+
+    assert_difference -> { Account.count } => 1 do
+      post depositories_path, params: {
+        account: {
+          name: "New Treasury",
+          balance: 7000,
+          currency: "USD",
+          accountable_type: "Depository",
+          return_to: "/foo/../../../etc/passwd",
+          accountable_attributes: {
+            subtype: "savings"
+          }
+        }
+      }
+    end
+
+    assert_redirected_to accounts_path
+  end
+
+  test "unsafe request return_to does not clear stored safe return_to" do
+    get new_depository_path(return_to: accounts_path)
+    get new_depository_path(return_to: "//evil.example/accounts")
+
+    assert_difference -> { Account.count } => 1 do
+      post depositories_path, params: {
+        account: {
+          name: "New Money Market",
+          balance: 3000,
+          currency: "USD",
+          accountable_type: "Depository",
+          accountable_attributes: {
+            subtype: "money_market"
+          }
+        }
+      }
+    end
+
+    assert_redirected_to accounts_path
   end
 end

--- a/test/controllers/depositories_controller_test.rb
+++ b/test/controllers/depositories_controller_test.rb
@@ -7,4 +7,88 @@ class DepositoriesControllerTest < ActionDispatch::IntegrationTest
     sign_in @user = users(:family_admin)
     @account = accounts(:depository)
   end
+
+  test "create redirects to stored return_to" do
+    Family.any_instance.stubs(:get_link_token).returns("test-link-token")
+
+    get new_depository_path(return_to: accounts_path)
+
+    assert_difference -> { Account.count } => 1 do
+      post depositories_path, params: {
+        account: {
+          name: "New Checking",
+          balance: 1000,
+          currency: "USD",
+          accountable_type: "Depository",
+          accountable_attributes: {
+            subtype: "checking"
+          }
+        }
+      }
+    end
+
+    assert_redirected_to accounts_path
+  end
+
+  test "create falls back to created account without return_to" do
+    assert_difference -> { Account.count } => 1 do
+      post depositories_path, params: {
+        account: {
+          name: "New Savings",
+          balance: 2500,
+          currency: "USD",
+          accountable_type: "Depository",
+          accountable_attributes: {
+            subtype: "savings"
+          }
+        }
+      }
+    end
+
+    created_account = Account.find_by!(name: "New Savings")
+    assert_redirected_to account_path(created_account)
+  end
+
+  test "create falls back to created account with unsafe account return_to" do
+    assert_difference -> { Account.count } => 1 do
+      post depositories_path, params: {
+        account: {
+          name: "New Certificate",
+          balance: 4000,
+          currency: "USD",
+          accountable_type: "Depository",
+          return_to: "//evil.example/accounts",
+          accountable_attributes: {
+            subtype: "cd"
+          }
+        }
+      }
+    end
+
+    created_account = Account.find_by!(name: "New Certificate")
+    assert_redirected_to account_path(created_account)
+  end
+
+  test "create falls back to created account with unsafe stored return_to" do
+    assert_difference -> { Account.count } => 1 do
+      post depositories_path,
+           params: {
+             account: {
+               name: "New Money Market",
+               balance: 3000,
+               currency: "USD",
+               accountable_type: "Depository",
+               accountable_attributes: {
+                 subtype: "money_market"
+               }
+             }
+           },
+           env: {
+             "rack.session" => { return_to: "//evil.example/accounts" }
+           }
+    end
+
+    created_account = Account.find_by!(name: "New Money Market")
+    assert_redirected_to account_path(created_account)
+  end
 end

--- a/test/controllers/properties_controller_test.rb
+++ b/test/controllers/properties_controller_test.rb
@@ -188,4 +188,41 @@ class PropertiesControllerTest < ActionDispatch::IntegrationTest
     assert draft_account.active?
     assert_redirected_to account_path(draft_account)
   end
+
+  test "address update redirects activated draft account to stored return_to" do
+    Family.any_instance.stubs(:get_link_token).returns("test-link-token")
+
+    get new_property_path(return_to: accounts_path)
+
+    post properties_path, params: {
+      account: {
+        name: "Return Property",
+        subtype: "house",
+        currency: "USD",
+        accountable_type: "Property",
+        accountable_attributes: {
+          year_built: 1995,
+          area_value: 1800,
+          area_unit: "sqft"
+        }
+      }
+    }
+
+    draft_account = Account.find_by!(name: "Return Property")
+    assert_redirected_to balances_property_path(draft_account)
+
+    patch update_address_property_path(draft_account), params: {
+      property: {
+        address_attributes: {
+          line1: "12 Return St",
+          locality: "Seattle",
+          region: "WA",
+          country: "US",
+          postal_code: "98101"
+        }
+      }
+    }
+
+    assert_redirected_to accounts_path
+  end
 end


### PR DESCRIPTION
Fixes #1766.

## Summary
- consume the stored safe `return_to` path after shared account subtype create flows instead of always landing on the created account
- sanitize stored and explicit return paths before redirecting, with unsafe paths falling back to the created account
- use the same stored return path when a draft property is activated after the address step

## Tests
- `git diff --check`
- `ruby -c app/controllers/concerns/store_location.rb`
- `ruby -c app/controllers/concerns/accountable_resource.rb`
- `ruby -c app/controllers/properties_controller.rb`
- `ruby -c test/controllers/depositories_controller_test.rb`
- `ruby -c test/controllers/properties_controller_test.rb`

Targeted Rails tests could not be run locally because this shell has Ruby 2.6.10 and no Bundler 2.6.7/Ruby 3.4.7 runtime available; Docker is installed but the daemon is not running. The PR adds controller coverage for the stored return path, fallback path, unsafe stored path, and draft property activation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect behavior by sanitizing return paths, preserving and consuming only safe stored destinations, honoring explicit safe return targets, and avoiding unsafe values clearing previously stored safe targets. Post-create and post-activation redirects now prefer stored safe destinations when available.

* **Tests**
  * Added integration tests covering safe vs unsafe return paths, stored vs explicit cases, path traversal, and post-create/post-activation redirect outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->