### PR TITLE
docs: explain self-hosted onboarding modes

### DIFF
--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -180,6 +180,16 @@ The first time you run the app, you will need to register a new account by hitti
 1. Enter your email
 2. Enter a password
 
+### Step 5a: Restrict future signups (optional)
+
+After creating your initial admin account, you can control how other people join your self-hosted instance from **Settings > Self-Hosting > Onboarding**.
+
+- **Open**: Anyone can create an account from the registration page.
+- **Invite-only**: New account creation stays enabled, but signups require a valid invite code.
+- **Closed**: The registration page is disabled for new signups.
+
+If you do not want additional self-service registrations, switch the instance to **Closed** after the initial setup.
+
 ### Step 6: Run the app in the background
 
 Most self-hosting users will want the Sure app to run in the background on their computer so they can access it at all times. To do this, hit `Ctrl+C` to stop the running process, and then run the following command:

--- a/docs/hosting/hetzner.md
+++ b/docs/hosting/hetzner.md
@@ -176,6 +176,16 @@ Now you can:
 2. **Create your admin account**: Click "Create your account" on the login page
 3. **Set up your first family**: Follow the onboarding process
 
+### Optional: Disable self-service registration
+
+Once your initial admin account is ready, open **Settings > Self-Hosting > Onboarding** to choose how signups should work:
+
+- **Open**: Anyone can register.
+- **Invite-only**: New signups require a valid invite code.
+- **Closed**: New signups from the registration page are blocked.
+
+For single-admin or tightly controlled deployments, set the onboarding mode to **Closed** after the initial setup.
+
 ## Step 7: Set Up Automated Backups
 
 Create a backup script to protect your data:


### PR DESCRIPTION
## Summary
- document the self-hosted onboarding modes in the Docker guide
- document the same signup controls in the Hetzner guide
- clarify that `Closed` disables new self-service registrations after the initial admin setup

## Testing
- not run (docs-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for restricting future signups after initial setup.
  * Documented onboarding options: Open, Invite-only, and Closed.
  * Clarified where to change registration settings and when to use Closed for tightly controlled deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->