### PR TITLE
fix(imports): add horizontal scroll to CSV sample data preview

### DIFF
--- a/app/views/imports/_table.html.erb
+++ b/app/views/imports/_table.html.erb
@@ -8,7 +8,7 @@
       <h2 class="text-sm text-secondary font-medium"><%= caption %></h2>
     </div>
   <% end %>
-  <div class="inline-block min-w-fit sm:w-full rounded-lg shadow-border-xs text-sm bg-container">
+  <div class="w-full overflow-x-auto rounded-lg shadow-border-xs text-sm bg-container">
     <table class="min-w-full">
       <thead>
         <tr>


### PR DESCRIPTION
## What
Fixes the sample-data preview table on the CSV import configuration page silently clipping columns instead of scrolling.

## How it works
The table's inner wrapper used `inline-block min-w-fit sm:w-full` with no overflow handling of its own, while the outer card wrapper has `overflow-hidden` (there for rounded-corner clipping, not meant to hide table content). A CSV with enough columns to overflow the narrow `max-w-lg` config page got clipped by that outer `overflow-hidden`, with the extra columns completely unreachable - no scrollbar, no indication there was more to see.

Changed the inner wrapper to `w-full overflow-x-auto` so it establishes its own horizontal scroll context, contained within the outer card, instead of relying on the parent to clip.

## Testing
Verified live in a browser: pasted a 15-column CSV into the import flow, confirmed a scrollbar appears under the sample table, and confirmed scrolling right reveals the previously-hidden columns. `bin/rubocop` (full repo) and `bundle exec erb_lint` clean. All 38 import controller tests pass - no test needed updating since this is a pure CSS fix with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the imports table container styling to better fit the page layout.
  * The table now spans the full width and supports horizontal scrolling on smaller screens, improving readability and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->