### PR TITLE
fix(preview): only redeploy on preview-cf label changes

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -2,7 +2,7 @@ name: Deploy PR Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - 'charts/**'
       - 'docs/**'
@@ -10,7 +10,9 @@ on:
 
 jobs:
   deploy-preview:
-    if: contains(github.event.pull_request.labels.*.name, 'preview-cf')
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
     name: Deploy to Cloudflare Containers
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- stop the preview deploy workflow from running on unrelated label removals
- only redeploy on label events when the label added is `preview-cf`
- keep deploys on open, synchronize, and reopen when the PR already has `preview-cf`

## Why
We traced duplicate Cloudflare preview deploys to unrelated label churn on preview-enabled PRs, especially security bot flips like `pr:verified` / `pr:flagged`. Those label changes were retriggering `Deploy PR Preview` and causing noisy duplicate runs and occasional racey Cloudflare failures.

## Testing
- verified the workflow diff in an isolated worktree off latest `main`
- confirmed the deploy workflow no longer listens to `unlabeled`
- confirmed `labeled` deploys only when `github.event.label.name == 'preview-cf'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR preview deployment workflow to improve trigger accuracy and label-based job execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->