### PR TITLE
[Bug]: filter_account_id bypasses finance account scope on reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -631,7 +631,8 @@ class ReportsController < ApplicationController
 
       # Filter by account
       if params[:filter_account_id].present?
-        allowed_ids = finance_account_ids & [ params[:filter_account_id] ]
+        filter_id = params[:filter_account_id].to_i
+        allowed_ids = finance_account_ids.include?(filter_id) ? [ filter_id ] : []
         scope = scope.where(entries: { account_id: allowed_ids })
       end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -631,7 +631,8 @@ class ReportsController < ApplicationController
 
       # Filter by account
       if params[:filter_account_id].present?
-        scope = scope.where(entries: { account_id: params[:filter_account_id] })
+        allowed_ids = finance_account_ids & [ params[:filter_account_id] ]
+        scope = scope.where(entries: { account_id: allowed_ids })
       end
 
       # Filter by amount range

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -224,6 +224,27 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_match /Invalid or expired API key/, @response.body
   end
 
+  test "filter_account_id cannot bypass finance account scoping" do
+    member = users(:family_member)
+    private_account = accounts(:investment)
+
+    assert_not_includes member.finance_accounts.pluck(:id), private_account.id
+
+    category = @family.categories.create!(name: "LEAKED_REPORTS_CATEGORY", color: "#737373", lucide_icon: "circle")
+    private_account.entries.create!(
+      name: "Admin-only spend",
+      date: Date.current,
+      amount: -25,
+      currency: "USD",
+      entryable: Transaction.new(category: category, kind: "standard")
+    )
+
+    sign_in member
+
+    get reports_path(period_type: :monthly, filter_account_id: private_account.id)
+    refute_includes @response.body, "LEAKED_REPORTS_CATEGORY"
+  end
+
   test "export transactions without API key uses session auth" do
     # Should use normal session-based authentication
     # The setup already signs in @user = users(:family_admin)

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -226,22 +226,38 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
 
   test "filter_account_id cannot bypass finance account scoping" do
     member = users(:family_member)
+    allowed_account = accounts(:depository)
     private_account = accounts(:investment)
 
+    assert_includes member.finance_accounts.pluck(:id), allowed_account.id
     assert_not_includes member.finance_accounts.pluck(:id), private_account.id
 
-    category = @family.categories.create!(name: "LEAKED_REPORTS_CATEGORY", color: "#737373", lucide_icon: "circle")
+    leaked_category = @family.categories.create!(name: "LEAKED_REPORTS_CATEGORY", color: "#737373", lucide_icon: "circle")
+    allowed_category = @family.categories.create!(name: "ALLOWED_REPORTS_CATEGORY", color: "#737373", lucide_icon: "circle")
+
     private_account.entries.create!(
       name: "Admin-only spend",
       date: Date.current,
       amount: -25,
       currency: "USD",
-      entryable: Transaction.new(category: category, kind: "standard")
+      entryable: Transaction.new(category: leaked_category, kind: "standard")
+    )
+    allowed_account.entries.create!(
+      name: "Shared checking spend",
+      date: Date.current,
+      amount: -15,
+      currency: "USD",
+      entryable: Transaction.new(category: allowed_category, kind: "standard")
     )
 
     sign_in member
 
     get reports_path(period_type: :monthly, filter_account_id: private_account.id)
+    refute_includes @response.body, "LEAKED_REPORTS_CATEGORY"
+    refute_includes @response.body, "ALLOWED_REPORTS_CATEGORY"
+
+    get reports_path(period_type: :monthly, filter_account_id: allowed_account.id)
+    assert_includes @response.body, "ALLOWED_REPORTS_CATEGORY"
     refute_includes @response.body, "LEAKED_REPORTS_CATEGORY"
   end
 


### PR DESCRIPTION
## Summary

Closes #2092.

Intersect `filter_account_id` with the user's allowed `finance_account_ids` before scoping report queries.

## Changes

- `app/controllers/reports_controller.rb`: scoped filter intersection.
- `test/controllers/reports_controller_test.rb`: `filter_account_id cannot bypass finance account scoping`.

## Test plan

- [ ] `bin/rails test test/controllers/reports_controller_test.rb -n filter_account_id`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account filter now properly validates and restricts filtering to user-authorized accounts. Attempts to filter by unauthorized accounts no longer return transaction data, preventing potential data access issues.

* **Tests**
  * Added integration test verifying that account filter correctly restricts transaction visibility to authorized accounts while blocking access to unauthorized ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->