### PR TITLE
feat: removed backup profile from docker compose yamls

### DIFF
--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -315,8 +315,6 @@ services:
       - sure_net
 
   backup:
-    profiles:
-      - backup
     image: prodrigestivill/postgres-backup-local
     restart: unless-stopped
     volumes:

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -120,8 +120,6 @@ services:
       - sure_net
 
   backup:
-    profiles:
-      - backup
     image: prodrigestivill/postgres-backup-local
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
The "backup" profile config was preventing the automatic backup service from being deployed when not using the backup profile, however, this isn't documented anywhere and seeing as these are plug & play example compose files, I suggest removing it entirely and leaving it up to the end user to keep or remove the entire service if they wish to disable backups, enabling the service by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated backup service configuration to be included in the default compose stack instead of being restricted to an optional profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->