### PR TITLE
fix(enable-banking): prefer non-DECOUPLED auth_method when ASPSP exposes multiple

### DIFF
--- a/app/controllers/enable_banking_items_controller.rb
+++ b/app/controllers/enable_banking_items_controller.rb
@@ -131,40 +131,31 @@ class EnableBankingItemsController < ApplicationController
       return
     end
 
-    # Re-fetch ASPSP list from provider to avoid session cookie overflow.
-    # We do not store full ASPSP metadata in the session to stay within the 4KB limit;
-    # instead, we re-query the provider here for the final authorization parameters.
-    aspsp_data = nil
     begin
-      provider_for_lookup = @enable_banking_item.enable_banking_provider
-      if provider_for_lookup
-        response = provider_for_lookup.get_aspsps(country: @enable_banking_item.country_code)
-        raw_aspsps = response[:aspsps] || response["aspsps"] || []
-        found = raw_aspsps.find { |a| a[:name] == aspsp_name || a["name"] == aspsp_name }
-        aspsp_data = found&.with_indifferent_access
-      end
-    rescue Provider::EnableBanking::EnableBankingError => e
-      Rails.logger.warn "Enable Banking: could not fetch ASPSP metadata in authorize: #{e.message}"
-    end
+      # Re-fetch ASPSP metadata from provider so we have the full auth_methods list
+      # (we don't store the full payload in the session — too big for the 4KB cookie).
+      # Provider errors are caught by the rescue below — we deliberately don't return
+      # `nil` from a lookup-side rescue, because that would silently regress
+      # multi-method banks like Handelsbanken to EB's DECOUPLED default the moment
+      # EB has a hiccup. Better to surface the EB error to the user.
+      aspsp_data = lookup_aspsp_metadata(@enable_banking_item, aspsp_name)
 
-    # Block DECOUPLED banks — our OAuth redirect flow doesn't support them
-    if aspsp_data.present?
-      # Adjust psu_type if the bank does not support the requested type
-      supported_types = Array(aspsp_data[:psu_types]).map(&:to_s)
-      if supported_types.any? && !supported_types.include?(psu_type)
-        psu_type = supported_types.first
+      selected_auth_method = nil
+      if aspsp_data.present?
+        # Adjust psu_type if the bank does not support the requested type
+        supported_types = Array(aspsp_data[:psu_types]).map(&:to_s)
+        if supported_types.any? && !supported_types.include?(psu_type)
+          psu_type = supported_types.first
+        end
+
+        # Some ASPSPs (e.g. Handelsbanken SE) expose both REDIRECT and DECOUPLED.
+        # Pick a non-DECOUPLED method when one exists and pass it through to EB.
+        # Filter by psu_type since EB's AuthMethod schema is PSU-type-tied.
+        selected_auth_method = EnableBankingItem.preferred_auth_method(aspsp_data, psu_type: psu_type)
+
+        return if reject_if_decoupled_only(selected_auth_method)
       end
 
-      first_method = Array(aspsp_data[:auth_methods]).first
-      approach = first_method&.dig(:approach) || first_method&.dig("approach")
-      if approach == "DECOUPLED"
-        redirect_to settings_providers_path, alert: t(".decoupled_not_supported",
-          default: "This bank uses a separate device authentication method which is not yet supported. Please add this account manually.")
-        return
-      end
-    end
-
-    begin
       target_item = if params[:new_connection] == "true"
         Current.family.enable_banking_items.create!(
           name: "Enable Banking Connection",
@@ -187,6 +178,7 @@ class EnableBankingItemsController < ApplicationController
         state: target_item.id,
         psu_type: psu_type,
         aspsp_data: aspsp_data,
+        auth_method: selected_auth_method,
         language: language
       )
 
@@ -266,7 +258,30 @@ class EnableBankingItemsController < ApplicationController
 
   # Re-authorize an expired session
   def reauthorize
+    # Guard against half-completed initial connections where `aspsp_name` was
+    # never persisted (e.g. EB session creation failed mid-flow). Without this,
+    # the upstream POST /auth call below returns WRONG_REQUEST_PARAMETERS and
+    # the user gets a confusing 422 alert. Steer them to pick a bank instead.
+    if @enable_banking_item.aspsp_name.blank?
+      redirect_to settings_providers_path, alert: t(".no_aspsp",
+        default: "This connection is missing a bank. Please remove it and start a new connection.")
+      return
+    end
+
     begin
+      # Re-query ASPSP metadata so the 90-day reauth picks the same non-DECOUPLED
+      # auth_method that the initial authorize chose. Without this, EB falls back
+      # to its default and silently regresses banks like Handelsbanken to DECOUPLED.
+      aspsp_data = lookup_aspsp_metadata(@enable_banking_item, @enable_banking_item.aspsp_name)
+      psu_type = @enable_banking_item.psu_type || "personal"
+      selected_auth_method = EnableBankingItem.preferred_auth_method(aspsp_data, psu_type: psu_type)
+
+      # Mirror the authorize-action guard: a bank that previously offered a
+      # non-DECOUPLED method may have changed its EB catalog entry to DECOUPLED-only
+      # between connect and reauth. Without this, we'd hand the user an EB URL the
+      # web flow can't complete.
+      return if aspsp_data.present? && reject_if_decoupled_only(selected_auth_method)
+
       language = I18n.locale.to_s.split("-").first
 
       redirect_url = @enable_banking_item.start_authorization(
@@ -274,6 +289,8 @@ class EnableBankingItemsController < ApplicationController
         redirect_url: enable_banking_callback_url,
         state: @enable_banking_item.id,
         psu_type: @enable_banking_item.psu_type || "personal",
+        aspsp_data: aspsp_data,
+        auth_method: selected_auth_method,
         language: language
       )
 
@@ -582,6 +599,43 @@ class EnableBankingItemsController < ApplicationController
 
     def set_enable_banking_item
       @enable_banking_item = Current.family.enable_banking_items.find(params[:id])
+    end
+
+    # Reject the request with the user-facing decoupled-not-supported alert
+    # when the chosen auth_method is DECOUPLED. Returns true if it redirected
+    # (caller should `return` immediately), false otherwise.
+    #
+    # When `selected_auth_method` is nil — i.e. EB returned no auth_methods at
+    # all (or the field was absent) — we deliberately do NOT reject: EB will
+    # pick a default and the flow may still succeed. Only an explicit DECOUPLED
+    # selection breaks the web UI today.
+    def reject_if_decoupled_only(selected_auth_method)
+      return false if selected_auth_method&.dig(:approach) != "DECOUPLED"
+
+      # Absolute i18n key so the alert resolves the same regardless of which
+      # action (authorize / reauthorize) called us.
+      redirect_to settings_providers_path,
+        alert: t("enable_banking_items.authorize.decoupled_not_supported",
+          default: "This bank only supports a separate-device authentication method which is not yet supported. Please add this account manually.")
+      true
+    end
+
+    # Look up a single ASPSP's metadata from Enable Banking's catalog.
+    # Returns the indifferent-access hash if found, nil if the catalog doesn't
+    # list this ASPSP. Provider errors are intentionally NOT rescued here:
+    # treating "catalog fetch failed" the same as "let EB pick" would silently
+    # regress multi-method banks (e.g. Handelsbanken) to EB's DECOUPLED default
+    # the moment EB has a hiccup. The outer authorize/reauthorize rescue blocks
+    # already render a user-facing alert for EnableBankingError.
+    def lookup_aspsp_metadata(item, aspsp_name)
+      return nil unless aspsp_name.present?
+      provider = item.enable_banking_provider
+      return nil unless provider
+
+      response = provider.get_aspsps(country: item.country_code)
+      raw_aspsps = response[:aspsps] || response["aspsps"] || []
+      found = raw_aspsps.find { |a| a[:name] == aspsp_name || a["name"] == aspsp_name }
+      found&.with_indifferent_access
     end
 
     def enable_banking_item_params

--- a/app/models/enable_banking_item.rb
+++ b/app/models/enable_banking_item.rb
@@ -59,30 +59,82 @@ class EnableBankingItem < ApplicationRecord
     end
   end
 
+  # Pick the preferred auth_method from an ASPSP's metadata.
+  #
+  # ASPSPs may expose multiple auth_methods (e.g. Handelsbanken SE returns both
+  # REDIRECT and DECOUPLED). When the caller does not pass `auth_method` to
+  # Enable Banking's POST /auth, EB picks its own default — for several Nordic
+  # banks that default is DECOUPLED, which the Sure web flow does not support.
+  #
+  # Preference order: REDIRECT > EMBEDDED > DECOUPLED. Returns the full method
+  # hash so callers can read both `:name` (to send to EB) and `:approach`
+  # (for the user-facing rejection check).
+  #
+  # When `psu_type` is given, only auth_methods that target that PSU type
+  # (or are PSU-type-agnostic — `psu_type` absent on the method) are
+  # considered. Per EB's schema each AuthMethod is tied to a specific
+  # PSU type, so an ASPSP that supports both personal+business may expose
+  # REDIRECT only for one of them; using a business-only method for a
+  # personal PSU would make EB's `/auth` fail or pick the wrong flow.
+  AUTH_APPROACH_PREFERENCE = %w[REDIRECT EMBEDDED DECOUPLED].freeze
+
+  def self.preferred_auth_method(aspsp_data, psu_type: nil)
+    return nil if aspsp_data.blank?
+
+    methods = Array(
+      aspsp_data.with_indifferent_access[:auth_methods]
+    ).map(&:with_indifferent_access)
+    return nil if methods.empty?
+
+    if psu_type.present?
+      psu_str = psu_type.to_s
+      # Inclusive filter: methods explicitly tied to our PSU type, plus
+      # PSU-type-agnostic methods (no `psu_type` key — legacy catalog entries).
+      methods = methods.select { |m| m[:psu_type].blank? || m[:psu_type].to_s == psu_str }
+      # No fallback to the unfiltered list: an empty result here means the
+      # ASPSP only exposes methods for other PSU types, and sending one of
+      # those to EB would bind a wrong-PSU session and fail. nil tells the
+      # caller to drop `auth_method` so EB picks its own default.
+      return nil if methods.empty?
+    end
+
+    methods.min_by do |m|
+      AUTH_APPROACH_PREFERENCE.index(m[:approach].to_s) || AUTH_APPROACH_PREFERENCE.length
+    end
+  end
+
   # Start the OAuth authorization flow
   # @param aspsp_name [String] Name of the selected ASPSP
   # @param redirect_url [String] Callback URL
   # @param state [String, nil] State parameter (passed through to callback)
   # @param psu_type [String] "personal" or "business"
   # @param aspsp_data [Hash, nil] Full ASPSP object from GET /aspsps (used to store metadata)
+  # @param auth_method [Hash, nil] Selected auth_method hash (from .preferred_auth_method).
+  #   When nil, no auth_method is sent to EB and EB picks its default.
   # @param language [String, nil] Two-letter language code
   # @return [String] Redirect URL for the user
   def start_authorization(aspsp_name:, redirect_url:, state: nil, psu_type: "personal",
-                          aspsp_data: nil, language: nil)
+                          aspsp_data: nil, auth_method: nil, language: nil)
     provider = enable_banking_provider
     raise StandardError.new("Enable Banking provider is not configured") unless provider
 
     validated_psu_type = psu_type
+    selected_method = auth_method&.with_indifferent_access
 
     # Store ASPSP metadata before calling provider so it's available even if auth fails
     if aspsp_data.present?
       aspsp_data = aspsp_data.with_indifferent_access
-      first_auth_method = aspsp_data.dig(:auth_methods, 0) || aspsp_data.dig("auth_methods", 0)
+      # When the caller didn't pass an explicit auth_method (e.g. older callsite,
+      # or the controller's helper returned nil after PSU filtering), fall back
+      # to picking one ourselves — but keep the PSU filter applied. Recomputing
+      # without psu_type here would re-introduce the wrong-PSU bind that the
+      # controller's filter just prevented.
+      selected_method ||= self.class.preferred_auth_method(aspsp_data, psu_type: psu_type)
       aspsp_types = aspsp_data[:psu_types] || []
       update!(
         aspsp_required_psu_headers: aspsp_data[:required_psu_headers] || [],
         aspsp_maximum_consent_validity: aspsp_data[:maximum_consent_validity],
-        aspsp_auth_approach: first_auth_method&.dig(:approach) || first_auth_method&.dig("approach"),
+        aspsp_auth_approach: selected_method&.dig(:approach),
         aspsp_psu_types: aspsp_types
       )
       validated_psu_type = psu_type.present? && aspsp_types.include?(psu_type) ? psu_type : nil
@@ -95,7 +147,8 @@ class EnableBankingItem < ApplicationRecord
       state: state,
       psu_type: validated_psu_type,
       maximum_consent_validity: aspsp_maximum_consent_validity,
-      language: language
+      language: language,
+      auth_method: selected_method&.dig(:name)
     )
 
     attributes = {

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -39,9 +39,14 @@ class Provider::EnableBanking
   # @param psu_type [String] "personal" or "business"
   # @param maximum_consent_validity [Integer, nil] Max consent duration in seconds from ASPSP (nil = use 90 days)
   # @param language [String, nil] Two-letter language code (e.g. "fr", "en")
+  # @param auth_method [String, nil] ASPSP-internal name of the auth_method to use
+  #   when the ASPSP exposes multiple (e.g. Handelsbanken offers both REDIRECT
+  #   and DECOUPLED). When nil, Enable Banking picks its default — which for
+  #   several Nordic banks is DECOUPLED.
   # @return [Hash] Contains :url and :authorization_id
   def start_authorization(aspsp_name:, aspsp_country:, redirect_url:, state: nil,
-                          psu_type: "personal", maximum_consent_validity: nil, language: nil)
+                          psu_type: "personal", maximum_consent_validity: nil,
+                          language: nil, auth_method: nil)
     max_seconds = maximum_consent_validity ? [ maximum_consent_validity, 1 ].max : 90.days.to_i
     valid_until = [ Time.current + max_seconds.seconds, Time.current + 90.days ].min
 
@@ -60,6 +65,7 @@ class Provider::EnableBanking
       psu_type: psu_type
     }
     body[:language] = language if language.present?
+    body[:auth_method] = auth_method if auth_method.present?
     body = body.compact
 
     response = self.class.post(

--- a/config/locales/views/enable_banking_items/en.yml
+++ b/config/locales/views/enable_banking_items/en.yml
@@ -9,7 +9,7 @@ en:
     authorize:
       authorization_failed: "Failed to initiate authorization: %{message}"
       bank_required: Please select a bank.
-      decoupled_not_supported: This bank uses a separate device authentication method which is not yet supported. Please add this account manually.
+      decoupled_not_supported: This bank only supports a separate-device authentication method which is not yet supported. Please add this account manually.
       invalid_redirect: The authorization URL received is invalid. Please try again.
       redirect_uri_not_allowed: Redirect not allowed. Please configure `%{callback_url}` in your Enable Banking app settings.
       unexpected_error: An unexpected error occurred. Please try again.
@@ -100,6 +100,7 @@ en:
       go_to_provider_settings: Go to Provider Settings
     reauthorize:
       invalid_redirect: The authorization URL received is invalid. Please try again.
+      no_aspsp: This connection is missing a bank. Please remove it and start a new connection.
       reauthorization_failed: Reauthorization failed
     select_bank:
       beta_label: Beta

--- a/test/controllers/enable_banking_items_controller_test.rb
+++ b/test/controllers/enable_banking_items_controller_test.rb
@@ -39,4 +39,156 @@ class EnableBankingItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes haystack, "ing-diba ag",
       "Expected the searchable data attribute to still include the bank name (existing name-search behavior)"
   end
+
+  test "authorize picks REDIRECT when ASPSP exposes both REDIRECT and DECOUPLED" do
+    # Handelsbanken SE is the motivating case: EB returns DECOUPLED first in the
+    # auth_methods list, and without an explicit auth_method picks DECOUPLED.
+    Provider::EnableBanking.any_instance.stubs(:get_aspsps).returns(
+      aspsps: [
+        {
+          name: "Handelsbanken",
+          country: "SE",
+          psu_types: [ "personal" ],
+          auth_methods: [
+            { name: "decoupled-bankid", approach: "DECOUPLED" },
+            { name: "redirect-bankid",  approach: "REDIRECT"  }
+          ]
+        }
+      ]
+    )
+
+    Provider::EnableBanking.any_instance.expects(:start_authorization).with do |args|
+      args[:auth_method] == "redirect-bankid"
+    end.returns(url: "https://api.enablebanking.com/auth/x", authorization_id: "auth_1")
+
+    post authorize_enable_banking_item_url(@item), params: { aspsp_name: "Handelsbanken" }
+
+    assert_redirected_to "https://api.enablebanking.com/auth/x"
+    assert_nil flash[:alert]
+    assert_equal "REDIRECT", @item.reload.aspsp_auth_approach
+  end
+
+  test "authorize rejects ASPSPs whose only auth_method is DECOUPLED" do
+    Provider::EnableBanking.any_instance.stubs(:get_aspsps).returns(
+      aspsps: [
+        {
+          name: "DecoupledOnly Bank",
+          country: "DE",
+          psu_types: [ "personal" ],
+          auth_methods: [ { name: "decoupled-only", approach: "DECOUPLED" } ]
+        }
+      ]
+    )
+
+    Provider::EnableBanking.any_instance.expects(:start_authorization).never
+
+    post authorize_enable_banking_item_url(@item), params: { aspsp_name: "DecoupledOnly Bank" }
+
+    assert_redirected_to settings_providers_path
+    assert_match(/separate-device/i, flash[:alert])
+  end
+
+  test "authorize without explicit auth_method for single-method REDIRECT banks" do
+    # Backward-compat: single-method REDIRECT banks should still work and the
+    # selected auth_method's name should be forwarded if present.
+    Provider::EnableBanking.any_instance.stubs(:get_aspsps).returns(
+      aspsps: [
+        {
+          name: "ING-DiBa AG",
+          country: "DE",
+          psu_types: [ "personal" ],
+          auth_methods: [ { name: "ing-redirect", approach: "REDIRECT" } ]
+        }
+      ]
+    )
+
+    Provider::EnableBanking.any_instance.expects(:start_authorization).with do |args|
+      args[:auth_method] == "ing-redirect"
+    end.returns(url: "https://api.enablebanking.com/auth/x", authorization_id: "auth_1")
+
+    post authorize_enable_banking_item_url(@item), params: { aspsp_name: "ING-DiBa AG" }
+
+    assert_redirected_to "https://api.enablebanking.com/auth/x"
+  end
+
+  test "authorize surfaces an EB catalog-fetch failure as an alert (fails closed)" do
+    # We intentionally don't fall back to "let EB pick" when get_aspsps raises:
+    # that would silently regress multi-method banks like Handelsbanken to
+    # EB's DECOUPLED default the moment EB has a hiccup. Surface the error
+    # to the user instead.
+    Provider::EnableBanking.any_instance.stubs(:get_aspsps).raises(
+      Provider::EnableBanking::EnableBankingError.new("upstream timeout", :request_failed)
+    )
+    Provider::EnableBanking.any_instance.expects(:start_authorization).never
+
+    post authorize_enable_banking_item_url(@item), params: { aspsp_name: "Handelsbanken" }
+
+    assert_redirected_to settings_providers_path
+    assert_match(/upstream timeout/i, flash[:alert])
+  end
+
+  test "authorize proceeds (no rejection) when EB returns no auth_methods at all" do
+    # Backward-compat: if EB's catalog entry has missing/empty auth_methods we
+    # let the request through without an explicit auth_method, so EB falls back
+    # to its own default. Previously this code path was implicit; the regression
+    # is that we must NOT reject when methods are unknown.
+    Provider::EnableBanking.any_instance.stubs(:get_aspsps).returns(
+      aspsps: [
+        {
+          name: "MysteryBank",
+          country: "DE",
+          psu_types: [ "personal" ]
+          # no auth_methods key at all
+        }
+      ]
+    )
+
+    Provider::EnableBanking.any_instance.expects(:start_authorization).with do |args|
+      args[:auth_method].nil?
+    end.returns(url: "https://api.enablebanking.com/auth/x", authorization_id: "auth_1")
+
+    post authorize_enable_banking_item_url(@item), params: { aspsp_name: "MysteryBank" }
+
+    assert_redirected_to "https://api.enablebanking.com/auth/x"
+    assert_nil flash[:alert]
+  end
+
+  test "reauthorize rejects when the bank's catalog entry has regressed to DECOUPLED-only" do
+    # A bank that originally exposed REDIRECT may have changed its EB catalog
+    # entry to DECOUPLED-only between connect and the 90-day reauth. Mirror the
+    # authorize-action guard so the user gets the same actionable alert instead
+    # of an EB URL the web flow can't complete.
+    @item.update_columns(aspsp_name: "DecoupledNow Bank")
+    Provider::EnableBanking.any_instance.stubs(:get_aspsps).returns(
+      aspsps: [
+        {
+          name: "DecoupledNow Bank",
+          country: "DE",
+          psu_types: [ "personal" ],
+          auth_methods: [ { name: "dec-only", approach: "DECOUPLED" } ]
+        }
+      ]
+    )
+    Provider::EnableBanking.any_instance.expects(:start_authorization).never
+
+    post reauthorize_enable_banking_item_url(@item)
+
+    assert_redirected_to settings_providers_path
+    assert_match(/separate-device/i, flash[:alert])
+  end
+
+  test "reauthorize rejects items with missing aspsp_name instead of calling EB" do
+    # Half-completed initial connections can land with aspsp_name = nil (e.g.
+    # EB session creation failed mid-flow). Without the guard, reauthorize
+    # would POST /auth with body.aspsp.name = null and surface a confusing
+    # WRONG_REQUEST_PARAMETERS alert to the user.
+    @item.update_columns(aspsp_name: nil)
+    Provider::EnableBanking.any_instance.expects(:get_aspsps).never
+    Provider::EnableBanking.any_instance.expects(:start_authorization).never
+
+    post reauthorize_enable_banking_item_url(@item)
+
+    assert_redirected_to settings_providers_path
+    assert_match(/missing a bank/i, flash[:alert])
+  end
 end

--- a/test/models/enable_banking_item_test.rb
+++ b/test/models/enable_banking_item_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EnableBankingItemTest < ActiveSupport::TestCase
+  test ".preferred_auth_method picks REDIRECT over DECOUPLED regardless of order" do
+    aspsp_data = {
+      auth_methods: [
+        { name: "decoupled-bankid", approach: "DECOUPLED" },
+        { name: "redirect-bankid",  approach: "REDIRECT"  }
+      ]
+    }
+
+    method = EnableBankingItem.preferred_auth_method(aspsp_data)
+
+    assert_equal "REDIRECT", method[:approach]
+    assert_equal "redirect-bankid", method[:name]
+  end
+
+  test ".preferred_auth_method picks EMBEDDED over DECOUPLED when REDIRECT absent" do
+    aspsp_data = {
+      auth_methods: [
+        { name: "dec", approach: "DECOUPLED" },
+        { name: "emb", approach: "EMBEDDED" }
+      ]
+    }
+
+    assert_equal "EMBEDDED", EnableBankingItem.preferred_auth_method(aspsp_data)[:approach]
+  end
+
+  test ".preferred_auth_method returns the only method when ASPSP exposes one" do
+    aspsp_data = { auth_methods: [ { name: "only", approach: "REDIRECT" } ] }
+
+    assert_equal "only", EnableBankingItem.preferred_auth_method(aspsp_data)[:name]
+  end
+
+  test ".preferred_auth_method returns DECOUPLED when it's the only option" do
+    aspsp_data = { auth_methods: [ { name: "dec-only", approach: "DECOUPLED" } ] }
+
+    # Controller is responsible for blocking on approach=="DECOUPLED"; this helper
+    # only ranks the methods. Returning the DECOUPLED method (rather than nil)
+    # keeps the API honest about what's available.
+    assert_equal "DECOUPLED", EnableBankingItem.preferred_auth_method(aspsp_data)[:approach]
+  end
+
+  test ".preferred_auth_method handles nil/empty input" do
+    assert_nil EnableBankingItem.preferred_auth_method(nil)
+    assert_nil EnableBankingItem.preferred_auth_method({})
+    assert_nil EnableBankingItem.preferred_auth_method(auth_methods: [])
+  end
+
+  test ".preferred_auth_method filters by psu_type when given" do
+    # ASPSP exposes REDIRECT only for business and DECOUPLED for personal.
+    # A personal-PSU caller must NOT get the business-only REDIRECT method,
+    # because EB binds the chosen method's psu_type and the /auth call would
+    # fail or land in the wrong flow.
+    aspsp_data = {
+      auth_methods: [
+        { name: "biz-redirect",  approach: "REDIRECT",  psu_type: "business" },
+        { name: "per-decoupled", approach: "DECOUPLED", psu_type: "personal" }
+      ]
+    }
+
+    personal = EnableBankingItem.preferred_auth_method(aspsp_data, psu_type: "personal")
+    business = EnableBankingItem.preferred_auth_method(aspsp_data, psu_type: "business")
+
+    assert_equal "per-decoupled", personal[:name], "personal PSU must not pick a business-only method"
+    assert_equal "biz-redirect", business[:name]
+  end
+
+  test ".preferred_auth_method returns nil when all methods target a different PSU type" do
+    # An ASPSP that exposes only business-typed methods being asked for a
+    # personal PSU: returning the business method would make EB's /auth fail
+    # or land in the wrong flow (psu_type binding mismatch). nil tells the
+    # caller to drop the explicit auth_method so EB picks its own default
+    # (which will likely still fail — but won't *guarantee* a wrong-PSU bind).
+    aspsp_data = {
+      auth_methods: [
+        { name: "biz-only-1", approach: "REDIRECT",  psu_type: "business" },
+        { name: "biz-only-2", approach: "DECOUPLED", psu_type: "business" }
+      ]
+    }
+
+    assert_nil EnableBankingItem.preferred_auth_method(aspsp_data, psu_type: "personal")
+  end
+
+  test ".preferred_auth_method treats methods without psu_type as PSU-type-agnostic" do
+    # EB's older catalog entries don't always carry psu_type on the method.
+    # Treat those as applying to any PSU — otherwise we'd reject every
+    # legacy single-method bank.
+    aspsp_data = {
+      auth_methods: [ { name: "legacy", approach: "REDIRECT" } ]
+    }
+
+    assert_equal "legacy", EnableBankingItem.preferred_auth_method(aspsp_data, psu_type: "personal")[:name]
+  end
+
+  test ".preferred_auth_method accepts string keys (raw HTTParty response)" do
+    aspsp_data = {
+      "auth_methods" => [
+        { "name" => "dec", "approach" => "DECOUPLED" },
+        { "name" => "red", "approach" => "REDIRECT" }
+      ]
+    }
+
+    assert_equal "REDIRECT", EnableBankingItem.preferred_auth_method(aspsp_data)[:approach]
+  end
+
+  test "#start_authorization fallback respects psu_type when caller passed no auth_method" do
+    # Regression guard: when the caller hands us aspsp_data but no explicit
+    # auth_method (older callsite, or controller's filter correctly returned
+    # nil), the fallback inside start_authorization must NOT recompute the
+    # preferred method without psu_type — that would bypass the PSU filter
+    # and could bind a business-only method to a personal /auth request.
+    require "openssl"
+
+    family = families(:dylan_family)
+    item = family.enable_banking_items.create!(
+      name: "Test", country_code: "SE",
+      application_id: "app", client_certificate: OpenSSL::PKey::RSA.new(2048).to_pem
+    )
+
+    aspsp_data = {
+      psu_types: [ "personal", "business" ],
+      auth_methods: [
+        { name: "biz-redirect", approach: "REDIRECT",  psu_type: "business" },
+        { name: "per-decoupled", approach: "DECOUPLED", psu_type: "personal" }
+      ]
+    }
+
+    Provider::EnableBanking.any_instance.expects(:start_authorization).with do |args|
+      # The fallback should pick the personal method (DECOUPLED) — not the
+      # business-only REDIRECT. The controller is responsible for rejecting
+      # this further upstream; the model's job here is only to not lie about
+      # which method it picked.
+      args[:auth_method] == "per-decoupled"
+    end.returns(url: "https://api.enablebanking.com/auth/x", authorization_id: "a1")
+
+    item.start_authorization(
+      aspsp_name: "MixedBank",
+      redirect_url: "https://example.com/cb",
+      psu_type: "personal",
+      aspsp_data: aspsp_data
+    )
+  end
+end

--- a/test/models/provider/enable_banking_test.rb
+++ b/test/models/provider/enable_banking_test.rb
@@ -61,4 +61,50 @@ class Provider::EnableBankingTest < ActiveSupport::TestCase
     assert_equal Date.new(2026, 1, 17), error.corrected_date_from
     assert error.wrong_transactions_period?
   end
+
+  test "start_authorization forwards auth_method when given" do
+    captured_body = nil
+
+    success_response = OpenStruct.new(
+      code: 200,
+      body: { url: "https://api.enablebanking.com/auth/x", authorization_id: "auth_1" }.to_json
+    )
+
+    Provider::EnableBanking.expects(:post).with do |_url, options|
+      captured_body = JSON.parse(options[:body])
+      true
+    end.returns(success_response)
+
+    @provider.start_authorization(
+      aspsp_name: "Handelsbanken",
+      aspsp_country: "SE",
+      redirect_url: "https://example.com/cb",
+      auth_method: "redirect"
+    )
+
+    assert_equal "redirect", captured_body["auth_method"]
+  end
+
+  test "start_authorization omits auth_method when not given" do
+    captured_body = nil
+
+    success_response = OpenStruct.new(
+      code: 200,
+      body: { url: "https://api.enablebanking.com/auth/x", authorization_id: "auth_1" }.to_json
+    )
+
+    Provider::EnableBanking.expects(:post).with do |_url, options|
+      captured_body = JSON.parse(options[:body])
+      true
+    end.returns(success_response)
+
+    @provider.start_authorization(
+      aspsp_name: "Handelsbanken",
+      aspsp_country: "SE",
+      redirect_url: "https://example.com/cb"
+    )
+
+    assert_not captured_body.key?("auth_method"),
+      "Expected auth_method to be absent so EB picks its default for single-method banks"
+  end
 end


### PR DESCRIPTION
## Summary

Sure's `EnableBankingItemsController#authorize` only ever inspects the *first* element of an ASPSP's `auth_methods` and unconditionally rejects the connection if that method's `approach` is `DECOUPLED`. This makes several large Nordic banks unreachable through the Enable Banking integration even though they *also* expose a usable `REDIRECT` method — most notably **Handelsbanken (SE)**, but per Enable Banking's catalog this is also the situation for Swedbank, SEB, Nordea, and Länsförsäkringar.

EB's API supports this exactly: `POST /auth` accepts an optional `auth_method` body field that selects which of the ASPSP's offered methods to bind to. Without it, EB picks its own default — and for the banks above that default happens to be `DECOUPLED`.

This PR teaches the controller to:

1. Inspect the *full* `auth_methods` list, not just the first entry.
2. Pick the preferred method via `EnableBankingItem.preferred_auth_method` — order `REDIRECT > EMBEDDED > DECOUPLED`.
3. Forward the selected method's `name` to EB's `POST /auth` so EB binds the session to it explicitly.
4. Only reject when *no* non-DECOUPLED method exists. Banks that genuinely only offer DECOUPLED still hit the same unchanged user-facing message; nothing changes for them until #1714-style full DECOUPLED support lands.
5. Re-apply the same selection in `reauthorize` so 90-day session renewals don't silently regress to EB's default.

Also bundled (tightly related, easy bisect — happy to split if you prefer):

- **Null-aspsp guard in `reauthorize`**: half-completed initial connections can land with `aspsp_name = nil` (e.g. EB session creation fails mid-flow). Without the guard, the next reauth call POSTs `{ aspsp: { name: null, ... } }`, EB returns `WRONG_REQUEST_PARAMETERS`, and the user gets a confusing 422 alert instead of being steered to remove + start over. New short-circuit + i18n alert + test.

Refs #1678 — this is the "if you want, you can submit a similar PR for your provider of choice" path @jjmata suggested. Unlike #1714 this does *not* implement the DECOUPLED-as-primary flow; it just picks a non-DECOUPLED method when the bank already offers one.

## Test plan

- [x] Unit: `EnableBankingItem.preferred_auth_method` (6 cases — both orderings, EMBEDDED fallback, single-method passthrough, DECOUPLED-only, nil/empty, string-keys)
- [x] Provider: `Provider::EnableBanking#start_authorization` forwards `auth_method` when given; omits it when not
- [x] Controller: `authorize` picks REDIRECT when ASPSP exposes mixed REDIRECT+DECOUPLED, rejects DECOUPLED-only ASPSPs, single-method REDIRECT banks unchanged
- [x] Controller: `reauthorize` short-circuits when `aspsp_name.blank?` instead of calling EB
- [x] **E2E on EB sandbox**: Connect Handelsbanken → 302 to `tilisy-sandbox/ais/start` (REDIRECT picked, no DECOUPLED rejection) → callback → `setup_accounts` rendered → accounts imported
- [x] **E2E on EB production against a real Handelsbanken account**: the full `/authorize` → BankID → callback → `setup_accounts` → import round-trip completes; ~30s for the BankID step

`bin/rubocop`, `bin/brakeman`, `bin/rails test` all green locally and via CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter auth-method selection that prefers REDIRECT → EMBEDDED → DECOUPLED and forwards the chosen method into the authorization flow.

* **Bug Fixes**
  * Only blocks explicit separate-device (DECOUPLED) flows to avoid false rejections.
  * Reauthorization now redirects with a “missing bank” alert when bank info is absent.
  * Persisted auth approach for clearer behavior and compatibility.

* **Documentation**
  * Updated user-facing messages for decoupled and missing-bank scenarios.

* **Tests**
  * Added integration and unit tests for selection, reauthorization, and request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->