### PR TITLE
fix(plaid): delete removed transactions by external_id, not legacy plaid_id

### DIFF
--- a/app/models/plaid_account/transactions/processor.rb
+++ b/app/models/plaid_account/transactions/processor.rb
@@ -43,7 +43,12 @@ class PlaidAccount::Transactions::Processor
     end
 
     def remove_plaid_transaction(raw_transaction)
-      account.entries.find_by(plaid_id: raw_transaction["transaction_id"])&.destroy
+      id = raw_transaction["transaction_id"]
+      # Entries are keyed by external_id + source under the current import path; fall back to the
+      # legacy plaid_id column for rows synced before the external_id migration.
+      entry = account.entries.find_by(external_id: id, source: "plaid") ||
+              account.entries.find_by(plaid_id: id)
+      entry&.destroy
     end
 
     # Since we find_or_create_by transactions, we don't need a distinction between added/modified

--- a/test/models/plaid_account/transactions/processor_test.rb
+++ b/test/models/plaid_account/transactions/processor_test.rb
@@ -35,7 +35,34 @@ class PlaidAccount::Transactions::ProcessorTest < ActiveSupport::TestCase
     processor.process
   end
 
-  test "removes transactions no longer in plaid" do
+  test "removes transactions stored with external_id/source" do
+    removed_id = "ext_destroy_me"
+    @plaid_account.current_account.entries.create!(
+      external_id: removed_id,
+      source: "plaid",
+      date: Date.current,
+      amount: 100,
+      name: "Destroy me",
+      currency: "USD",
+      entryable: Transaction.new
+    )
+
+    @plaid_account.update!(raw_transactions_payload: {
+      added: [],
+      modified: [],
+      removed: [ { "transaction_id" => removed_id } ]
+    })
+
+    processor = PlaidAccount::Transactions::Processor.new(@plaid_account)
+
+    assert_difference [ "Entry.count", "Transaction.count" ], -1 do
+      processor.process
+    end
+
+    assert_nil Entry.find_by(external_id: removed_id, source: "plaid")
+  end
+
+  test "removes legacy transactions stored with plaid_id" do
     destroyable_transaction_id = "destroy_me"
     @plaid_account.current_account.entries.create!(
       plaid_id: destroyable_transaction_id,


### PR DESCRIPTION
## Problem

Plaid's `/transactions/sync` returns retired charges in its `removed` array — most commonly when a **pending** charge posts under a *new* `transaction_id` (the old pending row is retired), and also for canceled/reversed authorizations.

`PlaidAccount::Transactions::Processor#remove_plaid_transaction` looked these rows up by the legacy **`plaid_id`** column:

```ruby
account.entries.find_by(plaid_id: raw_transaction["transaction_id"])&.destroy
```

But the current import path (`Account::ProviderImportAdapter#import_transaction`) keys entries by **`external_id` + `source`** and never writes `plaid_id`. `plaid_id` was made legacy by `20251027110502_add_external_id_and_source_to_entries` and `20251028104851_backfill_entries_external_id_from_plaid_id`.

So for any entry synced under the new scheme, the `removed` lookup matches nothing and the row is **never deleted** — leaving stale pending and duplicate transactions that accumulate over time.

The existing test masked this because it seeded the entry with `plaid_id` (the legacy way) rather than `external_id`.

## Fix

Look up by `external_id` + `source: "plaid"`, with a `plaid_id` fallback for rows synced before the migration:

```ruby
def remove_plaid_transaction(raw_transaction)
  id = raw_transaction["transaction_id"]
  entry = account.entries.find_by(external_id: id, source: "plaid") ||
          account.entries.find_by(plaid_id: id)
  entry&.destroy
end
```

`process` runs added/modified (claims/reconciliation) before `removed`, so a pending that was already claimed (its `external_id` reassigned to the posted id) won't match its old id and won't be wrongly deleted; a genuinely removed/canceled pending now matches by `external_id` and is deleted.

## Tests

- Added a regression test seeding the entry the current way (`external_id` + `source: "plaid"`) and asserting it is destroyed.
- Kept a test for the legacy `plaid_id` fallback.

## Out of scope (possible follow-ups)

- A one-time sweep to clear backlog already accumulated in existing installs.
- Generalizing the SimpleFIN-only stale-pending backstop (`Entry.auto_exclude_stale_pending` / `Entry.reconcile_pending_duplicates`) to all providers via `Account::Syncer#perform_post_sync`.

---

Opened as a **draft** so CI (tests, RuboCop, Brakeman, Pipelock) can verify before review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Plaid transactions are now correctly deleted when stored with the current external transaction ID format.
  * Legacy transactions stored with the previous Plaid identifier continue to be removed through a fallback lookup.
  * This prevents deleted transactions from remaining visible and keeps transaction histories more closely aligned with the latest Plaid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->