### PR TITLE
fix(design-system): DS::Menu :icon_sm variant for dense action lists

### DIFF
--- a/app/components/DS/menu.html.erb
+++ b/app/components/DS/menu.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div data: { controller: "DS--menu", DS__menu_placement_value: placement, DS__menu_offset_value: offset, DS__menu_mobile_fullwidth_value: mobile_fullwidth, testid: testid } do %>
-  <% if variant == :icon %>
-    <%= render DS::Button.new(variant: "icon", icon: icon_vertical ? "more-vertical" : "more-horizontal", aria: { haspopup: "menu", expanded: "false", controls: menu_id }, data: { DS__menu_target: "button" }) %>
+  <% if icon_only? %>
+    <%= render DS::Button.new(variant: "icon", size: icon_button_size, icon: icon_vertical ? "more-vertical" : "more-horizontal", aria: { haspopup: "menu", expanded: "false", controls: menu_id }, data: { DS__menu_target: "button" }) %>
   <% elsif variant == :button %>
     <%= button %>
   <% end %>

--- a/app/components/DS/menu.rb
+++ b/app/components/DS/menu.rb
@@ -31,7 +31,7 @@ class DS::Menu < DesignSystemComponent
 
   renders_many :items, DS::MenuItem
 
-  VARIANTS = %i[icon button].freeze
+  VARIANTS = %i[icon icon_sm button].freeze
 
   def initialize(variant: "icon", placement: "bottom-end", offset: 12, icon_vertical: false, no_padding: false, testid: nil, mobile_fullwidth: true, max_width: nil)
     @variant = variant.to_sym
@@ -45,5 +45,23 @@ class DS::Menu < DesignSystemComponent
     @menu_id = "menu-#{SecureRandom.hex(4)}"
 
     raise ArgumentError, "Invalid variant: #{@variant}. DS::Menu is for action lists only; use DS::Popover for mixed content (forms, pickers, account dropdowns)." unless VARIANTS.include?(@variant)
+  end
+
+  # `:icon_sm` renders the dropdown trigger as a 32x32 icon button (DS::Button
+  # `size: :sm`) instead of the default 44x44 `:md`. Use for action menus
+  # embedded in dense lists (e.g. the category dropdown row trigger) where the
+  # 44x44 enhanced-touch-target trigger introduced in #1840 makes every row
+  # ~8px taller and the cumulative list height regresses visibly.
+  #
+  # Trade-off: the `sm` icon button is 32x32, which meets WCAG 2.5.8 AA
+  # (24x24) but not 2.5.5 AAA enhanced (44x44). Acceptable for compact
+  # dropdown rows that aren't primary touch surfaces; do not use on
+  # standalone toolbar / row-action triggers where 44x44 should remain.
+  def icon_only?
+    variant == :icon || variant == :icon_sm
+  end
+
+  def icon_button_size
+    variant == :icon_sm ? "sm" : "md"
   end
 end

--- a/app/views/category/dropdowns/_row.html.erb
+++ b/app/views/category/dropdowns/_row.html.erb
@@ -29,7 +29,7 @@
     <%= render partial: "categories/badge", locals: { category: category } %>
   <% end %>
 
-  <%= render DS::Menu.new do |menu| %>
+  <%= render DS::Menu.new(variant: :icon_sm) do |menu| %>
     <% menu.with_item(variant: "link", text: t(".edit"), icon: "pencil-line", href: edit_category_path(category), data: { turbo_frame: :modal }) %>
     <% menu.with_item(variant: "link", text: t(".delete"), icon: "trash-2", href: new_category_deletion_path(category), data: { turbo_frame: :modal }, destructive: true) %>
   <% end %>

--- a/test/components/previews/menu_component_preview.rb
+++ b/test/components/previews/menu_component_preview.rb
@@ -5,6 +5,12 @@ class MenuComponentPreview < ViewComponent::Preview
     end
   end
 
+  def icon_sm
+    render DS::Menu.new(variant: "icon_sm") do |menu|
+      menu_contents(menu)
+    end
+  end
+
   def button
     render DS::Menu.new(variant: "button") do |menu|
       menu.with_button(text: "Open menu", variant: "secondary")


### PR DESCRIPTION
## Summary

PR #1840 bumped DS::Button icon-only `:md` size from `w-9 h-9` (36×36) to `w-11 h-11` (44×44) to meet WCAG 2.5.5 enhanced touch target. `DS::Menu` `:icon` variant uses `DS::Button` at the default `:md` size, so every row-level "..." trigger grew from 36×36 to 44×44.

For dense lists where each row carries its own action-list trigger — most visibly the transaction category dropdown (`app/views/category/dropdowns/_row.html.erb`) — the per-row height bump (+8px) compounds and visibly regresses the dropdown's density.

This PR adds a new `DS::Menu` variant:

- **`:icon_sm`** — renders the trigger as `DS::Button.new(variant: "icon", size: "sm", …)` = 32×32. Meets WCAG 2.5.8 AA (24×24); appropriate for compact in-row triggers where 44×44 isn't required.

Standalone toolbar / row-action `...` triggers should keep `:icon` for the AAA enhanced target.

Migrates `category/dropdowns/_row.html.erb` to `:icon_sm` to restore the pre-#1840 dropdown density.

## Test plan

- [ ] Open a transaction's category selector (transactions page → click category): rows render at compact height matching pre-#1840; `...` trigger is 32×32 and still operable.
- [ ] All other `DS::Menu` callsites still default to `:icon` (44×44) — verify a sampling: transactions row "..." menu (`app/views/transactions/_transaction.html.erb`), holdings row menu, etc. No height change.
- [ ] `:icon_sm` Lookbook preview (`/lookbook` → `Menu` → `icon_sm`) renders 32×32 trigger with the same action-list contents as `:icon`.
- [ ] Keyboard nav (Arrow Up/Down/Home/End, Enter/Space, Escape) on the `:icon_sm` trigger still works — the `aria-haspopup="menu"` / `aria-expanded` / `aria-controls` contract is preserved.

## Notes

- Helper methods (`icon_only?`, `icon_button_size`) introduced as small extensions so the template stays clean and the variant→size mapping is centralized. If we later want a `:icon_lg` for prominent triggers, the seam is in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a small icon menu variant for compact menu triggers in the design system.

* **Style**
  * Updated category dropdown menus to use the new small icon variant for improved layout efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->