### PR TITLE
Fix API key settings responsiveness in medium width range

### DIFF
--- a/app/views/settings/api_keys/created.html.erb
+++ b/app/views/settings/api_keys/created.html.erb
@@ -21,9 +21,9 @@
       <h4 class="font-medium text-primary mb-3"><%= t(".your_api_key") %></h4>
       <p class="text-secondary text-sm mb-3"><%= t(".copy_store_securely") %></p>
 
-      <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-        <div class="flex items-center justify-between gap-3">
-          <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
+      <div class="@container bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
+        <div class="flex flex-col items-start gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
+          <code id="api-key-display" class="font-mono text-sm text-primary break-all min-w-0" data-clipboard-target="source"><%= @api_key.plain_key %></code>
           <%= render DS::Button.new(
             text: t(".copy_key"),
             variant: "ghost",

--- a/app/views/settings/api_keys/created.turbo_stream.erb
+++ b/app/views/settings/api_keys/created.turbo_stream.erb
@@ -26,9 +26,9 @@
             <h4 class="font-medium text-primary mb-3"><%= t("settings.api_keys.created.your_api_key") %></h4>
             <p class="text-secondary text-sm mb-3"><%= t("settings.api_keys.created.copy_store_securely") %></p>
 
-            <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-              <div class="flex items-center justify-between gap-3">
-                <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @api_key.plain_key %></code>
+            <div class="@container bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
+              <div class="flex flex-col items-start gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
+                <code id="api-key-display" class="font-mono text-sm text-primary break-all min-w-0" data-clipboard-target="source"><%= @api_key.plain_key %></code>
                 <%= render DS::Button.new(
                   text: t("settings.api_keys.created.copy_key"),
                   variant: "ghost",

--- a/app/views/settings/api_keys/show.html.erb
+++ b/app/views/settings/api_keys/show.html.erb
@@ -22,9 +22,9 @@
         <h4 class="font-medium text-primary mb-3"><%= t(".newly_created.your_api_key") %></h4>
         <p class="text-secondary text-sm mb-3"><%= t(".newly_created.copy_store_securely") %></p>
 
-        <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-          <div class="flex items-center justify-between gap-3">
-            <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
+        <div class="@container bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
+          <div class="flex flex-col items-start gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
+            <code id="api-key-display" class="font-mono text-sm text-primary break-all min-w-0" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
             <%= render DS::Button.new(
               text: t(".newly_created.copy_api_key"),
               variant: "ghost",
@@ -110,9 +110,9 @@
         <h4 class="font-medium text-primary mb-3"><%= t(".current_api_key.title") %></h4>
         <p class="text-secondary text-sm mb-3"><%= t(".current_api_key.copy_store_securely") %></p>
 
-        <div class="bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
-          <div class="flex items-center justify-between gap-3">
-            <code id="api-key-display" class="font-mono text-sm text-primary break-all" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
+        <div class="@container bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
+          <div class="flex flex-col items-start gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
+            <code id="api-key-display" class="font-mono text-sm text-primary break-all min-w-0" data-clipboard-target="source"><%= @current_api_key.plain_key %></code>
             <%= render DS::Button.new(
               text: t(".current_api_key.copy_api_key"),
               variant: "ghost",


### PR DESCRIPTION
## Summary

Fixes #1565.

The `/settings/api_key` page layout broke in the medium viewport range (~768px–987px). At the `md:` breakpoint (768px) the settings layout introduces a fixed `min-w-64` (256px) sidebar, which shrinks the content card. The API-key value block forced the long `break-all` key and the copy button onto a single `flex justify-between` row, which collides in that narrowed card. Viewport breakpoints can't address this because the *card* width — not the viewport — is what's constrained.

## Changes

Use **container queries** (`@container` + `@lg:` variants), matching the existing convention used in `app/views/pages/dashboard/_outflows_donut.html.erb`:

- Mark the key-value box as `@container` so its children respond to the card's actual width.
- Stack the key value above the copy button when the card is narrow, switching to side-by-side (`@lg:flex-row`) only when there's room.
- Add `min-w-0` to the `<code>` element so it shrinks/wraps cleanly instead of overflowing.

Applied to all renderings of the key block:
- `app/views/settings/api_keys/show.html.erb` (newly-created + current-key)
- `app/views/settings/api_keys/created.html.erb`
- `app/views/settings/api_keys/created.turbo_stream.erb`

This preserves the original side-by-side desktop layout while eliminating the cramping across the full 768–987px range. Pure Tailwind class change — no logic or i18n changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key copy-to-clipboard functionality across API key management pages.
  * Enhanced responsive layout for API key display sections on mobile and desktop devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->