### PR TITLE
fix(preview): surface postgres startup failures and reset attempt timings

### DIFF
--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -101,6 +101,31 @@ summarize_log_tail() {
     cut -c 1-1600
 }
 
+fail_preview() {
+  local detail="$1"
+  trap - ERR
+  emit_status failed "$detail"
+  exit 1
+}
+
+postgres_cluster_snapshot() {
+  local snapshot=""
+  local cluster_status
+  local postgres_log
+
+  if command -v pg_lsclusters >/dev/null 2>&1; then
+    cluster_status="$(pg_lsclusters 2>&1 | tr '\n' '|' | sed 's/"/'"'"'/g' | cut -c 1-500)"
+    snapshot="clusters=${cluster_status}"
+  fi
+
+  postgres_log="/var/log/postgresql/postgresql-${PG_VERSION}-main.log"
+  if [ -f "$postgres_log" ]; then
+    snapshot="${snapshot} log=$(summarize_log_tail "$postgres_log" postgres)"
+  fi
+
+  printf '%s' "$snapshot"
+}
+
 trap 'emit_status failed "preview-entrypoint failed on line ${LINENO}"' ERR
 emit_status boot "preview-entrypoint started"
 
@@ -125,8 +150,7 @@ for i in {1..10}; do
 done
 
 if [ "$REDIS_READY" -ne 1 ]; then
-  echo "Redis did not become ready in time"
-  exit 1
+  fail_preview "redis did not become ready in time"
 fi
 
 # Start PostgreSQL
@@ -134,13 +158,15 @@ echo "Starting PostgreSQL..."
 emit_status postgres-start "starting postgres"
 PG_VERSION=$(ls /etc/postgresql/ | sort -V | tail -1)
 if [ -z "$PG_VERSION" ]; then
-  echo "Could not determine installed PostgreSQL version"
-  exit 1
+  fail_preview "could not determine installed PostgreSQL version"
 fi
 if sudo pg_ctlcluster --skip-systemctl-redirect "$PG_VERSION" main status > /dev/null 2>&1; then
   emit_status postgres-already-running "postgres cluster already running"
 else
-  sudo pg_ctlcluster --skip-systemctl-redirect "$PG_VERSION" main start
+  POSTGRES_START_LOG=/tmp/postgres-start.log
+  if ! sudo pg_ctlcluster --skip-systemctl-redirect "$PG_VERSION" main start >"$POSTGRES_START_LOG" 2>&1; then
+    fail_preview "pg_ctlcluster start failed: $(summarize_log_tail "$POSTGRES_START_LOG" pg_ctlcluster-start) | $(postgres_cluster_snapshot)"
+  fi
 fi
 
 # Wait for PostgreSQL to be ready
@@ -156,8 +182,7 @@ for i in {1..30}; do
 done
 
 if [ "$POSTGRES_READY" -ne 1 ]; then
-  echo "PostgreSQL did not become ready in time"
-  exit 1
+  fail_preview "postgres did not become ready in time: $(postgres_cluster_snapshot)"
 fi
 
 # Create database user and database if they don't exist

--- a/workers/preview/src/index.ts
+++ b/workers/preview/src/index.ts
@@ -155,6 +155,23 @@ export class RailsContainer extends Container {
     return history.filter((record) => kept.has(record));
   }
 
+  private isAttemptStart(record: DiagnosticRecord): boolean {
+    return (
+      record.event === "start" ||
+      (record.event === "entrypoint" && typeof record.payload?.stage === "string" && record.payload.stage === "boot")
+    );
+  }
+
+  private diagnosticsForLatestAttempt(allDiagnostics: DiagnosticRecord[]): DiagnosticRecord[] {
+    for (let index = allDiagnostics.length - 1; index >= 0; index -= 1) {
+      if (this.isAttemptStart(allDiagnostics[index])) {
+        return allDiagnostics.slice(index);
+      }
+    }
+
+    return allDiagnostics;
+  }
+
   private async getDiagnostics(): Promise<{
     state: unknown;
     containerRunning: boolean;
@@ -196,11 +213,12 @@ export class RailsContainer extends Container {
     return Math.round(((end - start) / 1000) * 100) / 100;
   }
 
-  private buildPreviewTimings(allDiagnostics: DiagnosticRecord[], previewReady: boolean): PreviewTimings {
-    const entrypointDiagnostics = allDiagnostics.filter(
+  private buildPreviewTimings(attemptDiagnostics: DiagnosticRecord[], previewReady: boolean): PreviewTimings {
+    const entrypointDiagnostics = attemptDiagnostics.filter(
       (item) => item.event === "entrypoint" && typeof item.payload?.stage === "string"
     );
-    const firstEventAt = (event: string) => this.validTimestamp(allDiagnostics.find((item) => item.event === event)?.at);
+    const firstEventAt = (event: string) =>
+      this.validTimestamp(attemptDiagnostics.find((item) => item.event === event)?.at);
     const firstStageAt = (...stages: string[]) =>
       this.validTimestamp(entrypointDiagnostics.find((item) => stages.includes(item.payload?.stage ?? ""))?.at);
 
@@ -240,7 +258,8 @@ export class RailsContainer extends Container {
     diagnosticsHistory: DiagnosticRecord[];
   }, options?: { probe?: boolean }): Promise<PreviewStatusPayload> {
     const allDiagnostics = [...base.diagnosticsHistory, ...(base.diagnostics ? [base.diagnostics] : [])];
-    const entrypointDiagnostics = allDiagnostics.filter(
+    const attemptDiagnostics = this.diagnosticsForLatestAttempt(allDiagnostics);
+    const entrypointDiagnostics = attemptDiagnostics.filter(
       (item) => item.event === "entrypoint" && typeof item.payload?.stage === "string"
     );
     const latestEntrypoint = entrypointDiagnostics.at(-1) ?? null;
@@ -258,7 +277,7 @@ export class RailsContainer extends Container {
     const previewFailed =
       entrypointDiagnostics.some((item) => FAILED_STAGES.has(item.payload?.stage ?? "")) ||
       base.diagnostics?.event === "error";
-    const timings = this.buildPreviewTimings(allDiagnostics, previewReady);
+    const timings = this.buildPreviewTimings(attemptDiagnostics, previewReady);
 
     let phase: PreviewProgress["phase"] = "cold";
     if (previewFailed) {


### PR DESCRIPTION
## Summary
- surface `pg_ctlcluster` startup failures directly in preview `_container_status` instead of only reporting a generic line-number crash
- include a compact PostgreSQL cluster snapshot when startup fails or never becomes ready
- compute preview boot/sample-data timings from the latest boot attempt so crash loops stop pinning metrics to the first failure hours earlier

## Why
The current Cloudflare preview failure for PR previews is dying immediately after `postgres-start`, but the live diagnostics only expose `preview-entrypoint failed on line 74`. At the same time, timing fields stay anchored to the first boot attempt even after repeated crash loops, which makes the artifacts less useful during debugging.

This keeps the current preview architecture intact, but gives the next failing run actionable PostgreSQL stderr/log context and fresher attempt-scoped timing data.

## Verification
- `bash -n` on the extracted preview entrypoint script
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npx tsc --noEmit` in `workers/preview`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for preview environment startup failures with enhanced diagnostic information.
  * Better error reporting for PostgreSQL and Redis startup issues.

* **Improvements**
  * More accurate timing metrics for preview readiness calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->