### PR TITLE
feat: Move "Merge" action for merchants/categories in sub menu

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -2,6 +2,12 @@
 <%= content_for :page_actions do %>
   <%= render DS::Menu.new do |menu| %>
     <% menu.with_item(
+        variant: "link",
+        text: t(".merge"),
+        href: merge_categories_path,
+        frame: :modal,
+        icon: "combine") %>
+    <% menu.with_item(
         variant: "button",
         text: t(".delete_all"),
         href: destroy_all_categories_path,
@@ -9,14 +15,6 @@
         icon: "trash-2",
         confirm: CustomConfirm.for_resource_deletion("all categories", high_severity: true)) %>
   <% end %>
-
-  <%= render DS::Link.new(
-    text: t(".merge"),
-    variant: "outline",
-    icon: "combine",
-    href: merge_categories_path,
-    frame: :modal
-  ) %>
 
   <%= render DS::Link.new(
     text: t(".new"),

--- a/app/views/family_merchants/index.html.erb
+++ b/app/views/family_merchants/index.html.erb
@@ -7,7 +7,8 @@
         href: merge_family_merchants_path,
         frame: :modal,
         icon: "combine") %>
-      %>
+         icon: "combine") %>
+   <% end %>
   <% end %>
   <%= render DS::Link.new(
     text: t(".new"),

--- a/app/views/family_merchants/index.html.erb
+++ b/app/views/family_merchants/index.html.erb
@@ -1,14 +1,18 @@
 <%= content_for :page_title, t(".title") %>
 <%= content_for :page_actions do %>
-  <%= render DS::Link.new(
-    text: t(".merge"),
-    variant: "outline",
-    href: merge_family_merchants_path,
-    frame: :modal
-  ) %>
+  <%= render DS::Menu.new do |menu| %>
+    <% menu.with_item(
+        variant: "link",
+        text: t(".merge"),
+        href: merge_family_merchants_path,
+        frame: :modal,
+        icon: "combine") %>
+      %>
+  <% end %>
   <%= render DS::Link.new(
     text: t(".new"),
     variant: "primary",
+    icon: "plus",
     href: new_family_merchant_path,
     frame: :modal
   ) %>

--- a/app/views/family_merchants/index.html.erb
+++ b/app/views/family_merchants/index.html.erb
@@ -7,8 +7,6 @@
         href: merge_family_merchants_path,
         frame: :modal,
         icon: "combine") %>
-         icon: "combine") %>
-   <% end %>
   <% end %>
   <%= render DS::Link.new(
     text: t(".new"),


### PR DESCRIPTION
This PR moves the “Merge” action for both merchants and categories pages to the submenu, and uses the same icons for consistency. This change ensures that the action button is properly displayed on mobile devices.

| Before | After |
|--------|--------|
| <img width="382" height="577" alt="Screenshot 2026-06-01 alle 20 15 56" src="https://github.com/user-attachments/assets/ab2bd0e6-fc1a-4e90-9c0c-2a03d812333d" /> | <img width="381" height="576" alt="Screenshot 2026-06-01 alle 20 16 31" src="https://github.com/user-attachments/assets/293e8c4c-e58c-4a95-b120-9cc1de6668d7" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Move the merge action into a dropdown menu on the categories index page.
  * Surface the merge action in a dropdown on the family merchants page and make the “New” action a modal link with a plus icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->