### PR TITLE
Show full dates in the categorize wizard

### DIFF
--- a/app/views/transactions/categorizes/_entry_row.html.erb
+++ b/app/views/transactions/categorizes/_entry_row.html.erb
@@ -6,7 +6,7 @@
            aria-label="<%= t("transactions.categorizes.entry_row.include_checkbox", name: entry.name) %>"
            data-action="change->categorize#uncheckRule">
     <span class="min-w-0 font-medium text-primary truncate"><%= entry.name %></span>
-    <span class="text-secondary whitespace-nowrap"><%= l(entry.date, format: :short) %></span>
+    <span class="text-secondary whitespace-nowrap"><%= format_date(entry.date) %></span>
     <span class="privacy-sensitive font-medium text-right whitespace-nowrap <%= entry.amount.negative? ? "text-green-600" : "text-primary" %>">
       <%= format_money(entry.amount_money.abs) %>
     </span>

--- a/test/controllers/transactions/categorizes_controller_test.rb
+++ b/test/controllers/transactions/categorizes_controller_test.rb
@@ -26,6 +26,19 @@ class Transactions::CategorizesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show renders full dates so multi-year lists are unambiguous" do
+    create_transaction(account: @account, name: "Starbucks", date: Date.new(2024, 7, 8))
+
+    get transactions_categorize_url
+
+    assert_response :success
+    # format_date uses the family's date_format preference, every variant of
+    # which includes the year; the previous :short format ("%b %d") did not,
+    # making rows ambiguous when the uncategorized list spans years.
+    expected = Date.new(2024, 7, 8).strftime(@family.date_format)
+    assert_match expected, response.body
+  end
+
   test "show renders the first group at position 0" do
     2.times { create_transaction(account: @account, name: "Netflix") }
     3.times { create_transaction(account: @account, name: "Starbucks") }


### PR DESCRIPTION
## Problem

The bulk categorise wizard renders each row's date with the `:short` format (`%b %d`), which omits the year. When the uncategorised backlog spans more than one year (common when adopting Sure with imported history) a date like "Jul 08" is ambiguous and transactions become hard to identify.

## Fix

Render the row date with the existing `format_date` helper, which uses the family's date-format preference from Settings; every selectable format includes the year. This has the advantage of respecting the user's date preference.  It's a one-line view change plus a regression test (which asserts that the wizard renders a prior-year transaction's full date per the family format).

## Scoping note

For context: the preference-aware format_date helper currently has only three call sites in the app — most rendered dates use locale formats (l(..., format: :short)) or strftime directly, so the Settings preference reaches very little of the UI today. This PR does **not** open that wider question, since adopting `format_date` changes the default appearance (e.g. prose-style list headers) in multiple places; it aims to fix an ambiguity issue in one view where the missing year causes a concrete identification problem, and does so by adopting the user-configurable date format as that seems to be the best way of doing so.

## Screenshots
<img width="1435" height="675" alt="cateorize_wizard_with_current_date_format_showing_multi-year_data" src="https://github.com/user-attachments/assets/1d1cb17e-0a31-43c3-902e-50292e1c3999" />
The current date format shown for a multi-year categorisation

<img width="1421" height="676" alt="cateorize_wizard_with_user_date_format_showing_multi-year_data" src="https://github.com/user-attachments/assets/16a8543e-96cf-4f29-8936-bc83e4dea53f" />
The proposed date format (user-configured) shown for the same categorisation, demonstrating the benefits of disambiguation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction category entry rows to render transaction dates using the standard year-inclusive date format for consistent display.

* **Tests**
  * Added an integration test that creates a dated transaction and verifies the categorization page output includes the expected year-inclusive date string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->