### PR TITLE
Speed up 'BudgetsController#show'

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -1,8 +1,17 @@
 module BudgetsHelper
+  # Derives the "any category over budget?" flag from the already-computed
+  # `categories_state` so we don't walk the full budget_categories list a
+  # second time and re-trigger `available_to_spend` / `subcategories` work
+  # for every parent card. The original version called
+  # `budget.budget_categories.any?(&:any_over_budget?)`, which on top of
+  # being a separate iteration also short-circuited *after* the first
+  # over-budget row — so for a budget where most categories are over budget
+  # it added very little, but for the common case where the first row is
+  # on-track it walked the entire list anyway.
   def budget_has_over_budget?(budget)
     return false unless budget.initialized?
 
-    budget.budget_categories.any?(&:any_over_budget?)
+    budget_categories_view_state(budget)[:over_budget_count].positive?
   end
 
   def budget_categories_view_state(budget)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -266,7 +266,7 @@ class Budget < ApplicationRecord
   # Budget allocations: How much user has budgeted for all parent categories combined
   # =============================================================================
   def allocated_spending
-    budget_categories.reject { |bc| bc.subcategory? }.sum(&:budgeted_spending)
+    @allocated_spending ||= budget_categories.reject { |bc| bc.subcategory? }.sum(&:budgeted_spending)
   end
 
   def allocated_percent
@@ -287,11 +287,14 @@ class Budget < ApplicationRecord
   # Income: How much user earned relative to what they expected to earn
   # =============================================================================
   def estimated_income
-    family.income_statement.median_income(interval: "month")
+    # Use the memoized `income_statement` helper rather than re-instantiating
+    # via `family.income_statement`, which throws away the per-instance memos
+    # for categories, period totals, exchange rates, etc.
+    income_statement.median_income(interval: "month")
   end
 
   def actual_income
-    family.income_statement.income_totals(period: self.period).total
+    income_statement.income_totals(period: self.period).total
   end
 
   def actual_income_percent

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -50,7 +50,8 @@ class BudgetCategory < ApplicationRecord
   end
 
   def actual_spending
-    budget.budget_category_actual_spending(self)
+    return @actual_spending if defined?(@actual_spending)
+    @actual_spending = budget.budget_category_actual_spending(self)
   end
 
   def update_budgeted_spending!(new_budgeted_spending)
@@ -100,11 +101,12 @@ class BudgetCategory < ApplicationRecord
   end
 
   def available_to_spend
-    if inherits_parent_budget?
+    return @available_to_spend if defined?(@available_to_spend)
+
+    @available_to_spend = if inherits_parent_budget?
       # Subcategories using parent budget share the parent's available_to_spend
       parent = parent_budget_category
-      return 0 unless parent
-      parent.available_to_spend
+      parent ? parent.available_to_spend : 0
     elsif subcategory?
       # Subcategory with individual limit
       (self[:budgeted_spending] || 0) - actual_spending
@@ -136,21 +138,36 @@ class BudgetCategory < ApplicationRecord
   end
 
   def percent_of_budget_spent
-    if inherits_parent_budget?
+    return @percent_of_budget_spent if defined?(@percent_of_budget_spent)
+
+    @percent_of_budget_spent = if inherits_parent_budget?
       # For subcategories using parent budget, show their spending as percentage of parent's budget
       parent = parent_budget_category
-      return 0 unless parent
-
-      parent_budget = parent[:budgeted_spending] || 0
-      return 0 if parent_budget == 0 && actual_spending == 0
-      return 100 if parent_budget == 0 && actual_spending > 0
-      (actual_spending.to_f / parent_budget) * 100
+      if parent.nil?
+        0
+      else
+        parent_budget = parent[:budgeted_spending] || 0
+        if parent_budget == 0 && actual_spending == 0
+          0
+        elsif parent_budget == 0 && actual_spending > 0
+          100
+        else
+          (actual_spending.to_f / parent_budget) * 100
+        end
+      end
     else
       budget_amount = self[:budgeted_spending] || 0
-      return 0 if budget_amount == 0 && actual_spending == 0
-      return 0 if budget_amount > 0 && actual_spending == 0
-      return 100 if budget_amount == 0 && actual_spending > 0
-      (actual_spending.to_f / budget_amount) * 100 if budget_amount > 0 && actual_spending > 0
+      if budget_amount == 0 && actual_spending == 0
+        0
+      elsif budget_amount > 0 && actual_spending == 0
+        0
+      elsif budget_amount == 0 && actual_spending > 0
+        100
+      elsif budget_amount > 0 && actual_spending > 0
+        (actual_spending.to_f / budget_amount) * 100
+      else
+        0
+      end
     end
   end
 
@@ -232,13 +249,21 @@ class BudgetCategory < ApplicationRecord
     budget.budget_categories.select { |bc| bc.category.parent_id == category.parent_id && bc.id != id }
   end
 
+  # Returns sibling BudgetCategory rows whose Category#parent_id matches this
+  # parent category. Previously this issued a fresh SQL query on every call,
+  # which created severe N+1 in views: `available_to_spend`, `over_budget?`,
+  # `near_limit?`, `bar_width_percent` all touch it for every parent card, and
+  # each card partial calls those methods multiple times.
+  #
+  # `budget.budget_categories` is already loaded with `includes(:category)` by
+  # the association scope, so we filter in-memory and memoize the result.
   def subcategories
-    return BudgetCategory.none unless category.parent_id.nil?
-    return BudgetCategory.none if category.id.nil?
+    return [] unless category.parent_id.nil?
+    return [] if category.id.nil?
 
-    budget.budget_categories
-      .joins(:category)
-      .where(categories: { parent_id: category.id })
+    @subcategories ||= budget.budget_categories.select do |bc|
+      bc.category.parent_id == category.id
+    end
   end
 
   private

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,6 +16,12 @@ Rails.application.configure do
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
+  # Optional `Server-Timing` response headers — handy for confirming where time
+  # is actually being spent (controller vs view vs DB) without re-deploying
+  # tracing changes. Enable temporarily with SERVER_TIMING=true; results are
+  # visible in any browser's dev tools Network → Timing tab.
+  config.server_timing = ENV["SERVER_TIMING"] == "true"
+
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,24 +1,58 @@
 if ENV["SENTRY_DSN"].present?
+  # Routes for which tracing/profiling are skipped because the data we get back
+  # is low signal relative to the latency they add on every sampled request.
+  # Add or remove patterns here as needed.
+  SENTRY_LOW_VALUE_PATH_PATTERNS = [
+    %r{\A/budgets(/|\z)},
+    %r{\A/reports(/|\z)},
+    %r{\A/?\z}, # root dashboard
+    %r{\A/(rails/|cable|assets/|packs/)}, # rails internals
+    %r{\A/up\z}, # healthcheck
+  ].freeze
+
   Sentry.init do |config|
     config.dsn = ENV["SENTRY_DSN"]
     config.environment = ENV["RAILS_ENV"]
     config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
     config.enabled_environments = %w[production]
 
-    # Enable sending logs to Sentry
-    config.enable_logs = true
-    # Patch Ruby logger to forward logs
-    config.enabled_patches = [ :logger ]
+    # Log forwarding is OFF by default. The Sentry `:logger` patch wraps
+    # `Logger#add` and ships *every* Rails log line (SQL Load lines included)
+    # through Sentry on every request — sampled or not. That's the single
+    # biggest reason "sentry-rails" keeps showing up in traces even after
+    # dropping the sample rates. Set SENTRY_ENABLE_LOGS=true only when you're
+    # actively chasing a log-only signal.
+    if ENV["SENTRY_ENABLE_LOGS"] == "true"
+      config.enable_logs = true
+      config.enabled_patches = [ :logger ]
+    end
 
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production.
-    config.traces_sample_rate = 0.25
+    # Tracing/profiling sample rates can be tuned per-deploy without code
+    # changes. Defaults are intentionally low so the average response time
+    # chart reflects real application work, not profiler overhead.
+    base_traces_rate   = (ENV["SENTRY_TRACES_SAMPLE_RATE"]   || "0.05").to_f
+    base_profiles_rate = (ENV["SENTRY_PROFILES_SAMPLE_RATE"] || "0.01").to_f
 
-    # Set profiles_sample_rate to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    config.profiles_sample_rate = 0.25
+    # `traces_sampler` lets us skip tracing entirely on specific paths.
+    # When this returns 0, `Sentry::Rails::CaptureExceptions` still runs as
+    # error-capture middleware but does NOT start a transaction / profile,
+    # which removes the bulk of per-request Sentry overhead on hot endpoints.
+    config.traces_sampler = ->(sampling_context) {
+      env = sampling_context[:env] || {}
+      path = env["PATH_INFO"].to_s
+
+      next 0.0 if SENTRY_LOW_VALUE_PATH_PATTERNS.any? { |pat| path.match?(pat) }
+
+      # Inherit the parent transaction's sampled state when present so
+      # distributed traces stay consistent.
+      if (parent = sampling_context[:parent_sampled])
+        next parent ? 1.0 : 0.0
+      end
+
+      base_traces_rate
+    }
+
+    config.profiles_sample_rate = base_profiles_rate
 
     config.release = Rails.root.join(".sure-version").read.strip rescue nil
     config.profiler_class = Sentry::Vernier::Profiler


### PR DESCRIPTION
I am currently very interested in this project. However, its slow response time is a drawback. Consequently, after investigating the project using Skylight, I decided to optimize "BudgetsController#show"—the specific endpoint identified as having a slow response time.

## Summary
Speed up `BudgetsController#show` by cutting repeated per-category work in models/helpers and reducing Sentry overhead on hot paths so production traces reflect real app time.
- **BudgetCategory**: Memoize `actual_spending`, `available_to_spend`, and `percent_of_budget_spent`; replace per-call SQL in `subcategories` with an in-memory filter over the already-loaded `budget.budget_categories` association.
- **Budget**: Memoize `allocated_spending`; route income helpers through the memoized `income_statement` instead of `family.income_statement`.
- **BudgetsHelper**: Derive `budget_has_over_budget?` from `budget_categories_view_state[:over_budget_count]` instead of a second full-category pass.
- **Sentry**: Disable log forwarding by default; `traces_sampler` skips `/budgets/*`, `/reports/*`, dashboard, and Rails internals; env-tunable sample rates.
- **Production**: Optional `Server-Timing` when `SERVER_TIMING=true`.

## Test plan
- [x] Open **Budgets** from the sidebar; use prev/next, **Today**, and month picker.
- [ x] Confirm category cards (spent %, over-budget styling, subcategories with parent budget).
- [ x] Compare latency with `SERVER_TIMING=true` if needed.
- [ x] Confirm Sentry transaction volume for `/budgets/*` drops while errors still capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented caching for budget calculations to reduce computational overhead on repeated requests.

* **Configuration**
  * Made error tracking and performance monitoring settings configurable via environment variables for greater operational control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->