### PR TITLE
fix(merchants): preserve manual merchant edits across provider sync

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -301,6 +301,20 @@ class Entry < ApplicationRecord
     excluded? || user_modified? || import_locked?
   end
 
+  # Bulk-marks the entries of the given transactions as user-modified so a
+  # later provider sync won't overwrite them (issue #1977). Used by merchant
+  # merge/convert/unlink flows, which reassign merchant_id directly on
+  # transactions and must protect that manual change from being reverted.
+  #
+  # @param transaction_ids [Array<String>] Transaction (entryable) ids
+  # @return [void]
+  def self.mark_user_modified_for_transactions!(transaction_ids)
+    ids = Array(transaction_ids).compact
+    return if ids.empty?
+
+    where(entryable_type: "Transaction", entryable_id: ids).update_all(user_modified: true)
+  end
+
   # Marks entry as user-modified after manual edit.
   # Called when user edits any field to prevent provider sync from overwriting.
   #

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -306,13 +306,23 @@ class Entry < ApplicationRecord
   # merge/convert/unlink flows, which reassign merchant_id directly on
   # transactions and must protect that manual change from being reverted.
   #
-  # @param transaction_ids [Array<String>] Transaction (entryable) ids
+  # Accepts a Transaction relation (preferred — the selection runs as a
+  # subquery so large merges/unlinks don't materialize ids or hit SQL
+  # parameter limits) or an explicit array of ids.
+  #
+  # @param transactions [ActiveRecord::Relation, Array<String>] Transactions or their ids
   # @return [void]
-  def self.mark_user_modified_for_transactions!(transaction_ids)
-    ids = Array(transaction_ids).compact
-    return if ids.empty?
+  def self.mark_user_modified_for_transactions!(transactions)
+    entryable_ids =
+      if transactions.is_a?(ActiveRecord::Relation)
+        transactions.select(:id)
+      else
+        ids = Array(transactions).compact.uniq
+        return if ids.empty?
+        ids
+      end
 
-    where(entryable_type: "Transaction", entryable_id: ids).update_all(user_modified: true)
+    where(entryable_type: "Transaction", entryable_id: entryable_ids).update_all(user_modified: true)
   end
 
   # Marks entry as user-modified after manual edit.

--- a/app/models/merchant/merger.rb
+++ b/app/models/merchant/merger.rb
@@ -39,8 +39,15 @@ class Merchant::Merger
 
     Merchant.transaction do
       source_merchants.each do |source|
+        scope = family.transactions.where(merchant_id: source.id)
+
+        # Protect the manual reassignment from being reverted on the next
+        # provider sync (issue #1977). Must run before the merchant_id update
+        # so the scope still matches the source merchant.
+        Entry.mark_user_modified_for_transactions!(scope.pluck(:id))
+
         # Reassign family's transactions to target
-        family.transactions.where(merchant_id: source.id).update_all(merchant_id: target_merchant.id)
+        scope.update_all(merchant_id: target_merchant.id)
 
         # Delete FamilyMerchant, keep ProviderMerchant (it may be used by other families)
         source.destroy! if source.is_a?(FamilyMerchant)

--- a/app/models/merchant/merger.rb
+++ b/app/models/merchant/merger.rb
@@ -44,7 +44,7 @@ class Merchant::Merger
         # Protect the manual reassignment from being reverted on the next
         # provider sync (issue #1977). Must run before the merchant_id update
         # so the scope still matches the source merchant.
-        Entry.mark_user_modified_for_transactions!(scope.pluck(:id))
+        Entry.mark_user_modified_for_transactions!(scope)
 
         # Reassign family's transactions to target
         scope.update_all(merchant_id: target_merchant.id)

--- a/app/models/provider_merchant.rb
+++ b/app/models/provider_merchant.rb
@@ -19,7 +19,7 @@ class ProviderMerchant < Merchant
 
       # Protect the manual reassignment from being reverted on the next
       # provider sync (issue #1977). Must run before the merchant_id update.
-      Entry.mark_user_modified_for_transactions!(scope.pluck(:id))
+      Entry.mark_user_modified_for_transactions!(scope)
 
       # Update only this family's transactions to point to new merchant
       scope.update_all(merchant_id: family_merchant.id)
@@ -47,7 +47,7 @@ class ProviderMerchant < Merchant
 
     # Protect the manual unlink from being reverted on the next provider sync
     # (issue #1977). Must run before the merchant_id is nulled.
-    Entry.mark_user_modified_for_transactions!(scope.pluck(:id))
+    Entry.mark_user_modified_for_transactions!(scope)
 
     scope.update_all(merchant_id: nil)
 

--- a/app/models/provider_merchant.rb
+++ b/app/models/provider_merchant.rb
@@ -15,8 +15,14 @@ class ProviderMerchant < Merchant
         website_url: attributes[:website_url].presence || website_url
       )
 
+      scope = family.transactions.where(merchant_id: id)
+
+      # Protect the manual reassignment from being reverted on the next
+      # provider sync (issue #1977). Must run before the merchant_id update.
+      Entry.mark_user_modified_for_transactions!(scope.pluck(:id))
+
       # Update only this family's transactions to point to new merchant
-      family.transactions.where(merchant_id: id).update_all(merchant_id: family_merchant.id)
+      scope.update_all(merchant_id: family_merchant.id)
 
       family_merchant
     end
@@ -37,7 +43,13 @@ class ProviderMerchant < Merchant
   # Does NOT delete the ProviderMerchant since it may be used by other families.
   # Tracks the unlink in FamilyMerchantAssociation so it shows as "recently unlinked".
   def unlink_from_family(family)
-    family.transactions.where(merchant_id: id).update_all(merchant_id: nil)
+    scope = family.transactions.where(merchant_id: id)
+
+    # Protect the manual unlink from being reverted on the next provider sync
+    # (issue #1977). Must run before the merchant_id is nulled.
+    Entry.mark_user_modified_for_transactions!(scope.pluck(:id))
+
+    scope.update_all(merchant_id: nil)
 
     # Track that this merchant was unlinked from this family
     association = FamilyMerchantAssociation.find_or_initialize_by(family: family, merchant: self)

--- a/test/models/merchant/merger_test.rb
+++ b/test/models/merchant/merger_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Merchant::MergerTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:dylan_family)
+    @target = merchants(:netflix)
+    @source = merchants(:amazon)
+  end
+
+  # Regression: issue #1977. Merging merchants reassigns merchant_id via
+  # update_all; without flagging the entries as user_modified, the next
+  # provider sync reverts the merge.
+  test "merge! flags reassigned transactions as user_modified" do
+    entry = create_transaction(merchant: @source)
+    assert_not entry.user_modified?
+
+    Merchant::Merger.new(family: @family, target_merchant: @target, source_merchants: [ @source ]).merge!
+
+    entry.reload
+    assert_equal @target.id, entry.entryable.merchant_id, "transaction is reassigned to the target merchant"
+    assert entry.user_modified?, "merged transaction's entry must be flagged so provider sync won't revert it"
+  end
+
+  test "merge! does not touch entries of unrelated merchants" do
+    other = create_transaction(merchant: @target)
+    assert_not other.user_modified?
+
+    Merchant::Merger.new(family: @family, target_merchant: @target, source_merchants: [ @source ]).merge!
+
+    other.reload
+    assert_not other.user_modified?, "transactions already on the target are untouched"
+  end
+end

--- a/test/models/provider_merchant_test.rb
+++ b/test/models/provider_merchant_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ProviderMerchantTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:dylan_family)
+    @provider_merchant = ProviderMerchant.create!(name: "Acme Synced", source: "plaid")
+  end
+
+  # Regression: issue #1977. Converting a synced merchant to a family merchant
+  # reassigns merchant_id via update_all; the entries must be flagged so the
+  # next provider sync doesn't revert the conversion.
+  test "convert_to_family_merchant_for flags reassigned transactions as user_modified" do
+    entry = create_transaction(merchant: @provider_merchant)
+    assert_not entry.user_modified?
+
+    family_merchant = @provider_merchant.convert_to_family_merchant_for(@family)
+
+    entry.reload
+    assert_equal family_merchant.id, entry.entryable.merchant_id
+    assert entry.user_modified?, "converted transaction's entry must be flagged so provider sync won't revert it"
+  end
+
+  # Regression: issue #1977. Unlinking a synced merchant nulls merchant_id;
+  # without the flag the next sync re-links it.
+  test "unlink_from_family flags affected transactions as user_modified" do
+    entry = create_transaction(merchant: @provider_merchant)
+    assert_not entry.user_modified?
+
+    @provider_merchant.unlink_from_family(@family)
+
+    entry.reload
+    assert_nil entry.entryable.merchant_id
+    assert entry.user_modified?, "unlinked transaction's entry must be flagged so provider sync won't re-link it"
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #1977.

Merging merchants, converting a synced (provider) merchant to a family merchant, and unlinking a merchant all reassign `transactions.merchant_id` in bulk — but never flag the affected entries as `user_modified`. The next provider sync sees those entries as unmodified and reverts the change, forcing the user to re-merge or fix each transaction again.

## Root cause

Three bulk-`update_all` sites change `merchant_id` without protecting the entries:

- `Merchant::Merger#merge!` — `family.transactions.where(merchant_id: source.id).update_all(merchant_id: target.id)`
- `ProviderMerchant#convert_to_family_merchant_for` — same pattern
- `ProviderMerchant#unlink_from_family` — nulls `merchant_id`

The provider sync skip-guard (`Account::ProviderImportAdapter#determine_skip_reason`) only leaves an entry alone when it's `excluded?`, `user_modified?`, or `import_locked?`. Since none of these flows set `user_modified`, the merchant gets overwritten on the next sync.

## Fix

Add `Entry.mark_user_modified_for_transactions!(transaction_ids)` and call it in all three flows **before** the `merchant_id` update (so the scope still matches the original merchant). Flagged entries are then skipped by the sync, so the manual change sticks.

- `app/models/entry.rb` — new bulk helper
- `app/models/merchant/merger.rb` — flag before reassign
- `app/models/provider_merchant.rb` — flag before convert and before unlink

No schema change; reuses the existing protection mechanism.

## Test plan

- [x] New model tests (`test/models/merchant/merger_test.rb`, `test/models/provider_merchant_test.rb`): merge / convert / unlink flag the affected entries as `user_modified`, and merge leaves unrelated transactions untouched.
- [x] **RED-verified** — the three `user_modified` assertions fail on `main` (no flag set) and pass on this branch.
- [x] 23 affected model + controller tests pass (`merger`, `provider_merchant`, `provider_merchant/enhancer`, `family_merchants_controller`, `api/v1/merchants_controller`).
- [x] `bin/rubocop -a` clean; `bin/brakeman --no-pager` no warnings.

## Before / after

After merging two merchants, the affected transaction is now marked **Protected from sync**, so a re-sync won't revert it.

**Before** (`main`) — merged transaction, no protection:
Before
<img width="1683" height="702" alt="pr1977-1-before-merge" src="https://github.com/user-attachments/assets/a96ff1c4-f392-4e29-ae3c-fbc7d42a3cfd" />


**After** (this PR) — the merge marks the entry protected:
After
<img width="1683" height="702" alt="pr1977-2-after-merge" src="https://github.com/user-attachments/assets/95ebdcd5-e8f2-47ea-8356-b483a876c180" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manual merchant reassignments and unlinks are now preserved during merges and provider operations; affected transactions are flagged so subsequent syncs won't revert them.
* **Tests**
  * Added tests confirming merges, conversions, and unlinks update transactions and flag associated records to maintain integrity across syncs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->