### PR TITLE
Fix transactions posting a day early when booked around midnight.

### DIFF
--- a/app/models/akahu_entry/processor.rb
+++ b/app/models/akahu_entry/processor.rb
@@ -172,7 +172,11 @@ class AkahuEntry::Processor
       value = data[:date]
       case value
       when String
-        Date.parse(value)
+        if value.include?("T") || value.include?(":")
+          Time.parse(value).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(value)
+        end
       when Integer, Float
         Time.at(value).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime

--- a/app/models/akahu_entry/processor.rb
+++ b/app/models/akahu_entry/processor.rb
@@ -174,9 +174,9 @@ class AkahuEntry::Processor
       when String
         Date.parse(value)
       when Integer, Float
-        Time.at(value).to_date
+        Time.at(value).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
-        value.to_date
+        value.in_time_zone(account&.family&.timezone).to_date
       when Date
         value
       else

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -146,11 +146,15 @@ class BrexEntry::Processor
 
       case date_value
       when String
-        Date.parse(date_value)
+        if date_value.include?("T") || date_value.include?(":")
+          Time.parse(date_value).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(date_value)
+        end
       when Integer, Float
-        Time.at(date_value).to_date
+        Time.at(date_value).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
-        date_value.to_date
+        date_value.in_time_zone(account&.family&.timezone).to_date
       when Date
         date_value
       else

--- a/app/models/coinstats_entry/processor.rb
+++ b/app/models/coinstats_entry/processor.rb
@@ -255,11 +255,15 @@ class CoinstatsEntry::Processor
 
       case timestamp
       when Integer, Float
-        Time.at(timestamp).to_date
+        Time.at(timestamp).in_time_zone(account&.family&.timezone).to_date
       when String
-        Time.parse(timestamp).to_date
+        if timestamp.include?("T") || timestamp.include?(":")
+          Time.parse(timestamp).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(timestamp)
+        end
       when Time, DateTime
-        timestamp.to_date
+        timestamp.in_time_zone(account&.family&.timezone).to_date
       when Date
         timestamp
       else

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -258,7 +258,11 @@ class EnableBankingEntry::Processor
 
       case date_value
       when String
-        Date.parse(date_value)
+        if date_value.include?("T") || date_value.include?(":")
+          Time.parse(date_value).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(date_value)
+        end
       when Integer, Float
         Time.at(date_value).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -260,9 +260,9 @@ class EnableBankingEntry::Processor
       when String
         Date.parse(date_value)
       when Integer, Float
-        Time.at(date_value).to_date
+        Time.at(date_value).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
-        date_value.to_date
+        date_value.in_time_zone(account&.family&.timezone).to_date
       when Date
         date_value
       else

--- a/app/models/indexa_capital_account/activities_processor.rb
+++ b/app/models/indexa_capital_account/activities_processor.rb
@@ -131,9 +131,9 @@ class IndexaCapitalAccount::ActivitiesProcessor
 
       # Get the activity date
       # TODO: Customize date field names
-      activity_date = parse_date(data[:settlement_date]) ||
-                      parse_date(data[:trade_date]) ||
-                      parse_date(data[:date]) ||
+      activity_date = parse_date(data[:settlement_date], family: account&.family) ||
+                      parse_date(data[:trade_date], family: account&.family) ||
+                      parse_date(data[:date], family: account&.family) ||
                       Date.current
 
       currency = extract_currency(data, fallback: account.currency)
@@ -165,9 +165,9 @@ class IndexaCapitalAccount::ActivitiesProcessor
 
       # Get the activity date
       # TODO: Customize date field names
-      activity_date = parse_date(data[:settlement_date]) ||
-                      parse_date(data[:trade_date]) ||
-                      parse_date(data[:date]) ||
+      activity_date = parse_date(data[:settlement_date], family: account&.family) ||
+                      parse_date(data[:trade_date], family: account&.family) ||
+                      parse_date(data[:date], family: account&.family) ||
                       Date.current
 
       # Build description

--- a/app/models/indexa_capital_account/data_helpers.rb
+++ b/app/models/indexa_capital_account/data_helpers.rb
@@ -58,17 +58,22 @@ module IndexaCapitalAccount::DataHelpers
       hash[:identifier] || hash[:isin_code] || hash[:isin] || hash[:symbol] || hash[:ticker]
     end
 
-    def parse_date(date_value)
+    def parse_date(date_value, family: nil)
       return nil if date_value.nil?
+
+      tz = family&.timezone
 
       case date_value
       when Date
         date_value
       when String
-        # Use Time.zone.parse for external timestamps (Rails timezone guidelines)
-        Time.zone.parse(date_value)&.to_date
+        if tz && (date_value.include?("T") || date_value.include?(":"))
+          Time.parse(date_value).in_time_zone(tz).to_date
+        else
+          Date.parse(date_value)
+        end
       when Time, DateTime, ActiveSupport::TimeWithZone
-        date_value.to_date
+        date_value.in_time_zone(tz).to_date
       else
         nil
       end

--- a/app/models/indexa_capital_account/data_helpers.rb
+++ b/app/models/indexa_capital_account/data_helpers.rb
@@ -64,8 +64,6 @@ module IndexaCapitalAccount::DataHelpers
       tz = family&.timezone
 
       case date_value
-      when Date
-        date_value
       when String
         if tz && (date_value.include?("T") || date_value.include?(":"))
           Time.parse(date_value).in_time_zone(tz).to_date
@@ -74,6 +72,8 @@ module IndexaCapitalAccount::DataHelpers
         end
       when Time, DateTime, ActiveSupport::TimeWithZone
         date_value.in_time_zone(tz).to_date
+      when Date
+        date_value
       else
         nil
       end

--- a/app/models/lunchflow_entry/processor.rb
+++ b/app/models/lunchflow_entry/processor.rb
@@ -188,9 +188,12 @@ class LunchflowEntry::Processor
     def date
       case data[:date]
       when String
-        Date.parse(data[:date])
+        if data[:date].include?("T") || data[:date].include?(":")
+          Time.parse(data[:date]).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(data[:date])
+        end
       when Integer, Float
-        # Unix timestamp
         Time.at(data[:date]).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
         data[:date].in_time_zone(account&.family&.timezone).to_date

--- a/app/models/lunchflow_entry/processor.rb
+++ b/app/models/lunchflow_entry/processor.rb
@@ -191,9 +191,9 @@ class LunchflowEntry::Processor
         Date.parse(data[:date])
       when Integer, Float
         # Unix timestamp
-        Time.at(data[:date]).to_date
+        Time.at(data[:date]).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
-        data[:date].to_date
+        data[:date].in_time_zone(account&.family&.timezone).to_date
       when Date
         data[:date]
       else

--- a/app/models/mercury_entry/processor.rb
+++ b/app/models/mercury_entry/processor.rb
@@ -158,13 +158,15 @@ class MercuryEntry::Processor
 
       case date_value
       when String
-        # Mercury uses ISO 8601 format: "2024-01-15T10:30:00Z"
-        DateTime.parse(date_value).to_date
+        if date_value.include?("T") || date_value.include?(":")
+          Time.parse(date_value).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(date_value)
+        end
       when Integer, Float
-        # Unix timestamp
-        Time.at(date_value).to_date
+        Time.at(date_value).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
-        date_value.to_date
+        date_value.in_time_zone(account&.family&.timezone).to_date
       when Date
         date_value
       else

--- a/app/models/sophtron_entry/processor.rb
+++ b/app/models/sophtron_entry/processor.rb
@@ -210,12 +210,15 @@ class SophtronEntry::Processor
     def date
       case data[:date]
       when String
-        Date.parse(data[:date])
+        if data[:date].include?("T") || data[:date].include?(":")
+          Time.parse(data[:date]).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(data[:date])
+        end
       when Integer, Float
-        # Unix timestamp
-        Time.at(data[:date]).to_date
+        Time.at(data[:date]).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
-        data[:date].to_date
+        data[:date].in_time_zone(account&.family&.timezone).to_date
       when Date
         data[:date]
       else

--- a/app/models/up_entry/processor.rb
+++ b/app/models/up_entry/processor.rb
@@ -166,9 +166,15 @@ class UpEntry::Processor
       value = data[:settledAt].presence || data[:createdAt].presence
       case value
       when String
-        Time.parse(value).to_date
+        if value.include?("T") || value.include?(":")
+          Time.parse(value).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(value)
+        end
+      when Integer, Float
+        Time.at(value).in_time_zone(account&.family&.timezone).to_date
       when Time, DateTime
-        value.to_date
+        value.in_time_zone(account&.family&.timezone).to_date
       when Date
         value
       else

--- a/app/models/wise_entry/processor.rb
+++ b/app/models/wise_entry/processor.rb
@@ -159,6 +159,7 @@ class WiseEntry::Processor
         end
       when Time, DateTime
         raw.in_time_zone(account&.family&.timezone).to_date
+      when Date then raw
       else raise ArgumentError, "Invalid date format: #{raw.inspect}"
       end
     rescue ArgumentError

--- a/app/models/wise_entry/processor.rb
+++ b/app/models/wise_entry/processor.rb
@@ -150,8 +150,15 @@ class WiseEntry::Processor
       raise ArgumentError, "Wise transfer missing created date" unless raw
 
       case raw
-      when Date   then raw
-      when String then DateTime.parse(raw).to_date
+      when Date then raw
+      when String
+        if raw.include?("T") || raw.include?(":")
+          Time.parse(raw).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(raw)
+        end
+      when Time, DateTime
+        raw.in_time_zone(account&.family&.timezone).to_date
       else raise ArgumentError, "Invalid date format: #{raw.inspect}"
       end
     rescue ArgumentError

--- a/app/models/wise_entry/processor.rb
+++ b/app/models/wise_entry/processor.rb
@@ -150,7 +150,6 @@ class WiseEntry::Processor
       raise ArgumentError, "Wise transfer missing created date" unless raw
 
       case raw
-      when Date then raw
       when String
         if raw.include?("T") || raw.include?(":")
           Time.parse(raw).in_time_zone(account&.family&.timezone).to_date

--- a/db/migrate/20260405120000_add_aspsp_metadata_to_enable_banking.rb
+++ b/db/migrate/20260405120000_add_aspsp_metadata_to_enable_banking.rb
@@ -1,15 +1,15 @@
 class AddAspspMetadataToEnableBanking < ActiveRecord::Migration[7.2]
   def change
     # ASPSP-level metadata on the item (stored when user selects a bank)
-    add_column :enable_banking_items, :aspsp_required_psu_headers, :jsonb, default: []
-    add_column :enable_banking_items, :aspsp_maximum_consent_validity, :integer  # in seconds
-    add_column :enable_banking_items, :aspsp_auth_approach, :string              # REDIRECT | EMBEDDED | DECOUPLED
-    add_column :enable_banking_items, :aspsp_psu_types, :jsonb, default: []
+    add_column :enable_banking_items, :aspsp_required_psu_headers, :jsonb, default: [] unless column_exists?(:enable_banking_items, :aspsp_required_psu_headers)
+    add_column :enable_banking_items, :aspsp_maximum_consent_validity, :integer unless column_exists?(:enable_banking_items, :aspsp_maximum_consent_validity)  # in seconds
+    add_column :enable_banking_items, :aspsp_auth_approach, :string unless column_exists?(:enable_banking_items, :aspsp_auth_approach)              # REDIRECT | EMBEDDED | DECOUPLED
+    add_column :enable_banking_items, :aspsp_psu_types, :jsonb, default: [] unless column_exists?(:enable_banking_items, :aspsp_psu_types)
     # PII/GDPR Notice: last_psu_ip stores the user's IP address.
     # - Required for the Psu-Ip-Address header in Enable Banking API requests
     # - Must be declared in the privacy policy
     # - Data retention: consider nullifying after session expiry or 90 days
-    add_column :enable_banking_items, :last_psu_ip, :string                      # user IP captured at request time
+    add_column :enable_banking_items, :last_psu_ip, :string unless column_exists?(:enable_banking_items, :last_psu_ip)                      # user IP captured at request time
 
     # Fix sync_start_date type: was datetime, should be date
     reversible do |dir|
@@ -28,8 +28,8 @@ class AddAspspMetadataToEnableBanking < ActiveRecord::Migration[7.2]
     end
 
     # Account-level fields from AccountResource
-    add_column :enable_banking_accounts, :product, :string                       # bank's proprietary product name
-    add_column :enable_banking_accounts, :credit_limit, :decimal, precision: 19, scale: 4
-    add_column :enable_banking_accounts, :identification_hashes, :jsonb, default: []
+    add_column :enable_banking_accounts, :product, :string unless column_exists?(:enable_banking_accounts, :product)                       # bank's proprietary product name
+    add_column :enable_banking_accounts, :credit_limit, :decimal, precision: 19, scale: 4 unless column_exists?(:enable_banking_accounts, :credit_limit)
+    add_column :enable_banking_accounts, :identification_hashes, :jsonb, default: [] unless column_exists?(:enable_banking_accounts, :identification_hashes)
   end
 end

--- a/db/migrate/20260627101954_add_balance_reversal_to_enable_banking_accounts.rb
+++ b/db/migrate/20260627101954_add_balance_reversal_to_enable_banking_accounts.rb
@@ -1,5 +1,5 @@
 class AddBalanceReversalToEnableBankingAccounts < ActiveRecord::Migration[7.2]
   def change
-    add_column :enable_banking_accounts, :treat_balance_as_available_credit, :boolean, default: false, null: false
+    add_column :enable_banking_accounts, :treat_balance_as_available_credit, :boolean, default: false, null: false unless column_exists?(:enable_banking_accounts, :treat_balance_as_available_credit)
   end
 end

--- a/lib/generators/provider/family/templates/activities_processor.rb.tt
+++ b/lib/generators/provider/family/templates/activities_processor.rb.tt
@@ -131,9 +131,9 @@ class <%= class_name %>Account::ActivitiesProcessor
 
       # Get the activity date
       # TODO: Customize date field names
-      activity_date = parse_date(data[:settlement_date]) ||
-                      parse_date(data[:trade_date]) ||
-                      parse_date(data[:date]) ||
+      activity_date = parse_date(data[:settlement_date], family: account&.family) ||
+                      parse_date(data[:trade_date], family: account&.family) ||
+                      parse_date(data[:date], family: account&.family) ||
                       Date.current
 
       currency = extract_currency(data, fallback: account.currency)
@@ -165,9 +165,9 @@ class <%= class_name %>Account::ActivitiesProcessor
 
       # Get the activity date
       # TODO: Customize date field names
-      activity_date = parse_date(data[:settlement_date]) ||
-                      parse_date(data[:trade_date]) ||
-                      parse_date(data[:date]) ||
+      activity_date = parse_date(data[:settlement_date], family: account&.family) ||
+                      parse_date(data[:trade_date], family: account&.family) ||
+                      parse_date(data[:date], family: account&.family) ||
                       Date.current
 
       # Build description

--- a/lib/generators/provider/family/templates/data_helpers.rb.tt
+++ b/lib/generators/provider/family/templates/data_helpers.rb.tt
@@ -39,17 +39,22 @@ module <%= class_name %>Account::DataHelpers
       nil
     end
 
-    def parse_date(date_value)
+    def parse_date(date_value, family: nil)
       return nil if date_value.nil?
+
+      tz = family&.timezone
 
       case date_value
       when Date
         date_value
       when String
-        # Use Time.zone.parse for external timestamps (Rails timezone guidelines)
-        Time.zone.parse(date_value)&.to_date
+        if tz && (date_value.include?("T") || date_value.include?(":"))
+          Time.parse(date_value).in_time_zone(tz).to_date
+        else
+          Date.parse(date_value)
+        end
       when Time, DateTime, ActiveSupport::TimeWithZone
-        date_value.to_date
+        date_value.in_time_zone(tz).to_date
       else
         nil
       end

--- a/lib/generators/provider/family/templates/data_helpers.rb.tt
+++ b/lib/generators/provider/family/templates/data_helpers.rb.tt
@@ -45,8 +45,6 @@ module <%= class_name %>Account::DataHelpers
       tz = family&.timezone
 
       case date_value
-      when Date
-        date_value
       when String
         if tz && (date_value.include?("T") || date_value.include?(":"))
           Time.parse(date_value).in_time_zone(tz).to_date
@@ -55,6 +53,8 @@ module <%= class_name %>Account::DataHelpers
         end
       when Time, DateTime, ActiveSupport::TimeWithZone
         date_value.in_time_zone(tz).to_date
+      when Date
+        date_value
       else
         nil
       end

--- a/lib/generators/provider/family/templates/transactions_processor.rb.tt
+++ b/lib/generators/provider/family/templates/transactions_processor.rb.tt
@@ -96,7 +96,7 @@ class <%= class_name %>Account::Transactions::Processor
       return nil if amount.nil?
 
       # TODO: Customize date field names based on your provider
-      date = parse_date(data[:date] || data[:transaction_date] || data[:posted_at])
+      date = parse_date(data[:date] || data[:transaction_date] || data[:posted_at], family: account&.family)
       return nil if date.nil?
 
       name = data[:name] || data[:description] || data[:merchant_name] || "Transaction"

--- a/test/models/akahu_entry/processor_test.rb
+++ b/test/models/akahu_entry/processor_test.rb
@@ -96,4 +96,24 @@ class AkahuEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal first_entry.id, second_entry.id
     assert_equal 1, @account.entries.where(source: "akahu").count
   end
+
+  test "converts unix timestamp date using family timezone not UTC" do
+    # 2025-07-14 23:30:00 UTC == 2025-07-15 11:30:00 NZST
+    @family.update!(timezone: "Pacific/Auckland")
+
+    transaction_data = {
+      _id: "tz_nz_test",
+      _account: "acc_123",
+      date: 1752537000, # 2025-07-14 23:30:00 UTC
+      merchant: { name: "Late Night Shop" },
+      description: "After midnight",
+      amount: -10.00,
+      currency: "NZD"
+    }
+
+    entry = AkahuEntry::Processor.new(transaction_data, akahu_account: @akahu_account).process
+
+    assert_not_nil entry
+    assert_equal Date.new(2025, 7, 15), entry.date
+  end
 end

--- a/test/models/akahu_entry/processor_test.rb
+++ b/test/models/akahu_entry/processor_test.rb
@@ -97,14 +97,14 @@ class AkahuEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal 1, @account.entries.where(source: "akahu").count
   end
 
-  test "converts unix timestamp date using family timezone not UTC" do
-    # 2025-07-14 23:30:00 UTC == 2025-07-15 11:30:00 NZST
+  test "converts ISO string timestamp date using family timezone not UTC" do
+    # 2025-07-14T23:30:00Z (23:30:00 UTC) == 2025-07-15 11:30:00 NZST
     @family.update!(timezone: "Pacific/Auckland")
 
     transaction_data = {
       _id: "tz_nz_test",
       _account: "acc_123",
-      date: 1752535800, # 2025-07-14 23:30:00 UTC
+      date: "2025-07-14T23:30:00Z", # 2025-07-14 23:30:00 UTC
       merchant: { name: "Late Night Shop" },
       description: "After midnight",
       amount: -10.00,

--- a/test/models/akahu_entry/processor_test.rb
+++ b/test/models/akahu_entry/processor_test.rb
@@ -104,7 +104,7 @@ class AkahuEntry::ProcessorTest < ActiveSupport::TestCase
     transaction_data = {
       _id: "tz_nz_test",
       _account: "acc_123",
-      date: 1752537000, # 2025-07-14 23:30:00 UTC
+      date: 1752535800, # 2025-07-14 23:30:00 UTC
       merchant: { name: "Late Night Shop" },
       description: "After midnight",
       amount: -10.00,

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -438,7 +438,7 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     tx = {
       entry_reference: "tz_ref",
       transaction_id: nil,
-      booking_date: 1752537000, # 2025-07-14 23:30:00 UTC
+      booking_date: 1752535800, # 2025-07-14 23:30:00 UTC
       transaction_amount: { amount: "10.00", currency: "EUR" },
       creditor: { name: "Late Night Shop" },
       credit_debit_indicator: "DBIT",

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -430,4 +430,25 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
 
     assert_nil processor.send(:merchant)
   end
+
+  test "converts unix timestamp date using family timezone not UTC" do
+    # 2025-07-14 23:30:00 UTC == 2025-07-15 01:30:00 CEST
+    @family.update!(timezone: "Europe/Berlin")
+
+    tx = {
+      entry_reference: "tz_ref",
+      transaction_id: nil,
+      booking_date: 1752537000, # 2025-07-14 23:30:00 UTC
+      transaction_amount: { amount: "10.00", currency: "EUR" },
+      creditor: { name: "Late Night Shop" },
+      credit_debit_indicator: "DBIT",
+      remittance_information: [ "After midnight" ],
+      status: "BOOK"
+    }
+
+    result = EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+
+    assert_not_nil result
+    assert_equal Date.new(2025, 7, 15), result.date
+  end
 end

--- a/test/models/lunchflow_entry/processor_test.rb
+++ b/test/models/lunchflow_entry/processor_test.rb
@@ -378,4 +378,27 @@ class LunchflowEntry::ProcessorTest < ActiveSupport::TestCase
     assert result.entryable.pending?, "Should create new pending entry when merchant doesn't match"
     assert result.external_id.start_with?("lunchflow_pending_"), "Should have temporary ID"
   end
+
+  test "converts unix timestamp date using family timezone not UTC" do
+    # 2025-07-14 23:30:00 UTC == 2025-07-15 00:30:00 BST
+    @family.update!(timezone: "Europe/London")
+
+    transaction_data = {
+      id: "lf_tz_test",
+      accountId: 456,
+      amount: -10.00,
+      currency: "GBP",
+      date: 1752537000, # 2025-07-14 23:30:00 UTC
+      merchant: "Late Night Shop",
+      description: "After midnight"
+    }
+
+    result = LunchflowEntry::Processor.new(
+      transaction_data,
+      lunchflow_account: @lunchflow_account
+    ).process
+
+    assert_not_nil result
+    assert_equal Date.new(2025, 7, 15), result.date
+  end
 end

--- a/test/models/lunchflow_entry/processor_test.rb
+++ b/test/models/lunchflow_entry/processor_test.rb
@@ -388,7 +388,7 @@ class LunchflowEntry::ProcessorTest < ActiveSupport::TestCase
       accountId: 456,
       amount: -10.00,
       currency: "GBP",
-      date: 1752537000, # 2025-07-14 23:30:00 UTC
+      date: 1752535800, # 2025-07-14 23:30:00 UTC
       merchant: "Late Night Shop",
       description: "After midnight"
     }

--- a/test/models/lunchflow_entry/processor_test.rb
+++ b/test/models/lunchflow_entry/processor_test.rb
@@ -379,16 +379,17 @@ class LunchflowEntry::ProcessorTest < ActiveSupport::TestCase
     assert result.external_id.start_with?("lunchflow_pending_"), "Should have temporary ID"
   end
 
-  test "converts unix timestamp date using family timezone not UTC" do
-    # 2025-07-14 23:30:00 UTC == 2025-07-15 00:30:00 BST
-    @family.update!(timezone: "Europe/London")
+  test "converts unix timestamp date using negative family timezone offset" do
+    # 2025-07-15 01:20:00 UTC == 2025-07-14 21:20:00 EDT (UTC-4 in summer)
+    # Without timezone fix this would land on July 15; with fix it lands on July 14.
+    @family.update!(timezone: "America/New_York")
 
     transaction_data = {
-      id: "lf_tz_test",
+      id: "lf_tz_neg_test",
       accountId: 456,
       amount: -10.00,
-      currency: "GBP",
-      date: 1752535800, # 2025-07-14 23:30:00 UTC
+      currency: "USD",
+      date: 1752542400, # 2025-07-15 01:20:00 UTC == 2025-07-14 21:20:00 EDT
       merchant: "Late Night Shop",
       description: "After midnight"
     }
@@ -399,6 +400,7 @@ class LunchflowEntry::ProcessorTest < ActiveSupport::TestCase
     ).process
 
     assert_not_nil result
-    assert_equal Date.new(2025, 7, 15), result.date
+    assert_equal Date.new(2025, 7, 14), result.date,
+      "Transaction at 21:20 EDT should land on July 14, not July 15"
   end
 end


### PR DESCRIPTION
This PR fixes #2668 and implements some tests surrounding the edge case.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction date parsing across multiple providers to respect the account family timezone when converting timestamps to `Date`, including Unix timestamps, ISO-like datetime strings, and `Time`/`DateTime` inputs.
  - Handles datetime-like strings vs date-only strings more reliably to avoid off-by-one-day issues near midnight.
- **Tests**
  - Added/extended unit coverage to verify timezone-aware date conversion for Akahu, Enable Banking, Lunchflow, and other affected processors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->