### PR TITLE
Use badge variant for category selects in transfer + bulk-edit views

### DIFF
--- a/app/views/transactions/bulk_updates/new.html.erb
+++ b/app/views/transactions/bulk_updates/new.html.erb
@@ -11,7 +11,7 @@
         <%= render DS::Disclosure.new(title: t(".transactions_section"), open: true) do %>
           <div class="space-y-2">
             <%= form.text_field :name, label: t(".name_label"), placeholder: t(".name_placeholder") %>
-            <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: t(".category_prompt"), label: t(".category_label"), class: "text-subdued" } %>
+            <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: t(".category_prompt"), label: t(".category_label"), class: "text-subdued", variant: :badge, searchable: true } %>
             <%= form.collection_select :merchant_id, Current.family.available_merchants_for(Current.user).alphabetically, :id, :name, { prompt: t(".merchant_prompt"), label: t(".merchant_label"), class: "text-subdued" } %>
             <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: t(".none"), multiple: true, label: t(".tags_label"), include_hidden: false } %>
             <%= form.text_area :notes, label: t(".notes_label"), placeholder: t(".notes_placeholder"), rows: 5 %>

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -84,7 +84,7 @@
       <%= styled_form_with model: @transfer,
               data: { controller: "auto-submit-form" }, class: "space-y-2" do |f| %>
         <% if @transfer.categorizable? %>
-          <%= f.collection_select :category_id, @categories.alphabetically, :id, :name, { label: t(".category"), include_blank: t(".uncategorized"), selected: @transfer.outflow_transaction.category&.id }, "data-auto-submit-form-target": "auto" %>
+          <%= f.collection_select :category_id, @categories.alphabetically, :id, :name, { label: t(".category"), include_blank: t(".uncategorized"), selected: @transfer.outflow_transaction.category&.id, variant: :badge, searchable: true }, "data-auto-submit-form-target": "auto" %>
         <% end %>
         <%= f.text_area :notes,
                   label: t(".note_label"),


### PR DESCRIPTION
There are a few inconsistencies in the way that category-select dropdowns are rendered across the app.  This PR addresses two of them, bringing the transfer drawer and the bulk-edit modal in line with the richer badge variant already in use in the transaction drawer.  Doing so makes the app UI more consistent, and improves the user experience when selecting categories.

## Not in Scope

I'm leaving the category-deletion modal out of this PR. It also contains a category-select drop-down (for the optional category remapping), but the short auto-height modal doesn't give the badge+searchable popover enough vertical room: forcing the menu open crops the options list. Making the popover escape the dialog would mean portaling DS::Select's menu to a fixed/top-layer position (the component currently clamps the menu to its scroll parent by design) - an app-wide change requiring much more thought and testing, and that I didn't think belonged in this cosmetic PR. So that dropdown is left as the plain list for now.

The "best" option for category pickers IMO would to use a hierarchical category list with both indentation and badges, applied consistently to _every_ category select - including fixing DS::Select's popover so it isn't clipped inside short modals. That's a larger, shared-component change though.  This PR picks off the easy wins in a way that doesn't rule out a more comprehensive update later.

<img width="556" height="639" alt="Transfer Drawer Without Badges" src="https://github.com/user-attachments/assets/0423a08b-ed33-470e-a83d-0d83ea4e6292" /><img width="558" height="635" alt="Transfer Drawer With Badges" src="https://github.com/user-attachments/assets/ca2371e1-c529-4971-a98b-84753428a583" />

Above: before and after screenshots showing the changes to the transfer drawer proposed in this PR

<img width="845" height="642" alt="Bulk Edit Without Badges" src="https://github.com/user-attachments/assets/889159d5-5d80-4b4f-8bc3-344e2f6ecd63" /><img width="836" height="641" alt="Bulk Edit With Badges" src="https://github.com/user-attachments/assets/5a2343df-e4bc-4814-a174-0c1e36633a25" />

Above: before and after screenshots showing the changes to the bulk edit modal proposed in this PR

<img width="564" height="266" alt="Delete Category Modal showing unimplemented cropped picker" src="https://github.com/user-attachments/assets/4f115ac8-fc2b-4617-ac58-c334bfccb5e4" />

Above: screenshot showing why this PR does not apply the same change to the "delete category" modal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable category selectors in transfer details and bulk update screens.
  * Updated the category picker to display badge-style options for a clearer, more interactive selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->