### PR TITLE
Add core zh-CN locale coverage

### DIFF
--- a/config/locales/models/category/zh-CN.yml
+++ b/config/locales/models/category/zh-CN.yml
@@ -1,0 +1,29 @@
+---
+zh-CN:
+  models:
+    category:
+      uncategorized: 未分类
+      other_investments: 其他投资
+      investment_contributions: 投资转入
+      defaults:
+        income: 收入
+        food_and_drink: 餐饮
+        groceries: 超市购物
+        shopping: 购物
+        transportation: 交通
+        travel: 旅行
+        entertainment: 娱乐
+        healthcare: 医疗健康
+        personal_care: 个人护理
+        home_improvement: 家居装修
+        mortgage_rent: 房贷/房租
+        utilities: 水电燃气
+        subscriptions: 订阅
+        insurance: 保险
+        sports_and_fitness: 运动健身
+        gifts_and_donations: 礼品与捐赠
+        taxes: 税费
+        loan_payments: 贷款还款
+        services: 服务
+        fees: 手续费
+        savings_and_investments: 储蓄与投资

--- a/config/locales/models/period/zh-CN.yml
+++ b/config/locales/models/period/zh-CN.yml
@@ -1,0 +1,54 @@
+---
+zh-CN:
+  period:
+    last_day:
+      label_short: "1天"
+      label: "最近一天"
+      comparison_label: "较昨日"
+    current_week:
+      label_short: "本周"
+      label: "本周至今"
+      comparison_label: "较本周初"
+    last_7_days:
+      label_short: "7天"
+      label: "最近 7 天"
+      comparison_label: "较上周"
+    current_month:
+      label_short: "本月"
+      label: "本月至今"
+      comparison_label: "较本月初"
+    last_month:
+      label_short: "上月"
+      label: "上个月"
+      comparison_label: "较上月"
+    last_30_days:
+      label_short: "30天"
+      label: "最近 30 天"
+      comparison_label: "较前 30 天"
+    last_90_days:
+      label_short: "90天"
+      label: "最近 90 天"
+      comparison_label: "较上一季度"
+    current_year:
+      label_short: "本年"
+      label: "本年至今"
+      comparison_label: "较年初"
+    last_365_days:
+      label_short: "365天"
+      label: "最近 365 天"
+      comparison_label: "较一年前"
+    last_5_years:
+      label_short: "5年"
+      label: "最近 5 年"
+      comparison_label: "较 5 年前"
+    last_10_years:
+      label_short: "10年"
+      label: "最近 10 年"
+      comparison_label: "较 10 年前"
+    all_time:
+      label_short: "全部"
+      label: "全部时间"
+      comparison_label: "较起始值"
+    custom:
+      label_short: "自定义"
+      label: "自定义周期"

--- a/config/locales/models/transaction/zh-CN.yml
+++ b/config/locales/models/transaction/zh-CN.yml
@@ -1,0 +1,11 @@
+---
+zh-CN:
+  activerecord:
+    errors:
+      models:
+        transaction:
+          attributes:
+            attachments:
+              too_many: "每笔交易最多只能上传 %{max} 个文件"
+              too_large: "第 %{index} 个文件过大（最大 %{max_mb}MB）"
+              invalid_format: "第 %{index} 个文件格式不受支持（%{file_format}）"

--- a/config/locales/views/account_statements/zh-CN.yml
+++ b/config/locales/views/account_statements/zh-CN.yml
@@ -1,0 +1,116 @@
+---
+zh-CN:
+  account_statements:
+    account_tab:
+      coverage_title: 对账单覆盖情况
+      coverage_description: 已上传对账单及余额核对覆盖的历史月份。
+      coverage_range: "%{start} - %{end}"
+      empty: 此账户尚未关联任何对账单。
+      open_inbox: 收件箱
+      statements_title: 对账单
+      year_label: 覆盖年份
+    balance:
+      unknown: 未知
+    coverage:
+      status:
+        ambiguous: 不明确
+        covered: 已覆盖
+        duplicate: 重复
+        mismatched: 不匹配
+        missing: 缺失
+        not_expected: 不需要
+    create:
+      duplicates:
+        one: 已跳过 1 份重复对账单。
+        other: "已跳过 %{count} 份重复对账单。"
+      invalid_file_type: 请上传符合大小限制的 PDF、CSV 或 XLSX 对账单。
+      no_files: 请至少选择一份对账单文件。
+      success:
+        one: 已上传 1 份对账单。
+        other: "已上传 %{count} 份对账单。"
+    destroy:
+      failure: 无法删除对账单。
+      success: 对账单已删除。
+    form:
+      account_upload: 上传对账单
+      files_hint: PDF、CSV 或 XLSX。每个文件最大 %{max_size}MB。
+      files_label: 对账单文件
+      inbox_upload: 上传
+    index:
+      account_label: 账户
+      confidence: "匹配度 %{confidence}"
+      empty_linked: 尚无已关联的对账单。
+      empty_unmatched: 对账单收件箱为空。
+      leave_unmatched: 保持未匹配
+      linked_title: 已关联对账单
+      no_suggestion: 暂无建议
+      storage_used: 已用存储
+      title: 对账单库
+      unmatched_title: 未匹配收件箱
+      upload_description: 将对账单上传到收件箱，或选择账户后立即关联。
+      upload_title: 上传对账单
+    link:
+      no_account: 请先选择账户，再关联此对账单。
+      success: 已将对账单关联到 %{account}。
+    period:
+      unknown: 账期未知
+    reconciliation:
+      checks:
+        closing_balance: 期末余额
+        opening_balance: 期初余额
+        period_movement: 期间变动
+        unknown_check: 未知核对项
+      matched: 已匹配
+      mismatched: 不匹配
+      unavailable: 未核对
+    reject:
+      success: 已拒绝对账单匹配。
+    show:
+      account_label: 账户
+      account_last4_hint: 账户后四位
+      account_name_hint: 账户名称提示
+      closing_balance: 期末余额
+      currency: 货币
+      delete: 删除
+      difference: 差额
+      download: 下载
+      institution_name_hint: 机构名称提示
+      ledger_amount: Sure 账面金额
+      linked_to: 已关联到 %{account}。
+      linking_title: 账户关联
+      link_suggestion: 关联建议
+      metadata_title: 对账单元数据
+      no_suggestion: 暂无账户建议。
+      opening_balance: 期初余额
+      period_end_on: 账期结束
+      period_start_on: 账期开始
+      reconciliation_title: 对账
+      reconciliation_unavailable: 请添加对账单账期以及期初或期末余额，并确保 Sure 在这些日期有余额历史。
+      reject: 拒绝
+      save: 保存对账单
+      statement_amount: 对账单
+      suggested_account: 建议关联 %{account}（匹配度 %{confidence}）。
+      title: 对账单
+      unlink: 取消关联
+      unmatched_account: 未匹配收件箱
+      unknown_value: 未知
+    status:
+      linked: 已关联
+      rejected: 已拒绝
+      unmatched: 未匹配
+    table:
+      account: 账户
+      actions: 操作
+      download: 下载
+      file: 文件
+      link_suggestion: 关联建议
+      period: 账期
+      reconciliation: 核对结果
+      reject: 拒绝建议
+      suggestion: 建议
+      unlink: 取消关联
+      view: 查看
+    unlink:
+      success: 对账单已移回未匹配收件箱。
+    update:
+      success: 对账单已更新。

--- a/config/locales/views/components/zh-CN.yml
+++ b/config/locales/views/components/zh-CN.yml
@@ -1,0 +1,162 @@
+---
+zh-CN:
+  UI:
+    account:
+      activity_feed:
+        toggle_selection_checkboxes: 切换选择
+      balance_reconciliation:
+        labels:
+          adjustments: 调整
+          buys: 买入
+          change_in_brokerage_cash: 券商账户现金变动
+          change_in_holdings_market: 持仓变动（市场价格波动）
+          change_in_holdings_trades: 持仓变动（买入/卖出）
+          charges: 费用
+          end_balance: 期末余额
+          end_principal: 期末本金
+          end_value: 期末价值
+          final_balance: 最终余额
+          final_principal: 最终本金
+          final_value: 最终价值
+          market_changes: 市场变动
+          net_cash_flow: 净现金流
+          net_principal_change: 本金净变动
+          net_value_change: 价值净变动
+          payments: 还款
+          sells: 卖出
+          start_balance: 期初余额
+          start_principal: 期初本金
+          start_value: 期初价值
+        tooltips:
+          adjustments: 手动对账或其他调整
+          adjustments_asset: 手动价值调整或估值
+          buys: 当天买入的加密货币
+          change_in_brokerage_cash: 存入、取出和交易带来的券商账户现金净变动
+          change_in_holdings_market: 市场价格波动带来的持仓价值变动
+          change_in_holdings_trades: 买卖证券对持仓造成的影响
+          charges: 当天新增的消费
+          end_balance: 计入所有交易后的计算余额
+          end_balance_investment: 计入所有活动后的计算余额
+          end_principal: 计入所有交易后的计算本金
+          end_value: 计入所有变动后的计算价值
+          final_balance: 当天最终账户余额
+          final_balance_credit: 当天最终应还余额
+          final_balance_crypto: 当天最终加密货币持仓价值
+          final_balance_investment: 当天最终投资组合价值
+          final_principal: 当天最终本金余额
+          final_value: 当天最终资产价值
+          market_changes: 市场价格波动带来的价值变动
+          net_cash_flow: 当天所有交易带来的余额净变动
+          net_principal_change: 当天本金还款和新增借款
+          net_value_change: 包含增值改良和折旧在内的全部价值变动
+          payments: 当天向信用卡还款的金额
+          sells: 当天卖出的加密货币
+          start_balance: 当天开始时的账户余额
+          start_balance_credit: 当天开始时的应还余额
+          start_balance_crypto: 当天开始时的加密货币持仓价值
+          start_balance_investment: 当天开始时的投资组合总价值
+          start_principal: 当天开始时的本金余额
+          start_value: 当天开始时的资产价值
+      chart:
+        no_data_available: "暂无数据"
+        title:
+          balance: 余额
+          cash_value: 现金价值
+          debt_balance: 债务余额
+          estimated_property_value: 房产估值
+          estimated_vehicle_value: 车辆估值
+          holdings_value: 持仓价值
+          remaining_principal_balance: 剩余本金余额
+          total_account_value: 账户总价值
+        views:
+          cash: 现金
+          holdings: 持仓
+          total_value: 总价值
+        vs_available_history: 与可用历史相比
+      activity_date:
+        balance_tooltip: "计入所有交易和调整后的日终余额"
+        no_balance_data: "此日期暂无余额数据"
+  ds:
+    alert:
+      variants:
+        info: 信息
+        success: 成功
+        warning: 警告
+        error: 错误
+        destructive: 错误
+    pill:
+      aria_label: "%{label}"
+      default_label: 预览
+    dialog:
+      close: 关闭
+    popover:
+      avatar_default_label: 打开菜单
+    tooltip:
+      trigger_label: 更多信息
+    link:
+      opens_in_new_tab: （在新标签页中打开）
+  provider_sync_summary:
+    title: 同步摘要
+    last_sync: "上次同步：%{time_ago} 前"
+    accounts:
+      title: 账户
+      total: "总数：%{count}"
+      linked: "已关联：%{count}"
+      unlinked: "未关联：%{count}"
+      institutions: "机构：%{count}"
+    transactions:
+      title: 交易
+      seen: "发现：%{count}"
+      imported: "已导入：%{count}"
+      updated: "已更新：%{count}"
+      skipped: "已跳过：%{count}"
+      fetching: "正在从券商获取..."
+      protected:
+        one: "%{count} 条受保护记录（未覆盖）"
+        other: "%{count} 条受保护记录（未覆盖）"
+      view_protected: 查看受保护记录
+    skip_reasons:
+      excluded: 已排除
+      user_modified: 用户已修改
+      import_locked: CSV 导入
+      protected: 受保护
+    holdings:
+      title: 持仓
+      found: "发现：%{count}"
+      processed: "已处理：%{count}"
+    trades:
+      title: 交易活动
+      imported: "已导入：%{count}"
+      skipped: "已跳过：%{count}"
+      fetching: "正在从券商获取活动..."
+    health:
+      title: 健康状态
+      view_error_details: 查看错误详情
+      rate_limited: "%{time_ago} 前触发限流"
+      recently: 刚刚
+      errors: "错误：%{count}"
+      pending_reconciled:
+        one: "%{count} 条重复待处理交易已对账"
+        other: "%{count} 条重复待处理交易已对账"
+      view_reconciled: 查看已对账交易
+      duplicate_suggestions:
+        one: "%{count} 条可能重复的交易需要审核"
+        other: "%{count} 条可能重复的交易需要审核"
+      view_duplicate_suggestions: 查看重复建议
+      stale_pending:
+        one: "%{count} 条过期待处理交易（已从预算中排除）"
+        other: "%{count} 条过期待处理交易（已从预算中排除）"
+      view_stale_pending: 查看受影响账户
+      stale_pending_count:
+        one: "%{count} 条交易"
+        other: "%{count} 条交易"
+      stale_unmatched:
+        one: "%{count} 条待处理交易需要手动审核"
+        other: "%{count} 条待处理交易需要手动审核"
+      view_stale_unmatched: 查看需要审核的交易
+      stale_unmatched_count:
+        one: "%{count} 条交易"
+        other: "%{count} 条交易"
+      data_warnings: "数据警告：%{count}"
+      notices: "通知：%{count}"
+      view_data_quality: 查看数据质量详情


### PR DESCRIPTION
Summary: Add Simplified Chinese locale coverage for core account statement, shared UI component, transaction attachment error, category, and period label strings. Preserve English locale key structure and interpolation variables. Validation: parsed selected zh-CN locale YAML with Python/PyYAML; compared keys and Rails interpolation variables against matching en.yml files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Simplified Chinese language translations across the application, including support for categories, time period labels, transaction error messages, account statement management, and UI components. This enables full Chinese localization for end-users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/2018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->