### PR TITLE
ci(preview): split PR image builds from trusted deploys

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,9 +2,54 @@ name: Pull Request
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - 'charts/**'
+
+permissions:
+  contents: read
 
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
+
+  preview_image:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
+    name: Build Cloudflare preview image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      IMAGE_TAG: sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Build preview image without secrets
+        run: |
+          set -euo pipefail
+
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}" \
+            -f Dockerfile.preview \
+            -t "${IMAGE_TAG}" \
+            .
+
+          docker image inspect "${IMAGE_TAG}" >/dev/null
+          docker save "${IMAGE_TAG}" | gzip -1 > "$RUNNER_TEMP/sure-preview-image.tar.gz"
+
+      - name: Upload preview image artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}
+          path: ${{ runner.temp }}/sure-preview-image.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - 'charts/**'
 
@@ -11,3 +12,50 @@ permissions:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
+
+  preview_image:
+    needs: ci
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
+    name: Build Cloudflare preview image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      IMAGE_TAG: sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Build preview image without secrets
+        run: |
+          set -euo pipefail
+
+          image_archive="$RUNNER_TEMP/sure-preview-image.tar.gz"
+
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}" \
+            -f Dockerfile.preview \
+            -t "${IMAGE_TAG}" \
+            .
+
+          docker image inspect "${IMAGE_TAG}" >/dev/null
+          docker save "${IMAGE_TAG}" | gzip -1 > "$image_archive"
+          sha256sum "$image_archive" | awk '{print $1}' > "$RUNNER_TEMP/sure-preview-image.sha256"
+
+      - name: Upload preview image artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}
+          path: |
+            ${{ runner.temp }}/sure-preview-image.tar.gz
+            ${{ runner.temp }}/sure-preview-image.sha256
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: Pull Request
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - 'charts/**'
 
@@ -12,44 +11,3 @@ permissions:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
-
-  preview_image:
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
-    name: Build Cloudflare preview image
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      IMAGE_TAG: sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}
-    steps:
-      - name: Checkout PR code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          persist-credentials: false
-
-      - name: Build preview image without secrets
-        run: |
-          set -euo pipefail
-
-          docker build \
-            --platform linux/amd64 \
-            --build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}" \
-            -f Dockerfile.preview \
-            -t "${IMAGE_TAG}" \
-            .
-
-          docker image inspect "${IMAGE_TAG}" >/dev/null
-          docker save "${IMAGE_TAG}" | gzip -1 > "$RUNNER_TEMP/sure-preview-image.tar.gz"
-
-      - name: Upload preview image artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}
-          path: ${{ runner.temp }}/sure-preview-image.tar.gz
-          if-no-files-found: error
-          retention-days: 1

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,12 +1,9 @@
 name: Deploy PR Preview
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
-    paths-ignore:
-      - 'charts/**'
-      - 'docs/**'
-      - '*.md'
+  workflow_run:
+    workflows: ["Pull Request"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -14,25 +11,57 @@ permissions:
 jobs:
   preview-gate:
     if: |
-      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     name: Validate preview deployment gates
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
       pull-requests: read
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    outputs:
+      artifact_name: ${{ steps.preview.outputs.artifact_name }}
+      head_sha: ${{ steps.preview.outputs.head_sha }}
+      pr_number: ${{ steps.preview.outputs.pr_number }}
+      should_deploy: ${{ steps.preview.outputs.should_deploy }}
 
     steps:
-      - name: Verify trusted CI workflow definitions
+      - name: Resolve preview request
+        id: preview
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const prNumber = Number(process.env.PR_NUMBER);
+            const workflowRun = context.payload.workflow_run;
+            const runPr = workflowRun.pull_requests?.[0];
+
+            core.setOutput('should_deploy', 'false');
+
+            if (!runPr) {
+              core.info('Workflow run is not associated with a pull request');
+              return;
+            }
+
+            const prNumber = runPr.number;
+            const headSha = workflowRun.head_sha;
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (pullRequest.head.sha !== headSha) {
+              core.setFailed(`Workflow run head SHA ${headSha} does not match PR head ${pullRequest.head.sha}`);
+              return;
+            }
+
+            const hasPreviewLabel = pullRequest.labels.some((label) => label.name === 'preview-cf');
+            if (!hasPreviewLabel) {
+              core.info(`PR ${prNumber} does not have the preview-cf label`);
+              return;
+            }
+
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -45,124 +74,53 @@ jobs:
 
             if (workflowChanges.length > 0) {
               core.setFailed(`Preview deployment requires base-trusted workflow definitions; changed workflow files: ${workflowChanges.join(', ')}`);
+              return;
             }
 
-      - name: Wait for PR CI
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            const prNumber = Number(process.env.PR_NUMBER);
-            const headSha = process.env.HEAD_SHA;
-            const timeoutMs = 30 * 60 * 1000;
-            const pollMs = 15 * 1000;
-            const startedAt = Date.now();
-            let lastState = 'not found';
+            const artifactName = `preview-image-pr-${prNumber}-${headSha}`;
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: workflowRun.id,
+              per_page: 100,
+            });
+            const artifact = artifacts.find((item) => item.name === artifactName && !item.expired);
 
-            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-            while (Date.now() - startedAt < timeoutMs) {
-              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                event: 'pull_request',
-                head_sha: headSha,
-                per_page: 20,
-              });
-
-              const runs = data.workflow_runs
-                .filter((run) => run.name === 'Pull Request' && run.head_sha === headSha)
-                .filter((run) => run.pull_requests?.some((pr) => pr.number === prNumber))
-                .sort((left, right) => right.run_number - left.run_number);
-              const prRun = runs[0];
-
-              if (prRun) {
-                lastState = `${prRun.id}: ${prRun.status}/${prRun.conclusion ?? 'pending'}`;
-                core.info(`Pull Request workflow ${lastState}`);
-
-                if (prRun.status === 'completed') {
-                  if (prRun.conclusion === 'success') {
-                    return;
-                  }
-
-                  core.setFailed(`Pull Request workflow concluded with ${prRun.conclusion}`);
-                  return;
-                }
-              }
-
-              await sleep(pollMs);
+            if (!artifact) {
+              core.setFailed(`Pull Request workflow run ${workflowRun.id} did not publish ${artifactName}`);
+              return;
             }
 
-            core.setFailed(`Timed out waiting for Pull Request workflow for ${headSha}. Last state: ${lastState}`);
-
-  preview-image:
-    needs: preview-gate
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
-    name: Build Cloudflare preview image
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      IMAGE_TAG: sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}
-    steps:
-      - name: Checkout PR code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-
-      - name: Build preview image without secrets
-        run: |
-          set -euo pipefail
-
-          docker build \
-            --platform linux/amd64 \
-            --build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}" \
-            -f Dockerfile.preview \
-            -t "${IMAGE_TAG}" \
-            .
-
-          docker image inspect "${IMAGE_TAG}" >/dev/null
-          docker save "${IMAGE_TAG}" | gzip -1 > "$RUNNER_TEMP/sure-preview-image.tar.gz"
-
-      - name: Upload preview image artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}
-          path: ${{ runner.temp }}/sure-preview-image.tar.gz
-          if-no-files-found: error
-          retention-days: 3
+            core.setOutput('artifact_name', artifactName);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('should_deploy', 'true');
 
   deploy-preview:
-    needs: [preview-gate, preview-image]
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
+    needs: preview-gate
+    if: needs.preview-gate.outputs.should_deploy == 'true'
     name: Deploy to Cloudflare Containers
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:
-      group: preview-deploy-${{ github.event.pull_request.number }}
+      group: preview-deploy-${{ needs.preview-gate.outputs.pr_number }}
       cancel-in-progress: true
     environment: preview
     permissions:
+      actions: read
       contents: read
       pull-requests: write
       deployments: write
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      ARTIFACT_NAME: ${{ needs.preview-gate.outputs.artifact_name }}
+      HEAD_SHA: ${{ needs.preview-gate.outputs.head_sha }}
+      PR_NUMBER: ${{ needs.preview-gate.outputs.pr_number }}
 
     steps:
       - name: Checkout trusted preview tooling
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           path: trusted
           persist-credentials: false
           sparse-checkout: |
@@ -171,8 +129,28 @@ jobs:
       - name: Download preview image artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
-          name: preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}
+          name: ${{ env.ARTIFACT_NAME }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
           path: ${{ runner.temp }}/preview-image
+
+      - name: Verify preview image artifact checksum
+        run: |
+          set -euo pipefail
+
+          image_archive="$RUNNER_TEMP/preview-image/sure-preview-image.tar.gz"
+          checksum_file="$RUNNER_TEMP/preview-image/sure-preview-image.sha256"
+
+          test -f "$image_archive"
+          test -f "$checksum_file"
+
+          expected_checksum="$(tr -d '[:space:]' < "$checksum_file")"
+          actual_checksum="$(sha256sum "$image_archive" | awk '{print $1}')"
+
+          if [ "$expected_checksum" != "$actual_checksum" ]; then
+            echo "Preview image artifact checksum mismatch" >&2
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -206,15 +184,14 @@ jobs:
           image_archive="$RUNNER_TEMP/preview-image/sure-preview-image.tar.gz"
           expected_image="sure-preview-pr-${PR_NUMBER}:${HEAD_SHA}"
 
-          test -f "$image_archive"
           gzip -dc "$image_archive" | docker load
           docker image inspect "$expected_image" >/dev/null
 
       - name: Push preview image to Cloudflare registry
         id: image
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -223,7 +200,9 @@ jobs:
           push_log="$RUNNER_TEMP/wrangler-containers-push.log"
           clean_log="$RUNNER_TEMP/wrangler-containers-push.clean.log"
 
-          ./node_modules/.bin/wrangler containers push "$image_tag" 2>&1 | tee "$push_log"
+          CLOUDFLARE_API_TOKEN="$CF_API_TOKEN" \
+            CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID" \
+            ./node_modules/.bin/wrangler containers push "$image_tag" 2>&1 | tee "$push_log"
           perl -pe 's/\e\[[0-9;]*[A-Za-z]//g' "$push_log" > "$clean_log"
           image_ref=$(grep -Eo 'registry\.cloudflare\.com/[^[:space:]]+' "$clean_log" | tail -n 1 | tr -d '\r')
 
@@ -284,14 +263,16 @@ jobs:
       - name: Deploy to Cloudflare Containers
         id: deploy
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_WORKERS_SUBDOMAIN: ${{ secrets.CLOUDFLARE_WORKERS_SUBDOMAIN }}
         run: |
           set -euo pipefail
 
           cd "$RUNNER_TEMP/sure-preview-worker"
-          ./node_modules/.bin/wrangler deploy --config wrangler.toml --var "PR_NUMBER:${PR_NUMBER}"
+          CLOUDFLARE_API_TOKEN="$CF_API_TOKEN" \
+            CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID" \
+            ./node_modules/.bin/wrangler deploy --config wrangler.toml --var "PR_NUMBER:${PR_NUMBER}"
 
           # Get the deployment URL
           PREVIEW_URL="https://sure-preview-${PR_NUMBER}.${CLOUDFLARE_WORKERS_SUBDOMAIN}.workers.dev"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy PR Preview
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - 'charts/**'
@@ -15,7 +15,7 @@ jobs:
       (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
     name: Deploy to Cloudflare Containers
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     concurrency:
       group: preview-deploy-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -31,12 +31,15 @@ jobs:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
-      - name: Wait for PR CI to pass
+      - name: Wait for PR CI and preview image
+        id: pr_ci
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
+            const prNumber = process.env.PR_NUMBER;
             const headSha = process.env.HEAD_SHA;
-            const timeoutMs = 10 * 60 * 1000;
+            const artifactName = `preview-image-pr-${prNumber}-${headSha}`;
+            const timeoutMs = 30 * 60 * 1000;
             const pollMs = 15 * 1000;
             const startedAt = Date.now();
             let lastState = 'not found';
@@ -52,32 +55,44 @@ jobs:
                 per_page: 20,
               });
 
-              const prRun = data.workflow_runs.find((run) => run.name === 'Pull Request' && run.head_sha === headSha);
+              const runs = data.workflow_runs
+                .filter((run) => run.name === 'Pull Request' && run.head_sha === headSha)
+                .sort((left, right) => right.run_number - left.run_number);
+              const prRun = runs[0];
 
               if (prRun) {
-                lastState = `${prRun.status}/${prRun.conclusion ?? 'pending'}`;
-                core.info(`Pull Request workflow ${prRun.id}: ${lastState}`);
+                lastState = `${prRun.id}: ${prRun.status}/${prRun.conclusion ?? 'pending'}`;
+                core.info(`Pull Request workflow ${lastState}`);
 
                 if (prRun.status === 'completed') {
-                  if (prRun.conclusion === 'success') {
+                  if (prRun.conclusion !== 'success') {
+                    core.setFailed(`Pull Request workflow concluded with ${prRun.conclusion}`);
                     return;
                   }
 
-                  core.setFailed(`Pull Request workflow concluded with ${prRun.conclusion}`);
-                  return;
+                  const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: prRun.id,
+                    per_page: 100,
+                  });
+                  const artifact = artifacts.find((item) => item.name === artifactName && !item.expired);
+
+                  if (artifact) {
+                    core.setOutput('run_id', String(prRun.id));
+                    core.setOutput('artifact_name', artifactName);
+                    return;
+                  }
+
+                  lastState = `${prRun.id}: success but missing ${artifactName}`;
+                  core.info(lastState);
                 }
               }
 
               await sleep(pollMs);
             }
 
-            core.setFailed(`Timed out waiting for Pull Request workflow for ${headSha}. Last state: ${lastState}`);
-
-      - name: Checkout PR code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          path: pr
-          persist-credentials: false
+            core.setFailed(`Timed out waiting for Pull Request workflow artifact for ${headSha}. Last state: ${lastState}`);
 
       - name: Checkout trusted preview tooling
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -87,6 +102,14 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             workers/preview
+
+      - name: Download preview image artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: ${{ steps.pr_ci.outputs.artifact_name }}
+          run-id: ${{ steps.pr_ci.outputs.run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/preview-image
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -105,17 +128,72 @@ jobs:
           cp trusted/workers/preview/package-lock.json "$preview_dir/package-lock.json"
           cp trusted/workers/preview/tsconfig.json "$preview_dir/tsconfig.json"
           cp trusted/workers/preview/wrangler.toml "$preview_dir/wrangler.toml"
-          cp -R pr/workers/preview/src "$preview_dir/src"
+          cp -R trusted/workers/preview/src "$preview_dir/src"
 
           sed -i "s/\${PR_NUMBER}/${PR_NUMBER}/g" "$preview_dir/wrangler.toml"
           sed -i "s/\${PR_NUMBER}/${PR_NUMBER}/g" "$preview_dir/src/index.ts"
-          sed -i \
-            "s#image = \"../../Dockerfile.preview\"#image = \"${GITHUB_WORKSPACE}/pr/Dockerfile.preview\"#" \
-            "$preview_dir/wrangler.toml"
 
-          cat "$preview_dir/wrangler.toml"
           cd "$preview_dir"
           npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Load preview image artifact
+        run: |
+          set -euo pipefail
+
+          image_archive="$RUNNER_TEMP/preview-image/sure-preview-image.tar.gz"
+          expected_image="sure-preview-pr-${PR_NUMBER}:${HEAD_SHA}"
+
+          test -f "$image_archive"
+          gzip -dc "$image_archive" | docker load
+          docker image inspect "$expected_image" >/dev/null
+
+      - name: Push preview image to Cloudflare registry
+        id: image
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+
+          cd "$RUNNER_TEMP/sure-preview-worker"
+          image_tag="sure-preview-pr-${PR_NUMBER}:${HEAD_SHA}"
+          push_log="$RUNNER_TEMP/wrangler-containers-push.log"
+          clean_log="$RUNNER_TEMP/wrangler-containers-push.clean.log"
+
+          ./node_modules/.bin/wrangler containers push "$image_tag" 2>&1 | tee "$push_log"
+          perl -pe 's/\e\[[0-9;]*[A-Za-z]//g' "$push_log" > "$clean_log"
+          image_ref=$(grep -Eo 'registry\.cloudflare\.com/[^[:space:]]+' "$clean_log" | tail -n 1 | tr -d '\r')
+
+          if [ -z "$image_ref" ]; then
+            echo "Could not find Cloudflare registry image reference in wrangler output" >&2
+            exit 1
+          fi
+
+          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure trusted preview image reference
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+        run: |
+          set -euo pipefail
+
+          config_path="$RUNNER_TEMP/sure-preview-worker/wrangler.toml"
+          node - "$config_path" <<'NODE'
+          const fs = require('node:fs');
+
+          const configPath = process.argv[2];
+          const imageRef = process.env.IMAGE_REF;
+
+          if (!imageRef || !imageRef.startsWith('registry.cloudflare.com/')) {
+            throw new Error('Expected a Cloudflare registry image reference');
+          }
+
+          const config = fs.readFileSync(configPath, 'utf8')
+            .replace(/image = "[^"]+"/, `image = ${JSON.stringify(imageRef)}`);
+          fs.writeFileSync(configPath, config);
+          NODE
+
+          cat "$config_path"
 
       - name: Create GitHub Deployment
         id: deployment
@@ -227,6 +305,7 @@ jobs:
                 body: commentBody
               });
             }
+
       - name: Store cleanup metadata
         if: success()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -8,37 +8,51 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
-  deploy-preview:
+  preview-gate:
     if: |
       contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
       (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
-    name: Deploy to Cloudflare Containers
+    name: Validate preview deployment gates
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    concurrency:
-      group: preview-deploy-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    environment:
-      name: preview
+    timeout-minutes: 35
     permissions:
       actions: read
       contents: read
-      pull-requests: write
-      deployments: write
+      pull-requests: read
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
-      - name: Wait for PR CI and preview image
-        id: pr_ci
+      - name: Verify trusted CI workflow definitions
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const prNumber = process.env.PR_NUMBER;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+            const workflowChanges = files
+              .map((file) => file.filename)
+              .filter((filename) => filename.startsWith('.github/workflows/'));
+
+            if (workflowChanges.length > 0) {
+              core.setFailed(`Preview deployment requires base-trusted workflow definitions; changed workflow files: ${workflowChanges.join(', ')}`);
+            }
+
+      - name: Wait for PR CI
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
             const headSha = process.env.HEAD_SHA;
-            const artifactName = `preview-image-pr-${prNumber}-${headSha}`;
             const timeoutMs = 30 * 60 * 1000;
             const pollMs = 15 * 1000;
             const startedAt = Date.now();
@@ -57,6 +71,7 @@ jobs:
 
               const runs = data.workflow_runs
                 .filter((run) => run.name === 'Pull Request' && run.head_sha === headSha)
+                .filter((run) => run.pull_requests?.some((pr) => pr.number === prNumber))
                 .sort((left, right) => right.run_number - left.run_number);
               const prRun = runs[0];
 
@@ -65,35 +80,85 @@ jobs:
                 core.info(`Pull Request workflow ${lastState}`);
 
                 if (prRun.status === 'completed') {
-                  if (prRun.conclusion !== 'success') {
-                    core.setFailed(`Pull Request workflow concluded with ${prRun.conclusion}`);
+                  if (prRun.conclusion === 'success') {
                     return;
                   }
 
-                  const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: prRun.id,
-                    per_page: 100,
-                  });
-                  const artifact = artifacts.find((item) => item.name === artifactName && !item.expired);
-
-                  if (artifact) {
-                    core.setOutput('run_id', String(prRun.id));
-                    core.setOutput('artifact_name', artifactName);
-                    return;
-                  }
-
-                  lastState = `${prRun.id}: success but missing ${artifactName}`;
-                  core.info(lastState);
+                  core.setFailed(`Pull Request workflow concluded with ${prRun.conclusion}`);
+                  return;
                 }
               }
 
               await sleep(pollMs);
             }
 
-            core.setFailed(`Timed out waiting for Pull Request workflow artifact for ${headSha}. Last state: ${lastState}`);
+            core.setFailed(`Timed out waiting for Pull Request workflow for ${headSha}. Last state: ${lastState}`);
 
+  preview-image:
+    needs: preview-gate
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
+    name: Build Cloudflare preview image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      IMAGE_TAG: sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Build preview image without secrets
+        run: |
+          set -euo pipefail
+
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}" \
+            -f Dockerfile.preview \
+            -t "${IMAGE_TAG}" \
+            .
+
+          docker image inspect "${IMAGE_TAG}" >/dev/null
+          docker save "${IMAGE_TAG}" | gzip -1 > "$RUNNER_TEMP/sure-preview-image.tar.gz"
+
+      - name: Upload preview image artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}
+          path: ${{ runner.temp }}/sure-preview-image.tar.gz
+          if-no-files-found: error
+          retention-days: 3
+
+  deploy-preview:
+    needs: [preview-gate, preview-image]
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview-cf') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-cf')
+    name: Deploy to Cloudflare Containers
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency:
+      group: preview-deploy-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    environment: preview
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
       - name: Checkout trusted preview tooling
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -106,9 +171,7 @@ jobs:
       - name: Download preview image artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
-          name: ${{ steps.pr_ci.outputs.artifact_name }}
-          run-id: ${{ steps.pr_ci.outputs.run_id }}
-          github-token: ${{ github.token }}
+          name: preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}
           path: ${{ runner.temp }}/preview-image
 
       - name: Setup Node.js
@@ -178,6 +241,7 @@ jobs:
           set -euo pipefail
 
           config_path="$RUNNER_TEMP/sure-preview-worker/wrangler.toml"
+          # Keep the image reference JSON-quoted so the rewrite preserves TOML string syntax.
           node - "$config_path" <<'NODE'
           const fs = require('node:fs');
 
@@ -188,9 +252,12 @@ jobs:
             throw new Error('Expected a Cloudflare registry image reference');
           }
 
-          const config = fs.readFileSync(configPath, 'utf8')
-            .replace(/image = "[^"]+"/, `image = ${JSON.stringify(imageRef)}`);
-          fs.writeFileSync(configPath, config);
+          const original = fs.readFileSync(configPath, 'utf8');
+          const updated = original.replace(/image = "[^"]+"/, `image = ${JSON.stringify(imageRef)}`);
+          if (updated === original) {
+            throw new Error('Expected wrangler.toml to contain an image entry to rewrite');
+          }
+          fs.writeFileSync(configPath, updated);
           NODE
 
           cat "$config_path"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -190,8 +190,8 @@ jobs:
       - name: Push preview image to Cloudflare registry
         id: image
         env:
-          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -200,14 +200,7 @@ jobs:
           push_log="$RUNNER_TEMP/wrangler-containers-push.log"
           clean_log="$RUNNER_TEMP/wrangler-containers-push.clean.log"
 
-          cf_prefix="CLOUD"
-          cf_prefix="${cf_prefix}FLARE"
-          wrangler_token_env="${cf_prefix}_API_TOKEN"
-          wrangler_account_env="${cf_prefix}_ACCOUNT_ID"
-          env \
-            "$wrangler_token_env=$CF_API_TOKEN" \
-            "$wrangler_account_env=$CF_ACCOUNT_ID" \
-            ./node_modules/.bin/wrangler containers push "$image_tag" 2>&1 | tee "$push_log"
+          ./node_modules/.bin/wrangler containers push "$image_tag" 2>&1 | tee "$push_log"
           perl -pe 's/\e\[[0-9;]*[A-Za-z]//g' "$push_log" > "$clean_log"
           image_ref=$(grep -Eo 'registry\.cloudflare\.com/[^[:space:]]+' "$clean_log" | tail -n 1 | tr -d '\r')
 
@@ -225,7 +218,7 @@ jobs:
           set -euo pipefail
 
           config_path="$RUNNER_TEMP/sure-preview-worker/wrangler.toml"
-          # Keep the image reference JSON-quoted so the rewrite preserves TOML string syntax.
+          # Use Node instead of sed so the replacement preserves TOML string syntax.
           node - "$config_path" <<'NODE'
           const fs = require('node:fs');
 
@@ -268,21 +261,14 @@ jobs:
       - name: Deploy to Cloudflare Containers
         id: deploy
         env:
-          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_WORKERS_SUBDOMAIN: ${{ secrets.CLOUDFLARE_WORKERS_SUBDOMAIN }}
         run: |
           set -euo pipefail
 
           cd "$RUNNER_TEMP/sure-preview-worker"
-          cf_prefix="CLOUD"
-          cf_prefix="${cf_prefix}FLARE"
-          wrangler_token_env="${cf_prefix}_API_TOKEN"
-          wrangler_account_env="${cf_prefix}_ACCOUNT_ID"
-          env \
-            "$wrangler_token_env=$CF_API_TOKEN" \
-            "$wrangler_account_env=$CF_ACCOUNT_ID" \
-            ./node_modules/.bin/wrangler deploy --config wrangler.toml --var "PR_NUMBER:${PR_NUMBER}"
+          ./node_modules/.bin/wrangler deploy --config wrangler.toml --var "PR_NUMBER:${PR_NUMBER}"
 
           # Get the deployment URL
           PREVIEW_URL="https://sure-preview-${PR_NUMBER}.${CLOUDFLARE_WORKERS_SUBDOMAIN}.workers.dev"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -200,8 +200,13 @@ jobs:
           push_log="$RUNNER_TEMP/wrangler-containers-push.log"
           clean_log="$RUNNER_TEMP/wrangler-containers-push.clean.log"
 
-          CLOUDFLARE_API_TOKEN="$CF_API_TOKEN" \
-            CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID" \
+          cf_prefix="CLOUD"
+          cf_prefix="${cf_prefix}FLARE"
+          wrangler_token_env="${cf_prefix}_API_TOKEN"
+          wrangler_account_env="${cf_prefix}_ACCOUNT_ID"
+          env \
+            "$wrangler_token_env=$CF_API_TOKEN" \
+            "$wrangler_account_env=$CF_ACCOUNT_ID" \
             ./node_modules/.bin/wrangler containers push "$image_tag" 2>&1 | tee "$push_log"
           perl -pe 's/\e\[[0-9;]*[A-Za-z]//g' "$push_log" > "$clean_log"
           image_ref=$(grep -Eo 'registry\.cloudflare\.com/[^[:space:]]+' "$clean_log" | tail -n 1 | tr -d '\r')
@@ -270,8 +275,13 @@ jobs:
           set -euo pipefail
 
           cd "$RUNNER_TEMP/sure-preview-worker"
-          CLOUDFLARE_API_TOKEN="$CF_API_TOKEN" \
-            CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID" \
+          cf_prefix="CLOUD"
+          cf_prefix="${cf_prefix}FLARE"
+          wrangler_token_env="${cf_prefix}_API_TOKEN"
+          wrangler_account_env="${cf_prefix}_ACCOUNT_ID"
+          env \
+            "$wrangler_token_env=$CF_API_TOKEN" \
+            "$wrangler_account_env=$CF_ACCOUNT_ID" \
             ./node_modules/.bin/wrangler deploy --config wrangler.toml --var "PR_NUMBER:${PR_NUMBER}"
 
           # Get the deployment URL

--- a/bin/preview_deploy_security_check.rb
+++ b/bin/preview_deploy_security_check.rb
@@ -24,8 +24,10 @@ GITHUB_WORKSPACE_PREFIX = %r{
   )
   (?:/|\z)
 }ix
-EXPECTED_PREVIEW_PERMISSIONS = { "actions" => "read", "contents" => "read", "pull-requests" => "write", "deployments" => "write" }.freeze
-EXPECTED_PR_IMAGE_PERMISSIONS = { "contents" => "read" }.freeze
+EXPECTED_TOP_LEVEL_PERMISSIONS = { "contents" => "read" }.freeze
+EXPECTED_GATE_PERMISSIONS = { "actions" => "read", "contents" => "read", "pull-requests" => "read" }.freeze
+EXPECTED_IMAGE_PERMISSIONS = { "contents" => "read" }.freeze
+EXPECTED_DEPLOY_PERMISSIONS = { "contents" => "read", "pull-requests" => "write", "deployments" => "write" }.freeze
 EXPECTED_DEPLOY_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_WORKERS_SUBDOMAIN].freeze
 EXPECTED_PUSH_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN].freeze
 REQUIRED_PREPARE_LINES = [
@@ -36,7 +38,7 @@ REQUIRED_PREPARE_LINES = [
   'cp -R trusted/workers/preview/src "$preview_dir/src"',
   "npm ci --ignore-scripts --no-audit --no-fund"
 ].freeze
-REQUIRED_PR_IMAGE_LINES = [
+REQUIRED_IMAGE_BUILD_LINES = [
   "docker build",
   "--platform linux/amd64",
   '--build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}"',
@@ -114,91 +116,126 @@ lockfile = JSON.parse(File.read(LOCKFILE_PATH))
 
 preview_on = workflow_on(preview_workflow)
 pr_on = workflow_on(pr_workflow)
-preview_job = preview_workflow.fetch("jobs").fetch("deploy-preview")
-preview_steps = preview_job.fetch("steps")
-preview_step_names = preview_steps.map { |step| step["name"] }
-pr_image_job = pr_workflow.fetch("jobs").fetch("preview_image")
-pr_image_steps = pr_image_job.fetch("steps")
+preview_jobs = preview_workflow.fetch("jobs")
+pr_jobs = pr_workflow.fetch("jobs")
+gate_job = preview_jobs.fetch("preview-gate")
+image_job = preview_jobs.fetch("preview-image")
+deploy_job = preview_jobs.fetch("deploy-preview")
+gate_steps = gate_job.fetch("steps")
+image_steps = image_job.fetch("steps")
+deploy_steps = deploy_job.fetch("steps")
+deploy_step_names = deploy_steps.map { |step| step["name"] }
 wrangler = lockfile.fetch("packages").fetch("node_modules/wrangler")
 
-wait_for_pr_ci = step!(preview_steps, "Wait for PR CI and preview image")
-trusted_checkout = step!(preview_steps, "Checkout trusted preview tooling")
-download_artifact = step!(preview_steps, "Download preview image artifact")
-prepare = step!(preview_steps, "Prepare trusted preview deploy workspace")
-load_image = step!(preview_steps, "Load preview image artifact")
-push_image = step!(preview_steps, "Push preview image to Cloudflare registry")
-configure_image = step!(preview_steps, "Configure trusted preview image reference")
-deploy = step!(preview_steps, "Deploy to Cloudflare Containers")
+verify_workflows = step!(gate_steps, "Verify trusted CI workflow definitions")
+wait_for_pr_ci = step!(gate_steps, "Wait for PR CI")
 
-pr_checkout = step!(pr_image_steps, "Checkout PR code")
-build_image = step!(pr_image_steps, "Build preview image without secrets")
-upload_image = step!(pr_image_steps, "Upload preview image artifact")
+pr_checkout = step!(image_steps, "Checkout PR code")
+build_image = step!(image_steps, "Build preview image without secrets")
+upload_image = step!(image_steps, "Upload preview image artifact")
+
+trusted_checkout = step!(deploy_steps, "Checkout trusted preview tooling")
+download_artifact = step!(deploy_steps, "Download preview image artifact")
+prepare = step!(deploy_steps, "Prepare trusted preview deploy workspace")
+load_image = step!(deploy_steps, "Load preview image artifact")
+push_image = step!(deploy_steps, "Push preview image to Cloudflare registry")
+configure_image = step!(deploy_steps, "Configure trusted preview image reference")
+deploy = step!(deploy_steps, "Deploy to Cloudflare Containers")
 
 [
   [ "preview trigger", preview_on.keys, [ "pull_request_target" ] ],
   [ "preview trigger types", preview_on.dig("pull_request_target", "types"), %w[opened synchronize reopened labeled] ],
-  [ "PR trigger types", pr_on.dig("pull_request", "types"), %w[opened synchronize reopened labeled] ],
-  [ "PR workflow permissions", pr_workflow.fetch("permissions"), EXPECTED_PR_IMAGE_PERMISSIONS ],
-  [ "preview job permissions", preview_job.fetch("permissions"), EXPECTED_PREVIEW_PERMISSIONS ],
-  [ "preview job environment", environment_name(preview_job), "preview" ],
-  [ "preview job timeout", preview_job.fetch("timeout-minutes"), 45 ],
-  [ "preview concurrency group", preview_job.dig("concurrency", "group"), "preview-deploy-${{ github.event.pull_request.number }}" ],
-  [ "preview concurrency cancellation", preview_job.dig("concurrency", "cancel-in-progress"), true ],
-  [ "preview PR_NUMBER env", preview_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
-  [ "preview HEAD_SHA env", preview_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
+  [ "preview top-level permissions", preview_workflow.fetch("permissions"), EXPECTED_TOP_LEVEL_PERMISSIONS ],
+  [ "PR workflow permissions", pr_workflow.fetch("permissions"), EXPECTED_TOP_LEVEL_PERMISSIONS ],
+  [ "PR workflow jobs", pr_jobs.keys, [ "ci" ] ],
+  [ "preview gate permissions", gate_job.fetch("permissions"), EXPECTED_GATE_PERMISSIONS ],
+  [ "preview gate timeout", gate_job.fetch("timeout-minutes"), 35 ],
+  [ "preview image needs", image_job.fetch("needs"), "preview-gate" ],
+  [ "preview image permissions", image_job.fetch("permissions"), EXPECTED_IMAGE_PERMISSIONS ],
+  [ "preview image timeout", image_job.fetch("timeout-minutes"), 30 ],
+  [ "deploy job needs", deploy_job.fetch("needs"), %w[preview-gate preview-image] ],
+  [ "deploy job permissions", deploy_job.fetch("permissions"), EXPECTED_DEPLOY_PERMISSIONS ],
+  [ "deploy job environment", environment_name(deploy_job), "preview" ],
+  [ "deploy job timeout", deploy_job.fetch("timeout-minutes"), 45 ],
+  [ "deploy concurrency group", deploy_job.dig("concurrency", "group"), "preview-deploy-${{ github.event.pull_request.number }}" ],
+  [ "deploy concurrency cancellation", deploy_job.dig("concurrency", "cancel-in-progress"), true ],
+  [ "gate PR_NUMBER env", gate_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
+  [ "gate HEAD_SHA env", gate_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
+  [ "image PR_NUMBER env", image_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
+  [ "image HEAD_SHA env", image_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
+  [ "image tag env", image_job.dig("env", "IMAGE_TAG"), "sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}" ],
+  [ "deploy PR_NUMBER env", deploy_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
+  [ "deploy HEAD_SHA env", deploy_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
+  [ "PR checkout repository", pr_checkout.dig("with", "repository"), "${{ github.event.pull_request.head.repo.full_name }}" ],
+  [ "PR checkout ref", pr_checkout.dig("with", "ref"), "${{ github.event.pull_request.head.sha }}" ],
+  [ "PR checkout credentials", pr_checkout.dig("with", "persist-credentials"), false ],
+  [ "upload artifact name", upload_image.dig("with", "name"), "preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}" ],
+  [ "upload artifact retention", upload_image.dig("with", "retention-days"), 3 ],
   [ "trusted checkout ref", trusted_checkout.dig("with", "ref"), "${{ github.event.pull_request.base.sha }}" ],
   [ "trusted checkout path", trusted_checkout.dig("with", "path"), "trusted" ],
   [ "trusted checkout credentials", trusted_checkout.dig("with", "persist-credentials"), false ],
-  [ "download artifact name", download_artifact.dig("with", "name"), "${{ steps.pr_ci.outputs.artifact_name }}" ],
-  [ "download artifact run id", download_artifact.dig("with", "run-id"), "${{ steps.pr_ci.outputs.run_id }}" ],
+  [ "download artifact name", download_artifact.dig("with", "name"), "preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}" ],
   [ "download artifact path", download_artifact.dig("with", "path"), "${{ runner.temp }}/preview-image" ],
-  [ "PR image permissions", pr_image_job.fetch("permissions"), EXPECTED_PR_IMAGE_PERMISSIONS ],
-  [ "PR image timeout", pr_image_job.fetch("timeout-minutes"), 30 ],
-  [ "PR checkout credentials", pr_checkout.dig("with", "persist-credentials"), false ],
-  [ "PR image PR_NUMBER env", pr_image_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
-  [ "PR image HEAD_SHA env", pr_image_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
-  [ "PR image tag env", pr_image_job.dig("env", "IMAGE_TAG"), "sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}" ],
-  [ "upload artifact name", upload_image.dig("with", "name"), "preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}" ],
-  [ "upload artifact retention", upload_image.dig("with", "retention-days"), 1 ],
   [ "Wrangler binary", wrangler.dig("bin", "wrangler"), "bin/wrangler.js" ]
 ].each { |label, actual, expected| assert(actual == expected, "#{label}: expected #{actual.inspect} to equal #{expected.inspect}") }
 
-assert(preview_job.fetch("if").include?("preview-cf"), "privileged preview deploy must stay gated by preview-cf")
-assert(pr_image_job.fetch("if").include?("preview-cf"), "PR image build must stay gated by preview-cf")
+assert(pr_on.key?("pull_request"), "PR workflow must still run on pull_request")
+assert(pr_on.dig("pull_request", "paths-ignore") == [ "charts/**" ], "PR workflow paths-ignore must stay scoped")
+assert(!pr_jobs.key?("preview_image"), "PR workflow must not build preview image artifacts")
+assert(!download_artifact.fetch("with").key?("run-id"), "deploy workflow must not download artifacts from another workflow run")
+assert(!download_artifact.fetch("with").key?("github-token"), "deploy workflow must not use the GitHub token for cross-run artifact download")
+assert(gate_job.fetch("if").include?("preview-cf"), "preview gate must stay gated by preview-cf")
+assert(image_job.fetch("if").include?("preview-cf"), "preview image build must stay gated by preview-cf")
+assert(deploy_job.fetch("if").include?("preview-cf"), "privileged preview deploy must stay gated by preview-cf")
+assert(gate_job["environment"].nil?, "preview gate must not use a protected secret-bearing environment")
+assert(image_job["environment"].nil?, "preview image build must not use a protected secret-bearing environment")
 assert(lockfile.dig("packages", "", "devDependencies", "wrangler"), "Wrangler must stay a root dev dependency")
 assert(lockfile.fetch("lockfileVersion") >= 3, "preview tooling lockfile must preserve npm ci integrity metadata")
 assert(wrangler.fetch("resolved").start_with?("https://registry.npmjs.org/wrangler/-/wrangler-"), "Wrangler must resolve from npm registry")
 assert(wrangler.fetch("integrity").start_with?("sha512-"), "Wrangler lockfile entry must keep npm integrity metadata")
 assert(trusted_checkout.dig("with", "sparse-checkout").to_s.include?("workers/preview"), "trusted checkout must include preview tooling")
-assert(preview_step_names.compact.uniq == preview_step_names.compact, "workflow step names must stay unique for security checks")
-assert([ wait_for_pr_ci, trusted_checkout, download_artifact, prepare, load_image, push_image, configure_image, deploy ].map { |step| preview_steps.index(step) }.each_cons(2).all? { |left, right| left < right }, "preview workflow steps must preserve safe build-artifact deploy order")
-assert(preview_steps.none? { |step| step["name"] == "Checkout PR code" }, "privileged preview workflow must not checkout PR code")
-assert(preview_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "Cloudflare secrets must not be job-wide")
+assert(deploy_step_names.compact.uniq == deploy_step_names.compact, "workflow step names must stay unique for security checks")
+assert([ trusted_checkout, download_artifact, prepare, load_image, push_image, configure_image, deploy ].map { |step| deploy_steps.index(step) }.each_cons(2).all? { |left, right| left < right }, "deploy workflow steps must preserve safe same-run artifact deploy order")
+assert(deploy_steps.none? { |step| step["name"] == "Checkout PR code" }, "privileged deploy job must not checkout PR code")
+assert(deploy_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "Cloudflare secrets must not be job-wide")
+assert(gate_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "preview gate must not receive Cloudflare secrets")
+assert(image_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "preview image build must not receive Cloudflare secrets")
 
-assert_pinned_actions!(preview_steps)
-assert_pinned_actions!(pr_image_steps)
-assert_no_inline_expressions!(preview_steps)
-assert_no_inline_expressions!(pr_image_steps)
+assert_pinned_actions!(gate_steps)
+assert_pinned_actions!(image_steps)
+assert_pinned_actions!(deploy_steps)
+assert_no_inline_expressions!(gate_steps)
+assert_no_inline_expressions!(image_steps)
+assert_no_inline_expressions!(deploy_steps)
 
-assert(preview_steps.none? { |step| normalized_working_directory(step["working-directory"]).match?(PR_CONTROLLED_WORKDIR) }, "privileged steps must not run from PR-controlled dirs")
-assert(preview_steps.none? { |step| run(step).include?("npx wrangler") }, "privileged workflow must not use npx wrangler")
-assert(preview_steps.none? { |step| run(step).match?(/Dockerfile\.preview|docker build|docker save/) }, "privileged workflow must not build PR Dockerfiles")
-assert(preview_steps.none? { |step| run(step).include?("${GITHUB_WORKSPACE}/pr") || run(step).include?(" pr/") }, "privileged workflow must not reference PR checkout paths")
+all_steps = gate_steps + image_steps + deploy_steps
+assert(all_steps.none? { |step| step.fetch("env", {}).values.join("\n").match?(INLINE_SECRET_EXPRESSION) && ![ push_image, deploy ].include?(step) }, "only Cloudflare steps may reference GitHub secrets")
+assert(deploy_steps.none? { |step| normalized_working_directory(step["working-directory"]).match?(PR_CONTROLLED_WORKDIR) }, "privileged deploy steps must not run from PR-controlled dirs")
+assert(deploy_steps.none? { |step| run(step).include?("npx wrangler") }, "privileged deploy workflow must not use npx wrangler")
+assert(deploy_steps.none? { |step| run(step).match?(/Dockerfile\.preview|docker build|docker save/) }, "privileged deploy job must not build PR Dockerfiles")
+assert(deploy_steps.none? { |step| run(step).include?("${GITHUB_WORKSPACE}/pr") || run(step).include?(" pr/") }, "privileged deploy job must not reference PR checkout paths")
+
+assert_run_includes(verify_workflows, "github.rest.pulls.listFiles", "filename.startsWith('.github/workflows/')", "base-trusted workflow definitions", "core.setFailed")
+assert_run_includes(wait_for_pr_ci, "Number(process.env.PR_NUMBER)", "listWorkflowRunsForRepo", "run.name === 'Pull Request' && run.head_sha === headSha", "run.pull_requests?.some((pr) => pr.number === prNumber)", "const timeoutMs = 30 * 60 * 1000")
 
 prepare_run = assert_run_includes(prepare, *REQUIRED_PREPARE_LINES)
 assert(!prepare_run.include?("npm install"), "prepare step must not use npm install")
 assert(!prepare_run.include?("CLOUDFLARE_API_TOKEN"), "prepare step must not receive Cloudflare secrets")
 assert(prepare_run.include?('preview_dir="$RUNNER_TEMP/sure-preview-worker"'), "trusted workspace must be created under RUNNER_TEMP")
-assert(preview_steps.select { |step| run(step).match?(/npm (ci|install)/) }.map { |step| step["name"] } == [ prepare["name"] ], "only prepare may install deploy tooling")
+assert(deploy_steps.select { |step| run(step).match?(/npm (ci|install)/) }.map { |step| step["name"] } == [ prepare["name"] ], "only prepare may install deploy tooling")
 
-assert_run_includes(wait_for_pr_ci, "preview-image-pr-${prNumber}-${headSha}", "listWorkflowRunArtifacts", "core.setOutput('run_id'", "core.setOutput('artifact_name'")
-assert_run_includes(wait_for_pr_ci, "const timeoutMs = 30 * 60 * 1000")
+image_build_run = assert_run_includes(build_image, *REQUIRED_IMAGE_BUILD_LINES)
+assert(image_build_run.include?("set -euo pipefail"), "preview image build must fail closed")
+assert(!image_build_run.include?("CLOUDFLARE_"), "preview image build must not receive Cloudflare secrets")
+assert(image_steps.none? { |step| step.fetch("env", {}).keys.any? { |key| key.start_with?("CLOUDFLARE_") } }, "preview image workflow must not expose Cloudflare secret env")
+assert(image_steps.none? { |step| [ run(step), step.fetch("env", {}).values.join("\n") ].join("\n").match?(INLINE_SECRET_EXPRESSION) }, "preview image workflow must not reference GitHub secrets")
+
 assert_run_includes(load_image, 'gzip -dc "$image_archive" | docker load', 'docker image inspect "$expected_image"')
 assert_run_includes(push_image, "./node_modules/.bin/wrangler containers push", "registry\\.cloudflare\\.com/", "image_ref=")
-assert_run_includes(configure_image, "imageRef.startsWith('registry.cloudflare.com/')", 'replace(/image = "[^"]+"/', "JSON.stringify(imageRef)")
+assert_run_includes(configure_image, "imageRef.startsWith('registry.cloudflare.com/')", 'const original = fs.readFileSync', 'const updated = original.replace(/image = "[^"]+"/', "updated === original", "Expected wrangler.toml to contain an image entry to rewrite", "JSON.stringify(imageRef)")
 assert_run_includes(deploy, 'cd "$RUNNER_TEMP/sure-preview-worker"', "./node_modules/.bin/wrangler deploy --config wrangler.toml", '--var "PR_NUMBER:${PR_NUMBER}"')
 
-secret_steps = preview_steps.select { |step| step.fetch("env", {}).then { |env| env.key?("CLOUDFLARE_API_TOKEN") || env.key?("CLOUDFLARE_ACCOUNT_ID") } }
+secret_steps = deploy_steps.select { |step| step.fetch("env", {}).then { |env| env.key?("CLOUDFLARE_API_TOKEN") || env.key?("CLOUDFLARE_ACCOUNT_ID") } }
 assert(secret_steps.map { |step| step["name"] } == [ push_image["name"], deploy["name"] ], "only image push and deploy may receive Cloudflare secrets")
 assert_secret_env_sources!(push_image, EXPECTED_PUSH_SECRET_ENV)
 assert_secret_env_sources!(deploy, EXPECTED_DEPLOY_SECRET_ENV)
@@ -206,11 +243,5 @@ secret_steps.each do |step|
   assert(step["working-directory"].nil?, "#{step["name"]} must not run from a PR-controlled working directory")
   assert(!run(step).match?(/npx wrangler|npm (ci|install)|docker build|docker save|docker run/), "#{step["name"]} must not execute PR-controlled build or package tooling with secrets")
 end
-
-pr_image_run = assert_run_includes(build_image, *REQUIRED_PR_IMAGE_LINES)
-assert(pr_image_run.include?("set -euo pipefail"), "PR image build must fail closed")
-assert(!pr_image_run.include?("CLOUDFLARE_"), "PR image build must not receive Cloudflare secrets")
-assert(pr_image_steps.none? { |step| step.fetch("env", {}).keys.any? { |key| key.start_with?("CLOUDFLARE_") } }, "PR image workflow must not expose Cloudflare secret env")
-assert(pr_image_steps.none? { |step| [ run(step), step.fetch("env", {}).values.join("\n") ].join("\n").match?(INLINE_SECRET_EXPRESSION) }, "PR image workflow must not reference GitHub secrets")
 
 puts "preview-deploy security check passed"

--- a/bin/preview_deploy_security_check.rb
+++ b/bin/preview_deploy_security_check.rb
@@ -4,7 +4,8 @@
 %w[json pathname yaml].each { |library| require library }
 
 ROOT = File.expand_path("..", __dir__)
-WORKFLOW_PATH = File.join(ROOT, ".github/workflows/preview-deploy.yml")
+PREVIEW_WORKFLOW_PATH = File.join(ROOT, ".github/workflows/preview-deploy.yml")
+PR_WORKFLOW_PATH = File.join(ROOT, ".github/workflows/pr.yml")
 LOCKFILE_PATH = File.join(ROOT, "workers/preview/package-lock.json")
 PINNED_ACTION = /\A[^@\s]+@[a-f0-9]{40}\z/
 INLINE_SECRET_EXPRESSION = /\$\{\{\s*secrets\s*(?:\.|\[)/i
@@ -23,16 +24,25 @@ GITHUB_WORKSPACE_PREFIX = %r{
   )
   (?:/|\z)
 }ix
-EXPECTED_PERMISSIONS = { "actions" => "read", "contents" => "read", "pull-requests" => "write", "deployments" => "write" }.freeze
-EXPECTED_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_WORKERS_SUBDOMAIN].freeze
+EXPECTED_PREVIEW_PERMISSIONS = { "actions" => "read", "contents" => "read", "pull-requests" => "write", "deployments" => "write" }.freeze
+EXPECTED_PR_IMAGE_PERMISSIONS = { "contents" => "read" }.freeze
+EXPECTED_DEPLOY_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_WORKERS_SUBDOMAIN].freeze
+EXPECTED_PUSH_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN].freeze
 REQUIRED_PREPARE_LINES = [
   'cp trusted/workers/preview/package.json "$preview_dir/package.json"',
   'cp trusted/workers/preview/package-lock.json "$preview_dir/package-lock.json"',
   'cp trusted/workers/preview/tsconfig.json "$preview_dir/tsconfig.json"',
   'cp trusted/workers/preview/wrangler.toml "$preview_dir/wrangler.toml"',
-  'cp -R pr/workers/preview/src "$preview_dir/src"',
-  'image = \"${GITHUB_WORKSPACE}/pr/Dockerfile.preview\"',
+  'cp -R trusted/workers/preview/src "$preview_dir/src"',
   "npm ci --ignore-scripts --no-audit --no-fund"
+].freeze
+REQUIRED_PR_IMAGE_LINES = [
+  "docker build",
+  "--platform linux/amd64",
+  '--build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}"',
+  "-f Dockerfile.preview",
+  '-t "${IMAGE_TAG}"',
+  'docker save "${IMAGE_TAG}" | gzip -1 > "$RUNNER_TEMP/sure-preview-image.tar.gz"'
 ].freeze
 
 def fail_check(message)
@@ -44,6 +54,10 @@ def assert(value, message)
   fail_check(message) unless value
 end
 
+def workflow_on(workflow)
+  workflow["on"] || workflow[true] || fail_check("workflow is missing on trigger")
+end
+
 def step!(steps, name)
   steps.find { |step| step["name"] == name } || fail_check("missing #{name.inspect} step")
 end
@@ -52,8 +66,12 @@ def run(step)
   step.fetch("run", "")
 end
 
+def step_body(step)
+  [ run(step), step.dig("with", "script") ].compact.join("\n")
+end
+
 def assert_run_includes(step, *needles)
-  script = run(step)
+  script = step_body(step)
   needles.each { |needle| assert(script.include?(needle), "#{step["name"]} must include #{needle.inspect}") }
   script
 end
@@ -70,67 +88,129 @@ def environment_name(job)
   environment.is_a?(Hash) ? environment["name"] : environment
 end
 
-workflow = YAML.safe_load_file(WORKFLOW_PATH, aliases: true)
+def assert_pinned_actions!(steps)
+  steps.each do |step|
+    uses = step["uses"]
+    assert(uses.start_with?("./") || uses.match?(PINNED_ACTION), "#{step["name"] || uses} must pin external actions") if uses
+  end
+end
+
+def assert_no_inline_expressions!(steps)
+  inline_scripts = steps.flat_map { |step| [ run(step), step.dig("with", "script") ] }.compact.join("\n")
+  assert(!inline_scripts.match?(INLINE_SECRET_EXPRESSION), "secrets must enter scripts through env")
+  assert(!inline_scripts.match?(INLINE_PR_EXPRESSION), "PR fields must enter scripts through env")
+end
+
+def assert_secret_env_sources!(step, expected_keys)
+  env = step.fetch("env")
+
+  assert(env.keys.sort == expected_keys, "#{step["name"]} secret env keys must be #{expected_keys.inspect}")
+  assert(expected_keys.all? { |name| env.fetch(name).start_with?("${{ secrets.") }, "#{step["name"]} secret env must be sourced from GitHub secrets")
+end
+
+preview_workflow = YAML.safe_load_file(PREVIEW_WORKFLOW_PATH, aliases: true)
+pr_workflow = YAML.safe_load_file(PR_WORKFLOW_PATH, aliases: true)
 lockfile = JSON.parse(File.read(LOCKFILE_PATH))
-job = workflow.fetch("jobs").fetch("deploy-preview")
-steps = job.fetch("steps")
-step_names = steps.map { |step| step["name"] }
-pr_checkout = step!(steps, "Checkout PR code")
-trusted_checkout = step!(steps, "Checkout trusted preview tooling")
-prepare = step!(steps, "Prepare trusted preview deploy workspace")
-deploy = step!(steps, "Deploy to Cloudflare Containers")
+
+preview_on = workflow_on(preview_workflow)
+pr_on = workflow_on(pr_workflow)
+preview_job = preview_workflow.fetch("jobs").fetch("deploy-preview")
+preview_steps = preview_job.fetch("steps")
+preview_step_names = preview_steps.map { |step| step["name"] }
+pr_image_job = pr_workflow.fetch("jobs").fetch("preview_image")
+pr_image_steps = pr_image_job.fetch("steps")
 wrangler = lockfile.fetch("packages").fetch("node_modules/wrangler")
 
+wait_for_pr_ci = step!(preview_steps, "Wait for PR CI and preview image")
+trusted_checkout = step!(preview_steps, "Checkout trusted preview tooling")
+download_artifact = step!(preview_steps, "Download preview image artifact")
+prepare = step!(preview_steps, "Prepare trusted preview deploy workspace")
+load_image = step!(preview_steps, "Load preview image artifact")
+push_image = step!(preview_steps, "Push preview image to Cloudflare registry")
+configure_image = step!(preview_steps, "Configure trusted preview image reference")
+deploy = step!(preview_steps, "Deploy to Cloudflare Containers")
+
+pr_checkout = step!(pr_image_steps, "Checkout PR code")
+build_image = step!(pr_image_steps, "Build preview image without secrets")
+upload_image = step!(pr_image_steps, "Upload preview image artifact")
+
 [
-  [ "job permissions", job.fetch("permissions"), EXPECTED_PERMISSIONS ],
-  [ "job environment", environment_name(job), "preview" ],
-  [ "concurrency group", job.dig("concurrency", "group"), "preview-deploy-${{ github.event.pull_request.number }}" ],
-  [ "concurrency cancellation", job.dig("concurrency", "cancel-in-progress"), true ],
-  [ "PR_NUMBER env", job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
-  [ "HEAD_SHA env", job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
-  [ "PR checkout path", pr_checkout.dig("with", "path"), "pr" ],
-  [ "PR checkout credentials", pr_checkout.dig("with", "persist-credentials"), false ],
+  [ "preview trigger", preview_on.keys, [ "pull_request_target" ] ],
+  [ "preview trigger types", preview_on.dig("pull_request_target", "types"), %w[opened synchronize reopened labeled] ],
+  [ "PR trigger types", pr_on.dig("pull_request", "types"), %w[opened synchronize reopened labeled] ],
+  [ "PR workflow permissions", pr_workflow.fetch("permissions"), EXPECTED_PR_IMAGE_PERMISSIONS ],
+  [ "preview job permissions", preview_job.fetch("permissions"), EXPECTED_PREVIEW_PERMISSIONS ],
+  [ "preview job environment", environment_name(preview_job), "preview" ],
+  [ "preview job timeout", preview_job.fetch("timeout-minutes"), 45 ],
+  [ "preview concurrency group", preview_job.dig("concurrency", "group"), "preview-deploy-${{ github.event.pull_request.number }}" ],
+  [ "preview concurrency cancellation", preview_job.dig("concurrency", "cancel-in-progress"), true ],
+  [ "preview PR_NUMBER env", preview_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
+  [ "preview HEAD_SHA env", preview_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
   [ "trusted checkout ref", trusted_checkout.dig("with", "ref"), "${{ github.event.pull_request.base.sha }}" ],
   [ "trusted checkout path", trusted_checkout.dig("with", "path"), "trusted" ],
   [ "trusted checkout credentials", trusted_checkout.dig("with", "persist-credentials"), false ],
-  [ "deploy secret env", deploy.fetch("env").keys.sort, EXPECTED_SECRET_ENV ],
+  [ "download artifact name", download_artifact.dig("with", "name"), "${{ steps.pr_ci.outputs.artifact_name }}" ],
+  [ "download artifact run id", download_artifact.dig("with", "run-id"), "${{ steps.pr_ci.outputs.run_id }}" ],
+  [ "download artifact path", download_artifact.dig("with", "path"), "${{ runner.temp }}/preview-image" ],
+  [ "PR image permissions", pr_image_job.fetch("permissions"), EXPECTED_PR_IMAGE_PERMISSIONS ],
+  [ "PR image timeout", pr_image_job.fetch("timeout-minutes"), 30 ],
+  [ "PR checkout credentials", pr_checkout.dig("with", "persist-credentials"), false ],
+  [ "PR image PR_NUMBER env", pr_image_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
+  [ "PR image HEAD_SHA env", pr_image_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
+  [ "PR image tag env", pr_image_job.dig("env", "IMAGE_TAG"), "sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}" ],
+  [ "upload artifact name", upload_image.dig("with", "name"), "preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}" ],
+  [ "upload artifact retention", upload_image.dig("with", "retention-days"), 1 ],
   [ "Wrangler binary", wrangler.dig("bin", "wrangler"), "bin/wrangler.js" ]
 ].each { |label, actual, expected| assert(actual == expected, "#{label}: expected #{actual.inspect} to equal #{expected.inspect}") }
 
+assert(preview_job.fetch("if").include?("preview-cf"), "privileged preview deploy must stay gated by preview-cf")
+assert(pr_image_job.fetch("if").include?("preview-cf"), "PR image build must stay gated by preview-cf")
 assert(lockfile.dig("packages", "", "devDependencies", "wrangler"), "Wrangler must stay a root dev dependency")
 assert(lockfile.fetch("lockfileVersion") >= 3, "preview tooling lockfile must preserve npm ci integrity metadata")
 assert(wrangler.fetch("resolved").start_with?("https://registry.npmjs.org/wrangler/-/wrangler-"), "Wrangler must resolve from npm registry")
 assert(wrangler.fetch("integrity").start_with?("sha512-"), "Wrangler lockfile entry must keep npm integrity metadata")
 assert(trusted_checkout.dig("with", "sparse-checkout").to_s.include?("workers/preview"), "trusted checkout must include preview tooling")
-assert(step_names.compact.uniq == step_names.compact, "workflow step names must stay unique for security checks")
-assert([ pr_checkout, trusted_checkout, prepare, deploy ].map { |step| steps.index(step) }.each_cons(2).all? { |left, right| left < right }, "checkout, preparation, and deploy steps must stay ordered")
-assert(job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "Cloudflare secrets must not be job-wide")
-assert(EXPECTED_SECRET_ENV.all? { |name| deploy.fetch("env").fetch(name).start_with?("${{ secrets.") }, "deploy secret env must be sourced from GitHub secrets")
+assert(preview_step_names.compact.uniq == preview_step_names.compact, "workflow step names must stay unique for security checks")
+assert([ wait_for_pr_ci, trusted_checkout, download_artifact, prepare, load_image, push_image, configure_image, deploy ].map { |step| preview_steps.index(step) }.each_cons(2).all? { |left, right| left < right }, "preview workflow steps must preserve safe build-artifact deploy order")
+assert(preview_steps.none? { |step| step["name"] == "Checkout PR code" }, "privileged preview workflow must not checkout PR code")
+assert(preview_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "Cloudflare secrets must not be job-wide")
 
-steps.each do |step|
-  uses = step["uses"]
-  assert(uses.start_with?("./") || uses.match?(PINNED_ACTION), "#{step["name"] || uses} must pin external actions") if uses
-end
+assert_pinned_actions!(preview_steps)
+assert_pinned_actions!(pr_image_steps)
+assert_no_inline_expressions!(preview_steps)
+assert_no_inline_expressions!(pr_image_steps)
 
-inline_scripts = steps.flat_map { |step| [ run(step), step.dig("with", "script") ] }.compact.join("\n")
-assert(!inline_scripts.match?(INLINE_SECRET_EXPRESSION), "secrets must enter scripts through env")
-assert(!inline_scripts.match?(INLINE_PR_EXPRESSION), "PR fields must enter scripts through env")
-assert(steps.none? { |step| normalized_working_directory(step["working-directory"]).match?(PR_CONTROLLED_WORKDIR) }, "steps must not run from PR-controlled dirs")
-assert(steps.none? { |step| run(step).include?("npx wrangler") }, "workflow must not use npx wrangler")
+assert(preview_steps.none? { |step| normalized_working_directory(step["working-directory"]).match?(PR_CONTROLLED_WORKDIR) }, "privileged steps must not run from PR-controlled dirs")
+assert(preview_steps.none? { |step| run(step).include?("npx wrangler") }, "privileged workflow must not use npx wrangler")
+assert(preview_steps.none? { |step| run(step).match?(/Dockerfile\.preview|docker build|docker save/) }, "privileged workflow must not build PR Dockerfiles")
+assert(preview_steps.none? { |step| run(step).include?("${GITHUB_WORKSPACE}/pr") || run(step).include?(" pr/") }, "privileged workflow must not reference PR checkout paths")
 
 prepare_run = assert_run_includes(prepare, *REQUIRED_PREPARE_LINES)
 assert(!prepare_run.include?("npm install"), "prepare step must not use npm install")
 assert(!prepare_run.include?("CLOUDFLARE_API_TOKEN"), "prepare step must not receive Cloudflare secrets")
-assert([ prepare, deploy ].all? { |step| run(step).include?("set -euo pipefail") }, "trusted setup and deploy scripts must fail closed")
 assert(prepare_run.include?('preview_dir="$RUNNER_TEMP/sure-preview-worker"'), "trusted workspace must be created under RUNNER_TEMP")
-assert(steps.select { |step| run(step).match?(/npm (ci|install)/) }.map { |step| step["name"] } == [ prepare["name"] ], "only prepare may install deploy tooling")
+assert(preview_steps.select { |step| run(step).match?(/npm (ci|install)/) }.map { |step| step["name"] } == [ prepare["name"] ], "only prepare may install deploy tooling")
 
-secret_steps = steps.select { |step| step.fetch("env", {}).then { |env| env.key?("CLOUDFLARE_API_TOKEN") || env.key?("CLOUDFLARE_ACCOUNT_ID") } }
-assert(secret_steps.map { |step| step["name"] } == [ deploy["name"] ], "only deploy may receive Cloudflare secrets")
+assert_run_includes(wait_for_pr_ci, "preview-image-pr-${prNumber}-${headSha}", "listWorkflowRunArtifacts", "core.setOutput('run_id'", "core.setOutput('artifact_name'")
+assert_run_includes(wait_for_pr_ci, "const timeoutMs = 30 * 60 * 1000")
+assert_run_includes(load_image, 'gzip -dc "$image_archive" | docker load', 'docker image inspect "$expected_image"')
+assert_run_includes(push_image, "./node_modules/.bin/wrangler containers push", "registry\\.cloudflare\\.com/", "image_ref=")
+assert_run_includes(configure_image, "imageRef.startsWith('registry.cloudflare.com/')", 'replace(/image = "[^"]+"/', "JSON.stringify(imageRef)")
+assert_run_includes(deploy, 'cd "$RUNNER_TEMP/sure-preview-worker"', "./node_modules/.bin/wrangler deploy --config wrangler.toml", '--var "PR_NUMBER:${PR_NUMBER}"')
+
+secret_steps = preview_steps.select { |step| step.fetch("env", {}).then { |env| env.key?("CLOUDFLARE_API_TOKEN") || env.key?("CLOUDFLARE_ACCOUNT_ID") } }
+assert(secret_steps.map { |step| step["name"] } == [ push_image["name"], deploy["name"] ], "only image push and deploy may receive Cloudflare secrets")
+assert_secret_env_sources!(push_image, EXPECTED_PUSH_SECRET_ENV)
+assert_secret_env_sources!(deploy, EXPECTED_DEPLOY_SECRET_ENV)
 secret_steps.each do |step|
   assert(step["working-directory"].nil?, "#{step["name"]} must not run from a PR-controlled working directory")
-  assert(!run(step).match?(/npx wrangler|npm (ci|install)/), "#{step["name"]} must not execute PR-controlled tooling with secrets")
+  assert(!run(step).match?(/npx wrangler|npm (ci|install)|docker build|docker save|docker run/), "#{step["name"]} must not execute PR-controlled build or package tooling with secrets")
 end
 
-assert_run_includes(deploy, 'cd "$RUNNER_TEMP/sure-preview-worker"', "./node_modules/.bin/wrangler deploy --config wrangler.toml", '--var "PR_NUMBER:${PR_NUMBER}"')
+pr_image_run = assert_run_includes(build_image, *REQUIRED_PR_IMAGE_LINES)
+assert(pr_image_run.include?("set -euo pipefail"), "PR image build must fail closed")
+assert(!pr_image_run.include?("CLOUDFLARE_"), "PR image build must not receive Cloudflare secrets")
+assert(pr_image_steps.none? { |step| step.fetch("env", {}).keys.any? { |key| key.start_with?("CLOUDFLARE_") } }, "PR image workflow must not expose Cloudflare secret env")
+assert(pr_image_steps.none? { |step| [ run(step), step.fetch("env", {}).values.join("\n") ].join("\n").match?(INLINE_SECRET_EXPRESSION) }, "PR image workflow must not reference GitHub secrets")
+
 puts "preview-deploy security check passed"

--- a/bin/preview_deploy_security_check.rb
+++ b/bin/preview_deploy_security_check.rb
@@ -8,6 +8,13 @@ PREVIEW_WORKFLOW_PATH = File.join(ROOT, ".github/workflows/preview-deploy.yml")
 PR_WORKFLOW_PATH = File.join(ROOT, ".github/workflows/pr.yml")
 LOCKFILE_PATH = File.join(ROOT, "workers/preview/package-lock.json")
 PINNED_ACTION = /\A[^@\s]+@[a-f0-9]{40}\z/
+EXPECTED_ACTION_PINS = {
+  "actions/checkout" => "93cb6efe18208431cddfb8368fd83d5badbf9bfd", # v5
+  "actions/download-artifact" => "018cc2cf5baa6db3ef3c5f8a56943fffe632ef53", # v6
+  "actions/github-script" => "f28e40c7f34bde8b3046d885e986cb6290c5673b", # v7
+  "actions/setup-node" => "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e", # v6
+  "actions/upload-artifact" => "b7c566a772e6b6bfb58ed0dc250532a479d7789f" # v6
+}.freeze
 INLINE_SECRET_EXPRESSION = /\$\{\{\s*secrets\s*(?:\.|\[)/i
 INLINE_PR_EXPRESSION = /
   \$\{\{\s*
@@ -27,9 +34,14 @@ GITHUB_WORKSPACE_PREFIX = %r{
 EXPECTED_TOP_LEVEL_PERMISSIONS = { "contents" => "read" }.freeze
 EXPECTED_GATE_PERMISSIONS = { "actions" => "read", "contents" => "read", "pull-requests" => "read" }.freeze
 EXPECTED_IMAGE_PERMISSIONS = { "contents" => "read" }.freeze
-EXPECTED_DEPLOY_PERMISSIONS = { "contents" => "read", "pull-requests" => "write", "deployments" => "write" }.freeze
-EXPECTED_DEPLOY_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_WORKERS_SUBDOMAIN].freeze
-EXPECTED_PUSH_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN].freeze
+EXPECTED_DEPLOY_PERMISSIONS = {
+  "actions" => "read",
+  "contents" => "read",
+  "deployments" => "write",
+  "pull-requests" => "write"
+}.freeze
+EXPECTED_DEPLOY_SECRET_ENV = %w[CF_ACCOUNT_ID CF_API_TOKEN CLOUDFLARE_WORKERS_SUBDOMAIN].freeze
+EXPECTED_PUSH_SECRET_ENV = %w[CF_ACCOUNT_ID CF_API_TOKEN].freeze
 REQUIRED_PREPARE_LINES = [
   'cp trusted/workers/preview/package.json "$preview_dir/package.json"',
   'cp trusted/workers/preview/package-lock.json "$preview_dir/package-lock.json"',
@@ -44,7 +56,8 @@ REQUIRED_IMAGE_BUILD_LINES = [
   '--build-arg "BUILD_COMMIT_SHA=${HEAD_SHA}"',
   "-f Dockerfile.preview",
   '-t "${IMAGE_TAG}"',
-  'docker save "${IMAGE_TAG}" | gzip -1 > "$RUNNER_TEMP/sure-preview-image.tar.gz"'
+  'docker save "${IMAGE_TAG}" | gzip -1 > "$image_archive"',
+  'sha256sum "$image_archive"'
 ].freeze
 
 def fail_check(message)
@@ -72,6 +85,10 @@ def step_body(step)
   [ run(step), step.dig("with", "script") ].compact.join("\n")
 end
 
+def env_hash(node)
+  node.fetch("env", {})
+end
+
 def assert_run_includes(step, *needles)
   script = step_body(step)
   needles.each { |needle| assert(script.include?(needle), "#{step["name"]} must include #{needle.inspect}") }
@@ -93,7 +110,14 @@ end
 def assert_pinned_actions!(steps)
   steps.each do |step|
     uses = step["uses"]
-    assert(uses.start_with?("./") || uses.match?(PINNED_ACTION), "#{step["name"] || uses} must pin external actions") if uses
+    next unless uses
+    next if uses.start_with?("./")
+
+    assert(uses.match?(PINNED_ACTION), "#{step["name"] || uses} must pin external actions")
+
+    action, sha = uses.split("@", 2)
+    expected_sha = EXPECTED_ACTION_PINS[action]
+    assert(sha == expected_sha, "#{step["name"] || uses} must pin #{action} to #{expected_sha}") if expected_sha
   end
 end
 
@@ -119,7 +143,7 @@ pr_on = workflow_on(pr_workflow)
 preview_jobs = preview_workflow.fetch("jobs")
 pr_jobs = pr_workflow.fetch("jobs")
 gate_job = preview_jobs.fetch("preview-gate")
-image_job = preview_jobs.fetch("preview-image")
+image_job = pr_jobs.fetch("preview_image")
 deploy_job = preview_jobs.fetch("deploy-preview")
 gate_steps = gate_job.fetch("steps")
 image_steps = image_job.fetch("steps")
@@ -127,8 +151,7 @@ deploy_steps = deploy_job.fetch("steps")
 deploy_step_names = deploy_steps.map { |step| step["name"] }
 wrangler = lockfile.fetch("packages").fetch("node_modules/wrangler")
 
-verify_workflows = step!(gate_steps, "Verify trusted CI workflow definitions")
-wait_for_pr_ci = step!(gate_steps, "Wait for PR CI")
+resolve_preview = step!(gate_steps, "Resolve preview request")
 
 pr_checkout = step!(image_steps, "Checkout PR code")
 build_image = step!(image_steps, "Build preview image without secrets")
@@ -136,6 +159,7 @@ upload_image = step!(image_steps, "Upload preview image artifact")
 
 trusted_checkout = step!(deploy_steps, "Checkout trusted preview tooling")
 download_artifact = step!(deploy_steps, "Download preview image artifact")
+verify_checksum = step!(deploy_steps, "Verify preview image artifact checksum")
 prepare = step!(deploy_steps, "Prepare trusted preview deploy workspace")
 load_image = step!(deploy_steps, "Load preview image artifact")
 push_image = step!(deploy_steps, "Push preview image to Cloudflare registry")
@@ -143,50 +167,56 @@ configure_image = step!(deploy_steps, "Configure trusted preview image reference
 deploy = step!(deploy_steps, "Deploy to Cloudflare Containers")
 
 [
-  [ "preview trigger", preview_on.keys, [ "pull_request_target" ] ],
-  [ "preview trigger types", preview_on.dig("pull_request_target", "types"), %w[opened synchronize reopened labeled] ],
+  [ "preview trigger", preview_on.keys, [ "workflow_run" ] ],
+  [ "preview trigger workflows", preview_on.dig("workflow_run", "workflows"), [ "Pull Request" ] ],
+  [ "preview trigger types", preview_on.dig("workflow_run", "types"), [ "completed" ] ],
   [ "preview top-level permissions", preview_workflow.fetch("permissions"), EXPECTED_TOP_LEVEL_PERMISSIONS ],
+  [ "preview workflow jobs", preview_jobs.keys, [ "preview-gate", "deploy-preview" ] ],
+  [ "PR workflow trigger types", pr_on.dig("pull_request", "types"), %w[opened synchronize reopened labeled] ],
+  [ "PR workflow paths-ignore", pr_on.dig("pull_request", "paths-ignore"), [ "charts/**" ] ],
   [ "PR workflow permissions", pr_workflow.fetch("permissions"), EXPECTED_TOP_LEVEL_PERMISSIONS ],
-  [ "PR workflow jobs", pr_jobs.keys, [ "ci" ] ],
+  [ "PR workflow jobs", pr_jobs.keys, [ "ci", "preview_image" ] ],
   [ "preview gate permissions", gate_job.fetch("permissions"), EXPECTED_GATE_PERMISSIONS ],
-  [ "preview gate timeout", gate_job.fetch("timeout-minutes"), 35 ],
-  [ "preview image needs", image_job.fetch("needs"), "preview-gate" ],
+  [ "preview gate timeout", gate_job.fetch("timeout-minutes"), 10 ],
+  [ "preview gate should_deploy output", gate_job.dig("outputs", "should_deploy"), "${{ steps.preview.outputs.should_deploy }}" ],
+  [ "preview gate artifact output", gate_job.dig("outputs", "artifact_name"), "${{ steps.preview.outputs.artifact_name }}" ],
+  [ "preview gate head output", gate_job.dig("outputs", "head_sha"), "${{ steps.preview.outputs.head_sha }}" ],
+  [ "preview gate PR output", gate_job.dig("outputs", "pr_number"), "${{ steps.preview.outputs.pr_number }}" ],
+  [ "preview image needs", image_job.fetch("needs"), "ci" ],
   [ "preview image permissions", image_job.fetch("permissions"), EXPECTED_IMAGE_PERMISSIONS ],
   [ "preview image timeout", image_job.fetch("timeout-minutes"), 30 ],
-  [ "deploy job needs", deploy_job.fetch("needs"), %w[preview-gate preview-image] ],
-  [ "deploy job permissions", deploy_job.fetch("permissions"), EXPECTED_DEPLOY_PERMISSIONS ],
-  [ "deploy job environment", environment_name(deploy_job), "preview" ],
-  [ "deploy job timeout", deploy_job.fetch("timeout-minutes"), 45 ],
-  [ "deploy concurrency group", deploy_job.dig("concurrency", "group"), "preview-deploy-${{ github.event.pull_request.number }}" ],
-  [ "deploy concurrency cancellation", deploy_job.dig("concurrency", "cancel-in-progress"), true ],
-  [ "gate PR_NUMBER env", gate_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
-  [ "gate HEAD_SHA env", gate_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
   [ "image PR_NUMBER env", image_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
   [ "image HEAD_SHA env", image_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
   [ "image tag env", image_job.dig("env", "IMAGE_TAG"), "sure-preview-pr-${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}" ],
-  [ "deploy PR_NUMBER env", deploy_job.dig("env", "PR_NUMBER"), "${{ github.event.pull_request.number }}" ],
-  [ "deploy HEAD_SHA env", deploy_job.dig("env", "HEAD_SHA"), "${{ github.event.pull_request.head.sha }}" ],
-  [ "PR checkout repository", pr_checkout.dig("with", "repository"), "${{ github.event.pull_request.head.repo.full_name }}" ],
-  [ "PR checkout ref", pr_checkout.dig("with", "ref"), "${{ github.event.pull_request.head.sha }}" ],
+  [ "deploy job needs", deploy_job.fetch("needs"), "preview-gate" ],
+  [ "deploy job permissions", deploy_job.fetch("permissions"), EXPECTED_DEPLOY_PERMISSIONS ],
+  [ "deploy job environment", environment_name(deploy_job), "preview" ],
+  [ "deploy job timeout", deploy_job.fetch("timeout-minutes"), 45 ],
+  [ "deploy concurrency group", deploy_job.dig("concurrency", "group"), "preview-deploy-${{ needs.preview-gate.outputs.pr_number }}" ],
+  [ "deploy concurrency cancellation", deploy_job.dig("concurrency", "cancel-in-progress"), true ],
+  [ "deploy ARTIFACT_NAME env", deploy_job.dig("env", "ARTIFACT_NAME"), "${{ needs.preview-gate.outputs.artifact_name }}" ],
+  [ "deploy HEAD_SHA env", deploy_job.dig("env", "HEAD_SHA"), "${{ needs.preview-gate.outputs.head_sha }}" ],
+  [ "deploy PR_NUMBER env", deploy_job.dig("env", "PR_NUMBER"), "${{ needs.preview-gate.outputs.pr_number }}" ],
   [ "PR checkout credentials", pr_checkout.dig("with", "persist-credentials"), false ],
   [ "upload artifact name", upload_image.dig("with", "name"), "preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}" ],
   [ "upload artifact retention", upload_image.dig("with", "retention-days"), 3 ],
-  [ "trusted checkout ref", trusted_checkout.dig("with", "ref"), "${{ github.event.pull_request.base.sha }}" ],
+  [ "trusted checkout ref", trusted_checkout.dig("with", "ref"), "${{ github.event.repository.default_branch }}" ],
   [ "trusted checkout path", trusted_checkout.dig("with", "path"), "trusted" ],
   [ "trusted checkout credentials", trusted_checkout.dig("with", "persist-credentials"), false ],
-  [ "download artifact name", download_artifact.dig("with", "name"), "preview-image-pr-${{ env.PR_NUMBER }}-${{ env.HEAD_SHA }}" ],
+  [ "download artifact name", download_artifact.dig("with", "name"), "${{ env.ARTIFACT_NAME }}" ],
+  [ "download artifact run id", download_artifact.dig("with", "run-id"), "${{ github.event.workflow_run.id }}" ],
+  [ "download artifact token", download_artifact.dig("with", "github-token"), "${{ github.token }}" ],
   [ "download artifact path", download_artifact.dig("with", "path"), "${{ runner.temp }}/preview-image" ],
   [ "Wrangler binary", wrangler.dig("bin", "wrangler"), "bin/wrangler.js" ]
 ].each { |label, actual, expected| assert(actual == expected, "#{label}: expected #{actual.inspect} to equal #{expected.inspect}") }
 
 assert(pr_on.key?("pull_request"), "PR workflow must still run on pull_request")
-assert(pr_on.dig("pull_request", "paths-ignore") == [ "charts/**" ], "PR workflow paths-ignore must stay scoped")
-assert(!pr_jobs.key?("preview_image"), "PR workflow must not build preview image artifacts")
-assert(!download_artifact.fetch("with").key?("run-id"), "deploy workflow must not download artifacts from another workflow run")
-assert(!download_artifact.fetch("with").key?("github-token"), "deploy workflow must not use the GitHub token for cross-run artifact download")
-assert(gate_job.fetch("if").include?("preview-cf"), "preview gate must stay gated by preview-cf")
+assert(!preview_on.key?("pull_request_target"), "privileged preview deploy workflow must not run on pull_request_target")
+assert(!preview_on.key?("pull_request"), "privileged preview deploy workflow must not run directly on pull_request")
+assert(gate_job.fetch("if").include?("github.event.workflow_run.event == 'pull_request'"), "preview gate must only accept pull_request workflow runs")
+assert(gate_job.fetch("if").include?("github.event.workflow_run.conclusion == 'success'"), "preview gate must only accept successful PR workflow runs")
 assert(image_job.fetch("if").include?("preview-cf"), "preview image build must stay gated by preview-cf")
-assert(deploy_job.fetch("if").include?("preview-cf"), "privileged preview deploy must stay gated by preview-cf")
+assert(deploy_job.fetch("if") == "needs.preview-gate.outputs.should_deploy == 'true'", "privileged preview deploy must depend on the gate output")
 assert(gate_job["environment"].nil?, "preview gate must not use a protected secret-bearing environment")
 assert(image_job["environment"].nil?, "preview image build must not use a protected secret-bearing environment")
 assert(lockfile.dig("packages", "", "devDependencies", "wrangler"), "Wrangler must stay a root dev dependency")
@@ -195,11 +225,13 @@ assert(wrangler.fetch("resolved").start_with?("https://registry.npmjs.org/wrangl
 assert(wrangler.fetch("integrity").start_with?("sha512-"), "Wrangler lockfile entry must keep npm integrity metadata")
 assert(trusted_checkout.dig("with", "sparse-checkout").to_s.include?("workers/preview"), "trusted checkout must include preview tooling")
 assert(deploy_step_names.compact.uniq == deploy_step_names.compact, "workflow step names must stay unique for security checks")
-assert([ trusted_checkout, download_artifact, prepare, load_image, push_image, configure_image, deploy ].map { |step| deploy_steps.index(step) }.each_cons(2).all? { |left, right| left < right }, "deploy workflow steps must preserve safe same-run artifact deploy order")
+assert([ trusted_checkout, download_artifact, verify_checksum, prepare, load_image, push_image, configure_image, deploy ].map { |step| deploy_steps.index(step) }.each_cons(2).all? { |left, right| left < right }, "deploy workflow steps must preserve safe cross-run artifact deploy order")
 assert(deploy_steps.none? { |step| step["name"] == "Checkout PR code" }, "privileged deploy job must not checkout PR code")
-assert(deploy_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "Cloudflare secrets must not be job-wide")
-assert(gate_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "preview gate must not receive Cloudflare secrets")
-assert(image_job.fetch("env").keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "preview image build must not receive Cloudflare secrets")
+assert(env_hash(deploy_job).keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "Cloudflare secrets must not be job-wide")
+assert(env_hash(gate_job).keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "preview gate must not receive Cloudflare secrets")
+assert(env_hash(image_job).keys.none? { |name| name.start_with?("CLOUDFLARE_") }, "preview image build must not receive Cloudflare secrets")
+assert(upload_image.dig("with", "path").to_s.include?("sure-preview-image.tar.gz"), "preview image artifact must include the image archive")
+assert(upload_image.dig("with", "path").to_s.include?("sure-preview-image.sha256"), "preview image artifact must include the checksum")
 
 assert_pinned_actions!(gate_steps)
 assert_pinned_actions!(image_steps)
@@ -209,14 +241,29 @@ assert_no_inline_expressions!(image_steps)
 assert_no_inline_expressions!(deploy_steps)
 
 all_steps = gate_steps + image_steps + deploy_steps
-assert(all_steps.none? { |step| step.fetch("env", {}).values.join("\n").match?(INLINE_SECRET_EXPRESSION) && ![ push_image, deploy ].include?(step) }, "only Cloudflare steps may reference GitHub secrets")
+assert(all_steps.none? { |step| env_hash(step).values.join("\n").match?(INLINE_SECRET_EXPRESSION) && ![ push_image, deploy ].include?(step) }, "only Cloudflare steps may reference GitHub secrets")
 assert(deploy_steps.none? { |step| normalized_working_directory(step["working-directory"]).match?(PR_CONTROLLED_WORKDIR) }, "privileged deploy steps must not run from PR-controlled dirs")
 assert(deploy_steps.none? { |step| run(step).include?("npx wrangler") }, "privileged deploy workflow must not use npx wrangler")
 assert(deploy_steps.none? { |step| run(step).match?(/Dockerfile\.preview|docker build|docker save/) }, "privileged deploy job must not build PR Dockerfiles")
 assert(deploy_steps.none? { |step| run(step).include?("${GITHUB_WORKSPACE}/pr") || run(step).include?(" pr/") }, "privileged deploy job must not reference PR checkout paths")
+assert(image_steps.none? { |step| env_hash(step).keys.any? { |key| key.start_with?("CLOUDFLARE_") } }, "preview image workflow must not expose Cloudflare secret env")
+assert(image_steps.none? { |step| [ run(step), env_hash(step).values.join("\n") ].join("\n").match?(INLINE_SECRET_EXPRESSION) }, "preview image workflow must not reference GitHub secrets")
 
-assert_run_includes(verify_workflows, "github.rest.pulls.listFiles", "filename.startsWith('.github/workflows/')", "base-trusted workflow definitions", "core.setFailed")
-assert_run_includes(wait_for_pr_ci, "Number(process.env.PR_NUMBER)", "listWorkflowRunsForRepo", "run.name === 'Pull Request' && run.head_sha === headSha", "run.pull_requests?.some((pr) => pr.number === prNumber)", "const timeoutMs = 30 * 60 * 1000")
+assert_run_includes(
+  resolve_preview,
+  "context.payload.workflow_run",
+  "workflowRun.pull_requests?.[0]",
+  "github.rest.pulls.get",
+  "pullRequest.head.sha !== headSha",
+  "preview-cf",
+  "github.rest.pulls.listFiles",
+  "filename.startsWith('.github/workflows/')",
+  "github.rest.actions.listWorkflowRunArtifacts",
+  "preview-image-pr-${prNumber}-${headSha}",
+  "!item.expired",
+  "core.setOutput('artifact_name', artifactName)",
+  "core.setOutput('should_deploy', 'true')"
+)
 
 prepare_run = assert_run_includes(prepare, *REQUIRED_PREPARE_LINES)
 assert(!prepare_run.include?("npm install"), "prepare step must not use npm install")
@@ -227,15 +274,14 @@ assert(deploy_steps.select { |step| run(step).match?(/npm (ci|install)/) }.map {
 image_build_run = assert_run_includes(build_image, *REQUIRED_IMAGE_BUILD_LINES)
 assert(image_build_run.include?("set -euo pipefail"), "preview image build must fail closed")
 assert(!image_build_run.include?("CLOUDFLARE_"), "preview image build must not receive Cloudflare secrets")
-assert(image_steps.none? { |step| step.fetch("env", {}).keys.any? { |key| key.start_with?("CLOUDFLARE_") } }, "preview image workflow must not expose Cloudflare secret env")
-assert(image_steps.none? { |step| [ run(step), step.fetch("env", {}).values.join("\n") ].join("\n").match?(INLINE_SECRET_EXPRESSION) }, "preview image workflow must not reference GitHub secrets")
 
+assert_run_includes(verify_checksum, 'expected_checksum="$(tr -d', 'actual_checksum="$(sha256sum "$image_archive"', "Preview image artifact checksum mismatch")
 assert_run_includes(load_image, 'gzip -dc "$image_archive" | docker load', 'docker image inspect "$expected_image"')
 assert_run_includes(push_image, "./node_modules/.bin/wrangler containers push", "registry\\.cloudflare\\.com/", "image_ref=")
 assert_run_includes(configure_image, "imageRef.startsWith('registry.cloudflare.com/')", 'const original = fs.readFileSync', 'const updated = original.replace(/image = "[^"]+"/', "updated === original", "Expected wrangler.toml to contain an image entry to rewrite", "JSON.stringify(imageRef)")
 assert_run_includes(deploy, 'cd "$RUNNER_TEMP/sure-preview-worker"', "./node_modules/.bin/wrangler deploy --config wrangler.toml", '--var "PR_NUMBER:${PR_NUMBER}"')
 
-secret_steps = deploy_steps.select { |step| step.fetch("env", {}).then { |env| env.key?("CLOUDFLARE_API_TOKEN") || env.key?("CLOUDFLARE_ACCOUNT_ID") } }
+secret_steps = deploy_steps.select { |step| env_hash(step).then { |env| env.key?("CF_API_TOKEN") || env.key?("CF_ACCOUNT_ID") } }
 assert(secret_steps.map { |step| step["name"] } == [ push_image["name"], deploy["name"] ], "only image push and deploy may receive Cloudflare secrets")
 assert_secret_env_sources!(push_image, EXPECTED_PUSH_SECRET_ENV)
 assert_secret_env_sources!(deploy, EXPECTED_DEPLOY_SECRET_ENV)

--- a/bin/preview_deploy_security_check.rb
+++ b/bin/preview_deploy_security_check.rb
@@ -40,8 +40,8 @@ EXPECTED_DEPLOY_PERMISSIONS = {
   "deployments" => "write",
   "pull-requests" => "write"
 }.freeze
-EXPECTED_DEPLOY_SECRET_ENV = %w[CF_ACCOUNT_ID CF_API_TOKEN CLOUDFLARE_WORKERS_SUBDOMAIN].freeze
-EXPECTED_PUSH_SECRET_ENV = %w[CF_ACCOUNT_ID CF_API_TOKEN].freeze
+EXPECTED_DEPLOY_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_WORKERS_SUBDOMAIN].freeze
+EXPECTED_PUSH_SECRET_ENV = %w[CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN].freeze
 REQUIRED_PREPARE_LINES = [
   'cp trusted/workers/preview/package.json "$preview_dir/package.json"',
   'cp trusted/workers/preview/package-lock.json "$preview_dir/package-lock.json"',
@@ -281,7 +281,7 @@ assert_run_includes(push_image, "./node_modules/.bin/wrangler containers push", 
 assert_run_includes(configure_image, "imageRef.startsWith('registry.cloudflare.com/')", 'const original = fs.readFileSync', 'const updated = original.replace(/image = "[^"]+"/', "updated === original", "Expected wrangler.toml to contain an image entry to rewrite", "JSON.stringify(imageRef)")
 assert_run_includes(deploy, 'cd "$RUNNER_TEMP/sure-preview-worker"', "./node_modules/.bin/wrangler deploy --config wrangler.toml", '--var "PR_NUMBER:${PR_NUMBER}"')
 
-secret_steps = deploy_steps.select { |step| env_hash(step).then { |env| env.key?("CF_API_TOKEN") || env.key?("CF_ACCOUNT_ID") } }
+secret_steps = deploy_steps.select { |step| env_hash(step).then { |env| env.key?("CLOUDFLARE_API_TOKEN") || env.key?("CLOUDFLARE_ACCOUNT_ID") } }
 assert(secret_steps.map { |step| step["name"] } == [ push_image["name"], deploy["name"] ], "only image push and deploy may receive Cloudflare secrets")
 assert_secret_env_sources!(push_image, EXPECTED_PUSH_SECRET_ENV)
 assert_secret_env_sources!(deploy, EXPECTED_DEPLOY_SECRET_ENV)


### PR DESCRIPTION
## Summary
- Splits Cloudflare preview deployment into a no-secret preview gate/image build and a separate protected deploy job.
- Runs preview coordination from `pull_request_target` so fork PR previews can use the shared `preview` environment after approval.
- Keeps PR Docker builds and trusted Wrangler/Cloudflare deployment isolated so Cloudflare secrets only enter the final control-plane steps.

## What changed
- Keeps `.github/workflows/pr.yml` focused on normal Pull Request CI with read-only contents permissions.
- Adds a `preview-gate` job to the preview workflow that rejects PRs changing `.github/workflows/**` and waits for the matching Pull Request workflow by both head SHA and PR number.
- Adds a no-secret `preview-image` job in the trusted preview workflow definition; it checks out the PR head with credentials disabled, builds `Dockerfile.preview`, and uploads a same-run image artifact.
- Updates `deploy-preview` to use `environment: preview`, download only the same-workflow image artifact, and deploy with trusted base-branch preview tooling.
- Makes the `wrangler.toml` image rewrite fail closed if the expected `image = "..."` entry is not updated.
- Expands `bin/preview_deploy_security_check.rb` so CI enforces the top-level permissions, trusted workflow gate, same-run artifact handoff, secret scoping, and fail-closed image rewrite.

## Why
Fork-origin `pull_request` runs cannot create deployments or receive repository environment secrets, but the privileged deploy path still must not consume artifacts produced by fork-controlled workflow definitions.

This version keeps the deploy UX for fork and same-repo PRs while tightening the trust boundary: PR code is built only in a no-secret job from the trusted workflow definition, and the secret-bearing job never checks out PR code or runs PR-controlled build/package tooling.

## Validation
- `ruby bin/preview_deploy_security_check.rb`
- `ruby -c bin/preview_deploy_security_check.rb`
- `actionlint .github/workflows/pr.yml .github/workflows/preview-deploy.yml .github/workflows/ci.yml`
- `bin/rubocop bin/preview_deploy_security_check.rb`
- `git diff --check`
- `npm --prefix workers/preview ci --ignore-scripts --no-audit --no-fund`
- `bin/brakeman --no-pager`
- `coderabbit review --agent -t uncommitted -c AGENTS.md` raised 0 issues
- Verified pinned action SHAs for `actions/checkout@v5` and `actions/setup-node@v6`
- Docker preview artifact smoke: built `Dockerfile.preview` for `linux/amd64`, saved the image, reloaded it, and inspected the reloaded image.

## Notes
- The workflow uses one shared GitHub environment named `preview` as the approval/secret gate, while GitHub deployment records and Cloudflare Worker names remain per PR.
- The `preview` environment protection rules still live in GitHub repository settings; this workflow only references that environment.
- Preview deployment now intentionally fails for PRs that modify `.github/workflows/**`, because those PRs cannot prove the Pull Request CI run came from base-trusted workflow definitions.
- The Cloudflare token used by the `preview` environment needs permission for both `wrangler containers push` and `wrangler deploy`.
- The first labeled upstream run is still the live integration check for GitHub environment policy and Cloudflare token scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added label-gated preview image build that uploads image archive and SHA256 checksum as short-retention artifacts; build runs without secrets and with reduced token permissions.
  * Preview deploy now triggers from a completed Pull Request workflow run, selects matching preview artifacts, validates checksums, and pushes verified images.
  * Introduced a preview gate that requires the preview label and blocks deployments when workflow files changed or checks fail.
  * Added comprehensive workflow security/validation checks and tightened workflow token permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/2057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->