### PR TITLE
fix: only mark overlapping statement periods as duplicate

### DIFF
--- a/app/models/account_statement/coverage.rb
+++ b/app/models/account_statement/coverage.rb
@@ -130,7 +130,7 @@ class AccountStatement::Coverage
       linked_statements = statements_covering(linked_statement_scope, month)
       ambiguous_statements = statements_covering(ambiguous_statement_scope, month)
 
-      status = if linked_statements.size > 1
+      status = if overlapping_statements?(linked_statements)
         "duplicate"
       elsif linked_statements.any? { |statement| statement.reconciliation_mismatched?(balance_lookup: balance_lookup) }
         "mismatched"
@@ -174,6 +174,13 @@ class AccountStatement::Coverage
           statement.period_end_on.present? &&
           statement.period_start_on <= month_end &&
           statement.period_end_on >= month_start
+      end
+    end
+
+    def overlapping_statements?(statements)
+      statements.combination(2).any? do |a, b|
+        a.period_start_on <= b.period_end_on &&
+          b.period_start_on <= a.period_end_on
       end
     end
 

--- a/app/models/account_statement/coverage.rb
+++ b/app/models/account_statement/coverage.rb
@@ -130,11 +130,11 @@ class AccountStatement::Coverage
       linked_statements = statements_covering(linked_statement_scope, month)
       ambiguous_statements = statements_covering(ambiguous_statement_scope, month)
 
-      status = if overlapping_statements?(linked_statements)
+      status = if linked_statements.many? && overlapping_statements?(linked_statements)
         "duplicate"
       elsif linked_statements.any? { |statement| statement.reconciliation_mismatched?(balance_lookup: balance_lookup) }
         "mismatched"
-      elsif linked_statements.one?
+      elsif linked_statements.any?
         "covered"
       elsif ambiguous_statements.any?
         "ambiguous"

--- a/test/models/account_statement_test.rb
+++ b/test/models/account_statement_test.rb
@@ -756,6 +756,41 @@ class AccountStatementTest < ActiveSupport::TestCase
     assert_equal "mismatched", statuses[mismatched_month]
   end
 
+  test "coverage does not mark adjacent statements as duplicate when they only share a calendar month" do
+    account = Account.create!(
+      family: @family,
+      owner: users(:family_admin),
+      name: "Adjacent Statement Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    march = Date.new(2026, 3, 1)
+
+    create_statement_with_period(
+      account: account,
+      period_start_on: Date.new(2026, 1, 8),
+      period_end_on: Date.new(2026, 3, 6),
+      content: "adjacent-a"
+    )
+
+    create_statement_with_period(
+      account: account,
+      period_start_on: Date.new(2026, 3, 7),
+      period_end_on: Date.new(2026, 4, 7),
+      content: "adjacent-b"
+    )
+
+    coverage = AccountStatement::Coverage.new(
+      account,
+      start_month: march,
+      end_month: march
+    )
+
+    assert_equal "covered", coverage.months.first.status
+  end
+
   private
 
     def create_statement(account:, month:, content:, suggested_account: nil, closing_balance: nil)
@@ -774,6 +809,26 @@ class AccountStatementTest < ActiveSupport::TestCase
         period_end_on: month.end_of_month,
         closing_balance: closing_balance
       )
+      statement
+    end
+
+    def create_statement_with_period(account:, period_start_on:, period_end_on:, content:, suggested_account: nil)
+      statement = AccountStatement.create_from_upload!(
+        family: @family,
+        account: account,
+        file: uploaded_file(
+          filename: "statement_#{content}_#{period_start_on}_#{period_end_on}.csv",
+          content_type: "text/csv",
+          content: "date,amount\n#{period_start_on},1\n#{period_end_on},2\n#{content}\n"
+        )
+      )
+
+      statement.update!(
+        suggested_account: suggested_account,
+        period_start_on: period_start_on,
+        period_end_on: period_end_on
+      )
+
       statement
     end
 end


### PR DESCRIPTION
Fixes #2568

## Summary

The statement coverage view currently marks a month as `duplicate` whenever more than one statement overlaps the same calendar month.

This change updates the duplicate detection logic so that a month is only marked as `duplicate` when two or more statements actually overlap each other's statement periods.

This prevents consecutive statements (for example `08/01 → 06/03` and `07/03 → 07/04`) from being incorrectly flagged as duplicates while preserving the existing behavior for genuine overlapping statements.

## Changes

- Only classify a month as `duplicate` when statement periods overlap.
- Keep consecutive, non-overlapping statements as `covered`.
- Add a regression test covering adjacent statement periods.

## Testing

- Added a regression test for adjacent statement periods.
- Existing duplicate coverage tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statement coverage detection so a month is marked as **duplicate** only when the covering statement periods actually overlap, not just when multiple statements exist.
  * Ensured months with any valid coverage are labeled **covered**, while **ambiguous** and **missing** behavior remains consistent.
* **Tests**
  * Added coverage for adjacent (non-overlapping) statement periods within the same month to confirm they are not treated as duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->