### PR TITLE
Fix SSO provider settings updates (preserve client_secret, persist default_role)

### DIFF
--- a/app/controllers/admin/sso_providers_controller.rb
+++ b/app/controllers/admin/sso_providers_controller.rb
@@ -50,7 +50,8 @@ module Admin
       authorize @sso_provider
 
       # Auto-update redirect_uri if name changed
-      params_hash = processed_params.to_h
+      params_hash = processed_params.to_h.with_indifferent_access
+      params_hash.delete(:client_secret) if params_hash[:client_secret].blank?
       if params_hash[:name].present? && params_hash[:name] != @sso_provider.name
         params_hash[:redirect_uri] = "#{request.base_url}/auth/#{params_hash[:name]}/callback"
       end

--- a/app/views/admin/sso_providers/_form.html.erb
+++ b/app/views/admin/sso_providers/_form.html.erb
@@ -83,7 +83,9 @@
     <%= form.password_field :client_secret,
         label: t("admin.sso_providers.form.client_secret_label"),
         placeholder: sso_provider.persisted? ? t("admin.sso_providers.form.client_secret_placeholder_existing") : t("admin.sso_providers.form.client_secret_placeholder_new"),
-        required: !sso_provider.persisted? %>
+        required: !sso_provider.persisted?,
+        autocomplete: "new-password",
+        value: nil %>
     <% if sso_provider.persisted? %>
       <p class="text-xs text-secondary -mt-2"><%= t("admin.sso_providers.form.client_secret_help_existing") %></p>
     <% end %>
@@ -190,14 +192,18 @@
   <div class="border-t border-primary pt-4 space-y-4">
     <h3 class="font-medium text-primary"><%= t("admin.sso_providers.form.provisioning_title") %></h3>
 
-    <%= form.select "settings[default_role]",
-        options_for_select([
-          [t("admin.sso_providers.form.role_guest", default: "Guest"), "guest"],
-          [t("admin.sso_providers.form.role_member"), "member"],
-          [t("admin.sso_providers.form.role_admin"), "admin"],
-          [t("admin.sso_providers.form.role_super_admin"), "super_admin"]
-        ], sso_provider.settings&.dig("default_role").to_s.presence || "member"),
-        { label: t("admin.sso_providers.form.default_role_label"), include_blank: false } %>
+    <div class="form-field">
+      <%= label_tag "sso_provider_settings_default_role", t("admin.sso_providers.form.default_role_label"), class: "form-field__label" %>
+      <%= select_tag "sso_provider[settings][default_role]",
+          options_for_select([
+            [t("admin.sso_providers.form.role_guest", default: "Guest"), "guest"],
+            [t("admin.sso_providers.form.role_member"), "member"],
+            [t("admin.sso_providers.form.role_admin"), "admin"],
+            [t("admin.sso_providers.form.role_super_admin"), "super_admin"]
+          ], sso_provider.settings&.dig("default_role").to_s.presence || "member"),
+          id: "sso_provider_settings_default_role",
+          class: "form-field__input" %>
+    </div>
     <p class="text-xs text-secondary -mt-2"><%= t("admin.sso_providers.form.default_role_help") %></p>
 
     <details class="mt-4">
@@ -249,22 +255,29 @@
     <h3 class="font-medium text-primary"><%= t("admin.sso_providers.form.advanced_title") %></h3>
 
     <div>
-      <%= form.text_field "settings[scopes]",
-          label: t("admin.sso_providers.form.scopes_label"),
-          value: sso_provider.settings&.dig("scopes"),
-          placeholder: "openid email profile groups" %>
+      <%= label_tag "sso_provider_settings_scopes", t("admin.sso_providers.form.scopes_label"), class: "form-field__label" %>
+      <%= text_field_tag "sso_provider[settings][scopes]",
+          sso_provider.settings&.dig("scopes"),
+          id: "sso_provider_settings_scopes",
+          class: "form-field__input",
+          placeholder: "openid email profile groups",
+          autocomplete: "off" %>
       <p class="text-xs text-secondary mt-1"><%= t("admin.sso_providers.form.scopes_help") %></p>
     </div>
 
-    <%= form.select "settings[prompt]",
-        options_for_select([
-          [t("admin.sso_providers.form.prompt_default"), ""],
-          [t("admin.sso_providers.form.prompt_login"), "login"],
-          [t("admin.sso_providers.form.prompt_consent"), "consent"],
-          [t("admin.sso_providers.form.prompt_select_account"), "select_account"],
-          [t("admin.sso_providers.form.prompt_none"), "none"]
-        ], sso_provider.settings&.dig("prompt")),
-        { label: t("admin.sso_providers.form.prompt_label"), include_blank: false } %>
+    <div class="form-field">
+      <%= label_tag "sso_provider_settings_prompt", t("admin.sso_providers.form.prompt_label"), class: "form-field__label" %>
+      <%= select_tag "sso_provider[settings][prompt]",
+          options_for_select([
+            [t("admin.sso_providers.form.prompt_default"), ""],
+            [t("admin.sso_providers.form.prompt_login"), "login"],
+            [t("admin.sso_providers.form.prompt_consent"), "consent"],
+            [t("admin.sso_providers.form.prompt_select_account"), "select_account"],
+            [t("admin.sso_providers.form.prompt_none"), "none"]
+          ], sso_provider.settings&.dig("prompt")),
+          id: "sso_provider_settings_prompt",
+          class: "form-field__input" %>
+    </div>
     <p class="text-xs text-secondary -mt-2"><%= t("admin.sso_providers.form.prompt_help") %></p>
   </div>
 

--- a/test/controllers/admin/sso_providers_controller_test.rb
+++ b/test/controllers/admin/sso_providers_controller_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Admin::SsoProvidersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    ensure_tailwind_build
+    sign_in users(:sure_support_staff)
+
+    @provider = SsoProvider.create!(
+      strategy: "google_oauth2",
+      name: "google_oauth2_test",
+      label: "Sign in with Google",
+      enabled: true,
+      client_id: "client-id",
+      client_secret: "existing-secret",
+      settings: { "default_role" => "member" }
+    )
+  end
+
+  test "edit form posts nested settings and optional client secret" do
+    get edit_admin_sso_provider_path(@provider)
+
+    assert_response :success
+    assert_includes response.body, 'name="sso_provider[settings][default_role]"'
+    assert_includes response.body, 'name="sso_provider[settings][scopes]"'
+    assert_includes response.body, 'name="sso_provider[settings][prompt]"'
+    assert_includes response.body, 'name="sso_provider[client_secret]"'
+    assert_no_match(/name="sso_provider\[client_secret\]"[^>]*required/, response.body)
+  end
+
+  test "update persists nested default role setting" do
+    patch admin_sso_provider_path(@provider), params: {
+      sso_provider: valid_update_params(settings: { default_role: "guest" })
+    }
+
+    assert_redirected_to admin_sso_providers_path
+    assert_equal "guest", @provider.reload.settings["default_role"]
+  end
+
+  test "update preserves existing client secret when blank" do
+    patch admin_sso_provider_path(@provider), params: {
+      sso_provider: valid_update_params(client_secret: "", label: "Updated Google")
+    }
+
+    assert_redirected_to admin_sso_providers_path
+    @provider.reload
+    assert_equal "Updated Google", @provider.label
+    assert_equal "existing-secret", @provider.client_secret
+  end
+
+  private
+    def valid_update_params(overrides = {})
+      {
+        strategy: @provider.strategy,
+        name: @provider.name,
+        label: @provider.label,
+        enabled: "1",
+        client_id: @provider.client_id,
+        client_secret: @provider.client_secret,
+        settings: @provider.settings
+      }.deep_merge(overrides)
+    end
+end


### PR DESCRIPTION
### Motivation
- The admin SSO provider edit form was not submitting nested `settings[...]` fields correctly so the "Default Role for New Users" selection did not persist. 
- When updating other fields the UI forced re-entering the `client_secret` because a blank secret in params was treated as a value that overwrote the stored secret. 

### Description
- Stop clobbering an existing secret by converting `processed_params` to indifferent-access and removing a blank `:client_secret` before updating in `Admin::SsoProvidersController#update` (use `params_hash = processed_params.to_h.with_indifferent_access` and `params_hash.delete(:client_secret) if params_hash[:client_secret].blank?`).
- Fix form field names for nested settings so `default_role`, `scopes`, and `prompt` submit as `sso_provider[settings][...]` by using `select_tag`/`text_field_tag` with the proper names instead of the previous helpers that produced incorrect names. 
- Make the `client_secret` field non-prepopulated and optional for persisted providers by rendering the password input with `value: nil` and `autocomplete: "new-password"`, and keep the server-side validations intact for new providers. 
- Add controller tests in `test/controllers/admin/sso_providers_controller_test.rb` covering the edit form fields, that nested `default_role` persists, and that an empty `client_secret` on update preserves the existing secret. 

### Testing
- Ran the new controller tests with `bin/rails test test/controllers/admin/sso_providers_controller_test.rb`, which passed (`2 tests` initially, then added a third — all tests passed).
- Ran style checks with `bin/rubocop app/controllers/admin/sso_providers_controller.rb test/controllers/admin/sso_providers_controller_test.rb`, which reported no offenses.
- Ran template linting with `bundle exec erb_lint app/views/admin/sso_providers/_form.html.erb`, which reported no errors after adding `autocomplete` attributes where required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2390f9f38483329ebae24fe585156f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where submitting a blank client secret during SSO provider configuration would incorrectly clear the existing stored secret value.

* **Improvements**
  * Enhanced the SSO provider configuration form with improved field structure, better accessibility features, and refined handling of authentication and OpenID Connect parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->