### PR TITLE
fix(ds): neutral text for goals status callout

### DIFF
--- a/app/views/goals/_status_callout.html.erb
+++ b/app/views/goals/_status_callout.html.erb
@@ -4,11 +4,11 @@
 
   variant_classes = case goal.status
                     when :behind
-                      "bg-warning/10 border-warning/20 text-warning"
+                      "bg-warning/10 border-warning/20"
                     when :on_track
-                      "bg-success/10 border-success/20 text-success"
+                      "bg-success/10 border-success/20"
                     else
-                      "bg-surface-inset border-secondary text-secondary"
+                      "bg-surface-inset border-secondary"
                     end
 
   icon_glyph = case goal.status
@@ -18,10 +18,16 @@
                else "info"
                end
 
+  icon_color = case goal.status
+               when :behind then "warning"
+               when :on_track then "success"
+               else "default"
+               end
+
   label = t("goals.status.#{goal.status}", default: goal.status.to_s.titleize)
 %>
-<div class="rounded-lg border px-3 py-2 text-sm flex items-center gap-2 <%= variant_classes %>">
-  <span class="shrink-0"><%= icon(icon_glyph, size: "sm") %></span>
+<div class="rounded-lg border px-3 py-2 text-sm flex items-center gap-2 text-primary <%= variant_classes %>">
+  <span class="shrink-0"><%= icon(icon_glyph, size: "sm", color: icon_color) %></span>
   <span class="font-medium"><%= label %></span>
   <span class="opacity-60">·</span>
   <span class="opacity-90 <%= "privacy-sensitive" if goal.status == :behind %>"><%= context %></span>


### PR DESCRIPTION
## What

The goals status callout (`app/views/goals/_status_callout.html.erb`) rendered its **entire body** in the status color — a "behind" goal showed a yellow icon **and** yellow label **and** yellow context text.

## Why it's wrong

Every other tinted box in the app follows the `DS::Alert` recipe: the tint (`bg-*/10 border-*/20`) carries the semantic, the body text stays **neutral** (`text-primary`), and only the **icon** gets the status color. This callout was the odd one out with fully colored text.

## Fix

- Drop `text-warning` / `text-success` / `text-secondary` from `variant_classes`.
- Add `text-primary` on the container.
- Add an `icon_color` (`warning` / `success` / `default`) and pass it to the icon.

Net result: same tinted box + status-colored icon, but the label and context text are now neutral — matching `DS::Alert` and the rest of the app.

## Testing

- `erb_lint` clean.
- No screenshot: the callout isn't a lookbook component and rendering it needs a goal with a `behind`/`on_track` status + data. Change verified by token inspection (see diff).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Status callout icons now display with explicit colors matching their status (warning, success, default) for improved visual clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot

"Behind" status callout — body text is now neutral (`text-primary`) while the icon keeps the semantic warning colour:

![PR 2312](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2312.png)
