### PR TITLE
fix(merchants): stop overwriting user-selected colors with a random one on every save

### DIFF
--- a/app/models/family_merchant.rb
+++ b/app/models/family_merchant.rb
@@ -11,7 +11,7 @@ class FamilyMerchant < Merchant
 
   private
     def set_default_color
-      self.color = COLORS.sample
+      self.color = COLORS.sample if color.blank?
     end
 
     def should_generate_logo?

--- a/test/models/family_merchant_test.rb
+++ b/test/models/family_merchant_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class FamilyMerchantTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "keeps explicitly chosen color on create" do
+    merchant = @family.merchants.create!(name: "Chosen Color Shop", color: "#6471eb")
+
+    assert_equal "#6471eb", merchant.color
+  end
+
+  test "assigns a default color when none is provided" do
+    merchant = @family.merchants.create!(name: "No Color Shop")
+
+    assert_includes FamilyMerchant::COLORS, merchant.color
+  end
+
+  test "assigns a default color when color is blank" do
+    merchant = @family.merchants.create!(name: "Blank Color Shop", color: "")
+
+    assert_includes FamilyMerchant::COLORS, merchant.color
+  end
+
+  test "does not reshuffle color when updating other attributes" do
+    merchant = @family.merchants.create!(name: "Stable Color Shop")
+    original_color = merchant.color
+
+    merchant.update!(name: "Stable Color Shop Renamed")
+
+    assert_equal original_color, merchant.reload.color
+  end
+
+  test "keeps newly selected color on update" do
+    merchant = @family.merchants.create!(name: "Recolored Shop")
+
+    merchant.update!(color: "#db5a54")
+
+    assert_equal "#db5a54", merchant.reload.color
+  end
+end


### PR DESCRIPTION
## Problem

`FamilyMerchant#set_default_color` runs as an unguarded `before_validation`:

```ruby
def set_default_color
  self.color = COLORS.sample
end
```

Since it assigns unconditionally on **every** validation, all explicitly assigned merchant colors are silently discarded:

- The merchant form's color picker (`_form.html.erb` radios, `:color` permitted in the controller) stores a random color instead of the chosen one.
- Every edit — even just a rename — reshuffles the merchant's color again (~90% of saves change it).
- `MerchantImport`'s `row.merchant_color.presence || COLORS.sample` and the API v1 merchants CSV import's `row[color_header].to_s.strip.presence` are both dead code — their values are overwritten before save.

Both import call sites already implement "explicit color, else random sample" themselves, which shows the callback was only ever intended to backfill a missing color (the column has no DB default and carries a presence validation).

Reported in #2760; independently surfaced by Codex review on #2758 ("saving a `FamilyMerchant` runs `set_default_color`, which unconditionally replaces `color` before validation").

## Fix

One-line guard, preserving the original backfill intent exactly:

```ruby
self.color = COLORS.sample if color.blank?
```

## Tests

New `test/models/family_merchant_test.rb`:
- explicit color kept on create
- default color assigned when color is nil or blank ("")
- color stable across unrelated updates (rename)
- newly selected color kept on update

## Impact & risk

- User-chosen merchant colors (UI, CSV import, API import) now persist; merchant avatar colors stop changing at random on edits.
- Backward compatible: no existing test asserts stored merchant colors (they couldn't — the result was random), and blank-color creation still gets a palette color, satisfying the presence validation.

Fixes #2760

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved a merchant’s explicitly selected color instead of replacing it automatically.
  * Default colors are now assigned only when no color is provided.
  * Updating other merchant details no longer changes the existing color.
  * Merchants can still update their color when desired.

* **Tests**
  * Added coverage for default, blank, preserved, and updated color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->