### PR TITLE
fix: request OIDC groups claims explicitly

### DIFF
--- a/app/services/oidc/provider_options_builder.rb
+++ b/app/services/oidc/provider_options_builder.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Oidc
+  class ProviderOptionsBuilder
+    DEFAULT_SCOPES = %i[openid email profile].freeze
+
+    class << self
+      def call(raw_cfg, env: ENV, rails_env: Rails.env, ssl_config: Rails.configuration.x.ssl)
+        cfg = raw_cfg.deep_symbolize_keys
+        name = (cfg[:name] || cfg[:id]).to_s
+
+        issuer = cfg[:issuer].presence || env["OIDC_ISSUER"].presence
+        client_id = cfg[:client_id].presence || env["OIDC_CLIENT_ID"].presence
+        client_secret = cfg[:client_secret].presence || env["OIDC_CLIENT_SECRET"].presence
+        redirect_uri = cfg[:redirect_uri].presence || env["OIDC_REDIRECT_URI"].presence
+
+        if rails_env.test?
+          issuer ||= "https://test.example.com"
+          client_id ||= "test_client_id"
+          client_secret ||= "test_client_secret"
+          redirect_uri ||= "http://test.example.com/callback"
+        end
+
+        return nil unless issuer.present? && client_id.present? && client_secret.present? && redirect_uri.present?
+
+        scopes = oidc_scopes(cfg)
+
+        options = {
+          name: name.to_sym,
+          scope: scopes,
+          response_type: :code,
+          issuer: issuer.to_s.strip,
+          discovery: true,
+          pkce: true,
+          client_options: {
+            identifier: client_id,
+            secret: client_secret,
+            redirect_uri: redirect_uri,
+            ssl: ssl_options(ssl_config)
+          }
+        }
+
+        prompt = cfg.dig(:settings, :prompt).presence
+        options[:prompt] = prompt if prompt.present?
+
+        extra_authorize_params = oidc_extra_authorize_params(cfg, scopes)
+        options[:extra_authorize_params] = extra_authorize_params if extra_authorize_params.present?
+
+        options
+      end
+
+      def oidc_scopes(cfg)
+        custom_scopes = cfg.dig(:settings, :scopes).presence
+        return DEFAULT_SCOPES unless custom_scopes.present?
+
+        custom_scopes.to_s.split(/\s+/).map(&:to_sym)
+      end
+
+      def oidc_extra_authorize_params(cfg, scopes = oidc_scopes(cfg))
+        return {} unless request_groups_claim?(cfg, scopes)
+
+        {
+          claims: JSON.generate(
+            id_token: { groups: { essential: true } },
+            userinfo: { groups: { essential: true } }
+          )
+        }
+      end
+
+      def request_groups_claim?(cfg, scopes = oidc_scopes(cfg))
+        scopes.map(&:to_s).include?("groups") || role_mapping(cfg).present?
+      end
+
+      private
+        def role_mapping(cfg)
+          cfg.dig(:settings, :role_mapping).presence || cfg.dig(:settings, "role_mapping").presence
+        end
+
+        def ssl_options(ssl_config)
+          ssl_opts = {}
+          ssl_opts[:ca_file] = ssl_config.ca_file if ssl_config&.ca_file.present?
+          ssl_opts[:verify] = false if ssl_config&.verify == false
+          ssl_opts
+        end
+    end
+  end
+end

--- a/app/services/oidc/provider_options_builder.rb
+++ b/app/services/oidc/provider_options_builder.rb
@@ -53,7 +53,7 @@ module Oidc
         custom_scopes = cfg.dig(:settings, :scopes).presence
         return DEFAULT_SCOPES unless custom_scopes.present?
 
-        custom_scopes.to_s.split(/\s+/).map(&:to_sym)
+        custom_scopes.to_s.split.map(&:to_sym)
       end
 
       def oidc_extra_authorize_params(cfg, scopes = oidc_scopes(cfg))
@@ -61,8 +61,8 @@ module Oidc
 
         {
           claims: JSON.generate(
-            id_token: { groups: { essential: true } },
-            userinfo: { groups: { essential: true } }
+            id_token: { groups: nil },
+            userinfo: { groups: nil }
           )
         }
       end
@@ -73,7 +73,7 @@ module Oidc
 
       private
         def role_mapping(cfg)
-          cfg.dig(:settings, :role_mapping).presence || cfg.dig(:settings, "role_mapping").presence
+          cfg.dig(:settings, :role_mapping).presence
         end
 
         def ssl_options(ssl_config)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -38,64 +38,17 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
     case strategy
     when "openid_connect"
-      # Support per-provider credentials from config or fall back to global ENV vars
-      issuer = cfg[:issuer].presence || ENV["OIDC_ISSUER"].presence
-      client_id = cfg[:client_id].presence || ENV["OIDC_CLIENT_ID"].presence
-      client_secret = cfg[:client_secret].presence || ENV["OIDC_CLIENT_SECRET"].presence
-      redirect_uri = cfg[:redirect_uri].presence || ENV["OIDC_REDIRECT_URI"].presence
+      oidc_options = Oidc::ProviderOptionsBuilder.call(cfg)
 
-      # In test environment, use test values if nothing is configured
-      if Rails.env.test?
-        issuer ||= "https://test.example.com"
-        client_id ||= "test_client_id"
-        client_secret ||= "test_client_secret"
-        redirect_uri ||= "http://test.example.com/callback"
-      end
-
-      # Skip if required fields are missing (except in test)
-      unless issuer.present? && client_id.present? && client_secret.present? && redirect_uri.present?
+      unless oidc_options.present?
         Rails.logger.warn("[OmniAuth] Skipping OIDC provider '#{name}' - missing required configuration")
         next
       end
 
-      # Custom scopes: parse from settings if provided, otherwise use defaults
-      custom_scopes = cfg.dig(:settings, :scopes).presence
-      scopes = if custom_scopes.present?
-        custom_scopes.to_s.split(/\s+/).map(&:to_sym)
-      else
-        %i[openid email profile]
-      end
-
-      # Build provider options
-      oidc_options = {
-        name: name.to_sym,
-        scope: scopes,
-        response_type: :code,
-        issuer: issuer.to_s.strip,
-        discovery: true,
-        pkce: true,
-        client_options: {
-          identifier: client_id,
-          secret: client_secret,
-          redirect_uri: redirect_uri,
-          ssl: begin
-                 ssl_config = Rails.configuration.x.ssl
-                 ssl_opts = {}
-                 ssl_opts[:ca_file] = ssl_config.ca_file if ssl_config&.ca_file.present?
-                 ssl_opts[:verify] = false if ssl_config&.verify == false
-                 ssl_opts
-               end
-        }
-      }
-
-      # Add prompt parameter if configured
-      prompt = cfg.dig(:settings, :prompt).presence
-      oidc_options[:prompt] = prompt if prompt.present?
-
       provider :openid_connect, oidc_options
 
       Rails.configuration.x.auth.oidc_enabled = true
-      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name, issuer: issuer)
+      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name, issuer: oidc_options[:issuer])
 
     when "google_oauth2"
       client_id = cfg[:client_id].presence || ENV["GOOGLE_OAUTH_CLIENT_ID"].presence

--- a/test/services/oidc/provider_options_builder_test.rb
+++ b/test/services/oidc/provider_options_builder_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+module Oidc
+  class ProviderOptionsBuilderTest < ActiveSupport::TestCase
+    test "uses default scopes when custom scopes are blank" do
+      options = ProviderOptionsBuilder.call(base_config)
+
+      assert_equal %i[openid email profile], options[:scope]
+      assert_nil options[:extra_authorize_params]
+    end
+
+    test "requests groups claim when groups scope is configured" do
+      options = ProviderOptionsBuilder.call(base_config(settings: { scopes: "openid email profile groups" }))
+
+      claims = JSON.parse(options.dig(:extra_authorize_params, :claims))
+      assert_equal({ "essential" => true }, claims.dig("id_token", "groups"))
+      assert_equal({ "essential" => true }, claims.dig("userinfo", "groups"))
+    end
+
+    test "requests groups claim when role mapping is configured" do
+      options = ProviderOptionsBuilder.call(base_config(settings: {
+        role_mapping: { member: [ "sure-members" ] }
+      }))
+
+      claims = JSON.parse(options.dig(:extra_authorize_params, :claims))
+      assert_equal({ "essential" => true }, claims.dig("id_token", "groups"))
+      assert_equal({ "essential" => true }, claims.dig("userinfo", "groups"))
+    end
+
+    test "includes configured prompt" do
+      options = ProviderOptionsBuilder.call(base_config(settings: { prompt: "login" }))
+
+      assert_equal "login", options[:prompt]
+    end
+
+    private
+      def base_config(overrides = {})
+        {
+          name: "openid_connect",
+          strategy: "openid_connect",
+          issuer: "https://idp.example.com",
+          client_id: "client-id",
+          client_secret: "client-secret",
+          redirect_uri: "https://sure.example.com/auth/openid_connect/callback",
+          settings: {}
+        }.deep_merge(overrides)
+      end
+  end
+end

--- a/test/services/oidc/provider_options_builder_test.rb
+++ b/test/services/oidc/provider_options_builder_test.rb
@@ -13,8 +13,10 @@ module Oidc
       options = ProviderOptionsBuilder.call(base_config(settings: { scopes: "openid email profile groups" }))
 
       claims = JSON.parse(options.dig(:extra_authorize_params, :claims))
-      assert_equal({ "essential" => true }, claims.dig("id_token", "groups"))
-      assert_equal({ "essential" => true }, claims.dig("userinfo", "groups"))
+      assert_nil claims.dig("id_token", "groups")
+      assert_nil claims.dig("userinfo", "groups")
+      assert_equal ["groups"], claims["id_token"].keys
+      assert_equal ["groups"], claims["userinfo"].keys
     end
 
     test "requests groups claim when role mapping is configured" do
@@ -23,8 +25,26 @@ module Oidc
       }))
 
       claims = JSON.parse(options.dig(:extra_authorize_params, :claims))
-      assert_equal({ "essential" => true }, claims.dig("id_token", "groups"))
-      assert_equal({ "essential" => true }, claims.dig("userinfo", "groups"))
+      assert_nil claims.dig("id_token", "groups")
+      assert_nil claims.dig("userinfo", "groups")
+      assert_equal ["groups"], claims["id_token"].keys
+      assert_equal ["groups"], claims["userinfo"].keys
+    end
+
+    test "discards blank scope tokens from surrounding whitespace" do
+      options = ProviderOptionsBuilder.call(base_config(settings: { scopes: "  openid   email profile groups  " }))
+
+      assert_equal %i[openid email profile groups], options[:scope]
+    end
+
+    test "returns nil when required configuration is missing" do
+      config = base_config.except(:client_secret)
+
+      assert_nil ProviderOptionsBuilder.call(
+        config,
+        env: {},
+        rails_env: ActiveSupport::StringInquirer.new("production")
+      )
     end
 
     test "includes configured prompt" do


### PR DESCRIPTION
## Summary
- extract OIDC provider option building into a dedicated builder
- send an explicit OIDC `claims` authorize param for `groups` when Sure is configured to use group claims
- keep existing scope/prompt handling intact and cover the new behavior with tests

## Why
Some providers (including Authelia setups) do not return the `groups` claim based on scope alone. Sure already supports mapping IdP groups to roles, but it was not explicitly requesting the `groups` claim in the authorization request.

## Testing
- `bin/rails test test/services/oidc/provider_options_builder_test.rb test/models/oidc_identity_test.rb test/models/sso_provider_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined OIDC authentication setup: unified option construction, improved scope handling, optional group-claims support, role-mapping integration, and stronger discovery/PKCE behavior.

* **Tests**
  * Added comprehensive tests covering scope parsing, group-claims construction, prompt handling, and missing-configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->