### PR TITLE
fix(admin/users): parent space-y-6 for sibling section spacing

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,12 +1,12 @@
 <%= content_for :page_title, t(".title") %>
 
-<div class="bg-container rounded-xl shadow-border-xs p-4">
-  <div class="mb-6">
+<div class="bg-container rounded-xl shadow-border-xs p-4 space-y-6">
+  <div>
     <p class="text-sm text-secondary"><%= t(".description") %></p>
   </div>
 
   <!-- Filters -->
-  <div class="mb-6">
+  <div>
     <%= form_with url: admin_users_path, method: :get, class: "flex gap-4 items-end flex-wrap" do |f| %>
       <div class="w-full md:w-auto">
         <%= f.label :role, t(".filters.role"), class: "block text-sm font-medium text-primary mb-1" %>
@@ -33,7 +33,7 @@
   </div>
 
   <!-- Summary: trials expiring in next 7 days -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
     <div class="bg-container-inset rounded-lg p-4">
       <div class="flex items-center gap-2 mb-2">
         <%= icon "calendar-clock", class: "w-5 h-5 text-secondary" %>


### PR DESCRIPTION
## Summary

The admin users page (`app/views/admin/users/index.html.erb`) wraps four top-level sibling sections inside a single outer card:

1. Description paragraph
2. Filter form
3. Trials-expiring summary grid
4. Families/groups list
5. Role descriptions (`settings_section` collapsible → `DS::Disclosure :card`)

The first three carried their own `mb-6`; the families list and the role descriptions section had no margin at all. Result: the families-list card sat **flush** against the role-descriptions card with zero vertical gap — visibly broken next to the well-spaced upper sections.

This PR moves the spacing to the **layout** level: hoist `space-y-6` onto the outer container and drop the per-child `mb-6`. All five siblings now get a consistent 24px gap. No spacing math distributed across children.

## Scope check

No other admin or settings pages match this exact pattern (single outer card + multiple sibling sections without parent `space-y`):

- The settings layout (`app/views/layouts/settings.html.erb`) already wraps `<%= yield %>` in `space-y-4`, so multi-`settings_section` pages like `settings/hostings/show` get gaps from the layout itself.
- Other pages with outer `bg-container rounded-xl shadow-border` cards (`settings/api_keys/show`, `settings/llm_usages/show`, etc.) either rely on that layout or carry their own internal `space-y-N`.

## Test plan

- [ ] `/admin/users` (as a super_admin): description / filters / summary / families list / role descriptions stack with a consistent 24px gap.
- [ ] Spot-check other admin and settings pages — none should regress; the change is scoped to this single file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing and layout on the admin users page with improved vertical margins and section separation for better visual organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->