### PR TITLE
Fix SimpleFIN partial auth reconnect status

### DIFF
--- a/app/models/provider_connection_status.rb
+++ b/app/models/provider_connection_status.rb
@@ -85,8 +85,8 @@ class ProviderConnectionStatus
       provider: provider[:key],
       provider_type: provider[:type],
       name: item_value(:name, provider[:key].humanize),
-      status: item_value(:status),
-      requires_update: item_boolean(:requires_update?),
+      status: item_status,
+      requires_update: item_requires_update?,
       credentials_configured: credentials_configured?,
       scheduled_for_deletion: item_boolean(:scheduled_for_deletion?),
       pending_account_setup: pending_account_setup?,
@@ -104,6 +104,18 @@ class ProviderConnectionStatus
 
     def credentials_configured?
       item_boolean(:credentials_configured?)
+    end
+
+    def item_status
+      return item.effective_status(latest_sync: latest_sync) if item.respond_to?(:setup_token_update_required?)
+
+      item_value(:status)
+    end
+
+    def item_requires_update?
+      return item.setup_token_update_required?(latest_sync: latest_sync) if item.respond_to?(:setup_token_update_required?)
+
+      item_boolean(:requires_update?)
     end
 
     def pending_account_setup?

--- a/app/models/simplefin_item.rb
+++ b/app/models/simplefin_item.rb
@@ -401,16 +401,34 @@ class SimplefinItem < ApplicationRecord
 
   # Check if the SimpleFin connection needs user attention
   def needs_attention?
-    requires_update? || stale_sync_status[:stale] || pending_account_setup?
+    setup_token_update_required? || stale_sync_status[:stale] || pending_account_setup?
   end
 
   # Get a summary of issues requiring attention
   def attention_summary
     issues = []
-    issues << "Connection needs update" if requires_update?
+    issues << "Connection needs update" if setup_token_update_required?
     issues << stale_sync_status[:message] if stale_sync_status[:stale]
     issues << "Accounts need setup" if pending_account_setup?
     issues
+  end
+
+  # A SimpleFIN setup token is only needed when the bridge access URL appears
+  # unusable. If the latest sync returned accounts, the access URL still works;
+  # any auth warning in that response belongs to an individual institution.
+  def setup_token_update_required?(latest_sync: nil)
+    return false unless requires_update?
+
+    latest = latest_sync || syncs.ordered.first
+    return true unless latest
+    return false if latest.in_progress? || latest.stale?
+
+    stats = parse_sync_stats(latest.sync_stats)
+    stats.to_h["total_accounts"].to_i.zero?
+  end
+
+  def effective_status(latest_sync: nil)
+    setup_token_update_required?(latest_sync: latest_sync) ? status : "good"
   end
 
   # Get reconciled duplicates count from the last sync

--- a/app/models/simplefin_item.rb
+++ b/app/models/simplefin_item.rb
@@ -421,10 +421,10 @@ class SimplefinItem < ApplicationRecord
 
     latest = latest_sync || syncs.ordered.first
     return true unless latest
-    return false if latest.in_progress? || latest.stale?
+    return false if latest.in_progress?
 
-    stats = parse_sync_stats(latest.sync_stats)
-    stats.to_h["total_accounts"].to_i.zero?
+    stats = parse_sync_stats(latest.sync_stats).to_h.stringify_keys
+    stats["total_accounts"].to_i.zero?
   end
 
   def effective_status(latest_sync: nil)

--- a/app/models/simplefin_item/importer.rb
+++ b/app/models/simplefin_item/importer.rb
@@ -46,9 +46,10 @@ class SimplefinItem::Importer
         import_regular_sync
       end
 
-      # Reset status to good if no auth errors occurred in this sync.
-      # This allows the item to recover automatically when a bank's auth issue is resolved
-      # in SimpleFIN Bridge, without requiring the user to manually reconnect.
+      # A successful import proves the SimpleFIN access URL still works, so clear
+      # any lingering item-level requires_update. Per-institution auth errors are
+      # recorded in sync stats but do not mean the access URL itself is dead; a
+      # dead access URL fails the fetch earlier and never reaches this line.
       maybe_clear_requires_update_status
 
       # Detect likely card-replacement scenarios (e.g., fraud replacement).
@@ -353,19 +354,17 @@ class SimplefinItem::Importer
       )
     end
 
-    # Reset status to good if no auth errors occurred in this sync.
-    # This allows automatic recovery when a bank's auth issue is resolved in SimpleFIN Bridge.
+    # Reset status to good after a successful import. Per-institution auth
+    # errors are recorded in sync stats, but they do not mean the SimpleFIN
+    # access URL itself is dead.
     def maybe_clear_requires_update_status
       return unless simplefin_item.requires_update?
 
-      auth_errors = stats.dig("error_buckets", "auth").to_i
-      if auth_errors.zero?
-        simplefin_item.update!(status: :good)
-        Rails.logger.info(
-          "SimpleFIN: cleared requires_update status for item ##{simplefin_item.id} " \
-          "(no auth errors in this sync)"
-        )
-      end
+      simplefin_item.update!(status: :good)
+      Rails.logger.info(
+        "SimpleFIN: cleared requires_update status for item ##{simplefin_item.id} " \
+        "after successful import"
+      )
     end
 
     def import_with_chunked_history

--- a/app/views/simplefin_items/_simplefin_item.html.erb
+++ b/app/views/simplefin_items/_simplefin_item.html.erb
@@ -15,6 +15,7 @@
          0
        end
      end %>
+  <% setup_token_update_required = simplefin_item.setup_token_update_required? %>
 
   <%= render DS::Disclosure.new(variant: :card, open: true) do |disclosure| %>
     <% disclosure.with_summary_content do %>
@@ -85,7 +86,7 @@
                 <%= icon "loader", size: "sm", class: "animate-spin" %>
                 <%= tag.span t(".syncing") %>
               </div>
-            <% elsif simplefin_item.setup_token_update_required? %>
+            <% elsif setup_token_update_required %>
               <div class="text-warning flex items-center gap-1">
                 <%= icon "alert-triangle", size: "sm", color: "warning" %>
                 <%= tag.span t(".requires_update") %>
@@ -147,7 +148,7 @@
 
         <% if Current.user&.admin? %>
           <div class="flex items-center gap-2">
-            <% if simplefin_item.setup_token_update_required? %>
+            <% if setup_token_update_required %>
               <%= render DS::Link.new(
                 text: t(".update"),
                 icon: "refresh-cw",

--- a/app/views/simplefin_items/_simplefin_item.html.erb
+++ b/app/views/simplefin_items/_simplefin_item.html.erb
@@ -85,7 +85,7 @@
                 <%= icon "loader", size: "sm", class: "animate-spin" %>
                 <%= tag.span t(".syncing") %>
               </div>
-            <% elsif simplefin_item.requires_update? %>
+            <% elsif simplefin_item.setup_token_update_required? %>
               <div class="text-warning flex items-center gap-1">
                 <%= icon "alert-triangle", size: "sm", color: "warning" %>
                 <%= tag.span t(".requires_update") %>
@@ -147,7 +147,7 @@
 
         <% if Current.user&.admin? %>
           <div class="flex items-center gap-2">
-            <% if simplefin_item.requires_update? %>
+            <% if simplefin_item.setup_token_update_required? %>
               <%= render DS::Link.new(
                 text: t(".update"),
                 icon: "refresh-cw",

--- a/test/controllers/onboardings_controller_test.rb
+++ b/test/controllers/onboardings_controller_test.rb
@@ -24,7 +24,7 @@ class OnboardingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "input[name='user[family_attributes][moniker]'][value='Family'][required]"
     assert_select "input[name='user[family_attributes][moniker]'][value='Group'][required]"
-    assert_select "p", text: /Will be using Sure with/i
+    assert_select "p.text-sm.font-medium.text-primary", text: /Will be using.*with/i
   end
 
   test "should get preferences" do

--- a/test/models/exchange_rate_pair_test.rb
+++ b/test/models/exchange_rate_pair_test.rb
@@ -31,8 +31,7 @@ class ExchangeRatePairTest < ActiveSupport::TestCase
         provider_name: "twelve_data"
       )
 
-      Setting.exchange_rate_provider = "yahoo_finance"
-      refreshed = ExchangeRatePair.for_pair(from: "USD", to: "EUR")
+      refreshed = ExchangeRatePair.for_pair(from: "USD", to: "EUR", provider_name: "yahoo_finance")
 
       assert_nil refreshed.first_provider_rate_on
       assert_equal "yahoo_finance", refreshed.provider_name

--- a/test/models/provider_connection_status_test.rb
+++ b/test/models/provider_connection_status_test.rb
@@ -89,4 +89,42 @@ class ProviderConnectionStatusTest < ActiveSupport::TestCase
     refute_includes kraken_status.keys, :api_secret
     assert_equal true, kraken_status[:credentials_configured]
   end
+
+  test "simplefin provider status does not require setup token after partial account sync" do
+    family = families(:dylan_family)
+    item = SimplefinItem.create!(
+      family: family,
+      name: "SimpleFIN",
+      access_url: "https://example.com/access",
+      status: :requires_update,
+      pending_account_setup: true
+    )
+    completed_sync = item.syncs.create!(
+      status: "completed",
+      created_at: Time.current,
+      completed_at: Time.current,
+      sync_stats: {
+        total_accounts: 18,
+        linked_accounts: 17,
+        unlinked_accounts: 1,
+        error_buckets: { auth: 1 }
+      }
+    )
+    provider = ProviderConnectionStatus::PROVIDERS.find { |entry| entry[:association] == :simplefin_items }
+
+    item.expects(:syncs).never
+
+    status = ProviderConnectionStatus.new(
+      provider,
+      item,
+      latest_sync: completed_sync,
+      latest_completed_sync: completed_sync,
+      syncing: false
+    ).to_h
+
+    assert_equal "good", status[:status]
+    assert_equal false, status[:requires_update]
+    assert_equal true, status[:pending_account_setup]
+    assert_equal "17 synced, 1 need setup", status.dig(:sync, :status_summary)
+  end
 end

--- a/test/models/simplefin_item/importer_partial_errors_test.rb
+++ b/test/models/simplefin_item/importer_partial_errors_test.rb
@@ -88,6 +88,18 @@ class SimplefinItem::ImporterPartialErrorsTest < ActiveSupport::TestCase
     assert_equal "requires_update", @item.status
   end
 
+  test "previously requires_update item is cleared after successful partial import with institution auth error" do
+    @item.update!(status: :requires_update)
+
+    @importer.send(:record_errors, [
+      "Connection to Cash App may need attention. Auth required"
+    ])
+    @importer.send(:maybe_clear_requires_update_status)
+
+    assert_equal "good", @item.reload.status,
+      "expected successful SimpleFIN import to clear item-level reconnect even when one institution needs auth"
+  end
+
   test "non-auth partial errors don't flip status" do
     @importer.send(:record_errors, [
       "Timed out fetching transactions from Chase",

--- a/test/models/simplefin_item_test.rb
+++ b/test/models/simplefin_item_test.rb
@@ -66,6 +66,22 @@ class SimplefinItemTest < ActiveSupport::TestCase
     assert_includes @simplefin_item.attention_summary, "Accounts need setup"
   end
 
+  test "setup token update is not required when latest sync stats use symbol keys" do
+    @simplefin_item.update!(status: :requires_update)
+    latest_sync = Sync.new(
+      syncable: @simplefin_item,
+      status: "completed",
+      completed_at: Time.current,
+      sync_stats: {
+        total_accounts: 18,
+        error_buckets: { auth: 1 }
+      }
+    )
+
+    refute @simplefin_item.setup_token_update_required?(latest_sync:)
+    assert_equal "good", @simplefin_item.effective_status(latest_sync:)
+  end
+
   test "setup token update is not required while latest sync is unresolved" do
     @simplefin_item.update!(status: :requires_update)
     Sync.create!(
@@ -78,6 +94,20 @@ class SimplefinItemTest < ActiveSupport::TestCase
 
     refute @simplefin_item.setup_token_update_required?
     assert_equal "good", @simplefin_item.effective_status
+  end
+
+  test "setup token update is required when latest sync is stale without accounts" do
+    @simplefin_item.update!(status: :requires_update)
+    Sync.create!(
+      syncable: @simplefin_item,
+      status: "stale",
+      sync_stats: {
+        "import_started" => true
+      }
+    )
+
+    assert @simplefin_item.setup_token_update_required?
+    assert_equal "requires_update", @simplefin_item.effective_status
   end
 
   test "can be marked for deletion" do

--- a/test/models/simplefin_item_test.rb
+++ b/test/models/simplefin_item_test.rb
@@ -30,6 +30,56 @@ class SimplefinItemTest < ActiveSupport::TestCase
     assert_equal "good", @simplefin_item.status
   end
 
+  test "setup token update is required when requires_update has no successful account sync" do
+    @simplefin_item.update!(status: :requires_update)
+    Sync.create!(
+      syncable: @simplefin_item,
+      status: "failed",
+      failed_at: Time.current,
+      error: "SimpleFIN access forbidden",
+      sync_stats: { "total_accounts" => 0 }
+    )
+
+    assert @simplefin_item.setup_token_update_required?
+    assert_equal "requires_update", @simplefin_item.effective_status
+    assert_includes @simplefin_item.attention_summary, "Connection needs update"
+  end
+
+  test "setup token update is not required when latest sync returned accounts" do
+    @simplefin_item.update!(status: :requires_update, pending_account_setup: true)
+    # Must be a terminal sync: a pending/in-progress sync short-circuits before
+    # the account-count check, so this would pass without exercising the branch.
+    Sync.create!(
+      syncable: @simplefin_item,
+      status: "completed",
+      completed_at: Time.current,
+      sync_stats: {
+        "total_accounts" => 18,
+        "error_buckets" => { "auth" => 1 },
+        "errors" => [ "Connection to Cash App may need attention. Auth required" ]
+      }
+    )
+
+    refute @simplefin_item.setup_token_update_required?
+    assert_equal "good", @simplefin_item.effective_status
+    refute_includes @simplefin_item.attention_summary, "Connection needs update"
+    assert_includes @simplefin_item.attention_summary, "Accounts need setup"
+  end
+
+  test "setup token update is not required while latest sync is unresolved" do
+    @simplefin_item.update!(status: :requires_update)
+    Sync.create!(
+      syncable: @simplefin_item,
+      status: "pending",
+      sync_stats: {
+        "import_started" => true
+      }
+    )
+
+    refute @simplefin_item.setup_token_update_required?
+    assert_equal "good", @simplefin_item.effective_status
+  end
+
   test "can be marked for deletion" do
     refute @simplefin_item.scheduled_for_deletion?
 


### PR DESCRIPTION
## Summary

This fixes SimpleFIN connections that still return account data but have one or more institution-level auth errors. In that partial-success state, the app should surface account setup/reconnect work for the affected institution, not ask for a new SimpleFIN setup token for the whole connection.

The change separates raw provider status from the user-facing setup-token requirement, clears stale item-level `requires_update` status after a successful import, and threads the preloaded latest sync into provider health serialization.

It also tightens two brittle tests that were failing under local development settings: one onboarding selector assertion and one exchange-rate provider-change test that should not depend on the ambient provider env.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection status and health indicators by deriving “update required” and effective status from the latest sync’s token/update conditions and sync statistics.
  * Updated attention messaging to more accurately separate “account setup” needs from “connection update” needs.
  * Fixed UI behavior so non-sync status indicators and admin controls show the correct “update” vs “sync” actions when a token update is required.
  * Successful imports now reliably clear stale item-level “needs update” state after partial imports.
* **Tests**
  * Expanded coverage for token-update-required logic, effective status outcomes, and provider connection status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->