### PR TITLE
fix(goals): default goal currency so it survives a failed create

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -61,7 +61,7 @@ class GoalsController < ApplicationController
   def create
     @goal = Current.family.goals.new(goal_params)
     accounts = lookup_accounts(params.dig(:goal, :account_ids))
-    @goal.currency = accounts.first.currency if accounts.any? && @goal.currency.blank?
+    @goal.currency = (accounts.first&.currency || Current.family.primary_currency_code) if @goal.currency.blank?
 
     Goal.transaction do
       accounts.each { |a| @goal.goal_accounts.build(account: a) }


### PR DESCRIPTION
## Problem

Reported in #2170. When a new goal fails server-side validation (in the video: no funding account selected), the **target-amount currency silently resets** from the family currency (CHF) to USD/`$`, and a spurious **"Currency must be filled"** error appears on a field the user can't set.

### Root cause

`goal_params` does **not** permit `:currency` — the goal's currency is only derived from the first linked account:

```ruby
@goal = Current.family.goals.new(goal_params)
accounts = lookup_accounts(params.dig(:goal, :account_ids))
@goal.currency = accounts.first.currency if accounts.any? && @goal.currency.blank?
```

So when create fails with **no account selected**, `@goal.currency` stays blank. On the re-rendered form, `shared/_money_field` falls back to its `"USD"` default (`form.object.currency` is blank), and the model's `validates :currency, presence: true` surfaces as a user-facing error on a derived field.

## Fix

Always default the currency: first linked account's currency when present, otherwise the family's primary currency.

```ruby
@goal.currency = (accounts.first&.currency || Current.family.primary_currency_code) if @goal.currency.blank?
```

Currency is now never blank across a failed submit, so:
- the money field keeps the family currency (CHF stays CHF), and
- the "Currency must be filled" error never appears on a field the user doesn't control. Only the real, actionable error ("Pick at least one depository account to fund this goal.") remains.

## Scope

One line in `app/controllers/goals_controller.rb#create`. Does **not** overlap with #2160 (which touches the form view, card component, picker, and JS — not the controller).

Fixes #2170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced goal creation to ensure currency is always properly set. Goals now automatically default to the family's primary currency when no associated accounts are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots

Reproduced with a **CHF** family: new goal, target amount `150`, no funding account selected, then submit (fails validation). Focus on the **Target amount** field.

| Before — currency resets to `$` | After — `CHF` retained |
|---|---|
| <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/fixes-20260603/form-polish-inline-and-usd.png" width="430"> | <img src="https://raw.githubusercontent.com/gariasf/sure/screenshots/goals-polish-20260603/fixes-20260603/form-currency-after-chf.png" width="430"> |

_(Captured against a throwaway instance seeded with a CHF family + one depository account.)_
