### PR TITLE
feat: Move import merchant button in sub menu

### DIFF
--- a/app/views/family_merchants/index.html.erb
+++ b/app/views/family_merchants/index.html.erb
@@ -7,13 +7,13 @@
         href: merge_family_merchants_path,
         frame: :modal,
         icon: "combine") %>
+    <% menu.with_item(
+        variant: "link",
+        text: t(".import"),
+        href: new_import_path(type: "MerchantImport"),
+        frame: :modal,
+        icon: "upload") %>
   <% end %>
-  <%= render DS::Link.new(
-    text: t(".import"),
-    variant: "outline",
-    icon: "upload",
-    href: new_import_path(type: "MerchantImport")
-  ) %>
   <%= render DS::Link.new(
     text: t(".new"),
     variant: "primary",


### PR DESCRIPTION
Move the "Import merchants" button in the sub menu, for better visibility on mobile

| Before | After |
|--------|--------|
| <img width="390" height="108" alt="Screenshot 2026-07-08 alle 19 13 13" src="https://github.com/user-attachments/assets/11d63ecd-944a-43d0-af2f-51d2b859a94f" /> | <img width="380" height="106" alt="Screenshot 2026-07-08 alle 19 12 37" src="https://github.com/user-attachments/assets/3cfe4826-8cb9-44d3-9215-8d6cfb63ab34" /> | 
