### PR TITLE
Fixes issue #2415 - Subcategories are not alphabetically ordered like Categories

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -4,7 +4,7 @@ class CategoriesController < ApplicationController
   before_action :set_transaction, only: :create
 
   def index
-    @categories = Current.family.categories.alphabetically.to_a
+    @categories = Current.family.categories.alphabetically_by_hierarchy.to_a
     @category_groups = Category::Group.for(@categories)
     @category_ids_with_transactions = category_ids_with_transactions(@categories)
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,7 +5,11 @@ class Category < ApplicationRecord
   belongs_to :family
 
   has_many :budget_categories, dependent: :destroy
-  has_many :subcategories, class_name: "Category", foreign_key: :parent_id, dependent: :nullify
+  has_many :subcategories,
+         -> { order(:name) },
+         class_name: "Category",
+         foreign_key: :parent_id,
+         dependent: :nullify
   belongs_to :parent, class_name: "Category", optional: true
 
   validates :name, :color, :lucide_icon, :family, presence: true


### PR DESCRIPTION
Details in https://github.com/we-promise/sure/issues/2415#issuecomment-4758617392

Fully tested the fix and the subcategories are now alphabetically ordered, following the same logic as Categories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The category management interface in settings has been improved to display categories in hierarchical order instead of simple alphabetical order, providing better organization and easier navigation through your category structure.
  * Subcategories now consistently display in alphabetical order by name throughout the application, ensuring a more organized and predictable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->