### PR TITLE
fix(tags): return 404 for missing or cross-family tag deletion

### DIFF
--- a/app/controllers/tag/deletions_controller.rb
+++ b/app/controllers/tag/deletions_controller.rb
@@ -13,10 +13,12 @@ class Tag::DeletionsController < ApplicationController
   private
 
     def set_tag
-      @tag = Current.family.tags.find_by(id: params[:tag_id])
+      @tag = Current.family.tags.find(params[:tag_id])
     end
 
     def set_replacement_tag
-      @replacement_tag = Current.family.tags.find_by(id: params[:replacement_tag_id])
+      if params[:replacement_tag_id].present?
+        @replacement_tag = Current.family.tags.find(params[:replacement_tag_id])
+      end
     end
 end

--- a/test/controllers/tag/deletions_controller_test.rb
+++ b/test/controllers/tag/deletions_controller_test.rb
@@ -32,4 +32,22 @@ class Tag::DeletionsControllerTest < ActionDispatch::IntegrationTest
       post tag_deletions_url(@tag)
     end
   end
+
+  test "create with invalid or cross-family tag_id returns not found" do
+    other_family_tag = families(:empty).tags.create!(name: "Other family tag")
+
+    assert_no_difference -> { Tag.count } do
+      post tag_deletions_url(tag_id: other_family_tag.id)
+    end
+
+    assert_response :not_found
+  end
+
+  test "create with invalid replacement_tag_id returns not found" do
+    assert_no_difference -> { Tag.count } do
+      post tag_deletions_url(@tag), params: { replacement_tag_id: "missing" }
+    end
+
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
## Summary

`Tag::DeletionsController` looked up the tag with `find_by`, so a missing `tag_id` or one belonging to another family left `@tag` as `nil`. `create` then called `@tag.replace_and_destroy!`, which raised `NoMethodError` and returned a 500. `set_replacement_tag` had the same pattern, so an invalid `replacement_tag_id` passed `nil` into `replace_and_destroy!` instead of returning 404.

Both lookups now use `find`, which raises `ActiveRecord::RecordNotFound` for a missing or out-of-scope id and is rendered as 404. `set_replacement_tag` keeps a `present?` guard so deleting a tag without choosing a replacement still works. This matches how `Category::DeletionsController` already handles the same case.

## Verification

`bin/rails test test/controllers/tag/deletions_controller_test.rb` passes. Two regression tests cover a cross-family `tag_id` and a missing `replacement_tag_id`; both return 500 (`NoMethodError` on `nil`) without the fix.

## Notes

The presence guard on `set_replacement_tag` is deliberate: a blank `replacement_tag_id` is valid and means delete without reassigning, so only a non-blank id that resolves to no in-scope tag is a 404.

Fixes #2469

<details><summary>Notes I made while reviewing this</summary>

- **minor** `test/controllers/tag/deletions_controller_test.rb:39` — The cross-family test asserts Tag.count is unchanged but the created other_family_tag itself increments Tag.count during setup outside the assert_no_difference block, so the assertion only proves the delete didn't fire — which is fine. The :not_found assertion is the real guard. No change required; noting the assertion carries little weight beyond the status check.
- **minor** `test/controllers/tag/deletions_controller_test.rb:36` — The single test titled 'invalid or cross-family tag_id' only exercises the cross-family branch (an existing tag owned by families(:empty)); it never sends a genuinely nonexistent id. Both map to RecordNotFound so coverage of the fix is fine, but the title over-claims relative to what is asserted.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag deletion error handling for missing or invalid tags.
  * Invalid replacement tags now return a 404 response instead of proceeding.
  * Failed deletion attempts no longer alter the total number of tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->