### PR TITLE
fix(sync): guard finalization against externally-staled syncs

### DIFF
--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -125,7 +125,7 @@ class Sync < ApplicationRecord
       unless syncable.present?
         Rails.logger.warn("Sync #{id} - syncable #{syncable_type}##{syncable_id} no longer exists. Marking as failed.")
         start! if may_start?
-        fail!
+        fail! if may_fail?
         update(error: "Syncable record was deleted")
         return
       end
@@ -134,7 +134,7 @@ class Sync < ApplicationRecord
       if syncable.respond_to?(:scheduled_for_deletion?) && syncable.scheduled_for_deletion?
         Rails.logger.warn("Sync #{id} - syncable #{syncable_type}##{syncable_id} is scheduled for deletion. Skipping sync.")
         start! if may_start?
-        fail!
+        fail! if may_fail?
         update(error: "Syncable record is scheduled for deletion")
         return
       end
@@ -144,7 +144,11 @@ class Sync < ApplicationRecord
       begin
         syncable.perform_sync(self)
       rescue => e
-        fail!
+        # Re-check state under a row lock (with_lock reloads): the sync may
+        # have been terminalized externally (marked stale by SyncCleanerJob)
+        # while this job was still running. An unguarded fail! on the in-memory
+        # record would silently overwrite that terminal status.
+        with_lock { fail! if may_fail? }
         update(error: e.message)
         report_error(e)
       ensure
@@ -169,8 +173,11 @@ class Sync < ApplicationRecord
         end
       end
 
-      # If we make it here, the sync is finalized.  Run post-sync, regardless of failure/success.
-      perform_post_sync
+      # If we make it here, the sync is finalized.  Run post-sync, regardless of failure/success —
+      # unless the sync was terminalized externally (marked stale by SyncCleanerJob while its job
+      # was still running). A stale sync's job has been written off: re-running transfer matching,
+      # rules, and broadcasts for it would apply side effects for work the system already abandoned.
+      perform_post_sync unless stale?
     end
 
     # If this sync has a parent, try to finalize it so the child status propagates up the chain.

--- a/test/models/sync_test.rb
+++ b/test/models/sync_test.rb
@@ -179,6 +179,39 @@ class SyncTest < ActiveSupport::TestCase
     assert_equal "completed", account_sync.reload.status
   end
 
+  test "sync staled mid-run does not run post-sync when its job finishes" do
+    syncable = accounts(:depository)
+    sync = Sync.create!(syncable: syncable)
+
+    # Simulate SyncCleanerJob marking the sync stale while the job is still running
+    syncable.expects(:perform_sync).with { |s| Sync.find(s.id).mark_stale!; true }
+
+    Account.any_instance.expects(:perform_post_sync).never
+    Account.any_instance.expects(:broadcast_sync_complete).never
+
+    sync.perform
+
+    assert_equal "stale", sync.reload.status
+  end
+
+  test "sync staled mid-run does not raise when its job fails" do
+    syncable = accounts(:depository)
+    sync = Sync.create!(syncable: syncable)
+
+    syncable.expects(:perform_sync).with { |s| Sync.find(s.id).mark_stale!; true }
+      .raises(StandardError.new("provider blew up"))
+
+    Account.any_instance.expects(:perform_post_sync).never
+    Account.any_instance.expects(:broadcast_sync_complete).never
+
+    assert_nothing_raised do
+      sync.perform
+    end
+
+    assert_equal "stale", sync.reload.status
+    assert_equal "provider blew up", sync.error
+  end
+
   test "clean marks stale incomplete rows" do
     stale_pending = Sync.create!(
       syncable: accounts(:depository),


### PR DESCRIPTION
## Summary

A `Sync` marked `stale` by `SyncCleanerJob` (hourly, 24h threshold) while its Sidekiq job is **still running** hits two lost-update paths when that job eventually finishes:

1. **Success path** — `finalize_if_all_children_finalized` correctly skips the status transition (`if syncing?` fails after `lock!` reloads), but then ran `perform_post_sync` unconditionally. Transfer auto-matching, rule application, and completion broadcasts were re-applied for a sync the system had already written off.
2. **Failure path** — the rescue in `Sync#perform` called an unguarded `fail!`. Since the external `mark_stale!` happened on a *different* instance, the running job's in-memory record still read `syncing`, so the AASM guard passed and the terminal `stale` status was **silently overwritten** with `failed`.

## Fix

- Rescue path re-checks state under a row lock (`with_lock` reloads before `fail! if may_fail?`), so an externally-terminalized sync is left untouched; the error message is still recorded and reported to Sentry.
- `finalize_if_all_children_finalized` skips `perform_post_sync` for `stale` syncs.
- Same `may_fail?` guard applied to the deleted-syncable guard paths (defensive).

**Deliberately unchanged:** post-sync still runs for `failed` syncs — that is intentional behavior (rules/transfer matching still apply over whatever child data landed) and is covered by the existing `"parent failure should not change status if child succeeds"` test, which still passes unmodified.

## Context

Found while auditing stuck/orphaned background-job handling (stuck syncs are the documented deploy-restart failure mode, see comment at the top of `sync.rb`). This is the first, self-contained slice; a follow-up PR generalizes the `SyncCleanerJob` stale-sweep pattern to imports and exports (which currently wedge forever, e.g. #2274).

## Tests

- `sync staled mid-run does not run post-sync when its job finishes` — asserts no `perform_post_sync`/`broadcast_sync_complete`, status stays `stale`.
- `sync staled mid-run does not raise when its job fails` — asserts no exception escapes to Sidekiq retry, status stays `stale`, error still recorded. (Fails against the naive in-memory `fail! if may_fail?` fix — the `with_lock` reload is load-bearing.)

`bin/rails test`: 5513 runs, 0 failures (1 pre-existing local-only error: missing libvips dylib in `ActiveStorageAuthorizationTest`, unrelated). `bin/rubocop`, `bin/brakeman`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync handling when a sync becomes stale or is scheduled for deletion during processing.
  * Prevented stale syncs from triggering post-sync actions such as transfers and broadcasts.
  * Preserved externally finalized sync states and error details when processing fails.

* **Tests**
  * Added coverage for syncs becoming stale during successful and failed processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->