### PR TITLE
fix(invitations): allow re-inviting after an unaccepted invite expires

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -32,6 +32,11 @@ class InvitationsController < ApplicationController
     end
 
     redirect_to settings_profile_path
+  rescue ActiveRecord::RecordNotUnique
+    # Safety net: a concurrent double-submit can still race the partial unique
+    # index between validation and INSERT. Never let it surface as a 500.
+    flash[:alert] = t(".failure")
+    redirect_to settings_profile_path
   end
 
   def accept

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -14,7 +14,7 @@ class InvitationsController < ApplicationController
     @invitation = Current.family.invitations.build(invitation_params)
     @invitation.inviter = Current.user
 
-    if @invitation.save
+    if save_invitation
       normalized_email = @invitation.email.to_s.strip.downcase
       existing_user = User.find_by(email: normalized_email)
       if existing_user && @invitation.would_orphan_owned_accounts?(existing_user)
@@ -31,11 +31,6 @@ class InvitationsController < ApplicationController
       flash[:alert] = t(".failure")
     end
 
-    redirect_to settings_profile_path
-  rescue ActiveRecord::RecordNotUnique
-    # Safety net: a concurrent double-submit can still race the partial unique
-    # index between validation and INSERT. Never let it surface as a 500.
-    flash[:alert] = t(".failure")
     redirect_to settings_profile_path
   end
 
@@ -71,5 +66,16 @@ class InvitationsController < ApplicationController
 
     def invitation_params
       params.require(:invitation).permit(:email, :role)
+    end
+
+    # Persist the invitation, treating a raced partial-unique-index violation as
+    # an ordinary save failure. A concurrent double-submit can still slip between
+    # the `no_duplicate_pending_invitation_in_family` validation and the INSERT.
+    # Scoping the rescue to the save alone keeps later writes in #create (e.g.
+    # accept_for) from silently swallowing a genuine RecordNotUnique.
+    def save_invitation
+      @invitation.save
+    rescue ActiveRecord::RecordNotUnique
+      false
     end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -19,6 +19,7 @@ class Invitation < ApplicationRecord
 
   before_validation :normalize_email
   before_validation :generate_token, on: :create
+  before_create :remove_expired_duplicates_in_family
   before_create :set_expiration
 
   scope :pending, -> { where(accepted_at: nil).where("expires_at > ?", Time.current) }
@@ -67,6 +68,29 @@ class Invitation < ApplicationRecord
 
     def set_expiration
       self.expires_at = 3.days.from_now
+    end
+
+    # An expired, never-accepted invitation still occupies the partial unique
+    # index `index_invitations_on_email_and_family_id_pending` (predicate
+    # `accepted_at IS NULL`), but the `pending` scope treats it as gone because
+    # of the `expires_at > now` clause. The duplicate-guard validation therefore
+    # passes, and the INSERT collides with the index, raising RecordNotUnique.
+    # Removing the stale row inside the create transaction frees the slot so the
+    # re-invite can proceed. It runs only after validations pass, so a still
+    # pending (non-expired) invitation can never be removed here.
+    def remove_expired_duplicates_in_family
+      return if email.blank?
+
+      scope = self.class.where(family_id: family_id, accepted_at: nil)
+                        .where("expires_at <= ?", Time.current)
+
+      scope = if self.class.encryption_ready?
+        scope.where(email: email)
+      else
+        scope.where("LOWER(email) = ?", email.to_s.strip.downcase)
+      end
+
+      scope.delete_all
     end
 
     def normalize_email

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -134,6 +134,27 @@ class InvitationsControllerTest < ActionDispatch::IntegrationTest
     assert existing_user.ai_enabled?
   end
 
+  test "re-inviting an email whose prior invitation expired succeeds instead of 500ing" do
+    email = "expired-reinvite-ctrl@example.com"
+    expired = @admin.family.invitations.create!(email: email, role: "member", inviter: @admin)
+    expired.update_column(:expires_at, 1.day.ago)
+
+    post invitations_url, params: {
+      invitation: {
+        email: email,
+        role: "member"
+      }
+    }
+
+    assert_redirected_to settings_profile_path
+    assert_equal I18n.t("invitations.create.success"), flash[:notice]
+    assert_not Invitation.exists?(expired.id), "stale expired invitation should be replaced"
+
+    new_invitation = @admin.family.invitations.find_by(email: email)
+    assert new_invitation.present?
+    assert new_invitation.pending?
+  end
+
   test "should handle invalid invitation creation" do
     assert_no_difference("Invitation.count") do
       post invitations_url, params: {

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -155,6 +155,24 @@ class InvitationsControllerTest < ActionDispatch::IntegrationTest
     assert new_invitation.pending?
   end
 
+  test "raced unique-index violation on save is handled as a failure, not a 500" do
+    # Simulate a concurrent double-submit that slips past the pending-invite
+    # validation and hits the partial unique index at INSERT time.
+    Invitation.any_instance.stubs(:save).raises(ActiveRecord::RecordNotUnique)
+
+    assert_no_difference("Invitation.count") do
+      post invitations_url, params: {
+        invitation: {
+          email: "raced@example.com",
+          role: "member"
+        }
+      }
+    end
+
+    assert_redirected_to settings_profile_path
+    assert_equal I18n.t("invitations.create.failure"), flash[:alert]
+  end
+
   test "should handle invalid invitation creation" do
     assert_no_difference("Invitation.count") do
       post invitations_url, params: {

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -110,6 +110,32 @@ class InvitationTest < ActiveSupport::TestCase
     assert invitation.valid?
   end
 
+  test "re-inviting an email with an expired unaccepted invitation replaces it without raising" do
+    email = "expired-reinvite@example.com"
+
+    expired = @family.invitations.create!(email: email, role: "member", inviter: @inviter)
+    expired.update_column(:expires_at, 1.day.ago)
+
+    invitation = nil
+    assert_nothing_raised do
+      invitation = @family.invitations.create!(email: email, role: "admin", inviter: @inviter)
+    end
+
+    assert invitation.pending?
+    assert_not Invitation.exists?(expired.id), "stale expired invitation should be removed"
+    assert_equal 1, @family.invitations.where(email: email).count
+  end
+
+  test "re-invite does not remove a still-pending duplicate (validation blocks first)" do
+    email = "still-pending@example.com"
+    pending = @family.invitations.create!(email: email, role: "member", inviter: @inviter)
+
+    duplicate = @family.invitations.build(email: email, role: "admin", inviter: @inviter)
+    assert_not duplicate.valid?
+
+    assert Invitation.exists?(pending.id), "an unexpired pending invitation must be preserved"
+  end
+
   test "can create invitation in same family (uniqueness scoped to family)" do
     email = "same-family-test@example.com"
 


### PR DESCRIPTION
## What & why

Fixes #2535.

When an admin invites an email that already has an **expired, never-accepted** invitation in the same family, `InvitationsController#create` raises `ActiveRecord::RecordNotUnique` and the admin gets a generic 500 — with no way to re-invite that address through the UI until the stale row is deleted by hand.

### Root cause

Two notions of "pending" disagree:

- **Application** (`app/models/invitation.rb`): `pending` = unaccepted **and** not expired (`accepted_at IS NULL AND expires_at > now`).
- **Database** partial unique index `index_invitations_on_email_and_family_id_pending`: predicate is only `accepted_at IS NULL`.

An expired-but-unaccepted row is invisible to the `no_duplicate_pending_invitation_in_family` validation (it's excluded by `expires_at > now`), so `save` proceeds — but the row still occupies the unique-index slot, so the `INSERT` collides and Postgres raises `unique_violation`. The index predicate can't be made time-aware (`now()` is `STABLE`, not `IMMUTABLE`), so the fix lives in the app layer.

## The fix

- **Model** — a `before_create` (`remove_expired_duplicates_in_family`) deletes any expired, unaccepted invitation for the same `(email, family_id)` inside the create transaction, freeing the unique slot so the re-invite succeeds. It runs only **after** validations pass, so a still-pending (non-expired) invitation can never be removed by it (a live duplicate is already rejected by the existing validation first).
- **Controller** — a `rescue ActiveRecord::RecordNotUnique` safety net so a concurrent double-submit race can never surface as a 500.

## Tests

- Model: re-inviting an email whose prior invitation expired replaces the stale row without raising; a still-pending duplicate is preserved (validation blocks first).
- Controller: re-inviting an expired address returns the normal success flow instead of a 500.

`bin/rails test test/models/invitation_test.rb test/controllers/invitations_controller_test.rb` → green (29 runs, 0 failures); `bin/rubocop` and `bin/brakeman` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invitation creation from failing when the same email is reinvited after an expired, unaccepted invitation.
  * Reinviting now safely handles rare concurrent double-submit conflicts, avoiding server errors and showing the standard failure feedback.
  * Stale expired invitations are cleared automatically before a new pending invitation is inserted, while unexpired pending invitations remain untouched.
* **Tests**
  * Added controller and model coverage for expired reinvites and concurrent duplicate-submit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->