### PR TITLE
fix(api): scope holdings endpoints to accounts accessible by the token owner

### DIFF
--- a/app/controllers/api/v1/holdings_controller.rb
+++ b/app/controllers/api/v1/holdings_controller.rb
@@ -7,8 +7,7 @@ class Api::V1::HoldingsController < Api::V1::BaseController
   before_action :set_holding, only: [ :show ]
 
   def index
-    family = current_resource_owner.family
-    holdings_query = family.holdings.joins(:account).where(accounts: { status: [ "draft", "active" ] })
+    holdings_query = accessible_holdings
 
     holdings_query = apply_filters(holdings_query)
     holdings_query = holdings_query.includes(:account, :security).chronological
@@ -36,10 +35,15 @@ class Api::V1::HoldingsController < Api::V1::BaseController
   private
 
     def set_holding
-      family = current_resource_owner.family
-      @holding = family.holdings.joins(:account).where(accounts: { status: %w[draft active] }).find(params[:id])
+      @holding = accessible_holdings.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       render json: { error: "not_found", message: "Holding not found" }, status: :not_found
+    end
+
+    # Holdings in accounts the user can access (owned or shared), not the whole family.
+    def accessible_holdings
+      account_ids = current_resource_owner.family.accounts.accessible_by(current_resource_owner).select(:id)
+      Holding.joins(:account).where(accounts: { status: %w[draft active], id: account_ids })
     end
 
     def ensure_read_scope

--- a/test/controllers/api/v1/holdings_controller_test.rb
+++ b/test/controllers/api/v1/holdings_controller_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::HoldingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @user.api_keys.active.destroy_all
+
+    @api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Read Key",
+      scopes: [ "read" ],
+      source: "web",
+      display_key: "test_read_#{SecureRandom.hex(8)}"
+    )
+
+    @account = accounts(:investment)
+    @holding = holdings(:one)
+
+    # An account owned by another family member, not shared with @user.
+    @other_member = users(:family_member)
+    @inaccessible_account = @family.accounts.create!(
+      name: "Member Brokerage",
+      accountable: Investment.new,
+      balance: 5000,
+      currency: "USD",
+      owner: @other_member
+    )
+    @inaccessible_holding = @inaccessible_account.holdings.create!(
+      security: securities(:msft),
+      date: Date.current,
+      qty: 5,
+      price: 100,
+      amount: 500,
+      currency: "USD"
+    )
+  end
+
+  test "lists holdings scoped to accessible accounts" do
+    get api_v1_holdings_url, headers: api_headers(@api_key)
+
+    assert_response :success
+    holding_ids = JSON.parse(response.body)["holdings"].map { |h| h["id"] }
+    assert_includes holding_ids, @holding.id
+    assert_not_includes holding_ids, @inaccessible_holding.id
+  end
+
+  test "account_ids filter cannot reach inaccessible accounts" do
+    get api_v1_holdings_url,
+        params: { account_ids: [ @inaccessible_account.id ] },
+        headers: api_headers(@api_key)
+
+    assert_response :success
+    holding_ids = JSON.parse(response.body)["holdings"].map { |h| h["id"] }
+    assert_not_includes holding_ids, @inaccessible_holding.id
+  end
+
+  test "shows an accessible holding" do
+    get api_v1_holding_url(@holding), headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_equal @holding.id, response_data["id"]
+  end
+
+  test "returns not found for an inaccessible holding" do
+    get api_v1_holding_url(@inaccessible_holding), headers: api_headers(@api_key)
+
+    assert_response :not_found
+  end
+
+  test "requires authentication" do
+    get api_v1_holdings_url
+
+    assert_response :unauthorized
+  end
+
+  private
+
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.display_key }
+    end
+end


### PR DESCRIPTION
## Summary

The `/api/v1/holdings` list and show endpoints scoped results to the whole family instead of the accounts the API token owner can actually access. A read scoped key could therefore read holdings (account name, quantity, price, market value) for accounts owned by other family members that were never shared with the key owner, and the `account_id` / `account_ids` filters made targeted enumeration easy.

This brings the holdings API in line with the balances API and the web holdings controller, both of which already scope through `accounts.accessible_by`.

Fixes #2467 

## What changed

- Added a single `accessible_holdings` scope that restricts holdings to accounts the token owner owns or has been shared, while keeping the existing `draft` / `active` status filter.
- Routed both `index` and `set_holding` through that scope, so the list, the show action, and the `account_id` / `account_ids` filters all respect access boundaries.

```ruby
# Holdings in accounts the user can access (owned or shared), not the whole family.
def accessible_holdings
  account_ids = current_resource_owner.family.accounts.accessible_by(current_resource_owner).select(:id)
  Holding.joins(:account).where(accounts: { status: %w[draft active], id: account_ids })
end
```

## Why

Holdings expose financial position data, so the leak is a real privacy gap between members of the same family. Scoping through `accessible_by` matches the established pattern and keeps the access rules consistent across the codebase.

## Testing

Added `test/controllers/api/v1/holdings_controller_test.rb`, covering list scoping, the `account_ids` enumeration vector, show for an accessible holding, a not found response for an inaccessible holding, and the authentication requirement.

```
5 runs, 12 assertions, 0 failures, 0 errors, 0 skips
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Holdings endpoint now properly restricts visibility to authorized holdings only
  * Fixed account filtering to prevent unauthorized access attempts

* **Tests**
  * Added comprehensive test coverage for holdings API access control and authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->