### PR TITLE
perf(accounts): fix N+1 syncing? queries on accounts/index

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -10,7 +10,7 @@ class AccountsController < ApplicationController
     @manual_accounts = family.accounts
           .listable_manual
           .where(id: @accessible_account_ids)
-          .includes(:accountable, :account_providers, :plaid_account, :simplefin_account)
+          .includes(:accountable, :account_providers, :plaid_account, :simplefin_account, :syncs)
           .order(:name)
     @plaid_items = visible_provider_items(family.plaid_items.ordered.includes(:syncs, :plaid_accounts))
     @simplefin_items = visible_provider_items(family.simplefin_items.ordered.includes(:syncs))
@@ -279,6 +279,9 @@ class AccountsController < ApplicationController
 
     # Builds sync stats maps for all provider types to avoid N+1 queries in views
     def build_sync_stats_maps
+      # Computed once; same answer for all items since they share this family
+      family_has_manual_accounts = family.accounts.listable_manual.exists?
+
       # SimpleFIN sync stats
       @simplefin_sync_stats_map = {}
       @simplefin_has_unlinked_map = {}
@@ -290,7 +293,7 @@ class AccountsController < ApplicationController
         latest_sync = item.syncs.ordered.first
         stats = latest_sync&.sync_stats || {}
         @simplefin_sync_stats_map[item.id] = stats
-        @simplefin_has_unlinked_map[item.id] = item.family.accounts.listable_manual.exists?
+        @simplefin_has_unlinked_map[item.id] = family_has_manual_accounts
 
         # Count unlinked accounts
         count = item.simplefin_accounts

--- a/app/models/concerns/syncable.rb
+++ b/app/models/concerns/syncable.rb
@@ -6,8 +6,11 @@ module Syncable
   end
 
   def syncing?
+    # When `syncs` is already loaded (e.g. preloaded on accounts/index), filter
+    # in memory to avoid an N+1 re-query; otherwise use the SQL scope. Both use
+    # the same definition of visibility (Sync#visible? mirrors Sync.visible).
     if syncs.loaded?
-      syncs.any? { |s| %w[pending syncing].include?(s.status) && s.created_at > Sync::VISIBLE_FOR.ago }
+      syncs.any?(&:visible?)
     else
       syncs.visible.any?
     end

--- a/app/models/concerns/syncable.rb
+++ b/app/models/concerns/syncable.rb
@@ -6,7 +6,11 @@ module Syncable
   end
 
   def syncing?
-    syncs.visible.any?
+    if syncs.loaded?
+      syncs.any? { |s| %w[pending syncing].include?(s.status) && s.created_at > Sync::VISIBLE_FOR.ago }
+    else
+      syncs.visible.any?
+    end
   end
 
   # Schedules a sync for syncable.  If there is an existing sync pending/syncing for this syncable,

--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -6,6 +6,11 @@ class Sync < ApplicationRecord
   # The max time that a sync will show in the UI (after 5 minutes)
   VISIBLE_FOR = 5.minutes
 
+  # Statuses considered "incomplete" (still in flight). Shared by the
+  # incomplete/visible scopes and the #visible? predicate so the SQL and
+  # in-memory definitions of visibility can't drift apart.
+  INCOMPLETE_STATUSES = %w[pending syncing].freeze
+
   include AASM
 
   Error = Class.new(StandardError)
@@ -16,8 +21,16 @@ class Sync < ApplicationRecord
   has_many :children, class_name: "Sync", foreign_key: :parent_id, dependent: :destroy
 
   scope :ordered, -> { order(created_at: :desc, id: :desc) }
-  scope :incomplete, -> { where("syncs.status IN (?)", %w[pending syncing]) }
+  scope :incomplete, -> { where(status: INCOMPLETE_STATUSES) }
   scope :visible, -> { incomplete.where("syncs.created_at > ?", VISIBLE_FOR.ago) }
+
+  # Ruby mirror of the `visible` scope, for in-memory checks over an already
+  # loaded `syncs` association (see Syncable#syncing?) without re-querying. Keep
+  # in lockstep with the scope above — both derive from INCOMPLETE_STATUSES and
+  # VISIBLE_FOR, so changing either constant updates both paths.
+  def visible?
+    INCOMPLETE_STATUSES.include?(status) && created_at > VISIBLE_FOR.ago
+  end
 
   after_commit :update_family_sync_timestamp
 

--- a/app/views/accounts/index/_account_groups.erb
+++ b/app/views/accounts/index/_account_groups.erb
@@ -3,7 +3,7 @@
 <% if accounts.any? %>
   <% ActiveRecord::Associations::Preloader.new(
        records: accounts,
-       associations: [ :account_shares, :accountable, :plaid_account, :simplefin_account, { account_providers: :provider } ]
+       associations: [ :account_shares, :accountable, :plaid_account, :simplefin_account, { account_providers: :provider }, :syncs ]
      ).call %>
 <% end %>
 <% accounts.group_by(&:accountable_type).sort_by { |group, _| group }.each do |group, accounts| %>

--- a/test/models/sync_test.rb
+++ b/test/models/sync_test.rb
@@ -3,6 +3,31 @@ require "test_helper"
 class SyncTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
+  # Guards against the in-memory predicate drifting from the SQL scope: for the
+  # same records, Sync#visible? must agree with Sync.visible (Syncable#syncing?
+  # relies on this equivalence when `syncs` is preloaded).
+  test "visible? mirrors the visible scope" do
+    syncable = accounts(:depository)
+    recent_pending = Sync.create!(syncable: syncable, status: :pending)
+    completed = Sync.create!(
+      syncable: syncable, status: :completed, completed_at: Time.current
+    )
+    stale_pending = Sync.create!(syncable: syncable, status: :pending)
+    stale_pending.update_column(:created_at, Sync::VISIBLE_FOR.ago - 1.minute)
+
+    visible_ids = Sync.visible.pluck(:id).to_set
+
+    [ recent_pending, completed, stale_pending ].each do |sync|
+      sync.reload
+      assert_equal visible_ids.include?(sync.id), sync.visible?,
+        "Sync##{sync.id} (#{sync.status}) visible? disagreed with Sync.visible"
+    end
+
+    assert recent_pending.visible?
+    assert_not completed.visible?
+    assert_not stale_pending.visible?
+  end
+
   test "does not run if not in a valid state" do
     syncable = accounts(:depository)
     sync = Sync.create!(syncable: syncable, status: :completed)


### PR DESCRIPTION
Closes https://github.com/we-promise/sure/issues/2446

## Problem

`AccountsController#index` was firing one SQL query per account to check syncing status, producing an N+1 on the family accounts page.

Reported in Sentry as **SURE-APP-2E** (694 events, still firing today) and **SURE-APP-YA** (129 events, 8 users, last seen today). The offending queries (104 per page load for a family with many accounts):

```sql
SELECT 1 AS one FROM "syncs"
WHERE "syncs"."syncable_id" = $1 AND "syncs"."syncable_type" = $2
  AND (syncs.status IN ($3, $4)) AND (syncs.created_at > $5)
LIMIT $6
```

## Root causes

**1. `Syncable#syncing?` bypasses preloaded syncs**

```ruby
def syncing?
  syncs.visible.any?  # fires SQL even when syncs are loaded
end
```

`syncs.visible` creates a new scoped relation, which re-queries the DB regardless of whether the `syncs` association was already preloaded via `includes`. Called once per account in `_account_groups.erb` (`accounts.any?(&:syncing?)`) and once per account in `_account.html.erb`.

**2. `item.family.accounts.listable_manual.exists?` fires per SimpleFIN item**

In `build_sync_stats_maps`, line 308 called `item.family.accounts.listable_manual.exists?` inside the simplefin items loop. Since all items belong to the same family, this is identical for every iteration.

## Fix

**`Syncable#syncing?` — check in-memory when loaded:**

```ruby
def syncing?
  if syncs.loaded?
    syncs.any? { |s| %w[pending syncing].include?(s.status) && s.created_at > Sync::VISIBLE_FOR.ago }
  else
    syncs.visible.any?
  end
end
```

The in-memory check mirrors the `visible` scope exactly: `incomplete` (status IN pending/syncing) + `created_at > 5.minutes.ago`.

**Preloading — add `:syncs` to two places:**

- `AccountsController#index`: `@manual_accounts.includes(..., :syncs)`
- `_account_groups.erb` view-level `Preloader` — covers accounts rendered via other code paths

**`build_sync_stats_maps` — compute once:**

```ruby
family_has_manual_accounts = family.accounts.listable_manual.exists?
# then use in the loop instead of item.family.accounts...exists?
```

## Test plan

- [x] `test/controllers/accounts_controller_test.rb` — 41 tests, 0 failures
- [x] `test/models/concerns/` — 25 tests, 0 failures
- [ ] Verify Sentry SURE-APP-2E / SURE-APP-YA resolve after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized account data retrieval to reduce unnecessary database queries during page loads
  * Enhanced sync status checking by eliminating redundant visibility calculations

* **Tests**
  * Added comprehensive test coverage for sync visibility verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->