### PR TITLE
feat: Tag channel payments with funding source, auto-generate linked bank record for reconciliation (#2192)

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -69,65 +69,118 @@ class Api::V1::TransactionsController < Api::V1::BaseController
   end
 
   def create
-    family = current_resource_owner.family
+  family = current_resource_owner.family
 
-    # Validate account_id is present
-    unless account_id_param.present?
-      render json: {
-        error: "validation_failed",
-        message: "Account ID is required",
-        errors: [ "Account ID is required" ]
-      }, status: :unprocessable_entity
-      return
-    end
+  # Validate account_id is present
+  unless account_id_param.present?
+    render json: {
+      error: "validation_failed",
+      message: "Account ID is required",
+      errors: [ "Account ID is required" ]
+    }, status: :unprocessable_entity
+    return
+  end
 
-    if idempotency_source_param.present? && idempotency_external_id.blank?
-      render json: {
-        error: "validation_failed",
-        message: "Source requires external_id",
-        errors: [ "Source requires external_id" ]
-      }, status: :unprocessable_entity
-      return
-    end
+  if idempotency_source_param.present? && idempotency_external_id.blank?
+    render json: {
+      error: "validation_failed",
+      message: "Source requires external_id",
+      errors: [ "Source requires external_id" ]
+    }, status: :unprocessable_entity
+    return
+  end
 
-    account = family.accounts.writable_by(current_resource_owner).find(account_id_param)
+  account = family.accounts.writable_by(current_resource_owner).find(account_id_param)
 
-    if idempotency_key_requested? && (existing_entry = existing_idempotent_entry(account))
-      return render_existing_idempotent_entry(existing_entry)
-    end
+  if idempotency_key_requested? && (existing_entry = existing_idempotent_entry(account))
+    return render_existing_idempotent_entry(existing_entry)
+  end
 
-    @entry = account.entries.new(entry_params_for_create)
+  # Handle channel payment: auto-generate a secondary record on the funding account
+  if channel_payment_requested?
+    funding_account = family.accounts.writable_by(current_resource_owner).find(funding_account_id_param)
 
-    if @entry.save
+    ApplicationRecord.transaction do
+      # Record A: on the payment channel account (e.g., Alipay)
+      # excluded: true → does NOT affect channel account balance
+      @entry = account.entries.new(entry_params_for_create.merge(excluded: true))
+      @entry.save!
+      @entry.transaction.update!(
+        channel: channel_payment_param,
+        channel_payment: true
+      )
+
+      # Record B: auto-generated on the funding account (e.g., bank card)
+      # excluded: false → DOES affect bank card balance (normal expense)
+      channel_name = channel_payment_param.presence || "Channel"
+      secondary_entry = funding_account.entries.new(
+        name: "#{channel_name} payment",
+        date: @entry.date,
+        amount: @entry.amount,
+        currency: @entry.currency,
+        notes: "Auto-generated from #{channel_name} channel transaction",
+        entryable_type: "Transaction",
+        entryable_attributes: {
+          category_id: nil,
+          merchant_id: nil
+        }
+      )
+      secondary_entry.save!
+      secondary_entry.transaction.update!(
+        channel_record: true,
+        channel: channel_payment_param,
+        channel_record_parent_id: @entry.transaction.id
+      )
+
       @entry.sync_account_later
+      secondary_entry.sync_account_later
       @entry.lock_saved_attributes!
       @entry.transaction.lock_attr!(:tag_ids) if @entry.transaction.tags.any?
 
       @transaction = @entry.transaction
-      render :show, status: :created
-    else
-      render json: {
-        error: "validation_failed",
-        message: "Transaction could not be created",
-        errors: @entry.errors.full_messages
-      }, status: :unprocessable_entity
     end
+
+    render :show, status: :created
+    return
+  end
+
+  @entry = account.entries.new(entry_params_for_create)
+
+  if @entry.save
+    @entry.sync_account_later
+    @entry.lock_saved_attributes!
+    @entry.transaction.lock_attr!(:tag_ids) if @entry.transaction.tags.any?
+
+    @transaction = @entry.transaction
+    render :show, status: :created
+  else
+    render json: {
+      error: "validation_failed",
+      message: "Transaction could not be created",
+      errors: @entry.errors.full_messages
+    }, status: :unprocessable_entity
+  end
 
   rescue ActiveRecord::RecordNotUnique
-    if idempotency_key_requested? && account && (existing_entry = existing_idempotent_entry(account))
-      render_existing_idempotent_entry(existing_entry)
-    else
-      raise
-    end
+  if idempotency_key_requested? && account && (existing_entry = existing_idempotent_entry(account))
+    render_existing_idempotent_entry(existing_entry)
+  else
+    raise
+  end
+  rescue ActiveRecord::RecordNotFound => e
+  render json: {
+    error: "not_found",
+    message: e.message
+  }, status: :not_found
   rescue => e
-    Rails.logger.error "TransactionsController#create error: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
+  Rails.logger.error "TransactionsController#create error: #{e.message}"
+  Rails.logger.error e.backtrace.join("\n")
 
-    render json: {
-      error: "internal_server_error",
-      message: "An unexpected error occurred"
-    }, status: :internal_server_error
-end
+  render json: {
+    error: "internal_server_error",
+    message: "An unexpected error occurred"
+  }, status: :internal_server_error
+  end
 
   def update
     if @entry.split_child?
@@ -308,7 +361,8 @@ end
     def transaction_params
       params.require(:transaction).permit(
         :date, :amount, :name, :description, :notes, :currency,
-        :category_id, :merchant_id, :nature, tag_ids: []
+        :category_id, :merchant_id, :nature, :channel, :channel_payment,
+        :funding_account_id, tag_ids: []
       )
     end
 
@@ -427,6 +481,20 @@ end
       else
         amount       # Use as provided
       end
+    end
+
+    # Channel payment helpers
+    def channel_payment_requested?
+      ActiveModel::Type::Boolean.new.cast(transaction_params[:channel_payment]) &&
+        funding_account_id_param.present?
+    end
+
+    def channel_payment_param
+      transaction_params[:channel]
+    end
+
+    def funding_account_id_param
+      transaction_params[:funding_account_id].presence
     end
 
     def safe_page_param

--- a/app/models/balance/sync_cache.rb
+++ b/app/models/balance/sync_cache.rb
@@ -34,7 +34,7 @@ class Balance::SyncCache
     end
 
     def converted_entries
-      @converted_entries ||= account.entries.excluding_split_parents.includes(:entryable).order(:date).to_a.map do |e|
+      @converted_entries ||= account.entries.excluding_split_parents.where(excluded: false).includes(:entryable).order(:date).to_a.map do |e|
         converted_entry = e.dup
 
         custom_rate = e.entryable.exchange_rate if e.entryable.respond_to?(:exchange_rate)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -84,6 +84,15 @@ class Transaction < ApplicationRecord
   # they represent real cash outflow from a budgeting perspective.
   BUDGET_EXCLUDED_KINDS = %w[funds_movement one_time cc_payment].freeze
 
+  # Channel payment associations
+  belongs_to :channel_record_parent, class_name: "Transaction", optional: true
+  has_one :channel_record_child, class_name: "Transaction", foreign_key: :channel_record_parent_id, dependent: :destroy
+
+  # Channel payment scopes
+  scope :channel_payments, -> { where(channel_payment: true) }
+  scope :channel_records, -> { where(channel_record: true) }
+  scope :excluding_channel_records, -> { where(channel_record: false) }
+
   # All valid investment activity labels (for UI dropdown)
   ACTIVITY_LABELS = [
     "Buy", "Sell", "Sweep In", "Sweep Out", "Dividend", "Reinvestment",

--- a/app/views/api/v1/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v1/transactions/_transaction.json.jbuilder
@@ -86,3 +86,32 @@ end
 # Additional metadata
 json.created_at transaction.created_at.iso8601
 json.updated_at transaction.updated_at.iso8601
+
+# Channel payment fields
+json.channel transaction.channel if transaction.channel.present?
+json.channel_payment transaction.channel_payment if transaction.channel_payment
+json.channel_record transaction.channel_record if transaction.channel_record
+
+if transaction.channel_record_parent_id.present?
+  json.channel_record_parent do
+    json.id transaction.channel_record_parent.id
+    json.amount transaction.channel_record_parent.entry.amount_money.format
+    json.name transaction.channel_record_parent.entry.name
+    json.account do
+      json.id transaction.channel_record_parent.entry.account.id
+      json.name transaction.channel_record_parent.entry.account.name
+    end
+  end
+end
+
+if transaction.channel_record_child.present?
+  json.channel_record_child do
+    json.id transaction.channel_record_child.id
+    json.amount transaction.channel_record_child.entry.amount_money.format
+    json.name transaction.channel_record_child.entry.name
+    json.account do
+      json.id transaction.channel_record_child.entry.account.id
+      json.name transaction.channel_record_child.entry.account.name
+    end
+  end
+end

--- a/db/migrate/20260605000000_add_channel_payment_fields_to_transactions.rb
+++ b/db/migrate/20260605000000_add_channel_payment_fields_to_transactions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddChannelPaymentFieldsToTransactions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :transactions, :channel, :string
+    add_column :transactions, :channel_payment, :boolean, default: false, null: false
+    add_column :transactions, :channel_record, :boolean, default: false, null: false
+    add_reference :transactions, :channel_record_parent,
+                  foreign_key: { to_table: :transactions },
+                  type: :uuid
+  end
+end

--- a/spec/requests/api/v1/transactions_spec.rb
+++ b/spec/requests/api/v1/transactions_spec.rb
@@ -176,7 +176,10 @@ RSpec.describe 'API V1 Transactions', type: :request do
               nature: { type: :string, enum: %w[income expense inflow outflow], description: 'Transaction nature (determines sign)' },
               external_id: { type: :string, description: 'Optional external idempotency key scoped to account and source' },
               source: { type: :string, description: 'Optional source namespace for external_id. Requires external_id and defaults to api when external_id is provided' },
-              tag_ids: { type: :array, items: { type: :string, format: :uuid }, description: 'Array of tag IDs' }
+              tag_ids: { type: :array, items: { type: :string, format: :uuid }, description: 'Array of tag IDs' },
+              channel: { type: :string, description: 'Payment channel name (e.g., "alipay", "wechat_pay", "paypal")' },
+              channel_payment: { type: :boolean, description: 'Mark as channel payment — if true, requires funding_account_id' },
+              funding_account_id: { type: :string, format: :uuid, description: 'Bank card/account ID that actually funded this channel payment' }
             },
             required: %w[account_id date amount name]
           }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -741,6 +741,16 @@ RSpec.configure do |config|
               other_account: { '$ref' => '#/components/schemas/Account', nullable: true }
             }
           },
+          ChannelRecordSide: {
+            type: :object,
+            required: %w[id amount name account],
+            properties: {
+              id: { type: :string, format: :uuid },
+              amount: { type: :string },
+              name: { type: :string },
+              account: { '$ref' => '#/components/schemas/Account' }
+            }
+          },
           RecurringTransaction: {
             type: :object,
             required: %w[id amount amount_cents currency expected_day_of_month last_occurrence_date next_expected_date status occurrence_count manual created_at updated_at],
@@ -800,6 +810,11 @@ RSpec.configure do |config|
                 items: { '$ref' => '#/components/schemas/Tag' }
               },
               transfer: { '$ref' => '#/components/schemas/Transfer', nullable: true },
+              channel: { type: :string, nullable: true },
+              channel_payment: { type: :boolean, nullable: true },
+              channel_record: { type: :boolean, nullable: true },
+              channel_record_parent: { '$ref' => '#/components/schemas/ChannelRecordSide', nullable: true },
+              channel_record_child: { '$ref' => '#/components/schemas/ChannelRecordSide', nullable: true },
               created_at: { type: :string, format: :'date-time' },
               updated_at: { type: :string, format: :'date-time' }
             }

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -757,6 +757,69 @@ end
     assert transaction_data["transfer"].key?("other_account")
   end
 
+  test "should create channel payment with auto-generated bank record" do
+    # Create a channel account (e.g., Alipay) and a funding account (bank card)
+    channel_account = @family.accounts.create!(
+      name: "Alipay Test",
+      balance: 1000,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    funding_account = @family.accounts.create!(
+      name: "Bank Card Test",
+      balance: 5000,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    entry_count_before = Entry.count
+    txn_count_before = Transaction.count
+
+    post api_v1_transactions_url, params: {
+      transaction: {
+        account_id: channel_account.id,
+        date: Date.current.to_s,
+        amount: 98.97,
+        name: "Starbucks - Grande Latte",
+        nature: "expense",
+        currency: "USD",
+        channel: "alipay",
+        channel_payment: true,
+        funding_account_id: funding_account.id
+      }
+    }, headers: api_headers(@api_key), as: :json
+
+    assert_response :created
+
+    # Two entries should have been created
+    assert_equal entry_count_before + 2, Entry.count
+    assert_equal txn_count_before + 2, Transaction.count
+
+    body = JSON.parse(response.body)
+
+    # Primary record (channel side) — balance NOT affected
+    assert body["channel_payment"], "Primary record should have channel_payment: true"
+    assert_equal "alipay", body["channel"]
+    assert_equal "Starbucks - Grande Latte", body["name"]
+
+    # Verify the channel account entry is excluded (no balance impact)
+    primary_entry = Entry.find_by!(entryable_id: body["id"], entryable_type: "Transaction")
+    assert primary_entry.excluded?, "Channel account entry should be excluded from balance"
+
+    # Check channel_record_child is present in response
+    assert body["channel_record_child"].present?, "Response should include channel_record_child"
+
+    # Secondary record (bank side) — balance IS affected
+    child = body["channel_record_child"]
+    assert child["id"].present?
+    assert_equal "Alipay payment", child["name"]
+    assert_equal funding_account.id, child["account"]["id"]
+
+    secondary_entry = Entry.find_by!(entryable_id: child["id"], entryable_type: "Transaction")
+    assert_not secondary_entry.excluded?, "Bank card entry should NOT be excluded from balance"
+  end
+
   private
 
     def api_headers(api_key)


### PR DESCRIPTION
## Summary

Implements #2192 — the ability to tag a transaction on a payment channel account (Alipay, WeChat Pay, PayPal) with its actual funding source, and auto-generate a corresponding bank-side record for reconciliation.

## Changes

### Database (Migration)
Added 4 columns to `transactions`:
- `channel` (string)
- `channel_payment` (boolean, default false)
- `channel_record` (boolean, default false)
- `channel_record_parent_id` (UUID, FK to transactions)

### Model (Transaction)
- `belongs_to :channel_record_parent` / `has_one :channel_record_child`
- Scopes: `channel_payments`, `channel_records`, `excluding_channel_records`

### Balance Fix (SyncCache)
- `converted_entries` now filters `excluded: false` so channel-side entries (excluded: true) do not distort the channel account balance

### Controller (create action)
When `channel_payment: true` + `funding_account_id` is provided:
1. Creates Record A (channel side) with `excluded: true` — no balance impact on the channel account
2. Creates Record B (bank side) as a normal expense — affects the funding account balance
3. Links them via `channel_record_parent_id`

Without these fields, normal transaction creation is unchanged.

### Serializer
Exposes `channel`, `channel_payment`, `channel_record`, plus nested `channel_record_child` / `channel_record_parent` objects.

### API Docs (RSwag)
- New `channel`, `channel_payment`, `funding_account_id` parameters on POST
- New `ChannelRecordSide` schema
- Transaction schema includes new fields

## Example API Call

POST /api/v1/transactions
{
  "transaction": {
    "account_id": "<alipay-account-id>",
    "date": "2026-06-05",
    "amount": 98.97,
    "name": "Starbucks - Grande Latte",
    "nature": "expense",
    "currency": "USD",
    "channel": "alipay",
    "channel_payment": true,
    "funding_account_id": "<bank-card-account-id>"
  }
}

Response includes channel_payment: true, channel: "alipay", and a channel_record_child object pointing to the auto-generated bank record.

## Testing
- Full Minitest covering the channel payment flow (2 records created, correct excluded flags, response shape)
- RSwag schema updates pass existing spec structure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for channel payment processing with automatic funding account linking, enabling seamless dual-entry transaction creation.
  * Extended transaction API to include channel metadata and linked transaction references for complete payment chain visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->