### PR TITLE
Address Indexa Capital provider review follow-ups

### DIFF
--- a/app/controllers/indexa_capital_items_controller.rb
+++ b/app/controllers/indexa_capital_items_controller.rb
@@ -125,13 +125,9 @@ class IndexaCapitalItemsController < ApplicationController
       return
     end
 
-    # Always fetch fresh data (accounts + balances) when user visits this page
-    fetch_accounts_synchronously(indexa_capital_item)
+    schedule_accounts_refresh(indexa_capital_item)
 
-    @indexa_capital_accounts = indexa_capital_item.indexa_capital_accounts
-                                                .left_joins(:account_provider)
-                                                .where(account_providers: { id: nil })
-                                                .order(:name)
+    @indexa_capital_accounts = unlinked_indexa_capital_accounts(indexa_capital_item)
   end
 
   def link_accounts
@@ -356,37 +352,19 @@ class IndexaCapitalItemsController < ApplicationController
       accountable_type.constantize
     end
 
-    def fetch_accounts_synchronously(indexa_capital_item)
-      provider = indexa_capital_item.indexa_capital_provider
-      return unless provider
-
-      accounts_data = provider.list_accounts
-
-      accounts_data.each do |account_data|
-        account_number = account_data[:account_number].to_s
-        next if account_number.blank?
-
-        # Fetch current balance from performance endpoint
-        balance = provider.get_account_balance(account_number: account_number)
-        account_data[:current_balance] = balance
-      rescue => e
-        Rails.logger.warn "IndexaCapitalItemsController - Failed to fetch balance for #{account_number}: #{e.message}"
-      end
-
-      accounts_data.each do |account_data|
-        account_number = account_data[:account_number].to_s
-        next if account_number.blank?
-
-        indexa_capital_account = indexa_capital_item.indexa_capital_accounts.find_or_initialize_by(
-          indexa_capital_account_id: account_number
-        )
-        indexa_capital_account.upsert_from_indexa_capital!(account_data)
-      end
-    rescue Provider::IndexaCapital::AuthenticationError => e
-      Rails.logger.error "IndexaCapitalItemsController - Auth failed during sync: #{e.message}"
+    def schedule_accounts_refresh(indexa_capital_item)
+      indexa_capital_item.sync_later unless indexa_capital_item.syncing?
+    rescue => e
+      Rails.logger.error(
+        "IndexaCapitalItemsController#select_accounts - Failed to schedule refresh: #{e.class} - #{e.message}"
+      )
       flash.now[:alert] = t("indexa_capital_items.select_accounts.api_error", message: e.message)
-    rescue Provider::IndexaCapital::Error => e
-      Rails.logger.error "IndexaCapitalItemsController - API error during sync: #{e.message}"
-      flash.now[:alert] = t("indexa_capital_items.select_accounts.api_error", message: e.message)
+    end
+
+    def unlinked_indexa_capital_accounts(indexa_capital_item)
+      indexa_capital_item.indexa_capital_accounts
+                         .left_joins(:account_provider)
+                         .where(account_providers: { id: nil })
+                         .order(:name)
     end
 end

--- a/app/jobs/indexa_capital_activities_fetch_job.rb
+++ b/app/jobs/indexa_capital_activities_fetch_job.rb
@@ -4,7 +4,7 @@ class IndexaCapitalActivitiesFetchJob < ApplicationJob
   queue_as :default
 
   sidekiq_options lock: :until_executed,
-                  lock_args_method: ->(args) { args.first },
+                  lock_args_method: ->(args) { [ args.first.id ] },
                   on_conflict: :log
 
   # Indexa Capital API does not provide an activities/transactions endpoint.

--- a/app/models/indexa_capital_account/data_helpers.rb
+++ b/app/models/indexa_capital_account/data_helpers.rb
@@ -82,7 +82,8 @@ module IndexaCapitalAccount::DataHelpers
       ticker = symbol.to_s.upcase.strip
       return nil if ticker.blank?
 
-      security = Security.find_by(ticker: ticker)
+      exchange = extract_exchange(symbol_data)&.upcase
+      security = Security.find_by(ticker: ticker, exchange_operating_mic: exchange)
 
       # If security exists but has a bad name (looks like a hash), update it
       if security && security.name&.start_with?("{")
@@ -101,13 +102,14 @@ module IndexaCapitalAccount::DataHelpers
       Security.create!(
         ticker: ticker,
         name: security_name,
-        exchange_mic: extract_exchange(symbol_data),
+        exchange_mic: exchange,
+        exchange_operating_mic: exchange,
         country_code: extract_country_code(symbol_data)
       )
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
       # Handle race condition - another process may have created it
       Rails.logger.error "IndexaCapitalAccount::DataHelpers - Failed to create security #{ticker}: #{e.message}"
-      Security.find_by(ticker: ticker)
+      Security.find_by(ticker: ticker, exchange_operating_mic: exchange)
     end
 
     def extract_security_name(symbol_data, fallback_ticker)

--- a/app/models/indexa_capital_item.rb
+++ b/app/models/indexa_capital_item.rb
@@ -16,7 +16,7 @@ class IndexaCapitalItem < ApplicationRecord
 
   # Encrypt sensitive credentials if ActiveRecord encryption is configured
   if encryption_ready?
-    encrypts :password, deterministic: true
+    encrypts :username, :document, :password, deterministic: true
     encrypts :api_token, deterministic: true
   end
 

--- a/app/models/provider/indexa_capital.rb
+++ b/app/models/provider/indexa_capital.rb
@@ -123,9 +123,18 @@ class Provider::IndexaCapital
 
     def with_retries(operation_name, max_retries: MAX_RETRIES)
       retries = 0
+      authentication_retried = false
 
       begin
         yield
+      rescue AuthenticationError => e
+        if retry_authentication?(e, authentication_retried)
+          authentication_retried = true
+          invalidate_token!
+          retry
+        end
+
+        raise
       rescue *RETRYABLE_ERRORS => e
         retries += 1
 
@@ -169,7 +178,22 @@ class Provider::IndexaCapital
     end
 
     def token
-      @token ||= token_auth? ? @api_token : authenticate!
+      @token ||= resolve_token
+    end
+
+    def resolve_token
+      token_auth? ? @api_token : authenticate!
+    end
+
+    def invalidate_token!
+      @token = nil unless token_auth?
+    end
+
+    def retry_authentication?(error, authentication_retried)
+      !authentication_retried &&
+        error.error_type == :unauthorized &&
+        !token_auth? &&
+        @token.present?
     end
 
     def authenticate!

--- a/test/controllers/indexa_capital_items_controller_test.rb
+++ b/test/controllers/indexa_capital_items_controller_test.rb
@@ -51,6 +51,20 @@ class IndexaCapitalItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "select_accounts schedules refresh without fetching provider accounts synchronously" do
+    @item.syncs.destroy_all
+    Provider::IndexaCapital.expects(:new).never
+
+    assert_difference "@item.syncs.count", 1 do
+      assert_enqueued_with job: SyncJob do
+        get select_accounts_indexa_capital_items_url(accountable_type: "Investment")
+      end
+    end
+
+    assert_response :success
+    assert_includes response.body, indexa_capital_accounts(:mutual_fund).name
+  end
+
   test "complete_account_setup creates accounts for selected indexa_capital_accounts" do
     ica = indexa_capital_accounts(:mutual_fund)
 

--- a/test/jobs/indexa_capital_activities_fetch_job_test.rb
+++ b/test/jobs/indexa_capital_activities_fetch_job_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class IndexaCapitalActivitiesFetchJobTest < ActiveSupport::TestCase
+  test "sidekiq lock key uses stable account id" do
+    indexa_capital_account = indexa_capital_accounts(:mutual_fund)
+    options = sidekiq_options
+    lock_args_method = options.fetch("lock_args_method") { options.fetch(:lock_args_method) }
+
+    assert_equal [ indexa_capital_account.id ], lock_args_method.call([ indexa_capital_account ])
+  end
+
+  private
+
+    def sidekiq_options
+      if IndexaCapitalActivitiesFetchJob.respond_to?(:get_sidekiq_options)
+        IndexaCapitalActivitiesFetchJob.get_sidekiq_options
+      else
+        IndexaCapitalActivitiesFetchJob.sidekiq_options_hash
+      end
+    end
+end

--- a/test/models/indexa_capital_account/data_helpers_test.rb
+++ b/test/models/indexa_capital_account/data_helpers_test.rb
@@ -129,6 +129,23 @@ class IndexaCapitalAccount::DataHelpersTest < ActiveSupport::TestCase
     assert_equal existing, result
   end
 
+  test "resolve_security selects existing security for matching exchange" do
+    Security.create!(ticker: "DUP939", name: "Nasdaq Listing", exchange_operating_mic: "XNAS")
+    nyse_security = Security.create!(ticker: "DUP939", name: "NYSE Listing", exchange_operating_mic: "XNYS")
+
+    result = @helper.resolve_security("dup939", { exchange: { mic_code: "XNYS" } })
+
+    assert_equal nyse_security, result
+  end
+
+  test "resolve_security stores exchange operating mic when creating security" do
+    result = @helper.resolve_security("mic939", { name: "MIC Test Security", exchange: { mic_code: "xmad" } })
+
+    assert_equal "MIC939", result.ticker
+    assert_equal "XMAD", result.exchange_operating_mic
+    assert_equal "XMAD", result.exchange_mic
+  end
+
   test "resolve_security creates new security when not found" do
     symbol_data = { name: "Test Company Inc" }
 

--- a/test/models/provider/indexa_capital_test.rb
+++ b/test/models/provider/indexa_capital_test.rb
@@ -120,11 +120,35 @@ class Provider::IndexaCapitalTest < ActiveSupport::TestCase
     provider = Provider::IndexaCapital.new(api_token: "bad_token")
 
     stub_response = OpenStruct.new(code: 401, body: "Unauthorized")
-    Provider::IndexaCapital.stubs(:get).returns(stub_response)
+    Provider::IndexaCapital.expects(:post).never
+    Provider::IndexaCapital.expects(:get).once.returns(stub_response)
 
     assert_raises Provider::IndexaCapital::AuthenticationError do
       provider.list_accounts
     end
+  end
+
+  test "credential auth refreshes a stale token once after unauthorized response" do
+    provider = Provider::IndexaCapital.new(
+      username: "user@example.com",
+      document: "12345678A",
+      password: "secret"
+    )
+
+    first_auth_response = OpenStruct.new(code: 200, body: { token: "expired_token" }.to_json)
+    second_auth_response = OpenStruct.new(code: 200, body: { token: "fresh_token" }.to_json)
+    unauthorized_response = OpenStruct.new(code: 401, body: "Unauthorized")
+    accounts_response = OpenStruct.new(code: 200, body: { accounts: [] }.to_json)
+    request_tokens = []
+
+    Provider::IndexaCapital.expects(:post).twice.returns(first_auth_response, second_auth_response)
+    Provider::IndexaCapital.expects(:get).twice.with do |_url, options|
+      request_tokens << options.fetch(:headers).fetch("X-AUTH-TOKEN")
+      true
+    end.returns(unauthorized_response, accounts_response)
+
+    assert_equal [], provider.list_accounts
+    assert_equal [ "expired_token", "fresh_token" ], request_tokens
   end
 
   test "rejects invalid account_number with path traversal" do


### PR DESCRIPTION
## Summary

Fixes #939.

- Avoid synchronous Indexa Capital provider account fetching from `select_accounts`; schedule a background refresh and render cached unlinked accounts instead.
- Retry stale credential-based auth tokens once after a `401`, while preserving API-token auth behavior without re-authentication.
- Resolve Indexa securities by ticker and exchange MIC, and persist exchange MIC metadata when creating securities.
- Encrypt Indexa `username` and `document` credentials.
- Stabilize the Indexa activities job Sidekiq lock key by account id.

## Testing

- `bin/rails test`
- `bin/rails test test/models/provider/indexa_capital_test.rb test/models/indexa_capital_account/data_helpers_test.rb test/controllers/indexa_capital_items_controller_test.rb test/jobs/indexa_capital_activities_fetch_job_test.rb`
- `bin/rubocop app/controllers/indexa_capital_items_controller.rb app/jobs/indexa_capital_activities_fetch_job.rb app/models/indexa_capital_account/data_helpers.rb app/models/indexa_capital_item.rb app/models/provider/indexa_capital.rb test/controllers/indexa_capital_items_controller_test.rb test/models/indexa_capital_account/data_helpers_test.rb test/models/provider/indexa_capital_test.rb test/jobs/indexa_capital_activities_fetch_job_test.rb`
- `npm run lint`
- `bin/brakeman`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Account selection now processes asynchronously for faster page responsiveness
  * Enhanced encryption applied to additional credential fields
  * Authentication failures now automatically trigger credential refresh and retry operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->