### PR TITLE
feat: add Enable Banking PSU IP retention cleanup

### DIFF
--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -177,7 +177,7 @@ class EnableBankingItemsController < ApplicationController
       end
 
       # Capture PSU IP for use in background sync PSU headers
-      target_item.update(last_psu_ip: request.remote_ip) if request.remote_ip.present?
+      target_item.record_psu_ip!(request.remote_ip)
 
       language = I18n.locale.to_s.split("-").first
 
@@ -239,7 +239,7 @@ class EnableBankingItemsController < ApplicationController
     end
 
     # Refresh PSU IP on callback (user's browser is present here)
-    enable_banking_item.update(last_psu_ip: request.remote_ip) if request.remote_ip.present?
+    enable_banking_item.record_psu_ip!(request.remote_ip)
 
     begin
       enable_banking_item.complete_authorization(code: code)

--- a/app/jobs/data_cleaner_job.rb
+++ b/app/jobs/data_cleaner_job.rb
@@ -4,6 +4,7 @@ class DataCleanerJob < ApplicationJob
   def perform
     clean_old_merchant_associations
     clean_expired_archived_exports
+    clean_stale_enable_banking_psu_ips
   end
 
   private
@@ -20,5 +21,12 @@ class DataCleanerJob < ApplicationJob
       deleted_count = ArchivedExport.expired.destroy_all.count
 
       Rails.logger.info("DataCleanerJob: Deleted #{deleted_count} expired archived exports") if deleted_count > 0
+    end
+
+    def clean_stale_enable_banking_psu_ips
+      cleared_count = EnableBankingItem.clear_stale_psu_ip!
+      return if cleared_count.zero?
+
+      Rails.logger.info("DataCleanerJob: Cleared PSU IP from #{cleared_count} Enable Banking items")
     end
 end

--- a/app/models/enable_banking_item.rb
+++ b/app/models/enable_banking_item.rb
@@ -48,7 +48,33 @@ class EnableBankingItem < ApplicationRecord
     !session_valid?
   end
 
-  # TODO: implement data retention policy for last_psu_ip (GDPR/CCPA — nullify after session expiry or 90 days)
+  # GDPR/CCPA: PSU IP is cleared after session expiry or PSU_IP_RETENTION_DAYS (see DataCleanerJob).
+  PSU_IP_RETENTION_DAYS = 90
+
+  scope :with_stale_psu_ip, -> {
+    now = Time.current
+    retention = PSU_IP_RETENTION_DAYS.days.ago
+
+    where.not(last_psu_ip: nil).where(
+      <<~SQL.squish,
+        (session_expires_at IS NOT NULL AND session_expires_at <= :now)
+        OR (last_psu_ip_at IS NOT NULL AND last_psu_ip_at <= :retention)
+        OR (last_psu_ip_at IS NULL AND updated_at <= :retention)
+      SQL
+      now: now,
+      retention: retention
+    )
+  }
+
+  def self.clear_stale_psu_ip!
+    with_stale_psu_ip.update_all(last_psu_ip: nil, last_psu_ip_at: nil)
+  end
+
+  def record_psu_ip!(ip)
+    return if ip.blank?
+
+    update!(last_psu_ip: ip, last_psu_ip_at: Time.current)
+  end
 
   validate :psu_type_in_aspsp_types
 

--- a/app/models/enable_banking_item.rb
+++ b/app/models/enable_banking_item.rb
@@ -58,8 +58,7 @@ class EnableBankingItem < ApplicationRecord
     where.not(last_psu_ip: nil).where(
       <<~SQL.squish,
         (session_expires_at IS NOT NULL AND session_expires_at <= :now)
-        OR (last_psu_ip_at IS NOT NULL AND last_psu_ip_at <= :retention)
-        OR (last_psu_ip_at IS NULL AND updated_at <= :retention)
+        OR (last_psu_ip_at <= :retention)
       SQL
       now: now,
       retention: retention

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -29,7 +29,7 @@ clean_data:
   cron: "0 3 * * *" # daily at 3:00 AM
   class: "DataCleanerJob"
   queue: "scheduled"
-  description: "Cleans up old data (e.g., expired merchant associations, expired archived exports)"
+  description: "Cleans up old data (e.g., expired merchant associations, expired archived exports, stale Enable Banking PSU IPs)"
 
 clean_debug_log_entries:
   cron: "30 3 * * *" # daily at 3:30 AM

--- a/db/migrate/20260520120000_add_last_psu_ip_at_to_enable_banking_items.rb
+++ b/db/migrate/20260520120000_add_last_psu_ip_at_to_enable_banking_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastPsuIpAtToEnableBankingItems < ActiveRecord::Migration[7.2]
+  def change
+    add_column :enable_banking_items, :last_psu_ip_at, :datetime
+  end
+end

--- a/db/migrate/20260520120100_backfill_last_psu_ip_at_on_enable_banking_items.rb
+++ b/db/migrate/20260520120100_backfill_last_psu_ip_at_on_enable_banking_items.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class BackfillLastPsuIpAtOnEnableBankingItems < ActiveRecord::Migration[7.2]
+  def up
+    say_with_time "Backfilling last_psu_ip_at from updated_at for existing PSU IPs" do
+      execute <<-SQL.squish
+        UPDATE enable_banking_items
+        SET last_psu_ip_at = updated_at
+        WHERE last_psu_ip IS NOT NULL
+          AND last_psu_ip_at IS NULL
+      SQL
+    end
+  end
+
+  def down
+    execute <<-SQL.squish
+      UPDATE enable_banking_items
+      SET last_psu_ip_at = NULL
+      WHERE last_psu_ip IS NOT NULL
+        AND last_psu_ip_at = updated_at
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_19_100000) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -561,6 +561,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_100000) do
     t.string "aspsp_auth_approach"
     t.jsonb "aspsp_psu_types", default: []
     t.string "last_psu_ip"
+    t.datetime "last_psu_ip_at"
     t.string "psu_type"
     t.index ["family_id"], name: "index_enable_banking_items_on_family_id"
     t.index ["status"], name: "index_enable_banking_items_on_status"

--- a/test/jobs/data_cleaner_job_test.rb
+++ b/test/jobs/data_cleaner_job_test.rb
@@ -9,6 +9,7 @@ class DataCleanerJobTest < ActiveJob::TestCase
 
   test "clears stale Enable Banking PSU IP addresses" do
     travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      recorded_at = 1.day.ago
       stale_item = EnableBankingItem.create!(
         family: @family,
         name: "Stale EB",
@@ -16,7 +17,7 @@ class DataCleanerJobTest < ActiveJob::TestCase
         application_id: "app_id",
         client_certificate: "cert",
         last_psu_ip: "203.0.113.10",
-        last_psu_ip_at: 1.day.ago,
+        last_psu_ip_at: recorded_at,
         session_id: "sess",
         session_expires_at: 1.hour.ago
       )
@@ -27,7 +28,7 @@ class DataCleanerJobTest < ActiveJob::TestCase
         application_id: "app_id",
         client_certificate: "cert",
         last_psu_ip: "203.0.113.11",
-        last_psu_ip_at: 1.day.ago,
+        last_psu_ip_at: recorded_at,
         session_id: "sess",
         session_expires_at: 30.days.from_now
       )
@@ -40,7 +41,7 @@ class DataCleanerJobTest < ActiveJob::TestCase
       assert_nil stale_item.last_psu_ip
       assert_nil stale_item.last_psu_ip_at
       assert_equal "203.0.113.11", fresh_item.last_psu_ip
-      assert_equal 1.day.ago, fresh_item.last_psu_ip_at
+      assert_in_delta recorded_at.to_f, fresh_item.last_psu_ip_at.to_f, 1.0
     end
   end
 end

--- a/test/jobs/data_cleaner_job_test.rb
+++ b/test/jobs/data_cleaner_job_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DataCleanerJobTest < ActiveJob::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "clears stale Enable Banking PSU IP addresses" do
+    travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      stale_item = EnableBankingItem.create!(
+        family: @family,
+        name: "Stale EB",
+        country_code: "FR",
+        application_id: "app_id",
+        client_certificate: "cert",
+        last_psu_ip: "203.0.113.10",
+        last_psu_ip_at: 1.day.ago,
+        session_id: "sess",
+        session_expires_at: 1.hour.ago
+      )
+      fresh_item = EnableBankingItem.create!(
+        family: @family,
+        name: "Fresh EB",
+        country_code: "FR",
+        application_id: "app_id",
+        client_certificate: "cert",
+        last_psu_ip: "203.0.113.11",
+        last_psu_ip_at: 1.day.ago,
+        session_id: "sess",
+        session_expires_at: 30.days.from_now
+      )
+
+      DataCleanerJob.perform_now
+
+      stale_item.reload
+      fresh_item.reload
+
+      assert_nil stale_item.last_psu_ip
+      assert_nil stale_item.last_psu_ip_at
+      assert_equal "203.0.113.11", fresh_item.last_psu_ip
+      assert_equal 1.day.ago, fresh_item.last_psu_ip_at
+    end
+  end
+end

--- a/test/models/enable_banking_item/psu_ip_retention_test.rb
+++ b/test/models/enable_banking_item/psu_ip_retention_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EnableBankingItem::PsuIpRetentionTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @base_attrs = {
+      family: @family,
+      name: "Test EB",
+      country_code: "FR",
+      application_id: "app_id",
+      client_certificate: "cert"
+    }
+  end
+
+  test "with_stale_psu_ip includes items with expired session" do
+    travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      item = create_item(
+        last_psu_ip: "203.0.113.1",
+        last_psu_ip_at: 1.day.ago,
+        session_id: "sess",
+        session_expires_at: 1.hour.ago
+      )
+
+      assert_includes EnableBankingItem.with_stale_psu_ip, item
+    end
+  end
+
+  test "with_stale_psu_ip includes items with IP older than retention period" do
+    travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      item = create_item(
+        last_psu_ip: "203.0.113.2",
+        last_psu_ip_at: 91.days.ago,
+        session_id: "sess",
+        session_expires_at: 30.days.from_now
+      )
+
+      assert_includes EnableBankingItem.with_stale_psu_ip, item
+    end
+  end
+
+  test "with_stale_psu_ip includes legacy items without last_psu_ip_at past retention" do
+    travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      item = EnableBankingItem.create!(@base_attrs.merge(
+        last_psu_ip: "203.0.113.3",
+        session_id: "sess",
+        session_expires_at: 30.days.from_now
+      ))
+      item.update_columns(updated_at: 91.days.ago, last_psu_ip_at: nil)
+
+      assert_includes EnableBankingItem.with_stale_psu_ip, item
+    end
+  end
+
+  test "with_stale_psu_ip excludes fresh IP with valid session" do
+    travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      item = create_item(
+        last_psu_ip: "203.0.113.4",
+        last_psu_ip_at: 10.days.ago,
+        session_id: "sess",
+        session_expires_at: 30.days.from_now
+      )
+
+      assert_not_includes EnableBankingItem.with_stale_psu_ip, item
+    end
+  end
+
+  test "clear_stale_psu_ip! nullifies IP fields" do
+    travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      item = create_item(
+        last_psu_ip: "203.0.113.5",
+        last_psu_ip_at: 1.day.ago,
+        session_id: "sess",
+        session_expires_at: 1.hour.ago
+      )
+
+      EnableBankingItem.clear_stale_psu_ip!
+      item.reload
+
+      assert_nil item.last_psu_ip
+      assert_nil item.last_psu_ip_at
+    end
+  end
+
+  test "record_psu_ip! sets IP and timestamp" do
+    travel_to Time.zone.parse("2026-05-20 12:00:00") do
+      item = EnableBankingItem.create!(@base_attrs)
+
+      item.record_psu_ip!("198.51.100.1")
+      item.reload
+
+      assert_equal "198.51.100.1", item.last_psu_ip
+      assert_equal Time.current, item.last_psu_ip_at
+    end
+  end
+
+  test "record_psu_ip! ignores blank IP" do
+    item = EnableBankingItem.create!(@base_attrs)
+
+    item.record_psu_ip!("")
+    item.reload
+
+    assert_nil item.last_psu_ip
+    assert_nil item.last_psu_ip_at
+  end
+
+  private
+
+    def create_item(**attrs)
+      EnableBankingItem.create!(@base_attrs.merge(attrs))
+    end
+end

--- a/test/models/enable_banking_item/psu_ip_retention_test.rb
+++ b/test/models/enable_banking_item/psu_ip_retention_test.rb
@@ -40,14 +40,15 @@ class EnableBankingItem::PsuIpRetentionTest < ActiveSupport::TestCase
     end
   end
 
-  test "with_stale_psu_ip includes legacy items without last_psu_ip_at past retention" do
+  test "with_stale_psu_ip uses last_psu_ip_at not updated_at for retention" do
     travel_to Time.zone.parse("2026-05-20 12:00:00") do
-      item = EnableBankingItem.create!(@base_attrs.merge(
-        last_psu_ip: "203.0.113.3",
+      item = create_item(
+        last_psu_ip: "203.0.113.6",
+        last_psu_ip_at: 91.days.ago,
         session_id: "sess",
         session_expires_at: 30.days.from_now
-      ))
-      item.update_columns(updated_at: 91.days.ago, last_psu_ip_at: nil)
+      )
+      item.update_columns(updated_at: Time.current)
 
       assert_includes EnableBankingItem.with_stale_psu_ip, item
     end


### PR DESCRIPTION
## Summary

- Adds `last_psu_ip_at` so Enable Banking PSU IP retention can be enforced accurately.
- Clears `last_psu_ip` / `last_psu_ip_at` when the banking session expires or the IP is older than 90 days, via the existing daily `DataCleanerJob`.
- Captures IP and timestamp together through `EnableBankingItem#record_psu_ip!` on OAuth authorize and callback.

## Why

Enable Banking requires storing the user’s IP for PSD2 `Psu-Ip-Address` headers, but the codebase had a GDPR/CCPA TODO with no automated cleanup. This implements scheduled data minimization without UI changes.

## Test plan

- [ ] `bin/rails db:migrate`
- [ ] `bin/rails test test/models/enable_banking_item/psu_ip_retention_test.rb`
- [ ] `bin/rails test test/jobs/data_cleaner_job_test.rb`
- [ ] `bin/rubocop` (if you touched only the files in this PR, spot-check those paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of stale PSU IP addresses in line with GDPR/CCPA (90-day retention).
  * Persisting PSU IP with timestamp during banking authorization flows.

* **Chores**
  * Database migration and backfill to add timestamp for PSU IP.
  * Updated scheduled job description to reflect added cleanup.

* **Tests**
  * Added tests for PSU IP retention logic and the cleanup job.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->