### PR TITLE
fix(db): remove duplicate columns from enable_banking_accounts schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -577,12 +577,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120000) do
     t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
+    t.boolean "treat_balance_as_available_credit", default: false, null: false
     t.string "uid"
     t.datetime "updated_at", null: false
-    t.string "product"
-    t.decimal "credit_limit", precision: 19, scale: 4
-    t.jsonb "identification_hashes", default: []
-    t.boolean "treat_balance_as_available_credit", default: false, null: false
     t.index ["account_id"], name: "index_enable_banking_accounts_on_account_id"
     t.index ["enable_banking_item_id"], name: "index_enable_banking_accounts_on_enable_banking_item_id"
     t.index ["identification_hashes"], name: "index_enable_banking_accounts_on_identification_hashes", using: :gin


### PR DESCRIPTION
## Problem

`db/schema.rb` defines three columns twice on `enable_banking_accounts` — `product`, `credit_limit`, and `identification_hashes`. A block of column definitions was appended after `updated_at` rather than merged into the alphabetical column list, so they appear both in their correct position and again at the end of the table.

Loading the schema fails hard:

```
$ bin/rails db:create
ArgumentError: you can't define an already defined column 'product' on 'enable_banking_accounts'.
  db/schema.rb:582 ... in create_table
Tasks: TOP => db:schema:load
```

Because `db:schema:load` runs in CI (and in every fresh dev/test DB setup), this breaks the pipeline on all branches, not just the one that introduced it.

## Fix

Deduplicate the table: keep a single definition of each column in alphabetical order, and move `treat_balance_as_available_credit` (the one genuinely new column in that appended block) into its correct alphabetical position.

No columns are added to or removed from the actual table — this only repairs the generated schema so it loads. The migration history is unchanged; this is what `bin/rails db:migrate` regenerates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database schema declaration order without changing tables, indexes, constraints, or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->