### PR TITLE
fix(ds): balance-sheet weight alignment + category pill padding

### DIFF
--- a/app/components/DS/pill.rb
+++ b/app/components/DS/pill.rb
@@ -178,7 +178,7 @@ class DS::Pill < DesignSystemComponent
       # tracking snap to Tailwind's scale to satisfy the design-system
       # "no arbitrary values" rule.
       base << "rounded-md uppercase"
-      base << (size == :md ? "px-2 py-0.5 text-[11px] tracking-wide gap-1" : "px-1.5 py-0.5 text-[10px] tracking-wider gap-1")
+      base << (size == :md ? "px-2 py-1 text-[11px] tracking-wide gap-1" : "px-1.5 py-0.5 text-[10px] tracking-wider gap-1")
     else
       # Badge mode (Pending / Active / Past due / category tag):
       # rounded-full pill shape (matches the existing convention used
@@ -186,7 +186,7 @@ class DS::Pill < DesignSystemComponent
       # the inline transaction badges). Normal case, snaps to the
       # design-system text scale (`text-xs` / `text-sm`).
       base << "rounded-full"
-      base << (size == :md ? "px-2 py-0.5 text-sm gap-1.5" : "px-1.5 py-0.5 text-xs gap-1")
+      base << (size == :md ? "px-2 py-1 text-sm gap-1.5" : "px-1.5 py-0.5 text-xs gap-1")
     end
     class_names(*base)
   end

--- a/app/views/pages/dashboard/_balance_sheet.html.erb
+++ b/app/views/pages/dashboard/_balance_sheet.html.erb
@@ -82,7 +82,7 @@
                       </div>
 
                       <div class="ml-auto flex items-center text-right gap-2">
-                        <div class="w-14 shrink-0 flex items-center justify-end gap-2">
+                        <div class="w-20 shrink-0 flex items-center justify-end gap-2">
                           <%
                               # Calculate weight as percentage of classification total
                               classification_total = classification_group.total_money.amount

--- a/app/views/pages/dashboard/_group_weight.html.erb
+++ b/app/views/pages/dashboard/_group_weight.html.erb
@@ -8,5 +8,5 @@
       <div class="w-0.5 h-2.5 rounded-lg <%= i < (effective_weight / 20.0).ceil ? "" : "opacity-20" %>" style="background-color: <%= color %>;"></div>
     <% end %>
   </div>
-  <p class="text-sm privacy-sensitive"><%= number_to_percentage(effective_weight, precision: 0) %></p>
+  <p class="text-sm whitespace-nowrap privacy-sensitive"><%= number_to_percentage(effective_weight, precision: 0) %></p>
 </div>


### PR DESCRIPTION
## What

Two dashboard balance-sheet weight-column bugs + a `DS::Pill` padding bump.

## Fixes

**1. Weight `%` wrapping + column misalignment** — `pages/dashboard/_balance_sheet.html.erb`, `_group_weight.html.erb`

The account-row weight cell was `w-14` (56px) — too narrow for the 5-bar gauge plus a space-separated locale percentage (ca/es format renders `"64 %"`), so 2-digit values wrapped the `%` onto a second line (1-digit `3 % / 0 %` fit). It was also narrower than the header + group-row weight columns (`w-20`), so the weight column didn't line up.

- Widen the account-row weight cell `w-14` → `w-20` (matches header/group, fixes the alignment).
- Add `whitespace-nowrap` to the percentage so a spaced `NN %` never wraps.

**2. Category pill padding** — `app/components/DS/pill.rb`

`:md` pills used `py-0.5` (2px), cramped for `text-sm`. Bump to `py-1`. Affects the 4 `:md` callers (category badge, goals preview, tag-select option, admin users).

## Testing

- `erb_lint` clean, `rubocop` clean.
- `DS::Pill` component test: 15 runs, 0 failures.
- Verified live (screenshots in thread).

Pre-existing (not a recent regression — `_balance_sheet` last changed in 2024).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased vertical padding on medium-sized pills in both marker and badge modes for improved touch targets and visual balance.
  * Widened the group-weight container on the dashboard balance sheet to improve layout proportions and reduce crowding.
  * Prevented the group weight percentage from wrapping so percentage values remain on a single line for consistent readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot

![PR 2275](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2275.png)
