### PR TITLE
fix: persist security name from provider search results

### DIFF
--- a/app/models/security/resolver.rb
+++ b/app/models/security/resolver.rb
@@ -134,6 +134,7 @@ class Security::Resolver
       )
 
       security.country_code = match.country_code
+      security.name = match.name if match.name.present? && security.name.blank?
 
       # Set provider when explicitly provided (user selection) or when the
       # record is new / has no provider yet. Automated syncs pass nil and


### PR DESCRIPTION
### Problem

When a security is resolved via a provider search (e.g. adding a holding from the security combobox), the matched security's `name` was never saved to the database. `Security::Resolver#find_or_create_provider_match!` only persisted `ticker`, `exchange_operating_mic`, `country_code`, and `price_provider`.

As a result, every provider-resolved security had `name: nil` in the DB. Since `Holding#name` is defined as:

```ruby
def name
  security.name || ticker
end
```

...the holding's display name fell back to the ticker, so both the name row and ticker row in the Holdings UI showed the ticker value (e.g. `118955` for an Indian mutual fund).

### Fix

One-line addition in `Security::Resolver#find_or_create_provider_match!` to assign the provider-returned name when the security is new or has no name yet:

```ruby
security.name = match.name if match.name.present? && security.name.blank?
```

The guard (`blank?`) prevents overwriting a name that was manually set by the user on an existing record.

### Affected providers

All providers that surface search results through [Security.search_provider](https://github.com/we-promise/sure/blob/50936000e7d5bed1aead37ce65c4f962b9f9f236/app/models/security/provided.rb#L40) — currently Yahoo Finance, Tiingo, EODHD, Twelve Data, Alpha Vantage, Binance, and mfapi — were all affected, since the bug is in the shared resolver rather than any individual provider.

### Testing

- Existing resolver tests continue to pass
- Manually verified: adding a new holding via the security combobox now persists the correct security name to the DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security names are now automatically populated from provider data when available, improving data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->