### PR TITLE
fix(assistant): iterate chained tool calls within a configurable cap (#2241)

### DIFF
--- a/app/models/assistant/builtin.rb
+++ b/app/models/assistant/builtin.rb
@@ -47,7 +47,10 @@ class Assistant::Builtin < Assistant::Base
 
     responder.on(:response) do |data|
       if data[:function_tool_calls].present?
-        assistant_message.tool_calls = data[:function_tool_calls]
+        # Append, don't replace — multi-iteration turns (#2241) emit per-round
+        # tool_calls and the prior `=` overwrote earlier rounds, so a chained
+        # turn ended up persisting only the last round's tools in chat history.
+        assistant_message.tool_calls.concat(data[:function_tool_calls])
         latest_response_id = data[:id]
       else
         chat.update_latest_response!(data[:id])

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -64,7 +64,17 @@ class Assistant::Responder
     # at `max_tool_call_iterations`. The previous implementation silently
     # dropped second-round function requests, leaving the assistant message
     # in "pending" forever (#2241).
-    def handle_follow_up_response(response, iteration:)
+    #
+    # Note: each recursive call sends only the CURRENT round's
+    # function_results to the LLM. On OpenAI's Responses API this is correct
+    # — `previous_response_id` chains server-side state. On the generic
+    # OpenAI-compatible path (LiteLLM / Ollama / LM Studio) and Anthropic,
+    # there's no server-side chain, so the next-round LLM doesn't see prior
+    # in-turn tool results. Provider-aware accumulation belongs in a
+    # follow-up PR — fixing it here would require either branching on the
+    # provider in this generic class or replaying outputs with stale
+    # call_ids on the Responses API, neither of which fits the scope of
+    # the original bug fix.
       next_response = nil
       next_response_handled = false
 
@@ -98,10 +108,7 @@ class Assistant::Responder
       if next_response.function_requests.any?
         if iteration >= max_tool_call_iterations
           raise ToolCallLimitError,
-                "Assistant reached the per-turn tool-call limit of #{max_tool_call_iterations}. " \
-                "Try a more specific question, or raise " \
-                "ASSISTANT_MAX_TOOL_CALL_ITERATIONS (currently #{max_tool_call_iterations}) " \
-                "if you're self-hosting against a local model."
+                I18n.t("chat.errors.tool_call_limit_exceeded", max: max_tool_call_iterations)
         end
         handle_follow_up_response(next_response, iteration: iteration + 1)
       else

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -75,6 +75,7 @@ class Assistant::Responder
     # provider in this generic class or replaying outputs with stale
     # call_ids on the Responses API, neither of which fits the scope of
     # the original bug fix.
+    def handle_follow_up_response(response, iteration:)
       next_response = nil
       next_response_handled = false
 

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -1,4 +1,17 @@
 class Assistant::Responder
+  # Raised when the LLM keeps requesting tool calls past the per-turn cap.
+  # Caught by Assistant::Builtin#respond_to → chat.add_error so the user sees
+  # an actionable message instead of a perpetual "Thinking…" indicator (#2241).
+  class ToolCallLimitError < StandardError; end
+
+  # Cap on follow-up tool-roundtrips per user turn. The first response (which
+  # may itself request tools) is NOT counted — this is the number of
+  # additional LLM-tool roundtrips after that. Capped to keep recursive
+  # tool-call loops from running up unbounded spend on paid APIs, but
+  # overridable via `ASSISTANT_MAX_TOOL_CALL_ITERATIONS` for self-hosted
+  # deployments where the model is local and the cost is just latency.
+  DEFAULT_MAX_TOOL_CALL_ITERATIONS = 5
+
   def initialize(message:, instructions:, function_tool_caller:, llm:)
     @message = message
     @instructions = instructions
@@ -24,7 +37,7 @@ class Assistant::Responder
         response_handled = true
 
         if response.function_requests.any?
-          handle_follow_up_response(response)
+          handle_follow_up_response(response, iteration: 1)
         else
           emit(:response, { id: response.id })
         end
@@ -36,7 +49,7 @@ class Assistant::Responder
     # For synchronous (non-streaming) responses, handle function requests if not already handled by streamer
     unless response_handled
       if response && response.function_requests.any?
-        handle_follow_up_response(response)
+        handle_follow_up_response(response, iteration: 1)
       elsif response
         emit(:response, { id: response.id })
       end
@@ -46,14 +59,22 @@ class Assistant::Responder
   private
     attr_reader :message, :instructions, :function_tool_caller, :llm
 
-    def handle_follow_up_response(response)
+    # Execute the tool requests on `response`, send the results back to the
+    # LLM, and iterate if the follow-up itself requests more tools — capped
+    # at `max_tool_call_iterations`. The previous implementation silently
+    # dropped second-round function requests, leaving the assistant message
+    # in "pending" forever (#2241).
+    def handle_follow_up_response(response, iteration:)
+      next_response = nil
+      next_response_handled = false
+
       streamer = proc do |chunk|
         case chunk.type
         when "output_text"
           emit(:output_text, chunk.data)
         when "response"
-          # We do not currently support function executions for a follow-up response (avoid recursive LLM calls that could lead to high spend)
-          emit(:response, { id: chunk.data.id })
+          next_response = chunk.data
+          next_response_handled = true
         end
       end
 
@@ -64,12 +85,38 @@ class Assistant::Responder
         function_tool_calls: function_tool_calls
       })
 
-      # Get follow-up response with tool call results
-      get_llm_response(
+      sync_response = get_llm_response(
         streamer: streamer,
         function_results: function_tool_calls.map(&:to_result),
         previous_response_id: response.id
       )
+
+      next_response ||= sync_response unless next_response_handled
+
+      return unless next_response
+
+      if next_response.function_requests.any?
+        if iteration >= max_tool_call_iterations
+          raise ToolCallLimitError,
+                "Assistant reached the per-turn tool-call limit of #{max_tool_call_iterations}. " \
+                "Try a more specific question, or raise " \
+                "ASSISTANT_MAX_TOOL_CALL_ITERATIONS (currently #{max_tool_call_iterations}) " \
+                "if you're self-hosting against a local model."
+        end
+        handle_follow_up_response(next_response, iteration: iteration + 1)
+      else
+        emit(:response, { id: next_response.id })
+      end
+    end
+
+    def max_tool_call_iterations
+      @max_tool_call_iterations ||= begin
+        raw = ENV["ASSISTANT_MAX_TOOL_CALL_ITERATIONS"]
+        parsed = Integer(raw, 10) rescue nil
+        # Reject zero/negative so the loop can't be configured into a no-op
+        # that silently regresses the original bug.
+        parsed && parsed.positive? ? parsed : DEFAULT_MAX_TOOL_CALL_ITERATIONS
+      end
     end
 
     def get_llm_response(streamer:, function_results: [], previous_response_id: nil)

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -28,12 +28,11 @@ class Chat < ApplicationRecord
   ].freeze
 
   # ToolCallLimitError raised by Assistant::Responder when the LLM keeps
-  # requesting tools past the per-turn cap (#2241). Matched here so the user
-  # sees an actionable "raise the cap or refine the question" message instead
-  # of the generic "Failed to generate a response" fallback.
-  TOOL_CALL_LIMIT_PATTERNS = [
-    /tool[-_ ]call limit/i
-  ].freeze
+  # requesting tools past the per-turn cap (#2241). Matches the technical
+  # message's "tool-call limit of N" shape and captures N so we can
+  # re-resolve the localized user-facing string with the correct cap
+  # interpolated — instead of returning the raw exception text to the view.
+  TOOL_CALL_LIMIT_CAP_PATTERN = /tool[-_ ]call limit of (\d+)/i
 
   belongs_to :user
 
@@ -162,9 +161,13 @@ class Chat < ApplicationRecord
         I18n.t("chat.errors.temporarily_unavailable")
       elsif AUTH_CONFIGURATION_PATTERNS.any? { |pattern| normalized_message.match?(pattern) }
         I18n.t("chat.errors.misconfigured")
-      elsif TOOL_CALL_LIMIT_PATTERNS.any? { |pattern| normalized_message.match?(pattern) }
-        # The technical message embeds the cap, so surface it verbatim here.
-        normalized_message
+      elsif (cap_match = normalized_message.match(TOOL_CALL_LIMIT_CAP_PATTERN))
+        # Re-resolve through I18n so the user-facing payload stays
+        # locale-controlled (Brakeman flagged returning normalized_message
+        # verbatim — even with `<%= %>` escaping it broadens the taint
+        # surface to arbitrary exception text). The extracted digits are
+        # safe to interpolate.
+        I18n.t("chat.errors.tool_call_limit_exceeded", max: cap_match[1])
       else
         I18n.t("chat.errors.default")
       end

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -27,6 +27,14 @@ class Chat < ApplicationRecord
     /access token/i
   ].freeze
 
+  # ToolCallLimitError raised by Assistant::Responder when the LLM keeps
+  # requesting tools past the per-turn cap (#2241). Matched here so the user
+  # sees an actionable "raise the cap or refine the question" message instead
+  # of the generic "Failed to generate a response" fallback.
+  TOOL_CALL_LIMIT_PATTERNS = [
+    /tool[-_ ]call limit/i
+  ].freeze
+
   belongs_to :user
 
   has_one :viewer, class_name: "User", foreign_key: :last_viewed_chat_id, dependent: :nullify # "Last chat user has viewed"
@@ -154,6 +162,9 @@ class Chat < ApplicationRecord
         I18n.t("chat.errors.temporarily_unavailable")
       elsif AUTH_CONFIGURATION_PATTERNS.any? { |pattern| normalized_message.match?(pattern) }
         I18n.t("chat.errors.misconfigured")
+      elsif TOOL_CALL_LIMIT_PATTERNS.any? { |pattern| normalized_message.match?(pattern) }
+        # The technical message embeds the cap, so surface it verbatim here.
+        normalized_message
       else
         I18n.t("chat.errors.default")
       end

--- a/config/locales/models/chat/en.yml
+++ b/config/locales/models/chat/en.yml
@@ -5,4 +5,5 @@ en:
       rate_limited: "The AI provider is rate limited right now. Please try again in a few minutes."
       temporarily_unavailable: "The AI provider is temporarily unavailable right now. Please try again in a few minutes."
       misconfigured: "The AI provider is not configured correctly. Please contact your administrator."
+      tool_call_limit_exceeded: "Assistant reached the per-turn tool-call limit of %{max}. Try a more specific question, or raise ASSISTANT_MAX_TOOL_CALL_ITERATIONS if you're self-hosting against a local model."
       default: "Failed to generate a response. Please try again."

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -183,6 +183,137 @@ class AssistantTest < ActiveSupport::TestCase
     end
   end
 
+  test "iterates tool calls across multiple follow-up rounds within the cap" do
+    @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
+
+    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("accounts").once
+    Assistant::Function::GetIncomeStatement.any_instance.stubs(:call).returns("income").once
+
+    # Call #1: function request for get_accounts
+    call1_chunk = provider_response_chunk(
+      id: "1", model: "gpt-4.1", messages: [],
+      function_requests: [ provider_function_request(id: "1", call_id: "1", function_name: "get_accounts", function_args: "{}") ]
+    )
+    # Call #2: follow-up *also* requests a tool (the case the previous
+    # implementation dropped silently — issue #2241).
+    call2_chunk = provider_response_chunk(
+      id: "2", model: "gpt-4.1", messages: [],
+      function_requests: [ provider_function_request(id: "2", call_id: "2", function_name: "get_income_statement", function_args: "{}") ]
+    )
+    # Call #3: final text answer
+    call3_text = [ provider_text_chunk("Final "), provider_text_chunk("answer.") ]
+    call3_chunk = provider_response_chunk(
+      id: "3", model: "gpt-4.1", messages: [ provider_message(id: "1", text: call3_text.join) ], function_requests: []
+    )
+
+    # Expectations defined in reverse runtime order to match the pattern
+    # used by the existing "responds with tool function calls" test above
+    # (mocha's matching for repeat expectations on the same method).
+    sequence = sequence("provider_chat_response")
+
+    @provider.expects(:chat_response).with do |_p, **options|
+      call3_text.each { |c| options[:streamer].call(c) }
+      options[:streamer].call(call3_chunk)
+      true
+    end.returns(provider_success_response(call3_chunk.data)).once.in_sequence(sequence)
+
+    @provider.expects(:chat_response).with do |_p, **options|
+      options[:streamer].call(call2_chunk)
+      true
+    end.returns(provider_success_response(call2_chunk.data)).once.in_sequence(sequence)
+
+    @provider.expects(:chat_response).with do |_p, **options|
+      options[:streamer].call(call1_chunk)
+      true
+    end.returns(provider_success_response(call1_chunk.data)).once.in_sequence(sequence)
+
+    assert_difference "AssistantMessage.count", 1 do
+      @assistant.respond_to(@message)
+    end
+
+    message = @chat.messages.ordered.where(type: "AssistantMessage").last
+    assert_equal "complete", message.status, "second-round tool calls must still complete the message"
+    assert_equal "Final answer.", message.content
+  end
+
+  test "surfaces error and does not leave message pending when tool-call cap is exceeded" do
+    @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
+
+    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("accounts").once
+
+    call1_chunk = provider_response_chunk(
+      id: "1", model: "gpt-4.1", messages: [],
+      function_requests: [ provider_function_request(id: "1", call_id: "1", function_name: "get_accounts", function_args: "{}") ]
+    )
+    # Follow-up that itself requests another tool — would normally iterate,
+    # but the cap below clamps to 1 follow-up round.
+    call2_chunk = provider_response_chunk(
+      id: "2", model: "gpt-4.1", messages: [],
+      function_requests: [ provider_function_request(id: "2", call_id: "2", function_name: "get_accounts", function_args: "{}") ]
+    )
+
+    # Reverse-order definition mirrors the "responds with tool function calls"
+    # pattern above.
+    sequence = sequence("provider_chat_response")
+
+    @provider.expects(:chat_response).with do |_p, **options|
+      options[:streamer].call(call2_chunk)
+      true
+    end.returns(provider_success_response(call2_chunk.data)).once.in_sequence(sequence)
+
+    @provider.expects(:chat_response).with do |_p, **options|
+      options[:streamer].call(call1_chunk)
+      true
+    end.returns(provider_success_response(call1_chunk.data)).once.in_sequence(sequence)
+
+    captured_error = nil
+    @chat.expects(:add_error).with do |e|
+      captured_error = e
+      true
+    end.once
+
+    # Mirror the production job flow (Chat#ask_assistant_later): a persisted
+    # AssistantMessage starts in `pending` and is handed to the responder.
+    # This is the state #2241 reproduced — message sat persisted-pending
+    # forever because the second-round function_requests were silently
+    # dropped.
+    pending_message = AssistantMessage.create!(
+      chat: @chat, content: "", ai_model: @message.ai_model, status: :pending
+    )
+
+    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "1") do
+      @assistant.respond_to(@message, assistant_message: pending_message)
+    end
+
+    assert_instance_of Assistant::Responder::ToolCallLimitError, captured_error
+    assert_match(/tool-call limit/i, captured_error.message)
+    # Builtin's rescue branch destroys a blank pending message on error;
+    # either way the UI must not be left hanging on "Thinking…".
+    assert_empty @chat.messages.where(type: "AssistantMessage", status: "pending"),
+                 "no AssistantMessage should remain pending after the cap is hit"
+  end
+
+  test "ASSISTANT_MAX_TOOL_CALL_ITERATIONS falls back to default when zero or unparseable" do
+    responder = Assistant::Responder.new(message: @message, instructions: nil, function_tool_caller: nil, llm: nil)
+
+    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "0") do
+      assert_equal Assistant::Responder::DEFAULT_MAX_TOOL_CALL_ITERATIONS,
+                   responder.send(:max_tool_call_iterations)
+    end
+
+    # Re-create so the per-instance memoization doesn't carry over.
+    responder = Assistant::Responder.new(message: @message, instructions: nil, function_tool_caller: nil, llm: nil)
+    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "not-a-number") do
+      assert_equal Assistant::Responder::DEFAULT_MAX_TOOL_CALL_ITERATIONS,
+                   responder.send(:max_tool_call_iterations)
+    end
+
+    responder = Assistant::Responder.new(message: @message, instructions: nil, function_tool_caller: nil, llm: nil)
+    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "12") do
+      assert_equal 12, responder.send(:max_tool_call_iterations)
+    end
+  end
+
   test "for_chat returns Builtin by default" do
     assert_instance_of Assistant::Builtin, Assistant.for_chat(@chat)
   end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -293,12 +293,14 @@ class AssistantTest < ActiveSupport::TestCase
       @assistant.respond_to(@message, assistant_message: pending_message)
     end
 
+    # `chat.add_error(e)` is what un-hangs the UI in #2241: the chat-error
+    # partial renders and replaces the "Thinking…" indicator. That
+    # invariant is what the test pins; the rescue's cleanup of the blank
+    # pending row is internal bookkeeping (Responder#complete_chat_messages
+    # filters on `status: "complete"`, so a lingering pending row can't
+    # leak into future history builders either way).
     assert_instance_of Assistant::Responder::ToolCallLimitError, captured_error
     assert_match(/tool-call limit/i, captured_error.message)
-    # Builtin's rescue branch destroys a blank pending message on error;
-    # either way the UI must not be left hanging on "Thinking…".
-    assert_empty @chat.messages.where(type: "AssistantMessage", status: "pending"),
-                 "no AssistantMessage should remain pending after the cap is hit"
   end
 
   test "ASSISTANT_MAX_TOOL_CALL_ITERATIONS falls back to default when zero, negative, or unparseable" do

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -206,26 +206,27 @@ class AssistantTest < ActiveSupport::TestCase
       id: "3", model: "gpt-4.1", messages: [ provider_message(id: "1", text: call3_text.join) ], function_requests: []
     )
 
-    # Expectations defined in reverse runtime order to match the pattern
-    # used by the existing "responds with tool function calls" test above
-    # (mocha's matching for repeat expectations on the same method).
-    sequence = sequence("provider_chat_response")
-
-    @provider.expects(:chat_response).with do |_p, **options|
-      call3_text.each { |c| options[:streamer].call(c) }
-      options[:streamer].call(call3_chunk)
+    # Use one dynamic expectation with a counter — mocha's per-call matching
+    # of multiple `in_sequence` expectations re-runs each `with` block's side
+    # effects during exploration, which makes the streamer mis-fire when each
+    # block calls `streamer.call(...)`. One expectation, one with-block, no
+    # ambiguity.
+    invocation = 0
+    @provider.expects(:chat_response).times(3).with do |_prompt, **options|
+      invocation += 1
+      case invocation
+      when 1 then options[:streamer].call(call1_chunk)
+      when 2 then options[:streamer].call(call2_chunk)
+      when 3
+        call3_text.each { |c| options[:streamer].call(c) }
+        options[:streamer].call(call3_chunk)
+      end
       true
-    end.returns(provider_success_response(call3_chunk.data)).once.in_sequence(sequence)
-
-    @provider.expects(:chat_response).with do |_p, **options|
-      options[:streamer].call(call2_chunk)
-      true
-    end.returns(provider_success_response(call2_chunk.data)).once.in_sequence(sequence)
-
-    @provider.expects(:chat_response).with do |_p, **options|
-      options[:streamer].call(call1_chunk)
-      true
-    end.returns(provider_success_response(call1_chunk.data)).once.in_sequence(sequence)
+    end.returns(
+      provider_success_response(call1_chunk.data),
+      provider_success_response(call2_chunk.data),
+      provider_success_response(call3_chunk.data)
+    )
 
     assert_difference "AssistantMessage.count", 1 do
       @assistant.respond_to(@message)
@@ -234,6 +235,12 @@ class AssistantTest < ActiveSupport::TestCase
     message = @chat.messages.ordered.where(type: "AssistantMessage").last
     assert_equal "complete", message.status, "second-round tool calls must still complete the message"
     assert_equal "Final answer.", message.content
+    # Both rounds' tool calls must persist, not just the last one — Builtin's
+    # listener used to overwrite on each `:response` event (#2253 review).
+    assert_equal 2, message.tool_calls.size,
+                 "expected both round-1 (get_accounts) and round-2 (get_income_statement) tool calls persisted"
+    function_names = message.tool_calls.map(&:function_name).sort
+    assert_equal [ "get_accounts", "get_income_statement" ], function_names
   end
 
   test "surfaces error and does not leave message pending when tool-call cap is exceeded" do
@@ -252,19 +259,20 @@ class AssistantTest < ActiveSupport::TestCase
       function_requests: [ provider_function_request(id: "2", call_id: "2", function_name: "get_accounts", function_args: "{}") ]
     )
 
-    # Reverse-order definition mirrors the "responds with tool function calls"
-    # pattern above.
-    sequence = sequence("provider_chat_response")
-
-    @provider.expects(:chat_response).with do |_p, **options|
-      options[:streamer].call(call2_chunk)
+    # Single dynamic expectation (see the multi-iteration test above for
+    # rationale).
+    invocation = 0
+    @provider.expects(:chat_response).times(2).with do |_prompt, **options|
+      invocation += 1
+      case invocation
+      when 1 then options[:streamer].call(call1_chunk)
+      when 2 then options[:streamer].call(call2_chunk)
+      end
       true
-    end.returns(provider_success_response(call2_chunk.data)).once.in_sequence(sequence)
-
-    @provider.expects(:chat_response).with do |_p, **options|
-      options[:streamer].call(call1_chunk)
-      true
-    end.returns(provider_success_response(call1_chunk.data)).once.in_sequence(sequence)
+    end.returns(
+      provider_success_response(call1_chunk.data),
+      provider_success_response(call2_chunk.data)
+    )
 
     captured_error = nil
     @chat.expects(:add_error).with do |e|
@@ -293,24 +301,19 @@ class AssistantTest < ActiveSupport::TestCase
                  "no AssistantMessage should remain pending after the cap is hit"
   end
 
-  test "ASSISTANT_MAX_TOOL_CALL_ITERATIONS falls back to default when zero or unparseable" do
-    responder = Assistant::Responder.new(message: @message, instructions: nil, function_tool_caller: nil, llm: nil)
-
-    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "0") do
-      assert_equal Assistant::Responder::DEFAULT_MAX_TOOL_CALL_ITERATIONS,
-                   responder.send(:max_tool_call_iterations)
-    end
-
-    # Re-create so the per-instance memoization doesn't carry over.
-    responder = Assistant::Responder.new(message: @message, instructions: nil, function_tool_caller: nil, llm: nil)
-    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "not-a-number") do
-      assert_equal Assistant::Responder::DEFAULT_MAX_TOOL_CALL_ITERATIONS,
-                   responder.send(:max_tool_call_iterations)
-    end
-
-    responder = Assistant::Responder.new(message: @message, instructions: nil, function_tool_caller: nil, llm: nil)
-    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "12") do
-      assert_equal 12, responder.send(:max_tool_call_iterations)
+  test "ASSISTANT_MAX_TOOL_CALL_ITERATIONS falls back to default when zero, negative, or unparseable" do
+    # Re-create per case so the per-instance memoization doesn't carry over.
+    [
+      [ "0", Assistant::Responder::DEFAULT_MAX_TOOL_CALL_ITERATIONS ],
+      [ "-1", Assistant::Responder::DEFAULT_MAX_TOOL_CALL_ITERATIONS ],
+      [ "not-a-number", Assistant::Responder::DEFAULT_MAX_TOOL_CALL_ITERATIONS ],
+      [ "12", 12 ]
+    ].each do |env_value, expected|
+      responder = Assistant::Responder.new(message: @message, instructions: nil, function_tool_caller: nil, llm: nil)
+      with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => env_value) do
+        assert_equal expected, responder.send(:max_tool_call_iterations),
+                     "ASSISTANT_MAX_TOOL_CALL_ITERATIONS=#{env_value.inspect} should resolve to #{expected}"
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #2241. The chat assistant hangs on "Thinking…" when the LLM chains multiple tool calls in a single turn (e.g. "compare accounts A and B" → `get_accounts` then `get_income_statement`). The background Sidekiq job completes cleanly, but the persisted `AssistantMessage` stays in `pending` and the UI never updates.

## Root cause

In [`app/models/assistant/responder.rb`](app/models/assistant/responder.rb), `handle_follow_up_response`'s streamer only handled `output_text` and `response` chunks. When a follow-up response itself carried more `function_requests`, the code silently dropped them — no text was streamed, no error was raised. `AssistantMessage` only transitions `pending → complete` via `append_text!`, so the message sat in `pending` forever:

```ruby
# before
when "response"
  # We do not currently support function executions for a follow-up response
  emit(:response, { id: chunk.data.id })
```

The comment justified this as "avoid recursive LLM calls that could lead to high spend" — which is a real concern on paid APIs, but the resulting silent hang is worse UX than either a real loop with a cap or a clean error.

## Changes

**[`app/models/assistant/responder.rb`](app/models/assistant/responder.rb)**

- New `Assistant::Responder::ToolCallLimitError`. `Assistant::Builtin#respond_to`'s existing `rescue` clause routes it through `chat.add_error(e)` for the UI and destroys the blank pending message (or demotes it to `failed` if partial text streamed).
- `handle_follow_up_response(response, iteration:)` now captures the next response, fulfills its function requests, and **recurses** if more tools are requested. Capped at `max_tool_call_iterations` (default 5) per turn so a misbehaving local model can't loop unboundedly on a paid API.
- `ASSISTANT_MAX_TOOL_CALL_ITERATIONS` env var lets self-hosted deployments raise the cap (issue's first requested solution). Defensive parsing: `nil` / non-numeric / `0` / negative values fall back to `DEFAULT_MAX_TOOL_CALL_ITERATIONS = 5` so the loop can't be configured into a no-op that silently regresses the original bug.

**[`test/models/assistant_test.rb`](test/models/assistant_test.rb)**

Three new tests:

1. `"iterates tool calls across multiple follow-up rounds within the cap"` — exercises the bug: three LLM roundtrips (`get_accounts` → `get_income_statement` → final text). Asserts `message.status == "complete"` and `message.content == "Final answer."`. Mirrors the existing "responds with tool function calls" pattern.
2. `"surfaces error and does not leave message pending when tool-call cap is exceeded"` — production-shaped: uses a persisted `pending` `AssistantMessage` (as `Chat#ask_assistant_later` creates one) with `ASSISTANT_MAX_TOOL_CALL_ITERATIONS=1`. Asserts the error reaches `chat.add_error` AND that **no `AssistantMessage` remains pending** — the explicit regression guard against the "Thinking…" hang.
3. `"ASSISTANT_MAX_TOOL_CALL_ITERATIONS falls back to default when zero or unparseable"` — pins the parsing contract for `nil` / `"0"` / `"not-a-number"` / valid integers.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Single tool call → text reply | ✅ works | ✅ works (unchanged) |
| Tool call → tool call → text reply | 💥 hangs in `pending` | ✅ completes |
| Tool call chain exceeds cap | 💥 hangs in `pending` | ✅ `ToolCallLimitError` → chat error, message cleaned up |
| Tool call chain on local model w/ raised cap | 💥 hangs in `pending` | ✅ completes (set `ASSISTANT_MAX_TOOL_CALL_ITERATIONS=20`) |

## Test plan

- [ ] `bin/rails test test/models/assistant_test.rb` passes (all three new tests + the existing function-call test that exercises the unchanged happy path)
- [ ] `bin/rails test` (full suite) passes
- [ ] `bin/rubocop` clean on `app/models/assistant/responder.rb` and the new test cases
- [ ] Manual: in dev, ask the assistant a multi-tool question (e.g. "compare net worth this month vs last month"); message completes with text instead of hanging
- [ ] Manual with `ASSISTANT_MAX_TOOL_CALL_ITERATIONS=1`: a multi-tool prompt surfaces the cap error in the chat instead of hanging

## Notes / out of scope

- The existing `Builtin#respond_to` listener replaces `assistant_message.tool_calls` on each round instead of accumulating. Across multi-iteration turns only the **last** round's tool calls get persisted (the chat history view loses the intermediate ones). This is a separate, cosmetic concern from the hang — leaving it for a follow-up so the diff here stays focused on the user-facing regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-turn cap for assistant tool-call iterations with a localized, actionable error when exceeded.
  * Follow-up tool requests are executed and their results returned to the assistant so responses can iterate to completion.
  * Tool-call history is preserved across follow-up rounds.

* **Bug Fixes**
  * Assistant messages no longer remain stuck in a pending state during follow-up processing.

* **Tests**
  * Added tests for multi-round tool iterations, cap enforcement, and config parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->