### PR TITLE
fix(accounts): expose 'New activity' menu item for crypto-exchange accounts

### DIFF
--- a/app/components/UI/account/activity_feed.html.erb
+++ b/app/components/UI/account/activity_feed.html.erb
@@ -18,22 +18,25 @@
                 data: { turbo_frame: :modal }) %>
           <% end %>
 
-          <% unless account.crypto? %>
-            <% if account.investment? %>
-              <% menu.with_item(
-                  variant: "link",
-                  text: t("accounts.show.activity.new_activity"),
-                  icon: "arrow-left-right",
-                  href: new_trade_path(account_id: account.id),
-                  data: { turbo_frame: :modal }) %>
-            <% else %>
-              <% menu.with_item(
-                  variant: "link",
-                  text: t("accounts.show.activity.new_transaction"),
-                  icon: "credit-card",
-                  href: new_transaction_path(account_id: account.id),
-                  data: { turbo_frame: :modal }) %>
-            <% end %>
+          <%# Issue #2167: gate "New activity" on supports_trades? — covers
+              investment accounts AND crypto-exchange. The old `unless crypto?`
+              gate blanket-excluded all crypto, hiding the menu item even from
+              exchange subtypes that DO support manual trades. Crypto wallets
+              still get neither item (sync-only). %>
+          <% if account.supports_trades? %>
+            <% menu.with_item(
+                variant: "link",
+                text: t("accounts.show.activity.new_activity"),
+                icon: "arrow-left-right",
+                href: new_trade_path(account_id: account.id),
+                data: { turbo_frame: :modal }) %>
+          <% elsif !account.crypto? %>
+            <% menu.with_item(
+                variant: "link",
+                text: t("accounts.show.activity.new_transaction"),
+                icon: "credit-card",
+                href: new_transaction_path(account_id: account.id),
+                data: { turbo_frame: :modal }) %>
           <% end %>
 
           <% menu.with_item(

--- a/app/components/UI/account/activity_feed.html.erb
+++ b/app/components/UI/account/activity_feed.html.erb
@@ -18,11 +18,6 @@
                 data: { turbo_frame: :modal }) %>
           <% end %>
 
-          <%# Issue #2167: gate "New activity" on supports_trades? — covers
-              investment accounts AND crypto-exchange. The old `unless crypto?`
-              gate blanket-excluded all crypto, hiding the menu item even from
-              exchange subtypes that DO support manual trades. Crypto wallets
-              still get neither item (sync-only). %>
           <% if account.supports_trades? %>
             <% menu.with_item(
                 variant: "link",

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -19,6 +19,52 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # Regression: issue #2167. The Activity-tab "New" menu was blanket-gated on
+  # `unless account.crypto?`, so crypto-exchange accounts (which DO support
+  # manual trades via Account#supports_trades?) lost the "New activity" item.
+  # Selectors are scoped to the activity-menu container so the assertions pin
+  # the menu region, not just any link on the page.
+  # Coverage matrix: crypto-exchange shows it, crypto-wallet hides it,
+  # investment shows it, depository shows "New transaction".
+  test "show: crypto-exchange account exposes 'New activity' link" do
+    crypto = accounts(:crypto)
+    crypto.accountable.update!(subtype: "exchange")
+    assert crypto.supports_trades?, "exchange crypto must support trades"
+
+    get account_url(crypto)
+    assert_response :success
+    assert_select "[data-testid='activity-menu'] a[href='#{new_trade_path(account_id: crypto.id)}']"
+  end
+
+  test "show: crypto-wallet account hides 'New activity' link" do
+    crypto = accounts(:crypto)
+    crypto.accountable.update!(subtype: "wallet")
+    refute crypto.supports_trades?, "wallet crypto must not support trades"
+
+    get account_url(crypto)
+    assert_response :success
+    # Positive anchor: an unlinked crypto-wallet still gets "New balance",
+    # so the menu DID render. Without this anchor, the count: 0 below would
+    # pass for the wrong reason if the whole menu failed to render.
+    assert_select "[data-testid='activity-menu'] a[href='#{new_valuation_path(account_id: crypto.id)}']"
+    assert_select "[data-testid='activity-menu'] a[href='#{new_trade_path(account_id: crypto.id)}']", count: 0
+  end
+
+  test "show: investment account exposes 'New activity' link" do
+    investment = accounts(:investment)
+
+    get account_url(investment)
+    assert_response :success
+    assert_select "[data-testid='activity-menu'] a[href='#{new_trade_path(account_id: investment.id)}']"
+  end
+
+  test "show: depository exposes 'New transaction' link (not 'New activity')" do
+    get account_url(@account)
+    assert_response :success
+    assert_select "[data-testid='activity-menu'] a[href='#{new_transaction_path(account_id: @account.id)}']"
+    assert_select "[data-testid='activity-menu'] a[href='#{new_trade_path(account_id: @account.id)}']", count: 0
+  end
+
   test "show lazily loads statement tab data unless statements tab is active" do
     AccountStatement::Coverage.expects(:for_year).never
     AccountStatement.expects(:reconciliation_statuses_for).never


### PR DESCRIPTION
## Summary
- Crypto-exchange accounts now show the **New activity** option in the Activity-tab "New" menu, matching investment accounts. Crypto wallets continue to show only **New balance** / **New transfer** (sync-only by design).

## Root Cause
The Activity-tab "New" menu in `UI::Account::ActivityFeed` (`app/components/UI/account/activity_feed.html.erb:21-37`) blanket-gated the "New activity" / "New transaction" item on `unless account.crypto?`. That hid the item from **every** crypto account — including the Exchange subtype, where:

- `Account#supports_trades?` (`app/models/account.rb:464`) returns `true`
- `Crypto#supports_trades?` (`app/models/crypto.rb:21`) returns `true` for `subtype == "exchange"`
- `TradesController` and `Trade::CreateForm` already accept manual trades against crypto-exchange accounts (no accountable-type gate)

The menu was the only layer blocking what the rest of the stack was ready to do.

## Fix
Replace the gate with `if account.supports_trades?` (covers investment + crypto-exchange) plus `elsif !account.crypto?` (non-crypto non-investment still gets "New transaction"). This mirrors the pattern already in `app/views/accounts/show/_menu.html.erb:12`, which has used `supports_trades?` / `!crypto?` for the same decision elsewhere — closing an internal inconsistency.

**Behavior matrix (only one cell intentionally changes):**

| Account | `supports_trades?` | Before | After |
|---|---|---|---|
| Investment | true | New activity | New activity |
| Crypto **exchange** | true | *(nothing)* | **New activity** ✓ |
| Crypto wallet / nil subtype | false | *(nothing)* | *(nothing)* |
| Depository / Loan / Property / Vehicle / CreditCard / Other | false | New transaction | New transaction |

## Scope notes
- **Unlinked crypto only.** The outer guard `if !account.linked? || !account.crypto?` (line 8, unchanged) still hides the entire menu for linked crypto accounts of any subtype. That preserves the existing "linked crypto is sync-only" design. Widening it to expose manual entry for a linked crypto-exchange would touch the broader linked-vs-manual contract and warrants its own issue.
- **Crypto-wallet remains sync-only.** Per `Crypto#supports_trades?`'s "wallets are sync-only" comment, wallets keep their current behavior. The reporter mentioned the symptom occurring "regardless of subtype"; this PR fixes the Exchange case (clear bug — `supports_trades?` is true but UI hides it) and leaves the wallet semantic to whoever owns the `supports_trades?` contract.

## Test Plan
- [x] Regression test added: `test/controllers/accounts_controller_test.rb` (4 new tests; selectors scoped to `[data-testid='activity-menu']`; the wallet test has a positive anchor on `new_valuation_path` so the absence assertion cannot false-pass on a non-rendered menu)
- [x] **RED proved** before the fix: 1 failure (crypto-exchange test), 3 pass — exactly the expected discrimination
- [x] **GREEN** after the fix: all 4 pass, plus the rest of the file (38 runs, 134 assertions, 0 failures) and crypto/model sanity (10/10)
- [x] `bin/rubocop test/controllers/accounts_controller_test.rb` — clean
- [x] Adversarial multi-lens review (correctness / edge-case / security / test-discrimination / consistency) before commit — verdict: ship


## Before / After
Same Coinbase Exchange account, same Activity tab, same "New" menu — only the ERB gate differs.

<!-- attach pr2167-1-before-crypto-exchange.png (menu: New balance + New transfer only)
     and pr2167-2-after-crypto-exchange.png (menu: New balance + New activity + New transfer) -->

The issue body also contains the reporter's original screenshots showing the investment-vs-crypto disparity.

Closes #2167


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected activity/transaction menu visibility so account types show only relevant options (crypto-exchange shows "New activity"/trade, crypto-wallet hides trade option but shows valuation, investment accounts show activity, depository accounts show "New transaction").

* **Tests**
  * Added regression tests covering menu visibility across crypto subtypes and account classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->