### PR TITLE
fix(db): make AddAdminRoleToCurrentUsers replay-safe on fresh db:migrate

### DIFF
--- a/db/migrate/20240520074309_add_admin_role_to_current_users.rb
+++ b/db/migrate/20240520074309_add_admin_role_to_current_users.rb
@@ -1,5 +1,16 @@
 class AddAdminRoleToCurrentUsers < ActiveRecord::Migration[7.2]
   def up
-    User.update_all(role: "admin")
+    # Raw SQL on purpose — do NOT replace with `User.update_all`.
+    #
+    # This data migration must not load the live User model. User declares
+    # `enum :ui_layout`, backed by a column added in a much later migration
+    # (20251030140000_add_ui_layout_to_users). On a fresh `db:migrate` replay
+    # the column does not exist yet when this runs, so loading the class raises
+    # "Undeclared attribute type for enum 'ui_layout'", aborting this and every
+    # subsequent migration and leaving fresh clones unable to bootstrap.
+    #
+    # `users.role` is a string column whose `admin` enum value is stored as the
+    # literal "admin", so this is equivalent to the original model call.
+    execute "UPDATE users SET role = 'admin'"
   end
 end


### PR DESCRIPTION
## Summary

Closes #1716. A fresh `bin/rails db:migrate` (new clone / `db:reset`) aborted partway through and left the DB in a partial state; `db:schema:load` was the only workaround.

**Root cause:** `20240520074309_add_admin_role_to_current_users` called `User.update_all(role: "admin")`, which loads the live `User` model. `User` declares `enum :ui_layout`, backed by a column added in a *much later* migration (`20251030140000`). On a fresh replay that column doesn't exist when the 2024 migration runs, so loading the class raises `Undeclared attribute type for enum 'ui_layout'` — aborting this migration and every one after it. (Existing devs were unaffected because their DB already had `ui_layout` by the time they'd hit a re-run.)

**Fix:** replace the model call with raw SQL. `users.role` is a `string` column whose `admin` enum value is stored as the literal `"admin"`, so it's equivalent — and it never loads the coupled model.

```ruby
execute "UPDATE users SET role = 'admin'"
```

A comment on the migration explains *why* it's raw SQL so it doesn't get "tidied" back into `User.update_all`.

## Verification — full replay from an empty DB

Replayed **all** migrations against a throwaway database, both ways:

**Before (main's version):**
```
== 20240520074309 AddAdminRoleToCurrentUsers: migrating ====
StandardError: An error has occurred, this and all later migrations canceled:
Undeclared attribute type for enum 'ui_layout' in User. ...
max applied version: 20240502205006   ← stops right before the bad migration
```

**After (this PR):**
```
applied: 355        ← every migration
20240520074309 AddAdminRoleToCurrentUsers → APPLIED ✓
pending (down) migrations: 0
```

## Audit

I checked every migration that references a model. This is the **only** pre-`ui_layout` migration that loads the live `User` model. The recent `20260503180000_rehash_plaintext_mfa_backup_codes` already uses the correct throwaway-model pattern (`class MigrationUser < ActiveRecord::Base`), so no other replay fix is needed.

## Out of scope

The issue's side-note about `Demo::DataCleaner` / the protected `DEMO_MONITORING_KEY` `ApiKey` `before_destroy` is a separate bug with its own in-flight branch (`claude/fix-api-key-deletion-aGYNW`); intentionally not bundled here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database migration reliability by refactoring the admin role assignment process to prevent potential conflicts with enum-backed columns during fresh migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->