### PR TITLE
Carry cost basis forward into gap-filled holdings

### DIFF
--- a/app/models/holding/gapfillable.rb
+++ b/app/models/holding/gapfillable.rb
@@ -19,7 +19,8 @@ module Holding::Gapfillable
             filled_holdings << holding
             previous_holding = holding
           else
-            # Create a new holding based on the previous day's data
+            # Carry the previous day's data forward, including cost_basis so
+            # avg_cost/trend stay consistent across gap-filled days.
             filled_holdings << Holding.new(
               account: previous_holding.account,
               security: previous_holding.security,
@@ -27,7 +28,8 @@ module Holding::Gapfillable
               qty: previous_holding.qty,
               price: previous_holding.price,
               currency: previous_holding.currency,
-              amount: previous_holding.amount
+              amount: previous_holding.amount,
+              cost_basis: previous_holding.cost_basis
             )
           end
         end

--- a/test/models/holding/forward_calculator_test.rb
+++ b/test/models/holding/forward_calculator_test.rb
@@ -111,6 +111,24 @@ class Holding::ForwardCalculatorTest < ActiveSupport::TestCase
     assert_holdings(expected, calculated)
   end
 
+  # Gap-filled days must carry cost_basis forward to keep avg_cost/trend
+  # consistent with the surrounding real holdings.
+  test "carries cost_basis forward into gap-filled holdings" do
+    wmt = Security.create!(ticker: "WMT", name: "Walmart Inc.")
+
+    # Only the trade date has a price; the following days have neither a market
+    # price nor a trade, so the calculator gap-fills them.
+    create_trade(wmt, qty: 100, date: 3.days.ago.to_date, price: 100, account: @account)
+
+    calculated = Holding::ForwardCalculator.new(@account).calculate
+
+    real_holding = calculated.find { |h| h.security == wmt && h.date == 3.days.ago.to_date }
+    gap_filled = calculated.find { |h| h.security == wmt && h.date == 1.day.ago.to_date }
+
+    assert_equal 100, real_holding.cost_basis
+    assert_equal real_holding.cost_basis, gap_filled.cost_basis
+  end
+
   test "offline tickers sync holdings based on most recent trade price" do
     offline_security = Security.create!(ticker: "OFFLINE", name: "Offline Ticker")
 


### PR DESCRIPTION
## Summary

`Holding.gapfill` carries the previous day's holding data forward for dates that have no real snapshot, but it left out `cost_basis`. Every synthesized day was stored with `cost_basis = nil`, which made `Holding#avg_cost` fall back to a per-holding trade query and report a different average cost, or no trend at all, on those days. This change carries `cost_basis` forward alongside the other values so the cost basis stays consistent across consecutive days for the same position.

## Root cause

`Holding::ForwardCalculator` and `Holding::ReverseCalculator` both compute `cost_basis` for real, trade-driven dates and then call the shared `Holding.gapfill` to fill the dates in between. The carry-forward in `gapfill` copied `qty`, `price`, `currency`, and `amount`, but not `cost_basis`, so the value was dropped on weekends, holidays, and trade gaps.

## Fix

Carry `cost_basis` forward from the previous real holding when building a gap-filled holding. This is correct because cost basis only changes on a buy trade, and gap-filled dates have none, so the previous real day's value applies unchanged. The fix lives in the shared `gapfill`, so both the forward and reverse calculators are covered in one place. `cost_basis_source` is intentionally not copied: calculator holdings never set it, and the materializer assigns the source when it persists the row.

## Testing

Added a test in `test/models/holding/forward_calculator_test.rb` that creates a single trade so the days after the trade date have no price of their own and are gap-filled. It asserts that a gap-filled day keeps the same `cost_basis` as the real trade day. The test fails before the change (the gap-filled day reports `nil`) and passes after.

```bash
bin/rails test test/models/holding/forward_calculator_test.rb
```

Closes #2475 