### PR TITLE
feat: show counterpart account in transfer transaction list row

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -57,8 +57,16 @@ class AccountsController < ApplicationController
   def show
     @chart_view = params[:chart_view] || "balance"
     @tab = params[:tab]
+    @accessible_account_ids = Current.user.accessible_accounts.pluck(:id).to_set
     @q = params.fetch(:q, {}).permit(:search, status: [])
-    entries = @account.entries.where(excluded: false).search(@q).reverse_chronological.includes(:entryable)
+    entries = @account.entries.where(excluded: false).search(@q).reverse_chronological.includes(
+      :entryable,
+      entryable: {
+        transfer_as_outflow: { inflow_transaction: { entry: :account } },
+        transfer_as_inflow: { outflow_transaction: { entry: :account } }
+      }
+    )
+
     if statement_tab_active?
       build_statement_tab_data
       return render_statement_tab_frame if statement_tab_frame_request?

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -59,13 +59,7 @@ class AccountsController < ApplicationController
     @tab = params[:tab]
     @accessible_account_ids = Current.user.accessible_accounts.pluck(:id).to_set
     @q = params.fetch(:q, {}).permit(:search, status: [])
-    entries = @account.entries.where(excluded: false).search(@q).reverse_chronological.includes(
-      :entryable,
-      entryable: {
-        transfer_as_outflow: { inflow_transaction: { entry: :account } },
-        transfer_as_inflow: { outflow_transaction: { entry: :account } }
-      }
-    )
+    entries = @account.entries.where(excluded: false).search(@q).reverse_chronological.includes(:entryable)
 
     if statement_tab_active?
       build_statement_tab_data
@@ -77,6 +71,17 @@ class AccountsController < ApplicationController
       limit: safe_per_page,
       params: request.query_parameters.except("tab").merge("tab" => "activity")
     )
+
+    # Preload transfer associations only for Transaction entries
+    txn_entryables = @entries.filter_map { |e| e.entryable if e.entryable_type == "Transaction" }
+    ActiveRecord::Associations::Preloader.new(
+      records: txn_entryables,
+      associations: {
+        transfer_as_outflow: { inflow_transaction: { entry: :account } },
+        transfer_as_inflow: { outflow_transaction: { entry: :account } }
+      }
+    ).call
+
     Transaction::ActivitySecurityPreloader.new(@entries).preload
 
     @activity_feed_data = Account::ActivityFeedData.new(@account, @entries)

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -14,9 +14,8 @@ class TransactionsController < ApplicationController
 
   def index
     @q = search_params
-    @accessible_account_ids = Current.user.accessible_accounts.pluck(:id).to_set
-    accessible_account_ids = @accessible_account_ids
-    @search = Transaction::Search.new(Current.family, filters: @q, accessible_account_ids: accessible_account_ids)
+    @accessible_account_ids = Current.user.accessible_accounts.pluck(:id)
+    @search = Transaction::Search.new(Current.family, filters: @q, accessible_account_ids: @accessible_account_ids)
 
     base_scope = @search.transactions_scope
                        .reverse_chronological

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -14,16 +14,18 @@ class TransactionsController < ApplicationController
 
   def index
     @q = search_params
-    accessible_account_ids = Current.user.accessible_accounts.pluck(:id)
+    @accessible_account_ids = Current.user.accessible_accounts.pluck(:id).to_set
+    accessible_account_ids = @accessible_account_ids
     @search = Transaction::Search.new(Current.family, filters: @q, accessible_account_ids: accessible_account_ids)
 
     base_scope = @search.transactions_scope
                        .reverse_chronological
                        .includes(
-                         { entry: :account },
-                         :category, :merchant, :tags,
-                         :transfer_as_inflow, :transfer_as_outflow
-                       )
+                          { entry: :account },
+                          :category, :merchant, :tags,
+                          transfer_as_outflow: { inflow_transaction: { entry: :account } },
+                          transfer_as_inflow: { outflow_transaction: { entry: :account } }
+                        )
 
     @pagy, @transactions = pagy(base_scope, limit: safe_per_page)
     Transaction::ActivitySecurityPreloader.new(@transactions).preload

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -153,10 +153,10 @@
                 <div class="text-secondary text-xs font-normal">
                   <% if transaction.transfer? %>
                     <span class="text-secondary">
-                      <%= transaction.loan_payment? ? t("transactions.show.loan_payment") : t("transactions.show.transfer") %> • 
+                      <%= transaction.loan_payment? ? t("transactions.show.loan_payment") : t("transactions.show.transfer") %> •
                       <% if transaction.transfer.present? %>
                         <% counterpart = transaction.transfer_as_outflow.present? ? transaction.transfer.to_account : transaction.transfer.from_account %>
-                        <% if counterpart.present? && Current.user.accessible_accounts.exists?(counterpart.id) %>
+                        <% if counterpart.present? && @accessible_account_ids&.include?(counterpart.id) %>
                           <% if transaction.transfer_as_outflow.present? %>
                             <%= entry.account.name %> → <%= counterpart.name %>
                           <% else %>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -153,7 +153,16 @@
                 <div class="text-secondary text-xs font-normal">
                   <% if transaction.transfer? %>
                     <span class="text-secondary">
-                      <%= transaction.loan_payment? ? t("transactions.show.loan_payment") : t("transactions.show.transfer") %> • <%= entry.account.name %>
+                      <%= transaction.loan_payment? ? t("transactions.show.loan_payment") : t("transactions.show.transfer") %> • 
+                      <% if transaction.transfer.present? %>
+                        <% if transaction.transfer_as_outflow.present? %>
+                          <%= entry.account.name %> → <%= transaction.transfer.to_account&.name %>
+                        <% else %>
+                          <%= entry.account.name %> ← <%= transaction.transfer.from_account&.name %>
+                        <% end %>
+                      <% else %>
+                        <%= entry.account.name %>
+                      <% end %>
                     </span>
                   <% else %>
                     <% if transaction.merchant&.present? %>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -155,10 +155,15 @@
                     <span class="text-secondary">
                       <%= transaction.loan_payment? ? t("transactions.show.loan_payment") : t("transactions.show.transfer") %> • 
                       <% if transaction.transfer.present? %>
-                        <% if transaction.transfer_as_outflow.present? %>
-                          <%= entry.account.name %> → <%= transaction.transfer.to_account&.name %>
+                        <% counterpart = transaction.transfer_as_outflow.present? ? transaction.transfer.to_account : transaction.transfer.from_account %>
+                        <% if counterpart.present? && Current.user.accessible_accounts.exists?(counterpart.id) %>
+                          <% if transaction.transfer_as_outflow.present? %>
+                            <%= entry.account.name %> → <%= counterpart.name %>
+                          <% else %>
+                            <%= entry.account.name %> ← <%= counterpart.name %>
+                          <% end %>
                         <% else %>
-                          <%= entry.account.name %> ← <%= transaction.transfer.from_account&.name %>
+                          <%= entry.account.name %>
                         <% end %>
                       <% else %>
                         <%= entry.account.name %>

--- a/test/views/transactions/transfer_counterpart_view_test.rb
+++ b/test/views/transactions/transfer_counterpart_view_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class Transactions::TransferCounterpartViewTest < ActionView::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @user = users(:family_admin)
+    Current.session = Session.create!(user: @user)
+
+    @checking = accounts(:depository) # "from" account
+    @savings = accounts(:credit_card) # "to" account
+
+    @accessible_account_ids = @user.accessible_accounts.pluck(:id).to_set
+  end
+
+  test "renders outflow transfer with arrow to destination account" do
+    outflow_tx = Transaction.create!(kind: "funds_movement")
+    outflow_entry = Entry.create!(
+      account: @checking, entryable: outflow_tx,
+      name: "Transfer to Savings", amount: 100, currency: "USD", date: Date.today
+    )
+
+    inflow_tx = Transaction.create!(kind: "funds_movement")
+    inflow_entry = Entry.create!(
+      account: @savings, entryable: inflow_tx,
+      name: "Transfer from Checking", amount: -100, currency: "USD", date: Date.today
+    )
+
+    Transfer.create!(
+      inflow_transaction: inflow_tx,
+      outflow_transaction: outflow_tx,
+      status: "confirmed"
+    )
+
+    html = render(partial: "transactions/transaction", locals: {
+      entry: outflow_entry, balance_trend: nil, view_ctx: "global"
+    })
+
+    assert_includes html, "→"
+    assert_includes html, @savings.name
+  end
+
+  test "renders inflow transfer with arrow from source account" do
+    outflow_tx = Transaction.create!(kind: "funds_movement")
+    outflow_entry = Entry.create!(
+      account: @checking, entryable: outflow_tx,
+      name: "Transfer to Savings", amount: 100, currency: "USD", date: Date.today
+    )
+
+    inflow_tx = Transaction.create!(kind: "funds_movement")
+    inflow_entry = Entry.create!(
+      account: @savings, entryable: inflow_tx,
+      name: "Transfer from Checking", amount: -100, currency: "USD", date: Date.today
+    )
+
+    Transfer.create!(
+      inflow_transaction: inflow_tx,
+      outflow_transaction: outflow_tx,
+      status: "confirmed"
+    )
+
+    html = render(partial: "transactions/transaction", locals: {
+      entry: inflow_entry, balance_trend: nil, view_ctx: "global"
+    })
+
+    assert_includes html, "←"
+    assert_includes html, @checking.name
+  end
+
+  test "falls back to account name when transfer has no counterpart" do
+    tx = Transaction.create!(kind: "funds_movement")
+    entry = Entry.create!(
+      account: @checking, entryable: tx,
+      name: "Unmatched Transfer", amount: 100, currency: "USD", date: Date.today
+    )
+
+    html = render(partial: "transactions/transaction", locals: {
+      entry: entry, balance_trend: nil, view_ctx: "global"
+    })
+
+    assert_includes html, @checking.name
+    assert_not_includes html, "→"
+    assert_not_includes html, "←"
+  end
+end

--- a/test/views/transactions/transfer_counterpart_view_test.rb
+++ b/test/views/transactions/transfer_counterpart_view_test.rb
@@ -10,6 +10,7 @@ class Transactions::TransferCounterpartViewTest < ActionView::TestCase
     @savings = accounts(:credit_card) # "to" account
 
     @accessible_account_ids = @user.accessible_accounts.pluck(:id).to_set
+    @split_parent_entry_ids = Set.new
   end
 
   test "renders outflow transfer with arrow to destination account" do


### PR DESCRIPTION
### Summary
Shows the source and destination account names in transfer transaction list rows, making it easier to identify where money is moving at a glance without needing to click into the transaction detail.

Current | Updated | 
| --- | --- |
| Transfer • Access | Transfer • Access → Saver |
| Transfer • Saver | Transfer • Saver ← Access |

### Problem
When managing multiple accounts (e.g., savings, term deposits, everyday accounts), it's hard to tell at a glance where money is moving to/from without clicking into each transfer details. Currently, transfer transactions in the transaction list only display the current account name (e.g., "Transfer • Access"). Renaming the bank description with rules (e.g., "Transfer to xx856" → "Transfer to Saver") isn't ideal either, as it alters the original description needed for auditing.

For example, If I transfer between two internal accounts in my bank, Account A and Account B, my bank description is something like this:
**Account A**: Transfer to xx856 - Bill *(outgoing expense for the account)*
**Account B**: Transfer from xx123 - Bill *(incoming income for the account)*

<img width="1423" height="128" alt="Sure-07-09-2026_09_03_AM" src="https://github.com/user-attachments/assets/ceb2085d-4aec-4743-b748-58aeb2b00f91" />
<img width="1414" height="124" alt="Sure-07-09-2026_09_04_AM" src="https://github.com/user-attachments/assets/6b960c0e-5419-45b6-bc55-9e0395f08145" />

> Sure automatically shows it as linked transaction flawlessly, haven't had any problem with it. But with only subtitle (e.g., "Transfer • Smart Access"), it is really hard to get the visibility at once.

### Changes
Modified app/views/transactions/_transaction.html.erb to display transfer direction with counterpart account name:
**Outflow**: Account → Destination
**Inflow**: Account ← Source
**Unmatched transfers (no linked Transfer record)**: falls back to showing just the account name

### Implementation
Uses existing `Transaction#transfer_as_outflow` and `Transfer#to_account/#from_account` methods. No new associations or controller changes needed and transfer data is already preloaded.

### Screenshots
#### Current 
<img width="1423" height="128" alt="Sure-07-09-2026_09_03_AM" src="https://github.com/user-attachments/assets/ceb2085d-4aec-4743-b748-58aeb2b00f91" />
<img width="1414" height="124" alt="Sure-07-09-2026_09_04_AM" src="https://github.com/user-attachments/assets/6b960c0e-5419-45b6-bc55-9e0395f08145" />

#### Updated:
#### Zoomed
<img width="1422" height="119" alt="image" src="https://github.com/user-attachments/assets/f7beb79a-3aab-4b4f-92de-ca96c21f6b7e" />
<img width="1405" height="119" alt="image" src="https://github.com/user-attachments/assets/bfd4508d-e0ff-4f3e-9588-89f002238437" />
<img width="918" height="109" alt="image" src="https://github.com/user-attachments/assets/20a5886f-bcfe-406d-bb2d-3a682aef0dfc" />
<img width="941" height="119" alt="image" src="https://github.com/user-attachments/assets/1a7913d5-2cf0-4bcd-8df9-e4f31cbd49c1" />

#### Transaction List
<img width="1479" height="233" alt="image" src="https://github.com/user-attachments/assets/03e049ce-893b-4eb8-b0e6-5f67679c9a6b" />

#### Source Account Transaction List
<img width="1442" height="488" alt="image" src="https://github.com/user-attachments/assets/d7f25daa-7e87-4ea3-9cb7-706a8810205a" />

#### Destination Account Transaction List
<img width="1457" height="853" alt="image" src="https://github.com/user-attachments/assets/bd621838-2802-4393-83c1-4dda71ea9528" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Transfer and loan-payment entries now show the counterpart account name with a directional arrow when related transfer details are available (outflow shows `→`, inflow shows `←`).

* **Bug Fixes**
  * When the counterpart transfer is missing or not accessible, labels now fall back to showing only the current account name.

* **Performance / UX Improvements**
  * Transactions and accounts pages now preload the latest sync/transfer-related metadata more reliably for smoother rendering.

* **Tests**
  * Added view tests covering outflow/inflow arrow directions and the non-matched fallback case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->