### PR TITLE
feat(mobile): notify users when a new app version is available

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -57,12 +57,13 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     if (hasKeystore) {
@@ -99,3 +100,6 @@ flutter {
     source '../..'
 }
 
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+}

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:label="Sure Finances"

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=512m
 android.useAndroidX=true
 android.enableJetifier=true

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx4G
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512m
 android.useAndroidX=true
 android.enableJetifier=true

--- a/mobile/android/settings.gradle
+++ b/mobile/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 rootProject.name = 'sure_mobile'

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -216,9 +216,13 @@ class _AppWrapperState extends State<AppWrapper> with WidgetsBindingObserver {
 
   Future<void> _checkForUpdates() async {
     if (!mounted) return;
-    final svc = UpdateNotificationService();
-    await svc.initialize(context);
-    await svc.checkAndNotify();
+    try {
+      final svc = UpdateNotificationService();
+      await svc.initialize(context);
+      await svc.checkAndNotify();
+    } catch (_) {
+      // Best-effort — platform channels unavailable in test environments
+    }
   }
 
   Future<void> _checkBackendConfig() async {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -220,8 +220,16 @@ class _AppWrapperState extends State<AppWrapper> with WidgetsBindingObserver {
       final svc = UpdateNotificationService();
       await svc.initialize(context);
       await svc.checkAndNotify();
-    } catch (_) {
-      // Best-effort — platform channels unavailable in test environments
+    } catch (e, stackTrace) {
+      LogService.instance.warning(
+        'UpdateNotificationService',
+        'Update check skipped: ${e.runtimeType}',
+      );
+      unawaited(TelemetryService.instance.captureHandledException(
+        e,
+        stackTrace,
+        operation: 'app.update_check',
+      ));
     }
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -20,6 +20,7 @@ import 'services/connectivity_service.dart';
 import 'services/log_service.dart';
 import 'services/preferences_service.dart';
 import 'services/telemetry_service.dart';
+import 'services/update_notification_service.dart';
 import 'theme/sure_theme.dart';
 
 void main() async {
@@ -116,6 +117,7 @@ class _AppWrapperState extends State<AppWrapper> with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
     _checkBackendConfig();
     _initDeepLinks();
+    _checkForUpdates();
   }
 
   @override
@@ -211,6 +213,13 @@ class _AppWrapperState extends State<AppWrapper> with WidgetsBindingObserver {
 
   bool _isSsoCallback(Uri uri) =>
       uri.scheme == 'sureapp' && uri.host == 'oauth';
+
+  Future<void> _checkForUpdates() async {
+    if (!mounted) return;
+    final svc = UpdateNotificationService();
+    await svc.initialize(context);
+    await svc.checkAndNotify();
+  }
 
   Future<void> _checkBackendConfig() async {
     final hasUrl = await TelemetryService.instance.traceAsync(

--- a/mobile/lib/services/update_notification_service.dart
+++ b/mobile/lib/services/update_notification_service.dart
@@ -8,8 +8,6 @@ import 'package:url_launcher/url_launcher.dart';
 class UpdateNotificationService {
   static const _notificationId = 42;
   static const _prefKey = 'last_update_notified_version';
-  static const _packageId = 'am.sure.mobile';
-  static const _playStoreUrl = 'https://play.google.com/store/apps/details?id=$_packageId';
 
   final _notifications = FlutterLocalNotificationsPlugin();
 
@@ -24,6 +22,16 @@ class UpdateNotificationService {
       const InitializationSettings(android: android, iOS: ios),
       onDidReceiveNotificationResponse: _onTap,
     );
+
+    // Handle tap from killed state — app relaunched by a notification tap
+    final launchDetails = await _notifications.getNotificationAppLaunchDetails();
+    if (launchDetails?.didNotificationLaunchApp == true) {
+      final url = launchDetails?.notificationResponse?.payload;
+      if (url != null) {
+        await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+        return;
+      }
+    }
 
     final plugin = _notifications
         .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
@@ -43,7 +51,7 @@ class UpdateNotificationService {
       builder: (_) => AlertDialog(
         title: const Text('Stay up to date'),
         content: const Text(
-          'Allow Sure to send you notifications so you know '
+          'Allow this app to send you notifications so you know '
           'when a new version is available.\n\n'
           'If you deny, you won\'t be notified about updates and may miss '
           'important improvements or bug fixes.',
@@ -64,10 +72,10 @@ class UpdateNotificationService {
   }
 
   Future<void> checkAndNotify() async {
-    final storeVersion = await _fetchPlayStoreVersion();
+    final packageInfo = await PackageInfo.fromPlatform();
+    final storeVersion = await _fetchPlayStoreVersion(packageInfo.packageName);
     if (storeVersion == null) return;
 
-    final packageInfo = await PackageInfo.fromPlatform();
     if (!_isNewer(storeVersion, packageInfo.version)) return;
 
     final prefs = await SharedPreferences.getInstance();
@@ -78,16 +86,23 @@ class UpdateNotificationService {
     final granted = plugin == null || (await plugin.areNotificationsEnabled() ?? false);
     if (!granted) return;
 
-    await _fire(storeVersion);
+    final playStoreUrl =
+        'https://play.google.com/store/apps/details?id=${packageInfo.packageName}';
+    await _fire(storeVersion, playStoreUrl);
     await prefs.setString(_prefKey, storeVersion);
   }
 
-  Future<String?> _fetchPlayStoreVersion() async {
+  Future<String?> _fetchPlayStoreVersion(String packageName) async {
     try {
-      final url = Uri.parse('$_playStoreUrl&hl=en');
+      final url = Uri.parse(
+        'https://play.google.com/store/apps/details?id=$packageName&hl=en',
+      );
       final response = await http.get(url).timeout(const Duration(seconds: 10));
       if (response.statusCode != 200) return null;
 
+      // Scrapes an undocumented Play Store HTML structure — Google can change it silently.
+      // When it breaks, storeVersion returns null and the check becomes a silent no-op.
+      // Consider migrating to the Google Play Developer API for a stable alternative.
       final match = RegExp(r'\[\[\["(\d+[\d.]+)"').firstMatch(response.body);
       if (match == null) {
         debugPrint('UpdateNotificationService: version regex found no match in Play Store response');
@@ -110,7 +125,7 @@ class UpdateNotificationService {
     return false;
   }
 
-  Future<void> _fire(String version) async {
+  Future<void> _fire(String version, String playStoreUrl) async {
     const details = NotificationDetails(
       android: AndroidNotificationDetails(
         'app_updates',
@@ -125,12 +140,16 @@ class UpdateNotificationService {
     await _notifications.show(
       _notificationId,
       'New version available',
-      'Sure $version is available on the Play Store.',
+      'Version $version is available on the Play Store.',
       details,
+      payload: playStoreUrl,
     );
   }
 
-  static void _onTap(NotificationResponse _) {
-    launchUrl(Uri.parse(_playStoreUrl), mode: LaunchMode.externalApplication);
+  static void _onTap(NotificationResponse response) {
+    final url = response.payload;
+    if (url != null) {
+      launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    }
   }
 }

--- a/mobile/lib/services/update_notification_service.dart
+++ b/mobile/lib/services/update_notification_service.dart
@@ -73,6 +73,11 @@ class UpdateNotificationService {
     final prefs = await SharedPreferences.getInstance();
     if (prefs.getString(_prefKey) == storeVersion) return;
 
+    final plugin = _notifications
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+    final granted = plugin == null || (await plugin.areNotificationsEnabled() ?? false);
+    if (!granted) return;
+
     await _fire(storeVersion);
     await prefs.setString(_prefKey, storeVersion);
   }
@@ -83,7 +88,10 @@ class UpdateNotificationService {
       final response = await http.get(url).timeout(const Duration(seconds: 10));
       if (response.statusCode != 200) return null;
 
-      final match = RegExp(r'\[\[\["(\d+\.\d+\.\d+)"').firstMatch(response.body);
+      final match = RegExp(r'\[\[\["(\d+[\d.]+)"').firstMatch(response.body);
+      if (match == null) {
+        debugPrint('UpdateNotificationService: version regex found no match in Play Store response');
+      }
       return match?.group(1);
     } catch (_) {
       return null;

--- a/mobile/lib/services/update_notification_service.dart
+++ b/mobile/lib/services/update_notification_service.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class UpdateNotificationService {
+  static const _notificationId = 42;
+  static const _prefKey = 'last_update_notified_version';
+  static const _packageId = 'am.sure.mobile';
+  static const _playStoreUrl = 'https://play.google.com/store/apps/details?id=$_packageId';
+
+  final _notifications = FlutterLocalNotificationsPlugin();
+
+  Future<void> initialize(BuildContext context) async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+    await _notifications.initialize(
+      const InitializationSettings(android: android, iOS: ios),
+      onDidReceiveNotificationResponse: _onTap,
+    );
+
+    final plugin = _notifications
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+    if (plugin == null) return;
+
+    final granted = await plugin.areNotificationsEnabled() ?? false;
+    if (granted) return;
+
+    if (!context.mounted) return;
+    final proceed = await _showRationale(context);
+    if (proceed) await plugin.requestNotificationsPermission();
+  }
+
+  Future<bool> _showRationale(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Stay up to date'),
+        content: const Text(
+          'Allow Sure to send you notifications so you know '
+          'when a new version is available.\n\n'
+          'If you deny, you won\'t be notified about updates and may miss '
+          'important improvements or bug fixes.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Not now'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Allow'),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  Future<void> checkAndNotify() async {
+    final storeVersion = await _fetchPlayStoreVersion();
+    if (storeVersion == null) return;
+
+    final packageInfo = await PackageInfo.fromPlatform();
+    if (!_isNewer(storeVersion, packageInfo.version)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getString(_prefKey) == storeVersion) return;
+
+    await _fire(storeVersion);
+    await prefs.setString(_prefKey, storeVersion);
+  }
+
+  Future<String?> _fetchPlayStoreVersion() async {
+    try {
+      final url = Uri.parse('$_playStoreUrl&hl=en');
+      final response = await http.get(url).timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) return null;
+
+      final match = RegExp(r'\[\[\["(\d+\.\d+\.\d+)"').firstMatch(response.body);
+      return match?.group(1);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  bool _isNewer(String store, String installed) {
+    final s = store.split('.').map(int.tryParse).toList();
+    final i = installed.split('.').map(int.tryParse).toList();
+    for (var idx = 0; idx < 3; idx++) {
+      final sv = idx < s.length ? (s[idx] ?? 0) : 0;
+      final iv = idx < i.length ? (i[idx] ?? 0) : 0;
+      if (sv > iv) return true;
+      if (sv < iv) return false;
+    }
+    return false;
+  }
+
+  Future<void> _fire(String version) async {
+    const details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        'app_updates',
+        'App Updates',
+        channelDescription: 'Notifications for new app versions',
+        importance: Importance.high,
+        priority: Priority.high,
+        icon: '@mipmap/ic_launcher',
+      ),
+      iOS: DarwinNotificationDetails(),
+    );
+    await _notifications.show(
+      _notificationId,
+      'New version available',
+      'Sure $version is available on the Play Store.',
+      details,
+    );
+  }
+
+  static void _onTap(NotificationResponse _) {
+    launchUrl(Uri.parse(_playStoreUrl), mode: LaunchMode.externalApplication);
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   local_auth: ^2.3.0
   flutter_markdown: ^0.7.2
   sentry_flutter: ^8.14.2
+  flutter_local_notifications: ^18.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Adds an `UpdateNotificationService` that checks the Play Store for a newer app version on startup and fires an OS-level push notification if one is found.

- Scrapes the Play Store page for the current latest version and compares it against the installed version using semver ordering
- Shows a rationale dialog before the system permission prompt so users understand why notifications are being requested; gracefully skips if they decline
- Deduplicates via `SharedPreferences` — the notification fires only once per new version, not on every app launch
- Tapping the notification opens the Play Store listing directly

**Android build changes required by `flutter_local_notifications`:**
- Java / JVM target: 1.8 → 11
- Kotlin: 1.9.24 → 2.1.0
- Core library desugaring enabled (`desugar_jdk_libs:2.1.4`)
- Gradle heap: `-Xmx4G` → `-Xmx8G -XX:MaxMetaspaceSize=512m` (prevents OOM during Jetify transforms)
- `POST_NOTIFICATIONS` permission added to `AndroidManifest.xml`

## Test plan

- [ ] Fresh install on Android 13+ → rationale dialog appears → tapping Allow → permission granted
- [ ] Tap "Not now" → no system prompt, no crash; app continues normally
- [ ] With an older installed version and a newer Play Store version → notification fires once on next launch, not again on subsequent launches
- [ ] `flutter pub get` resolves `flutter_local_notifications ^18.0.0` without conflicts
- [ ] `flutter build apk --debug` passes with no JVM/desugaring/Kotlin errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app checks for updates on startup and shows a high-priority alert when a newer Google Play version is available.
  * Dashboard widgets now support per-widget height/width controls, including a masonry-style layout.
  * Added YNAB import configuration as a selectable import option.
* **Platform Improvements**
  * Android requests notification permission when needed (with an in-app explanation) and supports opening Google Play from notification taps even after the app is closed.
* **Maintenance**
  * Improved Android build compatibility with Java 11 targeting and library desugaring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->