### PR TITLE
fix(sync): store EnableBanking credit card debt as balance instead of available credit

### DIFF
--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -48,10 +48,10 @@ class EnableBankingAccount::Processor
       if account.accountable_type == "Loan"
         balance = balance.abs
       elsif account.accountable_type == "CreditCard"
+        balance = balance.abs
         if enable_banking_account.credit_limit.present?
-          available = enable_banking_account.credit_limit - balance.abs
+          available = enable_banking_account.credit_limit - balance
           available_credit = [ available, 0 ].max
-          balance = available_credit
           unless account.accountable.present?
             Rails.logger.warn "EnableBankingAccount::Processor - CreditCard accountable missing for account #{account.id}"
           end
@@ -59,11 +59,6 @@ class EnableBankingAccount::Processor
           # Fallback: no credit_limit from API — compute it using available_credit defined at account level
           Rails.logger.info "Using stored available_credit fallback for account #{account.id}"
           available_credit = account.accountable.available_credit
-          outstanding = balance.abs
-          balance = [ available_credit - outstanding, 0 ].max
-        else
-          # Fallback: no credit_limit from API — display raw outstanding balance
-          # We cannot derive available credit without knowing the limit; leave balance unchanged.
         end
       end
 

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -44,19 +44,19 @@ class EnableBankingAccount::Processor
       # For CreditCards, we expect the main balance to reflect the absolute outstanding debt
       # rather than available credit, to ensure net worth calculations handle the liability accurately.
       # Any available credit metrics (from limits) are instead stored safely as metadata on the Accountable.
-      # Loans and CreditCards must always represent their outstanding balance as an absolute 
-      # positive debt amount, regardless of the API's reported sign, to ensure the BalanceSheet 
+      # Loans and CreditCards must always represent their outstanding balance as an absolute
+      # positive debt amount, regardless of the API's reported sign, to ensure the BalanceSheet
       # calculates net worth accurately.
       if account.accountable_type == "Loan" || account.accountable_type == "CreditCard"
         # Standardize the raw balance to an absolute positive debt
-        outstanding_debt = balance.abs 
-        
+        outstanding_debt = balance.abs
+
         # Override the top-level balance variable intended for the account
         balance = outstanding_debt
 
         if account.accountable_type == "CreditCard"
           if enable_banking_account.credit_limit.present?
-            # Compute available credit based on the strictly positive outstanding debt 
+            # Compute available credit based on the strictly positive outstanding debt
             available = enable_banking_account.credit_limit - outstanding_debt
             available_credit = [ available, 0 ].max
             unless account.accountable.present?

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -41,10 +41,9 @@ class EnableBankingAccount::Processor
       available_credit = nil
 
       # For liability accounts, ensure balance sign is correct.
-      # DELIBERATE UX DECISION: For CreditCards, we display the available credit (credit_limit - outstanding debt)
-      # rather than the raw outstanding debt. Do not revert this behavior, as future maintainers should understand
-      # users expect to see how much credit they have left rather than their debt balance.
-      # The 'available_credit' calculation overrides the 'balance' variable.
+      # For CreditCards, we expect the main balance to reflect the absolute outstanding debt
+      # rather than available credit, to ensure net worth calculations handle the liability accurately.
+      # Any available credit metrics (from limits) are instead stored safely as metadata on the Accountable.
       if account.accountable_type == "Loan"
         balance = balance.abs
       elsif account.accountable_type == "CreditCard"

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -44,20 +44,29 @@ class EnableBankingAccount::Processor
       # For CreditCards, we expect the main balance to reflect the absolute outstanding debt
       # rather than available credit, to ensure net worth calculations handle the liability accurately.
       # Any available credit metrics (from limits) are instead stored safely as metadata on the Accountable.
-      if account.accountable_type == "Loan"
-        balance = balance.abs
-      elsif account.accountable_type == "CreditCard"
-        balance = balance.abs
-        if enable_banking_account.credit_limit.present?
-          available = enable_banking_account.credit_limit - balance
-          available_credit = [ available, 0 ].max
-          unless account.accountable.present?
-            Rails.logger.warn "EnableBankingAccount::Processor - CreditCard accountable missing for account #{account.id}"
+      # Loans and CreditCards must always represent their outstanding balance as an absolute 
+      # positive debt amount, regardless of the API's reported sign, to ensure the BalanceSheet 
+      # calculates net worth accurately.
+      if account.accountable_type == "Loan" || account.accountable_type == "CreditCard"
+        # Standardize the raw balance to an absolute positive debt
+        outstanding_debt = balance.abs 
+        
+        # Override the top-level balance variable intended for the account
+        balance = outstanding_debt
+
+        if account.accountable_type == "CreditCard"
+          if enable_banking_account.credit_limit.present?
+            # Compute available credit based on the strictly positive outstanding debt 
+            available = enable_banking_account.credit_limit - outstanding_debt
+            available_credit = [ available, 0 ].max
+            unless account.accountable.present?
+              Rails.logger.warn "EnableBankingAccount::Processor - CreditCard accountable missing for account #{account.id}"
+            end
+          elsif account.accountable&.available_credit.present?
+            # Fallback: no credit_limit from API — compute it using available_credit defined at account level
+            Rails.logger.info "Using stored available_credit fallback for account #{account.id}"
+            available_credit = account.accountable.available_credit
           end
-        elsif account.accountable&.available_credit.present?
-          # Fallback: no credit_limit from API — compute it using available_credit defined at account level
-          Rails.logger.info "Using stored available_credit fallback for account #{account.id}"
-          available_credit = account.accountable.available_credit
         end
       end
 

--- a/test/models/enable_banking_account/processor_test.rb
+++ b/test/models/enable_banking_account/processor_test.rb
@@ -42,7 +42,7 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
     assert_nil result
   end
 
-  test "sets CC balance to available_credit when credit_limit is present" do
+  test "sets CC balance as absolute debt and tracks available_credit when limit is present" do
     cc_account = accounts(:credit_card)
     @enable_banking_account.update!(
       current_balance: 450.00,
@@ -53,13 +53,13 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
 
     EnableBankingAccount::Processor.new(@enable_banking_account).process
 
-    assert_equal 550.0, cc_account.reload.cash_balance
+    assert_equal 450.0, cc_account.reload.cash_balance
     if cc_account.accountable.respond_to?(:available_credit)
       assert_equal 550.0, cc_account.accountable.reload.available_credit
     end
   end
 
-  test "falls back to stored available_credit when credit_limit is absent" do
+  test "sets CC balance as absolute debt and keeps stored available_credit when limit absent" do
     cc_account = accounts(:credit_card)
     cc_account.accountable.update!(available_credit: 1000.0)
 
@@ -70,10 +70,11 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
 
     EnableBankingAccount::Processor.new(@enable_banking_account).process
 
-    assert_equal 700.0, cc_account.reload.cash_balance
+    assert_equal 300.0, cc_account.reload.cash_balance
+    assert_equal 1000.0, cc_account.accountable.reload.available_credit
   end
 
-  test "sets CC balance to raw outstanding when credit_limit is absent" do
+  test "sets CC balance to absolute debt when both limit and stored available_credit are absent" do
     cc_account = accounts(:credit_card)
     cc_account.accountable.update!(available_credit: nil)
 


### PR DESCRIPTION
Fixes #2458

### Description
Previously, the EnableBanking processor forcibly overrode the primary account balance for credit cards to be the available credit (`credit_limit - debt`) rather than the actual outstanding debt. 

Because credit cards are correctly classified as Liability accounts dynamically within the application, this caused the balance sheet to incorrectly treat the user's available credit mathematically as a debt in their net worth calculation.

This PR aligns the EnableBanking processor with the existing Plaid and SimpleFIN processors by:
1. Storing the absolute debt as the primary account balance.
2. Tracking the available credit via accountable metadata so it remains visible but mathematically inert for net worth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected linked credit card cash balance calculations to consistently use an absolute-debt interpretation from the banking account’s current balance.
  * Standardized balance normalization for both loans and credit cards to reflect positive outstanding debt.
  * Updated available credit handling: recalculates from the credit limit when present; otherwise preserves stored available credit while continuing to update cash balance from the banking account.
* **Tests**
  * Updated processor tests to match the revised credit card cash balance and available credit behavior, including the new edge-case expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->