### PR TITLE
fix(holdings): eliminate silent 1:1 FX fallback for missing exchange …

### DIFF
--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -292,10 +292,10 @@ class Holding < ApplicationRecord
           SELECT er.rate FROM exchange_rates er
           WHERE er.from_currency = trades.currency
             AND er.to_currency = ?
-            AND er.date BETWEEN entries.date - #{ExchangeRate::NEAREST_RATE_LOOKBACK_DAYS} AND entries.date
+            AND er.date BETWEEN entries.date - ? AND entries.date
           ORDER BY er.date DESC
           LIMIT 1
-        ) nearest_fx ON true", account.currency
+        ) nearest_fx ON true", account.currency, ExchangeRate::NEAREST_RATE_LOOKBACK_DAYS
       ])
 
       # If any foreign-currency buy trade has no rate within the lookback window,

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -276,10 +276,19 @@ class Holding < ApplicationRecord
     end
 
     # Calculates weighted average cost from buy trades.
-    # Returns nil if no trades exist (cost basis is unknown).
+    # Returns nil if no trades exist or if any foreign-currency trade is missing an
+    # exchange rate for its trade date (avoids a silent 1:1 substitution that would
+    # produce a wrong value rather than an honest nil).
     def calculate_avg_cost
-      trades = account.trades
+      buy_trades = account.trades
         .with_entry
+        .where(security_id: security.id)
+        .where("trades.qty > 0 AND entries.date <= ?", date)
+
+      # If any foreign-currency buy trade has no exchange rate for its trade date,
+      # cost basis is unknowable — return nil to match ForwardCalculator / ReverseCalculator.
+      missing_rate = buy_trades
+        .where("trades.currency != ?", account.currency)
         .joins(ActiveRecord::Base.sanitize_sql_array([
           "LEFT JOIN exchange_rates ON (
             exchange_rates.date = entries.date AND
@@ -287,16 +296,26 @@ class Holding < ApplicationRecord
             exchange_rates.to_currency = ?
           )", account.currency
         ]))
-        .where(security_id: security.id)
-        .where("trades.qty > 0 AND entries.date <= ?", date)
+        .where("exchange_rates.rate IS NULL")
+        .exists?
 
-      total_cost, total_qty = trades.pick(
-        Arel.sql("SUM(trades.price * trades.qty * COALESCE(exchange_rates.rate, 1))"),
-        Arel.sql("SUM(trades.qty)")
-      )
+      return nil if missing_rate
 
-      # Return nil when no trades exist - cost basis is genuinely unknown
-      # Previously this fell back to current market price, which was misleading
+      # All foreign rates are confirmed present; COALESCE fallback now only applies
+      # to domestic (same-currency) trades where treating rate = 1 is correct.
+      total_cost, total_qty = buy_trades
+        .joins(ActiveRecord::Base.sanitize_sql_array([
+          "LEFT JOIN exchange_rates ON (
+            exchange_rates.date = entries.date AND
+            exchange_rates.from_currency = trades.currency AND
+            exchange_rates.to_currency = ?
+          )", account.currency
+        ]))
+        .pick(
+          Arel.sql("SUM(trades.price * trades.qty * COALESCE(exchange_rates.rate, 1))"),
+          Arel.sql("SUM(trades.qty)")
+        )
+
       return nil unless total_qty && total_qty > 0
 
       Money.new(total_cost / total_qty, currency)

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -277,42 +277,43 @@ class Holding < ApplicationRecord
 
     # Calculates weighted average cost from buy trades.
     # Returns nil if no trades exist or if any foreign-currency trade is missing an
-    # exchange rate for its trade date (avoids a silent 1:1 substitution that would
-    # produce a wrong value rather than an honest nil).
+    # exchange rate within the 5-day lookback window (avoids a silent 1:1 substitution
+    # that would produce a wrong value rather than an honest nil).
     def calculate_avg_cost
       buy_trades = account.trades
         .with_entry
         .where(security_id: security.id)
         .where("trades.qty > 0 AND entries.date <= ?", date)
 
-      # If any foreign-currency buy trade has no exchange rate for its trade date,
+      # Use the same nearest-rate-within-5-days semantics as ExchangeRate.find_or_fetch_rate
+      # and Money#exchange_to so weekend/holiday trades resolve consistently.
+      nearest_rate_sql = ActiveRecord::Base.sanitize_sql_array([
+        "LEFT JOIN LATERAL (
+          SELECT er.rate FROM exchange_rates er
+          WHERE er.from_currency = trades.currency
+            AND er.to_currency = ?
+            AND er.date BETWEEN entries.date - #{ExchangeRate::NEAREST_RATE_LOOKBACK_DAYS} AND entries.date
+          ORDER BY er.date DESC
+          LIMIT 1
+        ) nearest_fx ON true", account.currency
+      ])
+
+      # If any foreign-currency buy trade has no rate within the lookback window,
       # cost basis is unknowable — return nil to match ForwardCalculator / ReverseCalculator.
       missing_rate = buy_trades
         .where("trades.currency != ?", account.currency)
-        .joins(ActiveRecord::Base.sanitize_sql_array([
-          "LEFT JOIN exchange_rates ON (
-            exchange_rates.date = entries.date AND
-            exchange_rates.from_currency = trades.currency AND
-            exchange_rates.to_currency = ?
-          )", account.currency
-        ]))
-        .where("exchange_rates.rate IS NULL")
+        .joins(nearest_rate_sql)
+        .where("nearest_fx.rate IS NULL")
         .exists?
 
       return nil if missing_rate
 
-      # All foreign rates are confirmed present; COALESCE fallback now only applies
+      # All foreign rates are confirmed present; COALESCE fallback only applies
       # to domestic (same-currency) trades where treating rate = 1 is correct.
       total_cost, total_qty = buy_trades
-        .joins(ActiveRecord::Base.sanitize_sql_array([
-          "LEFT JOIN exchange_rates ON (
-            exchange_rates.date = entries.date AND
-            exchange_rates.from_currency = trades.currency AND
-            exchange_rates.to_currency = ?
-          )", account.currency
-        ]))
+        .joins(nearest_rate_sql)
         .pick(
-          Arel.sql("SUM(trades.price * trades.qty * COALESCE(exchange_rates.rate, 1))"),
+          Arel.sql("SUM(trades.price * trades.qty * COALESCE(nearest_fx.rate, 1))"),
           Arel.sql("SUM(trades.qty)")
         )
 

--- a/app/models/holding/forward_calculator.rb
+++ b/app/models/holding/forward_calculator.rb
@@ -6,6 +6,8 @@ class Holding::ForwardCalculator
     @security_ids = security_ids
     # Track cost basis per security: { security_id => { total_cost: BigDecimal, total_qty: BigDecimal } }
     @cost_basis_tracker = Hash.new { |h, k| h[k] = { total_cost: BigDecimal("0"), total_qty: BigDecimal("0") } }
+    # Securities whose cost basis cannot be computed due to a missing FX rate on a trade date
+    @cost_basis_invalid = {}
   end
 
   def calculate
@@ -85,14 +87,19 @@ class Holding::ForwardCalculator
         next unless trade.qty > 0 # Only track buys
 
         security_id = trade.security_id
+        next if @cost_basis_invalid[security_id] # already invalidated by a prior missing rate
+
         tracker = @cost_basis_tracker[security_id]
 
-        # Convert trade price to account currency if needed
+        # Convert trade price to account currency using the trade's date so we look up
+        # the rate that actually existed at the time of the trade, not today's rate.
         trade_price = Money.new(trade.price, trade.currency)
         begin
-          converted_price = trade_price.exchange_to(account.currency).amount
+          converted_price = trade_price.exchange_to(account.currency, date: trade_entry.date).amount
         rescue Money::ConversionError
-          converted_price = trade.price
+          Rails.logger.warn("[Holding::ForwardCalculator] No FX rate for #{trade.currency}→#{account.currency} on #{trade_entry.date}. Cost basis for security #{security_id} is unknown.")
+          @cost_basis_invalid[security_id] = true
+          next
         end
 
         tracker[:total_cost] += converted_price * trade.qty
@@ -101,7 +108,10 @@ class Holding::ForwardCalculator
     end
 
     # Returns the current cost basis for a security, or nil if no buys recorded
+    # or if any buy had an unresolvable FX rate.
     def cost_basis_for(security_id, currency)
+      return nil if @cost_basis_invalid[security_id]
+
       tracker = @cost_basis_tracker[security_id]
       return nil if tracker[:total_qty].zero?
 

--- a/app/models/holding/reverse_calculator.rb
+++ b/app/models/holding/reverse_calculator.rb
@@ -82,17 +82,26 @@ class Holding::ReverseCalculator
     def precompute_cost_basis
       @cost_basis_snapshots = Hash.new { |h, k| h[k] = [] }
       tracker = Hash.new { |h, k| h[k] = { total_cost: BigDecimal("0"), total_qty: BigDecimal("0") } }
+      # Securities whose cost basis became unknowable due to a missing FX rate
+      invalid_securities = {}
 
       portfolio_cache.get_trades.sort_by(&:date).each do |trade_entry|
         trade = trade_entry.entryable
         next unless trade.qty > 0
 
         security_id = trade.security_id
+        # Once a security is invalid, skip further trades for it — the nil snapshot
+        # from the first failure already propagates nil for all subsequent dates.
+        next if invalid_securities[security_id]
+
         trade_price = Money.new(trade.price, trade.currency)
         begin
-          converted_price = trade_price.exchange_to(account.currency).amount
+          converted_price = trade_price.exchange_to(account.currency, date: trade_entry.date).amount
         rescue Money::ConversionError
-          converted_price = trade.price
+          Rails.logger.warn("[Holding::ReverseCalculator] No FX rate for #{trade.currency}→#{account.currency} on #{trade_entry.date}. Marking security #{security_id} cost basis as unknown.")
+          invalid_securities[security_id] = true
+          @cost_basis_snapshots[security_id] << [ trade_entry.date, nil ]
+          next
         end
 
         tracker[security_id][:total_cost] += converted_price * trade.qty

--- a/test/models/holding/forward_calculator_test.rb
+++ b/test/models/holding/forward_calculator_test.rb
@@ -111,6 +111,48 @@ class Holding::ForwardCalculatorTest < ActiveSupport::TestCase
     assert_holdings(expected, calculated)
   end
 
+  test "cost_basis is nil for a security whose trade has a missing FX rate" do
+    eur_security = Security.create!(ticker: "ASML", name: "ASML Holding")
+    Security::Price.create!(security: eur_security, date: 1.day.ago.to_date, price: 100)
+    Security::Price.create!(security: eur_security, date: Date.current,       price: 100)
+
+    # Trade denominated in EUR with no EUR→USD exchange rate in the DB
+    create_trade(eur_security, qty: 10, date: 1.day.ago.to_date, price: 50, account: @account, currency: "EUR")
+
+    holdings = Holding::ForwardCalculator.new(@account).calculate
+
+    today = holdings.find { |h| h.security == eur_security && h.date == Date.current }
+    assert_not_nil today
+    assert_nil today.cost_basis, "cost_basis should be nil when FX rate is missing"
+  end
+
+  test "cost_basis is nil for all dates after a trade with a missing FX rate" do
+    eur_security = Security.create!(ticker: "ASML", name: "ASML Holding")
+    Security::Price.create!(security: eur_security, date: 2.days.ago.to_date, price: 100)
+    Security::Price.create!(security: eur_security, date: 1.day.ago.to_date,  price: 100)
+    Security::Price.create!(security: eur_security, date: Date.current,        price: 100)
+
+    ExchangeRate.create!(from_currency: "EUR", to_currency: "USD", date: 2.days.ago.to_date, rate: 1.08)
+    # No EUR→USD rate exists for 1.day.ago
+
+    create_trade(eur_security, qty: 5,  date: 2.days.ago.to_date, price: 50, account: @account, currency: "EUR")
+    create_trade(eur_security, qty: 5,  date: 1.day.ago.to_date,  price: 55, account: @account, currency: "EUR")
+
+    holdings = Holding::ForwardCalculator.new(@account).calculate
+
+    # The first trade (2 days ago) has a known rate, so its holding has a cost_basis.
+    two_days_ago = holdings.find { |h| h.security == eur_security && h.date == 2.days.ago.to_date }
+    assert_not_nil two_days_ago
+    assert_not_nil two_days_ago.cost_basis, "cost_basis should be present before the missing-rate trade"
+
+    # Once the missing-rate trade occurs, all subsequent holdings must be nil.
+    [ 1.day.ago.to_date, Date.current ].each do |d|
+      h = holdings.find { |hh| hh.security == eur_security && hh.date == d }
+      assert_not_nil h
+      assert_nil h.cost_basis, "cost_basis should be nil on #{d} after the missing-rate trade"
+    end
+  end
+
   test "offline tickers sync holdings based on most recent trade price" do
     offline_security = Security.create!(ticker: "OFFLINE", name: "Offline Ticker")
 

--- a/test/models/holding/reverse_calculator_test.rb
+++ b/test/models/holding/reverse_calculator_test.rb
@@ -236,6 +236,41 @@ class Holding::ReverseCalculatorTest < ActiveSupport::TestCase
     assert_in_delta 100.0, cost_basis_for(calc, security, Date.current).to_f, 1e-6
   end
 
+  test "cost_basis_for returns nil when trade has a missing FX rate" do
+    security = Security.create!(ticker: "TST", name: "Test")
+    buy_date = 5.days.ago.to_date
+
+    # EUR trade with no EUR→USD exchange rate — ConversionError must propagate as nil
+    calc = calculator_with_trades(security) do
+      create_trade(security, account: @account, qty: 10, price: 50, date: buy_date, currency: "EUR")
+    end
+
+    assert_nil cost_basis_for(calc, security, buy_date)
+    assert_nil cost_basis_for(calc, security, Date.current)
+  end
+
+  test "cost_basis_for returns known value before missing-rate trade, nil after" do
+    security = Security.create!(ticker: "TST", name: "Test")
+    first_buy  = 10.days.ago.to_date
+    second_buy = 3.days.ago.to_date
+
+    ExchangeRate.create!(from_currency: "EUR", to_currency: "USD", date: first_buy, rate: 1.08)
+    # No rate exists for second_buy date
+
+    calc = calculator_with_trades(security) do
+      create_trade(security, account: @account, qty: 10, price: 100, date: first_buy,  currency: "EUR")
+      create_trade(security, account: @account, qty:  5, price: 120, date: second_buy, currency: "EUR")
+    end
+
+    # Before the missing-rate trade, cost basis should be computable
+    expected_first = BigDecimal("100") * BigDecimal("1.08")
+    assert_in_delta expected_first.to_f, cost_basis_for(calc, security, first_buy).to_f, 1e-4
+
+    # On and after the missing-rate trade, cost basis must be nil
+    assert_nil cost_basis_for(calc, security, second_buy)
+    assert_nil cost_basis_for(calc, security, Date.current)
+  end
+
   private
     def assert_holdings(expected, calculated)
       expected.each do |expected_entry|

--- a/test/models/holding_test.rb
+++ b/test/models/holding_test.rb
@@ -56,27 +56,55 @@ class HoldingTest < ActiveSupport::TestCase
     assert_equal Money.new(expected_nvda), @nvda.avg_cost
   end
 
-  test "calculates average cost basis from another currency" do
+  test "calculates average cost basis from another currency when exchange rates are present" do
+    rate_yesterday = BigDecimal("0.75")
+    rate_today     = BigDecimal("0.74")
+
+    ExchangeRate.create!(from_currency: "CAD", to_currency: "USD", date: 1.day.ago.to_date, rate: rate_yesterday)
+    ExchangeRate.create!(from_currency: "CAD", to_currency: "USD", date: Date.current,       rate: rate_today)
+
     create_trade(@amzn.security, account: @account, qty: 10, price: 212.00, date: 1.day.ago.to_date, currency: "CAD")
-    create_trade(@amzn.security, account: @account, qty: 15, price: 216.00, date: Date.current, currency: "CAD")
+    create_trade(@amzn.security, account: @account, qty: 15, price: 216.00, date: Date.current,       currency: "CAD")
 
-    create_trade(@nvda.security, account: @account, qty: 5, price: 128.00, date: 1.day.ago.to_date, currency: "CAD")
-    create_trade(@nvda.security, account: @account, qty: 30, price: 124.00, date: Date.current, currency: "CAD")
+    create_trade(@nvda.security, account: @account, qty: 5,  price: 128.00, date: 1.day.ago.to_date, currency: "CAD")
+    create_trade(@nvda.security, account: @account, qty: 30, price: 124.00, date: Date.current,       currency: "CAD")
 
-    # compute expected: sum(price * qty * rate) / sum(qty)
-    amzn_total_usd = BigDecimal("10") * BigDecimal("212.00") * BigDecimal("1") +
-                     BigDecimal("15") * BigDecimal("216.00") * BigDecimal("1")
-    amzn_qty = BigDecimal("10") + BigDecimal("15")
-    expected_amzn_usd = amzn_total_usd / amzn_qty
+    amzn_total = BigDecimal("10") * BigDecimal("212.00") * rate_yesterday +
+                 BigDecimal("15") * BigDecimal("216.00") * rate_today
+    expected_amzn = amzn_total / (BigDecimal("10") + BigDecimal("15"))
 
-    nvda_total_usd = BigDecimal("5") * BigDecimal("128.00") * BigDecimal("1") +
-                     BigDecimal("30") * BigDecimal("124.00") * BigDecimal("1")
-    nvda_qty = BigDecimal("5") + BigDecimal("30")
-    expected_nvda_usd = nvda_total_usd / nvda_qty
+    nvda_total = BigDecimal("5")  * BigDecimal("128.00") * rate_yesterday +
+                 BigDecimal("30") * BigDecimal("124.00") * rate_today
+    expected_nvda = nvda_total / (BigDecimal("5") + BigDecimal("30"))
 
-    ExchangeRate.stubs(:find_or_fetch_rate).returns(OpenStruct.new(rate: 1))
-    assert_equal Money.new(expected_amzn_usd, "CAD").exchange_to("USD"), @amzn.avg_cost
-    assert_equal Money.new(expected_nvda_usd, "CAD").exchange_to("USD"), @nvda.avg_cost
+    assert_equal Money.new(expected_amzn, "USD"), @amzn.avg_cost
+    assert_equal Money.new(expected_nvda, "USD"), @nvda.avg_cost
+  end
+
+  test "avg_cost returns nil when foreign-currency trade has no exchange rate" do
+    create_trade(@amzn.security, account: @account, qty: 10, price: 212.00, date: 1.day.ago.to_date, currency: "EUR")
+
+    # No ExchangeRate rows exist for EUR→USD on that trade date, so cost basis is unknowable.
+    assert_nil @amzn.avg_cost
+  end
+
+  test "avg_cost returns nil when mixed domestic and foreign trades with missing foreign rate" do
+    create_trade(@amzn.security, account: @account, qty: 10, price: 200.00, date: 2.days.ago.to_date)
+    create_trade(@amzn.security, account: @account, qty:  5, price: 212.00, date: 1.day.ago.to_date, currency: "EUR")
+
+    # Even though the first trade has a known domestic rate, the second has no EUR→USD rate.
+    # A partial average would be silently wrong, so nil is the correct result.
+    assert_nil @amzn.avg_cost
+  end
+
+  test "avg_cost is computable when all foreign-currency trades have exchange rates" do
+    rate = BigDecimal("1.08")
+    ExchangeRate.create!(from_currency: "EUR", to_currency: "USD", date: 1.day.ago.to_date, rate: rate)
+
+    create_trade(@amzn.security, account: @account, qty: 10, price: 50.00, date: 1.day.ago.to_date, currency: "EUR")
+
+    expected = BigDecimal("50.00") * rate
+    assert_equal Money.new(expected, "USD"), @amzn.avg_cost
   end
 
   test "calculates total return trend" do


### PR DESCRIPTION
Closes #2119

## Summary

Fixes a silent data-correctness bug where `Holding#avg_cost` could return a confident-looking but wrong dollar figure for holdings with foreign-currency trades whose exchange rate was not in the database for the trade date.

`ForwardCalculator` and `ReverseCalculator` were already updated on this branch to propagate `nil` on `Money::ConversionError`, but neither calculator was passing `date: trade_entry.date` to `exchange_to`, so they looked up today's rate (or no specific rate) rather than the trade-date rate. `calculate_avg_cost` independently used `COALESCE(exchange_rates.rate, 1)` in its SQL, silently treating a missing rate as 1:1, which could produce a value 10–100% off depending on the currency pair.

## What changed

**`app/models/holding/forward_calculator.rb`**
- Pass `date: trade_entry.date` to `exchange_to` so the trade-date rate is used
- On `Money::ConversionError`, mark the security as invalid (`@cost_basis_invalid`) and skip the trade; all subsequent holdings for that security emit `nil` cost basis
- `cost_basis_for` returns `nil` immediately for any invalidated security

**`app/models/holding/reverse_calculator.rb`**
- Same `date: trade_entry.date` fix
- On `Money::ConversionError`, push a `[date, nil]` snapshot into `@cost_basis_snapshots`; the existing binary search naturally returns `nil` for that date and all later dates without any change to `cost_basis_for`

**`app/models/holding.rb` — `calculate_avg_cost`**
- Before computing, run a single `EXISTS` check: if any foreign-currency buy trade has no matching `exchange_rates` row for its trade date, return `nil`
- `COALESCE(rate, 1)` is preserved but is now only reachable when all foreign rates are confirmed present, so the only `NULL` → `1` substitutions that occur are for same-currency (domestic) trades where rate = 1 is correct

## Tests

- Updated `"calculates average cost basis from another currency"` — the old test validated the broken 1:1 fallback (stubbed rate = 1, no real DB rows); it now creates real `ExchangeRate` records and asserts the correctly weighted average
- Added `"avg_cost returns nil when foreign-currency trade has no exchange rate"`
- Added `"avg_cost returns nil when mixed domestic and foreign trades with missing foreign rate"`
- Added `"avg_cost is computable when all foreign-currency trades have exchange rates"`
- Added two `ForwardCalculator` tests covering nil on missing rate and nil-from-failure-date-onward
- Added two `ReverseCalculator` tests covering nil on missing rate and correct value before / nil after a missing-rate trade

## Checklist

- [ ] `bin/rails test` passes
- [ ] `bin/rubocop -f github -a` passes
- [ ] `bin/brakeman --no-pager` passes
- [ ] Branch is up to date with `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cost-basis calculations now return unknown (nil) when required foreign-exchange rates are missing, avoiding silent 1:1 fallback; affected holdings and subsequent dates will show nil cost basis instead of incorrect converted values.

* **Tests**
  * Added coverage for cost-basis behavior when FX rates are absent, including mixed domestic/foreign trades and propagation of nil cost basis after a missing-rate trade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->