### PR TITLE
Optimize the responding velocity of "TransactionsController#index"

### DIFF
--- a/app/controllers/transactions/searches_controller.rb
+++ b/app/controllers/transactions/searches_controller.rb
@@ -1,0 +1,20 @@
+require "ostruct"
+
+class Transactions::SearchesController < ApplicationController
+  layout false
+
+  def menu
+    @q = menu_search_params
+    @filter_merchants = Current.family.cached_assigned_merchants_for(Current.user)
+  end
+
+  private
+    def menu_search_params
+      params.fetch(:q, {}).permit(
+        :search, :start_date, :end_date, :amount, :amount_operator,
+        :active_accounts_only,
+        accounts: [], account_ids: [],
+        categories: [], merchants: [], types: [], tags: [], status: []
+      ).to_h.compact_blank
+    end
+end

--- a/app/controllers/transactions/upcomings_controller.rb
+++ b/app/controllers/transactions/upcomings_controller.rb
@@ -1,0 +1,13 @@
+class Transactions::UpcomingsController < ApplicationController
+  layout false
+
+  def show
+    @projected_recurring = Current.family.recurring_transactions
+                                  .accessible_by(Current.user)
+                                  .active
+                                  .where("next_expected_date <= ? AND next_expected_date >= ?",
+                                         10.days.from_now.to_date,
+                                         Date.current)
+                                  .includes(:merchant)
+  end
+end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -53,16 +53,9 @@ class TransactionsController < ApplicationController
       Set.new
     end
 
-    @uncategorized_count = Current.accessible_entries.uncategorized_transactions.count
+    @uncategorized_count = uncategorized_count_for_index
 
-    # Load projected recurring transactions for next 10 days
-    @projected_recurring = Current.family.recurring_transactions
-                                  .accessible_by(Current.user)
-                                  .active
-                                  .where("next_expected_date <= ? AND next_expected_date >= ?",
-                                         10.days.from_now.to_date,
-                                         Date.current)
-                                  .includes(:merchant)
+    @has_projected_recurring = projected_recurring_exists?
 
     @breadcrumbs = [ [ t("breadcrumbs.home"), root_path ], [ t("breadcrumbs.transactions"), nil ] ]
   end
@@ -395,6 +388,25 @@ class TransactionsController < ApplicationController
   end
 
   private
+    def uncategorized_count_for_index
+      Rails.cache.fetch(
+        "uncategorized_count/#{Current.family.id}/#{Current.user.id}/#{Current.family.entries_cache_version}",
+        expires_in: 5.minutes
+      ) do
+        Current.accessible_entries.uncategorized_transactions.count
+      end
+    end
+
+    def projected_recurring_exists?
+      Current.family.recurring_transactions
+             .accessible_by(Current.user)
+             .active
+             .where("next_expected_date <= ? AND next_expected_date >= ?",
+                    10.days.from_now.to_date,
+                    Date.current)
+             .exists?
+    end
+
     def accessible_transactions
       Current.family.transactions
         .joins(entry: :account)

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -157,6 +157,16 @@ class Family < ApplicationRecord
     Merchant.where(id: merchant_ids)
   end
 
+  def cached_assigned_merchants_for(user)
+    Rails.cache.fetch(assigned_merchants_cache_key(user)) do
+      assigned_merchants_for(user).alphabetically.load
+    end
+  end
+
+  def assigned_merchants_cache_key(user)
+    "family/#{id}/assigned_merchants/#{user.id}/#{entries_cache_version}"
+  end
+
   def available_merchants_for(user)
     assigned_ids = Transaction.joins(:entry)
       .where(entries: { account_id: accounts.accessible_by(user).select(:id) })

--- a/app/views/transactions/_list.html.erb
+++ b/app/views/transactions/_list.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (transactions:, projected_recurring:, q:, pagy:) %>
+<%# locals: (transactions:, q:, pagy:) %>
 <div id="transactions"
   data-controller="bulk-select checkbox-toggle drag-and-drop-import"
   data-bulk-select-singular-label-value="<%= t(".transaction") %>"
@@ -20,7 +20,7 @@
     <%= render "transactions/selection_bar" %>
   </div>
 
-  <% if @pagy.count > 0 || (@projected_recurring.any? && @q.blank?) %>
+  <% if @pagy.count > 0 || (@has_projected_recurring && @q.blank?) %>
     <div class="grow overflow-y-auto">
       <% if @transactions.any? %>
         <div class="grid-cols-12 bg-container-inset rounded-xl px-5 py-3 text-xs uppercase font-medium text-secondary items-center mb-4 grid">

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -48,7 +48,7 @@
 
   <%= render "summary", totals: @search.totals %>
   <% if Current.family.recurring_transactions_disabled? %>
-    <%= render "transactions/list", transactions: @transactions, projected_recurring: @projected_recurring, q: params[:q], pagy: @pagy %>
+    <%= render "transactions/list", transactions: @transactions, q: params[:q], pagy: @pagy %>
   <% else %>
     <%= render DS::Tabs.new(active_tab: params[:tab].presence || "transactions") do |tabs| %>
       <% tabs.with_nav(classes: "max-w-fit") do |nav| %>
@@ -58,13 +58,17 @@
 
       <% tabs.with_panel(tab_id: "transactions") do %>
         <div class="bg-container rounded-xl shadow-border-xs">
-          <%= render "transactions/list", transactions: @transactions, projected_recurring: @projected_recurring, q: params[:q], pagy: @pagy %>
+          <%= render "transactions/list", transactions: @transactions, q: params[:q], pagy: @pagy %>
         </div>
       <% end %>
 
       <% tabs.with_panel(tab_id: "upcoming") do %>
         <div class="bg-container rounded-xl shadow-border-xs">
-          <%= render "transactions/upcoming" %>
+          <%= turbo_frame_tag "transactions-upcoming",
+              src: upcoming_transactions_path,
+              loading: :lazy do %>
+            <p class="text-sm text-secondary p-4"><%= t("transactions.upcoming.loading") %></p>
+          <% end %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/transactions/searches/_form.html.erb
+++ b/app/views/transactions/searches/_form.html.erb
@@ -27,7 +27,11 @@
       ) %>
 
       <% popover.with_custom_content do %>
-        <%= render "transactions/searches/menu", form: form %>
+        <%= turbo_frame_tag "transaction-filters-menu",
+            src: search_menu_transactions_path(q: @q, page: params[:page], per_page: params[:per_page]),
+            loading: :lazy do %>
+          <p class="text-sm text-secondary p-3"><%= t("transactions.searches.menu.loading") %></p>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/app/views/transactions/searches/filters/_merchant_filter.html.erb
+++ b/app/views/transactions/searches/filters/_merchant_filter.html.erb
@@ -5,7 +5,7 @@
     <%= icon("search", class: "absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
-    <% Current.family.assigned_merchants_for(Current.user).alphabetically.each do |merchant| %>
+    <% (@filter_merchants || Current.family.cached_assigned_merchants_for(Current.user)).each do |merchant| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= merchant.name %>">
         <%= form.check_box :merchants,
                            {

--- a/app/views/transactions/searches/menu.html.erb
+++ b/app/views/transactions/searches/menu.html.erb
@@ -1,0 +1,8 @@
+<%# The frame is loaded inside the outer #transactions-search form,
+    so we render fields_for (no inner <form>) to scope inputs as `q[...]`
+    and let the outer form's GET to transactions_path carry them. %>
+<%= turbo_frame_tag "transaction-filters-menu" do %>
+  <%= fields_for :q, OpenStruct.new(@q) do |form| %>
+    <%= render "transactions/searches/menu", form: form %>
+  <% end %>
+<% end %>

--- a/app/views/transactions/upcomings/show.html.erb
+++ b/app/views/transactions/upcomings/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "transactions-upcoming" do %>
+  <%= render "transactions/upcoming" %>
+<% end %>

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -13,12 +13,10 @@ if ENV["SENTRY_DSN"].present?
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
     # We recommend adjusting this value in production.
-    config.traces_sample_rate = 0.25
-
-    # Set profiles_sample_rate to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    config.profiles_sample_rate = 0.25
+    # Lower sampling keeps performance overhead down on hot paths like transactions#index.
+    # Use Skylight for steady-state APM; keep Sentry for errors and light trace sampling.
+    config.traces_sample_rate = 0.05
+    config.profiles_sample_rate = 0
 
     config.release = Rails.root.join(".sure-version").read.strip rescue nil
     config.profiler_class = Sentry::Vernier::Profiler

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -1,6 +1,8 @@
 ---
 en:
   transactions:
+    upcoming:
+      loading: Loading upcoming transactions…
     bulk_updates:
       new:
         cancel: Cancel
@@ -302,6 +304,7 @@ en:
           confirmed: Confirmed
           pending: Pending
       menu:
+        loading: Loading filters…
         account_filter: Account
         amount_filter: Amount
         apply: Apply

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -371,6 +371,8 @@ Rails.application.routes.draw do
     collection do
       delete :clear_filter
       patch :update_preferences
+      get :search_menu, to: "transactions/searches#menu"
+      get :upcoming, to: "transactions/upcomings#show"
     end
 
     member do

--- a/test/controllers/transactions/searches_controller_test.rb
+++ b/test/controllers/transactions/searches_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Transactions::SearchesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+  end
+
+  test "menu returns filter panel in turbo frame" do
+    get search_menu_transactions_url
+
+    assert_response :success
+    assert_select "turbo-frame#transaction-filters-menu"
+  end
+
+  test "menu scopes filter inputs under q so the outer form submits them" do
+    category = categories(:food_and_drink)
+    get search_menu_transactions_url(q: { categories: [ category.name ] })
+
+    assert_response :success
+    assert_select "input[type=checkbox][name='q[categories][]'][checked=checked][value=?]",
+      category.name
+    assert_select "form", false, "menu fragment must not contain its own <form> (nested forms)"
+  end
+end

--- a/test/controllers/transactions/upcomings_controller_test.rb
+++ b/test/controllers/transactions/upcomings_controller_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Transactions::UpcomingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+  end
+
+  test "show returns upcoming panel in turbo frame" do
+    get upcoming_transactions_url
+
+    assert_response :success
+    assert_select "turbo-frame#transactions-upcoming"
+  end
+end


### PR DESCRIPTION
### Fix Summary
1. Sentry (config/initializers/sentry.rb)
traces_sample_rate: 0.25 → 0.05
profiles_sample_rate: 0.25 → 0 (Vernier profiling off in production)

2. Database / caching
@uncategorized_count — cached 5 minutes, keyed by family, user, and entries_cache_version
Family#cached_assigned_merchants_for(user) — caches the merchant list used in the filter UI
@projected_recurring removed from index — replaced with @has_projected_recurring

3. Lazy loading (views)
Filter popover — turbo_frame with loading: :lazy loads GET /transactions/search_menu when the frame is shown
Upcoming tab — lazy turbo_frame → GET /transactions/upcoming

## Solution
Fixed #1948 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upcoming transactions panel with dynamic loading
  * Enhanced search filter menu with lazy-loaded interface

* **Improvements**
  * Optimized transaction search and filter performance through strategic caching
  * Improved merchant filter list loading efficiency
  * Added loading states for better user feedback during dynamic content retrieval

* **Chores**
  * Adjusted error tracking sampling rates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->