### PR TITLE
Add insurance account configuration

### DIFF
--- a/app/components/UI/account/balance_reconciliation.rb
+++ b/app/components/UI/account/balance_reconciliation.rb
@@ -16,7 +16,7 @@ class UI::Account::BalanceReconciliation < ApplicationComponent
       investment_items
     when "Loan"
       loan_items
-    when "Property", "Vehicle"
+    when "Insurance", "Property", "Vehicle"
       asset_items
     when "Crypto"
       crypto_items

--- a/app/components/UI/account_page.rb
+++ b/app/components/UI/account_page.rb
@@ -46,7 +46,7 @@ class UI::AccountPage < ApplicationComponent
     base_tabs = case account.accountable_type
     when "Investment", "Crypto"
       [ :activity, :holdings ]
-    when "Property", "Vehicle", "Loan"
+    when "Insurance", "Property", "Vehicle", "Loan"
       [ :activity, :overview ]
     else
       [ :activity ]

--- a/app/controllers/insurances_controller.rb
+++ b/app/controllers/insurances_controller.rb
@@ -1,0 +1,5 @@
+class InsurancesController < ApplicationController
+  include AccountableResource
+
+  permitted_accountable_attributes :id, *Insurance::POLICY_ATTRIBUTES
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -584,7 +584,7 @@ class Account < ApplicationRecord
     case accountable_type
     when "Depository", "CreditCard"
       :cash
-    when "Property", "Vehicle", "OtherAsset", "Loan", "OtherLiability"
+    when "Insurance", "Property", "Vehicle", "OtherAsset", "Loan", "OtherLiability"
       :non_cash
     when "Investment", "Crypto"
       :investment

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -1,7 +1,7 @@
 module Accountable
   extend ActiveSupport::Concern
 
-  TYPES = %w[Depository Investment Crypto Property Vehicle OtherAsset CreditCard Loan OtherLiability]
+  TYPES = %w[Depository Investment Insurance Crypto Property Vehicle OtherAsset CreditCard Loan OtherLiability]
 
   # Define empty hash to ensure all accountables have this defined
   SUBTYPES = {}.freeze

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -33,7 +33,7 @@ class Family::DataImporter
 
   SUPPORTED_TYPES = %w[Account Balance Category Tag Merchant RecurringTransaction Transaction Transfer RejectedTransfer Trade Holding Valuation Budget BudgetCategory Rule].freeze
   ACCOUNTABLE_TYPE_CLASSES = {
-    "Depository" => Depository, "Investment" => Investment, "Crypto" => Crypto,
+    "Depository" => Depository, "Investment" => Investment, "Insurance" => Insurance, "Crypto" => Crypto,
     "Property" => Property, "Vehicle" => Vehicle, "OtherAsset" => OtherAsset,
     "CreditCard" => CreditCard, "Loan" => Loan, "OtherLiability" => OtherLiability
   }.freeze
@@ -293,6 +293,7 @@ class Family::DataImporter
 
           # Copy any other accountable attributes
           safe_accountable_attrs = %w[subtype locked_attributes]
+          safe_accountable_attrs += Insurance::POLICY_ATTRIBUTES.map(&:to_s) if accountable_type == "Insurance"
           safe_accountable_attrs.each do |attr|
             if accountable.respond_to?("#{attr}=") && accountable_data[attr].present?
               accountable.send("#{attr}=", accountable_data[attr])
@@ -307,7 +308,7 @@ class Family::DataImporter
           balance: data["balance"].to_d,
           cash_balance: data["cash_balance"]&.to_d || data["balance"].to_d,
           currency: data["currency"] || @family.currency,
-          subtype: data["subtype"],
+          subtype: data["subtype"].presence || accountable_data["subtype"],
           institution_name: data["institution_name"],
           institution_domain: data["institution_domain"],
           notes: data["notes"],

--- a/app/models/insurance.rb
+++ b/app/models/insurance.rb
@@ -1,0 +1,76 @@
+class Insurance < ApplicationRecord
+  include Accountable
+
+  SUBTYPES = {
+    "life" => { short: "Life", long: "Life Insurance" },
+    "health" => { short: "Health", long: "Health Insurance" },
+    "disability" => { short: "Disability", long: "Disability Insurance" },
+    "long_term_care" => { short: "Long-term Care", long: "Long-term Care Insurance" },
+    "homeowners" => { short: "Homeowners", long: "Homeowners Insurance" },
+    "renters" => { short: "Renters", long: "Renters Insurance" },
+    "auto" => { short: "Auto", long: "Auto Insurance" },
+    "umbrella" => { short: "Umbrella", long: "Umbrella Insurance" },
+    "travel" => { short: "Travel", long: "Travel Insurance" },
+    "pet" => { short: "Pet", long: "Pet Insurance" },
+    "other" => { short: "Other", long: "Other Insurance" }
+  }.freeze
+
+  PREMIUM_FREQUENCIES = %w[monthly quarterly semi_annual annual one_time other].freeze
+  POLICY_ATTRIBUTES = %i[
+    subtype policy_number coverage_amount premium_amount premium_frequency
+    effective_date expiration_date renewal_date insured_name beneficiaries
+  ].freeze
+
+  validates :subtype, inclusion: { in: SUBTYPES.keys }, allow_blank: true
+  validates :premium_frequency, inclusion: { in: PREMIUM_FREQUENCIES }, allow_blank: true
+  validates :coverage_amount, :premium_amount,
+            numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :expiration_date_follows_effective_date
+
+  def policy_status(on: Date.current)
+    return :upcoming if effective_date.present? && effective_date > on
+    return :expired if expiration_date.present? && expiration_date < on
+    return :renewal_due if renewal_date.present? && renewal_date.between?(on, on + 30.days)
+    return :expiring_soon if expiration_date.present? && expiration_date.between?(on, on + 30.days)
+
+    :active
+  end
+
+  def coverage_amount_money
+    Money.new(coverage_amount, account.currency) if coverage_amount.present?
+  end
+
+  def premium_amount_money
+    Money.new(premium_amount, account.currency) if premium_amount.present?
+  end
+
+  def balance_display_name
+    "cash value"
+  end
+
+  def opening_balance_display_name
+    "opening cash value"
+  end
+
+  class << self
+    def color
+      "#0284C7"
+    end
+
+    def icon
+      "shield"
+    end
+
+    def classification
+      "asset"
+    end
+  end
+
+  private
+    def expiration_date_follows_effective_date
+      return if effective_date.blank? || expiration_date.blank?
+      return if expiration_date >= effective_date
+
+      errors.add(:expiration_date, :before_effective_date)
+    end
+end

--- a/app/models/valuation/name.rb
+++ b/app/models/valuation/name.rb
@@ -24,6 +24,8 @@ class Valuation::Name
         "Original purchase price"
       when "Loan"
         "Original principal"
+      when "Insurance"
+        "Opening cash value"
       when "Investment", "Crypto", "OtherAsset"
         "Opening account value"
       else
@@ -37,6 +39,8 @@ class Valuation::Name
         "Current market value"
       when "Loan"
         "Current loan balance"
+      when "Insurance"
+        "Current cash value"
       when "Investment", "Crypto", "OtherAsset"
         "Current account value"
       else
@@ -50,6 +54,8 @@ class Valuation::Name
         "Manual value update"
       when "Loan"
         "Manual principal update"
+      when "Insurance"
+        "Manual cash value update"
       else
         "Manual balance update"
       end

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (account:, url:) %>
+<%# locals: (account:, url:, balance_label: nil) %>
 
 <% if @error_message.present? %>
   <%= render DS::Alert.new(message: @error_message, variant: :error) %>
@@ -12,7 +12,7 @@
     <%= form.text_field :name, placeholder: t(".name_placeholder"), required: "required", label: t(".name_label") %>
 
     <% unless account.linked? %>
-      <%= form.money_field :balance, label: t(".balance"), required: true, default_currency: Current.family.currency %>
+      <%= form.money_field :balance, label: balance_label || t(".balance"), required: true, default_currency: Current.family.currency %>
     <% end %>
 
     <% if account.new_record? && !account.linked? %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -6,6 +6,7 @@
     <% unless params[:classification] == "liability" %>
       <%= render "account_type", accountable: Depository.new %>
       <%= render "account_type", accountable: Investment.new %>
+      <%= render "account_type", accountable: Insurance.new %>
       <%= render "account_type", accountable: Crypto.new %>
       <%= render "account_type", accountable: Property.new %>
       <%= render "account_type", accountable: Vehicle.new %>

--- a/app/views/insurances/_form.html.erb
+++ b/app/views/insurances/_form.html.erb
@@ -1,0 +1,57 @@
+<%# locals: (account:, url:) %>
+
+<%= render DS::Alert.new(
+  title: t("insurances.form.cash_value_title"),
+  message: t("insurances.form.cash_value_hint"),
+  variant: :info
+) %>
+
+<div class="mt-4">
+  <%= render "accounts/form", account: account, url: url, balance_label: t("insurances.form.cash_value") do |form| %>
+    <%= render "shared/ruler", classes: "my-4" %>
+
+    <div class="space-y-2">
+      <%= form.fields_for :accountable do |insurance_form| %>
+        <%= insurance_form.select :subtype,
+                                  Insurance.subtype_options_for_select,
+                                  { label: t("insurances.form.subtype"), prompt: t("insurances.form.subtype_prompt") } %>
+
+        <%= insurance_form.text_field :policy_number,
+                                      label: t("insurances.form.policy_number"),
+                                      placeholder: t("insurances.form.policy_number_placeholder") %>
+
+        <div class="flex items-center gap-2">
+          <%= insurance_form.money_field :coverage_amount,
+                                         label: t("insurances.form.coverage_amount"),
+                                         default_currency: Current.family.currency,
+                                         hide_currency: true,
+                                         min: 0 %>
+          <%= insurance_form.money_field :premium_amount,
+                                         label: t("insurances.form.premium_amount"),
+                                         default_currency: Current.family.currency,
+                                         hide_currency: true,
+                                         min: 0 %>
+        </div>
+
+        <%= insurance_form.select :premium_frequency,
+                                  Insurance::PREMIUM_FREQUENCIES.map { |frequency| [t("insurances.premium_frequencies.#{frequency}"), frequency] },
+                                  { label: t("insurances.form.premium_frequency"), prompt: t("insurances.form.premium_frequency_prompt") } %>
+
+        <div class="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          <%= insurance_form.date_field :effective_date, label: t("insurances.form.effective_date") %>
+          <%= insurance_form.date_field :renewal_date, label: t("insurances.form.renewal_date") %>
+          <%= insurance_form.date_field :expiration_date, label: t("insurances.form.expiration_date") %>
+        </div>
+
+        <%= insurance_form.text_field :insured_name,
+                                      label: t("insurances.form.insured_name"),
+                                      placeholder: t("insurances.form.insured_name_placeholder") %>
+
+        <%= insurance_form.text_area :beneficiaries,
+                                    label: t("insurances.form.beneficiaries"),
+                                    placeholder: t("insurances.form.beneficiaries_placeholder"),
+                                    rows: 3 %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/insurances/edit.html.erb
+++ b/app/views/insurances/edit.html.erb
@@ -1,0 +1,6 @@
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_header(title: t(".edit", account: @account.name)) %>
+  <% dialog.with_body do %>
+    <%= render "form", account: @account, url: insurance_path(@account) %>
+  <% end %>
+<% end %>

--- a/app/views/insurances/new.html.erb
+++ b/app/views/insurances/new.html.erb
@@ -1,0 +1,13 @@
+<% if params[:step] == "method_select" %>
+  <%= render "accounts/new/method_selector",
+             path: new_insurance_path(return_to: params[:return_to]),
+             provider_configs: @provider_configs,
+             accountable_type: "Insurance" %>
+<% else %>
+  <%= render DS::Dialog.new do |dialog| %>
+    <% dialog.with_header(title: t(".title")) %>
+    <% dialog.with_body do %>
+      <%= render "insurances/form", account: @account, url: insurances_path %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/insurances/tabs/_overview.html.erb
+++ b/app/views/insurances/tabs/_overview.html.erb
@@ -1,0 +1,70 @@
+<%# locals: (account:) %>
+<% insurance = account.insurance %>
+<% status_tone = { active: :success, upcoming: :neutral, renewal_due: :warning, expiring_soon: :warning, expired: :error }.fetch(insurance.policy_status) %>
+
+<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+  <%= summary_card title: t(".status") do %>
+    <%= render DS::Pill.new(
+      label: t("insurances.statuses.#{insurance.policy_status}"),
+      tone: status_tone,
+      marker: false
+    ) %>
+  <% end %>
+
+  <%= summary_card title: t(".type") do %>
+    <%= Insurance.long_subtype_label_for(insurance.subtype) || t(".unknown") %>
+  <% end %>
+
+  <%= summary_card title: t(".policy_number") do %>
+    <%= insurance.policy_number.presence || t(".unknown") %>
+  <% end %>
+
+  <%= summary_card title: t(".coverage_amount") do %>
+    <%= insurance.coverage_amount_money ? format_money(insurance.coverage_amount_money) : t(".unknown") %>
+  <% end %>
+
+  <%= summary_card title: t(".cash_value") do %>
+    <%= format_money(account.balance_money) %>
+  <% end %>
+
+  <%= summary_card title: t(".premium") do %>
+    <% if insurance.premium_amount_money %>
+      <%= t(
+        ".premium_with_frequency",
+        amount: format_money(insurance.premium_amount_money),
+        frequency: insurance.premium_frequency.present? ? t("insurances.premium_frequencies.#{insurance.premium_frequency}") : t(".frequency_unknown")
+      ) %>
+    <% else %>
+      <%= t(".unknown") %>
+    <% end %>
+  <% end %>
+
+  <%= summary_card title: t(".effective_date") do %>
+    <%= insurance.effective_date ? l(insurance.effective_date, format: :long) : t(".unknown") %>
+  <% end %>
+
+  <%= summary_card title: t(".renewal_date") do %>
+    <%= insurance.renewal_date ? l(insurance.renewal_date, format: :long) : t(".unknown") %>
+  <% end %>
+
+  <%= summary_card title: t(".expiration_date") do %>
+    <%= insurance.expiration_date ? l(insurance.expiration_date, format: :long) : t(".unknown") %>
+  <% end %>
+
+  <%= summary_card title: t(".insured_name") do %>
+    <%= insurance.insured_name.presence || t(".unknown") %>
+  <% end %>
+
+  <%= summary_card title: t(".beneficiaries") do %>
+    <%= insurance.beneficiaries.presence || t(".unknown") %>
+  <% end %>
+</div>
+
+<div class="flex justify-center py-8">
+  <%= render DS::Link.new(
+    text: t(".edit_insurance_details"),
+    variant: "ghost",
+    href: edit_insurance_path(account),
+    frame: :modal
+  ) %>
+</div>

--- a/config/locales/breadcrumbs/en.yml
+++ b/config/locales/breadcrumbs/en.yml
@@ -39,6 +39,7 @@ en:
     indexa_capital_items: Indexa Capital
     intro: Intro
     investments: Investments
+    insurances: Insurance
     invitations: Invitations
     invite_codes: Invite codes
     kraken_items: Kraken

--- a/config/locales/breadcrumbs/zh-CN.yml
+++ b/config/locales/breadcrumbs/zh-CN.yml
@@ -39,6 +39,7 @@ zh-CN:
     indexa_capital_items: Indexa Capital
     intro: 介绍
     investments: 投资
+    insurances: 保险
     invitations: 邀请
     invite_codes: 邀请码
     kraken_items: Kraken

--- a/config/locales/models/account/en.yml
+++ b/config/locales/models/account/en.yml
@@ -27,6 +27,7 @@ en:
       account/credit: Credit Card
       account/depository: Bank Account
       account/investment: Investment
+      account/insurance: Insurance
       account/loan: Loan
       account/other_asset: Other Asset
       account/other_liability: Other Liability

--- a/config/locales/models/account/zh-CN.yml
+++ b/config/locales/models/account/zh-CN.yml
@@ -14,6 +14,7 @@ zh-CN:
       account/credit: 信用卡
       account/depository: 银行账户
       account/investment: 投资账户
+      account/insurance: 保险
       account/loan: 贷款
       account/other_asset: 其他资产
       account/other_liability: 其他负债

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -144,6 +144,7 @@ en:
     types:
       depository: Cash
       investment: Investment
+      insurance: Insurance
       crypto: Crypto
       property: Property
       vehicle: Vehicle
@@ -154,6 +155,7 @@ en:
     types_plural:
       depository: Cash
       investment: Investments
+      insurance: Insurance
       crypto: Crypto
       property: Properties
       vehicle: Vehicles

--- a/config/locales/views/accounts/zh-CN.yml
+++ b/config/locales/views/accounts/zh-CN.yml
@@ -131,6 +131,7 @@ zh-CN:
     types:
       depository: 现金
       investment: 投资
+      insurance: 保险
       crypto: 加密资产
       property: 房产
       vehicle: 车辆
@@ -141,6 +142,7 @@ zh-CN:
     types_plural:
       depository: 现金
       investment: 投资
+      insurance: 保险
       crypto: 加密资产
       property: 房产
       vehicle: 车辆

--- a/config/locales/views/insurances/en.yml
+++ b/config/locales/views/insurances/en.yml
@@ -1,0 +1,97 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        insurance:
+          attributes:
+            expiration_date:
+              before_effective_date: must be on or after the effective date
+  insurances:
+    edit:
+      edit: Edit %{account}
+    form:
+      beneficiaries: Beneficiaries
+      beneficiaries_placeholder: Names and allocation details
+      cash_value_hint: Enter the policy's current cash or surrender value as the account balance. Use zero for policies without a cash value; coverage is tracked separately.
+      cash_value_title: How this affects net worth
+      cash_value: Cash or surrender value
+      coverage_amount: Coverage amount
+      effective_date: Effective date
+      expiration_date: Expiration date
+      insured_name: Insured person or asset
+      insured_name_placeholder: Name of the covered person or asset
+      policy_number: Policy number
+      policy_number_placeholder: e.g., POL-123456
+      premium_amount: Premium amount
+      premium_frequency: Premium frequency
+      premium_frequency_prompt: Select a frequency
+      renewal_date: Renewal date
+      subtype: Insurance type
+      subtype_prompt: Select insurance type
+    new:
+      title: Enter insurance details
+    premium_frequencies:
+      annual: Annual
+      monthly: Monthly
+      one_time: One time
+      other: Other
+      quarterly: Quarterly
+      semi_annual: Semiannual
+    statuses:
+      active: Active
+      expired: Expired
+      expiring_soon: Expiring soon
+      renewal_due: Renewal due
+      upcoming: Upcoming
+    subtypes:
+      auto:
+        long: Auto Insurance
+        short: Auto
+      disability:
+        long: Disability Insurance
+        short: Disability
+      health:
+        long: Health Insurance
+        short: Health
+      homeowners:
+        long: Homeowners Insurance
+        short: Homeowners
+      life:
+        long: Life Insurance
+        short: Life
+      long_term_care:
+        long: Long-term Care Insurance
+        short: Long-term Care
+      other:
+        long: Other Insurance
+        short: Other
+      pet:
+        long: Pet Insurance
+        short: Pet
+      renters:
+        long: Renters Insurance
+        short: Renters
+      travel:
+        long: Travel Insurance
+        short: Travel
+      umbrella:
+        long: Umbrella Insurance
+        short: Umbrella
+    tabs:
+      overview:
+        beneficiaries: Beneficiaries
+        cash_value: Cash value
+        coverage_amount: Coverage amount
+        edit_insurance_details: Edit insurance details
+        effective_date: Effective date
+        expiration_date: Expiration date
+        frequency_unknown: Frequency not set
+        insured_name: Insured person or asset
+        policy_number: Policy number
+        premium: Premium
+        premium_with_frequency: "%{amount} · %{frequency}"
+        renewal_date: Renewal date
+        status: Policy status
+        type: Type
+        unknown: Unknown

--- a/config/locales/views/insurances/zh-CN.yml
+++ b/config/locales/views/insurances/zh-CN.yml
@@ -1,0 +1,97 @@
+---
+zh-CN:
+  activerecord:
+    errors:
+      models:
+        insurance:
+          attributes:
+            expiration_date:
+              before_effective_date: 不能早于生效日期
+  insurances:
+    edit:
+      edit: 编辑%{account}
+    form:
+      beneficiaries: 受益人
+      beneficiaries_placeholder: 姓名及分配说明
+      cash_value_hint: 请将保单当前的现金价值或退保价值填为账户余额。没有现金价值的保单请填 0；保额会单独记录。
+      cash_value_title: 对净资产的影响
+      cash_value: 现金价值或退保价值
+      coverage_amount: 保额
+      effective_date: 生效日期
+      expiration_date: 到期日期
+      insured_name: 被保险人或标的
+      insured_name_placeholder: 被保障的人或资产名称
+      policy_number: 保单号
+      policy_number_placeholder: 例如 POL-123456
+      premium_amount: 保费金额
+      premium_frequency: 缴费频率
+      premium_frequency_prompt: 选择缴费频率
+      renewal_date: 续保日期
+      subtype: 保险类型
+      subtype_prompt: 选择保险类型
+    new:
+      title: 请输入保险详情
+    premium_frequencies:
+      annual: 每年
+      monthly: 每月
+      one_time: 一次性
+      other: 其他
+      quarterly: 每季度
+      semi_annual: 每半年
+    statuses:
+      active: 生效中
+      expired: 已到期
+      expiring_soon: 即将到期
+      renewal_due: 即将续保
+      upcoming: 尚未生效
+    subtypes:
+      auto:
+        long: 车险
+        short: 车险
+      disability:
+        long: 伤残保险
+        short: 伤残险
+      health:
+        long: 健康保险
+        short: 健康险
+      homeowners:
+        long: 房主保险
+        short: 房主险
+      life:
+        long: 人寿保险
+        short: 寿险
+      long_term_care:
+        long: 长期护理保险
+        short: 长护险
+      other:
+        long: 其他保险
+        short: 其他
+      pet:
+        long: 宠物保险
+        short: 宠物险
+      renters:
+        long: 租客保险
+        short: 租客险
+      travel:
+        long: 旅行保险
+        short: 旅行险
+      umbrella:
+        long: 伞式责任保险
+        short: 伞式保险
+    tabs:
+      overview:
+        beneficiaries: 受益人
+        cash_value: 现金价值
+        coverage_amount: 保额
+        edit_insurance_details: 编辑保险详情
+        effective_date: 生效日期
+        expiration_date: 到期日期
+        frequency_unknown: 未设置频率
+        insured_name: 被保险人或标的
+        policy_number: 保单号
+        premium: 保费
+        premium_with_frequency: "%{amount} · %{frequency}"
+        renewal_date: 续保日期
+        status: 保单状态
+        type: 类型
+        unknown: 未填写

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -553,6 +553,7 @@ Rails.application.routes.draw do
 
   resources :depositories, only: %i[new create edit update]
   resources :investments, only: %i[new create edit update]
+  resources :insurances, only: %i[new create edit update]
   resources :properties, only: %i[new create edit update] do
     member do
       get :balances

--- a/db/migrate/20260722120000_create_insurances.rb
+++ b/db/migrate/20260722120000_create_insurances.rb
@@ -1,0 +1,19 @@
+class CreateInsurances < ActiveRecord::Migration[7.2]
+  def change
+    create_table :insurances, id: :uuid do |t|
+      t.string :subtype
+      t.string :policy_number
+      t.decimal :coverage_amount, precision: 19, scale: 4
+      t.decimal :premium_amount, precision: 19, scale: 4
+      t.string :premium_frequency
+      t.date :effective_date
+      t.date :expiration_date
+      t.date :renewal_date
+      t.string :insured_name
+      t.text :beneficiaries
+      t.jsonb :locked_attributes, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -1173,6 +1173,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120000) do
     t.index ["family_id", "status"], name: "index_insights_on_family_id_and_status"
     t.check_constraint "priority::text = ANY (ARRAY['high'::character varying, 'medium'::character varying, 'low'::character varying]::text[])", name: "chk_insights_priority"
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'read'::character varying, 'dismissed'::character varying, 'expired'::character varying]::text[])", name: "chk_insights_status"
+  end
+
+  create_table "insurances", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "beneficiaries"
+    t.decimal "coverage_amount", precision: 19, scale: 4
+    t.datetime "created_at", null: false
+    t.date "effective_date"
+    t.date "expiration_date"
+    t.string "insured_name"
+    t.jsonb "locked_attributes", default: {}
+    t.string "policy_number"
+    t.decimal "premium_amount", precision: 19, scale: 4
+    t.string "premium_frequency"
+    t.date "renewal_date"
+    t.string "subtype"
+    t.datetime "updated_at", null: false
   end
 
   create_table "investments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/controllers/insurances_controller_test.rb
+++ b/test/controllers/insurances_controller_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+
+class InsurancesControllerTest < ActionDispatch::IntegrationTest
+  include AccountableResourceInterfaceTest
+
+  setup do
+    sign_in @user = users(:family_admin)
+    @account = accounts(:insurance)
+  end
+
+  test "creates with insurance details" do
+    assert_difference -> { Account.count } => 1,
+      -> { Insurance.count } => 1,
+      -> { Valuation.count } => 1,
+      -> { Entry.count } => 1 do
+      post insurances_path, params: {
+        account: {
+          name: "New Policy",
+          balance: 12500,
+          currency: "USD",
+          institution_name: "Sure Insurance",
+          institution_domain: "sure-insurance.example",
+          notes: "Policy notes",
+          accountable_type: "Insurance",
+          accountable_attributes: {
+            subtype: "life",
+            policy_number: "POL-123",
+            coverage_amount: 500000,
+            premium_amount: 150,
+            premium_frequency: "monthly",
+            effective_date: "2026-01-01",
+            expiration_date: "2036-01-01",
+            renewal_date: "2027-01-01",
+            insured_name: "Dylan",
+            beneficiaries: "Family trust"
+          }
+        }
+      }
+    end
+
+    created_account = Account.order(:created_at).last
+    insurance = created_account.insurance
+
+    assert_equal "New Policy", created_account.name
+    assert_equal 12500, created_account.balance
+    assert_equal "Insurance", created_account.accountable_type
+    assert_equal "life", insurance.subtype
+    assert_equal "POL-123", insurance.policy_number
+    assert_equal 500000, insurance.coverage_amount
+    assert_equal 150, insurance.premium_amount
+    assert_equal "monthly", insurance.premium_frequency
+    assert_equal Date.new(2026, 1, 1), insurance.effective_date
+    assert_equal Date.new(2036, 1, 1), insurance.expiration_date
+    assert_equal Date.new(2027, 1, 1), insurance.renewal_date
+    assert_equal "Dylan", insurance.insured_name
+    assert_equal "Family trust", insurance.beneficiaries
+
+    assert_redirected_to created_account
+    assert_equal "Insurance account created", flash[:notice]
+    assert_enqueued_with(job: SyncJob)
+  end
+
+  test "updates with insurance details" do
+    assert_no_difference [ "Account.count", "Insurance.count" ] do
+      patch insurance_path(@account), params: {
+        account: {
+          name: "Updated Policy",
+          balance: 30000,
+          currency: "USD",
+          accountable_type: "Insurance",
+          accountable_attributes: {
+            id: @account.accountable_id,
+            subtype: "umbrella",
+            policy_number: "POL-456",
+            coverage_amount: 1000000,
+            premium_amount: 500,
+            premium_frequency: "annual",
+            effective_date: "2026-02-01",
+            expiration_date: "2027-02-01",
+            renewal_date: "2027-01-01",
+            insured_name: "Dylan Family",
+            beneficiaries: "Household"
+          }
+        }
+      }
+    end
+
+    @account.reload
+    insurance = @account.insurance
+
+    assert_equal "Updated Policy", @account.name
+    assert_equal 30000, @account.balance
+    assert_equal "umbrella", insurance.subtype
+    assert_equal "POL-456", insurance.policy_number
+    assert_equal 1000000, insurance.coverage_amount
+    assert_equal 500, insurance.premium_amount
+    assert_equal "annual", insurance.premium_frequency
+    assert_equal Date.new(2026, 2, 1), insurance.effective_date
+    assert_equal Date.new(2027, 2, 1), insurance.expiration_date
+    assert_equal Date.new(2027, 1, 1), insurance.renewal_date
+    assert_equal "Dylan Family", insurance.insured_name
+    assert_equal "Household", insurance.beneficiaries
+
+    assert_redirected_to @account
+    assert_equal "Insurance account updated", flash[:notice]
+    assert_enqueued_with(job: SyncJob)
+  end
+
+  test "shows policy overview on the account page" do
+    get account_path(@account, tab: "overview")
+
+    assert_response :success
+    assert_select "main", text: /Life Insurance/
+    assert_select "main", text: /LIFE-12345/
+    assert_select "main", text: /Family trust/
+  end
+end

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -8,6 +8,16 @@ other_asset:
   accountable: one
   status: active
 
+insurance:
+  family: dylan_family
+  owner: family_admin
+  name: Whole Life Policy
+  balance: 25000
+  currency: USD
+  accountable_type: Insurance
+  accountable: one
+  status: active
+
 other_liability:
   family: dylan_family
   owner: family_admin

--- a/test/fixtures/insurances.yml
+++ b/test/fixtures/insurances.yml
@@ -1,0 +1,11 @@
+one:
+  subtype: life
+  policy_number: LIFE-12345
+  coverage_amount: 500000
+  premium_amount: 150
+  premium_frequency: monthly
+  effective_date: <%= 1.year.ago.to_date %>
+  expiration_date: <%= 10.years.from_now.to_date %>
+  renewal_date: <%= 6.months.from_now.to_date %>
+  insured_name: Dylan Family
+  beneficiaries: Family trust

--- a/test/models/account/current_balance_manager_test.rb
+++ b/test/models/account/current_balance_manager_test.rb
@@ -53,7 +53,7 @@ class Account::CurrentBalanceManagerTest < ActiveSupport::TestCase
   end
 
   test "all manual non cash accounts append reconciliations for current balance updates" do
-    [ Property, Vehicle, OtherAsset, Loan, OtherLiability ].each do |account_type|
+    [ Insurance, Property, Vehicle, OtherAsset, Loan, OtherLiability ].each do |account_type|
       account = @family.accounts.create!(
         name: "Test",
         balance: 1000,

--- a/test/models/balance/forward_calculator_test.rb
+++ b/test/models/balance/forward_calculator_test.rb
@@ -436,7 +436,7 @@ class Balance::ForwardCalculatorTest < ActiveSupport::TestCase
   end
 
   test "non cash accounts can only use valuations and transactions will be recorded but ignored for balance calculation" do
-    [ Property, Vehicle, OtherAsset, OtherLiability ].each do |account_type|
+    [ Insurance, Property, Vehicle, OtherAsset, OtherLiability ].each do |account_type|
       account = create_account_with_ledger(
         account: { type: account_type, currency: "USD" },
         entries: [

--- a/test/models/balance/reverse_calculator_test.rb
+++ b/test/models/balance/reverse_calculator_test.rb
@@ -594,7 +594,7 @@ class Balance::ReverseCalculatorTest < ActiveSupport::TestCase
   end
 
   test "non cash accounts can only use valuations and transactions will be recorded but ignored for balance calculation" do
-    [ Property, Vehicle, OtherAsset, OtherLiability ].each do |account_type|
+    [ Insurance, Property, Vehicle, OtherAsset, OtherLiability ].each do |account_type|
       account = create_account_with_ledger(
         account: { type: account_type, balance: 1000, cash_balance: 0, currency: "USD" },
         entries: [

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -31,6 +31,48 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal "Depository", account.accountable_type
   end
 
+  test "imports insurance policy details" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "insurance-1",
+          name: "Whole Life Policy",
+          balance: "25000.00",
+          currency: "USD",
+          accountable_type: "Insurance",
+          accountable: {
+            subtype: "life",
+            policy_number: "LIFE-123",
+            coverage_amount: "500000.00",
+            premium_amount: "150.00",
+            premium_frequency: "monthly",
+            effective_date: "2026-01-01",
+            expiration_date: "2036-01-01",
+            renewal_date: "2027-01-01",
+            insured_name: "Dylan",
+            beneficiaries: "Family trust"
+          }
+        }
+      }
+    ])
+
+    account = Family::DataImporter.new(@family, ndjson).import![:accounts].first
+    insurance = account.insurance
+
+    assert_equal "Insurance", account.accountable_type
+    assert_equal "life", insurance.subtype
+    assert_equal "LIFE-123", insurance.policy_number
+    assert_equal 500000, insurance.coverage_amount
+    assert_equal 150, insurance.premium_amount
+    assert_equal "monthly", insurance.premium_frequency
+    assert_equal Date.new(2026, 1, 1), insurance.effective_date
+    assert_equal Date.new(2036, 1, 1), insurance.expiration_date
+    assert_equal Date.new(2027, 1, 1), insurance.renewal_date
+    assert_equal "Dylan", insurance.insured_name
+    assert_equal "Family trust", insurance.beneficiaries
+  end
+
   test "imports non-destructive account status from ndjson" do
     ndjson = build_ndjson([
       {

--- a/test/models/insurance_test.rb
+++ b/test/models/insurance_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class InsuranceTest < ActiveSupport::TestCase
+  test "validates policy fields" do
+    insurance = Insurance.new(
+      subtype: "invalid",
+      premium_frequency: "weekly",
+      coverage_amount: -1,
+      premium_amount: -1,
+      effective_date: Date.new(2026, 2, 1),
+      expiration_date: Date.new(2026, 1, 1)
+    )
+
+    assert_not insurance.valid?
+    assert_includes insurance.errors[:subtype], "is not included in the list"
+    assert_includes insurance.errors[:premium_frequency], "is not included in the list"
+    assert_predicate insurance.errors[:coverage_amount], :present?
+    assert_predicate insurance.errors[:premium_amount], :present?
+    assert_predicate insurance.errors[:expiration_date], :present?
+  end
+
+  test "derives policy status from policy dates" do
+    insurance = Insurance.new
+    today = Date.new(2026, 7, 22)
+
+    assert_equal :active, insurance.policy_status(on: today)
+
+    insurance.effective_date = today + 1.day
+    assert_equal :upcoming, insurance.policy_status(on: today)
+
+    insurance.effective_date = today - 1.year
+    insurance.expiration_date = today - 1.day
+    assert_equal :expired, insurance.policy_status(on: today)
+
+    insurance.expiration_date = today + 1.year
+    insurance.renewal_date = today + 15.days
+    assert_equal :renewal_due, insurance.policy_status(on: today)
+
+    insurance.renewal_date = nil
+    insurance.expiration_date = today + 15.days
+    assert_equal :expiring_soon, insurance.policy_status(on: today)
+  end
+
+  test "returns monetary policy values in the account currency" do
+    account = accounts(:insurance)
+
+    assert_equal Money.new(500000, "USD"), account.insurance.coverage_amount_money
+    assert_equal Money.new(150, "USD"), account.insurance.premium_amount_money
+  end
+end

--- a/test/models/valuation/name_test.rb
+++ b/test/models/valuation/name_test.rb
@@ -1,6 +1,12 @@
 require "test_helper"
 
 class Valuation::NameTest < ActiveSupport::TestCase
+  test "generates cash value names for Insurance" do
+    assert_equal "Opening cash value", Valuation::Name.new("opening_anchor", "Insurance").to_s
+    assert_equal "Current cash value", Valuation::Name.new("current_anchor", "Insurance").to_s
+    assert_equal "Manual cash value update", Valuation::Name.new("reconciliation", "Insurance").to_s
+  end
+
   # Opening anchor tests
   test "generates opening anchor name for Property" do
     name = Valuation::Name.new("opening_anchor", "Property")

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -18,6 +18,16 @@ class AccountsTest < ApplicationSystemTestCase
     assert_account_created("Investment")
   end
 
+  test "can create insurance account" do
+    assert_account_created "Insurance" do
+      select "Life Insurance", from: "Insurance type"
+      fill_in "Policy number", with: "POL-123"
+      fill_in "account[accountable_attributes][coverage_amount]", with: 500000
+      fill_in "account[accountable_attributes][premium_amount]", with: 150
+      select "Monthly", from: "Premium frequency"
+    end
+  end
+
   test "can create crypto account" do
     assert_account_created("Crypto")
   end
@@ -140,7 +150,7 @@ class AccountsTest < ApplicationSystemTestCase
 
     def assert_account_created(accountable_type, &block)
       click_link Accountable.from_type(accountable_type).singular_display_name
-      click_link "Enter account balance" if accountable_type.in?(%w[Depository Investment Crypto Loan CreditCard])
+      click_link "Enter account balance" if accountable_type.in?(%w[Depository Investment Insurance Crypto Loan CreditCard])
 
       account_name = "[system test] #{accountable_type} Account"
       institution_name = "[system test] Institution"


### PR DESCRIPTION
## Product discussion

- #2753

This PR remains in draft pending maintainer feedback on the proposed insurance account model and scope.

## Summary

- add Insurance as a first-class accountable asset type
- capture policy type/number, coverage, premium cadence, dates, insured party, and beneficiaries
- track cash or surrender value through the existing non-cash valuation ledger while keeping coverage separate from net worth
- show derived policy status and policy details in a dedicated overview tab
- preserve insurance metadata through NDJSON import/export and add English/Chinese translations

## Design notes

Policies without cash value use a zero account balance, so they do not inflate net worth. Coverage amount and premiums are informational policy fields. Existing investment subtypes such as life insurance remain unchanged for backwards compatibility.

This first PR intentionally does not add claims tracking, renewal notification jobs, document storage, or insurer integrations. Those can build on the policy record later without changing the account model.

## Validation

- focused insurance/controller/valuation/balance tests: 75 runs, 3,041 assertions, 0 failures
- complete `Family::DataImporterTest`: 50 runs, 245 assertions, 0 failures
- RuboCop: 17 files, no offenses
- ERB lint: no errors
- `bin/rails zeitwerk:check`: passed
- `bin/brakeman -q --no-pager`: 0 security warnings

Full-suite note: `bin/rails test` was also attempted in the existing self-hosted container. With managed-mode flags it reached the end of worker output, but the parallel coordinator did not reap exited workers; two unrelated settings-hosting assertions also reflect container budget defaults (`0` vs `nil`). No insurance-related failures appeared.

## Additional bundled fix

The NDJSON importer now falls back to the nested accountable subtype when the top-level `subtype` is blank. This fixes a previously latent round-trip issue for all accountable types, not only Insurance, and has dedicated regression coverage.

## Data sensitivity

`policy_number`, `insured_name`, and `beneficiaries` currently follow the existing storage posture for account notes and comparable accountable metadata: they are stored as plaintext application columns. This PR does not establish a new encryption policy for insurance PII; confirmation of that posture remains part of the maintainer discussion in #2753 before the draft is promoted.
