### PR TITLE
perf(sparklines): avoid full account loads for linked charts

### DIFF
--- a/app/controllers/accountable_sparklines_controller.rb
+++ b/app/controllers/accountable_sparklines_controller.rb
@@ -16,19 +16,21 @@ class AccountableSparklinesController < ApplicationController
 
   private
     def family
-      Current.family
+      @family ||= Current.family
     end
 
-    def accountable
-      Accountable.from_type(params[:accountable_type]&.classify)
+    def account_scope
+      @account_scope ||= family.accounts.visible.where(accountable_type: @accountable.name)
     end
 
     def account_ids
-      family.accounts.visible.where(accountable_type: accountable.name).pluck(:id)
+      @account_ids ||= account_identity_rows.map(&:first).uniq
     end
 
-    def accounts
-      @accounts ||= family.accounts.visible.where(accountable_type: accountable.name)
+    def account_identity_rows
+      @account_identity_rows ||= account_scope
+        .left_outer_joins(:account_providers)
+        .pluck(:id, :plaid_account_id, :simplefin_account_id, Arel.sql("account_providers.id"))
     end
 
     def build_series
@@ -50,12 +52,14 @@ class AccountableSparklinesController < ApplicationController
     def requires_normalized_aggregation?
       return false unless %w[Investment Crypto].include?(@accountable.name)
 
-      accounts.linked.exists?
+      account_identity_rows.any? do |_account_id, plaid_account_id, simplefin_account_id, account_provider_id|
+        plaid_account_id.present? || simplefin_account_id.present? || account_provider_id.present?
+      end
     end
 
     def aggregate_normalized_series
-      Balance::LinkedInvestmentSeriesNormalizer.aggregate_accounts(
-        accounts: accounts,
+      Balance::LinkedInvestmentSeriesNormalizer.aggregate_account_ids(
+        account_ids: account_ids,
         currency: family.currency,
         period: Period.last_30_days,
         favorable_direction: @accountable.favorable_direction,

--- a/app/models/balance/linked_investment_series_normalizer.rb
+++ b/app/models/balance/linked_investment_series_normalizer.rb
@@ -3,9 +3,17 @@ class Balance::LinkedInvestmentSeriesNormalizer
 
   class << self
     def aggregate_accounts(accounts:, currency:, period:, favorable_direction:, interval: "1 day")
-      accounts = Array(accounts)
-      account_ids = accounts.map(&:id)
+      aggregate_account_ids(
+        account_ids: Array(accounts).map(&:id),
+        currency: currency,
+        period: period,
+        favorable_direction: favorable_direction,
+        interval: interval
+      )
+    end
 
+    def aggregate_account_ids(account_ids:, currency:, period:, favorable_direction:, interval: "1 day")
+      account_ids = Array(account_ids).compact
       series = Balance::ChartSeriesBuilder.new(
         account_ids: account_ids,
         currency: currency,
@@ -31,7 +39,7 @@ class Balance::LinkedInvestmentSeriesNormalizer
 
     private
       def common_supported_history_start_date(account_ids)
-        account_ids = Array(account_ids).compact
+        account_ids = Array(account_ids)
         return if account_ids.empty?
 
         activity_dates = Entry.where(account_id: account_ids)

--- a/test/controllers/accountable_sparklines_controller_test.rb
+++ b/test/controllers/accountable_sparklines_controller_test.rb
@@ -9,4 +9,40 @@ class AccountableSparklinesControllerTest < ActionDispatch::IntegrationTest
     get accountable_sparkline_url("depository")
     assert_response :success
   end
+
+  test "linked investment sparkline does not load full account records" do
+    AccountProvider.create!(
+      account: accounts(:investment),
+      provider: snaptrade_accounts(:fidelity_401k)
+    )
+
+    Rails.cache.clear
+
+    queries = capture_sql_queries do
+      get accountable_sparkline_url("investment")
+    end
+
+    assert_response :success
+    assert_match(/SELECT .*"accounts"\."id".*"account_providers"\."id" FROM "accounts"/, queries.join("\n"))
+    assert_empty queries.grep(/SELECT "accounts"\.\* FROM "accounts"/)
+    assert_empty queries.grep(/SELECT 1 AS one FROM "accounts".*JOIN "account_providers"/)
+    assert_empty queries.grep(/SELECT "accounts"\."id" FROM "accounts" WHERE "accounts"\."family_id" = .*"accounts"\."status" IN .*"accounts"\."accountable_type" =/)
+  end
+
+  private
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
+    end
 end


### PR DESCRIPTION
## Summary
- Reuse a compact account identity query for accountable sparkline requests.
- Detect linked investment/crypto accounts from account ids and provider markers without loading full account records.
- Let linked investment normalization aggregate from account ids directly while preserving the existing account-object entry point.
- Add a regression that proves linked investment sparklines avoid full account loads and separate linked-exists probes.

## Why
Sentry surfaced slow database work around accountable sparkline rendering. The linked investment/crypto path only needs account ids and provider-link markers to choose the normalized aggregation path, but the controller was doing extra account probes and full account loads before building the chart.

## Validation
- `bin/rails test test/controllers/accountable_sparklines_controller_test.rb`
- `bin/rails test`
- `bin/rubocop`
- `npm run lint`
- `bin/brakeman --no-pager`
- `bin/importmap audit`
- `bin/rails zeitwerk:check`
- `git diff --check`
- Security diff review: no reportable findings

## Notes
- Open PR/issue duplicate search did not find an existing focused fix for the accountable sparkline linked-account query path.
- The existing `aggregate_accounts` API remains in place; this adds an id-based path for callers that already have ids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved linked-investment sparkline data loading to reduce database queries and more accurately deduplicate account identities across providers, improving performance and correctness for linked accounts and normalized aggregation.
* **Tests**
  * Added an integration test to validate sparkline endpoint query behavior and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->