### PR TITLE
fix(trend): keep percent sign consistent with direction for negative/zero base

### DIFF
--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -52,11 +52,14 @@ class Trend
 
   def percent
     return 0.0 if previous.zero? && current.zero?
-    return Float::INFINITY if previous.zero?
+    return current.negative? ? -Float::INFINITY : Float::INFINITY if previous.zero?
 
     change = (current - previous).to_f
 
-    (change / previous.to_f * 100).round(1)
+    # Divide by the magnitude of the base so the sign of the percentage always
+    # tracks the actual change (and agrees with #direction). Dividing by a signed
+    # negative base would otherwise invert the sign (e.g. net worth -100 -> -50).
+    (change / previous.to_f.abs * 100).round(1)
   end
 
   def percent_formatted

--- a/test/models/trend_test.rb
+++ b/test/models/trend_test.rb
@@ -31,10 +31,28 @@ class TrendTest < ActiveSupport::TestCase
   test "infinitely up" do
     trend = Trend.new(current: 100, previous: 0)
     assert_equal "up", trend.direction
+    assert_equal Float::INFINITY, trend.percent
   end
 
   test "infinitely down" do
     trend = Trend.new(current: 0, previous: 100)
     assert_equal "down", trend.direction
+  end
+
+  test "percent sign tracks direction when the base is negative" do
+    # Net worth improving from -100 to -50 is a +50% change, not -50%.
+    improving = Trend.new(current: -50, previous: -100)
+    assert_equal "up", improving.direction
+    assert_equal 50.0, improving.percent
+
+    # Net worth worsening from -100 to -150 is a -50% change.
+    worsening = Trend.new(current: -150, previous: -100)
+    assert_equal "down", worsening.direction
+    assert_equal(-50.0, worsening.percent)
+  end
+
+  test "percent carries the sign of current when the base is zero" do
+    assert_equal(-Float::INFINITY, Trend.new(current: -100, previous: 0).percent)
+    assert_equal Float::INFINITY, Trend.new(current: 100, previous: 0).percent
   end
 end


### PR DESCRIPTION
## What & why

`Trend#percent` divided the delta by the **signed** previous value:

```ruby
(change / previous.to_f * 100).round(1)
```

When the base (`previous`) is negative, this inverts the sign of the result, so `percent` contradicts `#direction` (which is computed correctly by magnitude). The UI then renders an up arrow / favorable color next to a negative percentage, and vice-versa.

This is reachable anywhere a `Trend` is built from values that can go below zero — most visibly **net worth** (negative whenever liabilities exceed assets), which feeds the reports net-worth trend, balance sparklines, and chart/series aggregators.

```ruby
Trend.new(current: -50, previous: -100).direction # => "up"   (correct)
Trend.new(current: -50, previous: -100).percent   # => -50.0 (wrong; should be +50.0)
```

A related instance of the same sign issue: a zero base with a negative current returned `+Float::INFINITY` (`＋∞`) even though the direction is `down`.

## Fix

- Divide the delta by the **magnitude** of the base (`previous.to_f.abs`) so the percentage sign always tracks the actual change and agrees with `#direction`.
- When the base is zero, carry the sign of `current` so an all-negative move reports `-Infinity` (rendered `-∞`) instead of `+Infinity`.

The common single-sign case is unchanged: for a positive base, `abs` is a no-op, so existing behavior (e.g. `100 vs 50 => 100.0%`) is preserved.

## Tests

Added cases to `test/models/trend_test.rb` covering:
- negative base improving (`-100 -> -50` => `+50.0`, direction `up`)
- negative base worsening (`-100 -> -150` => `-50.0`, direction `down`)
- zero base carrying the sign of `current` (`+∞` / `-∞`)

Existing `Trend` tests remain green.

Fixes #2579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Percentage trend values now handle zero and negative starting points more consistently.
  * Positive and negative changes are reflected with the correct sign, even when the prior value is zero.
  * Existing “infinite increase” behavior is now more explicit and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->