### PR TITLE
perf(accounts): preload transfer, category, and split-parent associations on show

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -71,6 +71,9 @@ class AccountsController < ApplicationController
     )
     Transaction::ActivitySecurityPreloader.new(@entries).preload
 
+    # The preload and split-parent lookup below are intentionally scoped to the
+    # current page (@entries) — only this page is rendered, so a child entry
+    # whose split parent sits on another page deliberately won't resolve it.
     transactions = @entries.filter_map { |e| e.entryable if e.transaction? }
     if transactions.any?
       ActiveRecord::Associations::Preloader.new(

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -71,6 +71,21 @@ class AccountsController < ApplicationController
     )
     Transaction::ActivitySecurityPreloader.new(@entries).preload
 
+    transactions = @entries.filter_map { |e| e.entryable if e.transaction? }
+    if transactions.any?
+      ActiveRecord::Associations::Preloader.new(
+        records: transactions,
+        associations: [ :transfer_as_inflow, :transfer_as_outflow, :category, :merchant ]
+      ).call
+    end
+
+    entry_ids = @entries.map(&:id)
+    @split_parent_entry_ids = if entry_ids.any?
+      Entry.where(parent_entry_id: entry_ids).distinct.pluck(:parent_entry_id).to_set
+    else
+      Set.new
+    end
+
     @activity_feed_data = Account::ActivityFeedData.new(@account, @entries)
   end
 

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -19,6 +19,31 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show avoids N+1 transfer queries across paginated entries" do
+    queries = capture_sql_queries { get account_url(@account) }
+    assert_response :success
+
+    # Per-row transfer lookups (N+1 pattern) hit transfers with a single id
+    # Preloading batches them into IN(...) — assert no single-id lookups remain
+    per_row_transfer = queries.count { |q|
+      q.match?(/FROM "transfers".*WHERE.*"(inflow|outflow)_transaction_id"/) &&
+        !q.include?(" IN (")
+    }
+    assert_equal 0, per_row_transfer, "N+1 per-row transfer queries detected (#{per_row_transfer})"
+  end
+
+  test "show avoids N+1 split-parent queries across paginated entries" do
+    queries = capture_sql_queries { get account_url(@account) }
+    assert_response :success
+
+    # Per-row child-entry existence checks (N+1) hit entries with a single parent_entry_id
+    # @split_parent_entry_ids preloads this in one batch IN query
+    per_row_split = queries.count { |q|
+      q.match?(/FROM "entries".*WHERE.*"parent_entry_id"/) && !q.include?(" IN (")
+    }
+    assert_equal 0, per_row_split, "N+1 per-row split-parent queries detected (#{per_row_split})"
+  end
+
   test "show lazily loads statement tab data unless statements tab is active" do
     AccountStatement::Coverage.expects(:for_year).never
     AccountStatement.expects(:reconciliation_statuses_for).never


### PR DESCRIPTION
Closes #2462.

## Summary

`AccountsController#show` rendered the paginated activity feed with several N+1 query clusters that Sentry has flagged across 60–150 unique users:

- **[SURE-APP-PN](https://chancen.sentry.io/issues/SURE-APP-PN)** — 60 users, 764 events — `transfer_as_inflow` / `transfer_as_outflow` loaded per transaction row (the `transaction.transfer` path in the partial calls `transfer_as_inflow || transfer_as_outflow`, two queries each)
- **[SURE-APP-XE](https://chancen.sentry.io/issues/SURE-APP-XE)** — 32 users, 546 events — same transfer pattern + `category` per row (40 iterations × 3 queries = 120 extra queries per page)
- **[SURE-APP-26](https://chancen.sentry.io/issues/SURE-APP-26)** — 51 users, 553 events — same cluster
- **[SURE-APP-X3](https://chancen.sentry.io/issues/SURE-APP-X3)** / **[SURE-APP-X6](https://chancen.sentry.io/issues/SURE-APP-X6)** — slow DB reports on the same action

A fourth N+1 — `entry.split_parent?` (calls `child_entries.exists?` per entry) — fired because the view's `@split_parent_entry_ids` guard was never set by this action. `TransactionsController#index` already sets this variable; `AccountsController#show` was the only caller that didn't.

## Change

In `AccountsController#show`, after pagination:

1. Extract the transaction entryables from the paginated entries and batch-preload `transfer_as_inflow`, `transfer_as_outflow`, `category`, and `merchant` via `ActiveRecord::Associations::Preloader` — the same API already used in `accounts/index/_account_groups.erb`.
2. Set `@split_parent_entry_ids` with a single `WHERE parent_entry_id IN (...)` query — exactly matching the pattern in `TransactionsController#index`.

No view changes required; `_transaction.html.erb` already branches on `@split_parent_entry_ids` when set.

## Test plan

- [x] Two N+1 regression tests added to `AccountsControllerTest` using `SqlQueryCapture`: one asserting no per-row transfer queries (expecting batch `IN` form only), one asserting no per-row `parent_entry_id` existence checks
- [x] Existing `AccountsControllerTest` suite passes
- [x] `bin/rubocop` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account activity feed performance by optimizing how related transaction data is loaded for the current paginated page, reducing repeated lookups during rendering.
* **Tests**
  * Added integration tests to ensure the account activity feed avoids common N+1-style query patterns for transfers and split/parent entry relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
