### PR TITLE
fix: db:schema:load broken on main — duplicate columns in enable_banking_accounts

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -577,12 +577,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120000) do
     t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
+    t.boolean "treat_balance_as_available_credit", default: false, null: false
     t.string "uid"
     t.datetime "updated_at", null: false
-    t.string "product"
-    t.decimal "credit_limit", precision: 19, scale: 4
-    t.jsonb "identification_hashes", default: []
-    t.boolean "treat_balance_as_available_credit", default: false, null: false
     t.index ["account_id"], name: "index_enable_banking_accounts_on_account_id"
     t.index ["enable_banking_item_id"], name: "index_enable_banking_accounts_on_enable_banking_item_id"
     t.index ["identification_hashes"], name: "index_enable_banking_accounts_on_identification_hashes", using: :gin


### PR DESCRIPTION
## Problem

`main` currently cannot load its own schema. Every `bin/rails db:schema:load` (and therefore `db:prepare` / `db:setup` on a fresh database) aborts with:

```
ArgumentError: you can't define an already defined column 'product' on 'enable_banking_accounts'.
```

This breaks:

- **CI for every branch cut from current `main`** — the `test_unit` and `test_system` jobs both fail at the "DB setup and smoke test" step before a single test runs (reproduced on a fork run of the `Pull Request` workflow against `main` @ 565e049f: [test_unit/test_system failure](https://github.com/RealDiligent/sure/actions/runs/29938243873)).
- **Every fresh install / self-hosted setup**, since `db:prepare` schema-loads on a new database.

## Root cause

Commit 565e049f regenerated `db/schema.rb` in the sorted Rails 8.1 dump format, but the `enable_banking_accounts` table kept a stale trailing block that re-declares three columns already present in the sorted list above:

```ruby
t.string "uid"
t.datetime "updated_at", null: false
t.string "product"                                    # duplicate
t.decimal "credit_limit", precision: 19, scale: 4     # duplicate
t.jsonb "identification_hashes", default: []          # duplicate
t.boolean "treat_balance_as_available_credit", ...    # legitimate (20260627101954)
```

Rails raises on the first duplicate column during `schema:load`.

## Fix

Minimal 1-file change to `db/schema.rb`:

- Remove the three duplicated column declarations (`product`, `credit_limit`, `identification_hashes`) — their kept definitions are byte-identical to the removed ones.
- Keep the one legitimate new column, `treat_balance_as_available_credit` (matches its migration `20260627101954` exactly: `boolean, default: false, null: false`), moved into its sorted position so the file matches what the schema dumper generates.

A scan of the full schema confirms no other table has duplicate column declarations.

## Validation

Ran the repo's full `Pull Request` CI workflow on a fork with this fix applied: **all jobs green**, including `test_unit` and `test_system` which fail on unpatched `main`.

## Impact / risk

- Restores green CI for all open and future PRs, and un-breaks fresh installs.
- No behavioral change — the schema now simply declares each column once, identical to the pre-565e049f definitions plus the new boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered banking account schema fields for consistency.
  * No changes to available data or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->