### PR TITLE
fix(chat): resolve 21st message not rendering on mobile

### DIFF
--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -8,12 +8,12 @@ class Api::V1::ChatsController < Api::V1::BaseController
   before_action :set_chat, only: [ :show, :update, :destroy ]
 
   def index
-    @pagy, @chats = pagy(current_resource_owner.chats.ordered, items: 20)
+    @pagy, @chats = pagy(current_resource_owner.chats.ordered, limit: 20)
   end
 
   def show
     return unless @chat
-    @pagy, @messages = pagy(@chat.messages.ordered, items: 50)
+    @pagy, @messages = pagy(@chat.messages.ordered, limit: 50)
   end
 
   def create

--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -28,12 +28,6 @@ class Api::V1::ChatsController < Api::V1::BaseController
         )
 
         if @message.save
-          # NOTE: Commenting out duplicate job enqueue to fix mobile app receiving duplicate AI responses
-          # UserMessage model already triggers AssistantResponseJob via after_create_commit callback
-          # in app/models/user_message.rb:10-12, so this manual enqueue causes the job to run twice,
-          # resulting in duplicate AI responses with different content and wasted tokens.
-          # See: https://github.com/dwvwdv/sure (mobile app integration issue)
-          # AssistantResponseJob.perform_later(@message)
           render :show, status: :created
         else
           @chat.destroy

--- a/app/models/assistant/external.rb
+++ b/app/models/assistant/external.rb
@@ -1,6 +1,5 @@
 class Assistant::External < Assistant::Base
   Config = Struct.new(:url, :token, :agent_id, :session_key, keyword_init: true)
-  MAX_CONVERSATION_MESSAGES = 20
 
   class << self
     def for_chat(chat)
@@ -89,7 +88,7 @@ class Assistant::External < Assistant::Base
     end
 
     def build_conversation_messages
-      chat.conversation_messages.where(status: "complete").ordered.last(MAX_CONVERSATION_MESSAGES).map do |msg|
+      chat.conversation_messages.where(status: "complete").ordered.map do |msg|
         { role: msg.role, content: msg.content }
       end
     end

--- a/app/models/assistant/external.rb
+++ b/app/models/assistant/external.rb
@@ -88,8 +88,15 @@ class Assistant::External < Assistant::Base
     end
 
     def build_conversation_messages
-      chat.conversation_messages.where(status: "complete").ordered.map do |msg|
+      messages = chat.conversation_messages.where(status: "complete").ordered.map do |msg|
         { role: msg.role, content: msg.content }
       end
+      Assistant::HistoryTrimmer.new(messages, max_tokens: max_history_tokens).call
+    end
+
+    def max_history_tokens
+      explicit = ENV["EXTERNAL_ASSISTANT_MAX_HISTORY_TOKENS"].presence&.to_i
+      return explicit if explicit&.positive?
+      100_000
     end
 end

--- a/app/models/assistant/external.rb
+++ b/app/models/assistant/external.rb
@@ -88,8 +88,33 @@ class Assistant::External < Assistant::Base
     end
 
     def build_conversation_messages
-      messages = chat.conversation_messages.where(status: "complete").ordered.map do |msg|
-        { role: msg.role, content: msg.content }
+      messages = []
+      chat.conversation_messages.where(status: "complete").ordered.includes(:tool_calls).each do |msg|
+        if msg.tool_calls.any?
+          messages << {
+            role: msg.role,
+            content: msg.content || "",
+            tool_calls: msg.tool_calls.map(&:to_tool_call)
+          }
+          msg.tool_calls.map(&:to_result).each do |fn_result|
+            output = fn_result[:output]
+            content = if output.nil?
+              ""
+            elsif output.is_a?(String)
+              output
+            else
+              output.to_json
+            end
+            messages << {
+              role: "tool",
+              tool_call_id: fn_result[:call_id],
+              name: fn_result[:name],
+              content: content
+            }
+          end
+        elsif msg.content.present?
+          messages << { role: msg.role, content: msg.content }
+        end
       end
       Assistant::HistoryTrimmer.new(messages, max_tokens: max_history_tokens).call
     end

--- a/app/views/api/v1/chats/index.json.jbuilder
+++ b/app/views/api/v1/chats/index.json.jbuilder
@@ -12,7 +12,7 @@ end
 
 json.pagination do
   json.page @pagy.page
-  json.per_page @pagy.vars[:items]
+  json.per_page @pagy.limit
   json.total_count @pagy.count
   json.total_pages @pagy.pages
 end

--- a/app/views/api/v1/chats/show.json.jbuilder
+++ b/app/views/api/v1/chats/show.json.jbuilder
@@ -26,7 +26,7 @@ end
 if @pagy
   json.pagination do
     json.page @pagy.page
-    json.per_page @pagy.vars[:items]
+    json.per_page @pagy.limit
     json.total_count @pagy.count
     json.total_pages @pagy.pages
   end

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -19,7 +19,7 @@ class ChatProvider with ChangeNotifier {
   DateTime? _pollingStartTime;
   bool _isPollingRequestInFlight = false;
 
-  static const _pollingTimeout = Duration(seconds: 20);
+  static const _pollingTimeout = Duration(seconds: 60);
 
   /// Content length of the last assistant message from the previous poll.
   /// Used to detect when the LLM has finished writing (no growth between polls).
@@ -422,6 +422,7 @@ class ChatProvider with ChangeNotifier {
         if (newMessageCount > oldMessageCount) {
           shouldUpdate = true;
           _lastAssistantContentLength = null;
+          _pollingStartTime = DateTime.now(); // server acked the new message — reset timeout clock
         } else if (newMessageCount == oldMessageCount) {
           // Same count: check if any assistant message has more content
           for (final m in newMessages) {
@@ -442,7 +443,13 @@ class ChatProvider with ChangeNotifier {
 
         if (updatedChat.error != null && updatedChat.error!.isNotEmpty) {
           if (!shouldUpdate) {
-            _currentChat = updatedChat;
+            // Preserve existing messages if the error response has fewer — prevents
+            // a backend error from wiping out messages the user can already see.
+            if (updatedChat.messages.length >= (_currentChat?.messages.length ?? 0)) {
+              _currentChat = updatedChat;
+            } else {
+              _currentChat = _currentChat!.copyWith(error: updatedChat.error);
+            }
           }
           _stopPolling();
           _errorMessage = updatedChat.error;

--- a/test/models/assistant/external_config_test.rb
+++ b/test/models/assistant/external_config_test.rb
@@ -59,10 +59,10 @@ class Assistant::ExternalConfigTest < ActiveSupport::TestCase
     end
   end
 
-  test "build_conversation_messages truncates to last 20 messages" do
+  test "build_conversation_messages returns all complete messages without truncation" do
     chat = chats(:one)
 
-    # Create enough messages to exceed the 20-message cap
+    # Create messages well beyond the old 20-message cap to verify it's gone
     25.times do |i|
       role_class = i.even? ? UserMessage : AssistantMessage
       role_class.create!(chat: chat, content: "msg #{i}", ai_model: "test")
@@ -72,7 +72,8 @@ class Assistant::ExternalConfigTest < ActiveSupport::TestCase
       external = Assistant::External.new(chat)
       messages = external.send(:build_conversation_messages)
 
-      assert_equal 20, messages.length
+      # All 25 created + 3 fixture messages = 28 complete messages returned
+      assert messages.length > 20, "Expected all messages to be included, not truncated at 20"
       # Last message should be the most recent one we created
       assert_equal "msg 24", messages.last[:content]
     end

--- a/test/models/assistant/external_config_test.rb
+++ b/test/models/assistant/external_config_test.rb
@@ -73,7 +73,7 @@ class Assistant::ExternalConfigTest < ActiveSupport::TestCase
       messages = external.send(:build_conversation_messages)
 
       # All 25 created + 3 fixture messages = 28 complete messages returned
-      assert messages.length > 20, "Expected all messages to be included, not truncated at 20"
+      assert_equal 28, messages.length, "Expected all complete messages to be included"
       # Last message should be the most recent one we created
       assert_equal "msg 24", messages.last[:content]
     end


### PR DESCRIPTION
## Problem

Two bugs caused AI chat to silently break after 20 messages on mobile (web was unaffected):

**Bug 1 — Pagy v9 `items:` → `limit:` regression (root cause of rendering failure)**

The `chats_controller` used the Pagy v6 `items:` keyword which Pagy v9 silently ignores, falling back to its default of 20 items per page. This meant:
- Mobile always had 21 messages locally (after sending the 11th request)
- API always returned 20 → `shouldUpdate` was always `false`
- Polling's stable-check fired on the *previous* 10th assistant response (not the new one)
- Animation stopped, response never rendered

Diagnosed via polling debug logs: `old=21 new=20 shouldUpdate=false lastRole=assistant lastLen=77`

**Bug 2 — `Assistant::External` capped context at 20 messages**

`MAX_CONVERSATION_MESSAGES = 20` truncated the conversation history sent to the external agent once a chat grew past 10 turns, causing the AI to lose earlier context. (Same fix as #2698.)

## Fix

- `app/controllers/api/v1/chats_controller.rb` — `items:` → `limit:` on both `index` and `show` (Pagy v9 API)
- `app/models/assistant/external.rb` — remove `MAX_CONVERSATION_MESSAGES = 20` cap
- `mobile/lib/providers/chat_provider.dart`:
  - Raise polling timeout 20s → 60s
  - Reset timeout clock when server acks a new pending message (not just on content growth)
  - Preserve existing messages when an error response has fewer than what's locally cached

## Testing

Verified end-to-end on mobile: sent 11+ back-and-forth messages, all responses rendered correctly after fix.

## Test plan

- [ ] Start a chat and exchange 10 back-and-forth messages (20 total)
- [ ] Send an 11th message — response should render correctly
- [ ] Continue past message 21 — subsequent messages should render
- [ ] `bin/rails test test/models/assistant/external_config_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat polling reliability with a longer timeout and automatic timeout reset when new messages arrive.
  - Enhanced error handling by preserving existing messages when an update includes an error with fewer messages.
  - Fixed chat and message pagination to report the correct records per page.
- **Improvements**
  - Assistant replies now use complete completed conversation history (trimmed by a token budget instead of a fixed message limit), including expanded tool call results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->