### PR TITLE
fix(charts): deep-link donut categories by id, fall back to name for synthetics (#2096)

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -491,7 +491,7 @@ class TransactionsController < ApplicationController
                 :start_date, :end_date, :search, :amount,
                 :amount_operator, :active_accounts_only,
                 accounts: [], account_ids: [],
-                categories: [], merchants: [], types: [], tags: [], status: []
+                categories: [], category_ids: [], merchants: [], types: [], tags: [], status: []
               )
               .to_h
               .compact_blank

--- a/app/javascript/controllers/donut_chart_controller.js
+++ b/app/javascript/controllers/donut_chart_controller.js
@@ -228,11 +228,18 @@ export default class extends Controller {
   #handleClick(segment) {
     if (!segment.name || !this.startDateValue || !this.endDateValue) return;
 
-    const segmentName = encodeURIComponent(segment.name);
     const startDate = this.startDateValue;
     const endDate = this.endDateValue;
 
-    const url = `/transactions?q[categories][]=${segmentName}&q[start_date]=${startDate}&q[end_date]=${endDate}`;
+    // Prefer the category id when available so the filter survives renames
+    // and name collisions. Synthetic segments (e.g. "Uncategorized",
+    // "Other Investments") don't have a persisted id and still need the
+    // name-based filter, which understands the synthetic name in any locale.
+    const categoryFilter = segment.id
+      ? `q[category_ids][]=${encodeURIComponent(segment.id)}`
+      : `q[categories][]=${encodeURIComponent(segment.name)}`;
+
+    const url = `/transactions?${categoryFilter}&q[start_date]=${startDate}&q[end_date]=${endDate}`;
     window.location.href = url;
   }
 

--- a/app/javascript/controllers/donut_chart_controller.js
+++ b/app/javascript/controllers/donut_chart_controller.js
@@ -232,12 +232,20 @@ export default class extends Controller {
     const endDate = this.endDateValue;
 
     // Prefer the category id when available so the filter survives renames
-    // and name collisions. Synthetic segments (e.g. "Uncategorized",
-    // "Other Investments") don't have a persisted id and still need the
-    // name-based filter, which understands the synthetic name in any locale.
-    const categoryFilter = segment.id
-      ? `q[category_ids][]=${encodeURIComponent(segment.id)}`
-      : `q[categories][]=${encodeURIComponent(segment.name)}`;
+    // and name collisions. Synthetic segments still need the name-based
+    // filter: "Uncategorized" / "Other Investments" segments have no
+    // persisted id, and the reserved budget-donut segments
+    // (unusedSegmentId / overageSegmentId — default "unused" / "overage")
+    // carry sentinel string ids that aren't real category ids. In both
+    // cases fall back to the name-based filter, which already understands
+    // synthetic and locale-translated names.
+    const isReservedSyntheticId =
+      segment.id === this.unusedSegmentIdValue ||
+      segment.id === this.overageSegmentIdValue;
+    const categoryFilter =
+      segment.id && !isReservedSyntheticId
+        ? `q[category_ids][]=${encodeURIComponent(segment.id)}`
+        : `q[categories][]=${encodeURIComponent(segment.name)}`;
 
     const url = `/transactions?${categoryFilter}&q[start_date]=${startDate}&q[end_date]=${endDate}`;
     window.location.href = url;

--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -130,7 +130,14 @@ class Transaction::Search
     def apply_category_ids_filter(query, category_ids)
       return query unless category_ids.present?
 
-      scoped_ids = family.categories.where(id: category_ids).pluck(:id)
+      # Filter to syntactically valid UUIDs first — categories.id is uuid, so
+      # passing `not-a-uuid` (stale link, hand-edited query string) straight
+      # into the WHERE would raise a Postgres invalid-input error and 500 the
+      # transactions page. Reject malformed ids quietly.
+      valid_ids = Array(category_ids).select { |id| UuidFormat.valid?(id) }
+      return query.none if valid_ids.empty?
+
+      scoped_ids = family.categories.where(id: valid_ids).pluck(:id)
       return query.none if scoped_ids.empty?
 
       query.left_joins(:category).where(

--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -12,6 +12,7 @@ class Transaction::Search
   attribute :start_date, :string
   attribute :end_date, :string
   attribute :categories, array: true
+  attribute :category_ids, array: true
   attribute :merchants, array: true
   attribute :tags, array: true
   attribute :active_accounts_only, :boolean, default: true
@@ -34,6 +35,7 @@ class Transaction::Search
 
       query = apply_active_accounts_filter(query, active_accounts_only)
       query = apply_category_filter(query, categories)
+      query = apply_category_ids_filter(query, category_ids)
       query = apply_type_filter(query, types)
       query = apply_status_filter(query, status)
       query = apply_merchant_filter(query, merchants)
@@ -119,6 +121,23 @@ class Transaction::Search
       end
     end
 
+
+    # ID-based variant of apply_category_filter. Deep-links from the donut /
+    # cashflow charts thread the category id through the URL so renamed or
+    # name-collided categories still filter to the clicked slice. Parent ids
+    # match the parent itself and any of its child subcategories, mirroring
+    # the name-based filter's parent-inheritance semantics.
+    def apply_category_ids_filter(query, category_ids)
+      return query unless category_ids.present?
+
+      scoped_ids = family.categories.where(id: category_ids).pluck(:id)
+      return query.none if scoped_ids.empty?
+
+      query.left_joins(:category).where(
+        "categories.id IN (?) OR categories.parent_id IN (?)",
+        scoped_ids, scoped_ids
+      )
+    end
 
     def apply_category_filter(query, categories)
       return query unless categories.present?


### PR DESCRIPTION
## Summary

Donut-chart deep-links built the transactions URL as `q[categories][]=<display name>`, which breaks when a category is renamed or shares a name with another category. The Sankey deep-link added in #2083 inherits the same shape.

Thread the category id through:

- `Transaction::Search` learns a new `category_ids` attribute and an `apply_category_ids_filter` method. Parent ids match the parent and any of its child subcategories, mirroring the name-based filter's parent-inheritance semantics. Ids outside the family scope return an empty result rather than leaking other-family data.
- `TransactionsController#search_params` permits `category_ids: []` alongside the existing `categories: []`.
- `donut_chart_controller.js` prefers `q[category_ids][]=<id>` when the segment has a persisted id; synthetic segments ("Uncategorized", "Other Investments") fall back to the name-based filter, which already handles locale-translated synthetic names.

Closes #2096


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Transactions can now be filtered by category IDs in addition to category names, improving accuracy and reliability of category-based searches.
  * Donut chart interactions use the more robust category-ID filtering when available and fall back to name-based filtering for special segments, improving navigation and filter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->