### PR TITLE
fix(ds): one height rail for icon and text buttons

### DIFF
--- a/app/components/DS/buttonish.rb
+++ b/app/components/DS/buttonish.rb
@@ -34,16 +34,20 @@ class DS::Buttonish < DesignSystemComponent
     }
   }.freeze
 
+  # Icon-only containers share a height rail with the text buttons of the
+  # same size (sm ≈ 28px, md ≈ 36px, lg ≈ 48px), so a mixed row — icon
+  # trigger next to text buttons, the most common header layout — lines up
+  # instead of mixing 32/44px squares with 36px buttons.
   SIZES = {
     sm: {
       container_classes: "px-2 py-1",
-      icon_container_classes: "inline-flex items-center justify-center w-8 h-8",
+      icon_container_classes: "inline-flex items-center justify-center w-7 h-7",
       radius_classes: "rounded-md",
       text_classes: "text-sm"
     },
     md: {
       container_classes: "px-3 py-2",
-      icon_container_classes: "inline-flex items-center justify-center w-11 h-11",
+      icon_container_classes: "inline-flex items-center justify-center w-9 h-9",
       radius_classes: "rounded-lg",
       text_classes: "text-sm"
     },

--- a/app/components/DS/buttonish.rb
+++ b/app/components/DS/buttonish.rb
@@ -38,16 +38,21 @@ class DS::Buttonish < DesignSystemComponent
   # same size (sm ≈ 28px, md ≈ 36px, lg ≈ 48px), so a mixed row — icon
   # trigger next to text buttons, the most common header layout — lines up
   # instead of mixing 32/44px squares with 36px buttons.
+  #
+  # pointer-coarse restores the 44px square on touch devices: the visual
+  # rail is a pointer-precision tradeoff, and WCAG 2.5.5's 44x44 target
+  # minimum is about fingers, not mice. Coarse-pointer users get the full
+  # target; fine-pointer users get the aligned row.
   SIZES = {
     sm: {
       container_classes: "px-2 py-1",
-      icon_container_classes: "inline-flex items-center justify-center w-7 h-7",
+      icon_container_classes: "inline-flex items-center justify-center w-7 h-7 pointer-coarse:w-11 pointer-coarse:h-11",
       radius_classes: "rounded-md",
       text_classes: "text-sm"
     },
     md: {
       container_classes: "px-3 py-2",
-      icon_container_classes: "inline-flex items-center justify-center w-9 h-9",
+      icon_container_classes: "inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11",
       radius_classes: "rounded-lg",
       text_classes: "text-sm"
     },

--- a/app/components/DS/popover.html.erb
+++ b/app/components/DS/popover.html.erb
@@ -9,7 +9,7 @@
         the fallback `ds.popover.avatar_default_label` is used. %>
     <button type="button"
             data-DS--popover-target="button"
-            class="inline-flex items-center justify-center w-11 h-11 cursor-pointer rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white"
+            class="inline-flex items-center justify-center w-9 h-9 cursor-pointer rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white"
             aria-label="<%= trigger_aria_label %>"
             aria-haspopup="dialog"
             aria-expanded="false"

--- a/app/components/DS/popover.html.erb
+++ b/app/components/DS/popover.html.erb
@@ -9,7 +9,7 @@
         the fallback `ds.popover.avatar_default_label` is used. %>
     <button type="button"
             data-DS--popover-target="button"
-            class="inline-flex items-center justify-center w-9 h-9 cursor-pointer rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white"
+            class="inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 cursor-pointer rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 theme-dark:focus-visible:outline-white"
             aria-label="<%= trigger_aria_label %>"
             aria-haspopup="dialog"
             aria-expanded="false"

--- a/app/components/DS/select.html.erb
+++ b/app/components/DS/select.html.erb
@@ -31,7 +31,7 @@
         </button>
     </div>
   </div>
-  <div class="absolute z-50 p-1.5 w-full min-w-32 rounded-lg shadow-lg shadow-border-xs bg-container mt-1.5 transition duration-150 ease-out -translate-y-1 opacity-0 hidden" data-select-target="menu">
+  <div class="absolute z-50 p-1.5 w-full min-w-32 rounded-lg shadow-border-lg bg-container mt-1.5 transition duration-150 ease-out -translate-y-1 opacity-0 hidden" data-select-target="menu">
     <% if searchable %>
       <div class="flex items-center bg-container border border-secondary rounded-lg mb-1 focus-within:ring-4 focus-within:ring-alpha-black-200 theme-dark:focus-within:ring-alpha-white-300 transition-shadow">
         <%= render DS::SearchInput.new(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@ end %>
 
       <div class="flex items-center gap-1">
         <button type="button"
-                class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-secondary hover:text-primary transition-colors"
+                class="inline-flex items-center justify-center w-9 h-9 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors"
                 data-action="click->privacy-mode#toggle"
                 data-privacy-mode-target="toggle"
                 title="<%= t("layouts.application.privacy_mode") %>"
@@ -158,7 +158,7 @@ end %>
 
           <div class="flex items-center gap-2">
             <button type="button"
-                    class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-secondary hover:text-primary hover:bg-surface-hover transition-colors"
+                    class="inline-flex items-center justify-center w-9 h-9 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors"
                     data-action="click->privacy-mode#toggle"
                     data-privacy-mode-target="toggle"
                     title="<%= t("layouts.application.privacy_mode") %>"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@ end %>
 
       <div class="flex items-center gap-1">
         <button type="button"
-                class="inline-flex items-center justify-center w-9 h-9 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors"
+                class="inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors"
                 data-action="click->privacy-mode#toggle"
                 data-privacy-mode-target="toggle"
                 title="<%= t("layouts.application.privacy_mode") %>"
@@ -158,7 +158,7 @@ end %>
 
           <div class="flex items-center gap-2">
             <button type="button"
-                    class="inline-flex items-center justify-center w-9 h-9 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors"
+                    class="inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors"
                     data-action="click->privacy-mode#toggle"
                     data-privacy-mode-target="toggle"
                     title="<%= t("layouts.application.privacy_mode") %>"


### PR DESCRIPTION
## Summary

Icon-only buttons didn't share a height rail with the text buttons they sit next to, so every mixed header row in the app was misaligned: the transactions index trio (`…` menu trigger / Import / New transaction) mixed a 44px square with 36px buttons, and the app header put a hand-rolled 32px privacy toggle next to a 44px DS panel button.

The root cause lives in one place — `DS::Buttonish::SIZES` keyed icon containers to 32/44/48px squares while the text buttons of the same nominal size render ~28/36/48px. So this fixes the rail once instead of spot-patching headers:

- **`buttonish.rb`**: icon containers join the text rail — `sm` w-7, `md` w-9, `lg` already aligned at w-12.
- **`DS::Popover`** trigger: hand-rolled `w-11` joins at `w-9`.
- **Layout privacy toggle** (mobile + desktop): can't be a `DS::Button` directly (it carries two swappable icons and Stimulus targets), so it mirrors the md icon-button chrome instead — `w-9`, `rounded-lg`, `container-inset` hover. It previously sat at `w-8` with a different hover from the DS button beside it.

While in the dropdown neighborhood: **`DS::Select`'s panel** adopts `shadow-border-lg`, the elevation `DS::Menu` and `DS::Popover` already use, replacing its weaker `shadow-lg shadow-border-xs` combo — form dropdowns were the only overlays left on the old recipe.

## After

The transactions trio on one rail (measured 36/38/36px — Import's extra 2px is its border):

![trio after](https://raw.githubusercontent.com/gariasf/sure/b466654b7671106a0a66a19e7bfeb3d62dddc01a/trio-after.png)

## Notes

- Every md icon button app-wide shrinks 44 → 36px; that's the point, but it's the blast radius to eyeball (dialog close buttons, menu triggers, account headers).
- Verified in the browser via Playwright against demo data; height measurements above are from the live DOM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined sizing and spacing of icon-only buttons for improved alignment in mixed header layouts and better touch-device sizing.
  * Adjusted avatar trigger sizing in popover components for consistent touch and pointer behavior.
  * Enhanced shadow styling for select menu dropdowns for clearer depth.
  * Improved privacy toggle dimensions and hover states across mobile and desktop navigation for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->