### PR TITLE
Fix chained assistant tool calls

### DIFF
--- a/app/models/assistant/builtin.rb
+++ b/app/models/assistant/builtin.rb
@@ -47,7 +47,7 @@ class Assistant::Builtin < Assistant::Base
 
     responder.on(:response) do |data|
       if data[:function_tool_calls].present?
-        assistant_message.tool_calls = data[:function_tool_calls]
+        assistant_message.tool_calls.concat(data[:function_tool_calls])
         latest_response_id = data[:id]
       else
         chat.update_latest_response!(data[:id])

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -16,6 +16,8 @@ class Assistant::Responder
 
   def respond(previous_response_id: nil)
     response, response_has_text = request_response(previous_response_id: previous_response_id)
+    any_response_has_text = response_has_text
+    in_flight_function_results = []
     iteration = 0
 
     while response.function_requests.any?
@@ -26,6 +28,8 @@ class Assistant::Responder
       end
 
       function_tool_calls = function_tool_caller.fulfill_requests(response.function_requests)
+      function_results = function_tool_calls.map(&:to_result)
+      in_flight_function_results.concat(function_results)
 
       emit(:response, {
         id: response.id,
@@ -33,12 +37,13 @@ class Assistant::Responder
       })
 
       response, response_has_text = request_response(
-        function_results: function_tool_calls.map(&:to_result),
+        function_results: provider_preserves_response_context? ? function_results : in_flight_function_results.dup,
         previous_response_id: response.id
       )
+      any_response_has_text ||= response_has_text
     end
 
-    raise EmptyResponseError, "Assistant returned neither text nor tool calls" unless response_has_text
+    raise EmptyResponseError, "Assistant returned neither text nor tool calls" unless any_response_has_text
 
     emit(:response, { id: response.id })
   end
@@ -64,6 +69,10 @@ class Assistant::Responder
 
       response_has_text ||= response.messages.any? { |response_message| response_message.output_text.present? }
       [ response, response_has_text ]
+    end
+
+    def provider_preserves_response_context?
+      llm.respond_to?(:supports_responses_endpoint?) && llm.supports_responses_endpoint?
     end
 
     def max_tool_call_iterations

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -1,4 +1,8 @@
 class Assistant::Responder
+  ToolCallLimitError = Class.new(StandardError)
+  EmptyResponseError = Class.new(StandardError)
+  DEFAULT_MAX_TOOL_CALL_ITERATIONS = 5
+
   def initialize(message:, instructions:, function_tool_caller:, llm:)
     @message = message
     @instructions = instructions
@@ -11,50 +15,14 @@ class Assistant::Responder
   end
 
   def respond(previous_response_id: nil)
-    # Track whether response was handled by streamer
-    response_handled = false
+    response, response_has_text = request_response(previous_response_id: previous_response_id)
+    iteration = 0
 
-    # For the first response
-    streamer = proc do |chunk|
-      case chunk.type
-      when "output_text"
-        emit(:output_text, chunk.data)
-      when "response"
-        response = chunk.data
-        response_handled = true
-
-        if response.function_requests.any?
-          handle_follow_up_response(response)
-        else
-          emit(:response, { id: response.id })
-        end
-      end
-    end
-
-    response = get_llm_response(streamer: streamer, previous_response_id: previous_response_id)
-
-    # For synchronous (non-streaming) responses, handle function requests if not already handled by streamer
-    unless response_handled
-      if response && response.function_requests.any?
-        handle_follow_up_response(response)
-      elsif response
-        emit(:response, { id: response.id })
-      end
-    end
-  end
-
-  private
-    attr_reader :message, :instructions, :function_tool_caller, :llm
-
-    def handle_follow_up_response(response)
-      streamer = proc do |chunk|
-        case chunk.type
-        when "output_text"
-          emit(:output_text, chunk.data)
-        when "response"
-          # We do not currently support function executions for a follow-up response (avoid recursive LLM calls that could lead to high spend)
-          emit(:response, { id: chunk.data.id })
-        end
+    while response.function_requests.any?
+      iteration += 1
+      if iteration > max_tool_call_iterations
+        raise ToolCallLimitError,
+              "Assistant exceeded the tool-call limit of #{max_tool_call_iterations} for one response"
       end
 
       function_tool_calls = function_tool_caller.fulfill_requests(response.function_requests)
@@ -64,12 +32,45 @@ class Assistant::Responder
         function_tool_calls: function_tool_calls
       })
 
-      # Get follow-up response with tool call results
-      get_llm_response(
-        streamer: streamer,
+      response, response_has_text = request_response(
         function_results: function_tool_calls.map(&:to_result),
         previous_response_id: response.id
       )
+    end
+
+    raise EmptyResponseError, "Assistant returned neither text nor tool calls" unless response_has_text
+
+    emit(:response, { id: response.id })
+  end
+
+  private
+    attr_reader :message, :instructions, :function_tool_caller, :llm
+
+    def request_response(function_results: [], previous_response_id: nil)
+      response_has_text = false
+
+      streamer = proc do |chunk|
+        if chunk.type == "output_text" && chunk.data.present?
+          response_has_text = true
+          emit(:output_text, chunk.data)
+        end
+      end
+
+      response = get_llm_response(
+        streamer: streamer,
+        function_results: function_results,
+        previous_response_id: previous_response_id
+      )
+
+      response_has_text ||= response.messages.any? { |response_message| response_message.output_text.present? }
+      [ response, response_has_text ]
+    end
+
+    def max_tool_call_iterations
+      configured = Integer(ENV.fetch("ASSISTANT_MAX_TOOL_CALL_ITERATIONS", DEFAULT_MAX_TOOL_CALL_ITERATIONS).to_s, 10)
+      configured.positive? ? configured : DEFAULT_MAX_TOOL_CALL_ITERATIONS
+    rescue ArgumentError
+      DEFAULT_MAX_TOOL_CALL_ITERATIONS
     end
 
     def get_llm_response(streamer:, function_results: [], previous_response_id: nil)

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -163,6 +163,7 @@ class AssistantTest < ActiveSupport::TestCase
 
   test "responds after multiple rounds of tool calls" do
     @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
+    @provider.stubs(:supports_responses_endpoint?).returns(false)
 
     Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("accounts").twice
     Assistant::Function::GetIncomeStatement.any_instance.stubs(:call).returns("income").once
@@ -195,7 +196,8 @@ class AssistantTest < ActiveSupport::TestCase
     expect_provider_rounds(
       [ first_tools ],
       [ second_tools ],
-      [ final_text, final_response ]
+      [ final_text, final_response ],
+      expected_function_result_ids: [ [], [ "1" ], [ "1", "2", "3" ] ]
     )
 
     assert_difference "AssistantMessage.count", 1 do
@@ -207,6 +209,39 @@ class AssistantTest < ActiveSupport::TestCase
     assert_equal "Final answer.", response.content
     assert_equal [ "get_accounts", "get_accounts", "get_income_statement" ],
                  response.tool_calls.map(&:function_name).sort
+  end
+
+  test "keeps earlier text when the final tool follow-up is empty" do
+    @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
+    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("accounts").once
+
+    partial_text = provider_text_chunk("I found your accounts.")
+    tools_with_text = provider_response_chunk(
+      id: "1",
+      model: "gpt-4.1",
+      messages: [ provider_message(id: "1", text: partial_text.data) ],
+      function_requests: [
+        provider_function_request(id: "1", call_id: "1", function_name: "get_accounts", function_args: "{}")
+      ]
+    )
+    empty_follow_up = provider_response_chunk(
+      id: "2",
+      model: "gpt-4.1",
+      messages: [],
+      function_requests: []
+    )
+
+    expect_provider_rounds(
+      [ partial_text, tools_with_text ],
+      [ empty_follow_up ]
+    )
+
+    @assistant.respond_to(@message)
+
+    response = @chat.messages.ordered.where(type: "AssistantMessage").last
+    assert_equal "complete", response.status
+    assert_equal "I found your accounts.", response.content
+    assert_equal 1, response.tool_calls.size
   end
 
   test "cleans up the pending message when the tool-call limit is exceeded" do
@@ -651,8 +686,9 @@ class AssistantTest < ActiveSupport::TestCase
       )
     end
 
-    def expect_provider_rounds(*rounds)
+    def expect_provider_rounds(*rounds, expected_function_result_ids: nil)
       queued_rounds = rounds.dup
+      queued_result_ids = expected_function_result_ids&.dup
       responses = rounds.map do |chunks|
         response_chunk = chunks.find { |chunk| chunk.type == "response" }
         provider_success_response(response_chunk.data)
@@ -662,6 +698,9 @@ class AssistantTest < ActiveSupport::TestCase
         assert_equal @expected_session_id, options[:session_id]
         assert_equal @expected_user_identifier, options[:user_identifier]
         assert_equal @expected_conversation_history, options[:messages]
+        if queued_result_ids
+          assert_equal queued_result_ids.shift, options[:function_results].map { |result| result[:call_id] }
+        end
         chunks = queued_rounds.shift
         chunks.each { |chunk| options[:streamer].call(chunk) }
         true

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -124,10 +124,8 @@ class AssistantTest < ActiveSupport::TestCase
   test "responds with tool function calls" do
     @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
 
-    # Only first provider call executes function
     Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("test value").once
 
-    # Call #1: Function requests
     call1_response_chunk = provider_response_chunk(
       id: "1",
       model: "gpt-4.1",
@@ -137,9 +135,6 @@ class AssistantTest < ActiveSupport::TestCase
       ]
     )
 
-    call1_response = provider_success_response(call1_response_chunk.data)
-
-    # Call #2: Text response (that uses function results)
     call2_text_chunks = [
       provider_text_chunk("Your net worth is "),
       provider_text_chunk("$124,200")
@@ -152,35 +147,117 @@ class AssistantTest < ActiveSupport::TestCase
       function_requests: []
     )
 
-    call2_response = provider_success_response(call2_response_chunk.data)
-
-    sequence = sequence("provider_chat_response")
-
-    @provider.expects(:chat_response).with do |message, **options|
-      assert_equal @expected_session_id, options[:session_id]
-      assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
-      call2_text_chunks.each do |text_chunk|
-        options[:streamer].call(text_chunk)
-      end
-
-      options[:streamer].call(call2_response_chunk)
-      true
-    end.returns(call2_response).once.in_sequence(sequence)
-
-    @provider.expects(:chat_response).with do |message, **options|
-      assert_equal @expected_session_id, options[:session_id]
-      assert_equal @expected_user_identifier, options[:user_identifier]
-      assert_equal @expected_conversation_history, options[:messages]
-      options[:streamer].call(call1_response_chunk)
-      true
-    end.returns(call1_response).once.in_sequence(sequence)
+    expect_provider_rounds(
+      [ call1_response_chunk ],
+      [ *call2_text_chunks, call2_response_chunk ]
+    )
 
     assert_difference "AssistantMessage.count", 1 do
       @assistant.respond_to(@message)
       message = @chat.messages.ordered.where(type: "AssistantMessage").last
+      assert_equal "complete", message.status
+      assert_equal "Your net worth is $124,200", message.content
       assert_equal 1, message.tool_calls.size
     end
+  end
+
+  test "responds after multiple rounds of tool calls" do
+    @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
+
+    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("accounts").twice
+    Assistant::Function::GetIncomeStatement.any_instance.stubs(:call).returns("income").once
+
+    first_tools = provider_response_chunk(
+      id: "1",
+      model: "gpt-4.1",
+      messages: [],
+      function_requests: [
+        provider_function_request(id: "1", call_id: "1", function_name: "get_accounts", function_args: "{}")
+      ]
+    )
+    second_tools = provider_response_chunk(
+      id: "2",
+      model: "gpt-4.1",
+      messages: [],
+      function_requests: [
+        provider_function_request(id: "2", call_id: "2", function_name: "get_income_statement", function_args: "{}"),
+        provider_function_request(id: "2", call_id: "3", function_name: "get_accounts", function_args: "{}")
+      ]
+    )
+    final_text = provider_text_chunk("Final answer.")
+    final_response = provider_response_chunk(
+      id: "3",
+      model: "gpt-4.1",
+      messages: [ provider_message(id: "3", text: final_text.data) ],
+      function_requests: []
+    )
+
+    expect_provider_rounds(
+      [ first_tools ],
+      [ second_tools ],
+      [ final_text, final_response ]
+    )
+
+    assert_difference "AssistantMessage.count", 1 do
+      @assistant.respond_to(@message)
+    end
+
+    response = @chat.messages.ordered.where(type: "AssistantMessage").last
+    assert_equal "complete", response.status
+    assert_equal "Final answer.", response.content
+    assert_equal [ "get_accounts", "get_accounts", "get_income_statement" ],
+                 response.tool_calls.map(&:function_name).sort
+  end
+
+  test "cleans up the pending message when the tool-call limit is exceeded" do
+    @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
+    Assistant::Function::GetAccounts.any_instance.stubs(:call).returns("accounts").once
+
+    first_tools = provider_response_chunk(
+      id: "1",
+      model: "gpt-4.1",
+      messages: [],
+      function_requests: [
+        provider_function_request(id: "1", call_id: "1", function_name: "get_accounts", function_args: "{}")
+      ]
+    )
+    second_tools = provider_response_chunk(
+      id: "2",
+      model: "gpt-4.1",
+      messages: [],
+      function_requests: [
+        provider_function_request(id: "2", call_id: "2", function_name: "get_accounts", function_args: "{}")
+      ]
+    )
+
+    expect_provider_rounds([ first_tools ], [ second_tools ])
+    pending = AssistantMessage.create!(chat: @chat, content: "", ai_model: @message.ai_model, status: :pending)
+
+    with_env_overrides("ASSISTANT_MAX_TOOL_CALL_ITERATIONS" => "1") do
+      @assistant.respond_to(@message, assistant_message: pending)
+    end
+
+    assert_not AssistantMessage.exists?(pending.id)
+    assert_includes @chat.reload.technical_error_message, "tool-call limit"
+  end
+
+  test "cleans up the pending message when the model returns no text or tools" do
+    @assistant.expects(:get_model_provider).with("gpt-4.1").returns(@provider).once
+
+    empty_response = provider_response_chunk(
+      id: "1",
+      model: "gpt-4.1",
+      messages: [],
+      function_requests: []
+    )
+
+    expect_provider_rounds([ empty_response ])
+    pending = AssistantMessage.create!(chat: @chat, content: "", ai_model: @message.ai_model, status: :pending)
+
+    @assistant.respond_to(@message, assistant_message: pending)
+
+    assert_not AssistantMessage.exists?(pending.id)
+    assert_includes @chat.reload.technical_error_message, "neither text nor tool calls"
   end
 
   test "for_chat returns Builtin by default" do
@@ -572,5 +649,22 @@ class AssistantTest < ActiveSupport::TestCase
         ),
         usage: usage
       )
+    end
+
+    def expect_provider_rounds(*rounds)
+      queued_rounds = rounds.dup
+      responses = rounds.map do |chunks|
+        response_chunk = chunks.find { |chunk| chunk.type == "response" }
+        provider_success_response(response_chunk.data)
+      end
+
+      @provider.expects(:chat_response).times(rounds.length).with do |_message, **options|
+        assert_equal @expected_session_id, options[:session_id]
+        assert_equal @expected_user_identifier, options[:user_identifier]
+        assert_equal @expected_conversation_history, options[:messages]
+        chunks = queued_rounds.shift
+        chunks.each { |chunk| options[:streamer].call(chunk) }
+        true
+      end.returns(*responses)
     end
 end


### PR DESCRIPTION
Fixes #2241.

Clean current-main replacement for #2253.

### What changed
- Continue function calls until a text response, capped at five rounds
- Preserve tool calls from every round
- Fail cleanly on the cap or an empty response

### Tests
- `bin/rails test test/models/assistant_test.rb` (25 runs, 0 failures)
- `DISABLE_PARALLELIZATION=true bin/rails test` (5,701 runs, 0 failures)
- `bin/rubocop -f github`

Parallel DB setup is currently blocked on `main` by duplicate columns in `db/schema.rb`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant now supports multiple rounds of tool interactions before returning the final output.
  * Tool activity is accumulated across the full turn, and intermediate responses can include discovered tool calls.
  * Added safeguards to cap tool-call iterations and detect turns that produce no usable text.

* **Bug Fixes**
  * Prevented newly requested tool calls from overwriting existing tool-call data.

* **Tests**
  * Refreshed tool-calling tests with shared multi-round sequencing helpers and expanded edge-case coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->