### PR TITLE
fix(ai): preserve long external assistant chats

### DIFF
--- a/app/models/assistant/external.rb
+++ b/app/models/assistant/external.rb
@@ -1,6 +1,5 @@
 class Assistant::External < Assistant::Base
   Config = Struct.new(:url, :token, :agent_id, :session_key, keyword_init: true)
-  MAX_CONVERSATION_MESSAGES = 20
 
   class << self
     def for_chat(chat)
@@ -89,7 +88,7 @@ class Assistant::External < Assistant::Base
     end
 
     def build_conversation_messages
-      chat.conversation_messages.where(status: "complete").ordered.last(MAX_CONVERSATION_MESSAGES).map do |msg|
+      chat.conversation_messages.where(status: "complete").ordered.map do |msg|
         { role: msg.role, content: msg.content }
       end
     end

--- a/test/models/assistant/external_config_test.rb
+++ b/test/models/assistant/external_config_test.rb
@@ -59,10 +59,13 @@ class Assistant::ExternalConfigTest < ActiveSupport::TestCase
     end
   end
 
-  test "build_conversation_messages truncates to last 20 messages" do
+  test "build_conversation_messages preserves conversation history beyond 20 messages" do
     chat = chats(:one)
+    original_messages = chat.conversation_messages.where(status: "complete").ordered.map do |msg|
+      { role: msg.role, content: msg.content }
+    end
 
-    # Create enough messages to exceed the 20-message cap
+    # Reproduce a long chat: 13 user/assistant turns = 26 messages.
     25.times do |i|
       role_class = i.even? ? UserMessage : AssistantMessage
       role_class.create!(chat: chat, content: "msg #{i}", ai_model: "test")
@@ -72,8 +75,8 @@ class Assistant::ExternalConfigTest < ActiveSupport::TestCase
       external = Assistant::External.new(chat)
       messages = external.send(:build_conversation_messages)
 
-      assert_equal 20, messages.length
-      # Last message should be the most recent one we created
+      assert_equal original_messages.length + 25, messages.length
+      assert_equal original_messages.first, messages.first
       assert_equal "msg 24", messages.last[:content]
     end
   end


### PR DESCRIPTION
## Problem
Long external assistant conversations were being truncated to the last 20 complete chat messages before being forwarded to the external agent. That means once a thread grows past roughly 10 back-and-forth turns, older context silently disappears, which lines up with the long-conversation blocking investigation Juanjo flagged.

## Fix
- remove the hard `MAX_CONVERSATION_MESSAGES = 20` cap in `Assistant::External`
- forward the full complete conversation history to the external assistant
- replace the old truncation test with a regression test that proves long chat history is preserved

## Testing
- `bin/rails test test/models/assistant/external_config_test.rb`

## Notes
I originally tried to push the local worktree branch directly, but Git HTTPS auth on this machine is not wired up for `git push`, so the branch contents were uploaded through the GitHub API instead. The resulting remote branch still contains the same patch as the local worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Conversation history is no longer limited to the 20 most recent messages.
  * Assistants can now retain and use the complete available conversation history when responding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->