### PR TITLE
Return 404 for invalid or cross-family tag deletions

### DIFF
--- a/app/controllers/tag/deletions_controller.rb
+++ b/app/controllers/tag/deletions_controller.rb
@@ -13,10 +13,12 @@ class Tag::DeletionsController < ApplicationController
   private
 
     def set_tag
-      @tag = Current.family.tags.find_by(id: params[:tag_id])
+      @tag = Current.family.tags.find(params[:tag_id])
     end
 
     def set_replacement_tag
-      @replacement_tag = Current.family.tags.find_by(id: params[:replacement_tag_id])
+      if params[:replacement_tag_id].present?
+        @replacement_tag = Current.family.tags.find(params[:replacement_tag_id])
+      end
     end
 end

--- a/test/controllers/tag/deletions_controller_test.rb
+++ b/test/controllers/tag/deletions_controller_test.rb
@@ -32,4 +32,22 @@ class Tag::DeletionsControllerTest < ActionDispatch::IntegrationTest
       post tag_deletions_url(@tag)
     end
   end
+
+  test "create with invalid or cross family tag_id returns not found" do
+    other_family_tag = families(:empty).tags.create!(name: "Other family tag")
+
+    assert_no_difference -> { Tag.count } do
+      post tag_deletions_url(tag_id: other_family_tag.id)
+    end
+
+    assert_response :not_found
+  end
+
+  test "create with invalid replacement_tag_id returns not found" do
+    assert_no_difference -> { Tag.count } do
+      post tag_deletions_url(@tag), params: { replacement_tag_id: "missing" }
+    end
+
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
## What

`Tag::DeletionsController` used `find_by` to look up both the tag and its replacement. A missing id or a tag from another family left `@tag` as `nil`, so `create` called `replace_and_destroy!` on `nil` and raised `NoMethodError`, returning an HTTP 500. The same flaw let an invalid `replacement_tag_id` silently pass `nil` into the deletion.

This switches the lookups to `find`, matching the existing `Category::DeletionsController`, so out-of-scope ids now return a clean 404.

## Changes

* Look up the tag with `find` so missing or cross-family ids raise `RecordNotFound` (404).
* Guard the optional replacement lookup with `present?` and `find`, keeping the "no replacement" case valid while rejecting invalid ids.
* Add controller tests covering an invalid or cross-family `tag_id` and an invalid `replacement_tag_id`.

## Why

The behavior now mirrors `Category::DeletionsController`, keeping tag and category deletion consistent and ensuring family scoping returns 404 rather than leaking a server error.

## Testing

```bash
bin/rails test test/controllers/tag/deletions_controller_test.rb
```

Fixes #2469 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for tag deletion operations. The system now properly rejects requests with invalid or non-existent tags and replacement tags, returning appropriate error responses and ensuring data integrity is protected from incomplete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->