### PR TITLE
refactor(transactions): migrate transfer_match badges to DS::Pill

### DIFF
--- a/app/views/transactions/_transfer_match.html.erb
+++ b/app/views/transactions/_transfer_match.html.erb
@@ -6,11 +6,21 @@
       <%= icon "link-2", size: "sm", class: "text-secondary" %>
     </span>
   <% elsif transaction.transfer.pending? %>
-    <span class="hidden lg:inline-flex items-center rounded-full bg-surface-inset px-2 py-0.5 text-xs font-medium text-secondary">
-      <%= t("transactions.transfer_match.auto_matched") %>
+    <span class="hidden lg:inline">
+      <%= render DS::Pill.new(
+        label: t("transactions.transfer_match.auto_matched"),
+        tone: :neutral,
+        marker: false,
+        show_dot: false
+      ) %>
     </span>
-    <span class="inline-flex lg:hidden items-center rounded-full bg-surface-inset px-2 py-0.5 text-xs font-medium text-secondary">
-      <%= t("transactions.transfer_match.auto_matched_short") %>
+    <span class="inline lg:hidden">
+      <%= render DS::Pill.new(
+        label: t("transactions.transfer_match.auto_matched_short"),
+        tone: :neutral,
+        marker: false,
+        show_dot: false
+      ) %>
     </span>
 
     <%= button_to transfer_path(transaction.transfer, transfer: { status: "confirmed" }),


### PR DESCRIPTION
Follow-up to #1917 — clears the last deferred callsite from the transaction-bucket migration.

The responsive label-swap pair in `app/views/transactions/_transfer_match.html.erb` (long copy on lg+, short copy on mobile) was deferred from PR B because `DS::Pill` doesn't take a caller-controlled `class:` arg. Wrapping each pill in a `<span class="hidden lg:inline">` / `<span class="inline lg:hidden">` works without expanding the component API — the parent's `display` controls visibility; the child `DS::Pill` keeps its own `inline-flex` chrome when visible.

| Before | After |
|---|---|
| Two hand-rolled `<span>` badges with raw `rounded-full bg-surface-inset px-2 py-0.5 text-xs font-medium text-secondary` chrome | Two `DS::Pill(tone: :neutral, marker: false, show_dot: false)` wrapped in responsive-visibility spans |

Same tone + shape as the other neutral status badges migrated in #1917 (Pending, Review-recommended, Split).

## Test plan
- [x] `bundle exec erb_lint app/views/transactions/_transfer_match.html.erb` — clean
- [x] `bin/rails tailwindcss:build` — clean
- DS::Pill tests already cover the badge-mode rendering (shipped in #1917)

Refs #1751.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the auto-matched transaction indicator with improved visual styling and responsive layout that ensures consistent display across mobile, tablet, and desktop screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->