### PR TITLE
feat(mobile): align theme foundation with Sure tokens

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -20,6 +20,7 @@ import 'services/connectivity_service.dart';
 import 'services/log_service.dart';
 import 'services/preferences_service.dart';
 import 'services/telemetry_service.dart';
+import 'theme/sure_theme.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -76,93 +77,21 @@ class SureApp extends StatelessWidget {
         ),
       ],
       child: Consumer<ThemeProvider>(
-          builder: (context, themeProvider, _) => MaterialApp(
-                title: 'Sure Finances',
-                debugShowCheckedModeBanner: false,
-                navigatorObservers:
-                    TelemetryService.instance.navigatorObservers,
-                theme: ThemeData(
-                  fontFamily: 'Geist',
-                  fontFamilyFallback: const [
-                    'Inter',
-                    'Arial',
-                    'sans-serif',
-                  ],
-                  colorScheme: ColorScheme.fromSeed(
-                    seedColor: const Color(0xFF6366F1),
-                    brightness: Brightness.light,
-                  ),
-                  useMaterial3: true,
-                  appBarTheme: const AppBarTheme(
-                    centerTitle: true,
-                    elevation: 0,
-                  ),
-                  cardTheme: CardThemeData(
-                    elevation: 2,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
-                  inputDecorationTheme: InputDecorationTheme(
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    filled: true,
-                  ),
-                  elevatedButtonTheme: ElevatedButtonThemeData(
-                    style: ElevatedButton.styleFrom(
-                      minimumSize: const Size(double.infinity, 50),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                    ),
-                  ),
-                ),
-                darkTheme: ThemeData(
-                  fontFamily: 'Geist',
-                  fontFamilyFallback: const [
-                    'Inter',
-                    'Arial',
-                    'sans-serif',
-                  ],
-                  colorScheme: ColorScheme.fromSeed(
-                    seedColor: const Color(0xFF6366F1),
-                    brightness: Brightness.dark,
-                  ),
-                  useMaterial3: true,
-                  appBarTheme: const AppBarTheme(
-                    centerTitle: true,
-                    elevation: 0,
-                  ),
-                  cardTheme: CardThemeData(
-                    elevation: 2,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
-                  inputDecorationTheme: InputDecorationTheme(
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    filled: true,
-                  ),
-                  elevatedButtonTheme: ElevatedButtonThemeData(
-                    style: ElevatedButton.styleFrom(
-                      minimumSize: const Size(double.infinity, 50),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                    ),
-                  ),
-                ),
-                themeMode: themeProvider.themeMode,
-                routes: {
-                  '/config': (context) => const BackendConfigScreen(),
-                  '/login': (context) => const LoginScreen(),
-                  '/home': (context) => const MainNavigationScreen(),
-                },
-                home: const AppWrapper(),
-              )),
+        builder: (context, themeProvider, _) => MaterialApp(
+          title: 'Sure Finances',
+          debugShowCheckedModeBanner: false,
+          navigatorObservers: TelemetryService.instance.navigatorObservers,
+          theme: SureTheme.light,
+          darkTheme: SureTheme.dark,
+          themeMode: themeProvider.themeMode,
+          routes: {
+            '/config': (context) => const BackendConfigScreen(),
+            '/login': (context) => const LoginScreen(),
+            '/home': (context) => const MainNavigationScreen(),
+          },
+          home: const AppWrapper(),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/theme/sure_theme.dart
+++ b/mobile/lib/theme/sure_theme.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+import 'sure_tokens.dart';
+
+class SureTheme {
+  const SureTheme._();
+
+  static ThemeData get light => _build(SureTokens.light, Brightness.light);
+
+  static ThemeData get dark => _build(SureTokens.dark, Brightness.dark);
+
+  static ThemeData _build(SureTokenPalette tokens, Brightness brightness) {
+    final colorScheme = ColorScheme(
+      brightness: brightness,
+      primary: tokens.link,
+      onPrimary: tokens.textInverse,
+      secondary: tokens.info,
+      onSecondary: tokens.textInverse,
+      error: tokens.destructive,
+      onError: tokens.textInverse,
+      surface: tokens.surface,
+      onSurface: tokens.textPrimary,
+      surfaceContainerHighest: tokens.containerInset,
+      outline: tokens.borderSecondary,
+      outlineVariant: tokens.borderSubdued,
+    );
+
+    final inputBorder = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(SureTokens.radiusLg),
+      borderSide: BorderSide(color: tokens.borderSecondary),
+    );
+
+    final base = ThemeData(
+      fontFamily: SureTokens.fontSans,
+      fontFamilyFallback: SureTokens.fontFallback,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: tokens.surface,
+      useMaterial3: true,
+      appBarTheme: AppBarTheme(
+        centerTitle: true,
+        elevation: 0,
+        backgroundColor: tokens.surface,
+        foregroundColor: tokens.textPrimary,
+        surfaceTintColor: Colors.transparent,
+      ),
+      cardTheme: CardThemeData(
+        color: tokens.container,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: tokens.shadow,
+        elevation: 2,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(SureTokens.radiusLg),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: inputBorder,
+        enabledBorder: inputBorder,
+        focusedBorder: inputBorder.copyWith(
+          borderSide: BorderSide(color: tokens.borderPrimary),
+        ),
+        filled: true,
+        fillColor: tokens.container,
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          minimumSize: const Size(0, 50),
+          backgroundColor: tokens.buttonPrimary,
+          foregroundColor: tokens.textInverse,
+          disabledBackgroundColor: tokens.containerInset,
+          disabledForegroundColor: tokens.textSubdued,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(SureTokens.radiusLg),
+          ),
+        ),
+      ),
+    );
+
+    return base.copyWith(
+      textTheme: base.textTheme.apply(
+        bodyColor: tokens.textPrimary,
+        displayColor: tokens.textPrimary,
+      ),
+      primaryTextTheme: base.primaryTextTheme.apply(
+        bodyColor: tokens.textPrimary,
+        displayColor: tokens.textPrimary,
+      ),
+    );
+  }
+}

--- a/mobile/lib/theme/sure_theme.dart
+++ b/mobile/lib/theme/sure_theme.dart
@@ -65,7 +65,7 @@ class SureTheme {
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          minimumSize: const Size(0, 50),
+          minimumSize: const Size(double.infinity, 50),
           backgroundColor: tokens.buttonPrimary,
           foregroundColor: tokens.textInverse,
           disabledBackgroundColor: tokens.containerInset,

--- a/mobile/lib/theme/sure_theme.dart
+++ b/mobile/lib/theme/sure_theme.dart
@@ -18,6 +18,8 @@ class SureTheme {
       onSecondary: tokens.textInverse,
       error: tokens.destructive,
       onError: tokens.textInverse,
+      errorContainer: tokens.destructiveSubtle,
+      onErrorContainer: tokens.textPrimary,
       surface: tokens.surface,
       onSurface: tokens.textPrimary,
       surfaceContainerHighest: tokens.containerInset,

--- a/mobile/lib/theme/sure_tokens.dart
+++ b/mobile/lib/theme/sure_tokens.dart
@@ -1,0 +1,140 @@
+// GENERATED CODE - DO NOT EDIT BY HAND.
+// Source: design/tokens/sure.tokens.json
+// Build: node mobile/tool/generate_sure_tokens.mjs
+
+import 'dart:ui';
+
+class SureTokens {
+  const SureTokens._();
+
+  static const String version = '2.1.0';
+  static const String fontSans = 'Geist';
+  static const String fontMono = 'Geist Mono';
+
+  // Keep the existing Flutter fallback behavior until native mobile font assets
+  // are registered. The canonical web stack remains in sure.tokens.json.
+  static const List<String> fontFallback = <String>[
+    'Inter',
+    'Arial',
+    'sans-serif',
+  ];
+
+  static const double radiusMd = 8.0;
+  static const double radiusLg = 10.0;
+
+  static const light = SureTokenPalette(
+    surface: Color(0xFFF7F7F7),
+    surfaceHover: Color(0xFFF0F0F0),
+    surfaceInset: Color(0xFFF0F0F0),
+    surfaceInsetHover: Color(0xFFE7E7E7),
+    container: Color(0xFFFFFFFF),
+    containerHover: Color(0xFFF7F7F7),
+    containerInset: Color(0xFFF7F7F7),
+    containerInsetHover: Color(0xFFF0F0F0),
+    success: Color(0xFF078C52),
+    warning: Color(0xFFDC6803),
+    destructive: Color(0xFFEC2222),
+    destructiveSubtle: Color(0xFFFEB9B3),
+    info: Color(0xFF1570EF),
+    link: Color(0xFF1570EF),
+    shadow: Color(0x0F0B0B0B),
+    textPrimary: Color(0xFF171717),
+    textInverse: Color(0xFFFFFFFF),
+    textSecondary: Color(0xFF737373),
+    textSubdued: Color(0xFF9E9E9E),
+    borderPrimary: Color(0x260B0B0B),
+    borderSecondary: Color(0x1A0B0B0B),
+    borderSubdued: Color(0x0D0B0B0B),
+    buttonPrimary: Color(0xFF171717),
+    buttonPrimaryHover: Color(0xFF242424),
+    buttonDestructive: Color(0xFFEC2222),
+    buttonDestructiveHover: Color(0xFFC91313),
+  );
+
+  static const dark = SureTokenPalette(
+    surface: Color(0xFF0B0B0B),
+    surfaceHover: Color(0xFF242424),
+    surfaceInset: Color(0xFF242424),
+    surfaceInsetHover: Color(0xFF242424),
+    container: Color(0xFF171717),
+    containerHover: Color(0xFF242424),
+    containerInset: Color(0xFF242424),
+    containerInsetHover: Color(0xFF363636),
+    success: Color(0xFF32D583),
+    warning: Color(0xFFFDB022),
+    destructive: Color(0xFFED4E4E),
+    destructiveSubtle: Color(0xFFA40E0E),
+    info: Color(0xFF2E90FA),
+    link: Color(0xFF2E90FA),
+    shadow: Color(0x14FFFFFF),
+    textPrimary: Color(0xFFFFFFFF),
+    textInverse: Color(0xFF171717),
+    textSecondary: Color(0xFFCFCFCF),
+    textSubdued: Color(0xFF9E9E9E),
+    borderPrimary: Color(0x4DFFFFFF),
+    borderSecondary: Color(0x33FFFFFF),
+    borderSubdued: Color(0x1AFFFFFF),
+    buttonPrimary: Color(0xFFFFFFFF),
+    buttonPrimaryHover: Color(0xFFF7F7F7),
+    buttonDestructive: Color(0xFFED4E4E),
+    buttonDestructiveHover: Color(0xFFF13636),
+  );
+}
+
+class SureTokenPalette {
+  const SureTokenPalette({
+    required this.surface,
+    required this.surfaceHover,
+    required this.surfaceInset,
+    required this.surfaceInsetHover,
+    required this.container,
+    required this.containerHover,
+    required this.containerInset,
+    required this.containerInsetHover,
+    required this.success,
+    required this.warning,
+    required this.destructive,
+    required this.destructiveSubtle,
+    required this.info,
+    required this.link,
+    required this.shadow,
+    required this.textPrimary,
+    required this.textInverse,
+    required this.textSecondary,
+    required this.textSubdued,
+    required this.borderPrimary,
+    required this.borderSecondary,
+    required this.borderSubdued,
+    required this.buttonPrimary,
+    required this.buttonPrimaryHover,
+    required this.buttonDestructive,
+    required this.buttonDestructiveHover,
+  });
+
+  final Color surface;
+  final Color surfaceHover;
+  final Color surfaceInset;
+  final Color surfaceInsetHover;
+  final Color container;
+  final Color containerHover;
+  final Color containerInset;
+  final Color containerInsetHover;
+  final Color success;
+  final Color warning;
+  final Color destructive;
+  final Color destructiveSubtle;
+  final Color info;
+  final Color link;
+  final Color shadow;
+  final Color textPrimary;
+  final Color textInverse;
+  final Color textSecondary;
+  final Color textSubdued;
+  final Color borderPrimary;
+  final Color borderSecondary;
+  final Color borderSubdued;
+  final Color buttonPrimary;
+  final Color buttonPrimaryHover;
+  final Color buttonDestructive;
+  final Color buttonDestructiveHover;
+}

--- a/mobile/test/theme/sure_theme_test.dart
+++ b/mobile/test/theme/sure_theme_test.dart
@@ -21,6 +21,10 @@ void main() {
     expect(theme.colorScheme.onErrorContainer, SureTokens.light.textPrimary);
     expect(theme.scaffoldBackgroundColor, SureTokens.light.surface);
     expect(theme.cardTheme.color, SureTokens.light.container);
+    expect(
+      theme.elevatedButtonTheme.style?.minimumSize?.resolve({}),
+      const Size(double.infinity, 50),
+    );
   });
 
   test('dark theme uses Sure token values', () {
@@ -37,6 +41,10 @@ void main() {
     expect(theme.colorScheme.onErrorContainer, SureTokens.dark.textPrimary);
     expect(theme.scaffoldBackgroundColor, SureTokens.dark.surface);
     expect(theme.cardTheme.color, SureTokens.dark.container);
+    expect(
+      theme.elevatedButtonTheme.style?.minimumSize?.resolve({}),
+      const Size(double.infinity, 50),
+    );
   });
 
   testWidgets('app wires Sure light and dark themes', (tester) async {

--- a/mobile/test/theme/sure_theme_test.dart
+++ b/mobile/test/theme/sure_theme_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sure_mobile/main.dart';
+import 'package:sure_mobile/theme/sure_theme.dart';
+import 'package:sure_mobile/theme/sure_tokens.dart';
+
+void main() {
+  test('light theme uses Sure token values', () {
+    final theme = SureTheme.light;
+
+    expect(theme.brightness, Brightness.light);
+    expect(theme.textTheme.bodyMedium?.fontFamily, SureTokens.fontSans);
+    expect(theme.colorScheme.primary, SureTokens.light.link);
+    expect(theme.colorScheme.secondary, SureTokens.light.info);
+    expect(theme.colorScheme.surface, SureTokens.light.surface);
+    expect(theme.colorScheme.onSurface, SureTokens.light.textPrimary);
+    expect(theme.colorScheme.error, SureTokens.light.destructive);
+    expect(theme.scaffoldBackgroundColor, SureTokens.light.surface);
+    expect(theme.cardTheme.color, SureTokens.light.container);
+  });
+
+  test('dark theme uses Sure token values', () {
+    final theme = SureTheme.dark;
+
+    expect(theme.brightness, Brightness.dark);
+    expect(theme.textTheme.bodyMedium?.fontFamily, SureTokens.fontSans);
+    expect(theme.colorScheme.primary, SureTokens.dark.link);
+    expect(theme.colorScheme.secondary, SureTokens.dark.info);
+    expect(theme.colorScheme.surface, SureTokens.dark.surface);
+    expect(theme.colorScheme.onSurface, SureTokens.dark.textPrimary);
+    expect(theme.colorScheme.error, SureTokens.dark.destructive);
+    expect(theme.scaffoldBackgroundColor, SureTokens.dark.surface);
+    expect(theme.cardTheme.color, SureTokens.dark.container);
+  });
+
+  testWidgets('app wires Sure light and dark themes', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(const SureApp());
+
+    final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+    expect(materialApp.theme?.colorScheme.surface, SureTokens.light.surface);
+    expect(materialApp.darkTheme?.colorScheme.surface, SureTokens.dark.surface);
+    expect(materialApp.themeMode, ThemeMode.system);
+  });
+}

--- a/mobile/test/theme/sure_theme_test.dart
+++ b/mobile/test/theme/sure_theme_test.dart
@@ -16,6 +16,9 @@ void main() {
     expect(theme.colorScheme.surface, SureTokens.light.surface);
     expect(theme.colorScheme.onSurface, SureTokens.light.textPrimary);
     expect(theme.colorScheme.error, SureTokens.light.destructive);
+    expect(
+        theme.colorScheme.errorContainer, SureTokens.light.destructiveSubtle);
+    expect(theme.colorScheme.onErrorContainer, SureTokens.light.textPrimary);
     expect(theme.scaffoldBackgroundColor, SureTokens.light.surface);
     expect(theme.cardTheme.color, SureTokens.light.container);
   });
@@ -30,6 +33,8 @@ void main() {
     expect(theme.colorScheme.surface, SureTokens.dark.surface);
     expect(theme.colorScheme.onSurface, SureTokens.dark.textPrimary);
     expect(theme.colorScheme.error, SureTokens.dark.destructive);
+    expect(theme.colorScheme.errorContainer, SureTokens.dark.destructiveSubtle);
+    expect(theme.colorScheme.onErrorContainer, SureTokens.dark.textPrimary);
     expect(theme.scaffoldBackgroundColor, SureTokens.dark.surface);
     expect(theme.cardTheme.color, SureTokens.dark.container);
   });

--- a/mobile/test/theme/sure_tokens_test.dart
+++ b/mobile/test/theme/sure_tokens_test.dart
@@ -1,0 +1,122 @@
+// ignore_for_file: deprecated_member_use
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sure_mobile/theme/sure_tokens.dart';
+
+void main() {
+  late Map<String, dynamic> tokens;
+
+  setUpAll(() {
+    tokens =
+        jsonDecode(_tokensFile().readAsStringSync()) as Map<String, dynamic>;
+  });
+
+  test('generated tokens keep the canonical token version', () {
+    expect(SureTokens.version, tokens[r'$version']);
+  });
+
+  test(
+    'generated light and dark colors match representative canonical tokens',
+    () {
+      expect(
+        SureTokens.light.surface.value,
+        _resolveColor(tokens, 'color.surface', dark: false),
+      );
+      expect(
+        SureTokens.dark.surface.value,
+        _resolveColor(tokens, 'color.surface', dark: true),
+      );
+      expect(
+        SureTokens.light.textPrimary.value,
+        _resolveColor(tokens, 'utility.text-primary', dark: false),
+      );
+      expect(
+        SureTokens.dark.textPrimary.value,
+        _resolveColor(tokens, 'utility.text-primary', dark: true),
+      );
+      expect(
+        SureTokens.light.destructive.value,
+        _resolveColor(tokens, 'color.destructive', dark: false),
+      );
+      expect(
+        SureTokens.dark.destructive.value,
+        _resolveColor(tokens, 'color.destructive', dark: true),
+      );
+    },
+  );
+
+  test('generated radii match canonical dimensions', () {
+    expect(SureTokens.radiusMd, _resolveDimension(tokens, 'border.radius.md'));
+    expect(SureTokens.radiusLg, _resolveDimension(tokens, 'border.radius.lg'));
+  });
+}
+
+int _resolveColor(
+  Map<String, dynamic> tokens,
+  String path, {
+  required bool dark,
+}) {
+  final node = _nodeAt(tokens, path);
+  final extensions = node[r'$extensions'] as Map<String, dynamic>?;
+  final value = dark && extensions != null && extensions['sure.dark'] != null
+      ? extensions['sure.dark'] as String
+      : node[r'$value'] as String;
+
+  return _resolveColorValue(tokens, value, dark: dark);
+}
+
+int _resolveColorValue(
+  Map<String, dynamic> tokens,
+  String value, {
+  required bool dark,
+}) {
+  final hex = RegExp(r'^#([0-9a-fA-F]{6})$').firstMatch(value);
+  if (hex != null) {
+    return int.parse('FF${hex.group(1)!}', radix: 16);
+  }
+
+  final ref = RegExp(r'^\{([^|}]+)(?:\|([0-9]+)%?)?\}$').firstMatch(value);
+  if (ref != null) {
+    final resolved = _resolveColor(tokens, ref.group(1)!, dark: dark);
+    final alphaPercent = ref.group(2);
+    if (alphaPercent == null) return resolved;
+
+    final alpha = ((int.parse(alphaPercent) / 100) * 255).round();
+    return (alpha << 24) | (resolved & 0x00FFFFFF);
+  }
+
+  throw StateError('Unsupported color value: $value');
+}
+
+double _resolveDimension(Map<String, dynamic> tokens, String path) {
+  final value = _nodeAt(tokens, path)[r'$value'] as String;
+  final match = RegExp(r'^([0-9]+(?:\.[0-9]+)?)px$').firstMatch(value);
+  if (match == null) throw StateError('Unsupported dimension value: $value');
+
+  return double.parse(match.group(1)!);
+}
+
+Map<String, dynamic> _nodeAt(Map<String, dynamic> tokens, String path) {
+  dynamic current = tokens;
+  for (final part in path.split('.')) {
+    current = current[part];
+  }
+
+  return current as Map<String, dynamic>;
+}
+
+File _tokensFile() {
+  var directory = Directory.current;
+
+  for (var depth = 0; depth < 4; depth += 1) {
+    final file = File('${directory.path}/design/tokens/sure.tokens.json');
+    if (file.existsSync()) return file;
+
+    directory = directory.parent;
+  }
+
+  throw StateError('Could not locate design/tokens/sure.tokens.json');
+}

--- a/mobile/tool/generate_sure_tokens.mjs
+++ b/mobile/tool/generate_sure_tokens.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const TOKENS_PATH = resolve(ROOT, "design/tokens/sure.tokens.json");
+const OUT_PATH = resolve(ROOT, "mobile/lib/theme/sure_tokens.dart");
+
+const COLOR_TOKENS = [
+  ["surface", "color.surface"],
+  ["surfaceHover", "color.surface-hover"],
+  ["surfaceInset", "color.surface-inset"],
+  ["surfaceInsetHover", "color.surface-inset-hover"],
+  ["container", "color.container"],
+  ["containerHover", "color.container-hover"],
+  ["containerInset", "color.container-inset"],
+  ["containerInsetHover", "color.container-inset-hover"],
+  ["success", "color.success"],
+  ["warning", "color.warning"],
+  ["destructive", "color.destructive"],
+  ["destructiveSubtle", "color.destructive-subtle"],
+  ["info", "color.info"],
+  ["link", "color.link"],
+  ["shadow", "color.shadow"],
+  ["textPrimary", "utility.text-primary"],
+  ["textInverse", "utility.text-inverse"],
+  ["textSecondary", "utility.text-secondary"],
+  ["textSubdued", "utility.text-subdued"],
+  ["borderPrimary", "utility.border-primary"],
+  ["borderSecondary", "utility.border-secondary"],
+  ["borderSubdued", "utility.border-subdued"],
+  ["buttonPrimary", "utility.button-bg-primary"],
+  ["buttonPrimaryHover", "utility.button-bg-primary-hover"],
+  ["buttonDestructive", "utility.button-bg-destructive"],
+  ["buttonDestructiveHover", "utility.button-bg-destructive-hover"],
+];
+
+const RADIUS_TOKENS = [
+  ["radiusMd", "border.radius.md"],
+  ["radiusLg", "border.radius.lg"],
+];
+
+function readTokens() {
+  return JSON.parse(readFileSync(TOKENS_PATH, "utf8"));
+}
+
+function nodeAt(tokens, path) {
+  const node = path.split(".").reduce((current, part) => current?.[part], tokens);
+  if (!node || typeof node !== "object") {
+    throw new Error(`[mobile-tokens] Unknown token path: ${path}`);
+  }
+  return node;
+}
+
+function valueForMode(node, mode) {
+  if (mode === "dark" && node.$extensions?.["sure.dark"] !== undefined) {
+    return node.$extensions["sure.dark"];
+  }
+  if (node.$value === undefined) {
+    throw new Error("[mobile-tokens] Token is missing $value");
+  }
+  return node.$value;
+}
+
+function resolveColor(tokens, path, mode) {
+  const node = nodeAt(tokens, path);
+  const value = valueForMode(node, mode);
+  return resolveColorValue(tokens, value, mode, path);
+}
+
+function resolveColorValue(tokens, value, mode, sourcePath) {
+  if (typeof value !== "string") {
+    throw new Error(`[mobile-tokens] ${sourcePath} must resolve to a string color`);
+  }
+
+  const hexMatch = value.match(/^#([0-9a-fA-F]{6})$/);
+  if (hexMatch) {
+    return `0xFF${hexMatch[1].toUpperCase()}`;
+  }
+
+  const refMatch = value.match(/^\{([^|}]+)(?:\|([0-9]+)%?)?\}$/);
+  if (refMatch) {
+    const [, ref, alphaPercent] = refMatch;
+    const resolved = resolveColor(tokens, ref, mode);
+    if (!alphaPercent) return resolved;
+
+    const alpha = Math.round((Number(alphaPercent) / 100) * 255);
+    if (!Number.isFinite(alpha) || alpha < 0 || alpha > 255) {
+      throw new Error(`[mobile-tokens] Invalid alpha in ${sourcePath}: ${alphaPercent}`);
+    }
+    return `0x${alpha.toString(16).toUpperCase().padStart(2, "0")}${resolved.slice(4)}`;
+  }
+
+  throw new Error(`[mobile-tokens] ${sourcePath} has unsupported color value: ${value}`);
+}
+
+function resolveDimension(tokens, path) {
+  const node = nodeAt(tokens, path);
+  const value = valueForMode(node, "light");
+  const match = String(value).match(/^([0-9]+(?:\.[0-9]+)?)px$/);
+  if (!match) {
+    throw new Error(`[mobile-tokens] ${path} must be a px dimension`);
+  }
+  return Number(match[1]).toFixed(1);
+}
+
+function firstFontFamily(stack) {
+  for (const rawFamily of stack.split(",")) {
+    const family = rawFamily.trim();
+    if (!family) continue;
+
+    return family.replace(/^['"](.+)['"]$/, "$1");
+  }
+
+  throw new Error(`[mobile-tokens] Unsupported font stack: ${stack}`);
+}
+
+function emitPalette(tokens, mode) {
+  const lines = COLOR_TOKENS.map(
+    ([name, path]) => `    ${name}: Color(${resolveColor(tokens, path, mode)}),`,
+  );
+
+  return `  static const ${mode} = SureTokenPalette(\n${lines.join("\n")}\n  );`;
+}
+
+function buildDart(tokens) {
+  const fontSans = firstFontFamily(tokens.font.sans.$value);
+  const fontMono = firstFontFamily(tokens.font.mono.$value);
+  const radiusLines = RADIUS_TOKENS.map(
+    ([name, path]) => `  static const double ${name} = ${resolveDimension(tokens, path)};`,
+  );
+
+  return `// GENERATED CODE - DO NOT EDIT BY HAND.
+// Source: design/tokens/sure.tokens.json
+// Build: node mobile/tool/generate_sure_tokens.mjs
+
+import 'dart:ui';
+
+class SureTokens {
+  const SureTokens._();
+
+  static const String version = '${tokens.$version}';
+  static const String fontSans = '${fontSans}';
+  static const String fontMono = '${fontMono}';
+
+  // Keep the existing Flutter fallback behavior until native mobile font assets
+  // are registered. The canonical web stack remains in sure.tokens.json.
+  static const List<String> fontFallback = <String>[
+    'Inter',
+    'Arial',
+    'sans-serif',
+  ];
+
+${radiusLines.join("\n")}
+
+${emitPalette(tokens, "light")}
+
+${emitPalette(tokens, "dark")}
+}
+
+class SureTokenPalette {
+  const SureTokenPalette({
+${COLOR_TOKENS.map(([name]) => `    required this.${name},`).join("\n")}
+  });
+
+${COLOR_TOKENS.map(([name]) => `  final Color ${name};`).join("\n")}
+}
+`;
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+  const tokens = readTokens();
+  const output = buildDart(tokens);
+
+  if (check) {
+    let existing;
+    try {
+      existing = readFileSync(OUT_PATH, "utf8");
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        console.error(
+          "[mobile-tokens] mobile/lib/theme/sure_tokens.dart is missing. " +
+            "Run node mobile/tool/generate_sure_tokens.mjs.",
+        );
+        process.exit(1);
+      }
+      throw error;
+    }
+    if (existing !== output) {
+      console.error(
+        "[mobile-tokens] mobile/lib/theme/sure_tokens.dart is stale. " +
+          "Run node mobile/tool/generate_sure_tokens.mjs.",
+      );
+      process.exit(1);
+    }
+    console.log("[mobile-tokens] generated Dart tokens are current");
+    return;
+  }
+
+  writeFileSync(OUT_PATH, output);
+  console.log(`mobile tokens -> ${OUT_PATH.replace(ROOT + "/", "")}`);
+}
+
+try {
+  main();
+} catch (error) {
+  if (error.message?.startsWith("[mobile-tokens]")) {
+    console.error(error.message);
+    process.exit(1);
+  }
+  throw error;
+}


### PR DESCRIPTION
## Summary

Closes #2236.

Adds the first Flutter design-system foundation layer by deriving mobile theme values from Sure's canonical token JSON and routing the app through shared light/dark `ThemeData`.

This is the first implementation step under the mobile design-system coordination issue: #2235.

## What changed

- Added `mobile/tool/generate_sure_tokens.mjs` to generate typed Dart constants from `design/tokens/sure.tokens.json`.
- Added generated `SureTokens` and hand-written `SureTheme` under `mobile/lib/theme/`.
- Replaced duplicated inline `ThemeData` blocks in `mobile/lib/main.dart` with `SureTheme.light` and `SureTheme.dark`.
- Kept Material 3 and preserved the existing app routes/providers.
- Added focused tests for generated token parity, light/dark theme values, and app theme wiring.

## Why

The mobile app was using a separate Material seed color and duplicated inline theme definitions. That makes it easy for Flutter styling to drift away from Sure's design-system work. This gives later mobile UI PRs a shared foundation based on the same token source as the web app, without restyling individual screens in this PR.

## Screenshots

These are real iOS simulator screenshots. The visible difference here is global theme foundation only: neutral Sure surfaces/buttons and semantic link/info accents replace the old indigo seed-derived theme.

| Before | After |
| --- | --- |
| Light<br><img width="260" alt="Before light theme" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/00ff3a894334dac1655e10e785693e1914d25acf/docs/pr-screenshots/mobile-design-system-foundation/before-light.png"> | Light<br><img width="260" alt="After light theme" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/00ff3a894334dac1655e10e785693e1914d25acf/docs/pr-screenshots/mobile-design-system-foundation/after-light.png"> |
| Dark<br><img width="260" alt="Before dark theme" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/00ff3a894334dac1655e10e785693e1914d25acf/docs/pr-screenshots/mobile-design-system-foundation/before-dark.png"> | Dark<br><img width="260" alt="After dark theme" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/00ff3a894334dac1655e10e785693e1914d25acf/docs/pr-screenshots/mobile-design-system-foundation/after-dark.png"> |

## Validation

- `node mobile/tool/generate_sure_tokens.mjs --check`
- `npm run lint`
- `cd mobile && flutter analyze --no-fatal-infos`
- `cd mobile && flutter test`
- `cd mobile && flutter build ios --simulator --debug`
- `git diff --check`
- Codex Security diff scan: no reportable findings
- CodeRabbit local review: final pass reported no findings

## Notes

- This intentionally does not register Geist as a native mobile font asset. The generated token bridge keeps the canonical font names while preserving Flutter's existing fallback behavior until mobile-ready font assets are available.
- This intentionally does not migrate specific screens yet. Follow-up PRs can now use `SureTheme` and generated tokens instead of introducing mobile-only palettes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-driven light and dark Material 3 themes applied app-wide for consistent colors, typography, surfaces, and components.
* **Refactor**
  * Centralized theme configuration for cleaner, maintainable app-level styling and easier theme mode switching.
* **Tests**
  * New unit and widget tests to validate generated theme tokens and ensure light/dark visuals match design definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->