### PR TITLE
feat(ds): add Card and ListGroup primitives (#2135)

### DIFF
--- a/app/components/DS/card.rb
+++ b/app/components/DS/card.rb
@@ -1,0 +1,60 @@
+class DS::Card < DesignSystemComponent
+  # Nesting level controls the corner radius. Outer cards (rounded-xl) live
+  # directly on the page; inner cards (rounded-lg) nest inside an outer; tight
+  # cards (rounded-md) cover compact list-group containers. Standardizing the
+  # radius per nesting level removes the "stacked containers with the same
+  # radius" problem flagged in #2135.
+  LEVELS = %i[outer inner tight].freeze
+
+  PADDINGS = {
+    none: "",
+    xs:   "p-2",
+    sm:   "p-3",
+    md:   "p-4",
+    lg:   "p-6",
+    xl:   "p-12"
+  }.freeze
+
+  def initialize(level: :outer, padding: :md, overflow_hidden: false, tag: :div, **html_attrs)
+    @level = normalize_level(level)
+    @padding = normalize_padding(padding)
+    @overflow_hidden = overflow_hidden
+    @tag = tag
+    @html_attrs = html_attrs
+  end
+
+  def call
+    classes = class_names(container_classes, @html_attrs.delete(:class))
+    helpers.tag.send(@tag, class: classes, **@html_attrs) { content }
+  end
+
+  private
+    attr_reader :level, :padding, :overflow_hidden
+
+    def normalize_level(raw)
+      sym = raw.respond_to?(:to_sym) ? raw.to_sym : nil
+      LEVELS.include?(sym) ? sym : :outer
+    end
+
+    def normalize_padding(raw)
+      sym = raw.respond_to?(:to_sym) ? raw.to_sym : nil
+      PADDINGS.key?(sym) ? sym : :md
+    end
+
+    def container_classes
+      class_names(
+        "bg-container shadow-border-xs",
+        radius_class,
+        PADDINGS[padding].presence,
+        ("overflow-hidden" if overflow_hidden)
+      )
+    end
+
+    def radius_class
+      case level
+      when :outer then "rounded-xl"
+      when :inner then "rounded-lg"
+      when :tight then "rounded-md"
+      end
+    end
+end

--- a/app/components/DS/list_group.rb
+++ b/app/components/DS/list_group.rb
@@ -1,0 +1,33 @@
+class DS::ListGroup < DesignSystemComponent
+  # A list-group is a Card whose direct children are separated by a single
+  # divider line in a token-correct color. Folds together the
+  # `bg-container + shadow-border-xs + rounded-* + divide-y + divide-alpha-*`
+  # boilerplate that currently lives at every list-group call site in the app
+  # (#2135).
+  #
+  # Item padding lives on the items themselves, not on the container, so
+  # default padding here is :none. Pass a `padding:` only when the rare
+  # outer card uses uniform inset.
+
+  def initialize(level: :inner, padding: :none, overflow_hidden: true, **html_attrs)
+    @level = level
+    @padding = padding
+    @overflow_hidden = overflow_hidden
+    @html_attrs = html_attrs
+  end
+
+  def call
+    classes = class_names(
+      "divide-y divide-alpha-black-100 theme-dark:divide-alpha-white-100",
+      @html_attrs.delete(:class)
+    )
+
+    render(DS::Card.new(
+      level: @level,
+      padding: @padding,
+      overflow_hidden: @overflow_hidden,
+      class: classes,
+      **@html_attrs
+    )) { content }
+  end
+end

--- a/app/views/reports/_empty_state.html.erb
+++ b/app/views/reports/_empty_state.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-container rounded-xl shadow-border-xs p-12 text-center">
+<%= render DS::Card.new(level: :outer, padding: :xl, class: "text-center") do %>
   <%= icon("chart-bar", class: "w-16 h-16 text-subdued mx-auto mb-6") %>
 
   <h3 class="text-xl font-medium text-primary mb-3">
@@ -24,4 +24,4 @@
       frame: :modal
     ) %>
   </div>
-</div>
+<% end %>

--- a/app/views/reports/_summary_dashboard.html.erb
+++ b/app/views/reports/_summary_dashboard.html.erb
@@ -1,6 +1,6 @@
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
   <%# Total Income Card %>
-  <div class="bg-container rounded-xl shadow-border-xs p-6">
+  <%= render DS::Card.new(level: :outer, padding: :lg) do %>
     <div class="flex items-start justify-between mb-3">
       <div class="flex items-center gap-2">
         <%= icon("trending-up", size: "sm") %>
@@ -34,10 +34,10 @@
         </div>
       <% end %>
     </div>
-  </div>
+  <% end %>
 
   <%# Total Expenses Card %>
-  <div class="bg-container rounded-xl shadow-border-xs p-6">
+  <%= render DS::Card.new(level: :outer, padding: :lg) do %>
     <div class="flex items-start justify-between mb-3">
       <div class="flex items-center gap-2">
         <%= icon("trending-down", class: "w-5 h-5") %>
@@ -71,10 +71,10 @@
         </div>
       <% end %>
     </div>
-  </div>
+  <% end %>
 
   <%# Net Savings Card %>
-  <div class="bg-container rounded-xl shadow-border-xs p-6">
+  <%= render DS::Card.new(level: :outer, padding: :lg) do %>
     <div class="flex items-start justify-between mb-3">
       <div class="flex items-center gap-2">
         <%= icon("piggy-bank", class: "w-5 h-5") %>
@@ -93,10 +93,10 @@
         <%= t("reports.summary.income_minus_expenses") %>
       </p>
     </div>
-  </div>
+  <% end %>
 
   <%# Budget Performance Card %>
-  <div class="bg-container rounded-xl shadow-border-xs p-6">
+  <%= render DS::Card.new(level: :outer, padding: :lg) do %>
     <div class="flex items-start justify-between mb-3">
       <div class="flex items-center gap-2">
         <%= icon("gauge", class: "w-5 h-5") %>
@@ -128,5 +128,5 @@
         </p>
       <% end %>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/test/components/DS/card_test.rb
+++ b/test/components/DS/card_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class DS::CardTest < ViewComponent::TestCase
+  test "outer level renders rounded-xl with default md padding and bg-container chrome" do
+    render_inline(DS::Card.new) { "body" }
+
+    card = page.find("div", text: "body")
+    assert_includes card[:class], "rounded-xl"
+    assert_includes card[:class], "bg-container"
+    assert_includes card[:class], "shadow-border-xs"
+    assert_includes card[:class], "p-4"
+    refute_includes card[:class], "rounded-lg"
+    refute_includes card[:class], "rounded-md"
+  end
+
+  test "inner level downgrades radius to rounded-lg" do
+    render_inline(DS::Card.new(level: :inner)) { "body" }
+
+    card = page.find("div", text: "body")
+    assert_includes card[:class], "rounded-lg"
+    refute_includes card[:class], "rounded-xl"
+  end
+
+  test "tight level downgrades radius to rounded-md" do
+    render_inline(DS::Card.new(level: :tight)) { "body" }
+
+    card = page.find("div", text: "body")
+    assert_includes card[:class], "rounded-md"
+    refute_includes card[:class], "rounded-xl"
+    refute_includes card[:class], "rounded-lg"
+  end
+
+  test "padding: :none omits padding utility entirely" do
+    render_inline(DS::Card.new(padding: :none)) { "body" }
+
+    card = page.find("div", text: "body")
+    refute_match(/\bp-\d+\b/, card[:class])
+  end
+
+  test "overflow_hidden flag adds overflow-hidden utility" do
+    render_inline(DS::Card.new(overflow_hidden: true)) { "body" }
+
+    card = page.find("div", text: "body")
+    assert_includes card[:class], "overflow-hidden"
+  end
+
+  test "unknown level falls back to :outer" do
+    render_inline(DS::Card.new(level: :nonexistent)) { "body" }
+
+    card = page.find("div", text: "body")
+    assert_includes card[:class], "rounded-xl"
+  end
+
+  test "passthrough class merges with container classes" do
+    render_inline(DS::Card.new(class: "custom-extra")) { "body" }
+
+    card = page.find("div", text: "body")
+    assert_includes card[:class], "custom-extra"
+    assert_includes card[:class], "bg-container"
+  end
+
+  test "tag option swaps the wrapping element" do
+    render_inline(DS::Card.new(tag: :section)) { "body" }
+
+    assert_selector "section", text: "body"
+  end
+end

--- a/test/components/DS/list_group_test.rb
+++ b/test/components/DS/list_group_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class DS::ListGroupTest < ViewComponent::TestCase
+  test "wraps content in a Card with divide-y and token-correct divider colors" do
+    render_inline(DS::ListGroup.new) do
+      "<div>a</div><div>b</div>".html_safe
+    end
+
+    card = page.find("div", class: "bg-container")
+    assert_includes card[:class], "divide-y"
+    assert_includes card[:class], "divide-alpha-black-100"
+    assert_includes card[:class], "theme-dark:divide-alpha-white-100"
+  end
+
+  test "defaults to inner level and overflow_hidden so list rows clip cleanly" do
+    render_inline(DS::ListGroup.new) { "<div>row</div>".html_safe }
+
+    card = page.find("div", class: "bg-container")
+    assert_includes card[:class], "rounded-lg"
+    assert_includes card[:class], "overflow-hidden"
+  end
+
+  test "level passes through to the underlying Card" do
+    render_inline(DS::ListGroup.new(level: :tight)) { "<div>row</div>".html_safe }
+
+    card = page.find("div", class: "bg-container")
+    assert_includes card[:class], "rounded-md"
+  end
+
+  test "default padding is :none so item padding owns spacing" do
+    render_inline(DS::ListGroup.new) { "<div>row</div>".html_safe }
+
+    card = page.find("div", class: "bg-container")
+    refute_match(/\bp-\d+\b/, card[:class])
+  end
+end

--- a/test/components/previews/card_component_preview.rb
+++ b/test/components/previews/card_component_preview.rb
@@ -1,0 +1,25 @@
+class CardComponentPreview < ViewComponent::Preview
+  # @display container_classes max-w-[480px] space-y-4
+  # @param level select ["outer", "inner", "tight"]
+  # @param padding select ["none", "xs", "sm", "md", "lg", "xl"]
+  # @param overflow_hidden toggle
+  def default(level: "outer", padding: "md", overflow_hidden: false)
+    render DS::Card.new(level: level, padding: padding, overflow_hidden: overflow_hidden) do
+      content_tag(:p, "Card body content", class: "text-sm text-primary")
+    end
+  end
+
+  # @display container_classes max-w-[480px]
+  def nested
+    render DS::Card.new(level: :outer, padding: :lg) do
+      content_tag(:div, class: "space-y-4") do
+        safe_join([
+          content_tag(:h2, "Outer card", class: "text-lg font-medium text-primary"),
+          render(DS::Card.new(level: :inner, padding: :md)) do
+            content_tag(:p, "Inner card nested inside outer", class: "text-sm text-secondary")
+          end
+        ])
+      end
+    end
+  end
+end

--- a/test/components/previews/list_group_component_preview.rb
+++ b/test/components/previews/list_group_component_preview.rb
@@ -1,0 +1,13 @@
+class ListGroupComponentPreview < ViewComponent::Preview
+  # @display container_classes max-w-[480px]
+  # @param level select ["outer", "inner", "tight"]
+  def default(level: "inner")
+    render DS::ListGroup.new(level: level) do
+      safe_join(
+        [ "First item", "Second item", "Third item" ].map do |label|
+          content_tag(:div, label, class: "p-3 text-sm text-primary")
+        end
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes part of #2135. Ships two new design-system primitives — `DS::Card` and `DS::ListGroup` — plus lookbook previews, tests, and two exemplar migrations on the Reports page.

The audit in #2135 found ~37 call sites duplicating `bg-container shadow-border-xs rounded-* p-*` chrome, with three competing radii stacked on a single Reports page. The fix is one primitive whose `level:` API encodes nesting depth rather than absolute size, so child cards inside a parent card can step down a radius level without inventing new tokens.

## Changes

**Primitives**
- [`app/components/DS/card.rb`](app/components/DS/card.rb) — `DS::Card` with:
  - `level:` → `:outer` (rounded-xl) / `:inner` (rounded-lg) / `:tight` (rounded-md)
  - `padding:` → `:none` / `:xs` / `:sm` / `:md` (default) / `:lg` / `:xl` (maps to `p-2`..`p-12`)
  - `overflow_hidden:`, `tag:`, plus arbitrary HTML-attribute passthrough including `class:`
  - Always emits `bg-container shadow-border-xs` (border-only chrome across both themes, per the audit's recommendation)
- [`app/components/DS/list_group.rb`](app/components/DS/list_group.rb) — composes `DS::Card` with `divide-y divide-alpha-black-100 theme-dark:divide-alpha-white-100`. Defaults to `level: :inner`, `padding: :none`, `overflow_hidden: true` so list-row padding owns its own spacing and rows clip cleanly at the rounded corners.

**Lookbook**
- [`test/components/previews/card_component_preview.rb`](test/components/previews/card_component_preview.rb) — `default` (parameterized) and `nested` (outer-with-inner) previews.
- [`test/components/previews/list_group_component_preview.rb`](test/components/previews/list_group_component_preview.rb).

**Tests**
- [`test/components/DS/card_test.rb`](test/components/DS/card_test.rb) — radius-per-level mapping, padding tokens, `overflow_hidden`, unknown-level fallback to `:outer`, class passthrough merge, custom tag.
- [`test/components/DS/list_group_test.rb`](test/components/DS/list_group_test.rb) — divider classes, defaults, level passthrough.

**Exemplar migrations** (visual parity verified via class equivalence)
- [`app/views/reports/_empty_state.html.erb`](app/views/reports/_empty_state.html.erb): `bg-container rounded-xl shadow-border-xs p-12 text-center` → `DS::Card.new(level: :outer, padding: :xl, class: "text-center")`.
- [`app/views/reports/_summary_dashboard.html.erb`](app/views/reports/_summary_dashboard.html.erb): four duplicated `bg-container rounded-xl shadow-border-xs p-6` blocks → four `DS::Card.new(level: :outer, padding: :lg)` calls.

## Deliberately out of scope

- **Bulk migration of the remaining ~35 sites.** Each one needs visual-parity review; bundling them into this PR would bury the primitive design review. Pattern is documented in the previews + the two migrated files. Will follow up with one issue per page section.
- **Modal/drawer elevation, divider-insets, tab-pill radius alignment.** The audit groups these under the same umbrella, but they're separate token/component concerns and would inflate this PR.

## Test plan

- [ ] `bin/rails test test/components/DS/card_test.rb test/components/DS/list_group_test.rb` passes
- [ ] `bin/rails test` passes (full suite)
- [ ] `bin/rubocop` clean on the new `.rb` files
- [ ] `bundle exec erb_lint app/views/reports/_empty_state.html.erb app/views/reports/_summary_dashboard.html.erb` clean
- [ ] Lookbook at `/lookbook` renders the new `Card` and `ListGroup` previews
- [ ] Reports page (`/reports`) visually matches `main` — four metric cards and the empty state should be byte-identical in chrome
- [ ] Dark theme: card chrome and list-group dividers render with the alpha-white-* variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `Card` component for flexible container styling with customizable nesting levels and padding options.
  * Introduced `ListGroup` component for rendering lists with visual dividers.
  * Enhanced report empty state and dashboard cards to use new components for improved visual consistency.

* **Tests**
  * Added comprehensive test coverage for new Card and ListGroup components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->