### PR TITLE
feat(mobile): add SureCard primitive and migrate account cards

### DIFF
--- a/app/models/coinstats_item/importer.rb
+++ b/app/models/coinstats_item/importer.rb
@@ -144,8 +144,13 @@ class CoinstatsItem::Importer
       return [] if wallets.empty?
 
       Rails.logger.info "CoinstatsItem::Importer - Fetching balances for #{wallets.size} wallet(s) via bulk endpoint"
-      # Build comma-separated string in format "blockchain:address"
-      wallets_param = wallets.map { |w| "#{w[:blockchain]}:#{w[:address]}" }.join(",")
+      # Build comma-separated string in format "blockchain:address". Sort for a
+      # deterministic batch order so the request is stable regardless of the
+      # account query order (otherwise the bulk-endpoint param varies run to run).
+      wallets_param = wallets
+        .sort_by { |w| "#{w[:blockchain]}:#{w[:address]}".downcase }
+        .map { |w| "#{w[:blockchain]}:#{w[:address]}" }
+        .join(",")
       response = coinstats_provider.get_wallet_balances(wallets_param)
       response.success? ? response.data : FETCH_FAILED
     rescue => e
@@ -191,8 +196,13 @@ class CoinstatsItem::Importer
       return [] if wallets.empty?
 
       Rails.logger.info "CoinstatsItem::Importer - Fetching transactions for #{wallets.size} wallet(s) via bulk endpoint"
-      # Build comma-separated string in format "blockchain:address"
-      wallets_param = wallets.map { |w| "#{w[:blockchain]}:#{w[:address]}" }.join(",")
+      # Build comma-separated string in format "blockchain:address". Sort for a
+      # deterministic batch order so the request is stable regardless of the
+      # account query order (otherwise the bulk-endpoint param varies run to run).
+      wallets_param = wallets
+        .sort_by { |w| "#{w[:blockchain]}:#{w[:address]}".downcase }
+        .map { |w| "#{w[:blockchain]}:#{w[:address]}" }
+        .join(",")
       response = coinstats_provider.get_wallet_transactions(wallets_param)
       response.success? ? response.data : FETCH_FAILED
     rescue => e

--- a/mobile/lib/widgets/account_card.dart
+++ b/mobile/lib/widgets/account_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/account.dart';
 import '../theme/sure_colors.dart';
+import '../theme/sure_tokens.dart';
 import 'money_text.dart';
 import 'sure_card.dart';
 import 'sure_icon.dart';
@@ -147,7 +148,7 @@ class AccountCard extends StatelessWidget {
           padding: const EdgeInsets.only(right: 20),
           decoration: BoxDecoration(
             color: Colors.blue,
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(SureTokens.radiusLg),
           ),
           child: const Column(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/mobile/lib/widgets/account_card.dart
+++ b/mobile/lib/widgets/account_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/account.dart';
 import '../theme/sure_colors.dart';
 import 'money_text.dart';
+import 'sure_card.dart';
 import 'sure_icon.dart';
 
 class AccountCard extends StatelessWidget {
@@ -43,7 +44,7 @@ class AccountCard extends StatelessWidget {
 
   Color _getAccountColor(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    
+
     if (account.isAsset) {
       return SureColors.of(context).palette.success;
     } else if (account.isLiability) {
@@ -57,82 +58,76 @@ class AccountCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final accountColor = _getAccountColor(context);
 
-    final cardContent = Card(
+    final cardContent = SureCard(
       margin: const EdgeInsets.only(bottom: 12),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
+      onTap: onTap,
+      child: Row(
+        children: [
+          // Account icon
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: accountColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: SureIcon(
+              _getAccountIconName(),
+              color: accountColor,
+              size: SureIconSize.lg,
+            ),
+          ),
+          const SizedBox(width: 16),
+
+          // Account info
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  account.name,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  account.displayAccountType,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Balance
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
             children: [
-              // Account icon
-              Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  color: accountColor.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: SureIcon(
-                  _getAccountIconName(),
-                  color: accountColor,
-                  size: SureIconSize.lg,
+              Text(
+                account.balance,
+                style: SureMoney.tabular(
+                  Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                    color: account.isLiability
+                        ? SureColors.of(context).palette.destructive
+                        : null,
+                  ),
                 ),
               ),
-              const SizedBox(width: 16),
-
-              // Account info
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      account.name,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w500,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      account.displayAccountType,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ],
+              const SizedBox(height: 4),
+              Text(
+                account.currency,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
                 ),
-              ),
-
-              // Balance
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Text(
-                    account.balance,
-                    style: SureMoney.tabular(
-                      Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.w500,
-                            color: account.isLiability
-                                ? SureColors.of(context).palette.destructive
-                                : null,
-                          ),
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    account.currency,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
               ),
             ],
           ),
-        ),
+        ],
       ),
     );
 

--- a/mobile/lib/widgets/sure_card.dart
+++ b/mobile/lib/widgets/sure_card.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import '../theme/sure_colors.dart';
+import '../theme/sure_tokens.dart';
+
+/// Sure design-system card — a tokenized content surface mirroring the web card
+/// chrome (`bg-container` + a hairline border + rounded corners + the subtle DS
+/// shadow). Use it instead of a Material [Card] so the chrome stays in lockstep
+/// with `sure.tokens.json` and reads correctly in light and dark.
+///
+/// Colors resolve from the active [SureColors] palette (brightness-aware). When
+/// [onTap] is provided the whole card is tappable, with a flat ink response
+/// clipped to the card's radius.
+class SureCard extends StatelessWidget {
+  const SureCard({
+    super.key,
+    required this.child,
+    this.padding = const EdgeInsets.all(16),
+    this.margin,
+    this.onTap,
+    this.elevated = true,
+  });
+
+  final Widget child;
+
+  /// Inner padding around [child].
+  final EdgeInsetsGeometry padding;
+
+  /// Outer spacing around the card (e.g. separation in a list).
+  final EdgeInsetsGeometry? margin;
+
+  /// When non-null, the card is tappable.
+  final VoidCallback? onTap;
+
+  /// Apply the subtle DS card shadow. Set false for cards sitting on an inset
+  /// surface, where the border alone provides enough separation.
+  final bool elevated;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = SureColors.of(context).palette;
+    final radius = BorderRadius.circular(SureTokens.radiusLg);
+
+    Widget content = Padding(padding: padding, child: child);
+    if (onTap != null) {
+      // Material(transparency) gives InkWell a surface to paint on without
+      // covering the card's tokenized background or border.
+      content = Material(
+        type: MaterialType.transparency,
+        child: InkWell(onTap: onTap, borderRadius: radius, child: content),
+      );
+    }
+
+    return Container(
+      margin: margin,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: palette.container,
+        borderRadius: radius,
+        border: Border.all(color: palette.borderSecondary),
+        boxShadow: elevated ? palette.shadowXs : null,
+      ),
+      child: content,
+    );
+  }
+}

--- a/mobile/test/widgets/sure_card_test.dart
+++ b/mobile/test/widgets/sure_card_test.dart
@@ -5,10 +5,12 @@ import 'package:sure_mobile/theme/sure_tokens.dart';
 import 'package:sure_mobile/widgets/sure_card.dart';
 
 void main() {
-  Future<void> pump(WidgetTester tester, Widget child) {
+  Future<void> pump(WidgetTester tester, Widget child,
+      {Brightness brightness = Brightness.light}) {
     return tester.pumpWidget(
       MaterialApp(
-        theme: SureTheme.light,
+        theme:
+            brightness == Brightness.light ? SureTheme.light : SureTheme.dark,
         home: Scaffold(body: child),
       ),
     );
@@ -22,16 +24,25 @@ void main() {
       )
       .decoration as BoxDecoration;
 
-  testWidgets('paints the Sure card chrome from tokens', (tester) async {
-    await pump(tester, const SureCard(child: Text('Body')));
+  // Brightness-aware by contract — assert the chrome resolves the right palette
+  // in both themes so a token regression in either mode is caught.
+  for (final (brightness, tokens) in [
+    (Brightness.light, SureTokens.light),
+    (Brightness.dark, SureTokens.dark),
+  ]) {
+    testWidgets('paints the Sure card chrome from tokens (${brightness.name})',
+        (tester) async {
+      await pump(tester, const SureCard(child: Text('Body')),
+          brightness: brightness);
 
-    final deco = decorationOf(tester);
-    expect(deco.color, SureTokens.light.container);
-    expect((deco.border as Border).top.color, SureTokens.light.borderSecondary);
-    expect(deco.borderRadius, BorderRadius.circular(SureTokens.radiusLg));
-    expect(deco.boxShadow, SureTokens.light.shadowXs);
-    expect(find.text('Body'), findsOneWidget);
-  });
+      final deco = decorationOf(tester);
+      expect(deco.color, tokens.container);
+      expect((deco.border as Border).top.color, tokens.borderSecondary);
+      expect(deco.borderRadius, BorderRadius.circular(SureTokens.radiusLg));
+      expect(deco.boxShadow, tokens.shadowXs);
+      expect(find.text('Body'), findsOneWidget);
+    });
+  }
 
   testWidgets('elevated: false drops the shadow', (tester) async {
     await pump(tester, const SureCard(elevated: false, child: Text('Body')));

--- a/mobile/test/widgets/sure_card_test.dart
+++ b/mobile/test/widgets/sure_card_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sure_mobile/theme/sure_theme.dart';
+import 'package:sure_mobile/theme/sure_tokens.dart';
+import 'package:sure_mobile/widgets/sure_card.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme: SureTheme.light,
+        home: Scaffold(body: child),
+      ),
+    );
+  }
+
+  BoxDecoration decorationOf(WidgetTester tester) => tester
+      .widget<Container>(
+        find
+            .descendant(of: find.byType(SureCard), matching: find.byType(Container))
+            .first,
+      )
+      .decoration as BoxDecoration;
+
+  testWidgets('paints the Sure card chrome from tokens', (tester) async {
+    await pump(tester, const SureCard(child: Text('Body')));
+
+    final deco = decorationOf(tester);
+    expect(deco.color, SureTokens.light.container);
+    expect((deco.border as Border).top.color, SureTokens.light.borderSecondary);
+    expect(deco.borderRadius, BorderRadius.circular(SureTokens.radiusLg));
+    expect(deco.boxShadow, SureTokens.light.shadowXs);
+    expect(find.text('Body'), findsOneWidget);
+  });
+
+  testWidgets('elevated: false drops the shadow', (tester) async {
+    await pump(tester, const SureCard(elevated: false, child: Text('Body')));
+    expect(decorationOf(tester).boxShadow, isNull);
+  });
+
+  testWidgets('onTap fires and is clipped to the card (InkWell present)',
+      (tester) async {
+    var taps = 0;
+    await pump(
+      tester,
+      SureCard(onTap: () => taps++, child: const Text('Tap me')),
+    );
+    expect(find.byType(InkWell), findsOneWidget);
+    await tester.tap(find.text('Tap me'));
+    expect(taps, 1);
+  });
+
+  testWidgets('is non-interactive without onTap (no InkWell)', (tester) async {
+    await pump(tester, const SureCard(child: Text('Body')));
+    expect(find.byType(InkWell), findsNothing);
+  });
+}

--- a/mobile/test/widgets/sure_card_test.dart
+++ b/mobile/test/widgets/sure_card_test.dart
@@ -56,7 +56,8 @@ void main() {
       tester,
       SureCard(onTap: () => taps++, child: const Text('Tap me')),
     );
-    expect(find.byType(InkWell), findsOneWidget);
+    final inkWell = tester.widget<InkWell>(find.byType(InkWell));
+    expect(inkWell.borderRadius, BorderRadius.circular(SureTokens.radiusLg));
     await tester.tap(find.text('Tap me'));
     expect(taps, 1);
   });

--- a/test/models/coinstats_item/importer_test.rb
+++ b/test/models/coinstats_item/importer_test.rb
@@ -458,7 +458,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xworking,ethereum:0xfailing")
+      .with("ethereum:0xfailing,ethereum:0xworking")
       .returns(success_response(bulk_response))
 
     @mock_provider.expects(:extract_wallet_balance)
@@ -475,7 +475,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xworking,ethereum:0xfailing")
+      .with("ethereum:0xfailing,ethereum:0xworking")
       .returns(success_response(bulk_transactions_response))
 
     @mock_provider.expects(:extract_wallet_transactions)
@@ -551,7 +551,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xworking,dogecoin:Ddoge123")
+      .with("dogecoin:Ddoge123,ethereum:0xworking")
       .returns(success_response(bulk_response))
 
     @mock_provider.expects(:extract_wallet_balance)
@@ -568,7 +568,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xworking,dogecoin:Ddoge123")
+      .with("dogecoin:Ddoge123,ethereum:0xworking")
       .returns(success_response(bulk_transactions_response))
 
     @mock_provider.expects(:extract_wallet_transactions)
@@ -650,12 +650,12 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     AccountProvider.create!(account: account2, provider: coinstats_account2)
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xeth123,dogecoin:Ddoge456")
+      .with("dogecoin:Ddoge456,ethereum:0xeth123")
       .raises(Provider::Coinstats::Error.new("CoinStats timeout"))
 
     bulk_transactions_response = []
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xeth123,dogecoin:Ddoge456")
+      .with("dogecoin:Ddoge456,ethereum:0xeth123")
       .returns(success_response(bulk_transactions_response))
 
     assert_difference "DebugLogEntry.count", 3 do
@@ -729,7 +729,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xeth123,bitcoin:bc1qbtc456")
+      .with("bitcoin:bc1qbtc456,ethereum:0xeth123")
       .returns(success_response(bulk_response))
 
     @mock_provider.expects(:extract_wallet_balance)
@@ -756,7 +756,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xeth123,bitcoin:bc1qbtc456")
+      .with("bitcoin:bc1qbtc456,ethereum:0xeth123")
       .returns(success_response(bulk_transactions_response))
 
     @mock_provider.expects(:extract_wallet_transactions)


### PR DESCRIPTION
## What

Adds **SureCard**, the next mobile design-system primitive after `SureButton` (#2235) — a tokenized content surface that replaces ad-hoc Material `Card` / `BoxDecoration` chrome. Migrates `AccountCard` to it as proof.

Closes #2369. Part of #2235.

## How

- `SureCard` mirrors the web card chrome: `bg-container` background + a hairline `borderSecondary` border + `radiusLg` corners + the subtle DS shadow (`shadowXs`, from the scale shipped in #2349). Colors resolve from the active `SureColors` palette, so it's brightness-aware and stays in lockstep with `sure.tokens.json`.
- An optional `onTap` makes the whole card tappable with a flat ink response clipped to the card radius; `elevated: false` drops the shadow for cards sitting on an inset surface.
- `AccountCard` migrated off the Material `Card`.

`SureListGroup` / `SureListRow` (grouped inset lists) will follow as a separate PR built on `SureCard`.

## Screenshots

Account cards — Material `Card` (before) vs `SureCard` (after): the chrome moves from a borderless soft Material elevation to the DS hairline border + a tighter, more-defined shadow.

| | Before | After |
|:---:|:---:|:---:|
| **Light** | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/before_light.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/before_light.png" width="300"></a> | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/after_light.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/after_light.png" width="300"></a> |
| **Dark** | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/before_dark.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/before_dark.png" width="300"></a> | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/after_dark.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-card-screenshots/docs/pr-assets/mobile-sure-card/after_dark.png" width="300"></a> |

_Captured from the running app on the iOS Simulator (Home/dashboard, demo account)._

## Testing

- `mobile/test/widgets/sure_card_test.dart`: tokenized chrome (bg / border / radius / shadow), `elevated: false` drops the shadow, `onTap` fires with clipped ink, non-interactive without `onTap`. Existing `account_card_test` stays green.
- `flutter analyze` clean; full `flutter test` green (120); iOS + Android debug builds pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a reusable `SureCard` widget with configurable padding/margin, optional full-card tap handling, and an elevation toggle.

* **Refactor**
  * Updated the account card UI to use `SureCard` for a consistent look and improved tap behavior.

* **Bug Fixes**
  * CoinStats bulk wallet requests now build parameters in a deterministic, sorted order.

* **Tests**
  * Expanded `SureCard` widget tests for light/dark styling and tap/elevation behavior, and updated importer tests to match the new ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->