### PR TITLE
fix(helm): normalize appVersion to strip leading v (#2050)

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Resolve chart and app versions
         id: version
         shell: bash
+        # Bind workflow inputs to env so the values arrive as shell variables
+        # instead of being interpolated verbatim by the `${{ }}` runner pass.
+        # zizmor flags the direct expansion as a template-injection risk.
+        env:
+          CHART_VERSION_INPUT: ${{ inputs.chart_version }}
+          APP_VERSION_INPUT: ${{ inputs.app_version }}
         run: |
           set -euo pipefail
 
@@ -47,8 +53,8 @@ jobs:
             echo "${raw#v}"
           }
 
-          if [ -n "${{ inputs.chart_version }}" ]; then
-            CHART_VERSION="$(normalize_version "${{ inputs.chart_version }}")"
+          if [ -n "$CHART_VERSION_INPUT" ]; then
+            CHART_VERSION="$(normalize_version "$CHART_VERSION_INPUT")"
           elif [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
             CHART_VERSION="$(normalize_version "${GITHUB_REF_NAME}")"
           else
@@ -61,8 +67,8 @@ jobs:
           # `appVersion: "v0.7.1-rc.1"` into Chart.yaml / index.yaml, and Helm
           # then fails to pull `ghcr.io/we-promise/sure:v0.7.1-rc.1` (the real
           # tag is `0.7.1-rc.1`). See #2050.
-          if [ -n "${{ inputs.app_version }}" ]; then
-            APP_VERSION="$(normalize_version "${{ inputs.app_version }}")"
+          if [ -n "$APP_VERSION_INPUT" ]; then
+            APP_VERSION="$(normalize_version "$APP_VERSION_INPUT")"
           elif [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
             APP_VERSION="$(normalize_version "${GITHUB_REF_NAME}")"
           else

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -55,10 +55,16 @@ jobs:
             CHART_VERSION="0.0.0-nightly.$(date -u +'%Y%m%d.%H%M%S')"
           fi
 
+          # Normalize APP_VERSION the same way CHART_VERSION is — appVersion
+          # must match the OCI image tag in GHCR, which is published without a
+          # leading `v`. Without this, a release on tag `v0.7.1-rc.1` writes
+          # `appVersion: "v0.7.1-rc.1"` into Chart.yaml / index.yaml, and Helm
+          # then fails to pull `ghcr.io/we-promise/sure:v0.7.1-rc.1` (the real
+          # tag is `0.7.1-rc.1`). See #2050.
           if [ -n "${{ inputs.app_version }}" ]; then
-            APP_VERSION="${{ inputs.app_version }}"
+            APP_VERSION="$(normalize_version "${{ inputs.app_version }}")"
           elif [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
-            APP_VERSION="${GITHUB_REF_NAME}"
+            APP_VERSION="$(normalize_version "${GITHUB_REF_NAME}")"
           else
             APP_VERSION="${CHART_VERSION}"
           fi


### PR DESCRIPTION
## Summary

Releases triggered on a tag like `v0.7.1-rc.1` end up writing `appVersion: "v0.7.1-rc.1"` into Chart.yaml / the published index.yaml, but the Docker image is pushed to GHCR without the leading `v` (`ghcr.io/we-promise/sure:0.7.1-rc.1`). Flux CD / any consumer that pulls the chart then fails with `ImagePullBackoff` against `v0.7.1-rc.1` (a tag that doesn't exist).

`normalize_version` is already applied to `CHART_VERSION`; route the two tag-derived `APP_VERSION` paths through the same helper so the appVersion matches the published image tag.

Net change: one workflow file, `+8/-2` lines.

Closes #2050


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow updated to normalize application version formatting to match chart versions for consistent release tags.
  * When no explicit app version is provided, the app version now falls back to the resolved chart version.
  * Added documentation noting that app/tag values must not include a leading "v".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->