### PR TITLE
Fix(mobile): Convert chat timestamps to local timezone on deserialization

### DIFF
--- a/mobile/lib/models/chat.dart
+++ b/mobile/lib/models/chat.dart
@@ -26,8 +26,8 @@ class Chat {
       id: json['id'].toString(),
       title: json['title'] as String,
       error: json['error'] as String?,
-      createdAt: DateTime.parse(json['created_at'] as String),
-      updatedAt: DateTime.parse(json['updated_at'] as String),
+      createdAt: DateTime.parse(json['created_at'] as String).toLocal(),
+      updatedAt: DateTime.parse(json['updated_at'] as String).toLocal(),
       messages: json['messages'] != null
           ? (json['messages'] as List)
               .map((m) => Message.fromJson(m as Map<String, dynamic>))
@@ -35,7 +35,7 @@ class Chat {
           : [],
       messageCount: json['message_count'] as int?,
       lastMessageAt: json['last_message_at'] != null
-          ? DateTime.parse(json['last_message_at'] as String)
+          ? DateTime.parse(json['last_message_at'] as String).toLocal()
           : null,
     );
   }

--- a/mobile/lib/models/chat.dart
+++ b/mobile/lib/models/chat.dart
@@ -26,8 +26,8 @@ class Chat {
       id: json['id'].toString(),
       title: json['title'] as String,
       error: json['error'] as String?,
-      createdAt: DateTime.parse(json['created_at'] as String).toLocal(),
-      updatedAt: DateTime.parse(json['updated_at'] as String).toLocal(),
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
       messages: json['messages'] != null
           ? (json['messages'] as List)
               .map((m) => Message.fromJson(m as Map<String, dynamic>))
@@ -35,7 +35,7 @@ class Chat {
           : [],
       messageCount: json['message_count'] as int?,
       lastMessageAt: json['last_message_at'] != null
-          ? DateTime.parse(json['last_message_at'] as String).toLocal()
+          ? DateTime.parse(json['last_message_at'] as String)
           : null,
     );
   }
@@ -45,11 +45,11 @@ class Chat {
       'id': id,
       'title': title,
       'error': error,
-      'created_at': createdAt.toIso8601String(),
-      'updated_at': updatedAt.toIso8601String(),
+      'created_at': createdAt.toUtc().toIso8601String(),
+      'updated_at': updatedAt.toUtc().toIso8601String(),
       'messages': messages.map((m) => m.toJson()).toList(),
       'message_count': messageCount,
-      'last_message_at': lastMessageAt?.toIso8601String(),
+      'last_message_at': lastMessageAt?.toUtc().toIso8601String(),
     };
   }
 

--- a/mobile/lib/models/message.dart
+++ b/mobile/lib/models/message.dart
@@ -57,8 +57,8 @@ class Message {
       role: role,
       content: content,
       model: json['model'] as String?,
-      createdAt: DateTime.parse(json['created_at'] as String),
-      updatedAt: DateTime.parse(json['updated_at'] as String),
+      createdAt: DateTime.parse(json['created_at'] as String).toLocal(),
+      updatedAt: DateTime.parse(json['updated_at'] as String).toLocal(),
       toolCalls: json['tool_calls'] != null
           ? (json['tool_calls'] as List)
               .map((tc) => ToolCall.fromJson(tc as Map<String, dynamic>))

--- a/mobile/lib/models/message.dart
+++ b/mobile/lib/models/message.dart
@@ -57,8 +57,8 @@ class Message {
       role: role,
       content: content,
       model: json['model'] as String?,
-      createdAt: DateTime.parse(json['created_at'] as String).toLocal(),
-      updatedAt: DateTime.parse(json['updated_at'] as String).toLocal(),
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
       toolCalls: json['tool_calls'] != null
           ? (json['tool_calls'] as List)
               .map((tc) => ToolCall.fromJson(tc as Map<String, dynamic>))
@@ -74,8 +74,8 @@ class Message {
       'role': role,
       'content': content,
       'model': model,
-      'created_at': createdAt.toIso8601String(),
-      'updated_at': updatedAt.toIso8601String(),
+      'created_at': createdAt.toUtc().toIso8601String(),
+      'updated_at': updatedAt.toUtc().toIso8601String(),
       'tool_calls': toolCalls?.map((tc) => tc.toJson()).toList(),
     };
   }

--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -254,8 +254,9 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
   }
 
   String _formatTime(DateTime dateTime) {
-    final hour = dateTime.hour.toString().padLeft(2, '0');
-    final minute = dateTime.minute.toString().padLeft(2, '0');
+    final local = dateTime.toLocal();
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
     return '$hour:$minute';
   }
 

--- a/mobile/lib/screens/chat_list_screen.dart
+++ b/mobile/lib/screens/chat_list_screen.dart
@@ -155,7 +155,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
       return l.chatListDaysAgo(difference.inDays);
     } else {
       return DateFormat.yMd(Localizations.localeOf(context).toString())
-          .format(dateTime);
+          .format(dateTime.toLocal());
     }
   }
 


### PR DESCRIPTION
## Summary

- Chat timestamps (`created_at`, `updated_at`, `last_message_at`) returned from the API are UTC strings. Without conversion, Flutter's `DateTime.parse` treats them as UTC internally but displays them in UTC rather than the user's local time — causing chat history and message timestamps to appear offset for users outside UTC.
- Added `.toLocal()` to all `DateTime.parse` calls in `Chat.fromJson` and `Message.fromJson` so timestamps are converted to the device's local timezone immediately on deserialization.
- Affected fields: `Chat.createdAt`, `Chat.updatedAt`, `Chat.lastMessageAt`, `Message.createdAt`, `Message.updatedAt`.

## Test plan

- [ ] Open the mobile app as a user in a non-UTC timezone (e.g. UTC+2 or UTC-5)
- [ ] Navigate to the AI chat screen and open an existing chat
- [ ] Confirm the chat's timestamp and individual message timestamps display in local time, not UTC
- [ ] Send a new message and confirm its `createdAt` timestamp also reflects local time
- [ ] Verify no regression in chat ordering or message display for UTC users

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat and message timestamps are now correctly converted to the device’s local time before being shown in conversations and the chat list.
  * Timestamp serialization has been standardized to use UTC ISO-8601 format for created/updated/last-message times, improving consistency across the mobile experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->