### PR TITLE
fix(settings): preserve scroll position in settings nav

### DIFF
--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -3,7 +3,7 @@
     <%= link_to t("layouts.application.skip_to_main"), "#main",
         class: "sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-2 focus:rounded-lg focus:bg-container focus:text-primary focus:shadow-border-xs" %>
 
-    <div class="w-full md:w-auto md:min-w-64 shrink-0 md:h-full md:overflow-y-auto border-divider md:border-r">
+    <div id="settings-nav-container" data-controller="preserve-scroll" class="w-full md:w-auto md:min-w-64 shrink-0 md:h-full md:overflow-y-auto border-divider md:border-r">
       <div class="p-4">
         <%= render "settings/settings_nav" %>
       </div>


### PR DESCRIPTION
fix(settings): preserve scroll position in settings nav

The settings nav scrolled back to the top on every Turbo navigation. preserve-scroll was applied to the nav element itself, but that element has no overflow - scrollTop was always 0, so nothing was ever saved.

Apply preserve-scroll to the actual scrollable container and give it an id so the controller can key the saved position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings navigation now preserves scroll position when navigating between sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->