### PR TITLE
Add transaction name to get_transactions MCP tool output

### DIFF
--- a/app/models/assistant/function/get_transactions.rb
+++ b/app/models/assistant/function/get_transactions.rb
@@ -155,7 +155,8 @@ class Assistant::Function::GetTransactions < Assistant::Function
     normalized_transactions = paginated_transactions.map do |txn|
       entry = txn.entry
       {
-        date: entry.date,
+        name: entry.name,
+		date: entry.date,
         amount: entry.amount.abs,
         currency: entry.currency,
         formatted_amount: entry.amount_money.abs.format,

--- a/app/models/assistant/function/get_transactions.rb
+++ b/app/models/assistant/function/get_transactions.rb
@@ -156,7 +156,7 @@ class Assistant::Function::GetTransactions < Assistant::Function
       entry = txn.entry
       {
         name: entry.name,
-		date: entry.date,
+        date: entry.date,
         amount: entry.amount.abs,
         currency: entry.currency,
         formatted_amount: entry.amount_money.abs.format,


### PR DESCRIPTION
## Problem
The `get_transactions` MCP tool omits the transaction's name/description.
Per transaction it returns `date`, `amount`, `account`, `category`,
`merchant`, `tags`, `is_transfer` — but no name. The only name-like field
is `merchant`, which is `nil` unless a merchant has been assigned, so an
MCP client (e.g. an external AI assistant) cannot tell what a transaction
was for.

## Fix
`get_transactions` already loads `entry = txn.entry`, so `entry.name` —
the display name shown in the web UI and returned by the REST API — is
available with no extra query. This adds it to the serialized hash.

Additive and non-breaking; restores parity with the web UI and REST API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction details now include the transaction name field, providing more comprehensive transaction information for identification and reference purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->