### PR TITLE
fix: block unsafe OAuth redirect URIs in dynamic registration

### DIFF
--- a/app/controllers/oauth_registration_controller.rb
+++ b/app/controllers/oauth_registration_controller.rb
@@ -82,7 +82,8 @@ class OauthRegistrationController < ApplicationController
       return true if scheme == "https"
       return false unless scheme == "http"
 
-      LOOPBACK_HOSTS.include?(uri.host.downcase)
+      host = uri.host.downcase.delete_prefix("[").delete_suffix("]")
+      LOOPBACK_HOSTS.include?(host)
     rescue URI::InvalidURIError
       false
     end

--- a/app/controllers/oauth_registration_controller.rb
+++ b/app/controllers/oauth_registration_controller.rb
@@ -1,4 +1,6 @@
 class OauthRegistrationController < ApplicationController
+  LOOPBACK_HOSTS = [ "localhost", "127.0.0.1", "::1" ].freeze
+
   skip_authentication
   skip_before_action :verify_authenticity_token
   skip_before_action :require_onboarding_and_upgrade, raise: false
@@ -33,6 +35,14 @@ class OauthRegistrationController < ApplicationController
       return
     end
 
+    unless redirect_uris.all? { |uri| valid_redirect_uri?(uri) }
+      render json: {
+        error: "invalid_client_metadata",
+        error_description: "redirect_uris must use https or loopback http"
+      }, status: :bad_request
+      return
+    end
+
     client_name = body["client_name"].presence || "MCP Client"
 
     app = Doorkeeper::Application.new(
@@ -61,4 +71,19 @@ class OauthRegistrationController < ApplicationController
       error_description: "Invalid JSON"
     }, status: :bad_request
   end
+
+  private
+
+    def valid_redirect_uri?(raw_uri)
+      uri = URI.parse(raw_uri)
+      return false if uri.host.blank?
+
+      scheme = uri.scheme.to_s.downcase
+      return true if scheme == "https"
+      return false unless scheme == "http"
+
+      LOOPBACK_HOSTS.include?(uri.host.downcase)
+    rescue URI::InvalidURIError
+      false
+    end
 end

--- a/test/controllers/oauth_registration_controller_test.rb
+++ b/test/controllers/oauth_registration_controller_test.rb
@@ -95,6 +95,19 @@ class OauthRegistrationControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "http://localhost:3456/callback" ], json["redirect_uris"]
   end
 
+  test "allows ipv6 loopback http redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "http://[::1]:3456/callback" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_equal [ "http://[::1]:3456/callback" ], json["redirect_uris"]
+  end
+
   test "rejects custom scheme redirect uri" do
     post "/register",
       params: {

--- a/test/controllers/oauth_registration_controller_test.rb
+++ b/test/controllers/oauth_registration_controller_test.rb
@@ -68,4 +68,43 @@ class OauthRegistrationControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body)
     assert_equal "MCP Client", json["client_name"]
   end
+
+  test "rejects non-loopback http redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "http://evil.example/callback" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+    json = JSON.parse(response.body)
+    assert_equal "invalid_client_metadata", json["error"]
+  end
+
+  test "allows loopback http redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "http://localhost:3456/callback" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_equal [ "http://localhost:3456/callback" ], json["redirect_uris"]
+  end
+
+  test "rejects custom scheme redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "myapp://callback" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+    json = JSON.parse(response.body)
+    assert_equal "invalid_client_metadata", json["error"]
+  end
 end


### PR DESCRIPTION
## Root cause
POST /register accepted arbitrary redirect URIs while Doorkeeper redirect validation was configured to allow all schemes except javascript: and to disable HTTPS enforcement globally. This allowed registration of clients with insecure/non-loopback HTTP or custom-scheme callbacks, increasing risk of authorization code/token interception.

## Fix approach
Added strict redirect URI validation in OauthRegistrationController#create before creating the OAuth application:
- allow https:// URIs
- allow http:// only for loopback hosts (localhost, 127.0.0.1, ::1)
- reject all other redirect URI schemes/hosts

Also added controller tests to verify allowed and rejected cases.

## Impact
- closes a high-impact OAuth security gap in dynamic client registration
- preserves local/native development callbacks via loopback HTTP
- keeps change minimal and backward-compatible for secure clients

## Risks / tradeoffs
- clients using custom URI schemes or non-loopback HTTP callbacks must migrate to HTTPS or loopback HTTP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for OAuth registration redirect URLs to accept only HTTPS or approved loopback HTTP addresses.
  * Requests with any invalid redirect URI are now rejected with `400 bad_request` and `invalid_client_metadata`, including a clear explanation of the allowed formats.
  * Added tests to confirm loopback `http://localhost` and `http://[::1]` are accepted, while non-loopback HTTP and custom-scheme redirects are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->