### PR TITLE
fix(ds): shrink dialog close button to size sm

### DIFF
--- a/app/components/DS/dialog.rb
+++ b/app/components/DS/dialog.rb
@@ -142,6 +142,7 @@ class DS::Dialog < DesignSystemComponent
     classes = responsive? ? "ml-auto hidden lg:flex" : "ml-auto"
     render DS::Button.new(
       variant: "icon",
+      size: :sm,
       class: classes,
       icon: "x",
       title: I18n.t("ds.dialog.close"),


### PR DESCRIPTION
## What

The dialog close button used the default `:md` icon-button size — **44×44px box with a 20px glyph**. That's larger than the dialog's own action buttons (36px tall) and reads heavy next to the title.

## Change

`app/components/DS/dialog.rb` — pass `size: :sm` to the close button. Applies to **both modal and drawer** (shared `close_button`).

| | before | after |
|---|---|---|
| box | 44px (`w-11 h-11`) | **32px** (`w-8 h-8`) |
| glyph | 20px (`w-5 h-5`) | **16px** (`w-4 h-4`) |
| radius | `rounded-lg` | `rounded-md` |

## Accessibility

44px was the WCAG 2.5.5 (**AAA**) minimum touch target introduced in the DS::Button a11y audit (#1840). 32px relaxes that to **AA** — still clears WCAG 2.5.8 (AA, 24px min). Acceptable for a desktop dialog close control.

## Testing

- `rubocop` clean.
- No `DS::Dialog` component test exists (lookbook preview only); verified visually in lookbook.

## Screenshot

After (lookbook `Dialog / Modal`, dark) — 32px close button aligned with the title:

![PR 2309](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2309.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the dialog close (x) button to render at a smaller size for improved visual consistency and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Drawer variant

Per review feedback — drawer close button at the new `:sm` size, balanced against the title and footer action:

![PR 2309 drawer](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2309-drawer.png)
