### PR TITLE
fix(chat): clear assistant bubble on destroy so the chat doesn't hang on Thinking

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,10 +12,7 @@ class Message < ApplicationRecord
 
   after_create_commit -> { broadcast_append_to chat, target: chat.messages_target }, if: :broadcast?
   after_update_commit -> { broadcast_update_to chat }, if: :broadcast?
-  # Without this, a destroyed message leaves its rendered bubble on the page.
-  # The assistant demotes/destroys the streamed-nothing message when a provider
-  # call fails before any text arrives (see `Assistant::Builtin#respond_to`), so
-  # the pending "Thinking…" bubble would otherwise hang there forever.
+  # Clears the "Thinking…" bubble if the provider errors before any text streams.
   after_destroy_commit -> { broadcast_remove_to chat }, if: :broadcast?
 
   scope :ordered, -> { order(created_at: :asc) }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,6 +12,11 @@ class Message < ApplicationRecord
 
   after_create_commit -> { broadcast_append_to chat, target: chat.messages_target }, if: :broadcast?
   after_update_commit -> { broadcast_update_to chat }, if: :broadcast?
+  # Without this, a destroyed message leaves its rendered bubble on the page.
+  # The assistant demotes/destroys the streamed-nothing message when a provider
+  # call fails before any text arrives (see `Assistant::Builtin#respond_to`), so
+  # the pending "Thinking…" bubble would otherwise hang there forever.
+  after_destroy_commit -> { broadcast_remove_to chat }, if: :broadcast?
 
   scope :ordered, -> { order(created_at: :asc) }
 

--- a/test/models/assistant_message_test.rb
+++ b/test/models/assistant_message_test.rb
@@ -16,4 +16,13 @@ class AssistantMessageTest < ActiveSupport::TestCase
     assert_equal "update", streams.last["action"]
     assert_equal "assistant_message_#{message.id}", streams.last["target"]
   end
+
+  test "broadcasts remove after destroy so a failed turn's bubble is cleared" do
+    message = AssistantMessage.create!(chat: @chat, content: "Hello from assistant", ai_model: "gpt-4.1")
+    message.destroy!
+
+    streams = capture_turbo_stream_broadcasts(@chat)
+    assert_equal "remove", streams.last["action"]
+    assert_equal "assistant_message_#{message.id}", streams.last["target"]
+  end
 end


### PR DESCRIPTION
## What

The AI chat could get **stuck on "Thinking…" forever** when an assistant turn failed.

## Why

`chat#ask_assistant_later` creates a **persisted, pending** `AssistantMessage` and broadcasts it — that's the "Thinking…" bubble (`_assistant_message.html.erb` renders the pulse while `pending?`). The job then runs `Assistant::Builtin#respond_to`.

If the provider call errors **before any text streams** (blank content) — e.g. an Anthropic/OpenAI auth, model, rate-limit or network error on the first request — the rescue **destroys** that pending message:

```ruby
rescue => e
  if assistant_message&.persisted?
    if assistant_message.content.blank?
      assistant_message.destroy        # <- blank turn is destroyed
    else
      assistant_message.update_columns(status: "failed")
    end
  end
  chat.add_error(e)
end
```

But `Message` only broadcast on **create** and **update** — never on **destroy**:

```ruby
after_create_commit -> { broadcast_append_to chat, target: chat.messages_target }, if: :broadcast?
after_update_commit -> { broadcast_update_to chat }, if: :broadcast?
```

So the bubble's DOM element is never removed. The job has already failed (and `chat#add_error` appends an error below), yet the "Thinking…" pulse hangs there indefinitely.

## Fix

Broadcast a remove when a message is destroyed:

```ruby
after_destroy_commit -> { broadcast_remove_to chat }, if: :broadcast?
```

Now a failed-before-streaming turn clears its bubble; the appended error message is what remains.

## Scope

This fixes the **stuck-UI** symptom for any destroyed message. It does **not** change *why* a turn errors — that's provider config (model id vs configured provider, API key, rate limits). Worth checking `Chat#error` / Sidekiq logs for the underlying provider error separately.

## Testing

- New model test: `AssistantMessage` broadcasts a `remove` (targeting the message dom_id) on destroy.
- `bin/rails test test/models/assistant_message_test.rb` → 2 runs, 7 assertions, 0 failures.
- `rubocop` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted chat messages now reliably disappear from the live chat interface immediately after removal, including when message streaming fails and the “Thinking…” state would otherwise linger.

* **Tests**
  * Added coverage to verify that destroying an assistant message triggers the correct live-update event to remove the message from the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->