### PR TITLE
fix(ds): normalize legacy tooltip spacing to one recipe

### DIFF
--- a/app/views/holdings/_missing_price_tooltip.html.erb
+++ b/app/views/holdings/_missing_price_tooltip.html.erb
@@ -3,7 +3,7 @@
     <%= icon "info", size: "sm", color: "current" %>
     <%= tag.span t(".missing_data"), class: "font-normal text-xs" %>
   </div>
-  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-2 rounded w-64">
+  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-2 rounded-md w-64">
     <div class="text-inverse">
       <%= t(".description") %>
     </div>

--- a/app/views/investments/_value_tooltip.html.erb
+++ b/app/views/investments/_value_tooltip.html.erb
@@ -2,7 +2,7 @@
 
 <div data-controller="tooltip" data-tooltip-placement-value="right" data-tooltip-offset-value=10 data-tooltip-cross-axis-value=50>
   <%= icon("info", size: "sm") %>
-  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-2 rounded w-64">
+  <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-2 rounded-md w-64">
     <div class="text-inverse">
       <%= t(".total_value_tooltip") %>
     </div>

--- a/app/views/settings/llm_usages/show.html.erb
+++ b/app/views/settings/llm_usages/show.html.erb
@@ -134,7 +134,7 @@
                         <%= icon "alert-circle", class: "w-4 h-4 text-red-600 theme-dark:text-red-400" %>
                         <span class="text-red-600 theme-dark:text-red-400 font-medium"><%= t(".failed") %></span>
                       </div>
-                      <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-3 rounded w-72 text-left break-words whitespace-normal shadow-lg hidden">
+                      <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-2 rounded-md w-64 text-left break-words whitespace-normal hidden">
                         <div class="text-inverse">
                           <% if usage.http_status_code.present? %>
                             <p class="text-xs mt-1 text-inverse opacity-70">HTTP Status: <%= usage.http_status_code %></p>

--- a/app/views/shared/_money_field.html.erb
+++ b/app/views/shared/_money_field.html.erb
@@ -22,7 +22,7 @@
       <div class="form-field__actions">
         <div data-controller="tooltip">
           <%= icon "help-circle", size: "sm", color: "default", class: "cursor-help" %>
-          <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-inverse text-sm p-2 rounded w-64">
+          <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-inverse text-sm p-2 rounded-md w-64">
             <%= options[:label_tooltip] %>
           </div>
         </div>


### PR DESCRIPTION
## What

The inline tooltips that use the legacy `data-controller="tooltip"` mechanism (i.e. **not** `DS::Tooltip`) had drifted apart in spacing/radius, and none matched the `DS::Tooltip` dark-bubble recipe (`px-1.5 py-1 rounded-md`).

## Before

| file | padding | radius | width | shadow |
|---|---|---|---|---|
| `holdings/_missing_price_tooltip` | `p-2` | `rounded` (4px) | `w-64` | — |
| `investments/_value_tooltip` | `p-2` | `rounded` | `w-64` | — |
| `shared/_money_field` | `p-2` | `rounded` | `w-64` | — |
| `settings/llm_usages/show` | **`p-3`** | `rounded` | **`w-72`** | **`shadow-lg`** |

Radius `rounded` (4px) everywhere vs DS::Tooltip's `rounded-md` (6px); one clear outlier with extra padding, width and a drop shadow.

## After

All four → **`p-2 rounded-md w-64`** (drop the lone `p-3` / `w-72` / `shadow-lg`). Radius now matches `DS::Tooltip`; the dark data-tooltips share one recipe.

## Out of scope (noted)

These tooltips still use the legacy hover-only `tooltip` controller (no keyboard/Esc/`aria-describedby`), unlike `DS::Tooltip`. Migrating them onto the accessible controller is a larger, separate change — not included here.

## Testing

- `erb_lint` clean on all four changed lines. (A pre-existing `_money_field.html.erb:78` lint nit is untouched / out of scope.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined tooltip UI across holdings, investments, settings, and shared money fields by updating border-radius styling (switching to a medium-rounded look).
  * Adjusted tooltip spacing and sizing for failed LLM usage rows, and removed extra shadow emphasis to keep the presentation consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot

`settings/llm_usage` failed-row tooltip showing a full OpenAI 429 body — the long error wraps cleanly inside the normalized `w-64` box (`break-words whitespace-normal` retained) and stays legible over the data-dense table:

![PR 2311](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2311.png)
