### PR TITLE
perf(api): preload associations for transaction show

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -207,6 +207,12 @@ end
       @transaction = family.transactions
         .joins(entry: :account)
         .merge(Account.accessible_by(current_resource_owner))
+        .includes(
+          { entry: :account },
+          :category, :merchant, :tags,
+          transfer_as_outflow: { inflow_transaction: { entry: :account } },
+          transfer_as_inflow: { outflow_transaction: { entry: :account } }
+        )
         .find(params[:id])
       @entry = @transaction.entry
     rescue ActiveRecord::RecordNotFound

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -206,6 +206,19 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert response_data.key?("account")
   end
 
+  test "show preloads transaction associations without extra category queries" do
+    category = @family.categories.create!(name: "Food", color: "#000000", lucide_icon: "shapes")
+    @transaction.update!(category: category)
+
+    queries = capture_sql_queries do
+      get api_v1_transaction_url(@transaction), headers: api_headers(@api_key)
+    end
+
+    assert_response :success
+    category_queries = queries.grep(/FROM "categories"/i)
+    assert_equal 1, category_queries.size
+  end
+
   test "should show transaction with read-only API key" do
     get api_v1_transaction_url(@transaction), headers: api_headers(@read_only_api_key)
     assert_response :success
@@ -803,5 +816,21 @@ end
       )
 
       entry.transaction
+    end
+
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
     end
 end


### PR DESCRIPTION
## Summary

Eager-load the same transaction associations used by the API index response so `show` avoids category, merchant, tag, and transfer lookups.

## Test plan

- [x] Added SQL regression test for category lookups
- [ ] `bin/rails test test/controllers/api/v1/transactions_controller_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized transaction API endpoints to load related data more efficiently, improving response times.

* **Tests**
  * Added verification tests for transaction data loading performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->