### PR TITLE
Fix import dry_run dropping accounts count from confirmation preview

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -189,7 +189,7 @@ class Import < ApplicationRecord
       tags: Import::TagMapping.for_import(self).creational.count
     }
 
-    mappings.merge(
+    mappings.merge!(
       accounts: Import::AccountMapping.for_import(self).creational.count,
     ) if account.nil?
 

--- a/app/models/trade_import.rb
+++ b/app/models/trade_import.rb
@@ -57,7 +57,7 @@ class TradeImport < Import
   def dry_run
     mappings = { transactions: rows_count }
 
-    mappings.merge(
+    mappings.merge!(
       accounts: Import::AccountMapping.for_import(self).creational.count
     ) if account.nil?
 

--- a/test/models/trade_import_test.rb
+++ b/test/models/trade_import_test.rb
@@ -42,6 +42,34 @@ class TradeImportTest < ActiveSupport::TestCase
     assert_equal BigDecimal("1500"), row.signed_amount
   end
 
+  test "dry_run includes count of accounts to be created when no account is preselected" do
+    csv = <<~CSV
+      date,ticker,qty,price,account
+      2024-05-15,AAPL,10,150.00,NewAccount
+    CSV
+
+    @import.update!(
+      raw_file_str: csv,
+      date_col_label: "date",
+      ticker_col_label: "ticker",
+      qty_col_label: "qty",
+      price_col_label: "price",
+      account_col_label: "account",
+      date_format: "%Y-%m-%d",
+      signage_convention: "inflows_positive"
+    )
+
+    @import.generate_rows_from_csv
+    @import.mappings.create! key: "NewAccount", create_when_empty: true, type: "Import::AccountMapping"
+    @import.reload
+
+    assert_nil @import.account
+
+    dry_run = @import.dry_run
+    assert_equal 1, dry_run[:transactions]
+    assert_equal 1, dry_run[:accounts]
+  end
+
   test "imports trades and accounts" do
     aapl_resolver = mock
     googl_resolver = mock

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -70,6 +70,30 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert_equal "complete", @import.status
   end
 
+  test "dry_run includes count of accounts to be created when no account is preselected" do
+    csv = <<~CSV
+      date,name,amount,account
+      01/01/2024,Txn1,100,NewAccount
+    CSV
+
+    @import.update!(
+      raw_file_str: csv,
+      date_col_label: "date",
+      amount_col_label: "amount",
+      date_format: "%m/%d/%Y"
+    )
+
+    @import.generate_rows_from_csv
+    @import.mappings.create! key: "NewAccount", create_when_empty: true, type: "Import::AccountMapping"
+    @import.reload
+
+    assert_nil @import.account
+
+    dry_run = @import.dry_run
+    assert_equal 1, dry_run[:transactions]
+    assert_equal 1, dry_run[:accounts]
+  end
+
   test "imports transactions with separate type column for signage convention" do
     import = <<~CSV
       date,amount,amount_type


### PR DESCRIPTION
Fixes #2081.

## Summary

`Import#dry_run` and `TradeImport#dry_run` build the import confirmation summary with a non-mutating `Hash#merge` whose return value is discarded, so the `accounts:` key is never added to the hash:

```ruby
mappings.merge(                       # result discarded
  accounts: Import::AccountMapping.for_import(self).creational.count,
) if account.nil?

mappings                              # returned WITHOUT :accounts
```

`Hash#merge` returns a new hash and leaves the receiver unchanged. The `if account.nil?` guard shows the intent was to include the accounts count, so the fix is simply `merge!`.

### User-visible impact

When a CSV import maps its own `account` column (no pre-selected account), new accounts are created on publish — but the confirmation/preview screen (`app/views/import/confirms/show.html.erb`, `app/views/imports/_ready.html.erb`) iterates the `dry_run` hash and therefore silently omits the **Accounts: N** row. `app/helpers/imports_helper.rb` already defines an `accounts:` display resource, so the UI is designed to show this count but never receives it. Sibling importers (`AccountImport`, `CategoryImport`) build their `dry_run` hashes correctly, confirming this is an isolated defect.

## Changes

- `app/models/import.rb`: `merge` → `merge!` in `dry_run`.
- `app/models/trade_import.rb`: `merge` → `merge!` in `dry_run` (identical defect).
- Added regression tests in `test/models/transaction_import_test.rb` and `test/models/trade_import_test.rb` asserting `dry_run[:accounts]` is present when no account is preselected. These `account.nil?` branches were previously untested (existing tests pre-select an account), which is how the bug went unnoticed.

## Testing

```
bin/rails test test/models/transaction_import_test.rb test/models/trade_import_test.rb
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the dry run import preview functionality to correctly include and display the count of accounts that will be created during the import process when no account is preselected.

* **Tests**
  * Added comprehensive test coverage for dry run import previews to verify accurate reporting of both transaction and account counts during imports without a preselected account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->