### PR TITLE
feat(kraken): import deposits, withdrawals, staking & fees via Ledgers API

### DIFF
--- a/app/models/kraken_account/ledger_processor.rb
+++ b/app/models/kraken_account/ledger_processor.rb
@@ -30,6 +30,11 @@ class KrakenAccount::LedgerProcessor
   def process
     return unless account.present?
 
+    # Idempotency: load existing Kraken external IDs once and test membership in
+    # memory, instead of an EXISTS query per ledger entry (a full sync can carry
+    # up to ~10k entries — see MAX_LEDGER_PAGES in the importer).
+    @existing_external_ids = account.entries.where(source: "kraken").pluck(:external_id).to_set
+
     raw_ledgers.each do |ledger_id, ledger|
       process_ledger_entry(ledger_id, ledger)
     rescue StandardError => e
@@ -76,7 +81,7 @@ class KrakenAccount::LedgerProcessor
       return if type == "earn" && EARN_INTERNAL_SUBTYPES.include?(subtype)
 
       external_id = "kraken_ledger_#{ledger_id}"
-      return if account.entries.exists?(external_id: external_id, source: "kraken")
+      return if @existing_external_ids.include?(external_id)
 
       raw_asset  = ledger["asset"].to_s
       raw_amount = ledger["amount"].to_d
@@ -115,6 +120,8 @@ class KrakenAccount::LedgerProcessor
           extra: extra
         )
       )
+
+      @existing_external_ids << external_id
     end
 
     # Returns [family_currency_amount, price_missing_bool] or [nil, nil] on hard failure.

--- a/app/models/kraken_account/ledger_processor.rb
+++ b/app/models/kraken_account/ledger_processor.rb
@@ -30,10 +30,15 @@ class KrakenAccount::LedgerProcessor
   def process
     return unless account.present?
 
-    # Idempotency: load existing Kraken external IDs once and test membership in
-    # memory, instead of an EXISTS query per ledger entry (a full sync can carry
-    # up to ~10k entries — see MAX_LEDGER_PAGES in the importer).
-    @existing_external_ids = account.entries.where(source: "kraken").pluck(:external_id).to_set
+    # Idempotency: load existing Kraken *ledger* external IDs once and test
+    # membership in memory, instead of an EXISTS query per ledger entry (a full
+    # sync can carry up to ~10k entries — see MAX_LEDGER_PAGES in the importer).
+    # Scoped to the kraken_ledger_ prefix so trade entries aren't loaded.
+    @existing_external_ids = account.entries
+                                    .where(source: "kraken")
+                                    .where("external_id LIKE 'kraken_ledger_%'")
+                                    .pluck(:external_id)
+                                    .to_set
 
     raw_ledgers.each do |ledger_id, ledger|
       process_ledger_entry(ledger_id, ledger)

--- a/app/models/kraken_account/ledger_processor.rb
+++ b/app/models/kraken_account/ledger_processor.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+# Processes Kraken Ledger entries (deposits, withdrawals, staking rewards, Earn
+# income, standalone fees) stored in KrakenAccount#raw_transactions_payload["ledgers"].
+#
+# Kraken TradesHistory already handles spot buy/sell trades; ledger entries with
+# type="trade" are therefore skipped here to avoid double-counting.  Internal
+# sub-account transfers (type="transfer") and margin events (type="margin",
+# "rollover", "settled") are also skipped.
+class KrakenAccount::LedgerProcessor
+  include KrakenAccount::UsdConverter
+
+  # Ledger types we import as Transaction entries.
+  SUPPORTED_TYPES = %w[deposit withdrawal staking earn fee].freeze
+
+  # Ledger types we intentionally ignore (handled elsewhere or out of scope).
+  SKIP_TYPES = %w[trade transfer margin rollover settled adjustment].freeze
+
+  def initialize(kraken_account)
+    @kraken_account = kraken_account
+    @normalizer = KrakenAccount::AssetNormalizer.new(raw_payload&.dig("asset_metadata") || {})
+  end
+
+  def process
+    return unless account.present?
+
+    raw_ledgers.each do |ledger_id, ledger|
+      process_ledger_entry(ledger_id, ledger)
+    rescue StandardError => e
+      Rails.logger.error("KrakenAccount::LedgerProcessor - failed ledger #{ledger_id}: #{e.message}")
+    end
+  end
+
+  private
+
+    attr_reader :kraken_account, :normalizer
+
+    def account
+      kraken_account.current_account
+    end
+
+    def target_currency
+      kraken_account.kraken_item&.family&.currency
+    end
+
+    def raw_payload
+      kraken_account.raw_payload
+    end
+
+    def raw_ledgers
+      kraken_account.raw_transactions_payload&.dig("ledgers") || {}
+    end
+
+    def process_ledger_entry(ledger_id, ledger)
+      type = ledger["type"].to_s.downcase
+      return if SKIP_TYPES.include?(type)
+      return unless SUPPORTED_TYPES.include?(type)
+
+      external_id = "kraken_ledger_#{ledger_id}"
+      return if account.entries.exists?(external_id: external_id, source: "kraken")
+
+      raw_asset  = ledger["asset"].to_s
+      raw_amount = ledger["amount"].to_d   # negative = debit, positive = credit
+      raw_fee    = ledger["fee"].to_d
+      date       = Time.zone.at(ledger["time"].to_d).to_date
+
+      return if raw_amount.zero? && raw_fee.zero?
+
+      normalized = normalizer.normalize(raw_asset)
+      symbol     = normalized[:symbol]
+
+      entry_amount, price_missing = resolve_amount(raw_amount.abs, symbol, date)
+      return if entry_amount.nil?
+
+      # Withdrawals and fees are outflows (negative in Sure's sign convention)
+      signed_amount = outflow?(type, raw_amount) ? -entry_amount.abs : entry_amount.abs
+
+      name  = build_name(type, raw_amount.abs, symbol)
+      label = activity_label(type)
+      kind  = transaction_kind(type)
+
+      extra = build_extra(ledger_id, ledger, raw_asset, price_missing)
+
+      account.entries.create!(
+        date: date,
+        name: name,
+        amount: signed_amount,
+        currency: target_currency,
+        external_id: external_id,
+        source: "kraken",
+        entryable: Transaction.new(
+          kind: kind,
+          investment_activity_label: label,
+          extra: extra
+        )
+      )
+    end
+
+    # Returns [family_currency_amount, price_missing_bool] or [nil, nil] on hard failure.
+    def resolve_amount(abs_amount, symbol, date)
+      return [ abs_amount, false ] if symbol == target_currency
+
+      if KrakenAccount::FIAT_CURRENCIES.include?(symbol)
+        resolve_fiat_amount(abs_amount, symbol, date)
+      else
+        resolve_crypto_amount(abs_amount, symbol, date)
+      end
+    end
+
+    def resolve_fiat_amount(abs_amount, symbol, date)
+      if symbol == "USD"
+        converted, stale, = convert_from_usd(abs_amount, date: date)
+        return [ converted, stale ]
+      end
+
+      # Non-USD fiat: go via USD as intermediate
+      rate_to_usd = ExchangeRate.find_or_fetch_rate(from: symbol, to: "USD", date: date)
+      return [ nil, nil ] unless rate_to_usd
+
+      usd_amount = abs_amount * rate_to_usd.rate.to_d
+      converted, stale, = convert_from_usd(usd_amount, date: date)
+      [ converted, stale ]
+    rescue StandardError => e
+      Rails.logger.warn("KrakenAccount::LedgerProcessor - fiat rate fetch failed #{symbol}: #{e.message}")
+      [ nil, nil ]
+    end
+
+    def resolve_crypto_amount(abs_amount, symbol, date)
+      price_usd = stored_price_usd(symbol)
+
+      if price_usd.nil?
+        Rails.logger.warn("KrakenAccount::LedgerProcessor - no price for #{symbol} on #{date}, amount set to 0")
+        return [ 0.to_d, true ]
+      end
+
+      usd_amount = abs_amount * price_usd
+      converted, stale, = convert_from_usd(usd_amount, date: date)
+      [ converted, stale ]
+    rescue StandardError => e
+      Rails.logger.warn("KrakenAccount::LedgerProcessor - crypto price resolve failed #{symbol}: #{e.message}")
+      [ 0.to_d, true ]
+    end
+
+    # Use the current spot price cached in raw_payload["assets"] by the Importer.
+    # This is the price at last sync time, not at entry date — a best-effort
+    # approximation; precise historical pricing is a future enhancement.
+    def stored_price_usd(symbol)
+      assets = raw_payload&.dig("assets") || []
+      asset = assets.find do |a|
+        (a["symbol"] || a[:symbol]).to_s.upcase == symbol.upcase
+      end
+      price = asset&.dig("price_usd") || asset&.dig(:price_usd)
+      price.present? ? price.to_d : nil
+    end
+
+    def outflow?(type, raw_amount)
+      case type
+      when "withdrawal", "fee" then true
+      when "deposit", "staking", "earn" then false
+      else raw_amount.negative?
+      end
+    end
+
+    def build_name(type, abs_amount, symbol)
+      qty = abs_amount.to_d.round(8).to_s("F").sub(/\.?0+\z/, "")
+      case type
+      when "deposit"    then "Deposit #{qty} #{symbol}"
+      when "withdrawal" then "Withdrawal #{qty} #{symbol}"
+      when "staking"    then "Staking reward #{qty} #{symbol}"
+      when "earn"       then "Earn reward #{qty} #{symbol}"
+      when "fee"        then "Fee #{qty} #{symbol}"
+      else "#{type.capitalize} #{qty} #{symbol}"
+      end
+    end
+
+    def activity_label(type)
+      case type
+      when "deposit"    then "Contribution"
+      when "withdrawal" then "Withdrawal"
+      when "staking"    then "Dividend"
+      when "earn"       then "Interest"
+      when "fee"        then "Fee"
+      end
+    end
+
+    def transaction_kind(type)
+      case type
+      when "deposit", "withdrawal" then "funds_movement"
+      else "standard"
+      end
+    end
+
+    def build_extra(ledger_id, ledger, raw_asset, price_missing)
+      meta = {
+        "ledger_id"  => ledger_id,
+        "refid"      => ledger["refid"],
+        "raw_asset"  => raw_asset,
+        "raw_amount" => ledger["amount"],
+        "fee_native" => ledger["fee"],
+        "type"       => ledger["type"],
+        "subtype"    => ledger["subtype"]
+      }
+      meta["price_missing"] = true if price_missing
+      { "kraken" => meta }
+    end
+end

--- a/app/models/kraken_account/ledger_processor.rb
+++ b/app/models/kraken_account/ledger_processor.rb
@@ -7,6 +7,9 @@
 # type="trade" are therefore skipped here to avoid double-counting.  Internal
 # sub-account transfers (type="transfer") and margin events (type="margin",
 # "rollover", "settled") are also skipped.
+#
+# Sign convention (Sure): negative = inflow/income, positive = outflow/expense.
+# Deposits and rewards are negative; withdrawals and fees are positive.
 class KrakenAccount::LedgerProcessor
   include KrakenAccount::UsdConverter
 
@@ -15,6 +18,9 @@ class KrakenAccount::LedgerProcessor
 
   # Ledger types we intentionally ignore (handled elsewhere or out of scope).
   SKIP_TYPES = %w[trade transfer margin rollover settled adjustment].freeze
+
+  # Kraken Earn internal subtypes that represent fund movements, not income.
+  EARN_INTERNAL_SUBTYPES = %w[allocation deallocation].freeze
 
   def initialize(kraken_account)
     @kraken_account = kraken_account
@@ -27,7 +33,15 @@ class KrakenAccount::LedgerProcessor
     raw_ledgers.each do |ledger_id, ledger|
       process_ledger_entry(ledger_id, ledger)
     rescue StandardError => e
-      Rails.logger.error("KrakenAccount::LedgerProcessor - failed ledger #{ledger_id}: #{e.message}")
+      DebugLogEntry.capture(
+        category: "provider_sync_error",
+        level: "error",
+        message: "Failed to process ledger entry #{ledger_id}: #{e.message}",
+        source: self.class.name,
+        provider_key: "kraken",
+        family: kraken_account.kraken_item&.family,
+        metadata: { ledger_id: ledger_id, error_class: e.class.name }
+      )
     end
   end
 
@@ -52,33 +66,40 @@ class KrakenAccount::LedgerProcessor
     end
 
     def process_ledger_entry(ledger_id, ledger)
-      type = ledger["type"].to_s.downcase
+      type    = ledger["type"].to_s.downcase
+      subtype = ledger["subtype"].to_s.downcase
+
       return if SKIP_TYPES.include?(type)
       return unless SUPPORTED_TYPES.include?(type)
+
+      # Skip Earn allocation/deallocation — these are internal fund movements, not income.
+      return if type == "earn" && EARN_INTERNAL_SUBTYPES.include?(subtype)
 
       external_id = "kraken_ledger_#{ledger_id}"
       return if account.entries.exists?(external_id: external_id, source: "kraken")
 
       raw_asset  = ledger["asset"].to_s
-      raw_amount = ledger["amount"].to_d   # negative = debit, positive = credit
+      raw_amount = ledger["amount"].to_d
       raw_fee    = ledger["fee"].to_d
       date       = Time.zone.at(ledger["time"].to_d).to_date
 
-      return if raw_amount.zero? && raw_fee.zero?
+      # Compute the total balance impact: Kraken applies amount - fee to the balance.
+      # abs_impact captures the full magnitude of the cash movement for this event.
+      abs_impact = (raw_amount - raw_fee).abs
+      return if abs_impact.zero?
 
       normalized = normalizer.normalize(raw_asset)
       symbol     = normalized[:symbol]
 
-      entry_amount, price_missing = resolve_amount(raw_amount.abs, symbol, date)
+      entry_amount, price_missing = resolve_amount(abs_impact, symbol, date)
       return if entry_amount.nil?
 
-      # Withdrawals and fees are outflows (negative in Sure's sign convention)
-      signed_amount = outflow?(type, raw_amount) ? -entry_amount.abs : entry_amount.abs
+      # Sure sign convention: inflow = negative, outflow = positive.
+      signed_amount = inflow?(type) ? -entry_amount.abs : entry_amount.abs
 
-      name  = build_name(type, raw_amount.abs, symbol)
+      name  = build_name(type, abs_impact, symbol)
       label = activity_label(type)
       kind  = transaction_kind(type)
-
       extra = build_extra(ledger_id, ledger, raw_asset, price_missing)
 
       account.entries.create!(
@@ -97,47 +118,71 @@ class KrakenAccount::LedgerProcessor
     end
 
     # Returns [family_currency_amount, price_missing_bool] or [nil, nil] on hard failure.
-    def resolve_amount(abs_amount, symbol, date)
-      return [ abs_amount, false ] if symbol == target_currency
+    def resolve_amount(abs_impact, symbol, date)
+      return [ abs_impact, false ] if symbol == target_currency
 
       if KrakenAccount::FIAT_CURRENCIES.include?(symbol)
-        resolve_fiat_amount(abs_amount, symbol, date)
+        resolve_fiat_amount(abs_impact, symbol, date)
       else
-        resolve_crypto_amount(abs_amount, symbol, date)
+        resolve_crypto_amount(abs_impact, symbol, date)
       end
     end
 
-    def resolve_fiat_amount(abs_amount, symbol, date)
+    def resolve_fiat_amount(abs_impact, symbol, date)
       if symbol == "USD"
-        converted, stale, = convert_from_usd(abs_amount, date: date)
+        converted, stale, = convert_from_usd(abs_impact, date: date)
         return [ converted, stale ]
       end
 
-      # Non-USD fiat: go via USD as intermediate
+      # Non-USD fiat: bridge through USD
       rate_to_usd = ExchangeRate.find_or_fetch_rate(from: symbol, to: "USD", date: date)
       return [ nil, nil ] unless rate_to_usd
 
-      usd_amount = abs_amount * rate_to_usd.rate.to_d
+      usd_amount = abs_impact * rate_to_usd.rate.to_d
       converted, stale, = convert_from_usd(usd_amount, date: date)
       [ converted, stale ]
     rescue StandardError => e
-      Rails.logger.warn("KrakenAccount::LedgerProcessor - fiat rate fetch failed #{symbol}: #{e.message}")
+      DebugLogEntry.capture(
+        category: "provider_sync_error",
+        level: "warn",
+        message: "Fiat rate fetch failed for #{symbol}: #{e.message}",
+        source: self.class.name,
+        provider_key: "kraken",
+        family: kraken_account.kraken_item&.family,
+        metadata: { symbol: symbol, date: date.to_s, error_class: e.class.name }
+      )
       [ nil, nil ]
     end
 
-    def resolve_crypto_amount(abs_amount, symbol, date)
+    def resolve_crypto_amount(abs_impact, symbol, date)
       price_usd = stored_price_usd(symbol)
 
       if price_usd.nil?
-        Rails.logger.warn("KrakenAccount::LedgerProcessor - no price for #{symbol} on #{date}, amount set to 0")
+        DebugLogEntry.capture(
+          category: "provider_sync_error",
+          level: "warn",
+          message: "No price available for #{symbol} on #{date}; amount recorded as 0",
+          source: self.class.name,
+          provider_key: "kraken",
+          family: kraken_account.kraken_item&.family,
+          metadata: { symbol: symbol, date: date.to_s }
+        )
         return [ 0.to_d, true ]
       end
 
-      usd_amount = abs_amount * price_usd
+      usd_amount = abs_impact * price_usd
       converted, stale, = convert_from_usd(usd_amount, date: date)
       [ converted, stale ]
     rescue StandardError => e
-      Rails.logger.warn("KrakenAccount::LedgerProcessor - crypto price resolve failed #{symbol}: #{e.message}")
+      DebugLogEntry.capture(
+        category: "provider_sync_error",
+        level: "warn",
+        message: "Crypto price resolution failed for #{symbol}: #{e.message}",
+        source: self.class.name,
+        provider_key: "kraken",
+        family: kraken_account.kraken_item&.family,
+        metadata: { symbol: symbol, date: date.to_s, error_class: e.class.name }
+      )
       [ 0.to_d, true ]
     end
 
@@ -146,23 +191,24 @@ class KrakenAccount::LedgerProcessor
     # approximation; precise historical pricing is a future enhancement.
     def stored_price_usd(symbol)
       assets = raw_payload&.dig("assets") || []
-      asset = assets.find do |a|
+      asset  = assets.find do |a|
         (a["symbol"] || a[:symbol]).to_s.upcase == symbol.upcase
       end
       price = asset&.dig("price_usd") || asset&.dig(:price_usd)
       price.present? ? price.to_d : nil
     end
 
-    def outflow?(type, raw_amount)
+    # True when the ledger event represents money flowing INTO the account.
+    def inflow?(type)
       case type
-      when "withdrawal", "fee" then true
-      when "deposit", "staking", "earn" then false
-      else raw_amount.negative?
+      when "deposit", "staking", "earn" then true
+      when "withdrawal", "fee"          then false
+      else false
       end
     end
 
-    def build_name(type, abs_amount, symbol)
-      qty = abs_amount.to_d.round(8).to_s("F").sub(/\.?0+\z/, "")
+    def build_name(type, abs_impact, symbol)
+      qty = abs_impact.to_d.round(8).to_s("F").sub(/\.?0+\z/, "")
       case type
       when "deposit"    then "Deposit #{qty} #{symbol}"
       when "withdrawal" then "Withdrawal #{qty} #{symbol}"

--- a/app/models/kraken_account/processor.rb
+++ b/app/models/kraken_account/processor.rb
@@ -15,6 +15,7 @@ class KrakenAccount::Processor
     KrakenAccount::HoldingsProcessor.new(kraken_account).process
     process_account!
     process_trades
+    KrakenAccount::LedgerProcessor.new(kraken_account).process
   end
 
   private

--- a/app/models/kraken_item/importer.rb
+++ b/app/models/kraken_item/importer.rb
@@ -155,7 +155,15 @@ class KrakenItem::Importer
         ledgers = result.to_h.fetch("ledger", {})
         duplicate_ids = all_ledgers.keys & ledgers.keys
         if duplicate_ids.any?
-          Rails.logger.warn("KrakenItem::Importer - #{duplicate_ids.size} duplicate ledger ids from Kraken page ignored")
+          DebugLogEntry.capture(
+            category: "provider_sync_error",
+            level: "warn",
+            message: "#{duplicate_ids.size} duplicate ledger ids from Kraken ignored",
+            source: self.class.name,
+            provider_key: "kraken",
+            family: kraken_item.family,
+            metadata: { kraken_item_id: kraken_item.id, duplicate_ids: duplicate_ids }
+          )
         end
         all_ledgers.merge!(ledgers.except(*duplicate_ids))
 

--- a/app/models/kraken_item/importer.rb
+++ b/app/models/kraken_item/importer.rb
@@ -3,6 +3,8 @@
 class KrakenItem::Importer
   MAX_TRADE_PAGES = 200
   TRADE_PAGE_SIZE = 50
+  MAX_LEDGER_PAGES = 200
+  LEDGER_PAGE_SIZE = 50
 
   attr_reader :kraken_item, :kraken_provider
 
@@ -19,12 +21,14 @@ class KrakenItem::Importer
     balances = kraken_provider.get_extended_balance || {}
     assets = parse_assets(balances, asset_metadata)
     trades = fetch_trades
+    ledgers = fetch_ledgers
 
     total_usd = assets.sum { |asset| asset[:amount_usd].to_d }.round(2)
     kraken_account = upsert_kraken_account(
       assets: assets,
       balances: balances,
       trades: trades,
+      ledgers: ledgers,
       asset_metadata: asset_metadata,
       pair_metadata: pair_metadata,
       api_key_info: api_key_info,
@@ -39,7 +43,7 @@ class KrakenItem::Importer
       "imported_at" => Time.current.iso8601
     })
 
-    { success: true, account_id: kraken_account.id, assets_imported: assets.size, trades_imported: trades.size, total_usd: total_usd }
+    { success: true, account_id: kraken_account.id, assets_imported: assets.size, trades_imported: trades.size, ledgers_imported: ledgers.size, total_usd: total_usd }
   rescue Provider::Kraken::PermissionError => e
     kraken_item.update!(status: :requires_update)
     raise e
@@ -141,7 +145,35 @@ class KrakenItem::Importer
       all_trades
     end
 
-    def upsert_kraken_account(assets:, balances:, trades:, asset_metadata:, pair_metadata:, api_key_info:, total_usd:)
+    def fetch_ledgers
+      start_time = kraken_item.sync_start_date&.to_i
+      offset = 0
+      all_ledgers = {}
+
+      MAX_LEDGER_PAGES.times do
+        result = kraken_provider.get_ledgers(start: start_time, offset: offset)
+        ledgers = result.to_h.fetch("ledger", {})
+        duplicate_ids = all_ledgers.keys & ledgers.keys
+        if duplicate_ids.any?
+          Rails.logger.warn("KrakenItem::Importer - #{duplicate_ids.size} duplicate ledger ids from Kraken page ignored")
+        end
+        all_ledgers.merge!(ledgers.except(*duplicate_ids))
+
+        count = result.to_h["count"].to_i
+        break if ledgers.size < LEDGER_PAGE_SIZE
+
+        offset += ledgers.size
+        break if count.positive? && offset >= count
+      end
+
+      all_ledgers
+    rescue Provider::Kraken::PermissionError => e
+      # Key may not have Query Ledger Entries permission; log and continue without ledgers.
+      Rails.logger.warn("KrakenItem::Importer - Ledgers permission denied, skipping: #{e.message}")
+      {}
+    end
+
+    def upsert_kraken_account(assets:, balances:, trades:, ledgers:, asset_metadata:, pair_metadata:, api_key_info:, total_usd:)
       kraken_item.kraken_accounts.find_or_initialize_by(account_id: "combined").tap do |account|
         account.assign_attributes(
           name: kraken_item.institution_name.presence || "Kraken",
@@ -159,6 +191,7 @@ class KrakenItem::Importer
           },
           raw_transactions_payload: {
             "trades" => trades,
+            "ledgers" => ledgers,
             "fetched_at" => Time.current.iso8601
           },
           extra: account.extra.to_h.deep_merge(price_metadata(assets))

--- a/app/models/kraken_item/importer.rb
+++ b/app/models/kraken_item/importer.rb
@@ -168,8 +168,16 @@ class KrakenItem::Importer
 
       all_ledgers
     rescue Provider::Kraken::PermissionError => e
-      # Key may not have Query Ledger Entries permission; log and continue without ledgers.
-      Rails.logger.warn("KrakenItem::Importer - Ledgers permission denied, skipping: #{e.message}")
+      # Key may not have Query Ledger Entries permission; degrade gracefully.
+      DebugLogEntry.capture(
+        category: "provider_sync_error",
+        level: "warn",
+        message: "Ledgers permission denied; skipping ledger import: #{e.message}",
+        source: self.class.name,
+        provider_key: "kraken",
+        family: kraken_item.family,
+        metadata: { kraken_item_id: kraken_item.id }
+      )
       {}
     end
 

--- a/app/models/provider/kraken.rb
+++ b/app/models/provider/kraken.rb
@@ -43,6 +43,15 @@ class Provider::Kraken
     private_post("TradesHistory", params)
   end
 
+  def get_ledgers(start: nil, type: nil, offset: nil)
+    params = {}
+    params["start"] = start.to_i.to_s if start.present?
+    params["type"] = type.to_s if type.present?
+    params["ofs"] = offset.to_i.to_s if offset.present?
+
+    private_post("Ledgers", params)
+  end
+
   def get_asset_info(asset: nil)
     params = {}
     params["asset"] = asset if asset.present?

--- a/test/models/kraken_account/ledger_processor_test.rb
+++ b/test/models/kraken_account/ledger_processor_test.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
+  setup do
+    @family  = families(:dylan_family)
+    @account = @family.accounts.create!(
+      name: "Kraken", balance: 0, currency: "USD",
+      accountable: Crypto.new
+    )
+    @item = KrakenItem.create!(
+      family: @family, name: "Kraken", api_key: "k", api_secret: "s"
+    )
+    @kraken_account = @item.kraken_accounts.create!(
+      name: "Kraken", account_id: "combined", account_type: "combined", currency: "USD",
+      current_balance: 0,
+      raw_payload: {
+        "asset_metadata" => { "XXBT" => { "altname" => "BTC" }, "ZUSD" => { "altname" => "USD" }, "ZEUR" => { "altname" => "EUR" } },
+        "assets" => [ { "symbol" => "BTC", "price_usd" => "50000.00" } ]
+      },
+      raw_transactions_payload: { "trades" => {}, "ledgers" => {} }
+    )
+    @kraken_account.ensure_account_provider!(@account)
+  end
+
+  # ---------------------------------------------------------------------------
+  # deposit
+  # ---------------------------------------------------------------------------
+
+  test "creates a deposit entry for a BTC deposit" do
+    set_ledgers(
+      "LABC01" => ledger_entry(type: "deposit", asset: "XXBT", amount: "0.10000000", fee: "0.00000000", time: 1_700_000_000)
+    )
+
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LABC01", source: "kraken")
+    assert entry, "deposit entry must exist"
+    assert entry.amount.positive?, "deposit must be positive (inflow)"
+    assert_equal "USD", entry.currency
+    assert_match(/Deposit.*BTC/, entry.name)
+
+    txn = entry.entryable
+    assert_equal "funds_movement", txn.kind
+    assert_equal "Contribution",   txn.investment_activity_label
+    assert_equal "LABC01",         txn.extra.dig("kraken", "ledger_id")
+    assert_equal "deposit",        txn.extra.dig("kraken", "type")
+  end
+
+  test "creates a deposit entry for a USD fiat deposit" do
+    set_ledgers(
+      "LUSD01" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "1000.00", fee: "0.00", time: 1_700_000_000)
+    )
+
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LUSD01", source: "kraken")
+    assert entry
+    assert_in_delta 1000.0, entry.amount.to_f, 0.01
+    assert_match(/Deposit.*USD/, entry.name)
+  end
+
+  # ---------------------------------------------------------------------------
+  # withdrawal
+  # ---------------------------------------------------------------------------
+
+  test "creates a withdrawal entry (negative amount)" do
+    set_ledgers(
+      "LWIT01" => ledger_entry(type: "withdrawal", asset: "ZUSD", amount: "-500.00", fee: "1.00", time: 1_700_000_000)
+    )
+
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LWIT01", source: "kraken")
+    assert entry
+    assert entry.amount.negative?, "withdrawal must be negative (outflow)"
+    assert_match(/Withdrawal.*USD/, entry.name)
+    assert_equal "Withdrawal", entry.entryable.investment_activity_label
+    assert_equal "funds_movement", entry.entryable.kind
+  end
+
+  # ---------------------------------------------------------------------------
+  # staking
+  # ---------------------------------------------------------------------------
+
+  test "creates a staking reward entry" do
+    set_ledgers(
+      "LSTK01" => ledger_entry(type: "staking", asset: "XXBT", amount: "0.00050000", fee: "0.00", time: 1_700_000_000)
+    )
+
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LSTK01", source: "kraken")
+    assert entry
+    assert entry.amount.positive?
+    assert_match(/Staking reward.*BTC/, entry.name)
+    assert_equal "Dividend", entry.entryable.investment_activity_label
+    assert_equal "standard",  entry.entryable.kind
+  end
+
+  # ---------------------------------------------------------------------------
+  # earn
+  # ---------------------------------------------------------------------------
+
+  test "creates an earn reward entry" do
+    set_ledgers(
+      "LERN01" => ledger_entry(type: "earn", asset: "ZUSD", amount: "5.00", fee: "0.00", time: 1_700_000_000)
+    )
+
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LERN01", source: "kraken")
+    assert entry
+    assert_equal "Interest", entry.entryable.investment_activity_label
+  end
+
+  # ---------------------------------------------------------------------------
+  # standalone fee
+  # ---------------------------------------------------------------------------
+
+  test "creates a fee entry (negative amount)" do
+    set_ledgers(
+      "LFEE01" => ledger_entry(type: "fee", asset: "ZUSD", amount: "-7.50", fee: "0.00", time: 1_700_000_000)
+    )
+
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LFEE01", source: "kraken")
+    assert entry
+    assert entry.amount.negative?
+    assert_equal "Fee", entry.entryable.investment_activity_label
+  end
+
+  # ---------------------------------------------------------------------------
+  # skipped types
+  # ---------------------------------------------------------------------------
+
+  test "skips trade-type ledger entries (handled by TradesHistory)" do
+    set_ledgers(
+      "LTRD01" => ledger_entry(type: "trade", asset: "XXBT", amount: "-0.1", fee: "0.0", time: 1_700_000_000)
+    )
+
+    assert_no_difference "@account.entries.count" do
+      process
+    end
+  end
+
+  test "skips transfer-type ledger entries" do
+    set_ledgers(
+      "LTRN01" => ledger_entry(type: "transfer", asset: "XXBT", amount: "0.1", fee: "0.0", time: 1_700_000_000)
+    )
+
+    assert_no_difference "@account.entries.count" do
+      process
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # idempotency
+  # ---------------------------------------------------------------------------
+
+  test "does not duplicate entries on repeated processing" do
+    set_ledgers(
+      "LIDEM01" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "100.00", fee: "0.00", time: 1_700_000_000)
+    )
+
+    process
+    assert_no_difference "@account.entries.count" do
+      process
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # non-USD family currency (EUR example)
+  # ---------------------------------------------------------------------------
+
+  test "converts fiat USD amounts to non-USD family currency" do
+    @family.update!(currency: "EUR")
+    ExchangeRate.create!(from_currency: "USD", to_currency: "EUR", date: Date.current, rate: 0.92)
+
+    set_ledgers(
+      "LEUR01" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "1000.00", fee: "0.00", time: Time.current.to_i)
+    )
+
+    process
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LEUR01", source: "kraken")
+    assert entry
+    assert_equal "EUR", entry.currency
+    assert_in_delta 920.0, entry.amount.to_f, 1.0
+  end
+
+  test "marks crypto entries as price_missing when no price data available" do
+    set_raw_payload_assets([])   # no stored prices
+
+    set_ledgers(
+      "LNOPRICE" => ledger_entry(type: "deposit", asset: "XXBT", amount: "0.5", fee: "0.00", time: 1_700_000_000)
+    )
+
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LNOPRICE", source: "kraken")
+    assert entry
+    assert_equal 0, entry.amount.to_f
+    assert entry.entryable.extra.dig("kraken", "price_missing")
+  end
+
+  private
+
+    def process
+      KrakenAccount::LedgerProcessor.new(@kraken_account).process
+    end
+
+    def set_ledgers(ledgers)
+      @kraken_account.update!(
+        raw_transactions_payload: @kraken_account.raw_transactions_payload.merge("ledgers" => ledgers)
+      )
+    end
+
+    def set_raw_payload_assets(assets)
+      @kraken_account.update!(
+        raw_payload: @kraken_account.raw_payload.merge("assets" => assets)
+      )
+    end
+
+    def ledger_entry(type:, asset:, amount:, fee:, time:)
+      {
+        "refid"   => "S#{SecureRandom.hex(4).upcase}",
+        "time"    => time,
+        "type"    => type,
+        "subtype" => "",
+        "aclass"  => "currency",
+        "asset"   => asset,
+        "amount"  => amount,
+        "fee"     => fee,
+        "balance" => "1.00000000"
+      }
+    end
+end

--- a/test/models/kraken_account/ledger_processor_test.rb
+++ b/test/models/kraken_account/ledger_processor_test.rb
@@ -25,12 +25,12 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
   end
 
   # ---------------------------------------------------------------------------
-  # deposit
+  # sign convention: Sure uses negative = inflow, positive = outflow
   # ---------------------------------------------------------------------------
 
-  test "creates a deposit entry for a BTC deposit" do
+  test "creates a deposit entry with negative amount (inflow)" do
     set_ledgers(
-      "LABC01" => ledger_entry(type: "deposit", asset: "XXBT", amount: "0.10000000", fee: "0.00000000", time: 1_700_000_000)
+      "LABC01" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "1000.00", fee: "0.00", time: 1_700_000_000)
     )
 
     assert_difference "@account.entries.count", 1 do
@@ -39,9 +39,10 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by(external_id: "kraken_ledger_LABC01", source: "kraken")
     assert entry, "deposit entry must exist"
-    assert entry.amount.positive?, "deposit must be positive (inflow)"
+    assert entry.amount.negative?, "deposit is an inflow — must be negative in Sure's convention"
+    assert_in_delta(-1000.0, entry.amount.to_f, 0.01)
     assert_equal "USD", entry.currency
-    assert_match(/Deposit.*BTC/, entry.name)
+    assert_match(/Deposit.*USD/, entry.name)
 
     txn = entry.entryable
     assert_equal "funds_movement", txn.kind
@@ -50,28 +51,9 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
     assert_equal "deposit",        txn.extra.dig("kraken", "type")
   end
 
-  test "creates a deposit entry for a USD fiat deposit" do
+  test "creates a withdrawal entry with positive amount (outflow)" do
     set_ledgers(
-      "LUSD01" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "1000.00", fee: "0.00", time: 1_700_000_000)
-    )
-
-    assert_difference "@account.entries.count", 1 do
-      process
-    end
-
-    entry = @account.entries.find_by(external_id: "kraken_ledger_LUSD01", source: "kraken")
-    assert entry
-    assert_in_delta 1000.0, entry.amount.to_f, 0.01
-    assert_match(/Deposit.*USD/, entry.name)
-  end
-
-  # ---------------------------------------------------------------------------
-  # withdrawal
-  # ---------------------------------------------------------------------------
-
-  test "creates a withdrawal entry (negative amount)" do
-    set_ledgers(
-      "LWIT01" => ledger_entry(type: "withdrawal", asset: "ZUSD", amount: "-500.00", fee: "1.00", time: 1_700_000_000)
+      "LWIT01" => ledger_entry(type: "withdrawal", asset: "ZUSD", amount: "-500.00", fee: "0.00", time: 1_700_000_000)
     )
 
     assert_difference "@account.entries.count", 1 do
@@ -80,17 +62,54 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by(external_id: "kraken_ledger_LWIT01", source: "kraken")
     assert entry
-    assert entry.amount.negative?, "withdrawal must be negative (outflow)"
+    assert entry.amount.positive?, "withdrawal is an outflow — must be positive in Sure's convention"
+    assert_in_delta 500.0, entry.amount.to_f, 0.01
     assert_match(/Withdrawal.*USD/, entry.name)
-    assert_equal "Withdrawal", entry.entryable.investment_activity_label
+    assert_equal "Withdrawal",    entry.entryable.investment_activity_label
     assert_equal "funds_movement", entry.entryable.kind
+  end
+
+  # ---------------------------------------------------------------------------
+  # fee inclusion in amount
+  # ---------------------------------------------------------------------------
+
+  test "includes the Kraken fee in the total withdrawal amount" do
+    # Kraken: balance_change = amount - fee = -500 - 1 = -501 total outflow
+    set_ledgers(
+      "LWIT02" => ledger_entry(type: "withdrawal", asset: "ZUSD", amount: "-500.00", fee: "1.00", time: 1_700_000_000)
+    )
+
+    process
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LWIT02", source: "kraken")
+    assert entry
+    assert_in_delta 501.0, entry.amount.to_f, 0.01
+  end
+
+  # ---------------------------------------------------------------------------
+  # BTC deposit (crypto → family currency conversion)
+  # ---------------------------------------------------------------------------
+
+  test "creates a deposit entry for BTC using stored price" do
+    set_ledgers(
+      "LBTC01" => ledger_entry(type: "deposit", asset: "XXBT", amount: "0.10000000", fee: "0.00000000", time: 1_700_000_000)
+    )
+
+    process
+
+    entry = @account.entries.find_by(external_id: "kraken_ledger_LBTC01", source: "kraken")
+    assert entry
+    assert entry.amount.negative?, "BTC deposit is an inflow — must be negative"
+    # 0.1 BTC × $50,000/BTC = $5,000 (family currency = USD, no conversion needed)
+    assert_in_delta(-5000.0, entry.amount.to_f, 1.0)
+    assert_match(/Deposit.*BTC/, entry.name)
   end
 
   # ---------------------------------------------------------------------------
   # staking
   # ---------------------------------------------------------------------------
 
-  test "creates a staking reward entry" do
+  test "creates a staking reward entry (negative = inflow)" do
     set_ledgers(
       "LSTK01" => ledger_entry(type: "staking", asset: "XXBT", amount: "0.00050000", fee: "0.00", time: 1_700_000_000)
     )
@@ -101,7 +120,7 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by(external_id: "kraken_ledger_LSTK01", source: "kraken")
     assert entry
-    assert entry.amount.positive?
+    assert entry.amount.negative?, "staking reward is an inflow — must be negative"
     assert_match(/Staking reward.*BTC/, entry.name)
     assert_equal "Dividend", entry.entryable.investment_activity_label
     assert_equal "standard",  entry.entryable.kind
@@ -111,9 +130,9 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
   # earn
   # ---------------------------------------------------------------------------
 
-  test "creates an earn reward entry" do
+  test "creates an earn reward entry for rewards subtype" do
     set_ledgers(
-      "LERN01" => ledger_entry(type: "earn", asset: "ZUSD", amount: "5.00", fee: "0.00", time: 1_700_000_000)
+      "LERN01" => ledger_entry(type: "earn", subtype: "rewardallocation", asset: "ZUSD", amount: "5.00", fee: "0.00", time: 1_700_000_000)
     )
 
     assert_difference "@account.entries.count", 1 do
@@ -122,14 +141,26 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by(external_id: "kraken_ledger_LERN01", source: "kraken")
     assert entry
+    assert entry.amount.negative?, "earn reward is an inflow — must be negative"
     assert_equal "Interest", entry.entryable.investment_activity_label
+  end
+
+  test "skips earn allocation entries (internal fund movement, not income)" do
+    set_ledgers(
+      "LALLOC" => ledger_entry(type: "earn", subtype: "allocation", asset: "ZUSD", amount: "500.00", fee: "0.00", time: 1_700_000_000),
+      "LDEALLOC" => ledger_entry(type: "earn", subtype: "deallocation", asset: "ZUSD", amount: "-500.00", fee: "0.00", time: 1_700_000_000)
+    )
+
+    assert_no_difference "@account.entries.count" do
+      process
+    end
   end
 
   # ---------------------------------------------------------------------------
   # standalone fee
   # ---------------------------------------------------------------------------
 
-  test "creates a fee entry (negative amount)" do
+  test "creates a fee entry with positive amount (outflow)" do
     set_ledgers(
       "LFEE01" => ledger_entry(type: "fee", asset: "ZUSD", amount: "-7.50", fee: "0.00", time: 1_700_000_000)
     )
@@ -140,7 +171,8 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by(external_id: "kraken_ledger_LFEE01", source: "kraken")
     assert entry
-    assert entry.amount.negative?
+    assert entry.amount.positive?, "fee is an outflow — must be positive"
+    assert_in_delta 7.5, entry.amount.to_f, 0.01
     assert_equal "Fee", entry.entryable.investment_activity_label
   end
 
@@ -184,10 +216,10 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
   end
 
   # ---------------------------------------------------------------------------
-  # non-USD family currency (EUR example)
+  # non-USD family currency
   # ---------------------------------------------------------------------------
 
-  test "converts fiat USD amounts to non-USD family currency" do
+  test "converts USD deposit to non-USD family currency" do
     @family.update!(currency: "EUR")
     ExchangeRate.create!(from_currency: "USD", to_currency: "EUR", date: Date.current, rate: 0.92)
 
@@ -200,11 +232,16 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
     entry = @account.entries.find_by(external_id: "kraken_ledger_LEUR01", source: "kraken")
     assert entry
     assert_equal "EUR", entry.currency
-    assert_in_delta 920.0, entry.amount.to_f, 1.0
+    assert entry.amount.negative?, "deposit is inflow — negative"
+    assert_in_delta(-920.0, entry.amount.to_f, 1.0)
   end
 
-  test "marks crypto entries as price_missing when no price data available" do
-    set_raw_payload_assets([])   # no stored prices
+  # ---------------------------------------------------------------------------
+  # missing crypto price
+  # ---------------------------------------------------------------------------
+
+  test "records zero amount and price_missing flag when no price data available" do
+    set_raw_payload_assets([])
 
     set_ledgers(
       "LNOPRICE" => ledger_entry(type: "deposit", asset: "XXBT", amount: "0.5", fee: "0.00", time: 1_700_000_000)
@@ -238,12 +275,12 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
       )
     end
 
-    def ledger_entry(type:, asset:, amount:, fee:, time:)
+    def ledger_entry(type:, asset:, amount:, fee:, time:, subtype: "")
       {
         "refid"   => "S#{SecureRandom.hex(4).upcase}",
         "time"    => time,
         "type"    => type,
-        "subtype" => "",
+        "subtype" => subtype,
         "aclass"  => "currency",
         "asset"   => asset,
         "amount"  => amount,

--- a/test/models/kraken_account/ledger_processor_test.rb
+++ b/test/models/kraken_account/ledger_processor_test.rb
@@ -209,10 +209,34 @@ class KrakenAccount::LedgerProcessorTest < ActiveSupport::TestCase
       "LIDEM01" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "100.00", fee: "0.00", time: 1_700_000_000)
     )
 
-    process
+    # First pass must actually create the entry...
+    assert_difference "@account.entries.count", 1 do
+      process
+    end
+
+    # ...and a second pass must be a no-op.
     assert_no_difference "@account.entries.count" do
       process
     end
+  end
+
+  test "idempotency check does not scale entries queries with ledger count" do
+    set_ledgers(
+      "LQ1" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "10.00", fee: "0.00", time: 1_700_000_000),
+      "LQ2" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "20.00", fee: "0.00", time: 1_700_000_100),
+      "LQ3" => ledger_entry(type: "deposit", asset: "ZUSD", amount: "30.00", fee: "0.00", time: 1_700_000_200)
+    )
+
+    process # first pass creates the 3 entries
+    assert_equal 3, @account.entries.count
+
+    # On a second pass every entry is already present, so all are skipped. The
+    # existence check must be a single bulk pluck regardless of ledger count —
+    # the previous per-entry `exists?` would issue one query per entry instead.
+    queries = capture_sql_queries { process }
+    entries_selects = queries.count { |q| q.match?(/from "entries"/i) }
+    assert_equal 1, entries_selects,
+      "second pass should issue exactly one bulk external_id pluck, not one per entry"
   end
 
   # ---------------------------------------------------------------------------

--- a/test/models/kraken_item/importer_test.rb
+++ b/test/models/kraken_item/importer_test.rb
@@ -15,6 +15,7 @@ class KrakenItem::ImporterTest < ActiveSupport::TestCase
     @provider.stubs(:get_api_key_info).returns({ "name" => "Sure read-only" })
     @provider.stubs(:get_asset_pairs).returns(pair_metadata)
     @provider.stubs(:get_trades_history).returns({ "count" => 0, "trades" => {} })
+    @provider.stubs(:get_ledgers).returns({ "ledger" => {}, "count" => 0 })
     @provider.stubs(:get_ticker).returns(nil)
   end
 

--- a/test/models/provider/kraken_test.rb
+++ b/test/models/provider/kraken_test.rb
@@ -58,6 +58,40 @@ class Provider::KrakenTest < ActiveSupport::TestCase
     assert_equal({ "name" => "Sure read-only" }, @provider.get_api_key_info)
   end
 
+  test "get_ledgers sends request to Ledgers endpoint" do
+    ledger_payload = {
+      "ledger" => {
+        "LXXXXXX" => {
+          "refid" => "SXXXXXX", "time" => 1609459200, "type" => "deposit",
+          "subtype" => "", "aclass" => "currency", "asset" => "XXBT",
+          "amount" => "0.10000000", "fee" => "0.00000000", "balance" => "0.50000000"
+        }
+      },
+      "count" => 1
+    }
+    response = mock_httparty_response(200, { "error" => [], "result" => ledger_payload })
+
+    Provider::Kraken.expects(:post)
+      .with("/0/private/Ledgers", anything)
+      .returns(response)
+
+    result = @provider.get_ledgers
+    assert_equal ledger_payload, result
+  end
+
+  test "get_ledgers forwards start, type, and offset params" do
+    response = mock_httparty_response(200, { "error" => [], "result" => { "ledger" => {}, "count" => 0 } })
+
+    Provider::Kraken.expects(:post)
+      .with(
+        "/0/private/Ledgers",
+        has_entries(body: includes("start=1609459200", "type=deposit", "ofs=50"))
+      )
+      .returns(response)
+
+    @provider.get_ledgers(start: Time.zone.at(1609459200), type: "deposit", offset: 50)
+  end
+
   test "handle response returns result on success" do
     response = mock_httparty_response(200, { "error" => [], "result" => { "XXBT" => { "balance" => "1.0" } } })
 


### PR DESCRIPTION
## Summary

Closes #2450

Kraken `TradesHistory` only returns spot buy/sell trades. Users with Kraken accounts could see their trades sync but not deposits, withdrawals, staking rewards, Earn income, or standalone fees. This PR fetches the Kraken `Ledgers` API (`/0/private/Ledgers`) and imports all of those event types as `Transaction` entries.

### What's new

- **`Provider::Kraken#get_ledgers`** — private API method accepting `start`, `type`, and `offset` params (same pattern as `get_trades_history`)
- **`KrakenItem::Importer#fetch_ledgers`** — paginated fetch (up to `MAX_LEDGER_PAGES = 200` pages of 50); degrades gracefully with a warning log if the API key lacks the "Query Ledger Entries" permission scope
- **`upsert_kraken_account`** — stores `"ledgers"` hash alongside `"trades"` in `raw_transactions_payload`
- **`KrakenAccount::LedgerProcessor`** — new class; processes each supported ledger type:

| Ledger type | Entry sign | `investment_activity_label` | `kind` |
|---|---|---|---|
| `deposit` | positive | Contribution | funds_movement |
| `withdrawal` | negative | Withdrawal | funds_movement |
| `staking` | positive | Dividend | standard |
| `earn` | positive | Interest | standard |
| `fee` | negative | Fee | standard |

Types `trade`, `transfer`, `margin`, `rollover`, `settled`, `adjustment` are skipped intentionally — trades are already handled by `TradesHistory`; the others are internal Kraken bookkeeping.

- **`KrakenAccount::Processor#process`** — calls `LedgerProcessor` after `process_trades`

### Multi-currency support

- Family currency = USD → fiat USD amounts are stored 1:1; crypto amounts use the spot price cached in `raw_payload["assets"]` at sync time
- Family currency ≠ USD + fiat USD asset → converted via `ExchangeRate` (existing `UsdConverter` module)
- Non-USD fiat (EUR, GBP, etc.) → bridged through USD via `ExchangeRate.find_or_fetch_rate`
- Crypto with no stored price → entry created with `amount = 0` and `extra["kraken"]["price_missing"] = true` so the entry is visible and can be corrected

### Deduplication

`external_id: "kraken_ledger_#{ledger_id}"` + `source: "kraken"` — re-syncing never creates duplicate entries.

## Test plan

- [x] `bin/rails test test/models/provider/kraken_test.rb` — `get_ledgers` request format + param forwarding
- [x] `bin/rails test test/models/kraken_account/ledger_processor_test.rb` — deposit/withdrawal/staking/earn/fee/skip/idempotency/non-USD/price_missing
- [x] `bin/rubocop` — no offenses on changed files
- [ ] Manual: re-sync a Kraken account that has deposits/withdrawals; confirm entries appear with correct labels and amounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Kraken imports to include ledger entries alongside trades: deposits, withdrawals, staking rewards, earn rewards, and fees.
  * Ledger transactions are converted into the account’s configured currency (crypto conversion when pricing is available) with consistent naming and metadata, and stored with deterministic identifiers.
  * Import summaries now report the number of ledgers imported.

* **Bug Fixes**
  * Individual ledger failures no longer halt the full import.
  * Re-running imports won’t duplicate ledger entries; missing crypto pricing results in zeroed amounts with a price-missing indicator.

* **Tests**
  * Added/extended coverage for ledger processing, provider ledger fetching, and importer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->