### PR TITLE
Fix OIDC group role mapping claims

### DIFF
--- a/app/models/oidc/provider_options_builder.rb
+++ b/app/models/oidc/provider_options_builder.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Oidc
+  class ProviderOptionsBuilder
+    DEFAULT_SCOPES = %i[openid email profile].freeze
+
+    class << self
+      def call(raw_cfg, env: ENV, rails_env: Rails.env, ssl_config: Rails.configuration.x.ssl)
+        cfg = raw_cfg.deep_symbolize_keys
+        issuer = cfg[:issuer].presence || env["OIDC_ISSUER"].presence
+        client_id = cfg[:client_id].presence || env["OIDC_CLIENT_ID"].presence
+        client_secret = cfg[:client_secret].presence || env["OIDC_CLIENT_SECRET"].presence
+        redirect_uri = cfg[:redirect_uri].presence || env["OIDC_REDIRECT_URI"].presence
+
+        if rails_env.test?
+          issuer ||= "https://test.example.com"
+          client_id ||= "test_client_id"
+          client_secret ||= "test_client_secret"
+          redirect_uri ||= "http://test.example.com/callback"
+        end
+
+        return nil unless issuer.present? && client_id.present? && client_secret.present? && redirect_uri.present?
+
+        scopes = oidc_scopes(cfg)
+        options = {
+          name: provider_name(cfg).to_sym,
+          scope: scopes,
+          response_type: :code,
+          issuer: issuer.to_s.strip,
+          discovery: true,
+          pkce: true,
+          client_options: {
+            identifier: client_id,
+            secret: client_secret,
+            redirect_uri: redirect_uri,
+            ssl: ssl_options(ssl_config)
+          }
+        }
+
+        prompt = cfg.dig(:settings, :prompt).presence
+        options[:prompt] = prompt if prompt.present?
+
+        extra_authorize_params = oidc_extra_authorize_params(cfg, scopes)
+        options[:extra_authorize_params] = extra_authorize_params if extra_authorize_params.present?
+
+        options
+      end
+
+      def oidc_scopes(cfg)
+        custom_scopes = cfg.dig(:settings, :scopes).presence
+        return DEFAULT_SCOPES unless custom_scopes.present?
+
+        custom_scopes.to_s.split.map(&:to_sym)
+      end
+
+      private
+        def provider_name(cfg)
+          (cfg[:name] || cfg[:id]).to_s
+        end
+
+        def oidc_extra_authorize_params(cfg, scopes)
+          return {} unless request_groups_claim?(cfg, scopes)
+
+          # Best-effort OIDC Core claims request. Some IdPs still require
+          # provider-side scope/audience mapping before they emit groups.
+          {
+            claims: JSON.generate(
+              id_token: { groups: nil },
+              userinfo: { groups: nil }
+            )
+          }
+        end
+
+        def request_groups_claim?(cfg, scopes)
+          scopes.map(&:to_s).include?("groups") || role_mapping(cfg).present?
+        end
+
+        def role_mapping(cfg)
+          cfg.dig(:settings, :role_mapping).presence
+        end
+
+        def ssl_options(ssl_config)
+          ssl_opts = {}
+          ssl_opts[:ca_file] = ssl_config.ca_file if ssl_config&.ca_file.present?
+          ssl_opts[:verify] = false if ssl_config&.verify == false
+          ssl_opts
+        end
+    end
+  end
+end

--- a/app/models/oidc_identity.rb
+++ b/app/models/oidc_identity.rb
@@ -62,7 +62,7 @@ class OidcIdentity < ApplicationRecord
     return unless role_mapping.present?
 
     # Check roles in order of precedence (highest to lowest)
-    %w[super_admin admin member].each do |role|
+    %w[super_admin admin member guest].each do |role|
       mapped_groups = role_mapping[role] || role_mapping[role.to_sym] || []
       mapped_groups = Array(mapped_groups)
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -38,64 +38,17 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
     case strategy
     when "openid_connect"
-      # Support per-provider credentials from config or fall back to global ENV vars
-      issuer = cfg[:issuer].presence || ENV["OIDC_ISSUER"].presence
-      client_id = cfg[:client_id].presence || ENV["OIDC_CLIENT_ID"].presence
-      client_secret = cfg[:client_secret].presence || ENV["OIDC_CLIENT_SECRET"].presence
-      redirect_uri = cfg[:redirect_uri].presence || ENV["OIDC_REDIRECT_URI"].presence
+      oidc_options = Oidc::ProviderOptionsBuilder.call(cfg)
 
-      # In test environment, use test values if nothing is configured
-      if Rails.env.test?
-        issuer ||= "https://test.example.com"
-        client_id ||= "test_client_id"
-        client_secret ||= "test_client_secret"
-        redirect_uri ||= "http://test.example.com/callback"
-      end
-
-      # Skip if required fields are missing (except in test)
-      unless issuer.present? && client_id.present? && client_secret.present? && redirect_uri.present?
+      unless oidc_options.present?
         Rails.logger.warn("[OmniAuth] Skipping OIDC provider '#{name}' - missing required configuration")
         next
       end
 
-      # Custom scopes: parse from settings if provided, otherwise use defaults
-      custom_scopes = cfg.dig(:settings, :scopes).presence
-      scopes = if custom_scopes.present?
-        custom_scopes.to_s.split(/\s+/).map(&:to_sym)
-      else
-        %i[openid email profile]
-      end
-
-      # Build provider options
-      oidc_options = {
-        name: name.to_sym,
-        scope: scopes,
-        response_type: :code,
-        issuer: issuer.to_s.strip,
-        discovery: true,
-        pkce: true,
-        client_options: {
-          identifier: client_id,
-          secret: client_secret,
-          redirect_uri: redirect_uri,
-          ssl: begin
-                 ssl_config = Rails.configuration.x.ssl
-                 ssl_opts = {}
-                 ssl_opts[:ca_file] = ssl_config.ca_file if ssl_config&.ca_file.present?
-                 ssl_opts[:verify] = false if ssl_config&.verify == false
-                 ssl_opts
-               end
-        }
-      }
-
-      # Add prompt parameter if configured
-      prompt = cfg.dig(:settings, :prompt).presence
-      oidc_options[:prompt] = prompt if prompt.present?
-
       provider :openid_connect, oidc_options
 
       Rails.configuration.x.auth.oidc_enabled = true
-      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name, issuer: issuer)
+      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name, issuer: oidc_options[:issuer])
 
     when "google_oauth2"
       client_id = cfg[:client_id].presence || ENV["GOOGLE_OAUTH_CLIENT_ID"].presence

--- a/test/models/oidc/provider_options_builder_test.rb
+++ b/test/models/oidc/provider_options_builder_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Oidc
+  class ProviderOptionsBuilderTest < ActiveSupport::TestCase
+    test "uses default scopes when custom scopes are blank" do
+      options = ProviderOptionsBuilder.call(base_config)
+
+      assert_equal %i[openid email profile], options[:scope]
+      assert_nil options[:extra_authorize_params]
+    end
+
+    test "requests groups claim when groups scope is configured" do
+      options = ProviderOptionsBuilder.call(base_config(settings: { scopes: "openid email profile groups" }))
+
+      claims = JSON.parse(options.dig(:extra_authorize_params, :claims))
+      assert_equal [ "groups" ], claims["id_token"].keys
+      assert_equal [ "groups" ], claims["userinfo"].keys
+      assert_nil claims.dig("id_token", "groups")
+      assert_nil claims.dig("userinfo", "groups")
+    end
+
+    test "requests groups claim when role mapping is configured" do
+      options = ProviderOptionsBuilder.call(base_config(settings: {
+        role_mapping: { super_admin: [ "sure-admins" ] }
+      }))
+
+      claims = JSON.parse(options.dig(:extra_authorize_params, :claims))
+      assert_equal [ "groups" ], claims["id_token"].keys
+      assert_equal [ "groups" ], claims["userinfo"].keys
+    end
+
+    test "does not request groups claim for regular OIDC login without group mapping" do
+      options = ProviderOptionsBuilder.call(base_config(settings: { scopes: "openid email profile" }))
+
+      assert_nil options[:extra_authorize_params]
+    end
+
+    test "discards blank scope tokens from surrounding whitespace" do
+      options = ProviderOptionsBuilder.call(base_config(settings: { scopes: "  openid   email profile groups  " }))
+
+      assert_equal %i[openid email profile groups], options[:scope]
+    end
+
+    test "returns nil when required configuration is missing" do
+      config = base_config.except(:client_secret)
+
+      assert_nil ProviderOptionsBuilder.call(
+        config,
+        env: {},
+        rails_env: ActiveSupport::StringInquirer.new("production")
+      )
+    end
+
+    test "includes configured prompt" do
+      options = ProviderOptionsBuilder.call(base_config(settings: { prompt: "login" }))
+
+      assert_equal "login", options[:prompt]
+    end
+
+    private
+      def base_config(overrides = {})
+        {
+          name: "openid_connect",
+          strategy: "openid_connect",
+          issuer: "https://idp.example.com",
+          client_id: "client-id",
+          client_secret: "client-secret",
+          redirect_uri: "https://sure.example.com/auth/openid_connect/callback",
+          settings: {}
+        }.deep_merge(overrides)
+      end
+  end
+end

--- a/test/models/oidc_identity_test.rb
+++ b/test/models/oidc_identity_test.rb
@@ -92,6 +92,93 @@ class OidcIdentityTest < ActiveSupport::TestCase
     assert_equal "Jones", @user.last_name
   end
 
+  test "sync_user_attributes! applies guest role mapping from groups claim" do
+    @user.update!(role: :member)
+    AuthConfig.stubs(:sso_providers).returns([
+      {
+        name: @oidc_identity.provider,
+        settings: {
+          role_mapping: {
+            guest: [ "sure-guests" ]
+          }
+        }
+      }
+    ])
+    auth = OmniAuth::AuthHash.new(
+      provider: @oidc_identity.provider,
+      uid: @oidc_identity.uid,
+      info: { email: @user.email },
+      extra: {
+        raw_info: {
+          groups: [ "sure-guests" ]
+        }
+      }
+    )
+
+    @oidc_identity.sync_user_attributes!(auth)
+
+    assert_predicate @user.reload, :guest?
+  end
+
+  test "sync_user_attributes! prefers member over guest when both group mappings match" do
+    @user.update!(role: :guest)
+    AuthConfig.stubs(:sso_providers).returns([
+      {
+        name: @oidc_identity.provider,
+        settings: {
+          role_mapping: {
+            member: [ "sure-members" ],
+            guest: [ "sure-guests" ]
+          }
+        }
+      }
+    ])
+    auth = OmniAuth::AuthHash.new(
+      provider: @oidc_identity.provider,
+      uid: @oidc_identity.uid,
+      info: { email: @user.email },
+      extra: {
+        raw_info: {
+          groups: [ "sure-members", "sure-guests" ]
+        }
+      }
+    )
+
+    @oidc_identity.sync_user_attributes!(auth)
+
+    assert_predicate @user.reload, :member?
+  end
+
+  test "sync_user_attributes! leaves role unchanged when mapped groups claim is absent" do
+    @user.update!(role: :member)
+    AuthConfig.stubs(:sso_providers).returns([
+      {
+        name: @oidc_identity.provider,
+        settings: {
+          role_mapping: {
+            admin: [ "sure-admins" ],
+            guest: [ "sure-guests" ]
+          }
+        }
+      }
+    ])
+    auth = OmniAuth::AuthHash.new(
+      provider: @oidc_identity.provider,
+      uid: @oidc_identity.uid,
+      info: { email: @user.email },
+      extra: {
+        raw_info: {
+          name: "No Groups User"
+        }
+      }
+    )
+
+    @oidc_identity.sync_user_attributes!(auth)
+
+    assert_predicate @user.reload, :member?
+    assert_equal [], @oidc_identity.reload.info["groups"]
+  end
+
   test "creates from omniauth hash" do
     auth = OmniAuth::AuthHash.new({
       provider: "google_oauth2",


### PR DESCRIPTION
## Summary

- Move OIDC provider option construction into `Oidc::ProviderOptionsBuilder`
- Request the OIDC `groups` claim explicitly when the configured scopes include `groups` or role mapping is configured
- Include `guest` in group-to-role mapping precedence so the existing Guest Groups setting is applied

Fixes #2496

## Testing

- `bin/rails test test/models/oidc/provider_options_builder_test.rb test/models/oidc_identity_test.rb test/models/sso_provider_test.rb test/controllers/admin/sso_providers_controller_test.rb`
- `bin/rails test test/controllers/sessions_controller_test.rb test/controllers/oidc_accounts_controller_test.rb`
- `bin/rubocop app/models/oidc/provider_options_builder.rb app/models/oidc_identity.rb config/initializers/omniauth.rb test/models/oidc/provider_options_builder_test.rb test/models/oidc_identity_test.rb`
- `git diff --check`
- `bin/rails test`
- `bin/brakeman --no-pager`
- `ruby bin/preview_deploy_security_check.rb`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring OIDC sign-in with automatic provider setup from saved settings and environment values.
  * Expanded role assignment during SSO login to include the `guest` role when group mapping matches.

* **Bug Fixes**
  * Improved handling of missing or incomplete OIDC settings by skipping unavailable providers instead of failing.
  * Normalized scope parsing and preserved login behavior when group data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->