### PR TITLE
Prevent Brand Fetch client ID autofill

### DIFF
--- a/app/views/settings/hostings/_brand_fetch_settings.html.erb
+++ b/app/views/settings/hostings/_brand_fetch_settings.html.erb
@@ -34,6 +34,7 @@
     <%= form.text_field :brand_fetch_client_id,
                         label: t(".label"),
                         type: "password",
+                        autocomplete: "new-password",
                         placeholder: t(".placeholder"),
                         value: ENV.fetch("BRAND_FETCH_CLIENT_ID", Setting.brand_fetch_client_id),
                         disabled: ENV["BRAND_FETCH_CLIENT_ID"].present?,


### PR DESCRIPTION
## Summary

- Prevent password managers from autofilling the Brand Fetch Client ID field by setting an explicit autocomplete hint.
- Avoid accidental auto-submission of saved login passwords into Brandfetch CDN client-id URLs.

Closes #1147
Fixes #1912

## Testing

- bundle exec erb_lint app/views/settings/hostings/_brand_fetch_settings.html.erb