### PR TITLE
fix(reports): exclude investment_contribution from expense totals (#1750)

### DIFF
--- a/app/models/income_statement/totals.rb
+++ b/app/models/income_statement/totals.rb
@@ -54,14 +54,18 @@ class IncomeStatement::Totals
       SQL
     end
 
+    # loan_payment is the only transfer kind that still flows through these
+    # queries (investment_contribution is now filtered out by
+    # budget_excluded_kinds_sql per #1750). The CASE statements keep
+    # loan_payment classified as expense regardless of entry sign.
     # Original transactions-only query (for backwards compatibility)
     def transactions_only_query_sql
       <<~SQL
         SELECT
           c.id as category_id,
           c.parent_id as parent_category_id,
-          CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END as classification,
-          ABS(SUM(CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN ABS(ae.amount * COALESCE(er.rate, 1)) ELSE ae.amount * COALESCE(er.rate, 1) END)) as total,
+          CASE WHEN at.kind = 'loan_payment' THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END as classification,
+          ABS(SUM(CASE WHEN at.kind = 'loan_payment' THEN ABS(ae.amount * COALESCE(er.rate, 1)) ELSE ae.amount * COALESCE(er.rate, 1) END)) as total,
           COUNT(ae.id) as transactions_count,
           false as is_uncategorized_investment
         FROM (#{@transactions_scope.to_sql}) at
@@ -79,7 +83,7 @@ class IncomeStatement::Totals
           AND a.status IN ('draft', 'active')
           #{exclude_tax_advantaged_sql}
           #{include_finance_accounts_sql}
-        GROUP BY c.id, c.parent_id, CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END;
+        GROUP BY c.id, c.parent_id, CASE WHEN at.kind = 'loan_payment' THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END;
       SQL
     end
 
@@ -88,8 +92,8 @@ class IncomeStatement::Totals
         SELECT
           c.id as category_id,
           c.parent_id as parent_category_id,
-          CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END as classification,
-          ABS(SUM(CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN ABS(ae.amount * COALESCE(er.rate, 1)) ELSE ae.amount * COALESCE(er.rate, 1) END)) as total,
+          CASE WHEN at.kind = 'loan_payment' THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END as classification,
+          ABS(SUM(CASE WHEN at.kind = 'loan_payment' THEN ABS(ae.amount * COALESCE(er.rate, 1)) ELSE ae.amount * COALESCE(er.rate, 1) END)) as total,
           COUNT(ae.id) as entry_count,
           false as is_uncategorized_investment
         FROM (#{@transactions_scope.to_sql}) at
@@ -111,7 +115,7 @@ class IncomeStatement::Totals
           AND a.status IN ('draft', 'active')
           #{exclude_tax_advantaged_sql}
           #{include_finance_accounts_sql}
-        GROUP BY c.id, c.parent_id, CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END
+        GROUP BY c.id, c.parent_id, CASE WHEN at.kind = 'loan_payment' THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END
       SQL
     end
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -80,9 +80,14 @@ class Transaction < ApplicationRecord
   TRANSFER_KINDS = %w[funds_movement cc_payment loan_payment investment_contribution].freeze
 
   # Kinds excluded from budget/income-statement analytics.
-  # loan_payment and investment_contribution are intentionally NOT here —
-  # they represent real cash outflow from a budgeting perspective.
-  BUDGET_EXCLUDED_KINDS = %w[funds_movement one_time cc_payment].freeze
+  # investment_contribution is excluded so that explicit Transfers to an
+  # investment account behave like any other transfer (issue #1750) — the
+  # money has moved between two accounts the user owns, not been spent.
+  # Tax-advantaged investment accounts are handled separately via the
+  # tax_advantaged_account_ids exclusion in IncomeStatement::Totals.
+  # loan_payment is intentionally NOT here: it represents a real cash
+  # outflow against a liability that the budget should still surface.
+  BUDGET_EXCLUDED_KINDS = %w[funds_movement one_time cc_payment investment_contribution].freeze
 
   # All valid investment activity labels (for UI dropdown)
   ACTIVITY_LABELS = [

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -72,7 +72,7 @@ class Transaction < ApplicationRecord
     cc_payment: "cc_payment", # A CC payment, excluded from budget analytics (CC payments offset the sum of expense transactions)
     loan_payment: "loan_payment", # A payment to a Loan account, treated as an expense in budgets
     one_time: "one_time", # A one-time expense/income, excluded from budget analytics
-    investment_contribution: "investment_contribution" # Transfer to investment/crypto account, treated as an expense in budgets
+    investment_contribution: "investment_contribution" # Transfer to investment/crypto account, excluded from budget analytics via BUDGET_EXCLUDED_KINDS (#1750); tax-advantaged accounts have their own filter in IncomeStatement::Totals
   }
 
   # All kinds where money moves between accounts (transfer? returns true).

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -314,10 +314,9 @@ class IncomeStatementTest < ActiveSupport::TestCase
     income_statement = IncomeStatement.new(@family)
     totals = income_statement.totals(date_range: Period.last_30_days.date_range)
 
-    # investment_contribution should be included as an expense (visible in cashflow)
-    assert_equal 5, totals.transactions_count # Original 4 + investment_contribution
+    assert_equal 4, totals.transactions_count # original 4, investment_contribution excluded
     assert_equal Money.new(1000, @family.currency), totals.income_money
-    assert_equal Money.new(1900, @family.currency), totals.expense_money # 900 + 1000 investment
+    assert_equal Money.new(900, @family.currency), totals.expense_money
   end
 
   test "includes provider-imported investment_contribution inflows as expenses" do
@@ -344,10 +343,56 @@ class IncomeStatementTest < ActiveSupport::TestCase
     income_statement = IncomeStatement.new(@family)
     totals = income_statement.totals(date_range: Period.last_30_days.date_range)
 
-    # The provider-imported contribution should appear as an expense
-    assert_equal 5, totals.transactions_count # Original 4 + provider contribution
+    assert_equal 4, totals.transactions_count # original 4, investment_contribution excluded
     assert_equal Money.new(1000, @family.currency), totals.income_money
-    assert_equal Money.new(1400, @family.currency), totals.expense_money # 900 + 500 (abs of -500)
+    assert_equal Money.new(900, @family.currency), totals.expense_money
+  end
+  
+  test "excludes investment_contribution transactions from income statement totals" do
+    # Issue #1750: an explicit Transfer to an investment account should
+    # behave like any other transfer — the money moved between two
+    # accounts the user owns, not spent — and should not inflate the
+    # expense total on the Reports page.
+    create_transaction(
+      account: @checking_account,
+      amount: 1000,
+      category: nil,
+      kind: "investment_contribution"
+    )
+
+    income_statement = IncomeStatement.new(@family)
+    totals = income_statement.totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal 4, totals.transactions_count # original 4, investment_contribution excluded
+    assert_equal Money.new(1000, @family.currency), totals.income_money
+    assert_equal Money.new(900, @family.currency), totals.expense_money
+  end
+
+  test "excludes provider-imported investment_contribution inflows from income statement totals" do
+    # Same exclusion applies when the contribution lands on the investment
+    # account side as a negative-amount inflow (e.g. a payroll-deducted
+    # contribution imported by a provider). The kind is the load-bearing
+    # signal, not the entry sign.
+    investment_account = @family.accounts.create!(
+      name: "401k",
+      currency: @family.currency,
+      balance: 10000,
+      accountable: Investment.new
+    )
+
+    create_transaction(
+      account: investment_account,
+      amount: -500, # negative = inflow to the investment account
+      category: nil,
+      kind: "investment_contribution"
+    )
+
+    income_statement = IncomeStatement.new(@family)
+    totals = income_statement.totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal 4, totals.transactions_count
+    assert_equal Money.new(1000, @family.currency), totals.income_money
+    assert_equal Money.new(900, @family.currency), totals.expense_money
   end
 
   # Tax-Advantaged Account Exclusion Tests

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -347,7 +347,7 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_equal Money.new(1000, @family.currency), totals.income_money
     assert_equal Money.new(900, @family.currency), totals.expense_money
   end
-  
+
   test "excludes investment_contribution transactions from income statement totals" do
     # Issue #1750: an explicit Transfer to an investment account should
     # behave like any other transfer — the money moved between two


### PR DESCRIPTION
## Summary

Closes #1750.

When a user explicitly marks a transaction as a **Transfer** to an investment account, the outflow leg gets the `investment_contribution` kind. The Reports page was still counting that leg as an expense, inflating the spending total. The reporter's case (Mutual Fund / Other Investment, self-hosted, transaction explicitly marked as Transfer with From/To fields) reproduces the bug exactly.

## Root cause

`Transaction::BUDGET_EXCLUDED_KINDS` listed `funds_movement`, `one_time`, and `cc_payment` — the kinds that get filtered out of expense totals. `investment_contribution` was deliberately *not* in the list, and the inline comment said so:

> *"loan_payment and investment_contribution are intentionally NOT here — they represent real cash outflow from a budgeting perspective."*

That's one valid framing, but it conflicts with the user's mental model (they classified the transaction as a transfer, not an expense) and with how regular `funds_movement` transfers are already handled. Tax-advantaged investment accounts (Roth IRA, 401k, HSA) are already excluded by a *separate* path (`tax_advantaged_account_ids`), which shows the system already recognises "money into an investment account is not necessarily spending."

This PR flips the choice for `investment_contribution` only. **`loan_payment` keeps its current treatment** — reducing loan principal is a different conversation and wasn't reported.

## Changes

- **`app/models/transaction.rb`** — `BUDGET_EXCLUDED_KINDS` now includes `investment_contribution`. Comment rewritten to explain the rationale and to call out that `loan_payment` is intentionally still treated as an expense.
- **`app/models/income_statement/totals.rb`** — both SQL queries had `CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' …` to force `investment_contribution` to classify as expense regardless of entry sign. Since it's now filtered out by the `WHERE NOT IN` clause before reaching the `CASE`, the branch is dead code; simplified to `CASE WHEN at.kind = 'loan_payment'` (also in the matching `GROUP BY`).
- **`test/models/income_statement_test.rb`** — flipped both `"includes investment_contribution … as expenses"` tests to assert exclusion. One covers an outflow on the source side; the other covers a provider-imported negative-amount inflow on the destination side. The negative-sign case is important because it confirms the *kind* is the load-bearing signal, not the entry sign.

## Propagation / call sites checked

The change propagates automatically through every site that already filters on `BUDGET_EXCLUDED_KINDS`:

- `BudgetCategoriesController` (budget category totals)
- `ReportsController#build_transactions_breakdown`
- `ReportsController#build_transactions_breakdown_for_export`
- `ReportsController#build_monthly_breakdown_for_export`

So the breakdown table, CSV export, and monthly breakdown all stay consistent with the totals.

`Transaction::Search` uses `TRANSFER_KINDS` (not `BUDGET_EXCLUDED_KINDS`) and already excluded `investment_contribution` from the "expense" filter — `test/models/transaction/search_test.rb:262` locks that in. No change needed there.

Tax-advantaged account exclusion is independent (it filters on `accounts.id NOT IN (:tax_advantaged_account_ids)`) and is unaffected; its tests use `standard`-kind transactions.

## Test plan

- [ ] `bin/rails test test/models/income_statement_test.rb`
- [ ] `bin/rails test test/models/transaction/search_test.rb`
- [ ] `bin/rails test test/controllers/reports_controller_test.rb`
- [ ] `bin/rails test`
- [ ] `bin/rubocop -f github -a`
- [ ] `bundle exec erb_lint ./app/**/*.erb -a`
- [ ] `bin/brakeman --no-pager`
- [ ] Manual repro per the issue: create an Investment account (Mutual Fund / Other subtype), mark a transaction as "Transfer to [Investment account]", open Reports → confirm the transfer no longer appears in the expense total. Confirm it *still* appears in the Transactions list under the Transfer filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Investment contribution transactions are excluded from income statement and budget analytics; only loan payments remain a special-case for classification and totals.

* **Tests**
  * Tests updated to verify investment contributions do not change transaction counts or income/expense totals and to cover provider-imported contribution cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->