### PR TITLE
fix(ds): add focus ring to dashboard widget size control

### DIFF
--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -96,7 +96,7 @@
                 data-dashboard-widget-size-section-key-value="<%= section[:key] %>"
                 data-action="keydown->dashboard-widget-size#stopKeydown">
                 <summary
-                  class="list-none cursor-pointer text-secondary hover:text-primary transition-colors p-0.5 opacity-0 group-hover:opacity-100 [&::-webkit-details-marker]:hidden"
+                  class="focus-ring list-none cursor-pointer text-secondary hover:text-primary transition-colors p-0.5 opacity-0 group-hover:opacity-100 [&::-webkit-details-marker]:hidden"
                   aria-label="<%= t("pages.dashboard.widget_size.label") %>">
                   <%= icon("sliders-horizontal", size: "sm", class: "!w-3.5 !h-3.5") %>
                 </summary>


### PR DESCRIPTION
## Summary
- Add the canonical `focus-ring` utility to the dashboard widget-size `<summary>` control.

## Context
Closes #2363.

This keeps the current raw `<details>/<summary>` implementation for now, while making the interactive summary keyboard-focus visible until the `DS::Disclosure(:bare)` variant is available.

## Testing
- `git diff --check`

Not run:
- `bundle exec erb_lint app/views/pages/dashboard.html.erb` (local rbenv is missing Ruby 3.4.9 required by `.ruby-version`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated focus ring styling on dashboard section summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->