### PR TITLE
fix(sophtron): correct pluralization, guard rescue update!, and surfa…

### DIFF
--- a/app/models/provider/sophtron.rb
+++ b/app/models/provider/sophtron.rb
@@ -388,10 +388,13 @@ class Provider::Sophtron < Provider
       parsed = URI.parse(url)
       parsed.path.to_s.end_with?("/api") ? url : "#{url}/api"
     rescue URI::InvalidURIError => e
+      # Keep the raw URL out of the human-readable message so it doesn't leak
+      # into error-tracking payloads (e.g. Sentry). The configured value is
+      # preserved in details for admin-facing diagnostics.
       raise Error.new(
-        "Invalid Sophtron base URL: #{value}",
+        "Invalid Sophtron base URL",
         :invalid_base_url,
-        details: e.message
+        details: "value=#{value.inspect}; #{e.message}"
       )
     end
 

--- a/app/models/provider/sophtron.rb
+++ b/app/models/provider/sophtron.rb
@@ -387,8 +387,12 @@ class Provider::Sophtron < Provider
 
       parsed = URI.parse(url)
       parsed.path.to_s.end_with?("/api") ? url : "#{url}/api"
-    rescue URI::InvalidURIError
-      DEFAULT_BASE_URL
+    rescue URI::InvalidURIError => e
+      raise Error.new(
+        "Invalid Sophtron base URL: #{value}",
+        :invalid_base_url,
+        details: e.message
+      )
     end
 
     def normalize_account(account, user_institution_id:)

--- a/app/models/sophtron_item/importer.rb
+++ b/app/models/sophtron_item/importer.rb
@@ -340,7 +340,7 @@ class SophtronItem::Importer
         { success: true, transactions_count: transactions_count }
       rescue Provider::Sophtron::Error => e
         requires_update = e.error_type.in?([ :unauthorized, :access_forbidden ])
-        sophtron_item.update!(status: :requires_update) if requires_update
+        mark_requires_update if requires_update
         Rails.logger.error "SophtronItem::Importer - Sophtron API error for account #{sophtron_account.id}: #{e.message}"
         { success: false, transactions_count: 0, error: e.message, requires_update: requires_update }
       rescue JSON::ParserError => e
@@ -387,9 +387,19 @@ class SophtronItem::Importer
       nil
     rescue Provider::Sophtron::Error => e
       requires_update = e.error_type.in?([ :unauthorized, :access_forbidden ])
-      sophtron_item.update!(status: :requires_update) if requires_update
+      mark_requires_update if requires_update
       Rails.logger.error "SophtronItem::Importer - Sophtron API error refreshing account #{sophtron_account.id}: #{e.message}"
       { success: false, transactions_count: 0, error: e.message, requires_update: requires_update }
+    end
+
+    # Marks the item as requiring update without raising. Safe to call from
+    # within rescue blocks: a validation failure here must not crash the sync
+    # job, so we use the non-bang +update+ and log any failure instead of
+    # letting ActiveRecord::RecordInvalid propagate.
+    def mark_requires_update
+      return if sophtron_item.update(status: :requires_update)
+
+      Rails.logger.error "SophtronItem::Importer - Failed to mark item #{sophtron_item.id} as requires_update: #{sophtron_item.errors.full_messages.join(', ')}"
     end
 
     # Determines the appropriate start date for fetching transactions.

--- a/app/models/sophtron_item/syncer.rb
+++ b/app/models/sophtron_item/syncer.rb
@@ -121,7 +121,7 @@ class SophtronItem::Syncer
 
       if import_result[:transactions_failed].to_i.positive?
         errors << {
-          message: "#{import_result[:transactions_failed]} #{'account'.pluralize(import_result[:transactions_failed])} failed to import transactions",
+          message: "#{import_result[:transactions_failed]} #{'transaction'.pluralize(import_result[:transactions_failed])} failed to import transactions",
           category: "transaction_import"
         }
       end

--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -712,39 +712,45 @@ class AccountStatementTest < ActiveSupport::TestCase
   end
 
   test "coverage marks covered duplicate ambiguous and mismatched months" do
-    covered_month = 5.months.ago.to_date.beginning_of_month
-    missing_month = 4.months.ago.to_date.beginning_of_month
-    duplicate_month = 3.months.ago.to_date.beginning_of_month
-    ambiguous_month = 2.months.ago.to_date.beginning_of_month
-    mismatched_month = 1.month.ago.to_date.beginning_of_month
+    # Pin the clock so the computed months are deterministic and never collide
+    # with the relative-dated balance fixtures (which land on "yesterday").
+    # Without this the test fails on the 1st of every month, when
+    # 1.month.ago.end_of_month equals 1.day.ago. See balances.yml.
+    travel_to Date.new(2026, 5, 6) do
+      covered_month = 5.months.ago.to_date.beginning_of_month
+      missing_month = 4.months.ago.to_date.beginning_of_month
+      duplicate_month = 3.months.ago.to_date.beginning_of_month
+      ambiguous_month = 2.months.ago.to_date.beginning_of_month
+      mismatched_month = 1.month.ago.to_date.beginning_of_month
 
-    create_statement(account: @account, month: covered_month, content: "covered")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
-    create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
-    create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
+      create_statement(account: @account, month: covered_month, content: "covered")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
+      create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
+      create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
 
-    @account.balances.create!(
-      date: mismatched_month.end_of_month,
-      balance: 100,
-      currency: "USD",
-      start_cash_balance: 100,
-      cash_inflows: 0,
-      cash_outflows: 0
-    )
+      @account.balances.create!(
+        date: mismatched_month.end_of_month,
+        balance: 100,
+        currency: "USD",
+        start_cash_balance: 100,
+        cash_inflows: 0,
+        cash_outflows: 0
+      )
 
-    coverage = AccountStatement::Coverage.new(
-      @account,
-      start_month: covered_month,
-      end_month: mismatched_month
-    )
+      coverage = AccountStatement::Coverage.new(
+        @account,
+        start_month: covered_month,
+        end_month: mismatched_month
+      )
 
-    statuses = coverage.months.index_by(&:date).transform_values(&:status)
-    assert_equal "covered", statuses[covered_month]
-    assert_equal "missing", statuses[missing_month]
-    assert_equal "duplicate", statuses[duplicate_month]
-    assert_equal "ambiguous", statuses[ambiguous_month]
-    assert_equal "mismatched", statuses[mismatched_month]
+      statuses = coverage.months.index_by(&:date).transform_values(&:status)
+      assert_equal "covered", statuses[covered_month]
+      assert_equal "missing", statuses[missing_month]
+      assert_equal "duplicate", statuses[duplicate_month]
+      assert_equal "ambiguous", statuses[ambiguous_month]
+      assert_equal "mismatched", statuses[mismatched_month]
+    end
   end
 
   private

--- a/test/models/provider/sophtron_test.rb
+++ b/test/models/provider/sophtron_test.rb
@@ -216,6 +216,20 @@ class Provider::SophtronTest < ActiveSupport::TestCase
     assert_equal :unauthorized, response.error.error_type
   end
 
+  test "raises a configuration error for an invalid base url instead of silently defaulting" do
+    error = assert_raises(Provider::Sophtron::Error) do
+      Provider::Sophtron.new("developer-user", @access_key, base_url: "http://[invalid")
+    end
+
+    assert_equal :invalid_base_url, error.error_type
+  end
+
+  test "falls back to the default base url when base url is blank" do
+    provider = Provider::Sophtron.new("developer-user", @access_key, base_url: "")
+
+    assert_equal Provider::Sophtron::DEFAULT_BASE_URL, provider.base_url
+  end
+
   private
 
     def provider_data(response)

--- a/test/models/provider/sophtron_test.rb
+++ b/test/models/provider/sophtron_test.rb
@@ -222,6 +222,10 @@ class Provider::SophtronTest < ActiveSupport::TestCase
     end
 
     assert_equal :invalid_base_url, error.error_type
+    # The raw URL must not leak into the human-readable message (it could end up
+    # in error-tracking payloads); it belongs in details for diagnostics.
+    assert_not_includes error.message, "http://[invalid"
+    assert_includes error.details.to_s, "http://[invalid"
   end
 
   test "falls back to the default base url when base url is blank" do

--- a/test/models/sophtron_item/importer_test.rb
+++ b/test/models/sophtron_item/importer_test.rb
@@ -329,4 +329,15 @@ class SophtronItem::ImporterTest < ActiveSupport::TestCase
       assert_equal 0, result[:transactions_failed]
     end
   end
+
+  test "marking an item as requires_update does not raise when the update fails" do
+    importer = SophtronItem::Importer.new(@item, sophtron_provider: mock)
+
+    @item.stubs(:update).with(status: :requires_update).returns(false)
+    @item.stubs(:errors).returns(OpenStruct.new(full_messages: [ "Status is invalid" ]))
+
+    assert_nothing_raised do
+      importer.send(:mark_requires_update)
+    end
+  end
 end

--- a/test/models/sophtron_item/syncer_test.rb
+++ b/test/models/sophtron_item/syncer_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class SophtronItem::SyncerTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @item = @family.sophtron_items.create!(
+      name: "Sophtron",
+      user_id: "developer-user",
+      access_key: Base64.strict_encode64("secret-key"),
+      customer_id: "cust-1",
+      user_institution_id: "ui-1"
+    )
+    @syncer = SophtronItem::Syncer.new(@item)
+  end
+
+  test "pluralizes transaction import failures as transactions, not accounts" do
+    errors = @syncer.send(:import_errors_for, { success: false, transactions_failed: 2 })
+    message = errors.find { |e| e[:category] == "transaction_import" }[:message]
+
+    assert_equal "2 transactions failed to import transactions", message
+  end
+
+  test "uses the singular form for a single transaction import failure" do
+    errors = @syncer.send(:import_errors_for, { success: false, transactions_failed: 1 })
+    message = errors.find { |e| e[:category] == "transaction_import" }[:message]
+
+    assert_equal "1 transaction failed to import transactions", message
+  end
+end


### PR DESCRIPTION
fixes #1704

## Summary

Addresses the three high-priority items deferred from PR #1698 (Sophtron account mapping), as recommended in the issue — a focused PR covering the most critical bugs and the security/correctness concern.

* **Bug Fixes**
  * **Pluralization** (`sophtron_item/syncer.rb`): transaction import failures were pluralized with `'account'.pluralize`, producing messages like  "2 accounts failed to import transactions". Now uses `'transaction'.pluralize`.
  * **Unguarded `update!` in rescue blocks** (`sophtron_item/importer.rb`):
    `fetch_and_store_transactions` and `refresh_account_before_transaction_fetch` called `sophtron_item.update!` inside their `rescue` handlers, so an `ActiveRecord::RecordInvalid` could crash the sync job. Extracted a non-raising `mark_requires_update` helper (non-bang `update` + error log).
  * **Silent base URL fallback** (`provider/sophtron.rb`): `normalize_base_url` rescued `URI::InvalidURIError` and silently returned the production `DEFAULT_BASE_URL`. It now raises `Provider::Sophtron::Error` (`:invalid_base_url`) so misconfiguration surfaces instead of being masked.
    Blank values still fall back to the default.
* **Tests**
  * Transaction import failures pluralize as "transaction(s)" (singular + plural).
  * `mark_requires_update` does not raise when the underlying update fails.
  * Invalid base URL raises a configuration error; blank base URL falls back to the default.

## Out of scope (tracked separately in #1704)

Items 3, 5, 6, 7, 8, 9 (raw API response exposure, incremental-vs-full sync edge case, i18n strings, debug logging, code duplication, fat controller) are deferred per the issue's recommended phased approach.

## CI checklist (`.github/workflows/pr.yml` → `ci.yml`)

- [ ] `bin/brakeman --no-pager` — Ruby security scan
- [ ] `bin/importmap audit` — JS dependency scan
- [ ] `bin/rubocop -f github` — Ruby lint
- [ ] `npm run lint` — JS lint/format
- [ ] `bin/rails test` — unit tests:
      `test/models/provider/sophtron_test.rb`,
      `test/models/sophtron_item/importer_test.rb`,
      `test/models/sophtron_item/syncer_test.rb`

---

- **Issue:** Closes #1704
- **Branch:** `fix/1704-sophtron-critical-fixes`
- **Base:** `we-promise/sure:main` ← **Compare:** `web-dev0521:fix/1704-sophtron-critical-fixes`
- **Create PR:** https://github.com/web-dev0521/sure/pull/new/fix/1704-sophtron-critical-fixes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed Sophtron base URLs now raise an explicit invalid-base-URL error with details instead of silently falling back to the default.
  * Transaction import failures for unauthorized/access-forbidden no longer raise; items are marked as requiring update and failures are logged.
  * Corrected pluralization in transaction import failure messages.

* **Tests**
  * Added tests for base URL validation, error details, import error handling, and pluralization.
  * Made a test deterministic by pinning the current date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->