### PR TITLE
perf(activity): index transfers by transaction in activity feed

### DIFF
--- a/app/models/account/activity_feed_data.rb
+++ b/app/models/account/activity_feed_data.rb
@@ -57,17 +57,19 @@ class Account::ActivityFeedData
           .or(Transfer.where(outflow_transaction_id: transaction_ids))
           .to_a
 
-        # Group transfers by the date of their transaction entries
+        transfers_by_transaction_id = Hash.new { |hash, key| hash[key] = [] }
+        transfers.each do |transfer|
+          transfers_by_transaction_id[transfer.inflow_transaction_id] << transfer
+          transfers_by_transaction_id[transfer.outflow_transaction_id] << transfer
+        end
+
         result = Hash.new { |h, k| h[k] = [] }
 
         entries.each do |entry|
-          next unless entry.transaction? && transaction_ids.include?(entry.entryable_id)
+          next unless entry.transaction?
 
-          transfers.each do |transfer|
-            if transfer.inflow_transaction_id == entry.entryable_id ||
-               transfer.outflow_transaction_id == entry.entryable_id
-              result[entry.date] << transfer
-            end
+          transfers_by_transaction_id[entry.entryable_id].each do |transfer|
+            result[entry.date] << transfer
           end
         end
 


### PR DESCRIPTION
## Summary

Replace nested entry/transfer scans in `Account::ActivityFeedData` with a transaction-id lookup map when grouping transfers by activity date.

## Test plan

- [x] Existing `Account::ActivityFeedDataTest` transfer coverage
- [ ] `bin/rails test test/models/account/activity_feed_data_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal performance optimization for activity feed data retrieval through enhanced data indexing and lookup mechanisms. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->