### PR TITLE
chore(ds-pill): migrate budget-category status badges to DS::Pill (#1751)

### DIFF
--- a/app/views/budget_categories/_budget_category.html.erb
+++ b/app/views/budget_categories/_budget_category.html.erb
@@ -26,20 +26,11 @@
         <h3 class="flex-1 min-w-0 font-medium text-primary truncate"><%= budget_category.category.name %></h3>
         <div class="flex items-center gap-3 flex-shrink-0 ml-auto">
           <% if budget_category.over_budget? %>
-            <span class="inline-flex items-center gap-1 px-2 py-1 bg-red-500/10 text-red-500 text-xs font-medium rounded-full whitespace-nowrap">
-              <%= icon("alert-circle", size: "sm", color: "red") %>
-              <%= t("reports.budget_performance.status.over") %>
-            </span>
+            <%= render DS::Pill.new(label: t("reports.budget_performance.status.over"), tone: :error, marker: false, icon: "alert-circle") %>
           <% elsif budget_category.near_limit? %>
-            <span class="inline-flex items-center gap-1 px-2 py-1 bg-yellow-500/10 text-warning text-xs font-medium rounded-full whitespace-nowrap">
-              <%= icon("alert-triangle", size: "sm", color: "yellow") %>
-              <%= t("reports.budget_performance.status.warning") %>
-            </span>
+            <%= render DS::Pill.new(label: t("reports.budget_performance.status.warning"), tone: :warning, marker: false, icon: "alert-triangle") %>
           <% else %>
-            <span class="inline-flex items-center gap-1 px-2 py-1 bg-green-500/10 text-success text-xs font-medium rounded-full whitespace-nowrap">
-              <%= icon("check-circle", size: "sm", color: "green") %>
-              <%= t("reports.budget_performance.status.good") %>
-            </span>
+            <%= render DS::Pill.new(label: t("reports.budget_performance.status.good"), tone: :success, marker: false, icon: "check-circle") %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
## Summary

A small, bounded slice of #1751 (consolidate scattered pill/badge patterns into `DS::Pill`).

The three budget-category status badges (`over_budget` / `near_limit` / `good`) in `budget_categories/_budget_category.html.erb` were hand-rolled pill `<span>`s using **raw palette colors** — `bg-red-500/10 text-red-500`, `bg-yellow-500/10`, `bg-green-500/10` — which break the design-token rule. Their `icon(color: "red"|"yellow"|"green")` args were also **no-ops**: the icon helper's color map has no such keys, so the glyphs just inherited the span's text color (same latent bug class as the sync-toast `inverse` and budget icons).

All three now render via `DS::Pill.new(marker: false, tone:, icon:)`, which draws the icon + label on a semantic soft-tone background using DS tokens (ships AA contrast):

| state | tone | icon |
|---|---|---|
| over_budget | `:error` | `alert-circle` |
| near_limit | `:warning` | `alert-triangle` |
| good | `:success` | `check-circle` |

## Before / After

![before/after](https://raw.githubusercontent.com/gariasf/sure/screenshots/pill-budget-1751/before-after.png)

## Scope

Deliberately one budget file. #1751 is parked overall and there's in-flight pill-migration work on the transactions / providers / transfer-match callsites — this slice stays clear of those to avoid conflicts. The remaining callsites in #1751's list are a separate effort.

## Verification

`erb_lint` clean for the changed region (the one offense the linter reports in this file is a pre-existing multi-line `t(...)` nit at line ~70, untouched here). Renders verified via the component (screenshot above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated budget category status badges with improved visual design, featuring color-coded indicators and icons for clearer at-a-glance status recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->