### PR TITLE
fix(sharing): scope transfer form account-currencies JSON to accessible_by (#1803)

### DIFF
--- a/app/views/transfers/_form.html.erb
+++ b/app/views/transfers/_form.html.erb
@@ -1,4 +1,4 @@
-<% account_currencies = Current.family.accounts.map { |a| [a.id, a.currency] }.to_h.to_json %>
+<% account_currencies = Current.user.accessible_accounts.pluck(:id, :currency).to_h.to_json %>
 <%= styled_form_with model: transfer, class: "space-y-4", data: { turbo_frame: "_top", controller: "transfer-form", transfer_form_exchange_rate_url_value: exchange_rate_path, transfer_form_account_currencies_value: account_currencies } do |f| %>
   <% if transfer.errors.present? %>
     <div class="text-destructive flex items-center gap-2">

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -10,6 +10,24 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "new form does not leak unshared account ids in account-currencies JSON (#1803)" do
+    sign_in users(:family_member)
+    unshared_account = accounts(:other_asset)
+    shared_account = accounts(:depository)
+
+    get new_transfer_url
+
+    assert_response :success
+    map_node = css_select("[data-transfer-form-account-currencies-value]").first
+    assert map_node, "Expected the form to render data-transfer-form-account-currencies-value"
+    account_currencies = JSON.parse(map_node["data-transfer-form-account-currencies-value"])
+
+    assert_includes account_currencies.keys, shared_account.id,
+      "Expected the shared account id to be present in the account-currencies map"
+    refute_includes account_currencies.keys, unshared_account.id,
+      "Family member must not receive ids of unshared family accounts via the transfer form JSON"
+  end
+
   test "can create transfers" do
     assert_difference "Transfer.count", 1 do
       post transfers_url, params: {


### PR DESCRIPTION
## Summary

The new-transaction and new-transfer forms emit a client-side `data-*-account-currencies-value` attribute that maps every family account id to its currency. Both used `Current.family.accounts`, so the rendered HTML enumerated every account in the family — including the family admin's unshared personal accounts — for any signed-in member. Switching the source to `Current.user.accessible_accounts` brings the map in line with the already-scoped `<select>` immediately below it.

## Context

- Refs #1803, Bug 1 (UI leak). Bug 2 (per-family integration tokens) is architectural and explicitly out of scope.
- The underlying scoping primitive (`Account.accessible_by` / `User#accessible_accounts`) has been in place since PR #1272 (Family sharing) and PR #1300 (Recurring scoping). This PR routes the two form partials through it — the dashboard sidebar, `AccountsController#index`, `TransactionsController`, `TransfersController`, etc. already do.
- Two sibling PRs address the other leaking surfaces (import account selects; AI assistant function tools).

## Changes

- [app/views/transactions/_form.html.erb:3](app/views/transactions/_form.html.erb#L3) — replace `Current.family.accounts.map { |a| [a.id, a.currency] }.to_h.to_json` with `Current.user.accessible_accounts.pluck(:id, :currency).to_h.to_json`. The `.pluck` swap is a small bonus: avoids loading full `Account` records just to read two columns.
- [app/views/transfers/_form.html.erb:1](app/views/transfers/_form.html.erb#L1) — same swap.
- [test/controllers/transactions_controller_test.rb](test/controllers/transactions_controller_test.rb) — adds regression test `new form does not leak unshared account ids in account-currencies JSON (#1803)`.

## Test plan

- [ ] `bin/rails test test/controllers/transactions_controller_test.rb -n "/#1803/"` passes
- [ ] `bin/rails test test/controllers/transactions_controller_test.rb` (full file) passes
- [ ] Manual: sign in as `family_member` (`jakobdylan@yahoo.com`), open `/transactions/new`, view source, confirm `data-transaction-form-account-currencies-value` does not contain the ids of the dylan_family fixtures `Collectable Account`, `IOU (personal debt to friend)`, or `Plaid Depository Account`
- [ ] Manual: open `/transfers/new` as `family_member`, repeat the same view-source check on `data-transfer-form-account-currencies-value`

## Closes

Refs #1803 (Bug 1, UI leak). Not a full close — two sibling PRs cover the import flow and the AI assistant tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transfer form to only display accounts accessible to the current user, preventing visibility of unauthorized accounts.

* **Tests**
  * Added integration test to verify account access restrictions in transfer form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->