### PR TITLE
feat(mcp): support Streamable HTTP transport (protocol 2025-06-18)

### DIFF
--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -1,7 +1,7 @@
 class McpController < ApplicationController
   include OauthBase
 
-  PROTOCOL_VERSION = "2025-03-26"
+  PROTOCOL_VERSION = "2025-06-18"
 
   # Skip session-based auth and CSRF — this is a token-authenticated API
   skip_authentication
@@ -11,6 +11,7 @@ class McpController < ApplicationController
   skip_before_action :detect_os
 
   before_action :authenticate_mcp_token!
+  after_action :set_mcp_response_headers
 
   def handle
     body = parse_request_body
@@ -62,10 +63,12 @@ class McpController < ApplicationController
     end
 
     def handle_initialize
+      @mcp_session_id = SecureRandom.uuid
       {
         protocolVersion: PROTOCOL_VERSION,
         capabilities: { tools: {} },
-        serverInfo: { name: "sure", version: "1.0" }
+        serverInfo: { name: "sure", version: "1.0" },
+        sessionId: @mcp_session_id
       }
     end
 
@@ -172,5 +175,10 @@ class McpController < ApplicationController
         id: id,
         error: { code: code, message: message }
       }
+    end
+
+    def set_mcp_response_headers
+      response.set_header("Mcp-Protocol-Version", PROTOCOL_VERSION)
+      response.set_header("Mcp-Session-Id", @mcp_session_id) if @mcp_session_id.present?
     end
 end

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -1,7 +1,7 @@
 class McpController < ApplicationController
   include OauthBase
 
-  PROTOCOL_VERSION = "2025-03-26"
+  PROTOCOL_VERSION = "2025-06-18"
 
   # Skip session-based auth and CSRF — this is a token-authenticated API
   skip_authentication
@@ -11,6 +11,7 @@ class McpController < ApplicationController
   skip_before_action :detect_os
 
   before_action :authenticate_mcp_token!
+  after_action :set_mcp_response_headers
 
   def handle
     body = parse_request_body
@@ -62,10 +63,12 @@ class McpController < ApplicationController
     end
 
     def handle_initialize
+      @mcp_session_id = SecureRandom.uuid
       {
         protocolVersion: PROTOCOL_VERSION,
         capabilities: { tools: {} },
-        serverInfo: { name: "sure", version: "1.0" }
+        serverInfo: { name: "sure", version: "1.0" },
+        sessionId: @mcp_session_id
       }
     end
 
@@ -175,5 +178,10 @@ class McpController < ApplicationController
         id: id,
         error: { code: code, message: message }
       }
+    end
+
+    def set_mcp_response_headers
+      response.set_header("Mcp-Protocol-Version", PROTOCOL_VERSION)
+      response.set_header("Mcp-Session-Id", @mcp_session_id) if @mcp_session_id.present?
     end
 end

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -2,6 +2,8 @@ class McpController < ApplicationController
   include OauthBase
 
   PROTOCOL_VERSION = "2025-06-18"
+  SUPPORTED_PROTOCOL_VERSIONS = [ "2025-03-26", PROTOCOL_VERSION ].freeze
+  MCP_SESSION_TTL = 1.day
 
   # Skip session-based auth and CSRF — this is a token-authenticated API
   skip_authentication
@@ -49,9 +51,11 @@ class McpController < ApplicationController
     end
 
     def dispatch_jsonrpc(request_id, method, params)
+      return unless prepare_mcp_request_context(request_id, method, params)
+
       case method
       when "initialize"
-        handle_initialize
+        handle_initialize(request_id, params)
       when "tools/list"
         handle_tools_list
       when "tools/call"
@@ -62,10 +66,15 @@ class McpController < ApplicationController
       end
     end
 
-    def handle_initialize
+    def handle_initialize(request_id, params)
+      @mcp_protocol_version = negotiated_protocol_version(request_id, params)
+      return unless @mcp_protocol_version
+
       @mcp_session_id = SecureRandom.uuid
+      Rails.cache.write(mcp_session_cache_key(@mcp_session_id), mcp_user.id, expires_in: MCP_SESSION_TTL)
+
       {
-        protocolVersion: PROTOCOL_VERSION,
+        protocolVersion: @mcp_protocol_version,
         capabilities: { tools: {} },
         serverInfo: { name: "sure", version: "1.0" },
         sessionId: @mcp_session_id
@@ -164,6 +173,44 @@ class McpController < ApplicationController
       @mcp_user
     end
 
+    def prepare_mcp_request_context(request_id, method, params)
+      return true if method == "initialize"
+
+      @mcp_protocol_version = mcp_request_header("Mcp-Protocol-Version").presence || PROTOCOL_VERSION
+
+      unless SUPPORTED_PROTOCOL_VERSIONS.include?(@mcp_protocol_version)
+        render_jsonrpc_error(request_id, -32600, "Unsupported MCP protocol version: #{@mcp_protocol_version}")
+        return false
+      end
+
+      session_id = mcp_request_header("Mcp-Session-Id").presence
+      return true unless session_id
+
+      unless Rails.cache.read(mcp_session_cache_key(session_id)) == mcp_user.id
+        render_jsonrpc_error(request_id, -32600, "Invalid MCP session id")
+        return false
+      end
+
+      @mcp_session_id = session_id
+      true
+    end
+
+    def negotiated_protocol_version(request_id, params)
+      requested_version = params&.dig("protocolVersion").presence || PROTOCOL_VERSION
+      return requested_version if SUPPORTED_PROTOCOL_VERSIONS.include?(requested_version)
+
+      render_jsonrpc_error(request_id, -32600, "Unsupported MCP protocol version: #{requested_version}")
+      nil
+    end
+
+    def mcp_session_cache_key(session_id)
+      "mcp:session:#{session_id}"
+    end
+
+    def mcp_request_header(name)
+      request.headers[name] || request.get_header("HTTP_#{name.upcase.tr('-', '_')}")
+    end
+
     def render_mcp_unauthorized
       response.set_header(
         "WWW-Authenticate",
@@ -181,7 +228,7 @@ class McpController < ApplicationController
     end
 
     def set_mcp_response_headers
-      response.set_header("Mcp-Protocol-Version", PROTOCOL_VERSION)
+      response.set_header("Mcp-Protocol-Version", @mcp_protocol_version || PROTOCOL_VERSION)
       response.set_header("Mcp-Session-Id", @mcp_session_id) if @mcp_session_id.present?
     end
 end

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -55,7 +55,7 @@ class McpController < ApplicationController
 
       case method
       when "initialize"
-        handle_initialize(request_id, params)
+        handle_initialize(params)
       when "tools/list"
         handle_tools_list
       when "tools/call"
@@ -66,10 +66,8 @@ class McpController < ApplicationController
       end
     end
 
-    def handle_initialize(request_id, params)
-      @mcp_protocol_version = negotiated_protocol_version(request_id, params)
-      return unless @mcp_protocol_version
-
+    def handle_initialize(params)
+      @mcp_protocol_version = negotiated_protocol_version(params)
       @mcp_session_id = SecureRandom.uuid
       Rails.cache.write(mcp_session_cache_key(@mcp_session_id), mcp_user.id, expires_in: MCP_SESSION_TTL)
 
@@ -179,7 +177,12 @@ class McpController < ApplicationController
       @mcp_protocol_version = mcp_request_header("Mcp-Protocol-Version").presence || PROTOCOL_VERSION
 
       unless SUPPORTED_PROTOCOL_VERSIONS.include?(@mcp_protocol_version)
-        render_jsonrpc_error(request_id, -32600, "Unsupported MCP protocol version: #{@mcp_protocol_version}")
+        render_jsonrpc_error(
+          request_id,
+          -32600,
+          t("mcp.errors.unsupported_protocol_version", version: @mcp_protocol_version),
+          status: :bad_request
+        )
         return false
       end
 
@@ -187,7 +190,7 @@ class McpController < ApplicationController
       return true unless session_id
 
       unless Rails.cache.read(mcp_session_cache_key(session_id)) == mcp_user.id
-        render_jsonrpc_error(request_id, -32600, "Invalid MCP session id")
+        render_jsonrpc_error(request_id, -32600, t("mcp.errors.invalid_session_id"), status: :not_found)
         return false
       end
 
@@ -195,12 +198,11 @@ class McpController < ApplicationController
       true
     end
 
-    def negotiated_protocol_version(request_id, params)
+    def negotiated_protocol_version(params)
       requested_version = params&.dig("protocolVersion").presence || PROTOCOL_VERSION
       return requested_version if SUPPORTED_PROTOCOL_VERSIONS.include?(requested_version)
 
-      render_jsonrpc_error(request_id, -32600, "Unsupported MCP protocol version: #{requested_version}")
-      nil
+      PROTOCOL_VERSION
     end
 
     def mcp_session_cache_key(session_id)
@@ -219,12 +221,15 @@ class McpController < ApplicationController
       render json: { error: "unauthorized" }, status: :unauthorized
     end
 
-    def render_jsonrpc_error(id, code, message)
+    def render_jsonrpc_error(id, code, message, status: :ok, data: nil)
+      error = { code: code, message: message }
+      error[:data] = data if data
+
       render json: {
         jsonrpc: "2.0",
         id: id,
-        error: { code: code, message: message }
-      }
+        error: error
+      }, status: status
     end
 
     def set_mcp_response_headers

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -7,6 +7,10 @@ en:
       close: "Close"
   global:
     expand: "Expand"
+  mcp:
+    errors:
+      invalid_session_id: "Invalid MCP session id"
+      unsupported_protocol_version: "Unsupported MCP protocol version: %{version}"
   activerecord:
     errors:
       messages:

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -283,7 +283,7 @@ class McpControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "initialize rejects unsupported protocol versions" do
+  test "initialize negotiates unsupported protocol versions to the default version" do
     with_mcp_env do
       post "/mcp", params: jsonrpc_request("initialize", { protocolVersion: "2099-01-01" }, id: 24).to_json,
            headers: mcp_headers(@token)
@@ -291,8 +291,8 @@ class McpControllerTest < ActionDispatch::IntegrationTest
       assert_response :ok
       body = JSON.parse(response.body)
       assert_equal 24, body["id"]
-      assert_equal(-32600, body["error"]["code"])
-      assert_includes body["error"]["message"], "2099-01-01"
+      assert_equal MCP_PROTOCOL_VERSION, body.dig("result", "protocolVersion")
+      assert_equal MCP_PROTOCOL_VERSION, response.headers["Mcp-Protocol-Version"]
     end
   end
 
@@ -361,11 +361,24 @@ class McpControllerTest < ActionDispatch::IntegrationTest
              "Mcp-Session-Id" => SecureRandom.uuid
            )
 
-      assert_response :ok
+      assert_response :not_found
       body = JSON.parse(response.body)
       assert_equal 25, body["id"]
       assert_equal(-32600, body["error"]["code"])
       assert_includes body["error"]["message"], "Invalid MCP session id"
+    end
+  end
+
+  test "tools/list rejects unsupported MCP protocol version headers" do
+    with_mcp_env do
+      post "/mcp", params: jsonrpc_request("tools/list", {}, id: 26).to_json,
+           headers: mcp_headers(@token).merge("Mcp-Protocol-Version" => "2099-01-01")
+
+      assert_response :bad_request
+      body = JSON.parse(response.body)
+      assert_equal 26, body["id"]
+      assert_equal(-32600, body["error"]["code"])
+      assert_includes body["error"]["message"], "2099-01-01"
     end
   end
 

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -255,7 +255,7 @@ class McpControllerTest < ActionDispatch::IntegrationTest
 
   test "initialize returns server info and capabilities" do
     with_mcp_env do
-      post "/mcp", params: jsonrpc_request("initialize", { protocolVersion: "2025-03-26" }).to_json,
+      post "/mcp", params: jsonrpc_request("initialize", { protocolVersion: MCP_PROTOCOL_VERSION }).to_json,
            headers: mcp_headers(@token)
 
       assert_response :ok
@@ -267,6 +267,32 @@ class McpControllerTest < ActionDispatch::IntegrationTest
       assert_mcp_initialize_response(result)
       assert_equal "sure", result["serverInfo"]["name"]
       assert result["capabilities"].key?("tools")
+    end
+  end
+
+  test "initialize echoes a supported legacy protocol version" do
+    with_mcp_env do
+      post "/mcp", params: jsonrpc_request("initialize", { protocolVersion: "2025-03-26" }).to_json,
+           headers: mcp_headers(@token)
+
+      assert_response :ok
+      result = JSON.parse(response.body)["result"]
+      assert_equal "2025-03-26", result["protocolVersion"]
+      assert_equal "2025-03-26", response.headers["Mcp-Protocol-Version"]
+      assert_match(/\A[0-9a-f-]{36}\z/, result["sessionId"])
+    end
+  end
+
+  test "initialize rejects unsupported protocol versions" do
+    with_mcp_env do
+      post "/mcp", params: jsonrpc_request("initialize", { protocolVersion: "2099-01-01" }, id: 24).to_json,
+           headers: mcp_headers(@token)
+
+      assert_response :ok
+      body = JSON.parse(response.body)
+      assert_equal 24, body["id"]
+      assert_equal(-32600, body["error"]["code"])
+      assert_includes body["error"]["message"], "2099-01-01"
     end
   end
 
@@ -300,6 +326,46 @@ class McpControllerTest < ActionDispatch::IntegrationTest
         assert tool["inputSchema"].present?, "Tool #{tool['name']} missing inputSchema"
         assert_equal "object", tool["inputSchema"]["type"]
       end
+    end
+  end
+
+  test "tools/list accepts and echoes a valid MCP session id" do
+    with_mcp_cache do
+      with_mcp_env do
+        post "/mcp", params: jsonrpc_request("initialize").to_json,
+             headers: mcp_headers(@token)
+
+        assert_response :ok
+        session_id = response.headers["Mcp-Session-Id"]
+        assert session_id.present?, "initialize should return an MCP session id"
+
+        post "/mcp", params: jsonrpc_request("tools/list").to_json,
+             headers: mcp_headers(@token).merge(
+               "Mcp-Protocol-Version" => MCP_PROTOCOL_VERSION,
+               "Mcp-Session-Id" => session_id
+             )
+
+        assert_response :ok
+        assert_equal MCP_PROTOCOL_VERSION, response.headers["Mcp-Protocol-Version"]
+        assert_equal session_id, response.headers["Mcp-Session-Id"]
+        assert_kind_of Array, JSON.parse(response.body).dig("result", "tools")
+      end
+    end
+  end
+
+  test "tools/list rejects an invalid MCP session id" do
+    with_mcp_env do
+      post "/mcp", params: jsonrpc_request("tools/list", {}, id: 25).to_json,
+           headers: mcp_headers(@token).merge(
+             "Mcp-Protocol-Version" => MCP_PROTOCOL_VERSION,
+             "Mcp-Session-Id" => SecureRandom.uuid
+           )
+
+      assert_response :ok
+      body = JSON.parse(response.body)
+      assert_equal 25, body["id"]
+      assert_equal(-32600, body["error"]["code"])
+      assert_includes body["error"]["message"], "Invalid MCP session id"
     end
   end
 
@@ -551,6 +617,14 @@ class McpControllerTest < ActionDispatch::IntegrationTest
 
     def with_mcp_env(&block)
       with_env_overrides("MCP_API_TOKEN" => @token, "MCP_USER_EMAIL" => @user.email, &block) # pipelock:ignore
+    end
+
+    def with_mcp_cache
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      yield
+    ensure
+      Rails.cache = original_cache
     end
 
     def mcp_headers(token)

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class McpControllerTest < ActionDispatch::IntegrationTest
+  MCP_PROTOCOL_VERSION = "2025-06-18"
+
   setup do
     @user = users(:family_admin)
     @token = "test-mcp-token-#{SecureRandom.hex(8)}"
@@ -44,7 +46,7 @@ class McpControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     result = JSON.parse(response.body)["result"]
-    assert_equal "2025-03-26", result["protocolVersion"]
+    assert_mcp_initialize_response(result)
   end
 
   test "authenticates a token issued to a dynamically registered MCP client" do
@@ -94,7 +96,7 @@ class McpControllerTest < ActionDispatch::IntegrationTest
          headers: mcp_headers(token_response["access_token"])
 
     assert_response :ok
-    assert_equal "2025-03-26", JSON.parse(response.body).dig("result", "protocolVersion")
+    assert_mcp_initialize_response(JSON.parse(response.body)["result"])
   end
 
   test "rejects token with read-only scope" do
@@ -262,7 +264,7 @@ class McpControllerTest < ActionDispatch::IntegrationTest
 
       assert_equal "2.0", body["jsonrpc"]
       assert_equal 1, body["id"]
-      assert_equal "2025-03-26", result["protocolVersion"]
+      assert_mcp_initialize_response(result)
       assert_equal "sure", result["serverInfo"]["name"]
       assert result["capabilities"].key?("tools")
     end
@@ -564,5 +566,12 @@ class McpControllerTest < ActionDispatch::IntegrationTest
 
     def jsonrpc_notification(method, params = {})
       { jsonrpc: "2.0", method: method, params: params }
+    end
+
+    def assert_mcp_initialize_response(result)
+      assert_equal MCP_PROTOCOL_VERSION, result["protocolVersion"]
+      assert_match(/\A[0-9a-f-]{36}\z/, result["sessionId"])
+      assert_equal MCP_PROTOCOL_VERSION, response.headers["Mcp-Protocol-Version"]
+      assert_equal result["sessionId"], response.headers["Mcp-Session-Id"]
     end
 end


### PR DESCRIPTION
## Summary

Updates the MCP controller to support the Streamable HTTP transport (protocol version `2025-06-18`), fixing compatibility with clients like Bifrost v1.6.3+ that require the newer protocol headers.

## Changes

1. **Bump protocol version:** `"2025-03-26"` → `"2025-06-18"`
2. **Add `after_action` hook** to set `Mcp-Protocol-Version` header on every response — this is what Streamable HTTP clients check to confirm the transport is supported
3. **Generate a `sessionId`** on initialize and return it in the response + as a `Mcp-Session-Id` header on subsequent calls

## Why

Bifrost v1.6.3+ uses Streamable HTTP transport. Without these response headers, its client retries the initialize handshake 5 times and eventually fails with `context deadline exceeded` — even though every JSON-RPC message (initialize, notifications/initialized, tools/list, tools/call) is processed and responded to correctly by the controller.

## Testing

No new logic paths — just response headers and a session ID field. Existing auth, tool discovery, and tool execution flows are unchanged.

Closes #N/A (no existing issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MCP protocol version `2025-06-18`, while retaining compatibility with `2025-03-26`.
  * MCP initialization now negotiates the requested version and returns a unique session ID.
  * Responses include negotiated protocol and session headers.

* **Bug Fixes**
  * Added validation for protocol and session headers on subsequent requests.
  * Unsupported protocol versions and invalid session IDs now return clear JSON-RPC errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->