### PR TITLE
fix(tests): avoid account statement coverage rollover collision

### DIFF
--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -712,19 +712,28 @@ class AccountStatementTest < ActiveSupport::TestCase
   end
 
   test "coverage marks covered duplicate ambiguous and mismatched months" do
+    account = Account.create!(
+      family: @family,
+      owner: users(:family_admin),
+      name: "Coverage Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
     covered_month = 5.months.ago.to_date.beginning_of_month
     missing_month = 4.months.ago.to_date.beginning_of_month
     duplicate_month = 3.months.ago.to_date.beginning_of_month
     ambiguous_month = 2.months.ago.to_date.beginning_of_month
     mismatched_month = 1.month.ago.to_date.beginning_of_month
 
-    create_statement(account: @account, month: covered_month, content: "covered")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-a")
-    create_statement(account: @account, month: duplicate_month, content: "duplicate-b")
-    create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
-    create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
+    create_statement(account: account, month: covered_month, content: "covered")
+    create_statement(account: account, month: duplicate_month, content: "duplicate-a")
+    create_statement(account: account, month: duplicate_month, content: "duplicate-b")
+    create_statement(account: nil, suggested_account: account, month: ambiguous_month, content: "ambiguous")
+    create_statement(account: account, month: mismatched_month, content: "mismatched", closing_balance: 120)
 
-    @account.balances.create!(
+    account.balances.create!(
       date: mismatched_month.end_of_month,
       balance: 100,
       currency: "USD",
@@ -734,7 +743,7 @@ class AccountStatementTest < ActiveSupport::TestCase
     )
 
     coverage = AccountStatement::Coverage.new(
-      @account,
+      account,
       start_month: covered_month,
       end_month: mismatched_month
     )


### PR DESCRIPTION
## Summary
- use a fresh account in the coverage rollover test instead of the shared `depository` fixture
- avoid collisions with fixture balances created from relative dates like `1.day.ago`
- keep the test intent the same while removing the month-boundary flake

## Why
On month rollover dates like 2026-06-01, the test-generated `mismatched_month.end_of_month` can resolve to the same day as the fixture balance for `depository`, triggering a unique-index violation on `(account_id, date, currency)`.

## Testing
- `DISABLE_PARALLELIZATION=true bin/rails test test/models/account_statement_test.rb:714`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved account statement coverage test robustness by refactoring variable initialization patterns while maintaining existing validation assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->