### PR TITLE
Fix Trend percentage on negative and zero baselines

### DIFF
--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -52,18 +52,25 @@ class Trend
 
   def percent
     return 0.0 if previous.zero? && current.zero?
-    return Float::INFINITY if previous.zero?
 
+    # No baseline to divide by: report a signed infinity that matches the
+    # direction of the move, rather than always-positive infinity.
+    return signed_infinity if previous.zero?
+
+    # Measure the change against the *magnitude* of the prior value so the sign
+    # reflects the actual direction of change. Dividing by a signed baseline
+    # would flip the sign whenever `previous` is negative (e.g. a net worth
+    # moving from -100 to -50 is +50%, not -50%).
     change = (current - previous).to_f
 
-    (change / previous.to_f * 100).round(1)
+    (change / previous.to_f.abs * 100).round(1)
   end
 
   def percent_formatted
     if percent.finite?
       "#{percent.round(1)}%"
     else
-      percent > 0 ? "＋∞" : "-∞"
+      percent.positive? ? "＋∞" : "-∞"
     end
   end
 
@@ -80,6 +87,18 @@ class Trend
   end
 
   private
+    # An infinite percentage carrying the sign of the move's direction, used
+    # when there is no baseline (previous is zero) to compute against.
+    def signed_infinity
+      if direction.up?
+        Float::INFINITY
+      elsif direction.down?
+        -Float::INFINITY
+      else
+        0.0
+      end
+    end
+
     def red_hex
       "var(--color-destructive)"
     end

--- a/test/models/trend_test.rb
+++ b/test/models/trend_test.rb
@@ -37,4 +37,29 @@ class TrendTest < ActiveSupport::TestCase
     trend = Trend.new(current: 0, previous: 100)
     assert_equal "down", trend.direction
   end
+
+  test "negative baseline reports percent with the direction's sign" do
+    # Improving from -100 to -50 is an upward move of +50%, not -50%.
+    trend = Trend.new(current: -50, previous: -100)
+    assert_equal "up", trend.direction
+    assert_equal 50.0, trend.percent
+    assert_equal "50.0%", trend.percent_formatted
+  end
+
+  test "negative baseline getting worse reports a negative percent" do
+    # Falling from -50 to -100 is a downward move of -100%.
+    trend = Trend.new(current: -100, previous: -50)
+    assert_equal "down", trend.direction
+    assert_equal(-100.0, trend.percent)
+  end
+
+  test "infinite percent carries the direction's sign" do
+    up = Trend.new(current: 100, previous: 0)
+    assert_equal Float::INFINITY, up.percent
+    assert_equal "＋∞", up.percent_formatted
+
+    down = Trend.new(current: -100, previous: 0)
+    assert_equal(-Float::INFINITY, down.percent)
+    assert_equal "-∞", down.percent_formatted
+  end
 end


### PR DESCRIPTION
Fixes #2097.

## Summary

`Trend#percent` divided by the **signed** previous value and `Trend#percent_formatted` treated an infinite percentage as always positive, so trends with a negative or zero baseline were wrong while the object's own `direction`/`value`/`color` were correct.

- **Negative baseline -> sign flip.** `current: -50, previous: -100` (e.g. net worth improving from -100 to -50): `direction` is "up" and `value` is +50, but `percent` returned `-50%`. It now divides by `previous.abs`, so the sign reflects the direction of change -> `+50%`.
- **Zero baseline -> wrong infinity.** `current: -100, previous: 0`: `direction` is "down", but `percent_formatted` rendered `+∞` (because `Float::INFINITY > 0`). A new `signed_infinity` helper returns a direction-signed infinity, so it now renders `-∞`.

`Trend` backs every chart point (`Balance::ChartSeriesBuilder`, `Balance::SeriesAggregator`), so net-worth and liability/credit-card/loan trends (commonly negative) were affected.

## Changes

- `app/models/trend.rb`: divide by the magnitude of `previous`; add `signed_infinity` (branches on `direction`); `percent_formatted` uses the sign of the infinite percent.
- `test/models/trend_test.rb`: add cases for negative-baseline up/down and signed-infinity up/down. Existing positive-baseline behavior is unchanged.

## Testing

```
bin/rails test test/models/trend_test.rb
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trend percentage calculations to correctly display negative signs when metrics decline, even with negative baseline values.
  * Improved infinite percentage formatting to show the correct direction indicator (`+∞` for increases, `−∞` for decreases).

* **Tests**
  * Added test coverage for edge cases with negative baseline values and infinite percentages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->