### PR TITLE
perf(api): preload activity securities on transaction index

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -37,6 +37,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
       page: safe_page_param,
       limit: safe_per_page_param
     )
+    Transaction::ActivitySecurityPreloader.new(@transactions).preload
 
     # Make per_page available to the template
     @per_page = safe_per_page_param

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -187,6 +187,13 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test "index preloads activity securities for transactions" do
+    Transaction::ActivitySecurityPreloader.any_instance.expects(:preload).once
+
+    get api_v1_transactions_url, headers: api_headers(@api_key)
+    assert_response :success
+  end
+
   test "should reject index request with invalid API key" do
     get api_v1_transactions_url, headers: { "X-Api-Key" => "invalid-key" }
     assert_response :unauthorized


### PR DESCRIPTION
## Summary

Reuse `Transaction::ActivitySecurityPreloader` on the API index path so investment transaction responses avoid per-row security lookups.

## Test plan

- [x] Added controller expectation test
- [ ] `bin/rails test test/controllers/api/v1/transactions_controller_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to verify transaction data is properly preloaded when accessing the transactions API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->