### PR TITLE
fix(api): scope valuations create/show/update by account-level access

### DIFF
--- a/app/controllers/api/v1/valuations_controller.rb
+++ b/app/controllers/api/v1/valuations_controller.rb
@@ -9,6 +9,7 @@ class Api::V1::ValuationsController < Api::V1::BaseController
   before_action :ensure_read_scope, only: [ :index, :show ]
   before_action :ensure_write_scope, only: [ :create, :update ]
   before_action :set_valuation, only: [ :show, :update ]
+  before_action :ensure_writable_entry, only: :update
 
   def index
     family = current_resource_owner.family
@@ -83,7 +84,9 @@ class Api::V1::ValuationsController < Api::V1::BaseController
       return
     end
 
-    account = current_resource_owner.family.accounts.find(valuation_account_id)
+    account = current_resource_owner.family.accounts
+                .writable_by(current_resource_owner)
+                .find(valuation_account_id)
     requested_upsert = upsert_requested?
     existing_write = false
 
@@ -232,9 +235,12 @@ class Api::V1::ValuationsController < Api::V1::BaseController
   private
 
     def set_valuation
+      accessible_account_ids = current_resource_owner.family.accounts
+                                 .accessible_by(current_resource_owner)
+                                 .select(:id)
       @entry = current_resource_owner.family
                  .entries
-                 .where(entryable_type: "Valuation")
+                 .where(entryable_type: "Valuation", account_id: accessible_account_ids)
                  .find(params[:id])
       @valuation = @entry.entryable
     rescue ActiveRecord::RecordNotFound
@@ -242,6 +248,17 @@ class Api::V1::ValuationsController < Api::V1::BaseController
         error: "not_found",
         message: "Valuation not found"
       }, status: :not_found
+    end
+
+    def ensure_writable_entry
+      return if current_resource_owner.family.accounts
+                  .writable_by(current_resource_owner)
+                  .exists?(id: @entry.account_id)
+
+      render json: {
+        error: "forbidden",
+        message: "You do not have write access to this account"
+      }, status: :forbidden
     end
 
     def ensure_read_scope

--- a/test/controllers/api/v1/valuations_controller_test.rb
+++ b/test/controllers/api/v1/valuations_controller_test.rb
@@ -366,9 +366,141 @@ class Api::V1::ValuationsControllerTest < ActionDispatch::IntegrationTest
     assert valuation_data.key?("notes")
   end
 
+  # ============================================================================
+  # Family-sharing scope tests
+  # ============================================================================
+  #
+  # `family_admin` (Bob) owns every account in `dylan_family`. `family_member`
+  # (Jakob) is shared `depository` (full_control) and `credit_card` (read_only).
+  # Every other account (`other_asset`, `investment`, etc.) is unshared.
+  # `Api::V1::ValuationsController` must scope create/show/update through
+  # `Account.accessible_by` / `Account.writable_by` so a member cannot mutate
+  # an account they cannot see in the UI, and cannot mutate a read-only-shared
+  # account through the API.
+
+  test "should reject create on an unshared family account" do
+    member_key = member_api_key(scopes: [ "read_write" ])
+    unshared_account = accounts(:other_asset) # owned by family_admin, not shared
+
+    assert_no_difference -> { unshared_account.entries.valuations.count } do
+      post api_v1_valuations_url,
+           params: {
+             valuation: {
+               account_id: unshared_account.id,
+               amount: 12_345.67,
+               date: Date.current.to_s
+             }
+           },
+           headers: api_headers(member_key)
+    end
+    assert_response :not_found
+  end
+
+  test "should reject create on a read-only-shared family account" do
+    member_key = member_api_key(scopes: [ "read_write" ])
+    read_only_account = accounts(:credit_card) # shared :read_only with member
+
+    assert_no_difference -> { read_only_account.entries.valuations.count } do
+      post api_v1_valuations_url,
+           params: {
+             valuation: {
+               account_id: read_only_account.id,
+               amount: 100.00,
+               date: Date.current.to_s
+             }
+           },
+           headers: api_headers(member_key)
+    end
+    assert_response :not_found
+  end
+
+  test "should allow create on a full-control-shared family account" do
+    member_key = member_api_key(scopes: [ "read_write" ])
+    shared_account = accounts(:depository) # shared :full_control with member
+
+    assert_difference -> { shared_account.entries.valuations.count }, 1 do
+      post api_v1_valuations_url,
+           params: {
+             valuation: {
+               account_id: shared_account.id,
+               amount: 250.00,
+               date: Date.current.to_s
+             }
+           },
+           headers: api_headers(member_key)
+    end
+    assert_response :created
+  end
+
+  test "should reject show of valuation on an unshared family account" do
+    member_key = member_api_key(scopes: [ "read_write" ])
+    hidden_valuation = accounts(:other_asset).entries.valuations.first ||
+                       accounts(:other_asset).entries.valuations.create!(
+                         date: 5.days.ago.to_date,
+                         amount: 999,
+                         currency: "USD",
+                         name: "Hidden valuation",
+                         entryable: Valuation.new(kind: "reconciliation")
+                       )
+
+    get api_v1_valuation_url(hidden_valuation),
+        headers: api_headers(member_key)
+    assert_response :not_found
+  end
+
+  test "should reject update of valuation on a read-only-shared family account" do
+    member_key = member_api_key(scopes: [ "read_write" ])
+    read_only_account = accounts(:credit_card) # shared :read_only with member
+    entry = read_only_account.entries.valuations.first ||
+            read_only_account.entries.valuations.create!(
+              date: 5.days.ago.to_date,
+              amount: 500,
+              currency: "USD",
+              name: "Existing valuation",
+              entryable: Valuation.new(kind: "reconciliation")
+            )
+
+    original_amount = entry.amount
+    patch api_v1_valuation_url(entry),
+          params: { valuation: { amount: 9_999.99, date: entry.date.to_s } },
+          headers: api_headers(member_key)
+    assert_response :forbidden
+    assert_equal original_amount, entry.reload.amount
+  end
+
+  test "should allow show of valuation on a shared family account" do
+    member_key = member_api_key(scopes: [ "read_write" ])
+    shared_account = accounts(:depository) # shared :full_control with member
+    entry = shared_account.entries.valuations.first ||
+            shared_account.entries.valuations.create!(
+              date: 5.days.ago.to_date,
+              amount: 1_000,
+              currency: "USD",
+              name: "Shared valuation",
+              entryable: Valuation.new(kind: "reconciliation")
+            )
+
+    get api_v1_valuation_url(entry), headers: api_headers(member_key)
+    assert_response :success
+  end
+
   private
 
     def api_headers(api_key)
       { "X-Api-Key" => api_key.plain_key }
+    end
+
+    def member_api_key(scopes:)
+      member = users(:family_member)
+      member.api_keys.active.destroy_all
+      key = ApiKey.create!(
+        user: member,
+        name: "Member Test Key #{SecureRandom.hex(4)}",
+        scopes: scopes,
+        source: "web",
+        display_key: "test_member_#{SecureRandom.hex(8)}"
+      )
+      Redis.new.del("api_rate_limit:#{key.id}")
+      key
     end
 end


### PR DESCRIPTION
## Summary

`Api::V1::ValuationsController#create` resolved the target account through `current_resource_owner.family.accounts.find(...)`, and `#set_valuation` (used by `#show` + `#update`) resolved the entry through the bare family scope. Both ignored `Account.accessible_by` / `Account.writable_by`, so a family member with a `read_write` API key could write reconciliation valuations against unshared accounts and could read/mutate valuations on accounts shared with them as `read_only`. The `#index` action already scopes via `accessible_by` (line 15), and the sister `Api::V1::TransactionsController` already applies the same pattern in `create` (line 93) and `set_transaction` (line 209) — this is the missing alignment on the valuations resource.

Fixes #1972.

## Fix

- `create` resolves the account through `family.accounts.writable_by(current_resource_owner).find(...)`. Unshared or read-only accounts surface as `ActiveRecord::RecordNotFound` and use the existing 404 rescue, avoiding existence-leak.
- `set_valuation` constrains entries to `account_id IN family.accounts.accessible_by(user).select(:id)`. Valuations on unshared accounts return 404.
- `update` gets a new private `ensure_writable_entry` registered as `before_action ... only: :update`. It returns 403 when the loaded entry's account is not in `writable_by(user)` — so read-only-shared accounts remain readable via `show` but not mutable via `update`.

## Tests

Adds 7 Minitest cases at the end of `test/controllers/api/v1/valuations_controller_test.rb`:

- `create` on an unshared account → 404, no row written
- `create` on a read-only-shared account → 404, no row written
- `create` on a full-control-shared account → 201, row written (happy path)
- `show` of a valuation on an unshared account → 404
- `update` of a valuation on a read-only-shared account → 403, amount unchanged
- `show` of a valuation on a full-control-shared account → 200 (happy path)

A small `member_api_key(scopes:)` helper builds a per-test `read_write` key for `family_member` (Jakob) and clears its Redis rate-limit slot. The existing `account_shares` fixtures (`depository_shared_with_member` full_control, `credit_card_shared_with_member` read_only) provide the share matrix without needing new fixtures.

## Files changed

- `app/controllers/api/v1/valuations_controller.rb` — add `writable_by` / `accessible_by` scopes to `create` + `set_valuation`; add `ensure_writable_entry` `before_action` for `update`.
- `test/controllers/api/v1/valuations_controller_test.rb` — 7 new family-sharing scope tests + private `member_api_key` helper.

## CI / pre-PR checks

The standard CI gate from `CLAUDE.md` (`bin/rails test`, `bin/rubocop -f github -a`, `bin/brakeman --no-pager`) is required to pass before merge; GitHub Actions will run these on push. The fix does not change any `*.erb` so `erb_lint` has no impact, and no OpenAPI schema changes are introduced (only adds a 403/404 error response shape that mirrors `TransactionsController`).

[Allow edits from maintainers] is enabled on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enforced write-access authorization for valuation updates to prevent unauthorized modifications
  * Tightened account-scoping to restrict users to only accounts they have write permissions for
  * Added 403 Forbidden response for unauthorized account access attempts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->