### PR TITLE
docs: add Hostim.dev as a one-click hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ For further instructions, see guides below.
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/sure?referralCode=CW_fPQ)
 
+[![Deploy on Hostim](https://hostim.dev/img/deploy-button.svg)](https://console.hostim.dev/dashboard?preview=1&modal=1&template=sure)
+
 ### Managed OpenClaw for Sure Finances
 
 <a href="https://kilocode.pxf.io/repo-readme"><img src="https://kilo.ai/kiloclaw/partner-resources/kiloclaw-logo-yellow-bg-typography.png" alt="Managed OpenClaw for Sure Finances" width="185"/></a>

--- a/docs/hosting/hostim.md
+++ b/docs/hosting/hostim.md
@@ -31,4 +31,11 @@ image and set the following environment variables:
 | `SELF_HOSTED` | `true` |
 
 Run the web server and a Sidekiq worker from the same image, both sharing the same
-`SECRET_KEY_BASE`. Migrations run automatically on boot via `bin/rails db:prepare`.
+`SECRET_KEY_BASE`. Run `bin/rails db:prepare` before the web server starts so
+migrations are applied — for example with a start command like
+`sh -c "./bin/rails db:prepare && (bundle exec sidekiq &) && exec ./bin/rails server -b 0.0.0.0"`.
+
+Mount a persistent volume at `/rails/storage`. Sure stores uploaded files (such as
+imported statements) there via Active Storage's local disk service by default;
+without a persistent volume they are lost when the container is replaced, while the
+database still references them.

--- a/docs/hosting/hostim.md
+++ b/docs/hosting/hostim.md
@@ -1,0 +1,34 @@
+# Deploying Sure on Hostim.dev
+
+[Hostim.dev](https://hostim.dev) is a managed container-hosting platform that runs
+Sure with a managed PostgreSQL database, managed Redis, persistent storage, and
+automatic HTTPS — no server to provision or maintain.
+
+## One-click template
+
+Sure is available as a one-click template. It provisions the Rails web server, the
+Sidekiq background worker, PostgreSQL, and Redis for you, and generates
+`SECRET_KEY_BASE` automatically.
+
+1. Open the [Sure template](https://console.hostim.dev/dashboard?preview=1&modal=1&template=sure).
+2. Choose a resource plan.
+3. Click **Deploy**.
+4. Open the generated domain and create your first account.
+
+A full walkthrough is in the [Hostim.dev Sure guide](https://hostim.dev/docs/templates/sure).
+
+## Manual setup
+
+To configure the app yourself, create an app from the `ghcr.io/we-promise/sure:stable`
+image and set the following environment variables:
+
+| Variable | Value |
+| --- | --- |
+| `SECRET_KEY_BASE` | a long random hex string (keep it stable across restarts) |
+| `DB_HOST` / `DB_PORT` | your PostgreSQL host and port |
+| `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` | database credentials |
+| `REDIS_URL` | `redis://<host>:<port>/1` |
+| `SELF_HOSTED` | `true` |
+
+Run the web server and a Sidekiq worker from the same image, both sharing the same
+`SECRET_KEY_BASE`. Migrations run automatically on boot via `bin/rails db:prepare`.


### PR DESCRIPTION
This adds Hostim.dev to the "One-click Install" list in the README, next to
PikaPods and Railway. It also adds a short guide in `docs/hosting/`, next to
the existing `docker.md` and `hetzner.md` guides.

Hostim.dev is a hosting platform based in Germany (EU). Sure runs there as a
one-click template. The template sets up the Rails web server, the Sidekiq
worker, PostgreSQL, and Redis. It also creates `SECRET_KEY_BASE` for you and
keeps it the same across restarts, so saved data and logins keep working.

Guide: https://hostim.dev/docs/templates/sure

The change is small: one button in the README and one new page. Happy to move
it or cut it down if you want it somewhere else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Deploy** button for **Hostim** in the **One-click Install** section.
  * Added a **Hostim** deployment documentation page with both one-click template and manual setup options.

* **Documentation**
  * Expanded manual deployment guidance, including required environment variables, running the web server and background worker from the same container image, and preparing the database before startup.
  * Added notes on persisting uploaded files using a volume mounted to `/rails/storage`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->