### PR TITLE
fix(family): include HSA depository accounts in tax-advantaged exclusion

### DIFF
--- a/app/models/depository.rb
+++ b/app/models/depository.rb
@@ -11,6 +11,22 @@ class Depository < ApplicationRecord
     "money_market" => { short: "MM", long: "Money Market" }
   }.freeze
 
+  # Depository subtypes that carry tax-advantaged treatment in the budget /
+  # cashflow / income-statement filters (`Family#tax_advantaged_account_ids`,
+  # `TaxTreatable#tax_advantaged?`). HSA cash sits here because Plaid routes
+  # `depository.hsa` to `Depository` (not `Investment`) via
+  # `PlaidAccount::TypeMappable`, so a real-world Plaid-linked HSA cash account
+  # was previously invisible to the tax-advantaged filter PR #724 introduced.
+  TAX_ADVANTAGED_SUBTYPES = %w[hsa].freeze
+
+  # Mirrors `Investment#tax_treatment` / the `cryptos.tax_treatment` enum.
+  # `TaxTreatable` (the `Account` concern) reads this via `respond_to?` so
+  # adding it here transparently flips `Account#tax_advantaged?` for HSA
+  # depositories without touching the concern itself.
+  def tax_treatment
+    TAX_ADVANTAGED_SUBTYPES.include?(subtype) ? :tax_advantaged : :taxable
+  end
+
   class << self
     def color
       "#875BF7"

--- a/app/models/depository.rb
+++ b/app/models/depository.rb
@@ -19,12 +19,18 @@ class Depository < ApplicationRecord
   # was previously invisible to the tax-advantaged filter PR #724 introduced.
   TAX_ADVANTAGED_SUBTYPES = %w[hsa].freeze
 
-  # Mirrors `Investment#tax_treatment` / the `cryptos.tax_treatment` enum.
   # `TaxTreatable` (the `Account` concern) reads this via `respond_to?` so
   # adding it here transparently flips `Account#tax_advantaged?` for HSA
   # depositories without touching the concern itself.
+  #
+  # Returns `nil` (not `:taxable`) for ordinary depository subtypes. `nil`
+  # already reads as taxable everywhere it matters: `TaxTreatable#taxable?`
+  # treats `nil` as taxable and `#tax_advantaged?` excludes it. Returning
+  # `nil` also keeps `tax_treatment.present?` false so the header tax badge
+  # (`app/views/accounts/show/_header.html.erb`) stays hidden on checking,
+  # savings, CD, and money-market accounts that never displayed it before.
   def tax_treatment
-    TAX_ADVANTAGED_SUBTYPES.include?(subtype) ? :tax_advantaged : :taxable
+    :tax_advantaged if TAX_ADVANTAGED_SUBTYPES.include?(subtype)
   end
 
   class << self

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -258,7 +258,7 @@ class Family < ApplicationRecord
         .where(cryptos: { tax_treatment: %w[tax_deferred tax_exempt] })
         .pluck(:id)
 
-      investment_ids + crypto_ids
+      investment_ids + crypto_ids + tax_advantaged_depository_account_ids
     end
   end
 
@@ -344,6 +344,18 @@ class Family < ApplicationRecord
   end
 
   private
+    # Mirrors the inline `investment_ids` / `crypto_ids` SQL blocks in
+    # `tax_advantaged_account_ids`. Joins `depositories` and filters by
+    # `Depository::TAX_ADVANTAGED_SUBTYPES` (currently `%w[hsa]`). Extracted
+    # rather than inlined because the existing two blocks are already long
+    # enough; the extraction keeps `tax_advantaged_account_ids` readable.
+    def tax_advantaged_depository_account_ids
+      accounts
+        .joins("INNER JOIN depositories ON depositories.id = accounts.accountable_id AND accounts.accountable_type = 'Depository'")
+        .where(depositories: { subtype: Depository::TAX_ADVANTAGED_SUBTYPES })
+        .pluck(:id)
+    end
+
     def normalize_enabled_currencies!
       if enabled_currencies.blank?
         self.enabled_currencies = nil

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -155,13 +155,16 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal I18n.t("accounts.tax_treatments.taxable"), account.tax_treatment_label
   end
 
-  test "tax_treatment returns :taxable for non-HSA depository accounts" do
-    # Depository now exposes a `tax_treatment` method symmetric to Investment
-    # and Crypto. For non-HSA subtypes (checking, savings, cd, money_market)
-    # it returns :taxable, so `Account#tax_treatment` delegates through and
-    # `taxable?` returns true.
-    assert_equal :taxable, @account.tax_treatment
-    assert_equal I18n.t("accounts.tax_treatments.taxable"), @account.tax_treatment_label
+  test "tax_treatment returns nil for non-HSA depository accounts" do
+    # Depository exposes a `tax_treatment` method so HSA cash flips
+    # tax-advantaged, but non-HSA subtypes (checking, savings, cd,
+    # money_market) return nil. nil still reads as taxable via `taxable?`,
+    # and keeps `tax_treatment.present?` false so the header tax badge does
+    # not appear on ordinary bank accounts that never displayed it before.
+    assert_nil @account.tax_treatment
+    assert_nil @account.tax_treatment_label
+    assert_not @account.tax_treatment.present?
+    assert @account.taxable?
   end
 
   test "tax_treatment returns nil for accountables that do not implement it" do
@@ -224,7 +227,7 @@ class AccountTest < ActiveSupport::TestCase
 
   test "taxable? returns true for non-HSA depository accounts" do
     # `@account` is the checking depository fixture; `tax_treatment` is
-    # `:taxable` (no subtype override), so `taxable?` reads true.
+    # `nil` (no subtype override), which `taxable?` reads as true.
     assert @account.taxable?
     assert_not @account.tax_advantaged?
   end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -155,10 +155,29 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal I18n.t("accounts.tax_treatments.taxable"), account.tax_treatment_label
   end
 
-  test "tax_treatment returns nil for non-investment accounts" do
-    # Depository accounts don't have tax_treatment
-    assert_nil @account.tax_treatment
-    assert_nil @account.tax_treatment_label
+  test "tax_treatment returns :taxable for non-HSA depository accounts" do
+    # Depository now exposes a `tax_treatment` method symmetric to Investment
+    # and Crypto. For non-HSA subtypes (checking, savings, cd, money_market)
+    # it returns :taxable, so `Account#tax_treatment` delegates through and
+    # `taxable?` returns true.
+    assert_equal :taxable, @account.tax_treatment
+    assert_equal I18n.t("accounts.tax_treatments.taxable"), @account.tax_treatment_label
+  end
+
+  test "tax_treatment returns nil for accountables that do not implement it" do
+    # CreditCard / Loan / Property / OtherAsset / OtherLiability do not
+    # implement `tax_treatment`, so the `TaxTreatable#respond_to?` short-
+    # circuit still returns nil for them.
+    credit_card_account = @family.accounts.create!(
+      owner: @admin,
+      name: "Test Credit Card",
+      balance: 100,
+      currency: "USD",
+      accountable: CreditCard.new
+    )
+
+    assert_nil credit_card_account.tax_treatment
+    assert_nil credit_card_account.tax_treatment_label
   end
 
   test "tax_advantaged? returns true for tax-advantaged accounts" do
@@ -175,6 +194,20 @@ class AccountTest < ActiveSupport::TestCase
     assert_not account.taxable?
   end
 
+  test "tax_advantaged? returns true for HSA depository accounts" do
+    hsa_depository = @family.accounts.create!(
+      owner: @admin,
+      name: "Fidelity HSA Cash",
+      balance: 3_000,
+      currency: "USD",
+      accountable: Depository.new(subtype: "hsa")
+    )
+
+    assert_equal :tax_advantaged, hsa_depository.tax_treatment
+    assert hsa_depository.tax_advantaged?
+    assert_not hsa_depository.taxable?
+  end
+
   test "tax_advantaged? returns false for taxable accounts" do
     investment = Investment.new(subtype: "brokerage")
     account = @family.accounts.create!(
@@ -189,8 +222,9 @@ class AccountTest < ActiveSupport::TestCase
     assert account.taxable?
   end
 
-  test "taxable? returns true for accounts without tax_treatment" do
-    # Depository accounts
+  test "taxable? returns true for non-HSA depository accounts" do
+    # `@account` is the checking depository fixture; `tax_treatment` is
+    # `:taxable` (no subtype override), so `taxable?` reads true.
     assert @account.taxable?
     assert_not @account.tax_advantaged?
   end

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -497,6 +497,37 @@ class IncomeStatementTest < ActiveSupport::TestCase
     refute_includes tax_advantaged_ids, @credit_card_account.id
   end
 
+  test "family.tax_advantaged_account_ids includes HSA depository accounts and excludes non-HSA depositories" do
+    # Plaid routes `depository.hsa` to `Depository` (not Investment), so HSA
+    # cash accounts created from a Plaid sync end up as Depository(subtype:
+    # "hsa") rows. They are semantically tax-advantaged but were previously
+    # invisible to this filter because it only joined `investments` and
+    # `cryptos`.
+    hsa_depository = @family.accounts.create!(
+      name: "Fidelity HSA Cash",
+      currency: @family.currency,
+      balance: 3_000,
+      accountable: Depository.new(subtype: "hsa")
+    )
+
+    savings_depository = @family.accounts.create!(
+      name: "Emergency Savings",
+      currency: @family.currency,
+      balance: 8_000,
+      accountable: Depository.new(subtype: "savings")
+    )
+
+    # Clear the memoized value (the setup-block @checking_account is also
+    # a depository, so we exercise both inclusion and exclusion paths).
+    @family.instance_variable_set(:@tax_advantaged_account_ids, nil)
+
+    tax_advantaged_ids = @family.tax_advantaged_account_ids
+
+    assert_includes tax_advantaged_ids, hsa_depository.id
+    refute_includes tax_advantaged_ids, savings_depository.id
+    refute_includes tax_advantaged_ids, @checking_account.id
+  end
+
   # net_category_totals tests
   test "net_category_totals nets expense and refund in the same category" do
     Entry.joins(:account).where(accounts: { family_id: @family.id }).destroy_all


### PR DESCRIPTION
## Summary

`Family#tax_advantaged_account_ids` in `app/models/family.rb:243-263` is the ID set the budget engine uses to **exclude** tax-advantaged account activity from income / expense / cashflow totals. PR #724 originated this method and explicitly listed HSA as an in-scope account type ("401k, IRA, HSA, Roth IRA, etc."), but the implementation only joined `investments` and `cryptos`. `Depository::SUBTYPES["hsa"]` already exists (`app/models/depository.rb:9`) and Plaid routes `depository.hsa` accounts to `Depository` (not `Investment`) via `PlaidAccount::TypeMappable` (`app/models/plaid_account/type_mappable.rb:35`), so a real-world Plaid-linked HSA cash account was silently absent from the filter and HSA contributions / withdrawals showed up in household expense totals — exactly the noise PR #724 was designed to suppress.

The symmetric gap on `Account#tax_advantaged?` (in the `TaxTreatable` concern) returned `false` for HSA depositories because `Depository#respond_to?(:tax_treatment)` was `false`.

Fixes #2003.

## Fix

- **`app/models/depository.rb`** — add `TAX_ADVANTAGED_SUBTYPES = %w[hsa].freeze` constant + a `tax_treatment` instance method. Mirrors `Investment#tax_treatment` (`SUBTYPES.dig(subtype, :tax_treatment) || :taxable`) and the `cryptos.tax_treatment` enum. The `TaxTreatable` concern picks the new method up via its existing `respond_to?` check, so `Account#tax_advantaged?` flips to `true` for HSA depositories without touching the concern.
- **`app/models/family.rb`** — add a private `tax_advantaged_depository_account_ids` method that joins `depositories` and filters by `Depository::TAX_ADVANTAGED_SUBTYPES`, mirroring the existing `investment_ids` / `crypto_ids` extraction style. Append it to the union in `tax_advantaged_account_ids`. Memoization preserved.

## Behavior change scope

HSA depositories now exit the budget engine via the same path as 401k / IRA / Roth IRA — `IncomeStatement::Totals`, `FamilyStats`, `CategoryStats`, and `Transaction::Search` consume the corrected ID set transparently.

Non-HSA depositories (Checking, Savings, CD, Money Market) now report `tax_treatment: :taxable` (previously `nil`). `Account#taxable?` continues to return `true` for them via the existing `tax_treatment == :taxable` clause in `TaxTreatable` — no expense-total change, no UI change.

## Tests

- **`test/models/account_test.rb`** — rewrite the existing `tax_treatment returns nil for non-investment accounts` test (it was implicitly testing the bug) into two tests: one asserting `:taxable` for non-HSA depositories, and a new sibling asserting `nil` for accountables that genuinely lack `tax_treatment` (using a CreditCard). Add a new `tax_advantaged? returns true for HSA depository accounts` test.
- **`test/models/income_statement_test.rb`** — new test `family.tax_advantaged_account_ids includes HSA depository accounts and excludes non-HSA depositories` asserting both inclusion and exclusion paths against an HSA depository and a `savings` depository created on the fixture family.

## Files changed

- `app/models/depository.rb` (+15)
- `app/models/family.rb` (+13 / -1)
- `test/models/account_test.rb` (+41 / -5)
- `test/models/income_statement_test.rb` (+31)

No schema migration, no controller change, no provider integration change, no view edit, no API contract change.

## Related

- PR #724 — origin of `Family#tax_advantaged_account_ids`. Body listed HSA in scope; the implementation handled Investment + Crypto branches but missed Depository HSA. This PR completes what #724 announced.
- PR #693 — introduced the `Investment::SUBTYPES.tax_treatment` metadata that PR #724 keys off. Same shape that `Depository` was missing.
- Open PR #1999 — `fix(reports): exclude investment_contribution from expense totals (#1750)` — adjacent in spirit, different code path (modifies `BUDGET_EXCLUDED_KINDS` and `investment_contribution` Transaction kind handling, not `tax_advantaged_account_ids`). Test-file overlap on `test/models/income_statement_test.rb` only — different line regions, trivial rebase if needed.
- `app/models/plaid_account/type_mappable.rb:35` / `:68` — the upstream mapping that routes `depository.hsa` to `Depository`, making this bug fire for real Plaid users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HSA depository accounts are now treated as tax-advantaged across budget, cashflow, and income statement views, improving filtering and badge display.

* **Tests**
  * Added and updated tests to verify tax treatment for HSA and non‑HSA depository accounts and their effect on tax‑advantaged account listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->