### PR TITLE
fix(dashboard): align sankey zoom-out button with section header

### DIFF
--- a/app/views/pages/dashboard/_cashflow_sankey_chart.html.erb
+++ b/app/views/pages/dashboard/_cashflow_sankey_chart.html.erb
@@ -6,7 +6,7 @@
   data-sankey-chart-start-date-value="<%= period.start_date&.iso8601 %>"
   data-sankey-chart-end-date-value="<%= period.end_date&.iso8601 %>"
   class="w-full h-full privacy-sensitive flex flex-col gap-2">
-  <div class="flex justify-start">
+  <div class="flex justify-start px-4">
     <%= render DS::Button.new(
       variant: :icon,
       icon: "arrow-left",


### PR DESCRIPTION
## What

When you zoom into a category in the dashboard cashflow sankey, the "Back to full cashflow" zoom-out button appears **flush against the card's left edge**, 16px out of line with the section header title above it (and with the rest of the dashboard widgets).

## Cause

The dashboard section body is `<div class="py-4">` — **vertical padding only, no horizontal**. Each widget supplies its own horizontal inset. The sankey button row was bare:

```erb
<div class="flex justify-start">   <!-- no px -->
```

so it sat at x=0 of the card. The sibling `_net_worth_chart` widget aligns its top row with `px-4`; the sankey button row was the outlier.

## Fix

Add `px-4` to the button row so it lines up with the section header and the other widgets:

```diff
-  <div class="flex justify-start">
+  <div class="flex justify-start px-4">
```

The chart itself stays full-bleed (intentional for the viz); only the floating control is aligned.

## Notes

- Couldn't capture a screenshot locally (needs an account with cashflow data + a drill-down to reveal the button). Fix verified against the `_net_worth_chart` `px-4` convention. **If you actually want the button somewhere else** (e.g. top-right with the expand control), say so and I'll move it instead.
- The button is also a 44px `:icon` md button — if it feels chunky like the dialog close was, I can add `size: :sm` here too. Left out for now since the report was about positioning.

## Testing

- `erb_lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the cash flow Sankey chart layout by adjusting its wrapper padding for improved spacing and visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshot

Cashflow sankey with the zoom-out control revealed — its left edge now aligns with the "Cashflow" section header (`px-4`):

![PR 2313](https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2313.png)
