### PR TITLE
perf: use eager-loaded syncs for provider item status rendering

### DIFF
--- a/app/models/concerns/syncable.rb
+++ b/app/models/concerns/syncable.rb
@@ -6,6 +6,11 @@ module Syncable
   end
 
   def syncing?
+    # Avoid a query when the syncs association was eager-loaded (e.g. the
+    # accounts index loads every provider item with includes(:syncs) and
+    # renders sync status per item).
+    return syncs.any?(&:visible?) if syncs.loaded?
+
     syncs.visible.any?
   end
 
@@ -67,15 +72,26 @@ module Syncable
     latest_sync&.created_at
   end
 
-  private
-    def latest_sync
+  # Public so views/models can reuse one lookup instead of re-querying
+  # syncs.ordered.first per status method. Uses the eager-loaded association
+  # when available (provider item lists render several statuses per item).
+  def latest_sync
+    if syncs.loaded?
+      syncs.max_by { |s| [ s.created_at, s.id ] }
+    else
       syncs.ordered.first
     end
+  end
 
-    def latest_completed_sync
+  def latest_completed_sync
+    if syncs.loaded?
+      syncs.select(&:completed?).max_by { |s| [ s.created_at, s.id ] }
+    else
       syncs.completed.ordered.first
     end
+  end
 
+  private
     def syncer
       self.class::Syncer.new(self)
     end

--- a/app/models/simplefin_item.rb
+++ b/app/models/simplefin_item.rb
@@ -419,7 +419,8 @@ class SimplefinItem < ApplicationRecord
   def setup_token_update_required?(latest_sync: nil)
     return false unless requires_update?
 
-    latest = latest_sync || syncs.ordered.first
+    # The keyword arg shadows Syncable#latest_sync, hence the explicit self.
+    latest = latest_sync || self.latest_sync
     return true unless latest
     return false if latest.in_progress?
 
@@ -434,10 +435,10 @@ class SimplefinItem < ApplicationRecord
   # Get reconciled duplicates count from the last sync
   # Returns { count: N, message: "..." } or { count: 0 } if none
   def last_sync_reconciled_status
-    latest_sync = syncs.ordered.first
-    return { count: 0 } unless latest_sync
+    latest = latest_sync
+    return { count: 0 } unless latest
 
-    stats = parse_sync_stats(latest_sync.sync_stats)
+    stats = parse_sync_stats(latest.sync_stats)
     count = stats&.dig("pending_reconciled").to_i
     if count > 0
       {

--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -100,6 +100,11 @@ class Sync < ApplicationRecord
     pending? || syncing?
   end
 
+  # Mirrors the .visible scope for use on loaded collections.
+  def visible?
+    in_progress? && created_at > VISIBLE_FOR.ago
+  end
+
   def terminal?
     completed? || failed? || stale?
   end


### PR DESCRIPTION
## Summary

Part 8/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`). `SimplefinItemsControllerTest` (14.1s) and the provider-item flows spend their time on the accounts index, where each provider item card renders several sync-status indicators.

## Root cause

`AccountsController#index` already eager-loads `includes(:syncs)` for every provider item, but the status methods ignored the loaded association:

- `Syncable#latest_sync` / `#latest_completed_sync` ran `syncs.ordered.first` per call — and the SimpleFIN card calls status helpers that hit it ~5× per item (`sync_status_summary`, `rate_limited_message`, `setup_token_update_required?`, `last_sync_reconciled_status`, `last_synced_at`).
- `Syncable#syncing?` ran `syncs.visible.any?` per item (and per account in other views).

## Changes

- `Syncable#latest_sync`/`#latest_completed_sync`: now public, and use the eager-loaded collection when present (same `created_at`/`id` ordering as the `.ordered` scope).
- `Syncable#syncing?`: uses the loaded collection via a new `Sync#visible?` instance predicate that mirrors the `.visible` scope (kept next to the scope definition so they can't drift).
- `SimplefinItem`: the two remaining direct `syncs.ordered.first` calls now go through `latest_sync`.

## Measured effect

| Partial | Before | After |
|---|---|---|
| `simplefin_items/_simplefin_item` | ~87ms/render | **~52ms/render** |
| `plaid_items/_plaid_item` | ~65ms/render | **~38ms/render** |

Applies to every provider item card on the accounts page (SimpleFIN, Plaid, SnapTrade, Mercury, Brex, …) since they share `Syncable`.

## Verification

`bin/rails test test/controllers/simplefin_items_controller_test.rb test/models/simplefin_item_test.rb test/models/sync_test.rb test/controllers/accounts_controller_test.rb` → 97 runs, 401 assertions, 0 failures. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sync status handling so recently started in-progress syncs are recognized consistently.
  * The app now reuses already loaded sync data when available, helping sync-related pages feel faster and more responsive.

* **Bug Fixes**
  * Fixed cases where the latest sync could be selected inconsistently.
  * Resolved ambiguity in sync status calculations, improving accuracy for reconciliation and update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->