### PR TITLE
fix(impersonation): guard Sidekiq jobs link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -150,7 +150,8 @@ module ApplicationHelper
   end
 
   def sidekiq_web_available?
-    Rails.application.routes.named_routes.route_defined?(:sidekiq_web)
+    named_routes = Rails.application.routes.named_routes
+    named_routes.route_defined?(:sidekiq_web_path) || named_routes.route_defined?(:sidekiq_web_url)
   end
 
   def assistant_icon

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -149,6 +149,10 @@ module ApplicationHelper
     cookies[:admin] == "true"
   end
 
+  def sidekiq_web_available?
+    Rails.application.routes.named_routes.route_defined?(:sidekiq_web)
+  end
+
   def assistant_icon
     type = ENV["ASSISTANT_TYPE"].presence || Current.family&.assistant_type.presence || "builtin"
     type == "external" ? "claw" : "ai"

--- a/app/views/impersonation_sessions/_super_admin_bar.html.erb
+++ b/app/views/impersonation_sessions/_super_admin_bar.html.erb
@@ -3,9 +3,11 @@
     <%= icon "alert-triangle", size: "lg", color: "current", class: "mr-2" %>
     <span class="text-inverse font-semibold uppercase"><%= t(".super_admin") %></span>
   </div>
-  <div>
-    <%= link_to t(".jobs"), sidekiq_web_url, class: "text-white underline hover:text-gray-100" %>
-  </div>
+  <% if sidekiq_web_available? %>
+    <div>
+      <%= link_to t(".jobs"), sidekiq_web_url, class: "text-white underline hover:text-gray-100" %>
+    </div>
+  <% end %>
 
   <div class="flex items-center space-x-2 px-2 py-2 text-white">
     <% if Current.session.active_impersonator_session.present? %>

--- a/app/views/impersonation_sessions/_super_admin_bar.html.erb
+++ b/app/views/impersonation_sessions/_super_admin_bar.html.erb
@@ -5,7 +5,7 @@
   </div>
   <% if sidekiq_web_available? %>
     <div>
-      <%= link_to t(".jobs"), sidekiq_web_url, class: "text-white underline hover:text-gray-100" %>
+      <%= link_to t(".jobs"), sidekiq_web_url, class: "text-inverse underline hover:text-subdued" %>
     </div>
   <% end %>
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -44,6 +44,30 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "Test Header Title", content_for(:header_title)
   end
 
+  test "#sidekiq_web_available? returns true when the route is mounted" do
+    named_routes = Struct.new(:defined) do
+      def route_defined?(name)
+        defined.fetch(name)
+      end
+    end
+
+    Rails.application.routes.stub(:named_routes, named_routes.new({ sidekiq_web: true })) do
+      assert sidekiq_web_available?
+    end
+  end
+
+  test "#sidekiq_web_available? returns false when the route is unavailable" do
+    named_routes = Struct.new(:defined) do
+      def route_defined?(name)
+        defined.fetch(name, false)
+      end
+    end
+
+    Rails.application.routes.stub(:named_routes, named_routes.new({})) do
+      assert_not sidekiq_web_available?
+    end
+  end
+
   def setup
     @account1 = Account.new(currency: "USD", balance: 1)
     @account2 = Account.new(currency: "USD", balance: 2)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -51,7 +51,7 @@ class ApplicationHelperTest < ActionView::TestCase
       end
     end
 
-    Rails.application.routes.stub(:named_routes, named_routes.new({ sidekiq_web: true })) do
+    Rails.application.routes.stub(:named_routes, named_routes.new({ sidekiq_web_path: true })) do
       assert sidekiq_web_available?
     end
   end
@@ -65,6 +65,18 @@ class ApplicationHelperTest < ActionView::TestCase
 
     Rails.application.routes.stub(:named_routes, named_routes.new({})) do
       assert_not sidekiq_web_available?
+    end
+  end
+
+  test "#sidekiq_web_available? returns true when only the url helper is defined" do
+    named_routes = Struct.new(:defined) do
+      def route_defined?(name)
+        defined.fetch(name, false)
+      end
+    end
+
+    Rails.application.routes.stub(:named_routes, named_routes.new({ sidekiq_web_url: true })) do
+      assert sidekiq_web_available?
     end
   end
 


### PR DESCRIPTION
## Summary
- guard the super-admin `Jobs` link behind a route-availability helper
- avoid rendering `sidekiq_web_url` when the Sidekiq UI is not mounted in the current environment
- add helper coverage for both mounted and unmounted route cases

## Testing
- `bin/rails test test/helpers/application_helper_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Jobs link in the super admin bar is now shown only when the Sidekiq Web interface is available.
  * Prevents users from seeing a link that leads to an unavailable page.

* **New Features**
  * Added a helper to detect whether Sidekiq Web routes are defined, enabling conditional UI rendering.

* **Tests**
  * Added coverage to verify the link availability check works when the route is present, absent, or available via URL helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->