### PR TITLE
perf(reports): avoid category lazy loads in subcategory?

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -243,7 +243,7 @@ class Category < ApplicationRecord
   end
 
   def subcategory?
-    parent.present?
+    parent_id.present?
   end
 
   def name_with_parent

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -43,6 +43,17 @@ class CategoryTest < ActiveSupport::TestCase
     assert_equal subcategory, transaction.reload.category
   end
 
+  test "subcategory? checks parent_id without loading parent" do
+    category = categories(:subcategory)
+    category.update_column(:parent_id, categories(:food_and_drink).id)
+
+    queries = capture_sql_queries do
+      assert category.subcategory?
+    end
+
+    assert_empty queries.grep(/FROM "categories"/i)
+  end
+
   test "subcategory can only be one level deep" do
     category = categories(:subcategory)
 
@@ -77,4 +88,21 @@ class CategoryTest < ActiveSupport::TestCase
       assert_includes category.errors[:color], "is invalid"
     end
   end
+
+  private
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
+    end
 end


### PR DESCRIPTION
## Summary

Repurposed after overlap review with #2255.

The categories API partial now checks `parent_id` instead of `parent.present?` so preloaded index rows do not trigger parent association loads during JSON rendering.

## Relation to #2255

#2255 covers web reports category preloads. This PR targets the API categories JSON path only.

## Test plan

- [x] Added SQL regression test on API categories index
- [ ] `bin/rails test test/controllers/api/v1/categories_controller_test.rb`
