### PR TITLE
fix(mobile): regenerate stale Sure tokens on main

### DIFF
--- a/mobile/lib/theme/sure_tokens.dart
+++ b/mobile/lib/theme/sure_tokens.dart
@@ -33,7 +33,7 @@ class SureTokens {
     containerInsetHover: Color(0xFFF0F0F0),
     success: Color(0xFF078C52),
     warning: Color(0xFFDC6803),
-    destructive: Color(0xFFEC2222),
+    destructive: Color(0xFFF13636),
     destructiveSubtle: Color(0xFFFEB9B3),
     info: Color(0xFF1570EF),
     link: Color(0xFF1570EF),


### PR DESCRIPTION
Summary:
Regenerate mobile/lib/theme/sure_tokens.dart from the current canonical token JSON on main.

Why:
After #2237 merged, Mobile CI on main failed because the generated Flutter token file still had the old light destructive red (0xFFEC2222) while design/tokens/sure.tokens.json now resolves color.destructive to 0xFFF13636.

Verification:
- node mobile/tool/generate_sure_tokens.mjs --check
- The failing main run pointed at mobile/test/theme/sure_tokens_test.dart:40

This only syncs the generated file back to the canonical tokens already on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the destructive color used in error and warning states for improved visual refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->