### PR TITLE
Add HTTP timeout config to Provider::Github Octokit client

### DIFF
--- a/app/models/provider/github.rb
+++ b/app/models/provider/github.rb
@@ -1,16 +1,24 @@
 class Provider::Github
-  attr_reader :name, :owner, :branch
+  attr_reader :name, :owner, :branch, :client
 
   def initialize
     @name = "sure"
     @owner = "we-promise"
     @branch = "main"
+    @client = Octokit::Client.new(
+      connection_options: {
+        request: {
+          open_timeout: 10,
+          timeout: 10
+        }
+      }
+    )
   end
 
   def fetch_latest_release_notes
     begin
       Rails.cache.fetch("latest_github_release_notes", expires_in: 2.hours) do
-        release = Octokit.releases(repo).first
+        release = client.releases(repo).first
         if release
           {
             avatar: release.author.avatar_url,
@@ -18,7 +26,7 @@ class Provider::Github
             username: release.author.login,
             name: release.name,
             published_at: release.published_at,
-            body: Octokit.markdown(release.body, mode: "gfm", context: repo)
+            body: client.markdown(release.body, mode: "gfm", context: repo)
           }
         else
           nil


### PR DESCRIPTION
## Summary

Without explicit HTTP timeouts, `Octokit::Client` on a slow GitHub 
connection blocks a Puma worker indefinitely until the OS-level socket 
timeout fires (often 2+ minutes).

This PR adds `open_timeout: 10` and `read_timeout: 10` to the Faraday 
connection options on `Provider::Github`'s Octokit client, bounding 
the request to a safe duration. The existing `rescue` in 
`fetch_latest_release_notes` already handles the resulting 
`Faraday::TimeoutError` and returns `nil`, so the changelog fallback 
message kicks in gracefully.

## Changes

- `app/models/provider/github.rb` — initialize `Octokit::Client` with 
  Faraday connection timeout options

## Testing

- Existing tests pass: `bin/rails test test/models/`
- No new tests needed — timeout config is infrastructure-level and the 
  nil fallback path is already covered

## References

- Extracted from #1897 as suggested by @jjmata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced GitHub API client configuration with improved timeout handling for more reliable release notes fetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/we-promise/sure/pull/2061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->