### PR TITLE
refactor(views): migrate 6 residual inline alerts to DS::Alert

### DIFF
--- a/app/views/accounts/confirm_unlink.html.erb
+++ b/app/views/accounts/confirm_unlink.html.erb
@@ -6,19 +6,15 @@
       <%= t("accounts.confirm_unlink.description_html", account_name: @account.name, provider_name: @account.provider_name) %>
     </p>
 
-    <div class="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-      <div class="flex items-start gap-2">
-        <%= icon "alert-triangle", class: "w-4 h-4 text-yellow-600 mt-0.5 flex-shrink-0" %>
-        <div class="text-xs">
-          <p class="font-medium text-yellow-900 mb-1"><%= t("accounts.confirm_unlink.warning_title") %></p>
-          <ul class="text-yellow-700 list-disc list-inside space-y-1">
-            <li><%= t("accounts.confirm_unlink.warning_no_sync") %></li>
-            <li><%= t("accounts.confirm_unlink.warning_manual_updates") %></li>
-            <li><%= t("accounts.confirm_unlink.warning_transactions_kept") %></li>
-            <li><%= t("accounts.confirm_unlink.warning_can_delete") %></li>
-          </ul>
-        </div>
-      </div>
+    <div class="mb-4">
+      <%= render DS::Alert.new(title: t("accounts.confirm_unlink.warning_title"), variant: :warning) do %>
+        <ul class="list-disc list-inside">
+          <li><%= t("accounts.confirm_unlink.warning_no_sync") %></li>
+          <li><%= t("accounts.confirm_unlink.warning_manual_updates") %></li>
+          <li><%= t("accounts.confirm_unlink.warning_transactions_kept") %></li>
+          <li><%= t("accounts.confirm_unlink.warning_can_delete") %></li>
+        </ul>
+      <% end %>
     </div>
 
     <%= render DS::Button.new(

--- a/app/views/oidc_accounts/link.html.erb
+++ b/app/views/oidc_accounts/link.html.erb
@@ -3,12 +3,11 @@
 %>
 
 <% if @user_exists %>
-  <div class="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
-    <h3 class="text-sm font-medium text-yellow-800 mb-2"><%= t("oidc_accounts.link.verify_heading") %></h3>
-    <p class="text-sm text-yellow-700">
+  <div class="mb-6">
+    <%= render DS::Alert.new(title: t("oidc_accounts.link.verify_heading"), variant: :warning) do %>
       <% email_suffix = @pending_auth["email"].present? ? t("oidc_accounts.link.email_suffix_html", email: @pending_auth["email"]) : "" %>
       <%= t("oidc_accounts.link.verify_description_html", provider: @pending_auth["provider"], email_suffix: email_suffix).html_safe %>
-    </p>
+    <% end %>
   </div>
 
   <%= styled_form_with url: create_link_oidc_account_path, class: "space-y-4", data: { turbo: false } do |form| %>
@@ -26,18 +25,17 @@
                             placeholder: t("oidc_accounts.link.password_placeholder"),
                             autocomplete: "current-password" %>
 
-    <div class="text-sm text-gray-600 mt-2">
+    <div class="text-sm text-secondary mt-2">
       <p><%= t("oidc_accounts.link.verify_hint") %></p>
     </div>
 
     <%= form.submit t("oidc_accounts.link.submit_link") %>
   <% end %>
 <% else %>
-  <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-md">
-    <h3 class="text-sm font-medium text-blue-800 mb-2"><%= t("oidc_accounts.link.create_heading") %></h3>
-    <p class="text-sm text-blue-700">
+  <div class="mb-6">
+    <%= render DS::Alert.new(title: t("oidc_accounts.link.create_heading"), variant: :info) do %>
       <%= t("oidc_accounts.link.create_description_html", email: @pending_auth["email"], provider: @pending_auth["provider"]).html_safe %>
-    </p>
+    <% end %>
   </div>
 
   <div class="space-y-4">

--- a/app/views/oidc_accounts/link.html.erb
+++ b/app/views/oidc_accounts/link.html.erb
@@ -6,7 +6,7 @@
   <div class="mb-6">
     <%= render DS::Alert.new(title: t("oidc_accounts.link.verify_heading"), variant: :warning) do %>
       <% email_suffix = @pending_auth["email"].present? ? t("oidc_accounts.link.email_suffix_html", email: @pending_auth["email"]) : "" %>
-      <%= t("oidc_accounts.link.verify_description_html", provider: @pending_auth["provider"], email_suffix: email_suffix).html_safe %>
+      <p><%= t("oidc_accounts.link.verify_description_html", provider: @pending_auth["provider"], email_suffix: email_suffix).html_safe %></p>
     <% end %>
   </div>
 
@@ -34,7 +34,7 @@
 <% else %>
   <div class="mb-6">
     <%= render DS::Alert.new(title: t("oidc_accounts.link.create_heading"), variant: :info) do %>
-      <%= t("oidc_accounts.link.create_description_html", email: @pending_auth["email"], provider: @pending_auth["provider"]).html_safe %>
+      <p><%= t("oidc_accounts.link.create_description_html", email: @pending_auth["email"], provider: @pending_auth["provider"]).html_safe %></p>
     <% end %>
   </div>
 

--- a/app/views/oidc_accounts/new_user.html.erb
+++ b/app/views/oidc_accounts/new_user.html.erb
@@ -2,11 +2,12 @@
   header_title t("oidc_accounts.new_user.title")
 %>
 
-<div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-md">
-  <h3 class="text-sm font-medium text-blue-800 mb-2"><%= t("oidc_accounts.new_user.heading") %></h3>
-  <p class="text-sm text-blue-700">
-    <%= t("oidc_accounts.new_user.description", provider: @pending_auth["provider"]) %>
-  </p>
+<div class="mb-6">
+  <%= render DS::Alert.new(
+    title: t("oidc_accounts.new_user.heading"),
+    message: t("oidc_accounts.new_user.description", provider: @pending_auth["provider"]),
+    variant: :info
+  ) %>
 </div>
 
 <%= styled_form_with model: @user, url: create_user_oidc_account_path, class: "space-y-4", data: { turbo: false } do |form| %>

--- a/app/views/rules/confirm.html.erb
+++ b/app/views/rules/confirm.html.erb
@@ -15,31 +15,25 @@
 
     <% if @rule.actions.any? { |a| a.action_type == "auto_categorize" } %>
       <% affected_count = @rule.affected_resource_count %>
-      <div class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-        <div class="flex items-start gap-2">
-          <%= icon "info", class: "w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0" %>
-          <div class="text-xs">
-            <p class="font-medium text-blue-900 mb-1"><%= t(".ai_cost_title") %></p>
-            <% if @estimated_cost.present? %>
-              <p class="text-blue-700">
-                <%= t(".ai_cost_with_estimate_html", count: affected_count, cost: sprintf("%.4f", @estimated_cost)) %>
-              </p>
-            <% else %>
-              <p class="text-blue-700">
-                <%= t(".ai_cost_no_estimate_html", count: affected_count) %>
-                <% if @selected_model.present? %>
-                  <span class="font-semibold"><%= t(".cost_unavailable_model", model: @selected_model) %></span>
-                <% else %>
-                  <span class="font-semibold"><%= t(".cost_unavailable_no_provider") %></span>
-                <% end %>
-                <%= t(".cost_warning") %>
-              </p>
-            <% end %>
-            <p class="text-blue-600 mt-1">
-              <%= link_to t(".view_usage_history"), settings_llm_usage_path, class: "underline hover:text-blue-800" %>
+      <div class="mb-4">
+        <%= render DS::Alert.new(title: t(".ai_cost_title"), variant: :info) do %>
+          <% if @estimated_cost.present? %>
+            <p><%= t(".ai_cost_with_estimate_html", count: affected_count, cost: sprintf("%.4f", @estimated_cost)) %></p>
+          <% else %>
+            <p>
+              <%= t(".ai_cost_no_estimate_html", count: affected_count) %>
+              <% if @selected_model.present? %>
+                <span class="font-semibold"><%= t(".cost_unavailable_model", model: @selected_model) %></span>
+              <% else %>
+                <span class="font-semibold"><%= t(".cost_unavailable_no_provider") %></span>
+              <% end %>
+              <%= t(".cost_warning") %>
             </p>
-          </div>
-        </div>
+          <% end %>
+          <p>
+            <%= link_to t(".view_usage_history"), settings_llm_usage_path, class: "text-link underline" %>
+          </p>
+        <% end %>
       </div>
     <% end %>
 

--- a/app/views/rules/confirm_all.html.erb
+++ b/app/views/rules/confirm_all.html.erb
@@ -9,32 +9,28 @@
     </p>
 
     <% if @rules.any? { |r| r.actions.any? { |a| a.action_type == "auto_categorize" } } %>
-      <div class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-        <div class="flex items-start gap-2">
-          <%= icon "info", class: "w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0" %>
-          <div class="text-xs">
-            <p class="font-medium text-blue-900 mb-1"><%= t("rules.apply_all.ai_cost_title") %></p>
-            <% if @estimated_cost.present? %>
-              <p class="text-blue-700">
-                <%= t("rules.apply_all.ai_cost_message", transactions: @total_affected_count) %>
-                <%= t("rules.apply_all.estimated_cost", cost: sprintf("%.4f", @estimated_cost)) %>
-              </p>
-            <% else %>
-              <p class="text-blue-700">
-                <%= t("rules.apply_all.ai_cost_message", transactions: @total_affected_count) %>
-                <% if @selected_model.present? %>
-                  <span class="font-semibold"><%= t("rules.apply_all.cost_unavailable_model", model: @selected_model) %></span>
-                <% else %>
-                  <span class="font-semibold"><%= t("rules.apply_all.cost_unavailable_no_provider") %></span>
-                <% end %>
-                <%= t("rules.apply_all.cost_warning") %>
-              </p>
-            <% end %>
-            <p class="text-blue-600 mt-1">
-              <%= link_to t("rules.apply_all.view_usage"), settings_llm_usage_path, class: "underline hover:text-blue-800" %>
+      <div class="mb-4">
+        <%= render DS::Alert.new(title: t("rules.apply_all.ai_cost_title"), variant: :info) do %>
+          <% if @estimated_cost.present? %>
+            <p>
+              <%= t("rules.apply_all.ai_cost_message", transactions: @total_affected_count) %>
+              <%= t("rules.apply_all.estimated_cost", cost: sprintf("%.4f", @estimated_cost)) %>
             </p>
-          </div>
-        </div>
+          <% else %>
+            <p>
+              <%= t("rules.apply_all.ai_cost_message", transactions: @total_affected_count) %>
+              <% if @selected_model.present? %>
+                <span class="font-semibold"><%= t("rules.apply_all.cost_unavailable_model", model: @selected_model) %></span>
+              <% else %>
+                <span class="font-semibold"><%= t("rules.apply_all.cost_unavailable_no_provider") %></span>
+              <% end %>
+              <%= t("rules.apply_all.cost_warning") %>
+            </p>
+          <% end %>
+          <p>
+            <%= link_to t("rules.apply_all.view_usage"), settings_llm_usage_path, class: "text-link underline" %>
+          </p>
+        <% end %>
       </div>
     <% end %>
 

--- a/app/views/settings/llm_usages/show.html.erb
+++ b/app/views/settings/llm_usages/show.html.erb
@@ -165,16 +165,11 @@
     </div>
   </div>
 
-  <!-- Pricing Information -->
-  <div class="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-    <div class="flex items-start gap-2">
-      <%= icon "info", class: "w-5 h-5 text-blue-600 mt-0.5" %>
-      <div>
-        <p class="text-sm font-medium text-blue-900"><%= t(".cost_estimates_title") %></p>
-        <p class="text-xs text-blue-700 mt-1">
-          <%= t(".cost_estimates_description") %>
-        </p>
-      </div>
-    </div>
+  <div class="mt-6">
+    <%= render DS::Alert.new(
+      title: t(".cost_estimates_title"),
+      message: t(".cost_estimates_description"),
+      variant: :info
+    ) %>
   </div>
 </div>

--- a/test/controllers/oidc_accounts_controller_test.rb
+++ b/test/controllers/oidc_accounts_controller_test.rb
@@ -115,7 +115,7 @@ class OidcAccountsControllerTest < ActionController::TestCase
 
     get :link
     assert_response :success
-    assert_select "p", text: "Create New Account"
+    assert_select "p", text: /Create New Account/
     assert_select "strong", text: new_user_auth["email"]
   end
 
@@ -128,7 +128,7 @@ class OidcAccountsControllerTest < ActionController::TestCase
     get :link
     assert_response :success
 
-    assert_select "p", text: "Create New Account"
+    assert_select "p", text: /Create New Account/
     # No create account button rendered
     assert_select "button", text: "Create Account", count: 0
     assert_select "p", text: /New account creation via single sign-on is disabled/

--- a/test/controllers/oidc_accounts_controller_test.rb
+++ b/test/controllers/oidc_accounts_controller_test.rb
@@ -115,7 +115,7 @@ class OidcAccountsControllerTest < ActionController::TestCase
 
     get :link
     assert_response :success
-    assert_select "h3", text: "Create New Account"
+    assert_select "p", text: "Create New Account"
     assert_select "strong", text: new_user_auth["email"]
   end
 
@@ -128,7 +128,7 @@ class OidcAccountsControllerTest < ActionController::TestCase
     get :link
     assert_response :success
 
-    assert_select "h3", text: "Create New Account"
+    assert_select "p", text: "Create New Account"
     # No create account button rendered
     assert_select "button", text: "Create Account", count: 0
     assert_select "p", text: /New account creation via single sign-on is disabled/


### PR DESCRIPTION
## Summary

PR #1731 extended `DS::Alert` and migrated 9 inline alert blocks. Six hand-rolled alert blocks slipped through that sweep and stayed on raw palette tokens (`bg-blue-50 border border-blue-200`, `text-blue-900 / -700 / -600`, etc.) with no `theme-dark:` variants — so in dark mode they render as bright light-mode islands over the dark page surface.

This PR migrates the six residual blocks to `DS::Alert`, which resolves `bg-info/10`, `border-info/20`, `bg-warning/10`, `border-warning/20`, etc. from the `@theme` semantic tokens. Dark mode now gets the intended subtle tint over the page chrome.

### Migrated

| File | Variant | Notes |
|------|---------|-------|
| `app/views/settings/llm_usages/show.html.erb` | `:info` | "About Cost Estimates" notice — the most visible offender, bright pale-blue island in dark mode |
| `app/views/accounts/confirm_unlink.html.erb` | `:warning` | unlink warning with bullet list (uses block content) |
| `app/views/oidc_accounts/new_user.html.erb` | `:info` | first-time SSO sign-in heading |
| `app/views/oidc_accounts/link.html.erb` | `:warning` + `:info` | two blocks (verify existing user + create new) |
| `app/views/rules/confirm.html.erb` | `:info` | AI cost notice (uses block content for conditional estimate) |
| `app/views/rules/confirm_all.html.erb` | `:info` | AI cost notice |

Also fixes a stray `text-gray-600` paragraph in `oidc_accounts/link.html.erb` (caught by the `DeprecatedClasses` erb_lint rule introduced in #1849 once the file was reopened) → `text-secondary`.

### Out of scope

- `app/views/assistant_messages/_tool_calls.html.erb` — tool-call display panel using `bg-blue-50 border-blue-200`, not an alert. Wants its own dark-aware token treatment, deferred.
- `app/views/import/rows/_form.html.erb` — inline cell-error tooltip (`bg-red-50 border-red-200`). Not alert-shaped; should swap to `bg-destructive/10 border-destructive-subtle` once #1932 lands so the subtle destructive token is available.

### Test plan

- [ ] Dark mode + light mode, `/settings/llm_usage`: cost-estimates alert renders with subtle blue tint (no bright pale-blue rectangle).
- [ ] `/accounts/<id>/confirm_unlink`: warning alert with yellow tint + bullets renders correctly in both modes.
- [ ] OIDC sign-in (`/oidc_accounts/link` and `/oidc_accounts/new_user`): info/warning alerts render correctly with the html_safe interpolated description (provider name, email).
- [ ] Rules confirm + confirm_all dialogs: AI cost notice renders the conditional content (with/without estimate, with/without selected model) and the "view usage history" link.
- [ ] All six alerts use the DS::Alert icon, title, and content layout consistently with the rest of the app.

### Tracking

- #1911 — DS Drift weekly patrol (didn't catch these because they pre-date the scanner; tracker covers commits merged in the past week).
- #1715 — closed umbrella for design system follow-ups (alerts, badges, buttons, disclosures, search inputs).
- #1731 — the original `DS::Alert` extension + 9-alert migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced custom inline info/warning blocks with standardized design-system alert components across account confirmation, OIDC flows (link/new), rules confirmation dialogs, and LLM usage pricing; preserved content, conditional behavior, and unified visual styling/hint presentation.
* **Tests**
  * Updated controller test expectations to match the adjusted OIDC page markup (heading → paragraph).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->