### PR TITLE
feat(sidekiq): mount Web UI in production behind super-admin sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,13 @@ REDIS_URL=redis://localhost:6379/1
 # REDIS_SENTINEL_USERNAME=default
 # REDIS_PASSWORD=your-redis-password # pipelock:ignore
 
+# Sidekiq Web UI (/sidekiq)
+# The queue dashboard is reachable in production only by signed-in super admins
+# (the first user created on the instance). Optionally set BOTH variables below
+# to require basic-auth credentials as a second layer on top of that.
+# SIDEKIQ_WEB_USERNAME=
+# SIDEKIQ_WEB_PASSWORD=
+
 # App Domain
 # This is the domain that your Sure instance will be hosted at. It is used to generate links in emails and other places.
 APP_DOMAIN=

--- a/app/constraints/super_admin_constraint.rb
+++ b/app/constraints/super_admin_constraint.rb
@@ -1,0 +1,23 @@
+# Routing constraint for mounting engines that bypass ApplicationController
+# entirely (e.g. Sidekiq::Web). Resolves the signed session cookie the same
+# way Authentication#find_session_by_cookie does and requires the session's
+# user to be a super admin.
+#
+# The session's user is always the TRUE user: impersonation is resolved at the
+# Current level, so an impersonated member can never satisfy this, and a
+# super admin impersonating someone still is one. Sessions are only created
+# after MFA verification, so this does not bypass MFA either.
+#
+# Fails closed: any error (garbage cookie, unreachable DB) means the route
+# does not exist for the request (404).
+class SuperAdminConstraint
+  def matches?(request)
+    cookie_value = request.cookie_jar.signed[:session_token]
+    return false if cookie_value.blank?
+
+    Session.find_by(id: cookie_value)&.user&.super_admin? || false
+  rescue => e
+    Rails.logger.warn("SuperAdminConstraint rejected request: #{e.class}: #{e.message}")
+    false
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,13 @@
 require "sidekiq/web"
 
-if Rails.env.production?
+# Optional second authentication layer for /sidekiq. The route itself only
+# exists for signed-in super admins (see SuperAdminConstraint in routes.rb);
+# basic auth is layered on top ONLY when both variables are explicitly set.
+# There are deliberately no default credentials.
+if ENV["SIDEKIQ_WEB_USERNAME"].present? && ENV["SIDEKIQ_WEB_PASSWORD"].present?
   Sidekiq::Web.use(Rack::Auth::Basic) do |username, password|
-    configured_username = ::Digest::SHA256.hexdigest(ENV.fetch("SIDEKIQ_WEB_USERNAME", "sure"))
-    configured_password = ::Digest::SHA256.hexdigest(ENV.fetch("SIDEKIQ_WEB_PASSWORD", "sure"))
+    configured_username = ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_WEB_USERNAME"])
+    configured_password = ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_WEB_PASSWORD"])
 
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), configured_username) &
       ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), configured_password)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
-unless Rails.env.production?
-  require "sidekiq/web"
-  require "sidekiq/cron/web"
-end
+require "sidekiq/web"
+require "sidekiq/cron/web"
 
 Rails.application.routes.draw do
   resources :questrade_items, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
@@ -216,8 +214,18 @@ Rails.application.routes.draw do
     mount Rswag::Ui::Engine => "/api-docs"
   end
 
-  # Uses basic auth - see config/initializers/sidekiq.rb
-  mount Sidekiq::Web => "/sidekiq" unless Rails.env.production?
+  # Break-glass queue tooling. Development mounts it open for convenience;
+  # everywhere else (production, staging, test) the route only exists for a
+  # signed-in super admin — see app/constraints/super_admin_constraint.rb.
+  # An optional basic-auth second layer can be enabled via SIDEKIQ_WEB_USERNAME
+  # and SIDEKIQ_WEB_PASSWORD (config/initializers/sidekiq.rb).
+  if Rails.env.development?
+    mount Sidekiq::Web => "/sidekiq"
+  else
+    constraints SuperAdminConstraint.new do
+      mount Sidekiq::Web => "/sidekiq"
+    end
+  end
 
   # AI chats
   resources :chats do

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -327,3 +327,12 @@ docker compose exec db psql -U sure_user -d sure_development -c "SELECT 1;" # Th
 ### Slow `.csv` import (processing rows taking longer than expected)
 
 Importing comma-separated-value file(s) requires the `sure-worker` container to communicate with Redis. Check your worker logs for any unexpected errors, such as connection timeouts or Redis communication failures.
+
+### Inspecting background jobs (`/sidekiq`)
+
+Sure ships the Sidekiq Web dashboard at `/sidekiq`. The route only exists for a signed-in **super admin** — the first user created on your instance. Anyone else (including logged-out visitors) gets a 404, so there is nothing to configure to keep it safe. If you want a second layer of protection anyway, set both `SIDEKIQ_WEB_USERNAME` and `SIDEKIQ_WEB_PASSWORD` in your environment file to additionally require basic-auth credentials; there are no default credentials.
+
+For day-to-day triage of stuck syncs, imports, and exports, prefer **Settings → Background jobs** — it maps queue state onto the actual records and offers safe recovery actions. The Sidekiq dashboard is a break-glass tool; two warnings when using it directly:
+
+- Never manually retry `SimplefinConnectionUpdateJob` — it consumes a single-use setup token, and a retry permanently breaks that connection attempt.
+- Deleting or retrying jobs does **not** update the corresponding Sure record (a deleted `ImportJob` leaves its import stuck in `importing`) — use Settings → Background jobs for record-level recovery.

--- a/test/integration/sidekiq_web_access_test.rb
+++ b/test/integration/sidekiq_web_access_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class SidekiqWebAccessTest < ActionDispatch::IntegrationTest
+  test "logged-out visitor gets 404" do
+    get "/sidekiq"
+
+    assert_response :not_found
+  end
+
+  test "member gets 404" do
+    sign_in users(:family_member)
+
+    get "/sidekiq"
+
+    assert_response :not_found
+  end
+
+  test "family admin gets 404" do
+    sign_in users(:family_admin)
+
+    get "/sidekiq"
+
+    assert_response :not_found
+  end
+
+  test "super admin can access the dashboard" do
+    sign_in users(:sure_support_staff)
+
+    get "/sidekiq"
+
+    assert_response :success
+  end
+
+  test "garbage session cookie fails closed" do
+    cookies[:session_token] = "not-a-signed-cookie"
+
+    get "/sidekiq"
+
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
## Problem

Three related holes around `/sidekiq`:

1. **No production deployment has ever had it.** The mount is `unless Rails.env.production?` and the Docker image bakes `RAILS_ENV=production` — so self-hosted operators (and managed staff) have zero queue tooling.
2. **The production basic-auth block is dead code with default credentials.** `config/initializers/sidekiq.rb` guards the Web UI with `SIDEKIQ_WEB_USERNAME`/`PASSWORD` defaulting to `sure`/`sure` — inert today, but a booby trap for anyone who ever flipped the mount on.
3. **Custom non-production envs got it wide open.** A `RAILS_ENV=staging` deployment would mount the dashboard with **no authentication at all** (the auth block only ran `if production?`).

## What this does

- **Development**: open mount, unchanged.
- **Everywhere else** (production, staging, test): the route only exists for a signed-in **super admin**. New `SuperAdminConstraint` resolves the signed session cookie exactly like `Authentication#find_session_by_cookie`, then requires `session.user.super_admin?`. Anyone else — including logged-out probes — gets a 404, as if the route doesn't exist.
  - The session's user is always the **true** user: impersonation is resolved at the `Current` level, and `ImpersonationSession` validations forbid impersonating a super admin — so impersonation can't reach it in either direction that matters.
  - Sessions are only created **after MFA verification**, so the constraint doesn't bypass MFA.
  - Fails closed: garbage cookies, DB errors → 404.
- **Default credentials deleted.** Basic auth now activates only when both `SIDEKIQ_WEB_USERNAME` and `SIDEKIQ_WEB_PASSWORD` are explicitly set — an optional second layer on top of the constraint, not the primary gate. (Composes with the initializer hardening in #1944 — this goes further by making the primary gate session-based and actually mounting the route.)
- **Self-hosted operators get this with zero configuration**: the first user of an instance is auto-promoted to super_admin. The super-admin bar's Jobs link (`sidekiq_web_available?`) lights up automatically now that the route exists.
- **Docs**: `.env.example` + a `docs/hosting/docker.md` section, including break-glass warnings — never manually retry `SimplefinConnectionUpdateJob` (single-use setup token; a retry bricks the connection attempt), and deleting/retrying jobs in Sidekiq does **not** update the corresponding Sure record (use Settings → Background jobs from #2682 for record-level recovery).

CSRF note: Sidekiq 8's Web UI carries its own Rack-session CSRF protection and the Rails session middleware is present at the mount point.

## Relationship to other work

Final slice of the stuck-jobs series: #2680 (sync finalization races) → #2681 (hourly stuck-record reaper) → #2682 (super-admin operations console) → this (raw-queue break-glass access).

## Tests

`SidekiqWebAccessTest` (integration, exercises the real mounted engine): logged-out → 404, member → 404, family admin → 404, super admin → 200, garbage cookie → fails closed 404.

`bin/rails test`: 5516 runs, 0 failures (1 pre-existing local-only libvips error, unrelated). `bin/rubocop`, `bin/brakeman`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added restricted access to the Sidekiq dashboard at `/sidekiq`.
  - Super admins can access the dashboard outside development environments.
  - Optional HTTP basic authentication can provide an additional security layer.

- **Documentation**
  - Added dashboard access and background-job recovery guidance.
  - Documented precautions for retrying or deleting jobs.

- **Bug Fixes**
  - Invalid or missing login sessions now fail safely without exposing the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->