### PR TITLE
test: stabilize investment statement month-boundary spec

### DIFF
--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -235,7 +235,8 @@ class InvestmentStatementTest < ActiveSupport::TestCase
   end
 
   test "totals aggregate directly from trade entries" do
-    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current)
+    prior_month = 1.month.ago.to_date
+    period = Period.custom(start_date: prior_month.beginning_of_month, end_date: prior_month.end_of_month)
     shared_user = users(:new_email)
     investment_account = create_investment_account(balance: 500)
     hidden_account = create_investment_account(balance: 500)


### PR DESCRIPTION
## Summary
- make the investment statement totals spec use the previous full month instead of the current partial month
- avoid a first-of-month failure where the sell trade lands outside the test period

## Testing
- DISABLE_PARALLELIZATION=true bin/rails test test/models/investment_statement_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an investment statement aggregation test to use the previous month for its date range, aligning the test data with the expected trade period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->