### PR TITLE
perf: make provider retry backoff sleeps stubbable (SimpleFIN suite 23.5s → ~1s)

### DIFF
--- a/app/models/provider/akahu.rb
+++ b/app/models/provider/akahu.rb
@@ -137,7 +137,7 @@ class Provider::Akahu
             "Akahu API: #{operation_name} failed (attempt #{retries}/#{max_retries}): " \
             "#{e.class}: #{e.message}. Retrying in #{delay}s..."
           )
-          Kernel.sleep(delay)
+          sleep(delay)
           retry
         end
 

--- a/app/models/provider/simplefin.rb
+++ b/app/models/provider/simplefin.rb
@@ -36,7 +36,7 @@ class Provider::Simplefin
     # Use retry logic for transient network failures during token claim
     # Claim should be fast; keep request-path latency bounded.
     # Use self.class.post to inherit class-level SSL and timeout defaults
-    response = with_retries("POST /claim", max_retries: 1, sleep: false) do
+    response = with_retries("POST /claim", max_retries: 1, backoff: false) do
       self.class.post(claim_url, timeout: 15)
     end
 
@@ -126,7 +126,7 @@ class Provider::Simplefin
     # Execute a block with retry logic and exponential backoff for transient network errors.
     # This helps handle temporary network issues that cause autosync failures while
     # manual sync (with user retry) succeeds.
-    def with_retries(operation_name, max_retries: MAX_RETRIES, sleep: true)
+    def with_retries(operation_name, max_retries: MAX_RETRIES, backoff: true)
       retries = 0
 
       begin
@@ -140,7 +140,7 @@ class Provider::Simplefin
             "SimpleFin API: #{operation_name} failed (attempt #{retries}/#{max_retries}): " \
             "#{e.class}: #{e.message}. Retrying in #{delay}s..."
           )
-          Kernel.sleep(delay) if sleep && delay.to_f.positive?
+          sleep(delay) if backoff && delay.to_f.positive?
           retry
         else
           Rails.logger.error(

--- a/app/models/provider/up.rb
+++ b/app/models/provider/up.rb
@@ -166,7 +166,7 @@ class Provider::Up
             "Up API: #{operation_name} failed (attempt #{retries}/#{max_retries}): " \
             "#{e.class}: #{e.message}. Retrying in #{delay}s..."
           )
-          Kernel.sleep(delay)
+          sleep(delay)
           retry
         end
 


### PR DESCRIPTION
## Summary

Part 2/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`). `Provider::SimplefinTest` was the slowest suite in CI at **23.5s**, with a single test (`raises SimplefinError after max retries exceeded`) taking **16.8s**.

## Root cause

The retry helpers in `Provider::Simplefin`, `Provider::Akahu` and `Provider::Up` call `Kernel.sleep(delay)` for exponential backoff. The retry tests already stub sleeping via `@provider.stubs(:sleep)`, but that stubs the *instance* method — an explicit `Kernel.sleep` receiver bypasses it, so the tests really slept through the 2s/4s/8s backoff.

## Change

- Call `sleep(delay)` on the instance (same `Kernel` method, identical runtime behavior) so the existing test stubs take effect.
- In `Provider::Simplefin#with_retries`, rename the `sleep:` keyword to `backoff:` since the old name would shadow the method. It's only used internally (`claim_access_url`).

No behavior change in production: the same delays are slept.

## Measured effect

| Suite | Before | After |
|---|---|---|
| `Provider::SimplefinTest` + akahu + up provider tests (19 tests) | ~24s | **1.2s** |

## Verification

`bin/rails test test/models/provider/simplefin_test.rb test/models/provider/akahu_test.rb test/models/provider/up_test.rb` → 19 runs, 69 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry pause handling across several provider flows, keeping retry behavior consistent and more reliable.
  * Updated one access-claim path so its retry timing follows the latest backoff handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->