### PR TITLE
chore(rubocop): ignore generated schema spacing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,7 @@ Layout/IndentationConsistency:
 
 Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Exclude:
+    - "db/schema.rb"


### PR DESCRIPTION
## Summary
- Exclude the generated `db/schema.rb` file from `Layout/SpaceInsideArrayLiteralBrackets`.
- Keep the existing array-spacing rule active for hand-written Ruby code.

## Why
Rails regenerates `db/schema.rb` using normal array literal formatting like `["account_id"]`, while the inherited RuboCop style requires spaces inside array brackets. That makes a generated schema dump produce hundreds of repeat offenses even when application code is clean.

This keeps `schema.rb` treated as generated database metadata instead of hand-formatting it after every schema dump.

## Validation
- `bin/rubocop db/schema.rb --format simple`
- `bin/rubocop --format simple`
- `git diff --check`

## Notes
- I did not find an exact open issue to close for this lint-only cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality linting configuration to enforce additional spacing standards across the codebase, with targeted exclusions for auto-generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->