### PR TITLE
fix(i18n): correct Catalan gender agreement on add-account button

### DIFF
--- a/config/locales/views/accounts/ca.yml
+++ b/config/locales/views/accounts/ca.yml
@@ -146,7 +146,7 @@ ca:
         tipus de canvi històrics, preus de valors i més. Aquestes dades són necessàries
         per calcular saldos històrics precisos dels comptes."
       new_account: Nou compte
-      new_account_group: Nou %{account_group}
+      new_account_group: Afegeix %{account_group}
       new_asset: Nou actiu
       new_debt: Nou deute
       tabs:


### PR DESCRIPTION
## What & why

The per-group "new account" button in the accounts sidebar rendered the Catalan string `Nou %{account_group}` — a **masculine** template applied to every account type (the type name comes from `accounts.types.*`). For feminine types this produced incorrect gender agreement:

| Account type | Before | After |
| --- | --- | --- |
| Targeta de crèdit (f) | ❌ Nou targeta de crèdit | ✅ Afegeix targeta de crèdit |
| Inversió (f) | ❌ Nou inversió | ✅ Afegeix inversió |
| Propietat (f) | ❌ Nou propietat | ✅ Afegeix propietat |
| Préstec (m) | Nou préstec | ✅ Afegeix préstec |

A single gendered template can't agree with both masculine and feminine nouns. The string now uses the **gender-invariant verb** form `Afegeix %{account_group}` ("Add X"), which is grammatical for every type without per-gender keys. English and other locales are unchanged.

## Scope

One-line locale change in `config/locales/views/accounts/ca.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Catalan text shown in the account sidebar for creating a new account group, improving the wording for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->