### PR TITLE
fix(ds): add-account menu — right-size close + clickable rows

### DIFF
--- a/app/views/accounts/_account_type.html.erb
+++ b/app/views/accounts/_account_type.html.erb
@@ -1,11 +1,13 @@
 <%# locals: (accountable:) %>
 
 <%= link_to new_polymorphic_path(accountable, step: "method_select", return_to: params[:return_to]),
-            class: "flex items-center gap-4 w-full text-center focus:outline-hidden hover:bg-surface-hover focus:bg-surface-hover text-primary border border-transparent block px-2 rounded-lg p-2" do %>
+            class: "group flex items-center gap-4 w-full text-center focus:outline-hidden hover:bg-surface-hover focus:bg-surface-hover text-primary border border-transparent block px-2 rounded-lg p-2" do %>
   <%= render DS::FilledIcon.new(
     icon: accountable.icon,
     hex_color: accountable.color,
   ) %>
 
   <%= accountable.singular_display_name %>
+
+  <%= icon("chevron-right", size: "sm", class: "ml-auto shrink-0 text-subdued transition-colors group-hover:text-secondary") %>
 <% end %>

--- a/app/views/accounts/new/_container.html.erb
+++ b/app/views/accounts/new/_container.html.erb
@@ -9,14 +9,14 @@
           variant: "icon",
           icon: "arrow-left",
           href: back_path,
-          size: "lg"
+          size: "md"
         ) %>
         <% end %>
 
         <span class="text-primary"><%= title %></span>
       </div>
 
-      <%= icon("x", as_button: true, size: "lg", data: { action: "DS--dialog#close" }) %>
+      <%= icon("x", as_button: true, size: "md", data: { action: "DS--dialog#close" }) %>
     </div>
 
     <div class="p-2 text-subdued">

--- a/app/views/accounts/new/_method_selector.html.erb
+++ b/app/views/accounts/new/_method_selector.html.erb
@@ -10,11 +10,12 @@
          <% end %>
        <% end %>>
     <%# Manual entry option %>
-    <%= link_to path, class: "flex items-center gap-4 w-full text-center text-primary focus:outline-hidden focus:bg-surface border border-transparent focus:border focus:border-secondary px-2 hover:bg-surface rounded-lg p-2" do %>
+    <%= link_to path, class: "group flex items-center gap-4 w-full text-center text-primary focus:outline-hidden focus:bg-surface-hover border border-transparent focus:border focus:border-secondary px-2 hover:bg-surface-hover rounded-lg p-2" do %>
       <span class="flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-alpha-black-50 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]">
         <%= icon("keyboard") %>
       </span>
       <%= t("accounts.new.method_selector.manual_entry") %>
+      <%= icon("chevron-right", size: "sm", class: "ml-auto shrink-0 text-subdued transition-colors group-hover:text-secondary") %>
     <% end %>
 
     <%# Dynamic provider links - only admins can create provider connections %>
@@ -24,7 +25,7 @@
       <% is_lunchflow = config[:key] == "lunchflow" %>
 
       <%= link_to link_path,
-                  class: "text-primary flex items-center gap-4 w-full text-center focus:outline-hidden focus:bg-surface border border-transparent focus:border focus:border-primary px-2 hover:bg-surface rounded-lg p-2",
+                  class: "group text-primary flex items-center gap-4 w-full text-center focus:outline-hidden focus:bg-surface-hover border border-transparent focus:border focus:border-primary px-2 hover:bg-surface-hover rounded-lg p-2",
                   data: is_lunchflow ? {
                     turbo_frame: "modal",
                     turbo_action: "advance",
@@ -43,6 +44,8 @@
         <% else %>
           <%= t("accounts.new.method_selector.link_with_provider", provider: config[:name]) %>
         <% end %>
+
+        <%= icon("chevron-right", size: "sm", class: "ml-auto shrink-0 text-subdued transition-colors group-hover:text-secondary") %>
       <% end %>
     <% end %>
     <% end %>


### PR DESCRIPTION
## What

Affordance fixes for the add-account picker modal (`accounts/new/` — "What would you like to add?" and "How do you want to add it?").

## Fixes

- **Close / back buttons were oversized** (`_container.html.erb`): `icon("x", as_button: true, size: "lg")` and the `arrow-left` back link (`size: "lg"`) were much larger than every other modal close. Dropped both to `size: "md"`.
- **Rows didn't read as clickable** (`_account_type.html.erb`, `_method_selector.html.erb`): they had a hover background but no rest-state cue that they navigate to a next step. Added a trailing **chevron** (subdued at rest, brightens on hover via `group-hover`). Also standardized the method-selector rows onto the theme-aware `hover:bg-surface-hover` (were `hover:bg-surface`).

## Verified

- erb_lint clean. Verified live (screenshot in thread) — close button right-sized, every type row shows a `›` affordance.

## Follow-up

The footer keyboard-hint chips (Select ↵ / Navigate ↑↓ / Close ESC) are a more subjective "better design" ask — left for a focused follow-up (candidate: a reusable `DS::Kbd`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-chevron navigation icons to account type options, manual-entry link, and provider connection rows to improve visual navigation clarity.

* **Style**
  * Standardized and reduced icon sizes in the account creation dialog for visual consistency.
  * Enhanced hover/focus styling on account selection and provider link elements for clearer interactive feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot

![PR 2276](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2276.png)
