### PR TITLE
fix(enable-banking): retry booked transaction fetches on ASPSP_ERROR

### DIFF
--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -2,6 +2,7 @@ class EnableBankingItem::Importer
   # Maximum number of pagination requests to prevent infinite loops
   # Enable Banking typically returns ~100 transactions per page, so 100 pages = ~10,000 transactions
   MAX_PAGINATION_PAGES = 100
+  ASPSP_TRANSACTION_RETRY_DELAYS = [ 1, 5 ].freeze
 
   NETWORK_ERRORS = [
     ::SocketError,
@@ -446,6 +447,7 @@ class EnableBankingItem::Importer
       continuation_key = nil
       previous_continuation_key = nil
       page_count = 0
+      aspsp_retry_attempt = 0
 
       loop do
         page_count += 1
@@ -478,6 +480,19 @@ class EnableBankingItem::Importer
       end
 
       all_transactions
+    rescue Provider::EnableBanking::EnableBankingError => e
+      if e.aspsp_error? && transaction_status == "BOOK" && aspsp_retry_attempt < ASPSP_TRANSACTION_RETRY_DELAYS.length
+        delay = ASPSP_TRANSACTION_RETRY_DELAYS[aspsp_retry_attempt]
+        aspsp_retry_attempt += 1
+        Rails.logger.warn(
+          "EnableBankingItem::Importer - Retrying BOOK transaction fetch for account #{enable_banking_account.uid} " \
+          "after ASPSP_ERROR (attempt #{aspsp_retry_attempt + 1}/#{ASPSP_TRANSACTION_RETRY_DELAYS.length + 1}, sleep=#{delay}s)"
+        )
+        sleep(delay)
+        retry
+      end
+
+      raise
     rescue PaginationTruncatedError => e
       # Log as warning and return collected partial data instead of failing entirely.
       # This ensures accounts with huge history don't lose all synced data.

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -241,28 +241,29 @@ class Provider::EnableBanking
     end
 
     def handle_response(response)
+      response_data = parse_error_response_body(response.body)
+
       case response.code
       when 200, 201
         parse_response_body(response)
       when 204
         {}
       when 400
-        raise EnableBankingError.new("Bad request to Enable Banking API: #{response.body}", :bad_request)
+        raise mapped_error(response, response_data, default_type: :bad_request, default_message: "Bad request to Enable Banking API")
       when 401
-        raise EnableBankingError.new("Invalid credentials or expired JWT", :unauthorized)
+        raise mapped_error(response, response_data, default_type: :unauthorized, default_message: "Invalid credentials or expired JWT")
       when 403
-        raise EnableBankingError.new("Access forbidden - check your application permissions", :access_forbidden)
+        raise mapped_error(response, response_data, default_type: :access_forbidden, default_message: "Access forbidden - check your application permissions")
       when 404
-        raise EnableBankingError.new("Resource not found", :not_found)
+        raise mapped_error(response, response_data, default_type: :not_found, default_message: "Resource not found")
       when 408
-        raise EnableBankingError.new("Request timeout from Enable Banking API", :timeout)
+        raise mapped_error(response, response_data, default_type: :timeout, default_message: "Request timeout from Enable Banking API")
       when 422
-        response_data = parse_response_body(response)
-        raise EnableBankingError.new("Validation error from Enable Banking API: #{response.body}", :validation_error, response_data: response_data)
+        raise mapped_error(response, response_data, default_type: :validation_error, default_message: "Validation error from Enable Banking API")
       when 429
-        raise EnableBankingError.new("Rate limit exceeded. Please try again later.", :rate_limited)
+        raise mapped_error(response, response_data, default_type: :rate_limited, default_message: "Rate limit exceeded. Please try again later.")
       else
-        raise EnableBankingError.new("Failed to fetch data: #{response.code} #{response.message} - #{response.body}", :fetch_failed)
+        raise mapped_error(response, response_data, default_type: :fetch_failed, default_message: "Failed to fetch data")
       end
     end
 
@@ -273,6 +274,30 @@ class Provider::EnableBanking
     rescue JSON::ParserError => e
       Rails.logger.error "Enable Banking API: Failed to parse response: #{e.message}"
       raise EnableBankingError.new("Failed to parse API response", :parse_error)
+    end
+
+    def parse_error_response_body(body)
+      return nil if body.blank?
+
+      JSON.parse(body, symbolize_names: true)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def mapped_error(response, response_data, default_type:, default_message:)
+      error_code = response_data.is_a?(Hash) ? response_data[:error].presence : nil
+
+      error_type = case error_code
+      when "ASPSP_ERROR" then :aspsp_error
+      when "ASPSP_TIMEOUT" then :timeout
+      when "ASPSP_RATE_LIMIT_EXCEEDED" then :rate_limited
+      when "WRONG_TRANSACTIONS_PERIOD" then :validation_error
+      when "EXPIRED_SESSION" then :unauthorized
+      else default_type
+      end
+
+      suffix = response.body.present? ? ": #{response.body}" : nil
+      EnableBankingError.new("#{default_message}#{suffix}", error_type, response_data: response_data)
     end
 
     class EnableBankingError < StandardError
@@ -286,6 +311,10 @@ class Provider::EnableBanking
 
       def wrong_transactions_period?
         error_type == :validation_error && response_data.is_a?(Hash) && response_data[:error] == "WRONG_TRANSACTIONS_PERIOD"
+      end
+
+      def aspsp_error?
+        error_type == :aspsp_error
       end
 
       def corrected_date_from

--- a/test/models/enable_banking_item/importer_error_handling_test.rb
+++ b/test/models/enable_banking_item/importer_error_handling_test.rb
@@ -152,6 +152,28 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
     assert_not result[:success]
   end
 
+  test "fetch_paginated_transactions retries BOOK fetch on ASPSP_ERROR and returns later success" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid", account_id: SecureRandom.uuid)
+    @importer.stubs(:sleep)
+
+    error = Provider::EnableBanking::EnableBankingError.new(
+      "Failed to fetch data: 500 - {\"error\":\"ASPSP_ERROR\"}",
+      :aspsp_error,
+      response_data: { error: "ASPSP_ERROR" }
+    )
+
+    @mock_provider.expects(:get_account_transactions).twice.raises(error).then.returns({ transactions: [], continuation_key: nil })
+
+    result = @importer.send(
+      :fetch_paginated_transactions,
+      enable_banking_account,
+      start_date: Date.today,
+      transaction_status: "BOOK"
+    )
+
+    assert_equal [], result
+  end
+
   test "fetch_and_update_balance does not flip whole connection on per-account unauthorized error" do
     enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
     def @mock_provider.get_account_balances(**args)

--- a/test/models/provider/enable_banking_test.rb
+++ b/test/models/provider/enable_banking_test.rb
@@ -62,6 +62,25 @@ class Provider::EnableBankingTest < ActiveSupport::TestCase
     assert error.wrong_transactions_period?
   end
 
+  test "maps ASPSP_ERROR response bodies to aspsp_error regardless of http status" do
+    response = OpenStruct.new(
+      code: 500,
+      body: {
+        error: "ASPSP_ERROR",
+        detail: { message: "Bank backend unavailable" }
+      }.to_json,
+      message: "Internal Server Error"
+    )
+
+    error = assert_raises Provider::EnableBanking::EnableBankingError do
+      @provider.send(:handle_response, response)
+    end
+
+    assert_equal :aspsp_error, error.error_type
+    assert error.aspsp_error?
+    assert_equal "ASPSP_ERROR", error.response_data[:error]
+  end
+
   test "start_authorization includes auth_method in the request body when provided" do
     captured_body = nil
     response = OpenStruct.new(


### PR DESCRIPTION
## Summary
- map Enable Banking API error codes from response bodies instead of relying only on HTTP status
- classify `ASPSP_ERROR` as a transient bank-side failure and retry booked transaction fetches with short backoff
- add regression coverage for the new error mapping and retry path

## Testing
- `bin/rails test test/models/provider/enable_banking_test.rb`
- `bin/rails test test/models/enable_banking_item/importer_error_handling_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved transaction fetching with limited automatic retries when a provider-specific error occurs.
  * Added better error mapping so provider error details are surfaced more consistently.

* **Bug Fixes**
  * Transaction requests can now recover from certain temporary provider errors instead of failing immediately.
  * Error responses now preserve more useful details for downstream handling.

* **Tests**
  * Added regression coverage for retry behavior and provider error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->