### PR TITLE
Fix statement Turbo frame navigation and split view/edit actions (#2614)

### DIFF
--- a/app/views/accounts/show/_statements.html.erb
+++ b/app/views/accounts/show/_statements.html.erb
@@ -76,7 +76,10 @@
             <% statements.each do |statement| %>
               <tr id="<%= dom_id(statement) %>" class="border-b border-subdued hover:bg-surface-hover">
                 <td class="px-3 py-3">
-                  <%= link_to account_statement_path(statement), data: { turbo_frame: "_top" }, class: "flex items-center gap-2 min-w-0 text-sm font-medium text-primary hover:underline" do %>
+                  <%= link_to statement.original_file.attached? ? rails_blob_path(statement.original_file, disposition: "inline") : account_statement_path(statement),
+                      target: statement.original_file.attached? ? "_blank" : nil,
+                      data: { turbo_frame: "_top" },
+                      class: "flex items-center gap-2 min-w-0 text-sm font-medium text-primary hover:underline" do %>
                     <%= icon(account_statement_file_icon(statement), size: "sm") %>
                     <span class="truncate"><%= statement.filename %></span>
                   <% end %>
@@ -95,9 +98,24 @@
                 </td>
                 <td class="px-3 py-3">
                   <div class="flex items-center justify-end gap-3">
-                    <%= link_to account_statement_path(statement), data: { turbo_frame: "_top" }, aria: { label: t("account_statements.table.view") } do %>
-                      <%= icon("eye", class: "w-5 h-5 text-primary") %>
+                    <%# View: open the actual file inline (PDF) or download (CSV/XLSX) %>
+                    <% if statement.original_file.attached? %>
+                      <%= link_to rails_blob_path(statement.original_file, disposition: "inline"),
+                                  target: "_blank",
+                                  data: { turbo_frame: "_top" },
+                                  aria: { label: t("account_statements.table.view") } do %>
+                        <%= icon("eye", class: "w-5 h-5 text-primary") %>
+                      <% end %>
                     <% end %>
+
+                    <%# Edit: go to statement details/edit page %>
+                    <%= link_to account_statement_path(statement),
+                                data: { turbo_frame: "_top" },
+                                aria: { label: t("account_statements.table.edit") } do %>
+                      <%= icon("pencil", class: "w-5 h-5 text-primary") %>
+                    <% end %>
+
+                    <%# Download %>
                     <% if statement.original_file.attached? %>
                       <%= link_to rails_blob_path(statement.original_file, disposition: "attachment"), aria: { label: t("account_statements.table.download") } do %>
                         <%= icon("download", class: "w-5 h-5 text-primary") %>

--- a/app/views/accounts/show/_statements.html.erb
+++ b/app/views/accounts/show/_statements.html.erb
@@ -76,8 +76,9 @@
             <% statements.each do |statement| %>
               <tr id="<%= dom_id(statement) %>" class="border-b border-subdued hover:bg-surface-hover">
                 <td class="px-3 py-3">
-                  <%= link_to statement.original_file.attached? ? rails_blob_path(statement.original_file, disposition: "inline") : account_statement_path(statement),
-                      target: statement.original_file.attached? ? "_blank" : nil,
+                  <% file_attached = statement.original_file.attached? %>
+                  <%= link_to file_attached ? rails_blob_path(statement.original_file, disposition: "inline") : account_statement_path(statement),
+                      target: (file_attached ? "_blank" : nil),
                       data: { turbo_frame: "_top" },
                       class: "flex items-center gap-2 min-w-0 text-sm font-medium text-primary hover:underline" do %>
                     <%= icon(account_statement_file_icon(statement), size: "sm") %>
@@ -99,7 +100,7 @@
                 <td class="px-3 py-3">
                   <div class="flex items-center justify-end gap-3">
                     <%# View: open the actual file inline (PDF) or download (CSV/XLSX) %>
-                    <% if statement.original_file.attached? %>
+                    <% if file_attached %>
                       <%= link_to rails_blob_path(statement.original_file, disposition: "inline"),
                                   target: "_blank",
                                   data: { turbo_frame: "_top" },
@@ -116,7 +117,7 @@
                     <% end %>
 
                     <%# Download %>
-                    <% if statement.original_file.attached? %>
+                    <% if file_attached %>
                       <%= link_to rails_blob_path(statement.original_file, disposition: "attachment"), aria: { label: t("account_statements.table.download") } do %>
                         <%= icon("download", class: "w-5 h-5 text-primary") %>
                       <% end %>

--- a/app/views/accounts/show/_statements.html.erb
+++ b/app/views/accounts/show/_statements.html.erb
@@ -126,7 +126,7 @@
                       <%= button_to unlink_account_statement_path(statement),
                                     method: :patch,
                                     class: "flex items-center",
-                                    data: { turbo_frame: "_top" },
+                                    form: { data: { turbo_frame: "_top" } },
                                     aria: { label: t("account_statements.table.unlink") } do %>
                         <%= icon("unlink", class: "w-5 h-5 text-secondary") %>
                       <% end %>

--- a/app/views/accounts/show/_statements.html.erb
+++ b/app/views/accounts/show/_statements.html.erb
@@ -19,6 +19,7 @@
                           aria: { label: t("account_statements.account_tab.year_label") } %>
         <% end %>
         <%= link_to account_statements_path,
+                    data: { turbo_frame: "_top" },
                     class: "inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary-hover" do %>
           <%= icon("inbox", size: "sm") %>
           <%= t("account_statements.account_tab.open_inbox") %>
@@ -75,7 +76,7 @@
             <% statements.each do |statement| %>
               <tr id="<%= dom_id(statement) %>" class="border-b border-subdued hover:bg-surface-hover">
                 <td class="px-3 py-3">
-                  <%= link_to account_statement_path(statement), class: "flex items-center gap-2 min-w-0 text-sm font-medium text-primary hover:underline" do %>
+                  <%= link_to account_statement_path(statement), data: { turbo_frame: "_top" }, class: "flex items-center gap-2 min-w-0 text-sm font-medium text-primary hover:underline" do %>
                     <%= icon(account_statement_file_icon(statement), size: "sm") %>
                     <span class="truncate"><%= statement.filename %></span>
                   <% end %>
@@ -94,7 +95,7 @@
                 </td>
                 <td class="px-3 py-3">
                   <div class="flex items-center justify-end gap-3">
-                    <%= link_to account_statement_path(statement), aria: { label: t("account_statements.table.view") } do %>
+                    <%= link_to account_statement_path(statement), data: { turbo_frame: "_top" }, aria: { label: t("account_statements.table.view") } do %>
                       <%= icon("eye", class: "w-5 h-5 text-primary") %>
                     <% end %>
                     <% if statement.original_file.attached? %>
@@ -106,6 +107,7 @@
                       <%= button_to unlink_account_statement_path(statement),
                                     method: :patch,
                                     class: "flex items-center",
+                                    data: { turbo_frame: "_top" },
                                     aria: { label: t("account_statements.table.unlink") } do %>
                         <%= icon("unlink", class: "w-5 h-5 text-secondary") %>
                       <% end %>

--- a/config/locales/views/account_statements/ca.yml
+++ b/config/locales/views/account_statements/ca.yml
@@ -105,6 +105,7 @@ ca:
       account: Compte
       actions: Accions
       download: Descarrega
+      edit: Edita
       file: Fitxer
       link_suggestion: Suggeriment d'enllaç
       period: Període

--- a/config/locales/views/account_statements/de.yml
+++ b/config/locales/views/account_statements/de.yml
@@ -102,6 +102,7 @@ de:
       account: Konto
       actions: Aktionen
       download: Herunterladen
+      edit: Bearbeiten
       file: Datei
       link_suggestion: Verknüpfungsvorschlag
       period: Zeitraum

--- a/config/locales/views/account_statements/en.yml
+++ b/config/locales/views/account_statements/en.yml
@@ -102,6 +102,7 @@ en:
       account: Account
       actions: Actions
       download: Download
+      edit: Edit
       file: File
       link_suggestion: Link suggestion
       period: Period

--- a/config/locales/views/account_statements/es.yml
+++ b/config/locales/views/account_statements/es.yml
@@ -102,6 +102,7 @@ es:
       account: Cuenta
       actions: Acciones
       download: Descargar
+      edit: Editar
       file: Archivo
       link_suggestion: Sugerencia de vínculo
       period: Periodo

--- a/config/locales/views/account_statements/fr.yml
+++ b/config/locales/views/account_statements/fr.yml
@@ -107,6 +107,7 @@ fr:
       account: Compte
       actions: Actions
       download: Télécharger
+      edit: Modifier
       file: Fichier
       link_suggestion: Suggestion de lien
       period: Période

--- a/config/locales/views/account_statements/hu.yml
+++ b/config/locales/views/account_statements/hu.yml
@@ -102,6 +102,7 @@ hu:
       account: Számla
       actions: Műveletek
       download: Letöltés
+      edit: Szerkesztés
       file: Fájl
       link_suggestion: Kapcsolati javaslat
       period: Időszak

--- a/config/locales/views/account_statements/nl.yml
+++ b/config/locales/views/account_statements/nl.yml
@@ -102,6 +102,7 @@ nl:
       account: Account
       actions: Acties
       download: Downloaden
+      edit: Bewerken
       file: Bestand
       link_suggestion: Koppelsuggestie
       period: Periode

--- a/config/locales/views/account_statements/pt-BR.yml
+++ b/config/locales/views/account_statements/pt-BR.yml
@@ -102,6 +102,7 @@ pt-BR:
       account: Conta
       actions: Ações
       download: Baixar
+      edit: Editar
       file: Arquivo
       link_suggestion: Sugestão de vínculo
       period: Período

--- a/config/locales/views/account_statements/ru.yml
+++ b/config/locales/views/account_statements/ru.yml
@@ -110,6 +110,7 @@ ru:
       account: Счёт
       actions: Действия
       download: Скачать
+      edit: Редактировать
       file: Файл
       link_suggestion: Предложение привязки
       period: Период

--- a/config/locales/views/account_statements/vi.yml
+++ b/config/locales/views/account_statements/vi.yml
@@ -102,6 +102,7 @@ vi:
       account: Tài khoản
       actions: Hành động
       download: Tải xuống
+      edit: Chỉnh sửa
       file: Tệp
       link_suggestion: Gợi ý liên kết
       period: Kỳ

--- a/config/locales/views/account_statements/zh-CN.yml
+++ b/config/locales/views/account_statements/zh-CN.yml
@@ -102,6 +102,7 @@ zh-CN:
       account: 账户
       actions: 操作
       download: 下载
+      edit: 编辑
       file: 文件
       link_suggestion: 关联建议
       period: 周期

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -61,7 +61,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{account_statement_path(statement)}'][data-turbo-frame='_top'][aria-label='#{I18n.t("account_statements.table.edit")}']"
 
     # Unlink button escapes frame
-    assert_select "form[action='#{unlink_account_statement_path(statement)}'] button"
+    assert_select "form[action='#{unlink_account_statement_path(statement)}'][data-turbo-frame='_top'] button"
   end
 
   test "statements tab shows coverage and upload for statement managers with account write access" do

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -31,6 +31,39 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame[src='#{statements_path}']"
   end
 
+  test "statements tab links escape turbo frame for full-page navigation" do
+    # Upload a statement to ensure table rows render
+    statement = AccountStatement.create_from_upload!(
+      family: @account.family,
+      file: uploaded_file(
+        filename: "test.pdf",
+        content_type: "application/pdf",
+        content: "%PDF-1.4 test content"
+      ),
+      account: @account
+    )
+
+
+    get account_url(@account, tab: "statements")
+
+    assert_response :success
+
+    # Inbox link escapes frame
+    assert_select "a[href='#{account_statements_path}'][data-turbo-frame='_top']"
+
+    # Statement filename link escapes frame
+    assert_select "a[data-turbo-frame='_top']", text: statement.filename
+
+    # Eye/view icon escapes frame and opens in new tab
+    assert_select "a[target='_blank'][data-turbo-frame='_top'][aria-label='#{I18n.t("account_statements.table.view")}']"
+
+    # Edit icon escapes frame
+    assert_select "a[href='#{account_statement_path(statement)}'][data-turbo-frame='_top'][aria-label='#{I18n.t("account_statements.table.edit")}']"
+
+    # Unlink button escapes frame
+    assert_select "form[action='#{unlink_account_statement_path(statement)}'] button"
+  end
+
   test "statements tab shows coverage and upload for statement managers with account write access" do
     get account_url(@account, tab: "statements")
 


### PR DESCRIPTION
## 1. Fix statement links in account statements tab showing "Content missing"

### Problem
Clicking on a statement (filename link, eye icon, or inbox link) from an account's Statements tab shows "Content missing" instead of navigating to the statement page. The unlink button also fails silently.

This works correctly from Settings → Statement Vault.

Fixes #2614

<img width="2032" height="1192" alt="image" src="https://github.com/user-attachments/assets/a5aac901-ebe9-4196-874c-b76309afee7e" />

### Root Cause
The statements tab content is rendered inside a Turbo frame (`statements_tab_account_<id>`). Statement links inside this frame default to frame-local navigation, but `AccountStatementsController#show` renders a full page with the settings layout — no matching frame exists in the response, so Turbo discards it.

Console error: `The response (200) did not contain the expected <turbo-frame id='statements_tab_account_...'> and will be ignored.`

### Fix

Added `data: { turbo_frame: "_top" }` to all interactive elements in `app/views/accounts/show/_statements.html.erb`:

- Inbox link
- Statement filename links
- Eye/view icon links
- Unlink buttons

This tells Turbo to perform full-page navigation instead of frame-local navigation.

## 2. UX Enhancement: Split view/edit actions

While fixing the navigation, improved the statement actions to better match user expectations:

- **Filename click** → Opens the actual file inline (PDF in browser, download for CSV/XLSX)
- **Eye icon** → Opens the actual file inline in a new tab
- **Pencil icon** (new) → Navigates to the statement details/edit page
- **Download icon** → Downloads the file (unchanged)
- **Unlink icon** → Unlinks the statement (unchanged)

Previously, both the filename and eye icon pointed to the edit page, with no way to quickly view the file from the account's statements tab.

### Changes

- `app/views/accounts/show/_statements.html.erb`
  - Added `turbo_frame: "_top"` to all links/buttons
  - Changed filename link and eye icon to open the file inline via `rails_blob_path`
  - Added pencil icon linking to the statement details/edit page
  
### Screenshots
<img width="1208" height="160" alt="image" src="https://github.com/user-attachments/assets/1e348451-c330-4b18-ba04-c88ff9c0c2ca" />

- **Filename click**/ **Eye icon** - Opens the actual file inline (PDF in browser, download for CSV/XLSX)

<img width="1635" height="859" alt="image" src="https://github.com/user-attachments/assets/1954b4e8-db13-4e79-9b87-b50947bac5c5" />

- **Pencil icon** (new) - Navigates to the statement details/edit page

<img width="825" height="587" alt="image" src="https://github.com/user-attachments/assets/bd92cfda-8a50-483a-88eb-c698cf6c6251" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Uploaded statement filenames now open inline in a new tab when a file is available.

* **Bug Fixes**
  * Statements navigation and row actions now reliably leave the Turbo frame for full-page navigation.
  * “View” is shown only when a statement file is attached (opens in a new tab); “Edit” and “Unlink” force top-frame navigation.

* **Documentation**
  * Added localized “Edit” action labels across supported languages.

* **Tests**
  * Added an integration test covering statements tab UI, link targets, and new-tab/top-frame behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->