### PR TITLE
fix(db): narrow pgvector_available? rescue to database errors

### DIFF
--- a/db/migrate/20260316120000_create_vector_store_chunks.rb
+++ b/db/migrate/20260316120000_create_vector_store_chunks.rb
@@ -37,11 +37,15 @@ class CreateVectorStoreChunks < ActiveRecord::Migration[7.2]
     def pgvector_available?
       return false unless ENV["VECTOR_STORE_PROVIDER"].to_s.downcase == "pgvector"
 
-      result = ActiveRecord::Base.connection.execute(
-        "SELECT 1 FROM pg_available_extensions WHERE name = 'vector' LIMIT 1"
-      )
-      result.any?
-    rescue
-      false
+      # Narrow the rescue to the PostgreSQL probe only, so DB-related failures
+      # return false while configuration/unexpected errors still bubble up.
+      begin
+        result = ActiveRecord::Base.connection.execute(
+          "SELECT 1 FROM pg_available_extensions WHERE name = 'vector' LIMIT 1"
+        )
+        result.any?
+      rescue ActiveRecord::StatementInvalid, PG::Error
+        false
+      end
     end
 end


### PR DESCRIPTION
## Problem

`pgvector_available?` (in the `create_vector_store_chunks` migration) rescued bare `StandardError`, so any failure — configuration mistakes, unexpected runtime errors — was swallowed and silently reported as "extension unavailable".

## Fix

Scope the rescue to `ActiveRecord::StatementInvalid` / `PG::Error` around the probe query only. Genuine DB-probe failures still degrade to `false`; anything else surfaces instead of being hidden.

## Note

Split out from `fix/subtype-create-return-to-1766` (an unrelated fix that was bundled there); rebased cleanly onto `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for PostgreSQL extension detection to properly surface unexpected errors instead of silently suppressing them, ensuring more reliable system behavior.

* **Refactor**
  * Refined error detection logic for better accuracy and updated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->