### PR TITLE
Fix custom DB OIDC provider names

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -209,7 +209,7 @@ module Api
         else
           user.family = Family.new
 
-          provider_config = Rails.configuration.x.auth.sso_providers&.find { |p| p[:name] == cached[:provider] }
+          provider_config = AuthConfig.sso_providers&.find { |p| p[:name] == cached[:provider] }
           provider_default_role = provider_config&.dig(:settings, :default_role)
           user.role = User.role_for_new_family_creator(fallback_role: provider_default_role || :admin)
         end

--- a/app/controllers/oidc_accounts_controller.rb
+++ b/app/controllers/oidc_accounts_controller.rb
@@ -131,7 +131,7 @@ class OidcAccountsController < ApplicationController
 
       # Use provider-configured default role, or fall back to admin for family creators
       # First user of an instance always becomes super_admin regardless of provider config
-      provider_config = Rails.configuration.x.auth.sso_providers&.find { |p| p[:name] == @pending_auth["provider"] }
+      provider_config = AuthConfig.sso_providers&.find { |p| p[:name] == @pending_auth["provider"] }
       provider_default_role = provider_config&.dig(:settings, :default_role)
       @user.role = User.role_for_new_family_creator(fallback_role: provider_default_role || :admin)
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -116,7 +116,7 @@ class SessionsController < ApplicationController
 
   def mobile_sso_start
     provider = params[:provider].to_s
-    configured_providers = Rails.configuration.x.auth.sso_providers.map { |p| p[:name].to_s }
+    configured_providers = AuthConfig.sso_providers.map { |p| p[:name].to_s }
 
     unless configured_providers.include?(provider)
       mobile_sso_redirect(error: "invalid_provider", message: "SSO provider not configured")

--- a/app/models/auth_config.rb
+++ b/app/models/auth_config.rb
@@ -75,13 +75,9 @@ class AuthConfig
 
     def sso_providers
       if FeatureFlags.db_sso_providers?
-        # After boot, OmniAuth registers successfully configured providers into
-        # Rails.configuration.x.auth.sso_providers. Prefer that filtered list
-        # so we never render login buttons for providers that couldn't be
-        # registered (e.g., missing required fields in YAML fallback).
-        # Fall back to ProviderLoader for pre-boot contexts.
-        registered = Rails.configuration.x.auth.sso_providers
-        registered&.any? ? registered : ProviderLoader.load_providers
+        # Load live DB-backed providers so login paths see provider changes
+        # without an app restart; avoid memoizing stale OmniAuth config here.
+        ProviderLoader.load_providers
       else
         Rails.configuration.x.auth.sso_providers || []
       end

--- a/app/models/omniauth_provider_registry.rb
+++ b/app/models/omniauth_provider_registry.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+class OmniauthProviderRegistry
+  Registration = Struct.new(:strategy, :args, :options, :config, keyword_init: true)
+
+  class << self
+    def register(builder, raw_cfg)
+      registration = registration_for(raw_cfg)
+      return unless registration
+
+      builder.provider registration.strategy, *registration.args, registration.options
+      registration.config
+    end
+
+    def registration_for(raw_cfg)
+      cfg = raw_cfg.deep_symbolize_keys
+      strategy = cfg[:strategy].to_s
+
+      case strategy
+      when "openid_connect"
+        openid_connect_registration(cfg)
+      when "google_oauth2"
+        google_oauth2_registration(cfg)
+      when "github"
+        github_registration(cfg)
+      when "saml"
+        saml_registration(cfg)
+      end
+    end
+
+    def register_dynamic_database_oidc_provider(builder)
+      builder.provider :openid_connect, dynamic_database_oidc_options
+    end
+
+    private
+      def openid_connect_registration(cfg)
+        name = provider_name(cfg)
+        issuer = cfg[:issuer].presence || ENV["OIDC_ISSUER"].presence
+        client_id = cfg[:client_id].presence || ENV["OIDC_CLIENT_ID"].presence
+        client_secret = cfg[:client_secret].presence || ENV["OIDC_CLIENT_SECRET"].presence
+        redirect_uri = cfg[:redirect_uri].presence || ENV["OIDC_REDIRECT_URI"].presence
+
+        if Rails.env.test?
+          issuer ||= "https://test.example.com"
+          client_id ||= "test_client_id"
+          client_secret ||= "test_client_secret"
+          redirect_uri ||= "http://test.example.com/callback"
+        end
+
+        unless issuer.present? && client_id.present? && client_secret.present? && redirect_uri.present?
+          Rails.logger.warn("[OmniAuth] Skipping OIDC provider '#{name}' - missing required configuration")
+          return
+        end
+
+        Registration.new(
+          strategy: :openid_connect,
+          args: [],
+          options: openid_connect_options(cfg, name, issuer, client_id, client_secret, redirect_uri),
+          config: cfg.merge(name: name, issuer: issuer)
+        )
+      end
+
+      def google_oauth2_registration(cfg)
+        name = provider_name(cfg)
+        client_id = cfg[:client_id].presence || ENV["GOOGLE_OAUTH_CLIENT_ID"].presence
+        client_secret = cfg[:client_secret].presence || ENV["GOOGLE_OAUTH_CLIENT_SECRET"].presence
+
+        if Rails.env.test?
+          client_id ||= "test_client_id"
+          client_secret ||= "test_client_secret"
+        end
+
+        return unless client_id.present? && client_secret.present?
+
+        Registration.new(
+          strategy: :google_oauth2,
+          args: [ client_id, client_secret ],
+          options: {
+            name: name.to_sym,
+            scope: "userinfo.email,userinfo.profile"
+          },
+          config: cfg.merge(name: name)
+        )
+      end
+
+      def github_registration(cfg)
+        name = provider_name(cfg)
+        client_id = cfg[:client_id].presence || ENV["GITHUB_CLIENT_ID"].presence
+        client_secret = cfg[:client_secret].presence || ENV["GITHUB_CLIENT_SECRET"].presence
+
+        if Rails.env.test?
+          client_id ||= "test_client_id"
+          client_secret ||= "test_client_secret"
+        end
+
+        return unless client_id.present? && client_secret.present?
+
+        Registration.new(
+          strategy: :github,
+          args: [ client_id, client_secret ],
+          options: {
+            name: name.to_sym,
+            scope: "user:email"
+          },
+          config: cfg.merge(name: name)
+        )
+      end
+
+      def saml_registration(cfg)
+        name = provider_name(cfg)
+        settings = cfg[:settings] || {}
+
+        idp_metadata_url = settings[:idp_metadata_url].presence || settings["idp_metadata_url"].presence
+        idp_sso_url = settings[:idp_sso_url].presence || settings["idp_sso_url"].presence
+
+        unless idp_metadata_url.present? || idp_sso_url.present?
+          Rails.logger.warn("[OmniAuth] Skipping SAML provider '#{name}' - missing IdP configuration")
+          return
+        end
+
+        options = {
+          name: name.to_sym,
+          assertion_consumer_service_url: cfg[:redirect_uri].presence || "#{ENV['APP_URL']}/auth/#{name}/callback",
+          issuer: cfg[:issuer].presence || ENV["APP_URL"],
+          name_identifier_format: settings[:name_id_format].presence || settings["name_id_format"].presence ||
+                                  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+          attribute_statements: {
+            email: [ "email", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" ],
+            first_name: [ "first_name", "givenName", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" ],
+            last_name: [ "last_name", "surname", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" ],
+            groups: [ "groups", "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups" ]
+          }
+        }
+
+        if idp_metadata_url.present?
+          options[:idp_metadata_url] = idp_metadata_url
+        else
+          options[:idp_sso_service_url] = idp_sso_url
+          options[:idp_cert] = settings[:idp_certificate].presence || settings["idp_certificate"].presence
+          options[:idp_cert_fingerprint] = settings[:idp_cert_fingerprint].presence || settings["idp_cert_fingerprint"].presence
+        end
+
+        idp_slo_url = settings[:idp_slo_url].presence || settings["idp_slo_url"].presence
+        options[:idp_slo_service_url] = idp_slo_url if idp_slo_url.present?
+
+        Registration.new(
+          strategy: :saml,
+          args: [],
+          options: options,
+          config: cfg.merge(name: name, strategy: "saml")
+        )
+      end
+
+      def dynamic_database_oidc_options
+        {
+          name: :db_openid_connect,
+          request_path: method(:database_oidc_request_path?),
+          callback_path: method(:database_oidc_callback_path?),
+          setup: method(:setup_database_oidc_provider)
+        }.merge(openid_connect_options({}, "db_openid_connect", nil, nil, nil, nil))
+      end
+
+      def database_oidc_request_path?(env)
+        database_oidc_config_for(env).present? && !callback_request?(env)
+      end
+
+      def database_oidc_callback_path?(env)
+        database_oidc_config_for(env).present? && callback_request?(env)
+      end
+
+      def setup_database_oidc_provider(env)
+        registration = database_oidc_registration_for(env)
+        return unless registration
+
+        strategy = env["omniauth.strategy"]
+        strategy.options.deep_merge!(registration.options)
+      end
+
+      def database_oidc_config_for(env)
+        database_oidc_registration_for(env)&.config
+      end
+
+      def database_oidc_registration_for(env)
+        return unless FeatureFlags.db_sso_providers?
+        return env["sure.omniauth.database_oidc_registration"] if env.key?("sure.omniauth.database_oidc_registration")
+
+        name = auth_path_provider_name(env)
+        return env["sure.omniauth.database_oidc_registration"] = nil if name.blank? || name == "failure" || name == "logout"
+
+        ProviderLoader.load_providers.each do |provider|
+          next unless provider[:strategy].to_s == "openid_connect" && provider[:name].to_s == name
+
+          return env["sure.omniauth.database_oidc_registration"] = openid_connect_registration(provider)
+        end
+
+        env["sure.omniauth.database_oidc_registration"] = nil
+      end
+
+      def auth_path_provider_name(env)
+        path = env["PATH_INFO"].to_s
+        match = path.match(%r{\A/auth/([^/]+)(?:/callback)?\z})
+        match&.[](1)
+      end
+
+      def callback_request?(env)
+        env["PATH_INFO"].to_s.end_with?("/callback")
+      end
+
+      def openid_connect_options(cfg, name, issuer, client_id, client_secret, redirect_uri)
+        options = {
+          name: name.to_sym,
+          scope: openid_connect_scopes(cfg),
+          response_type: :code,
+          issuer: issuer.to_s.strip,
+          discovery: true,
+          pkce: true,
+          client_options: {
+            identifier: client_id,
+            secret: client_secret,
+            redirect_uri: redirect_uri,
+            ssl: ssl_options
+          }
+        }
+
+        prompt = cfg.dig(:settings, :prompt).presence || cfg.dig(:settings, "prompt").presence
+        options[:prompt] = prompt if prompt.present?
+        options
+      end
+
+      def openid_connect_scopes(cfg)
+        custom_scopes = cfg.dig(:settings, :scopes).presence || cfg.dig(:settings, "scopes").presence
+        return %i[openid email profile] if custom_scopes.blank?
+
+        custom_scopes.to_s.split(/\s+/).map(&:to_sym)
+      end
+
+      def ssl_options
+        ssl_config = Rails.configuration.x.ssl
+        options = {}
+        options[:ca_file] = ssl_config.ca_file if ssl_config&.ca_file.present?
+        options[:verify] = false if ssl_config&.verify == false
+        options
+      end
+
+      def provider_name(cfg)
+        (cfg[:name] || cfg[:id]).to_s
+      end
+  end
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -28,163 +28,17 @@ OmniAuth.config.on_failure = proc do |env|
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
+  OmniauthProviderRegistry.register_dynamic_database_oidc_provider(self)
+
   # Load providers from either YAML or DB via ProviderLoader
   providers = ProviderLoader.load_providers
 
   providers.each do |raw_cfg|
-    cfg = raw_cfg.deep_symbolize_keys
-    strategy = cfg[:strategy].to_s
-    name = (cfg[:name] || cfg[:id]).to_s
+    config = OmniauthProviderRegistry.register(self, raw_cfg)
+    next unless config
 
-    case strategy
-    when "openid_connect"
-      # Support per-provider credentials from config or fall back to global ENV vars
-      issuer = cfg[:issuer].presence || ENV["OIDC_ISSUER"].presence
-      client_id = cfg[:client_id].presence || ENV["OIDC_CLIENT_ID"].presence
-      client_secret = cfg[:client_secret].presence || ENV["OIDC_CLIENT_SECRET"].presence
-      redirect_uri = cfg[:redirect_uri].presence || ENV["OIDC_REDIRECT_URI"].presence
-
-      # In test environment, use test values if nothing is configured
-      if Rails.env.test?
-        issuer ||= "https://test.example.com"
-        client_id ||= "test_client_id"
-        client_secret ||= "test_client_secret"
-        redirect_uri ||= "http://test.example.com/callback"
-      end
-
-      # Skip if required fields are missing (except in test)
-      unless issuer.present? && client_id.present? && client_secret.present? && redirect_uri.present?
-        Rails.logger.warn("[OmniAuth] Skipping OIDC provider '#{name}' - missing required configuration")
-        next
-      end
-
-      # Custom scopes: parse from settings if provided, otherwise use defaults
-      custom_scopes = cfg.dig(:settings, :scopes).presence
-      scopes = if custom_scopes.present?
-        custom_scopes.to_s.split(/\s+/).map(&:to_sym)
-      else
-        %i[openid email profile]
-      end
-
-      # Build provider options
-      oidc_options = {
-        name: name.to_sym,
-        scope: scopes,
-        response_type: :code,
-        issuer: issuer.to_s.strip,
-        discovery: true,
-        pkce: true,
-        client_options: {
-          identifier: client_id,
-          secret: client_secret,
-          redirect_uri: redirect_uri,
-          ssl: begin
-                 ssl_config = Rails.configuration.x.ssl
-                 ssl_opts = {}
-                 ssl_opts[:ca_file] = ssl_config.ca_file if ssl_config&.ca_file.present?
-                 ssl_opts[:verify] = false if ssl_config&.verify == false
-                 ssl_opts
-               end
-        }
-      }
-
-      # Add prompt parameter if configured
-      prompt = cfg.dig(:settings, :prompt).presence
-      oidc_options[:prompt] = prompt if prompt.present?
-
-      provider :openid_connect, oidc_options
-
-      Rails.configuration.x.auth.oidc_enabled = true
-      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name, issuer: issuer)
-
-    when "google_oauth2"
-      client_id = cfg[:client_id].presence || ENV["GOOGLE_OAUTH_CLIENT_ID"].presence
-      client_secret = cfg[:client_secret].presence || ENV["GOOGLE_OAUTH_CLIENT_SECRET"].presence
-
-      # Test environment fallback
-      if Rails.env.test?
-        client_id ||= "test_client_id"
-        client_secret ||= "test_client_secret"
-      end
-
-      next unless client_id.present? && client_secret.present?
-
-      provider :google_oauth2,
-               client_id,
-               client_secret,
-               {
-                 name: name.to_sym,
-                 scope: "userinfo.email,userinfo.profile"
-               }
-
-      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name)
-
-    when "github"
-      client_id = cfg[:client_id].presence || ENV["GITHUB_CLIENT_ID"].presence
-      client_secret = cfg[:client_secret].presence || ENV["GITHUB_CLIENT_SECRET"].presence
-
-      # Test environment fallback
-      if Rails.env.test?
-        client_id ||= "test_client_id"
-        client_secret ||= "test_client_secret"
-      end
-
-      next unless client_id.present? && client_secret.present?
-
-      provider :github,
-               client_id,
-               client_secret,
-               {
-                 name: name.to_sym,
-                 scope: "user:email"
-               }
-
-      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name)
-
-    when "saml"
-      settings = cfg[:settings] || {}
-
-      # Require either metadata URL or manual SSO URL
-      idp_metadata_url = settings[:idp_metadata_url].presence || settings["idp_metadata_url"].presence
-      idp_sso_url = settings[:idp_sso_url].presence || settings["idp_sso_url"].presence
-
-      unless idp_metadata_url.present? || idp_sso_url.present?
-        Rails.logger.warn("[OmniAuth] Skipping SAML provider '#{name}' - missing IdP configuration")
-        next
-      end
-
-      # Build SAML options
-      saml_options = {
-        name: name.to_sym,
-        assertion_consumer_service_url: cfg[:redirect_uri].presence || "#{ENV['APP_URL']}/auth/#{name}/callback",
-        issuer: cfg[:issuer].presence || ENV["APP_URL"],
-        name_identifier_format: settings[:name_id_format].presence || settings["name_id_format"].presence ||
-                               "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-        attribute_statements: {
-          email: [ "email", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" ],
-          first_name: [ "first_name", "givenName", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" ],
-          last_name: [ "last_name", "surname", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" ],
-          groups: [ "groups", "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups" ]
-        }
-      }
-
-      # Use metadata URL or manual configuration
-      if idp_metadata_url.present?
-        saml_options[:idp_metadata_url] = idp_metadata_url
-      else
-        saml_options[:idp_sso_service_url] = idp_sso_url
-        saml_options[:idp_cert] = settings[:idp_certificate].presence || settings["idp_certificate"].presence
-        saml_options[:idp_cert_fingerprint] = settings[:idp_cert_fingerprint].presence || settings["idp_cert_fingerprint"].presence
-      end
-
-      # Optional: IdP SLO (Single Logout) URL
-      idp_slo_url = settings[:idp_slo_url].presence || settings["idp_slo_url"].presence
-      saml_options[:idp_slo_service_url] = idp_slo_url if idp_slo_url.present?
-
-      provider :saml, saml_options
-
-      Rails.configuration.x.auth.sso_providers << cfg.merge(name: name, strategy: "saml")
-    end
+    Rails.configuration.x.auth.oidc_enabled = true if config[:strategy].to_s == "openid_connect"
+    Rails.configuration.x.auth.sso_providers << config
   end
 
   if Rails.configuration.x.auth.sso_providers.empty?

--- a/test/models/omniauth_provider_registry_test.rb
+++ b/test/models/omniauth_provider_registry_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class OmniauthProviderRegistryTest < ActiveSupport::TestCase
+  setup do
+    @previous_test_mode = OmniAuth.config.test_mode
+    @previous_mock_auth = OmniAuth.config.mock_auth.dup
+    @previous_sso_providers = Rails.configuration.x.auth.sso_providers
+    OmniAuth.config.test_mode = true
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = @previous_test_mode
+    OmniAuth.config.mock_auth = @previous_mock_auth
+    Rails.configuration.x.auth.sso_providers = @previous_sso_providers
+  end
+
+  test "registers custom database OIDC provider callbacks dynamically" do
+    FeatureFlags.stubs(:db_sso_providers?).returns(true)
+    ProviderLoader.stubs(:load_providers).returns([ custom_oidc_provider ])
+
+    OmniAuth.config.mock_auth[:authentik] = OmniAuth::AuthHash.new(
+      provider: "authentik",
+      uid: "uid-123",
+      info: { email: "person@example.com" }
+    )
+
+    response = Rack::MockRequest.new(dynamic_omniauth_app).get("/auth/authentik/callback")
+
+    assert_equal 200, response.status
+    assert_equal "authentik", response.body
+  end
+
+  test "dynamic OIDC setup uses the custom provider name and redirect URI" do
+    registration = OmniauthProviderRegistry.registration_for(custom_oidc_provider)
+
+    assert_equal :openid_connect, registration.strategy
+    assert_equal :authentik, registration.options[:name]
+    assert_equal "https://app.example.com/auth/authentik/callback", registration.options.dig(:client_options, :redirect_uri)
+    assert_equal "login", registration.options[:prompt]
+    assert_equal "authentik", registration.config[:name]
+  end
+
+  test "does not intercept incomplete database OIDC providers" do
+    Rails.env.stubs(:test?).returns(false)
+    FeatureFlags.stubs(:db_sso_providers?).returns(true)
+    ProviderLoader.stubs(:load_providers).returns([
+      custom_oidc_provider.except(:client_secret)
+    ])
+
+    response = Rack::MockRequest.new(dynamic_omniauth_app).get("/auth/authentik/callback")
+
+    assert_equal 200, response.status
+    assert_equal "no auth", response.body
+  end
+
+  test "auth config returns current database providers instead of stale boot providers" do
+    FeatureFlags.stubs(:db_sso_providers?).returns(true)
+    Rails.configuration.x.auth.sso_providers = [
+      { id: "oidc", strategy: "openid_connect", name: "openid_connect" }
+    ]
+    ProviderLoader.stubs(:load_providers).returns([ custom_oidc_provider ])
+
+    providers = AuthConfig.sso_providers
+
+    assert_equal [ "authentik" ], providers.map { |provider| provider[:name] }
+  end
+
+  private
+    def dynamic_omniauth_app
+      Rack::Builder.new do
+        use Rack::Session::Cookie, secret: "a" * 64
+
+        use OmniAuth::Builder do
+          OmniauthProviderRegistry.register_dynamic_database_oidc_provider(self)
+        end
+
+        run lambda { |env|
+          auth = env["omniauth.auth"]
+          [ 200, { "content-type" => "text/plain" }, [ auth&.provider || "no auth" ] ]
+        }
+      end.to_app
+    end
+
+    def custom_oidc_provider
+      {
+        id: "authentik",
+        strategy: "openid_connect",
+        name: "authentik",
+        label: "Sign in with Authentik",
+        issuer: "https://idp.example.com",
+        client_id: "client-id",
+        client_secret: "client-secret",
+        redirect_uri: "https://app.example.com/auth/authentik/callback",
+        settings: {
+          scopes: "openid email profile groups",
+          prompt: "login"
+        }
+      }
+    end
+end


### PR DESCRIPTION
## Summary
- add a shared OmniAuth provider registry for static and database-backed providers
- dynamically register database-backed OIDC providers by their configured custom name
- read current database SSO provider config for login, mobile SSO, and JIT role defaults

Fixes #2495

## Verification
- bin/rubocop app/services/omniauth_provider_registry.rb config/initializers/omniauth.rb app/models/auth_config.rb app/controllers/sessions_controller.rb app/controllers/oidc_accounts_controller.rb app/controllers/api/v1/auth_controller.rb test/services/omniauth_provider_registry_test.rb
- DISABLE_PARALLELIZATION=true bin/rails test test/services/omniauth_provider_registry_test.rb test/controllers/sessions_controller_test.rb test/controllers/admin/sso_providers_controller_test.rb test/models/sso_provider_test.rb test/models/oidc_identity_test.rb
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSO provider handling now uses the latest configured provider list throughout login and account creation flows.
  * Support was added for dynamic database-backed OpenID Connect providers during sign-in.
  * OmniAuth provider setup is now handled in a more centralized and consistent way.

* **Bug Fixes**
  * New SSO users now receive the correct default role from the active provider configuration.
  * Mobile SSO provider validation now reflects current available providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->