### PR TITLE
fix(rules): make explicit re-apply override locked attributes

### DIFF
--- a/app/models/concerns/enrichable.rb
+++ b/app/models/concerns/enrichable.rb
@@ -41,20 +41,20 @@ module Enrichable
   end
 
   # Convenience method for a single attribute
-  def enrich_attribute(attr, value, source:, metadata: {})
-    enrich_attributes({ attr => value }, source:, metadata:)
+  def enrich_attribute(attr, value, source:, metadata: {}, ignore_locks: false)
+    enrich_attributes({ attr => value }, source:, metadata:, ignore_locks:)
   end
 
   # Enriches and logs all attributes that:
-  # - Are not locked
+  # - Are not locked (unless ignore_locks: true, e.g. an explicit rule re-apply)
   # - Are not ignored
   # - Have changed value from the last saved value
   # Returns true if any attributes were actually changed, false otherwise
-  def enrich_attributes(attrs, source:, metadata: {})
+  def enrich_attributes(attrs, source:, metadata: {}, ignore_locks: false)
     # Track current values before modification for virtual attributes (like tag_ids)
     current_values = {}
     enrichable_attrs = Array(attrs).reject do |attr_key, attr_value|
-      if locked?(attr_key) || ignored_enrichable_attributes.include?(attr_key)
+      if (locked?(attr_key) && !ignore_locks) || ignored_enrichable_attributes.include?(attr_key)
         true
       else
         # For virtual attributes (like tag_ids), use the getter method

--- a/app/models/rule/action_executor/exclude_transaction.rb
+++ b/app/models/rule/action_executor/exclude_transaction.rb
@@ -19,7 +19,8 @@ class Rule::ActionExecutor::ExcludeTransaction < Rule::ActionExecutor
       txn.entry.enrich_attribute(
         :excluded,
         true,
-        source: "rule"
+        source: "rule",
+        ignore_locks: ignore_attribute_locks
       )
     end
   end

--- a/app/models/rule/action_executor/set_investment_activity_label.rb
+++ b/app/models/rule/action_executor/set_investment_activity_label.rb
@@ -24,7 +24,8 @@ class Rule::ActionExecutor::SetInvestmentActivityLabel < Rule::ActionExecutor
       txn.enrich_attribute(
         :investment_activity_label,
         value,
-        source: "rule"
+        source: "rule",
+        ignore_locks: ignore_attribute_locks
       )
     end
   end

--- a/app/models/rule/action_executor/set_transaction_category.rb
+++ b/app/models/rule/action_executor/set_transaction_category.rb
@@ -22,7 +22,8 @@ class Rule::ActionExecutor::SetTransactionCategory < Rule::ActionExecutor
       txn.enrich_attribute(
         :category_id,
         category.id,
-        source: "rule"
+        source: "rule",
+        ignore_locks: ignore_attribute_locks
       )
     end
   end

--- a/app/models/rule/action_executor/set_transaction_merchant.rb
+++ b/app/models/rule/action_executor/set_transaction_merchant.rb
@@ -21,7 +21,8 @@ class Rule::ActionExecutor::SetTransactionMerchant < Rule::ActionExecutor
       txn.enrich_attribute(
         :merchant_id,
         merchant.id,
-        source: "rule"
+        source: "rule",
+        ignore_locks: ignore_attribute_locks
       )
     end
   end

--- a/app/models/rule/action_executor/set_transaction_name.rb
+++ b/app/models/rule/action_executor/set_transaction_name.rb
@@ -24,7 +24,8 @@ class Rule::ActionExecutor::SetTransactionName < Rule::ActionExecutor
       txn.entry.enrich_attribute(
         :name,
         value,
-        source: "rule"
+        source: "rule",
+        ignore_locks: ignore_attribute_locks
       )
     end
   end

--- a/app/models/rule/action_executor/set_transaction_tags.rb
+++ b/app/models/rule/action_executor/set_transaction_tags.rb
@@ -26,7 +26,8 @@ class Rule::ActionExecutor::SetTransactionTags < Rule::ActionExecutor
       txn.enrich_attribute(
         :tag_ids,
         merged_tag_ids,
-        source: "rule"
+        source: "rule",
+        ignore_locks: ignore_attribute_locks
       )
     end
   end

--- a/test/models/rule/action_test.rb
+++ b/test/models/rule/action_test.rb
@@ -38,6 +38,21 @@ class Rule::ActionTest < ActiveSupport::TestCase
     end
   end
 
+  test "set_transaction_category overrides locked category when ignore_attribute_locks" do
+    # Explicit "Re-apply" from the rules UI passes ignore_attribute_locks: true (issue #2051)
+    @txn1.lock_attr!(:category_id)
+
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "set_transaction_category",
+      value: @grocery_category.id
+    )
+
+    action.apply(@rule_scope, ignore_attribute_locks: true)
+
+    assert_equal @grocery_category.id, @txn1.reload.category_id
+  end
+
   test "set_transaction_tags" do
     tag = @family.tags.create!(name: "Rule test tag")
 
@@ -144,6 +159,22 @@ class Rule::ActionTest < ActiveSupport::TestCase
     [ @txn2, @txn3 ].each do |transaction|
       assert_equal new_name, transaction.reload.entry.name
     end
+  end
+
+  test "set_transaction_name overrides locked name when ignore_attribute_locks" do
+    # Explicit "Re-apply" from the rules UI passes ignore_attribute_locks: true (issue #2051)
+    new_name = "Renamed Transaction"
+    @txn1.entry.lock_attr!(:name)
+
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "set_transaction_name",
+      value: new_name
+    )
+
+    action.apply(@rule_scope, ignore_attribute_locks: true)
+
+    assert_equal new_name, @txn1.reload.entry.name
   end
 
   test "set_investment_activity_label" do


### PR DESCRIPTION
Fixes #2051

## Summary

Re-applying a rule from the rules UI had no effect on transactions whose attributes were locked (e.g. manually categorized or CSV-imported ones). The UI offers an explicit "Re-apply" action and the controller passes `ignore_attribute_locks: true`, but the rule still silently skipped those transactions — they showed up as "blocked" in the rule log, exactly as reported in #2051.

## Root Cause

`ignore_attribute_locks: true` is only half-implemented. Each `Rule::ActionExecutor` correctly skips the *scope-level* lock filter (`scope.enrichable(:category_id)` etc.) when the flag is set, but the per-record write goes through `Enrichable#enrich_attributes`, which unconditionally rejects any attribute present in `locked_attributes`:

```ruby
# app/models/concerns/enrichable.rb
enrichable_attrs = Array(attrs).reject do |attr_key, attr_value|
  if locked?(attr_key) || ignored_enrichable_attributes.include?(attr_key)
```

So locked transactions were included in the scope but then dropped one by one inside `enrich_attributes` — the flag was effectively a no-op for the records it was meant to unlock.

## Solution

Thread the flag through to the write:

- `Enrichable#enrich_attribute` / `#enrich_attributes` accept a new `ignore_locks:` keyword (default `false`, so every existing caller — provider syncs, AI enrichment, imports — behaves exactly as before).
- The six synchronous rule action executors (`set_transaction_category`, `set_transaction_merchant`, `set_transaction_tags`, `set_transaction_name`, `exclude_transaction`, `set_investment_activity_label`) pass `ignore_locks: ignore_attribute_locks`.

Deliberately **not** changed:

- The AI executors (`auto_categorize`, `auto_detect_merchants`) keep always respecting locks — async AI enrichment overriding explicit user edits is a separate product decision.
- The attribute lock itself is left in place after an override, so provider syncs still won't clobber the value later; only the user's explicit re-apply wins.

## Tests

Two regression tests in `test/models/rule/action_test.rb` (mirroring the existing lock tests there): one for a Transaction-level attribute (`category_id`) and one for an Entry-level attribute (`name`).

- Both tests **fail before the fix** (verified) and pass after.
- `bin/rails test` — full suite green (4877 runs).
- `bin/rubocop` — clean on changed files.
- `bin/brakeman --no-pager` — no new warnings (the single EOL-Rails advisory pre-exists on `main`).

## QA

1. Import transactions via CSV and categorize some of them during the import flow (this locks `category_id`).
2. Create a rule matching those transactions that sets a different category.
3. Click "Re-apply" on the rule.
4. Before this fix: nothing changes and the rule log reports the transactions as blocked. After: the category updates.

## Risks

- Behavior change is limited to the explicit re-apply path (`RulesController#apply` → `apply_later(ignore_attribute_locks: true)`); scheduled/automatic rule runs pass `false` and are unaffected.
- A re-apply now genuinely overwrites manual values for matching transactions — which is what the button promises and what #2051 expects.

## Checklist

- [x] Requirement confirmed
- [x] Root cause identified
- [x] Small focused diff
- [x] Regression test added (verified failing before fix)
- [x] Existing tests pass
- [x] Documentation reviewed (no doc changes needed)
- [x] No unrelated cleanup
- [x] PR opened as draft


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rules can now override locked transaction attributes when the ignore attribute locks option is enabled. This applies to transaction categories, merchants, names, and tags.

* **Tests**
  * Added test coverage verifying that locked attributes are overridden when rules are applied with the ignore attribute locks option enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->