### PR TITLE
design-system(mobile): SureDialog primitive + migrate all AlertDialog usages

### DIFF
--- a/mobile/lib/screens/calendar_screen.dart
+++ b/mobile/lib/screens/calendar_screen.dart
@@ -8,6 +8,8 @@ import '../providers/transactions_provider.dart';
 import '../providers/auth_provider.dart';
 import '../services/log_service.dart';
 import '../utils/amount_parser.dart';
+import '../widgets/sure_dialog.dart';
+import '../widgets/sure_button.dart';
 import '../l10n/app_localizations.dart';
 
 class CalendarScreen extends StatefulWidget {
@@ -200,11 +202,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
     showDialog(
       context: context,
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: Text(
-            formattedDate,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
+        return SureDialog(
+          title: formattedDate,
           content: SizedBox(
             width: double.maxFinite,
             child: transactions.isEmpty
@@ -229,9 +228,10 @@ class _CalendarScreenState extends State<CalendarScreen> {
                   ),
           ),
           actions: [
-            TextButton(
+            SureButton(
+              label: l.commonClose,
+              variant: SureButtonVariant.primary,
               onPressed: () => Navigator.of(context).pop(),
-              child: Text(l.commonClose),
             ),
           ],
         );

--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -8,6 +8,9 @@ import '../providers/chat_provider.dart';
 import '../models/message.dart';
 import '../constants/suggested_questions.dart';
 import '../widgets/typing_indicator.dart';
+import '../widgets/sure_dialog.dart';
+import '../widgets/sure_button.dart';
+import '../widgets/sure_text_field.dart';
 import '../l10n/app_localizations.dart';
 
 class _SendMessageIntent extends Intent {
@@ -212,24 +215,23 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
       builder: (context) {
         final dl = AppLocalizations.of(context);
         final controller = TextEditingController(text: currentTitle);
-        return AlertDialog(
-          title: Text(dl.chatConversationEditTitle),
-          content: TextField(
+        return SureDialog(
+          title: dl.chatConversationEditTitle,
+          content: SureTextField(
             controller: controller,
-            decoration: InputDecoration(
-              labelText: dl.chatConversationTitleLabel,
-              border: const OutlineInputBorder(),
-            ),
+            label: dl.chatConversationTitleLabel,
             autofocus: true,
           ),
           actions: [
-            TextButton(
+            SureButton(
+              label: dl.commonCancel,
+              variant: SureButtonVariant.ghost,
               onPressed: () => Navigator.pop(context),
-              child: Text(dl.commonCancel),
             ),
-            TextButton(
+            SureButton(
+              label: dl.commonSave,
+              variant: SureButtonVariant.primary,
               onPressed: () => Navigator.pop(context, controller.text.trim()),
-              child: Text(dl.commonSave),
             ),
           ],
         );

--- a/mobile/lib/screens/chat_list_screen.dart
+++ b/mobile/lib/screens/chat_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
 import '../providers/chat_provider.dart';
 import 'chat_conversation_screen.dart';
+import '../widgets/sure_dialog.dart';
 import '../l10n/app_localizations.dart';
 
 class ChatListScreen extends StatefulWidget {
@@ -74,27 +75,13 @@ class _ChatListScreenState extends State<ChatListScreen> {
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     final chatProvider = Provider.of<ChatProvider>(context, listen: false);
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final dl = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(dl.chatListDeleteTitle),
-          content: Text(
-            dl.chatListDeleteMultiContent(_selectedChatIds.length),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(dl.commonCancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              child: Text(dl.commonDelete, style: const TextStyle(color: Colors.red)),
-            ),
-          ],
-        );
-      },
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.chatListDeleteTitle,
+      message: l.chatListDeleteMultiContent(_selectedChatIds.length),
+      confirmLabel: l.commonDelete,
+      cancelLabel: l.commonCancel,
+      destructive: true,
     );
 
     if (confirmed != true || !mounted) return;
@@ -298,25 +285,14 @@ class _ChatListScreenState extends State<ChatListScreen> {
                     ),
                   ),
                   confirmDismiss: (direction) async {
-                    return await showDialog<bool>(
-                      context: context,
-                      builder: (context) {
-                        final l = AppLocalizations.of(context);
-                        return AlertDialog(
-                          title: Text(l.chatListDeleteTitle),
-                          content: Text(l.chatListDeleteSingleContent(chat.title)),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.pop(context, false),
-                              child: Text(l.commonCancel),
-                            ),
-                            TextButton(
-                              onPressed: () => Navigator.pop(context, true),
-                              child: Text(l.commonDelete, style: const TextStyle(color: Colors.red)),
-                            ),
-                          ],
-                        );
-                      },
+                    final l = AppLocalizations.of(context);
+                    return await SureDialog.confirm(
+                      context,
+                      title: l.chatListDeleteTitle,
+                      message: l.chatListDeleteSingleContent(chat.title),
+                      confirmLabel: l.commonDelete,
+                      cancelLabel: l.commonCancel,
+                      destructive: true,
                     );
                   },
                   onDismissed: (direction) async {

--- a/mobile/lib/screens/log_viewer_screen.dart
+++ b/mobile/lib/screens/log_viewer_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../l10n/app_localizations.dart';
 import '../services/log_service.dart';
+import '../widgets/sure_dialog.dart';
 
 class LogViewerScreen extends StatefulWidget {
   const LogViewerScreen({super.key});
@@ -130,28 +131,18 @@ class _LogViewerScreenState extends State<LogViewerScreen> {
           ),
           IconButton(
             icon: const Icon(Icons.delete),
-            onPressed: () {
-              showDialog(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: Text(l.logViewerClearLogs),
-                  content: Text(l.logViewerClearConfirm),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(context),
-                      child: Text(l.commonCancel),
-                    ),
-                    TextButton(
-                      onPressed: () {
-                        LogService.instance.clear();
-                        Navigator.pop(context);
-                      },
-                      style: TextButton.styleFrom(foregroundColor: Colors.red),
-                      child: Text(l.logViewerClear),
-                    ),
-                  ],
-                ),
+            onPressed: () async {
+              final confirmed = await SureDialog.confirm(
+                context,
+                title: l.logViewerClearLogs,
+                message: l.logViewerClearConfirm,
+                confirmLabel: l.logViewerClear,
+                cancelLabel: l.commonCancel,
+                destructive: true,
               );
+              if (confirmed == true) {
+                LogService.instance.clear();
+              }
             },
             tooltip: l.logViewerClearLogs,
           ),

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import '../providers/auth_provider.dart';
 import '../services/api_config.dart';
 import '../widgets/sure_button.dart';
+import '../widgets/sure_dialog.dart';
 import '../widgets/sure_logo.dart';
 import 'backend_config_screen.dart';
 import '../l10n/app_localizations.dart';
@@ -99,8 +100,8 @@ class _LoginScreenState extends State<LoginScreen> {
         final dl = AppLocalizations.of(dialogContext);
         return StatefulBuilder(
           builder: (_, setDialogState) {
-            return AlertDialog(
-              title: Text(dl.loginApiKeyDialogTitle),
+            return SureDialog(
+              title: dl.loginApiKeyDialogTitle,
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -127,16 +128,19 @@ class _LoginScreenState extends State<LoginScreen> {
                 ],
               ),
               actions: [
-                TextButton(
+                SureButton(
+                  label: dl.commonCancel,
+                  variant: SureButtonVariant.ghost,
                   onPressed: isLoading
                       ? null
                       : () {
                           apiKeyController.dispose();
                           Navigator.of(dialogContext).pop();
                         },
-                  child: Text(dl.commonCancel),
                 ),
-                ElevatedButton(
+                SureButton(
+                  label: dl.loginApiKeySignIn,
+                  loading: isLoading,
                   onPressed: isLoading
                       ? null
                       : () async {
@@ -173,13 +177,6 @@ class _LoginScreenState extends State<LoginScreen> {
                             );
                           }
                         },
-                  child: isLoading
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : Text(dl.loginApiKeySignIn),
                 ),
               ],
             );

--- a/mobile/lib/screens/main_navigation_screen.dart
+++ b/mobile/lib/screens/main_navigation_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../providers/auth_provider.dart';
+import '../widgets/sure_dialog.dart';
 import '../widgets/sure_logo.dart';
 import 'chat_list_screen.dart';
 import 'dashboard_screen.dart';
@@ -158,25 +159,12 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     final l = AppLocalizations.of(context);
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
 
-    final shouldEnable = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final dl = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(dl.navEnableAiChatTitle),
-          content: Text(dl.navEnableAiChatContent),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(false),
-              child: Text(dl.navEnableAiChatNotNow),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: Text(dl.navEnableAiChatConfirm),
-            ),
-          ],
-        );
-      },
+    final shouldEnable = await SureDialog.confirm(
+      context,
+      title: l.navEnableAiChatTitle,
+      message: l.navEnableAiChatContent,
+      confirmLabel: l.navEnableAiChatConfirm,
+      cancelLabel: l.navEnableAiChatNotNow,
     );
 
     if (shouldEnable != true) {

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -18,6 +18,8 @@ import '../models/custom_proxy_header.dart';
 import '../services/api_config.dart';
 import '../services/custom_proxy_headers_service.dart';
 import '../widgets/custom_proxy_headers_editor.dart';
+import '../widgets/sure_dialog.dart';
+import '../widgets/sure_button.dart';
 import '../l10n/app_localizations.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -96,22 +98,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _showUpdateDialog(String version, String? storeUrl) async {
-    final launch = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(AppLocalizations.of(ctx).settingsUpdateAvailableTitle),
-        content: Text(AppLocalizations.of(ctx).settingsUpdateAvailableContent(version)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(AppLocalizations.of(ctx).commonCancel),
-          ),
-          TextButton(
-            onPressed: storeUrl == null ? null : () => Navigator.pop(ctx, true),
-            child: Text(AppLocalizations.of(ctx).settingsUpdateNow),
-          ),
-        ],
-      ),
+    final launch = await SureDialog.confirm(
+      context,
+      title: AppLocalizations.of(context).settingsUpdateAvailableTitle,
+      message: AppLocalizations.of(context).settingsUpdateAvailableContent(version),
+      confirmLabel: AppLocalizations.of(context).settingsUpdateNow,
+      cancelLabel: AppLocalizations.of(context).commonCancel,
+      confirmEnabled: storeUrl != null,
     );
 
     if (launch == true && storeUrl != null && mounted) {
@@ -207,27 +200,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _handleClearLocalData(BuildContext context) async {
     final l = AppLocalizations.of(context);
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final l = AppLocalizations.of(context);
-        return AlertDialog(
-        title: Text(l.settingsClearDataTitle),
-        content: Text(l.settingsClearDataContent),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(l.commonCancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(
-              foregroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: Text(l.settingsClearData),
-          ),
-        ],
-      );},
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.settingsClearDataTitle,
+      message: l.settingsClearDataContent,
+      confirmLabel: l.settingsClearData,
+      cancelLabel: l.commonCancel,
+      destructive: true,
     );
 
     if (confirmed == true && context.mounted) {
@@ -286,28 +265,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _handleResetAccount(BuildContext context) async {
     final l = AppLocalizations.of(context);
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final dl = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(dl.settingsResetAccount),
-          content: Text(dl.settingsResetAccountContent),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(dl.commonCancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              style: TextButton.styleFrom(
-                foregroundColor: Theme.of(context).colorScheme.error,
-              ),
-              child: Text(dl.settingsResetAccount),
-            ),
-          ],
-        );
-      },
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.settingsResetAccount,
+      message: l.settingsResetAccountContent,
+      confirmLabel: l.settingsResetAccount,
+      cancelLabel: l.commonCancel,
+      destructive: true,
     );
 
     if (confirmed != true || !context.mounted) return;
@@ -358,28 +322,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _handleDeleteAccount(BuildContext context) async {
     final l = AppLocalizations.of(context);
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final dl = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(dl.settingsDeleteAccountTitle),
-          content: Text(dl.settingsDeleteAccountConfirmContent),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(dl.commonCancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              style: TextButton.styleFrom(
-                foregroundColor: Theme.of(context).colorScheme.error,
-              ),
-              child: Text(dl.settingsDeleteAccount),
-            ),
-          ],
-        );
-      },
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.settingsDeleteAccountTitle,
+      message: l.settingsDeleteAccountConfirmContent,
+      confirmLabel: l.settingsDeleteAccount,
+      cancelLabel: l.commonCancel,
+      destructive: true,
     );
 
     if (confirmed != true || !context.mounted) return;
@@ -414,24 +363,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _handleLogout(BuildContext context) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final l = AppLocalizations.of(context);
-        return AlertDialog(
-        title: Text(l.settingsSignOutTitle),
-        content: Text(l.settingsSignOutContent),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(l.commonCancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(l.settingsSignOut),
-          ),
-        ],
-      );},
+    final l = AppLocalizations.of(context);
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.settingsSignOutTitle,
+      message: l.settingsSignOutContent,
+      confirmLabel: l.settingsSignOut,
+      cancelLabel: l.commonCancel,
     );
 
     if (confirmed == true && context.mounted) {
@@ -454,8 +392,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       context: context,
       builder: (context) {
         final l = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(l.settingsProxyHeadersLabel),
+        return SureDialog(
+          title: l.settingsProxyHeadersLabel,
           content: SingleChildScrollView(
             child: Form(
               key: formKey,
@@ -479,16 +417,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           ),
           actions: [
-            TextButton(
+            SureButton(
+              label: l.commonCancel,
               onPressed: () => Navigator.pop(context, false),
-              child: Text(l.commonCancel),
+              variant: SureButtonVariant.ghost,
             ),
-            ElevatedButton(
+            SureButton(
+              label: l.commonSave,
               onPressed: () {
                 if (formKey.currentState?.validate() != true) return;
                 Navigator.pop(context, true);
               },
-              child: Text(l.commonSave),
+              variant: SureButtonVariant.primary,
             ),
           ],
         );

--- a/mobile/lib/screens/transactions_list_screen.dart
+++ b/mobile/lib/screens/transactions_list_screen.dart
@@ -10,6 +10,7 @@ import '../screens/transaction_edit_screen.dart';
 import '../screens/transaction_form_screen.dart';
 import '../widgets/account_detail_header.dart';
 import '../widgets/category_filter.dart';
+import '../widgets/sure_dialog.dart';
 import '../widgets/sync_status_badge.dart';
 import '../services/log_service.dart';
 import '../theme/sure_tokens.dart';
@@ -155,26 +156,13 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
     if (_selectedTransactions.isEmpty) return;
     final l = AppLocalizations.of(context);
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final dl = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(dl.transactionsListDeleteMultiTitle),
-          content: Text(dl.transactionsListDeleteMultiContent),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(dl.commonCancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              style: TextButton.styleFrom(foregroundColor: Colors.red),
-              child: Text(dl.commonDelete),
-            ),
-          ],
-        );
-      },
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.transactionsListDeleteMultiTitle,
+      message: l.transactionsListDeleteMultiContent,
+      confirmLabel: l.commonDelete,
+      cancelLabel: l.commonCancel,
+      destructive: true,
     );
 
     if (confirmed != true || !mounted) return;
@@ -220,29 +208,14 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final isPending = transaction.syncStatus == SyncStatus.pending;
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final dl = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(dl.transactionsListUndoTitle),
-          content: Text(
-            isPending
-                ? dl.transactionsListUndoRemovePending
-                : dl.transactionsListUndoRestoreConfirm,
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(dl.commonCancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              child: Text(dl.commonUndo),
-            ),
-          ],
-        );
-      },
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.transactionsListUndoTitle,
+      message: isPending
+          ? l.transactionsListUndoRemovePending
+          : l.transactionsListUndoRestoreConfirm,
+      confirmLabel: l.commonUndo,
+      cancelLabel: l.commonCancel,
     );
 
     if (confirmed != true) return;
@@ -291,26 +264,13 @@ class _TransactionsListScreenState extends State<TransactionsListScreen> {
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     final transactionsProvider = Provider.of<TransactionsProvider>(context, listen: false);
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        final dl = AppLocalizations.of(context);
-        return AlertDialog(
-          title: Text(dl.transactionsListDeleteTitle),
-          content: Text(dl.transactionsListDeleteSingleContent(transaction.name)),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(dl.commonCancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              style: TextButton.styleFrom(foregroundColor: Colors.red),
-              child: Text(dl.commonDelete),
-            ),
-          ],
-        );
-      },
+    final confirmed = await SureDialog.confirm(
+      context,
+      title: l.transactionsListDeleteTitle,
+      message: l.transactionsListDeleteSingleContent(transaction.name),
+      confirmLabel: l.commonDelete,
+      cancelLabel: l.commonCancel,
+      destructive: true,
     );
 
     if (confirmed != true) return false;

--- a/mobile/lib/widgets/sure_dialog.dart
+++ b/mobile/lib/widgets/sure_dialog.dart
@@ -82,17 +82,29 @@ class SureDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final palette = SureColors.of(context).palette;
 
-    final Widget? body = content ??
-        (message != null
-            ? Text(
-                message!,
-                style: TextStyle(
-                  fontSize: 14,
-                  height: 1.4,
-                  color: palette.textSecondary,
-                ),
-              )
-            : null);
+    // Bound the body to the available dialog height and let it scroll, so
+    // large content (long lists, forms) doesn't overflow on small screens —
+    // matching Material AlertDialog's scrollable content area. The body is a
+    // Flexible (loose) child of the Column: short content sizes naturally,
+    // tall content is capped and scrolls. Caller-supplied [content] keeps its
+    // own scrollable; a plain [message] is wrapped in one here.
+    Widget? body;
+    if (content != null) {
+      body = Flexible(child: content!);
+    } else if (message != null) {
+      body = Flexible(
+        child: SingleChildScrollView(
+          child: Text(
+            message!,
+            style: TextStyle(
+              fontSize: 14,
+              height: 1.4,
+              color: palette.textSecondary,
+            ),
+          ),
+        ),
+      );
+    }
 
     return Dialog(
       backgroundColor: Colors.transparent,

--- a/mobile/lib/widgets/sure_dialog.dart
+++ b/mobile/lib/widgets/sure_dialog.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+
+import '../theme/sure_colors.dart';
+import '../theme/sure_tokens.dart';
+import 'sure_button.dart';
+
+/// Sure design-system modal dialog — a tokenized replacement for the Material
+/// [AlertDialog]. It renders a rounded `container` surface with a hairline
+/// border and the DS elevation shadow, a semibold title, optional body, and a
+/// trailing actions row (typically [SureButton]s).
+///
+/// Colors resolve from the active [SureColors] palette, so it is brightness-
+/// aware and stays in lockstep with `sure.tokens.json` instead of inheriting
+/// Material's `AlertDialog` chrome. The [Dialog] wrapper is kept transparent and
+/// only provides the modal route's centering/inset/safe-area — every visible
+/// pixel is Sure-tokenized.
+class SureDialog extends StatelessWidget {
+  const SureDialog({
+    super.key,
+    required this.title,
+    this.message,
+    this.content,
+    this.actions = const [],
+  }) : assert(
+          message == null || content == null,
+          'Provide either message or content, not both',
+        );
+
+  /// Dialog heading.
+  final String title;
+
+  /// Convenience body text. Mutually exclusive with [content].
+  final String? message;
+
+  /// Arbitrary body content (e.g. a form field). Mutually exclusive with
+  /// [message].
+  final Widget? content;
+
+  /// Footer actions, laid out trailing-aligned and wrapping to a vertical stack
+  /// when they don't fit. Usually [SureButton]s.
+  final List<Widget> actions;
+
+  /// Show a confirm/cancel dialog and resolve to the user's choice: `true`
+  /// (confirmed), `false` (cancelled), or `null` (dismissed via barrier/back).
+  ///
+  /// Set [destructive] to render the confirm action in the destructive variant.
+  /// Set [confirmEnabled] to `false` to render a disabled confirm action (e.g.
+  /// while a precondition like a store URL is unmet).
+  static Future<bool?> confirm(
+    BuildContext context, {
+    required String title,
+    required String confirmLabel,
+    required String cancelLabel,
+    String? message,
+    bool destructive = false,
+    bool confirmEnabled = true,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => SureDialog(
+        title: title,
+        message: message,
+        actions: [
+          SureButton(
+            label: cancelLabel,
+            variant: SureButtonVariant.ghost,
+            onPressed: () => Navigator.pop(ctx, false),
+          ),
+          SureButton(
+            label: confirmLabel,
+            variant: destructive
+                ? SureButtonVariant.destructive
+                : SureButtonVariant.primary,
+            onPressed: confirmEnabled ? () => Navigator.pop(ctx, true) : null,
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = SureColors.of(context).palette;
+
+    final Widget? body = content ??
+        (message != null
+            ? Text(
+                message!,
+                style: TextStyle(
+                  fontSize: 14,
+                  height: 1.4,
+                  color: palette.textSecondary,
+                ),
+              )
+            : null);
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 420),
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: palette.container,
+          borderRadius: BorderRadius.circular(SureTokens.radiusLg),
+          border: Border.all(color: palette.borderSecondary),
+          boxShadow: palette.shadowLg,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: palette.textPrimary,
+              ),
+            ),
+            if (body != null) ...[
+              const SizedBox(height: 12),
+              body,
+            ],
+            if (actions.isNotEmpty) ...[
+              const SizedBox(height: 24),
+              OverflowBar(
+                alignment: MainAxisAlignment.end,
+                overflowAlignment: OverflowBarAlignment.end,
+                spacing: 8,
+                overflowSpacing: 8,
+                children: actions,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/widgets/sure_dialog_test.dart
+++ b/mobile/test/widgets/sure_dialog_test.dart
@@ -164,4 +164,39 @@ void main() {
     expect(find.widgetWithText(SureButton, 'Save'), findsOneWidget);
     expect(find.widgetWithText(SureButton, 'Cancel'), findsOneWidget);
   });
+
+  testWidgets('bounds oversized content so it scrolls instead of overflowing',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 640);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pump(
+      tester,
+      SureDialog(
+        title: 'Busy day',
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView(
+            shrinkWrap: true,
+            children: List.generate(
+              40,
+              (i) => SizedBox(height: 40, child: Text('row $i')),
+            ),
+          ),
+        ),
+        actions: [SureButton(label: 'Close', onPressed: () {})],
+      ),
+    );
+
+    // The body is height-bounded and scrollable, so there is no overflow even
+    // when the content far exceeds the available dialog height.
+    expect(tester.takeException(), isNull);
+    expect(
+      find.descendant(
+          of: find.byType(SureDialog), matching: find.byType(Scrollable)),
+      findsWidgets,
+    );
+  });
 }

--- a/mobile/test/widgets/sure_dialog_test.dart
+++ b/mobile/test/widgets/sure_dialog_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sure_mobile/theme/sure_theme.dart';
+import 'package:sure_mobile/theme/sure_tokens.dart';
+import 'package:sure_mobile/widgets/sure_button.dart';
+import 'package:sure_mobile/widgets/sure_dialog.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child,
+      {Brightness brightness = Brightness.light}) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme:
+            brightness == Brightness.light ? SureTheme.light : SureTheme.dark,
+        home: Scaffold(body: child),
+      ),
+    );
+  }
+
+  BoxDecoration surfaceOf(WidgetTester tester) => tester
+      .widget<Container>(
+        find
+            .descendant(
+                of: find.byType(SureDialog), matching: find.byType(Container))
+            .first,
+      )
+      .decoration as BoxDecoration;
+
+  SureButton buttonWithLabel(WidgetTester tester, String label) =>
+      tester.widget<SureButton>(find.widgetWithText(SureButton, label));
+
+  // Brightness-aware by contract — assert the modal surface resolves the right
+  // palette in both themes so a token regression in either mode is caught.
+  for (final (brightness, tokens) in [
+    (Brightness.light, SureTokens.light),
+    (Brightness.dark, SureTokens.dark),
+  ]) {
+    testWidgets('paints the Sure dialog chrome from tokens (${brightness.name})',
+        (tester) async {
+      await pump(
+        tester,
+        const SureDialog(title: 'Title', message: 'Body'),
+        brightness: brightness,
+      );
+
+      final deco = surfaceOf(tester);
+      expect(deco.color, tokens.container);
+      expect((deco.border as Border).top.color, tokens.borderSecondary);
+      expect(deco.borderRadius, BorderRadius.circular(SureTokens.radiusLg));
+      expect(deco.boxShadow, tokens.shadowLg);
+      expect(find.text('Title'), findsOneWidget);
+      expect(find.text('Body'), findsOneWidget);
+    });
+  }
+
+  testWidgets('asserts message and content are not both provided',
+      (tester) async {
+    expect(
+      () => SureDialog(title: 'T', message: 'M', content: const Text('C')),
+      throwsAssertionError,
+    );
+  });
+
+  testWidgets('confirm: tapping the confirm action resolves true',
+      (tester) async {
+    late BuildContext ctx;
+    await pump(tester, Builder(builder: (c) {
+      ctx = c;
+      return const SizedBox();
+    }));
+
+    final result = SureDialog.confirm(
+      ctx,
+      title: 'Delete?',
+      message: 'This cannot be undone.',
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(SureDialog), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(SureButton, 'Delete'));
+    await tester.pumpAndSettle();
+    expect(await result, isTrue);
+    expect(find.byType(SureDialog), findsNothing);
+  });
+
+  testWidgets('confirm: tapping cancel resolves false', (tester) async {
+    late BuildContext ctx;
+    await pump(tester, Builder(builder: (c) {
+      ctx = c;
+      return const SizedBox();
+    }));
+
+    final result = SureDialog.confirm(
+      ctx,
+      title: 'Sign out?',
+      confirmLabel: 'Sign out',
+      cancelLabel: 'Cancel',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(SureButton, 'Cancel'));
+    await tester.pumpAndSettle();
+    expect(await result, isFalse);
+  });
+
+  testWidgets('confirm: destructive renders the confirm in destructive variant',
+      (tester) async {
+    late BuildContext ctx;
+    await pump(tester, Builder(builder: (c) {
+      ctx = c;
+      return const SizedBox();
+    }));
+
+    SureDialog.confirm(
+      ctx,
+      title: 'Delete?',
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      destructive: true,
+    );
+    await tester.pumpAndSettle();
+
+    expect(buttonWithLabel(tester, 'Delete').variant,
+        SureButtonVariant.destructive);
+    expect(buttonWithLabel(tester, 'Cancel').variant, SureButtonVariant.ghost);
+  });
+
+  testWidgets('confirm: confirmEnabled false disables the confirm action',
+      (tester) async {
+    late BuildContext ctx;
+    await pump(tester, Builder(builder: (c) {
+      ctx = c;
+      return const SizedBox();
+    }));
+
+    SureDialog.confirm(
+      ctx,
+      title: 'Update available',
+      confirmLabel: 'Update now',
+      cancelLabel: 'Cancel',
+      confirmEnabled: false,
+    );
+    await tester.pumpAndSettle();
+
+    expect(buttonWithLabel(tester, 'Update now').onPressed, isNull);
+    expect(buttonWithLabel(tester, 'Cancel').onPressed, isNotNull);
+  });
+
+  testWidgets('renders custom content and trailing actions', (tester) async {
+    await pump(
+      tester,
+      SureDialog(
+        title: 'Rename',
+        content: const TextField(key: Key('field')),
+        actions: [
+          SureButton(label: 'Cancel', onPressed: () {}, variant: SureButtonVariant.ghost),
+          SureButton(label: 'Save', onPressed: () {}),
+        ],
+      ),
+    );
+
+    expect(find.byKey(const Key('field')), findsOneWidget);
+    expect(find.widgetWithText(SureButton, 'Save'), findsOneWidget);
+    expect(find.widgetWithText(SureButton, 'Cancel'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

Adds a **`SureDialog`** design-system primitive — a tokenized replacement for Material's `AlertDialog` — and migrates **every** `AlertDialog` in the app onto it: 16 sites across 8 screens. After this change there are no Material `AlertDialog`s left in the mobile app.

Closes #2454. Part of #2235.

## Why

Dialogs were the last large cluster of un-tokenized Material chrome: default M3 corner radius/elevation/typography with raw `TextButton`/`ElevatedButton`/`FilledButton` actions, ignoring the Sure palette and `SureButton`. This read off-brand and, in dark mode, inconsistent with the already-redesigned surfaces. It is also the prerequisite for the off-Material end phase (dropping `MaterialApp` and Material-styled widgets), which can't proceed while Material dialogs remain.

## How

- `lib/widgets/sure_dialog.dart` mirrors the `SureCard`/`SureButton` pattern: a rounded `container` surface with a hairline `borderSecondary` border and the DS elevation shadow, a semibold `textPrimary` title, an optional body (`message` text or arbitrary `content`), and a trailing actions row that wraps to a vertical stack when it doesn't fit. Colors resolve from the active `SureColors` palette, so it is brightness-aware and stays in lockstep with `sure.tokens.json`.
- A `SureDialog.confirm(...)` helper collapses the dominant confirm/cancel pattern to a one-liner returning `Future<bool?>`, with `destructive` and `confirmEnabled` flags that preserve each call site's exact behavior.
- Migrated all sites — settings (5 confirms + 1 form), transactions list (3), chat list (2), main navigation (1), login (1, custom), chat conversation (1, rename input → `SureTextField`), calendar (1, info), log viewer (1) — preserving localization strings, return values, and destructive/disabled states. This is a chrome swap, not a behavior change.

## Screenshots

Destructive confirm ("Delete account"), captured from the running app on the iOS Simulator (iPhone 17 Pro):

<table>
  <thead><tr><th>Mode</th><th>Before — Material <code>AlertDialog</code></th><th>After — <code>SureDialog</code></th></tr></thead>
  <tbody>
    <tr>
      <td><strong>Light</strong></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/before-dialog-light.png"><img width="240" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/before-dialog-light.png" alt="Before – light"></a><br><em>Flat Material chrome, text-only actions</em></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/after-dialog-light.png"><img width="240" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/after-dialog-light.png" alt="After – light"></a><br><em>Tokenized surface, ghost Cancel + destructive SureButton</em></td>
    </tr>
    <tr>
      <td><strong>Dark</strong></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/before-dialog-dark.png"><img width="240" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/before-dialog-dark.png" alt="Before – dark"></a><br><em>Material surface drifts from the redesigned dark theme</em></td>
      <td><a href="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/after-dialog-dark.png"><img width="240" src="https://raw.githubusercontent.com/JSONbored/sure-upstream/codex/pr-evidence/docs/pr-assets/mobile-sure-dialog/after-dialog-dark.png" alt="After – dark"></a><br><em>Dark <code>container</code> token, hairline border, dark-mode destructive red</em></td>
    </tr>
  </tbody>
</table>

## Testing

- `mobile/test/widgets/sure_dialog_test.dart` (8 new cases): token chrome resolves the right palette in light **and** dark (container/border/radius/shadow), the `message`/`content` assertion, `confirm` resolves true on confirm and false on cancel, `destructive` renders the destructive variant, `confirmEnabled: false` disables the confirm action, and the custom-content path renders content + trailing actions.
- `flutter analyze` — clean (the only 3 infos are pre-existing in `intro_screen_web.dart`, untouched here).
- `flutter test` — green (174, incl. the 8 above).
- iOS debug build/run verified on the simulator (screenshots above). No dependency changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced custom-styled `SureDialog` and `SureButton`/`SureTextField` components, and migrated confirmation dialogs across the app for consistent look and behavior (including destructive and disabled-confirm states).

* **Bug Fixes**
  * Ensured confirm/cancel flows return the correct results across dialog dismissals (null on dismiss, `true/false` on confirm/cancel), preserving existing action logic.

* **Tests**
  * Added comprehensive widget tests for `SureDialog`, including light/dark theme styling, validation rules, confirm/cancel outcomes, destructive variant styling, and scroll behavior for oversized content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->