### PR TITLE
perf(test): stub retry backoff sleeps in assistant client tests (~6s saved)

### DIFF
--- a/test/models/assistant/external/client_test.rb
+++ b/test/models/assistant/external/client_test.rb
@@ -44,6 +44,8 @@ class Assistant::External::ClientTest < ActiveSupport::TestCase
 
   test "retries transient errors then raises Assistant::Error" do
     Net::HTTP.any_instance.stubs(:request).raises(Net::OpenTimeout, "connection timed out")
+    # Skip the real 1s/2s retry backoff sleeps
+    Assistant::External::Client.any_instance.stubs(:sleep)
 
     error = assert_raises(Assistant::Error) do
       @client.chat(messages: [ { role: "user", content: "test" } ]) { |_| }

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -270,6 +270,8 @@ class AssistantTest < ActiveSupport::TestCase
     assistant = Assistant.for_chat(@chat)
 
     Net::HTTP.any_instance.stubs(:request).raises(Errno::ECONNREFUSED, "Connection refused")
+    # Skip the real 1s/2s retry backoff sleeps
+    Assistant::External::Client.any_instance.stubs(:sleep)
 
     with_env_overrides(
       "EXTERNAL_ASSISTANT_URL" => "http://localhost:18789/v1/chat",

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -398,6 +398,8 @@ class AssistantTest < ActiveSupport::TestCase
     assistant = Assistant.for_chat(@chat)
 
     Net::HTTP.any_instance.stubs(:request).raises(Errno::ECONNREFUSED, "Connection refused")
+    # Skip the real 1s/2s retry backoff sleeps
+    Assistant::External::Client.any_instance.stubs(:sleep)
 
     with_env_overrides(
       "EXTERNAL_ASSISTANT_URL" => "http://localhost:18789/v1/chat",


### PR DESCRIPTION
## Summary

Part 9/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`). Two of the slowest individual tests in the suite were assistant retry tests:

| Test | Time |
|---|---|
| `AssistantTest#external_assistant_adds_error_on_connection_failure` | 3.07s |
| `Assistant::External::ClientTest#retries_transient_errors_then_raises` | 3.01s |

## Root cause

Both exercise `Assistant::External::Client`'s transient-error path, which sleeps `1s` then `2s` between retries — the tests really slept through the backoff.

## Change

Stub the client instance's `sleep` in those two tests (mirroring the established pattern in `Provider::SimplefinTest`). Retry counting and error behavior are unchanged and still asserted.

## Measured effect

3.07s → **0.03s** and 3.01s → **0.00s**.

## Verification

`bin/rails test test/models/assistant_test.rb test/models/assistant/external/client_test.rb` → 34 runs, 136 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test speed by skipping real retry backoff delays in external assistant connection failure scenarios.
  * Kept existing assertions and behavior checks unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->