### PR TITLE
Complete missing French translations and fix locale quality issues

### DIFF
--- a/config/locales/models/period/fr.yml
+++ b/config/locales/models/period/fr.yml
@@ -8,46 +8,46 @@ fr:
     current_month:
       comparison_label: vs. début du mois
       label: Mois en cours
-      label_short: MTD
+      label_short: MC
     current_week:
       comparison_label: vs. début de la semaine
       label: Semaine en cours
-      label_short: WTD
+      label_short: SC
     current_year:
       comparison_label: vs. début de l'année
       label: Année en cours
-      label_short: YTD
+      label_short: AC
     custom:
       label: Période personnalisée
       label_short: Personnalisé
     last_10_years:
       comparison_label: vs il y a 10 ans
       label: 10 dernières années
-      label_short: 10Y
+      label_short: 10A
     last_30_days:
       comparison_label: vs. 30 derniers jours
       label: 30 derniers jours
-      label_short: 30D
+      label_short: 30J
     last_365_days:
       comparison_label: contre il y a 1 an
       label: 365 derniers jours
-      label_short: 365D
+      label_short: 365J
     last_5_years:
       comparison_label: vs il y a 5 ans
       label: 5 dernières années
-      label_short: 5Y
+      label_short: 5A
     last_7_days:
       comparison_label: vs. dernière semaine
       label: 7 derniers jours
-      label_short: 7D
+      label_short: 7J
     last_90_days:
       comparison_label: vs. dernier trimestre
       label: 90 derniers jours
-      label_short: 90D
+      label_short: 90J
     last_day:
       comparison_label: vs hier
       label: Dernier jour
-      label_short: 1D
+      label_short: 1J
     last_month:
       comparison_label: vs. mois dernier
       label: Le mois dernier

--- a/config/locales/views/akahu_items/fr.yml
+++ b/config/locales/views/akahu_items/fr.yml
@@ -66,7 +66,7 @@ fr:
       success: Compte Akahu lié à %{account_name}.
     provider_panel:
       add_connection: Ajouter une connexion Akahu
-      app_token_label: App Token
+      app_token_label: Jeton d'application
       app_token_placeholder: Collez votre jeton d'application Akahu
       connection_name_label: Nom de la connexion
       connection_name_placeholder: Akahu principal
@@ -79,7 +79,7 @@ fr:
       sync: Synchroniser
       syncing: Synchronisation...
       update_connection: Mettre à jour la connexion
-      user_token_label: User Token
+      user_token_label: Jeton utilisateur
       user_token_placeholder: Collez votre jeton utilisateur Akahu
     select_accounts:
       cancel: Annuler

--- a/config/locales/views/insights/fr.yml
+++ b/config/locales/views/insights/fr.yml
@@ -15,7 +15,7 @@ fr:
       new: Nouveau
       undo: Annuler
     feed:
-      header: Derniers
+      header: Dernières
       header_new: Nouveau
       view_all: Voir toutes les analyses
     figures:

--- a/config/locales/views/insights/fr.yml
+++ b/config/locales/views/insights/fr.yml
@@ -1,0 +1,114 @@
+---
+fr:
+  insights:
+    actions:
+      budget: Voir le budget
+      cash_flow_warning: Vérifier les transactions récurrentes
+      idle_cash: Aller au compte
+      net_worth_milestone: Voir le rapport de patrimoine net
+      savings_rate_change: Voir les transactions de ce mois
+      spending_anomaly: Voir les transactions de %{category}
+      subscription_audit: Vérifier les transactions récurrentes
+    card:
+      dismiss: Ignorer
+      dismissed: Insight ignoré
+      new: Nouveau
+      undo: Annuler
+    feed:
+      header: Derniers
+      header_new: Nouveau
+      view_all: Voir tous les insights
+    figures:
+      days_overdue:
+        one: "%{count} jour de retard"
+        other: "%{count} jours de retard"
+      idle_days:
+        one: inactif depuis %{count} jour
+        other: inactif depuis %{count} jours
+      of_budget: du budget
+      on_pace: au rythme actuel
+      today: aujourd'hui
+      vs_previous: vs mois précédent
+    index:
+      empty:
+        description: Les insights apparaissent ici dès qu'il y a suffisamment d'activité
+          sur vos comptes. Ils se rafraîchissent automatiquement chaque nuit.
+        title: Aucun insight pour l'instant
+      refresh: Rechercher de nouveaux insights
+      subtitle: Ce qui se passe dans vos finances, actualisé chaque nuit.
+      title: Insights
+    meta:
+      date_range: "%{from} au %{to}"
+      last_n_days:
+        one: Dernier jour
+        other: "%{count} derniers jours"
+      next_n_days:
+        one: Jour suivant
+        other: "%{count} prochains jours"
+    refresh:
+      checking: Vérification…
+      queued: Nous générons de nouveaux insights. Revenez dans une minute.
+    templates:
+      budget_at_risk:
+        near: "%{categories} approchent de leurs limites ce mois-ci. Vous avez utilisé
+          %{budget_spent_pct}% de votre budget total jusqu'à présent."
+        over: "%{categories} ont dépassé le budget ce mois-ci. Vous avez utilisé
+          %{budget_spent_pct}% de votre budget total jusqu'à présent."
+      budget_on_track: Vous avez dépensé %{spent} sur votre budget de %{budgeted}
+        (%{budget_spent_pct}%) et tout reste dans les limites.
+      cash_flow_warning:
+        low: D'après vos prochaines transactions récurrentes et vos dépenses habituelles,
+          votre solde de trésorerie pourrait descendre à %{projected_low} vers le
+          %{projected_low_date}.
+        negative: D'après vos prochaines transactions récurrentes et vos dépenses
+          habituelles, votre solde de trésorerie pourrait chuter à %{projected_low}
+          vers le %{projected_low_date}.
+      idle_cash: "%{account} détient %{balance} sans aucune activité depuis %{idle_days}
+        jours."
+      net_worth_milestone: Votre patrimoine net a franchi %{milestone} et s'élève
+        désormais à %{net_worth}.
+      savings_rate_change:
+        down: Vous avez épargné %{current_rate}% de vos revenus en %{month}, soit
+          %{change_pp} points de pourcentage de moins que %{previous_rate}% le mois
+          précédent.
+        down_negative: "Vous avez dépensé plus que vous n'avez gagné en %{month}
+          : votre taux d'épargne est tombé à %{current_rate}%, contre %{previous_rate}%
+          le mois précédent."
+        up: Vous avez épargné %{current_rate}% de vos revenus en %{month}, soit %{change_pp}
+          points de pourcentage de plus que %{previous_rate}% le mois précédent.
+      spending_anomaly:
+        above: Vous êtes en voie de dépenser %{projected_spend} pour %{category}
+          ce mois-ci, soit environ %{deviation_pct}% de plus que votre moyenne mensuelle
+          récente de %{baseline_spend}.
+        below: Vous êtes en voie de dépenser %{projected_spend} pour %{category}
+          ce mois-ci, soit environ %{deviation_pct}% de moins que votre moyenne mensuelle
+          récente de %{baseline_spend}.
+      subscription_audit: "%{name} (%{amount}) n'est pas réapparu depuis la date
+        prévue du %{expected_on}. Il est possible que l'abonnement ait été annulé
+        ou que le prélèvement ait changé de date."
+    titles:
+      budget_at_risk:
+        one: Une catégorie de votre budget nécessite votre attention
+        other: "%{count} catégories de votre budget nécessitent votre attention"
+      budget_on_track: Votre budget est sur la bonne voie
+      cash_flow_warning:
+        low: Votre solde de trésorerie pourrait devenir faible
+        negative: Votre solde de trésorerie pourrait devenir négatif
+      idle_cash: Liquidités inactives sur %{account}
+      net_worth_milestone: "Étape de patrimoine net : %{milestone}"
+      savings_rate_change:
+        down: Votre taux d'épargne a baissé en %{month}
+        up: Votre taux d'épargne s'est amélioré en %{month}
+      spending_anomaly:
+        above: Les dépenses de %{category} sont en hausse
+        below: Les dépenses de %{category} sont en baisse
+      subscription_audit: "%{name} est-il toujours actif ?"
+    types:
+      budget_at_risk: Budget
+      budget_on_track: Budget
+      cash_flow_warning: Trésorerie
+      idle_cash: Liquidités inactives
+      net_worth_milestone: Patrimoine net
+      savings_rate_change: Taux d'épargne
+      spending_anomaly: Dépenses
+      subscription_audit: Abonnements

--- a/config/locales/views/insights/fr.yml
+++ b/config/locales/views/insights/fr.yml
@@ -11,13 +11,13 @@ fr:
       subscription_audit: Vérifier les transactions récurrentes
     card:
       dismiss: Ignorer
-      dismissed: Insight ignoré
+      dismissed: Analyse ignorée
       new: Nouveau
       undo: Annuler
     feed:
       header: Derniers
       header_new: Nouveau
-      view_all: Voir tous les insights
+      view_all: Voir toutes les analyses
     figures:
       days_overdue:
         one: "%{count} jour de retard"
@@ -31,12 +31,12 @@ fr:
       vs_previous: vs mois précédent
     index:
       empty:
-        description: Les insights apparaissent ici dès qu'il y a suffisamment d'activité
-          sur vos comptes. Ils se rafraîchissent automatiquement chaque nuit.
-        title: Aucun insight pour l'instant
-      refresh: Rechercher de nouveaux insights
+        description: Les analyses apparaissent ici dès qu'il y a suffisamment d'activité
+          sur vos comptes. Elles se rafraîchissent automatiquement chaque nuit.
+        title: Aucune analyse pour l'instant
+      refresh: Rechercher de nouvelles analyses
       subtitle: Ce qui se passe dans vos finances, actualisé chaque nuit.
-      title: Insights
+      title: Analyses
     meta:
       date_range: "%{from} au %{to}"
       last_n_days:
@@ -47,7 +47,7 @@ fr:
         other: "%{count} prochains jours"
     refresh:
       checking: Vérification…
-      queued: Nous générons de nouveaux insights. Revenez dans une minute.
+      queued: Nous générons de nouvelles analyses. Revenez dans une minute.
     templates:
       budget_at_risk:
         near: "%{categories} approchent de leurs limites ce mois-ci. Vous avez utilisé

--- a/config/locales/views/layout/fr.yml
+++ b/config/locales/views/layout/fr.yml
@@ -2,7 +2,7 @@
 fr:
   layouts:
     application:
-      insights: Insights
+      insights: Analyses
       nav:
         assistant: Assistant
         budgets: Budgets

--- a/config/locales/views/layout/fr.yml
+++ b/config/locales/views/layout/fr.yml
@@ -2,6 +2,7 @@
 fr:
   layouts:
     application:
+      insights: Insights
       nav:
         assistant: Assistant
         budgets: Budgets

--- a/config/locales/views/loans/fr.yml
+++ b/config/locales/views/loans/fr.yml
@@ -18,7 +18,7 @@ fr:
     overview:
       interest_rate: Taux d'intérêt
       monthly_payment: Paiement mensuel
-      not_applicable: N/A
+      not_applicable: N/D
       original_principal: Principal initial
       remaining_principal: Principal restant
       term: Durée

--- a/config/locales/views/pages/fr.yml
+++ b/config/locales/views/pages/fr.yml
@@ -25,6 +25,8 @@ fr:
         title: Flux de trésorerie
         zoom_out: Retour à la trésorerie totale
       drag_to_reorder: Glisser pour réorganiser la section
+      insights_feed:
+        title: Insights
       investment_summary:
         add_investment: Ajoutez un compte d'investissement pour suivre votre portefeuille
         contributions: Apports

--- a/config/locales/views/pages/fr.yml
+++ b/config/locales/views/pages/fr.yml
@@ -26,7 +26,7 @@ fr:
         zoom_out: Retour à la trésorerie totale
       drag_to_reorder: Glisser pour réorganiser la section
       insights_feed:
-        title: Insights
+        title: Analyses
       investment_summary:
         add_investment: Ajoutez un compte d'investissement pour suivre votre portefeuille
         contributions: Apports

--- a/config/locales/views/questrade_items/fr.yml
+++ b/config/locales/views/questrade_items/fr.yml
@@ -1,0 +1,261 @@
+---
+fr:
+  questrade_items:
+    complete_account_setup:
+      all_skipped: Tous les comptes ont été ignorés. Aucun compte n'a été créé.
+      creation_failed: 'Échec de la création des comptes : %{error}'
+      no_accounts: Aucun compte à configurer.
+      success: "%{count} compte(s) créé(s) avec succès."
+    create:
+      success: Connexion Questrade créée avec succès
+    default_name: Connexion Questrade
+    destroy:
+      success: Connexion Questrade supprimée
+    errors:
+      provider_not_configured: Le fournisseur Questrade n'est pas configuré
+    index:
+      title: Connexions Questrade
+    institution_summary:
+      count:
+        one: "%{count} institution"
+        other: "%{count} institutions"
+      none: Aucune institution connectée
+    link_accounts:
+      all_already_linked:
+        one: Le compte sélectionné (%{names}) est déjà lié
+        other: 'Les %{count} comptes sélectionnés sont déjà liés : %{names}'
+      api_error: 'Erreur API : %{message}'
+      invalid_account_names:
+        one: Impossible de lier un compte sans nom
+        other: Impossible de lier %{count} comptes sans nom
+      link_failed: Échec de la liaison des comptes
+      no_accounts_selected: Veuillez sélectionner au moins un compte
+      no_api_key: Clé API Questrade introuvable. Veuillez la configurer dans les paramètres
+        du fournisseur.
+      partial_invalid: "%{created_count} compte(s) lié(s) avec succès, %{already_linked_count}
+        étaient déjà liés, %{invalid_count} compte(s) avaient des noms invalides"
+      partial_success: "%{created_count} compte(s) lié(s) avec succès. %{already_linked_count}
+        compte(s) étaient déjà liés : %{already_linked_names}"
+      success:
+        one: "%{count} compte lié avec succès"
+        other: "%{count} comptes liés avec succès"
+    link_existing_account:
+      account_already_linked: Ce compte est déjà lié à un fournisseur
+      api_error: 'Erreur API : %{message}'
+      invalid_account_name: Impossible de lier un compte sans nom
+      missing_parameters: Paramètres requis manquants
+      no_api_key: Clé API Questrade introuvable. Veuillez la configurer dans les paramètres
+        du fournisseur.
+      provider_account_already_linked: Ce compte Questrade est déjà lié à un autre
+        compte
+      provider_account_not_found: Compte Questrade introuvable
+      success: "%{account_name} lié avec succès à Questrade"
+    loading:
+      loading_message: Chargement des comptes Questrade…
+      loading_title: Chargement
+    panel:
+      field_descriptions: 'Description des champs :'
+      fields:
+        api_server:
+          description: Votre serveur API Questrade
+          label: Serveur API
+          placeholder_new: Collez le serveur API ici
+          placeholder_update: Saisissez un nouveau serveur API pour mettre à jour
+        refresh_token:
+          description: Votre jeton de rafraîchissement Questrade
+          label: Jeton de rafraîchissement
+          placeholder_new: Collez le jeton de rafraîchissement ici
+          placeholder_update: Saisissez un nouveau jeton de rafraîchissement pour
+            mettre à jour
+      optional: "(Facultatif)"
+      optional_with_default: "(facultatif, valeur par défaut : %{default_value})"
+      required: "(obligatoire)"
+      save_button: Enregistrer la configuration
+      setup_instructions: 'Instructions de configuration :'
+      status_configured_html: Configuré et prêt à l'emploi. Rendez-vous sur l'onglet
+        <a href="%{accounts_path}" class="link">Comptes</a> pour gérer et configurer
+        les comptes.
+      status_not_configured: Non configuré
+      step_1: Rendez-vous sur votre tableau de bord Questrade pour récupérer vos
+        identifiants
+      step_2: Saisissez vos identifiants ci-dessous et cliquez sur le bouton Enregistrer
+      step_3: Après une connexion réussie, rendez-vous sur l'onglet Comptes pour
+        configurer les nouveaux comptes
+      token_refresh_hint: Les jetons Questrade se renouvellent automatiquement à
+        chaque synchronisation de vos comptes. Si une connexion reste inutilisée
+        pendant plus de 7 jours et devient obsolète, collez un nouveau jeton ici
+        pour la réactiver sans la déconnecter.
+      update_button: Mettre à jour la configuration
+    preload_accounts:
+      no_credentials_configured: Veuillez d'abord configurer vos identifiants Questrade
+        dans les paramètres du fournisseur.
+    questrade_item:
+      accounts_need_setup: Des comptes doivent être configurés
+      delete: Supprimer la connexion
+      deletion_in_progress: suppression en cours…
+      error: Erreur
+      kind: Courtage
+      more_accounts_available:
+        one: "%{count} compte supplémentaire disponible"
+        other: "%{count} comptes supplémentaires disponibles"
+      no_accounts_description: Cette connexion n'a pas encore de comptes liés.
+      no_accounts_title: Aucun compte
+      provider_name: Questrade
+      requires_update: Connexion à mettre à jour
+      setup_action: Configurer les nouveaux comptes
+      setup_description: "%{linked} sur %{total} comptes liés. Choisissez les types
+        de compte pour vos comptes Questrade nouvellement importés."
+      setup_needed: Nouveaux comptes prêts à être configurés
+      status: Synchronisé il y a %{timestamp}
+      status_never: Jamais synchronisé
+      status_with_summary: Dernière synchronisation il y a %{timestamp} - %{summary}
+      syncing: Synchronisation…
+      total: Total
+      unlinked: Non lié
+      update_credentials: Mettre à jour les identifiants
+    select_accounts:
+      accounts_selected: comptes sélectionnés
+      api_error: 'Erreur API : %{message}'
+      cancel: Annuler
+      configure_name_in_provider: Impossible d'importer - veuillez configurer le
+        nom du compte dans Questrade
+      description: Sélectionnez les comptes que vous souhaitez lier à votre compte
+        %{product_name}.
+      link_accounts: Lier les comptes sélectionnés
+      no_accounts_found: Aucun compte trouvé. Veuillez vérifier la configuration
+        de votre clé API.
+      no_api_key: La clé API Questrade n'est pas configurée. Veuillez la configurer
+        dans les Paramètres.
+      no_credentials_configured: Veuillez d'abord configurer vos identifiants Questrade
+        dans les paramètres du fournisseur.
+      no_name_placeholder: "(Sans nom)"
+      title: Sélectionner les comptes Questrade
+    select_existing_account:
+      account_already_linked: Ce compte est déjà lié à un fournisseur
+      all_accounts_already_linked: Tous les comptes Questrade sont déjà liés
+      api_error: 'Erreur API : %{message}'
+      balance_label: 'Solde :'
+      cancel: Annuler
+      cancel_button: Annuler
+      configure_name_in_provider: Impossible d'importer - veuillez configurer le
+        nom du compte dans Questrade
+      connect_hint: Connectez un compte Questrade pour activer la synchronisation
+        automatique.
+      description: Sélectionnez un compte Questrade à lier avec ce compte. Les transactions
+        seront synchronisées et dédupliquées automatiquement.
+      header: Lier avec Questrade
+      link_account: Lier le compte
+      link_button: Lier ce compte
+      linking_to: 'Liaison à :'
+      no_account_specified: Aucun compte spécifié
+      no_accounts: Aucun compte Questrade non lié trouvé.
+      no_accounts_found: Aucun compte Questrade trouvé. Veuillez vérifier la configuration
+        de votre clé API.
+      no_api_key: La clé API Questrade n'est pas configurée. Veuillez la configurer
+        dans les Paramètres.
+      no_credentials_configured: Veuillez d'abord configurer vos identifiants Questrade
+        dans les paramètres du fournisseur.
+      no_name_placeholder: "(Sans nom)"
+      settings_link: Aller aux paramètres du fournisseur
+      subtitle: Choisissez un compte Questrade
+      title: Lier %{account_name} avec Questrade
+    setup_accounts:
+      account_type_label: 'Type de compte :'
+      account_types:
+        credit_card: Carte de crédit
+        crypto: Compte de cryptomonnaie
+        depository: Compte courant ou épargne
+        investment: Compte d'investissement
+        loan: Prêt ou hypothèque
+        other_asset: Autre actif
+        skip: Ignorer ce compte
+      accounts_count:
+        one: "%{count} compte disponible"
+        other: "%{count} comptes disponibles"
+      all_accounts_linked: Tous vos comptes Questrade ont déjà été configurés.
+      api_error: 'Erreur API : %{message}'
+      balance: Solde
+      cancel: Annuler
+      choose_account_type: 'Choisissez le type de compte correct pour chaque compte
+        Questrade :'
+      create_accounts: Créer les comptes
+      creating: Création des comptes…
+      creating_accounts: Création des comptes…
+      fetch_failed: Échec de la récupération des comptes
+      historical_data_range: 'Plage de données historiques :'
+      import_selected: Importer les comptes sélectionnés
+      instructions: Sélectionnez les comptes que vous souhaitez importer depuis Questrade.
+        Vous pouvez choisir plusieurs comptes.
+      no_accounts: Aucun compte non lié trouvé pour cette connexion Questrade.
+      no_accounts_to_setup: Aucun compte à configurer
+      no_api_key: La clé API Questrade n'est pas configurée. Veuillez vérifier les
+        paramètres de connexion.
+      select_all: Tout sélectionner
+      subtitle: Choisissez les types de compte corrects pour vos comptes importés
+      subtype_labels:
+        credit_card: ''
+        crypto: ''
+        depository: 'Sous-type de compte :'
+        investment: 'Type d''investissement :'
+        loan: 'Type de prêt :'
+        other_asset: ''
+      subtype_messages:
+        credit_card: Les cartes de crédit seront automatiquement configurées comme
+          comptes de carte de crédit.
+        crypto: Les comptes de cryptomonnaie seront configurés pour suivre les holdings
+          et les transactions.
+        other_asset: Aucune option supplémentaire nécessaire pour les autres actifs.
+      subtypes:
+        depository:
+          cd: Certificat de dépôt
+          checking: Compte courant
+          hsa: Compte épargne santé
+          money_market: Compte du marché monétaire
+          savings: Compte épargne
+        investment:
+          401k: 401(k)
+          403b: 403(b)
+          529_plan: Plan 529
+          angel: Investissement providentiel
+          brokerage: Courtage
+          hsa: Compte épargne santé
+          ira: IRA traditionnel
+          mutual_fund: Fonds commun de placement
+          pension: Pension
+          retirement: Retraite
+          roth_401k: Roth 401(k)
+          roth_ira: Roth IRA
+          tsp: Plan d'épargne Thrift
+        loan:
+          auto: Prêt auto
+          mortgage: Hypothèque
+          other: Autre prêt
+          student: Prêt étudiant
+      sync_start_date_help: Sélectionnez jusqu'où vous souhaitez synchroniser l'historique
+        des transactions.
+      sync_start_date_label: 'Commencer la synchronisation des transactions à partir
+        de :'
+      title: Configurer vos comptes Questrade
+    setup_required:
+      go_to_provider_settings: Aller aux paramètres du fournisseur
+      not_configured_description: Ajoutez votre connexion Questrade dans les paramètres
+        du fournisseur, puis revenez ici pour lier des comptes.
+      not_configured_title: Questrade n'est pas encore connecté
+      title: Connectez d'abord Questrade
+    sync:
+      status:
+        calculating: Calcul des soldes…
+        checking_setup: Vérification de la configuration du compte…
+        importing: Importation des comptes depuis Questrade…
+        importing_data: Importation des données du compte…
+        needs_setup: "%{count} comptes à configurer…"
+        processing: Traitement des holdings et des activités…
+      success: Synchronisation démarrée
+    sync_status:
+      no_accounts: Aucun compte trouvé
+      synced:
+        one: "%{count} compte synchronisé"
+        other: "%{count} comptes synchronisés"
+      synced_with_setup: "%{linked} synchronisé(s), %{unlinked} à configurer"
+    update:
+      success: Connexion Questrade mise à jour

--- a/config/locales/views/questrade_items/fr.yml
+++ b/config/locales/views/questrade_items/fr.yml
@@ -5,7 +5,9 @@ fr:
       all_skipped: Tous les comptes ont été ignorés. Aucun compte n'a été créé.
       creation_failed: 'Échec de la création des comptes : %{error}'
       no_accounts: Aucun compte à configurer.
-      success: "%{count} compte(s) créé(s) avec succès."
+      success:
+        one: "%{count} compte créé avec succès."
+        other: "%{count} comptes créés avec succès."
     create:
       success: Connexion Questrade créée avec succès
     default_name: Connexion Questrade

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -230,7 +230,7 @@ fr:
     providers:
       akahu_panel:
         step_1_html: Allez sur %{link} et créez une application personnelle.
-        step_2: Copiez votre jeton d'application (App Token) et votre jeton d'utilisateur (User Token).
+        step_2: Copiez votre jeton d'application et votre jeton d'utilisateur.
         step_3: Collez les jetons ci-dessous, enregistrez, puis liez vos comptes synchronisés.
       bank_sync:
         lede: Connectez des comptes externes pour que les transactions, les soldes et les holdings soient automatiquement transférés vers Sure.

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -36,7 +36,6 @@ fr:
         disable_modal_click_outside_description: Empêche les fenêtres modales de se fermer en cliquant à l'extérieur. Utile pour éviter de perdre accidentellement des modifications non sauvegardées.
         transactions_title: Transactions
         transactions_subtitle: Personnalisez l'affichage des transactions
-        transactions_title: Transactions
     debugs:
       show:
         context:
@@ -473,9 +472,11 @@ fr:
         mercury: Synchronisez automatiquement vos comptes professionnels Mercury.
         plaid: Connectez des milliers d'institutions financières américaines via Plaid.
         plaid_eu: Connectez des institutions financières européennes via Plaid (PSD2 / Open Banking).
+        questrade: Synchronisez directement vos comptes d'investissement Questrade via l'API Questrade.
         simplefin: Connectez des comptes bancaires américains via le protocole ouvert SimpleFIN.
         snaptrade: Connectez vos comptes de courtage via le réseau d'agrégation SnapTrade.
         sophtron: Connectez vos banques et services publics américains et canadiens.
+        wise: Synchronisez automatiquement vos soldes multi-devises Wise et vos transferts internationaux.
       up_panel:
         step_1_html: Allez sur %{link} et générez un jeton d'accès personnel.
         step_2: Copiez votre jeton d'accès personnel.

--- a/config/locales/views/settings/hostings/fr.yml
+++ b/config/locales/views/settings/hostings/fr.yml
@@ -143,6 +143,7 @@ fr:
           alpha_vantage: Alpha Vantage
           binance_public: Binance
           eodhd: EODHD
+          frankfurter: Frankfurter
           mfapi: MFAPI.in
           moex_public: MOEX
           tiingo: Tiingo

--- a/config/locales/views/simplefin_items/update.fr.yml
+++ b/config/locales/views/simplefin_items/update.fr.yml
@@ -1,7 +1,7 @@
 fr:
   simplefin_items:
     update:
-      success: "Connexion SimpleFIN mise à jour."
+      success: "Connexion SimpleFIN mise à jour avec succès ! Vos comptes sont en cours de reconnexion."
       errors:
-        blank_token: "Jeton d'accès SimpleFIN manquant. Veuillez fournir un jeton ou utiliser Lier des comptes existants pour continuer."
-        update_failed: "Échec de la mise à jour de la connexion SimpleFIN : %{message}"
+        blank_token: "Veuillez entrer un jeton de configuration SimpleFIN."
+        update_failed: "Échec de la mise à jour de la connexion : %{message}"

--- a/config/locales/views/simplefin_items/update.fr.yml
+++ b/config/locales/views/simplefin_items/update.fr.yml
@@ -1,0 +1,7 @@
+fr:
+  simplefin_items:
+    update:
+      success: "Connexion SimpleFIN mise à jour."
+      errors:
+        blank_token: "Jeton d'accès SimpleFIN manquant. Veuillez fournir un jeton ou utiliser Lier des comptes existants pour continuer."
+        update_failed: "Échec de la mise à jour de la connexion SimpleFIN : %{message}"

--- a/config/locales/views/transactions/fr.yml
+++ b/config/locales/views/transactions/fr.yml
@@ -339,7 +339,7 @@ fr:
       split_tooltip: Cette transaction a été fractionnée en plusieurs entrées
     transfer_match:
       auto_matched: Correspondance automatique
-      auto_matched_short: A/M
+      auto_matched_short: C/A
       confirm_match: Confirmer la correspondance
       payment_confirmed: Le paiement est confirmé
       reject_match: Rejeter la correspondance

--- a/config/locales/views/up_items/fr.yml
+++ b/config/locales/views/up_items/fr.yml
@@ -55,7 +55,7 @@ fr:
       success: Compte Up lié à %{account_name}.
       up_account_already_linked: Ce compte Up est déjà lié.
     provider_panel:
-      access_token_label: Personal Access Token
+      access_token_label: Jeton d'accès personnel
       access_token_placeholder: Collez votre jeton d'accès personnel Up
       add_connection: Ajouter une connexion Up
       connection_name_label: Nom de la connexion

--- a/config/locales/views/wise_items/fr.yml
+++ b/config/locales/views/wise_items/fr.yml
@@ -1,0 +1,167 @@
+---
+fr:
+  wise_items:
+    activities:
+      asset_fee: Frais Wise Assets
+      default_name: Activité Wise
+      interest: Intérêts Wise
+      jar_deposit: Transfert vers Jar
+      jar_withdrawal: Transfert depuis Jar
+      transfer_from_jar: "Transfert depuis %{jar}"
+      transfer_to_jar: "Transfert vers %{jar}"
+    complete_account_setup:
+      failed: Échec de la création du compte. Veuillez réessayer.
+      not_found: Solde Wise introuvable.
+      success: Compte créé et lié avec succès.
+    create:
+      connection_failed: Impossible de se connecter à Wise. Veuillez réessayer plus
+        tard.
+      invalid_token: Jeton API invalide. Veuillez vérifier et réessayer.
+      no_profiles_found: Aucun profil Wise trouvé. Veuillez vérifier votre jeton
+        API.
+    destroy:
+      success: Connexion Wise supprimée
+    entries:
+      default_name: Transaction Wise
+      fee_name: Frais Wise
+    link_accounts:
+      failed: Échec de la liaison du solde Wise. Veuillez réessayer.
+      not_found: Solde Wise introuvable.
+      success: Solde Wise lié au compte avec succès.
+    link_existing_account:
+      failed: Échec de la liaison du compte. Veuillez réessayer.
+      not_found: Compte ou solde Wise introuvable.
+      success: "%{account_name} lié avec succès à Wise"
+    link_profiles:
+      already_connected: Tous les profils sélectionnés sont déjà connectés.
+      no_profiles_selected: Veuillez sélectionner au moins un profil.
+      session_expired: Session expirée. Veuillez réessayer de vous connecter.
+      success:
+        one: "%{count} profil Wise connecté avec succès"
+        other: "%{count} profils Wise connectés avec succès"
+    profile_types:
+      business: Professionnel
+      personal: Personnel
+    provider_connection:
+      default_description: Connectez votre compte multi-devises Wise
+      default_name: Wise
+      description: Connectez-vous en utilisant %{name}
+      name: "Wise — %{name}"
+    provider_panel:
+      accounts_link: Comptes
+      add_connection: Ajouter une connexion Wise
+      configured_html: Connecté et synchronisation en cours. Rendez-vous sur l'onglet
+        %{accounts_link} pour gérer vos comptes.
+      connect: Connecter Wise
+      connection_name_label: Nom de la connexion
+      connection_name_placeholder: Wise Personnel
+      disconnect: Déconnecter
+      disconnect_confirm: Voulez-vous vraiment déconnecter %{name} ? Cela supprimera
+        toutes les données de compte synchronisées.
+      disconnect_label: "Déconnecter %{name}"
+      encryption_warning:
+        message: Configurez les clés de chiffrement Active Record avant d'ajouter
+          des jetons Wise en production. Sans chiffrement, les jetons sont stockés
+          en texte brut.
+        title: Le chiffrement de la base de données n'est pas configuré
+      instructions:
+        copy_token_html: Copiez le jeton et collez-le ci-dessous. Sure l'utilise
+          uniquement pour synchroniser vos soldes et transactions.
+        create_token: Créez un nouveau jeton API personnel avec un accès en lecture
+          seule
+        open_tokens: Accédez à Paramètres → Jetons API
+        sign_in_html: Visitez %{link} et connectez-vous à votre compte
+      keep_token_placeholder: Laisser vide pour conserver le jeton actuel
+      not_configured: Non configuré
+      sandbox_note_html: Utilisez l'URL de base <strong>sandbox</strong> (<code>https://api.sandbox.transferwise.tech</code>)
+        pour les tests. Définissez <code>WISE_BASE_URL</code> dans votre environnement.
+      setup_accounts: Configurer des comptes
+      setup_title: 'Instructions de configuration :'
+      sync: Synchroniser
+      token_label: Jeton API
+      token_placeholder: Collez votre jeton API personnel Wise
+      update_connection: Mettre à jour la connexion
+    select_accounts:
+      cancel: Annuler
+      description: Sélectionnez le solde en devise Wise que vous souhaitez lier à
+        votre compte %{product_name}.
+      link_account: Lier le solde
+      no_accounts_found: Tous les soldes Wise sont déjà liés à des comptes Sure.
+      no_connection: Aucune connexion Wise trouvée. Veuillez d'abord connecter Wise
+        dans les paramètres du fournisseur.
+      title: Sélectionner un solde Wise
+    select_existing_account:
+      cancel: Annuler
+      description: Sélectionnez le solde en devise Wise à lier à ce compte. Les transactions
+        seront synchronisées automatiquement.
+      link_account: Lier le solde
+      no_accounts_found: Aucun solde Wise non lié trouvé.
+      title: Lier %{account_name} avec Wise
+    select_profiles:
+      already_connected_label: Déjà connecté
+      cancel: Annuler
+      connect: Connecter les profils sélectionnés
+      description: Votre compte Wise a plusieurs profils. Sélectionnez ceux que vous
+        souhaitez synchroniser avec Sure.
+      session_expired: Session expirée. Veuillez réessayer de vous connecter.
+      subtitle: Choisissez les profils à connecter
+      title: Sélectionner les profils Wise
+      unnamed_profile: "(Profil sans nom)"
+    setup_accounts:
+      all_accounts_linked: Tous vos soldes en devises Wise ont été liés à des comptes
+        Sure.
+      create_account: Créer le compte
+      description: Créez un compte Sure pour chaque solde en devise Wise que vous
+        souhaitez suivre. Chaque devise devient son propre compte.
+      done: Terminé
+      no_accounts_to_setup: Tous les comptes sont configurés
+      subtitle: Liez vos soldes en devises Wise
+      title: Configurer les comptes Wise
+    sync:
+      success: Synchronisation démarrée
+    sync_status:
+      all_synced:
+        one: "%{count} compte synchronisé"
+        other: "%{count} comptes synchronisés"
+      no_accounts: Aucun compte trouvé
+      partial_setup: "%{synced} synchronisé(s), %{pending} à configurer"
+    syncer:
+      account_processing_failed:
+        one: "%{count} compte Wise a échoué lors du traitement."
+        other: "%{count} comptes Wise ont échoué lors du traitement."
+      account_sync_failed:
+        one: La synchronisation de %{count} compte Wise n'a pas pu être planifiée.
+        other: La synchronisation de %{count} comptes Wise n'a pas pu être planifiée.
+      accounts_failed:
+        one: "%{count} solde n'a pas pu être importé."
+        other: "%{count} soldes n'ont pas pu être importés."
+      accounts_need_setup:
+        one: "%{count} compte doit être configuré…"
+        other: "%{count} comptes doivent être configurés…"
+      calculating_balances: Calcul des soldes…
+      checking_account_configuration: Vérification de la configuration du compte…
+      credentials_invalid: Jeton API Wise invalide ou autorisations insuffisantes
+      failed: Échec de la synchronisation. Veuillez réessayer ou contacter le support.
+      import_failed: Échec de l'importation Wise.
+      importing_accounts: Importation des comptes depuis Wise…
+      processing_transactions: Traitement des transactions…
+      transactions_failed:
+        one: "%{count} solde a rencontré des échecs d'importation de transactions."
+        other: "%{count} soldes ont rencontré des échecs d'importation de transactions."
+    update:
+      success: Connexion Wise mise à jour
+    wise_item:
+      delete: Déconnecter
+      deletion_in_progress: suppression en cours…
+      error: Erreur de synchronisation
+      no_accounts_description: Lancez une synchronisation pour découvrir vos soldes
+        Wise, puis liez-les à des comptes Sure.
+      no_accounts_title: Aucun compte lié pour l'instant
+      setup_action: Configurer les comptes
+      setup_description: "%{linked} sur %{total} comptes liés. Créez des comptes
+        Sure pour vos soldes en devises Wise."
+      setup_needed: Nouveaux comptes prêts à être configurés
+      status: Synchronisé il y a %{timestamp}
+      status_never: Jamais synchronisé
+      status_with_summary: Dernière synchronisation il y a %{timestamp} — %{summary}
+      syncing: Synchronisation…

--- a/config/locales/views/wise_items/fr.yml
+++ b/config/locales/views/wise_items/fr.yml
@@ -31,7 +31,7 @@ fr:
     link_existing_account:
       failed: Échec de la liaison du compte. Veuillez réessayer.
       not_found: Compte ou solde Wise introuvable.
-      success: "%{account_name} lié avec succès à Wise"
+      success: "Liaison de %{account_name} à Wise réussie"
     link_profiles:
       already_connected: Tous les profils sélectionnés sont déjà connectés.
       no_profiles_selected: Veuillez sélectionner au moins un profil.


### PR DESCRIPTION
## Summary
Fills in every missing French locale key across the app and cleans up a handful of pre-existing quality issues found while auditing the French translations (`en`/`fr` key comparison over `config/locales/**`, 0 keys missing after this PR , was 380 across 8 files before).

## What's new
- **Insights** (dashboard analyses feed), **Questrade**, **Wise**, and the **SimpleFIN update flow** had no French translation at all (`insights/fr.yml` and `questrade_items/fr.yml` were literal copies of the English file, root key `en:` and all). Fully translated, following existing terminology already established elsewhere in the app (e.g. "Patrimoine net" for Net Worth, "Trésorerie" for Cash flow, Questrade's provider strings mirrored from `indexa_capital_items/fr.yml` which shares the same structure).
- Added 5 stray missing keys in `layout`, `pages`, `settings`, and `settings/hostings` (all pointing at the same newly-added features above, plus the Frankfurter FX provider).

## Terminology fix
- Renamed "Insights" → "Analyses" throughout (menu, page title, empty state, card labels) instead of leaving the English word untranslated, with correct feminine agreement ("Analyse ignorée", "Aucune analyse").

## Anglicism cleanup
Found by diffing every French value against its English source for matches, then checking each candidate against the surrounding context:
- `akahu_items`, `up_items`: token field *labels* were left in English ("App Token", "User Token", "Personal Access Token") while the placeholders right below them were already translated, now consistent.
- `settings`: dropped the now-redundant English parentheticals in the Akahu setup instructions.
- `loans`: "N/A" → "N/D", to match the same field's translation a few lines down in the same file.
- `transactions`: auto-match short label "A/M" → "C/A" so it derives from its own French expansion ("Correspondance automatique") instead of the English one.
- `models/period`: chart period chips (1D/7D/30D/90D/365D/5Y/10Y, WTD/MTD/YTD) now use French-derived short labels
  (1J/7J/30J/90J/365J/5A/10A, SC/MC/AC).

Deliberately left as-is: third-party dashboard field names quoted verbatim (SnapTrade/Plaid "Client ID", "Consumer Key"; IBKR Flex Query section names) so users can match what they see on those providers' own sites, US retirement-account terms (401(k), IRA) with no French equivalent, and brand names.

## Bonus fix
Fixed a pre-existing duplicate YAML key in `settings/fr.yml` (`transactions_title` was defined twice back-to-back), unrelated to translation but caught along the way.

## Test plan
- [ ] `bin/rails test`
- [ ] Manually switch locale to French and spot-check: Insights feed,  Questrade/Wise connection setup, Akahu/Up provider settings panels, a loan account overview, a matched transfer, and the dashboard period selector chips