### PR TITLE
Fix two crashes in `rake demo_data:default`

### DIFF
--- a/app/models/demo/data_cleaner.rb
+++ b/app/models/demo/data_cleaner.rb
@@ -11,6 +11,15 @@ class Demo::DataCleaner
     # Clear SSO audit logs first (they reference users)
     SsoAuditLog.destroy_all
 
+    # ApiKey#prevent_demo_monitoring_key_destroy! throws :abort to stop the demo
+    # monitoring key being revoked from the UI. That abort silently no-ops the
+    # entire Family.destroy_all cascade below (accounts/entries/trades all
+    # survive), which only then surfaces as a NOT NULL crash in
+    # `Security.destroy_all`. Safe to bypass here: this class only runs in
+    # dev/test (see #ensure_safe_environment!).
+
+    ApiKey.where(display_key: ApiKey::DEMO_MONITORING_KEY).delete_all
+
     Family.destroy_all
     Setting.destroy_all
     InviteCode.destroy_all

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -871,16 +871,14 @@ class Demo::Generator
       diff_amex     = amex_balance - target_amex
       diff_sapphire = sapphire_balance - target_sapphire
 
-      if diff_amex.abs > 250
-        adjust_payment = diff_amex.positive? ? diff_amex : 0
-        create_transfer!(@chase_checking, @amex_gold, adjust_payment, "Amex Balance Adjust", Date.current)
-        amex_balance -= adjust_payment
+      if diff_amex > 250
+        create_transfer!(@chase_checking, @amex_gold, diff_amex, "Amex Balance Adjust", Date.current)
+        amex_balance -= diff_amex
       end
 
-      if diff_sapphire.abs > 250
-        adjust_payment = diff_sapphire.positive? ? diff_sapphire : 0
-        create_transfer!(@chase_checking, @chase_sapphire, adjust_payment, "Sapphire Balance Adjust", Date.current)
-        sapphire_balance -= adjust_payment
+      if diff_sapphire > 250
+        create_transfer!(@chase_checking, @chase_sapphire, diff_sapphire, "Sapphire Balance Adjust", Date.current)
+        sapphire_balance -= diff_sapphire
       end
 
       puts "   💳 Charges generated: #{charges_this_run} | Payments: #{payments_this_run}"

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -874,11 +874,21 @@ class Demo::Generator
       if diff_amex > 250
         create_transfer!(@chase_checking, @amex_gold, diff_amex, "Amex Balance Adjust", Date.current)
         amex_balance -= diff_amex
+      elsif diff_amex < -250
+        # Balance landed below target: a transfer can't have a negative payment
+        # amount, so bring the card up to target with a direct charge instead.
+        shortfall = diff_amex.abs
+        create_transaction!(@amex_gold, shortfall, "Balance Reconciliation", random_expense_category, Date.current)
+        amex_balance += shortfall
       end
 
       if diff_sapphire > 250
         create_transfer!(@chase_checking, @chase_sapphire, diff_sapphire, "Sapphire Balance Adjust", Date.current)
         sapphire_balance -= diff_sapphire
+      elsif diff_sapphire < -250
+        shortfall = diff_sapphire.abs
+        create_transaction!(@chase_sapphire, shortfall, "Balance Reconciliation", random_expense_category, Date.current)
+        sapphire_balance += shortfall
       end
 
       puts "   💳 Charges generated: #{charges_this_run} | Payments: #{payments_this_run}"


### PR DESCRIPTION
### Problem

Running `rake demo_data:default` could fail in two different ways during demo data generation and cleanup.

1. `Demo::Generator#generate_credit_card_cycles!`
   The balance-adjust step always attempted to create a `"Balance Adjust"` transfer, even when the calculated balance diff was zero or negative (meaning the card balance was already below the target).
   This produced a `$0` transfer, which violates `Transfer` validation rules requiring opposite non-zero amounts.

   Additionally, simply skipping adjustments for negative diffs caused some demo credit cards (for example Sapphire and Amex) to finish well below their documented target balances.

2. `Demo::DataCleaner#destroy_everything!`
   `ApiKey` has a `before_destroy` guard (`prevent_demo_monitoring_key_destroy!`) that throws `:abort` to prevent the demo monitoring key from being removed through the UI.
   When `Family.destroy_all` triggered this callback, the destroy cascade silently stopped, leaving accounts, entries, and trades undeleted. The issue only surfaced later when `Security.destroy_all` failed with a `NOT NULL` constraint violation.

### Expected behavior

`rake demo_data:default` should complete successfully in both fresh-generation and clear-and-regenerate flows without validation or cleanup errors, while ensuring demo card balances reconcile correctly to their documented targets.

### Notes

Fixes applied:

* `Demo::Generator#generate_credit_card_cycles!`

  * Only create the `"Balance Adjust"` transfer when the computed diff is strictly positive.
  * Prevents invalid `$0` transfers from being created.
  * When the diff is negative (card balance below target), create a direct `"Balance Reconciliation"` charge on the card instead of a transfer.
  * Keeps demo credit card balances aligned with their intended targets without violating transfer validations.

* `Demo::DataCleaner#destroy_everything!`

  * Explicitly deletes the demo monitoring API key before calling `Family.destroy_all`.
  * Bypasses the `before_destroy` callback safely since this code path is only used in development/test environments.

Verified end-to-end with:

```bash id="f83kqp"
rake db:drop db:create db:schema:load
rake demo_data:default
SKIP_CLEAR=0 rake demo_data:default
```

Additionally verified across 10 seeds:

* Sapphire now consistently lands on its `$4,200` target balance instead of drifting below target.
* No transfer validation or cleanup errors occur during generation.

Issue #2585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**

  * Improved demo cleanup so all demo data can be reset reliably, including removing the demo monitoring API key.
  * Fixed credit card demo generation to properly reconcile balances above and below target values without creating invalid transfers.
  * Added reconciliation charges for under-target balances so demo cards consistently land on their expected ending balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
