### PR TITLE
fix(enable-banking): tolerate any 422 on PDNG fetch (#1805)

### DIFF
--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -267,7 +267,7 @@ class EnableBankingItem::Importer
           )
         rescue Provider::EnableBanking::EnableBankingError => e
           raise unless e.error_type == :validation_error
-          api_error = e.response_data.is_a?(Hash) ? e.response_data[:error] : nil
+          api_error = e.response_data.is_a?(Hash) ? (e.response_data[:error] || e.response_data["error"]) : nil
           Rails.logger.warn "EnableBankingItem::Importer - ASPSP does not support PDNG transaction status for account #{enable_banking_account.uid}, skipping pending transactions. API error: #{api_error || e.message}"
         end
       end

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -252,7 +252,12 @@ class EnableBankingItem::Importer
 
       pending_transactions = []
       if include_pending
-        # Also fetch pending transactions (visible for 1-3 days before they become BOOK) if setting is enabled
+        # Also fetch pending transactions (visible for 1-3 days before they become BOOK) if setting is enabled.
+        # The BOOK fetch above used the same date_from/date_to and succeeded, so any 422 raised here is
+        # necessarily about the transaction_status param. Different ASPSPs reject it with different bodies
+        # (e.g. ImaginV2 returns WRONG_REQUEST_PARAMETERS; others mention "transactionStatus" verbatim),
+        # so we treat every validation_error on PDNG as "ASPSP doesn't support pending" and continue with
+        # the booked transactions only. (Issue #1805)
         begin
           pending_transactions = fetch_paginated_transactions(
             enable_banking_account,
@@ -261,8 +266,9 @@ class EnableBankingItem::Importer
             psu_headers: enable_banking_item.build_psu_headers
           )
         rescue Provider::EnableBanking::EnableBankingError => e
-          raise unless e.error_type == :validation_error && e.message.include?("transactionStatus")
-          Rails.logger.warn "EnableBankingItem::Importer - ASPSP does not support PDNG transaction status for account #{enable_banking_account.uid}, skipping pending transactions. API error: #{e.message}"
+          raise unless e.error_type == :validation_error
+          api_error = e.response_data.is_a?(Hash) ? e.response_data[:error] : nil
+          Rails.logger.warn "EnableBankingItem::Importer - ASPSP does not support PDNG transaction status for account #{enable_banking_account.uid}, skipping pending transactions. API error: #{api_error || e.message}"
         end
       end
 

--- a/test/models/enable_banking_item/importer_error_handling_test.rb
+++ b/test/models/enable_banking_item/importer_error_handling_test.rb
@@ -112,18 +112,40 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
     assert result[:success]
   end
 
-  test "fetch_and_store_transactions fails when validation error is unrelated to transactionStatus" do
+  # Regression for #1805: ImaginV2 (and other Enable Banking connectors) reject PDNG with
+  # a generic WRONG_REQUEST_PARAMETERS body whose message does not mention "transactionStatus".
+  # The sync must still succeed and import booked transactions.
+  test "fetch_and_store_transactions succeeds when ASPSP rejects PDNG with WRONG_REQUEST_PARAMETERS" do
     enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
     @importer.stubs(:determine_sync_start_date).returns(Date.today)
     @importer.stubs(:include_pending?).returns(true)
 
-    date_error = Provider::EnableBanking::EnableBankingError.new(
-      "Validation error from Enable Banking API: {\"message\":\"Invalid date_from format\"}",
-      :validation_error
+    imagin_error = Provider::EnableBanking::EnableBankingError.new(
+      "Validation error from Enable Banking API: {\"error\":\"WRONG_REQUEST_PARAMETERS\"}",
+      :validation_error,
+      response_data: { error: "WRONG_REQUEST_PARAMETERS" }
     )
 
     @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "BOOK")).returns([])
-    @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "PDNG")).raises(date_error)
+    @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "PDNG")).raises(imagin_error)
+
+    result = @importer.send(:fetch_and_store_transactions, enable_banking_account)
+
+    assert result[:success]
+  end
+
+  test "fetch_and_store_transactions propagates non-validation EnableBankingError from PDNG fetch" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+    @importer.stubs(:determine_sync_start_date).returns(Date.today)
+    @importer.stubs(:include_pending?).returns(true)
+
+    rate_limit_error = Provider::EnableBanking::EnableBankingError.new(
+      "Rate limit exceeded. Please try again later.",
+      :rate_limited
+    )
+
+    @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "BOOK")).returns([])
+    @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "PDNG")).raises(rate_limit_error)
 
     result = @importer.send(:fetch_and_store_transactions, enable_banking_account)
 


### PR DESCRIPTION
## Summary

Fixes #1805. ImaginV2 (Spain) syncs through Enable Banking have been failing for ~12 days with a 422 `WRONG_REQUEST_PARAMETERS` even though PR #1789 was meant to handle this class of error.

## Root cause

PR #1789 added a rescue around the PDNG (pending-transactions) fetch but only swallowed the 422 when the API message contained the literal substring `"transactionStatus"`. ImaginV2 rejects the same call with a generic `WRONG_REQUEST_PARAMETERS` body whose message does not include that string, so the rescue re-raises and the entire sync dies — even though the booked-transactions fetch already succeeded.

The BOOK fetch above uses the same `date_from`/`date_to` and succeeded, so any 422 raised on the PDNG call is necessarily about the `transaction_status` parameter. Pending transactions are an optional best-effort enhancement (the importer comment itself says they're "visible for 1-3 days before they become BOOK"); failing the whole sync over them is the wrong tradeoff.

## What changes

- `app/models/enable_banking_item/importer.rb` — drop the `transactionStatus`-substring predicate. Tolerate any `:validation_error` raised by the PDNG fetch, log `response_data[:error]` (e.g. `WRONG_REQUEST_PARAMETERS`) for cleaner diagnostics, and fall back to the full message when absent.
- `test/models/enable_banking_item/importer_error_handling_test.rb`:
  - Kept the existing `transactionStatus`-message test (regression for #1789).
  - **Added** a regression test for #1805: 422 with `response_data: { error: "WRONG_REQUEST_PARAMETERS" }` — sync still succeeds.
  - **Replaced** the "unrelated validation error" test (its premise — that BOOK succeeds but PDNG fails with `Invalid date_from format` on the same date_from — wasn't realistic) with a meaningful boundary test: non-validation `EnableBankingError` (`:rate_limited`) on the PDNG fetch still propagates and fails the sync.

## What this does NOT change

- BOOK-fetch error handling is untouched. A 422 on BOOK still fails the sync (correct — without booked transactions there's nothing to import).
- Non-422 errors on PDNG (auth, rate-limit, 5xx, network) still propagate and fail the sync.
- The pending-include setting (`ENABLE_BANKING_INCLUDE_PENDING`, etc.) behavior is unchanged.

## Test plan

- [ ] `bin/rails test test/models/enable_banking_item/importer_error_handling_test.rb` passes
- [ ] `bin/rails test` passes
- [ ] `bin/rubocop -f github -a` clean
- [ ] `bin/brakeman --no-pager` clean
- [ ] Manual: trigger a sync on an Imagin/ImaginV2 account — booked transactions should import; logs should show `EnableBankingItem::Importer - ASPSP does not support PDNG transaction status for account <uid>, skipping pending transactions. API error: WRONG_REQUEST_PARAMETERS`
- [ ] Manual: confirm an ASPSP that supports PDNG (e.g. a German bank) still imports both booked and pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending-transaction import error handling: provider errors for pending transaction requests are now suppressed only when classified as validation-type errors, allowing booked transactions to continue syncing. Suppressed errors log a concise warning using the provider's API error when available, otherwise falling back to the error message; other error types still surface.

* **Tests**
  * Expanded test coverage for provider rejection scenarios to verify correct success/failure behavior for validation-type rejections and non-validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->