### PR TITLE
fix(tinkoff): resolve the tradeable listing and price bonds via BondBy

### DIFF
--- a/app/models/provider/tinkoff_invest.rb
+++ b/app/models/provider/tinkoff_invest.rb
@@ -77,6 +77,7 @@ class Provider::TinkoffInvest < Provider
       next [] if query.empty?
 
       find_instruments(query).filter_map do |row|
+        next nil unless row["apiTradeAvailableFlag"] # only surface instruments the API can actually price
         next nil unless surfaced_kind(row["instrumentType"])
 
         Provider::SecurityConcept::Security.new(
@@ -222,13 +223,19 @@ class Provider::TinkoffInvest < Provider
 
     def find_instruments(query)
       Rails.cache.fetch("tinkoff_invest:find:#{query.downcase}", expires_in: SEARCH_CACHE_TTL) do
-        body = post("InstrumentsService", "FindInstrument", query: query, apiTradeAvailableFlag: false)
+        # Return all matches (not just apiTradeAvailableFlag) — a ticker can have
+        # several non-tradeable listings plus one tradeable board; resolve_short
+        # ranks the tradeable one first while keeping a fallback for instruments
+        # Tinkoff lists but can't trade via API.
+        body = post("InstrumentsService", "FindInstrument", query: query)
         body["instruments"] || []
       end
     end
 
-    # Best FindInstrument hit for a ticker/ISIN: exact ticker (or ISIN) match,
-    # preferring a requested MIC, then a surfaced kind, then any result.
+    # Best FindInstrument hit for a ticker/ISIN. A ticker like SBER returns many
+    # listings (TQBR, SPB, dark boards); only the API-tradeable one has live
+    # prices, so rank tradeable first, then a requested-MIC match, then exact
+    # ticker/ISIN, then a surfaced kind.
     def resolve_short(symbol, exchange_operating_mic)
       key = symbol.to_s.strip
       Rails.cache.fetch("tinkoff_invest:short:#{key.downcase}:#{exchange_operating_mic}", expires_in: INSTRUMENT_CACHE_TTL) do
@@ -237,13 +244,17 @@ class Provider::TinkoffInvest < Provider
 
         exact = rows.select { |r| r["ticker"].to_s.upcase == up || r["isin"].to_s.upcase == up }
         pool = exact.any? ? exact : rows
-        pool = pool.select { |r| surfaced_kind(r["instrumentType"]) } if pool.any? { |r| surfaced_kind(r["instrumentType"]) }
+        typed = pool.select { |r| surfaced_kind(r["instrumentType"]) }
+        pool = typed if typed.any?
+        next nil if pool.empty?
 
-        if exchange_operating_mic.present?
-          preferred = pool.find { |r| mic_for(r["classCode"], r["exchange"]) == exchange_operating_mic.upcase }
-          preferred || pool.first
-        else
-          pool.first
+        mic = exchange_operating_mic.to_s.upcase
+        pool.min_by do |r|
+          [
+            r["apiTradeAvailableFlag"] ? 0 : 1,
+            (mic.present? && mic_for(r["classCode"], r["exchange"]) == mic) ? 0 : 1,
+            (r["ticker"].to_s.upcase == up || r["isin"].to_s.upcase == up) ? 0 : 1
+          ]
         end
       end
     end
@@ -256,8 +267,12 @@ class Provider::TinkoffInvest < Provider
       end
     end
 
+    # Bond nominal comes from BondBy (the generic GetInstrumentBy omits it).
+    # Returns the current (amortized) nominal so percent-of-par prices convert to
+    # money correctly across the bond's life.
     def instrument_nominal(uid)
-      quotation_to_d(instrument_detail(uid)["nominal"])
+      body = post("InstrumentsService", "BondBy", idType: "INSTRUMENT_ID_TYPE_UID", id: uid)
+      quotation_to_d((body["instrument"] || {})["nominal"])
     end
 
     # ================================

--- a/app/models/provider/tinkoff_invest.rb
+++ b/app/models/provider/tinkoff_invest.rb
@@ -253,7 +253,9 @@ class Provider::TinkoffInvest < Provider
     # ticker/ISIN match.
     def resolve_short(symbol, exchange_operating_mic)
       key = symbol.to_s.strip.sub(SUFFIX, "")
-      Rails.cache.fetch("tinkoff_invest:short:#{key.downcase}:#{exchange_operating_mic}", expires_in: INSTRUMENT_CACHE_TTL) do
+      # skip_nil so a transient empty/no-match response isn't cached as "unknown"
+      # for the full 24h TTL.
+      Rails.cache.fetch("tinkoff_invest:short:#{key.downcase}:#{exchange_operating_mic}", expires_in: INSTRUMENT_CACHE_TTL, skip_nil: true) do
         rows = find_instruments(key)
         up = key.upcase
 

--- a/app/models/provider/tinkoff_invest.rb
+++ b/app/models/provider/tinkoff_invest.rb
@@ -138,26 +138,34 @@ class Provider::TinkoffInvest < Provider
       bond = short["instrumentType"].to_s == "bond"
       currency = short["currency"].to_s.upcase
       mic = mic_for(short["classCode"], short["exchange"])
+
       # Bonds quote in % of par; multiply by nominal to get a money price. A
       # missing/invalid nominal is a provider-data failure, not a zero price.
-      nominal = bond ? instrument_nominal(uid) : nil
-      if bond && (nominal.nil? || nominal <= 0)
-        raise InvalidSecurityPriceError, "Missing or invalid T-Invest bond nominal for #{symbol}"
+      nominal = nil
+      amortizing = false
+      if bond
+        info = bond_info(uid)
+        nominal = info[:nominal]
+        amortizing = info[:amortizing]
+        raise InvalidSecurityPriceError, "Missing or invalid T-Invest bond nominal for #{symbol}" if nominal.nil? || nominal <= 0
       end
 
-      prices = candle_closes(uid, start_date, end_date).map do |date, close|
-        value = bond ? (close / 100) * nominal : close
-        Price.new(symbol: short["ticker"].to_s, date: date, price: value, currency: currency, exchange_operating_mic: mic)
-      end
+      ticker = short["ticker"].to_s
+      build = ->(date, raw) { Price.new(symbol: ticker, date: date, price: (bond ? (raw / 100) * nominal : raw), currency: currency, exchange_operating_mic: mic) }
+
+      # BondBy returns only the CURRENT nominal. For an amortizing bond the par
+      # shrinks over time, so applying today's nominal to historical percent-of-
+      # par closes would underprice them — skip the candle history and return
+      # just the live price. Fixed-par bonds and equities use full history.
+      prices = (bond && amortizing) ? [] : candle_closes(uid, start_date, end_date).map { |date, close| build.call(date, close) }
 
       # The candle endpoint lags the live session; append the last price for a
       # range reaching today.
       if end_date >= Date.current
         last = last_price(uid)
         if last
-          value = bond ? (last / 100) * nominal : last
           prices.reject! { |p| p.date == Date.current }
-          prices << Price.new(symbol: short["ticker"].to_s, date: Date.current, price: value, currency: currency, exchange_operating_mic: mic)
+          prices << build.call(Date.current, last)
         end
       end
 
@@ -221,23 +229,30 @@ class Provider::TinkoffInvest < Provider
     #           Instruments
     # ================================
 
+    # Users (and the MoexPublic resolver) paste exchange-suffixed tickers like
+    # "T.MOEX"/"SBER.ME"; T-Invest only knows the bare SECID, so strip the suffix
+    # before querying.
+    SUFFIX = /\.(ME|MOEX|MISX|MCX)\z/i
+
     def find_instruments(query)
-      Rails.cache.fetch("tinkoff_invest:find:#{query.downcase}", expires_in: SEARCH_CACHE_TTL) do
+      q = query.to_s.strip.sub(SUFFIX, "")
+      Rails.cache.fetch("tinkoff_invest:find:#{q.downcase}", expires_in: SEARCH_CACHE_TTL) do
         # Return all matches (not just apiTradeAvailableFlag) — a ticker can have
         # several non-tradeable listings plus one tradeable board; resolve_short
         # ranks the tradeable one first while keeping a fallback for instruments
         # Tinkoff lists but can't trade via API.
-        body = post("InstrumentsService", "FindInstrument", query: query)
+        body = post("InstrumentsService", "FindInstrument", query: q)
         body["instruments"] || []
       end
     end
 
     # Best FindInstrument hit for a ticker/ISIN. A ticker like SBER returns many
-    # listings (TQBR, SPB, dark boards); only the API-tradeable one has live
-    # prices, so rank tradeable first, then a requested-MIC match, then exact
-    # ticker/ISIN, then a surfaced kind.
+    # listings (TQBR, SPB, dark boards). When the caller supplied a MIC, honor it
+    # FIRST so a security is never priced off another exchange's listing; then
+    # prefer the API-tradeable board (the one with live prices), then an exact
+    # ticker/ISIN match.
     def resolve_short(symbol, exchange_operating_mic)
-      key = symbol.to_s.strip
+      key = symbol.to_s.strip.sub(SUFFIX, "")
       Rails.cache.fetch("tinkoff_invest:short:#{key.downcase}:#{exchange_operating_mic}", expires_in: INSTRUMENT_CACHE_TTL) do
         rows = find_instruments(key)
         up = key.upcase
@@ -251,8 +266,8 @@ class Provider::TinkoffInvest < Provider
         mic = exchange_operating_mic.to_s.upcase
         pool.min_by do |r|
           [
-            r["apiTradeAvailableFlag"] ? 0 : 1,
             (mic.present? && mic_for(r["classCode"], r["exchange"]) == mic) ? 0 : 1,
+            r["apiTradeAvailableFlag"] ? 0 : 1,
             (r["ticker"].to_s.upcase == up || r["isin"].to_s.upcase == up) ? 0 : 1
           ]
         end
@@ -267,12 +282,13 @@ class Provider::TinkoffInvest < Provider
       end
     end
 
-    # Bond nominal comes from BondBy (the generic GetInstrumentBy omits it).
-    # Returns the current (amortized) nominal so percent-of-par prices convert to
-    # money correctly across the bond's life.
-    def instrument_nominal(uid)
+    # Bond nominal + amortization flag from BondBy (the generic GetInstrumentBy
+    # omits nominal). `nominal` is the current (possibly amortized) par;
+    # `amortizing` tells the price path that historical par differs from today's.
+    def bond_info(uid)
       body = post("InstrumentsService", "BondBy", idType: "INSTRUMENT_ID_TYPE_UID", id: uid)
-      quotation_to_d((body["instrument"] || {})["nominal"])
+      ins = body["instrument"] || {}
+      { nominal: quotation_to_d(ins["nominal"]), amortizing: ins["amortizationFlag"] == true }
     end
 
     # ================================

--- a/test/models/provider/tinkoff_invest_test.rb
+++ b/test/models/provider/tinkoff_invest_test.rb
@@ -115,6 +115,32 @@ class Provider::TinkoffInvestTest < ActiveSupport::TestCase
     end
   end
 
+  test "fetch_security_prices returns only the live price for an amortizing bond" do
+    travel_to Date.new(2026, 6, 18) do
+      stub_find("RU000A10AAQ4", [ instrument_short(ticker: "RU000A10AAQ4", type: "bond", class_code: "TQCB", uid: "uid-bond", currency: "rub") ])
+      stub_bond_by("uid-bond", { "nominal" => { "units" => "417", "nano" => 710_000_000 }, "amortizationFlag" => true })
+      @provider.stubs(:post).with("MarketDataService", "GetCandles", anything).returns("candles" => [ candle("2026-06-10", units: 105, nano: 0) ])
+      @provider.stubs(:post).with("MarketDataService", "GetLastPrices", anything).returns("lastPrices" => [ { "price" => { "units" => "103", "nano" => 0 } } ])
+
+      response = @provider.fetch_security_prices(symbol: "RU000A10AAQ4", exchange_operating_mic: "MISX", start_date: Date.new(2026, 6, 10), end_date: Date.new(2026, 6, 18))
+
+      # The historical candle is skipped (today's nominal must not reprice old par);
+      # only the live price remains, converted with the current nominal.
+      assert_equal [ Date.new(2026, 6, 18) ], response.data.map(&:date)
+      assert_equal (BigDecimal("103") / 100 * BigDecimal("417.71")), response.data.first.price
+    end
+  end
+
+  test "resolve strips an exchange suffix before querying T-Invest" do
+    stub_find("T", [ instrument_short(ticker: "T", type: "share", class_code: "TQBR", uid: "uid-t") ])
+    stub_instrument_by("uid-t", instrument_full(name: "T-Tech", logo_name: "tcs2.png"))
+
+    response = @provider.fetch_security_info(symbol: "T.MOEX", exchange_operating_mic: "MISX")
+
+    assert response.success?
+    assert_equal "https://invest-brands.cdn-tinkoff.ru/tcs2x160.png", response.data.logo_url
+  end
+
   test "fetch_security_prices skips incomplete candles" do
     travel_to Date.new(2026, 6, 18) do
       stub_find("SBER", [ instrument_short(ticker: "SBER", type: "share", class_code: "TQBR", uid: "uid-sber", currency: "rub") ])

--- a/test/models/provider/tinkoff_invest_test.rb
+++ b/test/models/provider/tinkoff_invest_test.rb
@@ -88,7 +88,7 @@ class Provider::TinkoffInvestTest < ActiveSupport::TestCase
   test "fetch_security_prices converts bond percent-of-par to money via nominal" do
     travel_to Date.new(2026, 6, 18) do
       stub_find("RU000A10AAQ4", [ instrument_short(ticker: "RU000A10AAQ4", isin: "RU000A10AAQ4", type: "bond", class_code: "TQCB", uid: "uid-bond", currency: "rub") ])
-      stub_instrument_by("uid-bond", instrument_full(name: "Bond", nominal: { "units" => "1000", "nano" => 0 }))
+      stub_bond_by("uid-bond", { "nominal" => { "units" => "1000", "nano" => 0 } })
       @provider.stubs(:post).with("MarketDataService", "GetCandles", anything).returns(
         "candles" => [ candle("2026-06-17", units: 103, nano: 700_000_000) ] # 103.7% of par
       )
@@ -104,7 +104,7 @@ class Provider::TinkoffInvestTest < ActiveSupport::TestCase
   test "fetch_security_prices fails (no zero price) when a bond nominal is missing" do
     travel_to Date.new(2026, 6, 18) do
       stub_find("RU000A10AAQ4", [ instrument_short(ticker: "RU000A10AAQ4", type: "bond", class_code: "TQCB", uid: "uid-bond", currency: "rub") ])
-      stub_instrument_by("uid-bond", instrument_full(name: "Bond")) # no nominal
+      stub_bond_by("uid-bond", {}) # no nominal
       @provider.stubs(:post).with("MarketDataService", "GetCandles", anything).returns("candles" => [ candle("2026-06-17", units: 103, nano: 0) ])
       @provider.stubs(:post).with("MarketDataService", "GetLastPrices", anything).returns("lastPrices" => [])
 
@@ -143,10 +143,16 @@ class Provider::TinkoffInvestTest < ActiveSupport::TestCase
                .returns("instrument" => instrument)
     end
 
-    def instrument_short(ticker:, type:, class_code:, name: nil, uid: "uid", isin: "", currency: "rub", country: "RU", exchange: "moex")
+    def stub_bond_by(uid, instrument)
+      @provider.stubs(:post)
+               .with("InstrumentsService", "BondBy", has_entry(id: uid))
+               .returns("instrument" => instrument)
+    end
+
+    def instrument_short(ticker:, type:, class_code:, name: nil, uid: "uid", isin: "", currency: "rub", country: "RU", exchange: "moex", tradeable: true)
       {
         "ticker" => ticker, "name" => name || ticker, "instrumentType" => type,
-        "classCode" => class_code, "uid" => uid, "isin" => isin,
+        "classCode" => class_code, "uid" => uid, "isin" => isin, "apiTradeAvailableFlag" => tradeable,
         "currency" => currency, "countryOfRisk" => country, "exchange" => exchange
       }
     end


### PR DESCRIPTION
Follow-up to #2408, validated against the live T-Invest API.

## Problem
`FindInstrument` returns several listings per ticker — e.g. `SBER` resolves to **6** share entries (TQBR, SPEQ, 37M, SMAL, BEB, RDL). Only the `apiTradeAvailableFlag` listing (TQBR) has live market data. `resolve_short` took the first exact-ticker match, which was often a dark/non-API board (`37M`, exchange `unknown`) → `GetLastPrices`/`GetCandles` returned empty, so stocks/ETFs got no prices.

## Fix
- **resolve_short ranks tradeable-first** (then requested-MIC, then exact ticker/ISIN). SBER→TQBR (313.65), T→TQBR (282.76), LQDT→2.019.
- **find_instruments no longer hard-filters** on `apiTradeAvailableFlag`, so a qualified-investor instrument Tinkoff lists but can't API-trade still resolves for logos and otherwise falls back to another price provider. Search surfaces only tradeable instruments.
- **Bond nominal via `BondBy`** — the generic `GetInstrumentBy` omits `nominal`; `BondBy` returns the current amortized nominal (e.g. SFO Split Finance: 417.71 from initial 1000), so percent-of-par converts to money correctly.

## Verified end-to-end (live token)
| Ticker | logoName | price |
|---|---|---|
| SBER | sber3.png | 313.65 |
| T | tcs2.png | 282.76 |
| LQDT | vimlick.png | 2.019 |
| RU000A10AAQ4 (bond) | Yandex2026.png | 103.93% × 417.71 |

Logos resolve to real CDN PNGs (`invest-brands.cdn-tinkoff.ru/{logoName-.png}x160.png` → 200 image/png). Tests updated (tradeable flag in fixtures, `BondBy` stub for nominal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Securities search now surfaces only tradeable instruments and improves ticker matching for more reliable discovery.

* **Bug Fixes**
  * Bond pricing is more accurate: nominal values are resolved more reliably, and amortizing bonds now use the latest live appended price (skipping candle-based history) while non-amortizing bonds continue using the existing approach.

* **Tests**
  * Updated bond pricing and security discovery tests to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->