### PR TITLE
fix(i18n): use %{product_name} in api_keys usage_instructions (#1505)

### DIFF
--- a/config/locales/views/settings/api_keys/es.yml
+++ b/config/locales/views/settings/api_keys/es.yml
@@ -37,7 +37,7 @@ es:
           never_expires: "Nunca expira"
           permissions: "Permisos"
           usage_instructions_title: "Cómo usar tu clave API"
-          usage_instructions: "Incluye tu clave API en el encabezado X-Api-Key al realizar solicitudes a la API de Maybe:"
+          usage_instructions: "Incluye tu clave API en el encabezado X-Api-Key al realizar solicitudes a la API de %{product_name}:"
           regenerate_key: "Crear Nueva Clave"
           revoke_key: "Revocar Clave"
           revoke_confirmation: "¿Estás seguro de que deseas revocar esta clave API? Esta acción no se puede deshacer y deshabilitará inmediatamente todas las aplicaciones que usen esta clave."

--- a/config/locales/views/settings/api_keys/nb.yml
+++ b/config/locales/views/settings/api_keys/nb.yml
@@ -36,7 +36,7 @@ nb:
         never_expires: "Utløper aldri"
         permissions: "Tillatelser"
         usage_instructions_title: "Hvordan bruke din API-nøkkel"
-        usage_instructions: "Inkluder din API-nøkkel i X-Api-Key-headeren når du gjør forespørsler til Maybe API-et:"
+        usage_instructions: "Inkluder din API-nøkkel i X-Api-Key-headeren når du gjør forespørsler til %{product_name} API-et:"
         regenerate_key: "Opprett ny nøkkel"
         revoke_key: "Tilbakekall nøkkel"
         revoke_confirmation: "Er du sikker på at du vil tilbakekalle denne API-nøkkelen? Denne handlingen kan ikke angres og vil umiddelbart deaktivere alle applikasjoner som bruker denne nøkkelen."

--- a/config/locales/views/settings/api_keys/pl.yml
+++ b/config/locales/views/settings/api_keys/pl.yml
@@ -37,7 +37,7 @@ pl:
           never_expires: Nigdy nie wygasa
           permissions: Uprawnienia
           usage_instructions_title: Jak używać klucza API
-          usage_instructions: 'Dołącz klucz API w nagłówku X-Api-Key podczas wysyłania żądań do API Maybe:'
+          usage_instructions: 'Dołącz klucz API w nagłówku X-Api-Key podczas wysyłania żądań do API %{product_name}:'
           regenerate_key: Utwórz nowy klucz
           revoke_key: Unieważnij klucz
           revoke_confirmation: Czy na pewno chcesz unieważnić ten klucz API? Tej akcji nie można cofnąć, a wszystkie aplikacje używające tego klucza zostaną natychmiast wyłączone.

--- a/config/locales/views/settings/api_keys/tr.yml
+++ b/config/locales/views/settings/api_keys/tr.yml
@@ -36,7 +36,7 @@ tr:
         never_expires: "Süresiz"
         permissions: "Yetkiler"
         usage_instructions_title: "API anahtarınızı nasıl kullanırsınız"
-        usage_instructions: "Maybe API'ye istek yaparken API anahtarınızı X-Api-Key başlığına ekleyin:"
+        usage_instructions: "%{product_name} API'ye istek yaparken API anahtarınızı X-Api-Key başlığına ekleyin:"
         regenerate_key: "Yeni Anahtar Oluştur"
         revoke_key: "Anahtarı İptal Et"
         revoke_confirmation: "Bu API anahtarını iptal etmek istediğinizden emin misiniz? Bu işlem geri alınamaz ve bu anahtarı kullanan tüm uygulamalar hemen devre dışı kalır."

--- a/config/locales/views/settings/api_keys/zh-TW.yml
+++ b/config/locales/views/settings/api_keys/zh-TW.yml
@@ -37,7 +37,7 @@ zh-TW:
           never_expires: "永不過期"
           permissions: "權限範圍"
           usage_instructions_title: "如何使用您的 API 金鑰"
-          usage_instructions: "在向 Maybe API 發送請求時，請在 X-Api-Key 標頭 (Header) 中包含您的 API 金鑰："
+          usage_instructions: "在向 %{product_name} API 發送請求時，請在 X-Api-Key 標頭 (Header) 中包含您的 API 金鑰："
           regenerate_key: "建立新金鑰"
           revoke_key: "撤銷金鑰"
           revoke_confirmation: "您確定要撤銷此 API 金鑰嗎？此操作無法還原，且會立即停用所有使用此金鑰的應用程式。"


### PR DESCRIPTION
## Summary

Closes #1505.

The issue body singled out `en.yml` and `fr.yml` as still hardcoding "Maybe API" in the `settings.api_keys.show.current_api_key.usage_instructions` key, but those two were actually fixed in #1501 — both already use `%{product_name}`. The same swap was never applied to the other locales, so five translations still ship the stale brand.

The view side is already wired up: every render site passes `product_name: product_name` into the `t()` call:

- [app/views/settings/api_keys/show.html.erb:40, 128](app/views/settings/api_keys/show.html.erb#L40)
- [app/views/settings/api_keys/created.html.erb:73](app/views/settings/api_keys/created.html.erb#L73)
- [app/views/settings/api_keys/created.turbo_stream.erb:78](app/views/settings/api_keys/created.turbo_stream.erb#L78)

So the fix is locale-only.

## Changes

Five one-line edits in `config/locales/views/settings/api_keys/`:

| File | Before | After |
|---|---|---|
| `nb.yml:39` | `…til Maybe API-et:` | `…til %{product_name} API-et:` |
| `pl.yml:40` | `…do API Maybe:` | `…do API %{product_name}:` |
| `tr.yml:39` | `Maybe API'ye istek…` | `%{product_name} API'ye istek…` |
| `es.yml:40` | `…a la API de Maybe:` | `…a la API de %{product_name}:` |
| `zh-TW.yml:40` | `在向 Maybe API 發送…` | `在向 %{product_name} API 發送…` |

Each preserves the surrounding grammar (article, particle, spacing) of its translation.

## Verified

```
$ grep -rn "Maybe" config/locales/views/settings/api_keys/
config/locales/views/settings/api_keys/tr.yml:18:        description: "Maybe verilerinize…"
```

The only remaining "Maybe" reference is in `tr.yml:18` (`no_api_key.description`) — see "Out of scope" below.

## Out of scope

- **`tr.yml:18` `no_api_key.description`** — still says *"Maybe verilerinize…"*. Skipped because:
  1. The key is rendered via `t(".no_api_key.description")` with no `product_name:` argument, so swapping the literal for `%{product_name}` would leave the placeholder unresolved.
  2. The English equivalent at [en.yml:26](config/locales/views/settings/api_keys/en.yml#L26) also hardcodes "Sure", so this would need an EN/FR + view change first.
  3. It's not a `usage_instructions` key, which is what the issue scopes.

Happy to address as a follow-up if reviewers want a broader branding sweep.

## Test plan

- [ ] `bin/rails runner 'I18n.available_locales.each { |l| I18n.with_locale(l) { I18n.t("settings.api_keys.show.current_api_key.usage_instructions", product_name: "Sure") } }; puts "ok"'` — sanity check that every locale parses and resolves the placeholder.
- [ ] `bin/rails test`
- [ ] `bin/rubocop -f github -a`
- [ ] `bundle exec erb_lint ./app/**/*.erb -a`
- [ ] Manual: switch the UI to Spanish / Polish / Turkish / Norwegian / Traditional Chinese, open Settings → API Keys, confirm the usage-instructions sentence reads "Sure" (or whatever `Rails.configuration.x.product_name` is set to) instead of "Maybe".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API key usage instruction translations across Spanish, Norwegian, Polish, Turkish, and Traditional Chinese to dynamically reference the correct product name in API documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/2000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->