### PR TITLE
fix(accounts): subtype dropped on create when assigned before accountable_type

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -95,19 +95,43 @@ class Account < ApplicationRecord
   delegated_type :accountable, types: Accountable::TYPES, dependent: :destroy
   delegate :subtype, to: :accountable, allow_nil: true
 
-  # Writer for subtype that delegates to the accountable.
-  # This allows forms to set subtype directly on the account.
+  # Writer for subtype that delegates to the accountable, allowing forms to set
+  # subtype directly on the account.
   #
-  # On create the accountable may not be built yet: mass-assignment can apply
-  # `subtype` before `accountable_attributes` (which is what builds the
-  # accountable via accepts_nested_attributes_for). With no accountable in place
-  # `accountable&.subtype = value` is a silent no-op and the chosen subtype is
-  # dropped. Build the accountable from the delegated type first so the value is
-  # preserved; the later `accountable_attributes` assignment (update_only) then
-  # updates this same record instead of building a new one.
+  # On create the accountable is not built yet, and the chosen subtype is easy to
+  # drop because of mass-assignment ordering. Two cases:
+  #
+  #   1. `subtype` is applied while `accountable_type` is already known — build
+  #      the accountable from the delegated type so the value lands on it. The
+  #      later `accountable_attributes` assignment (update_only) then updates that
+  #      same record instead of building a new one.
+  #   2. `subtype` is applied *before* `accountable_type` — this is the real
+  #      controller path: strong-params `permit` preserves filter order, and
+  #      `account_params` lists `:subtype` before `:accountable_type`, so the
+  #      writer runs while the type (and thus `accountable_class`) is still
+  #      unknown. We can't build the accountable yet, so stash the value and
+  #      apply it from `accountable_type=` once the type is set.
   def subtype=(value)
     self.accountable = accountable_class.new if accountable.nil? && accountable_type.present?
-    accountable&.subtype = value
+
+    if accountable
+      accountable.subtype = value
+    else
+      @deferred_subtype = value
+    end
+  end
+
+  # Applies a subtype that arrived before the type was known (see `subtype=`
+  # case 2). `super` resolves `accountable_type`/`accountable_class` first, then
+  # the re-entrant `subtype=` builds the accountable and assigns the value.
+  def accountable_type=(value)
+    super
+
+    if defined?(@deferred_subtype)
+      pending = @deferred_subtype
+      remove_instance_variable(:@deferred_subtype)
+      self.subtype = pending
+    end
   end
 
   accepts_nested_attributes_for :accountable, update_only: true

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -129,6 +129,40 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal "checking", account.subtype
   end
 
+  test "subtype assigned before accountable_type is not dropped" do
+    # The real controller path: strong-params `permit` preserves filter order,
+    # and `account_params` lists `:subtype` before `:accountable_type`, so the
+    # subtype writer runs while the type is still unknown.
+    account = Account.new
+    account.subtype = "savings"
+    account.accountable_type = "Depository"
+
+    assert_not_nil account.accountable
+    assert_equal "savings", account.subtype
+    assert_equal "savings", account.accountable.subtype
+  end
+
+  test "subtype persists on create when attributes arrive in permit order" do
+    Account.any_instance.stubs(:sync_later)
+
+    # Mirrors `account_params`: `permit` yields keys in filter order, so the
+    # create hash carries `subtype` before `accountable_type` — the ordering
+    # that previously dropped the subtype on create.
+    account = Account.create_and_sync({
+      family: @family,
+      owner: @admin,
+      name: "Savings Account",
+      balance: 100,
+      subtype: "savings",
+      currency: "USD",
+      accountable_type: "Depository"
+    })
+
+    assert account.persisted?
+    assert_equal "savings", account.reload.subtype
+    assert_equal "savings", account.accountable.subtype
+  end
+
   test "accountable display names expose singular and group contexts" do
     assert_equal "Investment", Investment.singular_display_name
     assert_equal "Investments", Investment.display_name


### PR DESCRIPTION
## Problem

Creating an account and choosing a subtype (e.g. a Cash/Depository account set to **Savings**) silently drops the subtype on **create** — the account renders with the type's fallback label (`Depository.display_name` → "Cash") instead of the chosen "Savings". Editing an existing account works; only create is affected.

## Cause

#2356 made `Account#subtype=` build the accountable so a top-level `subtype` survives create:

```ruby
def subtype=(value)
  self.accountable = accountable_class.new if accountable.nil? && accountable_type.present?
  accountable&.subtype = value
end
```

This assumes `accountable_type` is already set when `subtype=` runs. The real controller path violates that assumption:

- `account_params` permits `:name, :balance, :subtype, :currency, :accountable_type, …` — **`:subtype` before `:accountable_type`**.
- `ActionController::Parameters#permit` builds its result by iterating the filter list **in order**, so the permitted hash carries `subtype` before `accountable_type`.
- Mass-assignment therefore calls `subtype=` while `accountable_type` (and thus `accountable_class`) is still blank → the build is skipped → `accountable&.subtype=` is a no-op → subtype dropped.

The existing regression test set `accountable_type` **first**, so it exercised the working order and never caught this.

## Fix

Make the writer order-independent. When `subtype` arrives before the type is known, stash it and apply it from an `accountable_type=` override once the type — and therefore `accountable_class` — is available.

```ruby
def subtype=(value)
  self.accountable = accountable_class.new if accountable.nil? && accountable_type.present?
  if accountable
    accountable.subtype = value
  else
    @deferred_subtype = value
  end
end

def accountable_type=(value)
  super
  if defined?(@deferred_subtype)
    pending = @deferred_subtype
    remove_instance_variable(:@deferred_subtype)
    self.subtype = pending
  end
end
```

## Tests

Added regression coverage for:
- `subtype` assigned **before** `accountable_type` (the permit order).
- `create_and_sync` with attributes in permit order.

Both fail on `main` and pass with this change. Existing subtype tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account subtype assignment to work correctly regardless of the order attributes are set, improving reliability of account configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->