### PR TITLE
fix(ds): sync-settings env notice → DS::Alert (was invisible: undefined warning-* classes)

### DIFF
--- a/app/views/settings/hostings/_sync_settings.html.erb
+++ b/app/views/settings/hostings/_sync_settings.html.erb
@@ -52,13 +52,6 @@
   </div>
 
   <% if env_configured %>
-    <div class="bg-warning-50 border border-warning-200 rounded-lg p-3">
-      <div class="flex items-start gap-2">
-        <%= icon("alert-circle", class: "w-5 h-5 text-warning-600 mt-0.5 shrink-0") %>
-        <p class="text-sm text-warning-800">
-          <%= t(".env_configured_message") %>
-        </p>
-      </div>
-    </div>
+    <%= render DS::Alert.new(message: t(".env_configured_message"), variant: :warning) %>
   <% end %>
 </div>


### PR DESCRIPTION
## Bug

`settings/hostings/_sync_settings.html.erb` rendered the "this is configured via an environment variable" notice with `bg-warning-50`, `border-warning-200`, `text-warning-600`, `text-warning-800`. **None of those exist as Tailwind utilities** (the design system exposes `--color-warning`, not a `warning-50/200/…` ramp), so the box rendered fully unstyled — no tint, no border, default text — i.e. effectively invisible as a warning.

## Fix

Replace the hand-built box with the canonical `DS::Alert.new(variant: :warning, message: ...)` — same recipe as the other migrated warning surfaces (neutral text + tinted icon/surface).

Notice is env-gated (only shows when `SIMPLEFIN_INCLUDE_PENDING` or `PLAID_INCLUDE_PENDING` is set), so no demo screenshot. erb_lint clean.

Surfaced by the settings design-consistency audit. Complements the warning-surface cleanup (#2246/#2247/#2249/#2250) — this specific partial wasn't covered by any of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the hostings sync settings warning to use the app’s standardized alert component. The warning now displays the localized “env configured” message with consistent styling and warning emphasis, improving visual consistency and accessibility while preserving existing form layout and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->