### PR TITLE
perf: use jemalloc as the default allocator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq \
-    && apt-get install --no-install-recommends -y curl libvips postgresql-client libyaml-0-2 procps \
+    && apt-get install --no-install-recommends -y curl libvips postgresql-client libyaml-0-2 procps libjemalloc2 \
     && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment
@@ -19,7 +19,7 @@ ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development" \
     BUILD_COMMIT_SHA=${BUILD_COMMIT_SHA}
-    
+
 # Throw-away build stage to reduce size of final image
 FROM base AS build
 

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -4,6 +4,9 @@
 JEMALLOC="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2"
 if [ -f "$JEMALLOC" ] && [ -z "${DISABLE_JEMALLOC}" ]; then
   export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}$JEMALLOC"
+  echo "jemalloc enabled (LD_PRELOAD=$LD_PRELOAD)"
+else
+  echo "jemalloc disabled (DISABLE_JEMALLOC=${DISABLE_JEMALLOC:-unset}, jemalloc present=$([ -f "$JEMALLOC" ] && echo yes || echo no))"
 fi
 
 # If running the rails server then create or migrate existing database

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -4,9 +4,10 @@
 JEMALLOC="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2"
 if [ -f "$JEMALLOC" ] && [ -z "${DISABLE_JEMALLOC}" ]; then
   export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}$JEMALLOC"
-  echo "jemalloc enabled (LD_PRELOAD=$LD_PRELOAD)"
 else
-  echo "jemalloc disabled (DISABLE_JEMALLOC=${DISABLE_JEMALLOC:-unset}, jemalloc present=$([ -f "$JEMALLOC" ] && echo yes || echo no))"
+  [ -n "${DISABLE_JEMALLOC}" ] \
+    && echo "WARNING: jemalloc disabled via DISABLE_JEMALLOC" \
+    || echo "WARNING: jemalloc not found at $JEMALLOC, skipping"
 fi
 
 # If running the rails server then create or migrate existing database

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,8 +2,8 @@
 
 # Use jemalloc to reduce memory fragmentation if available
 JEMALLOC="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2"
-if [ -f "$JEMALLOC" ]; then
-  export LD_PRELOAD="$JEMALLOC"
+if [ -f "$JEMALLOC" ] && [ -z "${DISABLE_JEMALLOC}" ]; then
+  export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}$JEMALLOC"
 fi
 
 # If running the rails server then create or migrate existing database

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+# Use jemalloc to reduce memory fragmentation if available
+JEMALLOC="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2"
+if [ -f "$JEMALLOC" ]; then
+  export LD_PRELOAD="$JEMALLOC"
+fi
+
 # If running the rails server then create or migrate existing database
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
   ./bin/rails db:prepare


### PR DESCRIPTION
## Summary

Swap Ruby's default `glibc malloc` allocator for [jemalloc](https://jemalloc.net/) in the Docker image. Two small infrastructure changes — no application code touched — that deliver across-the-board performance improvements on both lightweight and DB-backed endpoints.

---

## What is jemalloc?

`jemalloc` is a general-purpose `malloc(3)` implementation developed at Meta. It is the default allocator in Firefox, FreeBSD, and many high-throughput server environments. Compared to glibc's allocator, jemalloc:

- Uses per-thread arenas to dramatically reduce lock contention under concurrent load
- Actively returns unused memory pages to the OS instead of holding onto them indefinitely
- Produces a flatter, more predictable memory footprint over time

Ruby's object allocation patterns — many short-lived small objects, periodic GC, Ractors/threads — align almost perfectly with jemalloc's design goals.

---

## Benchmark results
 
> **Methodology:** `wrk` 2-minute load test, 2 threads, 10 connections. RSS sampled every second throughout each run. Both runs started from a cold boot of the same process.
 
Two endpoints were tested to show the effect across different workload weights.
 
---
 
### Run 1 — Unauthenticated redirect (`/` → login)
 
A lightweight baseline: no DB queries, no auth, just a redirect. Even here, jemalloc shows clear gains.
 
<img width="2292" height="1474" alt="image" src="https://github.com/user-attachments/assets/e1ee2705-35ec-4fe7-a59c-4afb5a20054a" />
 
| Metric | glibc malloc | jemalloc | Δ |
|---|---|---|---|
| **Requests/sec** | 481.34 | **527.81** | **+9.7%** ✅ |
| **Avg latency** | 71.46 ms | **47.40 ms** | **−33.7%** ✅ |
| **Latency stdev** | 144.30 ms | **77.29 ms** | **−46.5%** ✅ |
| **Max latency** | 1,510 ms | **1,180 ms** | **−21.9%** ✅ |
| Requests served (2 min) | 57,789 | **63,388** | **+9.7%** |
 
### Memory (RSS) — Run 1
 
| Metric | glibc malloc | jemalloc | Δ |
|---|---|---|---|
| **Peak RSS** | 308 MB | **306 MB** | −2 MB |
| **Memory growth (idle → peak)** | +24.1 MB | **+22.3 MB** | **−7%** ✅ |
 
---
 
### Run 2 — Authenticated account transactions page (`/accounts/:id`)
 
A real, DB-backed endpoint requiring a full Rails request cycle — auth, DB queries, view rendering. This is where jemalloc's per-thread arenas and reduced fragmentation have the most to offer.
 
<img width="2292" height="1474" alt="image" src="https://github.com/user-attachments/assets/d75e48b2-f0e9-4242-8875-050392e0b53b" />
 
| Metric | glibc malloc | jemalloc | Δ |
|---|---|---|---|
| **Requests/sec** | 4.29 | **7.51** | **+75.1%** ✅ |
| **Avg latency** | 485.67 ms | **387.30 ms** | **−20.3%** ✅ |
| **Latency stdev** | 195.82 ms | **131.53 ms** | **−32.8%** ✅ |
| **Max latency** | 1,360 ms | 1,370 ms | ~same |
| Requests served (2 min) | 515 | **902** | **+75.1%** ✅ |
 
jemalloc served **75% more requests** in the same window. Average latency dropped by 98ms and variance fell by a third — responses are faster and more consistent. The more work Ruby does per request, the more the allocator improvements compound.
 
### Memory (RSS) — Run 2
 
| Metric | glibc malloc | jemalloc | Δ |
|---|---|---|---|
| **Peak RSS** | 382 MB | 402 MB | +20 MB |
| **Memory growth (idle → peak)** | +276.1 MB | **+118.3 MB** | **−57%** ✅ |
 
The peak RSS is slightly higher for jemalloc — expected, since it processed 75% more requests. The meaningful metric is memory growth per unit of work: glibc malloc grew by 276 MB to serve 515 requests; jemalloc grew by only 118 MB to serve 902.
 
- **glibc malloc** grows monotonically and never returns memory to the OS. Once allocated, it stays allocated.
- **jemalloc** actively trims and returns pages between GC cycles — visible as oscillation in the RSS chart. This is the more important property for long-running production processes.
 
In production, over hours or days, this difference compounds: glibc malloc processes drift upward until they are recycled; jemalloc processes stabilize.

---

## Changes

**`Dockerfile`** — add `libjemalloc2` to the base image apt install:

```diff
-    && apt-get install --no-install-recommends -y curl libvips postgresql-client libyaml-0-2 procps \
+    && apt-get install --no-install-recommends -y curl libvips postgresql-client libyaml-0-2 procps libjemalloc2 \
```

**`bin/docker-entrypoint`** — preload jemalloc when available, with arch-aware path, `DISABLE_JEMALLOC` escape hatch, and silent happy path:

```diff
+# Use jemalloc to reduce memory fragmentation if available
+JEMALLOC="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2"
+if [ -f "$JEMALLOC" ] && [ -z "${DISABLE_JEMALLOC}" ]; then
+  export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}$JEMALLOC"
+else
+  [ -n "${DISABLE_JEMALLOC}" ] \
+    && echo "WARNING: jemalloc disabled via DISABLE_JEMALLOC" \
+    || echo "WARNING: jemalloc not found at $JEMALLOC, skipping"
+fi
```

**Logging behaviour:** the happy path is completely silent. A `WARNING:` line is only emitted in the two degraded cases — explicit opt-out via `DISABLE_JEMALLOC`, or library absent at the expected path — so production log aggregators see no routine noise.

**`LD_PRELOAD` scope:** the export is unconditional with respect to the `rails server` check that follows, so every process launched from this container — including Sidekiq workers — inherits jemalloc automatically. No separate configuration is needed. Sidekiq's multithreaded allocation patterns typically benefit at least as much as Puma; the benchmarks above measure Puma/Rails throughput only.

Two files, no application code touched. Fully reversible via `DISABLE_JEMALLOC=1`.

---

## Why now?

This is a well-established production optimisation used by [Shopify](https://shopify.engineering/adventures-in-production-rails-infrastructure), [GitHub](https://github.blog/engineering/), and most other high-traffic Rails deployments. The only reason it isn't on by default is that it requires installing a system package. For a Dockerised app like this one, that barrier is trivially low.

---

## Testing

- [x] App boots and serves requests correctly under jemalloc
- [x] No change in test suite results
- [x] RSS confirmed stable over 2+ minute load runs
- [x] Verified `LD_PRELOAD` is active via `/proc/self/maps` in container
- [x] Verified `DISABLE_JEMALLOC=1` suppresses preload and emits a single `WARNING:` line
- [x] Verified missing library path emits a `WARNING:` and falls back gracefully

---

## Updates (post-review)

> Changes made in response to code review feedback on this PR.

**Boot log noise** (f28b45c) — The entrypoint previously echoed a status line on every container start regardless of outcome. The happy path (jemalloc loaded) is now silent. Only the two non-default cases produce output, and both are prefixed `WARNING:` so they stand out in log aggregators:
- `WARNING: jemalloc disabled via DISABLE_JEMALLOC` — when the escape hatch is used
- `WARNING: jemalloc not found at <path>, skipping` — when the library is absent

**Sidekiq coverage noted** — `LD_PRELOAD` is exported before the `rails server` guard, so Sidekiq containers spawned from this image inherit jemalloc with no additional configuration. The benchmarks cover Puma/Rails only; Sidekiq's memory profile under jemalloc is typically better still due to its higher thread count and allocation rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a system-level runtime library to the container image.
  * Adjusted container startup to preload that library when available and to report whether preloading was activated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->