### PR TITLE
fix(jobs): delegate recurring-transaction sync gate to Sync.for_family

### DIFF
--- a/app/jobs/identify_recurring_transactions_job.rb
+++ b/app/jobs/identify_recurring_transactions_job.rb
@@ -42,21 +42,13 @@ class IdentifyRecurringTransactionsJob < ApplicationJob
       "recurring_transaction_identify:#{family_id}"
     end
 
+    # Debounce gate: delegate to `Sync.any_incomplete_for?`, which polls every
+    # `Syncable` provider association on `Family` via reflection. The previous
+    # hand-rolled list covered only 5 of the 14 `*_items` associations on
+    # `Family`, so a Coinbase/Mercury/Brex/etc. sync in flight silently
+    # bypassed this gate and let the identifier run against a partial dataset.
     def family_has_incomplete_syncs?(family)
-      # Check family's own syncs
-      return true if family.syncs.incomplete.exists?
-
-      # Check all provider items' syncs
-      return true if family.plaid_items.joins(:syncs).merge(Sync.incomplete).exists? if family.respond_to?(:plaid_items)
-      return true if family.simplefin_items.joins(:syncs).merge(Sync.incomplete).exists? if family.respond_to?(:simplefin_items)
-      return true if family.lunchflow_items.joins(:syncs).merge(Sync.incomplete).exists? if family.respond_to?(:lunchflow_items)
-      return true if family.enable_banking_items.joins(:syncs).merge(Sync.incomplete).exists? if family.respond_to?(:enable_banking_items)
-      return true if family.sophtron_items.joins(:syncs).merge(Sync.incomplete).exists? if family.respond_to?(:sophtron_items)
-
-      # Check accounts' syncs
-      return true if family.accounts.joins(:syncs).merge(Sync.incomplete).exists?
-
-      false
+      Sync.any_incomplete_for?(family)
     end
 
     def with_advisory_lock(family_id)

--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -71,6 +71,14 @@ class Sync < ApplicationRecord
       query
     end
 
+    # True iff the family has any pending/syncing Sync — across its own row,
+    # its accounts, and every Syncable provider `*_items` association. Built
+    # on `for_family` so new provider integrations are picked up automatically
+    # via `family_syncable_associations` reflection (no hand-rolled list).
+    def any_incomplete_for?(family)
+      for_family(family).incomplete.exists?
+    end
+
     private
       def account_syncable_ids(family, resource_owner)
         (resource_owner ? resource_owner.accessible_accounts : family.accounts)

--- a/test/jobs/identify_recurring_transactions_job_test.rb
+++ b/test/jobs/identify_recurring_transactions_job_test.rb
@@ -44,13 +44,14 @@ class IdentifyRecurringTransactionsJobTest < ActiveJob::TestCase
   end
 
   test "skips when a newer scheduled run supersedes this one" do
+    # Rails.cache is NullStore in the test env (writes are no-ops), so we stub
+    # the read directly to simulate a newer scheduled-at landing in the cache
+    # between this job being enqueued and being picked up.
     cache_key = "recurring_transaction_identify:#{@family.id}"
-    Rails.cache.write(cache_key, @scheduled_at + 10, expires_in: 1.minute)
+    Rails.cache.stubs(:read).with(cache_key).returns(@scheduled_at + 10)
 
     RecurringTransaction::Identifier.any_instance.expects(:identify_recurring_patterns).never
 
-    IdentifyRecurringTransactionsJob.new.perform(@family.id, @scheduled_at)
-  ensure
-    Rails.cache.delete("recurring_transaction_identify:#{@family.id}")
+    assert_nil IdentifyRecurringTransactionsJob.new.perform(@family.id, @scheduled_at)
   end
 end

--- a/test/jobs/identify_recurring_transactions_job_test.rb
+++ b/test/jobs/identify_recurring_transactions_job_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class IdentifyRecurringTransactionsJobTest < ActiveJob::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @scheduled_at = Time.current.to_f
+  end
+
+  test "skips identification while a Coinbase provider sync is in flight" do
+    coinbase_item = @family.coinbase_items.create!(
+      name: "Coinbase Pro",
+      api_key: "test-api-key-#{SecureRandom.hex(4)}",
+      api_secret: "test-api-secret-#{SecureRandom.hex(8)}"
+    )
+    Sync.create!(syncable: coinbase_item, status: :syncing)
+
+    RecurringTransaction::Identifier.any_instance.expects(:identify_recurring_patterns).never
+
+    IdentifyRecurringTransactionsJob.new.perform(@family.id, @scheduled_at)
+  end
+
+  test "skips identification while a Mercury provider sync is in flight" do
+    mercury_item = mercury_items(:one)
+    Sync.create!(syncable: mercury_item, status: :pending)
+
+    RecurringTransaction::Identifier.any_instance.expects(:identify_recurring_patterns).never
+
+    IdentifyRecurringTransactionsJob.new.perform(@family.id, @scheduled_at)
+  end
+
+  test "runs identification when no provider syncs are in flight" do
+    # Sanity: there are no incomplete syncs in the fixture set by default.
+    Sync.for_family(@family).incomplete.find_each(&:destroy)
+
+    RecurringTransaction::Identifier.any_instance.expects(:identify_recurring_patterns).once
+
+    IdentifyRecurringTransactionsJob.new.perform(@family.id, @scheduled_at)
+  end
+
+  test "skips when family is missing" do
+    RecurringTransaction::Identifier.any_instance.expects(:identify_recurring_patterns).never
+
+    IdentifyRecurringTransactionsJob.new.perform(SecureRandom.uuid, @scheduled_at)
+  end
+
+  test "skips when a newer scheduled run supersedes this one" do
+    cache_key = "recurring_transaction_identify:#{@family.id}"
+    Rails.cache.write(cache_key, @scheduled_at + 10, expires_in: 1.minute)
+
+    RecurringTransaction::Identifier.any_instance.expects(:identify_recurring_patterns).never
+
+    IdentifyRecurringTransactionsJob.new.perform(@family.id, @scheduled_at)
+  ensure
+    Rails.cache.delete("recurring_transaction_identify:#{@family.id}")
+  end
+end

--- a/test/models/sync_test.rb
+++ b/test/models/sync_test.rb
@@ -234,6 +234,29 @@ class SyncTest < ActiveSupport::TestCase
     assert_equal syncs.map(&:id).sort, Sync.for_family(family).where(id: syncs.map(&:id)).pluck(:id).sort
   end
 
+  test "any_incomplete_for? fires on a Sync against any Syncable provider item association" do
+    family = families(:dylan_family)
+    Sync.for_family(family).incomplete.find_each(&:destroy)
+    assert_not Sync.any_incomplete_for?(family)
+
+    mercury_item = mercury_items(:one)
+    incomplete = Sync.create!(syncable: mercury_item, status: :pending)
+    assert Sync.any_incomplete_for?(family),
+           "any_incomplete_for? should report true for an in-flight Mercury sync"
+
+    incomplete.update!(status: :completed)
+    assert_not Sync.any_incomplete_for?(family)
+  end
+
+  test "any_incomplete_for? fires on a Sync against the family itself" do
+    family = families(:dylan_family)
+    Sync.for_family(family).incomplete.find_each(&:destroy)
+    assert_not Sync.any_incomplete_for?(family)
+
+    Sync.create!(syncable: family, status: :syncing)
+    assert Sync.any_incomplete_for?(family)
+  end
+
   test "api error payload is present for failed syncs without raw error text" do
     sync = Sync.create!(syncable: accounts(:depository), status: :failed)
 


### PR DESCRIPTION
## Summary

`IdentifyRecurringTransactionsJob#family_has_incomplete_syncs?` (`app/jobs/identify_recurring_transactions_job.rb:45-60`) was the debounce gate that delayed `RecurringTransaction::Identifier` until in-flight provider syncs settled. The gate hand-rolled the list of provider `*_items` associations it polled — `plaid_items`, `simplefin_items`, `lunchflow_items`, `enable_banking_items`, `sophtron_items` — and silently missed **nine** other `Syncable` provider concerns on `Family` (`coinbase_items`, `binance_items`, `kraken_items`, `coinstats_items`, `snaptrade_items`, `mercury_items`, `brex_items`, `indexa_capital_items`, `ibkr_items`). When a sync on any of those nine was in flight, the gate fell through, the identifier ran against a partial dataset, and the resulting `RecurringTransaction` row got a stale `occurrence_count`; the late-arriving sync then re-scheduled the job and the follow-up run upserted via `find_or_initialize_by` inheriting the stale row.

The maintainers' own `Sync.for_family` (`app/models/sync.rb:61-75`) already enumerates every `*_items` association via `Family.reflect_on_all_associations(:has_many)` filtered by inclusion of the `Syncable` module — exactly the helper this gate should delegate to so the list cannot drift again. The file has had a single edit since creation (Apr 19, 2026, #591 bolting on Sophtron as the 5th entry); this PR closes the regression class so the next provider integration doesn't reopen it.

Fixes #1974.

## Fix

- Add `Sync.any_incomplete_for?(family)` class method on `Sync` that wraps `for_family(family).incomplete.exists?` — mirrors the existing `Sync.clean` / `Sync.for_family` class-method idiom and is reusable from any future caller that needs the same gate.
- Rewrite `IdentifyRecurringTransactionsJob#family_has_incomplete_syncs?` to delegate. 14 lines → 1, plus a docstring explaining the drift the delegation closes.

The reflection-based discovery in `family_syncable_associations` (`sync.rb:81-88`) was already trusted by `Sync.for_family` itself — same contract, same trust gate, no new abstraction.

## Tests

New file: `test/jobs/identify_recurring_transactions_job_test.rb` (5 tests)

- In-flight Coinbase sync → identifier is **not** called (would fail today; gate didn't poll `coinbase_items`)
- In-flight Mercury sync → identifier is **not** called (would fail today)
- No in-flight syncs → identifier **is** called (happy path)
- Missing family → no-op (existing guard)
- Superseded-by-newer-schedule → no-op (existing guard)

Added to `test/models/sync_test.rb` (2 tests)

- `Sync.any_incomplete_for?` returns true for an in-flight Mercury-item sync; flips to false once the sync completes
- `Sync.any_incomplete_for?` returns true for a sync directly on the `Family` row

The existing test `for_family includes syncable provider item associations from family reflections` (sync_test.rb:217) was the precedent that reflection-based discovery is the right pattern; the new tests extend that same shape to the `incomplete` predicate.

## Files changed

- `app/jobs/identify_recurring_transactions_job.rb` — delegate the gate; 14-line hand-rolled list deleted, replaced with 1-line call.
- `app/models/sync.rb` — new `Sync.any_incomplete_for?` class method (8 lines incl. docstring).
- `test/jobs/identify_recurring_transactions_job_test.rb` — new file, 5 tests.
- `test/models/sync_test.rb` — 2 new tests pinning `Sync.any_incomplete_for?`.

## CI / pre-PR checks

The standard CI gate from `CLAUDE.md` (`bin/rails test`, `bin/rubocop -f github -a`, `bin/brakeman --no-pager`) is required. No `*.erb` changed (erb_lint no-op). No API endpoint changed (rswag regeneration not required).

[Allow edits from maintainers] is enabled on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified internal sync-checking used by recurring transaction identification to more reliably detect incomplete syncs across a family and its linked provider items.

* **Tests**
  * Added tests for the recurring transactions job covering in-flight provider syncs, missing families, and cache-based scheduling suppression.
  * Added tests validating the new unified sync-detection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->