### PR TITLE
fix(coinstats): stabilize bulk wallet ordering

### DIFF
--- a/app/models/coinstats_item/importer.rb
+++ b/app/models/coinstats_item/importer.rb
@@ -31,6 +31,7 @@ class CoinstatsItem::Importer
     linked_accounts = coinstats_item.coinstats_accounts
                                     .joins(:account_provider)
                                     .includes(:account)
+                                    .order(:created_at, :id)
 
     if linked_accounts.empty?
       Rails.logger.info "CoinstatsItem::Importer - No linked accounts to sync for item #{coinstats_item.id}"


### PR DESCRIPTION
## Summary
- make CoinStats linked account loading deterministic during import
- preserve stable wallet ordering when building bulk balance/transaction params
- fix the post-merge CI failure on `main` from #2239

## Context
CI on `main` started failing right after #2239 merged.

The failing test was:
- `CoinstatsItem::ImporterTest#test_bulk_balance_fetch_failure_preserves_all_existing_wallet_balances_during_import`

Root cause was non-deterministic ordering from:
- `coinstats_item.coinstats_accounts.joins(:account_provider).includes(:account)`

That let Postgres/parallel CI return wallet rows in a different order, which flipped the bulk CoinStats wallet param string and broke the existing mock contract.

## Testing
- `bin/rails test test/models/coinstats_item/importer_test.rb`
- verified the failing GitHub Actions run on `main` was this exact test

## Notes
A full local suite rerun on this host later hit an unrelated environment issue in an ActiveStorage test due to missing `libvips`, so this PR is scoped to the confirmed CoinStats ordering regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in processing account data to ensure reliable and predictable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->