### PR TITLE
design-system(mobile): SureFontWeights tokens (named weight tiers)

### DIFF
--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -7,6 +7,8 @@
 @theme {
   --font-sans: 'Geist', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
   --color-white: #ffffff;
   --color-black: #0B0B0B;
   --color-success: var(--color-green-700);

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -11,6 +11,10 @@
     "mono": {
       "$value": "'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       "$type": "fontFamily"
+    },
+    "weight": {
+      "medium": { "$value": 500, "$type": "fontWeight" },
+      "semibold": { "$value": 600, "$type": "fontWeight" }
     }
   },
 

--- a/mobile/lib/screens/dashboard_screen.dart
+++ b/mobile/lib/screens/dashboard_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/connectivity_banner.dart';
 import '../widgets/net_worth_card.dart';
 import '../widgets/currency_filter.dart';
 import '../widgets/sure_icon.dart';
+import '../theme/sure_tokens.dart';
 import 'transaction_form_screen.dart';
 import 'transactions_list_screen.dart';
 
@@ -715,7 +716,7 @@ class _CollapsibleTypeHeader extends StatelessWidget {
             Text(
               title,
               style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w500,
+                    fontWeight: SureTokens.weightMedium,
                   ),
             ),
             const SizedBox(width: 8),
@@ -729,7 +730,7 @@ class _CollapsibleTypeHeader extends StatelessWidget {
                 count.toString(),
                 style: TextStyle(
                   color: colorScheme.onPrimaryContainer,
-                  fontWeight: FontWeight.w500,
+                  fontWeight: SureTokens.weightMedium,
                   fontSize: 11,
                 ),
               ),

--- a/mobile/lib/screens/recent_transactions_screen.dart
+++ b/mobile/lib/screens/recent_transactions_screen.dart
@@ -6,6 +6,7 @@ import '../models/account.dart';
 import '../providers/transactions_provider.dart';
 import '../providers/accounts_provider.dart';
 import '../providers/auth_provider.dart';
+import '../theme/sure_tokens.dart';
 import '../utils/amount_parser.dart';
 import '../widgets/money_text.dart';
 
@@ -232,7 +233,7 @@ class _RecentTransactionsScreenState extends State<RecentTransactionsScreen> {
       ),
       title: Text(
         transaction.name,
-        style: const TextStyle(fontWeight: FontWeight.w500),
+        style: const TextStyle(fontWeight: SureTokens.weightMedium),
       ),
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -274,7 +275,7 @@ class _RecentTransactionsScreenState extends State<RecentTransactionsScreen> {
             : '$sign${transaction.currency} ${_formatAmount(amount.abs())}',
         trend: moneyTrend,
         style: const TextStyle(
-          fontWeight: FontWeight.w500,
+          fontWeight: SureTokens.weightMedium,
           fontSize: 16,
         ),
       ),

--- a/mobile/lib/screens/transactions_list_screen.dart
+++ b/mobile/lib/screens/transactions_list_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/account_detail_header.dart';
 import '../widgets/category_filter.dart';
 import '../widgets/sync_status_badge.dart';
 import '../services/log_service.dart';
+import '../theme/sure_tokens.dart';
 import '../utils/amount_parser.dart';
 import '../widgets/money_text.dart';
 
@@ -564,7 +565,7 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
                                         child: Text(
                                           transaction.name,
                                           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                                fontWeight: FontWeight.w500,
+                                                fontWeight: SureTokens.weightMedium,
                                               ),
                                           overflow: TextOverflow.ellipsis,
                                         ),
@@ -586,7 +587,7 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
                                               _getCategoryDisplayName(transaction.categoryId, transaction.categoryName) ?? '',
                                               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                                                     color: colorScheme.onPrimaryContainer,
-                                                    fontWeight: FontWeight.w500,
+                                                    fontWeight: SureTokens.weightMedium,
                                                   ),
                                               overflow: TextOverflow.ellipsis,
                                             ),
@@ -664,7 +665,7 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
                                         trend: displayInfo['trend'] as MoneyTrend,
                                         overflow: TextOverflow.ellipsis,
                                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                              fontWeight: FontWeight.w500,
+                                              fontWeight: SureTokens.weightMedium,
                                             ),
                                       ),
                                     ),
@@ -689,7 +690,7 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
                                         style: TextStyle(
                                           color: Colors.blue,
                                           fontSize: 11,
-                                          fontWeight: FontWeight.w600,
+                                          fontWeight: SureTokens.weightSemibold,
                                         ),
                                       ),
                                     ),

--- a/mobile/lib/theme/sure_tokens.dart
+++ b/mobile/lib/theme/sure_tokens.dart
@@ -22,6 +22,9 @@ class SureTokens {
   static const double radiusMd = 8.0;
   static const double radiusLg = 10.0;
 
+  static const FontWeight weightMedium = FontWeight.w500;
+  static const FontWeight weightSemibold = FontWeight.w600;
+
   static const light = SureTokenPalette(
     surface: Color(0xFFF7F7F7),
     surfaceHover: Color(0xFFF0F0F0),

--- a/mobile/lib/widgets/account_card.dart
+++ b/mobile/lib/widgets/account_card.dart
@@ -88,7 +88,7 @@ class AccountCard extends StatelessWidget {
                 Text(
                   account.name,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
+                    fontWeight: SureTokens.weightMedium,
                   ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
@@ -112,7 +112,7 @@ class AccountCard extends StatelessWidget {
                 account.balance,
                 style: SureMoney.tabular(
                   Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
+                    fontWeight: SureTokens.weightMedium,
                     color: account.isLiability
                         ? SureColors.of(context).palette.destructive
                         : null,

--- a/mobile/lib/widgets/net_worth_card.dart
+++ b/mobile/lib/widgets/net_worth_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/sure_colors.dart';
+import '../theme/sure_tokens.dart';
 import 'money_text.dart';
 import 'sure_icon.dart';
 
@@ -69,7 +70,7 @@ class NetWorthCard extends StatelessWidget {
                           'Outdated',
                           style: Theme.of(context).textTheme.labelSmall?.copyWith(
                                 color: colorScheme.secondary,
-                                fontWeight: FontWeight.w500,
+                                fontWeight: SureTokens.weightMedium,
                               ),
                         ),
                       ),
@@ -81,7 +82,7 @@ class NetWorthCard extends StatelessWidget {
                   netWorthFormatted ?? '--',
                   style: SureMoney.tabular(
                     Theme.of(context).textTheme.headlineSmall?.copyWith(
-                          fontWeight: FontWeight.w500,
+                          fontWeight: SureTokens.weightMedium,
                           color: isStale
                               ? colorScheme.secondary
                               : colorScheme.onSurface,
@@ -212,7 +213,7 @@ class NetWorthCard extends StatelessWidget {
                   Text(
                     title,
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.w500,
+                          fontWeight: SureTokens.weightMedium,
                           color: color,
                         ),
                   ),
@@ -237,14 +238,14 @@ class NetWorthCard extends StatelessWidget {
                         Text(
                           entry.key,
                           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.w500,
+                                fontWeight: SureTokens.weightMedium,
                                 color: colorScheme.onSurfaceVariant,
                               ),
                         ),
                         Text(
                           formatAmount(entry.key, entry.value),
                           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.w500,
+                                fontWeight: SureTokens.weightMedium,
                               ),
                         ),
                       ],
@@ -306,7 +307,7 @@ class _FilterButton extends StatelessWidget {
                     child: Text(
                       '--',
                       style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                            fontWeight: FontWeight.w500,
+                            fontWeight: SureTokens.weightMedium,
                             color: colorScheme.onSurface,
                           ),
                     ),
@@ -317,7 +318,7 @@ class _FilterButton extends StatelessWidget {
                           formatAmount(sortedEntries.first.key, sortedEntries.first.value),
                           style: SureMoney.tabular(
                             Theme.of(context).textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.w500,
+                                  fontWeight: SureTokens.weightMedium,
                                   color: colorScheme.onSurface,
                                 ),
                           ),
@@ -339,7 +340,7 @@ class _FilterButton extends StatelessWidget {
                                   formatAmount(entry.key, entry.value),
                                   style: SureMoney.tabular(
                                     Theme.of(context).textTheme.titleMedium?.copyWith(
-                                          fontWeight: FontWeight.w500,
+                                          fontWeight: SureTokens.weightMedium,
                                           color: colorScheme.onSurface,
                                         ),
                                   ),

--- a/mobile/test/theme/sure_tokens_test.dart
+++ b/mobile/test/theme/sure_tokens_test.dart
@@ -53,6 +53,17 @@ void main() {
     expect(SureTokens.radiusLg, _resolveDimension(tokens, 'border.radius.lg'));
   });
 
+  test('generated font weights match canonical tiers', () {
+    expect(
+      SureTokens.weightMedium.value,
+      _resolveWeight(tokens, 'font.weight.medium'),
+    );
+    expect(
+      SureTokens.weightSemibold.value,
+      _resolveWeight(tokens, 'font.weight.semibold'),
+    );
+  });
+
   test('generated focus-ring and bg-inverse match canonical tokens', () {
     expect(
       SureTokens.light.focusRing.value,
@@ -125,6 +136,10 @@ int _resolveColorValue(
   }
 
   throw StateError('Unsupported color value: $value');
+}
+
+int _resolveWeight(Map<String, dynamic> tokens, String path) {
+  return _nodeAt(tokens, path)[r'$value'] as int;
 }
 
 double _resolveDimension(Map<String, dynamic> tokens, String path) {

--- a/mobile/tool/generate_sure_tokens.mjs
+++ b/mobile/tool/generate_sure_tokens.mjs
@@ -43,6 +43,14 @@ const RADIUS_TOKENS = [
   ["radiusLg", "border.radius.lg"],
 ];
 
+// Named font-weight tiers, mirroring the web DS's Tailwind weight utilities
+// (font-medium / font-semibold) so widgets reference a named token instead of a
+// raw FontWeight.
+const WEIGHT_TOKENS = [
+  ["weightMedium", "font.weight.medium"],
+  ["weightSemibold", "font.weight.semibold"],
+];
+
 // Single-layer elevation scale (shadow/*). Mode-aware: each token carries a
 // `sure.dark` extension, so light/dark emit different shadow colors.
 const SHADOW_TOKENS = [
@@ -117,6 +125,15 @@ function resolveDimension(tokens, path) {
   return Number(match[1]).toFixed(1);
 }
 
+function resolveWeight(tokens, path) {
+  const node = nodeAt(tokens, path);
+  const value = Number(valueForMode(node, "light"));
+  if (!Number.isInteger(value) || value < 100 || value > 900 || value % 100 !== 0) {
+    throw new Error(`[mobile-tokens] ${path} must be a font weight (100-900 in steps of 100)`);
+  }
+  return `FontWeight.w${value}`;
+}
+
 // Parse a single-layer CSS box-shadow ("<x>px <y>px <blur>px <spread>px {color}")
 // into a Dart `BoxShadow(...)` literal. Offsets and spread may be negative
 // (e.g. -4px); blur must be >= 0. A strict number pattern rejects malformed
@@ -170,6 +187,9 @@ function buildDart(tokens) {
   const radiusLines = RADIUS_TOKENS.map(
     ([name, path]) => `  static const double ${name} = ${resolveDimension(tokens, path)};`,
   );
+  const weightLines = WEIGHT_TOKENS.map(
+    ([name, path]) => `  static const FontWeight ${name} = ${resolveWeight(tokens, path)};`,
+  );
 
   return `// GENERATED CODE - DO NOT EDIT BY HAND.
 // Source: design/tokens/sure.tokens.json
@@ -193,6 +213,8 @@ class SureTokens {
   ];
 
 ${radiusLines.join("\n")}
+
+${weightLines.join("\n")}
 
 ${emitPalette(tokens, "light")}
 

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -104,6 +104,40 @@ class AccountsTest < ApplicationSystemTestCase
       end
     end
 
+    # The account page issues a Turbo morph refresh shortly after it loads
+    # (`turbo_refreshes_with method: :morph` reacting to a family-stream
+    # broadcast). Opening the menu while that refresh is in flight can detach the
+    # node mid-click ("Node with given id does not belong to the document") or
+    # wipe the just-opened edit form — neither of which Capybara auto-retries.
+    # Retry until the edit form is present so the test is deterministic instead
+    # of racing the broadcast (mirrors PropertyTest#open_account_edit_dialog).
+    def open_account_edit_dialog
+      3.times do
+        # A prior (slow) attempt may have already opened the edit form.
+        return if has_field?("Account name", wait: 0)
+
+        begin
+          within_testid("account-menu") do
+            # Open the menu only when it's closed. DS::Menu's trigger toggles
+            # (menu_controller#toggle), so blindly re-clicking an already-open
+            # menu would close it and hide "Edit", turning a slow-but-successful
+            # modal load into a fresh flake.
+            unless has_selector?("[role='menu']", visible: true, wait: 0)
+              find("button").click
+            end
+            click_on "Edit"
+          end
+        rescue Selenium::WebDriver::Error::WebDriverError => e
+          raise unless e.message.match?(
+            /does not belong to the document|stale element reference/i,
+          )
+          next
+        end
+        return if has_field?("Account name", wait: 2)
+      end
+      assert_field "Account name"
+    end
+
     def assert_account_created(accountable_type, &block)
       click_link Accountable.from_type(accountable_type).singular_display_name
       click_link "Enter account balance" if accountable_type.in?(%w[Depository Investment Crypto Loan CreditCard])
@@ -140,10 +174,7 @@ class AccountsTest < ApplicationSystemTestCase
 
       visit account_url(created_account)
 
-      within_testid("account-menu") do
-        find("button").click
-        click_on "Edit"
-      end
+      open_account_edit_dialog
 
       updated_institution_name = "[system test] Updated Institution"
       updated_institution_domain = "updated.example.com"


### PR DESCRIPTION
## Summary

Adds named font-weight design tokens so mobile widgets reference a DS tier instead of a raw `FontWeight`, mirroring the web design system's Tailwind weight utilities (`font-medium` / `font-semibold`).

Closes #2418. Part of the mobile design-system roadmap #2235.

## Change

- **`design/tokens/sure.tokens.json`** — canonical source: `font.weight.medium` (500), `font.weight.semibold` (600).
- **`mobile/tool/generate_sure_tokens.mjs`** — emits `SureTokens.weightMedium` / `weightSemibold` via a font-weight resolver (validates 100–900 in steps of 100); `sure_tokens.dart` regenerated.
- **`sure_tokens_test.dart`** — parity assertions for the generated weights.
- **Migration** — the dashboard-area money/hierarchy sites now use the tokens: `FontWeight.w500` → `SureTokens.weightMedium`, `FontWeight.w600` → `SureTokens.weightSemibold` across `net_worth_card`, `account_card`, `dashboard_screen`, `recent_transactions_screen`, `transactions_list_screen`.

Weight-only and scoped to the dashboard sweep (per the roadmap slice); other screens/primitives adopt the tokens in their own polish PRs.

## Test plan

- [x] `node mobile/tool/generate_sure_tokens.mjs --check` — generated file is current
- [x] `flutter analyze --no-fatal-infos` — no new issues
- [x] `flutter test` — green (166), incl. the new font-weight parity assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added medium and semibold font-weight tokens to the design system for more consistent typography across the app.
* **Refactor**
  * Updated dashboard, transaction screens, account card, and net-worth components to use the standardized medium font weight.
* **Tests**
  * Strengthened token tests to confirm generated medium/semibold values match expected tiers.
  * Improved system test reliability when opening the account edit dialog by adding retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Note: included CI de-flake commit

This branch also carries `test(system): de-flake account edit via account-menu` — the fix for a pre-existing flaky `ci / test_system` (`AccountsTest` racing the account page's Turbo morph refresh), unrelated to font weights. It is included here so this PR's own CI is green; the identical fix is also submitted standalone as #2421. Both make the same change, so whichever merges first leaves the other a clean no-op rebase.