### PR TITLE
fix(jobs): enqueue jobs after transaction commit to fix SyncJob deserialization race

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,18 @@
 class ApplicationJob < ActiveJob::Base
+  # Defer enqueuing until the surrounding Active Record transaction commits, so a
+  # job is never picked up by a worker before the records it references (by
+  # GlobalID) are committed and visible on the worker's connection — and is
+  # dropped entirely if the transaction rolls back. Without this, a job enqueued
+  # inside a transaction can be dequeued before COMMIT, fail to load its
+  # arguments (ActiveJob::DeserializationError), and be silently dropped by the
+  # `discard_on` below — the "stuck sync" regression for SyncJob enqueued in
+  # Syncable#sync_later.
+  #
+  # This is the Rails 8.2 default. On 8.1 the global
+  # `config.active_job.enqueue_after_transaction_commit` toggle is non-functional,
+  # so we set the class attribute on the base job, which every job inherits.
+  self.enqueue_after_transaction_commit = true
+
   retry_on ActiveRecord::Deadlocked
   discard_on ActiveJob::DeserializationError
   queue_as :low_priority # default queue

--- a/app/jobs/destroy_job.rb
+++ b/app/jobs/destroy_job.rb
@@ -1,6 +1,10 @@
 class DestroyJob < ApplicationJob
   queue_as :low_priority
-  self.enqueue_after_transaction_commit = :never
+  # Inherits enqueue_after_transaction_commit = true from ApplicationJob. (This
+  # previously read `= :never`, the removed Rails 7.2 symbol API; under 8.1 that
+  # symbol is truthy, so it already deferred — the explicit line was dead and
+  # misleading.) Deferring is correct here: destroy after the enclosing
+  # transaction commits, never against an uncommitted/rolled-back record.
 
   def perform(model)
     model.destroy

--- a/test/interfaces/syncable_interface_test.rb
+++ b/test/interfaces/syncable_interface_test.rb
@@ -18,6 +18,18 @@ module SyncableInterfaceTest
     @syncable.perform_sync(mock_sync)
   end
 
+  test "sync_later does not enqueue SyncJob while a surrounding transaction is still open" do
+    job_enqueued_mid_transaction = false
+
+    ActiveRecord::Base.transaction do
+      @syncable.sync_later
+      job_enqueued_mid_transaction = queue_adapter.enqueued_jobs.any? { |j| j[:job] == SyncJob }
+    end
+
+    assert_not job_enqueued_mid_transaction, "SyncJob was enqueued inside an open transaction (GlobalID race)"
+    assert_enqueued_with(job: SyncJob)
+  end
+
   test "second sync request widens existing pending window" do
     later_start = 2.days.ago.to_date
     first_sync = @syncable.sync_later(window_start_date: later_start, window_end_date: later_start)

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class ApplicationJobTest < ActiveJob::TestCase
+  # Throwaway subclass used only to exercise ApplicationJob's enqueue policy
+  # without depending on any real job's side effects.
+  class CanaryJob < ApplicationJob
+    def perform; end
+  end
+
+  test "defers enqueue until the surrounding transaction commits" do
+    enqueued_mid_transaction = nil
+
+    ActiveRecord::Base.transaction do
+      CanaryJob.perform_later
+      enqueued_mid_transaction = enqueued_jobs.any? { |job| job[:job] == CanaryJob }
+    end
+
+    assert_not enqueued_mid_transaction, "job was enqueued before the transaction committed"
+    assert_enqueued_with job: CanaryJob
+  end
+
+  test "drops the enqueue when the surrounding transaction rolls back" do
+    assert_no_enqueued_jobs do
+      ActiveRecord::Base.transaction do
+        CanaryJob.perform_later
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+
+  test "enqueues immediately when there is no surrounding transaction" do
+    assert_enqueued_with job: CanaryJob do
+      CanaryJob.perform_later
+    end
+  end
+end

--- a/test/jobs/destroy_job_test.rb
+++ b/test/jobs/destroy_job_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "ostruct"
 
 class DestroyJobTest < ActiveJob::TestCase
   test "destroys the model" do
@@ -9,9 +10,8 @@ class DestroyJobTest < ActiveJob::TestCase
   end
 
   test "resets scheduled_for_deletion when the destroy fails" do
-    model = mock
-    model.expects(:destroy).raises(ActiveRecord::RecordNotDestroyed.new("nope"))
-    model.expects(:respond_to?).with(:scheduled_for_deletion).returns(true)
+    model = OpenStruct.new(scheduled_for_deletion: true)
+    model.stubs(:destroy).raises(ActiveRecord::RecordNotDestroyed.new("nope"))
     model.expects(:update!).with(scheduled_for_deletion: false).once
 
     DestroyJob.perform_now(model)

--- a/test/jobs/destroy_job_test.rb
+++ b/test/jobs/destroy_job_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class DestroyJobTest < ActiveJob::TestCase
+  test "destroys the model" do
+    model = mock
+    model.expects(:destroy).once
+
+    DestroyJob.perform_now(model)
+  end
+
+  test "resets scheduled_for_deletion when the destroy fails" do
+    model = mock
+    model.expects(:destroy).raises(ActiveRecord::RecordNotDestroyed.new("nope"))
+    model.expects(:respond_to?).with(:scheduled_for_deletion).returns(true)
+    model.expects(:update!).with(scheduled_for_deletion: false).once
+
+    DestroyJob.perform_now(model)
+  end
+
+  test "inherits the deferred-enqueue policy from ApplicationJob" do
+    account = accounts(:depository)
+    enqueued_mid_transaction = nil
+
+    ActiveRecord::Base.transaction do
+      DestroyJob.perform_later(account)
+      enqueued_mid_transaction = enqueued_jobs.any? { |job| job[:job] == DestroyJob }
+    end
+
+    assert_not enqueued_mid_transaction, "DestroyJob enqueued before the transaction committed"
+    assert_enqueued_with job: DestroyJob
+  end
+end

--- a/test/models/snaptrade_account_test.rb
+++ b/test/models/snaptrade_account_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class SnaptradeAccountTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   setup do
     @family_a = families(:dylan_family)
     @family_b = families(:empty)
@@ -70,5 +72,33 @@ class SnaptradeAccountTest < ActiveSupport::TestCase
         current_balance: 1000
       )
     end
+  end
+
+  # Regression: the after_destroy callback enqueues SnaptradeConnectionCleanupJob,
+  # which references the account/item by id. If it is enqueued before the destroy
+  # transaction commits (Rails 8.1's immediate-enqueue default), a worker can run
+  # before COMMIT: its "do other accounts still share this authorization?" guard
+  # then sees the not-yet-deleted row, skips the provider call, and leaks the
+  # SnapTrade connection. Enqueuing must be deferred until commit.
+  test "connection cleanup job is deferred until the destroy transaction commits" do
+    account = SnaptradeAccount.create!(
+      snaptrade_item: @item_a,
+      snaptrade_account_id: "cleanup_uuid",
+      snaptrade_authorization_id: "auth_cleanup",
+      name: "Brokerage",
+      currency: "USD",
+      current_balance: 1000
+    )
+
+    enqueued_mid_transaction = nil
+
+    ActiveRecord::Base.transaction do
+      account.destroy!
+      enqueued_mid_transaction = enqueued_jobs.any? { |job| job[:job] == SnaptradeConnectionCleanupJob }
+    end
+
+    assert_not enqueued_mid_transaction,
+      "SnaptradeConnectionCleanupJob was enqueued before the destroy committed (would race COMMIT and leak the provider connection)"
+    assert_enqueued_with job: SnaptradeConnectionCleanupJob
   end
 end


### PR DESCRIPTION
## Summary

- Set `self.enqueue_after_transaction_commit = true` on `ApplicationJob` so every job defers enqueuing until the surrounding DB transaction commits (and drops the enqueue on rollback). Adopts the Rails 8.2 default; on 8.1 the global `config.active_job.enqueue_after_transaction_commit` toggle is non-functional, so it must be set on the base job class.
- Remove the dead `self.enqueue_after_transaction_commit = :never` on `DestroyJob` (removed Rails 7.2 symbol API; truthy under the 8.1 boolean attribute, so it already deferred) — it now inherits the base-class policy.
- Add invariant + regression test coverage for both affected paths.

Closes #2353

## Shared root cause

`enqueue_after_transaction_commit` controls whether a `perform_later` issued inside an Active Record transaction is deferred until that transaction commits.

- Rails 7.2: `config.load_defaults 7.2` set this to `:default`, and the Sidekiq adapter (`AbstractAdapter#enqueue_after_transaction_commit?`) returned `true`, so in-transaction enqueues were deferred until commit by default.
- Rails 8.0: the `:always`/`:never`/`:default` enum was collapsed to a boolean `class_attribute` defaulting to `false` (`activejob/lib/active_job/enqueuing.rb`); the global config toggle was deprecated.
- Rails 8.1 (current): the global `config.active_job.enqueue_after_transaction_commit` toggle is non-functional — the railtie excludes the key from global application ("This config can't be applied globally"). Only the per-class `class_attribute` is honored, defaulting to `false`. `raw_enqueue` defers via `ActiveRecord.after_all_transactions_commit` only when the attribute is truthy (`active_job/enqueue_after_transaction_commit.rb`).
- Rails 8.2: the default flips back to `true`; per the Active Job changelog, because "jobs would surprisingly run against uncommitted and rolled-back records."

## Bug 1 — `SyncJob` silently discarded (stuck syncs)

`Syncable#sync_later` (`app/models/concerns/syncable.rb:18`) opens `Sync.transaction` (`:19`), creates a `Sync` row, and calls `SyncJob.perform_later(sync)` (`:38`) inside that transaction. Under the 8.1 immediate-enqueue default, a Sidekiq worker on another connection can dequeue before `COMMIT`, fail to resolve the `Sync` GlobalID, and raise `ActiveJob::DeserializationError`. `ApplicationJob`'s `discard_on ActiveJob::DeserializationError` then drops the job silently — surfacing as a stuck / never-completing sync rather than a visible error (reported by Alessio and Murphy in Discord).

## Bug 2 — SnapTrade / Indexa connection-cleanup leak

`SnaptradeAccount` declares `after_destroy :enqueue_connection_cleanup` (`app/models/snaptrade_account.rb:24`), which enqueues `SnaptradeConnectionCleanupJob.perform_later(...)` (`:196`) from inside the destroy transaction — reached on connection removal, including the `SnaptradeItem has_many :snaptrade_accounts, dependent: :destroy` cascade (`app/models/snaptrade_item.rb:34`) via `destroy_later` → `DestroyJob.perform_later` (`:45`, `:47`).

The cleanup job guards on whether a sibling account still uses the authorization — `snaptrade_item.snaptrade_accounts.where(snaptrade_authorization_id:).exists?` (`app/jobs/snaptrade_connection_cleanup_job.rb:27`), early-returning ("Skipping deletion", `:32`) if so — otherwise calling `provider.delete_connection(...)` (`:49`). Under immediate enqueue:

1. Stale read → leaked connection: a worker running before `COMMIT` sees the not-yet-deleted row, the `exists?` guard returns a false positive, the job skips `provider.delete_connection`, and the SnapTrade brokerage authorization stays active at the provider even though the user disconnected.
2. Rollback → orphaned external delete: if the destroy rolls back after the worker already issued the irreversible `provider.delete_connection`, the local record persists while the provider-side connection is gone.

`IndexaCapitalAccount` has identical wiring (`app/models/indexa_capital_account.rb:23` → `IndexaCapitalConnectionCleanupJob.perform_later`, `:94`) and the same guard, but its `delete_connection` is a TODO placeholder, so for Indexa the enqueue-timing race exists structurally while the provider leak is latent. Only SnapTrade is production-impacting today.

## Why a single `ApplicationJob` change fixes both

`SyncJob`, `SnaptradeConnectionCleanupJob`, `IndexaCapitalConnectionCleanupJob`, and `DestroyJob` all inherit `ApplicationJob` and none override the attribute, so setting it once on the base class defers every in-transaction enqueue (and drops it on rollback). The per-class `class_attribute` is the only working lever — `config.active_job.enqueue_after_transaction_commit` is silently dropped on 8.1.

## What changed

- `app/jobs/application_job.rb` — `self.enqueue_after_transaction_commit = true` with rationale comment.
- `app/jobs/destroy_job.rb` — drop the stale `:never` override (behaviour-preserving on 8.1).
- `test/jobs/application_job_test.rb` — invariants: defers until commit, drops the enqueue on rollback, enqueues immediately when there is no surrounding transaction.
- `test/interfaces/syncable_interface_test.rb` — regression (Bug 1): `sync_later` does not enqueue `SyncJob` while a surrounding transaction is open.
- `test/models/snaptrade_account_test.rb` — regression (Bug 2): the `after_destroy` `SnaptradeConnectionCleanupJob` enqueue is deferred until the destroy transaction commits.
- `test/jobs/destroy_job_test.rb` — destroys the model, resets `scheduled_for_deletion` on failure, inherits the deferred-enqueue policy.

## Validation

- Each deferral-dependent test was confirmed red before the fix and green after (verified by toggling the flag off).
- `bin/rails test` — no new failures versus base (the only local failures are pre-existing and environmental: API rate-limiter specs require a running Redis).
- `bin/rubocop` clean; `bin/brakeman` reports 0 security warnings.

## Notes

- No UI changes; backend job-enqueue-timing only, so system tests are not applicable.
