### PR TITLE
docs(ds-toggle): warn against external hidden_field_tag with same name

### DIFF
--- a/app/components/DS/toggle.html.erb
+++ b/app/components/DS/toggle.html.erb
@@ -1,4 +1,5 @@
 <div class="relative inline-block select-none">
+  <%# Paired hidden field carries the off-state value when the checkbox is unchecked. Do NOT add an external `hidden_field_tag` with the same `name` in the caller view — it causes ID/label collisions and duplicate params. %>
   <%= hidden_field_tag name, unchecked_value, id: nil %>
   <%# `role="switch"` upgrades the underlying checkbox so AT users hear
       "switch, on" / "switch, off" instead of "checkbox, checked". The


### PR DESCRIPTION
## Summary

One-line ERB comment on `app/components/DS/toggle.html.erb` above the paired hidden field that carries the off-state value. Warns callers not to add an external `hidden_field_tag` with the same `name` — doing so causes ID/label collisions and duplicate params.

## Why

Hit this exact footgun while building a new toggle in `settings/preferences/show.html.erb` (see exploration PR #1924). The auto-generated id from a Rails `hidden_field_tag` matches the checkbox id that DS::Toggle assigns, so `<label for=…>` ends up targeting the (unclickable) hidden field instead of the checkbox, and the toggle silently stops working. A 30-minute debug session that a one-line comment would have prevented.

## Diff

```erb
<div class="relative inline-block select-none">
+  <%# Paired hidden field carries the off-state value when the checkbox is unchecked. Do NOT add an external `hidden_field_tag` with the same `name` in the caller view — it causes ID/label collisions and duplicate params. %>
   <%= hidden_field_tag name, unchecked_value, id: nil %>
```

## Test plan

- [ ] Comment is server-side (no runtime effect)
- [ ] Visual: re-render any DS::Toggle, confirm no markup diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification to the toggle component documentation explaining how off-state values are handled by the existing mechanism. Documentation advises against adding redundant field configurations to prevent ID collisions and duplicate parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->