### PR TITLE
fix(lunchflow): prune orphaned accounts deleted upstream (#1861)

### DIFF
--- a/app/models/lunchflow_item/importer.rb
+++ b/app/models/lunchflow_item/importer.rb
@@ -15,7 +15,16 @@ class LunchflowItem::Importer
     accounts_data = fetch_accounts_data
     unless accounts_data
       Rails.logger.error "LunchflowItem::Importer - Failed to fetch accounts data for item #{lunchflow_item.id}"
-      return { success: false, error: "Failed to fetch accounts data", accounts_imported: 0, transactions_imported: 0 }
+      return {
+        success: false,
+        error: "Failed to fetch accounts data",
+        accounts_updated: 0,
+        accounts_created: 0,
+        accounts_failed: 0,
+        accounts_pruned: 0,
+        transactions_imported: 0,
+        transactions_failed: 0
+      }
     end
 
     # Store raw payload
@@ -124,13 +133,21 @@ class LunchflowItem::Importer
     # unlinked records that pin the item to "Need setup" (#1861). Mirrors
     # SimpleFin's prune_orphaned_simplefin_accounts. LunchFlow linkage is only
     # via AccountProvider (no legacy FK), so a present account_provider means keep.
+    #
+    # account_id is nullable on lunchflow_accounts. A NULL account_id can never
+    # match an upstream id, and `where.not(account_id: upstream_account_ids)`
+    # alone would silently drop those rows (SQL `NULL NOT IN (...)` is never
+    # TRUE). We explicitly OR them back in so a NULL-id unlinked record — which
+    # has no upstream identity and would otherwise pin the item to "Need setup"
+    # forever — is also pruned. The per-record account_provider guard below still
+    # protects any linked record regardless of its account_id.
     def prune_orphaned_lunchflow_accounts(upstream_account_ids)
       return 0 if upstream_account_ids.blank?
 
-      orphaned = lunchflow_item.lunchflow_accounts
-        .includes(:account_provider)
+      scope = lunchflow_item.lunchflow_accounts.includes(:account_provider)
+      orphaned = scope
         .where.not(account_id: upstream_account_ids)
-        .where.not(account_id: nil)
+        .or(scope.where(account_id: nil))
 
       pruned = 0
       orphaned.each do |lunchflow_account|

--- a/app/models/lunchflow_item/importer.rb
+++ b/app/models/lunchflow_item/importer.rb
@@ -158,8 +158,12 @@ class LunchflowItem::Importer
 
         begin
           Rails.logger.info "LunchflowItem::Importer - Pruning orphaned LunchflowAccount id=#{lunchflow_account.id} account_id=#{lunchflow_account.account_id} (no longer exists upstream)"
-          lunchflow_account.destroy
-          pruned += 1
+          if lunchflow_account.destroy
+            pruned += 1
+          else
+            # A before_destroy callback halted deletion — don't inflate the count.
+            Rails.logger.warn "LunchflowItem::Importer - Destroy halted for LunchflowAccount id=#{lunchflow_account.id}; not counting as pruned"
+          end
         rescue => e
           # Don't let one failed destroy abort the whole import (transactions are
           # fetched in a later step). Mirrors the importer's continue-on-error style.

--- a/app/models/lunchflow_item/importer.rb
+++ b/app/models/lunchflow_item/importer.rb
@@ -156,9 +156,15 @@ class LunchflowItem::Importer
           next
         end
 
-        Rails.logger.info "LunchflowItem::Importer - Pruning orphaned LunchflowAccount id=#{lunchflow_account.id} account_id=#{lunchflow_account.account_id} (no longer exists upstream)"
-        lunchflow_account.destroy
-        pruned += 1
+        begin
+          Rails.logger.info "LunchflowItem::Importer - Pruning orphaned LunchflowAccount id=#{lunchflow_account.id} account_id=#{lunchflow_account.account_id} (no longer exists upstream)"
+          lunchflow_account.destroy
+          pruned += 1
+        rescue => e
+          # Don't let one failed destroy abort the whole import (transactions are
+          # fetched in a later step). Mirrors the importer's continue-on-error style.
+          Rails.logger.error "LunchflowItem::Importer - Failed to prune LunchflowAccount id=#{lunchflow_account.id}: #{e.message}"
+        end
       end
 
       pruned

--- a/app/models/lunchflow_item/importer.rb
+++ b/app/models/lunchflow_item/importer.rb
@@ -30,6 +30,7 @@ class LunchflowItem::Importer
     accounts_updated = 0
     accounts_created = 0
     accounts_failed = 0
+    accounts_pruned = 0
 
     if accounts_data[:accounts].present?
       # Get linked lunchflow account IDs (ones actually imported/used by the user)
@@ -73,9 +74,16 @@ class LunchflowItem::Importer
           end
         end
       end
+
+      # Remove records for accounts that no longer exist upstream so they don't
+      # linger as unlinked "Need setup" accounts (#1861). Guarded to a non-empty
+      # upstream list so a transient empty/failed response can't wipe out all
+      # accounts.
+      upstream_account_ids = accounts_data[:accounts].filter_map { |a| a[:id].to_s.presence }
+      accounts_pruned = prune_orphaned_lunchflow_accounts(upstream_account_ids)
     end
 
-    Rails.logger.info "LunchflowItem::Importer - Updated #{accounts_updated} accounts, created #{accounts_created} new (#{accounts_failed} failed)"
+    Rails.logger.info "LunchflowItem::Importer - Updated #{accounts_updated} accounts, created #{accounts_created} new (#{accounts_failed} failed), pruned #{accounts_pruned}"
 
     # Step 3: Fetch transactions only for linked accounts with active status
     transactions_imported = 0
@@ -103,12 +111,41 @@ class LunchflowItem::Importer
       accounts_updated: accounts_updated,
       accounts_created: accounts_created,
       accounts_failed: accounts_failed,
+      accounts_pruned: accounts_pruned,
       transactions_imported: transactions_imported,
       transactions_failed: transactions_failed
     }
   end
 
   private
+
+    # Removes LunchflowAccount records that no longer exist upstream and are not
+    # linked to any Account, so accounts deleted in Lunch Flow stop lingering as
+    # unlinked records that pin the item to "Need setup" (#1861). Mirrors
+    # SimpleFin's prune_orphaned_simplefin_accounts. LunchFlow linkage is only
+    # via AccountProvider (no legacy FK), so a present account_provider means keep.
+    def prune_orphaned_lunchflow_accounts(upstream_account_ids)
+      return 0 if upstream_account_ids.blank?
+
+      orphaned = lunchflow_item.lunchflow_accounts
+        .includes(:account_provider)
+        .where.not(account_id: upstream_account_ids)
+        .where.not(account_id: nil)
+
+      pruned = 0
+      orphaned.each do |lunchflow_account|
+        if lunchflow_account.account_provider.present?
+          Rails.logger.info "LunchflowItem::Importer - Keeping stale LunchflowAccount id=#{lunchflow_account.id} account_id=#{lunchflow_account.account_id} (still linked to Account)"
+          next
+        end
+
+        Rails.logger.info "LunchflowItem::Importer - Pruning orphaned LunchflowAccount id=#{lunchflow_account.id} account_id=#{lunchflow_account.account_id} (no longer exists upstream)"
+        lunchflow_account.destroy
+        pruned += 1
+      end
+
+      pruned
+    end
 
     def fetch_accounts_data
       begin

--- a/test/models/lunchflow_item/importer_orphan_prune_test.rb
+++ b/test/models/lunchflow_item/importer_orphan_prune_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class LunchflowItem::ImporterOrphanPruneTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @item = LunchflowItem.create!(
+      family: @family,
+      name: "Test Lunchflow",
+      api_key: "test_key_123",
+      status: :good
+    )
+    @importer = LunchflowItem::Importer.new(@item, lunchflow_provider: mock())
+  end
+
+  test "prunes orphaned unlinked LunchflowAccount no longer returned upstream" do
+    orphan = @item.lunchflow_accounts.create!(
+      account_id: "acct-old",
+      name: "Deleted Account",
+      currency: "USD"
+    )
+
+    pruned = @importer.send(:prune_orphaned_lunchflow_accounts, [ "acct-new" ])
+
+    assert_equal 1, pruned
+    assert_nil LunchflowAccount.find_by(id: orphan.id), "orphaned unlinked account should be deleted"
+  end
+
+  test "keeps unlinked LunchflowAccount that is still returned upstream" do
+    still_present = @item.lunchflow_accounts.create!(
+      account_id: "acct-keep",
+      name: "Active Account",
+      currency: "USD"
+    )
+
+    pruned = @importer.send(:prune_orphaned_lunchflow_accounts, [ "acct-keep" ])
+
+    assert_equal 0, pruned
+    assert_not_nil LunchflowAccount.find_by(id: still_present.id)
+  end
+
+  test "does not prune a LunchflowAccount linked via AccountProvider" do
+    linked = @item.lunchflow_accounts.create!(
+      account_id: "acct-linked",
+      name: "Linked Account",
+      currency: "USD"
+    )
+    account = @family.accounts.create!(
+      name: "Linked Checking",
+      balance: 100,
+      currency: "USD",
+      accountable: Depository.new(subtype: "checking")
+    )
+    AccountProvider.create!(account: account, provider: linked)
+
+    # Even though it's gone upstream, a linked account must be kept (deleting it
+    # would cascade-destroy the AccountProvider and orphan the user's Account).
+    pruned = @importer.send(:prune_orphaned_lunchflow_accounts, [ "acct-other" ])
+
+    assert_equal 0, pruned
+    assert_not_nil LunchflowAccount.find_by(id: linked.id), "linked account should not be deleted"
+  end
+
+  test "blank upstream list is a no-op so transient failures cannot wipe accounts" do
+    orphan = @item.lunchflow_accounts.create!(
+      account_id: "acct-old",
+      name: "Account",
+      currency: "USD"
+    )
+
+    assert_equal 0, @importer.send(:prune_orphaned_lunchflow_accounts, [])
+    assert_not_nil LunchflowAccount.find_by(id: orphan.id), "must not prune when upstream list is empty"
+  end
+
+  test "prunes multiple orphaned unlinked accounts" do
+    orphan1 = @item.lunchflow_accounts.create!(account_id: "old-1", name: "One", currency: "USD")
+    orphan2 = @item.lunchflow_accounts.create!(account_id: "old-2", name: "Two", currency: "USD")
+    kept = @item.lunchflow_accounts.create!(account_id: "new-1", name: "Three", currency: "USD")
+
+    pruned = @importer.send(:prune_orphaned_lunchflow_accounts, [ "new-1" ])
+
+    assert_equal 2, pruned
+    assert_nil LunchflowAccount.find_by(id: orphan1.id)
+    assert_nil LunchflowAccount.find_by(id: orphan2.id)
+    assert_not_nil LunchflowAccount.find_by(id: kept.id)
+  end
+end

--- a/test/models/lunchflow_item/importer_orphan_prune_test.rb
+++ b/test/models/lunchflow_item/importer_orphan_prune_test.rb
@@ -83,4 +83,39 @@ class LunchflowItem::ImporterOrphanPruneTest < ActiveSupport::TestCase
     assert_nil LunchflowAccount.find_by(id: orphan2.id)
     assert_not_nil LunchflowAccount.find_by(id: kept.id)
   end
+
+  test "prunes an unlinked LunchflowAccount with a nil account_id" do
+    # account_id is nullable; a NULL id can never match upstream and would be
+    # silently skipped by a plain `where.not(account_id: ...)` (SQL three-valued
+    # logic). Such an unlinked record is a genuine orphan and must be pruned.
+    orphan = @item.lunchflow_accounts.create!(
+      account_id: nil,
+      name: "Never received an upstream id",
+      currency: "USD"
+    )
+
+    pruned = @importer.send(:prune_orphaned_lunchflow_accounts, [ "acct-new" ])
+
+    assert_equal 1, pruned
+    assert_nil LunchflowAccount.find_by(id: orphan.id), "nil account_id orphan should be pruned"
+  end
+
+  test "import returns accounts_pruned in its result and prunes orphans end-to-end" do
+    orphan = @item.lunchflow_accounts.create!(
+      account_id: "acct-old",
+      name: "Deleted Account",
+      currency: "USD"
+    )
+
+    provider = mock()
+    provider.stubs(:get_accounts).returns(
+      accounts: [ { id: "acct-new", name: "New Account", currency: "USD" } ]
+    )
+
+    importer = LunchflowItem::Importer.new(@item, lunchflow_provider: provider)
+    result = importer.import
+
+    assert_equal 1, result[:accounts_pruned]
+    assert_nil LunchflowAccount.find_by(id: orphan.id), "orphan should be pruned through import"
+  end
 end


### PR DESCRIPTION
## Summary

Accounts deleted in Lunch Flow continued to appear in Sure as records marked **"Need setup"**, and the connection stayed permanently flagged for setup.

The LunchFlow importer creates/updates accounts returned by the API, but it never removed `LunchflowAccount` records for accounts that no longer exist upstream. Those orphaned records remain unlinked, so the syncer keeps counting them as "unlinked accounts" and sets `pending_account_setup: true` forever.

SimpleFIN already solved this with `prune_orphaned_simplefin_accounts`; LunchFlow just never got the same treatment. This PR ports that pattern.

Fixes #1861.

## Changes

- Add `LunchflowItem::Importer#prune_orphaned_lunchflow_accounts`. After importing, it deletes `LunchflowAccount` records whose `account_id` is no longer returned upstream **and** that are not linked to an `Account` via `AccountProvider`.
- Linked accounts are always kept — deleting one would cascade-destroy its `AccountProvider` (`dependent: :destroy`) and orphan the user's `Account`.
- The prune only runs when the upstream account list is non-empty, so a transient empty/failed API response can't wipe out all of a user's accounts (same guard as SimpleFIN).
- Expose `accounts_pruned` in the importer result hash and sync log line for observability.
- Because pruning happens during import (before the syncer recomputes unlinked accounts), the `pending_account_setup` "Need setup" flag clears automatically on the next sync.

## Test plan

- [ ] `bin/rails test test/models/lunchflow_item/importer_orphan_prune_test.rb`
- New tests cover: orphaned unlinked account pruned; still-present account kept AccountProvider-linked account kept; empty upstream list is a no-op; multiple orphans pruned.
- [ ] Manual: connect Lunch Flow, delete an account upstream, re-sync → the deleted account disappears from Accounts and the connection leaves "Need setup".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import process now reports how many accounts were pruned during each import (included in the import result).

* **Bug Fixes**
  * Orphaned accounts that no longer exist upstream are now removed, while preserving accounts that are still linked via providers and safely treating blank upstream data as a no-op.

* **Tests**
  * Added comprehensive test coverage for orphan-pruning behavior, including edge cases (such as multiple or nil-linked records) and an end-to-end check that the import result reflects the pruning count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->