### PR TITLE
fix(ai): prevent Anthropic chat crash on no-argument tool calls

### DIFF
--- a/app/models/assistant/function_tool_caller.rb
+++ b/app/models/assistant/function_tool_caller.rb
@@ -23,7 +23,7 @@ class Assistant::FunctionToolCaller
   private
     def execute(function_request)
       fn = find_function(function_request)
-      fn_args = JSON.parse(function_request.function_args)
+      fn_args = JSON.parse(function_request.function_args.presence || "{}")
       fn.call(fn_args)
     rescue => e
       raise FunctionExecutionError.new(

--- a/app/models/provider/anthropic/chat_parser.rb
+++ b/app/models/provider/anthropic/chat_parser.rb
@@ -50,7 +50,9 @@ class Provider::Anthropic::ChatParser
             id: block_value(block, :id),
             call_id: block_value(block, :id),
             function_name: block_value(block, :name),
-            function_args: input.is_a?(String) ? input : input.to_json
+            # A tool_use block with no arguments streams in as an empty string.
+            # Normalize it to an empty JSON object so downstream JSON.parse succeeds.
+            function_args: input.is_a?(String) ? input.presence || "{}" : (input || {}).to_json
           )
         end
     end

--- a/test/models/assistant/function_tool_caller_test.rb
+++ b/test/models/assistant/function_tool_caller_test.rb
@@ -49,6 +49,6 @@ class Assistant::FunctionToolCallerTest < ActiveSupport::TestCase
       @caller.fulfill_requests([ request ]).first
     end
 
-    assert_equal({}, JSON.parse(result.function_result))
+    assert_equal({}, result.function_result)
   end
 end

--- a/test/models/assistant/function_tool_caller_test.rb
+++ b/test/models/assistant/function_tool_caller_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class Assistant::FunctionToolCallerTest < ActiveSupport::TestCase
+  # Minimal stub function that echoes back whatever args it receives.
+  class EchoFunction < Assistant::Function
+    def self.name = "echo"
+    def self.description = "Echoes the received arguments"
+    def call(params = {}) = params
+  end
+
+  FunctionRequest = Provider::LlmConcept::ChatFunctionRequest
+
+  setup do
+    @caller = Assistant::FunctionToolCaller.new([ EchoFunction.new(nil) ])
+  end
+
+  test "parses JSON arguments and forwards them to the function" do
+    request = FunctionRequest.new(
+      id: "call_1", call_id: "call_1", function_name: "echo",
+      function_args: { "foo" => "bar" }.to_json
+    )
+
+    result = @caller.fulfill_requests([ request ]).first
+
+    assert_equal({ "foo" => "bar" }, result.function_result)
+  end
+
+  test "treats empty-string arguments as an empty argument set" do
+    request = FunctionRequest.new(
+      id: "call_2", call_id: "call_2", function_name: "echo",
+      function_args: ""
+    )
+
+    # Regression for #2722: JSON.parse("") used to raise, killing the turn.
+    result = assert_nothing_raised do
+      @caller.fulfill_requests([ request ]).first
+    end
+
+    assert_equal({}, result.function_result)
+  end
+
+  test "treats nil arguments as an empty argument set" do
+    request = FunctionRequest.new(
+      id: "call_3", call_id: "call_3", function_name: "echo",
+      function_args: nil
+    )
+
+    result = assert_nothing_raised do
+      @caller.fulfill_requests([ request ]).first
+    end
+
+    assert_equal({}, JSON.parse(result.function_result))
+  end
+end

--- a/test/models/provider/anthropic/chat_parser_test.rb
+++ b/test/models/provider/anthropic/chat_parser_test.rb
@@ -64,6 +64,37 @@ class Provider::Anthropic::ChatParserTest < ActiveSupport::TestCase
     assert_equal "toolu_42", parsed.function_requests.first.call_id
   end
 
+  test "normalizes empty-string tool input to an empty JSON object" do
+    raw = build_message(
+      id: "msg_5",
+      model: "claude-sonnet-4-6",
+      content: [
+        OpenStruct.new(type: :tool_use, id: "toolu_noargs", name: "get_categories", input: "")
+      ]
+    )
+
+    parsed = Provider::Anthropic::ChatParser.new(raw).parsed
+
+    req = parsed.function_requests.first
+    assert_equal "{}", req.function_args
+    # Must survive the downstream JSON.parse that fulfills the tool call.
+    assert_equal({}, JSON.parse(req.function_args))
+  end
+
+  test "normalizes nil tool input to an empty JSON object" do
+    raw = build_message(
+      id: "msg_6",
+      model: "claude-sonnet-4-6",
+      content: [
+        OpenStruct.new(type: :tool_use, id: "toolu_nil", name: "get_categories", input: nil)
+      ]
+    )
+
+    parsed = Provider::Anthropic::ChatParser.new(raw).parsed
+
+    assert_equal "{}", parsed.function_requests.first.function_args
+  end
+
   test "accepts hash-shaped content blocks" do
     raw = OpenStruct.new(
       id: "msg_4",


### PR DESCRIPTION
## Problem

When the chat assistant calls a tool that takes **no arguments** (e.g. `get_categories`), the whole turn fails with:

> Failed to generate a response. Please try again.

with the technical error:

```
Error calling function get_categories with arguments : unexpected end of input at line 1 column 1
Provider::Anthropic::Error
```

Tools *with* arguments work fine, so the bug only surfaces on argument-less calls, which makes it look intermittent/prompt-dependent. Reported in #2722 (native Anthropic provider, `claude-sonnet-4-5`, v0.7.2).

## Root cause

When the model streams a `tool_use` block with **no input**, the accumulated `input` arrives as an **empty string** rather than an empty object.

In `app/models/provider/anthropic/chat_parser.rb`, `function_requests` passed that value straight through:

```ruby
function_args: input.is_a?(String) ? input : input.to_json   # → "" for a no-arg call
```

`Assistant::FunctionToolCaller#execute` then does `JSON.parse(function_request.function_args)`, and `JSON.parse("")` raises `unexpected end of input`, which is re-wrapped as `Provider::Anthropic::Error` and kills the turn.

## Fix

Minimal, two-part change:

1. **At the source** — normalize empty/`nil` tool input to an empty JSON object in the Anthropic parser:
   ```ruby
   function_args: input.is_a?(String) ? input.presence || "{}" : (input || {}).to_json
   ```
2. **Defensive guard** — in `Assistant::FunctionToolCaller`, treat blank args as `{}` so *any* provider that emits empty/`nil` arguments cannot crash a turn:
   ```ruby
   fn_args = JSON.parse(function_request.function_args.presence || "{}")
   ```

## Tests

- `test/models/provider/anthropic/chat_parser_test.rb` — empty-string and `nil` tool input now normalize to `"{}"` and survive `JSON.parse`.
- `test/models/assistant/function_tool_caller_test.rb` (new) — regression coverage that empty/`nil` arguments no longer raise and resolve to an empty argument set.

## Impact & risk

- Restores argument-less tool calls (`get_categories`, `get_tags`, etc.) for the native Anthropic provider.
- Backward compatible: non-empty JSON arguments are unchanged; only previously-crashing empty input is affected.
- No new dependencies, no schema or API changes.

Fixes #2722

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of assistant tool requests when tool arguments are missing or blank, treating them as an empty argument set instead of failing.
  * Anthropic tool “tool use” inputs that are empty or nil are now normalized so downstream parsing succeeds.

* **Tests**
  * Added regression coverage for function tool argument parsing with valid JSON, empty strings, and nil values.
  * Added tests confirming consistent normalization of Anthropic tool inputs to an empty JSON object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->