### PR TITLE
perf(accounts): batch SimpleFIN unlinked account counts

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -285,17 +285,25 @@ class AccountsController < ApplicationController
       @simplefin_show_relink_map = {}
       @simplefin_duplicate_only_map = {}
 
+      simplefin_item_ids = @simplefin_items.map(&:id)
+      unlinked_counts_by_item_id = if simplefin_item_ids.empty?
+        {}
+      else
+        SimplefinAccount
+          .where(simplefin_item_id: simplefin_item_ids)
+          .left_joins(:account, :account_provider)
+          .where(accounts: { id: nil }, account_providers: { id: nil })
+          .group(:simplefin_item_id)
+          .count
+      end
+
       @simplefin_items.each do |item|
         latest_sync = item.syncs.ordered.first
         stats = latest_sync&.sync_stats || {}
         @simplefin_sync_stats_map[item.id] = stats
         @simplefin_has_unlinked_map[item.id] = item.family.accounts.listable_manual.exists?
 
-        # Count unlinked accounts
-        count = item.simplefin_accounts
-          .left_joins(:account, :account_provider)
-          .where(accounts: { id: nil }, account_providers: { id: nil })
-          .count
+        count = unlinked_counts_by_item_id[item.id].to_i
         @simplefin_unlinked_count_map[item.id] = count
 
         # CTA visibility

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -383,6 +383,19 @@ class AccountsControllerSimplefinCtaTest < ActionDispatch::IntegrationTest
     @family = families(:dylan_family)
   end
 
+  test "index batches SimpleFIN unlinked account counts" do
+    2.times do |idx|
+      item = SimplefinItem.create!(family: @family, name: "Conn#{idx}", access_url: "https://example.com/access#{idx}")
+      item.simplefin_accounts.create!(name: "Unlinked #{idx}", account_id: "sf_#{idx}", currency: "USD", current_balance: 1, account_type: "depository")
+    end
+
+    queries = capture_sql_queries { get accounts_path }
+
+    assert_response :success
+    count_queries = queries.grep(/SELECT COUNT\(\*\) .*simplefin_accounts/i)
+    assert_equal 1, count_queries.size
+  end
+
   test "when unlinked SFAs exist and manuals exist, shows setup button only" do
     item = SimplefinItem.create!(family: @family, name: "Conn", access_url: "https://example.com/access")
     # Unlinked SFA (no account and no provider link)
@@ -423,4 +436,21 @@ class AccountsControllerSimplefinCtaTest < ActionDispatch::IntegrationTest
     refute_includes @response.body, setup_accounts_simplefin_item_path(item)
     refute_includes @response.body, "Link existing accounts"
   end
+
+  private
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
+    end
 end


### PR DESCRIPTION
## Summary

Load unlinked SimpleFIN account counts in one grouped query on the accounts index instead of issuing a COUNT query per connection item.

## Test plan

- [x] Added controller SQL regression test
- [ ] `bin/rails test test/controllers/accounts_controller_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved efficiency of SimpleFIN account data retrieval through database query optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->