### PR TITLE
fix(sharing): scope import account selects to accessible_by (#1803)

### DIFF
--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -56,7 +56,7 @@
 
     <%= styled_form_with model: @import, scope: :import, url: import_upload_path(@import), multipart: true, class: "space-y-4" do |form| %>
       <%= form.select :account_id,
-            @import.family.accounts.visible.alphabetically.pluck(:name, :id),
+            Current.user.accessible_accounts.visible.alphabetically.pluck(:name, :id),
             { label: t(".qif_account_label"), include_blank: t(".qif_account_placeholder"), selected: @import.account_id },
             required: true %>
 
@@ -112,7 +112,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, @import.family.accounts.visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, Current.user.accessible_accounts.visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <label for="import_import_file_csv" class="flex flex-col items-center justify-center w-full h-64 border border-secondary border-dashed rounded-xl cursor-pointer" data-controller="file-upload" data-file-upload-target="uploadArea">
@@ -144,7 +144,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, @import.family.accounts.visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, Current.user.accessible_accounts.visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <%= form.text_area :raw_file_str,

--- a/app/views/imports/_pdf_import.html.erb
+++ b/app/views/imports/_pdf_import.html.erb
@@ -39,7 +39,7 @@
 
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.select_account", default: "Import to Account") %></h2>
-          <%= form_with model: import, url: import_path(import), method: :patch, class: "space-y-2" do |f| %>
+          <%= form_with model: import, scope: :import, url: import_path(import), method: :patch, class: "space-y-2" do |f| %>
             <% accounts = Current.user.accessible_accounts.manual.alphabetically.pluck(:name, :id) %>
             <% if accounts.any? %>
               <%= f.select :account_id, options_for_select(accounts, import.account_id), { include_blank: t("imports.pdf_import.select_account_placeholder", default: "Select an account...") }, class: "form-field__input" %>

--- a/app/views/imports/_pdf_import.html.erb
+++ b/app/views/imports/_pdf_import.html.erb
@@ -40,7 +40,7 @@
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.select_account", default: "Import to Account") %></h2>
           <%= form_with model: import, url: import_path(import), method: :patch, class: "space-y-2" do |f| %>
-            <% accounts = import.family.accounts.manual.alphabetically %>
+            <% accounts = Current.user.accessible_accounts.manual.alphabetically %>
             <% if accounts.any? %>
               <%= f.select :account_id, options_for_select(accounts.map { |a| [a.name, a.id] }, import.account_id), { include_blank: t("imports.pdf_import.select_account_placeholder", default: "Select an account...") }, class: "form-field__input" %>
               <% if import.account.nil? %>

--- a/app/views/imports/_pdf_import.html.erb
+++ b/app/views/imports/_pdf_import.html.erb
@@ -40,9 +40,9 @@
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.select_account", default: "Import to Account") %></h2>
           <%= form_with model: import, url: import_path(import), method: :patch, class: "space-y-2" do |f| %>
-            <% accounts = Current.user.accessible_accounts.manual.alphabetically %>
+            <% accounts = Current.user.accessible_accounts.manual.alphabetically.pluck(:name, :id) %>
             <% if accounts.any? %>
-              <%= f.select :account_id, options_for_select(accounts.map { |a| [a.name, a.id] }, import.account_id), { include_blank: t("imports.pdf_import.select_account_placeholder", default: "Select an account...") }, class: "form-field__input" %>
+              <%= f.select :account_id, options_for_select(accounts, import.account_id), { include_blank: t("imports.pdf_import.select_account_placeholder", default: "Select an account...") }, class: "form-field__input" %>
               <% if import.account.nil? %>
                 <p class="text-xs text-secondary"><%= t("imports.pdf_import.select_account_hint", default: "Choose which account to import these transactions into.") %></p>
               <% end %>

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -41,14 +41,10 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
     get import_upload_url(@import)
 
     assert_response :success
-    assert_match "Checking Account", response.body,
-      "Expected the shared account to appear in the account select"
-    refute_match "Collectable Account", response.body,
-      "Account select must not leak unshared assets to a non-owner family member"
-    refute_match "IOU (personal debt to friend)", response.body,
-      "Account select must not leak unshared liabilities to a non-owner family member"
-    refute_match "Plaid Depository Account", response.body,
-      "Account select must not leak unshared connected accounts to a non-owner family member"
+    assert_select 'select[name="import[account_id]"] option', text: "Checking Account"
+    assert_select 'select[name="import[account_id]"] option', text: "Collectable Account", count: 0
+    assert_select 'select[name="import[account_id]"] option', text: "IOU (personal debt to friend)", count: 0
+    assert_select 'select[name="import[account_id]"] option', text: "Plaid Depository Account", count: 0
   end
 
   test "invalid csv cannot be uploaded" do

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -35,6 +35,22 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "CSV uploaded successfully.", flash[:notice]
   end
 
+  test "account select does not leak unshared family accounts (#1803)" do
+    sign_in users(:family_member)
+
+    get import_upload_url(@import)
+
+    assert_response :success
+    assert_match "Checking Account", response.body,
+      "Expected the shared account to appear in the account select"
+    refute_match "Collectable Account", response.body,
+      "Account select must not leak unshared assets to a non-owner family member"
+    refute_match "IOU (personal debt to friend)", response.body,
+      "Account select must not leak unshared liabilities to a non-owner family member"
+    refute_match "Plaid Depository Account", response.body,
+      "Account select must not leak unshared connected accounts to a non-owner family member"
+  end
+
   test "invalid csv cannot be uploaded" do
     patch import_upload_url(@import), params: {
       import: {

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -363,4 +363,17 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to imports_path
   end
+
+  test "PDF import account select does not leak unshared family accounts (#1803)" do
+    sign_in users(:family_member)
+    pdf_import = imports(:pdf_with_rows)
+
+    get import_url(pdf_import)
+
+    assert_response :success
+    assert_select 'select[name="import[account_id]"] option', text: "Checking Account"
+    assert_select 'select[name="import[account_id]"] option', text: "Collectable Account", count: 0
+    assert_select 'select[name="import[account_id]"] option', text: "IOU (personal debt to friend)", count: 0
+    assert_select 'select[name="import[account_id]"] option', text: "Plaid Depository Account", count: 0
+  end
 end

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -367,6 +367,11 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
   test "PDF import account select does not leak unshared family accounts (#1803)" do
     sign_in users(:family_member)
     pdf_import = imports(:pdf_with_rows)
+    # The fixture has no attached pdf_file and no statement, so
+    # ImportsController#show would redirect to the upload page. The
+    # partial under test only renders for an uploaded PDF — stub the
+    # state so we exercise the actual account-select scoping path.
+    PdfImport.any_instance.stubs(:pdf_uploaded?).returns(true)
 
     get import_url(pdf_import)
 


### PR DESCRIPTION
## Summary

The CSV upload page (`/import/uploads`) and the PDF-import landing partial both populated their "Import to Account" dropdowns from `@import.family.accounts`, so any member running an import saw every account in the family — including the admin's unshared personal accounts — listed as a valid target. This is the most direct match to the reproduction steps in #1803. The fix re-routes each option list through `Current.user.accessible_accounts`, the same source the dashboard sidebar and the standard transactions/transfers controllers already use.

## Context

- Refs #1803, Bug 1 (UI leak). Bug 2 (per-family integration tokens) is architectural and explicitly out of scope.
- `Account.accessible_by` / `User#accessible_accounts` has been in place since PR #1272 (Family sharing) and PR #1300 (Recurring scoping). This PR routes the four import-flow call sites through it.
- Two sibling PRs cover the other leaking surfaces (new-transaction/transfer form JSON; AI assistant function tools).

## Changes

- [app/views/import/uploads/show.html.erb:59](app/views/import/uploads/show.html.erb#L59) — QIF account select: `@import.family.accounts.visible.alphabetically.pluck(:name, :id)` → `Current.user.accessible_accounts.visible.alphabetically.pluck(:name, :id)`.
- [app/views/import/uploads/show.html.erb:115](app/views/import/uploads/show.html.erb#L115) — same swap on the CSV-upload tab's account select.
- [app/views/import/uploads/show.html.erb:147](app/views/import/uploads/show.html.erb#L147) — same swap on the CSV-paste tab's account select.
- [app/views/imports/_pdf_import.html.erb:43](app/views/imports/_pdf_import.html.erb#L43) — `import.family.accounts.manual.alphabetically` → `Current.user.accessible_accounts.manual.alphabetically` for the PDF-import "Import to Account" dropdown.
- [test/controllers/import/uploads_controller_test.rb](test/controllers/import/uploads_controller_test.rb) — adds regression test `account select does not leak unshared family accounts (#1803)`.

## Test plan

- [ ] `bin/rails test test/controllers/import/uploads_controller_test.rb -n "/#1803/"` passes
- [ ] `bin/rails test test/controllers/import/uploads_controller_test.rb` (full file) passes
- [ ] Manual: sign in as `family_member`, visit `/import/uploads/<TransactionImport id>`, expand the CSV-upload and CSV-paste tabs, confirm the account `<select>` lists only `Checking Account` and `Credit Card` — never `Collectable Account`, `IOU (personal debt to friend)`, or `Plaid Depository Account`
- [ ] Manual: as `family_member`, open a `PdfImport` page and confirm the "Import to Account" dropdown shows the same scoped list

## Closes

Refs #1803 (Bug 1, UI leak). Not a full close — two sibling PRs cover the form JSON and the AI assistant tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import account selectors (QIF, CSV upload/paste, and PDF review) now only list accounts accessible to the signed-in user, preventing unshared family accounts from being offered as import destinations.

* **Tests**
  * Added integration tests verifying non-owner/shared users cannot see or select unshared accounts during import account selection (CSV and PDF).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->