### PR TITLE
fix: Avoid overlay in provider section on mobile

### DIFF
--- a/app/views/settings/providers/_connection_row.html.erb
+++ b/app/views/settings/providers/_connection_row.html.erb
@@ -19,7 +19,7 @@
                 data: details_data do %>
   <summary class="flex items-center gap-3 min-h-15 px-4 py-3.5 cursor-pointer rounded-xl list-none [&::-webkit-details-marker]:hidden">
     <%= icon "chevron-right", size: "sm", class: "!w-3.5 !h-3.5 text-secondary group-open:rotate-90 transition-transform" %>
-    <div class="flex items-center flex-wrap gap-2 min-w-0 flex-1">
+    <div class="flex items-center flex-wrap gap-1 min-w-0 flex-1">
       <div class="flex items-center gap-2 shrink-0 flex-1">
         <h3 class="text-sm font-medium text-primary"><%= entry[:title] %></h3>
         <%= render "settings/providers/maturity_badge", label: maturity_lbl %>

--- a/app/views/settings/providers/_connection_row.html.erb
+++ b/app/views/settings/providers/_connection_row.html.erb
@@ -17,22 +17,24 @@
 <%= tag.details open: open,
                 class: "group bg-container shadow-border-xs rounded-xl #{border_class}",
                 data: details_data do %>
-  <summary class="flex items-center gap-3 min-h-15 px-4 py-3.5 cursor-pointer rounded-xl list-none [&::-webkit-details-marker]:hidden">
-    <%= icon "chevron-right", size: "sm", class: "!w-3.5 !h-3.5 text-secondary group-open:rotate-90 transition-transform" %>
-    <div class="flex items-center flex-wrap gap-1 min-w-0 flex-1">
-      <div class="flex items-center gap-2 shrink-0 flex-1">
-        <h3 class="text-sm font-medium text-primary"><%= entry[:title] %></h3>
-        <%= render "settings/providers/maturity_badge", label: maturity_lbl %>
+  <summary class="min-h-15 px-4 py-3.5 cursor-pointer rounded-xl list-none [&::-webkit-details-marker]:hidden">
+    <div class="flex items-center gap-3">
+      <%= icon "chevron-right", size: "sm", class: "!w-3.5 !h-3.5 text-secondary group-open:rotate-90 transition-transform" %>
+      <div class="flex items-center flex-wrap gap-2 min-w-0 flex-1">
+        <div class="flex items-center gap-2 shrink-0 flex-1">
+          <h3 class="text-sm font-medium text-primary"><%= entry[:title] %></h3>
+          <%= render "settings/providers/maturity_badge", label: maturity_lbl %>
+        </div>
+        <div class="flex items-center gap-2 shrink-0 group-open:hidden">
+          <% if meta.present? %>
+            <span class="text-xs text-subdued"><%= meta %></span>
+          <% end %>
+          <%= status_pill %>
+        </div>
       </div>
-      <div class="flex items-center gap-2 shrink-0 group-open:hidden">
-        <% if meta.present? %>
-          <span class="text-xs text-subdued"><%= meta %></span>
-        <% end %>
-        <%= status_pill %>
+      <div class="group-open:hidden">
+        <%= sync_action if sync_action %>
       </div>
-    </div>
-    <div class="group-open:hidden">
-      <%= sync_action if sync_action %>
     </div>
   </summary>
   <div class="space-y-4 mt-4 px-4 pb-4">

--- a/app/views/settings/providers/_connection_row.html.erb
+++ b/app/views/settings/providers/_connection_row.html.erb
@@ -19,15 +19,19 @@
                 data: details_data do %>
   <summary class="flex items-center gap-3 min-h-15 px-4 py-3.5 cursor-pointer rounded-xl list-none [&::-webkit-details-marker]:hidden">
     <%= icon "chevron-right", size: "sm", class: "!w-3.5 !h-3.5 text-secondary group-open:rotate-90 transition-transform" %>
-    <div class="flex items-center gap-2 flex-wrap min-w-0 flex-1">
-      <h3 class="text-sm font-medium text-primary"><%= entry[:title] %></h3>
-      <%= render "settings/providers/maturity_badge", label: maturity_lbl %>
+    <div class="flex items-center flex-wrap gap-2 min-w-0 flex-1">
+      <div class="flex items-center gap-2 shrink-0 flex-1">
+        <h3 class="text-sm font-medium text-primary"><%= entry[:title] %></h3>
+        <%= render "settings/providers/maturity_badge", label: maturity_lbl %>
+      </div>
+      <div class="flex items-center gap-2 shrink-0 group-open:hidden">
+        <% if meta.present? %>
+          <span class="text-xs text-subdued"><%= meta %></span>
+        <% end %>
+        <%= status_pill %>
+      </div>
     </div>
-    <div class="flex items-center gap-2 shrink-0 group-open:hidden">
-      <% if meta.present? %>
-        <span class="text-xs text-subdued"><%= meta %></span>
-      <% end %>
-      <%= status_pill %>
+    <div class="group-open:hidden">
       <%= sync_action if sync_action %>
     </div>
   </summary>


### PR DESCRIPTION
This PR addresses an overlay issue on mobile devices for connection rows in “Providers” settings.

| Before | After |
|--------|--------|
| <img width="366" height="351" alt="Screenshot 2026-05-25 alle 18 00 59" src="https://github.com/user-attachments/assets/b3b11573-3840-451b-91ce-9855de0e2010" /> | <img width="368" height="334" alt="Screenshot 2026-05-25 alle 18 01 20" src="https://github.com/user-attachments/assets/7033f444-6c56-4bad-95ac-10a2876a32eb" /> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual layout of provider connection displays through restructured arrangement and better spacing.
  * Enhanced the presentation of connection metadata, status indicators, and sync action controls for improved user experience.
  * Optimized how connection details are organized and displayed on the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->