### PR TITLE
fix: Do not show pagination if no merchants are available

### DIFF
--- a/app/views/family_merchants/index.html.erb
+++ b/app/views/family_merchants/index.html.erb
@@ -38,6 +38,10 @@
           </table>
         </div>
       </div>
+
+      <div class="pt-4">
+        <%= render "shared/pagination", pagy: @pagy_family_merchants %>
+      </div>
     <% else %>
       <div class="flex justify-center items-center py-12">
         <div class="text-center flex flex-col items-center max-w-[300px]">
@@ -52,10 +56,6 @@
         </div>
       </div>
     <% end %>
-
-    <div class="pt-4">
-      <%= render "shared/pagination", pagy: @pagy_family_merchants %>
-    </div>
   </section>
 
   <section class="space-y-3">
@@ -105,15 +105,15 @@
           </table>
         </div>
       </div>
+
+      <div class="pt-4">
+        <%= render "shared/pagination", pagy: @pagy_provider_merchants %>
+      </div>
     <% else %>
       <div class="flex justify-center items-center py-8">
         <p class="text-secondary text-sm text-center"><%= t(".provider_empty", moniker: family_moniker_downcase) %></p>
       </div>
     <% end %>
-
-    <div class="pt-4">
-      <%= render "shared/pagination", pagy: @pagy_provider_merchants %>
-    </div>
   </section>
 
   <% if @unlinked_merchants.any? %>


### PR DESCRIPTION
Avoid displaying pagination if there are no merchants available.

| Before | After |
|--------|--------|
| <img width="389" height="754" alt="Screenshot 2026-06-01 alle 20 22 52" src="https://github.com/user-attachments/assets/bbfb4586-9c33-4a89-9dc5-10e11366d26f" /> | <img width="385" height="751" alt="Screenshot 2026-06-01 alle 20 22 24" src="https://github.com/user-attachments/assets/16204524-8e7d-4957-b73a-34386f626a93" /> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Pagination controls now only display when merchants are present, eliminating unnecessary UI elements and improving the user experience when no results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->