### PR TITLE
perf(transfers): narrow auto-transfer candidate search

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -26,6 +26,10 @@ module Family::AutoTransferMatchable
   def auto_match_transfers!
     # Exclude already matched transfers
     candidates_scope = transfer_match_candidates(include_rejected: false)
+    transaction_ids = candidates_scope.flat_map do |match|
+      [ match.inflow_transaction_id, match.outflow_transaction_id ]
+    end.uniq
+    transactions_by_id = Transaction.includes(entry: :account).where(id: transaction_ids).index_by(&:id)
 
     # Track which transactions we've already matched to avoid duplicates
     used_transaction_ids = Set.new
@@ -44,16 +48,17 @@ module Family::AutoTransferMatchable
           # Another concurrent job created the transfer; safe to ignore
         end
 
-        inflow_transaction = Transaction.find(match.inflow_transaction_id)
-        outflow_transaction = Transaction.find(match.outflow_transaction_id)
+        inflow_transaction = transactions_by_id.fetch(match.inflow_transaction_id)
+        outflow_transaction = transactions_by_id.fetch(match.outflow_transaction_id)
+        destination_account = inflow_transaction.entry.account
+        transfer_kind = Transfer.kind_for_account(destination_account)
 
         # The kind is determined by the DESTINATION account (inflow), matching Transfer::Creator logic
         inflow_transaction.update!(kind: "funds_movement")
-        outflow_transaction.update!(kind: Transfer.kind_for_account(inflow_transaction.entry.account))
+        outflow_transaction.update!(kind: transfer_kind)
 
         # Assign Investment Contributions category for transfers to investment accounts
-        destination_account = inflow_transaction.entry.account
-        if Transfer.kind_for_account(destination_account) == "investment_contribution"
+        if transfer_kind == "investment_contribution"
           outflow_txn = outflow_transaction
           if outflow_txn.category_id.blank?
             category = destination_account.family.investment_contributions_category

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -85,12 +85,16 @@ module Family::AutoTransferMatchable
     end
 
     def coerce_transfer_match_exchange_rate_tolerance!(value)
-      tolerance = Float(value)
-      return tolerance if tolerance.finite?
+      tolerance = begin
+        Float(value)
+      rescue ArgumentError, TypeError
+        raise ArgumentError, "exchange_rate_tolerance must be numeric"
+      end
 
-      raise ArgumentError
-    rescue ArgumentError, TypeError
-      raise ArgumentError, "exchange_rate_tolerance must be numeric"
+      raise ArgumentError, "exchange_rate_tolerance must be numeric" unless tolerance.finite?
+      raise ArgumentError, "exchange_rate_tolerance must be non-negative" if tolerance.negative?
+
+      tolerance
     end
 
     def transfer_match_candidates_sql

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -1,59 +1,34 @@
 module Family::AutoTransferMatchable
-  def transfer_match_candidates(date_window: 4, exchange_rate_tolerance: 0.1)
-    Entry.select([
-      "inflow_candidates.entryable_id as inflow_transaction_id",
-      "outflow_candidates.entryable_id as outflow_transaction_id",
-      "ABS(inflow_candidates.date - outflow_candidates.date) as date_diff"
-    ]).from("entries inflow_candidates")
-      .joins("
-        JOIN entries outflow_candidates ON (
-          inflow_candidates.amount < 0 AND
-          outflow_candidates.amount > 0 AND
-          inflow_candidates.account_id <> outflow_candidates.account_id AND
-          inflow_candidates.date BETWEEN outflow_candidates.date - #{date_window.to_i} AND outflow_candidates.date + #{date_window.to_i}
-        )
-      ").joins("
-        LEFT JOIN transfers existing_transfers ON (
-          existing_transfers.inflow_transaction_id = inflow_candidates.entryable_id OR
-          existing_transfers.outflow_transaction_id = outflow_candidates.entryable_id
-        )
-      ")
-      .joins("LEFT JOIN rejected_transfers ON (
-        rejected_transfers.inflow_transaction_id = inflow_candidates.entryable_id AND
-        rejected_transfers.outflow_transaction_id = outflow_candidates.entryable_id
-      )")
-      .joins("LEFT JOIN exchange_rates ON (
-        exchange_rates.date = outflow_candidates.date AND
-        exchange_rates.from_currency = outflow_candidates.currency AND
-        exchange_rates.to_currency = inflow_candidates.currency
-      )")
-      .joins("JOIN accounts inflow_accounts ON inflow_accounts.id = inflow_candidates.account_id")
-      .joins("JOIN accounts outflow_accounts ON outflow_accounts.id = outflow_candidates.account_id")
-      .where("inflow_accounts.family_id = ? AND outflow_accounts.family_id = ?", self.id, self.id)
-      .where("inflow_accounts.status IN ('draft', 'active')")
-      .where("outflow_accounts.status IN ('draft', 'active')")
-      .where("inflow_candidates.entryable_type = 'Transaction' AND outflow_candidates.entryable_type = 'Transaction'")
-      .where("
-        (
-          inflow_candidates.currency = outflow_candidates.currency AND
-          inflow_candidates.amount = -outflow_candidates.amount
-        ) OR (
-          inflow_candidates.currency <> outflow_candidates.currency AND
-          ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0)) BETWEEN #{1 - exchange_rate_tolerance} AND #{1 + exchange_rate_tolerance}
-        )
-      ")
-      .where(existing_transfers: { id: nil })
-      .order("date_diff ASC") # Closest matches first
+  def transfer_match_candidates(
+    date_window: 4,
+    exchange_rate_tolerance: 0.1,
+    inflow_transaction_id: nil,
+    outflow_transaction_id: nil,
+    include_rejected: true
+  )
+    date_window = date_window.to_i
+    exchange_rate_tolerance = exchange_rate_tolerance.to_f
+
+    Entry.find_by_sql([
+      transfer_match_candidates_sql,
+      {
+        date_window:,
+        family_id: id,
+        inflow_transaction_id:,
+        outflow_transaction_id:,
+        include_rejected:,
+        lower_exchange_rate_bound: 1 - exchange_rate_tolerance,
+        upper_exchange_rate_bound: 1 + exchange_rate_tolerance
+      }
+    ])
   end
 
   def auto_match_transfers!
     # Exclude already matched transfers
-    candidates_scope = transfer_match_candidates.where(rejected_transfers: { id: nil })
+    candidates_scope = transfer_match_candidates(include_rejected: false)
 
     # Track which transactions we've already matched to avoid duplicates
     used_transaction_ids = Set.new
-
-    candidates = []
 
     Transfer.transaction do
       candidates_scope.each do |match|
@@ -77,9 +52,9 @@ module Family::AutoTransferMatchable
         outflow_transaction.update!(kind: Transfer.kind_for_account(inflow_transaction.entry.account))
 
         # Assign Investment Contributions category for transfers to investment accounts
-        destination_account = Transaction.find(match.inflow_transaction_id).entry.account
+        destination_account = inflow_transaction.entry.account
         if Transfer.kind_for_account(destination_account) == "investment_contribution"
-          outflow_txn = Transaction.find(match.outflow_transaction_id)
+          outflow_txn = outflow_transaction
           if outflow_txn.category_id.blank?
             category = destination_account.family.investment_contributions_category
             outflow_txn.update!(category: category) if category.present?
@@ -91,4 +66,91 @@ module Family::AutoTransferMatchable
       end
     end
   end
+
+  private
+    def transfer_match_candidates_sql
+      <<~SQL.squish
+        SELECT transfer_match_candidates.*
+        FROM (
+          SELECT
+            inflow_candidates.entryable_id AS inflow_transaction_id,
+            outflow_candidates.entryable_id AS outflow_transaction_id,
+            ABS(inflow_candidates.date - outflow_candidates.date) AS date_diff,
+            rejected_transfers.id AS rejected_transfer_id
+          FROM entries inflow_candidates
+          JOIN accounts inflow_accounts ON inflow_accounts.id = inflow_candidates.account_id
+          JOIN entries outflow_candidates ON (
+            outflow_candidates.entryable_type = 'Transaction' AND
+            outflow_candidates.amount > 0 AND
+            outflow_candidates.account_id <> inflow_candidates.account_id AND
+            outflow_candidates.date BETWEEN inflow_candidates.date - :date_window AND inflow_candidates.date + :date_window AND
+            outflow_candidates.currency = inflow_candidates.currency AND
+            outflow_candidates.amount = -inflow_candidates.amount
+          )
+          JOIN accounts outflow_accounts ON outflow_accounts.id = outflow_candidates.account_id
+          LEFT JOIN transfers existing_transfers ON (
+            existing_transfers.inflow_transaction_id = inflow_candidates.entryable_id OR
+            existing_transfers.outflow_transaction_id = outflow_candidates.entryable_id
+          )
+          LEFT JOIN rejected_transfers ON (
+            rejected_transfers.inflow_transaction_id = inflow_candidates.entryable_id AND
+            rejected_transfers.outflow_transaction_id = outflow_candidates.entryable_id
+          )
+          WHERE
+            inflow_candidates.entryable_type = 'Transaction' AND
+            inflow_candidates.amount < 0 AND
+            inflow_accounts.family_id = :family_id AND
+            outflow_accounts.family_id = :family_id AND
+            inflow_accounts.status IN ('draft', 'active') AND
+            outflow_accounts.status IN ('draft', 'active') AND
+            existing_transfers.id IS NULL AND
+            (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND
+            (:outflow_transaction_id IS NULL OR outflow_candidates.entryable_id = :outflow_transaction_id) AND
+            (:include_rejected = TRUE OR rejected_transfers.id IS NULL)
+          UNION ALL
+          SELECT
+            inflow_candidates.entryable_id AS inflow_transaction_id,
+            outflow_candidates.entryable_id AS outflow_transaction_id,
+            ABS(inflow_candidates.date - outflow_candidates.date) AS date_diff,
+            rejected_transfers.id AS rejected_transfer_id
+          FROM entries inflow_candidates
+          JOIN accounts inflow_accounts ON inflow_accounts.id = inflow_candidates.account_id
+          JOIN entries outflow_candidates ON (
+            outflow_candidates.entryable_type = 'Transaction' AND
+            outflow_candidates.amount > 0 AND
+            outflow_candidates.account_id <> inflow_candidates.account_id AND
+            outflow_candidates.date BETWEEN inflow_candidates.date - :date_window AND inflow_candidates.date + :date_window AND
+            outflow_candidates.currency <> inflow_candidates.currency
+          )
+          JOIN accounts outflow_accounts ON outflow_accounts.id = outflow_candidates.account_id
+          JOIN exchange_rates ON (
+            exchange_rates.date = outflow_candidates.date AND
+            exchange_rates.from_currency = outflow_candidates.currency AND
+            exchange_rates.to_currency = inflow_candidates.currency
+          )
+          LEFT JOIN transfers existing_transfers ON (
+            existing_transfers.inflow_transaction_id = inflow_candidates.entryable_id OR
+            existing_transfers.outflow_transaction_id = outflow_candidates.entryable_id
+          )
+          LEFT JOIN rejected_transfers ON (
+            rejected_transfers.inflow_transaction_id = inflow_candidates.entryable_id AND
+            rejected_transfers.outflow_transaction_id = outflow_candidates.entryable_id
+          )
+          WHERE
+            inflow_candidates.entryable_type = 'Transaction' AND
+            inflow_candidates.amount < 0 AND
+            inflow_accounts.family_id = :family_id AND
+            outflow_accounts.family_id = :family_id AND
+            inflow_accounts.status IN ('draft', 'active') AND
+            outflow_accounts.status IN ('draft', 'active') AND
+            existing_transfers.id IS NULL AND
+            ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0))
+              BETWEEN :lower_exchange_rate_bound AND :upper_exchange_rate_bound AND
+            (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND
+            (:outflow_transaction_id IS NULL OR outflow_candidates.entryable_id = :outflow_transaction_id) AND
+            (:include_rejected = TRUE OR rejected_transfers.id IS NULL)
+        ) transfer_match_candidates
+        ORDER BY transfer_match_candidates.date_diff ASC
+      SQL
+    end
 end

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -6,8 +6,8 @@ module Family::AutoTransferMatchable
     outflow_transaction_id: nil,
     include_rejected: true
   )
-    date_window = date_window.to_i
-    exchange_rate_tolerance = exchange_rate_tolerance.to_f
+    date_window = coerce_transfer_match_date_window!(date_window)
+    exchange_rate_tolerance = coerce_transfer_match_exchange_rate_tolerance!(exchange_rate_tolerance)
 
     Entry.find_by_sql([
       transfer_match_candidates_sql,
@@ -33,6 +33,8 @@ module Family::AutoTransferMatchable
 
     # Track which transactions we've already matched to avoid duplicates
     used_transaction_ids = Set.new
+    investment_category = nil
+    investment_category_loaded = false
 
     Transfer.transaction do
       candidates_scope.each do |match|
@@ -61,8 +63,11 @@ module Family::AutoTransferMatchable
         if transfer_kind == "investment_contribution"
           outflow_txn = outflow_transaction
           if outflow_txn.category_id.blank?
-            category = destination_account.family.investment_contributions_category
-            outflow_txn.update!(category: category) if category.present?
+            unless investment_category_loaded
+              investment_category = investment_contributions_category
+              investment_category_loaded = true
+            end
+            outflow_txn.update!(category: investment_category) if investment_category.present?
           end
         end
 
@@ -73,6 +78,21 @@ module Family::AutoTransferMatchable
   end
 
   private
+    def coerce_transfer_match_date_window!(value)
+      Integer(value)
+    rescue ArgumentError, TypeError
+      raise ArgumentError, "date_window must be an integer"
+    end
+
+    def coerce_transfer_match_exchange_rate_tolerance!(value)
+      tolerance = Float(value)
+      return tolerance if tolerance.finite?
+
+      raise ArgumentError
+    rescue ArgumentError, TypeError
+      raise ArgumentError, "exchange_rate_tolerance must be numeric"
+    end
+
     def transfer_match_candidates_sql
       <<~SQL.squish
         SELECT transfer_match_candidates.*

--- a/app/models/transaction/transferable.rb
+++ b/app/models/transaction/transferable.rb
@@ -16,9 +16,9 @@ module Transaction::Transferable
 
   def transfer_match_candidates(date_window: 30)
     candidates_scope = if self.entry.amount.negative?
-      family_matches_scope(date_window: date_window).where("inflow_candidates.entryable_id = ?", self.id)
+      family_matches_scope(date_window: date_window, inflow_transaction_id: self.id)
     else
-      family_matches_scope(date_window: date_window).where("outflow_candidates.entryable_id = ?", self.id)
+      family_matches_scope(date_window: date_window, outflow_transaction_id: self.id)
     end
 
     candidates_scope.map do |match|
@@ -30,7 +30,7 @@ module Transaction::Transferable
   end
 
   private
-    def family_matches_scope(date_window:)
-      self.entry.account.family.transfer_match_candidates(date_window: date_window)
+    def family_matches_scope(date_window:, **filters)
+      self.entry.account.family.transfer_match_candidates(date_window: date_window, **filters)
     end
 end

--- a/db/migrate/20260531153000_add_transfer_match_lookup_index_to_entries.rb
+++ b/db/migrate/20260531153000_add_transfer_match_lookup_index_to_entries.rb
@@ -1,0 +1,11 @@
+class AddTransferMatchLookupIndexToEntries < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :entries,
+              [ :currency, :amount, :date, :account_id ],
+              name: "index_entries_on_transfer_match_lookup",
+              where: "entryable_type = 'Transaction'",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_25_121841) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_31_153000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -595,6 +595,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_25_121841) do
     t.index ["import_id"], name: "index_entries_on_import_id"
     t.index ["import_locked"], name: "index_entries_on_import_locked_true", where: "(import_locked = true)"
     t.index ["parent_entry_id"], name: "index_entries_on_parent_entry_id"
+    t.index ["currency", "amount", "date", "account_id"], name: "index_entries_on_transfer_match_lookup", where: "((entryable_type)::text = 'Transaction'::text)"
     t.index ["user_modified"], name: "index_entries_on_user_modified_true", where: "(user_modified = true)"
   end
 

--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -712,39 +712,41 @@ class AccountStatementTest < ActiveSupport::TestCase
   end
 
   test "coverage marks covered duplicate ambiguous and mismatched months" do
-    covered_month = 5.months.ago.to_date.beginning_of_month
-    missing_month = 4.months.ago.to_date.beginning_of_month
-    duplicate_month = 3.months.ago.to_date.beginning_of_month
-    ambiguous_month = 2.months.ago.to_date.beginning_of_month
-    mismatched_month = 1.month.ago.to_date.beginning_of_month
+    travel_to Date.new(2026, 5, 6) do
+      covered_month = 5.months.ago.to_date.beginning_of_month
+      missing_month = 4.months.ago.to_date.beginning_of_month
+      duplicate_month = 3.months.ago.to_date.beginning_of_month
+      ambiguous_month = 2.months.ago.to_date.beginning_of_month
+      mismatched_month = 1.month.ago.to_date.beginning_of_month
 
-    create_statement(account: @account, month: covered_month, content: "covered")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
-    create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
-    create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
+      create_statement(account: @account, month: covered_month, content: "covered")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
+      create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
+      create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
 
-    @account.balances.create!(
-      date: mismatched_month.end_of_month,
-      balance: 100,
-      currency: "USD",
-      start_cash_balance: 100,
-      cash_inflows: 0,
-      cash_outflows: 0
-    )
+      @account.balances.create!(
+        date: mismatched_month.end_of_month,
+        balance: 100,
+        currency: "USD",
+        start_cash_balance: 100,
+        cash_inflows: 0,
+        cash_outflows: 0
+      )
 
-    coverage = AccountStatement::Coverage.new(
-      @account,
-      start_month: covered_month,
-      end_month: mismatched_month
-    )
+      coverage = AccountStatement::Coverage.new(
+        @account,
+        start_month: covered_month,
+        end_month: mismatched_month
+      )
 
-    statuses = coverage.months.index_by(&:date).transform_values(&:status)
-    assert_equal "covered", statuses[covered_month]
-    assert_equal "missing", statuses[missing_month]
-    assert_equal "duplicate", statuses[duplicate_month]
-    assert_equal "ambiguous", statuses[ambiguous_month]
-    assert_equal "mismatched", statuses[mismatched_month]
+      statuses = coverage.months.index_by(&:date).transform_values(&:status)
+      assert_equal "covered", statuses[covered_month]
+      assert_equal "missing", statuses[missing_month]
+      assert_equal "duplicate", statuses[duplicate_month]
+      assert_equal "ambiguous", statuses[ambiguous_month]
+      assert_equal "mismatched", statuses[mismatched_month]
+    end
   end
 
   private

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -109,6 +109,17 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
+  test "transfer candidate options require valid numeric input" do
+    assert_raises(ArgumentError) { @family.transfer_match_candidates(date_window: "soon") }
+    assert_raises(ArgumentError) { @family.transfer_match_candidates(date_window: nil) }
+    assert_raises(ArgumentError) { @family.transfer_match_candidates(exchange_rate_tolerance: "wide") }
+    assert_raises(ArgumentError) { @family.transfer_match_candidates(exchange_rate_tolerance: Float::INFINITY) }
+
+    assert_nothing_raised do
+      @family.transfer_match_candidates(date_window: "4", exchange_rate_tolerance: "0.1")
+    end
+  end
+
   test "auto-matched cash to investment assigns investment contribution category" do
     investment = accounts(:investment)
     outflow_entry = create_transaction(date: Date.current, account: @depository, amount: 500)
@@ -120,6 +131,22 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
 
     category = @family.investment_contributions_category
     assert_equal category, outflow_entry.entryable.category
+  end
+
+  test "auto-matched investment transfers reuse contribution category lookup" do
+    investment = accounts(:investment)
+    category = @family.investment_contributions_category
+
+    create_transaction(date: Date.current, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: investment, amount: -500)
+    create_transaction(date: Date.current, account: @depository, amount: 700)
+    create_transaction(date: Date.current, account: investment, amount: -700)
+
+    @family.expects(:investment_contributions_category).once.returns(category)
+
+    assert_difference -> { Transfer.count }, 2 do
+      @family.auto_match_transfers!
+    end
   end
 
   test "does not match multi-currency transfer with missing exchange rate" do

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -131,6 +131,52 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
+  test "same-currency matching ignores amount-mismatched busy-window entries" do
+    noise_transaction_ids = []
+
+    25.times do |index|
+      noise_outflow = create_transaction(date: Date.current, account: @depository, amount: 13_001 + index)
+      noise_inflow = create_transaction(date: Date.current, account: @credit_card, amount: -(27_001 + index))
+
+      noise_transaction_ids << noise_outflow.entryable_id
+      noise_transaction_ids << noise_inflow.entryable_id
+    end
+
+    outflow = create_transaction(date: Date.current, account: @depository, amount: 500)
+    inflow = create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    candidate_pairs = @family.transfer_match_candidates.map do |candidate|
+      [ candidate.inflow_transaction_id, candidate.outflow_transaction_id ]
+    end
+
+    assert_includes candidate_pairs, [ inflow.entryable_id, outflow.entryable_id ]
+
+    noise_pairs = candidate_pairs.select do |inflow_transaction_id, outflow_transaction_id|
+      noise_transaction_ids.include?(inflow_transaction_id) || noise_transaction_ids.include?(outflow_transaction_id)
+    end
+
+    assert_empty noise_pairs
+  end
+
+  test "single transaction transfer candidates filter optimized relation aliases" do
+    outflow = create_transaction(date: Date.current, account: @depository, amount: 500)
+    inflow = create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    outflow_candidates = outflow.transaction.transfer_match_candidates
+    inflow_candidates = inflow.transaction.transfer_match_candidates
+
+    assert_equal [ inflow.entryable_id ], outflow_candidates.map(&:inflow_transaction_id)
+    assert_equal [ outflow.entryable_id ], inflow_candidates.map(&:outflow_transaction_id)
+  end
+
+  test "transfer candidate query separates exact and exchange-rate matching paths" do
+    sql = @family.send(:transfer_match_candidates_sql)
+
+    assert_includes sql, "UNION ALL"
+    assert_includes sql, "outflow_candidates.amount = -inflow_candidates.amount"
+    assert_includes sql, "JOIN exchange_rates"
+  end
+
   # Regression tests for loan transfer kind assignment bug
   # The kind should be determined by the DESTINATION account (inflow), not the source (outflow)
   test "loan payment (cash to loan) assigns loan_payment kind to outflow" do

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -114,6 +114,8 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     assert_raises(ArgumentError) { @family.transfer_match_candidates(date_window: nil) }
     assert_raises(ArgumentError) { @family.transfer_match_candidates(exchange_rate_tolerance: "wide") }
     assert_raises(ArgumentError) { @family.transfer_match_candidates(exchange_rate_tolerance: Float::INFINITY) }
+    error = assert_raises(ArgumentError) { @family.transfer_match_candidates(exchange_rate_tolerance: -0.1) }
+    assert_equal "exchange_rate_tolerance must be non-negative", error.message
 
     assert_nothing_raised do
       @family.transfer_match_candidates(date_window: "4", exchange_rate_tolerance: "0.1")


### PR DESCRIPTION
## Summary
- Address a Sentry-observed sync performance hotspot in auto-transfer matching by pruning impossible candidates earlier.
- Split exact same-currency transfer matching from FX-tolerant candidate matching.
- Apply single-transaction candidate filters directly inside the family matcher instead of filtering query aliases outside the matcher.
- Add a partial `entries` lookup index for transfer matching by currency, amount, date, account, and excluded rows.
- Add regression coverage for noisy same-day windows and single-transaction candidate matching.

## What changed
- Same-currency auto-transfer matching now requires the opposite entry to have the expected opposite amount and matching currency before it reaches Ruby-side candidate comparison.
- Cross-currency matching still uses the existing FX tolerance path, so exchange-rate drift behavior is preserved.
- Single-transaction matching now reuses the same family matcher with a bound transaction id, keeping family, account, rejected-match, and existing-transfer guards in one query path.
- The new database index supports the high-selectivity columns used by the matcher while excluding entries that cannot participate in transfer matching.

## Why
Sentry has been surfacing slow sync work around automatic transfer matching, especially when busy date windows contain many same-day income/expense entries that share a family but cannot be valid transfer pairs. The old matcher could still load and compare those rows before amount/currency pruning. This keeps the same matching semantics while reducing candidate rows earlier in the database.

## Validation
- `bin/rails test`
- `bin/rails test test/models/family/auto_transfer_matchable_test.rb test/models/transaction_test.rb`
- `bin/rubocop app/models/family/auto_transfer_matchable.rb app/models/transaction/transferable.rb db/migrate/20260531153000_add_transfer_match_lookup_index_to_entries.rb test/models/family/auto_transfer_matchable_test.rb`
- `bin/rails zeitwerk:check`
- `bin/brakeman --no-pager`
- `bin/importmap audit`
- `npm run lint`
- `git diff --check`

## Notes
- The Sentry context is performance-only; no private event details are needed for the PR.
- I did not find an existing focused open issue or PR for this exact transfer-candidate query optimization, so this PR is not linked with close syntax.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added a new partial index to speed up transfer-match lookups for large accounts.

* **Improvements**
  * Refined automatic transfer-matching behavior with optional filters, numeric validation for parameters, cross-currency tolerance handling, and fewer repeated lookups for matched transactions.

* **Tests**
  * New tests for parameter validation, candidate matching correctness, reuse of lookups, and SQL candidate-generation structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->