### PR TITLE
feat: add Google Gemini as alternative LLM provider

### DIFF
--- a/app/controllers/settings/hostings_controller.rb
+++ b/app/controllers/settings/hostings_controller.rb
@@ -110,6 +110,11 @@ class Settings::HostingsController < ApplicationController
     update_encrypted_setting(:tiingo_api_key)
     update_encrypted_setting(:eodhd_api_key)
     update_encrypted_setting(:alpha_vantage_api_key)
+    update_encrypted_setting(:gemini_api_key)
+
+    if hosting_params.key?(:gemini_model)
+      Setting.gemini_model = hosting_params[:gemini_model].presence
+    end
 
     if hosting_params.key?(:syncs_include_pending)
       Setting.syncs_include_pending = hosting_params[:syncs_include_pending] == "1"
@@ -175,7 +180,7 @@ class Settings::HostingsController < ApplicationController
       end
       parsed = Integer(raw, 10) rescue nil
       if parsed.nil? || parsed < minimum
-        label = t("settings.hostings.openai_settings.#{key}_label")
+        label = t("settings.hostings.llm_token_budget.#{key}_label")
         raise Setting::ValidationError, t(".invalid_llm_budget", field: label, minimum: minimum)
       end
       Setting.public_send("#{key}=", parsed)
@@ -223,7 +228,7 @@ class Settings::HostingsController < ApplicationController
   private
     def hosting_params
       return ActionController::Parameters.new unless params.key?(:setting)
-      params.require(:setting).permit(:onboarding_state, :require_email_confirmation, :invite_only_default_family_id, :brand_fetch_client_id, :brand_fetch_high_res_logos, :twelve_data_api_key, :tiingo_api_key, :eodhd_api_key, :alpha_vantage_api_key, :openai_access_token, :openai_uri_base, :openai_model, :openai_json_mode, :llm_context_window, :llm_max_response_tokens, :llm_max_items_per_call, :exchange_rate_provider, :securities_provider, :syncs_include_pending, :auto_sync_enabled, :auto_sync_time, :external_assistant_url, :external_assistant_token, :external_assistant_agent_id, securities_providers: [])
+      params.require(:setting).permit(:onboarding_state, :require_email_confirmation, :invite_only_default_family_id, :brand_fetch_client_id, :brand_fetch_high_res_logos, :twelve_data_api_key, :tiingo_api_key, :eodhd_api_key, :alpha_vantage_api_key, :openai_access_token, :openai_uri_base, :openai_model, :openai_json_mode, :gemini_api_key, :gemini_model, :llm_context_window, :llm_max_response_tokens, :llm_max_items_per_call, :exchange_rate_provider, :securities_provider, :syncs_include_pending, :auto_sync_enabled, :auto_sync_time, :external_assistant_url, :external_assistant_token, :external_assistant_agent_id, securities_providers: [])
     end
 
     def update_assistant_type

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -266,13 +266,18 @@ class Provider::Openai < Provider
     user_identifier: nil,
     family: nil
   )
+    # For custom providers (Gemini, Ollama, etc.) always use the configured
+    # model — the caller may pass an OpenAI model name like "gpt-4.1" which
+    # the custom endpoint won't recognise.
+    effective_model = custom_provider? ? @default_model : (model.presence || @default_model)
+
     if supports_responses_endpoint?
       # Native path uses the Responses API which chains history via
       # `previous_response_id`; it does NOT need (and must not receive)
       # inline message history in the input payload.
       native_chat_response(
         prompt: prompt,
-        model: model,
+        model: effective_model,
         instructions: instructions,
         functions: functions,
         function_results: function_results,
@@ -285,7 +290,7 @@ class Provider::Openai < Provider
     else
       generic_chat_response(
         prompt: prompt,
-        model: model,
+        model: effective_model,
         instructions: instructions,
         functions: functions,
         function_results: function_results,

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -65,7 +65,9 @@ class Provider::Registry
       def openai
         access_token = ENV["OPENAI_ACCESS_TOKEN"].presence || Setting.openai_access_token
 
-        return nil unless access_token.present?
+        # Fall back to Gemini (via its OpenAI-compatible endpoint) when no
+        # OpenAI key is configured — all existing call-sites continue to work.
+        return gemini unless access_token.present?
 
         uri_base = ENV["OPENAI_URI_BASE"].presence || Setting.openai_uri_base
         model = ENV["OPENAI_MODEL"].presence || Setting.openai_model
@@ -76,6 +78,22 @@ class Provider::Registry
         end
 
         Provider::Openai.new(access_token, uri_base: uri_base, model: model)
+      end
+
+      def gemini
+        api_key = ENV["GEMINI_API_KEY"].presence || Setting.gemini_api_key
+
+        return nil unless api_key.present?
+
+        # Gemini exposes an OpenAI-compatible endpoint so we reuse Provider::Openai.
+        # Default model is gemini-2.0-flash; override via Setting or GEMINI_MODEL env var.
+        model = ENV["GEMINI_MODEL"].presence || Setting.gemini_model.presence || "gemini-2.5-flash"
+
+        Provider::Openai.new(
+          api_key,
+          uri_base: "https://generativelanguage.googleapis.com/v1beta/openai/",
+          model: model
+        )
       end
 
       def yahoo_finance
@@ -147,7 +165,7 @@ class Provider::Registry
       when :securities
         %i[twelve_data yahoo_finance tiingo eodhd alpha_vantage mfapi binance_public]
       when :llm
-        %i[openai]
+        %i[openai gemini]
       else
         %i[plaid_us plaid_eu github openai]
       end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -10,6 +10,8 @@ class Setting < RailsSettings::Base
   field :openai_uri_base, type: :string, default: ENV["OPENAI_URI_BASE"]
   field :openai_model, type: :string, default: ENV["OPENAI_MODEL"]
   field :openai_json_mode, type: :string, default: ENV["LLM_JSON_MODE"]
+  field :gemini_api_key, type: :string, default: ENV["GEMINI_API_KEY"]
+  field :gemini_model, type: :string, default: ENV["GEMINI_MODEL"]
 
   # LLM token budget (applies to every outbound LLM call: chat, auto-categorize,
   # merchant detection, enhance-merchants, PDF processing). Defaults track
@@ -70,6 +72,7 @@ class Setting < RailsSettings::Base
       eodhd_api_key
       alpha_vantage_api_key
       openai_access_token
+      gemini_api_key
       external_assistant_token
     ].freeze
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,7 +156,8 @@ class User < ApplicationRecord
     when "external"
       Assistant::External.available_for?(self)
     else
-      ENV["OPENAI_ACCESS_TOKEN"].present? || Setting.openai_access_token.present?
+      ENV["OPENAI_ACCESS_TOKEN"].present? || Setting.openai_access_token.present? ||
+        ENV["GEMINI_API_KEY"].present? || Setting.gemini_api_key.present?
     end
   end
 

--- a/app/views/settings/hostings/_gemini_settings.html.erb
+++ b/app/views/settings/hostings/_gemini_settings.html.erb
@@ -1,0 +1,43 @@
+<div class="space-y-4">
+  <div>
+    <h2 class="font-medium mb-1"><%= t(".title") %></h2>
+    <% if ENV["GEMINI_API_KEY"].present? %>
+      <p class="text-sm text-secondary"><%= t(".env_configured_message") %></p>
+    <% else %>
+      <p class="text-secondary text-sm mb-4"><%= t(".description") %></p>
+    <% end %>
+  </div>
+
+  <%= styled_form_with model: Setting.new,
+                       url: settings_hosting_path,
+                       method: :patch,
+                       class: "space-y-4",
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+  <%= form.password_field :gemini_api_key,
+                          label: t(".api_key_label"),
+                          placeholder: t(".api_key_placeholder"),
+                          value: (Setting.gemini_api_key.present? ? "********" : nil),
+                          autocomplete: "off",
+                          autocapitalize: "none",
+                          spellcheck: "false",
+                          inputmode: "text",
+                          disabled: ENV["GEMINI_API_KEY"].present?,
+                          data: { "auto-submit-form-target": "auto" } %>
+  <p class="text-xs text-secondary mt-1"><%= t(".api_key_help_html") %></p>
+
+  <%= form.text_field :gemini_model,
+                      label: t(".model_label"),
+                      placeholder: t(".model_placeholder"),
+                      value: Setting.gemini_model,
+                      autocomplete: "off",
+                      autocapitalize: "none",
+                      spellcheck: "false",
+                      inputmode: "text",
+                      disabled: ENV["GEMINI_MODEL"].present?,
+                      data: { "auto-submit-form-target": "auto" } %>
+  <p class="text-xs text-secondary mt-1"><%= t(".model_help_html") %></p>
+  <% end %>
+</div>

--- a/app/views/settings/hostings/_llm_token_budget.html.erb
+++ b/app/views/settings/hostings/_llm_token_budget.html.erb
@@ -1,0 +1,39 @@
+<div class="space-y-4">
+  <p class="text-secondary text-sm"><%= t(".description") %></p>
+
+  <%= styled_form_with model: Setting.new,
+                       url: settings_hosting_path,
+                       method: :patch,
+                       class: "space-y-4",
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+  <%= form.number_field :llm_context_window,
+                        label: t(".context_window_label"),
+                        placeholder: "2048",
+                        value: Setting.llm_context_window,
+                        min: 256,
+                        disabled: ENV["LLM_CONTEXT_WINDOW"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+  <p class="text-xs text-secondary mt-1 mb-3"><%= t(".context_window_help") %></p>
+
+  <%= form.number_field :llm_max_response_tokens,
+                        label: t(".max_response_tokens_label"),
+                        placeholder: "512",
+                        value: Setting.llm_max_response_tokens,
+                        min: 64,
+                        disabled: ENV["LLM_MAX_RESPONSE_TOKENS"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+  <p class="text-xs text-secondary mt-1 mb-3"><%= t(".max_response_tokens_help") %></p>
+
+  <%= form.number_field :llm_max_items_per_call,
+                        label: t(".max_items_per_call_label"),
+                        placeholder: "25",
+                        value: Setting.llm_max_items_per_call,
+                        min: 1,
+                        disabled: ENV["LLM_MAX_ITEMS_PER_CALL"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+  <p class="text-xs text-secondary mt-1"><%= t(".max_items_per_call_help") %></p>
+  <% end %>
+</div>

--- a/app/views/settings/hostings/_openai_settings.html.erb
+++ b/app/views/settings/hostings/_openai_settings.html.erb
@@ -63,37 +63,5 @@
                   { disabled: ENV["LLM_JSON_MODE"].present?,
                     data: { "auto-submit-form-target": "auto" } } %>
   <p class="text-xs text-secondary mt-1"><%= t(".json_mode_help") %></p>
-
-  <div class="pt-4 border-t border-secondary">
-    <h3 class="font-medium mb-1"><%= t(".budget_heading") %></h3>
-    <p class="text-xs text-secondary mb-3"><%= t(".budget_description") %></p>
-
-    <%= form.number_field :llm_context_window,
-                          label: t(".context_window_label"),
-                          placeholder: "2048",
-                          value: Setting.llm_context_window,
-                          min: 256,
-                          disabled: ENV["LLM_CONTEXT_WINDOW"].present?,
-                          data: { "auto-submit-form-target": "auto" } %>
-    <p class="text-xs text-secondary mt-1 mb-3"><%= t(".context_window_help") %></p>
-
-    <%= form.number_field :llm_max_response_tokens,
-                          label: t(".max_response_tokens_label"),
-                          placeholder: "512",
-                          value: Setting.llm_max_response_tokens,
-                          min: 64,
-                          disabled: ENV["LLM_MAX_RESPONSE_TOKENS"].present?,
-                          data: { "auto-submit-form-target": "auto" } %>
-    <p class="text-xs text-secondary mt-1 mb-3"><%= t(".max_response_tokens_help") %></p>
-
-    <%= form.number_field :llm_max_items_per_call,
-                          label: t(".max_items_per_call_label"),
-                          placeholder: "25",
-                          value: Setting.llm_max_items_per_call,
-                          min: 1,
-                          disabled: ENV["LLM_MAX_ITEMS_PER_CALL"].present?,
-                          data: { "auto-submit-form-target": "auto" } %>
-    <p class="text-xs text-secondary mt-1"><%= t(".max_items_per_call_help") %></p>
-  </div>
   <% end %>
 </div>

--- a/app/views/settings/hostings/show.html.erb
+++ b/app/views/settings/hostings/show.html.erb
@@ -2,11 +2,23 @@
 <%= settings_section title: t(".ai_assistant") do %>
   <%= render "settings/hostings/assistant_settings" %>
 <% end %>
-<%= settings_section title: t(".general") do %>
-    <div class="space-y-6">
+<%= settings_section title: t(".ai_provider") do %>
+  <p class="text-sm text-secondary mb-6"><%= t(".ai_provider_description") %></p>
+  <div class="space-y-6">
     <%= render "settings/hostings/openai_settings" %>
-    <%= render "settings/hostings/brand_fetch_settings" %>
+    <div class="relative flex items-center py-1">
+      <div class="flex-grow border-t border-secondary"></div>
+      <span class="flex-shrink mx-4 text-xs text-secondary uppercase tracking-wider"><%= t(".ai_provider_or") %></span>
+      <div class="flex-grow border-t border-secondary"></div>
+    </div>
+    <%= render "settings/hostings/gemini_settings" %>
   </div>
+<% end %>
+<%= settings_section title: t(".llm_token_budget") do %>
+  <%= render "settings/hostings/llm_token_budget" %>
+<% end %>
+<%= settings_section title: t(".general") do %>
+  <%= render "settings/hostings/brand_fetch_settings" %>
 <% end %>
 <%= settings_section title: t(".financial_data_providers") do %>
   <div class="space-y-6">

--- a/config/locales/views/chats/en.yml
+++ b/config/locales/views/chats/en.yml
@@ -32,7 +32,7 @@ en:
     ai_consent:
       title: "Enable AI Chats"
       available_description: "AI chat can answer financial questions and provide insights based on your data. To use this feature you'll need to explicitly enable it."
-      unavailable_description_html: "To use the AI assistant, you need to set the <code class=\"bg-surface-inset px-1 py-0.5 rounded font-mono text-xs\">OPENAI_ACCESS_TOKEN</code> environment variable or configure it in the Self-Hosting settings of your instance."
+      unavailable_description_html: "To use the AI assistant, configure an AI provider in the <a href=\"/settings/hosting\" class=\"underline\">Self-Hosting settings</a>. You can use OpenAI (<code class=\"bg-surface-inset px-1 py-0.5 rounded font-mono text-xs\">OPENAI_ACCESS_TOKEN</code>) or Google Gemini (<code class=\"bg-surface-inset px-1 py-0.5 rounded font-mono text-xs\">GEMINI_API_KEY</code>)."
       enable_button: "Enable AI Chats"
       disable_note: "Disable anytime. All data sent to our LLM providers is anonymized."
   assistant_messages:

--- a/config/locales/views/settings/hostings/en.yml
+++ b/config/locales/views/settings/hostings/en.yml
@@ -20,6 +20,10 @@ en:
       show:
         general: General Settings
         ai_assistant: AI Assistant
+        ai_provider: AI Provider
+        ai_provider_description: "You only need one. Configure either OpenAI or Google Gemini — if both are set, OpenAI takes priority."
+        ai_provider_or: "or"
+        llm_token_budget: AI Token Budget
         financial_data_providers: Financial Data Providers
         sync_settings: Sync Settings
         invites: Invite Codes
@@ -90,6 +94,24 @@ en:
         title: Brand Fetch Settings
         high_res_label: Enable high-resolution logos
         high_res_description: When enabled, logos will be retrieved at 120x120 resolution instead of 40x40. This provides sharper images on high-DPI displays.
+      llm_token_budget:
+        description: Applies to every LLM call regardless of provider — chat history, auto-categorization, merchant detection, and PDF processing. Defaults are conservative for small-context local models. Raise for cloud models (OpenAI, Gemini) with large context windows.
+        context_window_label: Context Window (Optional)
+        context_window_help: "Total tokens the model will accept. Default: 2048 — raise to 8192+ for cloud OpenAI or large-context local models."
+        max_response_tokens_label: Max Response Tokens (Optional)
+        max_response_tokens_help: "Tokens reserved for the model's reply. Default: 512. Lower to free up room for longer history."
+        max_items_per_call_label: Max Items Per Batch (Optional)
+        max_items_per_call_help: "Upper bound for auto-categorize / merchant detection batches. Default: 25. Larger batches are auto-sliced to fit the context window."
+      gemini_settings:
+        title: Google Gemini
+        description: Enter your Google Gemini API key to use Gemini as your AI provider. When set (and no OpenAI key is configured), all AI features — chat, auto-categorization, and merchant detection — will use Gemini.
+        env_configured_message: Successfully configured through the GEMINI_API_KEY environment variable.
+        api_key_label: API Key
+        api_key_placeholder: Enter your Gemini API key here
+        api_key_help_html: 'Get your API key from <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener noreferrer" class="underline">Google AI Studio</a>. The free tier includes generous usage limits. Defaults to <code>gemini-2.5-flash</code>.'
+        model_label: Model (Optional)
+        model_placeholder: "gemini-2.5-flash (default)"
+        model_help_html: 'Leave blank for <code>gemini-2.5-flash</code> (recommended). Smarter: <code>gemini-2.5-pro</code>. Cheaper/faster: <code>gemini-2.5-flash-lite</code>. Thinking: <code>gemini-2.0-flash-thinking-exp-01-21</code>. <a href="https://ai.google.dev/gemini-api/docs/models/gemini" target="_blank" rel="noopener noreferrer" class="underline">All models →</a>'
       openai_settings:
         description: Enter the access token and optionally configure a custom OpenAI-compatible provider
         env_configured_message: Successfully configured through environment variables.
@@ -105,14 +127,6 @@ en:
         json_mode_none: None (best for standard models)
         json_mode_json_object: JSON Object
         json_mode_help: "Strict mode works best with thinking models (qwen-thinking, deepseek-reasoner). None mode works best with standard models (llama, mistral, gpt-oss)."
-        budget_heading: Token Budget
-        budget_description: Applies to every LLM call — chat history, auto-categorization, merchant detection, and PDF processing. Defaults are conservative for small-context local models. Raise for cloud models with larger context windows.
-        context_window_label: Context Window (Optional)
-        context_window_help: "Total tokens the model will accept. Default: 2048 — raise to 8192+ for cloud OpenAI or large-context local models."
-        max_response_tokens_label: Max Response Tokens (Optional)
-        max_response_tokens_help: "Tokens reserved for the model's reply. Default: 512. Lower to free up room for longer history."
-        max_items_per_call_label: Max Items Per Batch (Optional)
-        max_items_per_call_help: "Upper bound for auto-categorize / merchant detection batches. Default: 25. Larger batches are auto-sliced to fit the context window."
         title: OpenAI
       yahoo_finance_settings:
         title: Yahoo Finance

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -272,6 +272,41 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     assert_equal "Custom OpenAI-compatible (https://custom-api.example.com/v1)", custom_provider.provider_name
   end
 
+  test "chat_response uses configured model for custom providers, ignoring caller-supplied model" do
+    gemini_provider = Provider::Openai.new(
+      "test-gemini-key",
+      uri_base: "https://generativelanguage.googleapis.com/v1beta/openai/",
+      model: "gemini-2.5-flash"
+    )
+
+    # Mocha uses ruby2_keywords internally; by the time the .with block fires,
+    # the kwargs hash has lost its "keyword" flag and arrives as the first
+    # (only) positional element in *args.  Access it via args.first.
+    captured_model = nil
+    gemini_provider.stubs(:generic_chat_response).with { |*args|
+      captured_model = args.first[:model] if args.first.is_a?(Hash)
+      true
+    }
+
+    gemini_provider.chat_response("Hello", model: "gpt-4.1")
+
+    assert_equal "gemini-2.5-flash", captured_model,
+      "Custom provider should use its configured model, not the caller-supplied OpenAI model name"
+  end
+
+  test "chat_response uses caller-supplied model for standard OpenAI provider" do
+    captured_model = nil
+    @subject.stubs(:native_chat_response).with { |*args|
+      captured_model = args.first[:model] if args.first.is_a?(Hash)
+      true
+    }
+
+    @subject.chat_response("Hello", model: "gpt-4o")
+
+    assert_equal "gpt-4o", captured_model,
+      "Standard OpenAI provider should pass through the caller-supplied model"
+  end
+
   test "supported_models_description returns model prefixes for standard provider" do
     expected = "models starting with: gpt-4, gpt-5, o1, o3"
     assert_equal expected, @subject.supported_models_description

--- a/test/models/provider/registry_test.rb
+++ b/test/models/provider/registry_test.rb
@@ -2,9 +2,10 @@ require "test_helper"
 
 class Provider::RegistryTest < ActiveSupport::TestCase
   test "providers filters out nil values when provider is not configured" do
-    # Ensure OpenAI is not configured
-    ClimateControl.modify("OPENAI_ACCESS_TOKEN" => nil) do
+    # Ensure neither OpenAI nor Gemini is configured
+    ClimateControl.modify("OPENAI_ACCESS_TOKEN" => nil, "GEMINI_API_KEY" => nil) do
       Setting.stubs(:openai_access_token).returns(nil)
+      Setting.stubs(:gemini_api_key).returns(nil)
 
       registry = Provider::Registry.for_concept(:llm)
 
@@ -44,6 +45,86 @@ class Provider::RegistryTest < ActiveSupport::TestCase
       assert_nil registry.get_provider(:openai)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Gemini provider
+  # ---------------------------------------------------------------------------
+
+  test "gemini provider returns a Provider::Openai instance using Gemini base URL" do
+    ClimateControl.modify("GEMINI_API_KEY" => nil, "GEMINI_MODEL" => nil) do
+      Setting.stubs(:gemini_api_key).returns("test-gemini-key")
+      Setting.stubs(:gemini_model).returns(nil)
+
+      provider = Provider::Registry.get_provider(:gemini)
+
+      assert_not_nil provider
+      assert_instance_of Provider::Openai, provider
+      assert provider.custom_provider?, "Gemini provider should report as custom provider"
+    end
+  end
+
+  test "gemini provider uses configured model from Setting" do
+    ClimateControl.modify("GEMINI_API_KEY" => nil, "GEMINI_MODEL" => nil) do
+      Setting.stubs(:gemini_api_key).returns("test-gemini-key")
+      Setting.stubs(:gemini_model).returns("gemini-2.5-pro")
+
+      provider = Provider::Registry.get_provider(:gemini)
+
+      assert_equal "configured model: gemini-2.5-pro", provider.supported_models_description
+    end
+  end
+
+  test "gemini provider uses default model when none configured" do
+    ClimateControl.modify("GEMINI_API_KEY" => nil, "GEMINI_MODEL" => nil) do
+      Setting.stubs(:gemini_api_key).returns("test-gemini-key")
+      Setting.stubs(:gemini_model).returns(nil)
+
+      provider = Provider::Registry.get_provider(:gemini)
+
+      assert_equal "configured model: gemini-2.5-flash", provider.supported_models_description
+    end
+  end
+
+  test "gemini provider returns nil when no API key configured" do
+    ClimateControl.modify("GEMINI_API_KEY" => nil) do
+      Setting.stubs(:gemini_api_key).returns(nil)
+
+      provider = Provider::Registry.get_provider(:gemini)
+
+      assert_nil provider
+    end
+  end
+
+  test "openai falls back to gemini when no OpenAI key is set" do
+    ClimateControl.modify("OPENAI_ACCESS_TOKEN" => nil, "GEMINI_API_KEY" => nil, "GEMINI_MODEL" => nil) do
+      Setting.stubs(:openai_access_token).returns(nil)
+      Setting.stubs(:gemini_api_key).returns("test-gemini-key")
+      Setting.stubs(:gemini_model).returns(nil)
+
+      provider = Provider::Registry.get_provider(:openai)
+
+      assert_not_nil provider
+      assert_instance_of Provider::Openai, provider
+      assert provider.custom_provider?, "Fallback Gemini provider should report as custom provider"
+    end
+  end
+
+  test "openai takes priority over gemini when both are configured" do
+    ClimateControl.modify("OPENAI_ACCESS_TOKEN" => nil, "OPENAI_URI_BASE" => nil, "OPENAI_MODEL" => nil,
+                          "GEMINI_API_KEY" => nil) do
+      Setting.stubs(:openai_access_token).returns("test-openai-key")
+      Setting.stubs(:openai_uri_base).returns(nil)
+      Setting.stubs(:openai_model).returns(nil)
+      Setting.stubs(:gemini_api_key).returns("test-gemini-key")
+
+      provider = Provider::Registry.get_provider(:openai)
+
+      assert_not_nil provider
+      assert_equal "OpenAI", provider.provider_name
+    end
+  end
+
+  # ---------------------------------------------------------------------------
 
   test "openai provider falls back to Setting when ENV is empty string" do
     # Mock ENV to return empty string (common in Docker/env files)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -276,6 +276,21 @@ class UserTest < ActiveSupport::TestCase
     Setting.openai_access_token = previous
   end
 
+  test "ai_available? returns true when gemini api key set in settings" do
+    Rails.application.config.app_mode.stubs(:self_hosted?).returns(true)
+    previous = Setting.gemini_api_key
+    with_env_overrides OPENAI_ACCESS_TOKEN: nil, GEMINI_API_KEY: nil, EXTERNAL_ASSISTANT_URL: nil, EXTERNAL_ASSISTANT_TOKEN: nil do
+      Setting.openai_access_token = nil
+      Setting.gemini_api_key = nil
+      assert_not @user.ai_available?
+
+      Setting.gemini_api_key = "gemini-test-key"
+      assert @user.ai_available?
+    end
+  ensure
+    Setting.gemini_api_key = previous
+  end
+
   test "ai_available? returns true when external assistant is configured and family type is external" do
     Rails.application.config.app_mode.stubs(:self_hosted?).returns(true)
     previous = Setting.openai_access_token


### PR DESCRIPTION
## Summary

- **Google Gemini support**: Uses Gemini's OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/`) via the existing `Provider::Openai` class — no new provider class needed
- **Provider fallback logic**: OpenAI is used when `OPENAI_ACCESS_TOKEN` / `openai_access_token` setting is present; falls through to Gemini otherwise; if both are set, OpenAI wins
- **Bug fix — chat model override**: `chat_response` was always forwarding the caller-supplied model name (e.g. `"gpt-4.1"`) to custom providers, causing 404s from Gemini's endpoint. Now uses the provider's configured `@default_model` for any custom (non-standard-OpenAI) provider
- **Bug fix — AI availability gate**: `ai_available?` only checked OpenAI keys; updated to also check Gemini key so "Enable AI Chats" appears when only Gemini is configured
- **Settings UX**: OpenAI and Gemini sections displayed as peers with an "or" divider; token budget extracted into its own standalone section; Gemini partial includes an optional model field (default: `gemini-2.5-flash`)
- **Locale updates**: Self-hosting settings and chat unavailable message updated to mention both providers

## Test plan

- [ ] `test/models/provider/registry_test.rb` — 6 new tests covering Gemini provider creation, model precedence, nil when no key, and OpenAI↔Gemini fallback/priority
- [ ] `test/models/user_test.rb` — 1 new test: `ai_available?` returns true when only Gemini key is set
- [ ] `test/models/provider/openai_test.rb` — 2 new tests: custom providers use configured model; standard OpenAI passes caller-supplied model through
- [ ] Manual: set `GEMINI_API_KEY` only → "Enable AI Chats" button appears, chat works
- [ ] Manual: set both keys → OpenAI is used (check worker logs)
- [ ] Manual: Settings → Self-Hosting → AI Provider shows OpenAI / or / Gemini layout; token budget is in its own section below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Google Gemini as an AI provider option, allowing configuration of Gemini API key and model selection in Self-Hosting settings alongside OpenAI.
  * Reorganized LLM token budget settings into a dedicated configuration section for improved clarity.

* **Documentation**
  * Updated help text to guide users through Gemini provider configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->