### PR TITLE
feat(rules): add a Transaction tag condition filter

### DIFF
--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -597,6 +597,11 @@ class Family::DataExporter
         return rule_operand(condition.value, type: "Merchant", relation: @family.merchants)
       end
 
+      # Map tag UUIDs to names for portability
+      if condition.condition_type == "transaction_tag"
+        return rule_operand(condition.value, type: "Tag", relation: @family.tags)
+      end
+
       rule_operand(condition.value)
     end
 

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -617,6 +617,11 @@ class Family::DataExporter
         return rule_operand(condition.value, type: "Merchant", relation: @family.merchants)
       end
 
+      # Map tag UUIDs to names for portability
+      if condition.condition_type == "transaction_tag"
+        return rule_operand(condition.value, type: "Tag", relation: @family.tags)
+      end
+
       rule_operand(condition.value)
     end
 

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -1109,6 +1109,13 @@ class Family::DataImporter
         return merchant.id
       end
 
+      # Map tag names to IDs
+      if condition_type == "transaction_tag"
+        tag = @family.tags.find_by(name: value)
+        tag ||= @family.tags.create!(name: value)
+        return tag.id
+      end
+
       value
     end
 

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -1115,6 +1115,13 @@ class Family::DataImporter
         return merchant.id
       end
 
+      # Map tag names to IDs
+      if condition_type == "transaction_tag"
+        tag = @family.tags.find_by(name: value)
+        tag ||= @family.tags.create!(name: value)
+        return tag.id
+      end
+
       value
     end
 

--- a/app/models/rule/condition_filter/transaction_tag.rb
+++ b/app/models/rule/condition_filter/transaction_tag.rb
@@ -1,0 +1,22 @@
+class Rule::ConditionFilter::TransactionTag < Rule::ConditionFilter
+  def type
+    "select"
+  end
+
+  def options
+    family.tags.alphabetically.pluck(:name, :id)
+  end
+
+  def prepare(scope)
+    scope.left_joins(:tags)
+  end
+
+  def apply(scope, operator, value)
+    # Supported "select" operators are "=" (has this tag) and "is_null" (no tags).
+    # Neither can match a transaction's tag join more than once, so no DISTINCT is
+    # needed — and omitting it keeps the relation structurally compatible with the
+    # other filters when combined in a compound OR condition.
+    expression = build_sanitized_where_condition("tags.id", operator, value)
+    scope.where(expression)
+  end
+end

--- a/app/models/rule/condition_filter/transaction_tag.rb
+++ b/app/models/rule/condition_filter/transaction_tag.rb
@@ -7,16 +7,37 @@ class Rule::ConditionFilter::TransactionTag < Rule::ConditionFilter
     family.tags.alphabetically.pluck(:name, :id)
   end
 
+  # Tag membership is matched with a correlated EXISTS subquery rather than a
+  # join. A join on a has_many association would (a) let two ANDed tag conditions
+  # collapse onto the same `tags.id` alias — `tags.id = a AND tags.id = b` can
+  # never be true even when the transaction has both tags — and (b) return a
+  # transaction once per matching tagging row, inflating counts and making rule
+  # actions iterate duplicates. EXISTS keeps each condition independent and never
+  # multiplies rows, so no join (or DISTINCT) is needed here.
   def prepare(scope)
-    scope.left_joins(:tags)
+    scope
   end
 
   def apply(scope, operator, value)
-    # Supported "select" operators are "=" (has this tag) and "is_null" (no tags).
-    # Neither can match a transaction's tag join more than once, so no DISTINCT is
-    # needed — and omitting it keeps the relation structurally compatible with the
-    # other filters when combined in a compound OR condition.
-    expression = build_sanitized_where_condition("tags.id", operator, value)
-    scope.where(expression)
+    case operator
+    when "="
+      scope.where(tagging_exists(tag_id: value))
+    when "is_null"
+      scope.where(Arel::Nodes::Not.new(tagging_exists))
+    else
+      raise UnsupportedOperatorError, "Unsupported operator: #{operator} for type: #{type}"
+    end
   end
+
+  private
+    # Builds an Arel EXISTS node correlating taggings to the outer transactions
+    # row. When +tag_id+ is given it matches that specific tag; otherwise it
+    # matches any tag (negated for the "is_null" / has-no-tags operator).
+    def tagging_exists(tag_id: nil)
+      taggings = Tagging
+        .where(Tagging.arel_table[:taggable_id].eq(Transaction.arel_table[:id]))
+        .where(taggable_type: "Transaction")
+      taggings = taggings.where(tag_id: tag_id) if tag_id.present?
+      taggings.arel.exists
+    end
 end

--- a/app/models/rule/registry/transaction_resource.rb
+++ b/app/models/rule/registry/transaction_resource.rb
@@ -10,6 +10,7 @@ class Rule::Registry::TransactionResource < Rule::Registry
       Rule::ConditionFilter::TransactionType.new(rule),
       Rule::ConditionFilter::TransactionMerchant.new(rule),
       Rule::ConditionFilter::TransactionCategory.new(rule),
+      Rule::ConditionFilter::TransactionTag.new(rule),
       Rule::ConditionFilter::TransactionDetails.new(rule),
       Rule::ConditionFilter::TransactionNotes.new(rule),
       Rule::ConditionFilter::TransactionAccount.new(rule)

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -1842,6 +1842,47 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal category.id, action.value
   end
 
+  test "imports transaction_tag rule condition by remapping the tag name to an id" do
+    ndjson = build_ndjson([
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "Flag Reimbursable",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            {
+              condition_type: "transaction_tag",
+              operator: "=",
+              value: "Reimbursable"
+            }
+          ],
+          actions: [
+            {
+              action_type: "set_transaction_name",
+              value: "Reimbursable expense"
+            }
+          ]
+        }
+      }
+    ])
+
+    importer = Family::DataImporter.new(@family, ndjson)
+    importer.import!
+
+    rule = @family.rules.find_by(name: "Flag Reimbursable")
+    assert_not_nil rule
+
+    condition = rule.conditions.first
+    assert_equal "transaction_tag", condition.condition_type
+
+    # The tag should be created and the condition value remapped to its id
+    tag = @family.tags.find_by(name: "Reimbursable")
+    assert_not_nil tag
+    assert_equal tag.id, condition.value
+  end
+
   test "session rule reimport only replaces current family conditions and actions" do
     rule = @family.rules.build(name: "Original Rule", resource_type: "transaction", active: true)
     rule.conditions.build(condition_type: "transaction_name", operator: "like", value: "old")

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -1881,6 +1881,47 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal category.id, action.value
   end
 
+  test "imports transaction_tag rule condition by remapping the tag name to an id" do
+    ndjson = build_ndjson([
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "Flag Reimbursable",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            {
+              condition_type: "transaction_tag",
+              operator: "=",
+              value: "Reimbursable"
+            }
+          ],
+          actions: [
+            {
+              action_type: "set_transaction_name",
+              value: "Reimbursable expense"
+            }
+          ]
+        }
+      }
+    ])
+
+    importer = Family::DataImporter.new(@family, ndjson)
+    importer.import!
+
+    rule = @family.rules.find_by(name: "Flag Reimbursable")
+    assert_not_nil rule
+
+    condition = rule.conditions.first
+    assert_equal "transaction_tag", condition.condition_type
+
+    # The tag should be created and the condition value remapped to its id
+    tag = @family.tags.find_by(name: "Reimbursable")
+    assert_not_nil tag
+    assert_equal tag.id, condition.value
+  end
+
   test "session rule reimport only replaces current family conditions and actions" do
     rule = @family.rules.build(name: "Original Rule", resource_type: "transaction", active: true)
     rule.conditions.build(condition_type: "transaction_name", operator: "like", value: "old")

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -208,6 +208,63 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert filtered.none? { |t| t.tags.include?(tag) }
   end
 
+  test "compound AND of two transaction_tag conditions matches transactions having both tags" do
+    scope = @rule_scope
+
+    tag_a = @family.tags.create!(name: "Reimbursable")
+    tag_b = @family.tags.create!(name: "Business")
+
+    both = @account.transactions.first
+    both.tags << [ tag_a, tag_b ]
+
+    only_a = @account.transactions.second
+    only_a.tags << tag_a
+
+    parent_condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "compound",
+      operator: "and",
+      sub_conditions: [
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_a.id),
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_b.id)
+      ]
+    )
+
+    scope = parent_condition.prepare(scope)
+    filtered = parent_condition.apply(scope)
+
+    # Only the transaction carrying BOTH tags matches (a single joined alias could not)
+    assert_equal 1, filtered.count
+    assert_equal both.id, filtered.first.id
+  end
+
+  test "compound OR of transaction_tag conditions does not duplicate multi-tagged transactions" do
+    scope = @rule_scope
+
+    tag_a = @family.tags.create!(name: "Reimbursable")
+    tag_b = @family.tags.create!(name: "Business")
+
+    multi = @account.transactions.first
+    multi.tags << [ tag_a, tag_b ]
+
+    parent_condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "compound",
+      operator: "or",
+      sub_conditions: [
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_a.id),
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_b.id)
+      ]
+    )
+
+    scope = parent_condition.prepare(scope)
+    filtered = parent_condition.apply(scope)
+
+    # Matches both OR branches but must be returned exactly once (no join fan-out)
+    assert_equal 1, filtered.count
+    assert_equal [ multi.id ], filtered.map(&:id)
+  end
+
   test "applies is_null condition for transaction_merchant" do
     scope = @rule_scope
 

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -166,6 +166,48 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert filtered.all? { |t| t.category_id.nil? }
   end
 
+  test "applies transaction_tag condition" do
+    scope = @rule_scope
+
+    tag = @family.tags.create!(name: "Reimbursable")
+    tagged = @account.transactions.first
+    tagged.tags << tag
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_tag",
+      operator: "=",
+      value: tag.id
+    )
+
+    scope = condition.prepare(scope)
+    filtered = condition.apply(scope)
+
+    assert_equal 1, filtered.count
+    assert_equal tagged.id, filtered.first.id
+  end
+
+  test "applies is_null condition for transaction_tag" do
+    scope = @rule_scope
+
+    tag = @family.tags.create!(name: "Reimbursable")
+    @account.transactions.first.tags << tag
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_tag",
+      operator: "is_null",
+      value: nil
+    )
+
+    scope = condition.prepare(scope)
+    filtered = condition.apply(scope)
+
+    # The 4 transactions without any tag
+    assert_equal 4, filtered.count
+    assert filtered.none? { |t| t.tags.include?(tag) }
+  end
+
   test "applies is_null condition for transaction_merchant" do
     scope = @rule_scope
 

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -185,6 +185,48 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert filtered.all? { |t| t.category_id.nil? }
   end
 
+  test "applies transaction_tag condition" do
+    scope = @rule_scope
+
+    tag = @family.tags.create!(name: "Reimbursable")
+    tagged = @account.transactions.first
+    tagged.tags << tag
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_tag",
+      operator: "=",
+      value: tag.id
+    )
+
+    scope = condition.prepare(scope)
+    filtered = condition.apply(scope)
+
+    assert_equal 1, filtered.count
+    assert_equal tagged.id, filtered.first.id
+  end
+
+  test "applies is_null condition for transaction_tag" do
+    scope = @rule_scope
+
+    tag = @family.tags.create!(name: "Reimbursable")
+    @account.transactions.first.tags << tag
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_tag",
+      operator: "is_null",
+      value: nil
+    )
+
+    scope = condition.prepare(scope)
+    filtered = condition.apply(scope)
+
+    # The 4 transactions without any tag
+    assert_equal 4, filtered.count
+    assert filtered.none? { |t| t.tags.include?(tag) }
+  end
+
   test "applies is_null condition for transaction_merchant" do
     scope = @rule_scope
 

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -227,6 +227,63 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert filtered.none? { |t| t.tags.include?(tag) }
   end
 
+  test "compound AND of two transaction_tag conditions matches transactions having both tags" do
+    scope = @rule_scope
+
+    tag_a = @family.tags.create!(name: "Reimbursable")
+    tag_b = @family.tags.create!(name: "Business")
+
+    both = @account.transactions.first
+    both.tags << [ tag_a, tag_b ]
+
+    only_a = @account.transactions.second
+    only_a.tags << tag_a
+
+    parent_condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "compound",
+      operator: "and",
+      sub_conditions: [
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_a.id),
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_b.id)
+      ]
+    )
+
+    scope = parent_condition.prepare(scope)
+    filtered = parent_condition.apply(scope)
+
+    # Only the transaction carrying BOTH tags matches (a single joined alias could not)
+    assert_equal 1, filtered.count
+    assert_equal both.id, filtered.first.id
+  end
+
+  test "compound OR of transaction_tag conditions does not duplicate multi-tagged transactions" do
+    scope = @rule_scope
+
+    tag_a = @family.tags.create!(name: "Reimbursable")
+    tag_b = @family.tags.create!(name: "Business")
+
+    multi = @account.transactions.first
+    multi.tags << [ tag_a, tag_b ]
+
+    parent_condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "compound",
+      operator: "or",
+      sub_conditions: [
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_a.id),
+        Rule::Condition.new(condition_type: "transaction_tag", operator: "=", value: tag_b.id)
+      ]
+    )
+
+    scope = parent_condition.prepare(scope)
+    filtered = parent_condition.apply(scope)
+
+    # Matches both OR branches but must be returned exactly once (no join fan-out)
+    assert_equal 1, filtered.count
+    assert_equal [ multi.id ], filtered.map(&:id)
+  end
+
   test "applies is_null condition for transaction_merchant" do
     scope = @rule_scope
 


### PR DESCRIPTION
Closes #2557

### What

Adds a `transaction_tag` rule **condition** filter so rules can match transactions by an existing tag. Rules could already **set** tags (`set_transaction_tags` action) but there was no tag-based condition — this closes that asymmetry and enables rule chains like "if tagged *Reimbursable* → exclude from budget" or compound tag + amount/merchant conditions.

### How

- **`app/models/rule/condition_filter/transaction_tag.rb`** (new): a `select`-type filter mirroring `TransactionCategory`. Options are the family's tags; operators are the standard `Equal to` (`=`, has this tag) and `Is empty` (`is_null`, has no tags). It joins `transactions.tags` and filters on `tags.id`.
- **`app/models/rule/registry/transaction_resource.rb`**: register the new filter. The rule builder renders condition types dynamically from `rule.registry`, so it appears in the UI automatically — no view/JS changes needed.
- **`app/models/family/data_exporter.rb` / `data_importer.rb`**: remap the tag `UUID ⇄ name` for the new condition, exactly like the existing `transaction_category`/`transaction_merchant` conditions and the `set_transaction_tags` action, so tag-based rules survive a family export/import round-trip.

### Notes

- No `DISTINCT` is applied in the filter: the two supported `select` operators (`=`, `is_null`) can't match a transaction's tag join more than once, and omitting it keeps the relation structurally compatible with the other filters inside a compound `OR` condition (ActiveRecord `#or` requires structurally-compatible relations).
- No condition-type whitelist/enum exists to update (conditions resolve through `rule.registry.get_filter!`), and the change is fully additive.

### Tests

- `test/models/rule/condition_test.rb`: matching by tag (`=`) and untagged (`is_null`).
- `test/models/family/data_importer_test.rb`: importing a `transaction_tag` condition remaps the tag name to a (created) tag id.

> Note: I don't have a Ruby toolchain on this machine to run the suite locally; CI will exercise it. The change follows the existing `transaction_category`/`transaction_merchant` patterns closely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction tag filters to rules, including matching specific tags and finding untagged transactions.
  * Added support for combining tag conditions with “and” and “or” logic.
  * Transaction tags are now preserved when exporting and importing rules, including automatic tag creation when needed.

* **Tests**
  * Added coverage for tag-based filtering and rule import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->