### PR TITLE
feat(mobile): add SureChip primitive and migrate the currency filter

### DIFF
--- a/mobile/lib/widgets/currency_filter.dart
+++ b/mobile/lib/widgets/currency_filter.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'sure_chip.dart';
+
 class CurrencyFilter extends StatelessWidget {
   final Set<String> availableCurrencies;
   final Set<String> selectedCurrencies;
@@ -42,8 +44,8 @@ class CurrencyFilter extends StatelessWidget {
     }
 
     final sortedCurrencies = availableCurrencies.toList()..sort();
-    final colorScheme = Theme.of(context).colorScheme;
-    final isAllSelected = selectedCurrencies.isEmpty ||
+    final isAllSelected =
+        selectedCurrencies.isEmpty ||
         selectedCurrencies.length == availableCurrencies.length;
 
     return Container(
@@ -55,27 +57,10 @@ class CurrencyFilter extends StatelessWidget {
           // "All" chip
           Padding(
             padding: const EdgeInsets.only(right: 8),
-            child: FilterChip(
-              label: const Text('All'),
+            child: SureChip(
+              label: 'All',
               selected: isAllSelected,
-              onSelected: (_) {
-                onSelectionChanged({});
-              },
-              backgroundColor: colorScheme.surfaceContainerHighest,
-              selectedColor: colorScheme.primaryContainer,
-              checkmarkColor: colorScheme.onPrimaryContainer,
-              labelStyle: TextStyle(
-                color: isAllSelected
-                    ? colorScheme.onPrimaryContainer
-                    : colorScheme.onSurfaceVariant,
-                fontWeight: isAllSelected ? FontWeight.bold : FontWeight.normal,
-              ),
-              side: BorderSide(
-                color: isAllSelected
-                    ? colorScheme.primary
-                    : colorScheme.outline.withValues(alpha: 0.3),
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 8),
+              onSelected: (_) => onSelectionChanged({}),
             ),
           ),
 
@@ -84,12 +69,14 @@ class CurrencyFilter extends StatelessWidget {
             final isSelected =
                 selectedCurrencies.contains(currency) && !isAllSelected;
             final symbol = _getCurrencySymbol(currency);
-            final displayText = symbol.isNotEmpty ? '$currency ($symbol)' : currency;
+            final displayText = symbol.isNotEmpty
+                ? '$currency ($symbol)'
+                : currency;
 
             return Padding(
               padding: const EdgeInsets.only(right: 8),
-              child: FilterChip(
-                label: Text(displayText),
+              child: SureChip(
+                label: displayText,
                 selected: isSelected,
                 onSelected: (_) {
                   final newSelection = Set<String>.from(selectedCurrencies);
@@ -109,21 +96,6 @@ class CurrencyFilter extends StatelessWidget {
                     onSelectionChanged(newSelection);
                   }
                 },
-                backgroundColor: colorScheme.surfaceContainerHighest,
-                selectedColor: colorScheme.primaryContainer,
-                checkmarkColor: colorScheme.onPrimaryContainer,
-                labelStyle: TextStyle(
-                  color: isSelected
-                      ? colorScheme.onPrimaryContainer
-                      : colorScheme.onSurfaceVariant,
-                  fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
-                ),
-                side: BorderSide(
-                  color: isSelected
-                      ? colorScheme.primary
-                      : colorScheme.outline.withValues(alpha: 0.3),
-                ),
-                padding: const EdgeInsets.symmetric(horizontal: 8),
               ),
             );
           }),

--- a/mobile/lib/widgets/currency_filter.dart
+++ b/mobile/lib/widgets/currency_filter.dart
@@ -44,9 +44,12 @@ class CurrencyFilter extends StatelessWidget {
     }
 
     final sortedCurrencies = availableCurrencies.toList()..sort();
-    final isAllSelected =
-        selectedCurrencies.isEmpty ||
-        selectedCurrencies.length == availableCurrencies.length;
+    // Ignore stale codes that are no longer available, otherwise a leftover
+    // selection could make length-based "All" detection fire incorrectly.
+    final normalizedSelected =
+        selectedCurrencies.intersection(availableCurrencies);
+    final isAllSelected = normalizedSelected.isEmpty ||
+        normalizedSelected.length == availableCurrencies.length;
 
     return Container(
       height: 44,
@@ -67,7 +70,7 @@ class CurrencyFilter extends StatelessWidget {
           // Currency chips
           ...sortedCurrencies.map((currency) {
             final isSelected =
-                selectedCurrencies.contains(currency) && !isAllSelected;
+                normalizedSelected.contains(currency) && !isAllSelected;
             final symbol = _getCurrencySymbol(currency);
             final displayText = symbol.isNotEmpty
                 ? '$currency ($symbol)'
@@ -79,7 +82,7 @@ class CurrencyFilter extends StatelessWidget {
                 label: displayText,
                 selected: isSelected,
                 onSelected: (_) {
-                  final newSelection = Set<String>.from(selectedCurrencies);
+                  final newSelection = Set<String>.from(normalizedSelected);
                   if (isSelected) {
                     newSelection.remove(currency);
                   } else {
@@ -90,7 +93,8 @@ class CurrencyFilter extends StatelessWidget {
                     newSelection.add(currency);
                   }
                   // If all currencies selected, treat as "All"
-                  if (newSelection.length == availableCurrencies.length) {
+                  if (newSelection.length == availableCurrencies.length &&
+                      newSelection.containsAll(availableCurrencies)) {
                     onSelectionChanged({});
                   } else {
                     onSelectionChanged(newSelection);

--- a/mobile/lib/widgets/sure_chip.dart
+++ b/mobile/lib/widgets/sure_chip.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import '../theme/sure_colors.dart';
+
+/// Sure design-system filter chip — a tokenized selectable pill mirroring the web
+/// DS pill: a rounded-full chip that reads as bordered/neutral when unselected
+/// and filled (neutral `buttonPrimary` + inverse label) when selected.
+///
+/// Colors resolve from the active [SureColors] palette, so it's brightness-aware
+/// and stays in lockstep with `sure.tokens.json` (and avoids the Material
+/// `primaryContainer` tint the raw `FilterChip` falls back to).
+///
+/// ```dart
+/// SureChip(
+///   label: 'USD',
+///   selected: isSelected,
+///   onSelected: (next) => toggle(next),
+/// )
+/// ```
+class SureChip extends StatelessWidget {
+  const SureChip({
+    super.key,
+    required this.label,
+    this.selected = false,
+    this.onSelected,
+    this.leading,
+    this.enabled = true,
+  });
+
+  final String label;
+  final bool selected;
+
+  /// Called with the next selected value when tapped. When null the chip is
+  /// non-interactive (still renders its selected/unselected state).
+  final ValueChanged<bool>? onSelected;
+
+  /// Optional leading widget (e.g. a color dot or icon).
+  final Widget? leading;
+
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = SureColors.of(context).palette;
+    final theme = Theme.of(context);
+    final interactive = enabled && onSelected != null;
+
+    // Selected: filled neutral pill with an inverse label. Unselected: a
+    // transparent pill with a hairline border. The border lives on the shape so
+    // Material paints it and clips the ink to the stadium.
+    final shape = StadiumBorder(
+      side: selected
+          ? BorderSide.none
+          : BorderSide(color: palette.borderSecondary),
+    );
+
+    final content = ConstrainedBox(
+      // Enforce a comfortable minimum tap target regardless of context
+      // (Material FilterChip parity); the chip still sizes to content otherwise.
+      constraints: const BoxConstraints(minHeight: 44),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (leading != null) ...[leading!, const SizedBox(width: 6)],
+            Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: selected ? palette.textInverse : palette.textSecondary,
+                fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    return Semantics(
+      // Announce as a button only when it's actually tappable; a display-only
+      // chip is just a selected indicator, not a disabled button.
+      button: interactive ? true : null,
+      enabled: interactive ? true : null,
+      selected: selected,
+      child: Opacity(
+        opacity: enabled ? 1.0 : 0.5,
+        child: Material(
+          color: selected ? palette.buttonPrimary : const Color(0x00000000),
+          shape: shape,
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: interactive ? () => onSelected!(!selected) : null,
+            customBorder: shape,
+            child: content,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/widgets/currency_filter_test.dart
+++ b/mobile/test/widgets/currency_filter_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sure_mobile/theme/sure_theme.dart';
+import 'package:sure_mobile/widgets/currency_filter.dart';
+import 'package:sure_mobile/widgets/sure_chip.dart';
+
+// Proof that migrating the filter chips to SureChip preserved the selection
+// behavior (per-currency toggle + the "All" reset).
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required Set<String> selected,
+    required ValueChanged<Set<String>> onChanged,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme: SureTheme.light,
+        home: Scaffold(
+          body: CurrencyFilter(
+            availableCurrencies: const {'USD', 'EUR', 'GBP'},
+            selectedCurrencies: selected,
+            onSelectionChanged: onChanged,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders an "All" chip plus one SureChip per currency',
+      (tester) async {
+    await pump(tester, selected: const {}, onChanged: (_) {});
+    expect(find.byType(SureChip), findsNWidgets(4)); // All + 3 currencies
+    expect(find.text('All'), findsOneWidget);
+  });
+
+  testWidgets('selecting a currency reports just that currency',
+      (tester) async {
+    Set<String>? latest;
+    await pump(tester, selected: const {}, onChanged: (s) => latest = s);
+    await tester.tap(find.text('EUR (€)'));
+    expect(latest, {'EUR'});
+  });
+
+  testWidgets('tapping "All" resets the selection', (tester) async {
+    Set<String>? latest;
+    await pump(tester, selected: const {'EUR'}, onChanged: (s) => latest = s);
+    await tester.tap(find.text('All'));
+    expect(latest, isEmpty);
+  });
+}

--- a/mobile/test/widgets/sure_chip_test.dart
+++ b/mobile/test/widgets/sure_chip_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sure_mobile/theme/sure_theme.dart';
+import 'package:sure_mobile/theme/sure_tokens.dart';
+import 'package:sure_mobile/widgets/sure_chip.dart';
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester,
+    Widget child, {
+    Brightness brightness = Brightness.light,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme:
+            brightness == Brightness.light ? SureTheme.light : SureTheme.dark,
+        home: Scaffold(body: Center(child: child)),
+      ),
+    );
+  }
+
+  Material materialOf(WidgetTester tester) => tester.widget<Material>(
+        find
+            .descendant(
+                of: find.byType(SureChip), matching: find.byType(Material))
+            .first,
+      );
+
+  // Brightness-aware by contract — assert both selection states resolve the
+  // right tokens in light and dark.
+  for (final (brightness, tokens) in [
+    (Brightness.light, SureTokens.light),
+    (Brightness.dark, SureTokens.dark),
+  ]) {
+    testWidgets(
+      'selected chip fills with the neutral token (${brightness.name})',
+      (tester) async {
+        await pump(
+          tester,
+          const SureChip(label: 'USD', selected: true),
+          brightness: brightness,
+        );
+        expect(materialOf(tester).color, tokens.buttonPrimary);
+        final label = tester.widget<Text>(find.text('USD'));
+        expect(label.style?.color, tokens.textInverse);
+        expect(label.style?.fontWeight, FontWeight.w600);
+        // Filled chip drops the border.
+        expect(
+          (materialOf(tester).shape as StadiumBorder).side,
+          BorderSide.none,
+        );
+      },
+    );
+
+    testWidgets(
+      'unselected chip is a bordered transparent pill (${brightness.name})',
+      (tester) async {
+        await pump(
+          tester,
+          const SureChip(label: 'USD'),
+          brightness: brightness,
+        );
+        expect(materialOf(tester).color, const Color(0x00000000));
+        expect(
+          (materialOf(tester).shape as StadiumBorder).side.color,
+          tokens.borderSecondary,
+        );
+        final label = tester.widget<Text>(find.text('USD'));
+        expect(label.style?.color, tokens.textSecondary);
+        expect(label.style?.fontWeight, FontWeight.w500);
+      },
+    );
+  }
+
+  testWidgets('tapping reports the next selected value', (tester) async {
+    bool? next;
+    await pump(
+      tester,
+      SureChip(label: 'USD', selected: false, onSelected: (v) => next = v),
+    );
+    await tester.tap(find.byType(SureChip));
+    expect(next, isTrue);
+
+    await pump(
+      tester,
+      SureChip(label: 'USD', selected: true, onSelected: (v) => next = v),
+    );
+    await tester.tap(find.byType(SureChip));
+    expect(next, isFalse);
+  });
+
+  testWidgets('exposes button + selected semantics', (tester) async {
+    final handle = tester.ensureSemantics();
+    await pump(
+      tester,
+      SureChip(label: 'USD', selected: true, onSelected: (_) {}),
+    );
+    final node = tester.getSemantics(find.byType(SureChip));
+    expect(node.hasFlag(SemanticsFlag.isButton), isTrue);
+    expect(node.hasFlag(SemanticsFlag.isSelected), isTrue);
+    handle.dispose();
+  });
+
+  testWidgets('a chip without onSelected is non-interactive', (tester) async {
+    await pump(tester, const SureChip(label: 'USD'));
+    expect(tester.widget<InkWell>(find.byType(InkWell)).onTap, isNull);
+  });
+
+  testWidgets('enabled: false is non-interactive and dimmed', (tester) async {
+    var taps = 0;
+    await pump(
+      tester,
+      SureChip(label: 'USD', enabled: false, onSelected: (_) => taps++),
+    );
+    expect(tester.widget<InkWell>(find.byType(InkWell)).onTap, isNull);
+    expect(tester.widget<Opacity>(find.byType(Opacity)).opacity, 0.5);
+    await tester.tap(find.byType(SureChip));
+    expect(taps, 0);
+  });
+
+  testWidgets('meets the minimum tap-target height', (tester) async {
+    await pump(tester, const SureChip(label: 'USD'));
+    expect(
+        tester.getSize(find.byType(SureChip)).height, greaterThanOrEqualTo(44));
+  });
+}


### PR DESCRIPTION
## What

Adds **SureChip**, the filter-chip primitive following `SureTextField` (#2377) in the mobile design-system sequence (#2235). It replaces Material `FilterChip` usage (the `primaryContainer` selected tint + checkmark + `primary` blue border) with a tokenized pill mirroring the web DS. The currency filter is migrated as proof.

Closes #2379. Part of #2235.

## How

- `SureChip` is a selectable pill resolving from the active `SureColors` palette: **unselected** is a transparent stadium pill with a `borderSecondary` hairline and a `textSecondary` label; **selected** fills with the neutral `buttonPrimary` token + a `textInverse` label and drops the border (mirrors the DS filled pill — no Material blue, no checkmark).
- `onSelected` reports the next value; `enabled: false`/no callback renders a dimmed, non-interactive chip.
- **a11y:** `selected` state is exposed to screen readers, and it's announced as a button only when interactive (a display-only chip is a selected indicator, not a disabled button). Enforces a 44px min tap target and single-line ellipsised labels.
- `currency_filter.dart` migrated off Material `FilterChip` (selection logic — All-reset, per-currency toggle — preserved verbatim).

The segmented control will follow as a separate PR to complete the form-control set.

## Screenshots

The currency filter — Material `FilterChip` (before) vs `SureChip` (after): the selected chip moves from a blue-bordered, checkmarked, tinted rectangle to a clean filled-neutral stadium pill; unselected chips become hairline-bordered pills.

| | Before | After |
|:---:|:---:|:---:|
| **Light** | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/before_light.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/before_light.png" width="300"></a> | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/after_light.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/after_light.png" width="300"></a> |
| **Dark** | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/before_dark.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/before_dark.png" width="300"></a> | <a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/after_dark.png"><img src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex-mobile-sure-chip-screenshots/docs/pr-assets/mobile-sure-chip/after_dark.png" width="300"></a> |

_Captured from the running app on the iOS Simulator (currency filter, BTC selected)._

## Testing

- `mobile/test/widgets/sure_chip_test.dart`: selected vs unselected chrome (fill / border / label color + weight) in light **and** dark, `onSelected` reports the next value, button + selected semantics, non-interactive paths (`onSelected: null` and `enabled: false` + dimming), and the min tap-target height.
- `mobile/test/widgets/currency_filter_test.dart`: proof the migration preserved behavior — renders a chip per currency, selecting reports the right set, and "All" resets.
- `flutter analyze` clean (no new issues); full `flutter test` green (128); iOS + Android debug builds pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced **SureChip**, a theme-aware filter chip design-system component with selected/unselected styling, minimum tap target sizing, and optional toggle interactivity.

* **Improvements**
  * Updated **CurrencyFilter** to use **SureChip**, enhancing visual consistency and refining “All” vs individual currency selection behavior (including how “All” clears/represents selection).

* **Tests**
  * Added widget test coverage for **SureChip** and **CurrencyFilter**, including rendering, tap behavior, disabled states, and touch target requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->