### PR TITLE
feat(accounts): add full activity filters

### DIFF
--- a/app/components/UI/account/activity_feed.html.erb
+++ b/app/components/UI/account/activity_feed.html.erb
@@ -52,6 +52,8 @@
               scope: :q,
               method: :get,
               data: { controller: "auto-submit-form" } do |form| %>
+        <%= hidden_field_tag :tab, "activity" %>
+
         <div class="flex gap-2 mb-4">
           <div class="grow">
             <div class="flex items-center px-3 py-2 gap-2 border border-secondary rounded-lg focus-within:border-primary">
@@ -69,7 +71,7 @@
 
           <%= render DS::Popover.new(variant: "button", no_padding: true) do |popover| %>
             <% popover.with_button(
-              id: "activity-status-filter-button",
+              id: "activity-filters-button",
               type: "button",
               text: t("accounts.show.activity.filter"),
               variant: "outline",
@@ -77,44 +79,61 @@
             ) %>
 
             <% popover.with_custom_content do %>
-              <div class="p-3 space-y-3 min-w-[160px]">
-                <p class="text-xs font-medium text-secondary uppercase"><%= t("accounts.show.activity.status") %></p>
-                <div class="flex items-center gap-3">
-                  <%= check_box_tag "q[status][]",
-                                    "confirmed",
-                                    params.dig(:q, :status)&.include?("confirmed"),
-                                    id: "q_status_confirmed",
-                                    class: "checkbox checkbox--light",
-                                    form: "entries-search",
-                                    onchange: "document.getElementById('entries-search').requestSubmit()" %>
-                  <%= label_tag "q_status_confirmed", t("accounts.show.activity.confirmed"), class: "text-sm text-primary" %>
-                </div>
-                <div class="flex items-center gap-3">
-                  <%= check_box_tag "q[status][]",
-                                    "pending",
-                                    params.dig(:q, :status)&.include?("pending"),
-                                    id: "q_status_pending",
-                                    class: "checkbox checkbox--light",
-                                    form: "entries-search",
-                                    onchange: "document.getElementById('entries-search').requestSubmit()" %>
-                  <%= label_tag "q_status_pending", t("accounts.show.activity.pending"), class: "text-sm text-primary" %>
-                </div>
-              </div>
+              <%= render "transactions/searches/menu",
+                         form: form,
+                         filters: helpers.account_activity_search_filters,
+                         clear_filters_href: account_path(account, tab: "activity"),
+                         menu_id: "account-activity-filters-menu" %>
             <% end %>
           <% end %>
+
+          <%= button_tag type: "button",
+                id: "toggle-checkboxes-button",
+                aria: { label: t(".toggle_selection_checkboxes") },
+                class: "lg:hidden font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary border border-secondary hover:bg-surface-hover",
+                data: {
+                  action: "click->checkbox-toggle#toggle",
+                  checkbox_toggle_target: "toggleButton"
+                } do %>
+                <%= helpers.icon("list-todo") %>
+            <% end %>
+        </div>
       <% end %>
-      <%= button_tag type: "button",
-            id: "toggle-checkboxes-button",
-            aria: { label: t(".toggle_selection_checkboxes") },
-            class: "lg:hidden font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm text-primary border border-secondary hover:bg-surface-hover",
-            data: {
-              action: "click->checkbox-toggle#toggle",
-              checkbox_toggle_target: "toggleButton"
-            } do %>
-            <%= helpers.icon("list-todo") %>
-        <% end %>
-      </div>
     </div>
+
+    <ul id="account-activity-search-filters" class="flex items-center flex-wrap gap-2 mb-4">
+      <% q.reject { |key| key == "amount_operator" }.each do |param_key, param_value| %>
+        <% unless param_value.blank? %>
+          <% if param_key == "amount" %>
+            <% amount_operator = case q[:amount_operator]
+                                 when "equal"
+                                   t("transactions.searches.search.equal_to")
+                                 when "greater"
+                                   t("transactions.searches.search.greater_than")
+                                 when "less"
+                                   t("transactions.searches.search.less_than")
+                                 else
+                                   t("transactions.searches.search.#{q[:amount_operator]}", default: q[:amount_operator])
+                                 end %>
+            <%= render partial: "transactions/searches/filters/badge",
+                       locals: {
+                         param_key: "amount",
+                         param_value: "#{amount_operator} #{param_value}",
+                         clear_filter_path: clear_filter_account_path(account, param_key: "amount", param_value: param_value, **request.query_parameters)
+                       } %>
+          <% else %>
+            <% Array(param_value).each do |value| %>
+              <%= render partial: "transactions/searches/filters/badge",
+                         locals: {
+                           param_key: param_key,
+                           param_value: value,
+                           clear_filter_path: clear_filter_account_path(account, param_key: param_key, param_value: value, **request.query_parameters)
+                         } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </ul>
 
     <% if activity_dates.empty? %>
       <%= tag.p t("accounts.show.activity.no_entries"), class: "text-secondary text-sm p-4" %>

--- a/app/components/UI/account/activity_feed.rb
+++ b/app/components/UI/account/activity_feed.rb
@@ -1,10 +1,10 @@
 class UI::Account::ActivityFeed < ApplicationComponent
-  attr_reader :feed_data, :pagy, :search
+  attr_reader :feed_data, :pagy, :q
 
-  def initialize(feed_data:, pagy:, search: nil)
+  def initialize(feed_data:, pagy:, q: {})
     @feed_data = feed_data
     @pagy = pagy
-    @search = search
+    @q = q || {}
   end
 
   def id
@@ -31,5 +31,9 @@ class UI::Account::ActivityFeed < ApplicationComponent
   private
     def account
       feed_data.account
+    end
+
+    def search
+      q[:search]
     end
 end

--- a/app/components/UI/account_page.rb
+++ b/app/components/UI/account_page.rb
@@ -2,7 +2,7 @@ class UI::AccountPage < ApplicationComponent
   attr_reader :account, :chart_view, :chart_period, :statement_coverage, :statements, :reconciliation_statuses,
               :can_manage_statements
 
-  renders_one :activity_feed, ->(feed_data:, pagy:, search:) { UI::Account::ActivityFeed.new(feed_data: feed_data, pagy: pagy, search: search) }
+  renders_one :activity_feed, ->(feed_data:, pagy:, q:) { UI::Account::ActivityFeed.new(feed_data: feed_data, pagy: pagy, q: q) }
 
   def initialize(account:, chart_view: nil, chart_period: nil, active_tab: nil, statement_coverage: nil, statements: [],
                  reconciliation_statuses: {}, can_manage_statements: false)

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,7 +1,7 @@
 class AccountsController < ApplicationController
   include StreamExtensions
 
-  before_action :set_account, only: %i[show sparkline sync set_default remove_default]
+  before_action :set_account, only: %i[show sparkline sync set_default remove_default clear_filter]
   before_action :set_manageable_account, only: %i[toggle_active destroy unlink confirm_unlink select_provider]
   include Periodable
 
@@ -49,7 +49,7 @@ class AccountsController < ApplicationController
   def show
     @chart_view = params[:chart_view] || "balance"
     @tab = params[:tab]
-    @q = params.fetch(:q, {}).permit(:search, status: [])
+    @q = account_activity_search_params
     entries = @account.entries.where(excluded: false).search(@q).reverse_chronological.includes(:entryable)
     if statement_tab_active?
       build_statement_tab_data
@@ -82,6 +82,31 @@ class AccountsController < ApplicationController
     end
 
     redirect_to account_path(@account)
+  end
+
+  def clear_filter
+    updated_params = {
+      "tab" => "activity",
+      "q" => account_activity_search_params,
+      "page" => params[:page],
+      "per_page" => params[:per_page]
+    }
+
+    q_params = updated_params["q"] || {}
+    param_key = params[:param_key]
+    param_value = params[:param_value]
+
+    if q_params[param_key].is_a?(Array)
+      q_params[param_key].delete(param_value)
+      q_params.delete(param_key) if q_params[param_key].empty?
+    else
+      q_params.delete(param_key)
+      q_params.delete("amount_operator") if param_key == "amount"
+    end
+
+    updated_params["q"] = q_params.presence
+
+    redirect_to account_path(@account, updated_params)
   end
 
   def sparkline
@@ -221,6 +246,19 @@ class AccountsController < ApplicationController
 
     def set_account
       @account = Current.user.accessible_accounts.find(params[:id])
+    end
+
+    def account_activity_search_params
+      cleaned_params = params.fetch(:q, {})
+                            .permit(
+                              :start_date, :end_date, :search, :amount, :amount_operator,
+                              categories: [], merchants: [], types: [], tags: [], status: []
+                            )
+                            .to_h
+                            .compact_blank
+
+      cleaned_params.delete(:amount_operator) unless cleaned_params[:amount].present?
+      cleaned_params
     end
 
     def set_manageable_account

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -12,12 +12,16 @@ module TransactionsHelper
     ]
   end
 
+  def account_activity_search_filters
+    transaction_search_filters.reject { |filter| filter[:key] == "account_filter" }
+  end
+
   def get_transaction_search_filter_partial_path(filter)
     "transactions/searches/filters/#{filter[:key]}"
   end
 
-  def get_default_transaction_search_filter
-    transaction_search_filters[0]
+  def get_default_transaction_search_filter(filters = transaction_search_filters)
+    filters[0]
   end
 
   def in_split_group?(entry, params_grouped)

--- a/app/models/entry_search.rb
+++ b/app/models/entry_search.rb
@@ -5,12 +5,15 @@ class EntrySearch
   attribute :search, :string
   attribute :amount, :string
   attribute :amount_operator, :string
-  attribute :types, :string
+  attribute :types, array: true
   attribute :status, array: true
   attribute :accounts, array: true
   attribute :account_ids, array: true
   attribute :start_date, :string
   attribute :end_date, :string
+  attribute :categories, array: true
+  attribute :merchants, array: true
+  attribute :tags, array: true
 
   class << self
     def apply_search_filter(scope, search)
@@ -97,6 +100,88 @@ class EntrySearch
         scope
       end
     end
+
+    def apply_category_filter(scope, categories)
+      return scope unless categories.present?
+
+      all_uncategorized_names = Category.all_uncategorized_names
+      include_uncategorized = (categories & all_uncategorized_names).any?
+      real_categories = categories - all_uncategorized_names
+      parent_category_ids = Category.where(name: real_categories).pluck(:id)
+
+      query = scope.joins("LEFT JOIN categories ON categories.id = transactions.category_id")
+      uncategorized_condition = "categories.id IS NULL AND transactions.kind NOT IN (?)"
+
+      if parent_category_ids.empty?
+        if include_uncategorized
+          query.where(
+            "categories.name IN (?) OR (#{uncategorized_condition})",
+            real_categories.presence || [], Transaction::TRANSFER_KINDS
+          )
+        else
+          query.where(categories: { name: real_categories })
+        end
+      elsif include_uncategorized
+        query.where(
+          "categories.name IN (?) OR categories.parent_id IN (?) OR (#{uncategorized_condition})",
+          real_categories, parent_category_ids, Transaction::TRANSFER_KINDS
+        )
+      else
+        query.where(
+          "categories.name IN (?) OR categories.parent_id IN (?)",
+          real_categories, parent_category_ids
+        )
+      end
+    end
+
+    def apply_type_filter(scope, types)
+      return scope unless types.present?
+      return scope if types.sort == %w[expense income transfer]
+
+      case types.sort
+      when [ "transfer" ]
+        scope.where(transactions: { kind: Transaction::TRANSFER_KINDS })
+      when [ "expense" ]
+        scope.where("entries.amount >= 0").where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
+      when [ "income" ]
+        scope.where("entries.amount < 0").where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
+      when [ "expense", "transfer" ]
+        scope.where("entries.amount >= 0 OR transactions.kind IN (?)", Transaction::TRANSFER_KINDS)
+      when [ "income", "transfer" ]
+        scope.where("entries.amount < 0 OR transactions.kind IN (?)", Transaction::TRANSFER_KINDS)
+      when [ "expense", "income" ]
+        scope.where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
+      else
+        scope
+      end
+    end
+
+    def apply_merchant_filter(scope, merchants)
+      return scope unless merchants.present?
+
+      scope
+        .joins("INNER JOIN merchants ON merchants.id = transactions.merchant_id")
+        .where(merchants: { name: merchants })
+    end
+
+    def apply_tag_filter(scope, tags)
+      return scope unless tags.present?
+
+      scope.where(<<~SQL.squish, tags)
+        EXISTS (
+          SELECT 1
+          FROM taggings
+          INNER JOIN tags ON tags.id = taggings.tag_id
+          WHERE taggings.taggable_id = transactions.id
+            AND taggings.taggable_type = 'Transaction'
+            AND tags.name IN (?)
+        )
+      SQL
+    end
+
+    def apply_transaction_join(scope)
+      scope.joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+    end
   end
 
   def build_query(scope)
@@ -105,7 +190,25 @@ class EntrySearch
     query = self.class.apply_date_filters(query, start_date, end_date)
     query = self.class.apply_amount_filter(query, amount, amount_operator)
     query = self.class.apply_accounts_filter(query, accounts, account_ids)
+
+    if transaction_filters_present?
+      query = self.class.apply_transaction_join(query)
+      query = self.class.apply_category_filter(query, categories)
+      query = self.class.apply_type_filter(query, types)
+      query = self.class.apply_merchant_filter(query, merchants)
+      query = self.class.apply_tag_filter(query, tags)
+    end
+
     query = self.class.apply_status_filter(query, status)
     query
   end
+
+  private
+    def transaction_filters_present?
+      categories.present? || effective_type_filter_present? || merchants.present? || tags.present?
+    end
+
+    def effective_type_filter_present?
+      types.present? && types.sort != %w[expense income transfer]
+    end
 end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -8,5 +8,5 @@
       reconciliation_statuses: @statement_reconciliation_statuses,
       can_manage_statements: @can_manage_statements
     ) do |account_page| %>
-  <%= account_page.with_activity_feed(feed_data: @activity_feed_data, pagy: @pagy, search: @q[:search]) %>
+  <%= account_page.with_activity_feed(feed_data: @activity_feed_data, pagy: @pagy, q: @q) %>
 <% end %>

--- a/app/views/transactions/searches/_menu.html.erb
+++ b/app/views/transactions/searches/_menu.html.erb
@@ -1,14 +1,17 @@
-<%# locals: (form:) %>
+<%# locals: (form:, filters: transaction_search_filters, clear_filters_href: transactions_path(clear_filters: true), menu_id: "transaction-filters-menu") %>
+<% filters = local_assigns.fetch(:filters, transaction_search_filters) %>
+<% clear_filters_href = local_assigns.fetch(:clear_filters_href, transactions_path(clear_filters: true)) %>
+<% menu_id = local_assigns.fetch(:menu_id, "transaction-filters-menu") %>
 
 <%= render DS::Tabs.new(
   variant: :unstyled,
-  active_tab: get_default_transaction_search_filter[:key],
+  active_tab: get_default_transaction_search_filter(filters)[:key],
   active_btn_classes: "bg-surface text-primary",
   inactive_btn_classes: "text-secondary hover:bg-container-inset"
 ) do |tabs| %>
-  <div id="transaction-filters-menu" class="flex flex-col md:flex-row h-[50vh] lg:max-h-auto z-10 md:h-80 w-full md:w-[540px] top-12 right-0 overflow-hidden">
+  <div id="<%= menu_id %>" class="flex flex-col md:flex-row h-[50vh] lg:max-h-auto z-10 md:h-80 w-full md:w-[540px] top-12 right-0 overflow-hidden">
     <%= tabs.with_nav(classes: "shrink-0 flex w-full md:w-44 flex-row md:flex-col items-start p-3 text-sm font-medium text-secondary border-b md:border-b-0 md:border-r border-secondary overflow-x-auto md:overflow-x-visible") do |nav| %>
-      <% transaction_search_filters.each do |filter| %>
+      <% filters.each do |filter| %>
         <%= nav.with_btn(id: filter[:key], label: filter[:label], classes: "w-full px-3 py-2 flex gap-2 items-center rounded-md") do %>
           <%= icon(filter[:icon]) %>
           <%= tag.span(filter[:label], class: "text-sm font-medium") %>
@@ -18,7 +21,7 @@
 
     <div class="flex flex-col grow overflow-y-auto">
       <div class="grow p-3 border-b border-secondary overflow-y-auto">
-        <% transaction_search_filters.each do |filter| %>
+        <% filters.each do |filter| %>
           <%= tabs.with_panel(tab_id: filter[:key]) do %>
             <%= render partial: get_transaction_search_filter_partial_path(filter), locals: { form: form } %>
           <% end %>
@@ -31,7 +34,7 @@
             <%= render DS::Link.new(
             text: t(".clear_filters"),
             variant: "ghost",
-            href: transactions_path(clear_filters: true),
+            href: clear_filters_href,
           ) %>
           <% end %>
         </div>

--- a/app/views/transactions/searches/filters/_badge.html.erb
+++ b/app/views/transactions/searches/filters/_badge.html.erb
@@ -1,4 +1,5 @@
-<%# locals: (param_key:, param_value:) %>
+<%# locals: (param_key:, param_value:, clear_filter_path: nil) %>
+<% clear_filter_path = local_assigns[:clear_filter_path] %>
 <li class="flex items-center gap-1 text-sm border border-secondary rounded-3xl p-1.5">
   <% if param_key == "start_date" || param_key == "end_date" %>
     <div class="flex items-center gap-2">
@@ -46,7 +47,7 @@
     </div>
   <% end %>
 
-  <%= button_to clear_filter_transactions_path(param_key: param_key, param_value: param_value, **request.query_parameters),
+  <%= button_to clear_filter_path || clear_filter_transactions_path(param_key: param_key, param_value: param_value, **request.query_parameters),
         method: :delete,
         data: { turbo: false },
         class: "flex items-center cursor-pointer" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -426,6 +426,7 @@ Rails.application.routes.draw do
       patch :toggle_active
       patch :set_default
       patch :remove_default
+      delete :clear_filter
       get :select_provider
       get :confirm_unlink
       delete :unlink

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class AccountsControllerTest < ActionDispatch::IntegrationTest
   include ActionView::RecordIdentifier
+  include EntriesTestHelper
 
   setup do
     sign_in @user = users(:family_admin)
@@ -150,6 +151,114 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "##{dom_id(entry.entryable, "category_menu_desktop")} button.overflow-hidden"
     assert_select "##{dom_id(entry.entryable, "category_menu_desktop")} [data-testid='category-name']"
     assert_select "div.hidden.md\\:flex.min-w-0"
+  end
+
+  test "account activity filters by transaction attributes within the current account" do
+    @user.family.accounts.each { |account| account.entries.delete_all }
+    matching = create_transaction(
+      account: @account,
+      name: "Matching account activity",
+      date: Date.new(2026, 5, 20),
+      amount: 42,
+      category: categories(:food_and_drink),
+      merchant: merchants(:netflix),
+      tags: [ tags(:one) ],
+      kind: "standard"
+    )
+    create_transaction(
+      account: @account,
+      name: "Wrong category",
+      date: Date.new(2026, 5, 20),
+      amount: 42,
+      category: categories(:income),
+      merchant: merchants(:netflix),
+      tags: [ tags(:one) ],
+      kind: "standard"
+    )
+    other_account_entry = create_transaction(
+      account: accounts(:credit_card),
+      name: "Other account match",
+      date: Date.new(2026, 5, 20),
+      amount: 42,
+      category: categories(:food_and_drink),
+      merchant: merchants(:netflix),
+      tags: [ tags(:one) ],
+      kind: "standard"
+    )
+
+    get account_url(@account, tab: "activity", q: {
+      start_date: "2026-05-01",
+      end_date: "2026-05-31",
+      types: [ "expense" ],
+      categories: [ "Food & Drink" ],
+      merchants: [ "Netflix" ],
+      tags: [ "Trips" ]
+    })
+
+    assert_response :success
+    assert_select "##{dom_id(matching)}", count: 1
+    assert_select "##{dom_id(other_account_entry)}", count: 0
+    assert_select "turbo-frame[id^='entry_']", count: 1
+  end
+
+  test "account activity status filter supports pending transactions" do
+    @user.family.accounts.each { |account| account.entries.delete_all }
+    pending = create_transaction(account: @account, name: "Pending transaction")
+    pending.entryable.update!(extra: { "simplefin" => { "pending" => true } })
+    confirmed = create_transaction(account: @account, name: "Confirmed transaction")
+
+    get account_url(@account, tab: "activity", q: { status: [ "pending" ] })
+
+    assert_response :success
+    assert_select "##{dom_id(pending)}", count: 1
+    assert_select "##{dom_id(confirmed)}", count: 0
+  end
+
+  test "account activity filter menu shows transaction filters without account filter" do
+    get account_url(@account, tab: "activity")
+
+    assert_response :success
+    assert_select "#account-activity-filters-menu" do
+      assert_select "button", text: "Date"
+      assert_select "button", text: "Type"
+      assert_select "button", text: "Status"
+      assert_select "button", text: "Amount"
+      assert_select "button", text: "Category"
+      assert_select "button", text: "Tag"
+      assert_select "button", text: "Merchant"
+      assert_select "button", text: "Account", count: 0
+    end
+  end
+
+  test "account activity shows active filter badges" do
+    get account_url(@account, tab: "activity", q: { categories: [ "Food & Drink" ], tags: [ "Trips" ] })
+
+    assert_response :success
+    assert_select "#account-activity-search-filters", text: /Food & Drink/
+    assert_select "#account-activity-search-filters", text: /Trips/
+  end
+
+  test "clears one account activity filter value and preserves remaining filters" do
+    delete clear_filter_account_url(
+      @account,
+      tab: "activity",
+      param_key: "tags",
+      param_value: "Trips",
+      q: { categories: [ "Food & Drink" ], tags: [ "Trips", "Emergency fund" ] }
+    )
+
+    assert_redirected_to account_url(
+      @account,
+      tab: "activity",
+      q: { "categories" => [ "Food & Drink" ], "tags" => [ "Emergency fund" ] }
+    )
+  end
+
+  test "clears all account activity filters from menu link" do
+    get account_url(@account, tab: "activity", q: { categories: [ "Food & Drink" ] })
+
+    assert_response :success
+    assert_select "a[href='#{account_path(@account, tab: "activity")}']", text: "Clear filters"
   end
 
   test "should sync account" do

--- a/test/models/entry_search_test.rb
+++ b/test/models/entry_search_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class EntrySearchTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:dylan_family)
+    @account = accounts(:depository)
+    @other_account = accounts(:credit_card)
+    @family.accounts.each { |account| account.entries.delete_all }
+  end
+
+  test "filters account-scoped entries by transaction category" do
+    matching = create_transaction(account: @account, name: "Food", category: categories(:food_and_drink))
+    other_category = create_transaction(account: @account, name: "Other", category: categories(:income))
+    other_account = create_transaction(account: @other_account, name: "Other account food", category: categories(:food_and_drink))
+    create_valuation(account: @account, name: "Balance")
+
+    results = @account.entries.search(categories: [ "Food & Drink" ])
+
+    assert_includes results, matching
+    assert_not_includes results, other_category
+    assert_not_includes results, other_account
+  end
+
+  test "filters account-scoped entries by transaction type" do
+    expense = create_transaction(account: @account, name: "Expense", amount: 100, kind: "standard")
+    income = create_transaction(account: @account, name: "Income", amount: -100, kind: "standard")
+    transfer = create_transaction(account: @account, name: "Transfer", amount: 50, kind: "funds_movement")
+    create_valuation(account: @account, name: "Balance")
+
+    results = @account.entries.search(types: [ "expense" ])
+
+    assert_includes results, expense
+    assert_not_includes results, income
+    assert_not_includes results, transfer
+  end
+
+  test "filters account-scoped entries by merchant" do
+    matching = create_transaction(account: @account, name: "Netflix", merchant: merchants(:netflix))
+    other_merchant = create_transaction(account: @account, name: "Amazon", merchant: merchants(:amazon))
+    other_account = create_transaction(account: @other_account, name: "Other Netflix", merchant: merchants(:netflix))
+
+    results = @account.entries.search(merchants: [ "Netflix" ])
+
+    assert_includes results, matching
+    assert_not_includes results, other_merchant
+    assert_not_includes results, other_account
+  end
+
+  test "filters account-scoped entries by tag without duplicating entries" do
+    matching = create_transaction(account: @account, name: "Tagged", tags: [ tags(:one), tags(:two) ])
+    other_tag = create_transaction(account: @account, name: "Other tag", tags: [ tags(:three) ])
+    other_account = create_transaction(account: @other_account, name: "Other account tagged", tags: [ tags(:one) ])
+
+    results = @account.entries.search(tags: [ "Trips", "Emergency fund" ])
+
+    assert_equal [ matching.id ], results.pluck(:id)
+    assert_not_includes results, other_tag
+    assert_not_includes results, other_account
+  end
+end

--- a/test/system/account_activity_test.rb
+++ b/test/system/account_activity_test.rb
@@ -99,6 +99,23 @@ class AccountActivityTest < ApplicationSystemTestCase
     assert metrics["categoryOverflow"]
   end
 
+  test "account activity filter menu shows transaction filters without account filter" do
+    visit account_url(@account, tab: "activity")
+
+    click_button "Filter"
+
+    within "#account-activity-filters-menu" do
+      assert_button "Date"
+      assert_button "Type"
+      assert_button "Status"
+      assert_button "Amount"
+      assert_button "Category"
+      assert_button "Tag"
+      assert_button "Merchant"
+      assert_no_button "Account"
+    end
+  end
+
   private
     def ensure_tailwind_build
       return if self.class.instance_variable_defined?(:@tailwind_css_built)


### PR DESCRIPTION
Addresses #1480 , where the account activity view was missing the richer filtering available on the main transactions page.

I wanted the **account page** to feel closer to the main **transactions page** when reviewing activity. Before this, the account activity view only had a small status filter, so filtering by date, category, tag, merchant, type, or amount meant going back to the global transactions page.

This brings the **transactions filter** into the account activity view, while keeping it scoped to the account being viewed. The **account selector is intentionally omitted** on the single-account page, and active filter badges now show below the search field so it’s easy to see and clear what’s applied.

## Screenshots

### Account activity filter menu
<img width="636" height="530" alt="image" src="https://github.com/user-attachments/assets/7094b6aa-72cf-4ce6-8591-eea5cc3e19ea" />

The filter menu now matches the main transactions filter options, but excludes the **Account** tab because this page is already scoped to one account.

### Applied account activity filters
<img width="598" height="580" alt="image" src="https://github.com/user-attachments/assets/7f3887f7-94ef-41ab-a9a1-00b613d8e8fc" />

Applied filters appear as badges below the search field, making it clear why the account activity list is narrowed and allowing each filter to be cleared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applied search filters now display as removable badges in the activity feed for improved visibility and management.
  * Expanded filtering options to include category, merchant, tag, and transaction type in addition to existing filters.
  * Individual filters can be cleared independently while preserving other active filter selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/2041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->