### PR TITLE
Fix Sure NDJSON create/upload validation to reject malformed later lines

### DIFF
--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -353,10 +353,12 @@ class Api::V1::ImportsController < Api::V1::BaseController
     end
 
     def sure_import_validated_attributes(content:, filename:, content_type:)
-      unless SureImport.valid_ndjson_first_line?(content)
+      errors = SureImport.ndjson_validation_errors(content)
+      unless errors.empty?
         render json: {
           error: "invalid_ndjson",
-          message: "Invalid Sure NDJSON content."
+          message: "Invalid Sure NDJSON content.",
+          errors: errors
         }, status: :unprocessable_entity
         return
       end

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -50,7 +50,7 @@ class Import::UploadsController < ApplicationController
       content = uploaded.read
       uploaded.rewind
 
-      if ndjson_valid?(content)
+      if SureImport.valid_ndjson_content?(content)
         uploaded.rewind
         @import.ndjson_file.attach(uploaded)
         @import.sync_ndjson_rows_count!
@@ -99,21 +99,6 @@ class Import::UploadsController < ApplicationController
         return false if csv.count == 0
         true
       rescue CSV::MalformedCSVError
-        false
-      end
-    end
-
-    def ndjson_valid?(str)
-      return false if str.blank?
-
-      # Check at least first line is valid NDJSON
-      first_line = str.lines.first&.strip
-      return false if first_line.blank?
-
-      begin
-        record = JSON.parse(first_line)
-        record.key?("type") && record.key?("data")
-      rescue JSON::ParserError
         false
       end
     end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -226,7 +226,7 @@ class ImportsController < ApplicationController
 
       content = file.read
       file.rewind
-      unless SureImport.valid_ndjson_first_line?(content)
+      unless SureImport.valid_ndjson_content?(content)
         redirect_to new_import_path, alert: t("imports.create.invalid_ndjson_file_type")
         return
       end

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -90,6 +90,40 @@ class SureImport < Import
         false
       end
     end
+
+    def ndjson_validation_errors(content)
+      errors = []
+      nonblank_rows_count = 0
+
+      content.to_s.each_line.with_index(1) do |line, line_number|
+        next if line.strip.empty?
+
+        nonblank_rows_count += 1
+
+        begin
+          record = JSON.parse(line)
+        rescue JSON::ParserError => error
+          errors << "Line #{line_number} is not valid JSON: #{error.message}"
+          next
+        end
+
+        unless record.is_a?(Hash)
+          errors << "Line #{line_number} must be a JSON object."
+          next
+        end
+
+        unless record.key?("type") && record.key?("data")
+          errors << "Line #{line_number} must include type and data."
+        end
+      end
+
+      errors << "No data rows were found." if nonblank_rows_count.zero?
+      errors
+    end
+
+    def valid_ndjson_content?(content)
+      ndjson_validation_errors(content).empty?
+    end
   end
 
   def requires_csv_workflow?

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -587,6 +587,27 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "invalid_ndjson", json_response["error"]
   end
 
+  test "should reject Sure import when later NDJSON line is invalid" do
+    ndjson_content = [
+      { type: "Account", data: { id: "account_1", name: "Checking" } }.to_json,
+      "{\"type\":\"Transaction\",\"data\":"
+    ].join("\n")
+
+    assert_no_difference("Import.count") do
+      post api_v1_imports_url,
+           params: {
+             type: "SureImport",
+             raw_file_content: ndjson_content
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    assert_equal "invalid_ndjson", json_response["error"]
+    assert_includes json_response["errors"].first, "Line 2 is not valid JSON"
+  end
+
   test "should preflight CSV import without persisting records" do
     csv_content = "date,amount,name\n2023-01-01,-10.00,Test Transaction"
 

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -46,4 +46,27 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     assert_equal "Must be valid CSV with headers and at least one row of data", flash[:alert]
   end
+
+  test "rejects Sure import upload when later NDJSON line is invalid" do
+    sure_import = @user.family.imports.create!(type: "SureImport")
+    ndjson_content = [
+      { type: "Account", data: { id: "account_1", name: "Checking" } }.to_json,
+      "{\"type\":\"Transaction\",\"data\":"
+    ].join("\n")
+    invalid_file = Rack::Test::UploadedFile.new(
+      StringIO.new(ndjson_content),
+      "application/x-ndjson",
+      original_filename: "broken.ndjson"
+    )
+
+    patch import_upload_url(sure_import), params: {
+      import: {
+        ndjson_file: invalid_file
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal "Must be valid NDJSON with at least one record", flash[:alert]
+    assert_not sure_import.reload.ndjson_file.attached?
+  end
 end

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -137,4 +137,28 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to imports_path
   end
+
+  test "rejects Sure import when later NDJSON line is invalid" do
+    ndjson_content = [
+      { type: "Account", data: { id: "account_1", name: "Checking" } }.to_json,
+      "{\"type\":\"Transaction\",\"data\":"
+    ].join("\n")
+    invalid_file = Rack::Test::UploadedFile.new(
+      StringIO.new(ndjson_content),
+      "application/x-ndjson",
+      original_filename: "broken.ndjson"
+    )
+
+    assert_no_difference "Import.count" do
+      post imports_url, params: {
+        import: {
+          type: "SureImport",
+          import_file: invalid_file
+        }
+      }
+    end
+
+    assert_redirected_to new_import_url
+    assert_equal I18n.t("imports.create.invalid_ndjson_file_type"), flash[:alert]
+  end
 end

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -90,6 +90,26 @@ class SureImportTest < ActiveSupport::TestCase
     assert_not @import.uploaded?
   end
 
+  test "valid_ndjson_content? returns false when later line is invalid" do
+    ndjson = [
+      { type: "Account", data: { id: "uuid-1" } }.to_json,
+      "{\"type\":\"Transaction\",\"data\":"
+    ].join("\n")
+
+    assert_not SureImport.valid_ndjson_content?(ndjson)
+    assert_not_empty SureImport.ndjson_validation_errors(ndjson)
+  end
+
+  test "valid_ndjson_content? returns false when later line misses required keys" do
+    ndjson = [
+      { type: "Account", data: { id: "uuid-1" } }.to_json,
+      { type: "Transaction" }.to_json
+    ].join("\n")
+
+    assert_not SureImport.valid_ndjson_content?(ndjson)
+    assert_includes SureImport.ndjson_validation_errors(ndjson), "Line 2 must include type and data."
+  end
+
   test "configured? and cleaned? follow uploaded?" do
     attach_ndjson(build_ndjson([
       { type: "Account", data: { id: "uuid-1", name: "Test", balance: "1000", currency: "USD", accountable_type: "Depository" } }


### PR DESCRIPTION
## Related issues
Closes #2032

## Summary

This PR fixes a migration-critical bug where Sure NDJSON imports could pass upload when only the first line was valid, then fail later during publish.

- Add shared full-file NDJSON validation in `SureImport`:
  - `ndjson_validation_errors(content)`
  - `valid_ndjson_content?(content)`
- Enforce full-file validation in all Sure create/upload entry points:
  - `ImportsController#create_sure_import`
  - `Import::UploadsController#update_sure_import_upload`
  - `Api::V1::ImportsController#sure_import_validated_attributes`
- Remove duplicate first-line-only validation logic from upload controller.
- Improve API error response for invalid Sure NDJSON by returning line-level validation messages.

## Why

Sure import is often used for full-history migration. Accepting malformed NDJSON at upload time leads to late failures, poor UX, and inconsistent behavior versus preflight validation.

This change makes create/upload behavior consistent with preflight expectations by validating the entire file before attaching or creating import records.

## Scope of changes

- `app/models/sure_import.rb`
  - new reusable full-file validation methods
- `app/controllers/imports_controller.rb`
  - use full-file validation in `create_sure_import`
- `app/controllers/import/uploads_controller.rb`
  - use full-file validation and remove local first-line helper
- `app/controllers/api/v1/imports_controller.rb`
  - use shared validator and include `errors` array in invalid NDJSON response
- Regression tests added in:
  - `test/models/sure_import_test.rb`
  - `test/controllers/imports_controller_test.rb`
  - `test/controllers/import/uploads_controller_test.rb`
  - `test/controllers/api/v1/imports_controller_test.rb`

## Test plan

- [x] Model: reject NDJSON when a later line is invalid JSON
- [x] Model: reject NDJSON when a later line is missing required keys
- [x] Web create flow: reject malformed NDJSON with valid first line
- [x] Web upload flow: reject malformed NDJSON and do not attach file
- [x] API create flow: reject malformed NDJSON and return line-level errors
- [x] Run targeted test suites for touched model/controllers

## Risk and rollout notes

- Behavior is stricter by design: files that previously passed with hidden malformed lines now fail early.
- This is expected and desirable for data integrity.
- API clients may now receive an `errors` array for `invalid_ndjson` responses; this is additive and backward compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of NDJSON file uploads with detailed line-by-line error reporting to help users identify and correct malformed data before processing.
  * Improved error messaging when validation fails, providing specific feedback about which lines contain errors and why.

* **Tests**
  * Added comprehensive test coverage for NDJSON validation edge cases and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/2033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->