### PR TITLE
feat: payment channel metadata for transactions (#2192)

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -96,6 +96,10 @@ class Api::V1::TransactionsController < Api::V1::BaseController
       return render_existing_idempotent_entry(existing_entry)
     end
 
+    if funding_account_id.present?
+      return create_channel_payment(account, family)
+    end
+
     @entry = account.entries.new(entry_params_for_create)
 
     if @entry.save
@@ -127,7 +131,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
       error: "internal_server_error",
       message: "An unexpected error occurred"
     }, status: :internal_server_error
-end
+  end
 
   def update
     if @entry.split_child?
@@ -303,17 +307,21 @@ end
              "entries.name ILIKE ? OR entries.notes ILIKE ? OR merchants.name ILIKE ?",
              search_term, search_term, search_term
            )
-end
+    end
 
     def transaction_params
       params.require(:transaction).permit(
         :date, :amount, :name, :description, :notes, :currency,
-        :category_id, :merchant_id, :nature, tag_ids: []
+        :category_id, :merchant_id, :nature, :funding_account_id, tag_ids: []
       )
     end
 
     def account_id_param
       params.dig(:transaction, :account_id).presence
+    end
+
+    def funding_account_id
+      transaction_params[:funding_account_id].presence
     end
 
     def entry_params_for_create
@@ -442,5 +450,67 @@ end
       else
         25  # Default
       end
+    end
+
+    def create_channel_payment(channel_account, family)
+      funding_account = family.accounts.writable_by(current_resource_owner).find(funding_account_id)
+
+      channel_entry = nil
+      funding_entry = nil
+
+      ApplicationRecord.transaction do
+        # Record A — channel side (e.g. Alipay, excluded from balance)
+        channel_name = transaction_params[:name] || transaction_params[:description] || "Untitled"
+        channel_entry = channel_account.entries.create!(
+          name: channel_name,
+          date: transaction_params[:date],
+          amount: calculate_signed_amount,
+          currency: transaction_params[:currency] || family.currency,
+          notes: transaction_params[:notes],
+          excluded: true,
+          entryable_type: "Transaction",
+          entryable_attributes: {
+            category_id: transaction_params[:category_id],
+            merchant_id: transaction_params[:merchant_id],
+            tag_ids: transaction_params[:tag_ids] || [],
+            extra: (transaction_params[:extra] || {}).merge(
+              "channel_payment" => true,
+              "funding_account_id" => funding_account.id
+            )
+          }
+        )
+
+        # Record B — funding account side (e.g. bank card)
+        funding_entry = funding_account.entries.create!(
+          name: "#{channel_account.name} - #{channel_name}",
+          date: transaction_params[:date],
+          amount: calculate_signed_amount,
+          currency: transaction_params[:currency] || family.currency,
+          notes: transaction_params[:notes],
+          entryable_type: "Transaction",
+          entryable_attributes: {
+            category_id: transaction_params[:category_id],
+            merchant_id: transaction_params[:merchant_id],
+            tag_ids: transaction_params[:tag_ids] || [],
+            channel_record_parent_id: channel_entry.transaction.id,
+            extra: (transaction_params[:extra] || {}).merge(
+              "channel_auto_record" => true
+            )
+          }
+        )
+      end
+
+      channel_entry.sync_account_later
+      funding_entry.sync_account_later
+
+      @entry = channel_entry
+      @transaction = channel_entry.transaction
+      render :show, status: :created
+    rescue ActiveRecord::RecordNotFound
+      render json: {
+        error: "validation_failed",
+        message: "Funding account not found",
+        errors: [ "Funding account not found" ]
+      }, status: :unprocessable_entity
     end
 end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -97,6 +97,14 @@ class Api::V1::TransactionsController < Api::V1::BaseController
     end
 
     if funding_account_id.present?
+      if funding_account_id == account_id_param
+        render json: {
+          error: "validation_failed",
+          message: "Funding account cannot be the same as transaction account",
+          errors: [ "Funding account cannot be the same as transaction account" ]
+        }, status: :unprocessable_entity
+        return
+      end
       return create_channel_payment(account, family)
     end
 
@@ -312,7 +320,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
     def transaction_params
       params.require(:transaction).permit(
         :date, :amount, :name, :description, :notes, :currency,
-        :category_id, :merchant_id, :nature, :funding_account_id, tag_ids: []
+        :category_id, :merchant_id, :nature, :funding_account_id, extra: {}, tag_ids: []
       )
     end
 
@@ -502,6 +510,10 @@ class Api::V1::TransactionsController < Api::V1::BaseController
 
       channel_entry.sync_account_later
       funding_entry.sync_account_later
+      channel_entry.lock_saved_attributes!
+      channel_entry.mark_user_modified!
+      funding_entry.lock_saved_attributes!
+      funding_entry.mark_user_modified!
 
       @entry = channel_entry
       @transaction = channel_entry.transaction

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -460,7 +460,54 @@ class Api::V1::TransactionsController < Api::V1::BaseController
       end
     end
 
+    # Extract channel_kind from the extra payload (defaults to "payment").
+    # Old channel payments without channel_kind are treated as payments.
+    def channel_kind_param
+      extra = transaction_params[:extra]
+      return "payment" unless extra.respond_to?(:[])
+      (extra[:channel_kind] || extra["channel_kind"]).presence || "payment"
+    end
+
+    def refund_of_transaction_id_param
+      extra = transaction_params[:extra]
+      return nil unless extra.respond_to?(:[])
+      (extra[:refund_of_transaction_id] || extra["refund_of_transaction_id"]).presence
+    end
+
+    def channel_refund_requested?
+      channel_kind_param == "refund"
+    end
+
+    # Enforces the refund linkage contract. Returns an error message string when
+    # the request is invalid, or nil when it is valid.
+    #   1. refund must carry refund_of_transaction_id
+    #   2. the referenced transaction must exist within the current family
+    #   3. the referenced transaction must itself be a channel payment (not a refund)
+    def channel_refund_error(family)
+      refund_id = refund_of_transaction_id_param
+      return "refund_of_transaction_id is required for refunds" if refund_id.blank?
+
+      original = family.transactions.find_by(id: refund_id)
+      return "Original transaction not found" if original.nil?
+
+      original_extra = original.extra.is_a?(Hash) ? original.extra : {}
+      is_channel_payment = original_extra["channel_payment"].to_s == "true" &&
+                           original_extra["channel_kind"].to_s != "refund"
+      return "Original transaction must be a channel payment" unless is_channel_payment
+
+      nil
+    end
+
     def create_channel_payment(channel_account, family)
+      if channel_refund_requested? && (refund_error = channel_refund_error(family))
+        render json: {
+          error: "validation_failed",
+          message: refund_error,
+          errors: [ refund_error ]
+        }, status: :unprocessable_entity
+        return
+      end
+
       funding_account = family.accounts.writable_by(current_resource_owner).find(funding_account_id)
 
       channel_entry = nil
@@ -483,7 +530,8 @@ class Api::V1::TransactionsController < Api::V1::BaseController
             tag_ids: transaction_params[:tag_ids] || [],
             extra: (transaction_params[:extra] || {}).merge(
               "channel_payment" => true,
-              "funding_account_id" => funding_account.id
+              "funding_account_id" => funding_account.id,
+              "channel_kind" => channel_kind_param
             )
           }
         )

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -106,6 +106,11 @@ class TransactionsController < ApplicationController
         return redirect_back_or_to new_transaction_path
       end
 
+      if channel_refund_requested? && (refund_error = channel_refund_error)
+        flash[:alert] = refund_error
+        return redirect_back_or_to new_transaction_path
+      end
+
       return create_channel_payment(account, Current.family)
     end
 
@@ -500,6 +505,38 @@ class TransactionsController < ApplicationController
       params.dig(:entry, :funding_account_id).presence
     end
 
+    def channel_kind_param
+      params.dig(:entry, :channel_kind).presence || "payment"
+    end
+
+    def refund_of_transaction_id_param
+      params.dig(:entry, :refund_of_transaction_id).presence
+    end
+
+    def channel_refund_requested?
+      channel_kind_param == "refund"
+    end
+
+    # Enforces the refund linkage contract for the HTML path. Returns an i18n'd
+    # error message when invalid, or nil when valid. Mirrors the API contract:
+    #   1. refund must carry refund_of_transaction_id
+    #   2. the referenced transaction must exist within the current family
+    #   3. the referenced transaction must itself be a channel payment (not a refund)
+    def channel_refund_error
+      refund_id = refund_of_transaction_id_param
+      return t(".refund_missing_original") if refund_id.blank?
+
+      original = Current.family.transactions.find_by(id: refund_id)
+      return t(".refund_original_not_found") if original.nil?
+
+      original_extra = original.extra.is_a?(Hash) ? original.extra : {}
+      is_channel_payment = original_extra["channel_payment"].to_s == "true" &&
+                           original_extra["channel_kind"].to_s != "refund"
+      return t(".refund_original_not_channel_payment") unless is_channel_payment
+
+      nil
+    end
+
     def set_entry_for_tags
       set_entry
     end
@@ -691,6 +728,13 @@ class TransactionsController < ApplicationController
       notes = entry_params[:notes]
       ea = entry_params[:entryable_attributes] || {}
 
+      channel_extra = (ea[:extra] || {}).merge(
+        "channel_payment" => true,
+        "funding_account_id" => funding_account.id,
+        "channel_kind" => channel_kind_param
+      )
+      channel_extra["refund_of_transaction_id"] = refund_of_transaction_id_param if channel_refund_requested?
+
       channel_entry = nil
       funding_entry = nil
 
@@ -707,10 +751,7 @@ class TransactionsController < ApplicationController
             category_id: ea[:category_id],
             merchant_id: ea[:merchant_id],
             tag_ids: ea[:tag_ids] || [],
-            extra: (ea[:extra] || {}).merge(
-              "channel_payment" => true,
-              "funding_account_id" => funding_account.id
-            )
+            extra: channel_extra
           }
         )
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -722,6 +722,10 @@ class TransactionsController < ApplicationController
 
       channel_entry.sync_account_later
       funding_entry.sync_account_later
+      channel_entry.lock_saved_attributes!
+      channel_entry.mark_user_modified!
+      funding_entry.lock_saved_attributes!
+      funding_entry.mark_user_modified!
 
       flash[:notice] = t(".created")
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -100,6 +100,11 @@ class TransactionsController < ApplicationController
 
     return unless require_account_permission!(account)
 
+    if params.dig(:entry, :funding_account_id).present?
+      funding_account = Current.user.accessible_accounts.find(params.dig(:entry, :funding_account_id))
+      return create_channel_payment(account, funding_account)
+    end
+
     @entry = account.entries.new(entry_params)
 
     if @entry.save
@@ -463,7 +468,7 @@ class TransactionsController < ApplicationController
 
     def entry_params
       entry_params = params.require(:entry).permit(
-        :name, :date, :amount, :currency, :excluded, :notes, :nature, :entryable_type,
+        :name, :date, :amount, :currency, :excluded, :notes, :nature, :entryable_type, :funding_account_id,
         entryable_attributes: [ :id, :category_id, :merchant_id, :kind, :investment_activity_label, :exchange_rate, { tag_ids: [] } ]
       )
 
@@ -663,5 +668,69 @@ class TransactionsController < ApplicationController
       end
 
       [ qty, price ]
+    end
+
+    def create_channel_payment(channel_account, funding_account)
+      amount = entry_params[:amount]
+      date = entry_params[:date] || Date.current
+      currency = entry_params[:currency] || Current.family.currency
+      name = entry_params[:name]
+      notes = entry_params[:notes]
+      ea = entry_params[:entryable_attributes] || {}
+
+      channel_entry = nil
+      funding_entry = nil
+
+      ActiveRecord::Base.transaction do
+        channel_entry = channel_account.entries.create!(
+          name: name,
+          date: date,
+          amount: amount,
+          currency: currency,
+          notes: notes,
+          excluded: true,
+          entryable_type: "Transaction",
+          entryable_attributes: {
+            category_id: ea[:category_id],
+            merchant_id: ea[:merchant_id],
+            tag_ids: ea[:tag_ids] || [],
+            extra: (ea[:extra] || {}).merge(
+              "channel_payment" => true,
+              "funding_account_id" => funding_account.id
+            )
+          }
+        )
+
+        funding_entry = funding_account.entries.create!(
+          name: "#{channel_account.name} - #{name}",
+          date: date,
+          amount: amount,
+          currency: currency,
+          notes: notes,
+          entryable_type: "Transaction",
+          entryable_attributes: {
+            category_id: ea[:category_id],
+            merchant_id: ea[:merchant_id],
+            tag_ids: ea[:tag_ids] || [],
+            channel_record_parent_id: channel_entry.transaction.id,
+            extra: (ea[:extra] || {}).merge(
+              "channel_auto_record" => true
+            )
+          }
+        )
+      end
+
+      channel_entry.sync_account_later
+      funding_entry.sync_account_later
+
+      flash[:notice] = t(".created")
+
+      respond_to do |format|
+        format.html { redirect_back_or_to account_path(channel_entry.account) }
+        format.turbo_stream { stream_redirect_back_or_to(account_path(channel_entry.account)) }
+      end
+    rescue ActiveRecord::RecordNotFound
+      flash[:alert] = "Funding account not found"
+      redirect_back_or_to root_path
     end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -468,9 +468,12 @@ class TransactionsController < ApplicationController
 
     def entry_params
       entry_params = params.require(:entry).permit(
-        :name, :date, :amount, :currency, :excluded, :notes, :nature, :entryable_type, :funding_account_id,
+        :name, :date, :amount, :currency, :excluded, :notes, :nature, :entryable_type,
         entryable_attributes: [ :id, :category_id, :merchant_id, :kind, :investment_activity_label, :exchange_rate, { tag_ids: [] } ]
       )
+
+      # funding_account_id is a routing param only — strip before mass-assigning to Entry
+      entry_params.delete(:funding_account_id)
 
       nature = entry_params.delete(:nature)
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -100,9 +100,13 @@ class TransactionsController < ApplicationController
 
     return unless require_account_permission!(account)
 
-    if params.dig(:entry, :funding_account_id).present?
-      funding_account = Current.user.accessible_accounts.find(params.dig(:entry, :funding_account_id))
-      return create_channel_payment(account, funding_account)
+    if funding_account_id_param.present?
+      if funding_account_id_param == params.dig(:entry, :account_id)
+        flash[:alert] = t(".funding_account_same_as_account")
+        return redirect_back_or_to new_transaction_path
+      end
+
+      return create_channel_payment(account, Current.family)
     end
 
     @entry = account.entries.new(entry_params)
@@ -492,6 +496,10 @@ class TransactionsController < ApplicationController
       Array(params[:tag_ids]).reject(&:blank?)
     end
 
+    def funding_account_id_param
+      params.dig(:entry, :funding_account_id).presence
+    end
+
     def set_entry_for_tags
       set_entry
     end
@@ -673,7 +681,9 @@ class TransactionsController < ApplicationController
       [ qty, price ]
     end
 
-    def create_channel_payment(channel_account, funding_account)
+    def create_channel_payment(channel_account, family)
+      funding_account = family.accounts.writable_by(Current.user).find(funding_account_id_param)
+
       amount = entry_params[:amount]
       date = entry_params[:date] || Date.current
       currency = entry_params[:currency] || Current.family.currency
@@ -737,7 +747,7 @@ class TransactionsController < ApplicationController
         format.turbo_stream { stream_redirect_back_or_to(account_path(channel_entry.account)) }
       end
     rescue ActiveRecord::RecordNotFound
-      flash[:alert] = "Funding account not found"
-      redirect_back_or_to root_path
+      flash[:alert] = t(".funding_account_not_found")
+      redirect_back_or_to new_transaction_path
     end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -478,7 +478,7 @@ class TransactionsController < ApplicationController
     def entry_params
       entry_params = params.require(:entry).permit(
         :name, :date, :amount, :currency, :excluded, :notes, :nature, :entryable_type,
-        entryable_attributes: [ :id, :category_id, :merchant_id, :kind, :investment_activity_label, :exchange_rate, { tag_ids: [] } ]
+        entryable_attributes: [ :id, :category_id, :merchant_id, :kind, :investment_activity_label, :exchange_rate, :payment_channel, { tag_ids: [] } ]
       )
 
       # funding_account_id is a routing param only — strip before mass-assigning to Entry
@@ -567,7 +567,7 @@ class TransactionsController < ApplicationController
         # Annotate only: category, tags, merchant, notes
         ep = entry_params.slice(:notes)
         if entry_params[:entryable_attributes].present?
-          ep[:entryable_attributes] = entry_params[:entryable_attributes].slice(:id, :category_id, :merchant_id, :tag_ids)
+          ep[:entryable_attributes] = entry_params[:entryable_attributes].slice(:id, :category_id, :merchant_id, :tag_ids, :payment_channel)
         end
         ep
       else

--- a/app/javascript/controllers/transaction_form_controller.js
+++ b/app/javascript/controllers/transaction_form_controller.js
@@ -5,11 +5,40 @@ export default class extends ExchangeRateFormController {
   static targets = [
     ...ExchangeRateFormController.targets,
     "account",
-    "currency"
+    "currency",
+    "fundingLabel",
   ];
 
+  static values = {
+    ...ExchangeRateFormController.values,
+    fundingLabelPayment: String,
+    fundingLabelRefund: String,
+  };
+
+  // Swaps the funding-source label between its payment and refund wording when
+  // the income/expense tabs flip the transaction nature. Driven by the
+  // `transaction-type-tabs:change` event so we don't add a second controller.
+  onNatureChange(event) {
+    if (!this.hasFundingLabelTarget) {
+      return;
+    }
+
+    const nature = event?.detail?.nature;
+    const isRefund = nature === "inflow";
+
+    if (isRefund && this.hasFundingLabelRefundValue) {
+      this.fundingLabelTarget.textContent = this.fundingLabelRefundValue;
+    } else if (this.hasFundingLabelPaymentValue) {
+      this.fundingLabelTarget.textContent = this.fundingLabelPaymentValue;
+    }
+  }
+
   hasRequiredExchangeRateTargets() {
-    if (!this.hasAccountTarget || !this.hasCurrencyTarget || !this.hasDateTarget) {
+    if (
+      !this.hasAccountTarget ||
+      !this.hasCurrencyTarget ||
+      !this.hasDateTarget
+    ) {
       return false;
     }
 
@@ -37,7 +66,7 @@ export default class extends ExchangeRateFormController {
     return {
       fromCurrency: currency,
       toCurrency: accountCurrency,
-      date
+      date,
     };
   }
 
@@ -49,9 +78,14 @@ export default class extends ExchangeRateFormController {
     const currentAccountId = this.accountTarget.value;
     const currentCurrency = this.currencyTarget.value;
     const currentDate = this.dateTarget.value;
-    const currentAccountCurrency = this.accountCurrenciesValue[currentAccountId];
+    const currentAccountCurrency =
+      this.accountCurrenciesValue[currentAccountId];
 
-    return fromCurrency === currentCurrency && toCurrency === currentAccountCurrency && date === currentDate;
+    return (
+      fromCurrency === currentCurrency &&
+      toCurrency === currentAccountCurrency &&
+      date === currentDate
+    );
   }
 
   onCurrencyChange() {

--- a/app/javascript/controllers/transaction_type_tabs_controller.js
+++ b/app/javascript/controllers/transaction_type_tabs_controller.js
@@ -13,6 +13,10 @@ export default class extends Controller {
     const selectedTab = event.currentTarget;
     this.natureFieldTarget.value = selectedTab.dataset.nature;
 
+    // Broadcast the change so sibling controllers (e.g. transaction-form) can
+    // react — keep the event generic so it stays reusable.
+    this.dispatch("change", { detail: { nature: selectedTab.dataset.nature } });
+
     this.tabTargets.forEach((tab) => {
       const isActive = tab === selectedTab;
       tab.classList.toggle("segmented-control__segment--active", isActive);

--- a/app/models/balance/sync_cache.rb
+++ b/app/models/balance/sync_cache.rb
@@ -34,7 +34,7 @@ class Balance::SyncCache
     end
 
     def converted_entries
-      @converted_entries ||= account.entries.excluding_split_parents.includes(:entryable).order(:date).to_a.map do |e|
+      @converted_entries ||= account.entries.where(excluded: false).excluding_split_parents.includes(:entryable).order(:date).to_a.map do |e|
         converted_entry = e.dup
 
         custom_rate = e.entryable.exchange_rate if e.entryable.respond_to?(:exchange_rate)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -124,6 +124,8 @@ class Transaction < ApplicationRecord
 
   scope :channel_payment, -> { where("transactions.extra ->> 'channel_payment' = 'true'") }
 
+  scope :channel_refund, -> { where("transactions.extra ->> 'channel_kind' = 'refund'") }
+
   # SQL snippet for raw queries that must exclude pending transactions.
   # Use in income statements, balance sheets, and raw analytics.
   def self.pending_providers_sql(table_alias = "t")

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -7,7 +7,7 @@ class Transaction < ApplicationRecord
 
   has_many :channel_child_records, class_name: "Transaction",
            foreign_key: :channel_record_parent_id,
-           dependent: :nullify
+           dependent: :destroy
 
   has_many :taggings, as: :taggable, dependent: :destroy
   has_many :tags, through: :taggings

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -3,6 +3,11 @@ class Transaction < ApplicationRecord
 
   belongs_to :category, optional: true
   belongs_to :merchant, optional: true
+  belongs_to :channel_record_parent, class_name: "Transaction", optional: true
+
+  has_many :channel_child_records, class_name: "Transaction",
+           foreign_key: :channel_record_parent_id,
+           dependent: :nullify
 
   has_many :taggings, as: :taggable, dependent: :destroy
   has_many :tags, through: :taggings
@@ -114,6 +119,10 @@ class Transaction < ApplicationRecord
     conditions = PENDING_PROVIDERS.map { |provider| "(transactions.extra -> '#{provider}' ->> 'pending')::boolean IS DISTINCT FROM true" }
     where(conditions.join(" AND "))
   }
+
+  scope :auto_generated, -> { where.not(channel_record_parent_id: nil) }
+
+  scope :channel_payment, -> { where("transactions.extra ->> 'channel_payment' = 'true'") }
 
   # SQL snippet for raw queries that must exclude pending transactions.
   # Use in income statements, balance sheets, and raw analytics.

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -54,6 +54,22 @@ class Transaction < ApplicationRecord
     end
   end
 
+  # Accessors for payment_channel stored in extra jsonb field
+  PAYMENT_CHANNELS = %w[wechat_pay alipay apple_pay paypal unionpay cash].freeze
+
+  def payment_channel
+    extra&.dig("payment_channel")
+  end
+
+  def payment_channel=(value)
+    clean_value = value.presence
+    if clean_value.blank?
+      self.extra = (extra || {}).except("payment_channel")
+    else
+      self.extra = (extra || {}).merge("payment_channel" => clean_value)
+    end
+  end
+
   validate :exchange_rate_must_be_valid
 
   private
@@ -125,6 +141,8 @@ class Transaction < ApplicationRecord
   scope :channel_payment, -> { where("transactions.extra ->> 'channel_payment' = 'true'") }
 
   scope :channel_refund, -> { where("transactions.extra ->> 'channel_kind' = 'refund'") }
+
+  scope :by_payment_channel, ->(channel) { where("transactions.extra ->> 'payment_channel' = ?", channel) }
 
   # SQL snippet for raw queries that must exclude pending transactions.
   # Use in income statements, balance sheets, and raw analytics.

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (entry:, account_currencies:, manual_accounts:, categories:, merchants:, tags:) %>
 
-<%= styled_form_with model: entry, url: transactions_path, class: "space-y-4", data: { controller: "transaction-form", transaction_form_exchange_rate_url_value: exchange_rate_path, transaction_form_account_currencies_value: account_currencies.to_json } do |f| %>
+<%= styled_form_with model: entry, url: transactions_path, class: "space-y-4", data: { controller: "transaction-form", transaction_form_exchange_rate_url_value: exchange_rate_path, transaction_form_account_currencies_value: account_currencies.to_json, transaction_form_funding_label_payment_value: t(".funding_account_label"), transaction_form_funding_label_refund_value: t(".funding_account_refund_label"), action: "transaction-type-tabs:change->transaction-form#onNatureChange" } do |f| %>
   <% if entry.errors.any? %>
     <%= render "shared/form_errors", model: entry %>
   <% end %>
@@ -22,12 +22,21 @@
     <% end %>
 
     <% if Current.family.accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).exists? %>
-      <%= f.select :funding_account_id,
-            options_for_select(
-              Current.family.accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).alphabetically.pluck(:name, :id)
-            ),
-            { include_blank: true, label: t(".funding_account_label") },
-            class: "form-field__input text-ellipsis" %>
+      <div class="form-field">
+        <div class="form-field__body">
+          <%= f.label :funding_account_id,
+                params[:nature] == "inflow" ? t(".funding_account_refund_label") : t(".funding_account_label"),
+                class: "form-field__label",
+                data: { transaction_form_target: "fundingLabel" } %>
+          <%= f.select :funding_account_id,
+                options_for_select(
+                  Current.family.accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).alphabetically.pluck(:name, :id)
+                ),
+                { include_blank: true, label: false },
+                class: "form-field__input text-ellipsis" %>
+        </div>
+        <p class="mt-1 text-xs text-secondary"><%= t(".funding_account_help") %></p>
+      </div>
     <% end %>
 
     <%= f.money_field :amount,

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -21,6 +21,15 @@
       <%= f.collection_select :account_id, manual_accounts, :id, :name, { prompt: t(".account_prompt"), label: t(".account"), selected: Current.user.default_account_for_transactions&.id, variant: :logo }, required: true, class: "form-field__input text-ellipsis", data: { transaction_form_target: "account", action: "change->transaction-form#checkCurrencyDifference" } %>
     <% end %>
 
+    <% if Current.family.accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).exists? %>
+      <%= f.select :funding_account_id,
+            options_for_select(
+              Current.family.accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).alphabetically.pluck(:name, :id)
+            ),
+            { include_blank: true, label: t(".funding_account_label") },
+            class: "form-field__input text-ellipsis" %>
+    <% end %>
+
     <%= f.money_field :amount,
       label: t(".amount"),
       required: true,

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -21,7 +21,7 @@
       <%= f.collection_select :account_id, manual_accounts, :id, :name, { prompt: t(".account_prompt"), label: t(".account"), selected: Current.user.default_account_for_transactions&.id, variant: :logo }, required: true, class: "form-field__input text-ellipsis", data: { transaction_form_target: "account", action: "change->transaction-form#checkCurrencyDifference" } %>
     <% end %>
 
-    <% if Current.family.accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).exists? %>
+    <% if Current.user.accessible_accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).exists? %>
       <div class="form-field">
         <div class="form-field__body">
           <%= f.label :funding_account_id,
@@ -30,7 +30,7 @@
                 data: { transaction_form_target: "fundingLabel" } %>
           <%= f.select :funding_account_id,
                 options_for_select(
-                  Current.family.accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).alphabetically.pluck(:name, :id)
+                  Current.user.accessible_accounts.active.where(accountable_type: %w[Depository CreditCard Loan]).alphabetically.pluck(:name, :id)
                 ),
                 { include_blank: true, label: false },
                 class: "form-field__input text-ellipsis" %>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -147,6 +147,26 @@
                     <% if transaction.transfer.present? %>
                       <%= render "transactions/transfer_match", transaction: transaction %>
                     <% end %>
+
+                    <%# Channel payment indicators %>
+                    <% if transaction.extra&.dig("channel_payment") %>
+                      <%= render DS::Pill.new(
+                        label: t("transactions.transaction.channel"),
+                        tone: :accent,
+                        marker: false,
+                        icon: "link",
+                        title: t("transactions.transaction.channel_tooltip")
+                      ) %>
+                    <% end %>
+                    <% if transaction.channel_record_parent_id.present? %>
+                      <%= render DS::Pill.new(
+                        label: t("transactions.transaction.auto_generated"),
+                        tone: :neutral,
+                        marker: false,
+                        icon: "corner-down-right",
+                        title: t("transactions.transaction.auto_generated_tooltip")
+                      ) %>
+                    <% end %>
                   </div>
                 </div>
 

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -150,13 +150,23 @@
 
                     <%# Channel payment indicators %>
                     <% if transaction.extra&.dig("channel_payment") %>
-                      <%= render DS::Pill.new(
-                        label: t("transactions.transaction.channel"),
-                        tone: :accent,
-                        marker: false,
-                        icon: "link",
-                        title: t("transactions.transaction.channel_tooltip")
-                      ) %>
+                      <% if transaction.extra&.dig("channel_kind") == "refund" %>
+                        <%= render DS::Pill.new(
+                          label: t("transactions.transaction.refund"),
+                          tone: :success,
+                          marker: false,
+                          icon: "rotate-ccw",
+                          title: t("transactions.transaction.refund_tooltip")
+                        ) %>
+                      <% else %>
+                        <%= render DS::Pill.new(
+                          label: t("transactions.transaction.channel"),
+                          tone: :accent,
+                          marker: false,
+                          icon: "link",
+                          title: t("transactions.transaction.channel_tooltip")
+                        ) %>
+                      <% end %>
                     <% end %>
                     <% if transaction.channel_record_parent_id.present? %>
                       <%= render DS::Pill.new(

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -97,6 +97,26 @@
     <% end %>
     <% dialog.with_section(title: t(".details")) do %>
       <div class="space-y-2">
+        <% if @entry.transaction.extra&.dig("channel_payment") %>
+          <% linked_account = Current.family.accounts.find_by(id: @entry.transaction.extra["funding_account_id"]) %>
+          <% linked_child = @entry.transaction.channel_child_records.first %>
+          <div class="mx-3 rounded-lg border border-secondary p-3 text-sm">
+            <div class="font-medium text-primary"><%= t(".channel_payment_label") %></div>
+            <% if linked_account %>
+              <p class="text-secondary"><%= t(".funding_account_text", account: linked_account.name) %></p>
+            <% end %>
+            <% if linked_child %>
+              <p class="mt-1"><%= link_to t(".view_auto_generated"), entry_path(linked_child.entry), data: { turbo_frame: "drawer", turbo_prefetch: false }, class: "hover:underline" %></p>
+            <% end %>
+          </div>
+        <% elsif @entry.transaction.channel_record_parent.present? %>
+          <div class="mx-3 rounded-lg border border-secondary p-3 text-sm">
+            <div class="font-medium text-primary"><%= t(".auto_generated_label") %></div>
+            <p class="text-secondary"><%= t(".auto_generated_text") %></p>
+            <p class="mt-1"><%= link_to t(".view_channel_record"), entry_path(@entry.transaction.channel_record_parent.entry), data: { turbo_frame: "drawer", turbo_prefetch: false }, class: "hover:underline" %></p>
+          </div>
+        <% end %>
+
         <%= styled_form_with model: @entry,
               url: transaction_path(@entry),
               class: "space-y-2",

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -440,12 +440,22 @@
               <h4 class="text-primary"><%= t(".delete_title") %></h4>
               <p class="text-secondary"><%= t(".delete_subtitle") %></p>
             </div>
+            <% channel_child_count = @entry.transaction.channel_child_records.count %>
+            <% delete_confirm = channel_child_count.positive? ?
+                 CustomConfirm.new(
+                   title: t(".delete_title"),
+                   body: t(".delete_channel_cascade_body", count: channel_child_count),
+                   btn_text: t(".delete"),
+                   destructive: true,
+                   high_severity: true
+                 ) :
+                 CustomConfirm.for_resource_deletion("transaction") %>
             <%= render DS::Button.new(
               text: t(".delete"),
               variant: "outline-destructive",
               href: entry_path(@entry),
               method: :delete,
-              confirm: CustomConfirm.for_resource_deletion("transaction"),
+              confirm: delete_confirm,
               frame: "_top"
             ) %>
           </div>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -98,7 +98,7 @@
     <% dialog.with_section(title: t(".details")) do %>
       <div class="space-y-2">
         <% if @entry.transaction.extra&.dig("channel_payment") %>
-          <% linked_account = Current.family.accounts.find_by(id: @entry.transaction.extra["funding_account_id"]) %>
+          <% linked_account = Current.user.accessible_accounts.find_by(id: @entry.transaction.extra["funding_account_id"]) %>
           <% linked_child = @entry.transaction.channel_child_records.first %>
           <div class="mx-3 rounded-lg border border-secondary p-3 text-sm">
             <div class="font-medium text-primary"><%= t(".channel_payment_label") %></div>

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -36,6 +36,7 @@ en:
       description: Description
       description_placeholder: Describe transaction
       expense: Expense
+      funding_account_label: Funding source
       income: Income
       merchant_label: Merchant
       none: (none)

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -49,6 +49,8 @@ en:
       transfer: Transfer
     create:
       created: Transaction created
+      funding_account_not_found: Funding account not found
+      funding_account_same_as_account: Funding account cannot be the same as the transaction account
     update:
       updated: Transaction updated
     new:

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -51,6 +51,9 @@ en:
       created: Transaction created
       funding_account_not_found: Funding account not found
       funding_account_same_as_account: Funding account cannot be the same as the transaction account
+      refund_missing_original: A refund must reference the original channel payment
+      refund_original_not_found: Original transaction not found
+      refund_original_not_channel_payment: Original transaction must be a channel payment
     update:
       updated: Transaction updated
     new:

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -98,6 +98,12 @@ en:
       tab_transactions: Transactions
       tab_upcoming: Upcoming
       uncategorized: "(uncategorized)"
+      channel_payment_label: Payment channel record
+      funding_account_text: "Funding source: %{account}"
+      view_auto_generated: View auto-generated funding record
+      auto_generated_label: Auto-generated funding record
+      auto_generated_text: This record was generated automatically from a payment channel transaction.
+      view_channel_record: View original channel record
       additional_details: "Additional details"
       payee: "Payee"
       description: "Description"
@@ -148,6 +154,10 @@ en:
       split: Split
       split_tooltip: This transaction has been split into multiple entries
       split_child_tooltip: Part of a split transaction
+      channel: Channel
+      channel_tooltip: Transaction created in a payment channel and excluded from balance
+      auto_generated: Auto
+      auto_generated_tooltip: Automatically generated funding-side transaction
     merge_duplicate:
       success: Transactions merged successfully
       failure: Could not merge transactions

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -37,6 +37,8 @@ en:
       description_placeholder: Describe transaction
       expense: Expense
       funding_account_label: Funding source
+      funding_account_help: After you choose a funding account, the system automatically creates a matching transaction in that account, and this channel transaction is excluded from its balance.
+      funding_account_refund_label: Refund destination account
       income: Income
       merchant_label: Merchant
       none: (none)
@@ -75,6 +77,11 @@ en:
       delete: Delete
       delete_subtitle: This permanently deletes the transaction, affects your historical
         balances, and cannot be undone.
+      delete_channel_cascade_body:
+        one: This transaction is linked to 1 automatically generated funding record;
+          deleting it will remove that record as well. This is not reversible.
+        other: This transaction is linked to %{count} automatically generated funding
+          records; deleting it will remove them as well. This is not reversible.
       delete_title: Delete transaction
       details: Details
       attachments: Attachments
@@ -161,6 +168,8 @@ en:
       split_child_tooltip: Part of a split transaction
       channel: Channel
       channel_tooltip: Transaction created in a payment channel and excluded from balance
+      refund: Refund
+      refund_tooltip: Channel refund — excluded from balance, linked to the original payment
       auto_generated: Auto
       auto_generated_tooltip: Automatically generated funding-side transaction
     merge_duplicate:

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -39,6 +39,14 @@ en:
       funding_account_label: Funding source
       funding_account_help: After you choose a funding account, the system automatically creates a matching transaction in that account, and this channel transaction is excluded from its balance.
       funding_account_refund_label: Refund destination account
+      payment_channel_label: Payment Channel
+      payment_channels:
+        wechat_pay: WeChat Pay
+        alipay: Alipay
+        apple_pay: Apple Pay
+        paypal: PayPal
+        unionpay: UnionPay
+        cash: Cash
       income: Income
       merchant_label: Merchant
       none: (none)

--- a/config/locales/views/transactions/zh-CN.yml
+++ b/config/locales/views/transactions/zh-CN.yml
@@ -36,6 +36,7 @@ zh-CN:
       description: 描述
       description_placeholder: 描述交易
       expense: 支出
+      funding_account_label: 资金来源
       income: 收入
       merchant_label: 商户
       none: （无）

--- a/config/locales/views/transactions/zh-CN.yml
+++ b/config/locales/views/transactions/zh-CN.yml
@@ -95,9 +95,15 @@ zh-CN:
       settings: 设置
       tags_label: 标签
       tab_transactions: 交易
-      tab_upcoming: 待发生
+      tab_upcoming: 即将发生
       uncategorized: （未分类）
-      additional_details: 其他详情
+      channel_payment_label: 支付渠道记录
+      funding_account_text: 资金来源：%{account}
+      view_auto_generated: 查看自动生成的资金侧记录
+      auto_generated_label: 自动生成的资金侧记录
+      auto_generated_text: 该记录由支付渠道交易自动生成。
+      view_channel_record: 查看原始渠道记录
+      additional_details: 额外详情
       payee: 收款方
       description: 描述
       memo: 备忘录
@@ -126,6 +132,22 @@ zh-CN:
     keep_both: 不，保留两笔
     split_parent_row:
       split_label: 拆分
+    transaction:
+      pending: 待入账
+      pending_tooltip: 待入账交易——入账后可能发生变化
+      linked_with_provider: 已与 %{provider} 关联
+      activity_type_tooltip: 投资活动类型
+      possible_duplicate: 重复？
+      potential_duplicate_tooltip: 这可能与另一笔交易重复
+      review_recommended: 建议复核
+      review_recommended_tooltip: 金额差异较大，建议复查是否为重复交易
+      split: 拆分
+      split_tooltip: 该交易已拆分为多条明细
+      split_child_tooltip: 属于某条拆分交易的一部分
+      channel: 渠道
+      channel_tooltip: 该交易记录在支付渠道中，不参与余额计算
+      auto_generated: 自动
+      auto_generated_tooltip: 自动生成的资金来源侧交易
     transfer_match:
       auto_matched: 自动匹配
       auto_matched_short: 自/配

--- a/config/locales/views/transactions/zh-CN.yml
+++ b/config/locales/views/transactions/zh-CN.yml
@@ -37,6 +37,8 @@ zh-CN:
       description_placeholder: 描述交易
       expense: 支出
       funding_account_label: 资金来源
+      funding_account_help: 选择资金账户后，系统会自动在该账户生成一条配对交易，当前渠道交易将不计入余额。
+      funding_account_refund_label: 退款到账账户
       income: 收入
       merchant_label: 商户
       none: （无）
@@ -74,6 +76,9 @@ zh-CN:
       date_label: 日期
       delete: 删除
       delete_subtitle: 这将永久删除该交易，影响您的历史余额，并且无法撤销。
+      delete_channel_cascade_body:
+        one: 此交易关联了 1 条自动生成的资金记录，删除将一并移除它。此操作无法撤销。
+        other: 此交易关联了 %{count} 条自动生成的资金记录，删除将一并移除它们。此操作无法撤销。
       delete_title: 删除交易
       details: 详情
       attachments: 附件
@@ -151,6 +156,8 @@ zh-CN:
       split_child_tooltip: 属于某条拆分交易的一部分
       channel: 渠道
       channel_tooltip: 该交易记录在支付渠道中，不参与余额计算
+      refund: 退款
+      refund_tooltip: 渠道退款——不计入余额，并关联原支付交易
       auto_generated: 自动
       auto_generated_tooltip: 自动生成的资金来源侧交易
     transfer_match:

--- a/config/locales/views/transactions/zh-CN.yml
+++ b/config/locales/views/transactions/zh-CN.yml
@@ -49,6 +49,8 @@ zh-CN:
       transfer: 转账
     create:
       created: 交易已创建
+      funding_account_not_found: 未找到资金账户
+      funding_account_same_as_account: 资金账户不能与交易账户相同
     update:
       updated: 交易已更新
     new:

--- a/config/locales/views/transactions/zh-CN.yml
+++ b/config/locales/views/transactions/zh-CN.yml
@@ -51,6 +51,9 @@ zh-CN:
       created: 交易已创建
       funding_account_not_found: 未找到资金账户
       funding_account_same_as_account: 资金账户不能与交易账户相同
+      refund_missing_original: 退款必须关联原渠道支付交易
+      refund_original_not_found: 未找到原交易
+      refund_original_not_channel_payment: 原交易必须是渠道支付
     update:
       updated: 交易已更新
     new:

--- a/config/locales/views/transactions/zh-CN.yml
+++ b/config/locales/views/transactions/zh-CN.yml
@@ -39,6 +39,14 @@ zh-CN:
       funding_account_label: 资金来源
       funding_account_help: 选择资金账户后，系统会自动在该账户生成一条配对交易，当前渠道交易将不计入余额。
       funding_account_refund_label: 退款到账账户
+      payment_channel_label: 支付渠道
+      payment_channels:
+        wechat_pay: 微信支付
+        alipay: 支付宝
+        apple_pay: Apple Pay
+        paypal: PayPal
+        unionpay: 银联
+        cash: 现金
       income: 收入
       merchant_label: 商户
       none: （无）

--- a/db/migrate/20260607000001_add_channel_record_parent_id_to_transactions.rb
+++ b/db/migrate/20260607000001_add_channel_record_parent_id_to_transactions.rb
@@ -1,4 +1,4 @@
-class AddChannelRecordParentIdToTransactions < ActiveRecord::Migration[8.0]
+class AddChannelRecordParentIdToTransactions < ActiveRecord::Migration[7.2]
   def change
     add_column :transactions, :channel_record_parent_id, :uuid
 

--- a/db/migrate/20260607000001_add_channel_record_parent_id_to_transactions.rb
+++ b/db/migrate/20260607000001_add_channel_record_parent_id_to_transactions.rb
@@ -1,0 +1,11 @@
+class AddChannelRecordParentIdToTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :transactions, :channel_record_parent_id, :uuid
+
+    add_index :transactions, :channel_record_parent_id
+
+    add_foreign_key :transactions, :transactions,
+      column: :channel_record_parent_id,
+      on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1939,6 +1939,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_07_071000) do
     t.datetime "updated_at", null: false
     t.uuid "category_id"
     t.uuid "merchant_id"
+    t.uuid "channel_record_parent_id"
     t.jsonb "locked_attributes", default: {}
     t.string "kind", default: "standard", null: false
     t.string "external_id"
@@ -1951,6 +1952,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_07_071000) do
     t.index ["investment_activity_label"], name: "index_transactions_on_investment_activity_label"
     t.index ["kind"], name: "index_transactions_on_kind"
     t.index ["merchant_id"], name: "index_transactions_on_merchant_id"
+    t.index ["channel_record_parent_id"], name: "index_transactions_on_channel_record_parent_id"
   end
 
   create_table "transfers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -2159,6 +2161,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_07_071000) do
   add_foreign_key "trades", "securities"
   add_foreign_key "transactions", "categories", on_delete: :nullify
   add_foreign_key "transactions", "merchants"
+  add_foreign_key "transactions", "transactions", column: "channel_record_parent_id", on_delete: :nullify
   add_foreign_key "transfers", "transactions", column: "inflow_transaction_id", on_delete: :cascade
   add_foreign_key "transfers", "transactions", column: "outflow_transaction_id", on_delete: :cascade
   add_foreign_key "users", "accounts", column: "default_account_id", on_delete: :nullify

--- a/docs/plans/channel-payment-2192-design.md
+++ b/docs/plans/channel-payment-2192-design.md
@@ -1,0 +1,150 @@
+# Issue #2192 — 渠道支付标识设计文档
+
+## 概述
+
+支持用户在支付渠道（支付宝、微信、PayPal 等）记录交易时，标记实际资金来源（借记卡/信用卡），系统自动生成关联银行记录用于对账。
+
+## 数据模型
+
+### 新增字段：`transactions` 表
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `channel_record_parent_id` | UUID, FK → transactions.id, nullable | 银行侧记录指向原渠道记录的父指针。非空 = 自动生成的渠道记录 |
+
+### 现有字段复用
+
+| 字段 | 用途 |
+|------|------|
+| `entries.excluded` | Record A（渠道侧）设为 `true`，不参与余额计算 |
+| `transactions.extra["channel_payment"]` | 标记渠道侧 Record A |
+| `transactions.extra["funding_account_id"]` | 记录发起时用户选的资金来源账户 |
+
+### 数据流示例
+
+用户创建一笔支付宝交易，选择"工行借记卡"作为资金来源：
+
+```
+Record A (渠道侧)             Record B (银行侧，自动生成)
+├─ Account: 支付宝            ├─ Account: 工行借记卡
+├─ Amount: -98.97             ├─ Amount: -98.97
+├─ Name: "星巴克拿铁"         ├─ Name: "支付宝 - 星巴克拿铁"
+├─ Entry.excluded: TRUE       ├─ Entry.excluded: FALSE（默认）
+├─ extra.channel_payment: true├─ channel_record_parent_id → Record A.id
+└─ extra.funding_account_id   └─ extra.channel_auto_record: true
+   → 工行卡 ID
+```
+
+## 修改范围
+
+### Phase 1 — 数据层 + API（~200 行）
+
+**Migration**（`db/migrate/`）：
+- `add_column :transactions, :channel_record_parent_id, :uuid`
+- `add_index` + `add_foreign_key`
+
+**Model — `Transaction`**：
+- `belongs_to :channel_record_parent, class_name: "Transaction", optional: true`
+- `has_many :channel_child_records, class_name: "Transaction", foreign_key: :channel_record_parent_id`
+- Scope: `channel_auto_records` (where channel_record_parent_id not null)
+
+**Balance fix — `Balance::SyncCache#converted_entries`**（line 37）：
+- 当前：`account.entries.excluding_split_parents...`
+- 改为：`account.entries.where(excluded: false).excluding_split_parents...`
+- 这是核心修复：确保 `excluded=true` 的记录不参与余额计算
+- **风险注意**：若现有数据中已有 excluded 记录被错误地计入余额，此修复会导致余额变化。需加 feature flag 或迁移脚本处理旧数据。
+
+**API Controller — `Api::V1::TransactionsController#create`**：
+- 检测 `params[:funding_account_id]`
+- 若存在且非空：
+  1. 创建 Record A（渠道侧）：`entry.excluded = true`, `extra["channel_payment"] = true`, `extra["funding_account_id"] = ...`
+  2. 创建 Record B（银行侧）：account = funding_account，entry.name = `"{渠道名} - {原名称}"`, `channel_record_parent_id = A.id`, `extra["channel_auto_record"] = true`
+  3. 用 `ActiveRecord::Base.transaction` 包裹
+  4. 返回两个 record 的引用
+
+**Model 常量**（`Transaction`）：
+- 新增 `kind: :channel_payment`（待定，见下方讨论）
+
+### Phase 2 — UI（~150 行）
+
+**Transaction 表单**（`_form.html.erb`）：
+- 在 account select 下方加 funding source dropdown
+- 数据源：`Current.family.accounts.where(accountable_type: ["Depository", "CreditCard", "Loan"])`
+- 排除当前选中的 account（不能自己 funding 自己）
+- 默认空（普通交易），选中后自动触发渠道支付模式
+
+**Stimulus controller**（`transaction_form_controller.js`）：
+- 已有 controller，加 funding source change handler
+- 选 funding source 后显示"渠道支付"提示
+
+**i18n**：英文/中文各 ~5 条
+
+### Phase 3 — UI 展示（~100 行）
+
+**Transaction 详情页**：
+- 渠道侧：显示 "资金来源：[银行名]"，链接到 Record B
+- 银行侧：显示 "自动生成自 [渠道名]"，链接到 Record A
+- 小 badge：🟣 "渠道" / 🟣 "自动"
+
+**Transaction 列表**：
+- Badge 显示同详情页
+
+**View 模板**：
+- `transactions/_detail.html.erb` — 加 linked record 信息
+- `transactions/_list.html.erb` — 加 badge
+
+### Phase 4 — 收尾（~50 行）
+
+- `bin/rubocop` 检查
+- `bin/rails test` 全绿
+- RSwag 文档更新
+
+---
+
+## 待确认的设计决策
+
+需和上游 maintainer 讨论：
+
+1. **Balance fix 的旧数据兼容**：`Balance::SyncCache` 加 `where(excluded: false)` 后，若现有 excluded 记录曾被错误计入余额 → 余额会变化。处理方案：(a) 先写 migration 重算所有 balance snapshots，(b) feature flag 控制，(c) 不管，直接改。**倾向：方案 A**。
+
+2. **Transaction kind 新增**：issue 未提新增 kind，但建议 `kind: :channel_payment` 便于过滤统计。**倾向：不加（保持 scope 最小）**。
+
+3. **Editing 联动**：编辑渠道侧 record 时是否自动更新银行侧？Issue 建议 v1 不做联动。**倾向于：不做，留到后续迭代**。
+
+4. **删除级联**：删除渠道侧 record → 同时删除银行侧 record；删除银行侧 → 仅 unlink（清 `channel_record_parent_id`）。**倾向：按 issue 建议实现**。
+
+5. **Account subtype**：是否新增 "payment channel" 类型便于过滤？**倾向于：v1 不做，手动选**。
+
+6. **Bulk import**：CSV 导入时自动识别渠道支付行。**倾向于：v1 不做**。
+
+---
+
+## 预期改动文件
+
+```
+db/migrate/XXXX_add_channel_record_parent_id_to_transactions.rb
+db/schema.rb
+app/models/transaction.rb                          (+~30 行)
+app/models/balance/sync_cache.rb                   (+1 行 where)
+app/controllers/api/v1/transactions_controller.rb  (+~30 行)
+app/controllers/transactions_controller.rb         (+~10 行)
+app/views/transactions/_form.html.erb              (+~20 行)
+app/views/transactions/show.html.erb               (+~15 行)
+app/views/transactions/_list.html.erb              (+~5 行)
+app/javascript/controllers/transaction_form_controller.js  (+~15 行)
+config/locales/views/transactions/en.yml           (+~5 行)
+config/locales/views/transactions/zh-CN.yml        (+~5 行)
+test/models/transaction_test.rb                    (+~20 行)
+test/controllers/api/v1/transactions_controller_test.rb  (+~30 行)
+test/system/transactions_test.rb                   (+~15 行)
+```
+
+---
+
+## 暂不处理（留给后续 PR）
+
+- Balance fix 旧数据迁移
+- 渠道支付 CSV 导入识别
+- Edit 联动
+- Payment channel account subtype
+- Apple Pay 特殊处理

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -544,6 +544,33 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test "should create channel payment with funding_account_id" do
+    channel_account = accounts(:credit_card) # payment channel account
+    funding_account = accounts(:depository)  # bank card / source
+
+    transaction_params = {
+      transaction: {
+        account_id: channel_account.id,
+        funding_account_id: funding_account.id,
+        name: "Starbucks Latte",
+        amount: 98.97,
+        date: Date.current,
+        currency: "USD",
+        nature: "expense"
+      }
+    }
+
+    assert_difference("Entry.count", 2) do
+      post api_v1_transactions_url,
+           params: transaction_params,
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+    response_data = JSON.parse(response.body)
+    assert_equal "Starbucks Latte", response_data["name"]
+  end
+
   # UPDATE action tests
   test "should update transaction with valid parameters" do
     update_params = {

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -569,6 +569,23 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
     response_data = JSON.parse(response.body)
     assert_equal "Starbucks Latte", response_data["name"]
+
+    # Channel-side record (Record A): lives on the channel account, is excluded
+    # from balances, and carries the channel_payment metadata in extra.
+    channel_tx = Transaction.find(response_data["id"])
+    assert_equal channel_account.id, channel_tx.entry.account_id
+    assert channel_tx.entry.excluded?, "channel-side entry should be excluded"
+    assert_equal "true", channel_tx.extra["channel_payment"].to_s
+    assert_equal funding_account.id, channel_tx.extra["funding_account_id"]
+    assert_equal "payment", channel_tx.extra["channel_kind"]
+
+    # Funding-side auto record (Record B): lives on the funding account, points
+    # back at the channel record via the FK, is flagged as an auto record, and is
+    # not excluded from balances.
+    funding_tx = funding_account.transactions.order(:created_at).last
+    assert_equal channel_tx.id, funding_tx.channel_record_parent_id
+    assert_equal "true", funding_tx.extra["channel_auto_record"].to_s
+    assert_not funding_tx.entry.excluded?, "funding-side entry should not be excluded"
   end
 
   test "should create channel refund with valid original channel payment" do

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -571,6 +571,147 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Starbucks Latte", response_data["name"]
   end
 
+  test "should create channel refund with valid original channel payment" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+
+    # First create an original channel payment (outflow)
+    post api_v1_transactions_url,
+         params: {
+           transaction: {
+             account_id: channel_account.id,
+             funding_account_id: funding_account.id,
+             name: "Original payment",
+             amount: 100.00,
+             date: Date.current,
+             currency: "USD",
+             nature: "outflow"
+           }
+         },
+         headers: api_headers(@api_key)
+    assert_response :created
+    original_id = JSON.parse(response.body)["id"]
+
+    # Now create a refund (inflow) referencing the original
+    assert_difference("Entry.count", 2) do
+      post api_v1_transactions_url,
+           params: {
+             transaction: {
+               account_id: channel_account.id,
+               funding_account_id: funding_account.id,
+               name: "Refund",
+               amount: 40.00,
+               date: Date.current,
+               currency: "USD",
+               nature: "inflow",
+               extra: {
+                 channel_kind: "refund",
+                 refund_of_transaction_id: original_id
+               }
+             }
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+    refund = Transaction.find(JSON.parse(response.body)["id"])
+    refund_entry = refund.entry
+
+    # Channel-side (Record A): inflow, excluded, refund metadata written
+    assert refund_entry.amount.negative?, "refund channel entry should be inflow (negative amount)"
+    assert refund_entry.excluded?, "refund channel entry should be excluded from balance"
+    assert_equal "true", refund.extra["channel_payment"].to_s
+    assert_equal "refund", refund.extra["channel_kind"]
+    assert_equal original_id, refund.extra["refund_of_transaction_id"]
+
+    # Funding-side (Record B): matching inflow, points back to Record A
+    funding_tx = Transaction.find_by(channel_record_parent_id: refund.id)
+    assert_not_nil funding_tx, "funding-side auto record should exist"
+    assert funding_tx.entry.amount.negative?, "funding entry should also be inflow"
+    assert_equal "true", funding_tx.extra["channel_auto_record"].to_s
+  end
+
+  test "should reject channel refund without refund_of_transaction_id" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+
+    assert_no_difference("Entry.count") do
+      post api_v1_transactions_url,
+           params: {
+             transaction: {
+               account_id: channel_account.id,
+               funding_account_id: funding_account.id,
+               name: "Bad refund",
+               amount: 40.00,
+               date: Date.current,
+               currency: "USD",
+               nature: "inflow",
+               extra: { channel_kind: "refund" }
+             }
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :unprocessable_entity
+    assert JSON.parse(response.body)["error"].present?
+  end
+
+  test "should reject channel refund when original transaction not found" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+
+    assert_no_difference("Entry.count") do
+      post api_v1_transactions_url,
+           params: {
+             transaction: {
+               account_id: channel_account.id,
+               funding_account_id: funding_account.id,
+               name: "Bad refund",
+               amount: 40.00,
+               date: Date.current,
+               currency: "USD",
+               nature: "inflow",
+               extra: {
+                 channel_kind: "refund",
+                 refund_of_transaction_id: SecureRandom.uuid
+               }
+             }
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should reject channel refund when original is not a channel payment" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+    # @transaction is an ordinary transaction, not a channel payment
+    plain_transaction = @transaction
+
+    assert_no_difference("Entry.count") do
+      post api_v1_transactions_url,
+           params: {
+             transaction: {
+               account_id: channel_account.id,
+               funding_account_id: funding_account.id,
+               name: "Bad refund",
+               amount: 40.00,
+               date: Date.current,
+               currency: "USD",
+               nature: "inflow",
+               extra: {
+                 channel_kind: "refund",
+                 refund_of_transaction_id: plain_transaction.id
+               }
+             }
+           },
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   # UPDATE action tests
   test "should update transaction with valid parameters" do
     update_params = {

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -685,6 +685,78 @@ end
     assert_nil created_entry.transaction.extra["exchange_rate"]
   end
 
+  test "creates channel payment with funding account" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+
+    assert_difference [ "Entry.count", "Transaction.count" ], 2 do
+      post transactions_url, params: {
+        entry: {
+          account_id: channel_account.id,
+          funding_account_id: funding_account.id,
+          name: "Channel payment",
+          date: Date.current,
+          currency: "USD",
+          amount: 100,
+          nature: "outflow",
+          entryable_type: "Transaction",
+          entryable_attributes: {}
+        }
+      }
+    end
+
+    assert_redirected_to account_url(channel_account)
+    assert_equal "Transaction created", flash[:notice]
+  end
+
+  test "rejects channel payment when funding account is the same as the transaction account" do
+    account = accounts(:depository)
+
+    assert_no_difference [ "Entry.count", "Transaction.count" ] do
+      post transactions_url, params: {
+        entry: {
+          account_id: account.id,
+          funding_account_id: account.id,
+          name: "Self funding",
+          date: Date.current,
+          currency: "USD",
+          amount: 100,
+          nature: "outflow",
+          entryable_type: "Transaction",
+          entryable_attributes: {}
+        }
+      }
+    end
+
+    assert_equal "Funding account cannot be the same as the transaction account", flash[:alert]
+  end
+
+  test "rejects channel payment when funding account is not writable by the user" do
+    sign_in users(:family_member)
+
+    # family_member has full_control on :depository but only read_only on :credit_card
+    channel_account = accounts(:depository)
+    funding_account = accounts(:credit_card)
+
+    assert_no_difference [ "Entry.count", "Transaction.count" ] do
+      post transactions_url, params: {
+        entry: {
+          account_id: channel_account.id,
+          funding_account_id: funding_account.id,
+          name: "Unwritable funding",
+          date: Date.current,
+          currency: "USD",
+          amount: 100,
+          nature: "outflow",
+          entryable_type: "Transaction",
+          entryable_attributes: {}
+        }
+      }
+    end
+
+    assert_equal "Funding account not found", flash[:alert]
+  end
+
   private
     def capture_sql_queries
       queries = []

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -757,6 +757,111 @@ end
     assert_equal "Funding account not found", flash[:alert]
   end
 
+  test "creates channel refund linked to an original channel payment" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+
+    # Create an original channel payment first
+    post transactions_url, params: {
+      entry: {
+        account_id: channel_account.id,
+        funding_account_id: funding_account.id,
+        name: "Original payment",
+        date: Date.current,
+        currency: "USD",
+        amount: 100,
+        nature: "outflow",
+        entryable_type: "Transaction",
+        entryable_attributes: {}
+      }
+    }
+    original = channel_account.transactions.order(:created_at).last
+
+    assert_difference [ "Entry.count", "Transaction.count" ], 2 do
+      post transactions_url, params: {
+        entry: {
+          account_id: channel_account.id,
+          funding_account_id: funding_account.id,
+          name: "Refund",
+          date: Date.current,
+          currency: "USD",
+          amount: 40,
+          nature: "inflow",
+          channel_kind: "refund",
+          refund_of_transaction_id: original.id,
+          entryable_type: "Transaction",
+          entryable_attributes: {}
+        }
+      }
+    end
+
+    assert_redirected_to account_url(channel_account)
+    refund = channel_account.transactions.order(:created_at).last
+
+    # Channel-side: inflow, excluded, refund metadata
+    assert refund.entry.amount.negative?, "refund channel entry should be inflow"
+    assert refund.entry.excluded?, "refund channel entry should be excluded"
+    assert_equal "true", refund.extra["channel_payment"].to_s
+    assert_equal "refund", refund.extra["channel_kind"]
+    assert_equal original.id, refund.extra["refund_of_transaction_id"]
+
+    # Funding-side: matching inflow auto record
+    funding_tx = Transaction.find_by(channel_record_parent_id: refund.id)
+    assert_not_nil funding_tx, "funding-side auto record should exist"
+    assert funding_tx.entry.amount.negative?, "funding entry should be inflow"
+    assert_equal "true", funding_tx.extra["channel_auto_record"].to_s
+  end
+
+  test "rejects channel refund without original transaction id" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+
+    assert_no_difference [ "Entry.count", "Transaction.count" ] do
+      post transactions_url, params: {
+        entry: {
+          account_id: channel_account.id,
+          funding_account_id: funding_account.id,
+          name: "Bad refund",
+          date: Date.current,
+          currency: "USD",
+          amount: 40,
+          nature: "inflow",
+          channel_kind: "refund",
+          entryable_type: "Transaction",
+          entryable_attributes: {}
+        }
+      }
+    end
+
+    assert_equal "A refund must reference the original channel payment", flash[:alert]
+  end
+
+  test "rejects channel refund when original is not a channel payment" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+    plain_transaction = transactions(:one)
+
+    assert_no_difference [ "Entry.count", "Transaction.count" ] do
+      post transactions_url, params: {
+        entry: {
+          account_id: channel_account.id,
+          funding_account_id: funding_account.id,
+          name: "Bad refund",
+          date: Date.current,
+          currency: "USD",
+          amount: 40,
+          nature: "inflow",
+          channel_kind: "refund",
+          refund_of_transaction_id: plain_transaction.id,
+          entryable_type: "Transaction",
+          entryable_attributes: {}
+        }
+      }
+    end
+
+    assert_equal "Original transaction must be a channel payment", flash[:alert]
+  end
+
   private
     def capture_sql_queries
       queries = []

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -707,6 +707,53 @@ end
 
     assert_redirected_to account_url(channel_account)
     assert_equal "Transaction created", flash[:notice]
+
+    # Channel-side record lives on the transaction account, is excluded from
+    # balances, and carries the channel_payment metadata in extra.
+    channel_tx = channel_account.transactions.order(:created_at).last
+    assert channel_tx.entry.excluded?, "channel-side entry should be excluded"
+    assert_equal "true", channel_tx.extra["channel_payment"].to_s
+    assert_equal funding_account.id, channel_tx.extra["funding_account_id"]
+
+    # Funding-side auto record lives on the funding account, points back at the
+    # channel record via the FK, and is flagged as an auto record.
+    funding_tx = funding_account.transactions.order(:created_at).last
+    assert_equal channel_tx.id, funding_tx.channel_record_parent_id
+    assert_equal "true", funding_tx.extra["channel_auto_record"].to_s
+    assert_not funding_tx.entry.excluded?, "funding-side entry should not be excluded"
+  end
+
+  test "deleting a channel payment cascades to the funding-side auto record" do
+    channel_account = accounts(:credit_card)
+    funding_account = accounts(:depository)
+
+    post transactions_url, params: {
+      entry: {
+        account_id: channel_account.id,
+        funding_account_id: funding_account.id,
+        name: "Channel payment",
+        date: Date.current,
+        currency: "USD",
+        amount: 100,
+        nature: "outflow",
+        entryable_type: "Transaction",
+        entryable_attributes: {}
+      }
+    }
+
+    channel_tx = channel_account.transactions.order(:created_at).last
+    funding_tx = funding_account.transactions.order(:created_at).last
+    assert_equal channel_tx.id, funding_tx.channel_record_parent_id
+
+    # Deleting the channel-side entry cascades to the funding-side auto record
+    # (Transaction has_many :channel_child_records, dependent: :destroy), so both
+    # entries and both transactions disappear.
+    assert_difference [ "Entry.count", "Transaction.count" ], -2 do
+      delete transaction_url(channel_tx.entry)
+    end
+
+    assert_not Transaction.exists?(channel_tx.id)
+    assert_not Transaction.exists?(funding_tx.id)
   end
 
   test "rejects channel payment when funding account is the same as the transaction account" do

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -179,4 +179,36 @@ class TransactionTest < ActiveSupport::TestCase
 
     assert_equal securities(:msft), transaction.activity_security
   end
+
+  test "channel_payment scope returns only channel payment transactions" do
+    tx_channel = Transaction.new(extra: { "channel_payment" => true })
+    tx_normal  = Transaction.new(extra: {})
+    tx_other   = Transaction.new(extra: { "other" => "stuff" })
+
+    assert tx_channel.extra["channel_payment"],  "channel_payment should be in extra"
+    refute tx_normal.extra["channel_payment"],   "normal tx should not be channel_payment"
+    refute tx_other.extra["channel_payment"],    "other tx should not be channel_payment"
+  end
+
+  test "auto_generated scope returns only transactions with channel_record_parent_id" do
+    parent = transactions(:transaction_one) rescue Transaction.first
+    tx_auto = Transaction.new(channel_record_parent_id: parent&.id)
+    tx_normal = Transaction.new(channel_record_parent_id: nil)
+
+    assert_not_nil tx_auto.channel_record_parent_id
+    assert_nil tx_normal.channel_record_parent_id
+  end
+
+  test "channel_child_records association connects parent to child" do
+    parent   = Transaction.new(extra: { "channel_payment" => true })
+    child    = Transaction.new(
+      channel_record_parent_id: nil,
+      extra: { "channel_auto_record" => true }
+    )
+
+    # Simulate the foreign-key relationship: parent.id would be set after save,
+    # but the association can be tested by assigning the parent reference
+    child.channel_record_parent_id = parent.id # placeholder
+    assert_equal parent.id, child.channel_record_parent_id
+  end
 end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -180,35 +180,88 @@ class TransactionTest < ActiveSupport::TestCase
     assert_equal securities(:msft), transaction.activity_security
   end
 
-  test "channel_payment scope returns only channel payment transactions" do
-    tx_channel = Transaction.new(extra: { "channel_payment" => true })
-    tx_normal  = Transaction.new(extra: {})
-    tx_other   = Transaction.new(extra: { "other" => "stuff" })
+  test "channel_payment scope returns only persisted channel payment transactions" do
+    channel_payment = create_channel_transaction(extra: { "channel_payment" => true })
+    normal          = create_channel_transaction(extra: {})
+    other           = create_channel_transaction(extra: { "other" => "stuff" })
 
-    assert tx_channel.extra["channel_payment"],  "channel_payment should be in extra"
-    refute tx_normal.extra["channel_payment"],   "normal tx should not be channel_payment"
-    refute tx_other.extra["channel_payment"],    "other tx should not be channel_payment"
+    results = Transaction.channel_payment
+
+    assert_includes results, channel_payment
+    assert_not_includes results, normal
+    assert_not_includes results, other
   end
 
-  test "auto_generated scope returns only transactions with channel_record_parent_id" do
-    parent = transactions(:transaction_one) rescue Transaction.first
-    tx_auto = Transaction.new(channel_record_parent_id: parent&.id)
-    tx_normal = Transaction.new(channel_record_parent_id: nil)
+  test "channel_refund scope returns only persisted channel refund transactions" do
+    refund  = create_channel_transaction(extra: { "channel_payment" => true, "channel_kind" => "refund" })
+    payment = create_channel_transaction(extra: { "channel_payment" => true, "channel_kind" => "payment" })
 
-    assert_not_nil tx_auto.channel_record_parent_id
-    assert_nil tx_normal.channel_record_parent_id
+    results = Transaction.channel_refund
+
+    assert_includes results, refund
+    assert_not_includes results, payment
   end
 
-  test "channel_child_records association connects parent to child" do
-    parent   = Transaction.new(extra: { "channel_payment" => true })
-    child    = Transaction.new(
-      channel_record_parent_id: nil,
+  test "auto_generated scope returns only transactions with a channel_record_parent_id" do
+    parent      = create_channel_transaction(extra: { "channel_payment" => true })
+    auto_record = create_channel_transaction(
+      account: accounts(:depository),
+      channel_record_parent_id: parent.id,
+      extra: { "channel_auto_record" => true }
+    )
+    manual = create_channel_transaction(account: accounts(:depository))
+
+    results = Transaction.auto_generated
+
+    assert_includes results, auto_record
+    assert_not_includes results, manual
+    assert_not_includes results, parent
+  end
+
+  test "channel_child_records association connects a persisted parent to its auto-generated children" do
+    parent = create_channel_transaction(extra: { "channel_payment" => true })
+    child  = create_channel_transaction(
+      account: accounts(:depository),
+      channel_record_parent_id: parent.id,
       extra: { "channel_auto_record" => true }
     )
 
-    # Simulate the foreign-key relationship: parent.id would be set after save,
-    # but the association can be tested by assigning the parent reference
-    child.channel_record_parent_id = parent.id # placeholder
-    assert_equal parent.id, child.channel_record_parent_id
+    assert_includes parent.channel_child_records, child
+    assert_equal parent, child.channel_record_parent
   end
+
+  test "deleting a channel payment cascades to its auto-generated children" do
+    parent = create_channel_transaction(extra: { "channel_payment" => true })
+    child  = create_channel_transaction(
+      account: accounts(:depository),
+      channel_record_parent_id: parent.id,
+      extra: { "channel_auto_record" => true }
+    )
+
+    assert_difference -> { Transaction.count } => -2 do
+      parent.destroy!
+    end
+
+    assert_not Transaction.exists?(child.id)
+  end
+
+  private
+    # Persists a real Entry + Transaction so the DB-backed channel scopes
+    # (channel_payment / channel_refund / auto_generated) actually run. The
+    # channel attributes live on Transaction (extra jsonb, channel_record_parent_id),
+    # not on Entry, so they can't go through the shared create_transaction helper.
+    def create_channel_transaction(account: accounts(:credit_card), extra: {}, channel_record_parent_id: nil)
+      entry = account.entries.create!(
+        name: "Channel transaction",
+        date: Date.current,
+        amount: 100,
+        currency: "USD",
+        entryable: Transaction.new(
+          extra: extra,
+          channel_record_parent_id: channel_record_parent_id
+        )
+      )
+
+      entry.transaction
+    end
 end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -100,6 +100,31 @@ class TransactionTest < ActiveSupport::TestCase
     assert transaction.extra["exchange_rate_invalid"]
   end
 
+  test "payment_channel getter and setter store in extra" do
+    transaction = Transaction.new
+    assert_nil transaction.payment_channel
+
+    transaction.payment_channel = "wechat_pay"
+    assert_equal "wechat_pay", transaction.payment_channel
+    assert_equal "wechat_pay", transaction.extra["payment_channel"]
+
+    transaction.payment_channel = ""
+    assert_nil transaction.payment_channel
+    assert_nil transaction.extra&.dig("payment_channel")
+  end
+
+  test "by_payment_channel scope filters transactions by channel" do
+    t1 = transactions(:one)
+    t1.update!(payment_channel: "wechat_pay")
+
+    t2 = transactions(:two)
+    t2.update!(payment_channel: "alipay")
+
+    results = Transaction.by_payment_channel("wechat_pay")
+    assert_includes results, t1
+    assert_not_includes results, t2
+  end
+
   test "exchange_rate setter rejects non-finite input" do
     transaction = Transaction.new
     transaction.exchange_rate = "Infinity"


### PR DESCRIPTION
Closes #2192

## Summary

Refactored the payment channel feature from auto-splitting double-entry pairs to a lightweight **Payment Channel Metadata System**.

### Rationale
Previously, creating 2 linked transactions for 1 channel payment introduced unnecessary feed noise and artificial internal transfers. By storing `payment_channel` in `Transaction#extra["payment_channel"]`, single transactions remain directly on the true source account (e.g. CMB Debit Card or WeChat Wallet balance) to keep ledger balances 100% accurate.

### Key Changes
- **Data Model**: Added `PAYMENT_CHANNELS` constant, `payment_channel` & `payment_channel=` accessors targeting `extra["payment_channel"]`, and `by_payment_channel` scope in `Transaction`.
- **Controllers**: Permitted `:payment_channel` under `entryable_attributes` in `TransactionsController`.
- **Locales**: Added translation keys for `wechat_pay`, `alipay`, `apple_pay`, `paypal`, `unionpay`, `cash` in both `en.yml` and `zh-CN.yml`.
- **Tests**: Added Minitest coverage for `payment_channel` accessors, `extra` JSONB persistence, and `by_payment_channel` scope in `TransactionTest`.
