### PR TITLE
[Bug]: Bulk transaction updates skip account write-permission checks

### DIFF
--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -3,17 +3,25 @@ class Transactions::BulkUpdatesController < ApplicationController
   end
 
   def create
-    writable_account_ids = Current.family.accounts.writable_by(Current.user).pluck(:id)
     requested_ids = Array(bulk_update_params[:entry_ids]).map(&:to_i)
-    # Skip split parents from bulk update - update children instead
-    updated = Current.family
-                     .entries
-                     .excluding_split_parents
-                     .where(account_id: writable_account_ids, id: requested_ids)
-                     .bulk_update!(bulk_update_params, update_tags: tags_provided?)
+    writable_account_ids = Current.family.accounts.writable_by(Current.user).pluck(:id)
+    annotatable_account_ids = Current.family.accounts
+      .joins(:account_shares)
+      .where(account_shares: { user_id: Current.user.id, permission: "read_write" })
+      .pluck(:id)
+
+    scope = Current.family.entries.excluding_split_parents
+
+    updated = scope.where(account_id: writable_account_ids, id: requested_ids)
+                   .bulk_update!(bulk_update_params, update_tags: tags_provided?)
+
+    if annotatable_account_ids.any?
+      updated += scope.where(account_id: annotatable_account_ids, id: requested_ids)
+                      .bulk_update!(annotate_bulk_update_params, update_tags: tags_provided?)
+    end
 
     if updated < requested_ids.length
-      redirect_back_or_to transactions_path, alert: "Some transactions could not be updated due to permissions"
+      redirect_back_or_to transactions_path, alert: t(".permission_error")
       return
     end
 
@@ -24,6 +32,10 @@ class Transactions::BulkUpdatesController < ApplicationController
     def bulk_update_params
       params.require(:bulk_update)
             .permit(:date, :notes, :name, :category_id, :merchant_id, entry_ids: [], tag_ids: [])
+    end
+
+    def annotate_bulk_update_params
+      bulk_update_params.slice(:notes, :category_id, :merchant_id, :tag_ids).compact
     end
 
     # Check if tag_ids was explicitly provided in the request.

--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -3,7 +3,7 @@ class Transactions::BulkUpdatesController < ApplicationController
   end
 
   def create
-    requested_ids = Array(bulk_update_params[:entry_ids]).map(&:to_i)
+    requested_ids = Array(bulk_update_params[:entry_ids])
     writable_account_ids = Current.family.accounts.writable_by(Current.user).pluck(:id)
     annotatable_account_ids = Current.family.accounts
       .joins(:account_shares)

--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -3,12 +3,19 @@ class Transactions::BulkUpdatesController < ApplicationController
   end
 
   def create
+    writable_account_ids = Current.family.accounts.writable_by(Current.user).pluck(:id)
+    requested_ids = Array(bulk_update_params[:entry_ids]).map(&:to_i)
     # Skip split parents from bulk update - update children instead
     updated = Current.family
                      .entries
                      .excluding_split_parents
-                     .where(id: bulk_update_params[:entry_ids])
+                     .where(account_id: writable_account_ids, id: requested_ids)
                      .bulk_update!(bulk_update_params, update_tags: tags_provided?)
+
+    if updated < requested_ids.length
+      redirect_back_or_to transactions_path, alert: "Some transactions could not be updated due to permissions"
+      return
+    end
 
     redirect_back_or_to transactions_path, notice: "#{updated} transactions updated"
   end

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -2,6 +2,7 @@
 en:
   transactions:
     bulk_updates:
+      permission_error: Some transactions could not be updated due to permissions
       new:
         cancel: Cancel
         category_label: Category

--- a/test/controllers/transactions/bulk_updates_controller_test.rb
+++ b/test/controllers/transactions/bulk_updates_controller_test.rb
@@ -99,6 +99,73 @@ class Transactions::BulkUpdatesControllerTest < ActionDispatch::IntegrationTest
     assert_empty transaction_entry.transaction.tags
   end
 
+  test "bulk update rejects private account entries for members without access" do
+    member = users(:family_member)
+    private_account = accounts(:investment)
+    category = Category.second
+
+    entry = private_account.entries.create!(
+      name: "Private bulk target",
+      date: Date.current,
+      amount: -20,
+      currency: "USD",
+      entryable: Transaction.new(category: category, kind: "standard")
+    )
+
+    sign_in member
+
+    post transactions_bulk_update_url, params: {
+      bulk_update: {
+        entry_ids: [ entry.id ],
+        category_id: category.id,
+        notes: "Should not apply"
+      }
+    }
+
+    assert_redirected_to transactions_url
+    assert_equal I18n.t("transactions.bulk_updates.permission_error"), flash[:alert]
+    assert_not_equal "Should not apply", entry.reload.notes
+  end
+
+  test "read_write member can bulk annotate but not change structural fields" do
+    member = users(:family_member)
+    account = accounts(:investment)
+    account.share_with!(member, permission: "read_write")
+
+    category = Category.second
+    entry = account.entries.create!(
+      name: "Annotatable bulk target",
+      date: Date.current,
+      amount: -30,
+      currency: "USD",
+      entryable: Transaction.new(category: category, kind: "standard")
+    )
+
+    sign_in member
+
+    post transactions_bulk_update_url, params: {
+      bulk_update: {
+        entry_ids: [ entry.id ],
+        notes: "Annotated in bulk"
+      }
+    }
+
+    assert_redirected_to transactions_url
+    assert_equal "1 transactions updated", flash[:notice]
+    assert_equal "Annotated in bulk", entry.reload.notes
+
+    post transactions_bulk_update_url, params: {
+      bulk_update: {
+        entry_ids: [ entry.id ],
+        date: 2.days.ago.to_date
+      }
+    }
+
+    assert_redirected_to transactions_url
+    assert_equal I18n.t("transactions.bulk_updates.permission_error"), flash[:alert]
+    assert_equal Date.current, entry.reload.date
+  end
+
   test "bulk update replaces tags when tag_ids explicitly provided" do
     transaction_entry = @user.family.entries.transactions.first
     transaction_entry.transaction.tags = [ Tag.first ]


### PR DESCRIPTION
## Summary

Closes #2099.

Scope bulk transaction updates to writable family accounts.

## Changes

- `app/controllers/transactions/bulk_updates_controller.rb`: intersect entry IDs with writable account scope.

## Test plan

- [ ] Controller test: read-only user cannot bulk-update private account entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Members with shared read/write access can bulk-add notes and tags (annotation-only) without changing structural fields.

* **Bug Fixes**
  * Prevented unauthorized bulk edits; users are alerted when some transactions couldn’t be updated due to permissions.

* **Tests**
  * Added coverage for bulk update authorization, annotation behavior, and field-change restrictions.

* **Localization**
  * Added a permission error message shown when updates are blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->