### PR TITLE
Add automatic `not-gittensor` PR labeling

### DIFF
--- a/.github/workflows/label-not-gittensor.yml
+++ b/.github/workflows/label-not-gittensor.yml
@@ -1,0 +1,60 @@
+name: Label non-Gittensor PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add not-gittensor label for matched authors
+        uses: actions/github-script@v7
+        env:
+          GITTENSOR_USERS: ${{ vars.GITTENSOR_USERS || '[]' }}
+          GITTENSOR_EXCEPTIONS: ${{ vars.GITTENSOR_EXCEPTIONS || '[]' }}
+          TARGET_LABEL: not-gittensor
+        with:
+          script: |
+            const parseList = (raw, name) => {
+              try {
+                const parsed = JSON.parse(raw || '[]');
+                if (!Array.isArray(parsed)) {
+                  core.setFailed(`${name} must be a JSON array.`);
+                  return [];
+                }
+                return parsed.map((value) => String(value).toLowerCase());
+              } catch (error) {
+                core.setFailed(`Failed to parse ${name}: ${error.message}`);
+                return [];
+              }
+            };
+
+            const author = context.payload.pull_request.user.login.toLowerCase();
+            const users = new Set(parseList(process.env.GITTENSOR_USERS, 'GITTENSOR_USERS'));
+            const exceptions = new Set(parseList(process.env.GITTENSOR_EXCEPTIONS, 'GITTENSOR_EXCEPTIONS'));
+
+            if (!users.has(author) || exceptions.has(author)) {
+              core.info(`No label needed for @${author}.`);
+              return;
+            }
+
+            const existingLabels = context.payload.pull_request.labels.map((label) => label.name);
+            if (existingLabels.includes(process.env.TARGET_LABEL)) {
+              core.info(`Label ${process.env.TARGET_LABEL} already present.`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [process.env.TARGET_LABEL],
+            });
+
+            core.info(`Added ${process.env.TARGET_LABEL} to PR #${context.payload.pull_request.number}.`);


### PR DESCRIPTION
## Summary- add a PR workflow that applies `not-gittensor` to matched authors
- read Gittensor user and exception lists from GitHub Actions variables
- only label on PR open/reopen and keep the action idempotent

## Notes
- expected repo variables: `GITTENSOR_USERS`, `GITTENSOR_EXCEPTIONS`
- I could not set those variables via `gh` because the current token lacks Actions variables write access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to label pull requests based on configured criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->