### PR TITLE
feat(cashflow): deep-link category labels to filtered transactions

### DIFF
--- a/app/javascript/controllers/sankey_chart_controller.js
+++ b/app/javascript/controllers/sankey_chart_controller.js
@@ -175,11 +175,13 @@ export default class extends Controller {
       return;
     }
 
-    window.location.href = buildCategoryTransactionsUrl({
-      name: d.name,
-      startDate: this.startDateValue,
-      endDate: this.endDateValue,
-    });
+    Turbo.visit(
+      buildCategoryTransactionsUrl({
+        name: d.name,
+        startDate: this.startDateValue,
+        endDate: this.endDateValue,
+      }),
+    );
   }
 
   // Dynamic padding prevents padding from dominating when there are many nodes

--- a/app/javascript/controllers/sankey_chart_controller.js
+++ b/app/javascript/controllers/sankey_chart_controller.js
@@ -2,6 +2,10 @@ import { Controller } from "@hotwired/stimulus";
 import * as d3 from "d3";
 import { sankey } from "d3-sankey";
 import { sankeyNodeHasChildren, zoomSankeyData } from "utils/sankey_zoom";
+import {
+  buildCategoryTransactionsUrl,
+  isNavigableCategoryNode,
+} from "utils/transactions_filter_url";
 
 // Connects to data-controller="sankey-chart"
 export default class extends Controller {
@@ -12,6 +16,8 @@ export default class extends Controller {
     nodeWidth: { type: Number, default: 15 },
     nodePadding: { type: Number, default: 20 },
     currencySymbol: { type: String, default: "$" },
+    startDate: String,
+    endDate: String,
   };
 
   // Visual constants
@@ -160,6 +166,20 @@ export default class extends Controller {
     this.zoomRootId = node.id;
     this.#syncZoomControls();
     this.#draw({ animate: true });
+  }
+
+  #navigateToTransactions(d) {
+    if (!isNavigableCategoryNode(d.id)) {
+      // Structural node (Cash Flow / Surplus): keep current zoom behavior.
+      this.#zoomIn(d);
+      return;
+    }
+
+    window.location.href = buildCategoryTransactionsUrl({
+      name: d.name,
+      startDate: this.startDateValue,
+      endDate: this.endDateValue,
+    });
   }
 
   // Dynamic padding prevents padding from dominating when there are many nodes
@@ -480,6 +500,7 @@ export default class extends Controller {
     nodeGroups
       .selectAll("text")
       .style("cursor", (d) =>
+        isNavigableCategoryNode(d.id) ||
         sankeyNodeHasChildren(this.#visibleData(), d.id)
           ? "pointer"
           : "default",
@@ -494,7 +515,7 @@ export default class extends Controller {
       .on("mousemove", (event) => this.#updateTooltipPosition(event))
       .on("click", (event, d) => {
         event.stopPropagation();
-        this.#zoomIn(d);
+        this.#navigateToTransactions(d);
       })
       .on("mouseleave", () => {
         resetHover();

--- a/app/javascript/utils/transactions_filter_url.mjs
+++ b/app/javascript/utils/transactions_filter_url.mjs
@@ -1,0 +1,23 @@
+// Category nodes in the cashflow Sankey have ids prefixed income_/expense_
+// (incl. *_sub_). Structural nodes (cash_flow_node, surplus_node) are not
+// categories and must not deep-link to transactions.
+export function isNavigableCategoryNode(id) {
+  return /^(income|expense)_/.test(id);
+}
+
+// Builds a relative deep link to the transactions index, filtered by a single
+// category name and (optionally) a start/end date range. Mirrors the params
+// the transactions search form submits: q[categories][], q[start_date],
+// q[end_date].
+export function buildCategoryTransactionsUrl({
+  name,
+  startDate,
+  endDate,
+  basePath = "/transactions",
+}) {
+  const params = new URLSearchParams();
+  params.append("q[categories][]", name);
+  if (startDate) params.append("q[start_date]", startDate);
+  if (endDate) params.append("q[end_date]", endDate);
+  return `${basePath}?${params.toString()}`;
+}

--- a/app/views/pages/dashboard/_cashflow_sankey.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey.html.erb
@@ -11,13 +11,13 @@
   </div>
   <% if sankey_data[:links].present? %>
     <div class="w-full h-96">
-      <%= render "pages/dashboard/cashflow_sankey_chart", sankey_data: sankey_data %>
+      <%= render "pages/dashboard/cashflow_sankey_chart", sankey_data: sankey_data, period: period %>
     </div>
     <%= render DS::Dialog.new(id: "cashflow-expanded-dialog", auto_open: false, width: "custom", disable_frame: true, content_class: "!w-[96vw] max-w-[1650px]", data: { action: "close->cashflow-expand#restore" }) do |dialog| %>
       <% dialog.with_header(title: t("pages.dashboard.cashflow_sankey.title")) %>
       <% dialog.with_body do %>
         <div class="w-full h-[85dvh] max-h-[90dvh] overflow-y-auto overscroll-contain">
-          <%= render "pages/dashboard/cashflow_sankey_chart", sankey_data: sankey_data %>
+          <%= render "pages/dashboard/cashflow_sankey_chart", sankey_data: sankey_data, period: period %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/pages/dashboard/_cashflow_sankey_chart.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey_chart.html.erb
@@ -1,8 +1,10 @@
-<%# locals: (sankey_data:) %>
+<%# locals: (sankey_data:, period:) %>
 <div
   data-controller="sankey-chart"
   data-sankey-chart-data-value="<%= sankey_data.to_json %>"
   data-sankey-chart-currency-symbol-value="<%= sankey_data[:currency_symbol] %>"
+  data-sankey-chart-start-date-value="<%= period.start_date&.iso8601 %>"
+  data-sankey-chart-end-date-value="<%= period.end_date&.iso8601 %>"
   class="w-full h-full privacy-sensitive flex flex-col gap-2">
   <div class="flex justify-start">
     <%= render DS::Button.new(

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,6 +9,7 @@ pin_all_from "app/components", under: "controllers", to: ""
 pin_all_from "app/javascript/services", under: "services", to: "services"
 pin_all_from "app/javascript/utils", under: "utils", to: "utils"
 pin "utils/sankey_zoom", to: "utils/sankey_zoom.mjs"
+pin "utils/transactions_filter_url", to: "utils/transactions_filter_url.mjs"
 pin "@github/hotkey", to: "@github--hotkey.js" # @3.1.1
 pin "@simonwep/pickr", to: "@simonwep--pickr.js" # @1.9.1
 

--- a/test/javascript/utils/transactions_filter_url_test.mjs
+++ b/test/javascript/utils/transactions_filter_url_test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isNavigableCategoryNode,
+  buildCategoryTransactionsUrl,
+} from "../../../app/javascript/utils/transactions_filter_url.mjs";
+
+test("category nodes are navigable, structural nodes are not", () => {
+  assert.equal(isNavigableCategoryNode("expense_15"), true);
+  assert.equal(isNavigableCategoryNode("income_3"), true);
+  assert.equal(isNavigableCategoryNode("expense_sub_19"), true);
+  assert.equal(isNavigableCategoryNode("income_sub_7"), true);
+  assert.equal(isNavigableCategoryNode("cash_flow_node"), false);
+  assert.equal(isNavigableCategoryNode("surplus_node"), false);
+  // Bare aggregate ids are not category nodes.
+  assert.equal(isNavigableCategoryNode("income"), false);
+  assert.equal(isNavigableCategoryNode("expense"), false);
+});
+
+test("builds a transactions deep link with category and date range", () => {
+  const url = buildCategoryTransactionsUrl({
+    name: "Groceries",
+    startDate: "2026-05-01",
+    endDate: "2026-05-31",
+  });
+  assert.equal(
+    url,
+    "/transactions?q%5Bcategories%5D%5B%5D=Groceries&q%5Bstart_date%5D=2026-05-01&q%5Bend_date%5D=2026-05-31",
+  );
+});
+
+test("encodes category names with special characters", () => {
+  const url = buildCategoryTransactionsUrl({
+    name: "Food & Drink",
+    startDate: "2026-05-01",
+    endDate: "2026-05-31",
+  });
+  assert.match(url, /q%5Bcategories%5D%5B%5D=Food\+%26\+Drink/);
+});
+
+test("omits date params when dates are blank", () => {
+  const url = buildCategoryTransactionsUrl({
+    name: "Groceries",
+    startDate: "",
+    endDate: "",
+  });
+  assert.equal(url, "/transactions?q%5Bcategories%5D%5B%5D=Groceries");
+});


### PR DESCRIPTION
## What

In the dashboard **cashflow Sankey chart**, clicking a category's **text label** now navigates to the transactions page filtered by that category **and** the cashflow's active period date range.

- The colored node **bar** keeps its existing *zoom-into-subcategories* behavior — only the label navigates.
- Structural nodes (**Cash Flow**, **Surplus**) do not navigate.
- This mirrors the existing **donut chart** click-to-filter behavior (`donut_chart_controller.js`), reusing the same `q[categories][]` / `q[start_date]` / `q[end_date]` params the transactions search already accepts.

## Why

The cashflow chart surfaces spending by category, but there was no way to drill from a category into the underlying transactions for that timeframe. Users had to manually re-filter on the transactions page. This closes that loop.

## How

- New pure module `app/javascript/utils/transactions_filter_url.mjs` builds the deep link (`URLSearchParams`), with `isNavigableCategoryNode` to exclude structural nodes. Mirrors the existing `utils/sankey_zoom.mjs` pattern and is pinned in `config/importmap.rb`.
- Period `start_date` / `end_date` are threaded from the dashboard view into the Sankey Stimulus controller via data values.
- `sankey_chart_controller.js`: the label `click` now calls `#navigateToTransactions`; the bar `click` is unchanged.

Unit-tested with `node:test` (`test/javascript/utils/transactions_filter_url_test.mjs`), covering the navigable-node predicate, URL construction, special-character encoding, and blank-date omission.

## Release notes

- **Behavior change:** Clicking a **category label** in the cashflow Sankey chart now opens the filtered transactions list instead of zooming into subcategories. To zoom into a category's subcategories, click the colored **bar** (unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sankey category nodes are clickable to open a transactions list filtered by the selected category and current date range.

* **Improvements**
  * Nodes eligible for navigation show a pointer cursor for clearer affordance.
  * Chart now consistently receives and forwards the selected period so deep-links respect start/end dates.

* **Tests**
  * Added tests for category navigability, URL construction, encoding, and date-parameter behavior.

* **Chore**
  * Registered the transactions URL utility for front-end imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
