### PR TITLE
fix(categories): avoid index N+1 queries

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -4,7 +4,9 @@ class CategoriesController < ApplicationController
   before_action :set_transaction, only: :create
 
   def index
-    @categories = Current.family.categories.alphabetically
+    @categories = Current.family.categories.alphabetically.to_a
+    @category_groups = Category::Group.for(@categories)
+    @category_ids_with_transactions = category_ids_with_transactions(@categories)
 
     render layout: "settings"
   end
@@ -121,6 +123,17 @@ class CategoriesController < ApplicationController
 
     def category_merge_params
       params.permit(:target_id, source_ids: [])
+    end
+
+    def category_ids_with_transactions(categories)
+      category_ids = categories.map(&:id)
+      return {} if category_ids.empty?
+
+      Current.family.transactions
+                    .where(category_id: category_ids)
+                    .distinct
+                    .pluck(:category_id)
+                    .index_with(true)
     end
 
     def record_error_message(error)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -96,8 +96,10 @@ class Category < ApplicationRecord
     delegate :name, :color, to: :category
 
     def self.for(categories)
-      categories.select { |category| category.parent_id.nil? }.map do |category|
-        new(category, category.subcategories)
+      categories_by_parent_id = categories.to_a.group_by(&:parent_id)
+
+      categories_by_parent_id[nil].to_a.map do |category|
+        new(category, categories_by_parent_id[category.id].to_a)
       end
     end
 

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,6 +1,8 @@
-<%# locals: (category:) %>
+<%# locals: (category:, subcategories: nil, has_transactions: nil) %>
+<% subcategories ||= category.subcategories.to_a %>
+<% has_transactions = category.transactions.exists? if has_transactions.nil? %>
 
-<div id="<%= dom_id(category) %>" class="flex items-center gap-3 px-4 pb-4 <%= "pt-4" unless category.subcategory? %> <%= "pb-4" unless category.subcategories.any? %> bg-container">
+<div id="<%= dom_id(category) %>" class="flex items-center gap-3 px-4 pb-4 <%= "pt-4" unless category.subcategory? %> <%= "pb-4" unless subcategories.any? %> bg-container">
   <div class="flex min-w-0 flex-1 items-center gap-2.5" data-testid="category-content">
     <% if category.subcategory? %>
       <span style="color: <%= category.color %>">
@@ -15,7 +17,7 @@
     <%= render DS::Menu.new do |menu| %>
       <% menu.with_item(variant: "link", text: t(".edit"), icon: "pencil", href: edit_category_path(category), data: { turbo_frame: :modal }) %>
 
-      <% if category.transactions.any? %>
+      <% if has_transactions %>
         <% menu.with_item(variant: "link", text: t(".delete"), icon: "trash-2", href: new_category_deletion_path(category), destructive: true, data: { turbo_frame: :modal }) %>
       <% else %>
         <% menu.with_item(variant: "button", text: t(".delete"), icon: "trash-2", href: category_path(category), method: :delete) %>

--- a/app/views/categories/_category_list_group.html.erb
+++ b/app/views/categories/_category_list_group.html.erb
@@ -1,4 +1,5 @@
-<%# locals: (title:, categories:) %>
+<%# locals: (title:, categories:, category_groups: nil, category_ids_with_transactions: {}) %>
+<% category_groups ||= Category::Group.for(categories) %>
 
 <div class="rounded-xl bg-container-inset space-y-1 p-1">
   <div class="flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-secondary uppercase">
@@ -9,14 +10,20 @@
 
   <div class="shadow-border-xs rounded-lg bg-container">
     <div class="overflow-hidden rounded-lg">
-      <% Category::Group.for(categories).each_with_index do |group, idx| %>
-        <%= render group.category %>
+      <% category_groups.each_with_index do |group, idx| %>
+        <%= render "categories/category",
+                   category: group.category,
+                   subcategories: group.subcategories,
+                   has_transactions: category_ids_with_transactions.key?(group.category.id) %>
 
         <% group.subcategories.each do |subcategory| %>
-          <%= render subcategory %>
+          <%= render "categories/category",
+                     category: subcategory,
+                     subcategories: [],
+                     has_transactions: category_ids_with_transactions.key?(subcategory.id) %>
         <% end %>
 
-        <% unless idx == Category::Group.for(categories).count - 1 %>
+        <% unless idx == category_groups.count - 1 %>
           <%= render "shared/ruler" %>
         <% end %>
       <% end %>

--- a/app/views/categories/_category_list_group.html.erb
+++ b/app/views/categories/_category_list_group.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (title:, categories:, category_groups: nil, category_ids_with_transactions: {}) %>
+<%# locals: (title:, categories:, category_groups: nil, category_ids_with_transactions: nil) %>
 <% category_groups ||= Category::Group.for(categories) %>
 
 <div class="rounded-xl bg-container-inset space-y-1 p-1">
@@ -14,13 +14,13 @@
         <%= render "categories/category",
                    category: group.category,
                    subcategories: group.subcategories,
-                   has_transactions: category_ids_with_transactions.key?(group.category.id) %>
+                   has_transactions: category_ids_with_transactions&.key?(group.category.id) %>
 
         <% group.subcategories.each do |subcategory| %>
           <%= render "categories/category",
                      category: subcategory,
                      subcategories: [],
-                     has_transactions: category_ids_with_transactions.key?(subcategory.id) %>
+                     has_transactions: category_ids_with_transactions&.key?(subcategory.id) %>
         <% end %>
 
         <% unless idx == category_groups.count - 1 %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -30,7 +30,11 @@
 <div class="bg-container rounded-xl shadow-border-xs p-4">
   <% if @categories.any? %>
     <div class="space-y-4">
-      <%= render "categories/category_list_group", title: t(".categories"), categories: @categories %>
+      <%= render "categories/category_list_group",
+                 title: t(".categories"),
+                 categories: @categories,
+                 category_groups: @category_groups,
+                 category_ids_with_transactions: @category_ids_with_transactions %>
     </div>
   <% else %>
     <div class="flex justify-center items-center py-20">

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -16,6 +16,40 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
     assert_select "#category_#{categories(:food_and_drink).id} [data-testid='category-name']", text: categories(:food_and_drink).name
   end
 
+  test "index avoids per-category subcategory and transaction existence queries" do
+    4.times do |idx|
+      parent = @family.categories.create!(
+        name: "Performance Parent #{idx}",
+        color: "#000000",
+        lucide_icon: "folder"
+      )
+      child = @family.categories.create!(
+        name: "Performance Child #{idx}",
+        color: "#111111",
+        lucide_icon: "folder",
+        parent: parent
+      )
+      transaction = Transaction.create!(category: child)
+      Entry.create!(
+        account: accounts(:depository),
+        entryable: transaction,
+        name: "Performance transaction #{idx}",
+        date: Date.current,
+        amount: 10,
+        currency: "USD"
+      )
+    end
+
+    queries = capture_sql_queries { get categories_url }
+
+    assert_response :success
+    assert_select "[data-testid='category-name']", text: "Performance Parent 0"
+    assert_select "[data-testid='category-name']", text: "Performance Child 0"
+
+    assert_empty queries.grep(/FROM "categories" WHERE "categories"\."parent_id" =/)
+    assert_empty queries.grep(/FROM "transactions" WHERE "transactions"\."category_id" =/)
+  end
+
   test "new" do
     get new_category_url
     assert_response :success
@@ -300,4 +334,21 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to merge_categories_path
     assert Category.exists?(other.id)
   end
+
+  private
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
+    end
 end

--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -712,39 +712,41 @@ class AccountStatementTest < ActiveSupport::TestCase
   end
 
   test "coverage marks covered duplicate ambiguous and mismatched months" do
-    covered_month = 5.months.ago.to_date.beginning_of_month
-    missing_month = 4.months.ago.to_date.beginning_of_month
-    duplicate_month = 3.months.ago.to_date.beginning_of_month
-    ambiguous_month = 2.months.ago.to_date.beginning_of_month
-    mismatched_month = 1.month.ago.to_date.beginning_of_month
+    travel_to Date.new(2026, 5, 6) do
+      covered_month = 5.months.ago.to_date.beginning_of_month
+      missing_month = 4.months.ago.to_date.beginning_of_month
+      duplicate_month = 3.months.ago.to_date.beginning_of_month
+      ambiguous_month = 2.months.ago.to_date.beginning_of_month
+      mismatched_month = 1.month.ago.to_date.beginning_of_month
 
-    create_statement(account: @account, month: covered_month, content: "covered")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
-    create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
-    create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
+      create_statement(account: @account, month: covered_month, content: "covered")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
+      create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
+      create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
 
-    @account.balances.create!(
-      date: mismatched_month.end_of_month,
-      balance: 100,
-      currency: "USD",
-      start_cash_balance: 100,
-      cash_inflows: 0,
-      cash_outflows: 0
-    )
+      @account.balances.create!(
+        date: mismatched_month.end_of_month,
+        balance: 100,
+        currency: "USD",
+        start_cash_balance: 100,
+        cash_inflows: 0,
+        cash_outflows: 0
+      )
 
-    coverage = AccountStatement::Coverage.new(
-      @account,
-      start_month: covered_month,
-      end_month: mismatched_month
-    )
+      coverage = AccountStatement::Coverage.new(
+        @account,
+        start_month: covered_month,
+        end_month: mismatched_month
+      )
 
-    statuses = coverage.months.index_by(&:date).transform_values(&:status)
-    assert_equal "covered", statuses[covered_month]
-    assert_equal "missing", statuses[missing_month]
-    assert_equal "duplicate", statuses[duplicate_month]
-    assert_equal "ambiguous", statuses[ambiguous_month]
-    assert_equal "mismatched", statuses[mismatched_month]
+      statuses = coverage.months.index_by(&:date).transform_values(&:status)
+      assert_equal "covered", statuses[covered_month]
+      assert_equal "missing", statuses[missing_month]
+      assert_equal "duplicate", statuses[duplicate_month]
+      assert_equal "ambiguous", statuses[ambiguous_month]
+      assert_equal "mismatched", statuses[mismatched_month]
+    end
   end
 
   private

--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -748,13 +748,12 @@ class AccountStatementTest < ActiveSupport::TestCase
       end_month: mismatched_month
     )
 
-      statuses = coverage.months.index_by(&:date).transform_values(&:status)
-      assert_equal "covered", statuses[covered_month]
-      assert_equal "missing", statuses[missing_month]
-      assert_equal "duplicate", statuses[duplicate_month]
-      assert_equal "ambiguous", statuses[ambiguous_month]
-      assert_equal "mismatched", statuses[mismatched_month]
-    end
+    statuses = coverage.months.index_by(&:date).transform_values(&:status)
+    assert_equal "covered", statuses[covered_month]
+    assert_equal "missing", statuses[missing_month]
+    assert_equal "duplicate", statuses[duplicate_month]
+    assert_equal "ambiguous", statuses[ambiguous_month]
+    assert_equal "mismatched", statuses[mismatched_month]
   end
 
   private

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -21,6 +21,28 @@ class CategoryTest < ActiveSupport::TestCase
     assert_nil transactions.map { |t| t.reload.category }.uniq.first
   end
 
+  test "destroying parent category preserves subcategory transaction assignments" do
+    parent = @family.categories.create!(
+      name: "Parent With Child Transactions",
+      color: "#000000",
+      lucide_icon: "folder"
+    )
+    subcategory = @family.categories.create!(
+      name: "Child With Transactions",
+      color: "#111111",
+      lucide_icon: "folder",
+      parent: parent
+    )
+    transaction = Transaction.create!(category: subcategory)
+
+    assert_difference "Category.count", -1 do
+      parent.destroy!
+    end
+
+    assert_nil subcategory.reload.parent_id
+    assert_equal subcategory, transaction.reload.category
+  end
+
   test "subcategory can only be one level deep" do
     category = categories(:subcategory)
 

--- a/test/views/categories/category_list_group_view_test.rb
+++ b/test/views/categories/category_list_group_view_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class CategoryListGroupViewTest < ActionView::TestCase
+  test "falls back to transaction existence checks when no lookup is provided" do
+    category = categories(:food_and_drink)
+    transaction = Transaction.create!(category: category)
+    Entry.create!(
+      account: accounts(:depository),
+      entryable: transaction,
+      name: "Fallback transaction",
+      date: Date.current,
+      amount: 10,
+      currency: "USD"
+    )
+
+    html = render(partial: "categories/category_list_group", locals: {
+      title: "Categories",
+      categories: [ category ]
+    })
+
+    assert_includes html, new_category_deletion_path(category)
+    assert_not_includes html, "data-turbo-method=\"delete\""
+  end
+end


### PR DESCRIPTION
## Summary

Closes #2088

Fixes the Sentry-reported N+1 query pattern in `CategoriesController#index`. The categories settings page was doing repeated database work while rendering each row: category grouping could call back into `category.subcategories`, and each category row checked `category.transactions.any?` to decide whether to show the direct delete action or the deletion flow.

## What changed

- Materialize the current family's categories once in `CategoriesController#index`.
- Build `Category::Group` objects from that in-memory category list instead of asking each parent category for its subcategories.
- Precompute the set of category ids that have transactions with one `Current.family.transactions.distinct.pluck(:category_id)` query.
- Pass precomputed category groups and transaction-presence data into the category list partials so row rendering no longer performs per-category database checks.
- Keep the category partial fallback behavior intact for any caller that renders it without the precomputed locals.
- Add a controller regression test that renders the categories index and asserts the old per-category subcategory and transaction-existence query shapes are gone.
- Stabilize a date-sensitive account statement coverage test that blocked the full suite on current month-end-adjacent dates; this is test-only and does not change production behavior.

## Why

The categories settings index should scale with a small, bounded query set, not with the number of categories rendered. Larger category trees made the old rendering path increasingly expensive because the view could re-query for subcategories and transaction existence per row.

This keeps the existing page behavior the same:

- category hierarchy rendering is unchanged
- delete-menu behavior is unchanged
- family scoping stays under `Current.family`
- no raw SQL interpolation or new user input path is introduced

## Validation

- `bin/rails test test/controllers/categories_controller_test.rb test/models/category_test.rb test/models/account_statement_test.rb:714`
- `bin/rails test`
- `bin/rubocop`
- `npm run lint`
- `bundle exec erb_lint app/views/categories/index.html.erb app/views/categories/_category.html.erb app/views/categories/_category_list_group.html.erb`
- `bin/brakeman --no-pager`
- `bin/rails zeitwerk:check`
- `git diff --check`
- Codex Security diff scan: no findings

## Notes

No screenshots are included because this is a server-side performance/query-shape change with no intended visual or interaction changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved how categories are fetched, grouped and prepared for rendering to reduce redundant queries and improve index performance.
  * Added a lookup to identify which categories have transactions for use by the UI.

* **UI**
  * Category list now groups subcategories and passes a per-item transaction flag.
  * Delete actions open a guarded deletion workflow when transactions exist; otherwise perform immediate delete.

* **Tests**
  * Added a performance-focused index test, a view test for delete behavior, and stabilized a date-dependent model test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->