### PR TITLE
Fix BalanceSheet::AccountGroup ignoring included_in_finances? filter

### DIFF
--- a/app/models/balance_sheet/account_group.rb
+++ b/app/models/balance_sheet/account_group.rb
@@ -34,7 +34,14 @@ class BalanceSheet::AccountGroup
   end
 
   def total
-    accounts.sum(&:converted_balance)
+    # Mirror BalanceSheet::ClassificationGroup#total: exclude accounts the
+    # current user has opted out of their finances (shared accounts with
+    # include_in_finances = false). Otherwise group totals — and the weights
+    # derived from them — disagree with the filtered classification/net-worth
+    # totals shown on the same page.
+    accounts
+      .select { |a| a.respond_to?(:included_in_finances?) ? a.included_in_finances? : true }
+      .sum(&:converted_balance)
   end
 
   def weight

--- a/test/models/balance_sheet/account_group_test.rb
+++ b/test/models/balance_sheet/account_group_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class BalanceSheet::AccountGroupTest < ActiveSupport::TestCase
+  # Minimal account double: only the surface AccountGroup#total/#weight use.
+  StubAccount = Struct.new(:converted_balance, :include_in_finances) do
+    def included_in_finances?
+      include_in_finances
+    end
+  end
+
+  test "total excludes accounts the user opted out of their finances" do
+    group = BalanceSheet::AccountGroup.new(
+      name: "Depository",
+      color: "#000000",
+      accountable_type: "Depository",
+      accounts: [StubAccount.new(1000, true), StubAccount.new(2000, false)],
+      classification_group: nil
+    )
+
+    # The excluded 2000 account must not be counted (mirrors ClassificationGroup).
+    assert_equal 1000, group.total
+  end
+
+  test "weight is derived from the filtered total" do
+    classification = Struct.new(:total).new(1000)
+    group = BalanceSheet::AccountGroup.new(
+      name: "Depository",
+      color: "#000000",
+      accountable_type: "Depository",
+      accounts: [StubAccount.new(1000, true), StubAccount.new(2000, false)],
+      classification_group: classification
+    )
+
+    # numerator (filtered group total) and denominator (already-filtered
+    # classification total) are now consistent → 100%, not 300%.
+    assert_in_delta 100.0, group.weight, 0.001
+  end
+end


### PR DESCRIPTION
## Summary
Closes #2215

`BalanceSheet::ClassificationGroup#total` excludes accounts the current user opted out of their finances (shared accounts with `include_in_finances = false`), but `BalanceSheet::AccountGroup#total` summed every account. In shared-family setups the per-type group totals double-counted an opted-out account, and `weight` (unfiltered group total ÷ filtered classification total) could exceed 100% — contradicting the net-worth/classification totals on the same page.

## Change
- `app/models/balance_sheet/account_group.rb` — apply the same `included_in_finances?` filter in `#total` that `ClassificationGroup#total` uses. `#weight` becomes consistent automatically (same filtered set in numerator and denominator).
- `test/models/balance_sheet/account_group_test.rb` — unit test (stub accounts) asserting an opted-out account is excluded from `total` and that `weight` is computed from the filtered total.

## Why it's safe
- When all accounts are included (e.g. no user context — the case existing `balance_sheet_test.rb` exercises), the filter is a no-op, so current behavior/tests are unchanged.
- Behavior only changes for accounts explicitly excluded from a user's finances, bringing group totals in line with the classification/net-worth totals.

## Verification
- One-method change mirroring the existing `ClassificationGroup#total`, plus a fixture-free unit test. I don't have a Ruby toolchain locally, so the suite is left to CI (`bin/rails test test/models/balance_sheet/account_group_test.rb`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Balance sheet totals now respect user account preferences by excluding accounts users have opted out of their finances.
  * Weight calculations are now properly derived from filtered totals, ensuring consistent financial reporting across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->