### PR TITLE
fix(api): scope holdings API to accessible accounts

### DIFF
--- a/app/controllers/api/v1/holdings_controller.rb
+++ b/app/controllers/api/v1/holdings_controller.rb
@@ -7,8 +7,7 @@ class Api::V1::HoldingsController < Api::V1::BaseController
   before_action :set_holding, only: [ :show ]
 
   def index
-    family = current_resource_owner.family
-    holdings_query = family.holdings.joins(:account).where(accounts: { status: [ "draft", "active" ] })
+    holdings_query = accessible_holdings
 
     holdings_query = apply_filters(holdings_query)
     holdings_query = holdings_query.includes(:account, :security).chronological
@@ -36,10 +35,22 @@ class Api::V1::HoldingsController < Api::V1::BaseController
   private
 
     def set_holding
-      family = current_resource_owner.family
-      @holding = family.holdings.joins(:account).where(accounts: { status: %w[draft active] }).find(params[:id])
+      @holding = accessible_holdings.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       render json: { error: "not_found", message: "Holding not found" }, status: :not_found
+    end
+
+    # Holdings restricted to accounts the token owner can access (owned or shared),
+    # not the whole family. Mirrors Api::V1::BalancesController and the web
+    # HoldingsController, both of which scope through Account.accessible_by.
+    def accessible_holdings
+      Holding
+        .joins(:account)
+        .where(accounts: { status: %w[draft active], id: accessible_account_ids })
+    end
+
+    def accessible_account_ids
+      @accessible_account_ids ||= current_resource_owner.family.accounts.accessible_by(current_resource_owner).select(:id)
     end
 
     def ensure_read_scope

--- a/test/controllers/api/v1/holdings_controller_test.rb
+++ b/test/controllers/api/v1/holdings_controller_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::HoldingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @user.api_keys.active.destroy_all
+
+    @api_key = ApiKey.create!(
+      user: @user,
+      name: "Test Read Key",
+      scopes: [ "read" ],
+      source: "web",
+      display_key: "test_read_#{SecureRandom.hex(8)}"
+    )
+
+    @account = accounts(:investment)
+    @holding = holdings(:one)
+
+    # An account owned by another family member, never shared with @user.
+    @other_member = users(:family_member)
+    @private_account = @family.accounts.create!(
+      name: "Member Brokerage",
+      accountable: Investment.new,
+      balance: 5000,
+      currency: "USD",
+      owner: @other_member
+    )
+    @private_holding = @private_account.holdings.create!(
+      security: securities(:msft),
+      date: Date.current,
+      qty: 5,
+      price: 100,
+      amount: 500,
+      currency: "USD"
+    )
+  end
+
+  test "lists holdings scoped to accessible accounts" do
+    get api_v1_holdings_url, headers: api_headers(@api_key)
+
+    assert_response :success
+    holding_ids = JSON.parse(response.body)["holdings"].map { |holding| holding["id"] }
+    assert_includes holding_ids, @holding.id
+    assert_not_includes holding_ids, @private_holding.id
+  end
+
+  test "account_ids filter cannot reach inaccessible accounts" do
+    get api_v1_holdings_url,
+        params: { account_ids: [ @private_account.id ] },
+        headers: api_headers(@api_key)
+
+    assert_response :success
+    holding_ids = JSON.parse(response.body)["holdings"].map { |holding| holding["id"] }
+    assert_not_includes holding_ids, @private_holding.id
+  end
+
+  test "account_id filter cannot reach inaccessible accounts" do
+    get api_v1_holdings_url,
+        params: { account_id: @private_account.id },
+        headers: api_headers(@api_key)
+
+    assert_response :success
+    holding_ids = JSON.parse(response.body)["holdings"].map { |holding| holding["id"] }
+    assert_not_includes holding_ids, @private_holding.id
+  end
+
+  test "shows an accessible holding" do
+    get api_v1_holding_url(@holding), headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_equal @holding.id, response_data["id"]
+  end
+
+  test "returns not found for an inaccessible holding" do
+    get api_v1_holding_url(@private_holding), headers: api_headers(@api_key)
+
+    assert_response :not_found
+  end
+
+  test "requires authentication" do
+    get api_v1_holdings_url
+
+    assert_response :unauthorized
+  end
+
+  private
+
+    def api_headers(api_key)
+      { "X-Api-Key" => api_key.display_key }
+    end
+end


### PR DESCRIPTION
## Summary

The `/api/v1/holdings` list and show endpoints scoped results to the entire
family (`current_resource_owner.family.holdings`) instead of the accounts the API
token owner can actually access. A read-scoped key could therefore read holdings
(account id/name, quantity, price, market value) for accounts owned by other
family members that were never shared with the key owner, and the `account_id` /
`account_ids` filters made targeted enumeration trivial.

This brings the holdings API in line with `Api::V1::BalancesController` and the
web `HoldingsController`, both of which already scope through
`Account.accessible_by`.

Fixes #2467

## What changed

- Added an `accessible_holdings` scope that restricts holdings to accounts the
  token owner owns or has been shared, keeping the existing `draft` / `active`
  status filter.
- Routed both `index` and `set_holding` through it, so the list, the show
  action, and the `account_id` / `account_ids` filters all respect access
  boundaries.

```ruby
def accessible_holdings
  Holding
    .joins(:account)
    .where(accounts: { status: %w[draft active], id: accessible_account_ids })
end

def accessible_account_ids
  @accessible_account_ids ||= current_resource_owner.family.accounts.accessible_by(current_resource_owner).select(:id)
end
```

## Testing

Added `test/controllers/api/v1/holdings_controller_test.rb`, covering list
scoping, the `account_ids` and `account_id` enumeration vectors, show for an
accessible holding, a not-found response for an inaccessible holding, and the
authentication requirement.

<details><summary>Notes I made while reviewing this</summary>

- **minor** `app/controllers/api/v1/holdings_controller.rb:37` — Pre-existing, not introduced by this diff: set_holding calls accessible_holdings.find(params[:id]) with no UUID-format guard. A malformed id raises ActiveRecord::StatementInvalid (Postgres uuid cast), which set_holding does not rescue, yielding a 500 instead of 404. BalancesController guards this with valid_uuid?; holdings never has. The old code had the same gap, so it is not a regression from this change.
- **minor** `app/controllers/api/v1/holdings_controller.rb:43` — The endpoint's request/response shape is unchanged (same params, same JSON output), so no rswag docs regeneration is strictly required — but confirm the existing spec/requests/api/v1/holdings_spec.rb still passes so the mandatory API-consistency gate stays green.
- **minor** `test/controllers/api/v1/holdings_controller_test.rb:60` — The account_id/account_ids filter tests assert only that @private_holding is absent; on unfixed code these still pass because the pre-existing family-wide query already returns the private holding regardless of the added filter, so only the plain 'lists holdings' test truly proves the regression. This is fine as extra coverage but the filter tests are not independent proof of the fix.
- **minor** `test/controllers/api/v1/holdings_controller_test.rb:1` — The API-consistency rule lists 403/422 among the status codes to cover; the added Minitest covers index, show, 401 and 404 only. Holdings is a read-only endpoint (no CRUD, no writable params) so 403/422 are not reachable via this fix, making the omission defensible and in-scope — noting it only so the reviewer is aware the coverage is intentionally narrow.
- **minor** `app/controllers/api/v1/holdings_controller.rb:1` — Green could not be independently confirmed by execution: no Ruby/bundler is available in this review sandbox, so bin/rails test / rubocop / brakeman were not run here. Verdict rests on static analysis of the diff, the accessible_by scope, and the fixtures.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Holdings API results now include only holdings from accounts accessible to the authenticated requester.
  * Inaccessible holdings are excluded from list results, including when account filters are provided.
  * Direct requests for inaccessible holdings now return a not-found response.
  * Authentication is required to access holdings endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->