### PR TITLE
feat(design-system): extend DS::Pill with badge mode + semantic tones (#1751 PR A)

### DIFF
--- a/app/components/DS/pill.html.erb
+++ b/app/components/DS/pill.html.erb
@@ -9,7 +9,9 @@
         title="<%= title || t("ds.pill.aria_label", label: label) %>"></span>
 <% else %>
   <span class="<%= container_classes %>" style="<%= container_styles %>" title="<%= title || label %>">
-    <% if show_dot %>
+    <% if icon %>
+      <%= helpers.icon(icon, size: "xs", color: "current") %>
+    <% elsif show_dot %>
       <span class="inline-block shrink-0 rounded-full"
             style="width: <%= dot_size_px %>px; height: <%= dot_size_px %>px; background-color: <%= dot_color %>;"></span>
     <% end %>

--- a/app/components/DS/pill.rb
+++ b/app/components/DS/pill.rb
@@ -1,27 +1,60 @@
 class DS::Pill < DesignSystemComponent
-  TONES = %i[violet indigo fuchsia amber gray].freeze
+  TONES = %i[violet indigo fuchsia amber green gray red].freeze
   STYLES = %i[soft filled outline].freeze
   SIZES = %i[sm md].freeze
 
-  attr_reader :label, :tone, :style, :size, :show_dot, :dot_only, :title
+  # Semantic-name → visual-tone aliases. Lets callers say
+  # `tone: :success` instead of binding to the underlying palette name.
+  # The aliases live here (not on the caller) so the visual palette can
+  # be retuned without touching every callsite.
+  SEMANTIC_TONE_ALIASES = {
+    success:     :green,
+    warning:     :amber,
+    error:       :red,
+    destructive: :red,
+    info:        :indigo,
+    neutral:     :gray
+  }.freeze
 
-  # Generic inline pill primitive. Currently the home of Beta / Canary
-  # markers; can be reused for future tags (NEW, PRO, EXPERIMENTAL, etc.)
-  # without forking the component.
+  attr_reader :label, :tone, :style, :size, :show_dot, :dot_only, :title, :icon, :marker
+
+  # Generic inline pill primitive. Two modes:
+  #
+  # - `marker: true` (default) — the original shape from #1829: uppercase
+  #   10/11px text, tracking-wide. Reads as a stage marker (Beta, Canary,
+  #   NEW, PRO, EXPERIMENTAL, …).
+  #
+  # - `marker: false` — normal case, snaps to the DS text scale
+  #   (`text-xs` / `text-sm`). Reads as a status / category badge.
+  #   Pair with semantic tones (`:success`, `:warning`, `:error`,
+  #   `:info`, `:neutral`) for status badges; pair with visual tones
+  #   (`:violet`, `:indigo`, etc.) for category tags.
+  #
+  # Other options:
   #
   # - `dot_only: true` renders only the colored dot (no label, no border).
   #   Use on the collapsed sidebar nav, where there's no room for the label.
-  # - Sure has full violet / indigo / fuchsia / amber / gray ramps in the
-  #   design system; this component picks named tokens at render time. No
-  #   raw hex.
-  def initialize(label: nil, tone: :violet, style: :soft, size: :sm, show_dot: true, dot_only: false, title: nil)
+  # - `icon:` overrides the dot with a Lucide icon (sized xs, current color).
+  #   Useful for status pills that benefit from a glyph (circle-check,
+  #   triangle-alert, pause, etc.) rather than the generic dot.
+  # - Tones accept both visual names (`:violet`, `:amber`, …) and
+  #   semantic aliases (`:success`, `:warning`, `:error`,
+  #   `:destructive`, `:neutral`, `:info`). Aliases resolve via
+  #   `SEMANTIC_TONE_ALIASES`.
+  # - Sure has full violet / indigo / fuchsia / amber / green / gray /
+  #   red ramps in the design system; this component picks named tokens
+  #   at render time. No raw hex.
+  def initialize(label: nil, tone: :violet, style: :soft, size: :sm, show_dot: true, dot_only: false, title: nil, icon: nil, marker: true)
+    resolved_tone = SEMANTIC_TONE_ALIASES.fetch(tone.to_sym, tone.to_sym)
     @label = label || I18n.t("ds.pill.default_label", default: "Beta")
-    @tone = TONES.include?(tone.to_sym) ? tone.to_sym : :violet
+    @tone = TONES.include?(resolved_tone) ? resolved_tone : :violet
     @style = STYLES.include?(style.to_sym) ? style.to_sym : :soft
     @size = SIZES.include?(size.to_sym) ? size.to_sym : :sm
     @show_dot = show_dot
     @dot_only = dot_only
     @title = title
+    @icon = icon
+    @marker = marker
   end
 
   def palette
@@ -30,7 +63,9 @@ class DS::Pill < DesignSystemComponent
       indigo:  { bg: "var(--color-indigo-50)",  bg_dark: "var(--color-indigo-tint-10)",  text: "var(--color-indigo-700)",  text_dark: "var(--color-indigo-200)",  border: "var(--color-indigo-200)",  dot: "var(--color-indigo-500)",  fill: "var(--color-indigo-500)" },
       fuchsia: { bg: "var(--color-fuchsia-50)", bg_dark: "var(--color-fuchsia-tint-10)", text: "var(--color-fuchsia-700)", text_dark: "var(--color-fuchsia-200)", border: "var(--color-fuchsia-200)", dot: "var(--color-fuchsia-500)", fill: "var(--color-fuchsia-500)" },
       amber:   { bg: "var(--color-yellow-50)",  bg_dark: "var(--color-yellow-tint-10)",  text: "var(--color-yellow-700)",  text_dark: "var(--color-yellow-200)",  border: "var(--color-yellow-200)",  dot: "var(--color-yellow-500)",  fill: "var(--color-yellow-500)" },
-      gray:    { bg: "var(--color-gray-100)",   bg_dark: "var(--color-gray-tint-10)",    text: "var(--color-gray-700)",    text_dark: "var(--color-gray-200)",    border: "var(--color-gray-200)",    dot: "var(--color-gray-500)",    fill: "var(--color-gray-500)" }
+      green:   { bg: "var(--color-green-50)",   bg_dark: "var(--color-green-tint-10)",   text: "var(--color-green-700)",   text_dark: "var(--color-green-200)",   border: "var(--color-green-200)",   dot: "var(--color-green-500)",   fill: "var(--color-green-500)" },
+      gray:    { bg: "var(--color-gray-100)",   bg_dark: "var(--color-gray-tint-10)",    text: "var(--color-gray-700)",    text_dark: "var(--color-gray-200)",    border: "var(--color-gray-200)",    dot: "var(--color-gray-500)",    fill: "var(--color-gray-500)" },
+      red:     { bg: "var(--color-red-50)",     bg_dark: "var(--color-red-tint-10)",     text: "var(--color-red-700)",     text_dark: "var(--color-red-200)",     border: "var(--color-red-200)",     dot: "var(--color-red-500)",     fill: "var(--color-red-500)" }
     }[tone]
   end
 
@@ -68,15 +103,27 @@ class DS::Pill < DesignSystemComponent
 
   def container_classes
     base = [
-      "inline-flex items-center align-middle font-medium uppercase whitespace-nowrap shrink-0",
+      "inline-flex items-center align-middle font-medium whitespace-nowrap shrink-0",
       "border rounded-md",
       "leading-none"
     ]
-    # text-[10/11px] stays as arbitrary values: the pill is intentionally
-    # sub-12px (Sure's smallest scale token is text-xs / 12px) to read as
-    # a marker, not a label. Padding / gap / tracking snap to Tailwind's
-    # scale to satisfy the design-system "no arbitrary values" rule.
-    base << (size == :md ? "px-2 py-0.5 text-[11px] tracking-wide gap-1" : "px-1.5 py-0.5 text-[10px] tracking-wider gap-1")
+
+    if marker
+      # Marker mode (Beta / Canary / NEW): uppercase, sub-12px text,
+      # wider tracking. text-[10/11px] stays as arbitrary values — the
+      # pill is intentionally sub-12px (Sure's smallest scale token is
+      # text-xs / 12px) so it reads as a marker, not a label. Padding /
+      # gap / tracking snap to Tailwind's scale to satisfy the
+      # design-system "no arbitrary values" rule.
+      base << "uppercase"
+      base << (size == :md ? "px-2 py-0.5 text-[11px] tracking-wide gap-1" : "px-1.5 py-0.5 text-[10px] tracking-wider gap-1")
+    else
+      # Badge mode (Pending / Active / Past due / category tag):
+      # normal case, snaps to the design-system text scale
+      # (`text-xs` / `text-sm`). Padding bumps slightly so the badge
+      # reads as a status chip rather than a sub-12px marker.
+      base << (size == :md ? "px-2 py-0.5 text-sm gap-1.5" : "px-1.5 py-0.5 text-xs gap-1")
+    end
     class_names(*base)
   end
 end

--- a/test/components/DS/pill_test.rb
+++ b/test/components/DS/pill_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class DS::PillTest < ViewComponent::TestCase
+  test "marker mode (default) renders uppercase sub-12px chrome" do
+    render_inline(DS::Pill.new(label: "Beta", tone: :violet))
+
+    pill = page.find("span", text: "Beta")
+    assert_includes pill[:class], "uppercase"
+    # Marker keeps sub-12px text via arbitrary value (intentional — see component docs).
+    assert_match(/text-\[1[01]px\]/, pill[:class])
+  end
+
+  test "marker: false renders normal-case DS-scale chrome" do
+    render_inline(DS::Pill.new(label: "Active", tone: :success, marker: false))
+
+    pill = page.find("span", text: "Active")
+    refute_includes pill[:class], "uppercase"
+    # Badge mode snaps to text-xs / text-sm — no sub-12px arbitrary values.
+    assert_match(/text-(xs|sm)/, pill[:class])
+    refute_match(/text-\[1[01]px\]/, pill[:class])
+  end
+
+  test "semantic tone aliases resolve to visual palette tones" do
+    {
+      success:     :green,
+      warning:     :amber,
+      error:       :red,
+      destructive: :red,
+      info:        :indigo,
+      neutral:     :gray
+    }.each do |alias_name, expected_visual|
+      pill = DS::Pill.new(label: "x", tone: alias_name)
+      assert_equal expected_visual, pill.tone, "Expected #{alias_name} → #{expected_visual}, got #{pill.tone}"
+    end
+  end
+
+  test "unknown tone falls back to violet" do
+    pill = DS::Pill.new(label: "x", tone: :nonexistent)
+    assert_equal :violet, pill.tone
+  end
+
+  test "red tone palette resolves to red-* tokens" do
+    pill = DS::Pill.new(label: "Failed", tone: :error)
+    assert_includes pill.palette[:dot], "color-red-500"
+    assert_includes pill.palette[:bg], "color-red-50"
+  end
+
+  test "icon option renders glyph in place of dot" do
+    render_inline(DS::Pill.new(label: "Syncing", tone: :info, marker: false, icon: "loader"))
+
+    # Lucide icon helper renders the inline SVG; verifying we see at least one <svg>
+    # is enough — the icon helper is covered by its own tests.
+    assert_selector "svg"
+    # And the dot is suppressed when an icon takes its place.
+    refute_selector "span.rounded-full[style*='background-color']", count: 1
+  end
+end

--- a/test/components/DS/pill_test.rb
+++ b/test/components/DS/pill_test.rb
@@ -51,7 +51,9 @@ class DS::PillTest < ViewComponent::TestCase
     # Lucide icon helper renders the inline SVG; verifying we see at least one <svg>
     # is enough — the icon helper is covered by its own tests.
     assert_selector "svg"
-    # And the dot is suppressed when an icon takes its place.
-    refute_selector "span.rounded-full[style*='background-color']", count: 1
+    # And the dot is suppressed when an icon takes its place. `refute_selector
+    # ..., count: N` only fails when there are exactly N matches, so use
+    # `assert_no_selector` to strictly assert zero dots.
+    assert_no_selector "span.rounded-full[style*='background-color']"
   end
 end

--- a/test/components/previews/pill_component_preview.rb
+++ b/test/components/previews/pill_component_preview.rb
@@ -1,26 +1,68 @@
 class PillComponentPreview < ViewComponent::Preview
-  # @param tone select ["violet", "indigo", "fuchsia", "amber", "gray"]
+  # @param tone select ["violet", "indigo", "fuchsia", "amber", "green", "gray", "red", "success", "warning", "error", "info", "neutral"]
   # @param style select ["soft", "filled", "outline"]
   # @param size select ["sm", "md"]
   # @param label text
   # @param show_dot toggle
   # @param dot_only toggle
-  def default(tone: "violet", style: "soft", size: "sm", label: "Preview", show_dot: true, dot_only: false)
+  # @param marker toggle
+  # @param icon text
+  def default(tone: "violet", style: "soft", size: "sm", label: "Preview", show_dot: true, dot_only: false, marker: true, icon: nil)
     render DS::Pill.new(
       label: label,
       tone: tone.to_sym,
       style: style.to_sym,
       size: size.to_sym,
       show_dot: show_dot,
-      dot_only: dot_only
+      dot_only: dot_only,
+      marker: marker,
+      icon: icon.presence
     )
   end
 
+  # @!group Stage markers (marker: true — original #1829 shape)
   def canary
     render DS::Pill.new(label: "Canary", tone: :fuchsia)
+  end
+
+  def beta
+    render DS::Pill.new(label: "Beta", tone: :violet)
+  end
+
+  def new_marker
+    render DS::Pill.new(label: "New", tone: :indigo)
   end
 
   def dot_only_collapsed_sidebar
     render DS::Pill.new(dot_only: true, tone: :violet)
   end
+  # @!endgroup
+
+  # @!group Status badges (marker: false, semantic tones)
+  def status_active
+    render DS::Pill.new(label: "Active", tone: :success, marker: false)
+  end
+
+  def status_pending
+    render DS::Pill.new(label: "Pending", tone: :warning, marker: false)
+  end
+
+  def status_failed
+    render DS::Pill.new(label: "Failed", tone: :error, marker: false, icon: "circle-alert")
+  end
+
+  def status_archived
+    render DS::Pill.new(label: "Archived", tone: :neutral, marker: false)
+  end
+
+  def status_info
+    render DS::Pill.new(label: "Syncing", tone: :info, marker: false, icon: "loader")
+  end
+  # @!endgroup
+
+  # @!group Sizes (md)
+  def status_md
+    render DS::Pill.new(label: "Past due", tone: :error, marker: false, size: :md)
+  end
+  # @!endgroup
 end


### PR DESCRIPTION
Refs #1751 (PR A of N — API extension only, no callsite migrations).

The existing `DS::Pill` from #1829 is a stage marker (uppercase, sub-12px, tracking-wide — `Beta`, `Canary`, `NEW`). #1751 calls for the same primitive to also serve as the shared status / category badge across ~25 callsites. This PR extends the API to cover both use cases without forking the component. No callsites migrated yet — that lands in follow-up PRs sliced by bucket (transaction badges, provider badges, misc) to keep diffs small.

## What changed

**`marker: false` flag (default `true`)** — drops the uppercase + arbitrary sub-12px text and snaps to the DS text scale. Reads as a status badge, not a marker.

| Mode | `:sm` | `:md` |
|---|---|---|
| `marker: true` (default — unchanged from #1829) | text-[10px] uppercase tracking-wider | text-[11px] uppercase tracking-wide |
| `marker: false` (new — status / category badge) | text-xs | text-sm |

**Semantic tone aliases.** Status badges read more naturally with semantic names:

| Alias | Visual tone |
|---|---|
| `:success` | `:green` |
| `:warning` | `:amber` |
| `:error` / `:destructive` | `:red` |
| `:info` | `:indigo` |
| `:neutral` | `:gray` |

Visual-name tones still work — aliases resolve at init time via `SEMANTIC_TONE_ALIASES`. Unknown tones still fall back to `:violet`.

**`:red` tone.** Palette tokens already exist in `design/tokens/sure.tokens.json` (`red-50/100/200/500/700/tint-10`), so no token changes — just the palette mapping in `DS::Pill#palette`.

**`icon:` slot.** Already documented in the component doc-comment as planned. When set, the Lucide glyph replaces the colored dot.

## Backwards compatibility

`DS::Pill` currently has no in-app callsites — #1829 shipped the primitive ahead of consumers. Existing API is fully preserved: `marker:` defaults to `true`, so any caller using the unextended API renders exactly as before.

## Test plan

- [x] `bin/rails test test/components/DS/pill_test.rb` — 6 runs, 23 assertions, 0 failures (covers semantic-tone resolution, fallback, marker-mode chrome, badge-mode chrome, icon swap-in, red-palette wiring)
- [x] `bin/rails test test/components/` — all green
- [x] `bin/rubocop -f github app/components/DS/pill.rb test/components/DS/pill_test.rb test/components/previews/pill_component_preview.rb` — clean
- [x] `bundle exec erb_lint app/components/DS/pill.html.erb` — clean
- [x] Lookbook preview at `/lookbook/inspect/pill_component/default` — added groups for stage markers, status badges, and sizes

## Follow-ups (not in this PR)

- PR B — migrate transaction badges (`_transaction.erb`, `_split_parent_row`, `_header`, `_transfer_match`, `searches/filters/_badge`)
- PR C — migrate provider badges (`_status_pill`, `_maturity_badge`, `simplefin/_activity_badge`, sophtron inline)
- PR D — misc (`shared/_badge`, `shared/_color_badge`, `categories/_badge`, `accounts/_tax_treatment_badge`, `investment_activity/_badge`, `investment_activity/_quick_edit_badge`, `import/qif_category_selections`)

Each bucket touches disjoint files, so B / C / D can land in parallel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pill supports custom icons; providing an icon displays it and hides the dot.
  * Added semantic tone aliases (success, warning, error, info) and expanded color palette.
  * Marker vs badge modes now render distinct visual styles (marker uses uppercase; badge preserves normal casing and sizing).

* **Tests**
  * Added comprehensive tests covering tones, marker/badge styling, icon vs dot behavior, and palette mappings.

* **Previews**
  * Expanded component previews for marker, stage, status, and size variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->