### PR TITLE
fix(ds): goals — uniform New-goal → grid spacing

### DIFF
--- a/app/views/goals/index.html.erb
+++ b/app/views/goals/index.html.erb
@@ -99,7 +99,7 @@
              data-goals-filter-empty-both-value="<%= t(".search.empty_with_both", query: "__QUERY__") %>"
              data-goals-filter-empty-default-value="<%= t(".search.empty") %>">
       <% if @linkable_account_count > 0 %>
-        <div class="flex items-center justify-end mb-3">
+        <div class="flex items-center justify-end mb-4">
           <%= render DS::Link.new(
             text: t(".new_goal"),
             variant: "primary",


### PR DESCRIPTION
## Fix

The goals **New-goal action row** used `mb-3`, but the **search row** below it uses `mb-4`. So the gap from the header area to the goals grid was **inconsistent depending on state**: `mb-4` when the search row renders, `mb-3` when it's hidden (New-goal becomes the last element before the grid). Bump New-goal to `mb-4` → uniform gap either way.

## Note on the rest of the spacing audit
The audit flagged four "state-dependent page-action gap" candidates; on inspection **only this one is real**:
- **providers/show** — the lede + Sync-all row already sits in a `space-y-4` parent, so it's *not* flush against the cards. No change.
- **budgets/show** — the header `mb-4` + mobile `budget_tabs` `mb-4` are **correct sequential gaps** for three stacked elements (header → tabs → categories), not a doubled gap. No change.
- **dashboard** — the empty-state picker gap can't be verified without an account-less family; left alone rather than guess.

(Your actual gap reports — exports nesting, SSO, rules — are handled separately: exports in #2279, SSO in #2246, rules in #2244/#2250.)

4px gap normalization — no meaningful screenshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing in the goals page header area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->