### PR TITLE
Bump Puma dependency to >= 7.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "pg", "~> 1.5"
 gem "redis", "~> 5.4"
 
 # Deployment
-gem "puma", ">= 5.0"
+gem "puma", ">= 7.2.1"
 gem "bootsnap", require: false
 
 # Assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
@@ -918,7 +918,7 @@ DEPENDENCIES
   plaid
   posthog-ruby
   propshaft
-  puma (>= 5.0)
+  puma (>= 7.2.1)
   pundit
   rack-attack (~> 6.6)
   rack-cors


### PR DESCRIPTION
### Motivation
- Update the Puma webserver dependency to a newer minimum version (`>= 7.2.1`) to pick up bug fixes and compatibility with the current Ruby/Rails stack.

### Description
- Change `Gemfile` to require `puma` `>= 7.2.1` and update `Gemfile.lock` to reflect `puma (7.2.1)` replacing the previous `6.6.0` entry.

### Testing
- Ran `bundle install` and the test suite with `bundle exec rspec`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37b801d4548332b2941df0a6e9b8e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded a core server dependency to a newer version for enhanced performance and security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->