### PR TITLE
Add Ethereum currency metadata

### DIFF
--- a/config/currencies.yml
+++ b/config/currencies.yml
@@ -894,6 +894,20 @@ doge:
   delimiter: ","
   default_format: "%u%n"
   default_precision: 8
+eth:
+  name: Ethereum
+  priority: 100
+  iso_code: ETH
+  iso_numeric: ""
+  html_code: "&#x039E;"
+  symbol: "Ξ"
+  minor_unit: Wei
+  minor_unit_conversion: 1000000000000000000
+  smallest_denomination: 1
+  separator: "."
+  delimiter: ","
+  default_format: "%u%n"
+  default_precision: 8
 jep:
   name: Jersey Pound
   priority: 100

--- a/test/lib/money/currency_test.rb
+++ b/test/lib/money/currency_test.rb
@@ -31,4 +31,16 @@ class Money::CurrencyTest < ActiveSupport::TestCase
   test "step returns the smallest value of the currency" do
     assert_equal 0.01, @currency.step
   end
+
+  test "includes ethereum metadata" do
+    currency = Money::Currency.new(:eth)
+
+    assert_equal "ETH", currency.iso_code
+    assert_equal "Ethereum", currency.name
+    assert_equal "Ξ", currency.symbol
+    assert_equal "Wei", currency.minor_unit
+    assert_equal 1000000000000000000, currency.minor_unit_conversion
+    assert_equal 8, currency.default_precision
+    assert_equal 0.00000001, currency.step
+  end
 end


### PR DESCRIPTION
## Summary
- add ETH to `config/currencies.yml`
- use Wei as the internal minor unit conversion base
- add a money currency test covering ETH metadata

## Why
Sure raises `Money::Currency::UnknownCurrencyError` when a currency is missing from `config/currencies.yml`. Adding ETH prevents crashes when ETH-denominated data appears.

## Notes
- keeps display precision at 8 decimals
- uses `minor_unit_conversion: 1000000000000000000` so metadata matches Ethereum base units rather than a fiat-style 2-decimal shortcut


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum (ETH) as a supported currency with complete configuration including symbol (Ξ), conversion factors, and precision settings.

* **Tests**
  * Added test coverage to verify Ethereum currency metadata and configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->