### PR TITLE
fix(bank-sync): submit sync all as POST on v0.7.1

### DIFF
--- a/app/views/settings/providers/show.html.erb
+++ b/app/views/settings/providers/show.html.erb
@@ -12,15 +12,14 @@
       <p class="text-secondary"><%= t("settings.providers.bank_sync.lede") %></p>
       <% if @connected.any? || @needs_attention.any? %>
         <% sync_all_disabled = Current.family.last_sync_all_attempted_at.present? && Current.family.last_sync_all_attempted_at > 30.seconds.ago %>
-        <%= render DS::Link.new(
+        <%= render DS::Button.new(
               text: t("settings.providers.sync_all"),
               icon: "refresh-cw",
               variant: "outline",
               href: sync_all_settings_providers_path,
               method: :post,
               title: sync_all_disabled ? t("settings.providers.sync_all_recently") : nil,
-              aria: { disabled: sync_all_disabled.to_s },
-              class: sync_all_disabled ? "opacity-50 pointer-events-none" : nil
+              disabled: sync_all_disabled
             ) %>
       <% end %>
     </div>

--- a/test/controllers/settings/providers_controller_test.rb
+++ b/test/controllers/settings/providers_controller_test.rb
@@ -4,6 +4,7 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
   setup do
+    ensure_tailwind_build
     sign_in users(:family_admin)
 
     # Ensure provider adapters are loaded for all tests
@@ -51,6 +52,20 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, I18n.t("settings.providers.taglines.brex")
     assert_includes response.body, connect_form_settings_providers_path(provider_key: "brex")
     refute_includes response.body, "Test Brex Connection"
+  end
+
+  test "sync all control submits with POST" do
+    SimplefinItem.create!(
+      family: families(:dylan_family),
+      name: "Test SimpleFIN Sync All Control",
+      access_url: "https://bridge.simplefin.org/simplefin/access"
+    )
+
+    with_self_hosting do
+      get settings_providers_url
+      assert_response :success
+      assert_select "form[action=?][method=?]", sync_all_settings_providers_path, "post"
+    end
   end
 
   test "correctly identifies declared vs dynamic fields" do


### PR DESCRIPTION
## Summary
- render the Bank Sync `Sync all` control as a `DS::Button` so it submits a real POST form
- preserve the existing recent-sync disabled state using the button `disabled:` API
- add a regression test that asserts the control renders as a POST form

## Repro
On `app.sure.am`, clicking `Sync all` navigates to `/settings/providers/sync_all` and returns 404.

## Root cause
`v0.7.1-release-branch` renders the control as `DS::Link`, which ends up behaving like a GET navigation in this flow, but the route is POST-only.

## Validation
- reproduced the 404 on `app.sure.am`
- local Rails test execution is currently blocked on this host by missing `libyaml-0.so.2` / `psych` load failure
