### PR TITLE
fix(imports): sync mappings for API CSV imports

### DIFF
--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -105,8 +105,6 @@ class Api::V1::ImportsController < Api::V1::BaseController
 
     # 4. Save and Process
     if @import.save
-      import_ready_for_publish = true
-
       # Generate rows if file content was provided
       if @import.uploaded?
         begin
@@ -114,15 +112,21 @@ class Api::V1::ImportsController < Api::V1::BaseController
           @import.reload
           @import.sync_mappings
         rescue StandardError => e
-          import_ready_for_publish = false
           Rails.logger.error "Row generation or mapping sync failed for import #{@import.id}: #{e.message}"
+          @import.update!(status: :failed, error: e.message)
+          render json: {
+            error: "processing_failed",
+            message: "Import was uploaded but could not be processed.",
+            import_id: @import.id
+          }, status: :internal_server_error
+          return
         end
       end
 
       # If the import is configured (has rows), we can try to auto-publish or just leave it as pending
       # For API simplicity, if enough info is provided, we might want to trigger processing
 
-      if import_ready_for_publish && @import.configured? && params[:publish] == "true"
+      if @import.configured? && params[:publish] == "true"
         @import.publish_later
       end
 

--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -105,20 +105,24 @@ class Api::V1::ImportsController < Api::V1::BaseController
 
     # 4. Save and Process
     if @import.save
+      import_ready_for_publish = true
+
       # Generate rows if file content was provided
       if @import.uploaded?
         begin
           @import.generate_rows_from_csv
           @import.reload
+          @import.sync_mappings
         rescue StandardError => e
-          Rails.logger.error "Row generation failed for import #{@import.id}: #{e.message}"
+          import_ready_for_publish = false
+          Rails.logger.error "Row generation or mapping sync failed for import #{@import.id}: #{e.message}"
         end
       end
 
       # If the import is configured (has rows), we can try to auto-publish or just leave it as pending
       # For API simplicity, if enough info is provided, we might want to trigger processing
 
-      if @import.configured? && params[:publish] == "true"
+      if import_ready_for_publish && @import.configured? && params[:publish] == "true"
         @import.publish_later
       end
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -250,7 +250,11 @@ class Import < ApplicationRecord
         end
 
         updated_mappings.each { |m| m.save(validate: false) }
-        mapping_class.where.not(id: updated_mappings.map(&:id)).destroy_all
+
+        updated_mapping_ids = updated_mappings.map(&:id)
+        stale_mappings = mappings.where(type: mapping_class.name)
+        stale_mappings = stale_mappings.where.not(id: updated_mapping_ids) if updated_mapping_ids.any?
+        stale_mappings.destroy_all
       end
     end
   end

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -146,7 +146,7 @@ components:
           type: string
           format: uuid
           description: Import ID preserved for retry or inspection after upload succeeds
-            but publish fails
+            but preparation or publish fails
     MfaRequiredResponse:
       type: object
       required:
@@ -4521,7 +4521,7 @@ paths:
                 - "$ref": "#/components/schemas/ErrorResponse"
                 - "$ref": "#/components/schemas/ErrorResponseWithImportId"
         '500':
-          description: import uploaded but publish enqueue failed
+          description: import uploaded but preparation or publish enqueue failed
           content:
             application/json:
               schema:

--- a/spec/requests/api/v1/imports_spec.rb
+++ b/spec/requests/api/v1/imports_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe 'API V1 Imports', type: :request do
         run_test!
       end
 
-      response '500', 'import uploaded but publish enqueue failed' do
+      response '500', 'import uploaded but preparation or publish enqueue failed' do
         schema '$ref' => '#/components/schemas/ErrorResponseWithImportId'
 
         let(:body) do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -115,7 +115,7 @@ RSpec.configure do |config|
               import_id: {
                 type: :string,
                 format: :uuid,
-                description: 'Import ID preserved for retry or inspection after upload succeeds but publish fails'
+                description: 'Import ID preserved for retry or inspection after upload succeeds but preparation or publish fails'
               }
             }
           },

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -326,31 +326,69 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal category, transaction.category
   end
 
-  test "should not auto publish when API import mapping sync fails" do
+  test "should return error response and not auto publish when API import mapping sync fails" do
     TransactionImport.any_instance.stubs(:sync_mappings).raises(StandardError, "mapping failed")
     csv_content = "date,amount,name,category\n2024-01-03,-9.99,API Mapping Failure,Food & Drink"
 
-    assert_no_enqueued_jobs only: ImportJob do
-      post api_v1_imports_url,
-           params: {
-             raw_file_content: csv_content,
-             date_col_label: "date",
-             amount_col_label: "amount",
-             name_col_label: "name",
-             category_col_label: "category",
-             account_id: @account.id,
-             date_format: "%Y-%m-%d",
-             publish: "true"
-           },
-           headers: api_headers(@api_key)
+    assert_difference("Import.count", 1) do
+      assert_no_enqueued_jobs only: ImportJob do
+        post api_v1_imports_url,
+             params: {
+               raw_file_content: csv_content,
+               date_col_label: "date",
+               amount_col_label: "amount",
+               name_col_label: "name",
+               category_col_label: "category",
+               account_id: @account.id,
+               date_format: "%Y-%m-%d",
+               publish: "true"
+             },
+             headers: api_headers(@api_key)
+      end
     end
 
-    assert_response :created
+    assert_response :internal_server_error
+    json_response = JSON.parse(response.body)
+    assert_equal "processing_failed", json_response["error"]
+    assert_equal "Import was uploaded but could not be processed.", json_response["message"]
 
-    import = Import.find(JSON.parse(response.body)["data"]["id"])
+    import = Import.find(json_response["import_id"])
 
-    assert_equal "pending", import.status
+    assert_equal "failed", import.status
+    assert_equal "mapping failed", import.error
     assert_equal 1, import.rows_count
+  end
+
+  test "should return error response and not auto publish when API import row generation fails" do
+    TransactionImport.any_instance.stubs(:generate_rows_from_csv).raises(StandardError, "row generation failed")
+    csv_content = "date,amount,name\n2024-01-04,-9.99,API Row Failure"
+
+    assert_difference("Import.count", 1) do
+      assert_no_enqueued_jobs only: ImportJob do
+        post api_v1_imports_url,
+             params: {
+               raw_file_content: csv_content,
+               date_col_label: "date",
+               amount_col_label: "amount",
+               name_col_label: "name",
+               account_id: @account.id,
+               date_format: "%Y-%m-%d",
+               publish: "true"
+             },
+             headers: api_headers(@api_key)
+      end
+    end
+
+    assert_response :internal_server_error
+    json_response = JSON.parse(response.body)
+    assert_equal "processing_failed", json_response["error"]
+    assert_equal "Import was uploaded but could not be processed.", json_response["message"]
+
+    import = Import.find(json_response["import_id"])
+
+    assert_equal "failed", import.status
+    assert_equal "row generation failed", import.error
+    assert_equal 0, import.rows_count
   end
 
   test "should instantiate RuleImport before generating rows" do

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -266,6 +266,93 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "-10.00", import.rows.first.amount # Normalized
   end
 
+  test "should create category mappings for configured API import without publishing" do
+    category = categories(:food_and_drink)
+    csv_content = "date,amount,name,category\n2024-01-01,-10.00,API Grocery,#{category.name}"
+
+    assert_difference("Import::CategoryMapping.count", 1) do
+      post api_v1_imports_url,
+           params: {
+             raw_file_content: csv_content,
+             date_col_label: "date",
+             amount_col_label: "amount",
+             name_col_label: "name",
+             category_col_label: "category",
+             account_id: @account.id,
+             date_format: "%Y-%m-%d",
+             publish: "false"
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+
+    import = Import.find(JSON.parse(response.body)["data"]["id"])
+    mapping = import.mappings.categories.find_by!(key: category.name)
+
+    assert_equal "pending", import.status
+    assert_equal category, mapping.mappable
+  end
+
+  test "should apply category mappings when API import is published automatically" do
+    category = categories(:food_and_drink)
+    transaction_name = "API Categorized Grocery #{SecureRandom.hex(4)}"
+    csv_content = "date,amount,name,category\n2024-01-02,-12.34,#{transaction_name},#{category.name}"
+
+    assert_difference("Transaction.count", 1) do
+      perform_enqueued_jobs(only: ImportJob) do
+        post api_v1_imports_url,
+             params: {
+               raw_file_content: csv_content,
+               date_col_label: "date",
+               amount_col_label: "amount",
+               name_col_label: "name",
+               category_col_label: "category",
+               account_id: @account.id,
+               date_format: "%Y-%m-%d",
+               publish: "true"
+             },
+             headers: api_headers(@api_key)
+      end
+    end
+
+    assert_response :created
+
+    import = Import.find(JSON.parse(response.body)["data"]["id"])
+    transaction = import.entries.sole.transaction
+
+    assert_equal "complete", import.status
+    assert_equal category, import.mappings.categories.find_by!(key: category.name).mappable
+    assert_equal category, transaction.category
+  end
+
+  test "should not auto publish when API import mapping sync fails" do
+    TransactionImport.any_instance.stubs(:sync_mappings).raises(StandardError, "mapping failed")
+    csv_content = "date,amount,name,category\n2024-01-03,-9.99,API Mapping Failure,Food & Drink"
+
+    assert_no_enqueued_jobs only: ImportJob do
+      post api_v1_imports_url,
+           params: {
+             raw_file_content: csv_content,
+             date_col_label: "date",
+             amount_col_label: "amount",
+             name_col_label: "name",
+             category_col_label: "category",
+             account_id: @account.id,
+             date_format: "%Y-%m-%d",
+             publish: "true"
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+
+    import = Import.find(JSON.parse(response.body)["data"]["id"])
+
+    assert_equal "pending", import.status
+    assert_equal 1, import.rows_count
+  end
+
   test "should instantiate RuleImport before generating rows" do
     @family.categories.create!(
       name: "Groceries",

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -56,6 +56,45 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert_equal other_import, other_mapping.import
   end
 
+  test "sync_mappings removes category mappings for a removed column without touching other imports" do
+    other_import = @import.family.imports.create!(type: "TransactionImport")
+    other_mapping = other_import.mappings.create!(key: "KeepMe", type: "Import::CategoryMapping")
+
+    @import.update!(
+      account: accounts(:depository),
+      raw_file_str: <<~CSV,
+        date,amount,category
+        2024-01-01,-10.00,Food & Drink
+        2024-01-02,-20.00,Groceries
+      CSV
+      date_col_label: "date",
+      amount_col_label: "amount",
+      category_col_label: "category",
+      date_format: "%Y-%m-%d"
+    )
+    @import.generate_rows_from_csv
+    @import.sync_mappings
+
+    first_mapping = Import::CategoryMapping.for_import(@import).find_by!(key: "Food & Drink")
+    second_mapping = Import::CategoryMapping.for_import(@import).find_by!(key: "Groceries")
+
+    @import.update!(
+      raw_file_str: <<~CSV,
+        date,amount
+        2024-01-01,-10.00
+      CSV
+      category_col_label: nil,
+    )
+    @import.generate_rows_from_csv
+    @import.sync_mappings
+
+    assert_raises(ActiveRecord::RecordNotFound) { first_mapping.reload }
+    assert_raises(ActiveRecord::RecordNotFound) { second_mapping.reload }
+    assert_empty Import::CategoryMapping.for_import(@import).where(key: [ "Food & Drink", "Groceries" ])
+    assert Import::CategoryMapping.exists?(other_mapping.id)
+    assert_equal other_import, other_mapping.reload.import
+  end
+
   test "imports transactions, categories, tags, and accounts" do
     import = <<~CSV
       date,name,amount,category,tags,account,notes

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -28,6 +28,34 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert @import.publishable?
   end
 
+  test "sync_mappings only removes stale mappings for current import" do
+    other_import = @import.family.imports.create!(type: "TransactionImport")
+    other_mapping = other_import.mappings.create!(key: "KeepMe", type: "Import::CategoryMapping")
+
+    import_csv = <<~CSV
+      date,amount,category
+      2024-01-01,-10.00,Food & Drink
+    CSV
+
+    @import.update!(
+      raw_file_str: import_csv,
+      date_col_label: "date",
+      amount_col_label: "amount",
+      category_col_label: "category",
+      date_format: "%Y-%m-%d"
+    )
+    @import.generate_rows_from_csv
+
+    stale_mapping = @import.mappings.create!(key: "Stale", type: "Import::CategoryMapping")
+
+    @import.sync_mappings
+
+    assert_raises(ActiveRecord::RecordNotFound) { stale_mapping.reload }
+    assert Import::CategoryMapping.exists?(other_mapping.id)
+    assert_equal "KeepMe", other_mapping.reload.key
+    assert_equal other_import, other_mapping.import
+  end
+
   test "imports transactions, categories, tags, and accounts" do
     import = <<~CSV
       date,name,amount,category,tags,account,notes


### PR DESCRIPTION
Fixes #1867.

## Summary
- run the same mapping sync step for API-created CSV imports after row generation and before optional auto-publish
- keep stale mapping cleanup scoped to the current import so syncing one import does not remove mappings from another import
- add API coverage for configured imports with `publish=false` and `publish=true`, including category application after `ImportJob` runs
- add model coverage that `sync_mappings` removes stale mappings only for the current import

## Root cause
The web Configure flow generates rows and then calls `sync_mappings`, but the API create flow only generated rows. Because `publishable?` can pass with an empty mappings collection, `publish=true` could publish API imports before category mappings existed.

## Tests
- `git diff --check`
- `ruby -c app/controllers/api/v1/imports_controller.rb`
- `ruby -c app/models/import.rb`
- `ruby -c test/controllers/api/v1/imports_controller_test.rb`
- `ruby -c test/models/transaction_import_test.rb`

`bin/rails test test/controllers/api/v1/imports_controller_test.rb test/models/transaction_import_test.rb` could not boot locally because this shell has system Ruby 2.6.10 while the repo requires the Ruby 3.4.7/Bundler 2.6.7 stack; Bundler fails parsing `platforms: %i[windows jruby]` before tests run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Import now runs mapping synchronization as part of upload preparation and prevents automatic publishing if mapping sync or row preparation fails.
  * Stale mapping cleanup is limited to the current import to avoid removing unrelated mappings.

* **Bug Fixes**
  * Broadened failure handling and clearer logging when row generation or mapping synchronization fail; failed imports return a processing_failed response.

* **Tests**
  * Added integration and model tests covering mapping creation, auto-publish gating, and error paths.

* **Documentation**
  * API docs updated to note the import ID is preserved when preparation or publish fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->