### PR TITLE
feat(envelopes): add virtual envelopes — transaction-derived sinking funds & account-agnostic goals (#2085)

### DIFF
--- a/app/components/envelopes/avatar_component.html.erb
+++ b/app/components/envelopes/avatar_component.html.erb
@@ -1,0 +1,10 @@
+<span class="goal-avatar inline-flex items-center justify-center font-semibold <%= box_classes %> <%= text_classes %> <%= radius_classes %>"
+      style="--avatar-color: <%= color %>;"
+      aria-hidden="true"
+      data-testid="envelope-avatar">
+  <% if icon_name.present? %>
+    <%= helpers.icon(icon_name, size: icon_size, color: "current") %>
+  <% else %>
+    <%= initial %>
+  <% end %>
+</span>

--- a/app/components/envelopes/avatar_component.rb
+++ b/app/components/envelopes/avatar_component.rb
@@ -1,6 +1,6 @@
 class Envelopes::AvatarComponent < ApplicationComponent
   SIZES = {
-    "sm" => { box: "w-6 h-6", text: "text-[10px]", radius: "rounded-md" },
+    "sm" => { box: "w-6 h-6", text: "text-xs", radius: "rounded-md" },
     "md" => { box: "w-9 h-9", text: "text-sm", radius: "rounded-lg" },
     "lg" => { box: "w-11 h-11", text: "text-base", radius: "rounded-xl" },
     "xl" => { box: "w-16 h-16", text: "text-2xl", radius: "rounded-2xl" }

--- a/app/components/envelopes/avatar_component.rb
+++ b/app/components/envelopes/avatar_component.rb
@@ -1,0 +1,51 @@
+class Envelopes::AvatarComponent < ApplicationComponent
+  SIZES = {
+    "sm" => { box: "w-6 h-6", text: "text-[10px]", radius: "rounded-md" },
+    "md" => { box: "w-9 h-9", text: "text-sm", radius: "rounded-lg" },
+    "lg" => { box: "w-11 h-11", text: "text-base", radius: "rounded-xl" },
+    "xl" => { box: "w-16 h-16", text: "text-2xl", radius: "rounded-2xl" }
+  }.freeze
+
+  def initialize(envelope: nil, name: nil, color: nil, icon: nil, size: "md")
+    @envelope = envelope
+    @name = name || envelope&.name
+    @color = color || envelope&.color || Envelope::COLORS.first
+    @icon = icon || envelope&.icon
+    @size = SIZES.key?(size) ? size : "md"
+  end
+
+  attr_reader :color
+
+  # Don't expose @icon via attr_reader — `icon` collides with the global
+  # icon helper used inside the template.
+  def icon_name
+    @icon
+  end
+
+  def initial
+    return "?" if @name.blank?
+
+    @name.strip.first&.upcase || "?"
+  end
+
+  def icon_size
+    case @size
+    when "sm" then "xs"
+    when "md" then "sm"
+    when "lg" then "md"
+    when "xl" then "xl"
+    end
+  end
+
+  def box_classes
+    SIZES[@size][:box]
+  end
+
+  def text_classes
+    SIZES[@size][:text]
+  end
+
+  def radius_classes
+    SIZES[@size][:radius]
+  end
+end

--- a/app/components/envelopes/card_component.html.erb
+++ b/app/components/envelopes/card_component.html.erb
@@ -6,7 +6,7 @@
         <p class="text-base font-medium text-primary truncate">
           <a href="<%= envelope_path(envelope) %>"
              aria-label="<%= aria_label %>"
-             class="before:absolute before:inset-0 before:rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-100">
+             class="before:absolute before:inset-0 before:rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300">
             <%= envelope.name %>
           </a>
         </p>

--- a/app/components/envelopes/card_component.html.erb
+++ b/app/components/envelopes/card_component.html.erb
@@ -1,0 +1,41 @@
+<div class="group relative bg-container rounded-xl shadow-border-xs hover:bg-container-hover transition-colors p-6">
+  <div class="flex items-start gap-3">
+    <%= render Envelopes::AvatarComponent.new(envelope: envelope, size: "lg") %>
+    <div class="min-w-0 flex-1">
+      <div class="flex items-center gap-2 mb-0.5">
+        <p class="text-base font-medium text-primary truncate">
+          <a href="<%= envelope_path(envelope) %>"
+             aria-label="<%= aria_label %>"
+             class="before:absolute before:inset-0 before:rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-100">
+            <%= envelope.name %>
+          </a>
+        </p>
+        <%= render Envelopes::StatusPillComponent.new(envelope: envelope) %>
+      </div>
+      <p class="text-xs text-subdued truncate"><%= category_label %></p>
+    </div>
+  </div>
+
+  <div class="mt-5">
+    <div class="flex items-baseline gap-1.5">
+      <span class="text-xl font-medium tabular-nums privacy-sensitive <%= envelope.negative? ? "text-destructive" : "text-primary" %>">
+        <%= envelope.current_balance_money.format(precision: 0) %>
+      </span>
+      <% if envelope.has_target? %>
+        <span class="text-xs text-subdued tabular-nums privacy-sensitive">/ <%= envelope.target_amount_money.format(precision: 0) %></span>
+      <% end %>
+    </div>
+
+    <% if envelope.has_target? %>
+      <div class="mt-2 h-1.5 w-full rounded-full overflow-hidden" style="background-color: var(--budget-unused-fill);">
+        <div class="h-full rounded-full" style="width: <%= progress_percent %>%; background-color: <%= bar_color %>;"></div>
+      </div>
+    <% end %>
+
+    <p class="text-xs text-subdued tabular-nums mt-2 privacy-sensitive"><%= contribution_line %></p>
+  </div>
+
+  <div class="mt-4 flex items-center justify-between">
+    <span class="text-xs text-subdued"><%= footer_line %></span>
+  </div>
+</div>

--- a/app/components/envelopes/card_component.html.erb
+++ b/app/components/envelopes/card_component.html.erb
@@ -6,7 +6,7 @@
         <p class="text-base font-medium text-primary truncate">
           <a href="<%= envelope_path(envelope) %>"
              aria-label="<%= aria_label %>"
-             class="before:absolute before:inset-0 before:rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300">
+             class="before:absolute before:inset-0 before:rounded-xl focus-ring">
             <%= envelope.name %>
           </a>
         </p>

--- a/app/components/envelopes/card_component.rb
+++ b/app/components/envelopes/card_component.rb
@@ -23,12 +23,14 @@ class Envelopes::CardComponent < ApplicationComponent
     envelope.category&.name || I18n.t("envelopes.envelope_card.no_category")
   end
 
-  # Single screen-reader sentence for the whole-card link.
+  # Single screen-reader sentence for the whole-card link. Built from one
+  # translation key so locales control ordering and punctuation rather than a
+  # hard-coded join.
   def aria_label
-    status_text = I18n.t("envelopes.status.#{envelope.status}")
-    balance_text = I18n.t("envelopes.envelope_card.aria_balance",
-                          balance: envelope.current_balance_money.format(precision: 0))
-    [ envelope.name, status_text, balance_text ].join(", ")
+    I18n.t("envelopes.envelope_card.aria_label",
+           name: envelope.name,
+           status: I18n.t("envelopes.status.#{envelope.status}"),
+           balance: envelope.current_balance_money.format(precision: 0))
   end
 
   def contribution_line

--- a/app/components/envelopes/card_component.rb
+++ b/app/components/envelopes/card_component.rb
@@ -1,0 +1,50 @@
+class Envelopes::CardComponent < ApplicationComponent
+  def initialize(envelope:)
+    @envelope = envelope
+  end
+
+  attr_reader :envelope
+
+  def progress_percent
+    envelope.progress_percent
+  end
+
+  # Bar fill colour tracks status: red when overspent, green when funded /
+  # reached, neutral while a sinking fund just ticks along.
+  def bar_color
+    case envelope.status
+    when :negative then "var(--color-destructive)"
+    when :reached, :on_track then "var(--color-success)"
+    else "var(--color-gray-400)"
+    end
+  end
+
+  def category_label
+    envelope.category&.name || I18n.t("envelopes.envelope_card.no_category")
+  end
+
+  # Single screen-reader sentence for the whole-card link.
+  def aria_label
+    status_text = I18n.t("envelopes.status.#{envelope.status}")
+    balance_text = I18n.t("envelopes.envelope_card.aria_balance",
+                          balance: envelope.current_balance_money.format(precision: 0))
+    [ envelope.name, status_text, balance_text ].join(", ")
+  end
+
+  def contribution_line
+    I18n.t("envelopes.envelope_card.contribution",
+           amount: envelope.monthly_contribution_money.format(precision: 0))
+  end
+
+  def footer_line
+    if envelope.negative?
+      I18n.t("envelopes.envelope_card.overspent")
+    elsif envelope.reached?
+      I18n.t("envelopes.envelope_card.reached")
+    elsif envelope.has_target? && envelope.months_to_target
+      I18n.t("envelopes.envelope_card.months_to_target", count: envelope.months_to_target)
+    else
+      I18n.t("envelopes.envelope_card.sinking_fund")
+    end
+  end
+end

--- a/app/components/envelopes/card_component.rb
+++ b/app/components/envelopes/card_component.rb
@@ -15,7 +15,7 @@ class Envelopes::CardComponent < ApplicationComponent
     case envelope.status
     when :negative then "var(--color-destructive)"
     when :reached, :on_track then "var(--color-success)"
-    else "var(--color-gray-400)"
+    else "var(--budget-unused-fill)"
     end
   end
 

--- a/app/components/envelopes/status_pill_component.html.erb
+++ b/app/components/envelopes/status_pill_component.html.erb
@@ -1,0 +1,8 @@
+<%= render DS::Pill.new(
+  label: label,
+  tone: variant[:tone],
+  style: :outline,
+  icon: variant[:icon],
+  marker: false,
+  show_dot: false
+) %>

--- a/app/components/envelopes/status_pill_component.rb
+++ b/app/components/envelopes/status_pill_component.rb
@@ -1,0 +1,26 @@
+class Envelopes::StatusPillComponent < ApplicationComponent
+  # Maps the envelope's status to the DS::Pill primitive's tone + glyph.
+  # Outline style keeps the colored border on any card background.
+  VARIANTS = {
+    negative: { tone: :red,   icon: "triangle-alert" },
+    reached:  { tone: :green, icon: "circle-check-big" },
+    on_track: { tone: :green, icon: "circle-check" },
+    tracking: { tone: :gray,  icon: "infinity" }
+  }.freeze
+
+  def initialize(envelope:)
+    @envelope = envelope
+  end
+
+  def status_key
+    @envelope.status
+  end
+
+  def variant
+    VARIANTS.fetch(status_key, VARIANTS[:tracking])
+  end
+
+  def label
+    I18n.t("envelopes.status.#{status_key}", default: status_key.to_s.titleize)
+  end
+end

--- a/app/controllers/envelopes_controller.rb
+++ b/app/controllers/envelopes_controller.rb
@@ -88,13 +88,24 @@ class EnvelopesController < ApplicationController
     end
 
     # Categories the form may offer: everything in the family minus the ones
-    # already backing another envelope (the model enforces one envelope per
-    # category). The envelope being edited keeps its own category in the list.
+    # already backing another envelope and minus their parent/child relatives
+    # (subcategory spend rolls up, so the model rejects ancestor/descendant
+    # overlaps too — see Envelope#category_must_not_overlap_other_envelope).
+    # The envelope being edited keeps its own category in the list.
     def assignable_categories
       taken_ids = Current.family.envelopes
                          .where.not(category_id: nil)
                          .where.not(id: @envelope&.id)
-                         .select(:category_id)
-      Current.family.categories.alphabetically.where.not(id: taken_ids).to_a
+                         .pluck(:category_id)
+
+      relative_ids = Current.family.categories
+                            .where(id: taken_ids)
+                            .flat_map { |c| [ c.parent_id ] + c.subcategories.pluck(:id) }
+                            .compact
+
+      Current.family.categories
+             .alphabetically
+             .where.not(id: (taken_ids + relative_ids).uniq)
+             .to_a
     end
 end

--- a/app/controllers/envelopes_controller.rb
+++ b/app/controllers/envelopes_controller.rb
@@ -87,7 +87,14 @@ class EnvelopesController < ApplicationController
       )
     end
 
+    # Categories the form may offer: everything in the family minus the ones
+    # already backing another envelope (the model enforces one envelope per
+    # category). The envelope being edited keeps its own category in the list.
     def assignable_categories
-      Current.family.categories.alphabetically.to_a
+      taken_ids = Current.family.envelopes
+                         .where.not(category_id: nil)
+                         .where.not(id: @envelope&.id)
+                         .select(:category_id)
+      Current.family.categories.alphabetically.where.not(id: taken_ids).to_a
     end
 end

--- a/app/controllers/envelopes_controller.rb
+++ b/app/controllers/envelopes_controller.rb
@@ -4,7 +4,7 @@ class EnvelopesController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :envelope_not_found
 
   def index
-    @envelopes = Current.family.envelopes.alphabetically.includes(:category).to_a
+    @envelopes = Current.family.envelopes.alphabetically.includes(category: :subcategories).to_a
     @negative_count = @envelopes.count(&:negative?)
     @breadcrumbs = [
       [ t("breadcrumbs.home"), root_path ],
@@ -73,7 +73,7 @@ class EnvelopesController < ApplicationController
 
   private
     def set_envelope
-      @envelope = Current.family.envelopes.includes(:category).find(params[:id])
+      @envelope = Current.family.envelopes.includes(category: :subcategories).find(params[:id])
     end
 
     def envelope_not_found

--- a/app/controllers/envelopes_controller.rb
+++ b/app/controllers/envelopes_controller.rb
@@ -1,0 +1,93 @@
+class EnvelopesController < ApplicationController
+  before_action :require_preview_features!
+  before_action :set_envelope, only: %i[show edit update destroy]
+  rescue_from ActiveRecord::RecordNotFound, with: :envelope_not_found
+
+  def index
+    @envelopes = Current.family.envelopes.alphabetically.includes(:category).to_a
+    @negative_count = @envelopes.count(&:negative?)
+    @breadcrumbs = [
+      [ t("breadcrumbs.home"), root_path ],
+      [ t("envelopes.index.title"), nil ]
+    ]
+  end
+
+  def show
+    @recent_entries = @envelope.recent_entries.to_a
+    @breadcrumbs = [
+      [ t("breadcrumbs.home"), root_path ],
+      [ t("envelopes.index.title"), envelopes_path ],
+      [ @envelope.name, nil ]
+    ]
+  end
+
+  def new
+    @envelope = Current.family.envelopes.new(
+      color: Envelope::COLORS.sample,
+      currency: Current.family.primary_currency_code,
+      starts_on: Date.current.beginning_of_month
+    )
+    @categories = assignable_categories
+    @breadcrumbs = [
+      [ t("breadcrumbs.home"), root_path ],
+      [ t("envelopes.index.title"), envelopes_path ],
+      [ t("envelopes.new.heading"), nil ]
+    ]
+  end
+
+  def create
+    @envelope = Current.family.envelopes.new(envelope_params)
+    @envelope.save!
+
+    flash[:notice] = t(".success")
+    respond_to do |format|
+      format.html { redirect_to envelope_path(@envelope) }
+      format.turbo_stream { render turbo_stream: turbo_stream.action(:redirect, envelope_path(@envelope)) }
+    end
+  rescue ActiveRecord::RecordInvalid
+    @categories = assignable_categories
+    render :new, status: :unprocessable_entity
+  end
+
+  def edit
+    @categories = assignable_categories
+  end
+
+  def update
+    @envelope.update!(envelope_params)
+
+    flash[:notice] = t(".success")
+    respond_to do |format|
+      format.html { redirect_to envelope_path(@envelope) }
+      format.turbo_stream { render turbo_stream: turbo_stream.action(:redirect, envelope_path(@envelope)) }
+    end
+  rescue ActiveRecord::RecordInvalid
+    @categories = assignable_categories
+    render :edit, status: :unprocessable_entity
+  end
+
+  def destroy
+    @envelope.destroy!
+    redirect_to envelopes_path, notice: t(".success")
+  end
+
+  private
+    def set_envelope
+      @envelope = Current.family.envelopes.includes(:category).find(params[:id])
+    end
+
+    def envelope_not_found
+      redirect_to envelopes_path, alert: t("envelopes.errors.not_found")
+    end
+
+    def envelope_params
+      params.require(:envelope).permit(
+        :name, :category_id, :monthly_contribution, :currency,
+        :target_amount, :target_date, :starts_on, :color, :icon, :notes
+      )
+    end
+
+    def assignable_categories
+      Current.family.categories.alphabetically.to_a
+    end
+end

--- a/app/controllers/envelopes_controller.rb
+++ b/app/controllers/envelopes_controller.rb
@@ -98,14 +98,14 @@ class EnvelopesController < ApplicationController
                          .where.not(id: @envelope&.id)
                          .pluck(:category_id)
 
-      relative_ids = Current.family.categories
-                            .where(id: taken_ids)
-                            .flat_map { |c| [ c.parent_id ] + c.subcategories.pluck(:id) }
-                            .compact
+      # Parents (ancestors) and children (descendants) of taken categories —
+      # two flat queries rather than a query-per-category loop.
+      parent_ids = Current.family.categories.where(id: taken_ids).pluck(:parent_id).compact
+      child_ids  = Current.family.categories.where(parent_id: taken_ids).pluck(:id)
 
       Current.family.categories
              .alphabetically
-             .where.not(id: (taken_ids + relative_ids).uniq)
+             .where.not(id: (taken_ids + parent_ids + child_ids).uniq)
              .to_a
     end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,7 @@ class Category < ApplicationRecord
   belongs_to :family
 
   has_many :budget_categories, dependent: :destroy
+  has_many :envelopes, dependent: :nullify
   has_many :subcategories,
          -> { order(:name) },
          class_name: "Category",

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -34,6 +34,7 @@ class Envelope < ApplicationRecord
   validates :icon, inclusion: { in: ICONS, allow_nil: true }
   validate :category_must_belong_to_family
   validate :category_must_be_unused
+  validate :category_must_not_overlap_other_envelope
   validate :target_date_requires_target_amount
 
   monetize :monthly_contribution, :target_amount, :total_contributed, :total_spent,
@@ -151,6 +152,7 @@ class Envelope < ApplicationRecord
           .where(transactions: { category_id: spend_category_ids })
           .where(excluded: false)
           .where("entries.date >= ?", starts_on)
+          .merge(Transaction.excluding_pending)
           .order(date: :desc, created_at: :desc)
           .limit(limit)
   end
@@ -179,6 +181,21 @@ class Envelope < ApplicationRecord
 
       clashing = Envelope.where(category_id: category_id).where.not(id: id)
       errors.add(:category, :already_taken) if clashing.exists?
+    end
+
+    # Prevent ancestor/descendant overlap. Because spend rolls up from
+    # subcategories into the parent envelope (see spend_category_ids), letting
+    # a parent-category envelope coexist with one of its child-category
+    # envelopes would double-count the child's spend. Categories are at most
+    # two levels deep, so "related" is the parent plus any direct children.
+    def category_must_not_overlap_other_envelope
+      return if category.nil? || family.nil?
+
+      related_ids = ([ category.parent_id ] + category.subcategories.pluck(:id)).compact
+      return if related_ids.empty?
+
+      clashing = family.envelopes.where(category_id: related_ids).where.not(id: id)
+      errors.add(:category, :overlaps_envelope) if clashing.exists?
     end
 
     def target_date_requires_target_amount

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -1,0 +1,189 @@
+# A virtual envelope tracks an earmarked balance derived *entirely* from
+# transactions — a fixed monthly contribution credited each month, less the
+# money spent against its category. It has no link to a physical account
+# balance (account-agnostic): Sure tracks the allocation, not the location, so
+# many envelopes can share a single pooled account (e.g. one cash ISA).
+#
+# Two modes share one model and identical balance mechanics:
+#   - Sinking fund   → no target, runs indefinitely (holidays, gifts, clothing)
+#   - Virtual goal   → optional target (+ optional deadline); "reached" when
+#                      balance >= target (boiler, car fund)
+# The only difference is whether a target/deadline is displayed.
+#
+# Complements account-linked Goals (#1798): an envelope is the
+# transaction-derived balance mode, a Goal is the account-linked balance mode.
+# The two coexist.
+class Envelope < ApplicationRecord
+  include Monetizable
+
+  COLORS = Category::COLORS
+  ICONS = Category.icon_codes
+
+  belongs_to :family
+  # The category whose transactions debit this envelope. Optional so an
+  # envelope can exist before a category is wired up (it simply has no spend
+  # until one is set). Unique per category at the DB level.
+  belongs_to :category, optional: true
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :monthly_contribution, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :currency, presence: true
+  validates :starts_on, presence: true
+  validates :target_amount, numericality: { greater_than: 0 }, allow_nil: true
+  validates :color, format: { with: /\A#[0-9A-Fa-f]{6}\z/ }, allow_nil: true
+  validates :icon, inclusion: { in: ICONS, allow_nil: true }
+  validate :category_must_belong_to_family
+  validate :category_must_be_unused
+  validate :target_date_requires_target_amount
+
+  monetize :monthly_contribution, :target_amount, :total_contributed, :total_spent,
+           :current_balance, :remaining_amount
+
+  scope :alphabetically, -> { order(Arel.sql("LOWER(name) ASC")) }
+
+  # --- Balance mechanics (transaction-derived, account-agnostic) ---
+
+  # Number of monthly contributions that have accrued. The contribution for
+  # the start month lands immediately (so a fresh envelope isn't stuck at
+  # £0), hence the +1: start month → 1, next month → 2, and so on.
+  def months_elapsed
+    return 0 if starts_on.nil? || starts_on > Date.current
+
+    (Date.current.year - starts_on.year) * 12 + (Date.current.month - starts_on.month) + 1
+  end
+
+  # Total credited to the envelope to date: the monthly amount times the
+  # number of months elapsed. Accumulates indefinitely — never resets.
+  def total_contributed
+    monthly_contribution.to_d * months_elapsed
+  end
+
+  # Net spend categorised to this envelope's category (and its
+  # subcategories) since it started accruing. Sure stores expenses as
+  # positive amounts and income/refunds as negative, so summing entries.amount
+  # nets refunds back into the envelope. Amounts are converted to the
+  # envelope's currency via the daily exchange rate, falling back to 1:1 when
+  # no rate row exists (e.g. same-currency transactions). Pending and
+  # user-excluded entries are ignored, matching budget semantics.
+  def total_spent
+    return 0.to_d if category_id.nil? || starts_on.nil?
+
+    @total_spent ||= Entry
+      .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+      .joins("LEFT JOIN exchange_rates er ON er.date = entries.date AND er.from_currency = entries.currency AND er.to_currency = #{self.class.connection.quote(currency)}")
+      .where(account_id: family.accounts.visible.select(:id))
+      .where(transactions: { category_id: spend_category_ids })
+      .where(excluded: false)
+      .where("entries.date >= ?", starts_on)
+      .merge(Transaction.excluding_pending)
+      .sum("entries.amount * COALESCE(er.rate, 1)")
+      .to_d
+  end
+
+  # The running available balance. May go negative when spend outpaces
+  # contributions — spending is never blocked; future contributions
+  # replenish it.
+  def current_balance
+    total_contributed - total_spent
+  end
+
+  def negative?
+    current_balance.negative?
+  end
+
+  # Virtual-goal mode (a target is set) vs sinking-fund mode (no target).
+  def has_target?
+    target_amount.present?
+  end
+
+  def sinking_fund?
+    !has_target?
+  end
+
+  def reached?
+    has_target? && current_balance >= target_amount.to_d
+  end
+
+  # Amount still needed to hit the target (goal mode only). Nil for sinking
+  # funds; clamped at zero so an over-funded envelope reports 0, not negative.
+  def remaining_amount
+    return nil unless has_target?
+
+    [ target_amount.to_d - current_balance, 0 ].max
+  end
+
+  def progress_percent
+    return nil unless has_target?
+    return 0 if target_amount.to_d.zero?
+
+    [ [ (current_balance.to_d / target_amount.to_d * 100).round, 0 ].max, 100 ].min
+  end
+
+  # Months to reach the target at the current monthly contribution. Nil when
+  # there's no target or no contribution (can't project), 0 when already met.
+  def months_to_target
+    return nil unless has_target? && monthly_contribution.to_d.positive?
+    return 0 if remaining_amount.to_d.zero?
+
+    (remaining_amount.to_d / monthly_contribution.to_d).ceil
+  end
+
+  # Drives the status pill / warning indicator.
+  #   :negative → overspent (balance below zero); show a warning
+  #   :reached  → goal mode and target met
+  #   :on_track → goal mode, funded, not yet reached
+  #   :tracking → sinking fund (no target), funded
+  def status
+    return :negative if negative?
+    return :reached if reached?
+
+    has_target? ? :on_track : :tracking
+  end
+
+  # Recent spend/refund entries categorised to this envelope, newest first.
+  # Used on the show page to explain the balance.
+  def recent_entries(limit: 10)
+    return Entry.none if category_id.nil?
+
+    family.entries
+          .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+          .where(account_id: family.accounts.visible.select(:id))
+          .where(transactions: { category_id: spend_category_ids })
+          .where(excluded: false)
+          .where("entries.date >= ?", starts_on)
+          .order(date: :desc, created_at: :desc)
+          .limit(limit)
+  end
+
+  private
+    # The envelope's category plus any of its subcategories, so spend logged
+    # against a child category (e.g. "Flights" under "Holidays") still debits
+    # the envelope — matching how budget parent categories roll up.
+    def spend_category_ids
+      return [] if category.nil?
+
+      [ category.id ] + category.subcategories.pluck(:id)
+    end
+
+    def category_must_belong_to_family
+      return if category.nil? || family.nil?
+      return if category.family_id == family_id
+
+      errors.add(:category, :must_belong_to_family)
+    end
+
+    # Belt-and-suspenders for the partial-unique DB index: one category can
+    # back at most one envelope, otherwise its spend would be double-counted.
+    def category_must_be_unused
+      return if category_id.nil?
+
+      clashing = Envelope.where(category_id: category_id).where.not(id: id)
+      errors.add(:category, :already_taken) if clashing.exists?
+    end
+
+    def target_date_requires_target_amount
+      return if target_date.blank? || target_amount.present?
+
+      errors.add(:target_date, :requires_target_amount)
+    end
+end

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -69,16 +69,24 @@ class Envelope < ApplicationRecord
   def total_spent
     return 0.to_d if category_id.nil? || starts_on.nil?
 
-    @total_spent ||= Entry
-      .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
-      .joins("LEFT JOIN exchange_rates er ON er.date = entries.date AND er.from_currency = entries.currency AND er.to_currency = #{self.class.connection.quote(currency)}")
-      .where(account_id: family.accounts.visible.select(:id))
-      .where(transactions: { category_id: spend_category_ids })
-      .where(excluded: false)
-      .where("entries.date >= ?", starts_on)
-      .merge(Transaction.excluding_pending)
-      .sum("entries.amount * COALESCE(er.rate, 1)")
-      .to_d
+    @total_spent ||= begin
+      rate_join = ActiveRecord::Base.sanitize_sql_array([
+        "LEFT JOIN exchange_rates er ON er.date = entries.date " \
+        "AND er.from_currency = entries.currency AND er.to_currency = ?",
+        currency
+      ])
+
+      Entry
+        .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+        .joins(rate_join)
+        .where(account_id: family.accounts.visible.select(:id))
+        .where(transactions: { category_id: spend_category_ids })
+        .where(excluded: false)
+        .where("entries.date >= ?", starts_on)
+        .merge(Transaction.excluding_pending)
+        .sum("entries.amount * COALESCE(er.rate, 1)")
+        .to_d
+    end
   end
 
   # The running available balance. May go negative when spend outpaces
@@ -160,11 +168,13 @@ class Envelope < ApplicationRecord
   private
     # The envelope's category plus any of its subcategories, so spend logged
     # against a child category (e.g. "Flights" under "Holidays") still debits
-    # the envelope — matching how budget parent categories roll up.
+    # the envelope — matching how budget parent categories roll up. Memoized
+    # and read off the (preloaded on the index) association via `map` rather
+    # than `pluck`, so rendering many envelopes doesn't fire a query each.
     def spend_category_ids
       return [] if category.nil?
 
-      [ category.id ] + category.subcategories.pluck(:id)
+      @spend_category_ids ||= [ category.id ] + category.subcategories.map(&:id)
     end
 
     def category_must_belong_to_family

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -64,8 +64,9 @@ class Envelope < ApplicationRecord
   # positive amounts and income/refunds as negative, so summing entries.amount
   # nets refunds back into the envelope. Amounts are converted to the
   # envelope's currency via the daily exchange rate, falling back to 1:1 when
-  # no rate row exists (e.g. same-currency transactions). Pending and
-  # user-excluded entries are ignored, matching budget semantics.
+  # no rate row exists (e.g. same-currency transactions). Pending,
+  # user-excluded, and budget-excluded kinds (transfers, CC payments) are
+  # ignored, matching budget semantics.
   def total_spent
     return 0.to_d if category_id.nil? || starts_on.nil?
 
@@ -81,6 +82,7 @@ class Envelope < ApplicationRecord
         .joins(rate_join)
         .where(account_id: family.accounts.visible.select(:id))
         .where(transactions: { category_id: spend_category_ids })
+        .where.not(transactions: { kind: Transaction::BUDGET_EXCLUDED_KINDS })
         .where(excluded: false)
         .where("entries.date >= ?", starts_on)
         .merge(Transaction.excluding_pending)
@@ -158,6 +160,7 @@ class Envelope < ApplicationRecord
           .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
           .where(account_id: family.accounts.visible.select(:id))
           .where(transactions: { category_id: spend_category_ids })
+          .where.not(transactions: { kind: Transaction::BUDGET_EXCLUDED_KINDS })
           .where(excluded: false)
           .where("entries.date >= ?", starts_on)
           .merge(Transaction.excluding_pending)

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -37,8 +37,11 @@ class Envelope < ApplicationRecord
   validate :category_must_not_overlap_other_envelope
   validate :target_date_requires_target_amount
 
+  # NOTE: remaining_amount is intentionally not monetized — it returns nil for
+  # sinking funds (no target), which would make remaining_amount_money nil and
+  # blow up any caller chaining .format on it.
   monetize :monthly_contribution, :target_amount, :total_contributed, :total_spent,
-           :current_balance, :remaining_amount
+           :current_balance
 
   scope :alphabetically, -> { order(Arel.sql("LOWER(name) ASC")) }
 
@@ -152,12 +155,23 @@ class Envelope < ApplicationRecord
   end
 
   # Recent spend/refund entries categorised to this envelope, newest first.
-  # Used on the show page to explain the balance.
+  # Used on the show page to explain the balance. Each row exposes a
+  # `converted_amount` in the envelope's currency (same FX conversion as
+  # total_spent) so the activity feed reconciles with the balance card for
+  # multi-currency families instead of showing raw native amounts.
   def recent_entries(limit: 10)
     return Entry.none if category_id.nil?
 
+    rate_join = ActiveRecord::Base.sanitize_sql_array([
+      "LEFT JOIN exchange_rates er ON er.date = entries.date " \
+      "AND er.from_currency = entries.currency AND er.to_currency = ?",
+      currency
+    ])
+
     family.entries
           .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+          .joins(rate_join)
+          .select("entries.*", "entries.amount * COALESCE(er.rate, 1) AS converted_amount")
           .where(account_id: family.accounts.visible.select(:id))
           .where(transactions: { category_id: spend_category_ids })
           .where.not(transactions: { kind: Transaction::BUDGET_EXCLUDED_KINDS })
@@ -204,7 +218,7 @@ class Envelope < ApplicationRecord
     def category_must_not_overlap_other_envelope
       return if category.nil? || family.nil?
 
-      related_ids = ([ category.parent_id ] + category.subcategories.pluck(:id)).compact
+      related_ids = ([ category.parent_id ] + category.subcategories.map(&:id)).compact
       return if related_ids.empty?
 
       clashing = family.envelopes.where(category_id: related_ids).where.not(id: id)

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -53,6 +53,8 @@ class Family < ApplicationRecord
 
   has_many :goals, dependent: :destroy
 
+  has_many :envelopes, dependent: :destroy
+
   # Net inflow into every depository account linked to any primary-currency
   # goal, over the given window. Transfers between linked accounts net to zero
   # because both sides of an internal move land inside the same account set;

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -54,6 +54,8 @@ class Family < ApplicationRecord
 
   has_many :goals, dependent: :destroy
 
+  has_many :envelopes, dependent: :destroy
+
   # Net inflow into every depository account linked to any primary-currency
   # goal, over the given window. Transfers between linked accounts net to zero
   # because both sides of an internal move land inside the same account set;

--- a/app/views/envelopes/_color_picker.html.erb
+++ b/app/views/envelopes/_color_picker.html.erb
@@ -1,0 +1,72 @@
+<%# locals: (form:, colors:, icons:) %>
+<div data-controller="color-icon-picker" data-color-icon-picker-preset-colors-value="<%= colors %>">
+  <div class="w-fit relative">
+    <span class="goal-avatar inline-flex items-center justify-center w-11 h-11 rounded-xl font-semibold text-base"
+          style="--avatar-color: <%= form.object.color %>;"
+          data-color-icon-picker-target="avatar">
+      <% if form.object.icon.present? %>
+        <%= icon(form.object.icon, color: "current", size: "md") %>
+      <% elsif form.object.name.present? %>
+        <%= form.object.name.strip.first&.upcase %>
+      <% else %>
+        <%= icon("mail", color: "current", size: "md") %>
+      <% end %>
+    </span>
+
+    <%= render DS::Disclosure.new(
+          summary_class: "cursor-pointer absolute -bottom-1 -right-1 flex justify-center items-center bg-surface-inset hover:bg-surface-inset-hover border-2 w-6 h-6 border-subdued rounded-full text-secondary",
+          data: {
+            color_icon_picker_target: "details",
+            action: "mousedown->color-icon-picker#handleOutsideClick"
+          }) do |d| %>
+      <% d.with_summary_content do %>
+        <%= icon("pen", size: "xs") %>
+      <% end %>
+
+      <div class="absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 bg-container p-3 border border-alpha-black-25 rounded-2xl shadow-xs w-80 max-w-[calc(100vw-2rem)] max-h-[60vh] overflow-y-auto"
+           data-color-icon-picker-target="popup">
+        <div class="flex gap-2 flex-col mb-3" data-color-icon-picker-target="selection">
+          <div data-color-icon-picker-target="pickerSection"></div>
+          <h4 class="text-secondary text-xs uppercase tracking-wide"><%= t("envelopes.color_picker.color_heading") %></h4>
+          <div class="flex flex-wrap gap-2 items-center" data-color-icon-picker-target="colorsSection">
+            <% colors.each do |c| %>
+              <label class="relative">
+                <%= form.radio_button :color, c, class: "sr-only peer", data: { action: "change->color-icon-picker#handleColorChange" } %>
+                <div class="w-6 h-6 rounded-full cursor-pointer peer-checked:ring-2 peer-checked:ring-offset-2 peer-checked:ring-alpha-black-500" style="background-color: <%= c %>"></div>
+              </label>
+            <% end %>
+            <label class="relative">
+              <%= form.radio_button :color, "custom-color", class: "sr-only peer", data: { color_icon_picker_target: "colorPickerRadioBtn" } %>
+              <div class="w-6 h-6 rounded-full cursor-pointer peer-checked:ring-2 peer-checked:ring-offset-2 peer-checked:ring-alpha-black-500" data-color-icon-picker-target="pickerBtn" style="background: conic-gradient(red,orange,yellow,lime,green,teal,cyan,blue,indigo,purple,magenta,pink,red)"></div>
+            </label>
+          </div>
+          <div class="flex gap-2 items-center hidden flex-col" data-color-icon-picker-target="paletteSection">
+            <div class="flex gap-2 items-center w-full">
+              <div class="w-6 h-6 p-4 rounded-full cursor-pointer" style="background-color: <%= form.object.color %>" data-color-icon-picker-target="colorPreview"></div>
+              <%= form.text_field :color, data: { color_icon_picker_target: "colorInput" }, inline: true, pattern: "^#[0-9A-Fa-f]{6}$" %>
+              <%= icon "palette", size: "2xl", data: { action: "click->color-icon-picker#toggleSections" } %>
+            </div>
+            <div data-color-icon-picker-target="validationMessage" class="hidden self-start flex gap-1 items-center text-xs text-destructive">
+              <span><%= t("envelopes.color_picker.poor_contrast") %></span>
+              <button type="button" class="underline cursor-pointer" data-action="color-icon-picker#autoAdjust"><%= t("envelopes.color_picker.auto_adjust") %></button>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <h4 class="text-secondary text-xs uppercase tracking-wide"><%= t("envelopes.color_picker.icon_heading") %></h4>
+          <div class="flex flex-wrap gap-0.5 max-h-40 overflow-y-auto scrollbar">
+            <% icons.each do |icon_name| %>
+              <label class="relative">
+                <%= form.radio_button :icon, icon_name, class: "sr-only peer", data: { action: "change->color-icon-picker#handleIconChange change->color-icon-picker#handleIconColorChange", color_icon_picker_target: "icon" } %>
+                <div class="text-secondary w-7 h-7 flex m-0.5 items-center justify-center rounded-full cursor-pointer hover:bg-container-inset-hover peer-checked:bg-container-inset border border-transparent">
+                  <%= icon(icon_name, size: "sm", color: "current") %>
+                </div>
+              </label>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/envelopes/_empty_state.html.erb
+++ b/app/views/envelopes/_empty_state.html.erb
@@ -1,0 +1,16 @@
+<div class="bg-container rounded-xl shadow-border-xs py-16 px-6 text-center">
+  <div class="w-16 h-16 rounded-full bg-surface-inset inline-flex items-center justify-center text-secondary mb-4">
+    <%= icon("mail", size: "2xl") %>
+  </div>
+  <h2 class="text-lg font-semibold text-primary"><%= t(".heading") %></h2>
+  <p class="text-sm text-secondary mt-1 max-w-md mx-auto"><%= t(".body") %></p>
+  <div class="mt-5">
+    <%= render DS::Link.new(
+      text: t(".new_envelope"),
+      variant: "primary",
+      href: new_envelope_path,
+      icon: "plus",
+      frame: :modal
+    ) %>
+  </div>
+</div>

--- a/app/views/envelopes/_form.html.erb
+++ b/app/views/envelopes/_form.html.erb
@@ -1,0 +1,63 @@
+<%# locals: (envelope:, categories:) %>
+
+<div>
+  <% if envelope.errors[:base].any? %>
+    <%= render "shared/form_errors", model: envelope %>
+  <% end %>
+
+  <%= styled_form_with model: envelope,
+                       url: envelope.persisted? ? envelope_path(envelope) : envelopes_path,
+                       method: envelope.persisted? ? :patch : :post,
+                       class: "space-y-5" do |f| %>
+    <div class="flex justify-center">
+      <%= render "color_picker", form: f, colors: Envelope::COLORS, icons: Envelope::ICONS %>
+    </div>
+
+    <%= f.text_field :name,
+                     placeholder: t("envelopes.form.fields.name_placeholder"),
+                     autofocus: true,
+                     required: true,
+                     label: t("envelopes.form.fields.name") %>
+
+    <%= f.collection_select :category_id,
+                            categories,
+                            :id,
+                            :name_with_parent,
+                            { label: t("envelopes.form.fields.category"),
+                              include_blank: t("envelopes.form.fields.category_blank"),
+                              searchable: true },
+                            { } %>
+    <p class="-mt-3 text-xs text-secondary"><%= t("envelopes.form.fields.category_hint") %></p>
+
+    <div class="grid grid-cols-2 gap-3">
+      <%= f.money_field :monthly_contribution,
+                        label: t("envelopes.form.fields.monthly_contribution"),
+                        required: true %>
+      <%= f.date_field :starts_on,
+                       label: t("envelopes.form.fields.starts_on"),
+                       required: true %>
+    </div>
+
+    <div class="border-t border-subdued pt-5 space-y-1">
+      <span class="block text-sm font-medium text-primary"><%= t("envelopes.form.fields.target_heading") %></span>
+      <p class="text-xs text-secondary"><%= t("envelopes.form.fields.target_hint") %></p>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3">
+      <%= f.money_field :target_amount,
+                        label: t("envelopes.form.fields.target_amount"),
+                        hide_currency: true %>
+      <%= f.date_field :target_date,
+                       label: t("envelopes.form.fields.target_date") %>
+    </div>
+
+    <%= f.text_area :notes,
+                    label: t("envelopes.form.fields.notes"),
+                    rows: 2,
+                    placeholder: t("envelopes.form.fields.notes_placeholder") %>
+
+    <div class="flex justify-end pt-2">
+      <%= f.submit envelope.persisted? ? t("envelopes.form.save") : t("envelopes.form.create") %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/envelopes/_form.html.erb
+++ b/app/views/envelopes/_form.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (envelope:, categories:) %>
 
 <div>
-  <% if envelope.errors[:base].any? %>
+  <% if envelope.errors.any? %>
     <%= render "shared/form_errors", model: envelope %>
   <% end %>
 

--- a/app/views/envelopes/edit.html.erb
+++ b/app/views/envelopes/edit.html.erb
@@ -1,0 +1,6 @@
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_header(title: t(".heading")) %>
+  <% dialog.with_body do %>
+    <%= render "form", envelope: @envelope, categories: @categories %>
+  <% end %>
+<% end %>

--- a/app/views/envelopes/index.html.erb
+++ b/app/views/envelopes/index.html.erb
@@ -1,0 +1,40 @@
+<div class="space-y-8 pb-6 lg:pb-12">
+  <header>
+    <div class="flex items-center gap-2">
+      <h1 class="text-2xl font-semibold text-primary"><%= t(".title") %></h1>
+      <%= render DS::Pill.new(label: t("shared.preview"), size: :md) %>
+    </div>
+    <p class="text-sm text-secondary mt-1"><%= t(".subtitle") %></p>
+  </header>
+
+  <% if @envelopes.empty? %>
+    <%= render "empty_state" %>
+  <% else %>
+    <div class="flex items-center justify-end">
+      <%= render DS::Link.new(
+        text: t(".new_envelope"),
+        variant: "primary",
+        href: new_envelope_path,
+        icon: "plus",
+        frame: :modal
+      ) %>
+    </div>
+
+    <% if @negative_count.positive? %>
+      <%= render DS::Alert.new(variant: "warning", message: t(".negative_callout", count: @negative_count), live: :polite) %>
+    <% end %>
+
+    <section>
+      <div class="flex items-center gap-1.5 mb-4 text-[11px] font-medium uppercase tracking-wide text-secondary">
+        <span><%= t(".heading") %></span>
+        <span class="text-subdued">·</span>
+        <span class="tabular-nums"><%= @envelopes.size %></span>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3.5">
+        <% @envelopes.each do |envelope| %>
+          <%= render Envelopes::CardComponent.new(envelope: envelope) %>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/app/views/envelopes/new.html.erb
+++ b/app/views/envelopes/new.html.erb
@@ -1,0 +1,30 @@
+<% if turbo_frame_request? %>
+  <%= render DS::Dialog.new(width: "lg") do |dialog| %>
+    <% dialog.with_header(custom_header: true) do %>
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-start gap-3">
+          <%= render DS::FilledIcon.new(variant: :container, icon: "mail", size: "md", rounded: true) %>
+          <div>
+            <h2 class="text-base font-medium text-primary"><%= t(".heading") %></h2>
+            <p class="text-sm text-secondary mt-0.5"><%= t(".subtitle") %></p>
+          </div>
+        </div>
+        <%= render DS::Button.new(variant: "icon", icon: "x", title: t("common.close"), aria_label: t("common.close"), data: { action: "DS--dialog#close" }) %>
+      </div>
+    <% end %>
+    <% dialog.with_body do %>
+      <%= render "form", envelope: @envelope, categories: @categories %>
+    <% end %>
+  <% end %>
+<% else %>
+  <div class="max-w-2xl mx-auto py-8 px-4">
+    <header class="mb-6 flex items-start gap-3">
+      <%= render DS::FilledIcon.new(variant: :container, icon: "mail", size: "md", rounded: true) %>
+      <div>
+        <h1 class="text-xl font-medium text-primary"><%= t(".heading") %></h1>
+        <p class="text-sm text-secondary mt-0.5"><%= t(".subtitle") %></p>
+      </div>
+    </header>
+    <%= render "form", envelope: @envelope, categories: @categories %>
+  </div>
+<% end %>

--- a/app/views/envelopes/show.html.erb
+++ b/app/views/envelopes/show.html.erb
@@ -1,0 +1,115 @@
+<div class="space-y-4 pb-6 lg:pb-12">
+  <header class="flex items-start gap-3 sm:gap-4">
+    <div class="hidden sm:block">
+      <%= render Envelopes::AvatarComponent.new(envelope: @envelope, size: "xl") %>
+    </div>
+    <div class="min-w-0 flex-1">
+      <div class="flex items-center gap-2">
+        <h1 class="text-2xl font-semibold text-primary break-words"><%= @envelope.name %></h1>
+        <%= render Envelopes::StatusPillComponent.new(envelope: @envelope) %>
+      </div>
+      <p class="text-sm text-secondary mt-1">
+        <% if @envelope.category %>
+          <%= t(".header.category", category: @envelope.category.name_with_parent) %>
+        <% else %>
+          <%= t(".header.no_category") %>
+        <% end %>
+        ·
+        <%= @envelope.sinking_fund? ? t(".header.sinking_fund") : t(".header.virtual_goal") %>
+      </p>
+    </div>
+    <div class="shrink-0">
+      <%= render DS::Menu.new do |menu| %>
+        <% menu.with_item(variant: "link", text: t(".edit"), icon: "pencil", href: edit_envelope_path(@envelope), data: { turbo_frame: :modal }) %>
+        <% menu.with_item(
+             variant: "button",
+             text: t(".delete"),
+             icon: "trash-2",
+             href: envelope_path(@envelope),
+             method: :delete,
+             destructive: true,
+             confirm: CustomConfirm.for_resource_deletion(@envelope.name)
+           ) %>
+      <% end %>
+    </div>
+  </header>
+
+  <% if @envelope.negative? %>
+    <%= render DS::Alert.new(
+      variant: "warning",
+      title: t(".negative_banner.title"),
+      message: t(".negative_banner.body", amount: @envelope.current_balance_money.format(precision: 0)),
+      live: :polite
+    ) %>
+  <% end %>
+
+  <section class="bg-container rounded-xl shadow-border-xs p-5 sm:p-6">
+    <p class="text-[11px] font-medium uppercase tracking-wide text-secondary"><%= t(".balance.available") %></p>
+    <p class="text-3xl font-medium tabular-nums mt-1 privacy-sensitive <%= @envelope.negative? ? "text-destructive" : "text-primary" %>">
+      <%= @envelope.current_balance_money.format(precision: 0) %>
+    </p>
+
+    <% if @envelope.has_target? %>
+      <div class="mt-4">
+        <div class="flex items-baseline justify-between text-xs text-secondary mb-1.5 tabular-nums privacy-sensitive">
+          <span><%= t(".balance.of_target", target: @envelope.target_amount_money.format(precision: 0)) %></span>
+          <span><%= @envelope.progress_percent %>%</span>
+        </div>
+        <div class="h-2 w-full rounded-full overflow-hidden" style="background-color: var(--budget-unused-fill);">
+          <div class="h-full rounded-full"
+               style="width: <%= @envelope.progress_percent %>%; background-color: <%= @envelope.negative? ? "var(--color-destructive)" : "var(--color-success)" %>;"></div>
+        </div>
+        <% if @envelope.reached? %>
+          <p class="text-xs text-success mt-2"><%= t(".balance.reached") %></p>
+        <% elsif @envelope.months_to_target %>
+          <p class="text-xs text-secondary mt-2"><%= t(".balance.months_to_target", count: @envelope.months_to_target) %></p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <dl class="mt-5 grid grid-cols-2 gap-4 border-t border-subdued pt-4">
+      <div>
+        <dt class="text-xs text-secondary"><%= t(".balance.contributed") %></dt>
+        <dd class="text-sm font-medium text-primary tabular-nums mt-0.5 privacy-sensitive"><%= @envelope.total_contributed_money.format(precision: 0) %></dd>
+        <dd class="text-xs text-subdued mt-0.5 tabular-nums privacy-sensitive"><%= t(".balance.contribution_rate", amount: @envelope.monthly_contribution_money.format(precision: 0)) %></dd>
+      </div>
+      <div>
+        <dt class="text-xs text-secondary"><%= t(".balance.spent") %></dt>
+        <dd class="text-sm font-medium text-primary tabular-nums mt-0.5 privacy-sensitive"><%= @envelope.total_spent_money.format(precision: 0) %></dd>
+        <% if @envelope.category %>
+          <dd class="text-xs text-subdued mt-0.5"><%= t(".balance.spent_via", category: @envelope.category.name) %></dd>
+        <% end %>
+      </div>
+    </dl>
+  </section>
+
+  <% if @envelope.category %>
+    <section class="bg-container rounded-xl shadow-border-xs p-5">
+      <h2 class="text-sm font-medium text-primary mb-3"><%= t(".recent.heading") %></h2>
+      <% if @recent_entries.any? %>
+        <ul class="divide-y divide-subdued">
+          <% @recent_entries.each do |entry| %>
+            <li class="flex items-center justify-between gap-3 py-2.5">
+              <div class="min-w-0">
+                <p class="text-sm text-primary truncate"><%= entry.name %></p>
+                <p class="text-xs text-subdued tabular-nums"><%= I18n.l(entry.date, format: :long) %></p>
+              </div>
+              <span class="text-sm tabular-nums privacy-sensitive <%= entry.amount.negative? ? "text-success" : "text-primary" %>">
+                <%= entry.amount.negative? ? "+" : "−" %><%= Money.new(entry.amount.abs, entry.currency).format(precision: 0) %>
+              </span>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-sm text-secondary"><%= t(".recent.empty") %></p>
+      <% end %>
+    </section>
+  <% end %>
+
+  <% if @envelope.notes.present? %>
+    <section class="bg-container rounded-xl shadow-border-xs p-5">
+      <h2 class="text-sm font-medium text-primary mb-2"><%= t(".notes") %></h2>
+      <p class="text-sm text-secondary whitespace-pre-line"><%= @envelope.notes %></p>
+    </section>
+  <% end %>
+</div>

--- a/app/views/envelopes/show.html.erb
+++ b/app/views/envelopes/show.html.erb
@@ -89,13 +89,14 @@
       <% if @recent_entries.any? %>
         <ul class="divide-y divide-subdued">
           <% @recent_entries.each do |entry| %>
+            <% amount = entry.converted_amount.to_d %>
             <li class="flex items-center justify-between gap-3 py-2.5">
               <div class="min-w-0">
                 <p class="text-sm text-primary truncate"><%= entry.name %></p>
                 <p class="text-xs text-subdued tabular-nums"><%= I18n.l(entry.date, format: :long) %></p>
               </div>
-              <span class="text-sm tabular-nums privacy-sensitive <%= entry.amount.negative? ? "text-success" : "text-primary" %>">
-                <%= entry.amount.negative? ? "+" : "−" %><%= Money.new(entry.amount.abs, entry.currency).format(precision: 0) %>
+              <span class="text-sm tabular-nums privacy-sensitive <%= amount.negative? ? "text-success" : "text-primary" %>">
+                <%= amount.negative? ? "+" : "−" %><%= Money.new(amount.abs, @envelope.currency).format(precision: 0) %>
               </span>
             </li>
           <% end %>

--- a/app/views/envelopes/show.html.erb
+++ b/app/views/envelopes/show.html.erb
@@ -14,7 +14,7 @@
         <% else %>
           <%= t(".header.no_category") %>
         <% end %>
-        ·
+        <%= t(".header.separator") %>
         <%= @envelope.sinking_fund? ? t(".header.sinking_fund") : t(".header.virtual_goal") %>
       </p>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@ else
     { name: t(".nav.transactions"), path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
     { name: t(".nav.reports"), path: reports_path, icon: "chart-bar", icon_custom: false, active: page_active?(reports_path) },
     plan_nav_item,
+    preview_gated_nav_item({ name: t(".nav.envelopes"), path: envelopes_path, icon: "mail", icon_custom: false, active: page_active?(envelopes_path) }),
     { name: t(".nav.assistant"), path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
   ].compact
 end %>

--- a/config/locales/models/envelope/en.yml
+++ b/config/locales/models/envelope/en.yml
@@ -1,0 +1,24 @@
+---
+en:
+  activerecord:
+    attributes:
+      envelope:
+        name: Name
+        category: Spending category
+        monthly_contribution: Monthly contribution
+        currency: Currency
+        target_amount: Target amount
+        target_date: Target date
+        starts_on: Starts on
+        color: Color
+        icon: Icon
+        notes: Notes
+    errors:
+      models:
+        envelope:
+          attributes:
+            category:
+              must_belong_to_family: The category must belong to the same family as the envelope.
+              already_taken: That category already backs another envelope.
+            target_date:
+              requires_target_amount: Add a target amount before setting a target date.

--- a/config/locales/models/envelope/en.yml
+++ b/config/locales/models/envelope/en.yml
@@ -20,5 +20,6 @@ en:
             category:
               must_belong_to_family: The category must belong to the same family as the envelope.
               already_taken: That category already backs another envelope.
+              overlaps_envelope: A parent or sub-category of this category already backs another envelope.
             target_date:
               requires_target_amount: Add a target amount before setting a target date.

--- a/config/locales/views/envelopes/en.yml
+++ b/config/locales/views/envelopes/en.yml
@@ -43,6 +43,7 @@ en:
       header:
         category: "Spends from %{category}"
         no_category: No category linked
+        separator: "·"
         sinking_fund: Sinking fund
         virtual_goal: Virtual goal
       negative_banner:

--- a/config/locales/views/envelopes/en.yml
+++ b/config/locales/views/envelopes/en.yml
@@ -1,0 +1,91 @@
+---
+en:
+  envelopes:
+    color_picker:
+      color_heading: Color
+      icon_heading: Icon
+      poor_contrast: Poor contrast, choose darker color or
+      auto_adjust: auto-adjust.
+    index:
+      title: Envelopes
+      subtitle: Earmark money across months, no matter where it sits.
+      new_envelope: New envelope
+      heading: Envelopes
+      negative_callout:
+        one: 1 envelope is overspent. Future contributions will replenish it.
+        other: "%{count} envelopes are overspent. Future contributions will replenish them."
+    empty_state:
+      heading: No envelopes yet
+      body: Earmark a fixed amount each month toward holidays, gifts, or a boiler fund — tracked from your transactions, not tied to any one account.
+      new_envelope: Create your first envelope
+    new:
+      heading: New envelope
+      subtitle: Set a monthly contribution and let the balance build from your transactions.
+    edit:
+      heading: Edit envelope
+    create:
+      success: Envelope created.
+    update:
+      success: Envelope updated.
+    destroy:
+      success: Envelope deleted.
+    errors:
+      not_found: This envelope couldn't be found. It may have been deleted.
+    status:
+      negative: Overspent
+      reached: Reached
+      on_track: On track
+      tracking: Tracking
+    show:
+      edit: Edit
+      delete: Delete permanently
+      notes: Notes
+      header:
+        category: "Spends from %{category}"
+        no_category: No category linked
+        sinking_fund: Sinking fund
+        virtual_goal: Virtual goal
+      negative_banner:
+        title: This envelope is overspent
+        body: "The balance is %{amount}. Spending is never blocked — your next monthly contributions will replenish it."
+      balance:
+        available: Available balance
+        of_target: "of %{target}"
+        reached: Target reached. Nice work.
+        months_to_target:
+          one: About 1 month to target at the current contribution.
+          other: "About %{count} months to target at the current contribution."
+        contributed: Contributed
+        contribution_rate: "%{amount}/mo"
+        spent: Spent
+        spent_via: "via %{category}"
+      recent:
+        heading: Recent activity
+        empty: No transactions categorised here yet.
+    form:
+      create: Create envelope
+      save: Save changes
+      fields:
+        name: Name
+        name_placeholder: Holidays, Gifts, Boiler fund…
+        category: Spending category
+        category_blank: No category
+        category_hint: Transactions in this category are debited from the envelope automatically.
+        monthly_contribution: Monthly contribution
+        starts_on: Starts on
+        target_heading: Target (optional)
+        target_hint: Leave blank for a sinking fund that runs indefinitely. Add a target to make it a virtual goal.
+        target_amount: Target amount
+        target_date: Target date
+        notes: Notes (optional)
+        notes_placeholder: A reminder for future you…
+    envelope_card:
+      no_category: No category
+      aria_balance: "%{balance} available"
+      contribution: "%{amount}/mo"
+      overspent: Overspent
+      reached: Target reached
+      sinking_fund: Sinking fund
+      months_to_target:
+        one: About 1 month to target
+        other: "About %{count} months to target"

--- a/config/locales/views/envelopes/en.yml
+++ b/config/locales/views/envelopes/en.yml
@@ -81,7 +81,7 @@ en:
         notes_placeholder: A reminder for future you…
     envelope_card:
       no_category: No category
-      aria_balance: "%{balance} available"
+      aria_label: "%{name}, %{status}, %{balance} available"
       contribution: "%{amount}/mo"
       overspent: Overspent
       reached: Target reached

--- a/config/locales/views/layout/en.yml
+++ b/config/locales/views/layout/en.yml
@@ -10,6 +10,7 @@ en:
       nav:
         assistant: Assistant
         budgets: Budgets
+        envelopes: Envelopes
         home: Home
         plan: Plan
         reports: Reports

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,6 +441,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :envelopes
+
   resources :family_merchants, only: %i[index new create edit update destroy] do
     collection do
       get :merge

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -406,6 +406,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :envelopes
+
   resources :family_merchants, only: %i[index new create edit update destroy] do
     collection do
       get :merge

--- a/db/migrate/20260602120000_create_envelopes.rb
+++ b/db/migrate/20260602120000_create_envelopes.rb
@@ -1,0 +1,30 @@
+class CreateEnvelopes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :envelopes, id: :uuid do |t|
+      t.references :family, null: false, foreign_key: { on_delete: :cascade }, type: :uuid
+      t.references :category, foreign_key: { on_delete: :nullify }, type: :uuid, index: false
+      t.string :name, null: false
+      t.decimal :monthly_contribution, precision: 19, scale: 4, null: false, default: 0
+      t.string :currency, null: false
+      t.decimal :target_amount, precision: 19, scale: 4
+      t.date :target_date
+      t.date :starts_on, null: false
+      t.string :color
+      t.string :icon
+      t.text :notes
+
+      t.timestamps
+    end
+
+    add_index :envelopes, :category_id,
+              unique: true,
+              where: "category_id IS NOT NULL",
+              name: "index_envelopes_on_category_unique"
+
+    add_check_constraint :envelopes, "char_length(name) <= 255", name: "chk_envelopes_name_length"
+    add_check_constraint :envelopes, "monthly_contribution >= 0", name: "chk_envelopes_monthly_contribution_non_negative"
+    add_check_constraint :envelopes,
+                         "target_amount IS NULL OR target_amount > 0",
+                         name: "chk_envelopes_target_amount_positive"
+  end
+end

--- a/db/migrate/20260602120000_create_envelopes.rb
+++ b/db/migrate/20260602120000_create_envelopes.rb
@@ -26,5 +26,8 @@ class CreateEnvelopes < ActiveRecord::Migration[7.2]
     add_check_constraint :envelopes,
                          "target_amount IS NULL OR target_amount > 0",
                          name: "chk_envelopes_target_amount_positive"
+    add_check_constraint :envelopes,
+                         "target_date IS NULL OR target_amount IS NOT NULL",
+                         name: "chk_envelopes_target_date_requires_target_amount"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -655,6 +655,27 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
     t.index ["user_modified"], name: "index_entries_on_user_modified_true", where: "(user_modified = true)"
   end
 
+  create_table "envelopes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "family_id", null: false
+    t.uuid "category_id"
+    t.string "name", null: false
+    t.decimal "monthly_contribution", precision: 19, scale: 4, default: "0.0", null: false
+    t.string "currency", null: false
+    t.decimal "target_amount", precision: 19, scale: 4
+    t.date "target_date"
+    t.date "starts_on", null: false
+    t.string "color"
+    t.string "icon"
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_envelopes_on_category_unique", unique: true, where: "(category_id IS NOT NULL)"
+    t.index ["family_id"], name: "index_envelopes_on_family_id"
+    t.check_constraint "char_length(name::text) <= 255", name: "chk_envelopes_name_length"
+    t.check_constraint "monthly_contribution >= 0::numeric", name: "chk_envelopes_monthly_contribution_non_negative"
+    t.check_constraint "target_amount IS NULL OR target_amount > 0::numeric", name: "chk_envelopes_target_amount_positive"
+  end
+
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
@@ -2357,6 +2378,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
   add_foreign_key "entries", "accounts", on_delete: :cascade
   add_foreign_key "entries", "entries", column: "parent_entry_id", on_delete: :cascade
   add_foreign_key "entries", "imports"
+  add_foreign_key "envelopes", "categories", on_delete: :nullify
+  add_foreign_key "envelopes", "families", on_delete: :cascade
   add_foreign_key "eval_results", "eval_runs"
   add_foreign_key "eval_results", "eval_samples"
   add_foreign_key "eval_runs", "eval_datasets"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -678,6 +678,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
     t.check_constraint "reconciled_by_statement_id IS NULL OR reconciled_at IS NOT NULL", name: "chk_entries_reconciled_at_present_when_statement_set"
   end
 
+  create_table "envelopes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "family_id", null: false
+    t.uuid "category_id"
+    t.string "name", null: false
+    t.decimal "monthly_contribution", precision: 19, scale: 4, default: "0.0", null: false
+    t.string "currency", null: false
+    t.decimal "target_amount", precision: 19, scale: 4
+    t.date "target_date"
+    t.date "starts_on", null: false
+    t.string "color"
+    t.string "icon"
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_envelopes_on_category_unique", unique: true, where: "(category_id IS NOT NULL)"
+    t.index ["family_id"], name: "index_envelopes_on_family_id"
+    t.check_constraint "char_length(name::text) <= 255", name: "chk_envelopes_name_length"
+    t.check_constraint "monthly_contribution >= 0::numeric", name: "chk_envelopes_monthly_contribution_non_negative"
+    t.check_constraint "target_amount IS NULL OR target_amount > 0::numeric", name: "chk_envelopes_target_amount_positive"
+  end
+
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "active", default: true
     t.datetime "created_at", null: false
@@ -2467,6 +2488,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
   add_foreign_key "entries", "accounts", on_delete: :cascade
   add_foreign_key "entries", "entries", column: "parent_entry_id", on_delete: :cascade
   add_foreign_key "entries", "imports"
+  add_foreign_key "envelopes", "categories", on_delete: :nullify
+  add_foreign_key "envelopes", "families", on_delete: :cascade
   add_foreign_key "eval_results", "eval_runs"
   add_foreign_key "eval_results", "eval_samples"
   add_foreign_key "eval_runs", "eval_datasets"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -697,6 +697,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
     t.check_constraint "char_length(name::text) <= 255", name: "chk_envelopes_name_length"
     t.check_constraint "monthly_contribution >= 0::numeric", name: "chk_envelopes_monthly_contribution_non_negative"
     t.check_constraint "target_amount IS NULL OR target_amount > 0::numeric", name: "chk_envelopes_target_amount_positive"
+    t.check_constraint "target_date IS NULL OR target_amount IS NOT NULL", name: "chk_envelopes_target_date_requires_target_amount"
   end
 
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -674,6 +674,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
     t.check_constraint "char_length(name::text) <= 255", name: "chk_envelopes_name_length"
     t.check_constraint "monthly_contribution >= 0::numeric", name: "chk_envelopes_monthly_contribution_non_negative"
     t.check_constraint "target_amount IS NULL OR target_amount > 0::numeric", name: "chk_envelopes_target_amount_positive"
+    t.check_constraint "target_date IS NULL OR target_amount IS NOT NULL", name: "chk_envelopes_target_date_requires_target_amount"
   end
 
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/controllers/envelopes_controller_test.rb
+++ b/test/controllers/envelopes_controller_test.rb
@@ -1,0 +1,124 @@
+require "test_helper"
+
+class EnvelopesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => true))
+    sign_in @user
+    @envelope = envelopes(:holidays)
+    @category = categories(:income)
+    ensure_tailwind_build
+  end
+
+  test "redirects users without preview access" do
+    @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => false))
+
+    get envelopes_url
+
+    assert_redirected_to root_path
+    assert_match(/preview/i, flash[:alert])
+  end
+
+  test "index renders" do
+    get envelopes_url
+    assert_response :success
+    assert_match(/Envelopes/i, response.body)
+  end
+
+  test "show renders the envelope" do
+    get envelope_url(@envelope)
+    assert_response :success
+    assert_match(@envelope.name, response.body)
+  end
+
+  test "new renders the modal form" do
+    get new_envelope_url
+    assert_response :success
+  end
+
+  test "create persists an envelope" do
+    assert_difference -> { Envelope.count } => 1 do
+      post envelopes_url, params: {
+        envelope: {
+          name: "New envelope",
+          category_id: @category.id,
+          monthly_contribution: "250",
+          currency: "USD",
+          starts_on: Date.current.beginning_of_month.iso8601,
+          color: "#4da568"
+        }
+      }
+    end
+
+    envelope = Envelope.order(created_at: :desc).first
+    assert_redirected_to envelope_path(envelope)
+    assert_equal 250.to_d, envelope.monthly_contribution
+  end
+
+  test "create with a target_amount makes a virtual goal" do
+    post envelopes_url, params: {
+      envelope: {
+        name: "Boiler",
+        monthly_contribution: "100",
+        currency: "USD",
+        starts_on: Date.current.beginning_of_month.iso8601,
+        target_amount: "1500",
+        color: "#4da568"
+      }
+    }
+
+    envelope = Envelope.order(created_at: :desc).first
+    assert envelope.has_target?
+    assert_redirected_to envelope_path(envelope)
+  end
+
+  test "create rejects a blank name" do
+    assert_no_difference "Envelope.count" do
+      post envelopes_url, params: {
+        envelope: { name: "", monthly_contribution: "100", currency: "USD", starts_on: Date.current.iso8601 }
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "edit renders the modal form" do
+    get edit_envelope_url(@envelope)
+    assert_response :success
+  end
+
+  test "update changes the envelope" do
+    patch envelope_url(@envelope), params: {
+      envelope: { name: "Renamed", monthly_contribution: "400" }
+    }
+
+    assert_redirected_to envelope_path(@envelope)
+    assert_equal "Renamed", @envelope.reload.name
+    assert_equal 400.to_d, @envelope.monthly_contribution
+  end
+
+  test "update rejects an invalid contribution" do
+    patch envelope_url(@envelope), params: {
+      envelope: { monthly_contribution: "-50" }
+    }
+
+    assert_response :unprocessable_entity
+  end
+
+  test "destroy deletes the envelope" do
+    assert_difference "Envelope.count", -1 do
+      delete envelope_url(@envelope)
+    end
+
+    assert_redirected_to envelopes_path
+  end
+
+  test "scopes envelopes to the current family" do
+    other_family = Family.create!(name: "Other", currency: "USD", locale: "en", country: "US", timezone: "UTC")
+    foreign = other_family.envelopes.create!(name: "Foreign", monthly_contribution: 10, currency: "USD", starts_on: Date.current.beginning_of_month)
+
+    get envelope_url(foreign)
+
+    assert_redirected_to envelopes_path
+  end
+end

--- a/test/controllers/envelopes_controller_test.rb
+++ b/test/controllers/envelopes_controller_test.rb
@@ -99,6 +99,32 @@ class EnvelopesControllerTest < ActionDispatch::IntegrationTest
     assert_match %r{data-value="#{cat_free.id}"}, response.body
   end
 
+  test "new form omits the parent of a category already backing an envelope" do
+    family = @user.family
+    parent = Category.create!(name: "Holidays WT", family: family, color: "#4da568", lucide_icon: "plane")
+    child = Category.create!(name: "Flights WT", parent: parent, family: family)
+    family.envelopes.create!(name: "Flights env WT", category: child, monthly_contribution: 10, currency: "USD", starts_on: Date.current.beginning_of_month)
+
+    get new_envelope_url
+    assert_response :success
+    # Picking the parent would roll the child's spend up into it, so the model
+    # rejects the overlap — the form must not offer it (it would 422 on submit).
+    assert_no_match %r{data-value="#{parent.id}"}, response.body
+    assert_no_match %r{data-value="#{child.id}"}, response.body
+  end
+
+  test "new form omits child categories when their parent backs an envelope" do
+    family = @user.family
+    parent = Category.create!(name: "Bills WT", family: family, color: "#6471eb", lucide_icon: "house")
+    child = Category.create!(name: "Electric WT", parent: parent, family: family)
+    family.envelopes.create!(name: "Bills env WT", category: parent, monthly_contribution: 10, currency: "USD", starts_on: Date.current.beginning_of_month)
+
+    get new_envelope_url
+    assert_response :success
+    assert_no_match %r{data-value="#{parent.id}"}, response.body
+    assert_no_match %r{data-value="#{child.id}"}, response.body
+  end
+
   test "edit form keeps the envelope's own category assignable" do
     family = @user.family
     cat = Category.create!(name: "Owned WT", family: family, color: "#4da568", lucide_icon: "plane")

--- a/test/controllers/envelopes_controller_test.rb
+++ b/test/controllers/envelopes_controller_test.rb
@@ -87,6 +87,28 @@ class EnvelopesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "new form omits categories already backing another envelope" do
+    family = @user.family
+    cat_taken = Category.create!(name: "Taken WT", family: family, color: "#4da568", lucide_icon: "plane")
+    cat_free = Category.create!(name: "Free WT", family: family, color: "#6471eb", lucide_icon: "house")
+    family.envelopes.create!(name: "Owner WT", category: cat_taken, monthly_contribution: 10, currency: "USD", starts_on: Date.current.beginning_of_month)
+
+    get new_envelope_url
+    assert_response :success
+    assert_no_match %r{data-value="#{cat_taken.id}"}, response.body
+    assert_match %r{data-value="#{cat_free.id}"}, response.body
+  end
+
+  test "edit form keeps the envelope's own category assignable" do
+    family = @user.family
+    cat = Category.create!(name: "Owned WT", family: family, color: "#4da568", lucide_icon: "plane")
+    env = family.envelopes.create!(name: "Owner2 WT", category: cat, monthly_contribution: 10, currency: "USD", starts_on: Date.current.beginning_of_month)
+
+    get edit_envelope_url(env)
+    assert_response :success
+    assert_match %r{data-value="#{cat.id}"}, response.body
+  end
+
   test "update changes the envelope" do
     patch envelope_url(@envelope), params: {
       envelope: { name: "Renamed", monthly_contribution: "400" }

--- a/test/fixtures/envelopes.yml
+++ b/test/fixtures/envelopes.yml
@@ -1,0 +1,18 @@
+holidays:
+  family: dylan_family
+  category: food_and_drink
+  name: Holidays
+  monthly_contribution: 350
+  currency: USD
+  starts_on: <%= 2.months.ago.to_date.beginning_of_month %>
+  color: "#4da568"
+
+boiler_fund:
+  family: dylan_family
+  name: Boiler fund
+  monthly_contribution: 100
+  currency: USD
+  target_amount: 1200
+  target_date: <%= 10.months.from_now.to_date %>
+  starts_on: <%= 1.month.ago.to_date.beginning_of_month %>
+  color: "#6471eb"

--- a/test/models/envelope_test.rb
+++ b/test/models/envelope_test.rb
@@ -56,6 +56,25 @@ class EnvelopeTest < ActiveSupport::TestCase
     assert_includes dup.errors[:category], "That category already backs another envelope."
   end
 
+  test "rejects a category whose parent already backs another envelope" do
+    parent = Category.create!(name: "Bills test", family: @family, color: "#6471eb", lucide_icon: "house")
+    child = Category.create!(name: "Electric test", parent: parent, family: @family)
+    @family.envelopes.create!(name: "Bills env", category: parent, monthly_contribution: 10, currency: "USD", starts_on: Date.current.beginning_of_month)
+
+    overlap = @family.envelopes.new(name: "Electric env", category: child, monthly_contribution: 5, currency: "USD", starts_on: Date.current.beginning_of_month)
+    assert_not overlap.valid?
+    assert_includes overlap.errors[:category], "A parent or sub-category of this category already backs another envelope."
+  end
+
+  test "rejects a category whose subcategory already backs another envelope" do
+    parent = Category.create!(name: "Bills2 test", family: @family, color: "#6471eb", lucide_icon: "house")
+    child = Category.create!(name: "Water test", parent: parent, family: @family)
+    @family.envelopes.create!(name: "Water env", category: child, monthly_contribution: 5, currency: "USD", starts_on: Date.current.beginning_of_month)
+
+    overlap = @family.envelopes.new(name: "Bills env", category: parent, monthly_contribution: 10, currency: "USD", starts_on: Date.current.beginning_of_month)
+    assert_not overlap.valid?
+  end
+
   test "category must belong to the same family" do
     other_family = Family.create!(name: "Other", currency: "USD", locale: "en", country: "US", timezone: "UTC")
     foreign_category = Category.create!(name: "Foreign", family: other_family, color: "#4da568", lucide_icon: "plane")
@@ -155,6 +174,17 @@ class EnvelopeTest < ActiveSupport::TestCase
     excluded.update!(excluded: true)
 
     assert_equal 0.to_d, envelope.total_spent
+  end
+
+  test "recent_entries excludes pending transactions" do
+    envelope = build_envelope(months_ago: 0)
+    posted = create_transaction(account: @account, amount: 50, date: Date.current, category: @category)
+    pending = create_transaction(account: @account, amount: 75, date: Date.current, category: @category)
+    pending.transaction.update!(extra: { "plaid" => { "pending" => true } })
+
+    ids = envelope.recent_entries.map(&:id)
+    assert_includes ids, posted.id
+    assert_not_includes ids, pending.id
   end
 
   test "an envelope with no category has zero spend" do

--- a/test/models/envelope_test.rb
+++ b/test/models/envelope_test.rb
@@ -206,6 +206,15 @@ class EnvelopeTest < ActiveSupport::TestCase
     assert_not_includes ids, pending.id
   end
 
+  test "recent_entries exposes the amount converted to the envelope currency" do
+    envelope = build_envelope(months_ago: 0) # USD
+    ExchangeRate.create!(from_currency: "EUR", to_currency: "USD", rate: 1.1, date: Date.current)
+    create_transaction(account: @account, amount: 100, currency: "EUR", date: Date.current, category: @category)
+
+    entry = envelope.recent_entries.first
+    assert_equal 110.to_d, entry.converted_amount.to_d # 100 EUR * 1.1
+  end
+
   test "an envelope with no category has zero spend" do
     envelope = @family.envelopes.create!(name: "No cat", monthly_contribution: 100, currency: "USD", starts_on: Date.current.beginning_of_month)
     create_transaction(account: @account, amount: 500, date: Date.current, category: @category)

--- a/test/models/envelope_test.rb
+++ b/test/models/envelope_test.rb
@@ -176,6 +176,25 @@ class EnvelopeTest < ActiveSupport::TestCase
     assert_equal 0.to_d, envelope.total_spent
   end
 
+  test "budget-excluded kinds (transfers, CC payments) do not debit the envelope" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    create_transaction(account: @account, amount: 100, date: Date.current, category: @category, kind: "funds_movement")
+    create_transaction(account: @account, amount: 80, date: Date.current, category: @category, kind: "cc_payment")
+
+    assert_equal 0.to_d, envelope.total_spent
+    assert_equal 500.to_d, envelope.current_balance
+  end
+
+  test "recent_entries excludes budget-excluded kinds" do
+    envelope = build_envelope(months_ago: 0)
+    spend = create_transaction(account: @account, amount: 50, date: Date.current, category: @category)
+    transfer = create_transaction(account: @account, amount: 75, date: Date.current, category: @category, kind: "funds_movement")
+
+    ids = envelope.recent_entries.map(&:id)
+    assert_includes ids, spend.id
+    assert_not_includes ids, transfer.id
+  end
+
   test "recent_entries excludes pending transactions" do
     envelope = build_envelope(months_ago: 0)
     posted = create_transaction(account: @account, amount: 50, date: Date.current, category: @category)

--- a/test/models/envelope_test.rb
+++ b/test/models/envelope_test.rb
@@ -1,0 +1,232 @@
+require "test_helper"
+
+class EnvelopeTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:dylan_family)
+    @account = accounts(:depository)
+    @category = Category.create!(name: "Holidays test", family: @family, color: "#4da568", lucide_icon: "plane")
+  end
+
+  # Builds an envelope anchored to a known start month so the
+  # contribution-accrual maths are deterministic.
+  def build_envelope(months_ago: 0, **attrs)
+    @family.envelopes.create!({
+      name: "Test envelope",
+      category: @category,
+      monthly_contribution: 100,
+      currency: "USD",
+      starts_on: months_ago.months.ago.to_date.beginning_of_month
+    }.merge(attrs))
+  end
+
+  # --- Validations ---
+
+  test "valid fixture envelope saves" do
+    assert envelopes(:holidays).valid?
+  end
+
+  test "name is required" do
+    envelope = @family.envelopes.new(monthly_contribution: 10, currency: "USD", starts_on: Date.current)
+    assert_not envelope.valid?
+    assert_includes envelope.errors[:name], "can't be blank"
+  end
+
+  test "monthly_contribution cannot be negative" do
+    envelope = build_envelope
+    envelope.monthly_contribution = -1
+    assert_not envelope.valid?
+  end
+
+  test "monthly_contribution of zero is allowed" do
+    assert build_envelope(monthly_contribution: 0).valid?
+  end
+
+  test "target_amount must be positive when present" do
+    envelope = build_envelope
+    envelope.target_amount = 0
+    assert_not envelope.valid?
+  end
+
+  test "a category can back only one envelope" do
+    build_envelope
+    dup = @family.envelopes.new(name: "Another", category: @category, monthly_contribution: 5, currency: "USD", starts_on: Date.current)
+    assert_not dup.valid?
+    assert_includes dup.errors[:category], "That category already backs another envelope."
+  end
+
+  test "category must belong to the same family" do
+    other_family = Family.create!(name: "Other", currency: "USD", locale: "en", country: "US", timezone: "UTC")
+    foreign_category = Category.create!(name: "Foreign", family: other_family, color: "#4da568", lucide_icon: "plane")
+    envelope = @family.envelopes.new(name: "X", category: foreign_category, monthly_contribution: 5, currency: "USD", starts_on: Date.current)
+    assert_not envelope.valid?
+    assert_includes envelope.errors[:category], "The category must belong to the same family as the envelope."
+  end
+
+  test "target_date requires a target_amount" do
+    envelope = @family.envelopes.new(name: "X", monthly_contribution: 5, currency: "USD", starts_on: Date.current, target_date: Date.current)
+    assert_not envelope.valid?
+  end
+
+  # --- Contribution accrual (running balance, no monthly reset) ---
+
+  test "months_elapsed counts the start month immediately" do
+    assert_equal 1, build_envelope(months_ago: 0).months_elapsed
+  end
+
+  test "months_elapsed accumulates indefinitely across months" do
+    assert_equal 4, build_envelope(months_ago: 3).months_elapsed
+  end
+
+  test "total_contributed is the monthly amount times months elapsed" do
+    envelope = build_envelope(months_ago: 2, monthly_contribution: 350)
+    assert_equal 1050.to_d, envelope.total_contributed # 350 * 3 (start month + 2)
+  end
+
+  test "balance keeps accruing across months with no reset" do
+    envelope = build_envelope(months_ago: 5, monthly_contribution: 200)
+    # No spend → balance is the full six months of contributions.
+    assert_equal 1200.to_d, envelope.current_balance
+  end
+
+  # --- Spend debits ---
+
+  test "a transaction in the category debits the envelope" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    create_transaction(account: @account, amount: 120, date: Date.current, category: @category)
+
+    assert_equal 120.to_d, envelope.total_spent
+    assert_equal 380.to_d, envelope.current_balance # 500 - 120
+  end
+
+  test "spend accumulates across multiple transactions" do
+    envelope = build_envelope(months_ago: 1, monthly_contribution: 300)
+    create_transaction(account: @account, amount: 100, date: Date.current, category: @category)
+    create_transaction(account: @account, amount: 50, date: 1.month.ago.to_date, category: @category)
+
+    assert_equal 150.to_d, envelope.total_spent
+    assert_equal 450.to_d, envelope.current_balance # 600 - 150
+  end
+
+  test "a refund (negative amount) credits back into the envelope" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    create_transaction(account: @account, amount: 200, date: Date.current, category: @category)
+    create_transaction(account: @account, amount: -75, date: Date.current, category: @category)
+
+    assert_equal 125.to_d, envelope.total_spent # 200 - 75
+    assert_equal 375.to_d, envelope.current_balance
+  end
+
+  test "spend before the start date is ignored" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    create_transaction(account: @account, amount: 999, date: 2.months.ago.to_date, category: @category)
+
+    assert_equal 0.to_d, envelope.total_spent
+  end
+
+  test "transactions in other categories are ignored" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    other = Category.create!(name: "Other test", family: @family, color: "#6471eb", lucide_icon: "shapes")
+    create_transaction(account: @account, amount: 300, date: Date.current, category: other)
+
+    assert_equal 0.to_d, envelope.total_spent
+  end
+
+  test "subcategory spend rolls up into the envelope" do
+    sub = Category.create!(name: "Flights test", parent: @category, family: @family)
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    create_transaction(account: @account, amount: 80, date: Date.current, category: sub)
+
+    assert_equal 80.to_d, envelope.total_spent
+  end
+
+  test "pending transactions are excluded from spend" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    pending = create_transaction(account: @account, amount: 100, date: Date.current, category: @category)
+    pending.transaction.update!(extra: { "plaid" => { "pending" => true } })
+
+    assert_equal 0.to_d, envelope.total_spent
+  end
+
+  test "user-excluded entries are excluded from spend" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 500)
+    excluded = create_transaction(account: @account, amount: 100, date: Date.current, category: @category)
+    excluded.update!(excluded: true)
+
+    assert_equal 0.to_d, envelope.total_spent
+  end
+
+  test "an envelope with no category has zero spend" do
+    envelope = @family.envelopes.create!(name: "No cat", monthly_contribution: 100, currency: "USD", starts_on: Date.current.beginning_of_month)
+    create_transaction(account: @account, amount: 500, date: Date.current, category: @category)
+
+    assert_equal 0.to_d, envelope.total_spent
+  end
+
+  # --- Negative balance handling ---
+
+  test "envelope is allowed to go negative when overspent" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 100)
+    create_transaction(account: @account, amount: 250, date: Date.current, category: @category)
+
+    assert envelope.current_balance.negative?
+    assert envelope.negative?
+    assert_equal(-150.to_d, envelope.current_balance) # 100 - 250
+  end
+
+  test "status is :negative when overspent regardless of target" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 100, target_amount: 1000)
+    create_transaction(account: @account, amount: 250, date: Date.current, category: @category)
+
+    assert_equal :negative, envelope.status
+  end
+
+  # --- Sinking fund vs virtual goal modes ---
+
+  test "sinking fund has no target" do
+    envelope = build_envelope(months_ago: 0, target_amount: nil)
+    assert envelope.sinking_fund?
+    assert_not envelope.has_target?
+    assert_nil envelope.progress_percent
+    assert_nil envelope.remaining_amount
+    assert_equal :tracking, envelope.status
+  end
+
+  test "virtual goal exposes progress, remaining and reached" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 400, target_amount: 1000)
+    assert envelope.has_target?
+    assert_not envelope.sinking_fund?
+    assert_equal 40, envelope.progress_percent # 400 of 1000
+    assert_equal 600.to_d, envelope.remaining_amount
+    assert_not envelope.reached?
+    assert_equal :on_track, envelope.status
+  end
+
+  test "virtual goal is reached when balance meets target" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 1000, target_amount: 1000)
+    assert envelope.reached?
+    assert_equal 100, envelope.progress_percent
+    assert_equal 0.to_d, envelope.remaining_amount
+    assert_equal :reached, envelope.status
+  end
+
+  test "progress_percent is clamped between 0 and 100" do
+    over = build_envelope(months_ago: 0, monthly_contribution: 5000, target_amount: 1000, category: nil)
+    assert_equal 100, over.progress_percent
+
+    under = build_envelope(months_ago: 0, monthly_contribution: 100, target_amount: 1000)
+    create_transaction(account: @account, amount: 300, date: Date.current, category: @category)
+    assert_equal 0, under.progress_percent # negative balance clamps to 0
+  end
+
+  test "months_to_target projects from the monthly contribution" do
+    envelope = build_envelope(months_ago: 0, monthly_contribution: 100, target_amount: 500)
+    # Balance is 100 (one month), 400 remaining at 100/mo → 4 months.
+    assert_equal 4, envelope.months_to_target
+  end
+
+  test "months_to_target is nil without a target" do
+    assert_nil build_envelope(months_ago: 0, target_amount: nil).months_to_target
+  end
+end


### PR DESCRIPTION
## Summary

Adds **virtual envelopes** (closes #2085) — an earmarking mechanism that fills the gap between budget categories (which reset monthly and don't accumulate) and account-linked Goals (#1798, whose balance is derived from a dedicated physical account). An envelope's available balance is derived **entirely from transactions** and is **account-agnostic**: Sure tracks the allocation, not the location, so many envelopes can share a single pooled account (e.g. one cash ISA).

### Mechanics
- **Monthly contribution** — a fixed amount credited each month. The start month's contribution lands immediately, then one per month thereafter; the balance accumulates indefinitely with **no monthly reset**.
- **Spend debit** — any transaction categorised to the envelope's category (and its subcategories) automatically debits the balance. Refunds (income in the category) net back in. Pending and user-excluded entries are ignored, and amounts are FX-converted to the envelope's currency — matching budget semantics.
- **Running balance** = total contributed − net spend since the start date.

### Two modes, one model
- **Sinking fund** — no target; runs indefinitely (holidays, gifts, clothing).
- **Virtual goal** — optional target (+ optional deadline); "reached" when balance ≥ target (boiler fund, car fund).

Both share identical balance mechanics; the only difference is whether a target/deadline is displayed.

### Negative balances
Spending is **never blocked**. When spend outpaces contributions the balance goes negative, a warning indicator is shown, and future monthly contributions replenish it.

### Relationship to Goals (#1798)
This is the **transaction-derived** balance mode and coexists with the existing **account-linked** Goal mode — the latter is untouched.

### Implementation notes
- New `Envelope` model + `envelopes` table (UUID PK; partial-unique index so one category backs at most one envelope; check constraints mirroring the Goals migration).
- Balance logic lives on the model (skinny controller / fat model): `total_contributed`, `total_spent`, `current_balance`, `reached?`, `negative?`, `progress_percent`, `status`.
- `EnvelopesController` CRUD, preview-gated like Goals, with a new preview-gated nav item.
- ViewComponents (`Envelopes::CardComponent`, `AvatarComponent`, `StatusPillComponent`) and Hotwire modal forms reusing the existing `color-icon-picker` Stimulus controller and `DS::*` primitives — no new JS.
- Full i18n (`config/locales/views/envelopes/en.yml`, `config/locales/models/envelope/en.yml`, plus the nav key).

## Test plan

- [x] `bin/rails test test/models/envelope_test.rb` — contribution accrual, spend debits, running balance across months, refunds, negative balances, sinking-fund vs virtual-goal modes, validations (29 runs, 0 failures)
- [x] `bin/rails test test/controllers/envelopes_controller_test.rb` — preview gating, CRUD, family scoping (12 runs, 0 failures)
- [x] `bin/rails test` — full suite green (4721 runs, 19488 assertions, 0 failures, 0 errors)
- [x] `bin/rubocop` (no offenses), `bundle exec erb_lint ./app/**/*.erb` (no errors), `bin/brakeman --no-pager` (0 warnings)
- [x] Manual / end-to-end: enable preview features → **Envelopes** nav appears → created a sinking fund and a virtual goal → categorised a transaction (balance debited from $300 to $180) → overspent to −$320 and confirmed the negative-balance warning shows on both the show page and the index callout. Also confirmed the nav link is hidden and `/envelopes` redirects when preview is disabled.

Closes #2085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Envelopes: full CRUD for persistent savings envelopes (sinking‑fund and virtual‑goal modes), index/show/card views with balance, progress bar, status pill, recent activity, avatar, color/icon picker, empty state, modal forms, and navigation entry
* **Localization**
  * Complete English UI and model copy for envelopes
* **Tests**
  * Controller and model tests covering envelope behaviors and form/category UX
<!-- end of auto-generated comment: release notes by coderabbit.ai -->