### PR TITLE
fix: sidebar collapse preference not persisting after reload

### DIFF
--- a/app/javascript/controllers/app_layout_controller.js
+++ b/app/javascript/controllers/app_layout_controller.js
@@ -3,6 +3,7 @@ import { Controller } from "@hotwired/stimulus";
 // Connects to data-controller="dialog"
 export default class extends Controller {
   static targets = ["leftSidebar", "rightSidebar", "mobileSidebar"];
+  static values = { userId: String };
   static classes = [
     "expandedSidebar",
     "collapsedSidebar",


### PR DESCRIPTION
## What

Collapsing the left or right sidebar did not survive a page reload. The toggle animated correctly, but the preference was never saved.

## Why

The `app-layout` Stimulus controller saves the preference by calling `PATCH /users/${this.userIdValue}`, but it never declared a `static values` block. Without `userId` registered, Stimulus does not bind the `data-app-layout-user-id-value` attribute that the layout renders, so `this.userIdValue` resolves to `undefined`.

Every toggle therefore hit `/users/undefined`, which could not update `show_sidebar` or `show_ai_sidebar`, and the layout reset on the next load.

## How

Add the missing value declaration to the controller:

```js
static values = { userId: String };
```

Closes #2473 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Improved user preference management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->