### PR TITLE
perf(sync): bound family-level transfer matching to 90-day window

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -5,7 +5,8 @@ module Family::AutoTransferMatchable
     inflow_transaction_id: nil,
     outflow_transaction_id: nil,
     account_id: nil,
-    include_rejected: true
+    include_rejected: true,
+    since_date: nil
   )
     date_window = coerce_transfer_match_date_window!(date_window)
     exchange_rate_tolerance = coerce_transfer_match_exchange_rate_tolerance!(exchange_rate_tolerance)
@@ -20,14 +21,15 @@ module Family::AutoTransferMatchable
         account_id:,
         include_rejected:,
         lower_exchange_rate_bound: 1 - exchange_rate_tolerance,
-        upper_exchange_rate_bound: 1 + exchange_rate_tolerance
+        upper_exchange_rate_bound: 1 + exchange_rate_tolerance,
+        since_date:
       }
     ])
   end
 
-  def auto_match_transfers!(account: nil)
+  def auto_match_transfers!(account: nil, since_date: nil)
     # Exclude already matched transfers
-    candidates_scope = transfer_match_candidates(account_id: account&.id, include_rejected: false)
+    candidates_scope = transfer_match_candidates(account_id: account&.id, include_rejected: false, since_date:)
     transaction_ids = candidates_scope.flat_map do |match|
       [ match.inflow_transaction_id, match.outflow_transaction_id ]
     end.uniq
@@ -140,7 +142,8 @@ module Family::AutoTransferMatchable
             (:account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id) AND
             (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND
             (:outflow_transaction_id IS NULL OR outflow_candidates.entryable_id = :outflow_transaction_id) AND
-            (:include_rejected = TRUE OR rejected_transfers.id IS NULL)
+            (:include_rejected = TRUE OR rejected_transfers.id IS NULL) AND
+            (:since_date IS NULL OR inflow_candidates.date >= :since_date)
           UNION ALL
           SELECT
             inflow_candidates.entryable_id AS inflow_transaction_id,
@@ -185,7 +188,8 @@ module Family::AutoTransferMatchable
               BETWEEN :lower_exchange_rate_bound AND :upper_exchange_rate_bound AND
             (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND
             (:outflow_transaction_id IS NULL OR outflow_candidates.entryable_id = :outflow_transaction_id) AND
-            (:include_rejected = TRUE OR rejected_transfers.id IS NULL)
+            (:include_rejected = TRUE OR rejected_transfers.id IS NULL) AND
+            (:since_date IS NULL OR inflow_candidates.date >= :since_date)
         ) transfer_match_candidates
         ORDER BY transfer_match_candidates.date_diff ASC
       SQL

--- a/app/models/family/syncer.rb
+++ b/app/models/family/syncer.rb
@@ -20,7 +20,7 @@ class Family::Syncer
   end
 
   def perform_post_sync
-    family.auto_match_transfers!
+    family.auto_match_transfers!(since_date: 90.days.ago.to_date)
 
     Rails.logger.info("Applying rules for family #{family.id}")
     family.rules.where(active: true).each do |rule|


### PR DESCRIPTION
Closes https://github.com/we-promise/sure/issues/2447

## Problem

`Family::Syncer#perform_post_sync` called `auto_match_transfers!` with no date filter, causing a full cartesian scan across **all** entries in a family's accounts on every sync.

For families with 10,000+ entries, this is an O(N²) self-join on the entries table. Sentry reports this as **SURE-APP-WX**: 18,894 occurrences, still firing as of today, only affecting 5 accounts (users with large transaction histories).

The offending query scans every `Transaction` entry for the family, finds every pair that could be a transfer (matching amount, opposite sign, within 4-day window), and sorts them — with no upper bound on how many entries it examines.

## Fix

Add a `since_date:` parameter to `transfer_match_candidates` and `auto_match_transfers!`, and apply it as `AND (:since_date IS NULL OR inflow_candidates.date >= :since_date)` in both UNION halves of the SQL.

`Family::Syncer#perform_post_sync` now passes `since_date: 90.days.ago.to_date`, limiting each family-level post-sync scan to entries from the last 90 days.

**Why 90 days is safe:**

- Ongoing syncs add recent transactions — nearly all new entries fall within the 90-day window
- Historical transfers (>90 days) are already matched from prior syncs; the auto-match is idempotent and skips already-matched pairs
- For new bank connections with historical imports, the account-level sync path fires per-account and keeps `since_date: nil` (full history for that specific account)
- Manual entry scenarios also go through the account-level path

**Callers unchanged:**

- `account.family.auto_match_transfers!(account: account)` — account-level path, no `since_date` → still full history for that account
- Direct `transfer_match_candidates(...)` calls — `since_date` defaults to `nil` → backward compatible

## Behavioral note (for support / release notes)

This bounds **family-level post-sync auto-matching** to the last 90 days. One consequence worth flagging: any cross-account transfers that are still **unmatched and older than 90 days at the time this ships** won't be auto-matched going forward — e.g. a user whose accounts were briefly disconnected, with transfers during that gap, would need to match those manually. The account-level path keeps full history (`since_date: nil`), so new connections and historical imports are unaffected; this only concerns already-existing, still-unmatched transfers older than 90 days. Worth a line in release notes so support is aware.

_Edge case (practically a non-issue):_ the `since_date` filter keys off `inflow_candidates.date`, so a transfer whose two sides straddle the exact 90-day boundary could have one side excluded. Since the match window is ≤7 days, this only occurs for a transfer landing right at the boundary.

## Test plan

- [x] `test/models/family/auto_transfer_matchable_test.rb` — 19 tests, 0 failures
- [x] `test/models/family_test.rb` — 17 tests, 0 failures
- [x] `test/models/family/syncer_test.rb` — 3 tests, 0 failures
- [ ] Verify Sentry SURE-APP-WX resolves after deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic transfer matching by limiting candidates to recent transactions during synchronization.
  * Prevented older inflows from being considered for new automatic matches while preserving existing account and rejection filters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->