### PR TITLE
feat(transactions): add filter to exclude excluded transactions from search

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -528,7 +528,7 @@ class TransactionsController < ApplicationController
                 :start_date, :end_date, :search, :amount,
                 :amount_operator, :active_accounts_only,
                 accounts: [], account_ids: [],
-                categories: [], merchants: [], types: [], tags: [], status: []
+                categories: [], merchants: [], types: [], tags: [], status: [], excluded: []
               )
               .to_h
               .compact_blank

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -5,6 +5,7 @@ module TransactionsHelper
       { key: "date_filter", label: t("transactions.search.filters.date"), icon: "calendar" },
       { key: "type_filter", label: t("transactions.search.filters.type"), icon: "tag" },
       { key: "status_filter", label: t("transactions.search.filters.status"), icon: "clock" },
+      { key: "excluded_filter", label: t("transactions.search.filters.excluded"), icon: "eye-off" },
       { key: "amount_filter", label: t("transactions.search.filters.amount"), icon: "hash" },
       { key: "category_filter", label: t("transactions.search.filters.category"), icon: "shapes" },
       { key: "tag_filter", label: t("transactions.search.filters.tag"), icon: "tags" },

--- a/app/models/assistant/function/get_transactions.rb
+++ b/app/models/assistant/function/get_transactions.rb
@@ -126,6 +126,13 @@ class Assistant::Function::GetTransactions < Assistant::Function
           items: { enum: family_tag_names },
           minItems: 1,
           uniqueItems: true
+        },
+        excluded: {
+          type: "array",
+          description: "Filter by excluded state. \"active\" keeps transactions counted in budgets/reports, \"excluded\" keeps only those excluded from them. Omit (or pass both) to include all transactions.",
+          items: { enum: [ "active", "excluded" ] },
+          minItems: 1,
+          uniqueItems: true
         }
       }
     )
@@ -165,7 +172,8 @@ class Assistant::Function::GetTransactions < Assistant::Function
         category: txn.category&.name,
         merchant: txn.merchant&.name,
         tags: txn.tags.map(&:name),
-        is_transfer: txn.transfer?
+        is_transfer: txn.transfer?,
+        is_excluded: entry.excluded
       }
     end
 

--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -215,7 +215,7 @@ class Transaction::Search
       return query unless excluded_states.present?
       return query if excluded_states.uniq.sort == [ "active", "excluded" ] # Both selected = no filter
 
-      case excluded_states.sort
+      case excluded_states.uniq.sort
       when [ "active" ]
         query.where(entries: { excluded: false })
       when [ "excluded" ]

--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -7,6 +7,7 @@ class Transaction::Search
   attribute :amount_operator, :string
   attribute :types, array: true
   attribute :status, array: true
+  attribute :excluded, array: true
   attribute :accounts, array: true
   attribute :account_ids, array: true
   attribute :start_date, :string
@@ -36,6 +37,7 @@ class Transaction::Search
       query = apply_category_filter(query, categories)
       query = apply_type_filter(query, types)
       query = apply_status_filter(query, status)
+      query = apply_excluded_filter(query, excluded)
       query = apply_merchant_filter(query, merchants)
       query = apply_tag_filter(query, tags)
       query = EntrySearch.apply_search_filter(query, search)
@@ -204,6 +206,20 @@ class Transaction::Search
         query.pending
       when [ "confirmed" ]
         query.excluding_pending
+      else
+        query
+      end
+    end
+
+    def apply_excluded_filter(query, excluded_states)
+      return query unless excluded_states.present?
+      return query if excluded_states.uniq.sort == [ "active", "excluded" ] # Both selected = no filter
+
+      case excluded_states.sort
+      when [ "active" ]
+        query.where(entries: { excluded: false })
+      when [ "excluded" ]
+        query.where(entries: { excluded: true })
       else
         query
       end

--- a/app/views/transactions/searches/filters/_badge.html.erb
+++ b/app/views/transactions/searches/filters/_badge.html.erb
@@ -40,6 +40,11 @@
       <%= icon(param_value.downcase == "pending" ? "clock" : "check", size: "sm") %>
       <p><%= t(".#{param_value.downcase}") %></p>
     </div>
+  <% elsif param_key == "excluded" %>
+    <div class="flex items-center gap-2 px-1">
+      <%= icon(param_value.downcase == "excluded" ? "eye-off" : "eye", size: "sm") %>
+      <p><%= t(".#{param_value.downcase}") %></p>
+    </div>
   <% else %>
     <div class="flex items-center gap-2">
       <p><%= param_value %></p>

--- a/app/views/transactions/searches/filters/_excluded_filter.html.erb
+++ b/app/views/transactions/searches/filters/_excluded_filter.html.erb
@@ -1,0 +1,26 @@
+<%# locals: (form:) %>
+
+<div class="p-2 space-y-3">
+  <div class="flex items-center gap-3" data-filter-name="active">
+    <%= form.check_box :excluded,
+                           {
+                             multiple: true,
+                             checked: @q[:excluded]&.include?("active"),
+                             class: "checkbox checkbox--light"
+                           },
+                           "active",
+                           nil %>
+    <%= form.label :excluded, t(".active"), value: "active", class: "text-sm text-primary" %>
+  </div>
+  <div class="flex items-center gap-3" data-filter-name="excluded">
+    <%= form.check_box :excluded,
+                           {
+                             multiple: true,
+                             checked: @q[:excluded]&.include?("excluded"),
+                             class: "checkbox checkbox--light"
+                           },
+                           "excluded",
+                           nil %>
+    <%= form.label :excluded, t(".excluded"), value: "excluded", class: "text-sm text-primary" %>
+  </div>
+</div>

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -232,6 +232,7 @@ en:
         date: Date
         type: Type
         status: Status
+        excluded: Excluded
         amount: Amount
         category: Category
         tag: Tag
@@ -297,7 +298,9 @@ en:
           less_than: Less than
           placeholder: '0'
         badge:
+          active: Active
           expense: Expense
+          excluded: Excluded
           income: Income
           on_or_after: on or after %{date}
           on_or_before: on or before %{date}
@@ -311,6 +314,9 @@ en:
         status_filter:
           confirmed: Confirmed
           pending: Pending
+        excluded_filter:
+          active: Active
+          excluded: Excluded
       menu:
         account_filter: Account
         amount_filter: Amount
@@ -319,6 +325,7 @@ en:
         category_filter: Category
         clear_filters: Clear filters
         date_filter: Date
+        excluded_filter: Excluded
         merchant_filter: Merchant
         status_filter: Status
         tag_filter: Tag

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -670,4 +670,25 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     assert_includes confirmed_ids, confirmed.entryable.id
     assert_not_includes pending_ids, confirmed.entryable.id
   end
+
+  test "excluded filter hides or isolates excluded transactions" do
+    active = create_transaction(account: @checking_account, amount: 100, excluded: false)
+    excluded = create_transaction(account: @checking_account, amount: 100, excluded: true)
+
+    active_ids = Transaction::Search.new(@family, filters: { excluded: [ "active" ] }).transactions_scope.pluck(:id)
+    assert_includes active_ids, active.entryable.id
+    assert_not_includes active_ids, excluded.entryable.id
+
+    excluded_ids = Transaction::Search.new(@family, filters: { excluded: [ "excluded" ] }).transactions_scope.pluck(:id)
+    assert_includes excluded_ids, excluded.entryable.id
+    assert_not_includes excluded_ids, active.entryable.id
+
+    # Both selected (or none) is a no-op: excluded transactions remain visible by default
+    both_ids = Transaction::Search.new(@family, filters: { excluded: [ "active", "excluded" ] }).transactions_scope.pluck(:id)
+    default_ids = Transaction::Search.new(@family, filters: {}).transactions_scope.pluck(:id)
+    [ both_ids, default_ids ].each do |ids|
+      assert_includes ids, active.entryable.id
+      assert_includes ids, excluded.entryable.id
+    end
+  end
 end

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -691,4 +691,31 @@ class Transaction::SearchTest < ActiveSupport::TestCase
       assert_includes ids, excluded.entryable.id
     end
   end
+
+  test "excluded filter tolerates duplicate and unrecognized values" do
+    active = create_transaction(account: @checking_account, amount: 100, excluded: false)
+    excluded = create_transaction(account: @checking_account, amount: 100, excluded: true)
+
+    # Duplicates collapse to the single-value case rather than falling through to a no-op
+    dup_ids = Transaction::Search.new(@family, filters: { excluded: [ "active", "active" ] }).transactions_scope.pluck(:id)
+    assert_includes dup_ids, active.entryable.id
+    assert_not_includes dup_ids, excluded.entryable.id
+
+    # Unrecognized values are ignored (no filter applied) instead of returning nothing
+    garbage_ids = Transaction::Search.new(@family, filters: { excluded: [ "bogus" ] }).transactions_scope.pluck(:id)
+    assert_includes garbage_ids, active.entryable.id
+    assert_includes garbage_ids, excluded.entryable.id
+  end
+
+  test "excluded filter composes with another entries-scoped filter" do
+    active_confirmed = create_transaction(account: @checking_account, amount: 100, excluded: false)
+    excluded_confirmed = create_transaction(account: @checking_account, amount: 100, excluded: true)
+
+    ids = Transaction::Search.new(
+      @family, filters: { excluded: [ "active" ], status: [ "confirmed" ] }
+    ).transactions_scope.pluck(:id)
+
+    assert_includes ids, active_confirmed.entryable.id
+    assert_not_includes ids, excluded_confirmed.entryable.id
+  end
 end


### PR DESCRIPTION
## Summary

Adds an opt-in **Excluded** filter to transaction search so excluded transactions (entries flagged `excluded`) can be hidden or isolated. Previously they always appeared in search results with no way to filter them out.

- New **Excluded** filter in the transactions search menu with two options, **Active** and **Excluded**. It mirrors the existing **Status** filter exactly (both or neither selected = no-op), so default behavior is unchanged and excluded transactions still show by default.
- `Transaction::Search` gains an `excluded` filter (`active` / `excluded`) applied against `entries.excluded`.

## MCP / AI parity

`get_transactions` already forwards arbitrary filters to `Transaction::Search`, but the new `excluded` filter wasn't discoverable. Exposed it in the function's `params_schema` and added `is_excluded` to each returned transaction, so the in-app AI assistant and MCP clients can filter on it too.

## Tests

`test/models/transaction/search_test.rb` covers active-only / excluded-only / both / default (no-op), duplicate & unrecognized values, and composition with the `status` filter. The model and assistant-function suites pass locally (Ruby 3.4.9 + Postgres).

## Notes

- i18n keys added to `en.yml` only, matching the repo convention (other locales fall back to the base locale).
- The REST `/api/v1/transactions` endpoint has a pre-existing gap (no `status`/`excluded` filter); left out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Excluded” transaction filter with selectable Active/Excluded options in the search UI.
  * Transaction results can now be filtered by exclusion status and display an exclusion indicator in the list and assistant output.

* **Bug Fixes**
  * Fixed the search so selected Excluded filter values are preserved and applied correctly.
  * Improved handling of duplicate or unsupported filter values so results remain visible as expected.

* **Tests**
  * Added coverage for excluded-status filtering and its interaction with other transaction filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->