### PR TITLE
feat(balances): backdate opening anchor when earlier activity is added

### DIFF
--- a/app/models/account/anchorable.rb
+++ b/app/models/account/anchorable.rb
@@ -19,6 +19,15 @@ module Account::Anchorable
     opening_balance_manager.opening_date
   end
 
+  # Called when activity (a transaction/trade) is recorded on or before the
+  # opening anchor. Backdates the anchor so the activity is included in the
+  # balance curve, preserving the prior opening balance as a manual value update.
+  def backdate_opening_anchor_for_activity(date)
+    result = opening_balance_manager.backdate_for_activity(date)
+    sync_later if result.changes_made?
+    result
+  end
+
   def opening_anchor_balance
     opening_balance_manager.opening_balance
   end

--- a/app/models/account/opening_balance_manager.rb
+++ b/app/models/account/opening_balance_manager.rb
@@ -23,6 +23,46 @@ class Account::OpeningBalanceManager
     opening_anchor_valuation&.entry&.amount || 0
   end
 
+  # Keeps the opening anchor strictly before all activity.
+  #
+  # The balance engine only calculates forward from the opening anchor
+  # (current_anchor_date.downto(opening_anchor_date)), so any entry dated on or
+  # before the opening anchor would be invisible to the balance curve. When such
+  # activity is recorded we backdate the opening anchor to before it and
+  # preserve the previously-stated opening balance as a manual reconciliation
+  # ("manual value update") on its original date, so the known balance is not
+  # lost.
+  #
+  # Convert-once: only a meaningful (non-zero) opening balance is preserved as a
+  # reconciliation. The replacement opening anchor starts at 0 ("balance unknown
+  # before the earliest activity"), so subsequent earlier activity simply slides
+  # that zero anchor further back without spawning duplicate reconciliations.
+  def backdate_for_activity(activity_date)
+    return Result.new(success?: true, changes_made?: false, error: nil) if opening_anchor_valuation.nil?
+
+    anchor_entry = opening_anchor_valuation.entry
+    return Result.new(success?: true, changes_made?: false, error: nil) if activity_date > anchor_entry.date
+
+    ActiveRecord::Base.transaction do
+      new_opening_date = available_opening_date_before(activity_date, excluding: anchor_entry)
+
+      if anchor_entry.amount.zero?
+        # Auto-created (or genuinely zero) opening anchor — just slide it earlier.
+        anchor_entry.update!(date: new_opening_date)
+      else
+        # Preserve the originally-stated opening balance as a manual value update
+        # on its original date, then start a fresh zero opening anchor before the
+        # new activity.
+        opening_anchor_valuation.update!(kind: "reconciliation")
+        anchor_entry.update!(name: Valuation.build_reconciliation_name(account.accountable_type))
+        create_opening_anchor(balance: 0, date: new_opening_date)
+      end
+    end
+
+    @opening_anchor_valuation = nil # bust memo; kind/date changed above
+    Result.new(success?: true, changes_made?: true, error: nil)
+  end
+
   def set_opening_balance(balance:, date: nil)
     resolved_date = date || default_date
 
@@ -64,6 +104,17 @@ class Account::OpeningBalanceManager
       else
         2.years.ago.to_date
       end
+    end
+
+    # The opening anchor must sit before the activity. Valuations are unique per
+    # account+date, so step back past any existing valuation (e.g. the
+    # reconciliation we just preserved) on the target date.
+    def available_opening_date_before(activity_date, excluding:)
+      candidate = activity_date - 1.day
+      while account.entries.valuations.where(date: candidate).where.not(id: excluding.id).exists?
+        candidate -= 1.day
+      end
+      candidate
     end
 
     def create_opening_anchor(balance:, date:)

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -28,6 +28,13 @@ class Entry < ApplicationRecord
 
   before_destroy :prevent_individual_child_deletion, if: :split_child?
 
+  # When activity is recorded on or before the account's opening anchor, slide
+  # the anchor earlier so the entry is included in the balance curve (the engine
+  # only calculates forward from the opening anchor). Valuations are skipped:
+  # anchors/reconciliations are not "activity" and skipping them also prevents
+  # the replacement-anchor creation below from re-triggering this callback.
+  after_create_commit :backdate_account_opening_anchor, unless: :valuation?
+
   scope :visible, -> {
     joins(:account).where(accounts: { status: [ "draft", "active" ] })
   }
@@ -509,6 +516,10 @@ class Entry < ApplicationRecord
   end
 
   private
+
+    def backdate_account_opening_anchor
+      account.backdate_opening_anchor_for_activity(date)
+    end
 
     def cannot_unexclude_split_parent
       return unless excluded_changed?(from: true, to: false) && split_parent?

--- a/test/models/account/opening_balance_manager_test.rb
+++ b/test/models/account/opening_balance_manager_test.rb
@@ -298,6 +298,73 @@ class Account::OpeningBalanceManagerTest < ActiveSupport::TestCase
     assert_nil @depository_account.valuations.opening_anchor.first
   end
 
+  test "backdate_for_activity preserves a non-zero opening balance as a reconciliation and starts a zero anchor earlier" do
+    manager = Account::OpeningBalanceManager.new(@depository_account)
+    original_date = 4.months.ago.to_date
+    manager.set_opening_balance(balance: 1000, date: original_date)
+
+    activity_date = original_date - 10.days
+
+    assert_difference -> { @depository_account.valuations.opening_anchor.count } => 0,
+                      -> { @depository_account.valuations.reconciliation.count } => 1,
+                      -> { @depository_account.valuations.count } => 1 do
+      result = manager.backdate_for_activity(activity_date)
+      assert result.success?
+      assert result.changes_made?
+    end
+
+    # Original opening balance is preserved as a manual value update on its date
+    reconciliation = @depository_account.valuations.reconciliation.first
+    assert_equal original_date, reconciliation.entry.date
+    assert_equal 1000, reconciliation.entry.amount
+
+    # New opening anchor sits before the activity at a zero ("unknown") balance
+    opening_anchor = @depository_account.valuations.opening_anchor.first
+    assert_equal activity_date - 1.day, opening_anchor.entry.date
+    assert_equal 0, opening_anchor.entry.amount
+  end
+
+  test "backdate_for_activity slides a zero opening anchor earlier without adding a reconciliation" do
+    manager = Account::OpeningBalanceManager.new(@depository_account)
+    original_date = 2.months.ago.to_date
+    manager.set_opening_balance(balance: 0, date: original_date)
+    original_anchor_id = @depository_account.valuations.opening_anchor.first.id
+
+    activity_date = original_date - 5.days
+
+    assert_no_difference -> { @depository_account.valuations.count } do
+      result = manager.backdate_for_activity(activity_date)
+      assert result.success?
+      assert result.changes_made?
+    end
+
+    opening_anchor = @depository_account.valuations.opening_anchor.first
+    assert_equal original_anchor_id, opening_anchor.id # same record, just moved
+    assert_equal activity_date - 1.day, opening_anchor.entry.date
+    assert_equal 0, @depository_account.valuations.reconciliation.count
+  end
+
+  test "backdate_for_activity is a no-op when activity is after the opening anchor" do
+    manager = Account::OpeningBalanceManager.new(@depository_account)
+    manager.set_opening_balance(balance: 1000, date: 4.months.ago.to_date)
+
+    assert_no_difference -> { @depository_account.valuations.count } do
+      result = manager.backdate_for_activity(1.month.ago.to_date)
+      assert result.success?
+      assert_not result.changes_made?
+    end
+  end
+
+  test "backdate_for_activity is a no-op when there is no opening anchor" do
+    manager = Account::OpeningBalanceManager.new(@depository_account)
+
+    assert_no_difference -> { @depository_account.valuations.count } do
+      result = manager.backdate_for_activity(1.year.ago.to_date)
+      assert result.success?
+      assert_not result.changes_made?
+    end
+  end
+
   test "when no changes made, returns success with no changes made" do
     # First create an opening anchor
     manager = Account::OpeningBalanceManager.new(@depository_account)

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -99,6 +99,39 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal opening_date, opening_anchor.entry.date
   end
 
+  test "recording activity before the opening anchor backdates it and preserves the old balance as a reconciliation" do
+    account = @family.accounts.create!(
+      owner: @admin,
+      name: "Backdate Test",
+      balance: 1000,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    account.set_opening_anchor_balance(balance: 1000, date: 3.months.ago.to_date)
+
+    activity_date = 5.months.ago.to_date
+    account.entries.create!(
+      date: activity_date,
+      name: "Older transaction",
+      amount: 100,
+      currency: "USD",
+      entryable: Transaction.new
+    )
+
+    account.reload
+
+    # Previously-stated opening balance is preserved as a manual value update
+    assert_equal 1, account.valuations.reconciliation.count
+    reconciliation = account.valuations.reconciliation.first
+    assert_equal 3.months.ago.to_date, reconciliation.entry.date
+    assert_equal 1000, reconciliation.entry.amount
+
+    # Opening anchor is backdated before the activity at a zero balance
+    opening_anchor = account.valuations.opening_anchor.first
+    assert_equal activity_date - 1.day, opening_anchor.entry.date
+    assert_equal 0, opening_anchor.entry.amount
+  end
+
   test "accountable display names expose singular and group contexts" do
     assert_equal "Investment", Investment.singular_display_name
     assert_equal "Investments", Investment.display_name


### PR DESCRIPTION
## Problem

The balance engine only calculates **forward** from the opening anchor (`current_anchor_date.downto(opening_anchor_date)` in `Balance::ReverseCalculator`). Any entry dated on or before the opening anchor is therefore invisible to the balance curve — recording activity earlier than the opening balance silently dropped it from balances.

This bites when backfilling history (e.g. importing older transactions after setting a recent opening balance).

## Behavior

When a transaction/trade is created **on or before** the opening anchor date:

1. The opening anchor is automatically **backdated** to the day before that activity, so the entry is included in the balance curve.
2. The previously-stated opening balance is preserved as a **manual value update** (reconciliation) on its original date — the known balance is not lost.
3. The replacement opening anchor starts at **0** ("balance unknown before the earliest activity"). Subsequent earlier activity just slides that zero anchor further back, **without** spawning duplicate reconciliations (convert-once).

## Changes

- `Account::OpeningBalanceManager#backdate_for_activity` — core logic + a helper that steps past existing valuations to respect the per-account+date valuation uniqueness.
- `Account::Anchorable#backdate_opening_anchor_for_activity` — entry point that triggers a resync when changes are made.
- `Entry` `after_create_commit` hook — fires for activity only (`unless: :valuation?`), which also prevents the replacement-anchor creation from re-triggering the callback.
- Unit tests (`opening_balance_manager_test`) + integration test (`account_test`).

## Testing note

Changed files pass `ruby -c`; I was unable to run the full Rails suite in my environment. Recommend:

```
bin/rails test test/models/account/opening_balance_manager_test.rb test/models/account_test.rb
bin/rails test   # full run — the after_create_commit hook is global; verify no balance/sync tests regress
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accounts now automatically adjust their opening anchor when entries are recorded on or before that date, while preserving the original opening balance.

* **Tests**
  * Added comprehensive test coverage for opening anchor backdating scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->