### PR TITLE
fix(process-pdf-job): discard on RuntimeError and guard failed status

### DIFF
--- a/app/jobs/process_pdf_job.rb
+++ b/app/jobs/process_pdf_job.rb
@@ -1,10 +1,14 @@
 class ProcessPdfJob < ApplicationJob
   queue_as :medium_priority
 
+  discard_on(RuntimeError) do |job, err|
+    Rails.logger.error("[ProcessPdfJob] Discarded permanently (job_id=#{job.job_id}): #{err.message}")
+  end
+
   def perform(pdf_import)
     return unless pdf_import.is_a?(PdfImport)
     return reset_processing_claim(pdf_import) unless pdf_import.pdf_uploaded?
-    return if pdf_import.status == "complete"
+    return if pdf_import.status.in?(%w[complete failed])
     return reset_processing_claim(pdf_import) if pdf_import.ai_processed? && (!pdf_import.statement_with_transactions? || pdf_import.rows_count > 0)
 
     pdf_import.update!(status: :importing)

--- a/app/jobs/process_pdf_job.rb
+++ b/app/jobs/process_pdf_job.rb
@@ -2,7 +2,7 @@ class ProcessPdfJob < ApplicationJob
   queue_as :medium_priority
 
   discard_on(Provider::Error) do |job, err|
-    Rails.logger.error("[ProcessPdfJob] Discarded permanently (job_id=#{job.job_id}): #{err.message}")
+    Rails.logger.error("[ProcessPdfJob] Discarded permanently (job_id=#{job.job_id}, error_class=#{err.class.name})")
   end
 
   def perform(pdf_import)

--- a/app/jobs/process_pdf_job.rb
+++ b/app/jobs/process_pdf_job.rb
@@ -1,7 +1,7 @@
 class ProcessPdfJob < ApplicationJob
   queue_as :medium_priority
 
-  discard_on(RuntimeError) do |job, err|
+  discard_on(Provider::Error) do |job, err|
     Rails.logger.error("[ProcessPdfJob] Discarded permanently (job_id=#{job.job_id}): #{err.message}")
   end
 
@@ -56,7 +56,7 @@ class ProcessPdfJob < ApplicationJob
 
     def sanitize_error_message(error)
       case error
-      when RuntimeError, ArgumentError
+      when Provider::Error, RuntimeError, ArgumentError
         I18n.t("imports.pdf_import.processing_failed_with_message",
                message: error.message.truncate(500))
       else

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -217,8 +217,8 @@ class PdfImport < Import
     # Honors Setting.llm_provider (issue #2113) — Provider::Anthropic implements
     # process_pdf (PR #1985).
     provider = Provider::Registry.preferred_llm_provider
-    raise "AI provider not configured" unless provider
-    raise "AI provider does not support PDF processing" unless provider.supports_pdf_processing?
+    raise Provider::Error, "AI provider not configured" unless provider
+    raise Provider::Error, "AI provider does not support PDF processing" unless provider.supports_pdf_processing?
 
     response = provider.process_pdf(
       pdf_content: pdf_file_content,
@@ -227,7 +227,7 @@ class PdfImport < Import
 
     unless response.success?
       error_message = response.error&.message || "Unknown PDF processing error"
-      raise error_message
+      raise Provider::Error, error_message
     end
 
     result = response.data
@@ -245,7 +245,7 @@ class PdfImport < Import
     # Honors Setting.llm_provider (issue #2113) — Provider::Anthropic implements
     # extract_bank_statement (PR #1985).
     provider = Provider::Registry.preferred_llm_provider
-    raise "AI provider not configured" unless provider
+    raise Provider::Error, "AI provider not configured" unless provider
 
     response = provider.extract_bank_statement(
       pdf_content: pdf_file_content,
@@ -254,7 +254,7 @@ class PdfImport < Import
 
     unless response.success?
       error_message = response.error&.message || "Unknown extraction error"
-      raise error_message
+      raise Provider::Error, error_message
     end
 
     # BankStatementExtractor returns symbol keys, but every reader here (and in

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -217,8 +217,8 @@ class PdfImport < Import
     # Honors Setting.llm_provider (issue #2113) — Provider::Anthropic implements
     # process_pdf (PR #1985).
     provider = Provider::Registry.preferred_llm_provider
-    raise Provider::Error, "AI provider not configured" unless provider
-    raise Provider::Error, "AI provider does not support PDF processing" unless provider.supports_pdf_processing?
+    raise Provider::Error, I18n.t("imports.pdf_import.errors.provider_not_configured") unless provider
+    raise Provider::Error, I18n.t("imports.pdf_import.errors.provider_no_pdf_support") unless provider.supports_pdf_processing?
 
     response = provider.process_pdf(
       pdf_content: pdf_file_content,
@@ -245,7 +245,7 @@ class PdfImport < Import
     # Honors Setting.llm_provider (issue #2113) — Provider::Anthropic implements
     # extract_bank_statement (PR #1985).
     provider = Provider::Registry.preferred_llm_provider
-    raise Provider::Error, "AI provider not configured" unless provider
+    raise Provider::Error, I18n.t("imports.pdf_import.errors.provider_not_configured") unless provider
 
     response = provider.extract_bank_statement(
       pdf_content: pdf_file_content,

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -493,6 +493,9 @@ en:
       unknown_state_description: This import is in an unexpected state. Please return to imports.
       processing_failed_with_message: "%{message}"
       processing_failed_generic: "Processing failed: %{error}"
+      errors:
+        provider_not_configured: AI provider not configured
+        provider_no_pdf_support: AI provider does not support PDF processing
       ready_for_review_title: Ready for Review
       ready_for_review_description:
         one: "%{count} transaction from your statement isn't in this account yet. Review and publish it to add it."

--- a/test/jobs/process_pdf_job_test.rb
+++ b/test/jobs/process_pdf_job_test.rb
@@ -119,6 +119,28 @@ class ProcessPdfJobTest < ActiveJob::TestCase
     assert_equal "complete", @import.reload.status
   end
 
+  test "discards permanently and marks failed on Provider::Error" do
+    attach_pdf!(@import)
+    @import.expects(:process_with_ai).once.raises(Provider::Error, "Could not convert PDF to images")
+
+    assert_nothing_raised do
+      ProcessPdfJob.perform_now(@import)
+    end
+
+    assert_equal "failed", @import.reload.status
+    assert @import.error.present?
+  end
+
+  test "skips already failed import" do
+    attach_pdf!(@import)
+    @import.update!(status: :failed)
+    @import.expects(:process_with_ai).never
+
+    ProcessPdfJob.perform_now(@import)
+
+    assert_equal "failed", @import.reload.status
+  end
+
   private
 
     def attach_pdf!(import)


### PR DESCRIPTION
## What

Two small hardening changes to `ProcessPdfJob`:

1. **`discard_on(RuntimeError)`** — permanently discards the job when a `RuntimeError` is raised, instead of letting Sidekiq retry it 25 times over ~21 days. The discard block logs the `job_id` and error message so failures stay observable without spamming retries.

2. **Guard `failed` status** — the early-return guard that previously only covered `"complete"` now also covers `"failed"`. This prevents a re-enqueued or accidentally re-triggered job from attempting to reprocess an import that already failed.

## Incident context

A `ProcessPdfJob` has been failing and retrying since **June 7**. By June 22 it had reached `retry_count=22`. It fails every time with:

```
Failed to extract text from PDF: Invalid password ()
Could not convert PDF to images
```

This is a password-protected PDF — a deterministic, unrecoverable error. Each retry triggers PDF→image conversion via poppler/mini_magick, a known memory-leak risk on repeated failures (image buffers are allocated and abandoned). With 3 more retries pending before Sidekiq gives up, it would have continued retrying and leaking.

## Why

- `RuntimeError` in this job is almost always deterministic (e.g. invalid state, bad PDF format, wrong password). Retrying 25 times wastes resources and delays queue throughput with no chance of success.
- The poppler/mini_magick PDF→image conversion path can leak memory on each failed attempt, making repeated retries actively harmful.
- Without the `failed` guard, a duplicate enqueue or a background retry could clobber the `failed` status and re-run expensive AI processing on an import whose failure was already recorded and surfaced to the user.

## Retry behaviour after this change

| Exception | Retries |
|---|---|
| `RuntimeError` (or subclass) | **0** — discarded, error logged |
| `ActiveJob::DeserializationError` | **0** — discarded (inherited from `ApplicationJob`) |
| `ActiveRecord::Deadlocked` | **5** — exponential backoff (inherited from `ApplicationJob`) |
| Any other `StandardError` | **25** — Sidekiq default |

## Testing

- Verify a job that raises `RuntimeError` is discarded and not retried.
- Verify a job enqueued against a `failed` import returns early without changing status.
- Existing `ProcessPdfJob` tests should remain green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- PDF processing failures are now clearly marked as failed instead of repeatedly retrying, improving reliability and reducing delays.
- Completed and previously failed PDF imports are no longer processed again unnecessarily.
- Provider-related errors now receive consistent, user-facing messages during PDF processing and transaction extraction.
- Clearer messages are shown when AI processing is unavailable or the configured provider does not support PDF files.
- PDF imports better reconcile extracted transactions with existing account entries and avoid duplicate matches.
- Reassigning or reverting imports now refreshes related transaction records more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->