### PR TITLE
refactor(misc): migrate misc badges to DS::Pill (#1751 PR D)

### DIFF
--- a/app/components/DS/pill.rb
+++ b/app/components/DS/pill.rb
@@ -104,24 +104,26 @@ class DS::Pill < DesignSystemComponent
   def container_classes
     base = [
       "inline-flex items-center align-middle font-medium whitespace-nowrap shrink-0",
-      "border rounded-md",
-      "leading-none"
+      "border leading-none"
     ]
 
     if marker
-      # Marker mode (Beta / Canary / NEW): uppercase, sub-12px text,
-      # wider tracking. text-[10/11px] stays as arbitrary values — the
-      # pill is intentionally sub-12px (Sure's smallest scale token is
-      # text-xs / 12px) so it reads as a marker, not a label. Padding /
-      # gap / tracking snap to Tailwind's scale to satisfy the
-      # design-system "no arbitrary values" rule.
-      base << "uppercase"
+      # Marker mode (Beta / Canary / NEW): rounded-md (slight chip
+      # shape), uppercase, sub-12px text, wider tracking.
+      # text-[10/11px] stays as arbitrary values — the pill is
+      # intentionally sub-12px (Sure's smallest scale token is text-xs
+      # / 12px) so it reads as a marker, not a label. Padding / gap /
+      # tracking snap to Tailwind's scale to satisfy the design-system
+      # "no arbitrary values" rule.
+      base << "rounded-md uppercase"
       base << (size == :md ? "px-2 py-0.5 text-[11px] tracking-wide gap-1" : "px-1.5 py-0.5 text-[10px] tracking-wider gap-1")
     else
       # Badge mode (Pending / Active / Past due / category tag):
-      # normal case, snaps to the design-system text scale
-      # (`text-xs` / `text-sm`). Padding bumps slightly so the badge
-      # reads as a status chip rather than a sub-12px marker.
+      # rounded-full pill shape (matches the existing convention used
+      # by `settings/providers/_status_pill`, `_maturity_badge`, and
+      # the inline transaction badges). Normal case, snaps to the
+      # design-system text scale (`text-xs` / `text-sm`).
+      base << "rounded-full"
       base << (size == :md ? "px-2 py-0.5 text-sm gap-1.5" : "px-1.5 py-0.5 text-xs gap-1")
     end
     class_names(*base)

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,15 +1,13 @@
 module ReportsHelper
-  # Returns CSS classes for tax treatment badge styling
-  def tax_treatment_badge_classes(treatment)
+  # Returns the DS::Pill tone for a given tax treatment. Mirrors the
+  # mapping used by `accounts/_tax_treatment_badge.html.erb` so the
+  # report and the per-account badge stay visually aligned.
+  def tax_treatment_pill_tone(treatment)
     case treatment.to_sym
-    when :tax_exempt
-      "bg-green-500/10 text-green-600 theme-dark:text-green-400"
-    when :tax_deferred
-      "bg-blue-500/10 text-blue-600 theme-dark:text-blue-400"
-    when :tax_advantaged
-      "bg-purple-500/10 text-purple-600 theme-dark:text-purple-400"
-    else
-      "bg-gray-500/10 text-secondary"
+    when :tax_exempt     then :green
+    when :tax_deferred   then :indigo  # was raw blue-500/10 → closest DS tone
+    when :tax_advantaged then :violet  # was raw purple-500/10 → closest DS tone
+    else                      :neutral
     end
   end
 

--- a/app/views/accounts/_tax_treatment_badge.html.erb
+++ b/app/views/accounts/_tax_treatment_badge.html.erb
@@ -1,17 +1,17 @@
 <%# locals: (account:) %>
 <%
   treatment = account.tax_treatment
-  badge_classes = case treatment
-  when :tax_exempt
-    "bg-green-500/10 text-green-600 theme-dark:text-green-400"
-  when :tax_deferred
-    "bg-blue-500/10 text-blue-600 theme-dark:text-blue-400"
-  when :tax_advantaged
-    "bg-purple-500/10 text-purple-600 theme-dark:text-purple-400"
-  else
-    "bg-gray-tint-10 text-secondary"
-  end
+  tone = case treatment
+         when :tax_exempt     then :green
+         when :tax_deferred   then :indigo  # was raw blue-500/10 → maps to closest DS tone
+         when :tax_advantaged then :violet  # was raw purple-500/10 → maps to closest DS tone
+         else                      :neutral
+         end
 %>
-<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= badge_classes %>" title="<%= t("accounts.tax_treatment_descriptions.#{treatment}") %>">
-  <%= account.tax_treatment_label %>
-</span>
+<%= render DS::Pill.new(
+  label: account.tax_treatment_label,
+  tone: tone,
+  marker: false,
+  show_dot: false,
+  title: t("accounts.tax_treatment_descriptions.#{treatment}")
+) %>

--- a/app/views/import/qif_category_selections/show.html.erb
+++ b/app/views/import/qif_category_selections/show.html.erb
@@ -83,7 +83,7 @@
                   <div class="col-span-8 flex items-center gap-2">
                     <span class="text-sm text-primary"><%= category %></span>
                     <% if is_split %>
-                      <span class="inline-flex items-center rounded-full bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning"><%= t(".split_badge") %></span>
+                      <%= render DS::Pill.new(label: t(".split_badge"), tone: :warning, marker: false, show_dot: false) %>
                     <% end %>
                   </div>
                   <span class="col-span-3 text-sm text-secondary text-right">

--- a/app/views/investment_activity/_badge.html.erb
+++ b/app/views/investment_activity/_badge.html.erb
@@ -1,33 +1,14 @@
 <%# locals: (label:) %>
-<%# Simple non-interactive badge for displaying activity labels %>
+<%# Simple non-interactive badge for displaying activity labels. %>
 <%
-  # Color mapping for different investment activity labels
-  color = case label
-  when "Buy"
-    "rgb(59 130 246)" # blue
-  when "Sell"
-    "rgb(239 68 68)" # red
-  when "Dividend", "Interest"
-    "rgb(34 197 94)" # green
-  when "Contribution"
-    "rgb(168 85 247)" # purple
-  when "Withdrawal"
-    "rgb(249 115 22)" # orange
-  when "Fee"
-    "rgb(107 114 128)" # gray
-  when "Transfer", "Sweep In", "Sweep Out", "Exchange"
-    "rgb(107 114 128)" # gray
-  when "Reinvestment"
-    "rgb(59 130 246)" # blue
-  else
-    "rgb(107 114 128)" # gray for "Other"
-  end
+  tone = case label
+         when "Buy", "Reinvestment"                                then :indigo  # was raw blue
+         when "Sell"                                               then :red
+         when "Dividend", "Interest"                               then :green
+         when "Contribution"                                       then :violet  # was raw purple
+         when "Withdrawal"                                         then :amber   # was raw orange
+         when "Fee", "Transfer", "Sweep In", "Sweep Out", "Exchange" then :gray
+         else                                                           :gray
+         end
 %>
-
-<span class="inline-flex items-center gap-1 text-xs font-medium rounded px-1.5 py-0.5 border"
-      style="
-        background-color: color-mix(in oklab, <%= color %> 10%, transparent);
-        border-color: color-mix(in oklab, <%= color %> 20%, transparent);
-        color: <%= color %>;">
-  <%= label %>
-</span>
+<%= render DS::Pill.new(label: label, tone: tone, marker: false, show_dot: false) %>

--- a/app/views/reports/_investment_performance.html.erb
+++ b/app/views/reports/_investment_performance.html.erb
@@ -118,9 +118,13 @@
           <% investment_metrics[:gains_by_tax_treatment].each do |treatment, data| %>
             <div class="bg-container-inset rounded-lg p-4 space-y-3 flex-1 min-w-64">
               <div class="flex items-center justify-between">
-                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= tax_treatment_badge_classes(treatment) %>" title="<%= t("accounts.tax_treatment_descriptions.#{treatment}") %>">
-                  <%= t("accounts.tax_treatments.#{treatment}") %>
-                </span>
+                <%= render DS::Pill.new(
+                  label: t("accounts.tax_treatments.#{treatment}"),
+                  tone: tax_treatment_pill_tone(treatment),
+                  marker: false,
+                  show_dot: false,
+                  title: t("accounts.tax_treatment_descriptions.#{treatment}")
+                ) %>
                 <span class="text-sm font-semibold text-primary privacy-sensitive">
                   <%= format_money(data[:total_gain]) %>
                 </span>

--- a/app/views/shared/_badge.html.erb
+++ b/app/views/shared/_badge.html.erb
@@ -1,22 +1,22 @@
 <%# locals: (color: nil, pulse: false) %>
-
-<%
-  def badge_classes(c, p)
-    classes = case c
-              when "success"
-                "bg-green-500/5 text-green-500"
-              when "error"
-                "bg-red-500/5 text-red-500"
-              when "warning"
-                "bg-orange-500/5 text-orange-500"
-              else
-                "bg-gray-tint-5 text-secondary"
-              end
-
-    p ? "#{classes} animate-pulse" : classes
-  end
+<%#
+  Thin shim over DS::Pill: maps the shared/_badge string color values
+  (`success` / `error` / `warning` / nil) to semantic tones and renders
+  the yielded block as the pill label. `pulse: true` wraps the pill in
+  an `animate-pulse` span (DS::Pill itself doesn't support pulse).
 %>
-
-<span class="inline-flex items-center px-2 py-0.5 rounded-full ring ring-alpha-black-50 text-xs <%= badge_classes(color, pulse) %>">
-  <%= yield %>
-</span>
+<%
+  tone = case color
+         when "success" then :success
+         when "error"   then :error
+         when "warning" then :warning
+         else                :neutral
+         end
+  label = yield
+  pill = render DS::Pill.new(label: label, tone: tone, marker: false, show_dot: false)
+%>
+<% if pulse %>
+  <span class="animate-pulse inline-flex"><%= pill %></span>
+<% else %>
+  <%= pill %>
+<% end %>

--- a/app/views/transactions/_header.html.erb
+++ b/app/views/transactions/_header.html.erb
@@ -22,10 +22,13 @@
         <%= entry.date ? I18n.l(entry.date, format: :long) : "—" %>
       </span>
       <% if entry.transaction.pending? %>
-        <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary text-secondary" title="<%= t("transactions.transaction.pending_tooltip") %>">
-          <%= icon "clock", size: "sm", color: "current" %>
-          <%= t("transactions.transaction.pending") %>
-        </span>
+        <%= render DS::Pill.new(
+          label: t("transactions.transaction.pending"),
+          tone: :neutral,
+          marker: false,
+          icon: "clock",
+          title: t("transactions.transaction.pending_tooltip")
+        ) %>
       <% end %>
     </div>
   </div>

--- a/app/views/transactions/_split_parent_row.html.erb
+++ b/app/views/transactions/_split_parent_row.html.erb
@@ -36,10 +36,12 @@
               </div>
 
               <div class="flex items-center gap-1 flex-shrink-0">
-                <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary bg-surface-inset text-secondary">
-                  <%= icon "split", size: "sm", color: "current" %>
-                  <%= t("transactions.split_parent_row.split_label") %>
-                </span>
+                <%= render DS::Pill.new(
+                  label: t("transactions.split_parent_row.split_label"),
+                  tone: :neutral,
+                  marker: false,
+                  icon: "split"
+                ) %>
               </div>
             </div>
 

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -98,33 +98,45 @@
 
                     <%# Pending indicator %>
                     <% if transaction.pending? %>
-                      <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary text-secondary" title="<%= t("transactions.transaction.pending_tooltip") %>">
-                        <%= icon "clock", size: "sm", color: "current" %>
-                        <%= t("transactions.transaction.pending") %>
-                      </span>
+                      <%= render DS::Pill.new(
+                        label: t("transactions.transaction.pending"),
+                        tone: :neutral,
+                        marker: false,
+                        icon: "clock",
+                        title: t("transactions.transaction.pending_tooltip")
+                      ) %>
                     <% end %>
 
                     <%# Potential duplicate indicator - different styling for low vs medium confidence %>
                     <% if transaction.has_potential_duplicate? %>
                       <% if transaction.low_confidence_duplicate? %>
-                        <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary bg-surface-inset text-secondary" title="<%= t("transactions.transaction.review_recommended_tooltip") %>">
-                          <%= icon "help-circle", size: "sm", color: "current" %>
-                          <%= t("transactions.transaction.review_recommended") %>
-                        </span>
+                        <%= render DS::Pill.new(
+                          label: t("transactions.transaction.review_recommended"),
+                          tone: :neutral,
+                          marker: false,
+                          icon: "help-circle",
+                          title: t("transactions.transaction.review_recommended_tooltip")
+                        ) %>
                       <% else %>
-                        <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-warning bg-warning/10 text-warning" title="<%= t("transactions.transaction.potential_duplicate_tooltip") %>">
-                          <%= icon "alert-triangle", size: "sm", color: "current" %>
-                          <%= t("transactions.transaction.possible_duplicate") %>
-                        </span>
+                        <%= render DS::Pill.new(
+                          label: t("transactions.transaction.possible_duplicate"),
+                          tone: :warning,
+                          marker: false,
+                          icon: "alert-triangle",
+                          title: t("transactions.transaction.potential_duplicate_tooltip")
+                        ) %>
                       <% end %>
                     <% end %>
 
                     <%# Split indicator %>
                     <% if @split_parent_entry_ids ? @split_parent_entry_ids.include?(entry.id) : entry.split_parent? %>
-                      <span class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 border border-secondary bg-surface-inset text-secondary" title="<%= t("transactions.transaction.split_tooltip") %>">
-                        <%= icon "split", size: "sm", color: "current" %>
-                        <%= t("transactions.transaction.split") %>
-                      </span>
+                      <%= render DS::Pill.new(
+                        label: t("transactions.transaction.split"),
+                        tone: :neutral,
+                        marker: false,
+                        icon: "split",
+                        title: t("transactions.transaction.split_tooltip")
+                      ) %>
                     <% end %>
                     <% if entry.split_child? && !in_split_group %>
                       <span class="text-secondary" title="<%= t("transactions.transaction.split_child_tooltip") %>">

--- a/test/components/DS/pill_test.rb
+++ b/test/components/DS/pill_test.rb
@@ -1,16 +1,19 @@
 require "test_helper"
 
 class DS::PillTest < ViewComponent::TestCase
-  test "marker mode (default) renders uppercase sub-12px chrome" do
+  test "marker mode (default) renders uppercase sub-12px chrome with rounded-md" do
     render_inline(DS::Pill.new(label: "Beta", tone: :violet))
 
     pill = page.find("span", text: "Beta")
     assert_includes pill[:class], "uppercase"
     # Marker keeps sub-12px text via arbitrary value (intentional — see component docs).
     assert_match(/text-\[1[01]px\]/, pill[:class])
+    # Marker uses rounded-md (chip shape).
+    assert_includes pill[:class], "rounded-md"
+    refute_includes pill[:class], "rounded-full"
   end
 
-  test "marker: false renders normal-case DS-scale chrome" do
+  test "marker: false renders normal-case DS-scale chrome with rounded-full" do
     render_inline(DS::Pill.new(label: "Active", tone: :success, marker: false))
 
     pill = page.find("span", text: "Active")
@@ -18,6 +21,9 @@ class DS::PillTest < ViewComponent::TestCase
     # Badge mode snaps to text-xs / text-sm — no sub-12px arbitrary values.
     assert_match(/text-(xs|sm)/, pill[:class])
     refute_match(/text-\[1[01]px\]/, pill[:class])
+    # Badge uses rounded-full to match the existing _status_pill / _maturity_badge convention.
+    assert_includes pill[:class], "rounded-full"
+    refute_includes pill[:class], "rounded-md"
   end
 
   test "semantic tone aliases resolve to visual palette tones" do
@@ -51,9 +57,9 @@ class DS::PillTest < ViewComponent::TestCase
     # Lucide icon helper renders the inline SVG; verifying we see at least one <svg>
     # is enough — the icon helper is covered by its own tests.
     assert_selector "svg"
-    # And the dot is suppressed when an icon takes its place. `refute_selector
-    # ..., count: N` only fails when there are exactly N matches, so use
-    # `assert_no_selector` to strictly assert zero dots.
-    assert_no_selector "span.rounded-full[style*='background-color']"
+    # And the dot is suppressed when an icon takes its place. The dot is an
+    # `inline-block` span (parent pill is `inline-flex`), so target it by
+    # `inline-block.rounded-full` to avoid matching the parent pill.
+    assert_no_selector "span.inline-block.rounded-full"
   end
 end


### PR DESCRIPTION
## Summary

Migrates the misc / long-tail badge callsites called out in #1751 to `DS::Pill` (badge mode: `marker: false`, `show_dot: false`). No raw palette classes remain in the migrated files.

Stacked on #1917 (`feat/ds-pill-transactions-1751-b`), which ships the `marker: false` → `rounded-full` shape this PR depends on. **Merge #1917 first.**

Refs #1751.

## Migrated callsites

| File | Tone mapping |
| --- | --- |
| `app/views/shared/_badge.html.erb` | success/error/warning/default → `:success` / `:error` / `:warning` / `:neutral`. Preserved as a thin shim so the 10+ block-style callsites keep working; `pulse: true` wraps the pill in `animate-pulse`. |
| `app/views/accounts/_tax_treatment_badge.html.erb` | `:tax_exempt → :green`, `:tax_deferred → :indigo` (was raw blue), `:tax_advantaged → :violet` (was raw purple), default → `:neutral`. `title=` tooltip preserved. |
| `app/views/reports/_investment_performance.html.erb` (line ~121) | Same mapping via new `tax_treatment_pill_tone` helper in `reports_helper.rb`. Old `tax_treatment_badge_classes` helper had no other callers; replaced. |
| `app/views/import/qif_category_selections/show.html.erb` (line ~86) | Split badge → `tone: :warning`. |
| `app/views/investment_activity/_badge.html.erb` | Fixed activity enum: Buy/Reinvestment → `:indigo`, Sell → `:red`, Dividend/Interest → `:green`, Contribution → `:violet`, Withdrawal → `:amber`, Fee/Transfer/Sweep/Exchange/other → `:gray`. |

## Skipped (true mismatches)

| File | Reason |
| --- | --- |
| `app/views/shared/_color_badge.html.erb` | Renders an arbitrary user-supplied color via `color-mix(in oklab, #{color} ...)`. `DS::Pill` only supports the fixed tone enum — migrating would lose information. |
| `app/views/categories/_badge.html.erb` | Same reason; uses `category.color` (arbitrary hex per record) plus a `lucide_icon` from the category. |
| `app/views/investment_activity/_quick_edit_badge.html.erb` | Interactive button with a Stimulus controller (`activity-label-quick-edit`), click action, hover state, dropdown anchor, and chevron icon. `DS::Pill` renders a `<span>`; converting would destroy the interactive surface. |

## Test plan

- [x] `bin/rails tailwindcss:build` — clean (343 ms).
- [x] `bundle exec erb_lint` on all 5 migrated ERB files — no errors.
- [x] `bin/rails test test/components/DS/pill_test.rb` — 6 runs, 31 assertions, 0 failures.
- [x] `bin/rails test test/controllers/categories_controller_test.rb test/controllers/import/` — 24 runs, 95 assertions, 0 failures.
- [x] `bin/rails test test/controllers/reports_controller_test.rb` — 26 runs, 66 assertions, 0 failures.
- [x] `bin/rubocop` on `app/helpers/reports_helper.rb` — clean.