### PR TITLE
fix(transfers): prevent aborted transaction during concurrent auto-matching

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -43,14 +43,7 @@ module Family::AutoTransferMatchable
         next if used_transaction_ids.include?(match.inflow_transaction_id) ||
                used_transaction_ids.include?(match.outflow_transaction_id)
 
-        begin
-          Transfer.find_or_create_by!(
-            inflow_transaction_id: match.inflow_transaction_id,
-            outflow_transaction_id: match.outflow_transaction_id,
-          )
-        rescue ActiveRecord::RecordNotUnique
-          # Another concurrent job created the transfer; safe to ignore
-        end
+        find_or_create_transfer!(match)
 
         inflow_transaction = transactions_by_id.fetch(match.inflow_transaction_id)
         outflow_transaction = transactions_by_id.fetch(match.outflow_transaction_id)
@@ -80,6 +73,19 @@ module Family::AutoTransferMatchable
   end
 
   private
+    # Isolate the insert in a savepoint so losing the unique-index race to a
+    # concurrent job rolls back only this statement, not the surrounding transaction.
+    def find_or_create_transfer!(match)
+      Transfer.transaction(requires_new: true) do
+        Transfer.find_or_create_by!(
+          inflow_transaction_id: match.inflow_transaction_id,
+          outflow_transaction_id: match.outflow_transaction_id,
+        )
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # Concurrent job already created it; savepoint rolled back, transaction intact.
+    end
+
     def coerce_transfer_match_date_window!(value)
       Integer(value)
     rescue ArgumentError, TypeError

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -83,7 +83,10 @@ module Family::AutoTransferMatchable
         )
       end
     rescue ActiveRecord::RecordNotUnique
-      # Concurrent job already created it; savepoint rolled back, transaction intact.
+      # Lost the insert race; savepoint rolled back, transaction intact.
+    rescue ActiveRecord::RecordInvalid => e
+      # Same race caught by the uniqueness validation; re-raise anything else.
+      raise unless %i[inflow_transaction_id outflow_transaction_id].any? { |attr| e.record.errors.of_kind?(attr, :taken) }
     end
 
     def coerce_transfer_match_date_window!(value)

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -19,6 +19,41 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
+  test "concurrent unique-index race does not poison the surrounding transaction" do
+    outflow_entry = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: @credit_card, amount: -500)
+    inflow_id = inflow_entry.entryable_id
+
+    # An existing transfer we can collide with to trigger a real unique violation,
+    # mimicking a concurrent job that won the race. A genuine failing INSERT (not a
+    # synthetic raise) is what aborts the transaction, so only this reproduces the bug.
+    rival_out = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 250)
+    rival_in = create_transaction(date: Date.current, account: @credit_card, amount: -250)
+    rival = Transfer.create!(inflow_transaction_id: rival_in.entryable_id, outflow_transaction_id: rival_out.entryable_id)
+
+    original = Transfer.method(:find_or_create_by!)
+    Transfer.singleton_class.send(:define_method, :find_or_create_by!) do |attributes|
+      if attributes[:inflow_transaction_id] == inflow_id
+        insert!(inflow_transaction_id: rival.inflow_transaction_id, outflow_transaction_id: rival.outflow_transaction_id)
+      else
+        original.call(attributes)
+      end
+    end
+
+    begin
+      assert_nothing_raised { @family.auto_match_transfers! }
+    ensure
+      Transfer.singleton_class.send(:remove_method, :find_or_create_by!)
+    end
+
+    inflow_entry.reload
+    outflow_entry.reload
+
+    # Surrounding transaction stayed healthy, so kinds were still written.
+    assert_equal "funds_movement", inflow_entry.entryable.kind
+    assert_equal "cc_payment", outflow_entry.entryable.kind
+  end
+
   test "auto-matches multi-currency transfers" do
     load_exchange_prices
     create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -54,6 +54,38 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     assert_equal "cc_payment", outflow_entry.entryable.kind
   end
 
+  test "validation-path race during matching does not abort the run" do
+    outflow_entry = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    # A concurrent job already matched one of these transactions, so the uniqueness
+    # validation rejects the insert with :taken (a plain raise, no aborted SQL).
+    invalid = Transfer.new(inflow_transaction_id: inflow_entry.entryable_id, outflow_transaction_id: outflow_entry.entryable_id)
+    invalid.errors.add(:inflow_transaction_id, :taken)
+    Transfer.stubs(:find_or_create_by!).raises(ActiveRecord::RecordInvalid.new(invalid))
+
+    assert_nothing_raised { @family.auto_match_transfers! }
+
+    inflow_entry.reload
+    outflow_entry.reload
+
+    # The duplicate was swallowed, so the loop kept running and wrote kinds.
+    assert_equal "funds_movement", inflow_entry.entryable.kind
+    assert_equal "cc_payment", outflow_entry.entryable.kind
+  end
+
+  test "non-uniqueness validation failure during matching is not swallowed" do
+    create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    # A genuine (non-race) validation failure must surface, not be skipped silently.
+    invalid = Transfer.new
+    invalid.errors.add(:base, :different_accounts)
+    Transfer.stubs(:find_or_create_by!).raises(ActiveRecord::RecordInvalid.new(invalid))
+
+    assert_raises(ActiveRecord::RecordInvalid) { @family.auto_match_transfers! }
+  end
+
   test "auto-matches multi-currency transfers" do
     load_exchange_prices
     create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)


### PR DESCRIPTION
## Summary

Concurrent syncs of the same family could both reach `Family#auto_match_transfers!` and race on the unique index of the `transfers` table. On PostgreSQL the losing insert aborted the whole surrounding transaction, and the existing `rescue ActiveRecord::RecordNotUnique` could not recover it, so the next `update!` raised `PG::InFailedSqlTransaction` and the remaining candidates were skipped.

## Root cause

`find_or_create_by!` ran directly inside the outer `Transfer.transaction`. A unique violation aborts the active PostgreSQL transaction, and catching the Ruby exception does not reset that state, so every write after the rescue fails.

## Fix

The insert now runs inside its own savepoint via `Transfer.transaction(requires_new: true)`, extracted into a small `find_or_create_transfer!` helper. When the race is lost, only that statement rolls back to the savepoint, the `RecordNotUnique` is rescued, and the surrounding transaction stays healthy so the loop continues normally.

## Testing

Added a regression test that reproduces a genuine unique violation during matching (a real failing insert rather than a stubbed raise, since only a real failure aborts the transaction) and asserts the run completes and still writes the transfer kinds.

```bash
bin/rails test test/models/family/auto_transfer_matchable_test.rb
```

Closes #2471 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automatic transfer matching when concurrent operations cause unique-index collisions.
  * Ensures expected “already exists” and specific “taken” validation scenarios no longer surface errors and don’t disrupt writing related entry details.

* **Tests**
  * Added regression coverage for race-like unique-index collisions and validation-path behavior during automatic transfer matching, including cases where unexpected validation errors should still raise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->