### PR TITLE
docs: clarify encryption backfill for self-hosters

### DIFF
--- a/charts/sure/README.md
+++ b/charts/sure/README.md
@@ -497,6 +497,7 @@ migrations:
 
 - SimpleFin encryption is optional. If you enable it, you must provide Active Record Encryption keys.
 - The backfill Job runs a safe, idempotent Rake task to encrypt existing `access_url` values.
+- This Job is SimpleFin-specific. It does not replace the general `security:backfill_encryption` task for older plaintext data elsewhere in the app.
 
 ```yaml
 simplefin:
@@ -554,6 +555,15 @@ rails:
 ```
 
 Note: In self-hosted mode, if these env vars are not provided, they will be automatically generated from `SECRET_KEY_BASE`. In managed mode, these env vars must be explicitly provided via environment variables or Rails credentials.
+
+If you add custom `ACTIVE_RECORD_ENCRYPTION_*` values to an existing self-hosted deployment, `db:prepare` will still run automatically on install/upgrade, but older plaintext rows are not rewritten automatically. After the app is running with the new keys, run a one-off backfill such as:
+
+```bash
+kubectl exec -it deploy/sure-web -- bundle exec rake security:backfill_encryption
+kubectl exec -it deploy/sure-web -- env DRY_RUN=false bundle exec rake security:backfill_encryption
+```
+
+The first command is a dry-run preview. The task is idempotent.
 
 ## Advanced environment variable injection
 

--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -334,7 +334,7 @@ This is useful when:
 1. User sends a message in the Sure chat UI
 2. Sure sends the conversation to your agent's API endpoint (OpenAI chat completions format)
 3. Your agent processes it using whatever LLM, tools, or context it needs
-4. Your agent can call Sure's `/mcp` endpoint for financial data (accounts, transactions, balance sheet, holdings)
+4. Your agent can call Sure's `/mcp` endpoint for financial data and actions (accounts, transactions, balance sheet, budgets, file search, statement import, goals)
 5. Your agent streams the response back to Sure via Server-Sent Events (SSE)
 
 The agent's API must be **OpenAI chat completions compatible**: accept `POST` with a `messages` array, return SSE with `delta.content` chunks.
@@ -369,7 +369,12 @@ Sure exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) 
 
 **Authentication:** Bearer token via `Authorization` header
 
-**Environment variables:**
+Sure supports both:
+
+- OAuth bearer tokens issued through its discovery and registration endpoints (`/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, `POST /register`)
+- Static bearer tokens configured with `MCP_API_TOKEN` and `MCP_USER_EMAIL`
+
+**Static-token environment variables:**
 ```bash
 MCP_API_TOKEN=your-secret-token    # Bearer token the agent sends to authenticate
 MCP_USER_EMAIL=user@example.com    # Email of the Sure user the agent acts as
@@ -389,7 +394,7 @@ Content-Type: application/json
 | `tools/list` | Lists available tools with names, descriptions, and input schemas |
 | `tools/call` | Calls a specific tool by name with arguments |
 
-**Available tools** (exposed via `tools/list`):
+**Available tools** (exposed via `tools/list`; this list should be treated as dynamic):
 
 | Tool | Description |
 |------|-------------|
@@ -398,8 +403,10 @@ Content-Type: application/json
 | `get_holdings` | Investment holdings data |
 | `get_balance_sheet` | Current financial position |
 | `get_income_statement` | Income and expenses |
+| `get_budget` | Budget status and category breakdowns |
 | `import_bank_statement` | Import bank statement data |
 | `search_family_files` | Search uploaded documents |
+| `create_goal` | Create a savings goal |
 
 **Example: list tools**
 ```bash
@@ -654,8 +661,10 @@ def self.function_classes
     Function::GetHoldings,
     Function::GetBalanceSheet,
     Function::GetIncomeStatement,
+    Function::GetBudget,
     Function::ImportBankStatement,
-    Function::SearchFamilyFiles
+    Function::SearchFamilyFiles,
+    Function::CreateGoal
   ]
 end
 ```

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -95,6 +95,20 @@ SECRET_KEY_BASE="replacemewiththegeneratedstringfromthepriorstep"
 POSTGRES_PASSWORD="replacemewithyourdesireddatabasepassword"
 ```
 
+#### Optional: pin custom Active Record encryption keys
+
+Self-hosted Sure can derive Active Record encryption keys from `SECRET_KEY_BASE` automatically. That is enough for new self-hosted installs.
+
+If you want to provide dedicated encryption keys instead, add these variables to your `.env` before the first boot:
+
+```txt
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="generated-key-1"
+ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="generated-key-2"
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="generated-key-3"
+```
+
+If you are enabling these custom keys on an instance that already has data, see [Turning on Active Record encryption after first boot](#turning-on-active-record-encryption-after-first-boot).
+
 #### Using HTTPS
 
 Assuming you want to access your instance from the internet, you should have secured your URL address with an SSL certificate.  
@@ -326,3 +340,23 @@ docker compose exec db psql -U sure_user -d sure_development -c "SELECT 1;" # Th
 ### Slow `.csv` import (processing rows taking longer than expected)
 
 Importing comma-separated-value file(s) requires the `sure-worker` container to communicate with Redis. Check your worker logs for any unexpected errors, such as connection timeouts or Redis communication failures.
+
+### Turning on Active Record encryption after first boot
+
+If your instance already has data and you later add `ACTIVE_RECORD_ENCRYPTION_*` variables, restarting the containers is not enough to rewrite older plaintext values.
+
+- Normal app startup runs `db:prepare`, which covers schema setup and migrations.
+- New writes use encryption after the app boots with the keys.
+- Existing rows are not automatically re-encrypted on startup.
+
+Run the backfill task once after the app is up:
+
+```bash
+# Safe preview first (dry-run is the default)
+docker compose exec web bin/rails security:backfill_encryption
+
+# Perform the rewrite
+docker compose exec web env DRY_RUN=false bin/rails security:backfill_encryption
+```
+
+The task is idempotent, so it is safe to run again if needed.

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -180,6 +180,16 @@ The first time you run the app, you will need to register a new account by hitti
 1. Enter your email
 2. Enter a password
 
+### Step 5a: Restrict future signups (optional)
+
+After creating your initial admin account, you can control how other people join your self-hosted instance from **Settings > Self-Hosting > Onboarding**.
+
+- **Open**: Anyone can create an account from the registration page.
+- **Invite-only**: New account creation stays enabled, but signups require a valid invite code.
+- **Closed**: The registration page is disabled for new signups.
+
+If you do not want additional self-service registrations, switch the instance to **Closed** after the initial setup.
+
 ### Step 6: Run the app in the background
 
 Most self-hosting users will want the Sure app to run in the background on their computer so they can access it at all times. To do this, hit `Ctrl+C` to stop the running process, and then run the following command:

--- a/docs/hosting/hetzner.md
+++ b/docs/hosting/hetzner.md
@@ -176,6 +176,16 @@ Now you can:
 2. **Create your admin account**: Click "Create your account" on the login page
 3. **Set up your first family**: Follow the onboarding process
 
+### Optional: Disable self-service registration
+
+Once your initial admin account is ready, open **Settings > Self-Hosting > Onboarding** to choose how signups should work:
+
+- **Open**: Anyone can register.
+- **Invite-only**: New signups require a valid invite code.
+- **Closed**: New signups from the registration page are blocked.
+
+For single-admin or tightly controlled deployments, set the onboarding mode to **Closed** after the initial setup.
+
 ## Step 7: Set Up Automated Backups
 
 Create a backup script to protect your data:

--- a/docs/hosting/mcp.md
+++ b/docs/hosting/mcp.md
@@ -1,6 +1,6 @@
 # MCP Server for External AI Assistants
 
-Sure includes a Model Context Protocol (MCP) server endpoint that allows external AI assistants like Claude Desktop, GPT agents, or custom AI clients to query your financial data.
+Sure includes a Model Context Protocol (MCP) server endpoint that allows external AI assistants like Claude.ai, Claude Desktop, GPT agents, or custom AI clients to query and act on your financial data.
 
 ## What is MCP?
 
@@ -11,16 +11,32 @@ This is useful when:
 - You prefer to keep your LLM provider separate from Sure
 - You're building custom AI agents that need access to financial tools
 
-## Prerequisites
+## Authentication Modes
 
-To enable the MCP endpoint, you need to set two environment variables:
+Sure supports two ways to authenticate MCP clients:
+
+### 1. OAuth 2.0 / dynamic client registration (recommended)
+
+This is the best option for Claude.ai and other MCP clients that support OAuth. Sure exposes:
+
+- `/.well-known/oauth-protected-resource`
+- `/.well-known/oauth-authorization-server`
+- `POST /register` for dynamic client registration
+
+These endpoints let compatible MCP clients register a public OAuth client, redirect you back to Sure for sign-in, and receive a bearer token with the `read_write` scope.
+
+### 2. Static bearer token via environment variables
+
+This is the simpler fallback for custom agents, scripts, and deployments where you want to pin the MCP server to a specific Sure user.
+
+Set these environment variables:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `MCP_API_TOKEN` | Bearer token for authentication | `your-secret-token-here` |
 | `MCP_USER_EMAIL` | Email of the Sure user whose data the assistant can access | `user@example.com` |
 
-Both variables are **required**. The endpoint will not activate if either is missing.
+Both variables are required for the static-token flow.
 
 ### Generating a secure token
 
@@ -33,7 +49,7 @@ openssl rand -base64 32
 # Or use any secure password generator
 ```
 
-### Choosing the user
+### Choosing the user for static-token auth
 
 The `MCP_USER_EMAIL` must match an existing Sure user's email address. The AI assistant will have access to all financial data for that user's family.
 
@@ -82,11 +98,16 @@ POST /mcp
 
 ### Authentication
 
-All requests must include the `MCP_API_TOKEN` as a Bearer token:
+MCP requests authenticate with a bearer token:
 
 ```
-Authorization: Bearer <MCP_API_TOKEN>
+Authorization: Bearer <token>
 ```
+
+That token can come from either:
+
+- an OAuth authorization flow handled by the MCP client, or
+- the static `MCP_API_TOKEN` environment variable described above.
 
 ### Supported Methods
 
@@ -100,7 +121,9 @@ Sure implements the following JSON-RPC 2.0 methods:
 
 ### Available Tools
 
-The MCP endpoint exposes these financial tools:
+The MCP endpoint exposes the same tool registry used by Sure's builtin assistant. Clients should treat `tools/list` as the source of truth.
+
+At the time of writing, `tools/list` includes:
 
 | Tool | Description |
 |------|-------------|
@@ -109,8 +132,10 @@ The MCP endpoint exposes these financial tools:
 | `get_holdings` | Query investment holdings |
 | `get_balance_sheet` | Current financial position (assets, liabilities, net worth) |
 | `get_income_statement` | Income and expenses over a period |
+| `get_budget` | Budget status and budget category breakdowns |
 | `import_bank_statement` | Import bank statement data |
 | `search_family_files` | Search uploaded documents in the vault |
+| `create_goal` | Create a savings goal linked to depository accounts |
 
 These are the same tools used by Sure's builtin AI assistant.
 
@@ -167,6 +192,22 @@ curl -X POST https://your-sure-instance/mcp \
 
 Response includes tool names, descriptions, and JSON schemas for parameters.
 
+### OAuth discovery
+
+MCP clients that support OAuth can discover Sure's metadata automatically:
+
+```bash
+curl https://your-sure-instance/.well-known/oauth-protected-resource
+curl https://your-sure-instance/.well-known/oauth-authorization-server
+```
+
+The authorization-server metadata includes:
+
+- `authorization_endpoint`: `https://your-sure-instance/oauth/authorize`
+- `token_endpoint`: `https://your-sure-instance/oauth/token`
+- `registration_endpoint`: `https://your-sure-instance/register`
+- `scopes_supported`: `["read_write"]`
+
 ### Call a Tool
 
 Execute a tool to get transactions:
@@ -214,7 +255,7 @@ The MCP controller creates a **transient session** for each request. This preven
 
 Each MCP request:
 1. Authenticates the token
-2. Loads the user specified in `MCP_USER_EMAIL`
+2. Loads the authorized Sure user
 3. Creates a temporary session scoped to that user
 4. Executes the tool call
 5. Discards the session
@@ -281,14 +322,25 @@ The Pipelock proxy (port 8889) scans all MCP traffic before forwarding to Sure's
 
 ## Connecting AI Assistants
 
+### Claude.ai
+
+Sure's Settings UI is already geared toward Claude.ai OAuth integrations:
+
+1. Open **Settings -> Integrations** in Claude.ai
+2. Click **Add integration**
+3. Paste your Sure MCP URL
+4. Claude redirects you to Sure to sign in and authorize access
+
+If you are using Pipelock, use the reverse-proxy URL on port `8889`. Otherwise use the app URL ending in `/mcp`.
+
 ### Claude Desktop
 
-Configure Claude Desktop to use Sure's MCP server:
+If your Claude Desktop build expects a raw MCP endpoint instead of an OAuth integration flow, point it at:
 
-1. Open Claude Desktop settings
-2. Add a new MCP server
-3. Set the endpoint to `http://your-server:8889` (if using Pipelock) or `http://your-server:3000/mcp`
-4. Add the authorization header: `Authorization: Bearer your-secret-token`
+- `http://your-server:8889` when using Pipelock, or
+- `http://your-server:3000/mcp` for direct access
+
+Use either the client's OAuth support or a bearer token, depending on what that build supports.
 
 ### Custom Agents
 
@@ -301,23 +353,21 @@ Any AI agent that supports JSON-RPC 2.0 can connect to the MCP endpoint. The age
 
 ## Troubleshooting
 
-### "MCP endpoint not configured" error
-
-**Symptom:** Requests return HTTP 503 with "MCP endpoint not configured"
-
-**Fix:** Ensure both `MCP_API_TOKEN` and `MCP_USER_EMAIL` are set as environment variables and restart Sure.
-
 ### "unauthorized" error
 
 **Symptom:** Requests return HTTP 401 with "unauthorized"
 
-**Fix:** Verify the `Authorization` header contains the correct token: `Bearer <MCP_API_TOKEN>`
+**Fix:** Verify one of these is true:
 
-### "MCP user not configured" error
+- The OAuth flow completed successfully and the client is sending the issued bearer token
+- The static token matches `MCP_API_TOKEN`
+- If you are using the static-token flow, `MCP_USER_EMAIL` matches an active Sure user
 
-**Symptom:** Requests return HTTP 503 with "MCP user not configured"
+### Static token works, but the user still gets rejected
 
-**Fix:** The `MCP_USER_EMAIL` does not match an existing user. Check that:
+**Symptom:** Requests return HTTP 401 even though the bearer token matches `MCP_API_TOKEN`
+
+**Fix:** The `MCP_USER_EMAIL` probably does not match an existing active user. Check that:
 - The email is correct
 - The user exists in the database
 - There are no typos or extra spaces

--- a/docs/hosting/oidc.md
+++ b/docs/hosting/oidc.md
@@ -559,6 +559,7 @@ Each provider requires a callback URL configured in your identity provider:
 - Client secrets are encrypted at rest using Rails 7.2 ActiveRecord Encryption
 - Encryption keys are derived from `SECRET_KEY_BASE` by default
 - For additional security, set custom encryption keys (see `.env` for `ACTIVE_RECORD_ENCRYPTION_*` variables)
+- If you enable custom keys on an existing self-hosted instance, run `bin/rails security:backfill_encryption` once to rewrite older plaintext values
 
 ### Issuer validation
 


### PR DESCRIPTION
## Summary
- explain that self-hosted startup runs `db:prepare` but does not automatically rewrite existing plaintext rows after custom encryption keys are enabled
- document the one-off `security:backfill_encryption` flow for Docker and Helm users
- clarify that the existing Helm SimpleFin backfill job is narrower than the general app-wide encryption backfill

## Testing
- not run (docs-only changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded self-hosting guidance for custom encryption keys, including safe, repeatable backfill procedures for existing data.
  * Added instructions for controlling sign-up modes in Docker and Hetzner deployments.
  * Clarified MCP authentication options, OAuth discovery, static tokens, troubleshooting, and available tools.
  * Documented additional AI assistant capabilities, including budgets and goals.
  * Added operational encryption guidance to the OIDC hosting documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->