### PR TITLE
refactor(settings): debugs page onto settings_section

### DIFF
--- a/app/views/settings/debugs/show.html.erb
+++ b/app/views/settings/debugs/show.html.erb
@@ -1,12 +1,7 @@
 <%= content_for :page_title, t(".page_title") %>
 
 <div class="space-y-6">
-  <div class="bg-container rounded-xl shadow-border-xs p-4">
-    <h1 class="text-lg font-semibold text-primary"><%= t(".title") %></h1>
-    <p class="text-sm text-secondary mt-1"><%= t(".subtitle") %></p>
-  </div>
-
-  <div class="bg-container rounded-xl shadow-border-xs p-4">
+  <%= settings_section title: t(".title"), subtitle: t(".subtitle") do %>
     <%= form_with url: settings_debug_path, method: :get, class: "grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 items-end" do |f| %>
       <div>
         <%= f.label :category, t(".filters.category"), class: "block text-sm font-medium text-primary mb-1" %>
@@ -53,7 +48,7 @@
         <%= render DS::Link.new(text: t(".filters.reset"), href: settings_debug_path, variant: "ghost") %>
       </div>
     <% end %>
-  </div>
+  <% end %>
 
   <div class="bg-container rounded-xl shadow-border-xs overflow-hidden">
     <% if @debug_log_entries.any? %>


### PR DESCRIPTION
Part of the settings design-consistency pass.

## Change
The debug-log page hand-rolled its surfaces: a header card with a **second `<h1 font-semibold>`** (the layout already renders the page-title `<h1>`), then a separate filter card. Consolidate the header + filter into **one `settings_section(title:, subtitle:)`** — the canonical surface, with a proper `h2 font-medium` (fixes the heading-level + weight break and the redundant card).

The log **table stays an edge-to-edge `bg-container` card** on purpose — `settings_section`'s `p-4` would inset the table and float its `thead`.

## Deliberately deferred
- The filter form's **10× repeated input class strings** → a shared filter-field partial (bigger refactor).
- The bespoke empty state (`p-8 text-center`) → `DS::EmptyState` — needs #2143's component on `main` first.

## Verification
Page is **super-admin-gated** (`Admin::BaseController`); the demo user is `admin`, not super, so it isn't renderable here (no screenshot — same exemption as the managed-only payments page). Verified structurally: erb_lint clean, **headless ERB compile OK**, and a grep confirms no stray `<h1>` / `font-semibold` / bespoke header card remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved settings debug page template structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->