### PR TITLE
fix(design-system): DS::Disclosure :default summary_content layout

### DIFF
--- a/app/components/DS/disclosure.html.erb
+++ b/app/components/DS/disclosure.html.erb
@@ -1,13 +1,21 @@
 <%= tag.details class: details_classes, open: open, **details_opts do %>
   <%= tag.summary class: summary_classes do %>
     <% if summary_content? %>
-      <%# `<summary>` is `display: list-item`, so a flex inner div would
-          shrink-wrap to content width and any `justify-between` inside
-          the slot has nothing to distribute. Wrap in a `w-full` block
-          so caller-supplied flex rows stretch across the card. %>
-      <div class="w-full">
+      <% if variant == :default %>
+        <%# `:default` summary is already `flex justify-between`, so
+            caller-provided sibling divs get distributed directly.
+            Wrapping would collapse them into a single flex child and
+            kill the justify-between distribution. %>
         <%= summary_content %>
-      </div>
+      <% else %>
+        <%# Non-default summaries are `list-item` (no flex), so a flex
+            caller div would shrink-wrap to content width and any
+            `justify-between` inside has nothing to distribute. Wrap
+            in `w-full` so caller flex rows stretch across the card. %>
+        <div class="w-full">
+          <%= summary_content %>
+        </div>
+      <% end %>
     <% else %>
       <div class="flex items-center gap-3">
         <% if align == :left %>


### PR DESCRIPTION
## Summary

- PRs #1855 / #1857 / #1858 introduced a `<div class="w-full">` wrapper around `summary_content` in `DS::Disclosure`. It is required for the new `:card` / `:card_inset` / `:inline` variants, whose `<summary>` is `display: list-item` and would otherwise shrink-wrap a flex caller div.
- The same wrapper regressed the `:default` variant, whose `<summary>` is already `flex items-center justify-between`. Caller sibling divs collapsed into a single flex child, killing the `justify-between` distribution.
- Only one default-variant `summary_content` caller exists in the codebase — `app/views/accounts/_accountable_group.html.erb` (the homepage account-sidebar groups). On `main` the group name and the total / sparkline divs no longer aligned across the row.
- Fix: render `summary_content` bare for `:default` (summary is the flex container itself); keep the `w-full` wrapper for `:card`, `:card_inset`, `:inline`.

## Test plan

- [ ] Homepage sidebar (`/`): each account group row in `All` / `Assets` / `Debts` tabs renders name on the left, total + sparkline on the right, with `justify-between` distribution.
- [ ] Settings → Providers (`/settings/providers`): provider cards (Plaid, Mercury, IBKR, SimpleFIN, …) still render with the `:card` layout — logo + name on the left, status / actions on the right.
- [ ] IBKR settings flow: the embedded report-details panel (`:card_inset`) still spans full width.
- [ ] SnapTrade / Indexa Capital provider panels: the `:inline` "Alternative auth" / "Manage connections" toggles render unchanged.
- [ ] Title-only disclosures (`transactions/_form`, `trades/_header`, `transactions/bulk_updates/new`) unchanged — no `summary_content` slot, no regression possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved disclosure component summary layout handling to better control width rendering based on variant selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->