### PR TITLE
fix(test): make account_statement coverage test date-robust

### DIFF
--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -724,14 +724,17 @@ class AccountStatementTest < ActiveSupport::TestCase
     create_statement(account: nil, suggested_account: @account, month: ambiguous_month, content: "ambiguous")
     create_statement(account: @account, month: mismatched_month, content: "mismatched", closing_balance: 120)
 
-    @account.balances.create!(
-      date: mismatched_month.end_of_month,
-      balance: 100,
-      currency: "USD",
-      start_cash_balance: 100,
-      cash_inflows: 0,
-      cash_outflows: 0
-    )
+    # The depository fixture seeds balances at 1.day.ago / 2.days.ago, which
+    # land on mismatched_month.end_of_month when the suite runs on the first of
+    # the month. Upsert so the date-relative collision can't make this flaky.
+    @account.balances
+            .find_or_initialize_by(date: mismatched_month.end_of_month, currency: "USD")
+            .update!(
+              balance: 100,
+              start_cash_balance: 100,
+              cash_inflows: 0,
+              cash_outflows: 0
+            )
 
     coverage = AccountStatement::Coverage.new(
       @account,


### PR DESCRIPTION
## Problem

`ci / test_unit` fails on the **first of the month**. `AccountStatementTest#test_coverage_marks_covered_duplicate_ambiguous_and_mismatched_months` creates an account balance at `mismatched_month.end_of_month` (the previous month's last day). The `depository` fixture seeds balances at `1.day.ago` / `2.days.ago`; when the suite runs on the 1st, `1.day.ago` *is* the previous month's last day, so the explicit `create!` collides with the fixture balance:

```
PG::UniqueViolation: duplicate key value violates unique constraint
"index_account_balances_on_account_id_date_currency_unique"
test/models/account_statement_test.rb:727
```

Reproduces deterministically when the suite runs on the 1st (verified 2026-06-01 on a clean `main`).

## Fix

Upsert the balance via `find_or_initialize_by(...).update!(...)` so the date-relative collision can't make the test flaky. The mismatch assertion (account balance 100 vs statement closing balance 120) is unchanged on every other day.

## Verification

- The previously-failing test passes on 2026-06-01 (the trigger date)
- Full `account_statement_test.rb`: 39 runs, 0 failures
- rubocop clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite reliability by resolving issues with date-dependent account statement fixtures that would cause test failures on boundary dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->