### PR TITLE
perf: batch the reports trends chart into one month-grouped query

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -322,28 +322,25 @@ class ReportsController < ApplicationController
     end
 
     def build_trends_data(income_statement:)
-      # Generate month-by-month data based on the current period filter
+      # Month-by-month data based on the current period filter, fetched with a
+      # single month-grouped totals query instead of two queries per month.
       trends = []
 
-      # Generate list of months within the period
       current_month = @start_date.beginning_of_month
       end_of_period = @end_date.end_of_month
 
+      monthly_totals = income_statement.monthly_income_expense_totals(
+        period: Period.custom(start_date: current_month, end_date: @end_date)
+      )
+
       while current_month <= end_of_period
-        month_start = current_month
-        month_end = current_month.end_of_month
-
-        # Ensure we don't go beyond the end date
-        month_end = @end_date if month_end > @end_date
-
-        period = Period.custom(start_date: month_start, end_date: month_end)
-
-        income = income_statement.income_totals(period: period).total
-        expenses = income_statement.expense_totals(period: period).total
+        totals = monthly_totals[current_month] || { income: 0.to_d, expense: 0.to_d }
+        income = totals[:income]
+        expenses = totals[:expense]
 
         trends << {
-          month: month_start.strftime("%b %Y"),
-          is_current_month: (month_start.month == Date.current.month && month_start.year == Date.current.year),
+          month: current_month.strftime("%b %Y"),
+          is_current_month: (current_month.month == Date.current.month && current_month.year == Date.current.year),
           income: income,
           expenses: expenses,
           net: income - expenses

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -29,6 +29,28 @@ class IncomeStatement
     )
   end
 
+  # Income/expense sums per calendar month over the period, computed in a
+  # single query. Returns a hash of { Date (first of month) => { income:, expense: } }
+  # with BigDecimal sums. Used by the reports trends chart, which previously
+  # issued a totals query per month of the period.
+  def monthly_income_expense_totals(period:)
+    key = period_cache_key(period)
+    @monthly_income_expense_totals ||= {}
+    @monthly_income_expense_totals[key] ||= begin
+      rows = monthly_totals_query(
+        transactions_scope: family.transactions.visible.excluding_pending.in_period(period),
+        date_range: period.date_range
+      )
+
+      rows.group_by(&:month).transform_values do |month_rows|
+        {
+          income: month_rows.select { |r| r.classification == "income" }.sum { |r| r.total.to_d },
+          expense: month_rows.select { |r| r.classification == "expense" }.sum { |r| r.total.to_d }
+        }
+      end
+    end
+  end
+
   def expense_totals(period: Period.current_month)
     # Memoized per instance so callers that also invoke `net_category_totals`
     key = period_cache_key(period)
@@ -224,6 +246,14 @@ class IncomeStatement
       Rails.cache.fetch([
         "income_statement", "totals_query", "v2", family.id, user&.id, included_account_ids_hash, sql_hash, date_range.begin, date_range.end, family.entries_cache_version, family.accounts.maximum(:updated_at)&.to_i
       ]) { Totals.new(family, transactions_scope: transactions_scope, date_range: date_range, included_account_ids: included_account_ids).call }
+    end
+
+    def monthly_totals_query(transactions_scope:, date_range:)
+      sql_hash = Digest::MD5.hexdigest(transactions_scope.to_sql)
+
+      Rails.cache.fetch([
+        "income_statement", "monthly_totals_query", "v1", family.id, user&.id, included_account_ids_hash, sql_hash, date_range.begin, date_range.end, family.entries_cache_version, family.accounts.maximum(:updated_at)&.to_i
+      ]) { Totals.new(family, transactions_scope: transactions_scope, date_range: date_range, included_account_ids: included_account_ids, group_by_month: true).call }
     end
 
     def monetizable_currency

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -34,6 +34,28 @@ class IncomeStatement
     )
   end
 
+  # Income/expense sums per calendar month over the period, computed in a
+  # single query. Returns a hash of { Date (first of month) => { income:, expense: } }
+  # with BigDecimal sums. Used by the reports trends chart, which previously
+  # issued a totals query per month of the period.
+  def monthly_income_expense_totals(period:)
+    key = period_cache_key(period)
+    @monthly_income_expense_totals ||= {}
+    @monthly_income_expense_totals[key] ||= begin
+      rows = monthly_totals_query(
+        transactions_scope: family.transactions.visible.excluding_pending.in_period(period),
+        date_range: period.date_range
+      )
+
+      rows.group_by(&:month).transform_values do |month_rows|
+        {
+          income: month_rows.select { |r| r.classification == "income" }.sum { |r| r.total.to_d },
+          expense: month_rows.select { |r| r.classification == "expense" }.sum { |r| r.total.to_d }
+        }
+      end
+    end
+  end
+
   def expense_totals(period: Period.current_month)
     # Memoized per instance so callers that also invoke `net_category_totals`
     key = period_cache_key(period)
@@ -261,6 +283,14 @@ class IncomeStatement
       Rails.cache.fetch([
         "income_statement", "totals_query", "v2", family.id, user&.id, included_account_ids_hash, sql_hash, date_range.begin, date_range.end, family.entries_cache_version, family.accounts.maximum(:updated_at)&.to_i
       ]) { Totals.new(family, transactions_scope: transactions_scope, date_range: date_range, included_account_ids: included_account_ids).call }
+    end
+
+    def monthly_totals_query(transactions_scope:, date_range:)
+      sql_hash = Digest::MD5.hexdigest(transactions_scope.to_sql)
+
+      Rails.cache.fetch([
+        "income_statement", "monthly_totals_query", "v1", family.id, user&.id, included_account_ids_hash, sql_hash, date_range.begin, date_range.end, family.entries_cache_version, family.accounts.maximum(:updated_at)&.to_i
+      ]) { Totals.new(family, transactions_scope: transactions_scope, date_range: date_range, included_account_ids: included_account_ids, group_by_month: true).call }
     end
 
     def monetizable_currency

--- a/app/models/income_statement/totals.rb
+++ b/app/models/income_statement/totals.rb
@@ -1,10 +1,13 @@
 class IncomeStatement::Totals
-  def initialize(family, transactions_scope:, date_range:, include_trades: true, included_account_ids: nil)
+  def initialize(family, transactions_scope:, date_range:, include_trades: true, included_account_ids: nil, group_by_month: false)
     @family = family
     @transactions_scope = transactions_scope
     @date_range = date_range
     @include_trades = include_trades
     @included_account_ids = included_account_ids
+    @group_by_month = group_by_month
+
+    raise ArgumentError, "group_by_month requires include_trades" if @group_by_month && !@include_trades
 
     validate_date_range!
   end
@@ -20,13 +23,16 @@ class IncomeStatement::Totals
         classification: row["classification"],
         total: row["total"],
         transactions_count: row["transactions_count"],
-        is_uncategorized_investment: row["is_uncategorized_investment"]
+        is_uncategorized_investment: row["is_uncategorized_investment"],
+        month: row["month"]&.to_date
       )
     end
   end
 
   private
-    TotalsRow = Data.define(:parent_category_id, :category_id, :classification, :total, :transactions_count, :is_uncategorized_investment)
+    TotalsRow = Data.define(:parent_category_id, :category_id, :classification, :total, :transactions_count, :is_uncategorized_investment, :month) do
+      def initialize(month: nil, **rest) = super
+    end
 
     def query_sql
       ActiveRecord::Base.sanitize_sql_array([
@@ -43,6 +49,7 @@ class IncomeStatement::Totals
           parent_category_id,
           classification,
           is_uncategorized_investment,
+          #{"month," if @group_by_month}
           SUM(total) as total,
           SUM(entry_count) as transactions_count
         FROM (
@@ -50,7 +57,7 @@ class IncomeStatement::Totals
           UNION ALL
           #{trades_subquery_sql}
         ) combined
-        GROUP BY category_id, parent_category_id, classification, is_uncategorized_investment;
+        GROUP BY category_id, parent_category_id, classification, is_uncategorized_investment#{", month" if @group_by_month};
       SQL
     end
 
@@ -92,7 +99,7 @@ class IncomeStatement::Totals
           CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END as classification,
           ABS(SUM(CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN ABS(ae.amount * COALESCE(er.rate, 1)) ELSE ae.amount * COALESCE(er.rate, 1) END)) as total,
           COUNT(ae.id) as entry_count,
-          false as is_uncategorized_investment
+          false as is_uncategorized_investment#{",\n          date_trunc('month', ae.date)::date as month" if @group_by_month}
         FROM (#{@transactions_scope.to_sql}) at
         JOIN entries ae ON ae.entryable_id = at.id AND ae.entryable_type = 'Transaction'
         JOIN accounts a ON a.id = ae.account_id
@@ -113,7 +120,7 @@ class IncomeStatement::Totals
           AND a.exclude_from_reports = false
           #{exclude_tax_advantaged_sql}
           #{include_finance_accounts_sql}
-        GROUP BY c.id, c.parent_id, CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END
+        GROUP BY c.id, c.parent_id, CASE WHEN at.kind IN ('investment_contribution', 'loan_payment') THEN 'expense' WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END#{", date_trunc('month', ae.date)::date" if @group_by_month}
       SQL
     end
 
@@ -124,7 +131,7 @@ class IncomeStatement::Totals
       # Contributions/withdrawals are tracked separately as Transactions with activity labels
       <<~SQL
         SELECT NULL as category_id, NULL as parent_category_id, NULL as classification,
-               NULL as total, NULL as entry_count, NULL as is_uncategorized_investment
+               NULL as total, NULL as entry_count, NULL as is_uncategorized_investment#{",\n               NULL::date as month" if @group_by_month}
         WHERE false
       SQL
     end

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -39,6 +39,31 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_equal expected_total_expense, expense_totals.category_totals.find { |ct| ct.category.id == @food_category.id }.total
   end
 
+  test "monthly income/expense totals match per-month period totals" do
+    # Spread entries over two months
+    create_transaction(account: @checking_account, amount: -500, category: @income_category, date: 40.days.ago.to_date)
+    create_transaction(account: @checking_account, amount: 250, category: @groceries_category, date: 40.days.ago.to_date)
+
+    income_statement = IncomeStatement.new(@family)
+    start_date = 60.days.ago.to_date.beginning_of_month
+    period = Period.custom(start_date: start_date, end_date: Date.current)
+
+    monthly = income_statement.monthly_income_expense_totals(period: period)
+
+    month = start_date
+    while month <= Date.current
+      month_end = [ month.end_of_month, Date.current ].min
+      expected_income = income_statement.income_totals(period: Period.custom(start_date: month, end_date: month_end)).total
+      expected_expense = income_statement.expense_totals(period: Period.custom(start_date: month, end_date: month_end)).total
+
+      actual = monthly[month] || { income: 0.to_d, expense: 0.to_d }
+      assert_equal expected_income.to_d, actual[:income].to_d, "income mismatch for #{month}"
+      assert_equal expected_expense.to_d, actual[:expense].to_d, "expense mismatch for #{month}"
+
+      month = month.next_month
+    end
+  end
+
   test "orphaned categories still count as root category totals" do
     orphan_category = @family.categories.create! name: "Orphaned Category"
     orphan_category.update_column(:parent_id, SecureRandom.uuid)


### PR DESCRIPTION
## Summary

Part 6/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`). `ReportsControllerTest` was the 3rd slowest suite (18.6s), with ~65–70ms of DB time per index request.

## Root cause

`ReportsController#build_trends_data` looped over every month of the report period calling `income_totals` + `expense_totals` — two full totals queries (or cache round-trips) **per month**. The default 6-month report issued 12 extra queries per render; a 12-month period issued 24.

## Changes

- `IncomeStatement::Totals` gains a `group_by_month:` option: identical SQL and filters (budget-excluded kinds, pending exclusion, account scoping, FX conversion), plus a `date_trunc('month', …)` dimension in select/group-by. Guarded to the combined (trades-inclusive) path.
- New `IncomeStatement#monthly_income_expense_totals(period:)` — instance-memoized and Rails-cached like the existing totals, returning `{ month => { income:, expense: } }` from **one** query.
- `build_trends_data` now builds the same trends structure from that single call; months with no activity default to zeros exactly as before.

## Correctness

New test `monthly income/expense totals match per-month period totals` asserts the month-grouped sums equal the previous per-month `income_totals`/`expense_totals` for every month of a multi-month window with cross-month data.

## Measured effect

`ReportsController#index` DB time: ~65–70ms → **~55ms** per request (test-env probes, where the query cache is a null store; production first-renders save the same query fan-out).

## Verification

`bin/rails test test/models/income_statement_test.rb test/controllers/reports_controller_test.rb test/models/budget_test.rb test/models/budget_category_test.rb test/controllers/budget_categories_controller_test.rb test/controllers/pages_controller_test.rb` → 128 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Financial reports now provide month-by-month income and expense totals across selected date ranges.
  * Trend reporting has improved performance, especially over longer date ranges.
* **Bug Fixes**
  * Months without activity now consistently display zero values.
  * Current-month indicators remain accurate in trend reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->