### PR TITLE
perf(test): use MIN_COST bcrypt digests in user fixtures (~230ms saved per sign_in)

### DIFF
--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,13 @@
+# password_digest is BCrypt::Password.create(user_password_test, cost: BCrypt::Engine::MIN_COST).
+# Keep MIN_COST here: verification cost is embedded in the digest, so a
+# production-cost digest adds ~230ms of CPU to every sign_in in tests.
+
 empty:
   family: empty
   first_name: User
   last_name: One
   email: user1@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  password_digest: $2a$04$deKu1NIqviMgrl.4NkXcieFkAmLa33RN9Tw/R/Llr22eMd4x/o/RO
   onboarded_at: <%= 3.days.ago %>
   role: admin
   ai_enabled: true
@@ -16,7 +20,7 @@ sure_support_staff:
   first_name: Support
   last_name: Admin
   email: support@sure.am
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  password_digest: $2a$04$deKu1NIqviMgrl.4NkXcieFkAmLa33RN9Tw/R/Llr22eMd4x/o/RO
   role: super_admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
@@ -29,7 +33,7 @@ family_admin:
   first_name: Bob
   last_name: Dylan
   email: bob@bobdylan.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  password_digest: $2a$04$deKu1NIqviMgrl.4NkXcieFkAmLa33RN9Tw/R/Llr22eMd4x/o/RO
   role: admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
@@ -42,7 +46,7 @@ family_member:
   first_name: Jakob
   last_name: Dylan
   email: jakobdylan@yahoo.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  password_digest: $2a$04$deKu1NIqviMgrl.4NkXcieFkAmLa33RN9Tw/R/Llr22eMd4x/o/RO
   onboarded_at: <%= 3.days.ago %>
   role: member
   ai_enabled: true
@@ -56,7 +60,7 @@ new_email:
   last_name: User
   email: user@example.com
   unconfirmed_email: new@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  password_digest: $2a$04$deKu1NIqviMgrl.4NkXcieFkAmLa33RN9Tw/R/Llr22eMd4x/o/RO
   onboarded_at: <%= Time.current %>
   role: member
   ai_enabled: true
@@ -69,7 +73,7 @@ intro_user:
   first_name: Intro
   last_name: User
   email: intro@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  password_digest: $2a$04$deKu1NIqviMgrl.4NkXcieFkAmLa33RN9Tw/R/Llr22eMd4x/o/RO
   onboarded_at: <%= 1.day.ago %>
   role: guest
   ai_enabled: true
@@ -82,7 +86,7 @@ inactive_trial_user:
   first_name: Inactive
   last_name: User
   email: inactive@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
+  password_digest: $2a$04$deKu1NIqviMgrl.4NkXcieFkAmLa33RN9Tw/R/Llr22eMd4x/o/RO
   role: admin
   onboarded_at: <%= 90.days.ago %>
   ai_enabled: true


### PR DESCRIPTION
## Summary

Part 1/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`).

`test/fixtures/users.yml` stored password digests generated at **bcrypt cost 12** (`$2a$12$…`). bcrypt verification cost is embedded in the stored digest, so `ActiveModel::SecurePassword.min_cost` (which Rails enables in test) does not help at all when *verifying*: every `sign_in` helper call paid **~230ms of pure bcrypt CPU**. Roughly 100 test files sign in from their `setup` blocks, making this the single largest contributor to CI suite time found in the audit.

## Change

- Regenerated the shared fixture digest for `user_password_test` at `BCrypt::Engine::MIN_COST` (cost 4) — same password, same behavior, ~1000× cheaper to verify.
- Added a comment so the digest doesn't silently regress back to production cost.

## Measured effect

| Suites (serial run) | Before | After |
|---|---|---|
| sessions + mfa + settings/hostings + sophtron_items + password_resets (128 tests) | ~33s | **9.9s** |

Full-suite effect is much larger since nearly every controller/integration test signs in.

## Verification

`bin/rails test test/controllers/sessions_controller_test.rb test/controllers/mfa_controller_test.rb test/controllers/settings/hostings_controller_test.rb test/controllers/sophtron_items_controller_test.rb test/controllers/password_resets_controller_test.rb` → 128 runs, 602 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated fixture password digests to use a lower-cost setting, making test sign-ins faster.
  * Added notes clarifying the test-only digest configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->