### PR TITLE
Scope API v1 controllers through current_resource_owner

### DIFF
--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::ChatsController < Api::V1::BaseController
   before_action :set_chat, only: [ :show, :update, :destroy ]
 
   def index
-    @pagy, @chats = pagy(Current.user.chats.ordered, items: 20)
+    @pagy, @chats = pagy(current_resource_owner.chats.ordered, items: 20)
   end
 
   def show
@@ -17,7 +17,7 @@ class Api::V1::ChatsController < Api::V1::BaseController
   end
 
   def create
-    @chat = Current.user.chats.build(title: chat_params[:title])
+    @chat = current_resource_owner.chats.build(title: chat_params[:title])
 
     if @chat.save
       if chat_params[:message].present?
@@ -74,7 +74,7 @@ class Api::V1::ChatsController < Api::V1::BaseController
     end
 
     def set_chat
-      @chat = Current.user.chats.find(params[:id])
+      @chat = current_resource_owner.chats.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       render json: { error: "Chat not found" }, status: :not_found
     end

--- a/app/controllers/api/v1/import_sessions_controller.rb
+++ b/app/controllers/api/v1/import_sessions_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ImportSessionsController < Api::V1::BaseController
 
   def create
     @import_session = ImportSession.create_or_find_for!(
-      family: Current.family,
+      family: current_resource_owner.family,
       import_type: params[:type].to_s,
       client_session_id: params[:client_session_id].presence,
       expected_chunks: expected_chunks_param
@@ -68,7 +68,7 @@ class Api::V1::ImportSessionsController < Api::V1::BaseController
 
   private
     def set_import_session
-      @import_session = Current.family.import_sessions.find(params[:id])
+      @import_session = current_resource_owner.family.import_sessions.find(params[:id])
     end
 
     def ensure_read_scope

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -49,7 +49,7 @@ class Api::V1::MessagesController < Api::V1::BaseController
     end
 
     def set_chat
-      @chat = Current.user.chats.find(params[:chat_id])
+      @chat = current_resource_owner.chats.find(params[:chat_id])
     rescue ActiveRecord::RecordNotFound
       render json: { error: "Chat not found" }, status: :not_found
     end

--- a/app/controllers/api/v1/provider_connections_controller.rb
+++ b/app/controllers/api/v1/provider_connections_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::ProviderConnectionsController < Api::V1::BaseController
   before_action :ensure_read_scope
 
   def index
-    @provider_connections = ProviderConnectionStatus.for_family(Current.family)
+    @provider_connections = ProviderConnectionStatus.for_family(current_resource_owner.family)
     render :index
   rescue StandardError => e
     Rails.logger.error "ProviderConnectionsController#index error: #{e.message}"

--- a/app/controllers/api/v1/rule_runs_controller.rb
+++ b/app/controllers/api/v1/rule_runs_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::RuleRunsController < Api::V1::BaseController
     def rule_runs_scope
       RuleRun
         .joins(:rule)
-        .where(rules: { family_id: Current.family.id })
+        .where(rules: { family_id: current_resource_owner.family.id })
         .includes(:rule)
     end
 

--- a/app/controllers/api/v1/syncs_controller.rb
+++ b/app/controllers/api/v1/syncs_controller.rb
@@ -41,6 +41,6 @@ class Api::V1::SyncsController < Api::V1::BaseController
     end
 
     def family_syncs_query
-      Sync.for_family(Current.family, resource_owner: Current.user)
+      Sync.for_family(current_resource_owner.family, resource_owner: current_resource_owner)
     end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -45,7 +45,6 @@ class Api::V1::UsersController < Api::V1::BaseController
     user = current_resource_owner
 
     if user.deactivate
-      Current.session&.destroy
       render json: { message: "Account has been deleted" }
     else
       render json: { error: "Failed to delete account", details: user.errors.full_messages }, status: :unprocessable_entity

--- a/test/architecture/api_current_usage_test.rb
+++ b/test/architecture/api_current_usage_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApiCurrentUsageTest < ActiveSupport::TestCase
+  API_CONTROLLER_GLOB = Rails.root.join("app/controllers/api/**/*.rb").to_s
+  BASE_CONTROLLER = Rails.root.join("app/controllers/api/v1/base_controller.rb").to_s
+  DISALLOWED_CURRENT_REFERENCES = [
+    "Current.user",
+    "Current.family",
+    "Current.session"
+  ].freeze
+
+  # Api::V1::BaseController may set an unsaved session as a compatibility bridge
+  # for code paths that still derive Current.user from Current.session.user.
+  # Add new entries only when they are part of that bridge and document why.
+  ALLOWED_BASE_CONTROLLER_REFERENCES = [
+    "Current.session = @current_user.sessions.build(",
+    "Current.session.active_impersonator_session = nil"
+  ].freeze
+
+  test "api controllers scope through current_resource_owner instead of Current" do
+    violations = []
+
+    Dir.glob(API_CONTROLLER_GLOB).sort.each do |path|
+      File.readlines(path).each.with_index(1) do |line, line_number|
+        next unless DISALLOWED_CURRENT_REFERENCES.any? { |reference| line.include?(reference) }
+        next if allowed_base_controller_reference?(path, line)
+
+        relative_path = Pathname.new(path).relative_path_from(Rails.root)
+        violations << "#{relative_path}:#{line_number}: #{line.strip}"
+      end
+    end
+
+    assert_empty violations, <<~MESSAGE
+      API controllers should not read Current.user, Current.family, or Current.session.
+
+      Use current_resource_owner/current_resource_owner.family for API auth scoping.
+      The only allowed Current.session usage is the compatibility bridge in Api::V1::BaseController.
+
+      #{violations.join("\n")}
+    MESSAGE
+  end
+
+  private
+    def allowed_base_controller_reference?(path, line)
+      path == BASE_CONTROLLER && ALLOWED_BASE_CONTROLLER_REFERENCES.any? { |reference| line.include?(reference) }
+    end
+end


### PR DESCRIPTION
## Background

Follow-up to #2405.

That PR fixed the immediate impersonation-context issue by ensuring API-authenticated requests build a fresh session context instead of reusing an existing web session.

This PR is the next hardening step: API v1 controllers should scope resources directly through the authenticated token owner (`current_resource_owner`) instead of reading `Current.user` / `Current.family`.

## Summary

- Replace remaining API v1 business-controller reads from `Current.user` / `Current.family` with `current_resource_owner` / `current_resource_owner.family`
- Pass `current_resource_owner` explicitly to the balance sheet helper instead of relying on its `Current.user` default
- Remove `Current.session&.destroy` from the API account deletion path, since API requests no longer own a persisted web session context
- Add an architecture guard test to prevent API controllers from reintroducing `Current.user`, `Current.family`, or `Current.session` reads outside the BaseController compatibility bridge

## Notes

This intentionally does not refactor `ReportsController` or model-level `Current` defaults. Those are broader follow-ups and are outside this PR's API v1 controller sweep.

No OpenAPI update is needed because this does not change request or response contracts.

## Testing

- `bin/rails test test/architecture/api_current_usage_test.rb`
- `bin/rails test`
- `bin/rubocop app/controllers/api/v1 test/controllers/api/v1 test/architecture`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account and family scoping across API actions, so chats, messages, imports, syncs, provider connections, and rule runs are now consistently tied to the correct signed-in context.
  * Fixed account deletion flow so successful deletions no longer perform an extra session cleanup step.

* **Tests**
  * Added an architectural check to prevent API controllers from using outdated global context references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->