### PR TITLE
fix(cashflow): use Turbo.visit for donut chart deep-link navigation

### DIFF
--- a/app/javascript/controllers/donut_chart_controller.js
+++ b/app/javascript/controllers/donut_chart_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 import * as d3 from "d3";
+import { buildCategoryTransactionsUrl } from "utils/transactions_filter_url";
 
 // Connects to data-controller="donut-chart"
 export default class extends Controller {
@@ -250,14 +251,15 @@ export default class extends Controller {
 
   // Handles click on segment (optional, controlled by enableClick value)
   #handleClick(segment) {
-    if (!segment.name || !this.startDateValue || !this.endDateValue) return;
+    if (!segment.name) return;
 
-    const segmentName = encodeURIComponent(segment.name);
-    const startDate = this.startDateValue;
-    const endDate = this.endDateValue;
-
-    const url = `/transactions?q[categories][]=${segmentName}&q[start_date]=${startDate}&q[end_date]=${endDate}`;
-    window.location.href = url;
+    Turbo.visit(
+      buildCategoryTransactionsUrl({
+        name: segment.name,
+        startDate: this.startDateValue,
+        endDate: this.endDateValue,
+      }),
+    );
   }
 
   // Public methods for external highlighting (e.g., from category list hover)


### PR DESCRIPTION
## What

Replaces `window.location.href` with `Turbo.visit` in `donut_chart_controller.js` for the category deep-link navigation.

## Why

Spotted during review of #2083 (Sankey category deep-link). `Turbo.visit` is the established pattern for internal SPA navigation in this codebase (`selectable_link_controller`, `trade_form_controller`, `application.js`). `window.location.href` is reserved for external/auth redirects (Plaid, WebAuthn). The donut was the only internal chart navigation still using the full-page redirect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of donut chart segment navigation when filtering by date ranges.

* **Refactor**
  * Streamlined internal navigation handling for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->