### PR TITLE
Don't persist zero balances when a provider balance fetch fails

### DIFF
--- a/app/models/enable_banking_account.rb
+++ b/app/models/enable_banking_account.rb
@@ -105,7 +105,12 @@ class EnableBankingAccount < ApplicationRecord
 
     update!(
       current_balance: nil,
-      currency: parse_currency(snapshot[:currency]) || "EUR",
+      # Preserve an established currency when the snapshot omits or mangles it
+      # (normalized, so blank/invalid stored values still fall through) —
+      # EUR only for records that never had a valid currency. Mirrors the
+      # equivalent Lunch Flow fix; PSD2 payloads usually carry currency, so
+      # this is parity/safety rather than an observed failure.
+      currency: parse_currency(snapshot[:currency]) || parse_currency(currency) || "EUR",
       name: build_account_name(snapshot),
       account_id: snapshot[:uid],
       uid: snapshot[:identification_hash] || snapshot[:uid],

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -37,7 +37,19 @@ class EnableBankingAccount::Processor
       end
 
       account = enable_banking_account.current_account
-      balance = enable_banking_account.current_balance || 0
+      balance = enable_banking_account.current_balance
+
+      # A nil current_balance means this sync's balance fetch did not succeed:
+      # upsert_enable_banking_snapshot! clears it and only a successful
+      # balance fetch repopulates it. Coercing nil to 0 here would persist a
+      # zero balance (and a zero current_anchor valuation) onto a healthy
+      # account whenever the provider has a transient failure, so leave the
+      # account untouched instead.
+      if balance.nil?
+        Rails.logger.warn("EnableBankingAccount::Processor - No balance available for enable_banking_account #{enable_banking_account.id} (balance fetch failed or not yet run), skipping account update")
+        return
+      end
+
       available_credit = nil
 
       # For liability accounts, ensure balance sign is correct.

--- a/app/models/lunchflow_account.rb
+++ b/app/models/lunchflow_account.rb
@@ -37,7 +37,10 @@ class LunchflowAccount < ApplicationRecord
 
     assign_attributes(
       current_balance: nil, # Balance not provided by accounts endpoint
-      currency: parse_currency(snapshot[:currency]) || "USD",
+      # The accounts endpoint usually omits currency (the balance endpoint is
+      # the authoritative source) — preserve what we already know rather than
+      # resetting an established account to USD; USD only for new records.
+      currency: parse_currency(snapshot[:currency]) || currency || "USD",
       name: display_name,
       account_id: snapshot[:id].to_s,
       account_status: snapshot[:status],

--- a/app/models/lunchflow_account.rb
+++ b/app/models/lunchflow_account.rb
@@ -39,8 +39,10 @@ class LunchflowAccount < ApplicationRecord
       current_balance: nil, # Balance not provided by accounts endpoint
       # The accounts endpoint usually omits currency (the balance endpoint is
       # the authoritative source) — preserve what we already know rather than
-      # resetting an established account to USD; USD only for new records.
-      currency: parse_currency(snapshot[:currency]) || currency || "USD",
+      # resetting an established account to USD. Normalize the preserved value
+      # too: a blank/invalid stored currency must fall through to USD, not
+      # propagate (blank would fail the presence validation and break import).
+      currency: parse_currency(snapshot[:currency]) || parse_currency(currency) || "USD",
       name: display_name,
       account_id: snapshot[:id].to_s,
       account_status: snapshot[:status],

--- a/app/models/lunchflow_account/processor.rb
+++ b/app/models/lunchflow_account/processor.rb
@@ -38,7 +38,18 @@ class LunchflowAccount::Processor
 
       # Update account balance from latest Lunchflow data
       account = lunchflow_account.current_account
-      balance = lunchflow_account.current_balance || 0
+      balance = lunchflow_account.current_balance
+
+      # A nil current_balance means this sync's balance fetch did not succeed:
+      # upsert_lunchflow_snapshot! clears it (the accounts endpoint carries no
+      # balance) and only a successful balance fetch repopulates it. Coercing
+      # nil to 0 here would persist a zero balance (and the USD currency
+      # fallback) onto a healthy account whenever the provider has a
+      # transient failure, so leave the account untouched instead.
+      if balance.nil?
+        Rails.logger.warn("LunchflowAccount::Processor - No balance available for lunchflow_account #{lunchflow_account.id} (balance fetch failed or not yet run), skipping account update")
+        return
+      end
 
       # LunchFlow balance convention matches our app convention:
       # - Positive balance = debt (you owe money)

--- a/app/models/lunchflow_item/importer.rb
+++ b/app/models/lunchflow_item/importer.rb
@@ -269,7 +269,19 @@ class LunchflowItem::Importer
         begin
           fetch_and_update_balance(lunchflow_account)
         rescue => e
-          # Log but don't fail transaction import if balance fetch fails
+          # Log but don't fail transaction import if balance fetch fails.
+          # current_balance stays nil, so the processor will skip the balance
+          # update for this account — capture the failure, because the sync
+          # still reports success and this is otherwise invisible to support.
+          DebugLogEntry.capture(
+            category: "provider_sync",
+            level: "warn",
+            message: "Balance fetch failed for account #{lunchflow_account.account_id}; keeping previous balance",
+            source: self.class.name,
+            provider_key: "lunchflow",
+            family: lunchflow_item.family,
+            metadata: { account_id: lunchflow_account.account_id, error_class: e.class.name, error: e.message }
+          )
           Rails.logger.warn "LunchflowItem::Importer - Failed to update balance for account #{lunchflow_account.account_id}: #{e.message}"
         end
 

--- a/test/models/enable_banking_account_processor_test.rb
+++ b/test/models/enable_banking_account_processor_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class EnableBankingAccountProcessorTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @item = EnableBankingItem.new(family: @family, name: "Enable Banking",
+      country_code: "GB", application_id: "test-app")
+    @item.save!(validate: false)
+  end
+
+  test "skips the account update when current_balance is nil (failed balance fetch)" do
+    eb_acct = @item.enable_banking_accounts.create!(
+      name: "Checking",
+      uid: "eb_1",
+      currency: "GBP",
+      current_balance: nil
+    )
+
+    acct = accounts(:depository)
+    acct.update!(balance: 500, cash_balance: 500, currency: "GBP")
+    AccountProvider.create!(account: acct, provider: eb_acct)
+
+    EnableBankingAccount::Processor.new(eb_acct).send(:process_account!)
+
+    acct.reload
+    assert_equal BigDecimal("500"), acct.cash_balance,
+      "a sync whose balance fetch failed must not zero the account"
+    assert_equal BigDecimal("500"), acct.balance
+    assert_equal "GBP", acct.currency,
+      "a sync whose balance fetch failed must not change the account currency"
+  end
+
+  test "still updates the account when current_balance is present" do
+    eb_acct = @item.enable_banking_accounts.create!(
+      name: "Checking",
+      uid: "eb_2",
+      currency: "GBP",
+      current_balance: BigDecimal("250")
+    )
+
+    acct = accounts(:depository)
+    acct.update!(balance: 500, cash_balance: 500, currency: "GBP")
+    AccountProvider.create!(account: acct, provider: eb_acct)
+
+    EnableBankingAccount::Processor.new(eb_acct).send(:process_account!)
+
+    assert_equal BigDecimal("250"), acct.reload.cash_balance
+  end
+end

--- a/test/models/enable_banking_account_processor_test.rb
+++ b/test/models/enable_banking_account_processor_test.rb
@@ -26,6 +26,10 @@ class EnableBankingAccountProcessorTest < ActiveSupport::TestCase
     assert_equal BigDecimal("500"), acct.cash_balance,
       "a sync whose balance fetch failed must not zero the account"
     assert_equal BigDecimal("500"), acct.balance
+    # Parity/invariant check, not regression coverage: unlike Lunch Flow, the
+    # EB *processor* never had a currency-reset defect (its fallback chain
+    # already preferred the stored value), so this assertion also passes on
+    # main. The EB currency regression test lives at the model layer below.
     assert_equal "GBP", acct.currency,
       "a sync whose balance fetch failed must not change the account currency"
   end
@@ -45,5 +49,13 @@ class EnableBankingAccountProcessorTest < ActiveSupport::TestCase
     EnableBankingAccount::Processor.new(eb_acct).send(:process_account!)
 
     assert_equal BigDecimal("250"), acct.reload.cash_balance
+  end
+  test "snapshot upsert preserves an established currency when the payload omits it" do
+    eb_acct = @item.enable_banking_accounts.create!(name: "Checking", uid: "eb_3", currency: "GBP")
+
+    eb_acct.upsert_enable_banking_snapshot!({ uid: "eb_3", name: "Checking" })
+
+    assert_equal "GBP", eb_acct.reload.currency,
+      "an omitted payload currency must not reset an established account to EUR"
   end
 end

--- a/test/models/lunchflow_account_processor_test.rb
+++ b/test/models/lunchflow_account_processor_test.rb
@@ -60,4 +60,19 @@ class LunchflowAccountProcessorTest < ActiveSupport::TestCase
       "an established account's currency must survive a currency-less snapshot"
     assert_nil lf_acct.current_balance
   end
+
+  test "snapshot upsert falls back to USD when neither payload nor record has a valid currency" do
+    lf_acct = @item.lunchflow_accounts.create!(
+      name: "Checking",
+      account_id: "lf_4",
+      currency: "GBP"
+    )
+    # Simulate a record built from bad provider data (bypasses validation)
+    lf_acct.update_column(:currency, "")
+
+    lf_acct.upsert_lunchflow_snapshot!({ id: "lf_4", name: "Checking", status: "active" })
+
+    assert_equal "USD", lf_acct.reload.currency,
+      "a blank stored currency must fall through to USD, not fail validation"
+  end
 end

--- a/test/models/lunchflow_account_processor_test.rb
+++ b/test/models/lunchflow_account_processor_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class LunchflowAccountProcessorTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @item = LunchflowItem.new(family: @family, name: "Lunch Flow", api_key: "test_key")
+    @item.save!(validate: false)
+  end
+
+  test "skips the account update when current_balance is nil (failed balance fetch)" do
+    lf_acct = @item.lunchflow_accounts.create!(
+      name: "Checking",
+      account_id: "lf_1",
+      currency: "USD",
+      current_balance: nil
+    )
+
+    acct = accounts(:depository)
+    acct.update!(balance: 500, cash_balance: 500, currency: "GBP")
+    AccountProvider.create!(account: acct, provider: lf_acct)
+
+    LunchflowAccount::Processor.new(lf_acct).send(:process_account!)
+
+    acct.reload
+    assert_equal BigDecimal("500"), acct.balance,
+      "a sync whose balance fetch failed must not zero the account"
+    assert_equal "GBP", acct.currency,
+      "a sync whose balance fetch failed must not change the account currency"
+  end
+
+  test "still updates the account when current_balance is present" do
+    lf_acct = @item.lunchflow_accounts.create!(
+      name: "Checking",
+      account_id: "lf_2",
+      currency: "GBP",
+      current_balance: BigDecimal("250")
+    )
+
+    acct = accounts(:depository)
+    acct.update!(balance: 500, cash_balance: 500, currency: "GBP")
+    AccountProvider.create!(account: acct, provider: lf_acct)
+
+    LunchflowAccount::Processor.new(lf_acct).send(:process_account!)
+
+    assert_equal BigDecimal("250"), acct.reload.balance
+  end
+
+  test "snapshot upsert preserves the existing currency when the payload omits it" do
+    lf_acct = @item.lunchflow_accounts.create!(
+      name: "Checking",
+      account_id: "lf_3",
+      currency: "GBP"
+    )
+
+    # The real accounts endpoint carries neither balance nor currency.
+    lf_acct.upsert_lunchflow_snapshot!({ id: "lf_3", name: "Checking", status: "active" })
+
+    lf_acct.reload
+    assert_equal "GBP", lf_acct.currency,
+      "an established account's currency must survive a currency-less snapshot"
+    assert_nil lf_acct.current_balance
+  end
+end


### PR DESCRIPTION
Fixes #2616.

## Problem

If the Lunch Flow `transactions` call fails for an account during a sync for any transient cause (e.g. a 500 response, a timeout, a rate limit), that account's balance is set to 0 and its currency flipped to USD, with the sync still completing "successfully" (per-account errors are rescued and logged only). A provider-wide failure therefore zeroes every synced account at once.  Confirmed for Lunch Flow (full analysis and reproduction instructions in #2616) and for Enable Banking (same pattern, confirmed by Dosu on the issue: its `set_current_balance` call additionally persists a zero anchor valuation).

## Fix

Treat `current_balance: nil` as "no data this sync", not zero: it can only mean the balance fetch didn't succeed, since a genuine zero is `0`.  Both processors now log a warning and skip the account update, leaving the account at its last known state until a successful fetch (the option Dosu recommended on the issue: no change to the upsert's balance semantics).

One additional Lunch Flow change: the snapshot upsert no longer resets an established account's currency to USD when the `accounts` endpoint omits currency (which it usually does: the `balance` endpoint appears to be the authoritative source). The skip alone protects the linked account, but a later successful sync with a `balance` response that lacked a currency could still propagate the stuck USD.  Preserving the known currency closes that.  Balance upsert semantics are unchanged.

## Tests

`test/models/lunchflow_account_processor_test.rb` and `test/models/enable_banking_account_processor_test.rb` (patterned on `simplefin_account_processor_test.rb`): nil balance → account untouched (fails on `main`: balance/cash_balance become 0); present balance → still updates; currency-less Lunch Flow snapshot preserves the existing currency (fails on `main`: flips to USD).

## Additional Validation

Reproduced the failure end-to-end on the current `:stable` image as per #2616 (a stubbed provider raising the same `LunchflowError` that a real 500 produces): before the fix it shows the balance getting overwritten (`500.0 GBP` → `0.0 USD`); with the fix, the account is untouched and the skip is logged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented healthy banking/depository accounts from being overwritten with a zero/unchanged balance when balance fetch returns missing data.
  * Preserved existing account currency when sync snapshots omit currency (with safe fallback when currency is invalid).
* **Logging**
  * Added structured warning debug logging when balance sync fails, without interrupting overall transaction imports.
* **Tests**
  * Added/extended test coverage for nil balance handling and currency preservation/fallback for both Lunchflow and enable-banking syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->