### PR TITLE
fix(ds): dark-mode hover — alpha-black-25 → surface-hover on date-nav triggers

### DIFF
--- a/app/views/budgets/_budget_header.html.erb
+++ b/app/views/budgets/_budget_header.html.erb
@@ -28,7 +28,7 @@
   </div>
 
   <%= render DS::Popover.new(variant: "button") do |popover| %>
-    <% popover.with_button class: "flex items-center gap-1 hover:bg-alpha-black-25 cursor-pointer rounded-md p-2"  do %>
+    <% popover.with_button class: "flex items-center gap-1 hover:bg-surface-hover cursor-pointer rounded-md p-2"  do %>
       <span class="text-primary font-medium text-lg lg:text-base"><%= @budget.name %></span>
       <%= icon("chevron-down") %>
     <% end %>

--- a/app/views/budgets/_picker.html.erb
+++ b/app/views/budgets/_picker.html.erb
@@ -6,7 +6,7 @@
       <% last_month_of_previous_year = Date.new(year - 1, 12, 1) %>
 
       <% if Budget.budget_date_valid?(last_month_of_previous_year, family: family) %>
-        <%= link_to picker_budgets_path(year: year - 1), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+        <%= link_to picker_budgets_path(year: year - 1), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-surface-hover rounded-md" do %>
           <%= icon "chevron-left" %>
         <% end %>
       <% else %>
@@ -22,7 +22,7 @@
       <% first_month_of_next_year = Date.new(year + 1, 1, 1) %>
 
       <% if Budget.budget_date_valid?(first_month_of_next_year, family: family) %>
-        <%= link_to picker_budgets_path(year: year + 1), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-alpha-black-25 rounded-md" do %>
+        <%= link_to picker_budgets_path(year: year + 1), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-surface-hover rounded-md" do %>
           <%= icon "chevron-right" %>
         <% end %>
       <% else %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -101,7 +101,7 @@
           ) %>
 
           <% if @nav[:at_latest] %>
-            <button disabled aria-label="<%= t('reports.index.next_period') %>" class="text-subdued inline-flex items-center justify-center w-9 h-9 rounded-lg cursor-not-allowed">
+            <button disabled aria-label="<%= t("reports.index.next_period") %>" class="text-subdued inline-flex items-center justify-center w-9 h-9 rounded-lg cursor-not-allowed">
               <%= icon("chevron-right", color: "current") %>
             </button>
           <% else %>
@@ -116,7 +116,7 @@
 
         <% if [:monthly, :quarterly, :ytd].include?(@period_type) %>
           <%= render DS::Popover.new(variant: "button") do |popover| %>
-            <% popover.with_button class: "flex items-center gap-1 hover:bg-alpha-black-25 cursor-pointer rounded-md p-2" do %>
+            <% popover.with_button class: "flex items-center gap-1 hover:bg-surface-hover cursor-pointer rounded-md p-2" do %>
               <span class="text-primary font-medium text-lg lg:text-base"><%= @nav[:label] %></span>
               <%= icon("chevron-down") %>
             <% end %>


### PR DESCRIPTION
## Bug

The budget/report period **navigation triggers** — the `‹ ›` prev/next chevrons and the `Month ⌄` popover button — used `hover:bg-alpha-black-25`. That token is a **3% black overlay** (`--alpha(var(--color-black) / 3%)`), which is **invisible on dark surfaces**. So in dark mode these interactive controls had **no visible hover affordance** (your earlier note: "all interactive surfaces should indicate").

## Fix

Swap to the theme-aware `hover:bg-surface-hover` token already used by the settings nav:

| token | light | dark |
|---|---|---|
| `surface-hover` | `gray-100` | **`gray-800`** (visible) |
| ~~`alpha-black-25`~~ | black/3% | black/3% (**invisible**) |

4 occurrences across `budgets/_picker` (×2), `budgets/_budget_header`, `reports/index`.

## Verification
Token-level (above) — `surface-hover` resolves to a visible gray in both themes, vs the black-overlay it replaces; it's the exact token the settings nav already uses for dark-safe hover. (The state is a transient `:hover`, so no static screenshot.) erb_lint clean (also autocorrected a pre-existing single-quote in reports/index).

Scoped DS-wide sweep — a `grep` confirmed these were the only `(hover|focus|active):bg-alpha-black-*` interactive backgrounds in the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated hover background colors for interactive elements across budget and report interfaces, including popover trigger buttons and navigation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot — dark mode, trigger hovered

The `June 2026 ⌄` period trigger now shows a visible gray hover (`surface-hover` = `gray-800`, `rgb(36,36,36)`) on the dark page — previously `alpha-black-25` was invisible here. Verified live via `:hover` + computed style.

![dark hover](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2287-dark-hover.png)
