### PR TITLE
fix(dashboard): apply two-column layout at xl breakpoint, not 2xl

### DIFF
--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -36,7 +36,7 @@
     </div>
   <% end %>
 
-  <div class="grid grid-cols-1 <%= "2xl:grid-cols-2" if Current.user.dashboard_two_column? %> gap-6 pb-6 lg:pb-12" data-controller="dashboard-sortable" data-action="dragover->dashboard-sortable#dragOver drop->dashboard-sortable#drop" role="list" aria-label="Dashboard sections">
+  <div class="grid grid-cols-1 <%= "xl:grid-cols-2" if Current.user.dashboard_two_column? %> gap-6 pb-6 lg:pb-12" data-controller="dashboard-sortable" data-action="dragover->dashboard-sortable#dragOver drop->dashboard-sortable#drop" role="list" aria-label="Dashboard sections">
   <% if accessible_accounts.any? %>
     <% @dashboard_sections.each do |section| %>
       <% next unless section[:visible] %>


### PR DESCRIPTION
## What

The dashboard **Two-column layout** preference (`settings/appearances`) had no visible effect on most screens — toggling it on did nothing.

## Cause

`app/views/pages/dashboard.html.erb` only applied `2xl:grid-cols-2`. Tailwind `2xl` is **≥1536px**, but the setting copy promises *"Display dashboard widgets in two columns on large screens."* Anything below 1536px (most laptops, ~1280–1440px) stayed single-column, so the toggle appeared dead.

## Fix

`2xl:grid-cols-2` → `xl:grid-cols-2` (**≥1280px**). Two columns now engage on standard desktops and larger laptops while widgets keep usable width; single-column below 1280px (where two side-by-side widgets would be cramped).

```diff
-  <div class="grid grid-cols-1 <%= "2xl:grid-cols-2" if Current.user.dashboard_two_column? %> gap-6 ...">
+  <div class="grid grid-cols-1 <%= "xl:grid-cols-2" if Current.user.dashboard_two_column? %> gap-6 ...">
```

## Testing

- `erb_lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the dashboard’s responsive grid so the two-column layout activates at the `xl` breakpoint (instead of `2xl`), improving readability and consistency across more screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot

Two-column dashboard at the `xl` breakpoint (1440px viewport, per-user opt-in enabled):

![PR 2310](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2310.png)
