### PR TITLE
fix(prices): resolve dashed crypto tickers (BTC-USD, TRX-USD) via BinancePublic

### DIFF
--- a/app/models/provider/binance_public.rb
+++ b/app/models/provider/binance_public.rb
@@ -41,6 +41,18 @@ class Provider::BinancePublic < Provider
   # enough and avoids surfacing transient depeg ticks from market data.
   USD_STABLECOINS = %w[USDT USDC BUSD DAI FDUSD TUSD USDP PYUSD].freeze
 
+  # Quote tokens that can trail a base asset in a user-facing crypto ticker,
+  # e.g. Yahoo's canonical "BTC-USD" or a pasted "TRX/USDT". Binance's own
+  # pairs are unseparated ("BTCUSDT"), so to recover the base asset we strip a
+  # trailing quote token plus any separator. Sorted longest-first so "USDT" is
+  # matched before "USD" (otherwise "BTC-USDT" would strip to "BTC-T").
+  QUOTE_SUFFIX_TOKENS = (QUOTE_TO_CURRENCY.values + SUPPORTED_QUOTES)
+    .uniq.sort_by { |q| -q.length }.freeze
+
+  # Characters users/providers place between base and quote ("BTC-USD",
+  # "BTC/USD", "BTC_USD").
+  QUOTE_SEPARATOR = /[-\/_ ]\z/
+
   # Symbol prefix applied by holdings processors (CoinStats, Coinbase, Kraken,
   # Binance, SimpleFIN, Lunchflow) to distinguish crypto from stock tickers.
   CRYPTO_PREFIX = "CRYPTO:".freeze
@@ -68,12 +80,18 @@ class Provider::BinancePublic < Provider
 
   def search_securities(symbol, country_code: nil, exchange_operating_mic: nil)
     with_provider_response do
-      query = symbol.to_s.strip.upcase.delete_prefix(CRYPTO_PREFIX)
+      # Collapse separators so the canonical "BTC-USD" / "TRX/USDT" form is
+      # treated like Binance's own unseparated "BTCUSD" — the existing narrow
+      # matching then resolves it instead of falling through to an offline row.
+      query = symbol.to_s.strip.upcase.delete_prefix(CRYPTO_PREFIX).gsub(/[\s\-\/_]/, "")
       next [] if query.empty?
 
-      if USD_STABLECOINS.include?(query)
-        next [ stablecoin_search_result(query) ]
-      end
+      # Stablecoins have no Binance self-pair, so synthesize a result. Match the
+      # bare coin first (USDT, plus coins that themselves end in USD: PYUSD,
+      # FDUSD, TUSD, BUSD), then the "<coin>USD" form (e.g. "USDTUSD" from a
+      # pasted "USDT-USD") via its suffix-stripped base.
+      stablecoin = [ query, base_asset_query(query) ].find { |s| USD_STABLECOINS.include?(s) }
+      next [ stablecoin_search_result(stablecoin) ] if stablecoin
 
       symbols = exchange_info_symbols
 
@@ -86,8 +104,8 @@ class Provider::BinancePublic < Provider
 
         # Match on either the base asset (so "BTC" surfaces every BTC pair) or
         # the full Binance pair symbol (so users pasting their own portfolio
-        # ticker like "BTCEUR" or "BTCUSD" — which prefixes Binance's raw
-        # "BTCUSDT" — also hit a result).
+        # ticker like "BTCEUR", "BTCUSD", or "BTC-USD" — which prefix Binance's
+        # raw "BTCUSDT" once separators are collapsed — also hit a result).
         base.include?(query) || symbol == query || symbol.start_with?(query)
       end
 
@@ -240,6 +258,22 @@ class Provider::BinancePublic < Provider
   end
 
   private
+    # Recovers the base asset from a search query that carries an explicit
+    # quote suffix, with or without a separator:
+    #   "BTC-USD" -> "BTC", "TRX/USDT" -> "TRX", "BTCUSD" -> "BTC"
+    # Returns the query unchanged when no quote suffix is present (a bare base
+    # like "BTC" or "SOL", or a fuzzy fragment like "BIT") or when stripping
+    # would leave nothing (e.g. the bare quote "USD").
+    def base_asset_query(query)
+      QUOTE_SUFFIX_TOKENS.each do |token|
+        next unless query.end_with?(token)
+
+        base = query.delete_suffix(token).sub(QUOTE_SEPARATOR, "")
+        return base unless base.empty?
+      end
+      query
+    end
+
     # Synthetic search hit for a USD-pegged stablecoin. Binance has no self-pair
     # (USDTUSDT etc. don't exist), so we manufacture a result instead of letting
     # the resolver fall back to an offline CRYPTO:* row. The downstream price
@@ -319,7 +353,9 @@ class Provider::BinancePublic < Provider
         display_currency = QUOTE_TO_CURRENCY[quote]
         next unless ticker_up.end_with?(display_currency)
 
-        base = ticker_up.delete_suffix(display_currency)
+        # Strip the quote plus any separator so the canonical "BTC-USD" form
+        # yields "BTC" (not "BTC-") and builds a valid "BTCUSDT" pair.
+        base = ticker_up.delete_suffix(display_currency).sub(QUOTE_SEPARATOR, "")
         next if base.empty?
 
         # "{stablecoin}USD" form (e.g. "USDTUSD" produced by search_securities)

--- a/app/models/provider/binance_public.rb
+++ b/app/models/provider/binance_public.rb
@@ -41,16 +41,9 @@ class Provider::BinancePublic < Provider
   # enough and avoids surfacing transient depeg ticks from market data.
   USD_STABLECOINS = %w[USDT USDC BUSD DAI FDUSD TUSD USDP PYUSD].freeze
 
-  # Quote tokens that can trail a base asset in a user-facing crypto ticker,
-  # e.g. Yahoo's canonical "BTC-USD" or a pasted "TRX/USDT". Binance's own
-  # pairs are unseparated ("BTCUSDT"), so to recover the base asset we strip a
-  # trailing quote token plus any separator. Sorted longest-first so "USDT" is
-  # matched before "USD" (otherwise "BTC-USDT" would strip to "BTC-T").
-  QUOTE_SUFFIX_TOKENS = (QUOTE_TO_CURRENCY.values + SUPPORTED_QUOTES)
-    .uniq.sort_by { |q| -q.length }.freeze
-
-  # Characters users/providers place between base and quote ("BTC-USD",
-  # "BTC/USD", "BTC_USD").
+  # Trailing separator between base and quote in a stored pair ticker
+  # ("BTC-USD", "BTC/USD", "BTC_USD"), stripped so parse_ticker builds a valid
+  # Binance pair.
   QUOTE_SEPARATOR = /[-\/_ ]\z/
 
   # Symbol prefix applied by holdings processors (CoinStats, Coinbase, Kraken,
@@ -86,11 +79,16 @@ class Provider::BinancePublic < Provider
       query = symbol.to_s.strip.upcase.delete_prefix(CRYPTO_PREFIX).gsub(/[\s\-\/_]/, "")
       next [] if query.empty?
 
-      # Stablecoins have no Binance self-pair, so synthesize a result. Match the
-      # bare coin first (USDT, plus coins that themselves end in USD: PYUSD,
-      # FDUSD, TUSD, BUSD), then the "<coin>USD" form (e.g. "USDTUSD" from a
-      # pasted "USDT-USD") via its suffix-stripped base.
-      stablecoin = [ query, base_asset_query(query) ].find { |s| USD_STABLECOINS.include?(s) }
+      # Stablecoins have no Binance self-pair, so a USD-quoted query gets a
+      # synthetic 1.0 USD result: the bare coin ("USDT", or coins that end in
+      # USD like PYUSD/FDUSD), or the "<coin>USD" form ("USDTUSD", from a pasted
+      # "USDT-USD"). A non-USD quote like "USDTEUR" has a real Binance pair and
+      # must fall through to normal matching, so only the USD case short-circuits.
+      stablecoin = if USD_STABLECOINS.include?(query)
+        query
+      elsif query.end_with?("USD") && USD_STABLECOINS.include?(query.delete_suffix("USD"))
+        query.delete_suffix("USD")
+      end
       next [ stablecoin_search_result(stablecoin) ] if stablecoin
 
       symbols = exchange_info_symbols
@@ -258,22 +256,6 @@ class Provider::BinancePublic < Provider
   end
 
   private
-    # Recovers the base asset from a search query that carries an explicit
-    # quote suffix, with or without a separator:
-    #   "BTC-USD" -> "BTC", "TRX/USDT" -> "TRX", "BTCUSD" -> "BTC"
-    # Returns the query unchanged when no quote suffix is present (a bare base
-    # like "BTC" or "SOL", or a fuzzy fragment like "BIT") or when stripping
-    # would leave nothing (e.g. the bare quote "USD").
-    def base_asset_query(query)
-      QUOTE_SUFFIX_TOKENS.each do |token|
-        next unless query.end_with?(token)
-
-        base = query.delete_suffix(token).sub(QUOTE_SEPARATOR, "")
-        return base unless base.empty?
-      end
-      query
-    end
-
     # Synthetic search hit for a USD-pegged stablecoin. Binance has no self-pair
     # (USDTUSDT etc. don't exist), so we manufacture a result instead of letting
     # the resolver fall back to an offline CRYPTO:* row. The downstream price

--- a/test/models/provider/binance_public_test.rb
+++ b/test/models/provider/binance_public_test.rb
@@ -100,6 +100,22 @@ class Provider::BinancePublicTest < ActiveSupport::TestCase
     assert_equal "USD", parsed[:display_currency]
   end
 
+  test "parse_ticker strips a separator before the quote (TRX-USD)" do
+    parsed = @provider.send(:parse_ticker, "TRX-USD")
+    refute parsed[:stablecoin]
+    # Without separator handling this would build the invalid pair "TRX-USDT".
+    assert_equal "TRXUSDT", parsed[:binance_pair]
+    assert_equal "TRX", parsed[:base]
+    assert_equal "USD", parsed[:display_currency]
+  end
+
+  test "parse_ticker treats a separated stablecoin (USDT-USD) as stablecoin" do
+    parsed = @provider.send(:parse_ticker, "USDT-USD")
+    assert parsed[:stablecoin]
+    assert_nil parsed[:binance_pair]
+    assert_equal "USDT", parsed[:base]
+  end
+
   test "search_securities returns empty array when query does not match" do
     @provider.stubs(:exchange_info_symbols).returns(sample_exchange_info)
 
@@ -144,6 +160,49 @@ class Provider::BinancePublicTest < ActiveSupport::TestCase
     # "BTCUSD" is a prefix of Binance's raw "BTCUSDT" — that single USDT-backed
     # USD variant is what should come back (we store it as BTCUSD for the user).
     assert_equal [ "BTCUSD" ], tickers
+  end
+
+  test "search_securities resolves the canonical dashed BASE-USD form" do
+    @provider.stubs(:exchange_info_symbols).returns(sample_exchange_info)
+
+    # "BTC-USD" (Yahoo's crypto format, and what users paste) must resolve to
+    # the same single USD variant as "BTCUSD" — not fall through to offline.
+    response = @provider.search_securities("BTC-USD")
+
+    assert response.success?
+    assert_equal [ "BTCUSD" ], response.data.map(&:symbol)
+  end
+
+  test "search_securities resolves a dashed crypto the stock provider may miss (TRX-USD)" do
+    info = [ info_row("TRX", "USDT"), info_row("BTC", "USDT") ]
+    @provider.stubs(:exchange_info_symbols).returns(info)
+
+    response = @provider.search_securities("TRX-USD")
+
+    assert response.success?
+    assert_equal [ "TRXUSD" ], response.data.map(&:symbol)
+  end
+
+  test "search_securities accepts a slash separator (BTC/USD)" do
+    @provider.stubs(:exchange_info_symbols).returns(sample_exchange_info)
+
+    response = @provider.search_securities("BTC/USD")
+
+    assert response.success?
+    assert_equal [ "BTCUSD" ], response.data.map(&:symbol)
+  end
+
+  test "search_securities treats a dashed stablecoin (USDT-USD) as synthetic without hitting exchangeInfo" do
+    @provider.expects(:exchange_info_symbols).never
+
+    response = @provider.search_securities("USDT-USD")
+
+    assert response.success?
+    assert_equal 1, response.data.size
+    row = response.data.first
+    assert_equal "USDTUSD", row.symbol
+    assert_equal "USDT", row.name
+    assert_equal "USD", row.currency
   end
 
   test "search_securities ranks exact symbol match above base prefix match" do

--- a/test/models/provider/binance_public_test.rb
+++ b/test/models/provider/binance_public_test.rb
@@ -205,6 +205,19 @@ class Provider::BinancePublicTest < ActiveSupport::TestCase
     assert_equal "USD", row.currency
   end
 
+  test "search_securities keeps a native non-USD stablecoin pair (USDT-EUR) over the USD synthetic" do
+    info = [ info_row("USDT", "EUR"), info_row("BTC", "USDT") ]
+    @provider.stubs(:exchange_info_symbols).returns(info)
+
+    # Only USD-quoted stablecoins synthesize; a real EUR pair must survive.
+    response = @provider.search_securities("USDT-EUR")
+
+    assert response.success?
+    row = response.data.find { |s| s.symbol == "USDTEUR" }
+    assert_not_nil row, "expected native USDT/EUR pair, got #{response.data.map(&:symbol).inspect}"
+    assert_equal "EUR", row.currency
+  end
+
   test "search_securities ranks exact symbol match above base prefix match" do
     info = [
       info_row("BTC", "USDT"),   # base="BTC", symbol="BTCUSDT"


### PR DESCRIPTION
## What & why

`Provider::BinancePublic` is the dedicated crypto price provider ("crypto is handled exclusively by `Provider::BinancePublic`", per the note in `twelve_data.rb`). But its `search_securities` only matched:

- a **bare base asset** — `"BTC"`, `"SOL"`, or
- an **unseparated Binance pair / display ticker** — `"BTCUSDT"`, `"BTCUSD"`, `"BTCEUR"` (via `symbol == query` / `symbol.start_with?(query)`).

The **canonical `<BASE>-USD` form** — what Yahoo emits for crypto and what users paste from a portfolio (`"BTC-USD"`, `"TRX-USD"`, `"USDT-USD"`) — matched **nothing**: `base.include?("TRX-USD")` is false against base `"TRX"`, and `"TRXUSDT".start_with?("TRX-USD")` is false. The stablecoin short-circuit `USD_STABLECOINS.include?("USDT-USD")` also missed (the suffix breaks the bare-symbol lookup).

So a manual crypto holding entered as `TICKER-USD` resolves to a candidate **only** if the stock provider (e.g. Yahoo) happens to return it. When it doesn't — rate-limited, transient error, or simply not covered — the resolver falls through to an **offline security with no price feed**. In practice this leaves common coins (TRX, USDT, DOGE, ADA, …) silently stuck at cost basis while BTC/ETH/etc. price live.

## Fix

Make the dedicated crypto provider self-sufficient for the canonical format:

- **`search_securities`** collapses base/quote separators (`-`, `/`, `_`, space) in the query, so `"BTC-USD"` / `"TRX/USDT"` are treated exactly like the already-supported `"BTCUSD"` and resolve to the same single USD variant.
- Stablecoins are matched on the bare query **and** the suffix-stripped base, so a pasted `"USDT-USD"` still resolves to the synthetic 1.0 USD price (while bare coins that themselves end in `USD` — `PYUSD`, `FDUSD`, `TUSD`, `BUSD` — are not over-stripped).
- **`parse_ticker`** strips a trailing separator before building the Binance pair, so a stored `"TRX-USD"` yields the valid `"TRXUSDT"` pair instead of `"TRX-USDT"`.

No behavior change for the formats that already worked (`BTC`, `BTCUSD`, `BTCUSDT`, `BTCEUR`, bare stablecoins) — covered by existing + new regression tests.

## Tests

Added unit tests in `test/models/provider/binance_public_test.rb`:

- `search_securities` resolves `BTC-USD`, `BTC/USD`, `TRX-USD` (narrowly, to the single USD variant);
- dashed stablecoin `USDT-USD` synthesizes without hitting `exchangeInfo`;
- `parse_ticker` handles `TRX-USD` → `TRXUSDT` and `USDT-USD` → stablecoin;
- existing narrow/exact/stablecoin/no-match cases still hold.

> Note: I couldn't boot the full Rails suite locally (Ruby 3.4.9 toolchain unavailable on this machine); the new/changed logic is `ruby -c`-clean and was additionally validated against an extracted pure-Ruby harness covering all the above cases plus regressions. A maintainer CI run would be appreciated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ticker search now accepts additional input formats with separators (e.g., BTC-USD, TRX/USDT, BTC/USD), normalizing them to the same canonical result.
  * Improved stablecoin matching, including cases like USDT-USD resolving to the expected synthetic USD form while preserving native non-USD stablecoin pairs (e.g., USDT-EUR).

* **Bug Fixes**
  * Corrected ticker parsing when stripping quote suffixes, preventing malformed base symbols.

* **Chores**
  * Expanded automated test coverage for separator and stablecoin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->