### PR TITLE
design-system(mobile): SureSpacing + SureTypography scale tokens

### DIFF
--- a/mobile/lib/theme/sure_spacing.dart
+++ b/mobile/lib/theme/sure_spacing.dart
@@ -1,0 +1,39 @@
+/// Sure spacing scale.
+///
+/// Mirrors the Tailwind spacing defaults the web design system relies on
+/// (`1rem = 16px`, so each step is `value * 4px`). Hand-authored rather than
+/// generated from `design/tokens/sure.tokens.json` because spacing is not part
+/// of the canonical token file — it comes from Tailwind's built-in scale, which
+/// is stable and shared across the web and mobile apps.
+///
+/// Use these instead of raw numeric `EdgeInsets`/`SizedBox` values so padding
+/// and gaps stay on the scale. Component-specific dimensions (control heights,
+/// hairline dividers) intentionally stay as literals — they are sizing, not
+/// spacing-scale steps.
+class SureSpacing {
+  const SureSpacing._();
+
+  /// 4 — Tailwind `space-1`.
+  static const double xs = 4;
+
+  /// 6 — Tailwind `space-1.5`.
+  static const double sm = 6;
+
+  /// 8 — Tailwind `space-2`.
+  static const double md = 8;
+
+  /// 12 — Tailwind `space-3`.
+  static const double lg = 12;
+
+  /// 16 — Tailwind `space-4`.
+  static const double xl = 16;
+
+  /// 20 — Tailwind `space-5`.
+  static const double xxl = 20;
+
+  /// 24 — Tailwind `space-6`.
+  static const double xxxl = 24;
+
+  /// 32 — Tailwind `space-8`.
+  static const double huge = 32;
+}

--- a/mobile/lib/theme/sure_typography.dart
+++ b/mobile/lib/theme/sure_typography.dart
@@ -1,0 +1,31 @@
+/// Sure type scale.
+///
+/// Mirrors the Tailwind font-size defaults the web design system uses. Like
+/// [SureSpacing], this is hand-authored rather than generated from
+/// `design/tokens/sure.tokens.json` because the type scale comes from Tailwind's
+/// built-in `text-*` ramp, not the canonical token file.
+///
+/// Values are font sizes in logical pixels; the comment on each records the
+/// Tailwind step and its paired line-height for reference. Use these instead of
+/// raw `fontSize` literals so text stays on the scale.
+class SureTypography {
+  const SureTypography._();
+
+  /// 12 / 16 — Tailwind `text-xs`.
+  static const double xs = 12;
+
+  /// 14 / 20 — Tailwind `text-sm`.
+  static const double sm = 14;
+
+  /// 16 / 24 — Tailwind `text-base`.
+  static const double base = 16;
+
+  /// 18 / 28 — Tailwind `text-lg`.
+  static const double lg = 18;
+
+  /// 20 / 28 — Tailwind `text-xl`.
+  static const double xl = 20;
+
+  /// 24 / 32 — Tailwind `text-2xl`.
+  static const double xxl = 24;
+}

--- a/mobile/lib/theme/sure_typography.dart
+++ b/mobile/lib/theme/sure_typography.dart
@@ -5,9 +5,12 @@
 /// `design/tokens/sure.tokens.json` because the type scale comes from Tailwind's
 /// built-in `text-*` ramp, not the canonical token file.
 ///
-/// Values are font sizes in logical pixels; the comment on each records the
-/// Tailwind step and its paired line-height for reference. Use these instead of
-/// raw `fontSize` literals so text stays on the scale.
+/// Font sizes are in logical pixels; use them instead of raw `fontSize` literals
+/// so text stays on the scale. Each size has a paired line height
+/// ([xsLineHeight] … [xxlLineHeight]), also in logical pixels, matching the
+/// Tailwind `text-*` defaults. Flutter's `TextStyle.height` is a *multiplier*,
+/// so derive it as `lineHeight / fontSize` when an exact pairing is needed, e.g.
+/// `TextStyle(fontSize: SureTypography.sm, height: SureTypography.smLineHeight / SureTypography.sm)`.
 class SureTypography {
   const SureTypography._();
 
@@ -28,4 +31,22 @@ class SureTypography {
 
   /// 24 / 32 — Tailwind `text-2xl`.
   static const double xxl = 24;
+
+  /// Line height (logical px) paired with [xs] — Tailwind `text-xs`.
+  static const double xsLineHeight = 16;
+
+  /// Line height (logical px) paired with [sm] — Tailwind `text-sm`.
+  static const double smLineHeight = 20;
+
+  /// Line height (logical px) paired with [base] — Tailwind `text-base`.
+  static const double baseLineHeight = 24;
+
+  /// Line height (logical px) paired with [lg] — Tailwind `text-lg`.
+  static const double lgLineHeight = 28;
+
+  /// Line height (logical px) paired with [xl] — Tailwind `text-xl`.
+  static const double xlLineHeight = 28;
+
+  /// Line height (logical px) paired with [xxl] — Tailwind `text-2xl`.
+  static const double xxlLineHeight = 32;
 }

--- a/mobile/lib/widgets/sure_button.dart
+++ b/mobile/lib/widgets/sure_button.dart
@@ -2,7 +2,9 @@ import 'package:flutter/cupertino.dart' show CupertinoActivityIndicator;
 import 'package:flutter/material.dart';
 
 import '../theme/sure_colors.dart';
+import '../theme/sure_spacing.dart';
 import '../theme/sure_tokens.dart';
+import '../theme/sure_typography.dart';
 
 /// Sure design-system button variants, mirroring the web `DS::Button`
 /// (`DS::Buttonish::VARIANTS`).
@@ -113,7 +115,7 @@ class _SureButtonState extends State<SureButton> {
       mainAxisSize: widget.fullWidth ? MainAxisSize.max : MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        if (leading != null) ...[leading, const SizedBox(width: 8)],
+        if (leading != null) ...[leading, const SizedBox(width: SureSpacing.md)],
         // Flex only when full-width (bounded). A bare Flexible in a min-size Row
         // asserts under unbounded horizontal constraints, so an inline button
         // passes the self-sizing label directly.
@@ -262,22 +264,22 @@ class _SureButtonMetrics {
       case SureButtonSize.sm:
         return const _SureButtonMetrics(
           height: 28,
-          horizontalPadding: 12,
-          fontSize: 14,
+          horizontalPadding: SureSpacing.lg,
+          fontSize: SureTypography.sm,
           radius: SureTokens.radiusMd,
         );
       case SureButtonSize.md:
         return const _SureButtonMetrics(
           height: 36,
-          horizontalPadding: 16,
-          fontSize: 14,
+          horizontalPadding: SureSpacing.xl,
+          fontSize: SureTypography.sm,
           radius: SureTokens.radiusLg,
         );
       case SureButtonSize.lg:
         return const _SureButtonMetrics(
           height: 48,
-          horizontalPadding: 20,
-          fontSize: 16,
+          horizontalPadding: SureSpacing.xxl,
+          fontSize: SureTypography.base,
           radius: SureTokens.radiusLg,
         );
     }

--- a/mobile/lib/widgets/sure_card.dart
+++ b/mobile/lib/widgets/sure_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/sure_colors.dart';
+import '../theme/sure_spacing.dart';
 import '../theme/sure_tokens.dart';
 
 /// Sure design-system card — a tokenized content surface mirroring the web card
@@ -15,7 +16,7 @@ class SureCard extends StatelessWidget {
   const SureCard({
     super.key,
     required this.child,
-    this.padding = const EdgeInsets.all(16),
+    this.padding = const EdgeInsets.all(SureSpacing.xl),
     this.margin,
     this.onTap,
     this.elevated = true,

--- a/mobile/lib/widgets/sure_chip.dart
+++ b/mobile/lib/widgets/sure_chip.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/sure_colors.dart';
+import '../theme/sure_spacing.dart';
 
 /// Sure design-system filter chip — a tokenized selectable pill mirroring the web
 /// DS pill: a rounded-full chip that reads as bordered/neutral when unselected
@@ -59,11 +60,11 @@ class SureChip extends StatelessWidget {
       // (Material FilterChip parity); the chip still sizes to content otherwise.
       constraints: const BoxConstraints(minHeight: 44),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: SureSpacing.lg),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (leading != null) ...[leading!, const SizedBox(width: 6)],
+            if (leading != null) ...[leading!, const SizedBox(width: SureSpacing.sm)],
             Text(
               label,
               maxLines: 1,

--- a/mobile/lib/widgets/sure_chip.dart
+++ b/mobile/lib/widgets/sure_chip.dart
@@ -60,6 +60,10 @@ class SureChip extends StatelessWidget {
       // (Material FilterChip parity); the chip still sizes to content otherwise.
       constraints: const BoxConstraints(minHeight: 44),
       child: Padding(
+        // horizontal 14 is intentionally off the SureSpacing scale (between
+        // lg=12 and xl=16): it's the chip's tuned content inset for the
+        // FilterChip-parity look, not a spacing-scale step — don't "fix" it to a
+        // token. Vertical stays on-scale.
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: SureSpacing.lg),
         child: Row(
           mainAxisSize: MainAxisSize.min,

--- a/mobile/lib/widgets/sure_list_group.dart
+++ b/mobile/lib/widgets/sure_list_group.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/sure_colors.dart';
+import '../theme/sure_spacing.dart';
 import '../theme/sure_tokens.dart';
 import 'sure_icon.dart';
 
@@ -81,7 +82,11 @@ class SureListGroup extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Padding(
-                padding: const EdgeInsets.only(left: 16, right: 16, bottom: 8),
+                padding: const EdgeInsets.only(
+                  left: SureSpacing.xl,
+                  right: SureSpacing.xl,
+                  bottom: SureSpacing.md,
+                ),
                 child: Text(
                   header!.toUpperCase(),
                   style: Theme.of(context).textTheme.labelSmall?.copyWith(
@@ -156,10 +161,10 @@ class SureListRow extends StatelessWidget {
     }
 
     Widget content = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      padding: const EdgeInsets.symmetric(horizontal: SureSpacing.xl, vertical: 14),
       child: Row(
         children: [
-          if (leading != null) ...[leading!, const SizedBox(width: 12)],
+          if (leading != null) ...[leading!, const SizedBox(width: SureSpacing.lg)],
           Expanded(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -189,7 +194,7 @@ class SureListRow extends StatelessWidget {
             ),
           ),
           if (trailingWidget != null) ...[
-            const SizedBox(width: 12),
+            const SizedBox(width: SureSpacing.lg),
             trailingWidget,
           ],
         ],

--- a/mobile/lib/widgets/sure_segmented_control.dart
+++ b/mobile/lib/widgets/sure_segmented_control.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/sure_colors.dart';
+import '../theme/sure_spacing.dart';
 import '../theme/sure_tokens.dart';
 
 /// One segment of a [SureSegmentedControl].
@@ -144,7 +145,10 @@ class _SegmentState<T> extends State<_Segment<T>> {
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 150),
             curve: Curves.easeOut,
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+            padding: const EdgeInsets.symmetric(
+              vertical: SureSpacing.md,
+              horizontal: SureSpacing.md,
+            ),
             decoration: BoxDecoration(
               color: selected ? widget.selectedBg : const Color(0x00000000),
               borderRadius: BorderRadius.circular(SureTokens.radiusMd),
@@ -168,7 +172,7 @@ class _SegmentState<T> extends State<_Segment<T>> {
                     data: IconThemeData(color: fg, size: 18),
                     child: widget.segment.icon!,
                   ),
-                  const SizedBox(width: 6),
+                  const SizedBox(width: SureSpacing.sm),
                 ],
                 Flexible(
                   child: Text(

--- a/mobile/lib/widgets/sure_text_field.dart
+++ b/mobile/lib/widgets/sure_text_field.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../theme/sure_colors.dart';
+import '../theme/sure_spacing.dart';
 import '../theme/sure_tokens.dart';
 
 /// Sure design-system text field — a tokenized [TextFormField] wrapper mirroring
@@ -137,7 +138,7 @@ class SureTextField extends StatelessWidget {
         fillColor: palette.container,
         isDense: true,
         contentPadding: const EdgeInsets.symmetric(
-          horizontal: 16,
+          horizontal: SureSpacing.xl,
           vertical: 14,
         ),
         hintStyle: theme.textTheme.bodyLarge?.copyWith(
@@ -173,7 +174,7 @@ class SureTextField extends StatelessWidget {
         // detached label node.
         ExcludeSemantics(
           child: Padding(
-            padding: const EdgeInsets.only(left: 2, bottom: 6),
+            padding: const EdgeInsets.only(left: 2, bottom: SureSpacing.sm),
             child: Text(
               label!,
               style: theme.textTheme.labelMedium?.copyWith(


### PR DESCRIPTION
## Summary

Adds named spacing and type-scale constants mirroring the Tailwind defaults the web design system uses, so widgets reference a DS step instead of a raw `EdgeInsets`/`SizedBox`/`fontSize` literal.

Closes #2437. Part of the mobile design-system roadmap #2235.

## Change

- **`sure_spacing.dart`** — `SureSpacing.xs..huge` → Tailwind `space-1..space-8` (4..32px).
- **`sure_typography.dart`** — `SureTypography.xs..xxl` → Tailwind `text-xs..text-2xl` font sizes.
- Both hand-authored (not via `sure.tokens.json`/the generator) because spacing + the type ramp come from Tailwind's built-in scale, not the canonical token file.
- **Adoption** in the existing primitives: card padding, button metrics + icon gap, chip/segmented/list-group gaps + padding, text-field content padding + label gap.

Every migration is **value-preserving** (each token equals the literal it replaces), so there is no rendered layout change; off-scale one-offs (control heights, hairlines, the deliberate 14px field padding) stay literal.

## Screenshots

<table>
  <thead><tr><th>Mode</th><th>Before</th><th>After</th></tr></thead>
  <tbody>
    <tr>
      <td><strong>Light</strong></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/before-home-light.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/before-home-light.png" alt="Before – light"></a><br><em>Before – raw literals</em></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/after-home-light.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/after-home-light.png" alt="After – light"></a><br><em>After – SureSpacing/SureTypography tokens</em></td>
    </tr>
    <tr>
      <td><strong>Dark</strong></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/before-home-dark.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/before-home-dark.png" alt="Before – dark"></a><br><em>Before – raw literals</em></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/after-home-dark.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-spacing-type-scale/after-home-dark.png" alt="After – dark"></a><br><em>After – SureSpacing/SureTypography tokens</em></td>
    </tr>
  </tbody>
</table>

## Test plan

- [x] `flutter analyze --no-fatal-infos` — no new issues
- [x] `flutter test` — green (166), including the primitive geometry/chrome tests (unchanged because values are identical)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented a centralized design token system for spacing and typography to ensure consistent visual appearance and improved alignment across all UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->