### PR TITLE
fix(rules): validate Rule::Condition type registry + normalize legacy values

### DIFF
--- a/app/models/rule/condition.rb
+++ b/app/models/rule/condition.rb
@@ -1,4 +1,9 @@
 class Rule::Condition < ApplicationRecord
+  # Keep in sync with the keys returned by each Rule::Registry subclass'
+  # #condition_filters (plus "compound", which is handled directly in #apply
+  # rather than via a filter). A cross-check test in
+  # test/models/rule/condition_test.rb guards against drift between this list
+  # and the registry.
   SUPPORTED_CONDITION_TYPES = %w[
     compound
     transaction_account

--- a/app/models/rule/condition.rb
+++ b/app/models/rule/condition.rb
@@ -1,10 +1,28 @@
 class Rule::Condition < ApplicationRecord
+  SUPPORTED_CONDITION_TYPES = %w[
+    compound
+    transaction_account
+    transaction_amount
+    transaction_category
+    transaction_details
+    transaction_merchant
+    transaction_name
+    transaction_notes
+    transaction_type
+  ].freeze
+
+  LEGACY_CONDITION_TYPE_ALIASES = {
+    "name" => "transaction_name"
+  }.freeze
+
   belongs_to :rule, touch: true, optional: -> { where.not(parent_id: nil) }
   belongs_to :parent, class_name: "Rule::Condition", optional: true, inverse_of: :sub_conditions
 
   has_many :sub_conditions, -> { order(:created_at, :id) }, class_name: "Rule::Condition", foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent
 
-  validates :condition_type, presence: true
+  before_validation :normalize_legacy_condition_type
+
+  validates :condition_type, presence: true, inclusion: { in: SUPPORTED_CONDITION_TYPES, allow_blank: true }
   validates :operator, presence: true
   validates :value, presence: true, unless: -> { compound? || operator == "is_null" }
 
@@ -57,9 +75,18 @@ class Rule::Condition < ApplicationRecord
 
   def filter
     rule.registry.get_filter!(condition_type)
+  rescue Rule::Registry::UnsupportedConditionError
+    Rule::ConditionFilter::Unsupported.new(rule, condition_type)
   end
 
   private
+    def normalize_legacy_condition_type
+      return if condition_type.blank?
+
+      normalized = LEGACY_CONDITION_TYPE_ALIASES[condition_type]
+      self.condition_type = normalized if normalized
+    end
+
     def build_compound_scope(scope)
       if operator == "or"
         combined_scope = sub_conditions

--- a/app/models/rule/condition.rb
+++ b/app/models/rule/condition.rb
@@ -1,10 +1,29 @@
 class Rule::Condition < ApplicationRecord
+  SUPPORTED_CONDITION_TYPES = %w[
+    compound
+    transaction_account
+    transaction_amount
+    transaction_category
+    transaction_details
+    transaction_merchant
+    transaction_name
+    transaction_notes
+    transaction_tag
+    transaction_type
+  ].freeze
+
+  LEGACY_CONDITION_TYPE_ALIASES = {
+    "name" => "transaction_name"
+  }.freeze
+
   belongs_to :rule, touch: true, optional: -> { where.not(parent_id: nil) }
   belongs_to :parent, class_name: "Rule::Condition", optional: true, inverse_of: :sub_conditions
 
   has_many :sub_conditions, -> { order(:created_at, :id) }, class_name: "Rule::Condition", foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent
 
-  validates :condition_type, presence: true
+  before_validation :normalize_legacy_condition_type
+
+  validates :condition_type, presence: true, inclusion: { in: SUPPORTED_CONDITION_TYPES, allow_blank: true }
   validates :operator, presence: true
   validates :value, presence: true, unless: -> { compound? || operator == "is_null" }
 
@@ -57,9 +76,18 @@ class Rule::Condition < ApplicationRecord
 
   def filter
     rule.registry.get_filter!(condition_type)
+  rescue Rule::Registry::UnsupportedConditionError
+    Rule::ConditionFilter::Unsupported.new(rule, condition_type)
   end
 
   private
+    def normalize_legacy_condition_type
+      return if condition_type.blank?
+
+      normalized = LEGACY_CONDITION_TYPE_ALIASES[condition_type]
+      self.condition_type = normalized if normalized
+    end
+
     def build_compound_scope(scope)
       if operator == "or"
         combined_scope = sub_conditions

--- a/app/models/rule/condition.rb
+++ b/app/models/rule/condition.rb
@@ -1,21 +1,5 @@
 class Rule::Condition < ApplicationRecord
-  # Keep in sync with the keys returned by each Rule::Registry subclass'
-  # #condition_filters (plus "compound", which is handled directly in #apply
-  # rather than via a filter). A cross-check test in
-  # test/models/rule/condition_test.rb guards against drift between this list
-  # and the registry.
-  SUPPORTED_CONDITION_TYPES = %w[
-    compound
-    transaction_account
-    transaction_amount
-    transaction_category
-    transaction_details
-    transaction_merchant
-    transaction_name
-    transaction_notes
-    transaction_tag
-    transaction_type
-  ].freeze
+  SUPPORTED_CONDITION_TYPES = (Rule::Registry::TransactionResource.condition_filter_keys + [ "compound" ]).freeze
 
   LEGACY_CONDITION_TYPE_ALIASES = {
     "name" => "transaction_name"

--- a/app/models/rule/condition_filter.rb
+++ b/app/models/rule/condition_filter.rb
@@ -13,6 +13,10 @@ class Rule::ConditionFilter
     @rule = rule
   end
 
+  def self.key
+    name.demodulize.underscore
+  end
+
   def type
     "text"
   end
@@ -23,7 +27,7 @@ class Rule::ConditionFilter
   end
 
   def key
-    self.class.name.demodulize.underscore
+    self.class.key
   end
 
   def label

--- a/app/models/rule/condition_filter/unsupported.rb
+++ b/app/models/rule/condition_filter/unsupported.rb
@@ -1,0 +1,18 @@
+class Rule::ConditionFilter::Unsupported < Rule::ConditionFilter
+  def initialize(rule, condition_type)
+    super(rule)
+    @condition_type = condition_type.to_s
+  end
+
+  def key
+    @condition_type
+  end
+
+  def label
+    I18n.t("rule.conditions.unsupported_label", type: @condition_type)
+  end
+
+  def apply(scope, _operator, _value)
+    scope.none
+  end
+end

--- a/app/models/rule/condition_filter/unsupported.rb
+++ b/app/models/rule/condition_filter/unsupported.rb
@@ -13,6 +13,10 @@ class Rule::ConditionFilter::Unsupported < Rule::ConditionFilter
   end
 
   def apply(scope, _operator, _value)
+    Rails.logger.warn(
+      "Rule::ConditionFilter::Unsupported applied: " \
+      "rule_id=#{rule&.id.inspect} condition_type=#{@condition_type.inspect} — matching zero records"
+    )
     scope.none
   end
 end

--- a/app/models/rule/registry/transaction_resource.rb
+++ b/app/models/rule/registry/transaction_resource.rb
@@ -1,20 +1,26 @@
 class Rule::Registry::TransactionResource < Rule::Registry
+  CONDITION_FILTER_CLASSES = [
+    Rule::ConditionFilter::TransactionName,
+    Rule::ConditionFilter::TransactionAmount,
+    Rule::ConditionFilter::TransactionType,
+    Rule::ConditionFilter::TransactionMerchant,
+    Rule::ConditionFilter::TransactionCategory,
+    Rule::ConditionFilter::TransactionTag,
+    Rule::ConditionFilter::TransactionDetails,
+    Rule::ConditionFilter::TransactionNotes,
+    Rule::ConditionFilter::TransactionAccount
+  ].freeze
+
+  def self.condition_filter_keys
+    CONDITION_FILTER_CLASSES.map(&:key)
+  end
+
   def resource_scope
     family.transactions.visible.with_entry.merge(Entry.excluding_split_parents).where(entry: { date: rule.effective_date.. })
   end
 
   def condition_filters
-    [
-      Rule::ConditionFilter::TransactionName.new(rule),
-      Rule::ConditionFilter::TransactionAmount.new(rule),
-      Rule::ConditionFilter::TransactionType.new(rule),
-      Rule::ConditionFilter::TransactionMerchant.new(rule),
-      Rule::ConditionFilter::TransactionCategory.new(rule),
-      Rule::ConditionFilter::TransactionTag.new(rule),
-      Rule::ConditionFilter::TransactionDetails.new(rule),
-      Rule::ConditionFilter::TransactionNotes.new(rule),
-      Rule::ConditionFilter::TransactionAccount.new(rule)
-    ]
+    CONDITION_FILTER_CLASSES.map { |filter_class| filter_class.new(rule) }
   end
 
   def action_executors

--- a/config/locales/models/rule/en.yml
+++ b/config/locales/models/rule/en.yml
@@ -7,3 +7,6 @@ en:
           min_actions: "must have at least one action"
           duplicate_actions: "Rule cannot have duplicate actions %{types}"
           nested_conditions: "Compound conditions cannot be nested"
+  rule:
+    conditions:
+      unsupported_label: "Unsupported (%{type})"

--- a/db/migrate/20260616120000_normalize_rule_condition_types.rb
+++ b/db/migrate/20260616120000_normalize_rule_condition_types.rb
@@ -1,0 +1,12 @@
+class NormalizeRuleConditionTypes < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE rule_conditions
+      SET condition_type = 'transaction_name'
+      WHERE condition_type = 'name'
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20260616120000_normalize_rule_condition_types.rb
+++ b/db/migrate/20260616120000_normalize_rule_condition_types.rb
@@ -8,5 +8,7 @@ class NormalizeRuleConditionTypes < ActiveRecord::Migration[7.2]
   end
 
   def down
+    raise ActiveRecord::IrreversibleMigration,
+      "Cannot reverse normalization of legacy 'name' condition_type values"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_07_071000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_16_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -486,6 +486,17 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_not expense_filtered.map(&:id).include?(contribution_entry.transaction.id)
   end
 
+  test "SUPPORTED_CONDITION_TYPES matches the registry's filter keys" do
+    # Guards against drift: if a new condition filter is added to a Rule::Registry,
+    # SUPPORTED_CONDITION_TYPES must be updated too, otherwise the inclusion
+    # validation in Rule::Condition will reject types the registry can handle.
+    registry_keys = @transaction_rule.registry.condition_filters.map(&:key)
+    # "compound" is handled directly in Rule::Condition#apply rather than via a filter.
+    expected = (registry_keys + [ "compound" ]).sort
+
+    assert_equal expected, Rule::Condition::SUPPORTED_CONDITION_TYPES.sort
+  end
+
   test "validates condition_type against supported registry" do
     condition = Rule::Condition.new(
       rule: @transaction_rule,

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -486,6 +486,48 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_not expense_filtered.map(&:id).include?(contribution_entry.transaction.id)
   end
 
+  test "validates condition_type against supported registry" do
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "definitely_not_a_real_type",
+      operator: "like",
+      value: "x"
+    )
+
+    assert_not condition.valid?
+    assert_includes condition.errors[:condition_type], "is not included in the list"
+  end
+
+  test "normalizes legacy 'name' condition_type to 'transaction_name' on save" do
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "name",
+      operator: "like",
+      value: "starbucks"
+    )
+
+    assert condition.valid?, condition.errors.full_messages.to_sentence
+    assert_equal "transaction_name", condition.condition_type
+  end
+
+  test "filter falls back gracefully when persisted condition_type is unsupported" do
+    # Bypass validations to simulate legacy rows that already exist in the database.
+    condition = Rule::Condition.new(
+      condition_type: "transaction_name",
+      operator: "like",
+      value: "x"
+    )
+    condition.rule = @transaction_rule
+    condition.save!
+    condition.update_columns(condition_type: "name")
+    condition.reload
+
+    assert_nothing_raised do
+      assert_equal "Unsupported (name)", condition.filter.label
+      assert_equal "name", condition.filter.key
+    end
+  end
+
   test "transaction_type income excludes investment_contribution" do
     scope = @rule_scope
 

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -604,6 +604,17 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_not expense_filtered.map(&:id).include?(contribution_entry.transaction.id)
   end
 
+  test "SUPPORTED_CONDITION_TYPES matches the registry's filter keys" do
+    # Guards against drift: if a new condition filter is added to a Rule::Registry,
+    # SUPPORTED_CONDITION_TYPES must be updated too, otherwise the inclusion
+    # validation in Rule::Condition will reject types the registry can handle.
+    registry_keys = @transaction_rule.registry.condition_filters.map(&:key)
+    # "compound" is handled directly in Rule::Condition#apply rather than via a filter.
+    expected = (registry_keys + [ "compound" ]).sort
+
+    assert_equal expected, Rule::Condition::SUPPORTED_CONDITION_TYPES.sort
+  end
+
   test "validates condition_type against supported registry" do
     condition = Rule::Condition.new(
       rule: @transaction_rule,

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -604,6 +604,48 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_not expense_filtered.map(&:id).include?(contribution_entry.transaction.id)
   end
 
+  test "validates condition_type against supported registry" do
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "definitely_not_a_real_type",
+      operator: "like",
+      value: "x"
+    )
+
+    assert_not condition.valid?
+    assert_includes condition.errors[:condition_type], "is not included in the list"
+  end
+
+  test "normalizes legacy 'name' condition_type to 'transaction_name' on save" do
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "name",
+      operator: "like",
+      value: "starbucks"
+    )
+
+    assert condition.valid?, condition.errors.full_messages.to_sentence
+    assert_equal "transaction_name", condition.condition_type
+  end
+
+  test "filter falls back gracefully when persisted condition_type is unsupported" do
+    # Bypass validations to simulate legacy rows that already exist in the database.
+    condition = Rule::Condition.new(
+      condition_type: "transaction_name",
+      operator: "like",
+      value: "x"
+    )
+    condition.rule = @transaction_rule
+    condition.save!
+    condition.update_columns(condition_type: "name")
+    condition.reload
+
+    assert_nothing_raised do
+      assert_equal "Unsupported (name)", condition.filter.label
+      assert_equal "name", condition.filter.key
+    end
+  end
+
   test "transaction_type income excludes investment_contribution" do
     scope = @rule_scope
 

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -604,13 +604,8 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_not expense_filtered.map(&:id).include?(contribution_entry.transaction.id)
   end
 
-  test "SUPPORTED_CONDITION_TYPES matches the registry's filter keys" do
-    # Guards against drift: if a new condition filter is added to a Rule::Registry,
-    # SUPPORTED_CONDITION_TYPES must be updated too, otherwise the inclusion
-    # validation in Rule::Condition will reject types the registry can handle.
-    registry_keys = @transaction_rule.registry.condition_filters.map(&:key)
-    # "compound" is handled directly in Rule::Condition#apply rather than via a filter.
-    expected = (registry_keys + [ "compound" ]).sort
+  test "SUPPORTED_CONDITION_TYPES comes from the registry's filter keys" do
+    expected = (Rule::Registry::TransactionResource.condition_filter_keys + [ "compound" ]).sort
 
     assert_equal expected, Rule::Condition::SUPPORTED_CONDITION_TYPES.sort
   end

--- a/test/system/rules_test.rb
+++ b/test/system/rules_test.rb
@@ -34,4 +34,25 @@ class RulesTest < ApplicationSystemTestCase
     assert_selector "th", text: /queued\s+processed\s+modified\s+blocked/i
     assert_selector "td", text: "20 / 20 / 10 / 10"
   end
+
+  test "rules page renders gracefully when a condition has an unsupported condition_type" do
+    rule = @user.family.rules.create!(
+      name: "Legacy bad rule",
+      resource_type: "transaction",
+      conditions: [
+        Rule::Condition.new(condition_type: "transaction_name", operator: "like", value: "x")
+      ],
+      actions: [
+        Rule::Action.new(action_type: "set_transaction_category", value: categories(:food_and_drink).id)
+      ]
+    )
+
+    # Simulate a legacy row written before the inclusion validation existed.
+    rule.conditions.first.update_columns(condition_type: "name")
+
+    visit rules_path
+
+    assert_selector "h3", text: "Legacy bad rule"
+    assert_text "Unsupported (name)"
+  end
 end


### PR DESCRIPTION
## Summary

- Validate `Rule::Condition#condition_type` against a registry constant so unknown values can't reach `/rules`.
- Normalize the one known legacy value (`"name"`) to `"transaction_name"` on save via a `before_validation` callback.
- Render `/rules` and the edit form gracefully (`Unsupported (<key>)` label, `scope.none` apply) when a row still has an unsupported `condition_type`.
- Ship a one-shot migration to update any existing `name` rows to `transaction_name`.

Closes #1229

## What changed

- [app/models/rule/condition.rb](app/models/rule/condition.rb): add `SUPPORTED_CONDITION_TYPES` constant, `LEGACY_CONDITION_TYPE_ALIASES = { "name" => "transaction_name" }`, `before_validation :normalize_legacy_condition_type`, `validates :condition_type, inclusion: { in: SUPPORTED_CONDITION_TYPES, allow_blank: true }`, and rescue `Rule::Registry::UnsupportedConditionError` in `#filter` to return a placeholder.
- [app/models/rule/condition_filter/unsupported.rb](app/models/rule/condition_filter/unsupported.rb): new placeholder filter — `label` is `"Unsupported (<key>)"` (i18n), `apply` returns `scope.none`.
- [db/migrate/20260521120000_normalize_rule_condition_types.rb](db/migrate/20260521120000_normalize_rule_condition_types.rb): `UPDATE rule_conditions SET condition_type = 'transaction_name' WHERE condition_type = 'name'`.
- [db/schema.rb](db/schema.rb): bump schema version.
- [config/locales/models/rule/en.yml](config/locales/models/rule/en.yml): add `rule.conditions.unsupported_label`.
- [test/models/rule/condition_test.rb](test/models/rule/condition_test.rb): inclusion-rejection test, normalization test, and a `update_columns`-bypass test that proves `filter` no longer raises for a persisted unsupported value (the codepath that crashes `/rules` today via `_rule.html.erb`).

## Why

@jjmata asked the reporter for a PR ("Can you send a PR... would speed things up"). The reporter's `Suggested fix` was: validate `condition_type`, normalize legacy values, fail safely in the UI.

Scope note on legacy normalization: the reporter listed `transaction_details` alongside `name` as legacy, but per the dosubot maintainer-style comment and the existing tests at [test/models/rule/condition_test.rb:186-290](test/models/rule/condition_test.rb:186), `transaction_details` is a real registered filter that searches the `transactions.extra` JSONB metadata field — not a synonym for `transaction_name`. Silently rewriting it would change the semantics of valid rules, so this PR only normalizes the actually-unsupported value (`"name"`).

## Validation

I'm on Windows without a local Ruby/Postgres environment, so I have not been able to run `bin/rails test` locally — CI is the source of truth here. What CI will exercise:

- Existing `Rule::Condition` + `Rule::Registry` test suites continue to pass.
- New tests in [test/models/rule/condition_test.rb](test/models/rule/condition_test.rb) cover the inclusion validation, the `name` → `transaction_name` normalization, and the graceful-render path (`update_columns` bypass to simulate a row written before the validation existed).
- `bin/rubocop` and `bundle exec erb_lint` will run on changed files.

What I did do manually: read the registry (`Rule::Registry::TransactionResource#condition_filters`), the crashing view (`app/views/rule/conditions/_condition.html.erb`, `app/views/rules/_rule.html.erb` line 18 — `displayed_condition.filter.label`), the controller, `db/schema.rb` for the column, and confirmed `transaction_details` is a real filter (not legacy).

## Notes

- No API/OpenAPI surface changes (`Rule::Condition` is internal-only).
- Migration is a single `UPDATE` — `rule_conditions` is a small per-family table, so batching/`disable_ddl_transaction!` isn't warranted; happy to switch to a batched form if a reviewer prefers.
- The `Unsupported` filter returns `scope.none` from `apply`, so a stale row stops matching anything rather than silently matching everything. After the migration runs, the only way to land in that branch is `update_columns`-style bypass.
- English-only locale change; other locales fall back per Rails default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rules with unsupported condition types now render with an "Unsupported (type)" label instead of erroring.

* **Bug Fixes**
  * Legacy condition type values are normalized automatically on save and validated against supported types.
  * Filter evaluation for persisted unsupported types now fails gracefully (returns no matches) without raising exceptions.

* **Database Migrations**
  * Migration added to update legacy condition types in existing data.

* **Tests**
  * Coverage added for normalization, validation, graceful fallback, and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->