### PR TITLE
perf(api): avoid parent lookups in category JSON partial

### DIFF
--- a/app/views/api/v1/categories/_category.json.jbuilder
+++ b/app/views/api/v1/categories/_category.json.jbuilder
@@ -6,10 +6,10 @@ json.color category.color
 json.icon category.lucide_icon
 
 # Parent information (for subcategories)
-if category.parent.present?
+if category.parent_id.present?
   json.parent do
-    json.id category.parent.id
-    json.name category.parent.name
+    json.id category.parent_id
+    json.name category.parent&.name
   end
 else
   json.parent nil

--- a/test/controllers/api/v1/categories_controller_test.rb
+++ b/test/controllers/api/v1/categories_controller_test.rb
@@ -62,6 +62,19 @@ class Api::V1::CategoriesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes category_names, @category.name
   end
 
+  test "index avoids parent association lookups when categories are preloaded" do
+    parent = @user.family.categories.create!(name: "Parent API", color: "#000000", lucide_icon: "shapes")
+    @user.family.categories.create!(name: "Child API", color: "#111111", lucide_icon: "shapes", parent: parent)
+
+    queries = capture_sql_queries do
+      get "/api/v1/categories", params: {}, headers: api_headers(read_only_api_key)
+    end
+
+    assert_response :success
+    parent_lookup_queries = queries.grep(/FROM "categories".*WHERE "categories"\."id"/i)
+    assert_empty parent_lookup_queries
+  end
+
   test "should return proper category data structure" do
     get "/api/v1/categories", params: {}, headers: api_headers(read_only_api_key)
 
@@ -306,6 +319,22 @@ class Api::V1::CategoriesControllerTest < ActionDispatch::IntegrationTest
         scopes: %w[read],
         source: "mobile"
       )
+    end
+
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
     end
 
     def api_headers(api_key)


### PR DESCRIPTION
## Summary

Repurposed from #2322 after overlap review with #2255.

The categories API partial now checks `parent_id` instead of `parent.present?` so preloaded index rows do not trigger parent association loads during JSON rendering.

## Relation to #2255

#2255 covers web reports category preloads. This PR targets the API categories JSON path only.

## Test plan

- [x] Added SQL regression test on API categories index
- [ ] `bin/rails test test/controllers/api/v1/categories_controller_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized category API response serialization by adjusting how parent category data is determined and rendered, reducing unnecessary parent association lookups.

* **Tests**
  * Added coverage to verify the category listing endpoint avoids extra parent association queries when categories are preloaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->