### PR TITLE
perf(test): seed the rate-limit counter instead of issuing 100 requests per test

### DIFF
--- a/test/controllers/api/v1/base_controller_test.rb
+++ b/test/controllers/api/v1/base_controller_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class Api::V1::BaseControllerTest < ActionDispatch::IntegrationTest
+  include ApiRateLimitTestHelper
+
   setup do
     @user = users(:family_admin)
     @oauth_app = Doorkeeper::Application.create!(
@@ -367,11 +369,12 @@ class Api::V1::BaseControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should return 429 when rate limit exceeded" do
-    # Make 100 requests to exhaust the rate limit
-    100.times do
-      get "/api/v1/test", headers: { "X-Api-Key" => @plain_api_key }
-      assert_response :success
-    end
+    # Seed the counter at 99 so the next request exhausts the limit
+    # (equivalent to making 100 requests, without the request overhead)
+    seed_api_rate_limit(@api_key, 99)
+
+    get "/api/v1/test", headers: { "X-Api-Key" => @plain_api_key }
+    assert_response :success
 
     # 101st request should be rate limited
     get "/api/v1/test", headers: { "X-Api-Key" => @plain_api_key }
@@ -400,9 +403,7 @@ class Api::V1::BaseControllerTest < ActionDispatch::IntegrationTest
 
   test "should provide detailed rate limit information in 429 response" do
     # Exhaust the rate limit
-    100.times do
-      get "/api/v1/test", headers: { "X-Api-Key" => @plain_api_key }
-    end
+    seed_api_rate_limit(@api_key, 100)
 
     # Make the rate-limited request
     get "/api/v1/test", headers: { "X-Api-Key" => @plain_api_key }
@@ -426,11 +427,12 @@ class Api::V1::BaseControllerTest < ActionDispatch::IntegrationTest
     )
 
     begin
-      # Make 50 requests with first API key
-      50.times do
-        get "/api/v1/test", headers: { "X-Api-Key" => @plain_api_key }
-        assert_response :success
-      end
+      # Put the first API key halfway through its budget and verify it
+      # still works
+      seed_api_rate_limit(@api_key, 49)
+      get "/api/v1/test", headers: { "X-Api-Key" => @plain_api_key }
+      assert_response :success
+      assert_equal "50", response.headers["X-RateLimit-Remaining"]
 
       # Should still be able to make requests with second API key
       get "/api/v1/test", headers: { "X-Api-Key" => other_api_key.display_key }

--- a/test/controllers/api/v1/usage_controller_test.rb
+++ b/test/controllers/api/v1/usage_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Api::V1::UsageControllerTest < ActionDispatch::IntegrationTest
+  include ApiRateLimitTestHelper
+
   setup do
     @user = users(:family_admin)
     # Destroy any existing active API keys for this user
@@ -112,11 +114,8 @@ class Api::V1::UsageControllerTest < ActionDispatch::IntegrationTest
 
   test "should work correctly when approaching rate limit" do
     travel_to Time.zone.local(2026, 1, 1, 12, 15, 0) do
-      # Make 98 requests to get close to the limit
-      98.times do
-        get "/api/v1/test", headers: { "X-Api-Key" => @api_key.display_key }
-        assert_response :success
-      end
+      # Get close to the limit without issuing 98 real requests
+      seed_api_rate_limit(@api_key, 98)
 
       # Check usage - this should be request 99
       get "/api/v1/usage", headers: { "X-Api-Key" => @api_key.display_key }

--- a/test/support/api_rate_limit_test_helper.rb
+++ b/test/support/api_rate_limit_test_helper.rb
@@ -1,0 +1,9 @@
+module ApiRateLimitTestHelper
+  # Seeds the ApiRateLimiter Redis counter for the current hourly window so
+  # tests can start at/near the limit without issuing hundreds of real
+  # requests through the full stack.
+  def seed_api_rate_limit(api_key, count)
+    window_start = (Time.current.to_i / 3600) * 3600
+    Redis.new.hset("api_rate_limit:#{api_key.id}", window_start.to_s, count)
+  end
+end


### PR DESCRIPTION
## Summary

Part 10/10 of the CI test performance work (audit: `docs/performance/ci-test-timings-2026-07-02.md` on `claude/ci-test-performance-6d95pc`). Four API rate-limiting tests exhausted the hourly limit by issuing up to **100 real HTTP requests each** through the full Rails stack, costing ~1s per test:

- `Api::V1::BaseControllerTest#should_return_429_when_rate_limit_exceeded` (1.10s)
- `Api::V1::BaseControllerTest#should_provide_detailed_rate_limit_information_in_429_response` (1.02s)
- `Api::V1::BaseControllerTest#rate_limiting_should_be_per_API_key` (~0.5s)
- `Api::V1::UsageControllerTest#should_work_correctly_when_approaching_rate_limit` (1.02s)

## Changes

- New `ApiRateLimitTestHelper#seed_api_rate_limit(api_key, count)` in `test/support/` writes the `ApiRateLimiter` Redis hash entry for the current hourly window directly.
- The tests seed the counter (99/100/49/98 respectively) and make a single verifying request. All assertions — 429 payload and headers, per-key isolation, usage math including the request-counts-itself behavior — are unchanged.

## Measured effect

Each test drops from ~1s to **~0.03s** (~3.6s total).

## Verification

`bin/rails test test/controllers/api/v1/base_controller_test.rb test/controllers/api/v1/usage_controller_test.rb` → 33 runs, 124 assertions, 0 failures (1 pre-existing skip). Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpZe2ajeGkPRRBHfaJTfUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved API rate-limit test coverage, including request limits, response headers, error details, and isolation between API keys.
  * Added more efficient test setup for rate-limit scenarios, reducing reliance on repeated requests while preserving boundary-condition checks.
  * Confirmed successful requests and correct rate-limit responses continue to behave as expected.

* **Bug Fixes**
  * No production behavior changes; this update improves confidence in existing API rate-limit functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->