### PR TITLE
perf(sync): scope transfer matching after account sync

### DIFF
--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -13,7 +13,7 @@ class Account::Syncer
   end
 
   def perform_post_sync
-    account.family.auto_match_transfers!
+    account.family.auto_match_transfers!(account: account)
   end
 
   private

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -4,6 +4,7 @@ module Family::AutoTransferMatchable
     exchange_rate_tolerance: 0.1,
     inflow_transaction_id: nil,
     outflow_transaction_id: nil,
+    account_id: nil,
     include_rejected: true
   )
     date_window = coerce_transfer_match_date_window!(date_window)
@@ -16,6 +17,7 @@ module Family::AutoTransferMatchable
         family_id: id,
         inflow_transaction_id:,
         outflow_transaction_id:,
+        account_id:,
         include_rejected:,
         lower_exchange_rate_bound: 1 - exchange_rate_tolerance,
         upper_exchange_rate_bound: 1 + exchange_rate_tolerance
@@ -23,9 +25,9 @@ module Family::AutoTransferMatchable
     ])
   end
 
-  def auto_match_transfers!
+  def auto_match_transfers!(account: nil)
     # Exclude already matched transfers
-    candidates_scope = transfer_match_candidates(include_rejected: false)
+    candidates_scope = transfer_match_candidates(account_id: account&.id, include_rejected: false)
     transaction_ids = candidates_scope.flat_map do |match|
       [ match.inflow_transaction_id, match.outflow_transaction_id ]
     end.uniq
@@ -110,6 +112,7 @@ module Family::AutoTransferMatchable
           JOIN accounts inflow_accounts ON inflow_accounts.id = inflow_candidates.account_id
           JOIN entries outflow_candidates ON (
             outflow_candidates.entryable_type = 'Transaction' AND
+            outflow_candidates.excluded = FALSE AND
             outflow_candidates.amount > 0 AND
             outflow_candidates.account_id <> inflow_candidates.account_id AND
             outflow_candidates.date BETWEEN inflow_candidates.date - :date_window AND inflow_candidates.date + :date_window AND
@@ -127,12 +130,14 @@ module Family::AutoTransferMatchable
           )
           WHERE
             inflow_candidates.entryable_type = 'Transaction' AND
+            inflow_candidates.excluded = FALSE AND
             inflow_candidates.amount < 0 AND
             inflow_accounts.family_id = :family_id AND
             outflow_accounts.family_id = :family_id AND
             inflow_accounts.status IN ('draft', 'active') AND
             outflow_accounts.status IN ('draft', 'active') AND
             existing_transfers.id IS NULL AND
+            (:account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id) AND
             (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND
             (:outflow_transaction_id IS NULL OR outflow_candidates.entryable_id = :outflow_transaction_id) AND
             (:include_rejected = TRUE OR rejected_transfers.id IS NULL)
@@ -146,6 +151,7 @@ module Family::AutoTransferMatchable
           JOIN accounts inflow_accounts ON inflow_accounts.id = inflow_candidates.account_id
           JOIN entries outflow_candidates ON (
             outflow_candidates.entryable_type = 'Transaction' AND
+            outflow_candidates.excluded = FALSE AND
             outflow_candidates.amount > 0 AND
             outflow_candidates.account_id <> inflow_candidates.account_id AND
             outflow_candidates.date BETWEEN inflow_candidates.date - :date_window AND inflow_candidates.date + :date_window AND
@@ -167,12 +173,14 @@ module Family::AutoTransferMatchable
           )
           WHERE
             inflow_candidates.entryable_type = 'Transaction' AND
+            inflow_candidates.excluded = FALSE AND
             inflow_candidates.amount < 0 AND
             inflow_accounts.family_id = :family_id AND
             outflow_accounts.family_id = :family_id AND
             inflow_accounts.status IN ('draft', 'active') AND
             outflow_accounts.status IN ('draft', 'active') AND
             existing_transfers.id IS NULL AND
+            (:account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id) AND
             ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0))
               BETWEEN :lower_exchange_rate_bound AND :upper_exchange_rate_bound AND
             (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND

--- a/db/migrate/20260607071000_tighten_transfer_match_lookup_index.rb
+++ b/db/migrate/20260607071000_tighten_transfer_match_lookup_index.rb
@@ -1,0 +1,16 @@
+class TightenTransferMatchLookupIndex < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :entries,
+                 name: "index_entries_on_transfer_match_lookup",
+                 if_exists: true,
+                 algorithm: :concurrently
+
+    add_index :entries,
+              [ :currency, :amount, :date, :account_id ],
+              name: "index_entries_on_transfer_match_lookup",
+              where: "entryable_type = 'Transaction' AND excluded = false",
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260607071000_tighten_transfer_match_lookup_index.rb
+++ b/db/migrate/20260607071000_tighten_transfer_match_lookup_index.rb
@@ -1,7 +1,7 @@
 class TightenTransferMatchLookupIndex < ActiveRecord::Migration[7.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     remove_index :entries,
                  name: "index_entries_on_transfer_match_lookup",
                  if_exists: true,
@@ -11,6 +11,19 @@ class TightenTransferMatchLookupIndex < ActiveRecord::Migration[7.2]
               [ :currency, :amount, :date, :account_id ],
               name: "index_entries_on_transfer_match_lookup",
               where: "entryable_type = 'Transaction' AND excluded = false",
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :entries,
+                 name: "index_entries_on_transfer_match_lookup",
+                 if_exists: true,
+                 algorithm: :concurrently
+
+    add_index :entries,
+              [ :currency, :amount, :date, :account_id ],
+              name: "index_entries_on_transfer_match_lookup",
+              where: "entryable_type = 'Transaction'",
               algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_01_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_07_071000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -639,7 +639,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_01_120000) do
     t.index ["account_id", "date"], name: "index_entries_on_account_id_and_date"
     t.index ["account_id", "source", "external_id"], name: "index_entries_on_account_source_and_external_id", unique: true, where: "((external_id IS NOT NULL) AND (source IS NOT NULL))"
     t.index ["account_id"], name: "index_entries_on_account_id"
-    t.index ["currency", "amount", "date", "account_id"], name: "index_entries_on_transfer_match_lookup", where: "((entryable_type)::text = 'Transaction'::text)"
+    t.index ["currency", "amount", "date", "account_id"], name: "index_entries_on_transfer_match_lookup", where: "(((entryable_type)::text = 'Transaction'::text) AND (excluded = false))"
     t.index ["date"], name: "index_entries_on_date"
     t.index ["entryable_type"], name: "index_entries_on_entryable_type"
     t.index ["import_id"], name: "index_entries_on_import_id"

--- a/test/models/account/syncer_test.rb
+++ b/test/models/account/syncer_test.rb
@@ -2,6 +2,14 @@ require "test_helper"
 require "ostruct"
 
 class Account::SyncerTest < ActiveSupport::TestCase
+  test "post-sync auto matches only transfers touching the synced account" do
+    account = accounts(:depository)
+
+    account.family.expects(:auto_match_transfers!).with(account: account).once
+
+    Account::Syncer.new(account).perform_post_sync
+  end
+
   test "applies IBKR historical balance overrides after materialization" do
     family = families(:empty)
     account = family.accounts.create!(

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -98,6 +98,44 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     assert_no_difference -> { Transfer.count } do
       @family.auto_match_transfers!
     end
+
+    create_transaction(date: Date.current, account: @depository, amount: 700)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700, excluded: true)
+
+    assert_no_difference -> { Transfer.count } do
+      @family.auto_match_transfers!
+    end
+  end
+
+  test "does not consider excluded entries when matching transfers" do
+    create_transaction(date: Date.current, account: @depository, amount: 500, excluded: true)
+    create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    assert_no_difference -> { Transfer.count } do
+      @family.auto_match_transfers!
+    end
+  end
+
+  test "account-scoped auto-matching only considers pairs touching that account" do
+    depository_outflow = create_transaction(date: Date.current, account: @depository, amount: 500)
+    credit_card_inflow = create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    connected_outflow = create_transaction(date: Date.current, account: accounts(:connected), amount: 700)
+    loan_inflow = create_transaction(date: Date.current, account: @loan, amount: -700)
+
+    assert_difference -> { Transfer.count }, 1 do
+      @family.auto_match_transfers!(account: @depository)
+    end
+
+    Transfer.find_by!(
+      inflow_transaction_id: credit_card_inflow.entryable_id,
+      outflow_transaction_id: depository_outflow.entryable_id
+    )
+    assert_nil Transfer.find_by(inflow_transaction_id: loan_inflow.entryable_id, outflow_transaction_id: connected_outflow.entryable_id)
+
+    assert_difference -> { Transfer.count }, 1 do
+      @family.auto_match_transfers!(account: accounts(:connected))
+    end
   end
 
   test "does not match transactions outside the 4-day window" do
@@ -202,6 +240,9 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     sql = @family.send(:transfer_match_candidates_sql)
 
     assert_includes sql, "UNION ALL"
+    assert_includes sql, "inflow_candidates.excluded = FALSE"
+    assert_includes sql, "outflow_candidates.excluded = FALSE"
+    assert_includes sql, ":account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id"
     assert_includes sql, "outflow_candidates.amount = -inflow_candidates.amount"
     assert_includes sql, "JOIN exchange_rates"
   end


### PR DESCRIPTION
## Summary
- Scope post-sync transfer auto-matching to candidate pairs that touch the synced account.
- Keep manual/family-wide transfer matching available for broader repair flows.
- Align the transfer lookup index with the excluded-entry predicate used by the matching query.

## What changed
- Pass the synced account into `auto_match_transfers!` from `Account::Syncer`.
- Add an optional account filter to `transfer_match_candidates`.
- Explicitly exclude hidden/excluded entries in both inflow and outflow SQL branches.
- Replace the transfer lookup partial index predicate so it matches the query.
- Add regression coverage for account-scoped matching and excluded-entry matching.

## Why
Account sync should not need to rescan unrelated transfer candidates across the whole family after every individual account refresh. Narrowing the post-sync path keeps the same matching behavior for the synced account while reducing repeated database work on larger families.

Closes #2227

## Validation
- `bin/rubocop`
- `npm run lint`
- `bin/brakeman`
- `git diff --check`
- `bin/rails test test/models/family/auto_transfer_matchable_test.rb test/models/account/syncer_test.rb`
- `bin/rails test`
- CodeRabbit local review: 0 issues
- Codex Security diff review: no reportable findings

## Notes
Rails test validation was run in the project devcontainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-transfer matching can be scoped to a single account so only transfers touching the synced account are considered.
  * Entries marked as excluded are now ignored during transfer matching.

* **Performance & Infrastructure**
  * Transfer-matching lookup index tightened to reduce scanned rows and improve matching performance.

* **Tests**
  * Added tests covering account-scoped matching, exclusion behavior, and related SQL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->