### PR TITLE
feat(security): warn when ActiveRecord encryption is not configured

### DIFF
--- a/app/controllers/settings/securities_controller.rb
+++ b/app/controllers/settings/securities_controller.rb
@@ -8,5 +8,7 @@ class Settings::SecuritiesController < ApplicationController
     ]
     @oidc_identities = Current.user.oidc_identities.order(:provider)
     @webauthn_credentials = Current.user.webauthn_credentials.order(created_at: :asc)
+    @encryption_unconfigured = Rails.application.config.app_mode.self_hosted? &&
+      !ActiveRecordEncryptionConfig.explicitly_configured?
   end
 end

--- a/app/views/settings/securities/show.html.erb
+++ b/app/views/settings/securities/show.html.erb
@@ -1,5 +1,15 @@
 <%= content_for :page_title, t(".page_title") %>
 
+<% if @encryption_unconfigured %>
+  <div class="mb-4">
+    <%= render DS::Alert.new(
+          variant: :warning,
+          title: t(".encryption_warning.title"),
+          message: t(".encryption_warning.message")
+        ) %>
+  </div>
+<% end %>
+
 <%= settings_section title: t(".mfa_title"), subtitle: t(".mfa_description") do %>
   <div class="space-y-4">
     <div class="p-3 shadow-border-xs bg-container rounded-lg md:flex md:justify-between md:items-center">

--- a/app/views/settings/securities/show.html.erb
+++ b/app/views/settings/securities/show.html.erb
@@ -2,11 +2,15 @@
 
 <% if @encryption_unconfigured %>
   <div class="mb-4">
-    <%= render DS::Alert.new(
-          variant: :warning,
-          title: t(".encryption_warning.title"),
-          message: t(".encryption_warning.message")
-        ) %>
+    <%= render DS::Alert.new(variant: :warning, title: t(".encryption_warning.title")) do %>
+      <p><%= t(".encryption_warning.intro") %></p>
+      <ul class="list-disc pl-5">
+        <% t(".encryption_warning.keys").each do |key| %>
+          <li><%= key %></li>
+        <% end %>
+      </ul>
+      <p><%= t(".encryption_warning.generate") %></p>
+    <% end %>
   </div>
 <% end %>
 

--- a/config/initializers/encryption_warning.rb
+++ b/config/initializers/encryption_warning.rb
@@ -7,8 +7,7 @@ require Rails.root.join("lib/active_record_encryption_config").to_s
 
 Rails.application.config.after_initialize do
   app_mode = Rails.application.config.app_mode
-  if app_mode.respond_to?(:self_hosted?) && app_mode.self_hosted? &&
-     !ActiveRecordEncryptionConfig.explicitly_configured?
+  if app_mode.self_hosted? && !ActiveRecordEncryptionConfig.explicitly_configured?
     Rails.logger.warn(<<~WARN)
       [SECURITY] ActiveRecord Encryption is NOT configured. Sensitive data
       (API keys, provider/bank tokens, MFA secrets, and PII) are being stored

--- a/config/initializers/encryption_warning.rb
+++ b/config/initializers/encryption_warning.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Warn self-hosted operators when ActiveRecord Encryption is NOT configured.
+#
+# This emits a clear startup warning so plaintext-at-rest is never silent.
+require Rails.root.join("lib/active_record_encryption_config").to_s
+
+Rails.application.config.after_initialize do
+  app_mode = Rails.application.config.app_mode
+  if app_mode.respond_to?(:self_hosted?) && app_mode.self_hosted? &&
+     !ActiveRecordEncryptionConfig.explicitly_configured?
+    Rails.logger.warn(<<~WARN)
+      [SECURITY] ActiveRecord Encryption is NOT configured. Sensitive data
+      (API keys, provider/bank tokens, MFA secrets, and PII) are being stored
+      UNENCRYPTED at rest. To enable encryption, set the following keys in your Rails credentials or environment variables:
+        ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+        ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+        ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+      Generate a set with: bin/rails db:encryption:init
+    WARN
+  end
+end

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -213,6 +213,9 @@ en:
     securities:
       show:
         page_title: Security
+        encryption_warning:
+          title: Encryption keys missing
+          message: "Sensitive data like API keys and provider tokens are being stored unencrypted. Set primary_key, deterministic_key and key_derivation_salt in your Rails credentials or environment variables."
         mfa_title: Two-Factor Authentication
         mfa_description: Add an extra layer of security to your account by requiring a code from your authenticator app when signing in
         enable_mfa: Enable 2FA

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -215,7 +215,12 @@ en:
         page_title: Security
         encryption_warning:
           title: Encryption keys missing
-          message: "Sensitive data like API keys and provider tokens are being stored unencrypted. Set primary_key, deterministic_key and key_derivation_salt in your Rails credentials or environment variables."
+          intro: "Sensitive data (API keys, provider tokens, MFA secrets, and PII) are being stored unencrypted at rest. To enable encryption, set the following keys in your environment variables or Rails credentials:"
+          keys:
+            - ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+            - ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+            - ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+          generate: "Generate a set with: bin/rails db:encryption:init"
         mfa_title: Two-Factor Authentication
         mfa_description: Add an extra layer of security to your account by requiring a code from your authenticator app when signing in
         enable_mfa: Enable 2FA

--- a/test/controllers/settings/securities_controller_test.rb
+++ b/test/controllers/settings/securities_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Settings::SecuritiesControllerTest < ActionDispatch::IntegrationTest
+  setup { sign_in users(:family_admin) }
+
+  test "shows encryption warning when self-hosted and encryption is not configured" do
+    Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(false)
+
+    get settings_security_url
+
+    assert_response :success
+    assert_includes response.body, I18n.t("settings.securities.show.encryption_warning.title")
+  end
+
+  test "hides encryption warning when encryption is configured" do
+    Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(true)
+
+    get settings_security_url
+
+    assert_response :success
+    assert_not_includes response.body, I18n.t("settings.securities.show.encryption_warning.title")
+  end
+end

--- a/test/controllers/settings/securities_controller_test.rb
+++ b/test/controllers/settings/securities_controller_test.rb
@@ -22,4 +22,13 @@ class Settings::SecuritiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_not_includes response.body, I18n.t("settings.securities.show.encryption_warning.title")
   end
+
+  test "does not show encryption warning in managed mode" do
+    Rails.configuration.stubs(:app_mode).returns("managed".inquiry)
+
+    get settings_security_url
+
+    assert_response :success
+    assert_not_includes response.body, I18n.t("settings.securities.show.encryption_warning.title")
+  end
 end


### PR DESCRIPTION
 Make it obvious when a self-hosted instance is storing sensitive data   **unencrypted at rest**. No behaviour change, just added visibility.

 When no explicit encryption keys are configured (`ACTIVE_RECORD_ENCRYPTION_*`  env vars or Rails credentials), sensitive columns such as API keys, provider/bank tokens, and PII (email, names) are stored in plaintext.  The app boots and works normally, so users can be unaware their data isn't encrypted.

This PR adds warnings, gated on `app_mode.self_hosted? && !ActiveRecordEncryptionConfig.explicitly_configured?`:
  - **Startup log warning** (`config/initializers/encryption_warning.rb`) — visible
    in `docker logs`.
  - **Warning banner on `/settings/security`**, reusing the existing `DS::Alert`
    pattern already used for the encryption banner on `/settings/providers`.

  ## Screenshot
  
<img width="1290" height="575" alt="warning_banner" src="https://github.com/user-attachments/assets/d58c5739-2582-48bc-95e9-cc47bd51a1cc" />

  ## Testing

- `bin/rails test test/controllers/settings/securities_controller_test.rb` — green (banner shown when unconfigured, hidden when configured).
- `bin/rubocop` and `bundle exec erb_lint` — clean.
- Verified live in a self-hosted container both ways: banner + `[SECURITY]` log when unconfigured; neither when the keys are set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-hosted deployments now show an encryption-not-configured warning banner on the securities settings page.
  * The app also emits a startup warning indicating that sensitive data may be stored unencrypted at rest until encryption is properly enabled.

* **Documentation**
  * Added localized messaging describing the missing encryption requirements and the setup action to generate encryption keys.

* **Tests**
  * Added/expanded coverage to verify the banner behavior for self-hosted vs managed deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->