### PR TITLE
perf(budgets): fix N+1 in BudgetCategory#subcategories on budget show

### DIFF
--- a/app/controllers/budget_categories_controller.rb
+++ b/app/controllers/budget_categories_controller.rb
@@ -30,7 +30,9 @@ class BudgetCategoriesController < ApplicationController
   end
 
   def update
-    @budget_category = Current.family.budget_categories.find(params[:id])
+    @budget_category = Current.family.budget_categories
+                                     .includes(:category, budget: { budget_categories: :category })
+                                     .find(params[:id])
     @budget_category.update_budgeted_spending!(budgeted_spending_param)
 
     respond_to do |format|

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -6,6 +6,7 @@ class BudgetsController < ApplicationController
   end
 
   def show
+    @budget.budget_categories.includes(:category).load
     @source_budget = @budget.most_recent_initialized_budget unless @budget.initialized?
     @breadcrumbs = [ [ t("breadcrumbs.home"), root_path ], [ t("breadcrumbs.budgets"), nil ] ]
   end

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -230,6 +230,15 @@ class BudgetCategory < ApplicationRecord
     budget.budget_categories.select { |bc| bc.category.parent_id == category.parent_id && bc.id != id }
   end
 
+  # Budget categories whose category is a child of this (top-level) category.
+  #
+  # Returns an Array (an in-memory filter over the preloaded association), not an
+  # ActiveRecord::Relation — do not chain AR scopes (.where/.order/.count(:col)/
+  # etc.) on the result.
+  #
+  # Callers are expected to have `budget.budget_categories` already loaded with
+  # their `:category` preloaded (budgets#show and budget_categories#update both
+  # do this); otherwise this re-queries and N+1s on `bc.category`.
   def subcategories
     return [] unless category.parent_id.nil?
     return [] if category.id.nil?

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -231,12 +231,10 @@ class BudgetCategory < ApplicationRecord
   end
 
   def subcategories
-    return BudgetCategory.none unless category.parent_id.nil?
-    return BudgetCategory.none if category.id.nil?
+    return [] unless category.parent_id.nil?
+    return [] if category.id.nil?
 
-    budget.budget_categories
-      .joins(:category)
-      .where(categories: { parent_id: category.id })
+    budget.budget_categories.select { |bc| bc.category.parent_id == category.id }
   end
 
   private


### PR DESCRIPTION
Closes https://github.com/we-promise/sure/issues/2445

## Problem

`BudgetCategory#subcategories` was issuing one SQL query per parent category every time `available_to_spend` was computed during the budget show page render.

Reported in Sentry as **SURE-APP-ND** (815 events, 9 users) and **SURE-APP-AZ** (184 events, 31 users). The offending query:

```sql
SELECT budget_categories.*, categories.*
FROM budget_categories
INNER JOIN categories ON categories.id = budget_categories.category_id
WHERE budget_categories.budget_id = $1 AND categories.parent_id = $2
```

This fires once per top-level category while the view helper groups categories into over-budget / on-track sections via `BudgetCategory::Group.for` → `any_over_budget?` → `available_to_spend` → `subcategories`.

## Fix

Two changes:

**1. Preload budget_categories with categories in `BudgetsController#show`**

```ruby
@budget.budget_categories.includes(:category).load
```

This warms the in-memory collection (with categories attached) before the view iterates it.

**2. Change `BudgetCategory#subcategories` to filter in-memory**

```ruby
# before
budget.budget_categories.joins(:category).where(categories: { parent_id: category.id })

# after
budget.budget_categories.select { |bc| bc.category.parent_id == category.id }
```

When `budget.budget_categories` is already loaded (as it will be after the preload), `select { }` uses `Enumerable#select` on the cached collection — zero additional SQL. Mirrors the existing `siblings` method, which already uses this pattern.

The return type changes from `ActiveRecord::Relation` to `Array`, but all callers use only `each`, `reject`, and `sum`, which work identically on both.

## Test plan

- [x] `test/controllers/budget_categories_controller_test.rb` — 25 tests, 0 failures
- [x] `test/models/budget_category_test.rb` — 0 failures
- [ ] Verify Sentry SURE-APP-ND / SURE-APP-AZ resolve after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance in budget and category screens by eagerly loading related category information to minimize repeated database access.
  * Updated subcategory loading to use already-available in-memory data, returning a straightforward list for more consistent display behavior.
  * Enhanced budget/category update processing to preload the necessary related budget and category details before applying changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->