### PR TITLE
feat(api): expand external API with account CRUD, pending transactions, filters, merchant create, and rules CRUD

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -130,6 +130,11 @@ class Api::V1::AccountsController < Api::V1::BaseController
   private
 
     def set_writable_account
+      unless valid_uuid?(params[:id])
+        render json: { error: "not_found", message: "Account not found" }, status: :not_found
+        return
+      end
+
       @account = current_resource_owner.family.accounts
                                        .writable_by(current_resource_owner)
                                        .find(params[:id])
@@ -177,8 +182,8 @@ class Api::V1::AccountsController < Api::V1::BaseController
       date_str = params.dig(:account, :opening_balance_date)
       return nil if date_str.blank?
 
-      Date.parse(date_str)
-    rescue Date::Error
+      Date.iso8601(date_str)
+    rescue ArgumentError
       raise ArgumentError, "opening_balance_date is not a valid date"
     end
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -3,8 +3,9 @@
 class Api::V1::AccountsController < Api::V1::BaseController
   include Pagy::Backend
 
-  # Ensure proper scope authorization for read access
-  before_action :ensure_read_scope
+  before_action :ensure_read_scope   # catch-all: every action requires at least read scope
+  before_action :ensure_write_scope, only: [ :create, :update, :destroy ]
+  before_action :set_writable_account, only: [ :update, :destroy ]
 
   def index
     @per_page = safe_per_page_param
@@ -53,10 +54,87 @@ class Api::V1::AccountsController < Api::V1::BaseController
     }, status: :internal_server_error
   end
 
+  def create
+    opening_date = parse_opening_balance_date
+
+    type = params.dig(:account, :accountable_type)
+    unless Accountable::TYPES.include?(type)
+      valid_types = Accountable::TYPES.join(", ")
+      return render json: {
+        error: "validation_failed",
+        message: "accountable_type must be one of: #{valid_types}",
+        errors: [ "Accountable type must be one of: #{valid_types}" ]
+      }, status: :unprocessable_entity
+    end
+
+    @account = Account.create_and_sync(
+      account_params_for_create,
+      opening_balance_date: opening_date
+    )
+
+    render :show, status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: {
+      error: "validation_failed",
+      message: "Account could not be created",
+      errors: e.record.errors.full_messages
+    }, status: :unprocessable_entity
+  rescue ArgumentError, RuntimeError => e
+    render json: {
+      error: "validation_failed",
+      message: e.message,
+      errors: [ e.message ]
+    }, status: :unprocessable_entity
+  rescue => e
+    Rails.logger.error "AccountsController#create error: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    render json: {
+      error: "internal_server_error",
+      message: "An unexpected error occurred"
+    }, status: :internal_server_error
+  end
+
+  def update
+    if @account.update(account_params_for_update)
+      render :show
+    else
+      render json: {
+        error: "validation_failed",
+        message: "Account could not be updated",
+        errors: @account.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  rescue => e
+    Rails.logger.error "AccountsController#update error: #{e.message}"
+    render json: { error: "internal_server_error", message: "An unexpected error occurred" },
+           status: :internal_server_error
+  end
+
+  def destroy
+    if @account.linked?
+      return render json: {
+        error: "validation_failed",
+        message: "Cannot delete a linked account. Unlink the account from its provider first.",
+        errors: [ "Cannot delete a linked account. Unlink the account from its provider first." ]
+      }, status: :unprocessable_entity
+    end
+
+    @account.destroy_later
+    render json: { message: "Account queued for deletion" }, status: :ok
+  rescue => e
+    Rails.logger.error "AccountsController#destroy error: #{e.message}"
+    render json: { error: "internal_server_error", message: "An unexpected error occurred" },
+           status: :internal_server_error
+  end
+
   private
 
-    def ensure_read_scope
-      authorize_scope!(:read)
+    def set_writable_account
+      @account = current_resource_owner.family.accounts
+                                       .writable_by(current_resource_owner)
+                                       .find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "not_found", message: "Account not found" }, status: :not_found
     end
 
     def accounts_scope
@@ -68,5 +146,43 @@ class Api::V1::AccountsController < Api::V1::BaseController
 
     def include_disabled_accounts?
       ActiveModel::Type::Boolean.new.cast(params[:include_disabled])
+    end
+
+    def account_params_for_create
+      permitted = params.require(:account).permit(
+        :name, :balance, :currency, :accountable_type, :subtype
+      )
+
+      type = permitted[:accountable_type]
+      accountable_attributes = {}
+      accountable_attributes[:subtype] = permitted[:subtype] if permitted[:subtype].present?
+
+      if type == "Loan"
+        loan_params = params.require(:account).permit(:interest_rate, :term_months, :rate_type)
+        accountable_attributes.merge!(loan_params.to_h.symbolize_keys)
+      end
+
+      {
+        name: permitted[:name],
+        balance: permitted[:balance],
+        currency: permitted[:currency] || current_resource_owner.family.currency,
+        accountable_type: type,
+        accountable_attributes: accountable_attributes,
+        owner: current_resource_owner,
+        family: current_resource_owner.family
+      }.compact
+    end
+
+    def parse_opening_balance_date
+      date_str = params.dig(:account, :opening_balance_date)
+      return nil if date_str.blank?
+
+      Date.parse(date_str)
+    rescue Date::Error
+      raise ArgumentError, "opening_balance_date is not a valid date"
+    end
+
+    def account_params_for_update
+      params.require(:account).permit(:name, :currency, :subtype)
     end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -217,6 +217,10 @@ class Api::V1::BaseController < ApplicationController
       authorize_scope!(:read)
     end
 
+    def ensure_write_scope
+      authorize_scope!(:write)
+    end
+
     # Consistent JSON response method
     def render_json(data, status: :ok)
       render json: data, status: status

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -12,7 +12,8 @@ module Api
     #   GET /api/v1/merchants/:id
     #
     class MerchantsController < BaseController
-      before_action -> { authorize_scope!(:read) }
+      before_action :ensure_read_scope, only: [ :index, :show ]
+      before_action :ensure_write_scope, only: [ :create ]
 
       # List all merchants available to the family
       #
@@ -71,6 +72,24 @@ module Api
         render json: { error: "Failed to fetch merchant" }, status: :internal_server_error
       end
 
+      def create
+        @merchant = FamilyMerchant.new(merchant_params)
+        @merchant.family = current_resource_owner.family
+
+        if @merchant.save
+          render json: merchant_json(@merchant), status: :created
+        else
+          render json: {
+            error: "validation_failed",
+            message: "Merchant could not be created",
+            errors: @merchant.errors.full_messages
+          }, status: :unprocessable_entity
+        end
+      rescue => e
+        Rails.logger.error("API Merchants Create Error: #{e.message}")
+        render json: { error: "internal_server_error", message: "An unexpected error occurred" }, status: :internal_server_error
+      end
+
       private
 
         # Serialize a merchant to JSON format
@@ -85,6 +104,10 @@ module Api
             created_at: merchant.created_at,
             updated_at: merchant.updated_at
           }
+        end
+
+        def merchant_params
+          params.require(:merchant).permit(:name, :website_url)
         end
     end
   end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -85,6 +85,12 @@ module Api
             errors: @merchant.errors.full_messages
           }, status: :unprocessable_entity
         end
+      rescue ActionController::ParameterMissing => e
+        render json: {
+          error: "validation_failed",
+          message: e.message,
+          errors: [ e.message ]
+        }, status: :unprocessable_entity
       rescue => e
         Rails.logger.error("API Merchants Create Error: #{e.message}")
         render json: { error: "internal_server_error", message: "An unexpected error occurred" }, status: :internal_server_error

--- a/app/controllers/api/v1/rules_controller.rb
+++ b/app/controllers/api/v1/rules_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::RulesController < Api::V1::BaseController
   RESOURCE_TYPES = %w[transaction].freeze
 
   before_action :ensure_read_scope
-  before_action :set_rule, only: :show
+  before_action :ensure_write_scope, only: [ :create, :update, :destroy ]
+  before_action :set_rule, only: [ :show, :update, :destroy ]
 
   def index
     return render_invalid_resource_type_filter if invalid_resource_type_filter?
@@ -43,16 +44,65 @@ class Api::V1::RulesController < Api::V1::BaseController
     render :show
   end
 
+  def create
+    @rule = current_resource_owner.family.rules.build(rule_params)
+
+    if @rule.save
+      render :show, status: :created
+    else
+      render json: {
+        error: "validation_failed",
+        message: "Rule could not be created",
+        errors: @rule.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  rescue => e
+    Rails.logger.error "RulesController#create error: #{e.message}"
+    render json: { error: "internal_server_error", message: "An unexpected error occurred" }, status: :internal_server_error
+  end
+
+  def update
+    if @rule.update(rule_params)
+      render :show
+    else
+      render json: {
+        error: "validation_failed",
+        message: "Rule could not be updated",
+        errors: @rule.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  rescue => e
+    Rails.logger.error "RulesController#update error: #{e.message}"
+    render json: { error: "internal_server_error", message: "An unexpected error occurred" }, status: :internal_server_error
+  end
+
+  def destroy
+    @rule.destroy!
+    render json: { message: "Rule deleted successfully" }, status: :ok
+  rescue => e
+    Rails.logger.error "RulesController#destroy error: #{e.message}"
+    render json: { error: "internal_server_error", message: "An unexpected error occurred" }, status: :internal_server_error
+  end
+
   private
 
     def set_rule
       @rule = current_resource_owner.family.rules
         .includes(:actions, conditions: :sub_conditions)
         .find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "record_not_found", message: "Rule not found" }, status: :not_found
     end
 
-    def ensure_read_scope
-      authorize_scope!(:read)
+    def rule_params
+      params.require(:rule).permit(
+        :name, :resource_type, :active, :effective_date,
+        conditions_attributes: [
+          :id, :condition_type, :operator, :value, :_destroy,
+          sub_conditions_attributes: [ :id, :condition_type, :operator, :value, :_destroy ]
+        ],
+        actions_attributes: [ :id, :action_type, :value, :_destroy ]
+      )
     end
 
     def parse_boolean_filter(value)

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -6,7 +6,8 @@ class Api::V1::TransactionsController < Api::V1::BaseController
   # Ensure proper scope authorization for read vs write access
   before_action :ensure_read_scope
   before_action :ensure_write_scope, only: [ :create, :update, :destroy ]
-  before_action :set_transaction, only: [ :show, :update, :destroy ]
+  before_action :set_transaction, only: [ :show ]
+  before_action :set_writable_transaction, only: [ :update, :destroy ]
 
   def index
     family = current_resource_owner.family
@@ -207,6 +208,22 @@ end
       @transaction = family.transactions
         .joins(entry: :account)
         .merge(Account.accessible_by(current_resource_owner))
+        .find(params[:id])
+      @entry = @transaction.entry
+    rescue ActiveRecord::RecordNotFound
+      render json: {
+        error: "not_found",
+        message: "Transaction not found"
+      }, status: :not_found
+    end
+
+    def set_writable_transaction
+      raise ActiveRecord::RecordNotFound unless valid_uuid?(params[:id])
+
+      family = current_resource_owner.family
+      @transaction = family.transactions
+        .joins(entry: :account)
+        .merge(Account.writable_by(current_resource_owner))
         .find(params[:id])
       @entry = @transaction.entry
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
   include Pagy::Backend
 
   # Ensure proper scope authorization for read vs write access
-  before_action :ensure_read_scope, only: [ :index, :show ]
+  before_action :ensure_read_scope
   before_action :ensure_write_scope, only: [ :create, :update, :destroy ]
   before_action :set_transaction, only: [ :show, :update, :destroy ]
 
@@ -216,14 +216,6 @@ end
       }, status: :not_found
     end
 
-    def ensure_read_scope
-      authorize_scope!(:read)
-    end
-
-    def ensure_write_scope
-      authorize_scope!(:write)
-    end
-
     def apply_filters(query)
       # Account filtering
       if params[:account_id].present?
@@ -291,6 +283,17 @@ end
         end
       end
 
+      # Pending filter
+      if params[:pending].present?
+        pending_val = ActiveModel::Type::Boolean.new.cast(params[:pending])
+        query = pending_val ? query.pending : query.excluding_pending
+      end
+
+      # Source filter
+      if params[:source].present?
+        query = query.where(entries: { source: params[:source] })
+      end
+
       query
     end
 
@@ -308,7 +311,7 @@ end
     def transaction_params
       params.require(:transaction).permit(
         :date, :amount, :name, :description, :notes, :currency,
-        :category_id, :merchant_id, :nature, tag_ids: []
+        :category_id, :merchant_id, :nature, :pending, tag_ids: []
       )
     end
 
@@ -335,6 +338,11 @@ end
         entry_params[:source] = idempotency_source
       end
 
+      if transaction_params.key?(:pending)
+        pending_val = ActiveModel::Type::Boolean.new.cast(transaction_params[:pending])
+        entry_params[:entryable_attributes][:extra] = { "api" => { "pending" => pending_val } }
+      end
+
       entry_params.compact
     end
 
@@ -355,6 +363,13 @@ end
       # Only update amount if provided
       if transaction_params[:amount].present?
         entry_params[:amount] = calculate_signed_amount
+      end
+
+      if transaction_params.key?(:pending)
+        pending_val = ActiveModel::Type::Boolean.new.cast(transaction_params[:pending])
+        existing_extra = @entry.transaction.extra || {}
+        api_extra = existing_extra.fetch("api", {}).merge("pending" => pending_val)
+        entry_params[:entryable_attributes][:extra] = existing_extra.merge("api" => api_extra)
       end
 
       entry_params.compact

--- a/app/controllers/api/v1/valuations_controller.rb
+++ b/app/controllers/api/v1/valuations_controller.rb
@@ -6,9 +6,10 @@ class Api::V1::ValuationsController < Api::V1::BaseController
   InvalidFilterError = Class.new(StandardError)
   BOOLEAN_PARAM = ActiveModel::Type::Boolean.new
 
-  before_action :ensure_read_scope, only: [ :index, :show ]
+  before_action :ensure_read_scope
   before_action :ensure_write_scope, only: [ :create, :update ]
-  before_action :set_valuation, only: [ :show, :update ]
+  before_action :set_valuation, only: [ :show ]
+  before_action :set_writable_valuation, only: [ :update ]
 
   def index
     family = current_resource_owner.family
@@ -83,7 +84,7 @@ class Api::V1::ValuationsController < Api::V1::BaseController
       return
     end
 
-    account = current_resource_owner.family.accounts.find(valuation_account_id)
+    account = current_resource_owner.family.accounts.writable_by(current_resource_owner).find(valuation_account_id)
     requested_upsert = upsert_requested?
     existing_write = false
 
@@ -244,12 +245,19 @@ class Api::V1::ValuationsController < Api::V1::BaseController
       }, status: :not_found
     end
 
-    def ensure_read_scope
-      authorize_scope!(:read)
-    end
-
-    def ensure_write_scope
-      authorize_scope!(:write)
+    def set_writable_valuation
+      @entry = current_resource_owner.family
+                 .entries
+                 .where(entryable_type: "Valuation")
+                 .joins(:account)
+                 .merge(current_resource_owner.family.accounts.writable_by(current_resource_owner))
+                 .find(params[:id])
+      @valuation = @entry.entryable
+    rescue ActiveRecord::RecordNotFound
+      render json: {
+        error: "not_found",
+        message: "Valuation not found"
+      }, status: :not_found
     end
 
     def apply_filters(query)

--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -49,11 +49,9 @@ class Account::ProviderImportAdapter
       incoming_pending = false
       if extra.is_a?(Hash)
         pending_extra = extra.with_indifferent_access
-        incoming_pending =
-          ActiveModel::Type::Boolean.new.cast(pending_extra.dig("simplefin", "pending")) ||
-          ActiveModel::Type::Boolean.new.cast(pending_extra.dig("plaid", "pending")) ||
-          ActiveModel::Type::Boolean.new.cast(pending_extra.dig("lunchflow", "pending")) ||
-          ActiveModel::Type::Boolean.new.cast(pending_extra.dig("enable_banking", "pending"))
+        incoming_pending = Transaction::PENDING_PROVIDERS.any? do |provider|
+          ActiveModel::Type::Boolean.new.cast(pending_extra.dig(provider, "pending"))
+        end
       end
 
       # === PROTECTION CHECK: Skip entries that should not be overwritten ===
@@ -752,12 +750,7 @@ class Account::ProviderImportAdapter
       .where(amount: amount)
       .where(currency: currency)
       .where(date: (date - date_window.days)..date) # Pending must be ON or BEFORE posted date
-      .where(<<~SQL.squish)
-        (transactions.extra -> 'simplefin' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'plaid' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'lunchflow' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'enable_banking' ->> 'pending')::boolean = true
-      SQL
+      .where(pending_providers_sql_fragment)
       .order(date: :desc) # Prefer most recent pending transaction
 
     candidates.first
@@ -799,12 +792,7 @@ class Account::ProviderImportAdapter
       .where(currency: currency)
       .where(date: (date - date_window.days)..date) # Pending ON or BEFORE posted
       .where("ABS(entries.amount) BETWEEN ? AND ?", min_pending_abs, max_pending_abs)
-      .where(<<~SQL.squish)
-        (transactions.extra -> 'simplefin' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'plaid' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'lunchflow' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'enable_banking' ->> 'pending')::boolean = true
-      SQL
+      .where(pending_providers_sql_fragment)
 
     # If merchant_id is provided, prioritize matching by merchant
     if merchant_id.present?
@@ -869,12 +857,7 @@ class Account::ProviderImportAdapter
       .where(currency: currency)
       .where(date: (date - date_window.days)..date)
       .where("ABS(entries.amount) BETWEEN ? AND ?", min_pending_abs, max_pending_abs)
-      .where(<<~SQL.squish)
-        (transactions.extra -> 'simplefin' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'plaid' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'lunchflow' ->> 'pending')::boolean = true
-        OR (transactions.extra -> 'enable_banking' ->> 'pending')::boolean = true
-      SQL
+      .where(pending_providers_sql_fragment)
 
     # For low confidence, require BOTH merchant AND name match (stronger signal needed)
     if merchant_id.present? && name.present?
@@ -997,5 +980,9 @@ class Account::ProviderImportAdapter
         ex.delete(provider) if ex[provider].empty?
       end
       ex
+    end
+
+    def pending_providers_sql_fragment(table_alias = "transactions")
+      Transaction.pending_sql_fragment(table_alias)
     end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -94,7 +94,7 @@ class Transaction < ApplicationRecord
   INTERNAL_MOVEMENT_LABELS = [ "Transfer", "Sweep In", "Sweep Out", "Exchange" ].freeze
 
   # Providers that support pending transaction flags
-  PENDING_PROVIDERS = %w[simplefin plaid lunchflow enable_banking].freeze
+  PENDING_PROVIDERS = %w[simplefin plaid lunchflow enable_banking api].freeze
 
   # Pre-computed SQL fragment for subqueries that check if a transaction (aliased as "t") is pending.
   # Stored as a constant so static analysis can verify it contains no user input.
@@ -114,6 +114,14 @@ class Transaction < ApplicationRecord
     conditions = PENDING_PROVIDERS.map { |provider| "(transactions.extra -> '#{provider}' ->> 'pending')::boolean IS DISTINCT FROM true" }
     where(conditions.join(" AND "))
   }
+
+  # SQL fragment for subqueries that match pending transactions under a given table alias.
+  def self.pending_sql_fragment(table_alias = "transactions")
+    PENDING_PROVIDERS
+      .map { |provider| "(#{table_alias}.extra -> '#{provider}' ->> 'pending')::boolean = true" }
+      .join(" OR ")
+      .freeze
+  end
 
   # SQL snippet for raw queries that must exclude pending transactions.
   # Use in income statements, balance sheets, and raw analytics.

--- a/app/views/api/v1/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v1/transactions/_transaction.json.jbuilder
@@ -20,6 +20,7 @@ json.notes transaction.entry.notes
 json.external_id transaction.entry.external_id
 json.source transaction.entry.source
 json.classification transaction.entry.classification
+json.pending transaction.pending?
 
 # Account information
 json.account do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -493,13 +493,13 @@ Rails.application.routes.draw do
       patch "auth/enable_ai", to: "auth#enable_ai"
 
       # Production API endpoints
-      resources :accounts, only: [ :index, :show ]
+      resources :accounts, only: [ :index, :show, :create, :update, :destroy ]
       resources :balances, only: [ :index, :show ]
       resources :budgets, only: [ :index, :show ]
       resources :budget_categories, only: [ :index, :show ]
       resources :categories, only: [ :index, :show, :create ]
-      resources :merchants, only: [ :index, :show ]
-      resources :rules, only: [ :index, :show ]
+      resources :merchants, only: [ :index, :show, :create ]
+      resources :rules, only: [ :index, :show, :create, :update, :destroy ]
       resources :rule_runs, only: [ :index, :show ]
       resources :securities, only: [ :index, :show ]
       resources :security_prices, only: [ :index, :show ]

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3169,6 +3169,12 @@ paths:
       responses:
         '200':
           description: account updated
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
         '403':
           description: insufficient scope
           content:
@@ -3202,6 +3208,12 @@ paths:
       responses:
         '200':
           description: account deleted
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
         '403':
           description: insufficient scope
           content:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3065,6 +3065,12 @@ paths:
           description: account created
         '401':
           description: unauthorized
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
         '422':
           description: validation failed
       requestBody:
@@ -3105,6 +3111,7 @@ paths:
                       format: date
                       nullable: true
                       example: '2025-01-01'
+        required: true
   "/api/v1/accounts/{id}":
     parameters:
     - name: id
@@ -3162,6 +3169,12 @@ paths:
       responses:
         '200':
           description: account updated
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
         '404':
           description: not found
       requestBody:
@@ -3189,6 +3202,12 @@ paths:
       responses:
         '200':
           description: account deleted
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
         '404':
           description: not found
   "/api/v1/auth/signup":
@@ -5379,6 +5398,12 @@ paths:
           description: merchant created
         '401':
           description: unauthorized
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
         '422':
           description: validation failed
       requestBody:
@@ -7306,6 +7331,10 @@ paths:
                         format: uuid
                       description: Array of tag IDs to assign. Omit to preserve existing
                         tags; use [] to clear all tags.
+                    pending:
+                      type: boolean
+                      nullable: true
+                      example: false
         required: true
     delete:
       summary: Delete a transaction

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1458,6 +1458,8 @@ components:
         transfer:
           "$ref": "#/components/schemas/Transfer"
           nullable: true
+        pending:
+          type: boolean
         created_at:
           type: string
           format: date-time
@@ -3051,6 +3053,58 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/AccountCollection"
+    post:
+      summary: Create an account
+      tags:
+      - Accounts
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '201':
+          description: account created
+        '401':
+          description: unauthorized
+        '422':
+          description: validation failed
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - account
+              properties:
+                account:
+                  type: object
+                  required:
+                  - name
+                  - accountable_type
+                  - balance
+                  - currency
+                  properties:
+                    name:
+                      type: string
+                      example: My Checking Account
+                    accountable_type:
+                      type: string
+                      example: Depository
+                    subtype:
+                      type: string
+                      nullable: true
+                      example: checking
+                    balance:
+                      type: number
+                      format: float
+                      example: 1500.0
+                    currency:
+                      type: string
+                      example: USD
+                    opening_balance_date:
+                      type: string
+                      format: date
+                      nullable: true
+                      example: '2025-01-01'
   "/api/v1/accounts/{id}":
     parameters:
     - name: id
@@ -3098,6 +3152,45 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update an account
+      tags:
+      - Accounts
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '200':
+          description: account updated
+        '404':
+          description: not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                account:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    currency:
+                      type: string
+                    subtype:
+                      type: string
+                      nullable: true
+    delete:
+      summary: Delete an account
+      tags:
+      - Accounts
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: account deleted
+        '404':
+          description: not found
   "/api/v1/auth/signup":
     post:
       summary: Sign up a new user
@@ -5274,6 +5367,40 @@ paths:
                 type: array
                 items:
                   "$ref": "#/components/schemas/MerchantDetail"
+    post:
+      summary: Create a merchant
+      tags:
+      - Merchants
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '201':
+          description: merchant created
+        '401':
+          description: unauthorized
+        '422':
+          description: validation failed
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - merchant
+              properties:
+                merchant:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    name:
+                      type: string
+                      example: Corner Coffee
+                    website_url:
+                      type: string
+                      nullable: true
+                      example: https://cornercoffee.com
   "/api/v1/merchants/{id}":
     parameters:
     - name: id
@@ -5905,6 +6032,79 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
+    post:
+      summary: Create a rule
+      tags:
+      - Rules
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '201':
+          description: rule created
+        '401':
+          description: unauthorized
+        '403':
+          description: forbidden - requires read_write scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: validation failed
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - rule
+              properties:
+                rule:
+                  type: object
+                  required:
+                  - resource_type
+                  properties:
+                    name:
+                      type: string
+                      example: Auto coffee
+                    resource_type:
+                      type: string
+                      enum:
+                      - transaction
+                      example: transaction
+                    active:
+                      type: boolean
+                      example: true
+                    effective_date:
+                      type: string
+                      format: date
+                      example: '2024-01-01'
+                    conditions_attributes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          condition_type:
+                            type: string
+                            example: transaction_name
+                          operator:
+                            type: string
+                            example: like
+                          value:
+                            type: string
+                            example: coffee
+                    actions_attributes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          action_type:
+                            type: string
+                            example: set_transaction_name
+                          value:
+                            type: string
+                            example: Coffee
   "/api/v1/rules/{id}":
     parameters:
     - name: id
@@ -5934,6 +6134,115 @@ paths:
                 "$ref": "#/components/schemas/ErrorResponse"
         '403':
           description: forbidden - requires read scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '404':
+          description: rule not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update a rule
+      tags:
+      - Rules
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '200':
+          description: rule updated
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/RuleResponse"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: forbidden - requires read_write scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '404':
+          description: rule not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                rule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: Updated name
+                    active:
+                      type: boolean
+                      example: false
+                    effective_date:
+                      type: string
+                      format: date
+                    conditions_attributes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          condition_type:
+                            type: string
+                          operator:
+                            type: string
+                          value:
+                            type: string
+                          _destroy:
+                            type: boolean
+                    actions_attributes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          action_type:
+                            type: string
+                          value:
+                            type: string
+                          _destroy:
+                            type: boolean
+    delete:
+      summary: Delete a rule
+      tags:
+      - Rules
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: rule deleted
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/DeleteResponse"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: forbidden - requires read_write scope
           content:
             application/json:
               schema:
@@ -6786,6 +7095,18 @@ paths:
           type: array
           items:
             type: string
+      - name: pending
+        in: query
+        schema:
+          type: boolean
+        required: false
+        description: Filter by pending status (true/false)
+      - name: source
+        in: query
+        schema:
+          type: string
+        required: false
+        description: Filter by transaction source
       responses:
         '200':
           description: transactions filtered by date range
@@ -6881,6 +7202,10 @@ paths:
                         type: string
                         format: uuid
                       description: Array of tag IDs
+                    pending:
+                      type: boolean
+                      nullable: true
+                      example: true
                   required:
                   - account_id
                   - date

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'API V1 Accounts', type: :request do
       consumes 'application/json'
       produces 'application/json'
 
-      parameter name: :body, in: :body, schema: {
+      parameter name: :body, in: :body, required: true, schema: {
         type: :object,
         required: [ 'account' ],
         properties: {
@@ -139,6 +139,14 @@ RSpec.describe 'API V1 Accounts', type: :request do
 
       response '401', 'unauthorized' do
         let(:'X-Api-Key') { 'invalid' }
+        let(:body) { { account: { name: 'x', accountable_type: 'Depository', balance: 0, currency: 'USD' } } }
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { api_key_without_read_scope.plain_key }
         let(:body) { { account: { name: 'x', accountable_type: 'Depository', balance: 0, currency: 'USD' } } }
         run_test!
       end
@@ -222,6 +230,15 @@ RSpec.describe 'API V1 Accounts', type: :request do
         run_test!
       end
 
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { checking_account.id }
+        let(:'X-Api-Key') { api_key_without_read_scope.plain_key }
+        let(:body) { { account: { name: 'x' } } }
+        run_test!
+      end
+
       response '404', 'not found' do
         let(:id) { SecureRandom.uuid }
         let(:body) { { account: { name: 'x' } } }
@@ -236,6 +253,14 @@ RSpec.describe 'API V1 Accounts', type: :request do
 
       response '200', 'account deleted' do
         let(:id) { checking_account.id }
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { checking_account.id }
+        let(:'X-Api-Key') { api_key_without_read_scope.plain_key }
         run_test!
       end
 

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -103,6 +103,51 @@ RSpec.describe 'API V1 Accounts', type: :request do
         run_test!
       end
     end
+
+    post 'Create an account' do
+      tags 'Accounts'
+      security [ { apiKeyAuth: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: [ 'account' ],
+        properties: {
+          account: {
+            type: :object,
+            required: %w[name accountable_type balance currency],
+            properties: {
+              name: { type: :string, example: 'My Checking Account' },
+              accountable_type: { type: :string, example: 'Depository' },
+              subtype: { type: :string, nullable: true, example: 'checking' },
+              balance: { type: :number, format: :float, example: 1500.0 },
+              currency: { type: :string, example: 'USD' },
+              opening_balance_date: { type: :string, format: :date, nullable: true, example: '2025-01-01' }
+            }
+          }
+        }
+      }
+
+      response '201', 'account created' do
+        let(:body) do
+          { account: { name: 'New Account', accountable_type: 'Depository',
+                       subtype: 'checking', balance: 500.0, currency: 'USD' } }
+        end
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        let(:'X-Api-Key') { 'invalid' }
+        let(:body) { { account: { name: 'x', accountable_type: 'Depository', balance: 0, currency: 'USD' } } }
+        run_test!
+      end
+
+      response '422', 'validation failed' do
+        let(:body) { { account: { name: '', accountable_type: 'InvalidType', balance: 0, currency: 'USD' } } }
+        run_test!
+      end
+    end
   end
 
   path '/api/v1/accounts/{id}' do
@@ -147,6 +192,55 @@ RSpec.describe 'API V1 Accounts', type: :request do
 
         let(:id) { SecureRandom.uuid }
 
+        run_test!
+      end
+    end
+
+    patch 'Update an account' do
+      tags 'Accounts'
+      security [ { apiKeyAuth: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          account: {
+            type: :object,
+            properties: {
+              name: { type: :string },
+              currency: { type: :string },
+              subtype: { type: :string, nullable: true }
+            }
+          }
+        }
+      }
+
+      response '200', 'account updated' do
+        let(:id) { checking_account.id }
+        let(:body) { { account: { name: 'Renamed Account' } } }
+        run_test!
+      end
+
+      response '404', 'not found' do
+        let(:id) { SecureRandom.uuid }
+        let(:body) { { account: { name: 'x' } } }
+        run_test!
+      end
+    end
+
+    delete 'Delete an account' do
+      tags 'Accounts'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+
+      response '200', 'account deleted' do
+        let(:id) { checking_account.id }
+        run_test!
+      end
+
+      response '404', 'not found' do
+        let(:id) { SecureRandom.uuid }
         run_test!
       end
     end

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -230,6 +230,15 @@ RSpec.describe 'API V1 Accounts', type: :request do
         run_test!
       end
 
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { checking_account.id }
+        let(:'X-Api-Key') { 'invalid' }
+        let(:body) { { account: { name: 'x' } } }
+        run_test!
+      end
+
       response '403', 'insufficient scope' do
         schema '$ref' => '#/components/schemas/ErrorResponse'
 
@@ -253,6 +262,14 @@ RSpec.describe 'API V1 Accounts', type: :request do
 
       response '200', 'account deleted' do
         let(:id) { checking_account.id }
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { checking_account.id }
+        let(:'X-Api-Key') { 'invalid' }
         run_test!
       end
 

--- a/spec/requests/api/v1/merchants_spec.rb
+++ b/spec/requests/api/v1/merchants_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe 'API V1 Merchants', type: :request do
 
   let(:'X-Api-Key') { api_key.plain_key }
 
+  let(:read_only_api_key) do
+    key = ApiKey.generate_secure_key
+    ApiKey.create!(
+      user: user,
+      name: 'API Read Key',
+      key: key,
+      scopes: %w[read],
+      source: 'web'
+    )
+  end
+
   let!(:family_merchant) { family.merchants.create!(name: 'Coffee Shop') }
 
   path '/api/v1/merchants' do
@@ -76,6 +87,14 @@ RSpec.describe 'API V1 Merchants', type: :request do
 
       response '401', 'unauthorized' do
         let(:'X-Api-Key') { 'invalid' }
+        let(:body) { { merchant: { name: 'x' } } }
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { read_only_api_key.plain_key }
         let(:body) { { merchant: { name: 'x' } } }
         run_test!
       end

--- a/spec/requests/api/v1/merchants_spec.rb
+++ b/spec/requests/api/v1/merchants_spec.rb
@@ -47,6 +47,44 @@ RSpec.describe 'API V1 Merchants', type: :request do
         run_test!
       end
     end
+
+    post 'Create a merchant' do
+      tags 'Merchants'
+      security [ { apiKeyAuth: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: [ 'merchant' ],
+        properties: {
+          merchant: {
+            type: :object,
+            required: [ 'name' ],
+            properties: {
+              name: { type: :string, example: 'Corner Coffee' },
+              website_url: { type: :string, nullable: true, example: 'https://cornercoffee.com' }
+            }
+          }
+        }
+      }
+
+      response '201', 'merchant created' do
+        let(:body) { { merchant: { name: 'Brand New Merchant' } } }
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        let(:'X-Api-Key') { 'invalid' }
+        let(:body) { { merchant: { name: 'x' } } }
+        run_test!
+      end
+
+      response '422', 'validation failed' do
+        let(:body) { { merchant: { name: '' } } }
+        run_test!
+      end
+    end
   end
 
   path '/api/v1/merchants/{id}' do

--- a/spec/requests/api/v1/rules_spec.rb
+++ b/spec/requests/api/v1/rules_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe 'API V1 Rules', type: :request do
     ).tap { |api_key| api_key.save!(validate: false) }
   end
 
+  let(:write_api_key) do
+    key = ApiKey.generate_secure_key
+    ApiKey.create!(
+      user: user,
+      name: 'API Docs Write Key',
+      key: key,
+      scopes: %w[read_write],
+      source: 'monitoring'
+    )
+  end
+
   let(:'X-Api-Key') { api_key.plain_key }
 
   let!(:rule) do
@@ -114,6 +125,88 @@ RSpec.describe 'API V1 Rules', type: :request do
         run_test!
       end
     end
+
+    post 'Create a rule' do
+      tags 'Rules'
+      security [ { apiKeyAuth: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: [ 'rule' ],
+        properties: {
+          rule: {
+            type: :object,
+            required: [ 'resource_type' ],
+            properties: {
+              name: { type: :string, example: 'Auto coffee' },
+              resource_type: { type: :string, enum: %w[transaction], example: 'transaction' },
+              active: { type: :boolean, example: true },
+              effective_date: { type: :string, format: :date, example: '2024-01-01' },
+              conditions_attributes: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    condition_type: { type: :string, example: 'transaction_name' },
+                    operator: { type: :string, example: 'like' },
+                    value: { type: :string, example: 'coffee' }
+                  }
+                }
+              },
+              actions_attributes: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    action_type: { type: :string, example: 'set_transaction_name' },
+                    value: { type: :string, example: 'Coffee' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      response '201', 'rule created' do
+        let(:'X-Api-Key') { write_api_key.plain_key }
+        let(:body) do
+          { rule: {
+              resource_type: 'transaction', active: true,
+              conditions_attributes: [ { condition_type: 'transaction_name', operator: 'like', value: 'coffee' } ],
+              actions_attributes: [ { action_type: 'set_transaction_name', value: 'Coffee' } ]
+          } }
+        end
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        let(:'X-Api-Key') { nil }
+        let(:body) { { rule: { resource_type: 'transaction' } } }
+        run_test!
+      end
+
+      response '403', 'forbidden - requires read_write scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:body) { { rule: { resource_type: 'transaction' } } }
+        run_test!
+      end
+
+      response '422', 'validation failed' do
+        let(:'X-Api-Key') { write_api_key.plain_key }
+        let(:body) do
+          { rule: {
+              resource_type: 'transaction',
+              conditions_attributes: [ { condition_type: 'transaction_name', operator: 'like', value: 'test' } ],
+              actions_attributes: []
+          } }
+        end
+        run_test!
+      end
+    end
   end
 
   path '/api/v1/rules/{id}' do
@@ -153,6 +246,124 @@ RSpec.describe 'API V1 Rules', type: :request do
 
         let(:id) { SecureRandom.uuid }
 
+        run_test!
+      end
+    end
+
+    patch 'Update a rule' do
+      tags 'Rules'
+      security [ { apiKeyAuth: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          rule: {
+            type: :object,
+            properties: {
+              name: { type: :string, example: 'Updated name' },
+              active: { type: :boolean, example: false },
+              effective_date: { type: :string, format: :date },
+              conditions_attributes: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    id: { type: :string },
+                    condition_type: { type: :string },
+                    operator: { type: :string },
+                    value: { type: :string },
+                    _destroy: { type: :boolean }
+                  }
+                }
+              },
+              actions_attributes: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    id: { type: :string },
+                    action_type: { type: :string },
+                    value: { type: :string },
+                    _destroy: { type: :boolean }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      response '200', 'rule updated' do
+        schema '$ref' => '#/components/schemas/RuleResponse'
+
+        let(:'X-Api-Key') { write_api_key.plain_key }
+        let(:id) { rule.id }
+        let(:body) { { rule: { name: 'Updated name' } } }
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { nil }
+        let(:id) { rule.id }
+        let(:body) { { rule: { name: 'x' } } }
+        run_test!
+      end
+
+      response '403', 'forbidden - requires read_write scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { rule.id }
+        let(:body) { { rule: { name: 'x' } } }
+        run_test!
+      end
+
+      response '404', 'rule not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { write_api_key.plain_key }
+        let(:id) { SecureRandom.uuid }
+        let(:body) { { rule: { name: 'x' } } }
+        run_test!
+      end
+    end
+
+    delete 'Delete a rule' do
+      tags 'Rules'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+
+      response '200', 'rule deleted' do
+        schema '$ref' => '#/components/schemas/DeleteResponse'
+
+        let(:'X-Api-Key') { write_api_key.plain_key }
+        let(:id) { rule.id }
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { nil }
+        let(:id) { rule.id }
+        run_test!
+      end
+
+      response '403', 'forbidden - requires read_write scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { rule.id }
+        run_test!
+      end
+
+      response '404', 'rule not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { write_api_key.plain_key }
+        let(:id) { SecureRandom.uuid }
         run_test!
       end
     end

--- a/spec/requests/api/v1/transactions_spec.rb
+++ b/spec/requests/api/v1/transactions_spec.rb
@@ -323,7 +323,8 @@ RSpec.describe 'API V1 Transactions', type: :request do
                 type: :array,
                 items: { type: :string, format: :uuid },
                 description: 'Array of tag IDs to assign. Omit to preserve existing tags; use [] to clear all tags.'
-              }
+              },
+              pending: { type: :boolean, nullable: true, example: false }
             }
           }
         }

--- a/spec/requests/api/v1/transactions_spec.rb
+++ b/spec/requests/api/v1/transactions_spec.rb
@@ -128,6 +128,8 @@ RSpec.describe 'API V1 Transactions', type: :request do
       parameter name: :tag_ids, in: :query, required: false,
                 description: 'Filter by tag IDs',
                 schema: { type: :array, items: { type: :string } }
+      parameter name: :pending, in: :query, schema: { type: :boolean }, required: false, description: 'Filter by pending status (true/false)'
+      parameter name: :source,  in: :query, schema: { type: :string },  required: false, description: 'Filter by transaction source'
 
       response '200', 'transactions listed' do
         schema '$ref' => '#/components/schemas/TransactionCollection'
@@ -176,7 +178,8 @@ RSpec.describe 'API V1 Transactions', type: :request do
               nature: { type: :string, enum: %w[income expense inflow outflow], description: 'Transaction nature (determines sign)' },
               external_id: { type: :string, description: 'Optional external idempotency key scoped to account and source' },
               source: { type: :string, description: 'Optional source namespace for external_id. Requires external_id and defaults to api when external_id is provided' },
-              tag_ids: { type: :array, items: { type: :string, format: :uuid }, description: 'Array of tag IDs' }
+              tag_ids: { type: :array, items: { type: :string, format: :uuid }, description: 'Array of tag IDs' },
+              pending: { type: :boolean, nullable: true, example: true }
             },
             required: %w[account_id date amount name]
           }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -800,6 +800,7 @@ RSpec.configure do |config|
                 items: { '$ref' => '#/components/schemas/Tag' }
               },
               transfer: { '$ref' => '#/components/schemas/Transfer', nullable: true },
+              pending: { type: :boolean },
               created_at: { type: :string, format: :'date-time' },
               updated_at: { type: :string, format: :'date-time' }
             }

--- a/test/controllers/api/v1/accounts_controller_test.rb
+++ b/test/controllers/api/v1/accounts_controller_test.rb
@@ -25,6 +25,14 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
       source: "web",
       display_key: "other_family_read_#{SecureRandom.hex(8)}"
     )
+
+    @write_api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Write Key",
+      scopes: [ "read_write" ],
+      source: "mobile",
+      display_key: "test_write_#{SecureRandom.hex(8)}"
+    )
   end
 
   test "should require authentication" do
@@ -301,6 +309,141 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
     # Should be sorted alphabetically by name
     account_names = response_body["accounts"].map { |a| a["name"] }
     assert_equal account_names.sort, account_names
+  end
+
+  test "should create a depository account" do
+    post "/api/v1/accounts",
+      params: {
+        account: {
+          name: "My Checking",
+          accountable_type: "Depository",
+          subtype: "checking",
+          balance: 2000.0,
+          currency: "USD",
+          opening_balance_date: "2025-01-01"
+        }
+      },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal "My Checking", body["name"]
+    assert_equal "depository", body["account_type"]
+    assert_equal "checking", body["subtype"]
+    assert_equal "USD", body["currency"]
+  end
+
+  test "should reject invalid accountable_type on create" do
+    post "/api/v1/accounts",
+      params: { account: { name: "Bad", accountable_type: "NotAType", balance: 0, currency: "USD" } },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", JSON.parse(response.body)["error"]
+  end
+
+  test "should require read_write scope to create account" do
+    post "/api/v1/accounts",
+      params: { account: { name: "Test", accountable_type: "Depository", balance: 0, currency: "USD" } },
+      headers: api_headers(@api_key),
+      as: :json
+
+    assert_response :forbidden
+  end
+
+  test "should update account name" do
+    account = accounts(:depository)
+
+    patch "/api/v1/accounts/#{account.id}",
+      params: { account: { name: "Updated Name" } },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :success
+    assert_equal "Updated Name", JSON.parse(response.body)["name"]
+    assert_equal "Updated Name", account.reload.name
+  end
+
+  test "should not update another family's account" do
+    account = accounts(:depository)
+
+    patch "/api/v1/accounts/#{account.id}",
+      params: { account: { name: "Hacked" } },
+      headers: api_headers(@other_family_api_key),
+      as: :json
+
+    # ensure_write_scope fires before set_writable_account, so read-scoped key returns 403
+    assert_response :forbidden
+    assert_not_equal "Hacked", account.reload.name
+  end
+
+  test "should require read_write scope to update account" do
+    account = accounts(:depository)
+
+    patch "/api/v1/accounts/#{account.id}",
+      params: { account: { name: "Nope" } },
+      headers: api_headers(@api_key),
+      as: :json
+
+    assert_response :forbidden
+  end
+
+  test "should delete an account" do
+    account = Account.create_and_sync(
+      { name: "Temp Account", balance: 0, currency: "USD",
+        accountable_type: "Depository", accountable_attributes: { subtype: "checking" },
+        owner: @user, family: @user.family },
+      opening_balance_date: 1.year.ago.to_date
+    )
+
+    delete "/api/v1/accounts/#{account.id}",
+      headers: api_headers(@write_api_key)
+
+    assert_response :ok
+    assert_equal "Account queued for deletion", JSON.parse(response.body)["message"]
+  end
+
+  test "should reject deletion of a linked account" do
+    account = accounts(:depository)
+    Account.any_instance.stubs(:linked?).returns(true)
+
+    delete "/api/v1/accounts/#{account.id}",
+      headers: api_headers(@write_api_key)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", JSON.parse(response.body)["error"]
+  end
+
+  test "should require read_write scope to delete account" do
+    account = accounts(:depository)
+
+    delete "/api/v1/accounts/#{account.id}",
+      headers: api_headers(@api_key)
+
+    assert_response :forbidden
+  end
+
+  test "should return 422 for malformed opening_balance_date" do
+    post "/api/v1/accounts",
+      params: {
+        account: {
+          name: "Bad Date Account",
+          accountable_type: "Depository",
+          subtype: "checking",
+          balance: 0,
+          currency: "USD",
+          opening_balance_date: "not-a-date"
+        }
+      },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert_equal "validation_failed", body["error"]
+    assert_match(/not a valid date/i, body["errors"].first)
   end
 
   private

--- a/test/controllers/api/v1/accounts_controller_test.rb
+++ b/test/controllers/api/v1/accounts_controller_test.rb
@@ -379,6 +379,27 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal "Hacked", account.reload.name
   end
 
+  test "should return 404 when other family write key tries to update account" do
+    account = accounts(:depository)
+    other_write_key = ApiKey.create!(
+      user: @other_family_user,
+      name: "Other Write Key",
+      scopes: [ "read_write" ],
+      source: "mobile",
+      display_key: "other_write_#{SecureRandom.hex(8)}"
+    )
+
+    patch "/api/v1/accounts/#{account.id}",
+      params: { account: { name: "Hacked" } },
+      headers: api_headers(other_write_key),
+      as: :json
+
+    assert_response :not_found
+    assert_not_equal "Hacked", account.reload.name
+  ensure
+    other_write_key&.destroy
+  end
+
   test "should require read_write scope to update account" do
     account = accounts(:depository)
 
@@ -423,6 +444,15 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
       headers: api_headers(@api_key)
 
     assert_response :forbidden
+  end
+
+  test "should return 404 when deleting missing or inaccessible account" do
+    delete "/api/v1/accounts/#{SecureRandom.uuid}",
+      headers: api_headers(@write_api_key)
+
+    assert_response :not_found
+    response_body = JSON.parse(response.body)
+    assert_equal "not_found", response_body["error"]
   end
 
   test "should return 422 for malformed opening_balance_date" do

--- a/test/controllers/api/v1/merchants_controller_test.rb
+++ b/test/controllers/api/v1/merchants_controller_test.rb
@@ -11,18 +11,6 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal @user.family_id, @other_family_user.family_id,
       "Test setup error: @other_family_user must belong to a different family"
 
-    @oauth_app = Doorkeeper::Application.create!(
-      name: "Test App",
-      redirect_uri: "https://example.com/callback",
-      scopes: "read"
-    )
-
-    @access_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
     @merchant = @user.family.merchants.first || @user.family.merchants.create!(
       name: "Test Merchant"
     )
@@ -57,7 +45,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index returns user's family merchants successfully" do
-    get api_v1_merchants_url, headers: auth_headers
+    get api_v1_merchants_url, headers: api_headers(@api_key)
 
     assert_response :success
 
@@ -76,7 +64,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
     # Create a merchant in another family
     other_merchant = @other_family_user.family.merchants.create!(name: "Other Merchant")
 
-    get api_v1_merchants_url, headers: auth_headers
+    get api_v1_merchants_url, headers: api_headers(@api_key)
 
     assert_response :success
     merchants = JSON.parse(response.body)
@@ -94,7 +82,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show returns merchant successfully" do
-    get api_v1_merchant_url(@merchant), headers: auth_headers
+    get api_v1_merchant_url(@merchant), headers: api_headers(@api_key)
 
     assert_response :success
 
@@ -104,7 +92,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show returns 404 for non-existent merchant" do
-    get api_v1_merchant_url(id: SecureRandom.uuid), headers: auth_headers
+    get api_v1_merchant_url(id: SecureRandom.uuid), headers: api_headers(@api_key)
 
     assert_response :not_found
   end
@@ -112,7 +100,7 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   test "show returns 404 for merchant from another family" do
     other_merchant = @other_family_user.family.merchants.create!(name: "Other Merchant")
 
-    get api_v1_merchant_url(other_merchant), headers: auth_headers
+    get api_v1_merchant_url(other_merchant), headers: api_headers(@api_key)
 
     assert_response :not_found
   end
@@ -144,15 +132,25 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
   test "should require read_write scope to create merchant" do
     post "/api/v1/merchants",
       params: { merchant: { name: "Test" } },
-      headers: { "X-Api-Key" => @api_key.plain_key },
+      headers: api_headers(@api_key),
       as: :json
 
     assert_response :forbidden
   end
 
+  test "should require authentication to create merchant" do
+    assert_no_difference "FamilyMerchant.count" do
+      post "/api/v1/merchants",
+        params: { merchant: { name: "Unauth Shop" } },
+        as: :json
+    end
+
+    assert_response :unauthorized
+  end
+
   private
 
-    def auth_headers
-      { "Authorization" => "Bearer #{@access_token.token}" }
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.plain_key }
     end
 end

--- a/test/controllers/api/v1/merchants_controller_test.rb
+++ b/test/controllers/api/v1/merchants_controller_test.rb
@@ -26,6 +26,27 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
     @merchant = @user.family.merchants.first || @user.family.merchants.create!(
       name: "Test Merchant"
     )
+
+    @user.api_keys.active.destroy_all
+
+    @write_api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Write Key",
+      scopes: [ "read_write" ],
+      source: "web",
+      display_key: "write_#{SecureRandom.hex(8)}"
+    )
+
+    @api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Read Key",
+      scopes: [ "read" ],
+      source: "mobile",
+      display_key: "read_#{SecureRandom.hex(8)}"
+    )
+
+    Redis.new.del("api_rate_limit:#{@write_api_key.id}")
+    Redis.new.del("api_rate_limit:#{@api_key.id}")
   end
 
   # Index action tests
@@ -94,6 +115,39 @@ class Api::V1::MerchantsControllerTest < ActionDispatch::IntegrationTest
     get api_v1_merchant_url(other_merchant), headers: auth_headers
 
     assert_response :not_found
+  end
+
+  test "should create a merchant" do
+    post "/api/v1/merchants",
+      params: { merchant: { name: "New Coffee Shop" } },
+      headers: { "X-Api-Key" => @write_api_key.plain_key },
+      as: :json
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal "New Coffee Shop", body["name"]
+    assert_equal "FamilyMerchant", body["type"]
+  end
+
+  test "should reject duplicate merchant name within family" do
+    FamilyMerchant.create!(name: "Existing Shop", family: @user.family)
+
+    post "/api/v1/merchants",
+      params: { merchant: { name: "Existing Shop" } },
+      headers: { "X-Api-Key" => @write_api_key.plain_key },
+      as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", JSON.parse(response.body)["error"]
+  end
+
+  test "should require read_write scope to create merchant" do
+    post "/api/v1/merchants",
+      params: { merchant: { name: "Test" } },
+      headers: { "X-Api-Key" => @api_key.plain_key },
+      as: :json
+
+    assert_response :forbidden
   end
 
   private

--- a/test/controllers/api/v1/rules_controller_test.rb
+++ b/test/controllers/api/v1/rules_controller_test.rb
@@ -215,6 +215,16 @@ class Api::V1::RulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  test "should require authentication to create rule" do
+    assert_no_difference "Rule.count" do
+      post api_v1_rules_url,
+        params: { rule: { name: "Unauth", resource_type: "transaction" } },
+        as: :json
+    end
+
+    assert_response :unauthorized
+  end
+
   test "should update a rule name" do
     patch api_v1_rule_url(@rule),
       params: { rule: { name: "Updated name" } },
@@ -271,11 +281,37 @@ class Api::V1::RulesControllerTest < ActionDispatch::IntegrationTest
     assert_not Rule.exists?(rule_id)
   end
 
+  test "should require read_write scope to update rule" do
+    patch api_v1_rule_url(@rule),
+      params: { rule: { name: "Blocked" } },
+      headers: api_headers(@api_key),
+      as: :json
+
+    assert_response :forbidden
+    assert_not_equal "Blocked", @rule.reload.name
+  end
+
+  test "should require authentication to update rule" do
+    patch api_v1_rule_url(@rule),
+      params: { rule: { name: "Unauth" } },
+      as: :json
+
+    assert_response :unauthorized
+    assert_not_equal "Unauth", @rule.reload.name
+  end
+
   test "should require read_write scope to delete rule" do
     delete api_v1_rule_url(@rule),
       headers: api_headers(@api_key)
 
     assert_response :forbidden
+    assert Rule.exists?(@rule.id)
+  end
+
+  test "should require authentication to delete rule" do
+    delete api_v1_rule_url(@rule)
+
+    assert_response :unauthorized
     assert Rule.exists?(@rule.id)
   end
 

--- a/test/controllers/api/v1/rules_controller_test.rb
+++ b/test/controllers/api/v1/rules_controller_test.rb
@@ -16,7 +16,16 @@ class Api::V1::RulesControllerTest < ActionDispatch::IntegrationTest
       display_key: "test_read_#{SecureRandom.hex(8)}"
     )
 
+    @write_api_key = ApiKey.create!(
+      user: @user,
+      name: "Write Key",
+      scopes: [ "read_write" ],
+      source: "mobile",
+      display_key: "test_write_#{SecureRandom.hex(8)}"
+    )
+
     Redis.new.del("api_rate_limit:#{@api_key.id}")
+    Redis.new.del("api_rate_limit:#{@write_api_key.id}")
 
     @rule = @family.rules.build(
       name: "Coffee cleanup",
@@ -152,6 +161,122 @@ class Api::V1::RulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
     json_response = JSON.parse(response.body)
     assert_equal "record_not_found", json_response["error"]
+  end
+
+  test "should create a rule" do
+    post api_v1_rules_url,
+      params: {
+        rule: {
+          name: "Auto coffee",
+          resource_type: "transaction",
+          active: true,
+          effective_date: "2024-01-01",
+          conditions_attributes: [
+            { condition_type: "transaction_name", operator: "like", value: "coffee" }
+          ],
+          actions_attributes: [
+            { action_type: "set_transaction_name", value: "Coffee" }
+          ]
+        }
+      },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal "Auto coffee", body["data"]["name"]
+    assert_equal 1, body["data"]["conditions"].length
+    assert_equal 1, body["data"]["actions"].length
+  end
+
+  test "should reject rule with no actions" do
+    post api_v1_rules_url,
+      params: {
+        rule: {
+          resource_type: "transaction",
+          conditions_attributes: [
+            { condition_type: "transaction_name", operator: "like", value: "test" }
+          ],
+          actions_attributes: []
+        }
+      },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should require read_write scope to create rule" do
+    post api_v1_rules_url,
+      params: { rule: { resource_type: "transaction" } },
+      headers: api_headers(@api_key),
+      as: :json
+
+    assert_response :forbidden
+  end
+
+  test "should update a rule name" do
+    patch api_v1_rule_url(@rule),
+      params: { rule: { name: "Updated name" } },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :success
+    assert_equal "Updated name", JSON.parse(response.body)["data"]["name"]
+    assert_equal "Updated name", @rule.reload.name
+  end
+
+  test "should add a condition to a rule" do
+    original_count = @rule.conditions.count
+
+    patch api_v1_rule_url(@rule),
+      params: {
+        rule: {
+          conditions_attributes: [
+            { condition_type: "transaction_amount", operator: ">", value: "10" }
+          ]
+        }
+      },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :success
+    assert_equal original_count + 1, @rule.reload.conditions.count
+  end
+
+  test "should not update another family's rule" do
+    other_family = Family.create!(name: "OtherRuleFamily", currency: "USD", locale: "en")
+    other_rule = other_family.rules.build(name: "Other", resource_type: "transaction", active: true)
+    other_rule.conditions.build(condition_type: "transaction_name", operator: "like", value: "x")
+    other_rule.actions.build(action_type: "set_transaction_name", value: "X")
+    other_rule.save!
+
+    patch api_v1_rule_url(other_rule),
+      params: { rule: { name: "Hacked" } },
+      headers: api_headers(@write_api_key),
+      as: :json
+
+    assert_response :not_found
+    assert_not_equal "Hacked", other_rule.reload.name
+  end
+
+  test "should delete a rule" do
+    rule_id = @rule.id
+
+    delete api_v1_rule_url(@rule),
+      headers: api_headers(@write_api_key)
+
+    assert_response :ok
+    assert_equal "Rule deleted successfully", JSON.parse(response.body)["message"]
+    assert_not Rule.exists?(rule_id)
+  end
+
+  test "should require read_write scope to delete rule" do
+    delete api_v1_rule_url(@rule),
+      headers: api_headers(@api_key)
+
+    assert_response :forbidden
+    assert Rule.exists?(@rule.id)
   end
 
   private

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -757,6 +757,77 @@ end
     assert transaction_data["transfer"].key?("other_account")
   end
 
+  test "should create pending transaction" do
+    account = accounts(:depository)
+
+    post "/api/v1/transactions",
+      params: { transaction: { account_id: account.id, name: "Pending charge", amount: 50.00, date: Date.today.to_s, pending: true } },
+      headers: api_headers(@api_key),
+      as: :json
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal true, body["pending"]
+  end
+
+  test "should transition pending transaction to posted" do
+    account = accounts(:depository)
+
+    post "/api/v1/transactions",
+      params: { transaction: { account_id: account.id, name: "Pending charge", amount: 50.00, date: Date.today.to_s, pending: true } },
+      headers: api_headers(@api_key),
+      as: :json
+    assert_response :created
+    txn_id = JSON.parse(response.body)["id"]
+
+    patch "/api/v1/transactions/#{txn_id}",
+      params: { transaction: { pending: false } },
+      headers: api_headers(@api_key),
+      as: :json
+
+    assert_response :success
+    assert_equal false, JSON.parse(response.body)["pending"]
+  end
+
+  test "should filter pending transactions" do
+    account = accounts(:depository)
+
+    post "/api/v1/transactions",
+      params: { transaction: { account_id: account.id, name: "Pending txn", amount: 10.0, date: Date.today.to_s, pending: true } },
+      headers: api_headers(@api_key),
+      as: :json
+    assert_response :created
+
+    get "/api/v1/transactions", params: { pending: "true" }, headers: api_headers(@api_key)
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body["transactions"].all? { |t| t["pending"] == true }
+    assert body["transactions"].any? { |t| t["name"] == "Pending txn" }
+  end
+
+  test "should filter non-pending transactions" do
+    get "/api/v1/transactions", params: { pending: "false" }, headers: api_headers(@api_key)
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body["transactions"].all? { |t| t["pending"] == false }
+  end
+
+  test "should filter transactions by source" do
+    account = accounts(:depository)
+
+    post "/api/v1/transactions",
+      params: { transaction: { account_id: account.id, name: "Imported txn", amount: 25.0, date: Date.today.to_s, source: "my_importer", external_id: "ext_#{SecureRandom.hex(4)}" } },
+      headers: api_headers(@api_key),
+      as: :json
+    assert_response :created
+
+    get "/api/v1/transactions", params: { source: "my_importer" }, headers: api_headers(@api_key)
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body["transactions"].all? { |t| t["source"] == "my_importer" }
+    assert body["transactions"].any? { |t| t["name"] == "Imported txn" }
+  end
+
   private
 
     def api_headers(api_key)

--- a/test/controllers/api/v1/valuations_controller_test.rb
+++ b/test/controllers/api/v1/valuations_controller_test.rb
@@ -267,6 +267,31 @@ class Api::V1::ValuationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test "should not allow valuation create on account not writable by user" do
+    other_user = users(:family_member)
+    unwritable_account = Account.create!(
+      name: "Other User Account",
+      balance: 1000,
+      currency: "USD",
+      accountable_type: "Depository",
+      accountable: Depository.create!,
+      family: @family,
+      owner: other_user
+    )
+
+    post api_v1_valuations_url,
+         params: {
+           valuation: {
+             account_id: unwritable_account.id,
+             amount: 5000.00,
+             date: Date.current
+           }
+         },
+         headers: api_headers(@api_key)
+
+    assert_response :not_found
+  end
+
   # UPDATE action tests
   test "should update valuation with valid parameters" do
     entry = @valuation.entry


### PR DESCRIPTION
## Summary

- **Account CRUD** — `POST/PATCH/DELETE /api/v1/accounts` for all 9 accountable types via the canonical `Account.create_and_sync` path, including opening balance date support
- **Pending transactions** — `POST/PATCH /api/v1/transactions` accepts `pending: true/false`; surfaces in responses; create pending → PATCH to post. Hooks into existing `PENDING_PROVIDERS` via a new `"api"` provider key
- **Transaction index filters** — `?pending=true/false` and `?source=<source>` on `GET /api/v1/transactions`
- **Merchant create** — `POST /api/v1/merchants` creates a `FamilyMerchant`
- **Rules CRUD** — `POST/PATCH/DELETE /api/v1/rules` with nested conditions and actions
- **Security** — `writable_by` enforced on valuation create/update; `ensure_write_scope` consolidated to `BaseController` with catch-all read scope guard
- **Bug fix** — `find_pending_transaction*` SQL derived from `PENDING_PROVIDERS` (was hardcoded), preventing duplicates when a provider posts an API-created pending transaction
- **Error handling** — account create returns 422 for predictable validation failures; malformed `opening_balance_date` returns 422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accounts API: create, update, delete accounts
  * Merchant creation endpoint
  * Rules API: create, update, delete rules
  * Transactions: new pending flag in responses and requests; filter by pending and source

* **Security / Authorization**
  * Stricter read vs write scope enforcement and writable-resource checks

* **Documentation**
  * OpenAPI updated for new endpoints and pending/source fields

* **Tests**
  * Expanded request and controller tests for new endpoints, scopes, and pending behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->