### PR TITLE
fix(sync): discover nightly provider items reflectively

### DIFF
--- a/app/models/family/syncer.rb
+++ b/app/models/family/syncer.rb
@@ -1,29 +1,6 @@
 class Family::Syncer
   attr_reader :family
 
-  # Registry of item association names that participate in family sync.
-  # Each model must:
-  #   1. Include Syncable
-  #   2. Define a `syncable` scope (items ready for auto-sync)
-  #
-  # To add a new provider: add its association name here.
-  # The model handles its own "ready to sync" logic via the syncable scope.
-  SYNCABLE_ITEM_ASSOCIATIONS = %i[
-    plaid_items
-    simplefin_items
-    lunchflow_items
-    akahu_items
-    enable_banking_items
-    indexa_capital_items
-    coinbase_items
-    coinstats_items
-    mercury_items
-    brex_items
-    binance_items
-    snaptrade_items
-    sophtron_items
-  ].freeze
-
   def initialize(family)
     @family = family
   end
@@ -49,14 +26,25 @@ class Family::Syncer
 
   private
 
-    # Collects all syncable items from registered providers + manual accounts.
-    # Each provider model defines its own `syncable` scope that encapsulates
-    # the "ready to sync" business logic (active, configured, etc.)
+    # Collect all syncable provider items via reflection so new `*_items`
+    # integrations participate in nightly family sync as soon as they include
+    # Syncable and expose a `syncable` scope.
     def child_syncables
-      provider_items = SYNCABLE_ITEM_ASSOCIATIONS.flat_map do |association|
+      provider_items = syncable_item_associations.flat_map do |association|
         family.public_send(association).syncable
       end
 
       provider_items + family.accounts.manual
+    end
+
+    def syncable_item_associations
+      Family.reflect_on_all_associations(:has_many).filter_map do |association|
+        next unless association.name.to_s.end_with?("_items")
+        next unless association.klass.included_modules.include?(Syncable)
+
+        association.name
+      rescue NameError
+        nil
+      end
     end
 end

--- a/test/models/family/syncer_test.rb
+++ b/test/models/family/syncer_test.rb
@@ -14,11 +14,6 @@ class Family::SyncerTest < ActiveSupport::TestCase
     )
 
     manual_accounts_count = @family.accounts.manual.count
-    plaid_items_count = @family.plaid_items.syncable.count
-    brex_items_count = @family.brex_items.syncable.count
-    akahu_items_count = @family.akahu_items.syncable.count
-    binance_items_count = @family.binance_items.syncable.count
-
     syncer = Family::Syncer.new(@family)
 
     Account.any_instance
@@ -26,29 +21,35 @@ class Family::SyncerTest < ActiveSupport::TestCase
            .with(parent_sync: family_sync, window_start_date: nil, window_end_date: nil)
            .times(manual_accounts_count)
 
-    PlaidItem.any_instance
-               .expects(:sync_later)
-               .with(parent_sync: family_sync, window_start_date: nil, window_end_date: nil)
-               .times(plaid_items_count)
-
-    BrexItem.any_instance
-            .expects(:sync_later)
-            .with(parent_sync: family_sync, window_start_date: nil, window_end_date: nil)
-            .times(brex_items_count)
-
-    AkahuItem.any_instance
-             .expects(:sync_later)
-             .with(parent_sync: family_sync, window_start_date: nil, window_end_date: nil)
-             .times(akahu_items_count)
-
-    BinanceItem.any_instance
-               .expects(:sync_later)
-               .with(parent_sync: family_sync, window_start_date: nil, window_end_date: nil)
-               .times(binance_items_count)
+    syncable_item_associations.each do |association|
+      association.klass.any_instance
+                 .expects(:sync_later)
+                 .with(parent_sync: family_sync, window_start_date: nil, window_end_date: nil)
+                 .times(@family.public_send(association.name).syncable.count)
+    end
 
     syncer.perform_sync(family_sync)
 
     assert_equal "completed", family_sync.reload.status
+  end
+
+  test "syncs ibkr items through reflective provider discovery" do
+    family_sync = syncs(:family)
+    syncer = Family::Syncer.new(@family)
+
+    assert_includes syncable_item_associations.map(&:name), :ibkr_items
+
+    Account.any_instance.stubs(:sync_later)
+    syncable_item_associations.reject { |association| association.name == :ibkr_items }.each do |association|
+      association.klass.any_instance.stubs(:sync_later)
+    end
+
+    IbkrItem.any_instance
+            .expects(:sync_later)
+            .with(parent_sync: family_sync, window_start_date: nil, window_end_date: nil)
+            .times(@family.ibkr_items.syncable.count)
+
+    syncer.perform_sync(family_sync)
   end
 
   test "only applies active rules during sync" do
@@ -79,16 +80,21 @@ class Family::SyncerTest < ActiveSupport::TestCase
 
     # Mock the account and plaid item syncs to avoid side effects
     Account.any_instance.stubs(:sync_later)
-    PlaidItem.any_instance.stubs(:sync_later)
-    SimplefinItem.any_instance.stubs(:sync_later)
-    LunchflowItem.any_instance.stubs(:sync_later)
-    EnableBankingItem.any_instance.stubs(:sync_later)
-    SophtronItem.any_instance.stubs(:sync_later)
-    BrexItem.any_instance.stubs(:sync_later)
-    AkahuItem.any_instance.stubs(:sync_later)
-    BinanceItem.any_instance.stubs(:sync_later)
+    syncable_item_associations.each do |association|
+      association.klass.any_instance.stubs(:sync_later)
+    end
 
     syncer.perform_sync(family_sync)
     syncer.perform_post_sync
   end
+
+  private
+    def syncable_item_associations
+      Family.reflect_on_all_associations(:has_many).select do |association|
+        association.name.to_s.end_with?("_items") &&
+          association.klass.included_modules.include?(Syncable)
+      rescue NameError
+        false
+      end
+    end
 end


### PR DESCRIPTION
## Summary
- replace the hardcoded nightly family sync provider list with reflective discovery of `has_many *_items` associations that include `Syncable`
- make the nightly family sync path follow the same pattern already used by `Sync.for_family`
- add test coverage proving IBKR is now included through the reflective provider discovery path

## Why
Interactive Brokers items were syncable themselves, but they were omitted from `Family::Syncer`'s hand-maintained nightly sync registry. That meant manual sync worked while scheduled family sync skipped IBKR.

## Testing
- `bin/rails test test/models/family/syncer_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how provider item types eligible for synchronization are discovered, removing the need for fixed lists and improving adaptability as associations evolve.

* **Tests**
  * Refreshed synchronization test coverage to automatically detect eligible provider item associations, reducing reliance on hardcoded expectations and improving resilience of the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->