### PR TITLE
fix: Keep with auto for category badge

### DIFF
--- a/app/views/categories/_badge.html.erb
+++ b/app/views/categories/_badge.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (category:) %>
 <% category ||= Category.uncategorized %>
 
-<div class="min-w-0 w-full">
+<div class="min-w-0">
   <span class="flex w-full items-center gap-1 text-sm font-medium rounded-full px-1.5 py-1 border focus-visible:outline-none focus-visible:ring-0"
         style="
           background-color: color-mix(in oklab, <%= category.color %> 10%, transparent);


### PR DESCRIPTION
This PR removes the `w-full` class from the category badge container to prevent badges from becoming excessively long in the settings page.

| Before | After |
|--------|--------|
| <img width="880" height="594" alt="Screenshot 2026-05-24 alle 19 56 14" src="https://github.com/user-attachments/assets/a797fb4e-e046-42f6-bad0-3fb8951e766a" /> | <img width="858" height="591" alt="Screenshot 2026-05-24 alle 19 55 19" src="https://github.com/user-attachments/assets/1b792133-01d1-4354-82e4-1e78e4f31a52" />
 | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted category badge width styling to provide more flexible layout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->