### PR TITLE
chore(i18n): remove dead transfers.form.* exchange-rate keys

### DIFF
--- a/config/locales/views/transfers/ca.yml
+++ b/config/locales/views/transfers/ca.yml
@@ -7,14 +7,10 @@ ca:
       success: Transferència eliminada
     form:
       amount: Import
-      calculate_rate_tab: Calcula la taxa de canvi
-      convert_tab: Converteix amb la taxa de canvi
       date: Data
       destination_amount: Import rebut
       destination_amount_display: 'Import rebut: %{amount}'
-      exchange_rate: Taxa de canvi
       exchange_rate_display: 'Taxa de canvi: %{rate}'
-      exchange_rate_help: Tria com introduir l'import de la transferència.
       expense: Despesa
       from: Des de
       income: Ingrés

--- a/config/locales/views/transfers/en.yml
+++ b/config/locales/views/transfers/en.yml
@@ -7,14 +7,10 @@ en:
       success: Transfer removed
     form:
       amount: Amount
-      calculate_rate_tab: Calculate FX rate
-      convert_tab: Convert with FX rate
       date: Date
       destination_amount: Destination amount
       destination_amount_display: "Destination amount: %{amount}"
-      exchange_rate: Exchange rate
       exchange_rate_display: "Exchange rate: %{rate}"
-      exchange_rate_help: Choose how to enter the transfer amount.
       expense: Expense
       from: From
       income: Income

--- a/config/locales/views/transfers/es.yml
+++ b/config/locales/views/transfers/es.yml
@@ -7,14 +7,10 @@ es:
       success: Transferencia eliminada
     form:
       amount: Importe
-      calculate_rate_tab: Calcular tasa
-      convert_tab: Convertir con tasa
       date: Fecha
       destination_amount: Importe de destino
       destination_amount_display: "Importe de destino: %{amount}"
-      exchange_rate: Tasa de cambio
       exchange_rate_display: "Tasa de cambio: %{rate}"
-      exchange_rate_help: Elige cómo introducir el importe de la transferencia.
       expense: Gasto
       from: Desde
       income: Ingreso

--- a/config/locales/views/transfers/fr.yml
+++ b/config/locales/views/transfers/fr.yml
@@ -7,14 +7,10 @@ fr:
       success: Transfert supprimé
     form:
       amount: Montant
-      calculate_rate_tab: Calculer le taux de change
-      convert_tab: Convertir avec taux de change
       date: Date
       destination_amount: Montant de destination
       destination_amount_display: "Montant de destination : %{amount}"
-      exchange_rate: Taux de change
       exchange_rate_display: "Taux de change : %{rate}"
-      exchange_rate_help: Choisissez comment saisir le montant du transfert.
       expense: Dépense
       from: De
       income: Revenu

--- a/config/locales/views/transfers/hu.yml
+++ b/config/locales/views/transfers/hu.yml
@@ -7,14 +7,10 @@ hu:
       success: Átutalás eltávolítva
     form:
       amount: Összeg
-      calculate_rate_tab: Árfolyam kiszámítása
-      convert_tab: Átváltás árfolyammal
       date: Dátum
       destination_amount: Célösszeg
       destination_amount_display: "Célösszeg: %{amount}"
-      exchange_rate: Árfolyam
       exchange_rate_display: "Árfolyam: %{rate}"
-      exchange_rate_help: Válaszd meg, hogyan adod meg az átutalás összegét.
       expense: Kiadás
       from: Honnan
       income: Bevétel

--- a/config/locales/views/transfers/vi.yml
+++ b/config/locales/views/transfers/vi.yml
@@ -7,14 +7,10 @@ vi:
       success: Chuyển khoản đã được xóa
     form:
       amount: Số tiền
-      calculate_rate_tab: Tính tỷ giá ngoại hối
-      convert_tab: Chuyển đổi với tỷ giá ngoại hối
       date: Ngày
       destination_amount: Số tiền đích
       destination_amount_display: "Số tiền đích: %{amount}"
-      exchange_rate: Tỷ giá
       exchange_rate_display: "Tỷ giá: %{rate}"
-      exchange_rate_help: Chọn cách nhập số tiền chuyển khoản.
       expense: Chi tiêu
       from: Từ
       income: Thu nhập


### PR DESCRIPTION
### Summary
The transfer and transaction forms render the exchange-rate tab UI via `shared.exchange_rate_tabs.*` exclusively, so four `transfers.form.*` keys are never looked up. This removes those dead keys from every locale file that carries them.

### Root cause
During the French-translation PR #1501 review, @andronedev identified that `transfers.form.{calculate_rate_tab, convert_tab, exchange_rate, exchange_rate_help}` were left behind when the exchange-rate tabs were extracted into the shared `shared/_exchange_rate_tabs` partial. `app/views/transfers/_form.html.erb` and `app/views/transactions/_form.html.erb` reference only `shared.exchange_rate_tabs.*`; nothing reads the `transfers.form.*` variants.

### Solution
Delete the four dead keys from the six locale files that carry them (`en, fr, es, ca, hu, vi`). Live siblings (`exchange_rate_display`, `destination_amount`, …) are left intact. No view or code changes — the keys are unreferenced. Follows prior i18n cleanup PRs (#1356, #644).

### Tests
- No runtime test: the keys are never rendered, so there is no observable behavior to assert.
- Verified with `bundle exec i18n-tasks unused` — the four keys are listed before and absent after.
- All six YAML files parse; `test/i18n_test.rb` loads every locale without error.
- `transfers_controller_test.rb` shows no new failures (the 2 `tailwind.css not found` errors are pre-existing/environmental).

### QA
N/A — locale-only cleanup; the affected UI renders from `shared.exchange_rate_tabs.*`, which is unchanged.

### Risks
None identified — removing i18n keys that no template references cannot change observable behavior.

### Checklist
- [x] Requirement confirmed against the issue
- [x] Root cause identified (dead `transfers.form.*` keys; views use `shared.exchange_rate_tabs.*`)
- [x] Smallest possible diff, scoped to one subsystem
- [x] Verified dead via `i18n-tasks unused` (no runtime test applicable)
- [x] rubocop clean; no Ruby/security surface touched
- [x] System tests N/A (no UI behavior change)
- [x] Conventions followed (no new dep, no app/services/, locale-only)
- [x] No competing/overlapping PR; targets `main`; allow-maintainer-edits enabled
- [x] Opened as draft

Fixes #1508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated transfer form text across Catalan, English, Spanish, French, Hungarian, and Vietnamese.
  * Simplified the exchange-rate section by removing localized labels/help for rate calculation and conversion, while keeping the existing date, destination amount, and exchange-rate display wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->