### PR TITLE
chore(ci): finish Node 24 GitHub Actions migration

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -54,7 +54,7 @@ jobs:
           wrangler delete --name "$WORKER_NAME" --force || echo "Worker may not exist"
 
       - name: Delete GitHub Deployment
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const environment = `preview-pr-${{ github.event.pull_request.number }}`;

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Resolve preview request
         id: preview
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const { resolvePreviewRequest } = require('./trusted-preview-resolver/workers/preview/deploy/resolve_preview_request.cjs');
@@ -66,7 +66,7 @@ jobs:
       - name: Create GitHub Deployment
         if: env.IS_FORK == 'false'
         id: deployment
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const prNumber = process.env.PR_NUMBER;
@@ -551,7 +551,7 @@ jobs:
 
     steps:
       - name: Update Deployment Status
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const state = process.env.DEPLOY_RESULT === 'success' ? 'success' : 'failure';
@@ -581,7 +581,7 @@ jobs:
 
     steps:
       - name: Comment on PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const previewUrl = process.env.PREVIEW_URL;

--- a/bin/preview_deploy_security_check.rb
+++ b/bin/preview_deploy_security_check.rb
@@ -16,7 +16,7 @@ PINNED_ACTION = /\A[^@\s]+@[a-f0-9]{40}\z/
 EXPECTED_ACTION_PINS = {
   "actions/checkout" => "93cb6efe18208431cddfb8368fd83d5badbf9bfd", # v5
   "actions/download-artifact" => "018cc2cf5baa6db3ef3c5f8a56943fffe632ef53", # v6
-  "actions/github-script" => "f28e40c7f34bde8b3046d885e986cb6290c5673b", # v7
+  "actions/github-script" => "ed597411d8f924073f98dfc5c65a23a2325f34cd", # v8
   "actions/setup-node" => "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e", # v6
   "actions/upload-artifact" => "b7c566a772e6b6bfb58ed0dc250532a479d7789f" # v6
 }.freeze


### PR DESCRIPTION
## Summary
- update the remaining preview workflows from actions/github-script v7 to v8
- finish the GitHub Actions runtime migration to Node 24-compatible action versions
- note that the old not-gittensor workflow is already gone on current main

## Testing
- not run (workflow pin updates only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD preview workflows and related security checks to use a newer pinned implementation of the GitHub script action.
  * No runtime behavior or public APIs were changed; workflow logic, inputs, and scripts remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->