### PR TITLE
perf: skip application layout for modal/drawer turbo frame requests (~200ms per dialog open)

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -42,6 +42,10 @@ class AccountsController < ApplicationController
     @provider_configs = Provider::Factory.registered_adapters.flat_map do |adapter_class|
       adapter_class.connection_configs(family: family)
     end
+
+    # The dialog loads into the "modal" turbo frame; skip the full layout
+    # (which renders the account sidebar twice) for frame requests.
+    render layout: false if turbo_frame_request?
   end
 
   def sync_all

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -48,6 +48,10 @@ class AccountsController < ApplicationController
     @provider_configs = Provider::Factory.registered_adapters.flat_map do |adapter_class|
       adapter_class.connection_configs(family: family)
     end
+
+    # The dialog loads into the "modal" turbo frame; skip the full layout
+    # (which renders the account sidebar twice) for frame requests.
+    render layout: false if turbo_frame_request?
   end
 
   def sync_all

--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -7,6 +7,12 @@ module AccountableResource
     before_action :set_account, only: [ :show ]
     before_action :set_manageable_account, only: [ :edit, :update ]
     before_action :set_link_options, only: :new
+
+    # The new/edit dialogs are fetched into the "modal" turbo frame; Turbo
+    # discards everything outside the frame, so skip the application layout
+    # (which renders the account sidebar twice) for those requests. create/
+    # update are included for their validation-error re-renders.
+    layout -> { turbo_frame_request? ? false : "application" }, only: %i[new edit create update]
   end
 
   class_methods do

--- a/app/controllers/concerns/entryable_resource.rb
+++ b/app/controllers/concerns/entryable_resource.rb
@@ -7,6 +7,12 @@ module EntryableResource
     before_action :set_entry, only: %i[show update destroy]
 
     helper_method :can_edit_entry?, :can_annotate_entry?
+
+    # The new dialog loads into the "modal" frame and show into the "drawer"
+    # frame; Turbo discards everything outside the frame, so skip the
+    # application layout (which renders the account sidebar twice) for those
+    # requests. create/update are included for validation-error re-renders.
+    layout -> { turbo_frame_request? ? false : "application" }, only: %i[new show create update]
   end
 
   def show

--- a/test/interfaces/accountable_resource_interface_test.rb
+++ b/test/interfaces/accountable_resource_interface_test.rb
@@ -15,6 +15,16 @@ module AccountableResourceInterfaceTest
     assert_response :success
   end
 
+  test "modal frame requests skip the application layout" do
+    Family.any_instance.stubs(:get_link_token).returns("test-link-token")
+
+    get new_polymorphic_url(@account.accountable), headers: { "Turbo-Frame" => "modal" }
+
+    assert_response :success
+    assert_select "turbo-frame#modal"
+    assert_select "body", count: 0
+  end
+
   test "update saves currency change" do
     @account.update!(currency: "USD")
 

--- a/test/interfaces/entryable_resource_interface_test.rb
+++ b/test/interfaces/entryable_resource_interface_test.rb
@@ -13,6 +13,14 @@ module EntryableResourceInterfaceTest
     assert_response :success
   end
 
+  test "modal frame requests skip the application layout" do
+    get new_polymorphic_url(@entry.entryable), headers: { "Turbo-Frame" => "modal" }
+
+    assert_response :success
+    assert_select "turbo-frame#modal"
+    assert_select "body", count: 0
+  end
+
   test "destroys entry" do
     assert_difference "Entry.count", -1 do
       delete entry_url(@entry)


### PR DESCRIPTION
## Summary

Part 5/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`). Per-request instrumentation showed modal form operations among the slowest per-request flows: `CreditCardsController#new` 220ms view, `TransactionsController#new` 205ms, `TransactionsController#show` (drawer) 236ms — for responses where Turbo only keeps the small dialog frame.

## Root cause

Every `frame: :modal` / drawer link fetches its content with a `Turbo-Frame` header, but the server rendered the **entire application layout** — including the account sidebar twice (desktop + mobile) — around the dialog. Turbo then discards everything outside the frame.

## Changes

- `AccountableResource` (9 account-type controllers): render without layout on frame requests for `new`/`edit` (+ `create`/`update` so validation-error re-renders benefit).
- `EntryableResource` (transactions, trades, valuations): same for `new`/`show` (drawer) + `create`/`update`.
- `AccountsController#new` (account method selector modal): same.
- Direct (non-frame) navigation still renders the full layout.
- New shared interface tests assert frame requests return only the dialog frame (runs across all 12 including controllers).

## Measured effect

Frame-request renders drop from ~200–240ms of view time to single-digit ms; the layout render only happens for full page visits. This affects every modal open in the app (new account, edit account, new transaction, transaction drawer, trades, valuations).

## Verification

`bin/rails test` across all 12 accountable/entryable controller test files + accounts controller → 164 runs, 706 assertions, 0 failures. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Turbo Frame (“modal”) requests for account and entry pages now render without the full application layout, preventing duplicated sidebar/content in frame dialogs.
  * Form flows including **new/edit/create/update** behave correctly when loaded inside a Turbo Frame.

* **Tests**
  * Added interface coverage to confirm Turbo Frame requests return the expected `turbo-frame#modal` content and omit the surrounding page body layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->