### PR TITLE
fix(i18n): resolve close button label in goals dialog across all locales

### DIFF
--- a/app/views/goals/new.html.erb
+++ b/app/views/goals/new.html.erb
@@ -9,7 +9,7 @@
             <p class="text-sm text-secondary mt-0.5"><%= t(".subtitle") %></p>
           </div>
         </div>
-        <%= render DS::Button.new(variant: "icon", icon: "x", title: t("common.close"), aria_label: t("common.close"), data: { action: "DS--dialog#close" }) %>
+        <%= render DS::Button.new(variant: "icon", icon: "x", title: t("defaults.common.close"), aria_label: t("defaults.common.close"), data: { action: "DS--dialog#close" }) %>
       </div>
     <% end %>
     <% dialog.with_body do %>

--- a/config/locales/defaults/ru.yml
+++ b/config/locales/defaults/ru.yml
@@ -7,8 +7,6 @@ ru:
         restrict_dependent_destroy:
           has_many: 'Невозможно удалить запись, так как существуют зависимости: %{record}'
           has_one: 'Невозможно удалить запись, так как существует зависимость: %{record}'
-  common:
-    close: Закрыть
   date:
     abbr_day_names:
     - Вс

--- a/config/locales/defaults/tr.yml
+++ b/config/locales/defaults/tr.yml
@@ -7,8 +7,6 @@ tr:
         restrict_dependent_destroy:
           has_many: Bağlı kayıtlar %{record} bulunduğu için kayıt silinemedi
           has_one: Bağlı bir kayıt %{record} bulunduğu için kayıt silinemedi
-  common:
-    close: Kapat
   date:
     abbr_day_names:
     - Pzr

--- a/config/locales/defaults/zh-CN.yml
+++ b/config/locales/defaults/zh-CN.yml
@@ -225,5 +225,3 @@ zh-CN:
       long: "%Y年%m月%d日 %H:%M"
       short: "%m月%d日 %H:%M"
     pm: 下午
-  common:
-    close: 关闭


### PR DESCRIPTION
Closes #2740.

## Problem

`app/views/goals/new.html.erb:12` calls `t("common.close")`, but there is no top-level `common.close` key in `en.yml` — the string only exists as `defaults.common.close`. Since `config.i18n.fallbacks = true` falls back to `en`, and `en` doesn't define the key either, the lookup fails in every locale except `ru`, `tr` and `zh-CN`, which each carry a top-level `common:` block (most likely added as local workarounds by translators who hit this).

The failed lookup is passed directly into the button's `title` and `aria_label`, so literal markup ends up in text meant for screen readers:

```
t("common.close") @ en
=> "<span class=\"translation_missing\" title=\"translation missing: en.common.close, locale: en\">Close</span>"
```

`defaults.common.close` is the canonical key — it's defined in `en` and already used by `settings/providers/_drawer_header.html.erb:18,19` and `shared/notifications/_sync_toast.html.erb:30`.

## Change

- `app/views/goals/new.html.erb` — use `t("defaults.common.close")`
- `config/locales/defaults/{ru,tr,zh-CN}.yml` — drop the now-dead top-level `common:` blocks

No `en.yml` or other source changes.

## Verification

Resolution across locales, via `bin/rails runner` (before → after):

| locale | `common.close` before | `defaults.common.close` |
|---|---|---|
| en | ❌ unresolved | ✅ `"Close"` |
| ca | ❌ unresolved | ✅ `"Tanca"` |
| fr | ❌ unresolved | ✅ `"Fermer"` |
| it | ❌ unresolved | ✅ `"Chiudi"` |
| de / es | ❌ unresolved | ✅ falls back to `"Close"` |
| ru | ✅ `"Закрыть"` | ✅ `"Закрыть"` |
| tr | ✅ `"Kapat"` | ✅ `"Kapat"` |
| zh-CN | ✅ `"关闭"` | ✅ `"关闭"` |

After the change the view renders `"Close"` under `en` — no `translation_missing` span.

- `grep -rn 't("common\.' app/` → no call sites remain
- `bundle exec i18n-tasks unused` → neither `common.close` nor `defaults.common.close` appears
- `bundle exec erb_lint app/views/goals/new.html.erb` → no errors
- `bin/rails test test/controllers/goals_controller_test.rb` → 23 runs, 81 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the dialog close button’s translated label and accessibility text across supported locales.
  * Added missing Turkish messages for dependent-record deletion errors involving one-to-many and one-to-one relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->