### PR TITLE
fix(settings): preserve content scroll position per page across navigation

### DIFF
--- a/app/javascript/controllers/settings_scroll_controller.js
+++ b/app/javascript/controllers/settings_scroll_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Preserves the settings content scroll position PER PAGE across Turbo Drive
+// navigation. Settings nav items are plain links (full-body Turbo visits), and
+// Turbo only restores window scroll — so this nested overflow-y-auto container
+// snaps to top on every visit.
+//
+// Keyed by pathname: returning to a page restores its scroll, a brand-new page
+// starts at the top, and a same-page re-render (e.g. a settings form that
+// auto-submits) keeps scroll. This differs from the nav's `preserve-scroll`
+// controller, which intentionally carries one position across all pages because
+// the nav is the same persistent element on every settings page.
+export default class extends Controller {
+  static positions = {};
+
+  connect() {
+    this.save = this.save.bind(this);
+    document.addEventListener("turbo:before-cache", this.save);
+    this.restore();
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-cache", this.save);
+  }
+
+  save() {
+    this.constructor.positions[window.location.pathname] = {
+      top: this.element.scrollTop,
+      left: this.element.scrollLeft,
+    };
+  }
+
+  restore() {
+    const pos = this.constructor.positions[window.location.pathname];
+    if (!pos) return;
+    this.element.scrollTop = pos.top;
+    this.element.scrollLeft = pos.left;
+  }
+}

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -11,7 +11,7 @@
 
     <main id="main" class="grow flex h-full">
       <div class="relative max-w-4xl mx-auto flex flex-col w-full h-full">
-        <div class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]">
+        <div data-controller="settings-scroll" class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]">
           <div class="sticky top-0 z-10 px-3 md:px-10 pt-1.5 md:pt-3 pb-3 bg-surface border-b border-tertiary shrink-0">
             <% if content_for?(:breadcrumbs) %>
               <%= yield :breadcrumbs %>


### PR DESCRIPTION
## Problem

Settings nav items are plain Turbo Drive links (full-body visits). Turbo Drive only restores **window** scroll, but the settings content lives in a nested `overflow-y-auto` container (`layouts/settings.html.erb`). So switching settings pages snapped the content back to the top every time, losing your place.

## Fix

A small `settings-scroll` Stimulus controller on the content container, keyed by `pathname`:

- Return to a page you'd scrolled → **restores** its position.
- Open a new page → **top** (does not carry the previous page's scroll).
- A same-page re-render (e.g. a settings form that auto-submits) → **keeps** scroll.

It's deliberately separate from the nav's existing `preserve-scroll` controller, which keys by element `id` to carry one shared position across pages (correct for the persistent nav, wrong for per-page content).

## Verified live

Preferences scrolled to 250 → navigate to Appearance (opens at top, 0) → back to Preferences (restores 250). Behavioral fix; no visual diff to screenshot.

erb_lint + biome clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scroll position on the settings page is now preserved when navigating between sections or returning to the page, so you stay at the same spot (including horizontal and vertical offsets) without manual scrolling. This applies to the main settings content area and maintains context across in-app navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->