### PR TITLE
fix(settings/debugs): migrate in-cell <details> to DS::Disclosure :inline

### DIFF
--- a/app/views/settings/debugs/show.html.erb
+++ b/app/views/settings/debugs/show.html.erb
@@ -87,10 +87,12 @@
                 </td>
                 <td class="px-4 py-3 text-xs text-secondary align-top">
                   <% if entry.metadata.present? %>
-                    <details>
-                      <summary class="cursor-pointer"><%= t(".table.view_metadata") %></summary>
-                      <pre class="mt-2 whitespace-pre-wrap break-words"><%= JSON.pretty_generate(entry.metadata) %></pre>
-                    </details>
+                    <%= render DS::Disclosure.new(variant: :inline) do |disclosure| %>
+                      <% disclosure.with_summary_content do %>
+                        <span class="text-xs text-secondary"><%= t(".table.view_metadata") %></span>
+                      <% end %>
+                      <pre class="whitespace-pre-wrap break-words"><%= JSON.pretty_generate(entry.metadata) %></pre>
+                    <% end %>
                   <% else %>
                     <%= t(".missing_value") %>
                   <% end %>


### PR DESCRIPTION
Closes #1895. Closes #1898.

Follow-up to #1903 — that PR fixed the two token findings from the weekly drift scan but deferred the third (raw `<details>` in `app/views/settings/debugs/show.html.erb`) because `DS::Disclosure(variant: :inline)` wasn't on `main` yet. #1858 landed that variant overnight, so the migration unblocks.

| Before | After |
|---|---|
| Raw `<details>` + `<summary class="cursor-pointer">` in the metadata cell | `DS::Disclosure(variant: :inline)` with custom summary content |

`:inline` is the right variant for an in-table-cell expander — no surface, no padding, no shadow; reads as plain text-link copy. Matches the recommendation in both bot issues.

## Test plan

- [x] `bundle exec erb_lint app/views/settings/debugs/show.html.erb` — clean
- [x] `bin/rails tailwindcss:build` — clean
- [x] Verified `:inline` variant exists on `main` (`app/components/DS/disclosure.rb:18-22`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the debug log metadata display component to align with design system standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->