### PR TITLE
refactor(providers): migrate provider badges to DS::Pill (#1751 PR C)

### DIFF
--- a/app/components/DS/pill.rb
+++ b/app/components/DS/pill.rb
@@ -104,24 +104,26 @@ class DS::Pill < DesignSystemComponent
   def container_classes
     base = [
       "inline-flex items-center align-middle font-medium whitespace-nowrap shrink-0",
-      "border rounded-md",
-      "leading-none"
+      "border leading-none"
     ]
 
     if marker
-      # Marker mode (Beta / Canary / NEW): uppercase, sub-12px text,
-      # wider tracking. text-[10/11px] stays as arbitrary values — the
-      # pill is intentionally sub-12px (Sure's smallest scale token is
-      # text-xs / 12px) so it reads as a marker, not a label. Padding /
-      # gap / tracking snap to Tailwind's scale to satisfy the
-      # design-system "no arbitrary values" rule.
-      base << "uppercase"
+      # Marker mode (Beta / Canary / NEW): rounded-md (slight chip
+      # shape), uppercase, sub-12px text, wider tracking.
+      # text-[10/11px] stays as arbitrary values — the pill is
+      # intentionally sub-12px (Sure's smallest scale token is text-xs
+      # / 12px) so it reads as a marker, not a label. Padding / gap /
+      # tracking snap to Tailwind's scale to satisfy the design-system
+      # "no arbitrary values" rule.
+      base << "rounded-md uppercase"
       base << (size == :md ? "px-2 py-0.5 text-[11px] tracking-wide gap-1" : "px-1.5 py-0.5 text-[10px] tracking-wider gap-1")
     else
       # Badge mode (Pending / Active / Past due / category tag):
-      # normal case, snaps to the design-system text scale
-      # (`text-xs` / `text-sm`). Padding bumps slightly so the badge
-      # reads as a status chip rather than a sub-12px marker.
+      # rounded-full pill shape (matches the existing convention used
+      # by `settings/providers/_status_pill`, `_maturity_badge`, and
+      # the inline transaction badges). Normal case, snaps to the
+      # design-system text scale (`text-xs` / `text-sm`).
+      base << "rounded-full"
       base << (size == :md ? "px-2 py-0.5 text-sm gap-1.5" : "px-1.5 py-0.5 text-xs gap-1")
     end
     class_names(*base)

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -50,21 +50,6 @@ module SettingsHelper
     render partial: "settings/section", locals: { title: title, subtitle: subtitle, content: content, collapsible: collapsible, open: open, auto_open_param: auto_open_param, status: status, meta: meta, actions: actions, badge: badge }
   end
 
-  def status_pill_classes(status)
-    pill = "bg-surface-inset text-primary"
-
-    case status.to_s.to_sym
-    when :ok
-      { dot: "bg-success", pill: pill }
-    when :warn
-      { dot: "bg-warning", pill: pill }
-    when :err
-      { dot: "bg-destructive", pill: pill }
-    else
-      { dot: "bg-gray-400", pill: pill }
-    end
-  end
-
   def provider_summary(provider_key)
     key = provider_key.to_s.downcase
 

--- a/app/views/settings/providers/_maturity_badge.html.erb
+++ b/app/views/settings/providers/_maturity_badge.html.erb
@@ -1,4 +1,10 @@
 <%# locals: (label:) %>
 <% if label %>
-  <span class="text-xs font-medium px-1.5 py-px rounded-full bg-surface-inset border border-tertiary text-secondary"><%= label %></span>
+  <%= render DS::Pill.new(
+    label: label,
+    tone: :neutral,
+    marker: false,
+    show_dot: false,
+    size: :sm
+  ) %>
 <% end %>

--- a/app/views/settings/providers/_status_pill.html.erb
+++ b/app/views/settings/providers/_status_pill.html.erb
@@ -1,7 +1,15 @@
 <%# locals: (status:) %>
-<% classes = status_pill_classes(status) %>
-<% dot_class, pill_class = classes[:dot], classes[:pill] %>
-<span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium <%= pill_class %>">
-  <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 <%= dot_class %>"></span>
-  <%= t("settings.providers.status.#{status}") %>
-</span>
+<%
+  tone = case status.to_s.to_sym
+         when :ok  then :success
+         when :warn then :warning
+         when :err  then :error
+         else :neutral
+         end
+%>
+<%= render DS::Pill.new(
+  label: t("settings.providers.status.#{status}"),
+  tone: tone,
+  marker: false,
+  size: :sm
+) %>

--- a/app/views/sophtron_items/_sophtron_item.html.erb
+++ b/app/views/sophtron_items/_sophtron_item.html.erb
@@ -24,7 +24,13 @@
             <div class="flex items-center gap-2">
               <%= tag.p provider_display_name, class: "font-medium text-primary" %>
               <% if manual_sync_required %>
-                <span class="rounded-full bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning"><%= t(".manual_sync") %></span>
+                <%= render DS::Pill.new(
+                  label: t(".manual_sync"),
+                  tone: :warning,
+                  marker: false,
+                  show_dot: false,
+                  size: :sm
+                ) %>
               <% end %>
               <% if sophtron_item.scheduled_for_deletion? %>
                 <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>

--- a/app/views/transactions/_header.html.erb
+++ b/app/views/transactions/_header.html.erb
@@ -22,10 +22,13 @@
         <%= entry.date ? I18n.l(entry.date, format: :long) : "—" %>
       </span>
       <% if entry.transaction.pending? %>
-        <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary text-secondary" title="<%= t("transactions.transaction.pending_tooltip") %>">
-          <%= icon "clock", size: "sm", color: "current" %>
-          <%= t("transactions.transaction.pending") %>
-        </span>
+        <%= render DS::Pill.new(
+          label: t("transactions.transaction.pending"),
+          tone: :neutral,
+          marker: false,
+          icon: "clock",
+          title: t("transactions.transaction.pending_tooltip")
+        ) %>
       <% end %>
     </div>
   </div>

--- a/app/views/transactions/_split_parent_row.html.erb
+++ b/app/views/transactions/_split_parent_row.html.erb
@@ -36,10 +36,12 @@
               </div>
 
               <div class="flex items-center gap-1 flex-shrink-0">
-                <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary bg-surface-inset text-secondary">
-                  <%= icon "split", size: "sm", color: "current" %>
-                  <%= t("transactions.split_parent_row.split_label") %>
-                </span>
+                <%= render DS::Pill.new(
+                  label: t("transactions.split_parent_row.split_label"),
+                  tone: :neutral,
+                  marker: false,
+                  icon: "split"
+                ) %>
               </div>
             </div>
 

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -98,33 +98,45 @@
 
                     <%# Pending indicator %>
                     <% if transaction.pending? %>
-                      <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary text-secondary" title="<%= t("transactions.transaction.pending_tooltip") %>">
-                        <%= icon "clock", size: "sm", color: "current" %>
-                        <%= t("transactions.transaction.pending") %>
-                      </span>
+                      <%= render DS::Pill.new(
+                        label: t("transactions.transaction.pending"),
+                        tone: :neutral,
+                        marker: false,
+                        icon: "clock",
+                        title: t("transactions.transaction.pending_tooltip")
+                      ) %>
                     <% end %>
 
                     <%# Potential duplicate indicator - different styling for low vs medium confidence %>
                     <% if transaction.has_potential_duplicate? %>
                       <% if transaction.low_confidence_duplicate? %>
-                        <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary bg-surface-inset text-secondary" title="<%= t("transactions.transaction.review_recommended_tooltip") %>">
-                          <%= icon "help-circle", size: "sm", color: "current" %>
-                          <%= t("transactions.transaction.review_recommended") %>
-                        </span>
+                        <%= render DS::Pill.new(
+                          label: t("transactions.transaction.review_recommended"),
+                          tone: :neutral,
+                          marker: false,
+                          icon: "help-circle",
+                          title: t("transactions.transaction.review_recommended_tooltip")
+                        ) %>
                       <% else %>
-                        <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-warning bg-warning/10 text-warning" title="<%= t("transactions.transaction.potential_duplicate_tooltip") %>">
-                          <%= icon "alert-triangle", size: "sm", color: "current" %>
-                          <%= t("transactions.transaction.possible_duplicate") %>
-                        </span>
+                        <%= render DS::Pill.new(
+                          label: t("transactions.transaction.possible_duplicate"),
+                          tone: :warning,
+                          marker: false,
+                          icon: "alert-triangle",
+                          title: t("transactions.transaction.potential_duplicate_tooltip")
+                        ) %>
                       <% end %>
                     <% end %>
 
                     <%# Split indicator %>
                     <% if @split_parent_entry_ids ? @split_parent_entry_ids.include?(entry.id) : entry.split_parent? %>
-                      <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary bg-surface-inset text-secondary" title="<%= t("transactions.transaction.split_tooltip") %>">
-                        <%= icon "split", size: "sm", color: "current" %>
-                        <%= t("transactions.transaction.split") %>
-                      </span>
+                      <%= render DS::Pill.new(
+                        label: t("transactions.transaction.split"),
+                        tone: :neutral,
+                        marker: false,
+                        icon: "split",
+                        title: t("transactions.transaction.split_tooltip")
+                      ) %>
                     <% end %>
                     <% if entry.split_child? && !in_split_group %>
                       <span class="text-secondary" title="<%= t("transactions.transaction.split_child_tooltip") %>">

--- a/test/components/DS/pill_test.rb
+++ b/test/components/DS/pill_test.rb
@@ -1,16 +1,19 @@
 require "test_helper"
 
 class DS::PillTest < ViewComponent::TestCase
-  test "marker mode (default) renders uppercase sub-12px chrome" do
+  test "marker mode (default) renders uppercase sub-12px chrome with rounded-md" do
     render_inline(DS::Pill.new(label: "Beta", tone: :violet))
 
     pill = page.find("span", text: "Beta")
     assert_includes pill[:class], "uppercase"
     # Marker keeps sub-12px text via arbitrary value (intentional — see component docs).
     assert_match(/text-\[1[01]px\]/, pill[:class])
+    # Marker uses rounded-md (chip shape).
+    assert_includes pill[:class], "rounded-md"
+    refute_includes pill[:class], "rounded-full"
   end
 
-  test "marker: false renders normal-case DS-scale chrome" do
+  test "marker: false renders normal-case DS-scale chrome with rounded-full" do
     render_inline(DS::Pill.new(label: "Active", tone: :success, marker: false))
 
     pill = page.find("span", text: "Active")
@@ -18,6 +21,9 @@ class DS::PillTest < ViewComponent::TestCase
     # Badge mode snaps to text-xs / text-sm — no sub-12px arbitrary values.
     assert_match(/text-(xs|sm)/, pill[:class])
     refute_match(/text-\[1[01]px\]/, pill[:class])
+    # Badge uses rounded-full to match the existing _status_pill / _maturity_badge convention.
+    assert_includes pill[:class], "rounded-full"
+    refute_includes pill[:class], "rounded-md"
   end
 
   test "semantic tone aliases resolve to visual palette tones" do
@@ -51,9 +57,9 @@ class DS::PillTest < ViewComponent::TestCase
     # Lucide icon helper renders the inline SVG; verifying we see at least one <svg>
     # is enough — the icon helper is covered by its own tests.
     assert_selector "svg"
-    # And the dot is suppressed when an icon takes its place. `refute_selector
-    # ..., count: N` only fails when there are exactly N matches, so use
-    # `assert_no_selector` to strictly assert zero dots.
-    assert_no_selector "span.rounded-full[style*='background-color']"
+    # And the dot is suppressed when an icon takes its place. The dot is an
+    # `inline-block` span (parent pill is `inline-flex`), so target it by
+    # `inline-block.rounded-full` to avoid matching the parent pill.
+    assert_no_selector "span.inline-block.rounded-full"
   end
 end


### PR DESCRIPTION
## Summary

Stacks on #1917. Migrates provider-bucket pill/badge callsites to `DS::Pill` (badge mode, `rounded-full`).

**Callsites migrated (3):**

- `app/views/settings/providers/_status_pill.html.erb` — provider connection status pill. Status → tone:
  | status | tone |
  | --- | --- |
  | `:ok` | `:success` |
  | `:warn` | `:warning` |
  | `:err` | `:error` |
  | else (`:off`) | `:neutral` |
- `app/views/settings/providers/_maturity_badge.html.erb` — alpha/beta label. `tone: :neutral, show_dot: false`.
- `app/views/sophtron_items/_sophtron_item.html.erb` (line 27) — "manual sync required" warning. `tone: :warning, show_dot: false`.

The `_status_pill` partial is preserved (still rendered from `_connection_row`); it now just wraps `DS::Pill`. Dead helper `SettingsHelper#status_pill_classes` removed (no remaining callers).

**Skipped:**

- `app/views/simplefin_items/_activity_badge.html.erb` — not a pill. Renders `<p>` text with `text-warning` plus an inline icon below the heading. No `rounded-full`, no chip semantics. Migrating it would change layout, not consolidate a pill pattern.

## Test plan

- [x] `bin/rails tailwindcss:build` — clean
- [x] `bundle exec erb_lint` (3 migrated files) — no errors
- [x] `bin/rubocop` on `settings_helper.rb` — clean
- [x] `bin/rails test test/components/DS/pill_test.rb` — 6 runs, 0 failures
- [x] `bin/rails test test/controllers/settings/` — 88 runs, 0 failures
- [x] `bin/rails test test/helpers/` — 24 runs, 0 failures

Refs #1751.