### PR TITLE
fix(i18n): use existing localized labels in web UI

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -93,6 +93,29 @@ class Category < ApplicationRecord
   UNCATEGORIZED_NAME_KEY = "models.category.uncategorized"
   OTHER_INVESTMENTS_NAME_KEY = "models.category.other_investments"
   INVESTMENT_CONTRIBUTIONS_NAME_KEY = "models.category.investment_contributions"
+  DEFAULT_CATEGORY_TRANSLATION_KEYS = %w[
+    income
+    food_and_drink
+    groceries
+    shopping
+    transportation
+    travel
+    entertainment
+    healthcare
+    personal_care
+    home_improvement
+    mortgage_rent
+    utilities
+    subscriptions
+    insurance
+    sports_and_fitness
+    gifts_and_donations
+    taxes
+    loan_payments
+    services
+    fees
+    savings_and_investments
+  ].freeze
 
   class Group
     attr_reader :category, :subcategories
@@ -200,7 +223,38 @@ class Category < ApplicationRecord
       end.uniq
     end
 
+    def localized_default_name_for(name)
+      i18n_key = default_category_translation_key_for(name)
+
+      i18n_key ? I18n.t(i18n_key, default: name) : name
+    end
+
     private
+      def default_category_translation_key_for(name)
+        default_category_translation_keys_by_name[name.to_s]
+      end
+
+      def default_category_translation_keys_by_name
+        @default_category_translation_keys_by_name ||= begin
+          # Default categories store the translated name in the `name` column, so
+          # older families may have default names from any supported locale. This
+          # display-layer bridge maps those known labels back to their i18n key
+          # before rendering in the current locale. A future schema-level
+          # default_key would remove the ambiguity with user-created categories.
+          i18n_keys = DEFAULT_CATEGORY_TRANSLATION_KEYS.index_with { |key| "models.category.defaults.#{key}" }
+          i18n_keys["uncategorized"] = UNCATEGORIZED_NAME_KEY
+          i18n_keys["other_investments"] = OTHER_INVESTMENTS_NAME_KEY
+          i18n_keys["investment_contributions"] = INVESTMENT_CONTRIBUTIONS_NAME_KEY
+
+          LanguagesHelper::SUPPORTED_LOCALES.each_with_object({}) do |locale, mapping|
+            i18n_keys.each_value do |i18n_key|
+              translated_name = I18n.t(i18n_key, locale: locale, default: nil)
+              mapping[translated_name.to_s] ||= i18n_key if translated_name.present?
+            end
+          end
+        end
+      end
+
       def default_categories
         [
           [ I18n.t("models.category.defaults.income"),                "#22c55e", "circle-dollar-sign" ],
@@ -252,6 +306,14 @@ class Category < ApplicationRecord
 
   def name_with_parent
     subcategory? ? "#{parent.name} > #{name}" : name
+  end
+
+  def display_name
+    self.class.localized_default_name_for(name)
+  end
+
+  def display_name_with_parent
+    subcategory? ? "#{parent.display_name} > #{display_name}" : display_name
   end
 
   # Predicate: is this the synthetic "Uncategorized" category?

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -54,6 +54,10 @@ module Accountable
       subtype_label_for(subtype, format: :long)
     end
 
+    def subtype_options_for_select
+      self::SUBTYPES.keys.map { |subtype| [ long_subtype_label_for(subtype), subtype ] }
+    end
+
     def favorable_direction
       classification == "asset" ? "up" : "down"
     end

--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -142,7 +142,7 @@ class Investment < ApplicationRecord
 
       region_order.filter_map do |region|
         next unless grouped[region]
-        [ region_label_for(region), grouped[region].map { |k, v| [ v[:long], k ] } ]
+        [ region_label_for(region), grouped[region].map { |k, _v| [ long_subtype_label_for(k), k ] } ]
       end
     end
   end

--- a/app/views/budget_categories/_budget_category.html.erb
+++ b/app/views/budget_categories/_budget_category.html.erb
@@ -1,5 +1,7 @@
 <%# locals: (budget_category:, show_budget_meta: true) %>
 
+<% category_display_name = budget_category.category.display_name %>
+
 <%= turbo_frame_tag dom_id(budget_category), class: "flex-1 min-w-0 block" do %>
   <%= link_to budget_budget_category_path(budget_category.budget, budget_category), class: "group block w-full px-4 py-2 bg-container", data: { turbo_frame: "drawer" } do %>
 
@@ -17,13 +19,13 @@
             <%= render DS::FilledIcon.new(
               variant: :text,
               hex_color: budget_category.category.color,
-              text: budget_category.category.name,
+              text: category_display_name,
               size: "md",
               rounded: true
             ) %>
           <% end %>
         </div>
-        <h3 class="flex-1 min-w-0 font-medium text-primary truncate"><%= budget_category.category.name %></h3>
+        <h3 class="flex-1 min-w-0 font-medium text-primary truncate"><%= category_display_name %></h3>
         <div class="flex items-center gap-3 flex-shrink-0 ml-auto">
           <% if budget_category.over_budget? %>
             <%= render DS::Pill.new(label: t("reports.budget_performance.status.over"), tone: :error, marker: false, icon: "alert-circle") %>
@@ -96,7 +98,7 @@
             <%= render DS::FilledIcon.new(
               variant: :text,
               hex_color: budget_category.category.color,
-              text: budget_category.category.name,
+              text: category_display_name,
               size: "sm",
               rounded: true
             ) %>
@@ -104,9 +106,9 @@
         </div>
 
         <div class="min-w-0 flex-1">
-          <p class="text-sm font-medium text-primary truncate"><%= budget_category.category.name %></p>
+          <p class="text-sm font-medium text-primary truncate"><%= category_display_name %></p>
           <p class="text-sm text-secondary font-medium privacy-sensitive">
-            <%= budget_category.median_monthly_expense_money.format %> avg
+            <%= t("budget_categories.budget_category_form.monthly_average", amount: budget_category.median_monthly_expense_money.format(precision: 0)) %>
           </p>
         </div>
 

--- a/app/views/budget_categories/_budget_category_donut.html.erb
+++ b/app/views/budget_categories/_budget_category_donut.html.erb
@@ -16,7 +16,7 @@
         </span>
       <% else %>
         <span class="text-sm uppercase" style="color: <%= budget_category.category.color %>">
-          <%= budget_category.category.name.first.upcase %>
+          <%= budget_category.category.display_name.first.upcase %>
         </span>
       <% end %>
     </div>

--- a/app/views/budget_categories/_budget_category_form.html.erb
+++ b/app/views/budget_categories/_budget_category_form.html.erb
@@ -6,7 +6,7 @@
   <div class="w-1 h-3 rounded-xl mt-1" style="background-color: <%= budget_category.category.color %>"></div>
 
   <div class="text-sm mr-3">
-    <p class="text-primary font-medium mb-0.5"><%= budget_category.category.name %></p>
+    <p class="text-primary font-medium mb-0.5"><%= budget_category.category.display_name %></p>
 
     <p class="text-secondary privacy-sensitive"><%= t("budget_categories.budget_category_form.monthly_average", amount: budget_category.median_monthly_expense_money.format(precision: 0)) %></p>
   </div>

--- a/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
+++ b/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
@@ -6,7 +6,7 @@
   <div class="w-1 h-3 rounded-xl mt-1" style="background-color: <%= budget_category.category.color %>"></div>
 
   <div class="text-sm mr-3">
-    <p class="text-primary font-medium mb-0.5"><%= budget_category.category.name %></p>
+    <p class="text-primary font-medium mb-0.5"><%= budget_category.category.display_name %></p>
     <p class="text-secondary privacy-sensitive"><%= t("budget_categories.budget_category_form.monthly_average", amount: budget_category.avg_monthly_expense_money.format(precision: 0)) %></p>
   </div>
 

--- a/app/views/budget_categories/show.html.erb
+++ b/app/views/budget_categories/show.html.erb
@@ -3,7 +3,7 @@
     <div>
       <p class="text-sm text-secondary"><%= t(".category") %></p>
       <h3 class="text-2xl font-medium text-primary">
-        <%= @budget_category.name %>
+        <%= @budget_category.category.display_name %>
       </h3>
 
       <% if @budget_category.budget.initialized? %>

--- a/app/views/budgets/_actuals_summary.html.erb
+++ b/app/views/budgets/_actuals_summary.html.erb
@@ -20,7 +20,7 @@
           <% budget.income_category_totals.each do |category_total| %>
             <div class="flex items-center gap-1.5">
               <div class="w-2.5 h-2.5 rounded-full shrink-0" style="background-color: <%= category_total.category.color %>"></div>
-              <span class="text-secondary"><%= category_total.category.name %></span>
+              <span class="text-secondary"><%= category_total.category.display_name %></span>
               <span class="text-primary"><%= number_to_percentage(category_total.weight, precision: 0) %></span>
             </div>
           <% end %>
@@ -46,7 +46,7 @@
           <% budget.expense_category_totals.each do |category_total| %>
             <div class="flex items-center gap-1.5">
               <div class="w-2.5 h-2.5 rounded-full shrink-0" style="background-color: <%= category_total.category.color %>"></div>
-              <span class="text-secondary"><%= category_total.category.name %></span>
+              <span class="text-secondary"><%= category_total.category.display_name %></span>
               <span class="text-primary"><%= number_to_percentage(category_total.weight, precision: 0) %></span>
             </div>
           <% end %>

--- a/app/views/budgets/_budget_donut.html.erb
+++ b/app/views/budgets/_budget_donut.html.erb
@@ -39,7 +39,7 @@
         <div class="flex flex-col gap-2 items-center">
           <div class="flex items-center gap-3">
             <div class="w-1 h-3 rounded-xl" style="background-color: <%= bc.category.color %>"></div>
-            <p class="text-sm text-secondary"><%= bc.category.name %></p>
+            <p class="text-sm text-secondary"><%= bc.category.display_name %></p>
           </div>
 
           <p data-donut-chart-target="amount" class="text-3xl font-medium privacy-sensitive whitespace-nowrap <%= bc.available_to_spend.negative? ? "text-destructive" : "text-primary" %>">

--- a/app/views/categories/_badge.html.erb
+++ b/app/views/categories/_badge.html.erb
@@ -8,7 +8,7 @@
     cell) instead of overflowing them. %>
 <div class="min-w-0">
   <%= render DS::Pill.new(
-        label: category.name,
+        label: category.display_name,
         custom_color: category.color,
         icon: category.lucide_icon.presence,
         icon_size: "sm",
@@ -16,5 +16,5 @@
         size: :md,
         truncate: true,
         label_testid: "category-name",
-        title: category.name) %>
+        title: category.display_name) %>
 </div>

--- a/app/views/categories/_category_name_mobile.html.erb
+++ b/app/views/categories/_category_name_mobile.html.erb
@@ -1,7 +1,7 @@
 <span id="category_name_mobile_<%= transaction.id %>" class="text-secondary lg:hidden min-w-0 truncate">
   <% if transaction.transfer&.categorizable? || transaction.transfer.nil? %>
-    <%= transaction.category&.name || Category.uncategorized.name %>
+    <%= transaction.category&.display_name || Category.uncategorized.display_name %>
   <% else %>
-    <%= transaction.transfer&.payment? ? payment_category.name :  transfer_category.name %>
+    <%= transaction.transfer&.payment? ? payment_category.display_name :  transfer_category.display_name %>
   <% end %>
 </span>

--- a/app/views/categories/merge.html.erb
+++ b/app/views/categories/merge.html.erb
@@ -4,7 +4,7 @@
     <%= styled_form_with url: perform_merge_categories_path, method: :post, class: "space-y-4" do |f| %>
       <%= f.collection_select :target_id,
             @categories,
-            :id, :name_with_parent,
+            :id, :display_name_with_parent,
             { prompt: t(".select_target"), label: t(".target_label") },
             { required: true } %>
 
@@ -14,7 +14,7 @@
           <% @categories.each do |category| %>
             <label class="flex items-center gap-2 p-2 hover:bg-surface-hover rounded cursor-pointer">
               <%= check_box_tag "source_ids[]", category.id, false, class: "rounded border-secondary" %>
-              <span class="text-sm text-primary"><%= category.name_with_parent %></span>
+              <span class="text-sm text-primary"><%= category.display_name_with_parent %></span>
             </label>
           <% end %>
         </div>

--- a/app/views/category/deletions/new.html.erb
+++ b/app/views/category/deletions/new.html.erb
@@ -1,29 +1,29 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: t(".delete_category"), subtitle: t(".explanation", category_name: @category.name)) %>
+  <% dialog.with_header(title: t(".delete_category"), subtitle: t(".explanation", category_name: @category.display_name)) %>
 
   <% dialog.with_body do %>
     <%= styled_form_with url: category_deletions_path(@category),
                        data: {
                          turbo: false,
                          controller: "deletion",
-                         deletion_submit_text_when_not_replacing_value: t(".delete_and_leave_uncategorized", category_name: @category.name),
-                         deletion_submit_text_when_replacing_value: t(".delete_and_recategorize", category_name: @category.name) } do |f| %>
+                         deletion_submit_text_when_not_replacing_value: t(".delete_and_leave_uncategorized", category_name: @category.display_name),
+                         deletion_submit_text_when_replacing_value: t(".delete_and_recategorize", category_name: @category.display_name) } do |f| %>
       <%= f.collection_select :replacement_category_id,
                             Current.family.categories.alphabetically_by_hierarchy.without(@category),
-                            :id, :name_with_parent,
+                            :id, :display_name_with_parent,
                             { prompt: t(".replacement_category_prompt"), label: t(".category"), container_class: "mb-4" },
                             data: { deletion_target: "replacementField", action: "deletion#chooseSubmitButton" } %>
 
       <%= render DS::Button.new(
         variant: "destructive",
         type: :submit,
-        text: t(".delete_and_leave_uncategorized", category_name: @category.name),
+        text: t(".delete_and_leave_uncategorized", category_name: @category.display_name),
         full_width: true,
         data: { deletion_target: "destructiveSubmitButton" }
       ) %>
 
       <%= render DS::Button.new(
-        text: t(".delete_and_recategorize", category_name: @category.name),
+        text: t(".delete_and_recategorize", category_name: @category.display_name),
         type: :submit,
         data: { deletion_target: "safeSubmitButton" },
         hidden: true,

--- a/app/views/category/dropdowns/_row.html.erb
+++ b/app/views/category/dropdowns/_row.html.erb
@@ -7,7 +7,7 @@
       aria_selected: is_selected.to_s,
       class: ["filterable-item flex justify-between items-center border-none rounded-lg px-2 py-1 group w-full hover:bg-container-inset-hover",
               { "bg-container-inset": is_selected }],
-      data: { filter_name: category.name } do %>
+      data: { filter_name: category.display_name } do %>
   <%= button_to transaction_category_path(
         @transaction.entry,
         grouped: params[:grouped],

--- a/app/views/cryptos/_form.html.erb
+++ b/app/views/cryptos/_form.html.erb
@@ -3,7 +3,7 @@
 <%= render "accounts/form", account: account, url: url do |form| %>
   <%= form.fields_for :accountable do |crypto_form| %>
     <%= crypto_form.select :subtype,
-                          Crypto::SUBTYPES.map { |k, v| [v[:long], k] },
+                          Crypto.subtype_options_for_select,
                           { label: t("cryptos.form.subtype_label"), prompt: t("cryptos.form.subtype_prompt"), include_blank: t("cryptos.form.subtype_none") } %>
 
     <%= crypto_form.select :tax_treatment,

--- a/app/views/depositories/_form.html.erb
+++ b/app/views/depositories/_form.html.erb
@@ -2,6 +2,6 @@
 
 <%= render "accounts/form", account: account, url: url do |form| %>
   <%= form.select :subtype,
-                 Depository::SUBTYPES.map { |k, v| [v[:long], k] },
+                 Depository.subtype_options_for_select,
                  { label: true, prompt: t("depositories.form.subtype_prompt"), include_blank: t("depositories.form.none") } %>
 <% end %>

--- a/app/views/loans/_form.html.erb
+++ b/app/views/loans/_form.html.erb
@@ -31,7 +31,7 @@
 
       <div>
         <%= loan_form.select :subtype,
-                  Loan::SUBTYPES.map { |k, v| [v[:long], k] },
+                  Loan.subtype_options_for_select,
                   { label: true, prompt: t("loans.form.subtype_prompt"), include_blank: t("loans.form.none") } %>
       </div>
     <% end %>

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -23,7 +23,7 @@
                                        placeholder: t("properties.form.area_placeholder"),
                                        min: 0 %>
         <%= property_form.select :area_unit,
-                                 [[t("properties.overview_fields.square_feet", default: "Square Feet"), "sqft"], [t("properties.overview_fields.square_meters", default: "Square Meters"), "sqm"]],
+                                 [[t("properties.overview_fields.square_feet"), "sqft"], [t("properties.overview_fields.square_meters"), "sqm"]],
                                  { label: t("properties.form.area_unit") } %>
       </div>
 

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "accounts/form", account: account, url: url do |form| %>
   <%= form.select :subtype,
-                 Property::SUBTYPES.map { |k, v| [v[:long], k] },
+                 Property.subtype_options_for_select,
                  { label: true, prompt: t("properties.form.subtype_prompt"), include_blank: t("properties.form.none") } %>
 
   <%= render "shared/ruler", classes: "my-4" %>
@@ -23,7 +23,7 @@
                                        placeholder: t("properties.form.area_placeholder"),
                                        min: 0 %>
         <%= property_form.select :area_unit,
-                                 [["Square Feet", "sqft"], ["Square Meters", "sqm"]],
+                                 [[t("properties.overview_fields.square_feet", default: "Square Feet"), "sqft"], [t("properties.overview_fields.square_meters", default: "Square Meters"), "sqm"]],
                                  { label: t("properties.form.area_unit") } %>
       </div>
 

--- a/app/views/properties/_overview_fields.html.erb
+++ b/app/views/properties/_overview_fields.html.erb
@@ -10,7 +10,7 @@
 
   <%= form.fields_for :accountable do |property_form| %>
     <%= property_form.select :subtype,
-                Property::SUBTYPES.map { |k, v| [v[:long], k] },
+                Property.subtype_options_for_select,
                 { prompt: t(".subtype_prompt"), label: t(".property_type_label") }, required: true %>
 
     <div class="flex items-center gap-2">

--- a/app/views/splits/_category_select.html.erb
+++ b/app/views/splits/_category_select.html.erb
@@ -26,7 +26,7 @@
         <% else %>
           <span class="size-1.5 rounded-full" style="background-color: <%= hex_color %>;"></span>
         <% end %>
-        <%= selected_category.name %>
+        <%= selected_category.display_name %>
       </span>
     <% else %>
       <%= t("splits.new.uncategorized") %>
@@ -68,7 +68,7 @@
              aria-selected="<%= is_selected %>"
              data-action="click->select#select"
              data-value="<%= category.id %>"
-             data-filter-name="<%= category.name %>">
+             data-filter-name="<%= category.display_name %>">
           <span class="check-icon <%= "hidden" unless is_selected %>">
             <%= icon("check") %>
           </span>
@@ -79,7 +79,7 @@
             <% else %>
               <span class="size-1.5 rounded-full" style="background-color: <%= hex_color %>;"></span>
             <% end %>
-            <%= category.name %>
+            <%= category.display_name %>
           </span>
         </div>
       <% end %>

--- a/app/views/splits/edit.html.erb
+++ b/app/views/splits/edit.html.erb
@@ -8,7 +8,7 @@
           <% if (category = @entry.entryable.try(:category)) %>
             <span class="text-secondary">&middot;</span>
             <span style="color: <%= category.color %>"><%= icon category.lucide_icon, size: "xs", color: "current" %></span>
-            <span><%= category.name %></span>
+            <span><%= category.display_name %></span>
           <% end %>
         </p>
       </div>

--- a/app/views/splits/new.html.erb
+++ b/app/views/splits/new.html.erb
@@ -8,7 +8,7 @@
           <% if (category = @entry.entryable.try(:category)) %>
             <span class="text-secondary">&middot;</span>
             <span style="color: <%= category.color %>"><%= icon category.lucide_icon, size: "xs", color: "current" %></span>
-            <span><%= category.name %></span>
+            <span><%= category.display_name %></span>
           <% end %>
         </p>
       </div>

--- a/app/views/transactions/categorizes/show.html.erb
+++ b/app/views/transactions/categorizes/show.html.erb
@@ -128,11 +128,11 @@
                         style="background-color: color-mix(in oklab, <%= category.color %> 10%, transparent);
                                border-color: color-mix(in oklab, <%= category.color %> 20%, transparent);
                                color: <%= category.color %>;"
-                        data-filter-name="<%= category.name %>">
+                        data-filter-name="<%= category.display_name %>">
                   <% if category.lucide_icon.present? %>
                     <%= icon(category.lucide_icon, size: "sm", color: "current") %>
                   <% end %>
-                  <%= category.name %>
+                  <%= category.display_name %>
                 </button>
               <% end %>
             </div>

--- a/app/views/transactions/searches/filters/_category_filter.html.erb
+++ b/app/views/transactions/searches/filters/_category_filter.html.erb
@@ -11,7 +11,7 @@
       ) %>
   <div class="my-2" id="list" data-list-filter-target="list">
     <% family_categories.each do |category| %>
-      <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= category.name %>">
+      <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= category.display_name %>">
         <%= form.check_box :categories,
                            {
                              multiple: true,
@@ -20,7 +20,7 @@
                            },
                            category.name,
                            nil %>
-        <%= form.label :categories, category.name, value: category.name, class: "text-sm text-primary cursor-pointer" do %>
+        <%= form.label :categories, category.display_name, value: category.name, class: "text-sm text-primary cursor-pointer" do %>
           <%= render partial: "categories/badge", locals: { category: category } %>
         <% end %>
       </div>

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -63,6 +63,56 @@ class CategoryTest < ActiveSupport::TestCase
     assert_equal names, names.uniq  # No duplicates
   end
 
+  test "display_name localizes default category names" do
+    I18n.with_locale(:"zh-CN") do
+      assert_equal "餐饮", categories(:food_and_drink).display_name
+      assert_equal "未分类", Category.uncategorized.display_name
+    end
+  end
+
+  test "display_name returns default category names in english" do
+    I18n.with_locale(:en) do
+      assert_equal "Food & Drink", categories(:food_and_drink).display_name
+      assert_equal "Uncategorized", Category.uncategorized.display_name
+    end
+  end
+
+  test "display_name preserves custom category names" do
+    category = Category.new(name: "School Supplies", color: "#123456", lucide_icon: "book", family: @family)
+
+    I18n.with_locale(:"zh-CN") do
+      assert_equal "School Supplies", category.display_name
+    end
+  end
+
+  test "display_name_with_parent localizes default parent and child names" do
+    category = Category.new(
+      name: "Groceries",
+      color: "#123456",
+      lucide_icon: "shopping-bag",
+      family: @family,
+      parent: categories(:food_and_drink)
+    )
+
+    I18n.with_locale(:"zh-CN") do
+      assert_equal "餐饮 > 杂货", category.display_name_with_parent
+    end
+  end
+
+  test "display_name_with_parent preserves custom child names" do
+    category = Category.new(
+      name: "Coffee Beans",
+      color: "#123456",
+      lucide_icon: "coffee",
+      family: @family,
+      parent: categories(:food_and_drink)
+    )
+
+    I18n.with_locale(:"zh-CN") do
+      assert_equal "餐饮 > Coffee Beans", category.display_name_with_parent
+    end
+  end
+
   test "should accept valid 6-digit hex colors" do
     [ "#FFFFFF", "#000000", "#123456", "#ABCDEF", "#abcdef" ].each do |color|
       category = Category.new(name: "Category #{color}", color: color, lucide_icon: "shapes", family: @family)


### PR DESCRIPTION
## Problem

Some web UI surfaces still render stored English/default labels even when localized values already exist.

This is most visible for:
- default category names in budget/category/transaction UI
- account subtype options in account forms
- a small budget monthly-average label that still rendered `avg`

For example, users with zh-CN enabled could still see category labels such as `Food & Drink`, `Groceries`, or `Entertainment` even though `models.category.defaults.*` already contains localized values.

## Fix

- Add `Category#display_name` / `display_name_with_parent` for Web display.
- Map known default category labels from supported locales back to their i18n keys, then render them in the current locale.
- Use `display_name` across the main Web category surfaces: budgets, category badges, category filters, category dropdowns, split forms, and categorize flow.
- Reuse existing account subtype i18n helpers in account forms instead of reading raw `SUBTYPES[:long]` labels.
- Reuse the existing budget monthly-average translation instead of rendering a hardcoded `avg`.

## Scope

This intentionally does not add or modify locale YAML files. The goal is to use translations that already exist.

This is also Web UI only. API JSON responses continue to return the stored category `name` value to avoid changing API contracts or expanding this PR into rswag/OpenAPI updates.

## Notes

Default categories currently store their translated name in the `name` column, so this PR uses a display-layer bridge that recognizes known default labels across `LanguagesHelper::SUPPORTED_LOCALES`. A future schema-level `default_key` would be a more robust identity for default categories, but that would require a migration and is outside this narrow fix.

## Testing

- `ruby -c app/models/category.rb`
- `ruby -c test/models/category_test.rb`
- Verified default category display mapping with Rails runner:
  - `Food & Drink` -> `餐饮`
  - `Groceries` -> `杂货`
  - custom category names remain unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default category names are now localized for the current language, including nested parent/child labels, with graceful fallback when translations are missing.
* **Bug Fixes**
  * Category labels are consistently shown using localized display names across badges, filters, pickers, dialogs, dropdowns, summaries, and donut views.
  * Budget category “monthly average” is now fully localized.
* **New Features**
  * Added shared subtype dropdown option generation and applied it to crypto, depository, loan, and property forms.
* **Tests**
  * Added coverage for localized default category display behavior across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->