### PR TITLE
refactor(settings): consistency pass — header-less settings_section + guides

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -45,7 +45,7 @@ module SettingsHelper
     }
   end
 
-  def settings_section(title:, subtitle: nil, collapsible: false, open: true, auto_open_param: nil, status: nil, meta: nil, actions: nil, badge: nil, &block)
+  def settings_section(title: nil, subtitle: nil, collapsible: false, open: true, auto_open_param: nil, status: nil, meta: nil, actions: nil, badge: nil, &block)
     content = capture(&block)
     render partial: "settings/section", locals: { title: title, subtitle: subtitle, content: content, collapsible: collapsible, open: open, auto_open_param: auto_open_param, status: status, meta: meta, actions: actions, badge: badge }
   end

--- a/app/views/family_exports/index.html.erb
+++ b/app/views/family_exports/index.html.erb
@@ -1,8 +1,7 @@
 <%= content_for :page_title, t(".title") %>
 
-<%= settings_section title: t(".title") do %>
-  <div class="space-y-4">
-    <% has_processing = @exports.any? { |e| e.pending? || e.processing? } %>
+<%= settings_section do %>
+  <% has_processing = @exports.any? { |e| e.pending? || e.processing? } %>
     <%= turbo_frame_tag "family_exports",
         data: has_processing ? {
           controller: "polling",
@@ -18,7 +17,7 @@
           <p><%= @pagy.count %></p>
         </div>
 
-        <div class="bg-container rounded-lg shadow-border-xs overflow-x-auto">
+        <div class="overflow-x-auto">
           <% if @exports.any? %>
             <table class="w-full overflow-x-auto">
               <thead>
@@ -135,5 +134,4 @@
       <%= icon("plus") %>
       <%= t(".new") %>
     <% end %>
-  </div>
 <% end %>

--- a/app/views/settings/_section.html.erb
+++ b/app/views/settings/_section.html.erb
@@ -36,12 +36,14 @@
   <% end %>
 <% else %>
   <section class="bg-container shadow-border-xs rounded-xl p-4 space-y-4">
-    <div>
-      <h2 class="text-lg font-medium text-primary"><%= title %></h2>
-      <% if subtitle.present? %>
-        <p class="text-secondary text-sm mt-1"><%= subtitle %></p>
-      <% end %>
-    </div>
+    <% if title.present? %>
+      <div>
+        <h2 class="text-lg font-medium text-primary"><%= title %></h2>
+        <% if subtitle.present? %>
+          <p class="text-secondary text-sm mt-1"><%= subtitle %></p>
+        <% end %>
+      </div>
+    <% end %>
     <div class="space-y-4">
       <%= content %>
     </div>

--- a/app/views/settings/appearances/show.html.erb
+++ b/app/views/settings/appearances/show.html.erb
@@ -35,7 +35,7 @@
           data: { controller: "auto-submit-form" } do |f| %>
       <div class="flex cursor-pointer items-center gap-4 justify-between">
         <div class="text-sm space-y-1">
-          <h4 class="text-primary"><%= t(".dashboard_two_column_title") %></h4>
+          <p class="text-primary font-medium"><%= t(".dashboard_two_column_title") %></p>
           <p class="text-secondary"><%= t(".dashboard_two_column_description") %></p>
         </div>
         <%= render DS::Toggle.new(
@@ -56,7 +56,7 @@
           data: { controller: "auto-submit-form" } do |f| %>
       <div class="flex cursor-pointer items-center gap-4 justify-between">
         <div class="text-sm space-y-1">
-          <h4 class="text-primary"><%= t(".split_grouped_title") %></h4>
+          <p class="text-primary font-medium"><%= t(".split_grouped_title") %></p>
           <p class="text-secondary"><%= t(".split_grouped_description") %></p>
         </div>
         <%= render DS::Toggle.new(

--- a/app/views/settings/guides/show.html.erb
+++ b/app/views/settings/guides/show.html.erb
@@ -1,5 +1,7 @@
-<%= content_for :page_title, "Guides" %>
+<%= content_for :page_title, t(".page_title") %>
 
-<div class="bg-container rounded-xl shadow-border-xs p-4 prose prose-sm max-w-none">
-  <%= @guide_content.html_safe %>
-</div>
+<%= settings_section do %>
+  <div class="prose prose-sm max-w-none">
+    <%= @guide_content.html_safe %>
+  </div>
+<% end %>

--- a/app/views/settings/payments/show.html.erb
+++ b/app/views/settings/payments/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= settings_section title: t(".subscription_title"), subtitle: t(".subscription_subtitle") do %>
   <div class="space-y-4">
-    <div class="p-3 shadow-border-xs bg-container rounded-lg flex justify-between items-center">
+    <div class="p-4 bg-container-inset rounded-lg flex justify-between items-center">
       <div class="flex items-center gap-3">
         <%= render DS::FilledIcon.new(
           icon: "gem",

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -29,9 +29,7 @@
             { label: t(".month_start_day"), hint: t(".month_start_day_hint") },
             { data: { auto_submit_form_target: "auto" } } %>
         <% if @user.family.uses_custom_month_start? %>
-          <div class="text-sm text-warning bg-warning/10 p-3 rounded-lg">
-            <%= t(".month_start_day_warning") %>
-          </div>
+          <%= render DS::Alert.new(message: t(".month_start_day_warning"), variant: :warning) %>
         <% end %>
         <p class="text-xs italic pl-2 text-secondary"><%= t(".translations_notice") %></p>
       <% end %>
@@ -162,7 +160,7 @@
                           <div class="flex items-center gap-2">
                             <span class="text-sm font-medium text-primary"><%= currency.iso_code %></span>
                             <% if base_currency %>
-                              <span class="inline-flex items-center rounded-full bg-surface px-2 py-0.5 text-[11px] font-medium text-secondary">
+                              <span class="inline-flex items-center rounded-full bg-surface px-2 py-0.5 text-xs font-medium text-secondary">
                                 <%= t(".base_currency_badge") %>
                               </span>
                             <% end %>
@@ -207,7 +205,7 @@
     toggle row is the entire surface. Posts directly to
     settings#preferences#update via the Settings::PreferencesController,
     matching the auto-submit pattern used on the Appearance page. %>
-<section class="bg-container shadow-border-xs rounded-xl p-4">
+<%= settings_section do %>
   <%= form_with url: settings_preferences_path, method: :patch,
         data: { controller: "auto-submit-form" } do |f| %>
     <%# Wrapping the row in <label for=…> makes the title + description
@@ -215,7 +213,7 @@
         affordance on the container is honest. %>
     <label for="user_preview_features_enabled" class="flex cursor-pointer items-center gap-4 justify-between">
       <div class="text-sm space-y-1">
-        <h4 class="text-primary"><%= t(".preview.title") %></h4>
+        <p class="text-primary font-medium"><%= t(".preview.title") %></p>
         <p class="text-secondary"><%= t(".preview.description") %></p>
       </div>
       <%= render DS::Toggle.new(
@@ -226,4 +224,4 @@
       ) %>
     </label>
   <% end %>
-</section>
+<% end %>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -9,7 +9,9 @@
 
       <% if @user.unconfirmed_email.present? %>
         <p class="mt-2 text-sm text-secondary">
-          You have requested to change your email to <%= @user.unconfirmed_email %>. Please go to your email and confirm for the change to take effect. If you haven't received the email, please check your spam folder, or <%= link_to "request a new confirmation email", resend_confirmation_email_user_path(@user), class: "hover:underline text-secondary" %>.
+          <%= t(".unconfirmed_email_notice_html",
+                email: @user.unconfirmed_email,
+                resend_link: link_to(t(".resend_confirmation_link"), resend_confirmation_email_user_path(@user), class: "hover:underline text-secondary")) %>
         </p>
       <% end %>
 
@@ -49,9 +51,7 @@
               <%= render "settings/user_avatar", avatar_url: user.profile_image&.variant(:small)&.url, initials: user.initials %>
             </div>
             <p class="text-primary font-medium text-sm"><%= user.display_name %></p>
-            <div class="rounded-md bg-surface px-1.5 py-0.5">
-              <p class="uppercase text-secondary font-medium text-xs"><%= t("users.roles.#{user.role}", default: user.role.humanize) %></p>
-            </div>
+            <%= render DS::Pill.new(label: t("users.roles.#{user.role}", default: user.role.humanize), tone: :gray, marker: false, size: :sm) %>
             <% if Current.user.admin? && user != Current.user %>
               <div class="ml-auto">
                 <%= render DS::Button.new(
@@ -67,16 +67,14 @@
         <% end %>
         <% if @pending_invitations.any? %>
           <% @pending_invitations.each do |invitation| %>
-            <div class="flex gap-2 items-center justify-between bg-container p-4 border border-alpha-black-25 rounded-lg">
+            <div class="flex gap-2 items-center justify-between bg-container p-4 shadow-border-xs rounded-lg">
               <div class="flex gap-2 items-center">
                 <div class="w-9 h-9 shrink-0">
                   <div class="text-inverse w-full h-full bg-surface-inset rounded-full flex items-center justify-center text-lg uppercase"><%= invitation.email[0] %></div>
                 </div>
-                <div class="flex">
+                <div class="flex items-center gap-2">
                   <p class="text-primary font-medium text-sm"><%= invitation.email %></p>
-                  <div class="rounded-md bg-surface px-1.5 py-0.5">
-                    <p class="uppercase text-secondary font-medium text-xs"><%= t(".pending") %></p>
-                  </div>
+                  <%= render DS::Pill.new(label: t(".pending"), tone: :gray, marker: false, size: :sm) %>
                 </div>
               </div>
               <div class="flex items-center gap-4">

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -207,7 +207,9 @@ en:
         profile_title: Personal
         remove_invitation: Remove Invitation
         remove_member: Remove Member
+        resend_confirmation_link: request a new confirmation email
         save: Save
+        unconfirmed_email_notice_html: You have requested to change your email to %{email}. Please go to your email and confirm for the change to take effect. If you haven't received the email, please check your spam folder, or %{resend_link}.
     securities:
       show:
         page_title: Security

--- a/config/locales/views/settings/guides/en.yml
+++ b/config/locales/views/settings/guides/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  settings:
+    guides:
+      show:
+        page_title: Guides


### PR DESCRIPTION
First step of the **settings design-consistency pass** (from the 16-agent settings audit).

## Foundation
`settings_section` now accepts `title: nil` — renders the canonical surface (`bg-container shadow-border-xs rounded-xl p-4 space-y-4`) **without** a header block. This lets header-less cards (which several pages hand-roll today) route through the one shared recipe. No visual change to existing titled callers.

## First migration: Guides
- Hardcoded `content_for :page_title, "Guides"` → `t(".page_title")` (new locale key).
- Hand-rolled `bg-container rounded-xl shadow-border-xs p-4` card → `settings_section` (header-less) wrapping the prose.

## Scope note
This is a **coordinated** consistency pass — it deliberately **skips pages already owned by open PRs** (securities SSO → #2246; ai_prompts + llm_usages → #2244; warning surfaces → #2247/#2250) to avoid duplicating in-flight work. Subsequent commits/PRs migrate the remaining non-overlapping pages (profiles, providers, debugs, payments, appearances) onto the same recipe.


## Screenshot — Guides on the header-less card

![PR 2279](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2279.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Settings sections now accept optional titles and omit header markup when no title is provided.
  * Simplified section and table containers for cleaner, flatter HTML output.

* **Improvements**
  * Guides page uses a localized page title and is wrapped in the unified settings layout.
  * Consistent heading/container styling across settings, alert component for warnings, currency badge typography and subscription header spacing adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot — family_exports un-nested (was "Exports" ×3 in 3 stacked cards)

![family_exports](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2279-family-exports.png)


## Screenshot — appearance (h4 toggle labels -> p, consistent cards)

![appearance](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2279-appearance.png)

## Screenshot — profiles (role chips -> DS::Pill, unified borders, i18n notice)

![profiles](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2279-profiles.png)
