### PR TITLE
Add optional PostHog session recording and initialization

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -67,6 +67,20 @@ static String _baseUrl = 'http://localhost:3000';
 static String _baseUrl = 'https://your-sure-server.com';
 ```
 
+### 6. (Optional) Configure PostHog Session Recording
+
+PostHog is configured with **compile-time** Dart defines (not `.env`):
+
+```bash
+flutter run \
+  --dart-define=POSTHOG_API_KEY=phc_your_project_key \
+  --dart-define=POSTHOG_HOST=https://us.i.posthog.com
+```
+
+- `POSTHOG_API_KEY` is required to enable PostHog.
+- `POSTHOG_HOST` is optional and defaults to `https://us.i.posthog.com`.
+- If `POSTHOG_API_KEY` is not passed, the app logs that PostHog is disabled and continues normally.
+
 ### 5. Run the App
 
 ```bash

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -17,10 +17,12 @@ import 'services/api_config.dart';
 import 'services/connectivity_service.dart';
 import 'services/log_service.dart';
 import 'services/preferences_service.dart';
+import 'services/posthog_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await ApiConfig.initialize();
+  await PostHogService.initialize();
 
   // Add initial log entry
   LogService.instance.info('App', 'Sure app starting...');

--- a/mobile/lib/services/posthog_service.dart
+++ b/mobile/lib/services/posthog_service.dart
@@ -1,0 +1,33 @@
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+import 'log_service.dart';
+
+class PostHogService {
+  PostHogService._();
+
+  static const String _apiKey = String.fromEnvironment('POSTHOG_API_KEY');
+  static const String _host = String.fromEnvironment(
+    'POSTHOG_HOST',
+    defaultValue: 'https://us.i.posthog.com',
+  );
+
+  static Future<void> initialize() async {
+    if (_apiKey.isEmpty) {
+      LogService.instance.info(
+        'PostHog',
+        'PostHog disabled: POSTHOG_API_KEY is not configured.',
+      );
+      return;
+    }
+
+    final config = PostHogConfig(_apiKey, host: _host);
+    config.sessionReplay = true;
+
+    await Posthog().setup(config);
+
+    LogService.instance.info(
+      'PostHog',
+      'PostHog initialized with session replay enabled.',
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   package_info_plus: ^8.0.0
   local_auth: ^2.3.0
   flutter_markdown: ^0.7.2
+  posthog_flutter: ^5.24.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
- Add optional analytics and session replay support to the mobile app that can be enabled at build/run time without requiring runtime secrets in `.env`.
- Ensure the app continues to function when PostHog is not configured and provide clear logging for disabled/enabled states.

### Description
- Added `posthog_flutter` dependency to `pubspec.yaml` and created `lib/services/posthog_service.dart` to encapsulate PostHog setup and session replay configuration. 
- `PostHogService` reads compile-time Dart defines `POSTHOG_API_KEY` and `POSTHOG_HOST` and skips initialization when `POSTHOG_API_KEY` is not provided, logging the disabled state via `LogService`. 
- Initialized `PostHogService` in `lib/main.dart` before app startup and added the import for the new service. 
- Updated `mobile/README.md` with instructions to enable PostHog using `--dart-define=POSTHOG_API_KEY=...` and `--dart-define=POSTHOG_HOST=...`, and documented defaults and behavior.

### Testing
- No unit tests were added for this change. 
- Ran `flutter pub get` and `flutter analyze` on the modified project and both completed successfully. 
- Verified that when `POSTHOG_API_KEY` is not supplied the service logs a disabled message and the app continues to start normally (manual smoke verification, no automated integration tests added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13476ae1a48332a260a5cdbd76e8c3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostHog session recording capability to the mobile app with configurable API key and optional host settings.

* **Documentation**
  * Updated Getting Started guide with PostHog configuration instructions using optional compile-time variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->