### PR TITLE
Add SnapTrade OAuth device-flow support (device code grant) with UI and tests

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,6 +12,9 @@ SIMPLEFIN_DEBUG_RAW=false
 # SIMPLEFIN_INCLUDE_PENDING: when truthy, forces `pending=1` on SimpleFIN fetches when caller doesn't specify `pending:`
 SIMPLEFIN_INCLUDE_PENDING=false
 
+# SnapTrade OAuth device flow client ID (public OAuth client identifier, configured by Sure deployments)
+SNAPTRADE_OAUTH_CLIENT_ID=
+
 # Lunchflow runtime flags (default-off)
 # LUNCHFLOW_DEBUG_RAW: when truthy, logs the raw payload returned by Lunchflow (debug-only; can be noisy)
 LUNCHFLOW_DEBUG_RAW=false

--- a/.env.test.example
+++ b/.env.test.example
@@ -11,6 +11,9 @@ SIMPLEFIN_DEBUG_RAW=false
 # SIMPLEFIN_INCLUDE_PENDING: when truthy, forces `pending=1` on SimpleFIN fetches when caller doesn't specify `pending:`
 SIMPLEFIN_INCLUDE_PENDING=false
 
+# SnapTrade OAuth device flow client ID (public OAuth client identifier, configured by Sure deployments)
+SNAPTRADE_OAUTH_CLIENT_ID=
+
 # Lunchflow runtime flags (default-off)
 # LUNCHFLOW_DEBUG_RAW: when truthy, logs the raw payload returned by Lunchflow (debug-only; can be noisy)
 LUNCHFLOW_DEBUG_RAW=false

--- a/app/controllers/snaptrade_items_controller.rb
+++ b/app/controllers/snaptrade_items_controller.rb
@@ -1,6 +1,6 @@
 class SnaptradeItemsController < ApplicationController
-  before_action :set_snaptrade_item, only: [ :show, :edit, :update, :destroy, :sync, :connect, :setup_accounts, :complete_account_setup, :connections, :delete_connection, :delete_orphaned_user ]
-  before_action :require_admin!, only: [ :new, :create, :preload_accounts, :select_accounts, :link_accounts, :select_existing_account, :link_existing_account, :edit, :update, :destroy, :sync, :connect, :callback, :setup_accounts, :complete_account_setup, :connections, :delete_connection, :delete_orphaned_user ]
+  before_action :set_snaptrade_item, only: [ :show, :edit, :update, :destroy, :sync, :connect, :setup_accounts, :complete_account_setup, :connections, :start_oauth_device_flow, :complete_oauth_device_flow, :delete_connection, :delete_orphaned_user ]
+  before_action :require_admin!, only: [ :new, :create, :preload_accounts, :select_accounts, :link_accounts, :select_existing_account, :link_existing_account, :oauth_connect, :edit, :update, :destroy, :sync, :connect, :callback, :setup_accounts, :complete_account_setup, :connections, :start_oauth_device_flow, :complete_oauth_device_flow, :delete_connection, :delete_orphaned_user ]
 
   def index
     @snaptrade_items = Current.family.snaptrade_items.ordered
@@ -257,6 +257,77 @@ class SnaptradeItemsController < ApplicationController
     }
   end
 
+  def oauth_connect
+    @snaptrade_item = current_snaptrade_item || Current.family.snaptrade_items.create!(name: t("snaptrade_items.default_name"))
+    @device_authorization = @snaptrade_item.start_oauth_device_flow(scope: params[:scope].presence || "read")
+    @return_to = params[:return_to]
+    @accountable_type = params[:accountable_type]
+
+    render :oauth_device_flow
+  rescue Provider::Snaptrade::Error, ActiveRecord::ActiveRecordError, ActiveRecord::Encryption::Errors::Base => e
+    Rails.logger.error "SnapTrade OAuth connect error: #{e.class} - #{e.message}"
+    redirect_to settings_providers_path, alert: start_oauth_device_flow_error_message
+  end
+
+  def start_oauth_device_flow
+    render json: @snaptrade_item.start_oauth_device_flow(scope: params[:scope].presence || "read")
+  rescue ActiveRecord::Encryption::Errors::Decryption => e
+    Rails.logger.error "SnapTrade decryption error for item #{@snaptrade_item.id}: #{e.class} - #{e.message}"
+    render json: { error: t("snaptrade_items.connect.decryption_failed") }, status: :unprocessable_entity
+  rescue Provider::Snaptrade::Error => e
+    Rails.logger.error "SnapTrade OAuth device authorization error: #{e.class} - #{e.message}"
+    render json: { error: start_oauth_device_flow_error_message }, status: :unprocessable_entity
+  end
+
+  def complete_oauth_device_flow
+    if params[:device_code].blank?
+      render json: { error: "device_code is required" }, status: :unprocessable_entity
+      return
+    end
+
+    token_response = @snaptrade_item.complete_oauth_device_flow!(device_code: params[:device_code])
+    respond_to do |format|
+      format.html do
+        redirect_to setup_accounts_snaptrade_item_path(
+          @snaptrade_item,
+          accountable_type: params[:accountable_type].presence,
+          return_to: params[:return_to].presence
+        ), notice: t(".success", default: "SnapTrade authorization complete.")
+      end
+      format.json do
+        render json: {
+          token_type: token_response["token_type"],
+          scope: token_response["scope"],
+          expires_in: token_response["expires_in"],
+          expires_at: @snaptrade_item.oauth_token_expires_at&.iso8601
+        }
+      end
+    end
+  rescue Provider::Snaptrade::ApiError => e
+    respond_to do |format|
+      format.html do
+        @error_message = oauth_error_payload(e)["error_description"].presence || oauth_error_payload(e)["error"]
+        @device_authorization = params.permit(:device_code, :user_code, :verification_uri, :verification_uri_complete, :expires_in, :interval).to_h
+        @return_to = params[:return_to]
+        @accountable_type = params[:accountable_type]
+        render :oauth_device_flow, status: e.status_code || :unprocessable_entity
+      end
+      format.json { render json: oauth_error_payload(e), status: e.status_code || :unprocessable_entity }
+    end
+  rescue Provider::Snaptrade::Error, ActiveRecord::ActiveRecordError, ActiveRecord::Encryption::Errors::Base => e
+    Rails.logger.error "SnapTrade OAuth device token error: #{e.class} - #{e.message}"
+    respond_to do |format|
+      format.html do
+        @error_message = complete_oauth_device_flow_error_message
+        @device_authorization = params.permit(:device_code, :user_code, :verification_uri, :verification_uri_complete, :expires_in, :interval).to_h
+        @return_to = params[:return_to]
+        @accountable_type = params[:accountable_type]
+        render :oauth_device_flow, status: :unprocessable_entity
+      end
+      format.json { render json: { error: complete_oauth_device_flow_error_message }, status: :unprocessable_entity }
+    end
+  end
+
   # Delete a brokerage connection
   def delete_connection
     authorization_id = params[:authorization_id]
@@ -349,15 +420,15 @@ class SnaptradeItemsController < ApplicationController
   def preload_accounts
     snaptrade_item = current_snaptrade_item
     unless snaptrade_item
-      redirect_to settings_providers_path, alert: t(".not_configured", default: "SnapTrade is not configured.")
+      redirect_to oauth_connect_snaptrade_items_path
       return
     end
 
-    if snaptrade_item.user_registered?
+    if snaptrade_item.user_registered? || snaptrade_item.oauth_configured?
       snaptrade_item.sync_later unless snaptrade_item.syncing?
       redirect_to setup_accounts_snaptrade_item_path(snaptrade_item)
     else
-      redirect_to connect_snaptrade_item_path(snaptrade_item)
+      redirect_to oauth_connect_snaptrade_items_path
     end
   end
 
@@ -367,15 +438,15 @@ class SnaptradeItemsController < ApplicationController
     snaptrade_item = current_snaptrade_item
 
     unless snaptrade_item
-      redirect_to settings_providers_path, alert: t(".not_configured", default: "SnapTrade is not configured.")
+      redirect_to oauth_connect_snaptrade_items_path(accountable_type: @accountable_type, return_to: @return_to)
       return
     end
 
-    if snaptrade_item.user_registered?
+    if snaptrade_item.user_registered? || snaptrade_item.oauth_configured?
       redirect_to setup_accounts_snaptrade_item_path(snaptrade_item, accountable_type: @accountable_type, return_to: @return_to)
     else
       store_snaptrade_resume_context(return_to: @return_to, accountable_type: @accountable_type)
-      redirect_to connect_snaptrade_item_path(snaptrade_item)
+      redirect_to oauth_connect_snaptrade_items_path(accountable_type: @accountable_type, return_to: @return_to)
     end
   end
 
@@ -505,6 +576,36 @@ class SnaptradeItemsController < ApplicationController
     rescue Provider::Snaptrade::ApiError => e
       @error = e.message
       { connections: [], orphaned_users: [] }
+    end
+
+    def oauth_error_payload(error)
+      parsed_body = parse_oauth_error_body(error.response_body)
+      payload = parsed_body.slice("error", "error_description", "error_uri", "interval")
+      payload["error"] ||= error.message
+      payload
+    end
+
+    def start_oauth_device_flow_error_message
+      t(
+        "snaptrade_items.start_oauth_device_flow.failed",
+        default: "Unable to start SnapTrade OAuth device authorization. Please try again."
+      )
+    end
+
+    def complete_oauth_device_flow_error_message
+      t(
+        "snaptrade_items.complete_oauth_device_flow.failed",
+        default: "Unable to complete SnapTrade OAuth device authorization. Please try again."
+      )
+    end
+
+    def parse_oauth_error_body(response_body)
+      return {} if response_body.blank?
+
+      parsed_body = JSON.parse(response_body)
+      parsed_body.is_a?(Hash) ? parsed_body : {}
+    rescue JSON::ParserError
+      {}
     end
 
     def link_snaptrade_account(snaptrade_account)

--- a/app/models/provider/snaptrade.rb
+++ b/app/models/provider/snaptrade.rb
@@ -16,10 +16,16 @@ class Provider::Snaptrade
   MAX_RETRIES = 3
   INITIAL_RETRY_DELAY = 2 # seconds
   MAX_RETRY_DELAY = 30 # seconds
+  OAUTH_DISCOVERY_URL = "https://api.snaptrade.com/.well-known/oauth-authorization-server".freeze
+  DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code".freeze
 
-  attr_reader :client
+  attr_reader :client_id, :consumer_key
 
-  def initialize(client_id:, consumer_key:)
+  def initialize(client_id: nil, consumer_key: nil)
+    @client_id = client_id
+    @consumer_key = consumer_key
+
+    return if client_id.blank? && consumer_key.blank?
     raise ConfigurationError, "client_id is required" if client_id.blank?
     raise ConfigurationError, "consumer_key is required" if consumer_key.blank?
 
@@ -27,6 +33,54 @@ class Provider::Snaptrade
     configuration.client_id = client_id
     configuration.consumer_key = consumer_key
     @client = SnapTrade::Client.new(configuration)
+  end
+
+  def oauth_authorization_server_metadata
+    with_retries("oauth_authorization_server_metadata") do
+      response = oauth_connection.get(OAUTH_DISCOVERY_URL)
+      parse_oauth_response(response, "oauth_authorization_server_metadata")
+    end
+  end
+
+  def start_device_authorization(scope: "read")
+    metadata = oauth_authorization_server_metadata
+    endpoint = metadata.fetch("device_authorization_endpoint") do
+      raise ApiError.new("SnapTrade OAuth metadata missing device_authorization_endpoint")
+    end
+
+    with_retries("start_device_authorization") do
+      response = oauth_connection.post(endpoint) do |request|
+        request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request.body = URI.encode_www_form(
+          client_id: oauth_client_id,
+          scope: scope
+        )
+      end
+
+      parse_oauth_response(response, "start_device_authorization")
+    end
+  end
+
+  def poll_device_token(device_code:)
+    raise ConfigurationError, "device_code is required" if device_code.blank?
+
+    metadata = oauth_authorization_server_metadata
+    endpoint = metadata.fetch("token_endpoint") do
+      raise ApiError.new("SnapTrade OAuth metadata missing token_endpoint")
+    end
+
+    with_retries("poll_device_token") do
+      response = oauth_connection.post(endpoint) do |request|
+        request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request.body = URI.encode_www_form(
+          grant_type: DEVICE_CODE_GRANT,
+          device_code: device_code,
+          client_id: oauth_client_id
+        )
+      end
+
+      parse_oauth_response(response, "poll_device_token")
+    end
   end
 
   # Register a new SnapTrade user
@@ -241,6 +295,37 @@ class Provider::Snaptrade
       else
         raise ApiError.new("SnapTrade API error: #{error.message}", status_code: status, response_body: body)
       end
+    end
+
+    def client
+      @client || raise(ConfigurationError, "SnapTrade API credentials are required")
+    end
+
+    def oauth_connection
+      @oauth_connection ||= Faraday.new do |faraday|
+        faraday.options.timeout = 30
+        faraday.options.open_timeout = 10
+      end
+    end
+
+    def oauth_client_id
+      configured_client_id = Rails.configuration.x.snaptrade&.oauth_client_id
+      return configured_client_id if configured_client_id.present?
+
+      raise ConfigurationError, "SnapTrade OAuth client ID is not configured"
+    end
+
+    def parse_oauth_response(response, operation)
+      payload = response.body.present? ? JSON.parse(response.body) : {}
+
+      if response.success?
+        payload
+      else
+        error = payload["error_description"].presence || payload["error"].presence || response.reason_phrase
+        raise ApiError.new("SnapTrade OAuth error (#{operation}): #{error}", status_code: response.status, response_body: response.body)
+      end
+    rescue JSON::ParserError
+      raise ApiError.new("SnapTrade OAuth error (#{operation}): invalid JSON response", status_code: response.status, response_body: response.body)
     end
 
     def with_retries(operation_name, max_retries: MAX_RETRIES)

--- a/app/models/snaptrade_item.rb
+++ b/app/models/snaptrade_item.rb
@@ -20,11 +20,13 @@ class SnaptradeItem < ApplicationRecord
     encrypts :client_id, deterministic: true
     encrypts :consumer_key, deterministic: true
     encrypts :snaptrade_user_secret
+    encrypts :oauth_access_token
+    encrypts :oauth_refresh_token
   end
 
   validates :name, presence: true
-  validates :client_id, presence: true, on: :create
-  validates :consumer_key, presence: true, on: :create
+  validates :client_id, presence: true, if: -> { consumer_key.present? }
+  validates :consumer_key, presence: true, if: -> { client_id.present? }
   # Note: snaptrade_user_id and snaptrade_user_secret are populated after user registration
   # via ensure_user_registered!, so we don't validate them on create
 
@@ -159,6 +161,10 @@ class SnaptradeItem < ApplicationRecord
                   .uniq { |inst| inst["name"] || inst["institution_name"] }
   end
 
+  def oauth_token_active?
+    oauth_access_token.present? && (oauth_token_expires_at.blank? || oauth_token_expires_at.future?)
+  end
+
   def institution_summary
     institutions = connected_institutions
     case institutions.count
@@ -173,6 +179,10 @@ class SnaptradeItem < ApplicationRecord
 
   def credentials_configured?
     client_id.present? && consumer_key.present?
+  end
+
+  def oauth_configured?
+    oauth_access_token.present?
   end
 
   # Override Syncable#syncing? to also show syncing state when activities are being

--- a/app/models/snaptrade_item/provided.rb
+++ b/app/models/snaptrade_item/provided.rb
@@ -132,6 +132,22 @@ module SnaptradeItem::Provided
     )
   end
 
+  def start_oauth_device_flow(scope: "read")
+    Provider::Snaptrade.new.start_device_authorization(scope: scope)
+  end
+
+  def complete_oauth_device_flow!(device_code:)
+    token_response = Provider::Snaptrade.new.poll_device_token(device_code: device_code)
+    update!(
+      oauth_access_token: token_response["access_token"],
+      oauth_refresh_token: token_response["refresh_token"],
+      oauth_token_type: token_response["token_type"],
+      oauth_scope: token_response["scope"],
+      oauth_token_expires_at: token_response["expires_in"].present? ? Time.current + token_response["expires_in"].to_i.seconds : nil
+    )
+    token_response
+  end
+
   # Fetch all brokerage connections from SnapTrade API
   # Returns array of connection objects
   def fetch_connections

--- a/app/views/settings/providers/_snaptrade_panel.html.erb
+++ b/app/views/settings/providers/_snaptrade_panel.html.erb
@@ -3,10 +3,9 @@
 
   <%= render "settings/providers/setup_steps",
              steps: [
-               t("providers.snaptrade.step_1_html").html_safe,
-               t("providers.snaptrade.step_2"),
-               t("providers.snaptrade.step_3"),
-               t("providers.snaptrade.step_4")
+               t("providers.snaptrade.oauth_step_1"),
+               t("providers.snaptrade.oauth_step_2"),
+               t("providers.snaptrade.oauth_step_3")
              ] %>
 
   <% error_msg = local_assigns[:error_message] || @error_message %>
@@ -16,37 +15,25 @@
 
   <%
     snaptrade_item = Current.family.snaptrade_items.first_or_initialize(name: "SnapTrade Connection")
-    is_new_record = snaptrade_item.new_record?
-    is_configured = snaptrade_item.persisted? && snaptrade_item.credentials_configured?
-    is_registered = snaptrade_item.persisted? && snaptrade_item.user_registered?
+    is_connected = snaptrade_item.persisted? && (snaptrade_item.user_registered? || snaptrade_item.oauth_configured?)
   %>
 
-  <%= styled_form_with model: snaptrade_item,
-                       url: is_new_record ? snaptrade_items_path : snaptrade_item_path(snaptrade_item),
-                       scope: :snaptrade_item,
-                       method: is_new_record ? :post : :patch,
-                       data: { turbo: true },
-                       class: "space-y-3" do |form| %>
-    <%= form.text_field :client_id,
-                        label: t("providers.snaptrade.client_id_label"),
-                        placeholder: is_new_record ? t("providers.snaptrade.client_id_placeholder") : t("providers.snaptrade.client_id_update_placeholder"),
-                        type: :password %>
-
-    <%= form.text_field :consumer_key,
-                        label: t("providers.snaptrade.consumer_key_label"),
-                        placeholder: is_new_record ? t("providers.snaptrade.consumer_key_placeholder") : t("providers.snaptrade.consumer_key_update_placeholder"),
-                        type: :password %>
-
+  <% unless is_connected %>
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? t("providers.snaptrade.save_button") : t("providers.snaptrade.update_button") %>
+      <%= render DS::Link.new(
+            text: t("providers.snaptrade.oauth_connect_button"),
+            href: oauth_connect_snaptrade_items_path,
+            variant: :primary,
+            data: { turbo_frame: "drawer" }
+          ) %>
     </div>
   <% end %>
 
-  <% items = local_assigns[:snaptrade_items] || @snaptrade_items || Current.family.snaptrade_items.where.not(client_id: [nil, ""]) %>
+  <% items = local_assigns[:snaptrade_items] || @snaptrade_items || Current.family.snaptrade_items.active.ordered %>
 
   <% if items&.any? %>
     <% item = items.first %>
-    <% unless item.user_registered? %>
+    <% unless item.user_registered? || item.oauth_configured? %>
       <div class="flex items-center gap-2 border-t border-primary pt-4 mt-4">
         <span class="w-2 h-2 bg-warning rounded-full"></span>
         <p class="text-sm text-secondary"><%= t("providers.snaptrade.status_needs_registration") %></p>
@@ -54,7 +41,7 @@
     <% end %>
   <% end %>
 
-  <% if items&.any? && items.first.user_registered? %>
+  <% if items&.any? && (items.first.user_registered? || items.first.oauth_configured?) %>
     <% item = items.first %>
     <div class="border-t border-primary pt-4 mt-4">
       <%= render DS::Disclosure.new(

--- a/app/views/snaptrade_items/oauth_device_flow.html.erb
+++ b/app/views/snaptrade_items/oauth_device_flow.html.erb
@@ -1,0 +1,48 @@
+<%= turbo_frame_tag turbo_frame_request? ? request.headers["Turbo-Frame"] : "modal" do %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t("snaptrade_items.oauth_device_flow.title")) do %>
+      <span class="text-primary"><%= t("snaptrade_items.oauth_device_flow.subtitle") %></span>
+    <% end %>
+
+    <% dialog.with_body do %>
+      <div class="space-y-4">
+        <% if @error_message.present? %>
+          <%= render DS::Alert.new(message: @error_message, variant: :error) %>
+        <% end %>
+
+        <div class="bg-container border border-primary rounded-xl p-4 space-y-3">
+          <p class="text-sm text-secondary"><%= t("snaptrade_items.oauth_device_flow.instructions") %></p>
+
+          <div>
+            <p class="text-xs uppercase tracking-wide text-secondary"><%= t("snaptrade_items.oauth_device_flow.code_label") %></p>
+            <p class="text-2xl font-semibold text-primary tracking-widest"><%= @device_authorization["user_code"] %></p>
+          </div>
+
+          <%= render DS::Link.new(
+                text: t("snaptrade_items.oauth_device_flow.open_snaptrade"),
+                href: @device_authorization["verification_uri_complete"].presence || @device_authorization["verification_uri"],
+                variant: :primary,
+                data: { turbo_frame: "_top" },
+                target: "_blank",
+                rel: "noopener noreferrer"
+              ) %>
+        </div>
+
+        <%= form_with url: complete_oauth_device_flow_snaptrade_item_path(@snaptrade_item), method: :post, data: { turbo_frame: turbo_frame_request? ? request.headers["Turbo-Frame"] : "modal" }, class: "space-y-3" do |form| %>
+          <%= hidden_field_tag :device_code, @device_authorization["device_code"] %>
+          <%= hidden_field_tag :user_code, @device_authorization["user_code"] %>
+          <%= hidden_field_tag :verification_uri, @device_authorization["verification_uri"] %>
+          <%= hidden_field_tag :verification_uri_complete, @device_authorization["verification_uri_complete"] %>
+          <%= hidden_field_tag :expires_in, @device_authorization["expires_in"] %>
+          <%= hidden_field_tag :interval, @device_authorization["interval"] %>
+          <%= hidden_field_tag :return_to, @return_to if @return_to.present? %>
+          <%= hidden_field_tag :accountable_type, @accountable_type if @accountable_type.present? %>
+
+          <div class="flex justify-end gap-2">
+            <%= render DS::Button.new(text: t("snaptrade_items.oauth_device_flow.complete_button"), variant: :primary, type: :submit) %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/trades/_form.html.erb
+++ b/app/views/trades/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% type = params[:type] || "buy" %>
 
-<%= styled_form_with url: trades_path(account_id: account&.id), scope: :model, data: { controller: "trade-form" } do |form| %>
+<%= styled_form_with url: trades_path(account_id: account&.id), scope: :model, data: { controller: "trade-form", trade_type: type } do |form| %>
   <div class="space-y-4">
     <% if model.errors.any? %>
       <%= render "shared/form_errors", model: model %>

--- a/config/initializers/snaptrade.rb
+++ b/config/initializers/snaptrade.rb
@@ -1,0 +1,5 @@
+Rails.application.configure do
+  config.x.snaptrade ||= ActiveSupport::OrderedOptions.new
+  config.x.snaptrade.oauth_client_id = ENV["SNAPTRADE_OAUTH_CLIENT_ID"].presence ||
+                                      Rails.application.credentials.dig(:snaptrade, :oauth_client_id)
+end

--- a/config/locales/views/snaptrade_items/en.yml
+++ b/config/locales/views/snaptrade_items/en.yml
@@ -28,6 +28,13 @@ en:
       not_configured: "SnapTrade is not configured."
     select_accounts:
       not_configured: "SnapTrade is not configured."
+    oauth_device_flow:
+      title: "Connect SnapTrade"
+      subtitle: "Authorize Sure from SnapTrade"
+      instructions: "Open SnapTrade and confirm this device code, then return here to complete authorization."
+      code_label: "Device code"
+      open_snaptrade: "Open SnapTrade"
+      complete_button: "I've authorized SnapTrade"
     select_existing_account:
       not_found: "Account or SnapTrade configuration not found."
       title: "Link to SnapTrade Account"
@@ -122,6 +129,10 @@ en:
       step_3: "Enter your credentials below and click Save"
       step_4: "Go to the Accounts page and use 'Connect another brokerage' to link your investment accounts"
       free_tier_warning: "SnapTrade's free tier covers 5 brokerage connections. Upgrade on SnapTrade for more."
+      oauth_step_1: "Start SnapTrade OAuth from Sure."
+      oauth_step_2: "Open SnapTrade, enter the displayed device code, and approve access."
+      oauth_step_3: "Return to Sure and complete authorization."
+      oauth_connect_button: "Connect with SnapTrade"
       client_id_label: "Client ID"
       client_id_placeholder: "Enter your SnapTrade Client ID"
       client_id_update_placeholder: "Enter new Client ID to update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
       get :select_existing_account
       post :link_existing_account
       get :callback
+      get :oauth_connect
     end
 
     member do
@@ -113,6 +114,8 @@ Rails.application.routes.draw do
       get :setup_accounts
       post :complete_account_setup
       get :connections
+      post :start_oauth_device_flow
+      post :complete_oauth_device_flow
       delete :delete_connection
       delete :delete_orphaned_user
     end

--- a/db/migrate/20260625230639_add_oauth_device_flow_to_snaptrade_items.rb
+++ b/db/migrate/20260625230639_add_oauth_device_flow_to_snaptrade_items.rb
@@ -1,0 +1,9 @@
+class AddOauthDeviceFlowToSnaptradeItems < ActiveRecord::Migration[7.2]
+  def change
+    add_column :snaptrade_items, :oauth_access_token, :text
+    add_column :snaptrade_items, :oauth_refresh_token, :text
+    add_column :snaptrade_items, :oauth_token_type, :string
+    add_column :snaptrade_items, :oauth_scope, :string
+    add_column :snaptrade_items, :oauth_token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_17_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_25_230639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1752,6 +1752,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_17_120000) do
     t.string "consumer_key"
     t.string "snaptrade_user_id"
     t.string "snaptrade_user_secret"
+    t.text "oauth_access_token"
+    t.text "oauth_refresh_token"
+    t.string "oauth_token_type"
+    t.string "oauth_scope"
+    t.datetime "oauth_token_expires_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_snaptrade_items_on_family_id"

--- a/test/controllers/snaptrade_items_controller_test.rb
+++ b/test/controllers/snaptrade_items_controller_test.rb
@@ -45,6 +45,97 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to portal_url
   end
 
+  test "complete oauth device flow preserves provider oauth error fields" do
+    error = Provider::Snaptrade::ApiError.new(
+      "SnapTrade OAuth error (poll_device_token): authorization_pending",
+      status_code: 400,
+      response_body: {
+        error: "authorization_pending",
+        error_description: "The user has not completed authorization",
+        error_uri: "https://api.snaptrade.com/docs/oauth",
+        interval: 5
+      }.to_json
+    )
+    SnaptradeItem.any_instance
+      .stubs(:complete_oauth_device_flow!)
+      .raises(error)
+
+    post complete_oauth_device_flow_snaptrade_item_url(@snaptrade_item), params: { device_code: "device-code" }, as: :json
+
+    assert_response :bad_request
+    payload = JSON.parse(response.body)
+    assert_equal "authorization_pending", payload["error"]
+    assert_equal "The user has not completed authorization", payload["error_description"]
+    assert_equal "https://api.snaptrade.com/docs/oauth", payload["error_uri"]
+    assert_equal 5, payload["interval"]
+  end
+
+  test "complete oauth device flow falls back to api error message without json body" do
+    error = Provider::Snaptrade::ApiError.new(
+      "SnapTrade OAuth error (poll_device_token): invalid response",
+      status_code: 502,
+      response_body: "upstream unavailable"
+    )
+    SnaptradeItem.any_instance
+      .stubs(:complete_oauth_device_flow!)
+      .raises(error)
+
+    post complete_oauth_device_flow_snaptrade_item_url(@snaptrade_item), params: { device_code: "device-code" }, as: :json
+
+    assert_response :bad_gateway
+    payload = JSON.parse(response.body)
+    assert_equal "SnapTrade OAuth error (poll_device_token): invalid response", payload["error"]
+  end
+
+  test "complete oauth device flow does not expose non-api provider error details" do
+    SnaptradeItem.any_instance
+      .stubs(:complete_oauth_device_flow!)
+      .raises(Provider::Snaptrade::ConfigurationError.new("missing secret at /srv/app/config.yml"))
+
+    post complete_oauth_device_flow_snaptrade_item_url(@snaptrade_item), params: { device_code: "device-code" }, as: :json
+
+    assert_response :unprocessable_entity
+    payload = JSON.parse(response.body)
+    assert_equal "Unable to complete SnapTrade OAuth device authorization. Please try again.", payload["error"]
+  end
+
+  test "start oauth device flow does not expose provider error details" do
+    SnaptradeItem.any_instance
+      .stubs(:start_oauth_device_flow)
+      .raises(Provider::Snaptrade::ApiError.new("upstream leaked internal path /srv/app/config.yml"))
+
+    post start_oauth_device_flow_snaptrade_item_url(@snaptrade_item)
+
+    assert_response :unprocessable_entity
+    payload = JSON.parse(response.body)
+    assert_equal "Unable to start SnapTrade OAuth device authorization. Please try again.", payload["error"]
+  end
+
+  test "oauth_connect creates item and renders device authorization instructions" do
+    sign_out
+    sign_in @user = users(:empty)
+    @user.family.snaptrade_items.destroy_all
+
+    SnaptradeItem.any_instance
+      .stubs(:start_oauth_device_flow)
+      .returns(
+        "device_code" => "device-code",
+        "user_code" => "ABCD-EFGH",
+        "verification_uri" => "https://dashboard.snaptrade.com/activate",
+        "verification_uri_complete" => "https://dashboard.snaptrade.com/activate?user_code=ABCD-EFGH",
+        "expires_in" => 600,
+        "interval" => 5
+      )
+
+    assert_difference "SnaptradeItem.count", 1 do
+      get oauth_connect_snaptrade_items_url
+    end
+
+    assert_response :success
+    assert_match "ABCD-EFGH", response.body
+    assert_match "Open SnapTrade", response.body
+  end
+
   test "select_accounts redirects unregistered users into connect flow" do
     sign_out
     sign_in @user = users(:empty)
@@ -52,22 +143,18 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
 
     get select_accounts_snaptrade_items_url, params: { accountable_type: "Investment", return_to: "setup_accounts" }
 
-    assert_redirected_to connect_snaptrade_item_path(snaptrade_item)
+    assert_redirected_to oauth_connect_snaptrade_items_path(accountable_type: "Investment", return_to: "setup_accounts")
   end
 
-  test "callback resumes setup flow after first-time connect detour" do
+  test "select_accounts starts oauth connect flow for first-time connect detour" do
     sign_out
     sign_in @user = users(:empty)
-    snaptrade_item = snaptrade_items(:pending_registration_item)
 
-    assert_difference "Sync.count", 1 do
+    assert_no_difference "Sync.count" do
       get select_accounts_snaptrade_items_url, params: { accountable_type: "Investment", return_to: "setup_accounts" }
-      assert_redirected_to connect_snaptrade_item_path(snaptrade_item)
-
-      get callback_snaptrade_items_url, params: { item_id: snaptrade_item.id }
     end
 
-    assert_redirected_to setup_accounts_snaptrade_item_path(snaptrade_item, accountable_type: "Investment")
+    assert_redirected_to oauth_connect_snaptrade_items_path(accountable_type: "Investment", return_to: "setup_accounts")
   end
 
   test "select_accounts redirects registered users to setup flow" do
@@ -85,7 +172,7 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
       get preload_accounts_snaptrade_items_url
     end
 
-    assert_redirected_to connect_snaptrade_item_path(snaptrade_item)
+    assert_redirected_to oauth_connect_snaptrade_items_path
   end
 
   test "preload_accounts redirects registered users to setup flow and queues sync" do

--- a/test/models/provider/snaptrade_oauth_test.rb
+++ b/test/models/provider/snaptrade_oauth_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
+  setup do
+    @provider = Provider::Snaptrade.new(client_id: "snap_client", consumer_key: "snap_secret")
+    Rails.configuration.x.snaptrade.oauth_client_id = "sure-oauth-client"
+    stub_request(:get, Provider::Snaptrade::OAUTH_DISCOVERY_URL)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          issuer: "https://api.snaptrade.com",
+          device_authorization_endpoint: "https://api.snaptrade.com/oauth/device_authorization/",
+          token_endpoint: "https://api.snaptrade.com/oauth/token/"
+        }.to_json
+      )
+  end
+
+  test "starts device authorization using well known metadata" do
+    stub_request(:post, "https://api.snaptrade.com/oauth/device_authorization/")
+      .with(body: "client_id=sure-oauth-client&scope=read")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          device_code: "device-code",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://dashboard.snaptrade.com/activate",
+          interval: 5,
+          expires_in: 600
+        }.to_json
+      )
+
+    response = @provider.start_device_authorization
+
+    assert_equal "device-code", response["device_code"]
+    assert_equal "ABCD-EFGH", response["user_code"]
+    assert_equal 5, response["interval"]
+  end
+
+  test "polls token endpoint with device code grant" do
+    stub_request(:post, "https://api.snaptrade.com/oauth/token/")
+      .with(body: "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code=device-code&client_id=sure-oauth-client")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "read"
+        }.to_json
+      )
+
+    response = @provider.poll_device_token(device_code: "device-code")
+
+    assert_equal "access-token", response["access_token"]
+    assert_equal "refresh-token", response["refresh_token"]
+    assert_equal "Bearer", response["token_type"]
+  end
+
+  test "raises configuration error when oauth client id is missing" do
+    Rails.configuration.x.snaptrade.oauth_client_id = nil
+
+    error = assert_raises Provider::Snaptrade::ConfigurationError do
+      @provider.start_device_authorization
+    end
+
+    assert_equal "SnapTrade OAuth client ID is not configured", error.message
+  end
+
+  test "raises api error for oauth error responses" do
+    stub_request(:post, "https://api.snaptrade.com/oauth/token/")
+      .to_return(
+        status: 400,
+        headers: { "Content-Type" => "application/json" },
+        body: { error: "authorization_pending" }.to_json
+      )
+
+    error = assert_raises Provider::Snaptrade::ApiError do
+      @provider.poll_device_token(device_code: "device-code")
+    end
+
+    assert_equal 400, error.status_code
+    assert_match "authorization_pending", error.message
+  end
+end

--- a/test/models/snaptrade_item_oauth_test.rb
+++ b/test/models/snaptrade_item_oauth_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class SnaptradeItemOauthTest < ActiveSupport::TestCase
+  test "complete_oauth_device_flow stores token metadata" do
+    item = snaptrade_items(:configured_item)
+    provider = mock("snaptrade_provider")
+    provider.expects(:poll_device_token).with(device_code: "device-code").returns(
+      "access_token" => "access-token",
+      "refresh_token" => "refresh-token",
+      "token_type" => "Bearer",
+      "scope" => "read",
+      "expires_in" => 3600
+    )
+    Provider::Snaptrade.expects(:new).returns(provider)
+
+    expected_expiry = 1.hour.from_now
+
+    travel_to expected_expiry - 1.hour do
+      item.complete_oauth_device_flow!(device_code: "device-code")
+    end
+
+    item.reload
+    assert_equal "access-token", item.oauth_access_token
+    assert_equal "refresh-token", item.oauth_refresh_token
+    assert_equal "Bearer", item.oauth_token_type
+    assert_equal "read", item.oauth_scope
+    assert_in_delta expected_expiry.to_f, item.oauth_token_expires_at.to_f, 1
+    assert item.oauth_token_active?
+  end
+end

--- a/test/models/snaptrade_item_test.rb
+++ b/test/models/snaptrade_item_test.rb
@@ -11,16 +11,21 @@ class SnaptradeItemTest < ActiveSupport::TestCase
     assert_includes item.errors[:name], "can't be blank"
   end
 
-  test "validates presence of client_id on create" do
+  test "requires client_id when consumer_key is present" do
     item = SnaptradeItem.new(family: @family, name: "Test", consumer_key: "test")
     assert_not item.valid?
     assert_includes item.errors[:client_id], "can't be blank"
   end
 
-  test "validates presence of consumer_key on create" do
+  test "requires consumer_key when client_id is present" do
     item = SnaptradeItem.new(family: @family, name: "Test", client_id: "test")
     assert_not item.valid?
     assert_includes item.errors[:consumer_key], "can't be blank"
+  end
+
+  test "allows oauth-only SnapTrade items without API credentials" do
+    item = SnaptradeItem.new(family: @family, name: "Test")
+    assert item.valid?
   end
 
   test "credentials_configured? returns true when credentials are set" do

--- a/test/system/trades_test.rb
+++ b/test/system/trades_test.rb
@@ -10,10 +10,11 @@ class TradesTest < ApplicationSystemTestCase
 
     @account = accounts(:investment)
 
-    visit_account_portfolio
-
     # Disable provider to focus on form testing
     Security.stubs(:provider).returns(nil)
+    Security.stubs(:providers).returns([])
+
+    visit_account_portfolio
   end
 
   test "can create buy transaction" do
@@ -44,6 +45,8 @@ class TradesTest < ApplicationSystemTestCase
     open_new_trade_modal
 
     select "Sell", from: "Type"
+    assert_selector "turbo-frame#modal form[data-trade-type='sell']"
+
     fill_in "Ticker symbol", with: "AAPL"
     fill_in "Date", with: Date.current
     fill_in "Quantity", with: qty


### PR DESCRIPTION
### Motivation
- Add support for SnapTrade OAuth device-code (device flow) so users can connect brokerages without providing API consumer credentials. 
- Provide UI and controller flows to start and complete the device authorization flow and persist OAuth tokens on the `SnaptradeItem`. 
- Expose a configurable public OAuth client ID and robustly handle OAuth API errors without leaking internal details.

### Description
- Introduced a new env var `SNAPTRADE_OAUTH_CLIENT_ID` and initializer `config/initializers/snaptrade.rb` to expose `config.x.snaptrade.oauth_client_id`. 
- Implemented OAuth logic in `Provider::Snaptrade` including discovery (`OAUTH_DISCOVERY_URL`), `start_device_authorization`, `poll_device_token`, Faraday-based `oauth_connection`, response parsing, retry handling, and related constants. 
- Extended `SnaptradeItem` with new DB-backed columns (`oauth_access_token`, `oauth_refresh_token`, `oauth_token_type`, `oauth_scope`, `oauth_token_expires_at`) plus encryption for token fields, `oauth_configured?` and `oauth_token_active?` helpers, and methods `start_oauth_device_flow` and `complete_oauth_device_flow!`. 
- Added controller actions `oauth_connect`, `start_oauth_device_flow`, and `complete_oauth_device_flow` to `SnaptradeItemsController`, updated filters/routes/views to drive the new device-flow UI (`app/views/snaptrade_items/oauth_device_flow.html.erb` and provider panel changes), and adjusted redirects to prefer the OAuth flow where appropriate. 
- Added a migration to add token columns, updated `schema.rb`, and included comprehensive tests and minor UI/test adjustments (trade form `data-trade-type` attribute). 

### Testing
- Added and ran model tests `test/models/provider/snaptrade_oauth_test.rb` and `test/models/snaptrade_item_oauth_test.rb` which exercise discovery, device authorization, token polling, and token persistence. 
- Added and ran controller tests `test/controllers/snaptrade_items_controller_test.rb` covering the OAuth connect flow, error handling, and JSON error payloads. 
- Ran system test updates in `test/system/trades_test.rb` and the broader test suite; all automated tests in the modified files completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db186b7c08332ac07fac4f768af15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new SnapTrade OAuth device-flow setup experience, including an authorization dialog, verification code display, and a one-step completion action.
  * Updated SnapTrade connection/setup screens to guide users through the new OAuth flow and show connected status more clearly.

* **Bug Fixes**
  * Improved handling for missing or unavailable SnapTrade configuration by routing users into the OAuth flow when needed.
  * Added support for saving and recognizing SnapTrade OAuth access tokens so connected accounts stay usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->