### PR TITLE
fix(exports): include merchants.csv in family data export

### DIFF
--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -31,6 +31,10 @@ class Family::DataExporter
       zipfile.put_next_entry("categories.csv")
       zipfile.write generate_categories_csv
 
+      # Add merchants.csv
+      zipfile.put_next_entry("merchants.csv")
+      zipfile.write generate_merchants_csv
+
       # Add rules.csv
       zipfile.put_next_entry("rules.csv")
       zipfile.write generate_rules_csv
@@ -134,6 +138,22 @@ class Family::DataExporter
             category.color,
             category.parent&.name,
             category.lucide_icon
+          ]
+        end
+      end
+    end
+
+    def generate_merchants_csv
+      CSV.generate do |csv|
+        # Headers match MerchantImport's expected columns so the export round-trips
+        csv << [ "name", "color", "website_url" ]
+
+        # Only export family merchants belonging to this family
+        @family.merchants.find_each do |merchant|
+          csv << [
+            merchant.name,
+            merchant.color,
+            merchant.website_url
           ]
         end
       end

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -55,7 +55,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     assert zip_data.is_a?(StringIO)
 
     # Check that the zip contains all expected files
-    expected_files = [ "version.txt", "accounts.csv", "transactions.csv", "trades.csv", "categories.csv", "rules.csv", "attachments.json", "all.ndjson" ]
+    expected_files = [ "version.txt", "accounts.csv", "transactions.csv", "trades.csv", "categories.csv", "merchants.csv", "rules.csv", "attachments.json", "all.ndjson" ]
 
     Zip::File.open_buffer(zip_data) do |zip|
       actual_files = zip.entries.map(&:name)
@@ -194,9 +194,56 @@ class Family::DataExporterTest < ActiveSupport::TestCase
       categories_csv = zip.read("categories.csv")
       assert categories_csv.include?("name,color,parent_category,lucide_icon")
 
+      # Check merchants.csv
+      merchants_csv = zip.read("merchants.csv")
+      assert merchants_csv.include?("name,color,website_url")
+
       # Check rules.csv
       rules_csv = zip.read("rules.csv")
       assert rules_csv.include?("name,resource_type,active,effective_date,conditions,actions")
+    end
+  end
+
+  test "exports merchants in CSV format scoped to the family" do
+    merchant = @family.merchants.create!(name: "Coffee Shop", website_url: "https://coffeeshop.com")
+    other_merchant = @other_family.merchants.create!(name: "Other Family Store")
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      rows = CSV.parse(zip.read("merchants.csv"), headers: true)
+      row = rows.find { |csv_row| csv_row["name"] == merchant.name }
+
+      assert_not_nil row
+      assert_equal merchant.color, row["color"]
+      assert_equal merchant.website_url, row["website_url"]
+      refute rows.any? { |csv_row| csv_row["name"] == other_merchant.name }
+    end
+  end
+
+  test "exported merchants CSV round-trips through MerchantImport" do
+    merchant = @family.merchants.create!(name: "Pizza Palace", website_url: "https://pizzapalace.com")
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      import = @other_family.imports.create!(
+        type: "MerchantImport",
+        raw_file_str: zip.read("merchants.csv"),
+        col_sep: ","
+      )
+      import.generate_rows_from_csv
+      row = import.rows.reload.find_by!(name: "Pizza Palace")
+
+      assert_equal merchant.color, row.merchant_color
+      assert_equal "https://pizzapalace.com", row.merchant_website
+
+      assert_difference -> { @other_family.merchants.count }, 1 do
+        import.send(:import!)
+      end
+
+      imported = @other_family.merchants.find_by!(name: "Pizza Palace")
+      assert_equal "https://pizzapalace.com", imported.website_url
     end
   end
 

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -238,11 +238,14 @@ class Family::DataExporterTest < ActiveSupport::TestCase
       assert_equal merchant.color, row.merchant_color
       assert_equal "https://pizzapalace.com", row.merchant_website
 
-      assert_difference -> { @other_family.merchants.count }, 1 do
+      # The export carries every family merchant (incl. fixtures), so scope the
+      # count assertion to the merchant under test.
+      assert_difference -> { @other_family.merchants.where(name: "Pizza Palace").count }, 1 do
         import.send(:import!)
       end
 
       imported = @other_family.merchants.find_by!(name: "Pizza Palace")
+      assert_equal merchant.color, imported.color
       assert_equal "https://pizzapalace.com", imported.website_url
     end
   end


### PR DESCRIPTION
## Problem

The family data export (`/family_exports`) produces a ZIP with `accounts.csv`, `transactions.csv`, `trades.csv`, `categories.csv`, and `rules.csv` — but **no `merchants.csv`**. Merchant data only exists inside the `all.ndjson` bulk file.

This makes CSV backups lossy and the import/export cycle asymmetric: merchants can already be **imported** via CSV (`MerchantImport`, added in #1992), but can't be exported as CSV. Reported in #2736 and confirmed by the repo's Dosu bot analysis on that issue.

## Fix

Minimal, additive change to `Family::DataExporter`:

- Add `generate_merchants_csv`, modeled on the existing `generate_categories_csv`, exporting the family's merchants (family-scoped only).
- Write it into the export ZIP as `merchants.csv`.
- Headers are exactly `name,color,website_url` — matching what `MerchantImport#generate_rows_from_csv` looks up, so the exported file round-trips through the existing import with no changes needed there.

Nothing else consumes the ZIP's CSV entry list strictly (`SureImport` reads only `all.ndjson`), so the new entry is backward compatible.

## Tests

- Updated the required-files and CSV-headers assertions in `data_exporter_test.rb`.
- New test: merchants CSV contains the family's merchants and excludes other families' merchants.
- New test: exported `merchants.csv` round-trips through `MerchantImport` (rows generated, merchant created in the target family with its website).

## Impact & risk

- Backups/exports now include merchant data in the portable CSV format.
- Purely additive — no existing file formats or behaviors changed, no schema/API changes, no new dependencies.

Fixes #2736

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data exports now include a dedicated `merchants.csv` file in the generated ZIP.
  * Merchant names, colors, and website URLs are included for the current family.

* **Bug Fixes**
  * Improved export validation and merchant data round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->