### PR TITLE
perf(accounts): hoist SimpleFIN manual-account existence check

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -285,11 +285,13 @@ class AccountsController < ApplicationController
       @simplefin_show_relink_map = {}
       @simplefin_duplicate_only_map = {}
 
+      family_has_manual_accounts = family.accounts.listable_manual.exists?
+
       @simplefin_items.each do |item|
         latest_sync = item.syncs.ordered.first
         stats = latest_sync&.sync_stats || {}
         @simplefin_sync_stats_map[item.id] = stats
-        @simplefin_has_unlinked_map[item.id] = item.family.accounts.listable_manual.exists?
+        @simplefin_has_unlinked_map[item.id] = family_has_manual_accounts
 
         # Count unlinked accounts
         count = item.simplefin_accounts

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -383,6 +383,19 @@ class AccountsControllerSimplefinCtaTest < ActionDispatch::IntegrationTest
     @family = families(:dylan_family)
   end
 
+  test "index batches manual-account existence check for SimpleFIN items" do
+    2.times do |idx|
+      item = SimplefinItem.create!(family: @family, name: "Conn#{idx}", access_url: "https://example.com/access#{idx}")
+      item.simplefin_accounts.create!(name: "Unlinked #{idx}", account_id: "sf_#{idx}", currency: "USD", current_balance: 1, account_type: "depository")
+    end
+
+    queries = capture_sql_queries { get accounts_path }
+
+    assert_response :success
+    manual_exists_queries = queries.grep(/FROM "accounts".*listable_manual/i)
+    assert_equal 1, manual_exists_queries.size
+  end
+
   test "when unlinked SFAs exist and manuals exist, shows setup button only" do
     item = SimplefinItem.create!(family: @family, name: "Conn", access_url: "https://example.com/access")
     # Unlinked SFA (no account and no provider link)
@@ -423,4 +436,21 @@ class AccountsControllerSimplefinCtaTest < ActionDispatch::IntegrationTest
     refute_includes @response.body, setup_accounts_simplefin_item_path(item)
     refute_includes @response.body, "Link existing accounts"
   end
+
+  private
+    def capture_sql_queries
+      queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached]
+        next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+        queries << payload[:sql].squish
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      queries
+    end
 end


### PR DESCRIPTION
## Summary

Repurposed from #2323 after overlap review with #2255.

Compute `listable_manual` account presence once per accounts index request instead of repeating `EXISTS` for every SimpleFIN connection item.

## Relation to other PRs

- Complements #2324 (batched unlinked SFA counts)
- Does not overlap #2255 reports category changes

## Test plan

- [x] Added SQL regression test on accounts index
- [ ] `bin/rails test test/controllers/accounts_controller_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  - Improved efficiency of account synchronization status checks by computing manual-account availability once and reusing it across displayed SimpleFIN sync statuses.

* **Tests**
  - Added an integration test that verifies the optimized batching behavior by asserting only a single “manual account existence” database check is performed during the accounts index request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->