### PR TITLE
fix(reports): hide tax-advantaged transactions in breakdown

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -366,6 +366,7 @@ class ReportsController < ApplicationController
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
         .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
         .includes(entry: :account, category: :parent)
+      transactions = exclude_tax_advantaged_accounts(transactions)
 
       # Apply filters (includes finance account scoping)
       transactions = apply_transaction_filters(transactions)
@@ -378,6 +379,7 @@ class ReportsController < ApplicationController
         .merge(Account.included_in_reports)
         .where(entries: { entryable_type: "Trade", excluded: false, date: @period.date_range })
         .includes(entry: :account, category: :parent)
+      trades = exclude_tax_advantaged_accounts(trades)
 
       trades = apply_entry_filters(trades)
 
@@ -617,6 +619,13 @@ class ReportsController < ApplicationController
       scope
     end
 
+    def exclude_tax_advantaged_accounts(scope)
+      tax_advantaged_account_ids = Current.family.tax_advantaged_account_ids
+      return scope if tax_advantaged_account_ids.blank?
+
+      scope.where.not(accounts: { id: tax_advantaged_account_ids })
+    end
+
     # Filters applicable to both transactions and trades (entry-level + category)
     def apply_entry_filters(scope)
       # Scope to user's finance accounts
@@ -673,6 +682,7 @@ class ReportsController < ApplicationController
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
         .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
         .includes(entry: :account, category: [])
+      transactions = exclude_tax_advantaged_accounts(transactions)
 
       transactions = apply_transaction_filters(transactions)
 
@@ -711,6 +721,7 @@ class ReportsController < ApplicationController
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
         .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
         .includes(entry: :account, category: [])
+      transactions = exclude_tax_advantaged_accounts(transactions)
 
       transactions = apply_transaction_filters(transactions)
 

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -348,6 +348,40 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "text/csv", @response.media_type
   end
 
+  test "export transactions excludes tax-advantaged account transactions" do
+    taxable_category = @family.categories.create!(name: "Export Taxable Income", color: "#111111")
+    retirement_category = @family.categories.create!(name: "Export Retirement Income", color: "#222222")
+    taxable_account = @family.accounts.create!(
+      owner: @user,
+      name: "Export Taxable Brokerage",
+      balance: 0,
+      currency: "USD",
+      accountable: Investment.new(subtype: "brokerage")
+    )
+    retirement_account = @family.accounts.create!(
+      owner: @user,
+      name: "Export 401k",
+      balance: 0,
+      currency: "USD",
+      accountable: Investment.new(subtype: "401k")
+    )
+
+    create_transaction(account: taxable_account, name: "Taxable export dividend", amount: -100, category: taxable_category)
+    create_transaction(account: retirement_account, name: "401k export dividend", amount: -200, category: retirement_category)
+
+    get export_transactions_reports_path(
+      format: :csv,
+      period_type: :monthly,
+      start_date: Date.current.beginning_of_month,
+      end_date: Date.current.end_of_month
+    )
+
+    assert_response :ok
+    assert_equal "text/csv", @response.media_type
+    assert_match /Export Taxable Income/, @response.body
+    assert_no_match /Export Retirement Income/, @response.body
+  end
+
   test "export transactions swaps dates when end_date is before start_date" do
     start_date = Date.current
     end_date = 1.month.ago.to_date
@@ -384,6 +418,44 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     # Subcategories
     assert_select "tr[data-category='category-#{subcategory_movies.id}']", text: /^Movies/
     assert_select "tr[data-category='category-#{subcategory_games.id}']", text: /^Games/
+  end
+
+  test "index excludes tax-advantaged account transactions from activity breakdown" do
+    @family.accounts.each { |account| account.entries.destroy_all }
+
+    taxable_category = @family.categories.create!(name: "Reports Taxable Income", color: "#111111")
+    retirement_category = @family.categories.create!(name: "Reports Retirement Income", color: "#222222")
+    taxable_account = @family.accounts.create!(
+      owner: @user,
+      name: "Reports Taxable Brokerage",
+      balance: 0,
+      currency: "USD",
+      accountable: Investment.new(subtype: "brokerage")
+    )
+    retirement_account = @family.accounts.create!(
+      owner: @user,
+      name: "Reports 401k",
+      balance: 0,
+      currency: "USD",
+      accountable: Investment.new(subtype: "401k")
+    )
+
+    create_transaction(account: taxable_account, name: "Taxable dividend", amount: -100, category: taxable_category)
+    create_transaction(account: retirement_account, name: "401k dividend", amount: -200, category: retirement_category)
+    create_trade(securities(:aapl), account: taxable_account, qty: 1, date: Date.current, price: 100)
+    create_trade(securities(:aapl), account: retirement_account, qty: 1, date: Date.current, price: 200)
+
+    get reports_path(period_type: :monthly)
+    assert_response :ok
+
+    assert_select "tr[data-category='category-#{taxable_category.id}']", text: /Reports Taxable Income/
+    assert_select "tr[data-category='category-#{retirement_category.id}']", count: 0
+
+    other_investments_row = css_select("tr[data-category='category-other_investments']").first
+    assert_not_nil other_investments_row
+    assert_match(/#{Regexp.escape(Category.other_investments.name)}/, other_investments_row.text)
+    assert_match(/#{Regexp.escape(I18n.t("reports.transactions_breakdown.table.entries", count: 1))}/, other_investments_row.text)
+    assert_match(/\$100\.00/, other_investments_row.text)
   end
 
   test "monthly period navigation shows previous month link" do


### PR DESCRIPTION
## Summary

Hide tax-advantaged account transactions from the Reports Activity Breakdown so it matches the existing income statement exclusion logic.

## Related issue

Fixes #2548

## Verification

- bin/rails test test/controllers/reports_controller_test.rb
- bin/rubocop app/controllers/reports_controller.rb test/controllers/reports_controller_test.rb
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reports to omit tax-advantaged (retirement) account activity from both on-screen activity breakdowns and exported reports (CSV/XLSX/PDF), including month-by-month exports.
* **Tests**
  * Added coverage ensuring retirement-account categories are excluded while taxable categories remain visible in the activity breakdown page and the current-month CSV export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->