### PR TITLE
Fix date-dependent flake in investment_statement_test

### DIFF
--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -235,7 +235,9 @@ class InvestmentStatementTest < ActiveSupport::TestCase
   end
 
   test "totals aggregate directly from trade entries" do
-    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current)
+    # Use the full current month: a month-to-date period collapses to a single
+    # day on the 1st, which would drop the start_date + 1.day trade below.
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
     shared_user = users(:new_email)
     investment_account = create_investment_account(balance: 500)
     hidden_account = create_investment_account(balance: 500)


### PR DESCRIPTION
## What
`test "totals aggregate directly from trade entries"` in `test/models/investment_statement_test.rb` builds a month-to-date period (`beginning_of_month..Date.current`) but places a trade at `start_date + 1.day`.

On the **1st of the month** that period collapses to a single day (`[1st, 1st]`), so the `start_date + 1.day` trade falls outside the range and `withdrawals` aggregate to `0` — failing `assert_equal Money.new(40, "USD"), totals.withdrawals` (got `0`). The test passes every other day of the month.

## Fix
Use the full current month (`beginning_of_month..end_of_month`) so the period is always multi-day and the `start_date + 1.day` trade stays in range. The before-period trade (`start_date - 1.day`, in the previous month) remains correctly excluded.

## Repro
Run on the 1st of a month (or set the machine clock to the 1st):
`bin/rails test test/models/investment_statement_test.rb` -> `test_totals_aggregate_directly_from_trade_entries` fails (withdrawals `0`, expected `40`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an investment statement test to use a full month-to-date range, ensuring trades later in the month are included in the calculation.
  * Clarified the test note to explain why the broader date range is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->