### PR TITLE
fix(settings): securities-provider checkmarks invisible in dark mode

### DIFF
--- a/app/views/settings/hostings/_provider_selection.html.erb
+++ b/app/views/settings/hostings/_provider_selection.html.erb
@@ -59,7 +59,7 @@
             <input type="checkbox"
                    name="setting[securities_providers][]"
                    value="<%= value %>"
-                   class="rounded border-primary text-primary focus:ring-primary"
+                   class="checkbox checkbox--light"
                    <%= "checked" if enabled_providers.include?(value) %>
                    <%= "disabled" if disabled %>
                    data-auto-submit-form-target="auto">


### PR DESCRIPTION
## Problem

On the hosting settings page ("Securities Providers"), the checkboxes are invisible when checked in **dark mode** — a checked box shows a white check on a white fill, so there's no visual indication of which providers are enabled.

## Cause

`app/views/settings/hostings/_provider_selection.html.erb` styled the checkbox with raw Tailwind utilities:

```erb
class="rounded border-primary text-primary focus:ring-primary"
```

In dark mode `text-primary` resolves to white. The browser's checked state fills the box with `currentColor` and draws the checkmark in white → white-on-white.

Every other checkbox in the app uses the theme-aware design-system component (`settings/preferences`, transaction filters, goals, trades, etc.):

```erb
class="checkbox checkbox--light"
```

`.checkbox--light` has a `@variant theme-dark` block that renders a **dark check on a light fill** in dark mode.

## Fix

Use the design-system `checkbox checkbox--light` classes, consistent with the rest of the app. One-line change.

## Test

- Light mode: unchanged.
- Dark mode: checked providers now show a visible dark checkmark on a light fill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of checkboxes in the hosting provider selection interface for a lighter appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->