### PR TITLE
fix: invert non-gittensor label condition

### DIFF
--- a/.github/workflows/label-not-gittensor.yml
+++ b/.github/workflows/label-not-gittensor.yml
@@ -39,7 +39,7 @@ jobs:
             const users = new Set(parseList(process.env.GITTENSOR_USERS, 'GITTENSOR_USERS'));
             const exceptions = new Set(parseList(process.env.GITTENSOR_EXCEPTIONS, 'GITTENSOR_EXCEPTIONS'));
 
-            if (!users.has(author) || exceptions.has(author)) {
+            if (users.has(author) || exceptions.has(author)) {
               core.info(`No label needed for @${author}.`);
               return;
             }


### PR DESCRIPTION
## Summary
- invert the `not-gittensor` labeling condition
- skip labeling PRs opened by users in `GITTENSOR_USERS`
- keep exception users skipped as before

## Testing
- inspected workflow logic in `.github/workflows/label-not-gittensor.yml`
- confirmed the inverted condition is present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the pull request management workflow to adjust automated labeling criteria. The eligibility logic determining which pull requests receive labels has been refined to improve contributor categorization and routing accuracy. These changes enhance the consistency of automated pull request management processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->