### PR TITLE
fix(ds): canonical separators and destructive tokens in usage/rules tables

### DIFF
--- a/app/views/rules/index.html.erb
+++ b/app/views/rules/index.html.erb
@@ -133,9 +133,9 @@
             </th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-100">
+        <tbody class="divide-y divide-alpha-black-200 theme-dark:divide-alpha-white-200">
           <% @recent_runs.each do |run| %>
-            <tr class="<%= "bg-red-50 theme-dark:bg-red-950/30" if run.failed? %>">
+            <tr class="<%= "bg-red-tint-5 theme-dark:bg-red-tint-10" if run.failed? %>">
               <td class="px-4 py-3 text-sm text-primary whitespace-nowrap">
                 <%= run.executed_at.strftime("%b %d, %Y %I:%M %p") %>
               </td>
@@ -155,7 +155,7 @@
                   <% end %>
                   <% if run.failed? && run.error_message.present? %>
                     <div data-controller="tooltip" data-tooltip-content-value="<%= run.error_message %>">
-                      <%= icon("info", size: "sm", class: "text-red-500") %>
+                      <%= icon("info", size: "sm", color: "destructive") %>
                     </div>
                   <% end %>
                 </div>

--- a/app/views/settings/llm_usages/show.html.erb
+++ b/app/views/settings/llm_usages/show.html.erb
@@ -115,9 +115,9 @@
               <th class="px-4 py-3 text-right text-xs font-medium text-secondary uppercase"><%= t(".col_cost") %></th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-100">
+          <tbody class="divide-y divide-alpha-black-200 theme-dark:divide-alpha-white-200">
             <% @llm_usages.each do |usage| %>
-              <tr class="<%= "bg-red-50 theme-dark:bg-red-950/30" if usage.failed? %>">
+              <tr class="<%= "bg-red-tint-5 theme-dark:bg-red-tint-10" if usage.failed? %>">
                 <td class="px-4 py-3 text-sm text-primary whitespace-nowrap">
                   <%= usage.created_at.strftime("%b %d, %Y %I:%M %p") %>
                 </td>
@@ -131,8 +131,8 @@
                   <% if usage.failed? %>
                     <div data-controller="tooltip" class="inline-flex justify-end">
                       <div class="inline-flex items-center gap-1 cursor-help">
-                        <%= icon "alert-circle", class: "w-4 h-4 text-red-600 theme-dark:text-red-400" %>
-                        <span class="text-red-600 theme-dark:text-red-400 font-medium"><%= t(".failed") %></span>
+                        <%= icon "alert-circle", size: "sm", color: "destructive" %>
+                        <span class="text-destructive font-medium"><%= t(".failed") %></span>
                       </div>
                       <div role="tooltip" data-tooltip-target="tooltip" class="tooltip bg-inverse text-sm p-3 rounded w-72 text-left break-words whitespace-normal shadow-lg hidden">
                         <div class="text-inverse">


### PR DESCRIPTION
## Problem

The **LLM usage** table (Settings → AI usage) and the **rules recent-runs** table use hardcoded color classes instead of design-system tokens:

- `divide-gray-100` row separators — a fixed light gray with **no dark-theme variant**, so the dividers render wrong in dark mode (reported).
- Raw reds for failed rows (`bg-red-50` / `bg-red-950/30`, `text-red-500/600`).

Every other table in the app (`settings/debugs`, `admin/users`, …) uses the canonical alpha dividers + `text-destructive`. These two pages are the only `divide-gray-100` users.

## Fix

Token-only swap in `app/views/settings/llm_usages/show.html.erb` and `app/views/rules/index.html.erb`:

| Non-canon | Canonical |
|---|---|
| `divide-gray-100` | `divide-alpha-black-200 theme-dark:divide-alpha-white-200` |
| `bg-red-50 theme-dark:bg-red-950/30` | `bg-red-tint-5 theme-dark:bg-red-tint-10` |
| `text-red-600 theme-dark:text-red-400` | `text-destructive` |
| `icon(…, class: "text-red-500")` | `icon(…, color: "destructive")` |

No structural or behavior change.

## Test plan

- `erb_lint` — clean.
- Canonical classes verified against existing usage + design-system source.
- Note: screenshots omitted — these tables are empty in demo data (no LLM usage / rule runs), so the fix isn't visible without seeded data. The change matches the canonical pattern used by populated tables elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated “Recent Runs” and “Recent Usage” table styling to improve dark mode support, including divider colors and failed-row backgrounds.
  * Refined error state indicators by switching tooltip/label styling to a consistent “destructive” color scheme for improved visibility and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->