### PR TITLE
fix(mobile): make offline transaction replay idempotent

### DIFF
--- a/mobile/lib/providers/transactions_provider.dart
+++ b/mobile/lib/providers/transactions_provider.dart
@@ -219,6 +219,8 @@ class TransactionsProvider with ChangeNotifier {
           categoryId: categoryId,
           merchantId: merchantId,
           tagIds: tagIds == null || tagIds.isEmpty ? null : tagIds,
+          externalId: localTransaction.localId,
+          source: TransactionsService.mobileIdempotencySource,
         )
             .then((result) async {
           if (_isDisposed) return;

--- a/mobile/lib/services/offline_storage_service.dart
+++ b/mobile/lib/services/offline_storage_service.dart
@@ -28,6 +28,9 @@ class OfflineStorageService {
     String? serverId,
     SyncStatus syncStatus = SyncStatus.pending,
   }) async {
+    // Generated once when the transaction enters the offline queue, then
+    // persisted as transactions.local_id and reused as the mobile idempotency
+    // key on every replay attempt.
     final localId = _uuid.v4();
 
     _log.info(

--- a/mobile/lib/services/sync_service.dart
+++ b/mobile/lib/services/sync_service.dart
@@ -138,6 +138,8 @@ class SyncService with ChangeNotifier {
             categoryId: transaction.categoryId,
             merchantId: transaction.merchantId,
             tagIds: transaction.tagIds,
+            externalId: transaction.localId,
+            source: TransactionsService.mobileIdempotencySource,
           );
 
           if (result['success'] == true) {

--- a/mobile/lib/services/transactions_service.dart
+++ b/mobile/lib/services/transactions_service.dart
@@ -4,6 +4,8 @@ import '../models/transaction.dart';
 import 'api_config.dart';
 
 class TransactionsService {
+  static const String mobileIdempotencySource = 'sure_mobile';
+
   final http.Client _client;
 
   TransactionsService({http.Client? client})
@@ -21,8 +23,15 @@ class TransactionsService {
     String? categoryId,
     String? merchantId,
     List<String>? tagIds,
+    String? externalId,
+    String? source,
   }) async {
     final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/transactions');
+    // Idempotency is only valid when both halves of the key are present.
+    final hasIdempotencyKey = externalId != null &&
+        externalId.isNotEmpty &&
+        source != null &&
+        source.isNotEmpty;
 
     final body = {
       'transaction': {
@@ -36,6 +45,8 @@ class TransactionsService {
         if (categoryId != null) 'category_id': categoryId,
         if (merchantId != null) 'merchant_id': merchantId,
         if (tagIds != null) 'tag_ids': tagIds,
+        if (hasIdempotencyKey) 'external_id': externalId,
+        if (hasIdempotencyKey) 'source': source,
       }
     };
 

--- a/mobile/test/models/transaction_metadata_test.dart
+++ b/mobile/test/models/transaction_metadata_test.dart
@@ -57,6 +57,26 @@ void main() {
       expect(restored.syncStatus, SyncStatus.synced);
     });
 
+    test('pending offline replay keeps the stored local id', () {
+      final pendingTransaction = OfflineTransaction(
+        localId: 'local_123',
+        accountId: 'acct_1',
+        name: 'Coffee',
+        date: '2026-06-01',
+        amount: r'$4.50',
+        currency: 'USD',
+        nature: 'expense',
+        syncStatus: SyncStatus.pending,
+      );
+
+      final restored = OfflineTransaction.fromDatabaseMap(
+        pendingTransaction.toDatabaseMap(),
+      );
+
+      expect(restored.localId, 'local_123');
+      expect(restored.syncStatus, SyncStatus.pending);
+    });
+
     test('preserves omitted tag state for stored rows without tag columns', () {
       final restored = OfflineTransaction.fromDatabaseMap({
         'server_id': 'tx_1',

--- a/mobile/test/services/transactions_service_test.dart
+++ b/mobile/test/services/transactions_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -5,6 +7,139 @@ import 'package:sure_mobile/services/transactions_service.dart';
 
 void main() {
   group('TransactionsService', () {
+    test(
+      'sends idempotency fields when creating mobile transactions',
+      () async {
+        final service = TransactionsService(
+          client: MockClient((request) async {
+            expect(request.method, 'POST');
+            expect(request.url.path, '/api/v1/transactions');
+            expect(request.body, contains('"external_id":"local_123"'));
+            expect(request.body, contains('"source":"sure_mobile"'));
+            return http.Response(
+              '{"id":"tx_1","account":{"id":"acct_1"},"name":"Coffee",'
+              '"date":"2026-06-01","amount":"\$4.50","currency":"USD",'
+              '"classification":"expense"}',
+              201,
+            );
+          }),
+        );
+
+        final result = await service.createTransaction(
+          accessToken: 'token',
+          accountId: 'acct_1',
+          name: 'Coffee',
+          date: '2026-06-01',
+          amount: '4.50',
+          currency: 'USD',
+          nature: 'expense',
+          externalId: 'local_123',
+          source: TransactionsService.mobileIdempotencySource,
+        );
+
+        expect(result['success'], true);
+        expect(result['transaction'].id, 'tx_1');
+      },
+    );
+
+    test('omits idempotency fields when creating regular transactions',
+        () async {
+      final service = TransactionsService(
+        client: MockClient((request) async {
+          final payload = jsonDecode(request.body) as Map<String, dynamic>;
+          final transaction = payload['transaction'] as Map<String, dynamic>;
+
+          expect(transaction.containsKey('external_id'), false);
+          expect(transaction.containsKey('source'), false);
+
+          return http.Response(
+            '{"id":"tx_1","account":{"id":"acct_1"},"name":"Coffee",'
+            '"date":"2026-06-01","amount":"\$4.50","currency":"USD",'
+            '"classification":"expense"}',
+            201,
+          );
+        }),
+      );
+
+      final result = await service.createTransaction(
+        accessToken: 'token',
+        accountId: 'acct_1',
+        name: 'Coffee',
+        date: '2026-06-01',
+        amount: '4.50',
+        currency: 'USD',
+        nature: 'expense',
+      );
+
+      expect(result['success'], true);
+    });
+
+    test('omits empty idempotency fields when creating transactions', () async {
+      final service = TransactionsService(
+        client: MockClient((request) async {
+          final payload = jsonDecode(request.body) as Map<String, dynamic>;
+          final transaction = payload['transaction'] as Map<String, dynamic>;
+
+          expect(transaction.containsKey('external_id'), false);
+          expect(transaction.containsKey('source'), false);
+
+          return http.Response(
+            '{"id":"tx_1","account":{"id":"acct_1"},"name":"Coffee",'
+            '"date":"2026-06-01","amount":"\$4.50","currency":"USD",'
+            '"classification":"expense"}',
+            201,
+          );
+        }),
+      );
+
+      final result = await service.createTransaction(
+        accessToken: 'token',
+        accountId: 'acct_1',
+        name: 'Coffee',
+        date: '2026-06-01',
+        amount: '4.50',
+        currency: 'USD',
+        nature: 'expense',
+        externalId: '',
+        source: '',
+      );
+
+      expect(result['success'], true);
+    });
+
+    test('omits partial idempotency fields when creating transactions',
+        () async {
+      final service = TransactionsService(
+        client: MockClient((request) async {
+          final payload = jsonDecode(request.body) as Map<String, dynamic>;
+          final transaction = payload['transaction'] as Map<String, dynamic>;
+
+          expect(transaction.containsKey('external_id'), false);
+          expect(transaction.containsKey('source'), false);
+
+          return http.Response(
+            '{"id":"tx_1","account":{"id":"acct_1"},"name":"Coffee",'
+            '"date":"2026-06-01","amount":"\$4.50","currency":"USD",'
+            '"classification":"expense"}',
+            201,
+          );
+        }),
+      );
+
+      final result = await service.createTransaction(
+        accessToken: 'token',
+        accountId: 'acct_1',
+        name: 'Coffee',
+        date: '2026-06-01',
+        amount: '4.50',
+        currency: 'USD',
+        nature: 'expense',
+        externalId: 'local_123',
+      );
+
+      expect(result['success'], true);
+    });
+
     test('preserves field-level update errors', () async {
       final service = TransactionsService(
         client: MockClient((request) async {
@@ -31,24 +166,26 @@ void main() {
       );
     });
 
-    test('returns null transaction for empty successful update responses',
-        () async {
-      final service = TransactionsService(
-        client: MockClient((request) async {
-          expect(request.method, 'PATCH');
-          return http.Response('', 204);
-        }),
-      );
+    test(
+      'returns null transaction for empty successful update responses',
+      () async {
+        final service = TransactionsService(
+          client: MockClient((request) async {
+            expect(request.method, 'PATCH');
+            return http.Response('', 204);
+          }),
+        );
 
-      final result = await service.updateTransaction(
-        accessToken: 'token',
-        transactionId: 'tx_1',
-        name: 'Coffee',
-      );
+        final result = await service.updateTransaction(
+          accessToken: 'token',
+          transactionId: 'tx_1',
+          name: 'Coffee',
+        );
 
-      expect(result['success'], true);
-      expect(result['transaction'], isNull);
-    });
+        expect(result['success'], true);
+        expect(result['transaction'], isNull);
+      },
+    );
 
     test('fetches one transaction after an empty update response', () async {
       var requestCount = 0;


### PR DESCRIPTION
## Summary
- Include stable idempotency metadata when replaying mobile-created offline transactions.
- Omit idempotency fields for regular creates and incomplete key pairs.
- Add service-level regression coverage for idempotent and non-idempotent create payloads.

## What changed
- Add a mobile idempotency source constant to `TransactionsService`.
- Let `createTransaction` send `source` and `external_id` only when both values are present.
- Pass the local transaction ID during offline replay paths in `TransactionsProvider` and `SyncService`.
- Expand transaction service tests around create payloads.

## Why
Offline pending transaction replay can retry after reconnect. If the server accepted an earlier create but the client did not persist the response, replaying without a stable idempotency key can create duplicates.

Closes #2229

## Validation
- `flutter analyze --no-fatal-infos --no-pub`
- `flutter test --no-pub`
- `flutter build apk --debug --no-pub`
- `flutter build ios --simulator --debug --no-pub`
- `git diff --check`
- CodeRabbit local review: valid finding fixed before commit
- Codex Security diff review: no reportable findings

## Notes
The mobile validation used the repo-pinned Flutter toolchain and restored generated dependency/plugin churn after local package resolution. Analyzer output still includes existing info-level findings in unchanged files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction creation and sync reliability by sending local-identifying metadata so retries and uploads are deduplicated and tracked correctly.
  * Ensures locally queued transactions retain their local identifier across persistence/replay to avoid duplicates.

* **Tests**
  * Expanded coverage for transaction creation and update behaviors around identification metadata and empty responses.

* **Documentation**
  * Added inline comments clarifying local-id lifecycle in offline storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->