### PR TITLE
Fix SimpleFIN epoch-string balance dates causing PG::DatetimeFieldOverflow

### DIFF
--- a/app/models/simplefin_account.rb
+++ b/app/models/simplefin_account.rb
@@ -119,19 +119,13 @@ class SimplefinAccount < ApplicationRecord
     end
 
     def parse_balance_date(balance_date_value)
+      parsed = Simplefin::DateUtils.parse_provider_time(balance_date_value)
+      return parsed if parsed.present?
       return nil if balance_date_value.nil?
 
-      case balance_date_value
-      when String
-        Time.parse(balance_date_value)
-      when Numeric
-        Time.at(balance_date_value)
-      when Time, DateTime
-        balance_date_value
-      else
-        nil
-      end
-    rescue ArgumentError, TypeError
+      Rails.logger.warn("Invalid balance date for SimpleFin account: #{balance_date_value}")
+      nil
+    rescue ArgumentError, TypeError, NameError
       Rails.logger.warn("Invalid balance date for SimpleFin account: #{balance_date_value}")
       nil
     end

--- a/app/models/simplefin_item/importer.rb
+++ b/app/models/simplefin_item/importer.rb
@@ -107,7 +107,7 @@ class SimplefinItem::Importer
         currency: (account_data[:currency].presence || account_data["currency"].presence || sfa.currency.presence || sfa.current_account&.currency.presence || simplefin_item.family&.currency.presence || "USD"),
         current_balance: account_data[:balance],
         available_balance: account_data[:"available-balance"],
-        balance_date: (account_data["balance-date"] || account_data[:"balance-date"]),
+        balance_date: normalize_balance_date(account_data["balance-date"] || account_data[:"balance-date"]),
         raw_payload: account_data,
         org_data: account_data[:org]
       )
@@ -734,6 +734,16 @@ class SimplefinItem::Importer
       simplefin_item.last_synced_at - sync_buffer_period.days
     end
 
+    def normalize_balance_date(value)
+      return nil if value.nil?
+
+      parsed = Simplefin::DateUtils.parse_provider_time(value)
+      return parsed if parsed.present?
+
+      Rails.logger.warn("Invalid balance date for SimpleFin importer: #{value.inspect}")
+      nil
+    end
+
     def import_account(account_data)
       account_id = account_data[:id].to_s
 
@@ -781,7 +791,7 @@ class SimplefinItem::Importer
         currency: (account_data[:currency].presence || account_data["currency"].presence || simplefin_account.currency.presence || simplefin_account.current_account&.currency.presence || simplefin_item.family&.currency.presence || "USD"),
         current_balance: account_data[:balance],
         available_balance: account_data[:"available-balance"],
-        balance_date: (account_data["balance-date"] || account_data[:"balance-date"]),
+        balance_date: normalize_balance_date(account_data["balance-date"] || account_data[:"balance-date"]),
         raw_payload: account_data,
         org_data: account_data[:org]
       }

--- a/lib/simplefin/date_utils.rb
+++ b/lib/simplefin/date_utils.rb
@@ -4,26 +4,42 @@ module Simplefin
   module DateUtils
     module_function
 
-    # Parses provider-supplied dates that may be String (ISO), Numeric (epoch seconds),
-    # Time/DateTime, or Date. Returns a Date or nil when unparseable.
-    def parse_provider_date(val)
+    # Parses provider-supplied timestamps that may be String (ISO or epoch string),
+    # Numeric (epoch seconds), Time/DateTime, or Date. Returns a Time or nil when
+    # unparseable.
+    def parse_provider_time(val)
       return nil if val.nil?
 
       case val
-      when Date
+      when Time
         val
-      when Time, DateTime
-        val.to_date
+      when DateTime
+        val.to_time
+      when Date
+        val.to_time
       when Integer, Float
         return nil if val.to_i == 0
-        Time.at(val).utc.to_date
+        Time.at(val).utc
       when String
-        Date.parse(val)
+        stripped = val.strip
+        return nil if stripped.empty? || stripped == "0"
+
+        if stripped.match?(/\A\d+(?:\.\d+)?\z/)
+          Time.at(stripped.to_f).utc
+        else
+          Time.parse(stripped)
+        end
       else
         nil
       end
     rescue ArgumentError, TypeError
       nil
+    end
+
+    # Parses provider-supplied dates that may be String (ISO), Numeric (epoch seconds),
+    # Time/DateTime, or Date. Returns a Date or nil when unparseable.
+    def parse_provider_date(val)
+      parse_provider_time(val)&.to_date
     end
   end
 end

--- a/test/models/simplefin_account_test.rb
+++ b/test/models/simplefin_account_test.rb
@@ -71,6 +71,23 @@ class SimplefinAccountTest < ActiveSupport::TestCase
     assert_equal snapshot, @simplefin_account.raw_payload
   end
 
+  test "parses numeric-string epoch balance-date in snapshot" do
+    epoch_string = Time.utc(2026, 6, 17, 12, 34, 56).to_i.to_s
+    snapshot = {
+      "balance" => 2000.0,
+      "available-balance" => 1800.0,
+      "balance-date" => epoch_string,
+      "currency" => "USD",
+      "type" => "investment",
+      "name" => "Traditional IRA",
+      "id" => "trad_ira_1"
+    }
+
+    @simplefin_account.upsert_simplefin_snapshot!(snapshot)
+
+    assert_equal Time.at(epoch_string.to_i).utc, @simplefin_account.balance_date
+  end
+
   test "can upsert transactions" do
     transactions = [
       { "id" => "txn_1", "amount" => -50.00, "description" => "Coffee Shop", "posted" => "2024-01-01" },

--- a/test/models/simplefin_item/importer_test.rb
+++ b/test/models/simplefin_item/importer_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class SimplefinItem::ImporterTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @item = SimplefinItem.create!(
+      family: @family,
+      name: "SimpleFIN Importer Test",
+      access_url: "https://example.com/access"
+    )
+    @importer = SimplefinItem::Importer.new(@item, simplefin_provider: nil)
+  end
+
+  test "normalizes numeric-string epoch balance-date for importer upserts" do
+    epoch_string = Time.utc(2026, 6, 17, 12, 34, 56).to_i.to_s
+
+    parsed = @importer.send(:normalize_balance_date, epoch_string)
+
+    assert_equal Time.at(epoch_string.to_i).utc, parsed
+  end
+end


### PR DESCRIPTION
## Problem

SimpleFIN returns `balance-date` as a Unix epoch string (e.g. `"1781706835"`) for investment accounts. The importer was passing this raw string directly to Postgres, causing:

```
PG::DatetimeFieldOverflow: date/time field value out of range
```

## Fix

- Add `Simplefin::DateUtils.parse_provider_time` to handle ISO strings, numeric epochs, and numeric epoch strings
- Route `balance-date` through the shared parser in both importer paths
- Add regression tests

## Files changed

- `lib/simplefin/date_utils.rb`
- `app/models/simplefin_account.rb`
- `app/models/simplefin_item/importer.rb`
- `test/models/simplefin_account_test.rb`
- `test/models/simplefin_item/importer_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of balance date parsing when importing SimpleFIN financial data by enhancing support for multiple timestamp formats, including epoch values and string representations. This ensures more robust and accurate date handling during account synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->