### PR TITLE
fix(family-sharing): scope form + import account lists to accessible_accounts (#1803)

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -385,7 +385,7 @@ class TransactionsController < ApplicationController
   end
 
   def exchange_rate
-    account = Current.family.accounts.find(params[:account_id])
+    account = Current.user.accessible_accounts.find(params[:account_id])
     currency_from = params[:currency]
     date = params[:date]&.to_date || Date.current
 

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,6 +1,7 @@
 <%# locals: (entry:, account_currencies:, manual_accounts:, categories:, merchants:, tags:) %>
 
-<%= styled_form_with model: entry, url: transactions_path, class: "space-y-4", data: { controller: "transaction-form", transaction_form_exchange_rate_url_value: exchange_rate_path, transaction_form_account_currencies_value: account_currencies.to_json } do |f| %>
+<% account_currencies = accessible_accounts.pluck(:id, :currency).to_h.to_json %>
+<%= styled_form_with model: entry, url: transactions_path, class: "space-y-4", data: { controller: "transaction-form", transaction_form_exchange_rate_url_value: exchange_rate_path, transaction_form_account_currencies_value: account_currencies } do |f| %>
   <% if entry.errors.any? %>
     <%= render "shared/form_errors", model: entry %>
   <% end %>

--- a/app/views/transfers/_form.html.erb
+++ b/app/views/transfers/_form.html.erb
@@ -1,4 +1,4 @@
-<% account_currencies = Current.family.accounts.map { |a| [a.id, a.currency] }.to_h.to_json %>
+<% account_currencies = accessible_accounts.pluck(:id, :currency).to_h.to_json %>
 <%= styled_form_with model: transfer, class: "space-y-4", data: { turbo_frame: "_top", controller: "transfer-form", transfer_form_exchange_rate_url_value: exchange_rate_path, transfer_form_account_currencies_value: account_currencies } do |f| %>
   <% if transfer.errors.present? %>
     <div class="text-destructive flex items-center gap-2">

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -11,6 +11,19 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "csv upload dropdown only lists accounts accessible to the signed-in user" do
+    # family_member has shares for :depository (full_control) and :credit_card (read_only)
+    # but not for :investment, owned by family_admin. The optional account dropdown
+    # in the CSV upload form must not leak unshared account names.
+    sign_in users(:family_member)
+
+    get import_upload_url(@import)
+
+    assert_response :success
+    assert_includes response.body, accounts(:depository).name
+    refute_includes response.body, accounts(:investment).name
+  end
+
   test "uploads valid csv by copy and pasting" do
     patch import_upload_url(@import), params: {
       import: {

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -439,6 +439,8 @@ end
     get new_transaction_url
 
     assert_response :success
+    assert_includes response.body, accounts(:depository).id.to_s
+    assert_includes response.body, accounts(:credit_card).id.to_s
     refute_includes response.body, accounts(:investment).id.to_s
     refute_includes response.body, accounts(:loan).id.to_s
   end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -430,6 +430,19 @@ end
     assert_not entry.protected_from_sync?
   end
 
+  test "new only exposes account ids accessible to the signed-in user" do
+    # family_member has shares for :depository (full_control) and :credit_card (read_only)
+    # but not for :investment or :loan. The currency JSON map at the top of the
+    # form should not leak ids/currencies of unshared accounts.
+    sign_in users(:family_member)
+
+    get new_transaction_url
+
+    assert_response :success
+    refute_includes response.body, accounts(:investment).id
+    refute_includes response.body, accounts(:loan).id
+  end
+
   test "new with duplicate_entry_id pre-fills form from source transaction" do
     @entry.reload
 

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -439,8 +439,8 @@ end
     get new_transaction_url
 
     assert_response :success
-    refute_includes response.body, accounts(:investment).id
-    refute_includes response.body, accounts(:loan).id
+    refute_includes response.body, accounts(:investment).id.to_s
+    refute_includes response.body, accounts(:loan).id.to_s
   end
 
   test "new with duplicate_entry_id pre-fills form from source transaction" do

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -18,9 +18,9 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     get new_transfer_url
 
     assert_response :success
-    assert_includes response.body, accounts(:depository).id
-    refute_includes response.body, accounts(:investment).id
-    refute_includes response.body, accounts(:loan).id
+    assert_includes response.body, accounts(:depository).id.to_s
+    refute_includes response.body, accounts(:investment).id.to_s
+    refute_includes response.body, accounts(:loan).id.to_s
   end
 
   test "can create transfers" do

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -10,6 +10,19 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "new only exposes accounts accessible to the signed-in user" do
+    # family_member has shares for :depository (full_control) and :credit_card (read_only)
+    # but not for :investment or :loan, which are owned solely by family_admin.
+    sign_in users(:family_member)
+
+    get new_transfer_url
+
+    assert_response :success
+    assert_includes response.body, accounts(:depository).id
+    refute_includes response.body, accounts(:investment).id
+    refute_includes response.body, accounts(:loan).id
+  end
+
   test "can create transfers" do
     assert_difference "Transfer.count", 1 do
       post transfers_url, params: {


### PR DESCRIPTION
## Summary

Closes part of #1803 (the UI leak half).

Non-admin family members could see ids, currencies, and names of accounts the family admin owns but has not shared with them. The account detail routes already enforced access (unshared accounts 404), but several form-render paths still embedded the full `Current.family.accounts` list in the page.

- `app/views/transfers/_form.html.erb:1` — JSON map of every family account id + currency for the JS currency-difference check.
- `app/views/transactions/_form.html.erb:3` — same pattern.
- `app/views/import/uploads/show.html.erb:59, 115, 147` — QIF and CSV upload account dropdowns. The matching `Import::UploadsController#update` already used `accessible_accounts.find(...)`, so this was a pure UI leak.
- `app/controllers/transactions_controller.rb:374` (`exchange_rate`) — found by family scope instead of user scope. The action isn't currently routed (the live endpoint is `ExchangeRatesController#show`), but tightened for defense in depth.

All four switch to the existing `accessible_accounts` helper, which delegates to `Current.user.accessible_accounts` (owned + shared via `AccountShare`).

## Out of scope

The second half of #1803 — integration tokens (Plaid / EnableBanking / SimpleFIN / Lunchflow `*_items`) being scoped to `family_id` instead of `user_id`, so members overwrite each other's sessions — needs a schema change, backfill, and controller/view rework. Tracking it as a follow-up rather than mixing it into this PR.

## Provider-item controllers

The audit also found `Current.family.accounts.find(params[:account_id])` in many `*_items_controller.rb` files (plaid, simplefin, enable_banking, snaptrade, ibkr, sophtron, indexa_capital, mercury, lunchflow, brex, coinbase, binance, kraken). Every one of those controllers has `before_action :require_admin!`, so they're not reachable by the non-admin member described in the bug. Tightening them is a separate hardening pass.

## Test plan

- [ ] `bin/rails test test/controllers/transfers_controller_test.rb` — new test `"new only exposes accounts accessible to the signed-in user"` passes.
- [ ] `bin/rails test test/controllers/transactions_controller_test.rb` — new test `"new only exposes account ids accessible to the signed-in user"` passes.
- [ ] `bin/rails test test/controllers/import/uploads_controller_test.rb` — new test `"csv upload dropdown only lists accounts accessible to the signed-in user"` passes.
- [ ] Full suite: `bin/rails test`
- [ ] `bin/rubocop -f github -a`
- [ ] `bundle exec erb_lint ./app/**/*.erb -a`
- [ ] `bin/brakeman --no-pager`
- [ ] Manual: sign in as a non-admin family member; open new transfer, new transaction, and a CSV import upload page; confirm the dropdowns and inline JSON only contain shared accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account lists in forms, import uploads, and exchange-rate lookups now show only accounts the signed-in user can access, preventing exposure of unpermitted accounts.

* **Tests**
  * Added integration tests verifying transaction, transfer, and import upload pages and exchange-rate endpoints display only accounts accessible to the signed-in user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->