### PR TITLE
feat(mobile): normalize dashboard text weight to DS Medium (500)

### DIFF
--- a/mobile/lib/screens/dashboard_screen.dart
+++ b/mobile/lib/screens/dashboard_screen.dart
@@ -710,7 +710,7 @@ class _CollapsibleTypeHeader extends StatelessWidget {
             Text(
               title,
               style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
+                    fontWeight: FontWeight.w500,
                   ),
             ),
             const SizedBox(width: 8),
@@ -724,7 +724,7 @@ class _CollapsibleTypeHeader extends StatelessWidget {
                 count.toString(),
                 style: TextStyle(
                   color: colorScheme.onPrimaryContainer,
-                  fontWeight: FontWeight.bold,
+                  fontWeight: FontWeight.w500,
                   fontSize: 11,
                 ),
               ),

--- a/mobile/lib/screens/recent_transactions_screen.dart
+++ b/mobile/lib/screens/recent_transactions_screen.dart
@@ -274,7 +274,7 @@ class _RecentTransactionsScreenState extends State<RecentTransactionsScreen> {
             : '$sign${transaction.currency} ${_formatAmount(amount.abs())}',
         trend: moneyTrend,
         style: const TextStyle(
-          fontWeight: FontWeight.bold,
+          fontWeight: FontWeight.w500,
           fontSize: 16,
         ),
       ),

--- a/mobile/lib/screens/transactions_list_screen.dart
+++ b/mobile/lib/screens/transactions_list_screen.dart
@@ -564,7 +564,7 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
                                         child: Text(
                                           transaction.name,
                                           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                                fontWeight: FontWeight.w600,
+                                                fontWeight: FontWeight.w500,
                                               ),
                                           overflow: TextOverflow.ellipsis,
                                         ),
@@ -664,7 +664,7 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
                                         trend: displayInfo['trend'] as MoneyTrend,
                                         overflow: TextOverflow.ellipsis,
                                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                              fontWeight: FontWeight.bold,
+                                              fontWeight: FontWeight.w500,
                                             ),
                                       ),
                                     ),

--- a/mobile/lib/widgets/account_card.dart
+++ b/mobile/lib/widgets/account_card.dart
@@ -89,7 +89,7 @@ class AccountCard extends StatelessWidget {
                     Text(
                       account.name,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
+                        fontWeight: FontWeight.w500,
                       ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
@@ -113,7 +113,7 @@ class AccountCard extends StatelessWidget {
                     account.balance,
                     style: SureMoney.tabular(
                       Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
+                            fontWeight: FontWeight.w500,
                             color: account.isLiability
                                 ? SureColors.of(context).palette.destructive
                                 : null,

--- a/mobile/lib/widgets/net_worth_card.dart
+++ b/mobile/lib/widgets/net_worth_card.dart
@@ -68,7 +68,7 @@ class NetWorthCard extends StatelessWidget {
                           'Outdated',
                           style: Theme.of(context).textTheme.labelSmall?.copyWith(
                                 color: colorScheme.secondary,
-                                fontWeight: FontWeight.w600,
+                                fontWeight: FontWeight.w500,
                               ),
                         ),
                       ),
@@ -80,7 +80,7 @@ class NetWorthCard extends StatelessWidget {
                   netWorthFormatted ?? '--',
                   style: SureMoney.tabular(
                     Theme.of(context).textTheme.headlineSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
+                          fontWeight: FontWeight.w500,
                           color: isStale
                               ? colorScheme.secondary
                               : colorScheme.onSurface,
@@ -209,7 +209,7 @@ class NetWorthCard extends StatelessWidget {
                   Text(
                     title,
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.bold,
+                          fontWeight: FontWeight.w500,
                           color: color,
                         ),
                   ),
@@ -241,7 +241,7 @@ class NetWorthCard extends StatelessWidget {
                         Text(
                           formatAmount(entry.key, entry.value),
                           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.bold,
+                                fontWeight: FontWeight.w500,
                               ),
                         ),
                       ],
@@ -303,7 +303,7 @@ class _FilterButton extends StatelessWidget {
                     child: Text(
                       '--',
                       style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                            fontWeight: FontWeight.bold,
+                            fontWeight: FontWeight.w500,
                             color: colorScheme.onSurface,
                           ),
                     ),
@@ -314,7 +314,7 @@ class _FilterButton extends StatelessWidget {
                           formatAmount(sortedEntries.first.key, sortedEntries.first.value),
                           style: SureMoney.tabular(
                             Theme.of(context).textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.bold,
+                                  fontWeight: FontWeight.w500,
                                   color: colorScheme.onSurface,
                                 ),
                           ),
@@ -336,7 +336,7 @@ class _FilterButton extends StatelessWidget {
                                   formatAmount(entry.key, entry.value),
                                   style: SureMoney.tabular(
                                     Theme.of(context).textTheme.titleMedium?.copyWith(
-                                          fontWeight: FontWeight.bold,
+                                          fontWeight: FontWeight.w500,
                                           color: colorScheme.onSurface,
                                         ),
                                   ),


### PR DESCRIPTION
## Summary

Part of the mobile design-system sequence (#2235). The dashboard used Material's default **bold (700)** and **semibold (600)** weights for headings, names, and money. The web/PWA design system uses **font-medium (500)** for emphasis — effectively no bold and no semibold — so this normalizes the dashboard text tier to one uniform Medium (500).

Weight-only: no font-size, color, or structural changes, so there's **zero layout shift**. Self-contained — independent of the Geist (#2342) and money-typography work.

Closes #2343.

## What changed (14 weight-only sites, 5 files)

- `mobile/lib/widgets/net_worth_card.dart` (7) — net-worth headline, currency-breakdown modal title + amount, the asset/liability filter balances (`--`, single, and wheel rows), and the stale "Outdated" badge.
- `mobile/lib/widgets/account_card.dart` (2) — account name + balance.
- `mobile/lib/screens/dashboard_screen.dart` (2) — collapsible-type section header + count badge.
- `mobile/lib/screens/transactions_list_screen.dart` (2) — transaction name + amount.
- `mobile/lib/screens/recent_transactions_screen.dart` (1) — transaction amount (the name was already w500).

Every change is `FontWeight.bold` / `FontWeight.w600` → `FontWeight.w500`. Nothing else changes (symmetric diff, zero net lines). Money keeps its tabular figures (`SureMoney.tabular`) and semantic color — only the weight changes.

## Why

The web DS treats Medium (500) as the single emphasis weight. Fixing only the bold (700) sites would have left paired labels at semibold (600) — so a money amount would render **lighter than its own label**, and the transactions list would disagree with the recent-transactions screen, which is already uniform at 500. Migrating both weights lands one consistent Medium tier. The swipe "Undo" button pill (an interactive control with a hardcoded color) is intentionally left for a future button-primitive slice.

## Screenshots

Real iOS Simulator (iPhone 17 Pro) on locally-seeded demo data — same account/data, same font; only the text weight differs. Before = Material bold/semibold; after = uniform DS Medium (500). Clearest on the net-worth headline, account names, and balances — note that at Medium weight the account names render more fully (e.g. "Chase Premier Checking" no longer truncates) and an account name no longer sits heavier than its own balance.

<table>
  <thead><tr><th>Dashboard</th><th>Before (bold / semibold)</th><th>After (Medium 500)</th></tr></thead>
  <tbody>
    <tr>
      <td><strong>Light</strong></td>
      <td><img width="200" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/mobile-type-scale-screenshots/docs/pr-assets/mobile-type-scale/before-home-light.png"></td>
      <td><img width="200" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/mobile-type-scale-screenshots/docs/pr-assets/mobile-type-scale/after-home-light.png"></td>
    </tr>
    <tr>
      <td><strong>Dark</strong></td>
      <td><img width="200" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/mobile-type-scale-screenshots/docs/pr-assets/mobile-type-scale/before-home-dark.png"></td>
      <td><img width="200" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/mobile-type-scale-screenshots/docs/pr-assets/mobile-type-scale/after-home-dark.png"></td>
    </tr>
  </tbody>
</table>

## Validation

- `cd mobile && flutter analyze --no-fatal-infos` — clean (pre-existing info-level issues only, none in the 5 changed files)
- `cd mobile && flutter test` — 95 passed (incl. `account_card_test` destructive-token + `money_text_test` semantic-color/tabular, confirming color + tabular invariants hold)
- `cd mobile && flutter build ios --simulator --debug` — builds
- `cd mobile && flutter build apk --debug` — builds
- CodeRabbit local review: no findings
- Adversarial review (security + correctness): PASS — no security surface (pure presentational weight swaps), no layout shift, inverted-hierarchy concern resolved

## Notes

- Weight-only DS alignment; applies the design-system's Medium emphasis weight on the dashboard text tier.
- Part of #2235.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined text styling and typography consistency throughout the app, including dashboard, transaction lists, account cards, and financial overview displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->