### PR TITLE
perf(reports): collapse investment flow aggregates

### DIFF
--- a/app/models/investment_flow_statement.rb
+++ b/app/models/investment_flow_statement.rb
@@ -28,7 +28,8 @@ class InvestmentFlowStatement
       .where(investment_activity_label: %w[Contribution Withdrawal])
 
     if user
-      scope = scope.joins(entry: :account).merge(Account.included_in_finances_for(user))
+      account_ids = family.accounts.included_in_finances_for(user).select(:id)
+      scope = scope.where(entries: { account_id: account_ids })
     end
 
     contributions, withdrawals = scope.pick(

--- a/app/models/investment_flow_statement.rb
+++ b/app/models/investment_flow_statement.rb
@@ -1,6 +1,16 @@
 class InvestmentFlowStatement
   include Monetizable
 
+  CONTRIBUTIONS_TOTAL_SQL = Arel.sql(
+    "COALESCE(ABS(SUM(CASE WHEN transactions.investment_activity_label = 'Contribution' " \
+    "THEN entries.amount ELSE 0 END)), 0)"
+  )
+  WITHDRAWALS_TOTAL_SQL = Arel.sql(
+    "COALESCE(ABS(SUM(CASE WHEN transactions.investment_activity_label = 'Withdrawal' " \
+    "THEN entries.amount ELSE 0 END)), 0)"
+  )
+  private_constant :CONTRIBUTIONS_TOTAL_SQL, :WITHDRAWALS_TOTAL_SQL
+
   attr_reader :family, :user
 
   def initialize(family, user: nil)
@@ -21,10 +31,10 @@ class InvestmentFlowStatement
       scope = scope.joins(entry: :account).merge(Account.included_in_finances_for(user))
     end
 
-    transactions = scope
-
-    contributions = transactions.where(investment_activity_label: "Contribution").sum("entries.amount").abs
-    withdrawals = transactions.where(investment_activity_label: "Withdrawal").sum("entries.amount").abs
+    contributions, withdrawals = scope.pick(
+      CONTRIBUTIONS_TOTAL_SQL,
+      WITHDRAWALS_TOTAL_SQL
+    )
 
     PeriodTotals.new(
       contributions: Money.new(contributions, family.currency),

--- a/test/models/investment_flow_statement_test.rb
+++ b/test/models/investment_flow_statement_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class InvestmentFlowStatementTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:empty)
+    @user = users(:empty)
+    @account = @family.accounts.create!(
+      owner: @user,
+      name: "Investment Cash",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+  end
+
+  test "period totals aggregate contributions and withdrawals in one query" do
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
+
+    create_flow(label: "Contribution", amount: -125, date: period.start_date)
+    create_flow(label: "Contribution", amount: 25, date: period.start_date + 1.day)
+    create_flow(label: "Withdrawal", amount: 45, date: period.start_date + 1.day)
+    create_flow(label: "Withdrawal", amount: -5, date: period.start_date + 2.days)
+    create_flow(label: "Transfer", amount: 70, date: period.start_date + 2.days)
+    create_flow(label: "Contribution", amount: -999, date: period.start_date - 1.day)
+
+    statement = InvestmentFlowStatement.new(@family, user: @user)
+    totals = nil
+    queries = capture_sql_queries { totals = statement.period_totals(period: period) }
+
+    assert_equal Money.new(100, "USD"), totals.contributions
+    assert_equal Money.new(40, "USD"), totals.withdrawals
+    assert_equal Money.new(60, "USD"), totals.net_flow
+
+    aggregate_queries = queries.grep(/SUM\(CASE WHEN transactions\.investment_activity_label = 'Contribution'/)
+    assert_equal 1, aggregate_queries.size
+    assert_includes aggregate_queries.first, "transactions.investment_activity_label = 'Withdrawal'"
+    assert_empty queries.grep(/"transactions"\."investment_activity_label" = \$\d/)
+  end
+
+  private
+    def create_flow(label:, amount:, date:)
+      @account.entries.create!(
+        name: label,
+        amount: amount,
+        date: date,
+        currency: "USD",
+        entryable: Transaction.new(
+          kind: "standard",
+          investment_activity_label: label
+        )
+      )
+    end
+
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
+    end
+end

--- a/test/models/investment_flow_statement_test.rb
+++ b/test/models/investment_flow_statement_test.rb
@@ -16,6 +16,9 @@ class InvestmentFlowStatementTest < ActiveSupport::TestCase
   test "period totals aggregate contributions and withdrawals in one query" do
     period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
 
+    @account.share_with!(users(:new_email), permission: "read_only", include_in_finances: true)
+    @account.share_with!(users(:intro_user), permission: "read_only", include_in_finances: true)
+
     create_flow(label: "Contribution", amount: -125, date: period.start_date)
     create_flow(label: "Contribution", amount: 25, date: period.start_date + 1.day)
     create_flow(label: "Withdrawal", amount: 45, date: period.start_date + 1.day)
@@ -35,6 +38,7 @@ class InvestmentFlowStatementTest < ActiveSupport::TestCase
     assert_equal 1, aggregate_queries.size
     assert_includes aggregate_queries.first, "transactions.investment_activity_label = 'Withdrawal'"
     assert_empty queries.grep(/"transactions"\."investment_activity_label" = \$\d/)
+    assert_includes aggregate_queries.first, '"entries"."account_id" IN (SELECT DISTINCT "accounts"."id"'
   end
 
   private


### PR DESCRIPTION
## Summary
- Computes investment-flow contribution and withdrawal totals with one aggregate query.
- Preserves the existing family/user visibility and account-finance scoping.
- Preserves `ABS(SUM(amount))` behavior for correction/reversal rows and covers that with a model regression test.

## Why
Sentry surfaced slow database work around `ReportsController#index`. This removes an avoidable duplicate aggregate in the reports path without broad reports refactoring or changing report totals.

## Validation
- `git diff --check upstream/main...HEAD`
- `bin/rubocop app/models/investment_flow_statement.rb test/models/investment_flow_statement_test.rb`
- `bin/brakeman --quiet`
- `bin/rails test test/controllers/reports_controller_test.rb test/models/investment_flow_statement_test.rb`
- `bin/rails test` -> 4787 runs, 19902 assertions, 0 failures, 0 errors, 26 skips

Closes #2188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved investment flow statement calculations to aggregate contributions and withdrawals in a single, more efficient query.

* **Tests**
  * Added test coverage for period totals to verify contribution, withdrawal, and net flow accuracy and that aggregation and account filtering are performed in one query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->