### PR TITLE
fix: Replace platform-wide broadcast_refresh with sync toast

### DIFF
--- a/app/javascript/controllers/sync_toast_controller.js
+++ b/app/javascript/controllers/sync_toast_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="sync-toast"
+//
+// Shown when a background sync completes and the family's data changes.
+// - If the user is not interacting with a form, auto-reloads after a short delay.
+// - If the user is mid-form, the toast stays visible so they can choose when to refresh.
+export default class extends Controller {
+  static values = {
+    autoRefreshDelay: { type: Number, default: 500 },
+  };
+
+  connect() {
+    if (!this.#userIsInteracting()) {
+      this._timer = setTimeout(() => this.refresh(), this.autoRefreshDelayValue);
+    }
+  }
+
+  disconnect() {
+    clearTimeout(this._timer);
+  }
+
+  refresh() {
+    clearTimeout(this._timer);
+    window.location.reload();
+  }
+
+  #userIsInteracting() {
+    const el = document.activeElement;
+    if (!el || el === document.body || el === document.documentElement) return false;
+    return el.closest("form") !== null;
+  }
+}

--- a/app/javascript/controllers/sync_toast_controller.js
+++ b/app/javascript/controllers/sync_toast_controller.js
@@ -7,7 +7,7 @@ import { Controller } from "@hotwired/stimulus";
 // - If the user is mid-form, the toast stays visible so they can choose when to refresh.
 export default class extends Controller {
   static values = {
-    autoRefreshDelay: { type: Number, default: 500 },
+    autoRefreshDelay: { type: Number, default: 2000 },
   };
 
   connect() {
@@ -28,6 +28,6 @@ export default class extends Controller {
   #userIsInteracting() {
     const el = document.activeElement;
     if (!el || el === document.body || el === document.documentElement) return false;
-    return el.closest("form") !== null;
+    return el.isContentEditable || el.closest("form, dialog, [role='dialog']") !== null;
   }
 }

--- a/app/models/family/sync_complete_event.rb
+++ b/app/models/family/sync_complete_event.rb
@@ -14,9 +14,9 @@ class Family::SyncCompleteEvent
     # This avoids wiping in-progress form state when a background sync fires.
     # The partial contains no user-scoped data (Current.user is nil here), so
     # each browser re-fetches the page on its own authenticated request.
-    family.broadcast_append_to(
+    family.broadcast_replace_to(
       family,
-      target: "notification-tray",
+      target: "sync-toast",
       partial: "shared/notifications/sync_toast"
     )
 

--- a/app/models/family/sync_complete_event.rb
+++ b/app/models/family/sync_complete_event.rb
@@ -6,11 +6,19 @@ class Family::SyncCompleteEvent
   end
 
   def broadcast
-    # Broadcast a refresh signal instead of rendered HTML. Each user's browser
-    # re-fetches via their own authenticated request, so the balance sheet and
-    # net worth chart are correctly scoped to the current user (Current.user is
-    # nil in background jobs, which would produce an unscoped family-wide view).
-    family.broadcast_refresh
+    # Append a lightweight toast to the notification tray instead of a full
+    # page refresh.  The sync-toast Stimulus controller handles two cases:
+    #   - User is idle       → auto-reloads after a short delay
+    #   - User is mid-form   → toast stays visible; user clicks "Refresh now"
+    #
+    # This avoids wiping in-progress form state when a background sync fires.
+    # The partial contains no user-scoped data (Current.user is nil here), so
+    # each browser re-fetches the page on its own authenticated request.
+    family.broadcast_append_to(
+      family,
+      target: "notification-tray",
+      partial: "shared/notifications/sync_toast"
+    )
 
     # Schedule recurring transaction pattern identification (debounced to run after all syncs complete)
     begin

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -22,6 +22,7 @@
       <div id="notification-tray" class="space-y-1 w-full">
         <%= render_flash_notifications %>
 
+        <div id="sync-toast"></div>
         <div id="cta"></div>
       </div>
     </div>

--- a/app/views/shared/notifications/_sync_toast.html.erb
+++ b/app/views/shared/notifications/_sync_toast.html.erb
@@ -3,7 +3,7 @@
      class="relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs">
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-info">
-      <%= icon "refresh-cw", size: "xs", color: "white" %>
+      <%= icon "refresh-cw", size: "xs", color: "inverse" %>
     </div>
   </div>
 

--- a/app/views/shared/notifications/_sync_toast.html.erb
+++ b/app/views/shared/notifications/_sync_toast.html.erb
@@ -8,13 +8,15 @@
 
   <div class="space-y-1 flex-1">
     <p class="text-primary text-sm font-medium"><%= t("shared.sync_toast.message") %></p>
-    <button class="text-xs text-info underline hover:opacity-80 transition-opacity"
+    <button type="button" class="text-xs text-info underline hover:opacity-80 transition-opacity"
             data-action="click->sync-toast#refresh">
       <%= t("shared.sync_toast.refresh") %>
     </button>
   </div>
 
   <div class="absolute -top-2 -right-2">
-    <%= icon "x", class: "p-0.5 hidden group-hover:inline-block border border-alpha-black-50 border-solid rounded-lg bg-container text-subdued cursor-pointer", data: { action: "click->element-removal#remove" } %>
+    <button type="button" class="p-0.5 hidden group-hover:inline-block border border-alpha-black-50 border-solid rounded-lg bg-container text-subdued cursor-pointer" aria-label="<%= t('defaults.common.close') %>" data-action="click->element-removal#remove">
+      <%= icon "x" %>
+    </button>
   </div>
 </div>

--- a/app/views/shared/notifications/_sync_toast.html.erb
+++ b/app/views/shared/notifications/_sync_toast.html.erb
@@ -1,4 +1,5 @@
-<div data-controller="sync-toast element-removal"
+<div id="sync-toast"
+     data-controller="sync-toast element-removal"
      class="relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs">
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-info">

--- a/app/views/shared/notifications/_sync_toast.html.erb
+++ b/app/views/shared/notifications/_sync_toast.html.erb
@@ -1,0 +1,20 @@
+<div data-controller="sync-toast element-removal"
+     class="relative flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs">
+  <div class="h-5 w-5 shrink-0 p-px text-primary">
+    <div class="flex h-full items-center justify-center rounded-full bg-info">
+      <%= icon "refresh-cw", size: "xs", color: "white" %>
+    </div>
+  </div>
+
+  <div class="space-y-1 flex-1">
+    <p class="text-primary text-sm font-medium"><%= t("shared.sync_toast.message") %></p>
+    <button class="text-xs text-info underline hover:opacity-80 transition-opacity"
+            data-action="click->sync-toast#refresh">
+      <%= t("shared.sync_toast.refresh") %>
+    </button>
+  </div>
+
+  <div class="absolute -top-2 -right-2">
+    <%= icon "x", class: "p-0.5 hidden group-hover:inline-block border border-alpha-black-50 border-solid rounded-lg bg-container text-subdued cursor-pointer", data: { action: "click->element-removal#remove" } %>
+  </div>
+</div>

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -1,5 +1,9 @@
 ---
 en:
+  shared:
+    sync_toast:
+      message: "Your data has been updated"
+      refresh: "Refresh now"
   defaults:
     brand_name: "%{brand_name}"
     product_name: "%{product_name}"

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -1,9 +1,5 @@
 ---
 en:
-  shared:
-    sync_toast:
-      message: "Your data has been updated"
-      refresh: "Refresh now"
   defaults:
     brand_name: "%{brand_name}"
     product_name: "%{product_name}"

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -4,6 +4,9 @@ en:
     self_hostable:
       redis_configured: "Redis is now configured properly! You can now setup your Sure application."
   shared:
+    sync_toast:
+      message: "Your data has been updated"
+      refresh: "Refresh now"
     confirm_modal:
       accept: Confirm
       body_html: "<p>You will not be able to undo this decision</p>"


### PR DESCRIPTION
## Problem

Every time any account sync completed (triggered by a transaction add/update, a provider sync, a worker update, etc.), `Family::SyncCompleteEvent#broadcast` called `family.broadcast_refresh`.

This caused a **full page reload for every connected family member**, regardless of what they were currently doing. If a user was mid-form — e.g. adding a transaction, filling out import fields, editing a split — the page would silently reload and discard all their input.

`broadcast_refresh` was used because `Current.user` is `nil` in background jobs, making it impossible to render user-scoped HTML (net worth chart, balance sheet) server-side. Each client needed to re-request the page with their own session.

## Fix

Instead of `family.broadcast_refresh`, `Family::SyncCompleteEvent` now appends a lightweight static toast to the existing `#notification-tray` via `broadcast_append_to`.

The toast contains **no user-scoped data** — it is plain static HTML — so the `Current.user: nil` constraint is no longer a problem. Each browser still re-requests the page on its own authenticated session, but **only when it's safe to do so**.

A new `sync-toast` Stimulus controller handles two cases:

| User state | Behaviour |
|---|---|
| Idle (no focused form) | Auto-reloads the page after 500 ms |
| Mid-form (form element focused) | Toast stays visible; user clicks "Refresh now" at their convenience |

The close button (`×`) lets the user dismiss the toast entirely if they don't want to refresh.

## Files changed

- `app/models/family/sync_complete_event.rb` — swap `broadcast_refresh` → `broadcast_append_to`
- `app/views/shared/notifications/_sync_toast.html.erb` — new toast partial
- `app/javascript/controllers/sync_toast_controller.js` — new Stimulus controller
- `config/locales/defaults/en.yml` — `shared.sync_toast.*` locale strings

## Testing

1. Open the app in two browser tabs.
2. In one tab, start filling out the "Add transaction" form (do not submit).
3. In the other tab (or via rails console), trigger a sync: `Account.first.sync_later`
4. **Expected:** the first tab shows a "Your data has been updated — Refresh now" toast without reloading the page.
5. Click "Refresh now" — page reloads with updated data.
6. Repeat with the form tab idle (no focused input) — page should auto-reload after ~500 ms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sync toast notification that appears when data sync completes.
  * The toast auto-refreshes the page after 2 seconds if you’re not actively editing forms or interacting with dialogs.
  * You can manually refresh immediately or dismiss the toast via on-screen action buttons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->