### PR TITLE
fix: Make "Insight" button visible on mobile

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@ end %>
         <%= icon("panel-left", as_button: true, data: { action: "app-layout#openMobileSidebar"}) %>
       <% end %>
 
-      <%= link_to home_path, class: "block" do %>
+      <%= link_to home_path, class: "absolute left-1/2 -translate-x-1/2" do %>
         <%= image_tag "logomark-color.svg", class: "w-9 h-9 mx-auto" %>
       <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,23 @@ end %>
       <% end %>
 
       <div class="flex items-center gap-1">
+        <% if Current.family %>
+          <% unread_insights_count = Current.family.insights.active.count %>
+          <%# Prefetch disabled: /insights marks insights read on real visits
+              and deliberately skips prefetch requests, so a prefetched
+              response served on click would never clear the badge. %>
+          <%= link_to insights_path,
+                class: "relative inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors focus-ring",
+                title: t("layouts.application.insights"),
+                aria: { label: t("layouts.application.insights") },
+                data: { turbo_prefetch: false } do %>
+            <%= icon("lightbulb", size: "sm") %>
+            <% if unread_insights_count.positive? %>
+              <span class="absolute top-1 right-1 min-w-4 h-4 px-1 rounded-full bg-inverse text-inverse text-[10px] font-medium flex items-center justify-center pointer-events-none"><%= unread_insights_count > 9 ? "9+" : unread_insights_count %></span>
+            <% end %>
+          <% end %>
+        <% end %>
+
         <button type="button"
                 class="inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors focus-ring"
                 data-action="click->privacy-mode#toggle"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,6 +58,23 @@ end %>
       <% end %>
 
       <div class="flex items-center gap-1">
+        <% if Current.family %>
+          <% unread_insights_count = Current.family.insights.active.count %>
+          <%# Prefetch disabled: /insights marks insights read on real visits
+              and deliberately skips prefetch requests, so a prefetched
+              response served on click would never clear the badge. %>
+          <%= link_to insights_path,
+                class: "relative inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors focus-ring",
+                title: t("layouts.application.insights"),
+                aria: { label: t("layouts.application.insights") },
+                data: { turbo_prefetch: false } do %>
+            <%= icon("lightbulb", size: "sm") %>
+            <% if unread_insights_count.positive? %>
+              <span class="absolute top-1 right-1 min-w-4 h-4 px-1 rounded-full bg-inverse text-inverse text-[10px] font-medium flex items-center justify-center pointer-events-none"><%= unread_insights_count > 9 ? "9+" : unread_insights_count %></span>
+            <% end %>
+          <% end %>
+        <% end %>
+
         <button type="button"
                 class="inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors focus-ring"
                 data-action="click->privacy-mode#toggle"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@ end %>
         <%= icon("panel-left", as_button: true, data: { action: "app-layout#openMobileSidebar"}) %>
       <% end %>
 
-      <%= link_to home_path, class: "block" do %>
+      <%= link_to home_path, class: "absolute left-1/2 -translate-x-1/2" do %>
         <%= image_tag "logomark-color.svg", class: "w-9 h-9 mx-auto" %>
       <% end %>
 


### PR DESCRIPTION
The new “Insight” button is not visible on mobile devices. This PR adds it to the mobile navigation bar as well.

| Before | After |
|--------|--------|
| <img width="773" height="252" alt="Istantanea 2026-09-19 at 19 00 31" src="https://github.com/user-attachments/assets/3fd4191a-d88a-469e-a1c9-9d7d6393c49b" /> | <img width="771" height="257" alt="Istantanea 2026-09-19 at 18 59 17" src="https://github.com/user-attachments/assets/ce64b928-7400-417d-afa6-ea3d7ca67b23" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared “Insights” button to the mobile and desktop navigation when Insights is available.
  * Shows the number of unread insights, capped at `9+`, directly on the navigation button.
  * Added an explanatory tooltip to the Insights button.

* **UI Improvements**
  * Centered the home/logo link in the mobile top navigation for improved alignment.
  * Standardized the Insights navigation experience across mobile and desktop layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->