### PR TITLE
fix(account): show activity label for accounts supporting trades

### DIFF
--- a/app/components/UI/account/chart.html.erb
+++ b/app/components/UI/account/chart.html.erb
@@ -4,7 +4,7 @@
       <div class="flex items-center gap-1">
         <%= tag.p title, class: "text-sm font-medium text-secondary" %>
 
-        <% if account.investment? %>
+        <% if account.supports_trades? %>
           <%= render "investments/value_tooltip", balance: account.balance_money, holdings: holdings_value_money, cash: account.cash_balance_money %>
         <% end %>
       </div>
@@ -19,7 +19,7 @@
 
     <%= form_with url: account_path(account), method: :get, data: { controller: "auto-submit-form" } do |form| %>
       <div class="flex items-center gap-2">
-        <% if account.investment? %>
+        <% if account.supports_trades? %>
           <%= form.select :chart_view,
             [[t(".views.total_value"), "balance"], [t(".views.holdings"), "holdings_balance"], [t(".views.cash"), "cash_balance"]],
             { selected: view },

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -180,8 +180,8 @@
       </div>
 
       <div class="hidden md:flex min-w-0 items-center gap-1 col-span-2">
-        <% if entry.account.investment? && !transaction.transfer? %>
-          <%# For investment accounts, show activity label instead of category %>
+        <% if entry.account.supports_trades? && !transaction.transfer? %>
+          <%# For investment/crypto accounts, show activity label instead of category %>
           <%= render "investment_activity/quick_edit_badge", entry: entry, entryable: transaction %>
         <% else %>
           <%= render "transactions/transaction_category", transaction: transaction, variant: "desktop", in_split_group: in_split_group %>


### PR DESCRIPTION
 ## Summary

 Previously, the account chart view selector (holdings/cash/total value) and the transaction activity badge were gated behind account.investment?. This excluded crypto exchange accounts (Coinbase, Kraken, etc.) which also support trades via supports_trades?.

##  Changes
  - account/chart.html.erb: Replace investment? with supports_trades? for the chart view selector and holdings value tooltip
  - transactions/_transaction.html.erb: Replace investment? with supports_trades? for showing the activity label badge instead of a category label
  
 ## Behavior
  - supports_trades? returns true for all investment accounts (unchanged) and for crypto accounts with subtype exchange
  - Crypto wallet/other subtypes are unaffected — they continue showing categories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated account chart and transaction views to display trade-related UI elements based on refined account capability detection. Chart tooltips and activity labels now render according to account trade support status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/1993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->