### PR TITLE
fix(imports): support QIF dd mmm yyyy date format

### DIFF
--- a/app/models/concerns/qif_parser.rb
+++ b/app/models/concerns/qif_parser.rb
@@ -354,12 +354,15 @@ module QifParser
   #   - Optional spaces around components:  6/ 4'20  →  6/4/20
   #   - Dot separators:  04.06.2020
   #   - Dash separators:  04-06-2020
+  #   - Month-name separators:  26 Jan 2026  (Amex-style "dd mmm yyyy")
   #
   # This method:
   #   1. Strips whitespace
   #   2. Replaces the Quicken apostrophe with the file's date separator
-  #   3. Expands 2-digit years to 4-digit (00-99 → 2000-2099, capped at current year)
-  #   4. Returns a cleaned date string suitable for Date.strptime
+  #   3. Collapses whitespace (removes it for numeric dates; keeps single
+  #      spaces for month-name dates since the space IS the separator)
+  #   4. Expands 2-digit years to 4-digit (00-99 → 2000-2099, capped at current year)
+  #   5. Returns a cleaned date string suitable for Date.strptime
   def self.normalize_qif_date(date_str)
     return nil if date_str.blank?
 
@@ -371,12 +374,20 @@ module QifParser
       s = s.gsub("'", sep)
     end
 
-    # Remove internal spaces (e.g. "6/ 4/20" → "6/4/20")
-    s = s.gsub(/\s+/, "")
+    # Whitespace handling depends on the date style:
+    #   - Month-name dates (e.g. "26 Jan 2026") use spaces as the field
+    #     separator, so collapse multiples to a single space.
+    #   - Numeric dates (e.g. Quicken's padded "6/ 4/20") use / . or - as
+    #     separators and may carry stray padding spaces, so strip them.
+    if s.match?(/[A-Za-z]/)
+      s = s.gsub(/\s+/, " ").strip
+    else
+      s = s.gsub(/\s+/, "")
+    end
 
     # Expand 2-digit year at end to 4-digit, but only when the string doesn't
     # already contain a 4-digit number (which would be a full year).
-    if !s.match?(/\d{4}/) && (m = s.match(%r{\A(.+[/.\-])(\d{2})\z}))
+    if !s.match?(/\d{4}/) && (m = s.match(%r{\A(.+[/.\- ])(\d{2})\z}))
       short_year = m[2].to_i
       full_year  = 2000 + short_year
       full_year -= 100 if full_year > Date.today.year

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -16,6 +16,7 @@ class Family < ApplicationRecord
     [ "D/MM/YYYY", "%e/%m/%Y" ],
     [ "YYYY.MM.DD", "%Y.%m.%d" ],
     [ "YYYYMMDD", "%Y%m%d" ],
+    # QIF month-name imports rely on QifParser preserving normalized spaces.
     [ "DD MMM YYYY", "%d %b %Y" ]
   ].freeze
 

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -15,7 +15,8 @@ class Family < ApplicationRecord
     [ "MM/DD/YYYY", "%m/%d/%Y" ],
     [ "D/MM/YYYY", "%e/%m/%Y" ],
     [ "YYYY.MM.DD", "%Y.%m.%d" ],
-    [ "YYYYMMDD", "%Y%m%d" ]
+    [ "YYYYMMDD", "%Y%m%d" ],
+    [ "DD MMM YYYY", "%d %b %Y" ]
   ].freeze
 
 

--- a/test/models/qif_import_test.rb
+++ b/test/models/qif_import_test.rb
@@ -866,6 +866,10 @@ class QifImportTest < ActiveSupport::TestCase
     assert_equal "6/4/2020", QifParser.send(:normalize_qif_date, "6/ 4/2020")
   end
 
+  test "normalize_qif_date expands 2-digit year for month-name dates" do
+    assert_equal "26 Jan 2026", QifParser.send(:normalize_qif_date, "26 Jan 26")
+  end
+
   test "normalize_qif_date converts apostrophe 2-digit year" do
     assert_equal "6/4/2020", QifParser.send(:normalize_qif_date, "6/ 4'20")
   end
@@ -912,6 +916,10 @@ class QifImportTest < ActiveSupport::TestCase
 
   test "parse_qif_date parses month-name format (DD MMM YYYY)" do
     assert_equal "2026-01-26", QifParser.send(:parse_qif_date, "26 Jan 2026", date_format: "%d %b %Y")
+  end
+
+  test "parse_qif_date parses month-name format with 2-digit year" do
+    assert_equal "2026-01-26", QifParser.send(:parse_qif_date, "26 Jan 26", date_format: "%d %b %Y")
   end
 
   test "parse_qif_date returns nil for invalid date" do

--- a/test/models/qif_import_test.rb
+++ b/test/models/qif_import_test.rb
@@ -854,6 +854,18 @@ class QifImportTest < ActiveSupport::TestCase
 
   # ── QifParser: normalize_qif_date ──────────────────────────────────────────
 
+  test "normalize_qif_date preserves single spaces for month-name dates" do
+    assert_equal "26 Jan 2026", QifParser.send(:normalize_qif_date, "26 Jan 2026")
+  end
+
+  test "normalize_qif_date collapses multiple spaces in month-name dates" do
+    assert_equal "26 Jan 2026", QifParser.send(:normalize_qif_date, "26  Jan  2026")
+  end
+
+  test "normalize_qif_date still strips spaces from numeric dates" do
+    assert_equal "6/4/2020", QifParser.send(:normalize_qif_date, "6/ 4/2020")
+  end
+
   test "normalize_qif_date converts apostrophe 2-digit year" do
     assert_equal "6/4/2020", QifParser.send(:normalize_qif_date, "6/ 4'20")
   end
@@ -896,6 +908,10 @@ class QifImportTest < ActiveSupport::TestCase
 
   test "parse_qif_date parses ISO format (YYYY-MM-DD)" do
     assert_equal "2020-06-04", QifParser.send(:parse_qif_date, "2020-06-04", date_format: "%Y-%m-%d")
+  end
+
+  test "parse_qif_date parses month-name format (DD MMM YYYY)" do
+    assert_equal "2026-01-26", QifParser.send(:parse_qif_date, "26 Jan 2026", date_format: "%d %b %Y")
   end
 
   test "parse_qif_date returns nil for invalid date" do
@@ -962,6 +978,11 @@ class QifImportTest < ActiveSupport::TestCase
     assert_equal "%Y-%m-%d", Import.detect_date_format(samples)
   end
 
+  test "detect_date_format identifies month-name DD MMM YYYY format" do
+    samples = [ "26 Jan 2026", "23 Jan 2026", "02 Feb 2026" ]
+    assert_equal "%d %b %Y", Import.detect_date_format(samples)
+  end
+
   test "detect_date_format returns fallback for blank samples" do
     assert_equal "%Y-%m-%d", Import.detect_date_format([])
     assert_equal "%Y-%m-%d", Import.detect_date_format(nil)
@@ -1014,6 +1035,48 @@ class QifImportTest < ActiveSupport::TestCase
 
     # Should not re-detect since qif_date_format is already set
     assert_equal "%d/%m/%Y", @import.reload.qif_date_format
+  end
+
+  # Reproduces #2498: Amex-style QIF with dd mmm yyyy dates previously failed
+  # with "Unable to detect date format" because normalize_qif_date stripped all
+  # spaces (turning "26 Jan 2026" into the unparseable "26Jan2026").
+  AMEX_DDD_MMM_YYYY_QIF = <<~QIF
+    !Type:CCard
+    D26 Jan 2026
+    N20260126
+    T-25.24
+    PAMAZON.COM.CA           WWW.AMAZON.CO
+    M
+    ^
+    D23 Jan 2026
+    N20260123
+    T-10.49
+    PSKIPTHEDISHES           WINNIPEG (BROAD
+    M
+    ^
+  QIF
+
+  test "generate_rows_from_csv auto-detects DD MMM YYYY format" do
+    @import.update!(raw_file_str: AMEX_DDD_MMM_YYYY_QIF)
+    @import.generate_rows_from_csv
+
+    assert_equal "%d %b %Y", @import.reload.qif_date_format
+    row = @import.rows.find_by(name: "AMAZON.COM.CA           WWW.AMAZON.CO")
+    assert_not_nil row
+    assert_equal "2026-01-26", row.date
+    assert_equal "-25.24",     row.amount
+  end
+
+  test "DD MMM YYYY format appears in valid_date_formats_with_preview for Amex QIF" do
+    @import.update!(raw_file_str: AMEX_DDD_MMM_YYYY_QIF)
+    @import.generate_rows_from_csv
+
+    formats = @import.valid_date_formats_with_preview
+    format_strs = formats.map { |f| f[:format] }
+
+    assert_includes format_strs, "%d %b %Y"
+    dd_mmm = formats.find { |f| f[:format] == "%d %b %Y" }
+    assert_equal "2026-01-26", dd_mmm[:preview]
   end
 
   # ── QifParser: try_parse_date ───────────────────────────────────────────────


### PR DESCRIPTION
## What & why

American Express transaction exports produce QIF files whose `D` fields use `dd mmm yyyy` dates, e.g.:

```
!Type:CCard
D26 Jan 2026
N20260126
T-25.24
PAMAZON.COM.CA           WWW.AMAZON.CO
M
^
```

Import failed with **"Unable to detect date format"** — the UI refused to proceed ("None of the supported date formats could parse the dates in this file").

## Root cause

Two issues combined:

1. **`QifParser.normalize_qif_date` stripped all internal whitespace** (`s.gsub(/\s+/, "")`). For month-name dates the spaces **are** the field separators, so `26 Jan 2026` became the unparseable `26Jan2026`.
2. **`Family::DATE_FORMATS` had no candidate mapping to `dd mmm yyyy`**, so `Import.detect_date_format` could not match it even after correct normalization.

## Fix

### `app/models/concerns/qif_parser.rb`
`normalize_qif_date` now branches on whether the date string contains a month abbreviation (alphabetic characters):

- **Month-name dates** (e.g. `26 Jan 2026`): collapse runs of whitespace to a single space — the space is the separator and must be preserved.
- **Numeric dates** (e.g. Quicken's padded `6/ 4/20`): unchanged — strip all internal whitespace.

The 2-digit-year expansion regex separator class was extended from `[/.\-]` to `[/.\- ]` so month-name dates with 2-digit years (e.g. `26 Jan 26` → `26 Jan 2026`) are also normalized. The existing year-cap-at-current-year logic still applies.

### `app/models/family.rb`
Added `["DD MMM YYYY", "%d %b %Y"]` to `Family::DATE_FORMATS`. This list is the candidate set for `Import.detect_date_format` and the option set shown in the QIF date-format dropdown (`valid_date_formats_with_preview`).

## Scope

Behaviour for existing numeric-date QIF files is **unchanged** — verified by the pre-existing `normalize_qif_date` / `parse` / `extract_raw_dates` tests still passing. No migration; only Ruby model/test changes.

## Tests

New coverage in `test/models/qif_import_test.rb`:

- `normalize_qif_date` preserves single spaces for month-name dates; collapses multiples; still strips spaces from purely numeric dates.
- `parse_qif_date` parses `26 Jan 2026` with `%d %b %Y`.
- `detect_date_format` identifies `%d %b %Y` from month-name samples.
- Integration: `generate_rows_from_csv` auto-detects `%d %b %Y` on an Amex-style sample QIF and produces correct rows.
- `valid_date_formats_with_preview` surfaces `%d %b %Y` with the correct preview date for the Amex QIF.

Verification:
- `bin/rails test test/models/qif_import_test.rb` → 109 runs, 0 failures
- `bin/rails test test/models/family_test.rb test/models/import_encoding_test.rb test/models/import_session_test.rb test/models/actual_import_test.rb` → 56 runs, 0 failures
- `bin/rubocop app/models/concerns/qif_parser.rb app/models/family.rb test/models/qif_import_test.rb` → no offenses

Fixes #2498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `DD MMM YYYY` date imports (for example, `01 Jan 2025`).
* **Bug Fixes**
  * Improved QIF month-name date normalization: collapses repeated whitespace to single spaces while stripping extra ends; numeric-date whitespace is removed.
  * Broadened 2-digit year expansion to handle an optional space delimiter before the trailing year.
  * Updated date detection and import previews to recognize and correctly use `DD MMM YYYY`.
* **Tests**
  * Added unit and integration coverage for `DD MMM YYYY`, including format detection and previewed/parsed transaction dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->