### PR TITLE
fix(mobile): in-progress feedback for the Clear local data action

### DIFF
--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -30,7 +30,13 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _groupByType = false;
   String? _appVersion;
-  // Tracks which destructive action is in progress ('clear', 'reset', 'delete'),
+  // Identifiers for the in-progress destructive action. Defined once so the
+  // discriminator can't drift via a mistyped string literal across handlers and
+  // tiles.
+  static const String _clearAction = 'clear';
+  static const String _resetAction = 'reset';
+  static const String _deleteAction = 'delete';
+  // Tracks which destructive action is in progress (one of the constants above),
   // or null when idle. Used to disable all three tiles while any one is running.
   String? _activeDestructiveAction;
   bool _biometricSupported = false;
@@ -232,7 +238,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
 
     if (confirmed == true && context.mounted) {
-      setState(() => _activeDestructiveAction = 'clear');
+      setState(() => _activeDestructiveAction = _clearAction);
       try {
         final offlineStorage = OfflineStorageService();
         final log = LogService.instance;
@@ -316,7 +322,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     if (confirmed != true || !context.mounted) return;
 
-    setState(() => _activeDestructiveAction = 'reset');
+    setState(() => _activeDestructiveAction = _resetAction);
     try {
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
       final accessToken = await authProvider.getValidAccessToken();
@@ -388,7 +394,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     if (confirmed != true || !context.mounted) return;
 
-    setState(() => _activeDestructiveAction = 'delete');
+    setState(() => _activeDestructiveAction = _deleteAction);
     try {
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
       final accessToken = await authProvider.getValidAccessToken();
@@ -751,7 +757,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.delete_outline),
             title: Text(l.settingsClearDataTitle),
             subtitle: Text(l.settingsClearDataTileSubtitle),
-            trailing: _activeDestructiveAction == 'clear'
+            trailing: _activeDestructiveAction == _clearAction
                 ? const SizedBox(
                     width: 20,
                     height: 20,
@@ -804,7 +810,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.restart_alt, color: Colors.red),
             title: Text(l.settingsResetAccount),
             subtitle: Text(l.settingsResetAccountTileSubtitle),
-            trailing: _activeDestructiveAction == 'reset'
+            trailing: _activeDestructiveAction == _resetAction
                 ? const SizedBox(
                     width: 20,
                     height: 20,
@@ -820,7 +826,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.delete_forever, color: Colors.red),
             title: Text(l.settingsDeleteAccount),
             subtitle: Text(l.settingsDeleteAccountTileSubtitle),
-            trailing: _activeDestructiveAction == 'delete'
+            trailing: _activeDestructiveAction == _deleteAction
                 ? const SizedBox(
                     width: 20,
                     height: 20,

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -30,9 +30,9 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _groupByType = false;
   String? _appVersion;
-  bool _isResettingAccount = false;
-  bool _isDeletingAccount = false;
-  bool _isClearingData = false;
+  // Tracks which destructive action is in progress ('clear', 'reset', 'delete'),
+  // or null when idle. Used to disable all three tiles while any one is running.
+  String? _activeDestructiveAction;
   bool _biometricSupported = false;
   bool _biometricEnabled = false;
   bool _isTogglingBiometric = false;
@@ -232,7 +232,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
 
     if (confirmed == true && context.mounted) {
-      setState(() => _isClearingData = true);
+      setState(() => _activeDestructiveAction = 'clear');
       try {
         final offlineStorage = OfflineStorageService();
         final log = LogService.instance;
@@ -272,7 +272,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           );
         }
       } finally {
-        if (mounted) setState(() => _isClearingData = false);
+        if (mounted) setState(() => _activeDestructiveAction = null);
       }
     }
   }
@@ -316,7 +316,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     if (confirmed != true || !context.mounted) return;
 
-    setState(() => _isResettingAccount = true);
+    setState(() => _activeDestructiveAction = 'reset');
     try {
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
       final accessToken = await authProvider.getValidAccessToken();
@@ -356,7 +356,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         );
       }
     } finally {
-      if (mounted) setState(() => _isResettingAccount = false);
+      if (mounted) setState(() => _activeDestructiveAction = null);
     }
   }
 
@@ -388,7 +388,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     if (confirmed != true || !context.mounted) return;
 
-    setState(() => _isDeletingAccount = true);
+    setState(() => _activeDestructiveAction = 'delete');
     try {
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
       final accessToken = await authProvider.getValidAccessToken();
@@ -413,7 +413,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         );
       }
     } finally {
-      if (mounted) setState(() => _isDeletingAccount = false);
+      if (mounted) setState(() => _activeDestructiveAction = null);
     }
   }
 
@@ -751,14 +751,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.delete_outline),
             title: Text(l.settingsClearDataTitle),
             subtitle: Text(l.settingsClearDataTileSubtitle),
-            trailing: _isClearingData
+            trailing: _activeDestructiveAction == 'clear'
                 ? const SizedBox(
                     width: 20,
                     height: 20,
                     child: CircularProgressIndicator(strokeWidth: 2))
                 : null,
-            enabled: !_isClearingData,
-            onTap: _isClearingData
+            enabled: _activeDestructiveAction == null,
+            onTap: _activeDestructiveAction != null
                 ? null
                 : () => _handleClearLocalData(context),
           ),
@@ -804,14 +804,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.restart_alt, color: Colors.red),
             title: Text(l.settingsResetAccount),
             subtitle: Text(l.settingsResetAccountTileSubtitle),
-            trailing: _isResettingAccount
+            trailing: _activeDestructiveAction == 'reset'
                 ? const SizedBox(
                     width: 20,
                     height: 20,
                     child: CircularProgressIndicator(strokeWidth: 2))
                 : null,
-            enabled: !_isResettingAccount && !_isDeletingAccount,
-            onTap: _isResettingAccount || _isDeletingAccount
+            enabled: _activeDestructiveAction == null,
+            onTap: _activeDestructiveAction != null
                 ? null
                 : () => _handleResetAccount(context),
           ),
@@ -820,14 +820,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.delete_forever, color: Colors.red),
             title: Text(l.settingsDeleteAccount),
             subtitle: Text(l.settingsDeleteAccountTileSubtitle),
-            trailing: _isDeletingAccount
+            trailing: _activeDestructiveAction == 'delete'
                 ? const SizedBox(
                     width: 20,
                     height: 20,
                     child: CircularProgressIndicator(strokeWidth: 2))
                 : null,
-            enabled: !_isDeletingAccount && !_isResettingAccount,
-            onTap: _isDeletingAccount || _isResettingAccount
+            enabled: _activeDestructiveAction == null,
+            onTap: _activeDestructiveAction != null
                 ? null
                 : () => _handleDeleteAccount(context),
           ),

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -32,6 +32,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String? _appVersion;
   bool _isResettingAccount = false;
   bool _isDeletingAccount = false;
+  bool _isClearingData = false;
   bool _biometricSupported = false;
   bool _biometricEnabled = false;
   bool _isTogglingBiometric = false;
@@ -231,6 +232,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
 
     if (confirmed == true && context.mounted) {
+      setState(() => _isClearingData = true);
       try {
         final offlineStorage = OfflineStorageService();
         final log = LogService.instance;
@@ -269,6 +271,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           );
         }
+      } finally {
+        if (mounted) setState(() => _isClearingData = false);
       }
     }
   }
@@ -747,7 +751,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.delete_outline),
             title: Text(l.settingsClearDataTitle),
             subtitle: Text(l.settingsClearDataTileSubtitle),
-            onTap: () => _handleClearLocalData(context),
+            trailing: _isClearingData
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2))
+                : null,
+            enabled: !_isClearingData,
+            onTap: _isClearingData
+                ? null
+                : () => _handleClearLocalData(context),
           ),
 
           if (_biometricSupported) ...[


### PR DESCRIPTION
## Summary

Closes #1045 (no in-progress feedback during destructive async operations). The reset- and delete-account tiles already disable and show a spinner while their requests run — but **Clear local data**, which asynchronously wipes offline storage and clears the category/merchant/tag providers, had no feedback. The settings list stayed fully interactive during the wipe, inviting a second tap.

This completes the in-progress feedback across **all** destructive async actions in Settings.

## Change

In `mobile/lib/screens/settings_screen.dart`, mirror the established reset/delete pattern:
- add an `_isClearingData` flag, set before the work and cleared in a `finally` with a `mounted` guard;
- give the Clear-local-data `ListTile` a trailing `CircularProgressIndicator` and `enabled`/`onTap` guards while it runs.

## Screenshots

<table>
  <thead><tr><th>Mode</th><th>Before</th><th>After</th></tr></thead>
  <tbody>
    <tr>
      <td><strong>Light</strong></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/before-settings-light.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/before-settings-light.png" alt="Before – light"></a><br><em>Before – no feedback, tile fully interactive</em></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/after-settings-light.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/after-settings-light.png" alt="After – light"></a><br><em>After – spinner + tile disabled while clearing</em></td>
    </tr>
    <tr>
      <td><strong>Dark</strong></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/before-settings-dark.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/before-settings-dark.png" alt="Before – dark"></a><br><em>Before – no feedback, tile fully interactive</em></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/after-settings-dark.png"><img width="220" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-clear-data-loading/after-settings-dark.png" alt="After – dark"></a><br><em>After – spinner + tile disabled while clearing</em></td>
    </tr>
  </tbody>
</table>

## Test plan

- [x] `flutter analyze --no-fatal-infos` — no new issues
- [x] `flutter test` — green (166)

(The reset/delete loading states already in `main` shipped without a dedicated widget test; this mirrors that exact pattern in the same screen. `SettingsScreen` requires a large provider/biometric/upgrader harness to pump, so no new test is added — consistent with existing coverage.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the settings screen to show a loading spinner and temporarily disable interaction while destructive operations are running (clear local data, reset account, delete account).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
