### PR TITLE
Fix Trend#percent sign inversion for a negative baseline

### DIFF
--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -56,7 +56,11 @@ class Trend
 
     change = (current - previous).to_f
 
-    (change / previous.to_f * 100).round(1)
+    # Normalize by the magnitude of the baseline so the sign reflects the
+    # direction of change. Dividing by a signed negative `previous` (e.g. a
+    # negative net worth or overdrawn balance) inverts the sign — an
+    # improvement from -1000 to -500 would otherwise read as -50%.
+    (change / previous.to_f.abs * 100).round(1)
   end
 
   def percent_formatted

--- a/test/models/trend_test.rb
+++ b/test/models/trend_test.rb
@@ -37,4 +37,16 @@ class TrendTest < ActiveSupport::TestCase
     trend = Trend.new(current: 0, previous: 100)
     assert_equal "down", trend.direction
   end
+
+  test "percent uses magnitude of a negative baseline" do
+    # Net worth improving from -1000 to -500 is a +50% change, not -50%.
+    improving = Trend.new(current: -500, previous: -1000)
+    assert_equal "up", improving.direction
+    assert_equal 50.0, improving.percent
+
+    # Worsening from -1000 to -1500 is a -50% change.
+    worsening = Trend.new(current: -1500, previous: -1000)
+    assert_equal "down", worsening.direction
+    assert_equal(-50.0, worsening.percent)
+  end
 end


### PR DESCRIPTION
## Summary
Closes #2213

`Trend#percent` divided the change by the *signed* `previous`, so a negative baseline inverted the sign: net worth improving from `-1000` to `-500` (a +50% change) rendered as **-50%** on the dashboard/reports net-worth widget. Net worth (and overdrawn balances) are legitimately negative, so this hits real users.

## Change
- `app/models/trend.rb` — divide by `previous.to_f.abs` so the percentage sign reflects the direction of change. `value` and `direction` already compute the correct sign; only `percent` was affected.
- `test/models/trend_test.rb` — add a negative-baseline regression test (improving `-1000→-500` ⇒ +50%, worsening `-1000→-1500` ⇒ -50%).

## Why it's safe
- For positive baselines `abs` is a no-op, so all existing behavior/tests are unchanged.
- Only the sign for negative baselines changes — to the correct direction.

## Verification
- One-token change plus a regression test. Math verified by hand (see issue); I don't have a Ruby toolchain in this environment, so the suite is left to CI (`bin/rails test test/models/trend_test.rb`). The new test fails on `main` (returns -50.0 / +50.0) and passes with this change; existing positive-baseline tests are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected percent change calculations when baseline values are negative, ensuring improvements and declines display with appropriate signs.

* **Tests**
  * Added test coverage for negative baseline scenarios to verify correct percentage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->