### PR TITLE
perf(reports): preload category parents in income statement

### DIFF
--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -134,7 +134,7 @@ class IncomeStatement
     NetCategoryTotals = Data.define(:net_expense_categories, :net_income_categories, :total_net_expense, :total_net_income, :currency)
 
     def categories
-      @categories ||= family.categories.all.to_a
+      @categories ||= family.categories.includes(:parent).all.to_a
     end
 
     def period_cache_key(period)

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -20,6 +20,14 @@ class IncomeStatementTest < ActiveSupport::TestCase
     create_transaction(account: @credit_card_account, amount: 400, category: @groceries_category)
   end
 
+  test "categories preload parent associations" do
+    income_statement = IncomeStatement.new(@family)
+
+    categories = income_statement.send(:categories)
+
+    assert categories.all? { |category| category.association(:parent).loaded? || category.parent_id.nil? }
+  end
+
   test "calculates totals for transactions" do
     income_statement = IncomeStatement.new(@family)
     totals = income_statement.totals(date_range: Period.last_30_days.date_range)


### PR DESCRIPTION
## Summary

Eager-load parent categories when caching family categories for report totals.

## Test plan

- [x] Added association preload test
- [ ] `bin/rails test test/models/income_statement_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify parent associations are preloaded when loading categories.

* **Refactor**
  * Updated category loading mechanism in income statement to include parent associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->