### PR TITLE
perf: skip the before/after data census in FamilyResetJob resets

### DIFF
--- a/app/jobs/family_reset_job.rb
+++ b/app/jobs/family_reset_job.rb
@@ -2,10 +2,13 @@ class FamilyResetJob < ApplicationJob
   queue_as :low_priority
 
   def perform(family, load_sample_data_for_email: nil)
+    # report: false skips the before/after count queries - the Result is
+    # discarded here, we only need the deletion side effects.
     Family::FinancialDataReset.new(
       family: family,
       dry_run: false,
-      confirmed: true
+      confirmed: true,
+      report: false
     ).call
 
     if load_sample_data_for_email.present?

--- a/app/models/family/financial_data_reset.rb
+++ b/app/models/family/financial_data_reset.rb
@@ -73,7 +73,10 @@ class Family::FinancialDataReset
 
   attr_reader :user, :family
 
-  def initialize(user: nil, family: nil, dry_run: true, confirmed: false)
+  # report: false skips the ~33 COUNT queries taken before and after the
+  # deletion. Callers that discard the Result's counts (e.g. FamilyResetJob)
+  # can opt out; the returned Result then carries empty count hashes.
+  def initialize(user: nil, family: nil, dry_run: true, confirmed: false, report: true)
     if user && family && user.family != family
       raise ArgumentError, "user and family must belong to the same family"
     end
@@ -82,12 +85,13 @@ class Family::FinancialDataReset
     @family = family || user&.family
     @dry_run = ActiveModel::Type::Boolean.new.cast(dry_run)
     @confirmed = ActiveModel::Type::Boolean.new.cast(confirmed)
+    @report = ActiveModel::Type::Boolean.new.cast(report)
 
     raise ArgumentError, "user or family is required" unless @family
   end
 
   def call
-    before_counts = counts
+    before_counts = report? ? counts : {}
     if destructive_without_confirmation?
       raise ConfirmationRequiredError, "Pass confirmed: true to Family::FinancialDataReset to delete financial data."
     end
@@ -102,7 +106,7 @@ class Family::FinancialDataReset
       end
       purge_unattached_blobs(blob_ids)
       family.reload
-      after_counts = counts
+      after_counts = report? ? counts : {}
     end
 
     Result.new(
@@ -117,6 +121,10 @@ class Family::FinancialDataReset
 
   def dry_run?
     @dry_run
+  end
+
+  def report?
+    @report
   end
 
   private

--- a/app/models/family/financial_data_reset.rb
+++ b/app/models/family/financial_data_reset.rb
@@ -75,7 +75,10 @@ class Family::FinancialDataReset
 
   attr_reader :user, :family
 
-  def initialize(user: nil, family: nil, dry_run: true, confirmed: false)
+  # report: false skips the ~33 COUNT queries taken before and after the
+  # deletion. Callers that discard the Result's counts (e.g. FamilyResetJob)
+  # can opt out; the returned Result then carries empty count hashes.
+  def initialize(user: nil, family: nil, dry_run: true, confirmed: false, report: true)
     if user && family && user.family != family
       raise ArgumentError, "user and family must belong to the same family"
     end
@@ -84,12 +87,13 @@ class Family::FinancialDataReset
     @family = family || user&.family
     @dry_run = ActiveModel::Type::Boolean.new.cast(dry_run)
     @confirmed = ActiveModel::Type::Boolean.new.cast(confirmed)
+    @report = ActiveModel::Type::Boolean.new.cast(report)
 
     raise ArgumentError, "user or family is required" unless @family
   end
 
   def call
-    before_counts = counts
+    before_counts = report? ? counts : {}
     if destructive_without_confirmation?
       raise ConfirmationRequiredError, "Pass confirmed: true to Family::FinancialDataReset to delete financial data."
     end
@@ -104,7 +108,7 @@ class Family::FinancialDataReset
       end
       purge_unattached_blobs(blob_ids)
       family.reload
-      after_counts = counts
+      after_counts = report? ? counts : {}
     end
 
     Result.new(
@@ -119,6 +123,10 @@ class Family::FinancialDataReset
 
   def dry_run?
     @dry_run
+  end
+
+  def report?
+    @report
   end
 
   private

--- a/test/models/family/financial_data_reset_test.rb
+++ b/test/models/family/financial_data_reset_test.rb
@@ -58,6 +58,23 @@ class Family::FinancialDataResetTest < ActiveSupport::TestCase
     end
   end
 
+  test "report: false skips count queries but still deletes financial data" do
+    assert_operator @family.accounts.count, :>, 0
+
+    result = Family::FinancialDataReset.new(
+      user: @user,
+      dry_run: false,
+      confirmed: true,
+      report: false
+    ).call
+
+    assert_equal({}, result.before_counts)
+    assert_equal({}, result.after_counts)
+    assert result.deleted_counts.values.all?(&:zero?)
+    assert_equal 0, @family.reload.accounts.count
+    assert User.exists?(@user.id)
+  end
+
   test "destructive reset without confirmation does not partially mutate financial data" do
     create_extra_target_data!(family: @family, label: "Unconfirmed")
     before_counts = reset_counts(@family)


### PR DESCRIPTION
## Summary

Part 7/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`). The family reset flow accounted for ~14s of CI across `Family::FinancialDataResetTest` (6.1s), `FamilyResetJobTest` (~3.2s) and the `UsersControllerTest` reset tests.

## Root cause

`Family::FinancialDataReset#call` takes a full census of the family's data **before and after** deletion — ~33 `COUNT` queries per pass plus ~20 Active Storage attachment counts, doubled for destructive runs. `FamilyResetJob` (the production caller of the destructive path) discards the returned `Result`, so all that counting was pure overhead on every reset.

## Changes

- `Family::FinancialDataReset.new(..., report: true)` — new option; `report: false` skips both count passes and returns empty count hashes in the `Result`. Default `true` keeps the admin dry-run and `Api::V1::UsersController` census behavior unchanged.
- `FamilyResetJob` passes `report: false`.
- Test covering that `report: false` still deletes data and returns empty counts.

## Measured effect

| Test | Before | After |
|---|---|---|
| `FamilyResetJobTest#resets_family_data_successfully` | 1.13s | **0.79s** |
| `FamilyResetJobTest#reset_leaves_another_family's_imports…` | 1.08s | **0.70s** |
| `FamilyResetJobTest#resets…Plaid_credentials_are_invalid` | 1.03s | **0.75s** |

Production async resets save ~90 queries each.

## Verification

`bin/rails test test/models/family/financial_data_reset_test.rb test/jobs/family_reset_job_test.rb test/controllers/users_controller_test.rb test/controllers/api/v1/users_controller_test.rb` → 39 runs, 213 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Financial data resets now skip unnecessary count reporting when it is not needed, while still removing the family’s financial records.
  * Reset results may return empty before-and-after summaries in this mode, with deletion totals shown as zeroes instead of calculated counts.
  * User records remain preserved during the reset process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->