### PR TITLE
Require omniauth-rails_csrf_protection v2.0+ for Rails 8.2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,8 @@ gem "pdf-reader", "~> 2.12"
 
 # OpenID Connect, OAuth & SAML authentication
 gem "omniauth", "~> 2.1"
-gem "omniauth-rails_csrf_protection"
+# v2.0+ drops the deprecated `ActiveSupport::Configurable` (removed in Rails 8.2)
+gem "omniauth-rails_csrf_protection", ">= 2.0"
 gem "omniauth_openid_connect"
 gem "omniauth-google-oauth2"
 gem "omniauth-github"

--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,6 @@ gem "pdf-reader", "~> 2.12"
 
 # OpenID Connect, OAuth & SAML authentication
 gem "omniauth", "~> 2.1"
-# v2.0+ drops the deprecated `ActiveSupport::Configurable` (removed in Rails 8.2)
 gem "omniauth-rails_csrf_protection", ">= 2.0"
 gem "omniauth_openid_connect"
 gem "omniauth-google-oauth2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
-    omniauth-rails_csrf_protection (1.0.2)
+    omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     omniauth-saml (2.2.4)
@@ -906,7 +906,7 @@ DEPENDENCIES
   omniauth (~> 2.1)
   omniauth-github
   omniauth-google-oauth2
-  omniauth-rails_csrf_protection
+  omniauth-rails_csrf_protection (>= 2.0)
   omniauth-saml (~> 2.1)
   omniauth_openid_connect
   ostruct


### PR DESCRIPTION
## Summary
Updates the `omniauth-rails_csrf_protection` gem dependency to require version 2.0 or higher to ensure (future) compatibility with Rails 8.2, which removes the deprecated `ActiveSupport::Configurable` that earlier versions of this gem depend on.

## Changes
- Updated `omniauth-rails_csrf_protection` gem constraint from no version specification to `>= 2.0`
- Added explanatory comment documenting why this version constraint is necessary

## Details
The `omniauth-rails_csrf_protection` gem versions prior to 2.0 rely on `ActiveSupport::Configurable`, which was removed in Rails 8.2. By requiring version 2.0 or higher, we ensure the gem uses a compatible implementation and prevent potential runtime errors when upgrading to Rails 8.2.

https://claude.ai/code/session_019eC5BNZmL6LPBMCUr35ev9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Security**
  * Increased the minimum supported version for authentication request protection to better align CSRF behavior with upcoming Rails updates and reduce risk from older, incompatible versions.
* **Chores**
  * Enforced a clearer version baseline to improve upgrade reliability and minimize compatibility surprises during future Rails changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->