### PR TITLE
Fix API CSV import silent success when row generation fails

### DIFF
--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -112,6 +112,12 @@ class Api::V1::ImportsController < Api::V1::BaseController
           @import.reload
         rescue StandardError => e
           Rails.logger.error "Row generation failed for import #{@import.id}: #{e.message}"
+          clean_up_failed_csv_import(@import)
+          render json: {
+            error: "import_row_generation_failed",
+            message: "Import could not be created"
+          }, status: :internal_server_error
+          return
         end
       end
 
@@ -294,6 +300,14 @@ class Api::V1::ImportsController < Api::V1::BaseController
       ensure
         import.destroy if import.persisted?
       end
+    end
+
+    def clean_up_failed_csv_import(import)
+      return unless import&.persisted?
+
+      import.destroy
+    rescue StandardError => e
+      Rails.logger.warn "Failed to destroy CSV import #{import.id}: #{e.message}"
     end
 
     def sure_import_upload_attributes

--- a/test/controllers/api/v1/imports_controller_test.rb
+++ b/test/controllers/api/v1/imports_controller_test.rb
@@ -307,6 +307,27 @@ class Api::V1::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "-10.00", import.rows.first.amount # Normalized
   end
 
+  test "should return error and clean up import when CSV row generation fails" do
+    csv_content = "date,amount,name\n2023-01-01,-10.00,Test Transaction"
+    TransactionImport.any_instance.stubs(:generate_rows_from_csv).raises(StandardError, "row generation exploded")
+
+    assert_no_difference("Import.count") do
+      post api_v1_imports_url,
+           params: {
+             raw_file_content: csv_content,
+             date_col_label: "date",
+             amount_col_label: "amount",
+             name_col_label: "name",
+             account_id: @account.id
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :internal_server_error
+    json_response = JSON.parse(response.body)
+    assert_equal "import_row_generation_failed", json_response["error"]
+  end
+
   test "should instantiate RuleImport before generating rows" do
     @family.categories.create!(
       name: "Groceries",


### PR DESCRIPTION
## Related issues
Closes #2034

## Summary

This PR fixes a critical API reliability bug where `POST /api/v1/imports` could return `201 Created` even when CSV row generation failed internally.

- Fail API create request when `generate_rows_from_csv` raises.
- Return explicit error response:
  - `error: "import_row_generation_failed"`
  - `message: "Import could not be created"`
- Clean up the partially created CSV import record so clients do not see phantom successful imports.

## Why

Previously, row-generation exceptions were logged but swallowed, and the endpoint continued to return success. That caused silent partial failures for API clients and automation pipelines.

This change makes API behavior truthful and deterministic: if ingestion fails, the request fails.

## Scope of changes

- `app/controllers/api/v1/imports_controller.rb`
  - In `create`, stop swallowing row-generation exceptions.
  - Add `clean_up_failed_csv_import(import)` helper to destroy failed persisted imports.
  - Return `500` JSON error when row generation fails.
- `test/controllers/api/v1/imports_controller_test.rb`
  - Add regression test: returns error and leaves no persisted import when row generation raises.

## Test plan

- [x] Added regression test for row-generation exception path in API create flow.
- [x] Verified response is `500 Internal Server Error`.
- [x] Verified response error code is `import_row_generation_failed`.
- [x] Verified failed import is cleaned up (`Import.count` does not increase).
- [x] Ran `bin/rails test test/controllers/api/v1/imports_controller_test.rb`.

## Risk and rollout notes

- API behavior change: clients that previously received false `201` on this failure path will now receive explicit `500` errors.
- This is expected and improves data integrity and client correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV import failures now properly clean up incomplete import records and return clear error responses to prevent orphaned data in the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/2035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->