### PR TITLE
Fix Plaid sync failure for loan subtypes missing from Loan::SUBTYPES

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -5,6 +5,9 @@ class Loan < ApplicationRecord
     "mortgage" => { short: "Mortgage", long: "Mortgage" },
     "student" => { short: "Student Loan", long: "Student Loan" },
     "auto" => { short: "Auto Loan", long: "Auto Loan" },
+    "home_equity" => { short: "Home Equity", long: "Home Equity Loan" },
+    "line_of_credit" => { short: "Line of Credit", long: "Line of Credit" },
+    "business" => { short: "Business Loan", long: "Business Loan" },
     "other" => { short: "Other Loan", long: "Other Loan" }
   }.freeze
 

--- a/test/models/plaid_account/type_mappable_test.rb
+++ b/test/models/plaid_account/type_mappable_test.rb
@@ -32,4 +32,18 @@ class PlaidAccount::TypeMappableTest < ActiveSupport::TestCase
     assert_equal "other", @mock_processor.map_subtype("depository", nil)
     assert_equal "other", @mock_processor.map_subtype("depository", "unknown")
   end
+
+  test "every mapped subtype is a valid subtype of its accountable" do
+    PlaidAccount::TypeMappable::TYPE_MAPPING.each do |plaid_type, config|
+      accountable_class = config[:accountable]
+      next unless accountable_class.const_defined?(:SUBTYPES)
+
+      config[:subtype_mapping].each do |plaid_subtype, subtype|
+        assert_includes accountable_class::SUBTYPES.keys, subtype,
+          "TYPE_MAPPING maps #{plaid_type}/#{plaid_subtype.inspect} to #{subtype.inspect}, " \
+          "which is not a valid #{accountable_class} subtype — syncing such an account fails " \
+          "with 'Validation failed: Accountable subtype is not included in the list'"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2297

## Problem

`PlaidAccount::TypeMappable` maps the Plaid loan subtypes `"home equity"`, `"line of credit"`, and `"business"` to `home_equity`, `line_of_credit`, and `business` — but `Loan::SUBTYPES` never defined them. Linking any such account (e.g. a HELOC that the institution reports as `loan / "line of credit"`) makes the item's first sync fail with:

```
Validation failed: Accountable subtype is not included in the list
```

Because Link itself succeeded, the failure is silent in the UI (the #1792 UX gap) — the user just never sees their accounts.

## Changes

- **`app/models/loan.rb`** — add the three missing subtypes to `Loan::SUBTYPES`: `home_equity` ("Home Equity Loan"), `line_of_credit` ("Line of Credit"), `business` ("Business Loan"). These are exactly the values the Plaid mapper already emits; the loan section was the only mapper/model mismatch in an audit of the full `TYPE_MAPPING`.
- **`test/models/plaid_account/type_mappable_test.rb`** — add a regression test walking the entire `TYPE_MAPPING` and asserting every emitted subtype is valid for its accountable, so the mapper and models can't silently drift apart again.

Follows the pattern of earlier subtype fixes (#1022, #923, #1036).

## Validation

- Reproduced with a real production Plaid item (First New York FCU HELOC reported as `loan / "line of credit"`): sync failed with the validation error above.
- With this change applied to a live self-hosted instance, the same item re-synced successfully; the HELOC account was created as Loan / Line of Credit with correct balance, and the new regression test fails on `main` / passes with this change.

## Attribution

This fix was diagnosed, written, and prepared with [Claude Code](https://claude.com/claude-code) running Anthropic's **Fable 5** model, with a human (repo owner) reviewing the diff and validating the fix against a live production Plaid connection before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for three new loan types: home equity loans, lines of credit, and business loans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->