### PR TITLE
fix(goals): UI polish — submit validation, container-responsive cards, picker & filter fixes

### DIFF
--- a/app/components/DS/buttonish.rb
+++ b/app/components/DS/buttonish.rb
@@ -77,7 +77,10 @@ class DS::Buttonish < DesignSystemComponent
 
   def container_classes(override_classes = nil)
     class_names(
-      "font-medium whitespace-nowrap",
+      # Tailwind v4 preflight sets `cursor: pointer` on all <button>s, which
+      # also applies while disabled. Override so disabled buttons read as
+      # non-interactive.
+      "font-medium whitespace-nowrap disabled:cursor-not-allowed",
       merged_base_classes,
       full_width ? "w-full justify-center" : nil,
       container_size_classes,

--- a/app/components/DS/buttonish.rb
+++ b/app/components/DS/buttonish.rb
@@ -79,8 +79,11 @@ class DS::Buttonish < DesignSystemComponent
     class_names(
       # Tailwind v4 preflight sets `cursor: pointer` on all <button>s, which
       # also applies while disabled. Override so disabled buttons read as
-      # non-interactive.
-      "font-medium whitespace-nowrap disabled:cursor-not-allowed",
+      # non-interactive. The aria-disabled twins cover buttons that gate via
+      # `aria-disabled` to stay clickable/focusable (e.g. submit buttons whose
+      # click handler surfaces validation errors — a truly disabled default
+      # submit would also swallow Enter-key implicit submission).
+      "font-medium whitespace-nowrap disabled:cursor-not-allowed aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
       merged_base_classes,
       full_width ? "w-full justify-center" : nil,
       container_size_classes,

--- a/app/components/goals/card_component.html.erb
+++ b/app/components/goals/card_component.html.erb
@@ -5,20 +5,27 @@
   <div class="flex items-start gap-3">
     <%= render Goals::AvatarComponent.new(goal: goal, size: "lg") %>
     <div class="min-w-0 flex-1">
-      <div class="flex items-center gap-2 mb-0.5">
-        <p class="text-base font-medium text-primary truncate">
-          <a href="<%= goal_path(goal) %>"
-             aria-label="<%= aria_label %>"
-             class="before:absolute before:inset-0 before:rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-100">
-            <%= goal.name %>
-          </a>
-        </p>
+      <%# Name owns its row at full width — the status pill moved to the meta
+          line below so it stops eating the title space on narrow cards. %>
+      <p class="text-base font-medium text-primary truncate">
+        <a href="<%= goal_path(goal) %>"
+           aria-label="<%= aria_label %>"
+           class="before:absolute before:inset-0 before:rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-100">
+          <%= goal.name %>
+        </a>
+      </p>
+      <div class="flex items-center gap-2 mt-0.5">
         <%= render Goals::StatusPillComponent.new(goal: goal) %>
+        <% if secondary_line.present? %>
+          <p class="min-w-0 text-xs text-subdued truncate"><%= secondary_line %></p>
+        <% end %>
       </div>
-      <p class="text-xs text-subdued truncate"><%= secondary_line %></p>
     </div>
 
-    <%= render DS::ProgressRing.new(percent: progress_percent, tone: ring_tone) %>
+    <%# shrink-0 keeps the ring at full size; the name block shrinks first. %>
+    <div class="shrink-0">
+      <%= render DS::ProgressRing.new(percent: progress_percent, tone: ring_tone) %>
+    </div>
   </div>
 
   <div class="mt-5">
@@ -31,10 +38,13 @@
     <% end %>
   </div>
 
-  <div class="mt-4 flex items-center justify-between">
-    <div class="flex items-center gap-2">
+  <%# flex-wrap + gap so the account label and the footer line wrap onto
+      separate lines under a gap when cramped, instead of butting together
+      (the "1 accountcatch up" run-on at narrow card widths). %>
+  <div class="mt-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+    <div class="flex items-center gap-2 min-w-0">
       <%= render Goals::AccountStackComponent.new(accounts: linked_accounts, color_map: goal.account_color_map) %>
-      <span class="text-xs text-subdued"><%= linked_accounts_count_label %></span>
+      <span class="text-xs text-subdued whitespace-nowrap"><%= linked_accounts_count_label %></span>
     </div>
     <span class="text-xs text-subdued tabular-nums <%= "privacy-sensitive" if footer_has_money? %>">
       <%= footer_line %><% if has_pending_pledge? %> · <%= t("goals.goal_card.pending_count", count: pending_pledges_count) %><% end %>

--- a/app/components/goals/card_component.rb
+++ b/app/components/goals/card_component.rb
@@ -51,17 +51,18 @@ class Goals::CardComponent < ApplicationComponent
   end
 
   def secondary_line
-    if goal.completed?
-      I18n.t("goals.goal_card.completed")
-    elsif goal.target_date.nil?
-      I18n.t("goals.goal_card.no_target_date")
+    # nil when the status pill already carries it — the pill now sits on this
+    # same meta line, so "Completed Completed" / "Open Open" would read twice.
+    return nil if goal.completed? || goal.target_date.nil?
+
+    days = (goal.target_date - Date.current).to_i
+    if days >= 0
+      # Count only ("211 days left"); the full target date lives on the show
+      # page. Appending "· by <long date>" here overflowed the card's single
+      # line and truncated to a useless "211 d…".
+      I18n.t("goals.goal_card.days_left", count: days)
     else
-      days = (goal.target_date - Date.current).to_i
-      if days >= 0
-        I18n.t("goals.goal_card.days_left_by", count: days, date: I18n.l(goal.target_date, format: :long))
-      else
-        I18n.t("goals.goal_card.past_due")
-      end
+      I18n.t("goals.goal_card.past_due")
     end
   end
 

--- a/app/javascript/controllers/goal_form_controller.js
+++ b/app/javascript/controllers/goal_form_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
     "accountsError",
     "linkedAccountCheckbox",
     "suggested",
+    "submitButton",
   ];
 
   static INVALID_INPUT_CLASSES = ["ring-2", "ring-destructive", "border-destructive"];
@@ -35,12 +36,16 @@ export default class extends Controller {
       this._defaultAvatarHTML = this.avatarPreviewTarget.innerHTML;
     }
     this.updateSuggested();
+    // Edit form arrives pre-filled (valid) so this enables immediately; new
+    // form arrives empty so the submit starts disabled.
+    this.refreshSubmitState();
   }
 
   nameChanged() {
     if (this.hasNameInputTarget) {
       this.clearFieldError(this.nameInputTarget, this.hasNameErrorTarget ? this.nameErrorTarget : null);
     }
+    this.refreshSubmitState();
     if (!this.hasAvatarPreviewTarget || !this.hasNameInputTarget) return;
 
     // If the user has explicitly picked an icon, leave it alone. Name
@@ -62,6 +67,7 @@ export default class extends Controller {
     if (this.hasAmountInputTarget) {
       this.clearFieldError(this.amountInputTarget, this.hasAmountErrorTarget ? this.amountErrorTarget : null);
     }
+    this.refreshSubmitState();
   }
 
   linkedAccountChanged() {
@@ -69,6 +75,52 @@ export default class extends Controller {
     if (this.linkedAccountCheckboxTargets.some((cb) => cb.checked) && this.hasAccountsErrorTarget) {
       this.accountsErrorTarget.classList.add("hidden");
     }
+    this.refreshSubmitState();
+  }
+
+  // Required to create a goal: a name, a positive target amount, and at least
+  // one funding account. Mirrors the server-side Goal validations (name
+  // presence, target_amount > 0, must_have_at_least_one_linked_account) so the
+  // button only enables when a submit would actually succeed.
+  isValid() {
+    const name = this.hasNameInputTarget ? this.nameInputTarget.value.trim() : "";
+    const amount = this.hasAmountInputTarget ? Number.parseFloat(this.amountInputTarget.value) : Number.NaN;
+    const hasAccount = this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
+    return name.length > 0 && Number.isFinite(amount) && amount > 0 && hasAccount;
+  }
+
+  refreshSubmitState() {
+    if (this.hasSubmitButtonTarget) {
+      this.submitButtonTarget.disabled = !this.isValid();
+    }
+  }
+
+  // Backstop for the disabled button: covers the funding-accounts group (a
+  // checkbox group can't carry native `required`) and any path that re-enables
+  // the button out from under us. Surfaces the inline errors and focuses the
+  // first offending field instead of a silent no-op.
+  validateOnSubmit(event) {
+    if (this.isValid()) return;
+
+    event.preventDefault();
+
+    const nameEmpty = !(this.hasNameInputTarget && this.nameInputTarget.value.trim().length > 0);
+    const amount = this.hasAmountInputTarget ? Number.parseFloat(this.amountInputTarget.value) : Number.NaN;
+    const amountInvalid = !(Number.isFinite(amount) && amount > 0);
+    const noAccount = !this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
+
+    if (nameEmpty) {
+      this.showFieldError(this.nameInputTarget, this.hasNameErrorTarget ? this.nameErrorTarget : null);
+    }
+    if (amountInvalid) {
+      this.showFieldError(this.amountInputTarget, this.hasAmountErrorTarget ? this.amountErrorTarget : null);
+    }
+    if (noAccount && this.hasAccountsErrorTarget) {
+      this.accountsErrorTarget.classList.remove("hidden");
+    }
+
+    const firstInvalid = nameEmpty ? this.nameInputTarget : amountInvalid ? this.amountInputTarget : null;
+    firstInvalid?.focus();
   }
 
   // Hook for any input that influences the suggested-pace hint

--- a/app/javascript/controllers/goal_form_controller.js
+++ b/app/javascript/controllers/goal_form_controller.js
@@ -27,6 +27,11 @@ export default class extends Controller {
     currency: { type: String, default: "USD" },
     suggestedWithDate: { type: String, default: "Save {monthly}/mo across {accounts} to hit it on time." },
     suggestedNoDate: { type: String, default: "Set a target date to project a finish line." },
+    // Only the create form must pick an account. On edit the checkboxes are
+    // populated from visible accounts only, so a goal backed by a now-hidden
+    // account renders none — and the controller preserves existing links when
+    // account_ids is omitted. Requiring a checkbox there would wedge the form.
+    requireAccount: { type: Boolean, default: true },
   };
 
   connect() {
@@ -85,8 +90,8 @@ export default class extends Controller {
   isValid() {
     const name = this.hasNameInputTarget ? this.nameInputTarget.value.trim() : "";
     const amount = this.hasAmountInputTarget ? Number.parseFloat(this.amountInputTarget.value) : Number.NaN;
-    const hasAccount = this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
-    return name.length > 0 && Number.isFinite(amount) && amount > 0 && hasAccount;
+    const accountOk = !this.requireAccountValue || this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
+    return name.length > 0 && Number.isFinite(amount) && amount > 0 && accountOk;
   }
 
   refreshSubmitState() {
@@ -107,7 +112,7 @@ export default class extends Controller {
     const nameEmpty = !(this.hasNameInputTarget && this.nameInputTarget.value.trim().length > 0);
     const amount = this.hasAmountInputTarget ? Number.parseFloat(this.amountInputTarget.value) : Number.NaN;
     const amountInvalid = !(Number.isFinite(amount) && amount > 0);
-    const noAccount = !this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
+    const noAccount = this.requireAccountValue && !this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
 
     if (nameEmpty) {
       this.showFieldError(this.nameInputTarget, this.hasNameErrorTarget ? this.nameErrorTarget : null);

--- a/app/javascript/controllers/goal_form_controller.js
+++ b/app/javascript/controllers/goal_form_controller.js
@@ -41,8 +41,8 @@ export default class extends Controller {
       this._defaultAvatarHTML = this.avatarPreviewTarget.innerHTML;
     }
     this.updateSuggested();
-    // Edit form arrives pre-filled (valid) so this enables immediately; new
-    // form arrives empty so the submit starts disabled.
+    // Edit form arrives pre-filled (valid) so this clears immediately; new
+    // form arrives empty so the submit starts visually disabled.
     this.refreshSubmitState();
   }
 
@@ -94,16 +94,22 @@ export default class extends Controller {
     return name.length > 0 && Number.isFinite(amount) && amount > 0 && accountOk;
   }
 
+  // `aria-disabled` instead of the `disabled` attribute: a truly disabled
+  // default submit also blocks Enter-key implicit submission, so an invalid
+  // form would be a dead button with every inline error still hidden. With
+  // aria-disabled the button keeps its not-allowed affordance (styled via the
+  // DS `aria-disabled:` variants) while clicks and Enter still reach
+  // validateOnSubmit, which surfaces the errors and moves focus.
   refreshSubmitState() {
     if (this.hasSubmitButtonTarget) {
-      this.submitButtonTarget.disabled = !this.isValid();
+      this.submitButtonTarget.setAttribute("aria-disabled", String(!this.isValid()));
     }
   }
 
-  // Backstop for the disabled button: covers the funding-accounts group (a
-  // checkbox group can't carry native `required`) and any path that re-enables
-  // the button out from under us. Surfaces the inline errors and focuses the
-  // first offending field instead of a silent no-op.
+  // The real gate for the submit: covers the funding-accounts group (a
+  // checkbox group can't carry native `required`) and everything the
+  // aria-disabled affordance merely hints at. Surfaces the inline errors and
+  // focuses the first offending field instead of a silent no-op.
   validateOnSubmit(event) {
     if (this.isValid()) return;
 
@@ -124,7 +130,13 @@ export default class extends Controller {
       this.accountsErrorTarget.classList.remove("hidden");
     }
 
-    const firstInvalid = nameEmpty ? this.nameInputTarget : amountInvalid ? this.amountInputTarget : null;
+    const firstInvalid = nameEmpty
+      ? this.nameInputTarget
+      : amountInvalid
+        ? this.amountInputTarget
+        : noAccount
+          ? this.linkedAccountCheckboxTargets[0]
+          : null;
     firstInvalid?.focus();
   }
 

--- a/app/views/goals/_color_picker.html.erb
+++ b/app/views/goals/_color_picker.html.erb
@@ -20,7 +20,8 @@
     <details class="group"
              data-color-icon-picker-target="details"
              data-action="mousedown->color-icon-picker#handleOutsideClick">
-      <summary class="list-none cursor-pointer absolute -bottom-1 -right-1 flex justify-center items-center bg-surface-inset hover:bg-surface-inset-hover border-2 w-6 h-6 border-subdued rounded-full text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300">
+      <summary aria-label="<%= t("goals.color_picker.trigger_label") %>"
+               class="list-none cursor-pointer absolute -bottom-1 -right-1 flex justify-center items-center bg-surface-inset hover:bg-surface-inset-hover border-2 w-6 h-6 border-subdued rounded-full text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300">
         <%= icon("pen", size: "xs") %>
       </summary>
 

--- a/app/views/goals/_color_picker.html.erb
+++ b/app/views/goals/_color_picker.html.erb
@@ -14,15 +14,15 @@
       <% end %>
     </span>
 
-    <%= render DS::Disclosure.new(
-          summary_class: "cursor-pointer absolute -bottom-1 -right-1 flex justify-center items-center bg-surface-inset hover:bg-surface-inset-hover border-2 w-6 h-6 border-subdued rounded-full text-secondary",
-          data: {
-            color_icon_picker_target: "details",
-            action: "mousedown->color-icon-picker#handleOutsideClick"
-          }) do |d| %>
-      <% d.with_summary_content do %>
+    <%# Raw <details> instead of DS::Disclosure: the disclosure wraps its body
+        in an `mt-2` div that lives in normal flow, which pushed the form down
+        ~8px every time this absolutely-positioned popover opened. %>
+    <details class="group"
+             data-color-icon-picker-target="details"
+             data-action="mousedown->color-icon-picker#handleOutsideClick">
+      <summary class="list-none cursor-pointer absolute -bottom-1 -right-1 flex justify-center items-center bg-surface-inset hover:bg-surface-inset-hover border-2 w-6 h-6 border-subdued rounded-full text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300">
         <%= icon("pen", size: "xs") %>
-      <% end %>
+      </summary>
 
       <div class="absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 bg-container p-3 border border-alpha-black-25 rounded-2xl shadow-xs w-80 max-w-[calc(100vw-2rem)] max-h-[60vh] overflow-y-auto"
            data-color-icon-picker-target="popup">
@@ -68,6 +68,6 @@
           </div>
         </div>
       </div>
-    <% end %>
+    </details>
   </div>
 </div>

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -24,7 +24,7 @@
       <p class="<%= "hidden" unless goal.errors[:name].any? %> mt-1.5 text-xs text-destructive" data-goal-form-target="nameError"><%= t("goals.form.errors.name_required") %></p>
     </div>
 
-    <div class="grid grid-cols-2 gap-3">
+    <div class="grid grid-cols-2 gap-3 items-start">
       <div>
         <%= f.money_field :target_amount,
                           label: t("goals.form.fields.target_amount"),

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -2,6 +2,7 @@
 
 <div data-controller="goal-form"
      data-goal-form-currency-value="<%= Current.family.primary_currency_code %>"
+     data-goal-form-require-account-value="<%= !goal.persisted? %>"
      data-goal-form-suggested-with-date-value="<%= t("goals.form.suggested_with_date") %>"
      data-goal-form-suggested-no-date-value="<%= t("goals.form.suggested_no_date") %>">
   <% if goal.errors[:base].any? %>

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -5,10 +5,6 @@
      data-goal-form-require-account-value="<%= !goal.persisted? %>"
      data-goal-form-suggested-with-date-value="<%= t("goals.form.suggested_with_date") %>"
      data-goal-form-suggested-no-date-value="<%= t("goals.form.suggested_no_date") %>">
-  <% if goal.errors[:base].any? %>
-    <%= render "shared/form_errors", model: goal %>
-  <% end %>
-
   <%= styled_form_with model: goal,
                        url: goal.persisted? ? goal_path(goal) : goals_path,
                        method: goal.persisted? ? :patch : :post,
@@ -25,7 +21,7 @@
                        required: true,
                        label: t("goals.form.fields.name"),
                        data: { goal_form_target: "nameInput", action: "input->goal-form#nameChanged" } %>
-      <p class="hidden mt-1.5 text-xs text-destructive" data-goal-form-target="nameError"><%= t("goals.form.errors.name_required") %></p>
+      <p class="<%= "hidden" unless goal.errors[:name].any? %> mt-1.5 text-xs text-destructive" data-goal-form-target="nameError"><%= t("goals.form.errors.name_required") %></p>
     </div>
 
     <div class="grid grid-cols-2 gap-3">
@@ -35,7 +31,7 @@
                           hide_currency: true,
                           required: true,
                           amount_data: { goal_form_target: "amountInput", action: "input->goal-form#suggestedChanged" } %>
-        <p class="hidden mt-1.5 text-xs text-destructive" data-goal-form-target="amountError"><%= t("goals.form.errors.amount_required") %></p>
+        <p class="<%= "hidden" unless goal.errors[:target_amount].any? %> mt-1.5 text-xs text-destructive" data-goal-form-target="amountError"><%= t("goals.form.errors.amount_required") %></p>
       </div>
       <%= f.date_field :target_date,
                        label: t("goals.form.fields.target_date"),
@@ -76,7 +72,7 @@
           </div>
         <% end %>
       </div>
-      <p class="hidden mt-1.5 text-xs text-destructive" data-goal-form-target="accountsError"><%= t("goals.form.errors.accounts_required") %></p>
+      <p class="<%= "hidden" unless goal.errors[:base].any? %> mt-1.5 text-xs text-destructive" data-goal-form-target="accountsError"><%= t("goals.form.errors.accounts_required") %></p>
     </div>
 
     <%= f.text_area :notes,

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -11,7 +11,8 @@
   <%= styled_form_with model: goal,
                        url: goal.persisted? ? goal_path(goal) : goals_path,
                        method: goal.persisted? ? :patch : :post,
-                       class: "space-y-5" do |f| %>
+                       class: "space-y-5",
+                       data: { action: "submit->goal-form#validateOnSubmit" } do |f| %>
     <div class="flex justify-center">
       <%= render "color_picker", form: f, colors: Goal::COLORS, icons: Goal::ICONS %>
     </div>
@@ -83,7 +84,8 @@
                     placeholder: t("goals.form.fields.notes_placeholder") %>
 
     <div class="flex justify-end pt-2">
-      <%= f.submit goal.persisted? ? t("goals.form.save") : t("goals.form.create") %>
+      <%= f.submit goal.persisted? ? t("goals.form.save") : t("goals.form.create"),
+                   data: { goal_form_target: "submitButton" } %>
     </div>
   <% end %>
 </div>

--- a/app/views/goals/index.html.erb
+++ b/app/views/goals/index.html.erb
@@ -1,4 +1,8 @@
-<div class="space-y-8 pb-6 lg:pb-12">
+<%# @container so the KPI strip + card grids respond to the actual content
+    width (which shrinks when the account / AI sidebars are open) rather than
+    the viewport. Viewport breakpoints kept 3 columns in a narrow center
+    column and crushed the cards. %>
+<div class="@container space-y-8 pb-6 lg:pb-12">
   <header>
     <div class="flex items-center gap-2">
       <h1 class="text-2xl font-semibold text-primary"><%= t(".title") %></h1>
@@ -11,7 +15,7 @@
     <%= render "empty_state", linkable_account_count: @linkable_account_count %>
   <% else %>
     <%# KPI strip. Contributed last 30d (with prior-30d comparison) / Needs / On track %>
-    <section class="grid grid-cols-1 md:grid-cols-3 gap-3">
+    <section class="grid grid-cols-1 @3xl:grid-cols-3 gap-3">
       <div class="bg-container rounded-xl shadow-border-xs px-5 py-5">
         <p class="text-[11px] font-medium uppercase tracking-wide text-secondary"><%= t(".kpi.contributed_label") %></p>
         <p class="text-3xl font-medium text-primary tabular-nums mt-2 privacy-sensitive">
@@ -117,7 +121,11 @@
                   action: "input->goals-filter#filter"
                 }
               ) %>
-          <div class="inline-flex items-center gap-1 p-1 bg-surface-inset rounded-xl">
+          <%# overflow-x-auto + nowrap chips: the segmented control scrolls
+              horizontally when the column is too narrow for all six chips,
+              rather than wrapping "On track" mid-label or forcing the row
+              wider than the viewport. %>
+          <div class="inline-flex items-center gap-1 p-1 bg-surface-inset rounded-xl overflow-x-auto max-w-full">
             <% %w[all on_track behind no_target_date paused completed].each do |status| %>
               <% active = status == "all" %>
               <button type="button"
@@ -125,7 +133,7 @@
                       data-action="click->goals-filter#selectChip"
                       data-status="<%= status %>"
                       aria-pressed="<%= active %>"
-                      class="px-2.5 py-1 text-xs font-medium rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-100 <%= active ? "bg-container shadow-border-xs text-primary" : "text-secondary" %>">
+                      class="shrink-0 whitespace-nowrap px-2.5 py-1 text-xs font-medium rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-100 <%= active ? "bg-container shadow-border-xs text-primary" : "text-secondary" %>">
                 <%= t(".chips.#{status}") %>
               </button>
             <% end %>
@@ -139,7 +147,7 @@
           <span class="text-subdued">·</span>
           <span class="tabular-nums" data-goals-filter-target="count"><%= @grid_goals.size %></span>
         </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3.5" data-goals-filter-target="grid">
+        <div class="grid grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3 gap-3.5" data-goals-filter-target="grid">
           <% @grid_goals.each do |goal| %>
             <%= render Goals::CardComponent.new(goal: goal) %>
           <% end %>
@@ -179,7 +187,7 @@
               <span class="tabular-nums"><%= @archived_goals.size %></span>
             </span>
           <% end %>
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3.5">
+          <div class="grid grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3 gap-3.5">
             <% @archived_goals.each do |goal| %>
               <%= render Goals::CardComponent.new(goal: goal, filterable: false) %>
             <% end %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -224,7 +224,7 @@
             <% end %>
           </div>
         </div>
-        <div class="flex-1 min-h-[200px]"
+        <div class="flex-1 min-h-[200px] privacy-sensitive"
              data-controller="goal-projection-chart"
              data-goal-projection-chart-data-value="<%= @goal.projection_payload.to_json %>"
              data-goal-projection-chart-aria-label-value="<%= t("goals.show.projection.aria_label", name: @goal.name) %>"

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -223,9 +223,6 @@ en:
       days_left:
         one: 1 day left
         other: "%{count} days left"
-      days_left_by:
-        one: 1 day left · by %{date}
-        other: "%{count} days left · by %{date}"
       pace_with_target: "%{avg}/mo · target %{target}/mo"
       pace_no_target: "%{avg}/mo avg"
       footer_paused: Paused

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -2,6 +2,7 @@
 en:
   goals:
     color_picker:
+      trigger_label: Choose color and icon
       color_heading: Color
       icon_heading: Icon
       poor_contrast: Poor contrast, choose darker color or


### PR DESCRIPTION
Polish pass on the (preview-gated) Goals feature — five independent fixes, each with a before/after below.

## What's fixed

### 1. New-goal form can't be submitted empty
The submit button was always enabled, and the funding-accounts checkbox group has no native `required`, so a goal with **no linked account** could be submitted and only fail server-side (422). The button is now disabled until **name + positive target amount + ≥1 account** are present, with a submit-time guard that surfaces the inline errors and focuses the first offending field. Disabled DS buttons also now use `cursor: not-allowed` (Tailwind v4 preflight gives every `<button>` `cursor: pointer`, even while disabled).

| Before — enabled while empty | After — disabled until valid |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/repro-form-empty.png" width="430"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/after-form-empty-disabled.png" width="430"> |

### 2. Cards respond to the real column width, not the viewport
The grid used viewport breakpoints (`lg:grid-cols-3`), so with the account / AI sidebars open the center column kept three columns in a ~340px space and the cards collapsed (pills overlapping rings, footer text merging). Switched the grids + KPI strip to **container queries** (`@container`), so column count tracks the actual content width.

| Before — both sidebars open | After |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/repro-both-sidebars-1280.png" width="430"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/after-both-sidebars-1280-final.png" width="430"> |

### 3. Card titles get their space back
The status pill shared the title row and ate 70–84px, truncating names to "Hou…" / "Vac…" at 3-up. Moved the pill to the meta line under the title; the title now spans the full header width. Also drops the redundant secondary word when the pill already says it ("Open", "Completed").

| Before — "Hou…" | After — full titles, pill on meta line |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/before-card-titles-1280.png" width="430"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/after-card-pill-meta-final-1280.png" width="430"> |

### 4. Filter tabs scroll instead of wrapping
"On track" wrapped mid-label on narrow columns. Chips are now `whitespace-nowrap` and the segmented group scrolls horizontally rather than wrapping the label or forcing the row wider than the viewport.

| Before — "On / track" | After — single line, scrolls |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/before-tabs-wrap-390.png" width="300"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/after-tabs-nowrap-390-chips.png" width="300"> |

### 5. Color/icon picker stops nudging the form
`DS::Disclosure` wraps its body in an `mt-2` div that lives in normal flow, so opening the absolutely-positioned picker popover shifted the form down ~8px. The picker now uses a raw `<details>` so the popover overlays without reflowing the content beneath it.

| Before — opens, form jumps ~8px | After — no shift |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/before-picker-open-shift.png" width="430"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/rev/after-picker-open-noshift.png" width="430"> |

### 6. Projection chart respects privacy mode
The goal show page's projection chart rendered real amounts while privacy mode masked everything around it. The chart container is now `privacy-sensitive` like the rest of the page's monetary surfaces.

## Scope note
The disabled-cursor fix touches `DS::Buttonish` (applies to every disabled button app-wide — the correct place for it). Everything else is Goals-local.

## Verified
Exercised across widths (mobile/PWA → 1920), sidebar combinations (off / left / right / both), light + dark, and goal counts (empty / few / many) with all statuses present.

- `bin/rails test` — goals model / controller / pledges / job: **96 runs, 0 failures**
- `bin/rubocop`, `bundle exec erb_lint`, `biome lint` — clean
- `bin/brakeman --no-pager` — 0 warnings

Opened as **draft** for a look at the card-layout direction (status pill on the meta line) before finalizing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Goal form validates on submit, with real-time submit-button enable/disable and optional linked-account requirement.

* **UI/UX Improvements**
  * Reworked goal card layout: preserved progress-ring sizing, improved wrapping/spacing for linked accounts and status chips, and container-based responsive breakpoints.
  * Goal cards show simplified secondary/meta text for completed or no-target goals.
  * Color/icon picker switched to a native popover pattern.
  * Projection chart wrapper marked as privacy-sensitive.

* **Style**
  * Buttons use a disabled-cursor styling.

* **Localization**
  * Color picker trigger label updated to “Choose color and icon”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Added in follow-up commits

### 6. Validation errors render inline on server re-render
The client-side controller already shows per-field errors and disables submit, but a server 422 (JS off, or a race) fell back to the top run-on banner ("X can't be blank, Y…, and Z."). The existing inline hints are now server-aware, so a failed submit shows the same per-field red text the client path does; the base-error banner is dropped (base only ever carried the account requirement, which now renders beside the funding list).

| Before — run-on banner | After — per-field inline hints |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/fixes-20260603/form-errors-before-banner.png" width="430"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/fixes-20260603/form-errors-after-inline.png" width="430"> |

### 7. Target-date input no longer stretches when the amount error shows
The amount / date row is a two-column grid; the amount column carries its inline error underneath, so when it appeared the default `items-stretch` stretched the **date** input taller than the amount input. Anchored the row with `items-start`. (Visible in the "after" above — both inputs keep equal height with the error below the amount column.)

### 8. Projection chart blurs under privacy mode
The chart's SVG axis labels + annotations (target, " short", ticks) rendered in cleartext while privacy mode blurred every other number. Tagged the chart container `privacy-sensitive`, matching the net-worth / cashflow-sankey charts.

| Before — chart numbers leak | After — blurred with the rest |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/fixes-20260603/privacy-before-leak.png" width="430"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/fixes-20260603/privacy-after-fixed.png" width="430"> |

_Screenshots captured against a throwaway instance seeded with a CHF family + a goal with linked-account history._

