### PR TITLE
Respect CoinStats wallet rate limits

### DIFF
--- a/app/models/coinstats_item/importer.rb
+++ b/app/models/coinstats_item/importer.rb
@@ -3,6 +3,12 @@
 class CoinstatsItem::Importer
   include CoinstatsTransactionIdentifiable
 
+  FETCH_FAILED = Object.new.freeze
+  DEFI_UNSUPPORTED_BLOCKCHAINS = %w[
+    bitcoin btc litecoin ltc dogecoin doge ripple xrp stellar xlm
+    cardano ada polkadot dot cosmos atom
+  ].freeze
+
   attr_reader :coinstats_item, :coinstats_provider
 
   # @param coinstats_item [CoinstatsItem] Item containing accounts to import
@@ -43,6 +49,19 @@ class CoinstatsItem::Importer
 
     bulk_balance_data = fetch_balances_for_accounts(wallet_accounts)
     bulk_transactions_data = fetch_transactions_for_accounts(wallet_accounts)
+
+    if fetch_failed?(bulk_balance_data) || fetch_failed?(bulk_transactions_data)
+      accounts_failed += wallet_accounts.size
+      Rails.logger.warn "CoinstatsItem::Importer - Wallet bulk fetch failed; preserving existing wallet snapshots for item #{coinstats_item.id}"
+
+      return {
+        success: false,
+        accounts_updated: 0,
+        accounts_failed: accounts_failed,
+        transactions_imported: 0
+      }
+    end
+
     portfolio_coins_data = fetch_portfolio_coins_for_exchange(exchange_accounts)
     portfolio_transactions_data = fetch_portfolio_transactions_for_exchange(exchange_accounts)
 
@@ -110,7 +129,7 @@ class CoinstatsItem::Importer
 
     # Fetch balance data for all linked accounts using the bulk endpoint
     # @param linked_accounts [Array<CoinstatsAccount>] Accounts to fetch balances for
-    # @return [Array<Hash>, nil] Bulk balance data, or nil on error
+    # @return [Array<Hash>, Object] Bulk balance data, or FETCH_FAILED on error
     def fetch_balances_for_accounts(linked_accounts)
       # Extract unique wallet addresses and blockchains
       wallets = linked_accounts.filter_map do |account|
@@ -122,16 +141,16 @@ class CoinstatsItem::Importer
         { address: address, blockchain: blockchain }
       end.uniq { |w| [ w[:address].downcase, w[:blockchain].downcase ] }
 
-      return nil if wallets.empty?
+      return [] if wallets.empty?
 
       Rails.logger.info "CoinstatsItem::Importer - Fetching balances for #{wallets.size} wallet(s) via bulk endpoint"
       # Build comma-separated string in format "blockchain:address"
       wallets_param = wallets.map { |w| "#{w[:blockchain]}:#{w[:address]}" }.join(",")
       response = coinstats_provider.get_wallet_balances(wallets_param)
-      response.success? ? response.data : nil
+      response.success? ? response.data : FETCH_FAILED
     rescue => e
       Rails.logger.warn "CoinstatsItem::Importer - Bulk balance fetch failed: #{e.message}"
-      nil
+      FETCH_FAILED
     end
 
     def fetch_portfolio_coins_for_exchange(linked_accounts)
@@ -148,7 +167,7 @@ class CoinstatsItem::Importer
 
     # Fetch transaction data for all linked accounts using the bulk endpoint
     # @param linked_accounts [Array<CoinstatsAccount>] Accounts to fetch transactions for
-    # @return [Array<Hash>, nil] Bulk transaction data, or nil on error
+    # @return [Array<Hash>, Object] Bulk transaction data, or FETCH_FAILED on error
     def fetch_transactions_for_accounts(linked_accounts)
       # Extract unique wallet addresses and blockchains
       wallets = linked_accounts.filter_map do |account|
@@ -160,16 +179,16 @@ class CoinstatsItem::Importer
         { address: address, blockchain: blockchain }
       end.uniq { |w| [ w[:address].downcase, w[:blockchain].downcase ] }
 
-      return nil if wallets.empty?
+      return [] if wallets.empty?
 
       Rails.logger.info "CoinstatsItem::Importer - Fetching transactions for #{wallets.size} wallet(s) via bulk endpoint"
       # Build comma-separated string in format "blockchain:address"
       wallets_param = wallets.map { |w| "#{w[:blockchain]}:#{w[:address]}" }.join(",")
       response = coinstats_provider.get_wallet_transactions(wallets_param)
-      response.success? ? response.data : nil
+      response.success? ? response.data : FETCH_FAILED
     rescue => e
       Rails.logger.warn "CoinstatsItem::Importer - Bulk transaction fetch failed: #{e.message}"
-      nil
+      FETCH_FAILED
     end
 
     def fetch_portfolio_transactions_for_exchange(linked_accounts)
@@ -472,6 +491,10 @@ class CoinstatsItem::Importer
       end
     end
 
+    def fetch_failed?(data)
+      data.equal?(FETCH_FAILED)
+    end
+
     def find_matching_portfolio_coin(balance_data, coinstats_account)
       Array(balance_data).map(&:with_indifferent_access).find do |coin_data|
         coin = coin_data[:coin].to_h.with_indifferent_access
@@ -598,6 +621,7 @@ class CoinstatsItem::Importer
       unique_wallets = (wallet_accounts + defi_accounts).uniq(&:id).filter_map do |account|
         raw = account.raw_payload.to_h.with_indifferent_access
         next unless raw[:address].present? && raw[:blockchain].present?
+        next unless defi_supported_blockchain?(raw[:blockchain])
 
         { address: raw[:address], blockchain: raw[:blockchain] }
       end.uniq { |w| [ w[:address].downcase, w[:blockchain].downcase ] }
@@ -616,5 +640,9 @@ class CoinstatsItem::Importer
     rescue => e
       Rails.logger.warn "CoinstatsItem::Importer - DeFi sync failed: #{e.message}"
       Set.new
+    end
+
+    def defi_supported_blockchain?(blockchain)
+      blockchain.present? && !DEFI_UNSUPPORTED_BLOCKCHAINS.include?(blockchain.to_s.downcase)
     end
 end

--- a/app/models/provider/coinstats.rb
+++ b/app/models/provider/coinstats.rb
@@ -2,12 +2,26 @@
 # Handles authentication and requests to the CoinStats OpenAPI.
 class Provider::Coinstats < Provider
   include HTTParty
+  include Provider::RateLimitable
   extend SslConfigurable
 
   # Subclass so errors caught in this provider are raised as Provider::Coinstats::Error
   Error = Class.new(Provider::Error)
+  class RateLimitError < Error
+    attr_reader :retry_after
+
+    def initialize(message, details: nil, retry_after: nil)
+      super(message, details: details)
+      @retry_after = retry_after
+    end
+  end
 
   BASE_URL = "https://openapiv1.coinstats.app"
+  PROVIDER_ENV_PREFIX = "COINSTATS"
+  MIN_REQUEST_INTERVAL = 0.5
+  MAX_RETRIES = 2
+  INITIAL_RETRY_DELAY = 1
+  MAX_RETRY_DELAY = 10
 
   headers "User-Agent" => "Sure Finance CoinStats Client (https://github.com/we-promise/sure)"
   default_options.merge!({ timeout: 120 }.merge(httparty_ssl_options))
@@ -322,12 +336,14 @@ class Provider::Coinstats < Provider
   # @return [Provider::Response] Response with DeFi position data
   def get_wallet_defi(address:, connection_id:)
     with_provider_response do
-      res = self.class.get(
-        "#{BASE_URL}/wallet/defi",
-        headers: auth_headers,
-        query: { address: address, connectionId: connection_id }
-      )
-      handle_response(res)
+      with_retries("GET /wallet/defi") do
+        res = self.class.get(
+          "#{BASE_URL}/wallet/defi",
+          headers: auth_headers,
+          query: { address: address, connectionId: connection_id }
+        )
+        handle_response(res)
+      end
     end
   rescue SocketError, Net::OpenTimeout, Net::ReadTimeout => e
     Rails.logger.error "CoinStats API: GET /wallet/defi failed: #{e.class}: #{e.message}"
@@ -343,12 +359,14 @@ class Provider::Coinstats < Provider
     return with_provider_response { [] } if wallets.blank?
 
     with_provider_response do
-      res = self.class.get(
-        "#{BASE_URL}/wallet/balances",
-        headers: auth_headers,
-        query: { wallets: wallets }
-      )
-      handle_response(res)
+      with_retries("GET /wallet/balances") do
+        res = self.class.get(
+          "#{BASE_URL}/wallet/balances",
+          headers: auth_headers,
+          query: { wallets: wallets }
+        )
+        handle_response(res)
+      end
     end
   rescue SocketError, Net::OpenTimeout, Net::ReadTimeout => e
     Rails.logger.error "CoinStats API: GET /wallet/balances failed: #{e.class}: #{e.message}"
@@ -385,12 +403,14 @@ class Provider::Coinstats < Provider
     return with_provider_response { [] } if wallets.blank?
 
     with_provider_response do
-      res = self.class.get(
-        "#{BASE_URL}/wallet/transactions",
-        headers: auth_headers,
-        query: { wallets: wallets }
-      )
-      handle_response(res)
+      with_retries("GET /wallet/transactions") do
+        res = self.class.get(
+          "#{BASE_URL}/wallet/transactions",
+          headers: auth_headers,
+          query: { wallets: wallets }
+        )
+        handle_response(res)
+      end
     end
   rescue SocketError, Net::OpenTimeout, Net::ReadTimeout => e
     Rails.logger.error "CoinStats API: GET /wallet/transactions failed: #{e.class}: #{e.message}"
@@ -429,11 +449,47 @@ class Provider::Coinstats < Provider
 
   private
 
+    def default_error_transformer(error)
+      return error if error.is_a?(Error)
+
+      super
+    end
+
     def auth_headers
       {
         "X-API-KEY" => api_key,
         "Accept" => "application/json"
       }
+    end
+
+    def with_retries(operation_name, max_retries: MAX_RETRIES)
+      retries = 0
+
+      begin
+        throttle_request
+        yield
+      rescue RateLimitError => e
+        retries += 1
+
+        if retries <= max_retries
+          delay = e.retry_after.presence || calculate_retry_delay(retries)
+          Rails.logger.warn(
+            "CoinStats API: #{operation_name} rate limited " \
+            "(attempt #{retries}/#{max_retries}). Retrying in #{delay}s..."
+          )
+          sleep(delay) if delay.to_f.positive?
+          retry
+        end
+
+        Rails.logger.error "CoinStats API: #{operation_name} rate limited after #{max_retries} retries"
+        raise
+      end
+    end
+
+    def calculate_retry_delay(retry_count)
+      base_delay = INITIAL_RETRY_DELAY * (2 ** (retry_count - 1))
+      jitter = base_delay * rand * 0.25
+      [ base_delay + jitter, MAX_RETRY_DELAY ].min
     end
 
     # The CoinStats API uses standard HTTP status codes to indicate the success or failure of requests.
@@ -454,12 +510,15 @@ class Provider::Coinstats < Provider
       when 404
         log_api_error(response, "Not Found")
         raise_api_error(response, fallback: "CoinStats: Resource not found")
+      when 406
+        log_api_error(response, "Not Acceptable")
+        raise_api_error(response, fallback: "CoinStats: Credits limit reached")
       when 409
         log_api_error(response, "Conflict")
         raise_api_error(response, fallback: "CoinStats: Resource conflict")
       when 429
         log_api_error(response, "Too Many Requests")
-        raise_api_error(response, fallback: "CoinStats: Rate limit exceeded, try again later")
+        raise_api_error(response, fallback: "CoinStats: Rate limit exceeded, try again later", error_class: RateLimitError)
       when 500
         log_api_error(response, "Internal Server Error")
         raise_api_error(response, fallback: "CoinStats: Server error, try again later")
@@ -476,14 +535,19 @@ class Provider::Coinstats < Provider
       Rails.logger.error "CoinStats API: #{response.code} #{error_type} - #{response.body}"
     end
 
-    def raise_api_error(response, fallback:)
+    def raise_api_error(response, fallback:, error_class: Error)
       error_payload = parse_error_payload(response.body)
       message = error_payload[:message].presence || fallback
       request_id = error_payload[:request_id].presence
+      retry_after = retry_after_seconds(response)
 
       message = "#{message} (requestId: #{request_id})" if request_id.present?
 
-      raise Error.new(message, details: error_payload.compact.presence)
+      if error_class == RateLimitError
+        raise error_class.new(message, details: error_payload.compact.presence, retry_after: retry_after)
+      end
+
+      raise error_class.new(message, details: error_payload.compact.presence)
     end
 
     def parse_error_payload(body)
@@ -497,5 +561,14 @@ class Provider::Coinstats < Provider
       }
     rescue JSON::ParserError
       {}
+    end
+
+    def retry_after_seconds(response)
+      retry_after = response.headers["Retry-After"] || response.headers["retry-after"]
+      return nil if retry_after.blank?
+
+      Integer(retry_after)
+    rescue ArgumentError, NoMethodError
+      nil
     end
 end

--- a/test/models/coinstats_item/importer_test.rb
+++ b/test/models/coinstats_item/importer_test.rb
@@ -175,7 +175,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     assert_equal 2, coinstats_account.raw_transactions_payload.count
   end
 
-  test "handles rate limit error during transactions fetch gracefully" do
+  test "bails and preserves wallet snapshot when transactions fetch is rate limited" do
     crypto = Crypto.create!
     account = @family.accounts.create!(
       accountable: crypto,
@@ -186,6 +186,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     coinstats_account = @coinstats_item.coinstats_accounts.create!(
       name: "Ethereum Wallet",
       currency: "USD",
+      current_balance: 1000,
       raw_payload: { address: "0x123abc", blockchain: "ethereum" }
     )
     AccountProvider.create!(account: account, provider: coinstats_account)
@@ -202,24 +203,24 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
       .with("ethereum:0x123abc")
       .returns(success_response(bulk_response))
 
-    @mock_provider.expects(:extract_wallet_balance)
-      .with(bulk_response, "0x123abc", "ethereum")
-      .returns(balance_data)
+    @mock_provider.expects(:extract_wallet_balance).never
 
-    # Bulk transaction fetch fails with error - returns error response from fetch_transactions_for_accounts
     @mock_provider.expects(:get_wallet_transactions)
       .with("ethereum:0x123abc")
-      .raises(Provider::Coinstats::Error.new("Rate limited"))
+      .raises(Provider::Coinstats::RateLimitError.new("Rate limited"))
 
-    # When bulk fetch fails, extract_wallet_transactions is not called (bulk_transactions_data is nil)
+    @mock_provider.expects(:extract_wallet_transactions).never
 
     importer = CoinstatsItem::Importer.new(@coinstats_item, coinstats_provider: @mock_provider)
-    result = importer.import
 
-    # Should still succeed since balance was updated
-    assert result[:success]
-    assert_equal 1, result[:accounts_updated]
-    assert_equal 0, result[:transactions_imported]
+    assert_no_changes -> { coinstats_account.reload.current_balance.to_f } do
+      result = importer.import
+
+      refute result[:success]
+      assert_equal 0, result[:accounts_updated]
+      assert_equal 1, result[:accounts_failed]
+      assert_equal 0, result[:transactions_imported]
+    end
   end
 
   test "preserves exchange portfolio snapshot when portfolio coin fetch is missing" do
@@ -596,6 +597,53 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
   end
 
   # DeFi / staking tests
+
+  test "skips DeFi sync for unsupported blockchains" do
+    crypto = Crypto.create!
+    account = @family.accounts.create!(
+      accountable: crypto,
+      name: "Bitcoin Wallet",
+      balance: 4500,
+      currency: "USD"
+    )
+    coinstats_account = @coinstats_item.coinstats_accounts.create!(
+      name: "Bitcoin Wallet",
+      currency: "USD",
+      account_id: "bitcoin",
+      raw_payload: { address: "bc1qbtc456", blockchain: "bitcoin" }
+    )
+    AccountProvider.create!(account: account, provider: coinstats_account)
+
+    balance_data = [
+      { coinId: "bitcoin", name: "Bitcoin", symbol: "BTC", amount: 0.1, price: 45000 }
+    ]
+    bulk_response = [
+      { blockchain: "bitcoin", address: "bc1qbtc456", connectionId: "bitcoin", balances: balance_data }
+    ]
+    bulk_transactions_response = [
+      { blockchain: "bitcoin", address: "bc1qbtc456", connectionId: "bitcoin", transactions: [] }
+    ]
+
+    @mock_provider.expects(:get_wallet_defi).never
+    @mock_provider.expects(:get_wallet_balances)
+      .with("bitcoin:bc1qbtc456")
+      .returns(success_response(bulk_response))
+    @mock_provider.expects(:extract_wallet_balance)
+      .with(bulk_response, "bc1qbtc456", "bitcoin")
+      .returns(balance_data)
+    @mock_provider.expects(:get_wallet_transactions)
+      .with("bitcoin:bc1qbtc456")
+      .returns(success_response(bulk_transactions_response))
+    @mock_provider.expects(:extract_wallet_transactions)
+      .with(bulk_transactions_response, "bc1qbtc456", "bitcoin")
+      .returns([])
+
+    result = CoinstatsItem::Importer.new(@coinstats_item, coinstats_provider: @mock_provider).import
+
+    assert result[:success]
+    assert_equal 1, result[:accounts_updated]
+    assert_equal 4500.0, coinstats_account.reload.current_balance.to_f
+  end
 
   test "creates DeFi account with balance equal to total position value, not quantity * price" do
     crypto = Crypto.create!

--- a/test/models/provider/coinstats_test.rb
+++ b/test/models/provider/coinstats_test.rb
@@ -5,6 +5,75 @@ class Provider::CoinstatsTest < ActiveSupport::TestCase
     @provider = Provider::Coinstats.new("test_api_key")
   end
 
+  test "retries wallet requests on rate limit with retry after" do
+    response = Struct.new(:code, :body, :headers)
+    rate_limited_response = response.new(
+      429,
+      { message: "Too Many Requests" }.to_json,
+      { "Retry-After" => "3" }
+    )
+    success_response = response.new(
+      200,
+      [ { blockchain: "ethereum", address: "0x123abc", balances: [] } ].to_json,
+      {}
+    )
+
+    @provider.stubs(:min_request_interval).returns(0)
+    @provider.expects(:sleep).with(3).once
+
+    Provider::Coinstats.expects(:get)
+      .with(
+        "#{Provider::Coinstats::BASE_URL}/wallet/balances",
+        headers: {
+          "X-API-KEY" => "test_api_key",
+          "Accept" => "application/json"
+        },
+        query: { wallets: "ethereum:0x123abc" }
+      )
+      .twice
+      .returns(rate_limited_response, success_response)
+
+    result = @provider.get_wallet_balances("ethereum:0x123abc")
+
+    assert result.success?
+    assert_equal "ethereum", result.data.first[:blockchain]
+  end
+
+  test "maps CoinStats credit limit responses without retrying" do
+    response = Struct.new(:code, :body, :headers)
+    credit_limited_response = response.new(
+      406,
+      {
+        statusCode: 406,
+        message: "Credits limit reached. Please upgrade your plan or wait for renewal.",
+        requestId: "test-request-id",
+        path: "/wallet/defi"
+      }.to_json,
+      {}
+    )
+
+    @provider.stubs(:min_request_interval).returns(0)
+    @provider.expects(:sleep).never
+
+    Provider::Coinstats.expects(:get)
+      .with(
+        "#{Provider::Coinstats::BASE_URL}/wallet/defi",
+        headers: {
+          "X-API-KEY" => "test_api_key",
+          "Accept" => "application/json"
+        },
+        query: { address: "0x123abc", connectionId: "ethereum" }
+      )
+      .once
+      .returns(credit_limited_response)
+
+    result = @provider.get_wallet_defi(address: "0x123abc", connection_id: "ethereum")
+
+    refute result.success?
+    assert_match "Credits limit reached", result.error.message
+    assert_equal 406, result.error.details[:status_code]
+  end
+
   test "extract_wallet_balance finds matching wallet by address and connectionId" do
     bulk_data = [
       {


### PR DESCRIPTION
## Summary
- throttle CoinStats wallet endpoints to the documented 2 req/sec free-tier limit
- retry 429 responses with Retry-After when present and exponential backoff when absent
- preserve CoinStats error details, bail cleanly on wallet fetch failures, and skip DeFi fetches for unsupported blockchains
- handle CoinStats 406 credit exhaustion separately from 429 rate limiting

## Verification
- bin/rails test test/models/provider/coinstats_test.rb test/models/coinstats_item/importer_test.rb

## Live API behavior checked
CoinStats /wallet/defi returned 406 credit exhaustion and 429 rate limit JSON bodies with requestId/path, but did not include Retry-After or X-RateLimit headers in the observed responses, so fallback backoff is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API rate limiting with automatic retry mechanism for wallet data fetches.
  * Enhanced error recovery to preserve existing wallet data during temporary API failures.
  * Fixed DeFi sync to correctly skip unsupported blockchains.

* **Tests**
  * Added test coverage for rate limit retry behavior and wallet snapshot preservation.
  * Added test verification for DeFi sync behavior with unsupported blockchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->