### PR TITLE
Pass `APP_BUNDLE_ID` into iOS archive

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -153,7 +153,7 @@ jobs:
         working-directory: mobile
         if: ${{ steps.check_prereqs.outputs.enabled == 'true' }}
         env:
-          APP_BUNDLE_ID: am.sure.mobile
+          APP_BUNDLE_ID: ${{ vars.IOS_APP_BUNDLE_ID || 'am.sure.mobile' }}
           IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
           PROFILE_NAME: ${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}
           IOS_DISTRIBUTION_CERT_NAME: ${{ secrets.IOS_DISTRIBUTION_CERT_NAME }}
@@ -173,13 +173,14 @@ jobs:
           path = Path("ios/Runner.xcodeproj/project.pbxproj")
           text = path.read_text()
 
+          app_bundle_id = os.environ["APP_BUNDLE_ID"]
           team = os.environ["IOS_TEAM_ID"]
           profile = os.environ["PROFILE_NAME"]
           identity = os.environ["IOS_DISTRIBUTION_CERT_NAME"]
 
           def patch_block(match):
               block = match.group(0)
-              if "PRODUCT_BUNDLE_IDENTIFIER = am.sure.mobile;" not in block:
+              if f"PRODUCT_BUNDLE_IDENTIFIER = {app_bundle_id};" not in block:
                   return block
               if "CODE_SIGN_STYLE = Manual;" not in block:
                   block = block.replace("CURRENT_PROJECT_VERSION = \"$(FLUTTER_BUILD_NUMBER)\";", "CURRENT_PROJECT_VERSION = \"$(FLUTTER_BUILD_NUMBER)\";\n\t\t\t\tCODE_SIGN_STYLE = Manual;")
@@ -246,6 +247,7 @@ jobs:
             -destination 'generic/platform=iOS' \
             MARKETING_VERSION="$IOS_VERSION" \
             CURRENT_PROJECT_VERSION="$IOS_BUILD_NUMBER" \
+            APP_BUNDLE_IDENTIFIER="$APP_BUNDLE_ID" \
             archive
 
           mkdir -p "$EXPORT_PATH"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -180,8 +180,9 @@ jobs:
 
           def patch_block(match):
               block = match.group(0)
-              if f"PRODUCT_BUNDLE_IDENTIFIER = {app_bundle_id};" not in block:
+              if "PRODUCT_BUNDLE_IDENTIFIER =" not in block:
                   return block
+              block = re.sub(r'PRODUCT_BUNDLE_IDENTIFIER = .*?;', f'PRODUCT_BUNDLE_IDENTIFIER = {app_bundle_id};', block)
               if "CODE_SIGN_STYLE = Manual;" not in block:
                   block = block.replace("CURRENT_PROJECT_VERSION = \"$(FLUTTER_BUILD_NUMBER)\";", "CURRENT_PROJECT_VERSION = \"$(FLUTTER_BUILD_NUMBER)\";\n\t\t\t\tCODE_SIGN_STYLE = Manual;")
               if '"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";' not in block:
@@ -247,7 +248,7 @@ jobs:
             -destination 'generic/platform=iOS' \
             MARKETING_VERSION="$IOS_VERSION" \
             CURRENT_PROJECT_VERSION="$IOS_BUILD_NUMBER" \
-            APP_BUNDLE_IDENTIFIER="$APP_BUNDLE_ID" \
+            PRODUCT_BUNDLE_IDENTIFIER="$APP_BUNDLE_ID" \
             archive
 
           mkdir -p "$EXPORT_PATH"


### PR DESCRIPTION
## Summary
- Make iOS bundle ID configurable via workflow input with default `am.sure.mobile`, allowing fork override with `tech.chancen.companion`.
- Use the same `APP_BUNDLE_ID` when patching iOS project bundle identifier.
- Pass `APP_BUNDLE_IDENTIFIER` into the Xcode archive command so it always matches the provisioning profile key in ExportOptions.plist.

## Why this
This fixes archive/provisioning-profile mismatch when building App Store/TestFlight in forks where the bundle ID differs from upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated iOS TestFlight build workflow to support a configurable app bundle identifier via workflow settings (default unchanged). The selected bundle identifier is now applied during the build and used when updating related project settings. No other upload, credential, artifact, or cleanup behavior was modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->