### PR TITLE
fix(settings/debugs): replace 2 raw palette tokens (DS drift)

### DIFF
--- a/app/views/settings/debugs/show.html.erb
+++ b/app/views/settings/debugs/show.html.erb
@@ -59,7 +59,7 @@
     <% if @debug_log_entries.any? %>
       <div class="overflow-x-auto">
         <table class="w-full">
-          <thead class="bg-surface-default border-b border-primary">
+          <thead class="bg-surface border-b border-primary">
             <tr>
               <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase"><%= t(".table.time") %></th>
               <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase"><%= t(".table.level") %></th>
@@ -70,7 +70,7 @@
               <th class="px-4 py-3 text-left text-xs font-medium text-secondary uppercase"><%= t(".table.metadata") %></th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-100">
+          <tbody class="divide-y divide-alpha-black-200 theme-dark:divide-alpha-white-200">
             <% @debug_log_entries.each do |entry| %>
               <tr>
                 <td class="px-4 py-3 text-sm text-primary whitespace-nowrap"><%= l(entry.created_at, format: :long) %></td>


### PR DESCRIPTION
Refs #1895, #1898 (partial — see below).

Fixes the two non-`<details>` findings from the weekly `sure-design` drift scan in `app/views/settings/debugs/show.html.erb`:

| Before | After | Reason |
|---|---|---|
| `bg-surface-default` | `bg-surface` | `bg-surface-default` doesn't map to any DS color var (`--color-surface-default` isn't defined); `--color-surface` is the canonical token. |
| `divide-gray-100` | `divide-alpha-black-200 theme-dark:divide-alpha-white-200` | No `divide-primary` utility exists. Matches the existing tbody divider pattern in `admin/sso_providers/index.html.erb`, `admin/users/index.html.erb`, and `settings/preferences/show.html.erb`. |

## Why not the `<details>` migration too?

The bot's third finding is the in-cell `<details>` metadata expander. Both bot issues recommend `DS::Disclosure(variant: :inline)`. That variant is added in #1858 and is not yet on `main`.

The existing `:default` variant renders `bg-surface px-3 py-2 rounded-xl` chrome on the summary, which is wrong for an in-table-cell trigger (turns it into a card instead of an inline expander). A follow-up PR will swap the raw `<details>` for `DS::Disclosure(variant: :inline)` once #1858 lands.

This PR therefore partially addresses #1895 and #1898 — both stay open until the `<details>` migration lands.

## Test plan

- [x] `bundle exec erb_lint app/views/settings/debugs/show.html.erb` — clean
- [x] `bin/rails tailwindcss:build` — clean (verifies the replacement classes resolve)
- [x] Verified via grep: `bg-surface` resolves to `--color-surface` (line 19 of `_generated.css`); `divide-alpha-black-200` is used by 4 existing views with identical intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated debug log table styling to use theme-aware CSS classes for improved visual consistency across light and dark modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->