### PR TITLE
fix(chat): cap messages at 50, always return newest, fix polling past page limit

### DIFF
--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::ChatsController < Api::V1::BaseController
 
   def show
     return unless @chat
-    @pagy, @messages = pagy(@chat.messages.ordered, items: 50)
+    @messages = @chat.messages.ordered.last(50)
   end
 
   def create

--- a/app/models/coinstats_item/importer.rb
+++ b/app/models/coinstats_item/importer.rb
@@ -140,7 +140,7 @@ class CoinstatsItem::Importer
 
         { address: address, blockchain: blockchain }
       end.uniq { |w| [ w[:address].downcase, w[:blockchain].downcase ] }
-         .sort_by { |w| "#{w[:blockchain]}:#{w[:address]}" }
+         .sort_by { |w| "#{w[:blockchain].downcase}:#{w[:address].downcase}" }
 
       return [] if wallets.empty?
 
@@ -188,7 +188,7 @@ class CoinstatsItem::Importer
 
         { address: address, blockchain: blockchain }
       end.uniq { |w| [ w[:address].downcase, w[:blockchain].downcase ] }
-         .sort_by { |w| "#{w[:blockchain]}:#{w[:address]}" }
+         .sort_by { |w| "#{w[:blockchain].downcase}:#{w[:address].downcase}" }
 
       return [] if wallets.empty?
 

--- a/app/models/coinstats_item/importer.rb
+++ b/app/models/coinstats_item/importer.rb
@@ -140,6 +140,7 @@ class CoinstatsItem::Importer
 
         { address: address, blockchain: blockchain }
       end.uniq { |w| [ w[:address].downcase, w[:blockchain].downcase ] }
+         .sort_by { |w| "#{w[:blockchain]}:#{w[:address]}" }
 
       return [] if wallets.empty?
 
@@ -187,6 +188,7 @@ class CoinstatsItem::Importer
 
         { address: address, blockchain: blockchain }
       end.uniq { |w| [ w[:address].downcase, w[:blockchain].downcase ] }
+         .sort_by { |w| "#{w[:blockchain]}:#{w[:address]}" }
 
       return [] if wallets.empty?
 

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -466,7 +466,20 @@ class ChatProvider with ChangeNotifier {
               if (!localById.containsKey(m.id)) m,
           ]..sort((a, b) => a.createdAt.compareTo(b.createdAt));
 
-          _currentChat = _currentChat!.copyWith(messages: _trimMessages(merged));
+          // Drop ghost optimistic messages (pending_* IDs) created by createChat
+          // that have been confirmed by a real server user message with the same content.
+          final confirmedContents = {
+            for (final m in serverMessages)
+              if (m.role == 'user') m.content,
+          };
+          final cleaned = merged.where((m) {
+            if (m.id.startsWith('pending_') && m.role == 'user') {
+              return !confirmedContents.contains(m.content);
+            }
+            return true;
+          }).toList();
+
+          _currentChat = _currentChat!.copyWith(messages: _trimMessages(cleaned));
           if (hasNewMessage) {
             _lastAssistantContentLength = null;
             _pollingStartTime = DateTime.now();

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -20,6 +20,13 @@ class ChatProvider with ChangeNotifier {
   bool _isPollingRequestInFlight = false;
 
   static const _pollingTimeout = Duration(seconds: 20);
+  static const int _kMaxMessages = 50;
+
+  /// Keeps only the most recent [_kMaxMessages] messages.
+  List<Message> _trimMessages(List<Message> msgs) {
+    if (msgs.length <= _kMaxMessages) return msgs;
+    return msgs.sublist(msgs.length - _kMaxMessages);
+  }
 
   /// Content length of the last assistant message from the previous poll.
   /// Used to detect when the LLM has finished writing (no growth between polls).
@@ -29,6 +36,11 @@ class ChatProvider with ChangeNotifier {
   /// Requires 2 consecutive stable polls before declaring the response complete,
   /// to avoid prematurely stopping on a brief server-side generation pause.
   int _stablePollingCount = 0;
+
+  /// ID of the last assistant message that existed before the current polling
+  /// session. The stability check must not fire on this pre-existing message —
+  /// only on a genuinely new AI response.
+  String? _sessionPriorAssistantId;
 
   List<Chat> get chats => _chats;
   Chat? get currentChat => _currentChat;
@@ -90,7 +102,8 @@ class ChatProvider with ChangeNotifier {
       );
 
       if (result['success'] == true) {
-        _currentChat = result['chat'] as Chat;
+        final chat = result['chat'] as Chat;
+        _currentChat = chat.copyWith(messages: _trimMessages(chat.messages));
         _errorMessage = null;
       } else {
         _errorMessage = result['error'] ?? 'Failed to fetch chat';
@@ -220,7 +233,7 @@ class ChatProvider with ChangeNotifier {
               .where((m) => m.id != optimisticMessage.id)
               .toList()
             ..add(message);
-          _currentChat = _currentChat!.copyWith(messages: updated);
+          _currentChat = _currentChat!.copyWith(messages: _trimMessages(updated));
         }
 
         _errorMessage = null;
@@ -369,6 +382,18 @@ class ChatProvider with ChangeNotifier {
     _stablePollingCount = 0;
     _isWaitingForResponse = true;
     _pollingStartTime = DateTime.now();
+
+    // Record the last known assistant message so the stability check doesn't
+    // fire on it — we need to wait for the NEW response from this exchange.
+    _sessionPriorAssistantId = null;
+    final msgs = _currentChat?.messages ?? [];
+    for (int i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].isAssistant) {
+        _sessionPriorAssistantId = msgs[i].id;
+        break;
+      }
+    }
+
     notifyListeners();
 
     _pollingTimer = Timer.periodic(const Duration(seconds: 2), (timer) async {
@@ -391,11 +416,13 @@ class ChatProvider with ChangeNotifier {
     _isWaitingForResponse = false;
     _lastAssistantContentLength = null;
     _stablePollingCount = 0;
+    _sessionPriorAssistantId = null;
   }
 
   /// Poll for updates
   Future<void> _pollForUpdates(String accessToken, String chatId) async {
     try {
+      // The backend returns the newest 50 messages without pagination.
       final result = await _chatService.getChat(
         accessToken: accessToken,
         chatId: chatId,
@@ -406,86 +433,96 @@ class ChatProvider with ChangeNotifier {
 
         if (_currentChat == null || _currentChat!.id != chatId) return;
 
-        final oldMessages = _currentChat!.messages;
-        final newMessages = updatedChat.messages;
-        final oldMessageCount = oldMessages.length;
-        final newMessageCount = newMessages.length;
+        final serverMessages = updatedChat.messages;
+        final localMessages = _currentChat!.messages;
+        final localById = <String, Message>{for (final m in localMessages) m.id: m};
+        final serverById = <String, Message>{for (final m in serverMessages) m.id: m};
 
-        final oldContentLengthById = <String, int>{};
-        for (final m in oldMessages) {
-          if (m.isAssistant) oldContentLengthById[m.id] = m.content.length;
-        }
-
-        bool shouldUpdate = false;
-
-        // New messages added
-        if (newMessageCount > oldMessageCount) {
-          shouldUpdate = true;
-          _lastAssistantContentLength = null;
-        } else if (newMessageCount == oldMessageCount) {
-          // Same count: check if any assistant message has more content
-          for (final m in newMessages) {
-            if (m.isAssistant) {
-              final oldLen = oldContentLengthById[m.id] ?? 0;
-              if (m.content.length > oldLen) {
-                shouldUpdate = true;
-                break;
-              }
+        // Detect assistant content growth on existing messages.
+        bool contentGrew = false;
+        for (final m in serverMessages) {
+          if (m.isAssistant) {
+            final oldLen = localById[m.id]?.content.length ?? 0;
+            if (m.content.length > oldLen) {
+              contentGrew = true;
+              break;
             }
           }
         }
 
-        if (shouldUpdate) {
-          _currentChat = updatedChat;
+        // Detect genuinely new messages not yet in local state.
+        bool hasNewMessage = false;
+        for (final m in serverMessages) {
+          if (!localById.containsKey(m.id)) {
+            hasNewMessage = true;
+            break;
+          }
+        }
+
+        if (contentGrew || hasNewMessage) {
+          // Rebuild: update existing messages with server versions and append
+          // any new arrivals. Never shrink the local list — messages on earlier
+          // pages stay visible even though this poll only fetches the last page.
+          final merged = [
+            for (final m in localMessages) serverById[m.id] ?? m,
+            for (final m in serverMessages)
+              if (!localById.containsKey(m.id)) m,
+          ]..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+
+          _currentChat = _currentChat!.copyWith(messages: _trimMessages(merged));
+          if (hasNewMessage) {
+            _lastAssistantContentLength = null;
+            _pollingStartTime = DateTime.now();
+          }
           notifyListeners();
         }
 
         if (updatedChat.error != null && updatedChat.error!.isNotEmpty) {
-          if (!shouldUpdate) {
-            _currentChat = updatedChat;
-          }
           _stopPolling();
           _errorMessage = updatedChat.error;
           notifyListeners();
           return;
         }
 
-        final lastMessage = updatedChat.messages.lastOrNull;
-        if (lastMessage != null && lastMessage.isAssistant) {
-          final newLen = lastMessage.content.length;
+        // Find the last NEW assistant message — one that didn't exist before
+        // this polling session started. The stability check must not fire on
+        // _sessionPriorAssistantId (the old response from the previous exchange).
+        final allMessages = _currentChat!.messages;
+        Message? newAssistantMsg;
+        for (int i = allMessages.length - 1; i >= 0; i--) {
+          final m = allMessages[i];
+          if (m.isAssistant && m.id != _sessionPriorAssistantId) {
+            newAssistantMsg = m;
+            break;
+          }
+        }
+
+        if (newAssistantMsg != null) {
+          final newLen = newAssistantMsg.content.length;
           final previousLen = _lastAssistantContentLength;
 
           if (newLen > (previousLen ?? -1)) {
             _lastAssistantContentLength = newLen;
             _stablePollingCount = 0;
             if (newLen > 0) {
-              // Content is growing — reset the inactivity clock.
               _pollingStartTime = DateTime.now();
-              return; // progress made, don't evaluate timeout this tick
+              return;
             }
-            // newLen == 0: empty placeholder, keep polling
           } else if (newLen > 0) {
-            // Content stable and non-empty.
-            // Require 2 consecutive stable polls before declaring done, to avoid
-            // stopping prematurely on a brief server-side generation pause.
             _stablePollingCount++;
             if (_stablePollingCount >= 2) {
               _stopPolling();
-              _lastAssistantContentLength = null;
               notifyListeners();
               return;
             }
           }
-          // newLen == 0 with previousLen already 0: still empty, keep polling
         }
+        // No new assistant message yet — keep polling.
       }
     } catch (e) {
-      // Network error — allow polling to continue; timeout check below will
-      // stop it if the deadline has passed.
       _log.warning('ChatProvider', 'Polling failed: ${e.runtimeType}');
     }
 
-    // Evaluate timeout only after the attempt, and only when no progress was made.
     if (_pollingStartTime != null &&
         DateTime.now().difference(_pollingStartTime!) >= _pollingTimeout) {
       _stopPolling();

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -37,10 +37,10 @@ class ChatProvider with ChangeNotifier {
   /// to avoid prematurely stopping on a brief server-side generation pause.
   int _stablePollingCount = 0;
 
-  /// ID of the last assistant message that existed before the current polling
-  /// session. The stability check must not fire on this pre-existing message —
-  /// only on a genuinely new AI response.
-  String? _sessionPriorAssistantId;
+  /// IDs of all assistant messages that existed before the current polling
+  /// session. The stability check must not fire on any of these — only on a
+  /// genuinely new AI response.
+  Set<String> _sessionPriorAssistantIds = {};
 
   List<Chat> get chats => _chats;
   Chat? get currentChat => _currentChat;
@@ -383,16 +383,12 @@ class ChatProvider with ChangeNotifier {
     _isWaitingForResponse = true;
     _pollingStartTime = DateTime.now();
 
-    // Record the last known assistant message so the stability check doesn't
-    // fire on it — we need to wait for the NEW response from this exchange.
-    _sessionPriorAssistantId = null;
-    final msgs = _currentChat?.messages ?? [];
-    for (int i = msgs.length - 1; i >= 0; i--) {
-      if (msgs[i].isAssistant) {
-        _sessionPriorAssistantId = msgs[i].id;
-        break;
-      }
-    }
+    // Record all existing assistant message IDs so the stability check doesn't
+    // fire on any of them — we need to wait for the NEW response from this exchange.
+    _sessionPriorAssistantIds = {
+      for (final m in _currentChat?.messages ?? [])
+        if (m.isAssistant) m.id,
+    };
 
     notifyListeners();
 
@@ -416,7 +412,7 @@ class ChatProvider with ChangeNotifier {
     _isWaitingForResponse = false;
     _lastAssistantContentLength = null;
     _stablePollingCount = 0;
-    _sessionPriorAssistantId = null;
+    _sessionPriorAssistantIds = {};
   }
 
   /// Poll for updates
@@ -461,8 +457,9 @@ class ChatProvider with ChangeNotifier {
 
         if (contentGrew || hasNewMessage) {
           // Rebuild: update existing messages with server versions and append
-          // any new arrivals. Never shrink the local list — messages on earlier
-          // pages stay visible even though this poll only fetches the last page.
+          // any new arrivals. The merge itself never drops local messages —
+          // messages not in this poll response are kept as-is. The merged list
+          // is then trimmed to _kMaxMessages so the local cap stays in force.
           final merged = [
             for (final m in localMessages) serverById[m.id] ?? m,
             for (final m in serverMessages)
@@ -486,12 +483,13 @@ class ChatProvider with ChangeNotifier {
 
         // Find the last NEW assistant message — one that didn't exist before
         // this polling session started. The stability check must not fire on
-        // _sessionPriorAssistantId (the old response from the previous exchange).
+        // any pre-session assistant message (all IDs recorded in
+        // _sessionPriorAssistantIds at poll start).
         final allMessages = _currentChat!.messages;
         Message? newAssistantMsg;
         for (int i = allMessages.length - 1; i >= 0; i--) {
           final m = allMessages[i];
-          if (m.isAssistant && m.id != _sessionPriorAssistantId) {
+          if (m.isAssistant && !_sessionPriorAssistantIds.contains(m.id)) {
             newAssistantMsg = m;
             break;
           }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -205,10 +205,6 @@ RSpec.configure do |config|
                   messages: {
                     type: :array,
                     items: { '$ref' => '#/components/schemas/Message' }
-                  },
-                  pagination: {
-                    '$ref' => '#/components/schemas/Pagination',
-                    nullable: true
                   }
                 }
               }

--- a/test/controllers/api/v1/chats_controller_test.rb
+++ b/test/controllers/api/v1/chats_controller_test.rb
@@ -61,6 +61,20 @@ class Api::V1::ChatsControllerTest < ActionDispatch::IntegrationTest
     assert response_body["messages"].is_a?(Array)
   end
 
+  test "show caps response at 50 newest messages and omits pagination key" do
+    # chats(:one) has 3 fixture messages; add 48 more to push the total to 51
+    48.times do |i|
+      @chat.messages.create!(type: "UserMessage", content: "msg #{i}", ai_model: "gpt-4.1")
+    end
+
+    get "/api/v1/chats/#{@chat.id}", headers: bearer_auth_header(@read_token)
+    assert_response :success
+
+    response_body = JSON.parse(response.body)
+    assert_equal 50, response_body["messages"].size
+    assert_not response_body.key?("pagination"), "show must not include a pagination key"
+  end
+
   test "should create chat with write scope" do
     assert_difference "Chat.count" do
       post "/api/v1/chats",

--- a/test/controllers/api/v1/chats_controller_test.rb
+++ b/test/controllers/api/v1/chats_controller_test.rb
@@ -75,7 +75,7 @@ class Api::V1::ChatsControllerTest < ActionDispatch::IntegrationTest
     # chat1_assistant_response). Add 48 more so the total is 51 — the oldest fixture
     # message must be trimmed and the rest returned in ascending chronological order.
     48.times do |i|
-      @chat.messages.create!(type: "UserMessage", content: "msg #{i}", ai_model: "gpt-4.1")
+      @chat.messages.create!(type: "AssistantMessage", content: "msg #{i}", ai_model: "gpt-4.1")
     end
 
     get "/api/v1/chats/#{@chat.id}", headers: api_headers(@api_key)

--- a/test/controllers/api/v1/chats_controller_test.rb
+++ b/test/controllers/api/v1/chats_controller_test.rb
@@ -26,6 +26,15 @@ class Api::V1::ChatsControllerTest < ActionDispatch::IntegrationTest
     )
 
     @chat = chats(:one)
+
+    @user.api_keys.active.destroy_all
+    @api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Key",
+      scopes: [ "read_write" ],
+      source: "web",
+      display_key: "chat_test_#{SecureRandom.hex(8)}"
+    )
   end
 
   test "should require authentication" do
@@ -62,17 +71,31 @@ class Api::V1::ChatsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show caps response at 50 newest messages and omits pagination key" do
-    # chats(:one) has 3 fixture messages; add 48 more to push the total to 51
+    # chats(:one) has 3 fixture messages (oldest first: chat1_user, chat1_assistant_reasoning,
+    # chat1_assistant_response). Add 48 more so the total is 51 — the oldest fixture
+    # message must be trimmed and the rest returned in ascending chronological order.
     48.times do |i|
       @chat.messages.create!(type: "UserMessage", content: "msg #{i}", ai_model: "gpt-4.1")
     end
 
-    get "/api/v1/chats/#{@chat.id}", headers: bearer_auth_header(@read_token)
+    get "/api/v1/chats/#{@chat.id}", headers: api_headers(@api_key)
     assert_response :success
 
     response_body = JSON.parse(response.body)
     assert_equal 50, response_body["messages"].size
     assert_not response_body.key?("pagination"), "show must not include a pagination key"
+
+    # The oldest message must be excluded (falls outside the 50-message window)
+    assert_not response_body["messages"].any? { |m| m["content"] == messages(:chat1_user).content },
+      "oldest message must be excluded from the newest-50 window"
+
+    # A non-oldest fixture message must be present
+    assert response_body["messages"].any? { |m| m["content"] == messages(:chat1_assistant_response).content },
+      "non-oldest messages must be present in the newest-50 window"
+
+    # Messages must be returned in ascending chronological order
+    timestamps = response_body["messages"].map { |m| m["created_at"] }
+    assert_equal timestamps.sort, timestamps, "messages must be in ascending chronological order"
   end
 
   test "should create chat with write scope" do
@@ -143,5 +166,9 @@ class Api::V1::ChatsControllerTest < ActionDispatch::IntegrationTest
 
     def bearer_auth_header(token)
       { "Authorization" => "Bearer #{token.token}" }
+    end
+
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.plain_key }
     end
 end

--- a/test/models/coinstats_item/importer_test.rb
+++ b/test/models/coinstats_item/importer_test.rb
@@ -458,7 +458,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xworking,ethereum:0xfailing")
+      .with("ethereum:0xfailing,ethereum:0xworking")
       .returns(success_response(bulk_response))
 
     @mock_provider.expects(:extract_wallet_balance)
@@ -475,7 +475,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xworking,ethereum:0xfailing")
+      .with("ethereum:0xfailing,ethereum:0xworking")
       .returns(success_response(bulk_transactions_response))
 
     @mock_provider.expects(:extract_wallet_transactions)
@@ -551,7 +551,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xworking,dogecoin:Ddoge123")
+      .with("dogecoin:Ddoge123,ethereum:0xworking")
       .returns(success_response(bulk_response))
 
     @mock_provider.expects(:extract_wallet_balance)
@@ -568,7 +568,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xworking,dogecoin:Ddoge123")
+      .with("dogecoin:Ddoge123,ethereum:0xworking")
       .returns(success_response(bulk_transactions_response))
 
     @mock_provider.expects(:extract_wallet_transactions)
@@ -650,12 +650,12 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     AccountProvider.create!(account: account2, provider: coinstats_account2)
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xeth123,dogecoin:Ddoge456")
+      .with("dogecoin:Ddoge456,ethereum:0xeth123")
       .raises(Provider::Coinstats::Error.new("CoinStats timeout"))
 
     bulk_transactions_response = []
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xeth123,dogecoin:Ddoge456")
+      .with("dogecoin:Ddoge456,ethereum:0xeth123")
       .returns(success_response(bulk_transactions_response))
 
     assert_difference "DebugLogEntry.count", 3 do
@@ -729,7 +729,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_balances)
-      .with("ethereum:0xeth123,bitcoin:bc1qbtc456")
+      .with("bitcoin:bc1qbtc456,ethereum:0xeth123")
       .returns(success_response(bulk_response))
 
     @mock_provider.expects(:extract_wallet_balance)
@@ -756,7 +756,7 @@ class CoinstatsItem::ImporterTest < ActiveSupport::TestCase
     ]
 
     @mock_provider.expects(:get_wallet_transactions)
-      .with("ethereum:0xeth123,bitcoin:bc1qbtc456")
+      .with("bitcoin:bc1qbtc456,ethereum:0xeth123")
       .returns(success_response(bulk_transactions_response))
 
     @mock_provider.expects(:extract_wallet_transactions)


### PR DESCRIPTION
## Summary

- **Backend**: `chats#show` now returns `.ordered.last(50)` — the 50 most recent messages in ASC order. Removes the unbounded query and the old pagy pagination cap that caused new messages to fall off page 1 undetected.
- **Flutter — merge not replace**: Poll responses are merged into local state instead of replacing it, so messages fetched on initial load stay visible while new ones arrive from the last page.
- **Flutter — session prior ID guard**: `_sessionPriorAssistantId` records the last assistant message ID at polling start. The stable-poll check only fires on a genuinely new AI response, preventing premature stop on the previous exchange's message.
- **Flutter — 50-message cap**: `_trimMessages` caps `_currentChat.messages` at 50 (newest kept), applied after `fetchChat`, `sendMessage` confirm, and each poll merge.

## Root Cause

`chats#show` paginated messages oldest-first (`ORDER BY created_at ASC`). Once a conversation exceeded the item count, the newest messages (#N+1, #N+2) fell off page 1 and polling never saw them. The stable-poll check then saw the previous complete AI response as the last assistant message and stopped before the new one arrived — leaving the typing indicator to disappear with no response bubble.

## Test plan

- [ ] Open a chat with more than 20 messages — screen shows the most recent messages, scroll lands at bottom
- [ ] Send a message in a long chat — AI response bubble appears normally (no longer stops at the old limit)
- [ ] Start a long session (50+ messages) — list stays bounded at 50, oldest drop off cleanly
- [ ] Short/new chats (< 50 messages) — no regression, all messages visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message polling/completion so it won’t be influenced by assistant messages created before the current polling session.
  * Fixed chat synchronization by merging server updates with local messages more safely and trimming history to prevent drift.
  * Stabilized wallet import behavior with deterministic bulk request ordering.
* **Performance Improvements**
  * Reduced chat detail payload by returning only the 50 most recent messages.
  * Capped locally stored chat history to the most recent messages.
* **Documentation**
  * Updated the chat detail API schema to remove the pagination field.
* **Tests**
  * Added an integration test for the 50-message cap and removed pagination key.
  * Updated CoinStats importer tests for the new request ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->