### PR TITLE
feat(transactions): index attachments in the vector store (#1204)

### DIFF
--- a/app/controllers/transaction_attachments_controller.rb
+++ b/app/controllers/transaction_attachments_controller.rb
@@ -17,6 +17,8 @@ class TransactionAttachmentsController < ApplicationController
     attachments = attachment_params
 
     if attachments.present?
+      blobs_to_index = []
+
       @transaction.with_lock do
         # Check attachment count limit before attaching
         current_count = @transaction.attachments.count
@@ -32,8 +34,10 @@ class TransactionAttachmentsController < ApplicationController
 
         existing_ids = @transaction.attachments.pluck(:id)
         attachment_proxy = @transaction.attachments.attach(attachments)
+        newly_added = Array(attachment_proxy).reject { |a| existing_ids.include?(a.id) }
 
         if @transaction.valid?
+          blobs_to_index = newly_added.map(&:blob)
           count = new_count
           message = count == 1 ? t("transactions.attachments.uploaded_one") : t("transactions.attachments.uploaded_many", count: count)
           respond_to do |format|
@@ -42,7 +46,6 @@ class TransactionAttachmentsController < ApplicationController
           end
         else
           # Remove invalid attachments
-          newly_added = Array(attachment_proxy).reject { |a| existing_ids.include?(a.id) }
           newly_added.each(&:purge)
           error_messages = @transaction.errors.full_messages_for(:attachments).join(", ")
           respond_to do |format|
@@ -51,6 +54,10 @@ class TransactionAttachmentsController < ApplicationController
           end
         end
       end
+
+      # Enqueue vector-store indexing only after the attachments are committed,
+      # so the background job can reliably load the persisted blobs.
+      enqueue_attachment_indexing(blobs_to_index)
     else
       respond_to do |format|
         format.html { redirect_back_or_to transaction_path(@transaction), alert: t("transactions.attachments.no_files_selected") }
@@ -71,7 +78,10 @@ class TransactionAttachmentsController < ApplicationController
       return
     end
 
+    family = @transaction.entry.account.family
+    blob_id = @attachment.blob_id
     @attachment.purge
+    enqueue_attachment_removal(family, blob_id)
     message = t("transactions.attachments.attachment_deleted")
     respond_to do |format|
       format.html { redirect_back_or_to transaction_path(@transaction), notice: message }
@@ -102,6 +112,21 @@ class TransactionAttachmentsController < ApplicationController
       permission = @transaction.entry.account.permission_for(Current.user)
       @can_upload = permission.in?([ :owner, :full_control, :read_write ])
       @can_delete = permission.in?([ :owner, :full_control ])
+    end
+
+    def enqueue_attachment_indexing(blobs)
+      return if blobs.blank?
+      return unless VectorStore.configured?
+
+      blobs.each do |blob|
+        IndexTransactionAttachmentJob.perform_later(@transaction, blob)
+      end
+    end
+
+    def enqueue_attachment_removal(family, blob_id)
+      return unless VectorStore.configured?
+
+      RemoveTransactionAttachmentJob.perform_later(family, blob_id)
     end
 
     def attachment_params

--- a/app/jobs/index_transaction_attachment_job.rb
+++ b/app/jobs/index_transaction_attachment_job.rb
@@ -1,0 +1,45 @@
+class IndexTransactionAttachmentJob < ApplicationJob
+  queue_as :low_priority
+
+  # If the transaction or blob was deleted before this job ran, there's nothing
+  # to index — drop it quietly rather than retrying forever.
+  discard_on ActiveJob::DeserializationError
+
+  # Indexes a transaction's file attachment into the family's vector store so it
+  # becomes available for semantic search (mirrors ProcessPdfJob's upload).
+  #
+  # @param transaction [Transaction]
+  # @param blob [ActiveStorage::Blob] the attached file's blob
+  def perform(transaction, blob)
+    return unless VectorStore.configured?
+    return unless supported_extension?(blob)
+
+    family = transaction.entry.account.family
+
+    # Idempotent: avoid re-uploading the same attachment (e.g. on retry).
+    return if document_exists?(family, blob)
+
+    family.upload_document(
+      file_content: blob.download,
+      filename: blob.filename.to_s,
+      metadata: {
+        "type" => "transaction_attachment",
+        "transaction_id" => transaction.id,
+        "attachment_blob_id" => blob.id.to_s
+      }
+    )
+  end
+
+  private
+
+    def supported_extension?(blob)
+      ext = File.extname(blob.filename.to_s).downcase
+      VectorStore::Base::SUPPORTED_EXTENSIONS.include?(ext)
+    end
+
+    def document_exists?(family, blob)
+      family.family_documents
+            .where("metadata ->> 'attachment_blob_id' = ?", blob.id.to_s)
+            .exists?
+    end
+end

--- a/app/jobs/remove_transaction_attachment_job.rb
+++ b/app/jobs/remove_transaction_attachment_job.rb
@@ -1,0 +1,21 @@
+class RemoveTransactionAttachmentJob < ApplicationJob
+  queue_as :low_priority
+
+  discard_on ActiveJob::DeserializationError
+
+  # Removes a transaction attachment from the family's vector store after the
+  # attachment has been deleted. The blob is already purged by the time this
+  # runs, so we locate the indexed document by the blob id stored in metadata.
+  #
+  # @param family [Family]
+  # @param blob_id [Integer, String] the purged attachment's blob id
+  def perform(family, blob_id)
+    return unless VectorStore.configured?
+
+    family.family_documents
+          .where("metadata ->> 'attachment_blob_id' = ?", blob_id.to_s)
+          .find_each do |family_document|
+      family.remove_document(family_document)
+    end
+  end
+end

--- a/test/controllers/transaction_attachments_controller_test.rb
+++ b/test/controllers/transaction_attachments_controller_test.rb
@@ -141,4 +141,32 @@ class TransactionAttachmentsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/turbo-stream action="append" target="notification-tray"/, response.body)
     assert_match("Attachment deleted successfully", response.body)
   end
+
+  test "enqueues vector store indexing when configured" do
+    VectorStore.stubs(:configured?).returns(true)
+    file = fixture_file_upload("test.txt", "application/pdf")
+
+    assert_enqueued_with(job: IndexTransactionAttachmentJob) do
+      post transaction_attachments_path(@transaction), params: { attachment: file }
+    end
+  end
+
+  test "does not enqueue vector store indexing when not configured" do
+    VectorStore.stubs(:configured?).returns(false)
+    file = fixture_file_upload("test.txt", "application/pdf")
+
+    assert_no_enqueued_jobs only: IndexTransactionAttachmentJob do
+      post transaction_attachments_path(@transaction), params: { attachment: file }
+    end
+  end
+
+  test "enqueues vector store removal on delete when configured" do
+    VectorStore.stubs(:configured?).returns(true)
+    @transaction.attachments.attach(io: StringIO.new("test"), filename: "test.pdf", content_type: "application/pdf")
+    attachment = @transaction.attachments.first
+
+    assert_enqueued_with(job: RemoveTransactionAttachmentJob) do
+      delete transaction_attachment_path(@transaction, attachment)
+    end
+  end
 end

--- a/test/jobs/index_transaction_attachment_job_test.rb
+++ b/test/jobs/index_transaction_attachment_job_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class IndexTransactionAttachmentJobTest < ActiveJob::TestCase
+  setup do
+    @entry = entries(:transaction)
+    @transaction = @entry.entryable
+    @family = @transaction.entry.account.family
+  end
+
+  test "uploads a supported attachment to the family vector store" do
+    VectorStore.stubs(:configured?).returns(true)
+    blob = attach!("receipt.pdf", "application/pdf")
+
+    Family.any_instance.expects(:upload_document).with do |file_content:, filename:, metadata:|
+      assert_equal "receipt.pdf", filename
+      assert_equal "transaction_attachment", metadata["type"]
+      assert_equal @transaction.id, metadata["transaction_id"]
+      assert_equal blob.id.to_s, metadata["attachment_blob_id"]
+      true
+    end.returns(family_documents(:tax_return))
+
+    IndexTransactionAttachmentJob.perform_now(@transaction, blob)
+  end
+
+  test "does nothing when the vector store is not configured" do
+    VectorStore.stubs(:configured?).returns(false)
+    blob = attach!("receipt.pdf", "application/pdf")
+
+    Family.any_instance.expects(:upload_document).never
+
+    IndexTransactionAttachmentJob.perform_now(@transaction, blob)
+  end
+
+  test "skips attachments with unsupported extensions" do
+    VectorStore.stubs(:configured?).returns(true)
+    blob = attach!("photo.webp", "image/webp")
+
+    Family.any_instance.expects(:upload_document).never
+
+    IndexTransactionAttachmentJob.perform_now(@transaction, blob)
+  end
+
+  test "does not re-upload an attachment that is already indexed" do
+    VectorStore.stubs(:configured?).returns(true)
+    blob = attach!("receipt.pdf", "application/pdf")
+
+    @family.family_documents.create!(
+      filename: "receipt.pdf",
+      content_type: "application/pdf",
+      file_size: 10,
+      provider_file_id: "file-existing",
+      status: "ready",
+      metadata: { "attachment_blob_id" => blob.id.to_s }
+    )
+
+    Family.any_instance.expects(:upload_document).never
+
+    IndexTransactionAttachmentJob.perform_now(@transaction, blob)
+  end
+
+  private
+
+    def attach!(filename, content_type)
+      @transaction.attachments.attach(
+        io: StringIO.new("file-bytes"),
+        filename: filename,
+        content_type: content_type
+      )
+      @transaction.attachments.find { |a| a.filename.to_s == filename }.blob
+    end
+end

--- a/test/jobs/remove_transaction_attachment_job_test.rb
+++ b/test/jobs/remove_transaction_attachment_job_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class RemoveTransactionAttachmentJobTest < ActiveJob::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "removes the indexed document matching the purged blob id" do
+    VectorStore.stubs(:configured?).returns(true)
+
+    document = @family.family_documents.create!(
+      filename: "receipt.pdf",
+      content_type: "application/pdf",
+      file_size: 10,
+      provider_file_id: "file-123",
+      status: "ready",
+      metadata: { "attachment_blob_id" => "555" }
+    )
+
+    @family.expects(:remove_document).with(document).returns(true)
+
+    RemoveTransactionAttachmentJob.perform_now(@family, 555)
+  end
+
+  test "does nothing when the vector store is not configured" do
+    VectorStore.stubs(:configured?).returns(false)
+
+    @family.expects(:remove_document).never
+
+    RemoveTransactionAttachmentJob.perform_now(@family, 555)
+  end
+
+  test "does nothing when no document matches the blob id" do
+    VectorStore.stubs(:configured?).returns(true)
+
+    @family.expects(:remove_document).never
+
+    RemoveTransactionAttachmentJob.perform_now(@family, 999)
+  end
+end

--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -712,39 +712,45 @@ class AccountStatementTest < ActiveSupport::TestCase
   end
 
   test "coverage marks covered duplicate ambiguous and mismatched months" do
-    covered_month = 5.months.ago.to_date.beginning_of_month
-    missing_month = 4.months.ago.to_date.beginning_of_month
-    duplicate_month = 3.months.ago.to_date.beginning_of_month
-    ambiguous_month = 2.months.ago.to_date.beginning_of_month
-    mismatched_month = 1.month.ago.to_date.beginning_of_month
+    # Pin the clock so the computed months are deterministic and never collide
+    # with the relative-dated balance fixtures (which land on "yesterday").
+    # Without this the test fails on the 1st of every month, when
+    # 1.month.ago.end_of_month equals 1.day.ago. See balances.yml.
+    travel_to Date.new(2026, 5, 6) do
+      covered_month = 5.months.ago.to_date.beginning_of_month
+      missing_month = 4.months.ago.to_date.beginning_of_month
+      duplicate_month = 3.months.ago.to_date.beginning_of_month
+      ambiguous_month = 2.months.ago.to_date.beginning_of_month
+      mismatched_month = 1.month.ago.to_date.beginning_of_month
 
-    create_statement(account: @account, month: covered_month, content: "covered")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
-    create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
-    create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
+      create_statement(account: @account, month: covered_month, content: "covered")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
+      create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
+      create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
+      create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
 
-    @account.balances.create!(
-      date: mismatched_month.end_of_month,
-      balance: 100,
-      currency: "USD",
-      start_cash_balance: 100,
-      cash_inflows: 0,
-      cash_outflows: 0
-    )
+      @account.balances.create!(
+        date: mismatched_month.end_of_month,
+        balance: 100,
+        currency: "USD",
+        start_cash_balance: 100,
+        cash_inflows: 0,
+        cash_outflows: 0
+      )
 
-    coverage = AccountStatement::Coverage.new(
-      @account,
-      start_month: covered_month,
-      end_month: mismatched_month
-    )
+      coverage = AccountStatement::Coverage.new(
+        @account,
+        start_month: covered_month,
+        end_month: mismatched_month
+      )
 
-    statuses = coverage.months.index_by(&:date).transform_values(&:status)
-    assert_equal "covered", statuses[covered_month]
-    assert_equal "missing", statuses[missing_month]
-    assert_equal "duplicate", statuses[duplicate_month]
-    assert_equal "ambiguous", statuses[ambiguous_month]
-    assert_equal "mismatched", statuses[mismatched_month]
+      statuses = coverage.months.index_by(&:date).transform_values(&:status)
+      assert_equal "covered", statuses[covered_month]
+      assert_equal "missing", statuses[missing_month]
+      assert_equal "duplicate", statuses[duplicate_month]
+      assert_equal "ambiguous", statuses[ambiguous_month]
+      assert_equal "mismatched", statuses[mismatched_month]
+    end
   end
 
   private


### PR DESCRIPTION
fixes #1204

## Summary

Indexes transaction file attachments in the OpenAI vector store so they become
available for semantic search. Attachments (added in PR #713) were stored in
Active Storage but never wired into the existing vector store pipeline. This
mirrors the `ProcessPdfJob` pattern for upload and adds the matching cleanup on
deletion.

* **Features**
  * **`IndexTransactionAttachmentJob`** — on upload, downloads the attachment
    blob and calls `family.upload_document(file_content:, filename:, metadata:)`.
    Metadata tags the document as a transaction attachment
    (`type`, `transaction_id`, `attachment_blob_id`). Skips unsupported
    extensions (e.g. `.webp`) and is idempotent on retry (won't double-upload
    the same blob).
  * **`RemoveTransactionAttachmentJob`** — on deletion, the blob is already
    purged, so it locates the indexed `FamilyDocument` by the
    `attachment_blob_id` stored in metadata and calls
    `family.remove_document(...)`.
  * **`TransactionAttachmentsController`** — enqueues indexing **after** the
    attachments are committed (so the job reliably loads persisted blobs), and
    enqueues removal after `purge`. Both paths are no-ops unless
    `VectorStore.configured?`.

## Design notes

* **Blob → document mapping:** rather than a schema migration, the link is
  stored in `FamilyDocument.metadata["attachment_blob_id"]`, which is also how
  the removal job finds what to delete. This reuses the existing
  `FamilyDocument` / `provider_file_id` plumbing.
* **Background jobs** (low priority) match the `ProcessPdfJob` pattern: they
  receive model instances, resolve the family via
  `transaction.entry.account.family`, and `discard_on
  ActiveJob::DeserializationError` so a since-deleted record is dropped quietly.
* **Indexing is enqueued outside the `with_lock` transaction** so the job never
  races ahead of the attachment commit.
* Only vector-store-supported extensions are uploaded
  (`VectorStore::Base::SUPPORTED_EXTENSIONS`); unsupported types (e.g. `webp`)
  are skipped.

## Files

* `app/jobs/index_transaction_attachment_job.rb` (new)
* `app/jobs/remove_transaction_attachment_job.rb` (new)
* `app/controllers/transaction_attachments_controller.rb` — enqueue on create/destroy
* `test/jobs/index_transaction_attachment_job_test.rb` (new)
* `test/jobs/remove_transaction_attachment_job_test.rb` (new)
* `test/controllers/transaction_attachments_controller_test.rb` — enqueue assertions

## Tests

* Index job: uploads supported attachments with correct metadata; no-op when the
  vector store isn't configured; skips unsupported extensions; idempotent.
* Remove job: removes the document matching the purged blob id; no-op when
  unconfigured or when nothing matches.
* Controller: enqueues index on upload / remove on delete only when configured.

## CI checklist (`.github/workflows/pr.yml` → `ci.yml`)

- [ ] `bin/brakeman --no-pager` — Ruby security scan
- [ ] `bin/importmap audit` — JS dependency scan
- [ ] `bin/rubocop -f github` — Ruby lint
- [ ] `bin/rails test` — unit tests (job + controller tests above)

> Not run locally — no Ruby runtime / app container in the dev environment. CI
> will execute these on the PR.

---

- **Issue:** Closes #1204
- **Branch:** `feat/1204-attachment-vector-store`
- **Base:** `we-promise/sure:main` ← **Compare:** `web-dev0521:feat/1204-attachment-vector-store`
- **Create PR:** https://github.com/web-dev0521/sure/pull/new/feat/1204-attachment-vector-store


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction attachments are automatically indexed in the vector store (when configured) after attachment completes.
  * Deleting attachments enqueues removal from the vector store.
  * Background jobs perform indexing/removal with idempotency and support for supported file types.

* **Bug Fixes**
  * Failed attachment attempts purge newly added files and prevent unnecessary indexing.

* **Tests**
  * Added integration and job tests covering indexing/removal behavior and deterministic time handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->