### PR TITLE
fix(transfers): isolate concurrent transfer match in a savepoint

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -43,14 +43,7 @@ module Family::AutoTransferMatchable
         next if used_transaction_ids.include?(match.inflow_transaction_id) ||
                used_transaction_ids.include?(match.outflow_transaction_id)
 
-        begin
-          Transfer.find_or_create_by!(
-            inflow_transaction_id: match.inflow_transaction_id,
-            outflow_transaction_id: match.outflow_transaction_id,
-          )
-        rescue ActiveRecord::RecordNotUnique
-          # Another concurrent job created the transfer; safe to ignore
-        end
+        find_or_create_transfer!(match)
 
         inflow_transaction = transactions_by_id.fetch(match.inflow_transaction_id)
         outflow_transaction = transactions_by_id.fetch(match.outflow_transaction_id)
@@ -80,6 +73,31 @@ module Family::AutoTransferMatchable
   end
 
   private
+    # Create the transfer for a matched candidate, tolerating a concurrent sync
+    # that already inserted the same pair.
+    #
+    # The insert runs in its own savepoint (requires_new: true). On PostgreSQL a
+    # failed statement aborts the entire surrounding transaction, so rescuing a
+    # RecordNotUnique raised by find_or_create_by! is not enough on its own: the
+    # next write would fail with PG::InFailedSqlTransaction and the remaining
+    # candidates would be silently dropped. Isolating the insert in a savepoint
+    # rolls back only the failed statement, leaving the outer transaction healthy.
+    def find_or_create_transfer!(match)
+      Transfer.transaction(requires_new: true) do
+        Transfer.find_or_create_by!(
+          inflow_transaction_id: match.inflow_transaction_id,
+          outflow_transaction_id: match.outflow_transaction_id,
+        )
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # Another concurrent job won the insert race; the savepoint rolled back and
+      # the transfer already exists, so treat it as created.
+    rescue ActiveRecord::RecordInvalid => e
+      # The same race can surface through the uniqueness validation when the rival
+      # row is already committed. Swallow only that case; re-raise anything else.
+      raise unless %i[inflow_transaction_id outflow_transaction_id].any? { |attr| e.record.errors.of_kind?(attr, :taken) }
+    end
+
     def coerce_transfer_match_date_window!(value)
       Integer(value)
     rescue ArgumentError, TypeError

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -43,7 +43,10 @@ module Family::AutoTransferMatchable
         next if used_transaction_ids.include?(match.inflow_transaction_id) ||
                used_transaction_ids.include?(match.outflow_transaction_id)
 
-        find_or_create_transfer!(match)
+        # Skip this candidate when the transfer for this exact pair was not created
+        # (a concurrent sync claimed one of the transactions for a different pairing);
+        # marking it matched here would leave a transaction matched with no Transfer.
+        next unless find_or_create_transfer!(match)
 
         inflow_transaction = transactions_by_id.fetch(match.inflow_transaction_id)
         outflow_transaction = transactions_by_id.fetch(match.outflow_transaction_id)
@@ -90,12 +93,26 @@ module Family::AutoTransferMatchable
         )
       end
     rescue ActiveRecord::RecordNotUnique
-      # Another concurrent job won the insert race; the savepoint rolled back and
-      # the transfer already exists, so treat it as created.
+      # The composite unique index rejected the insert because this exact
+      # (inflow, outflow) pair was committed concurrently between our find and our
+      # insert. Return that committed row; if it is somehow absent, return nil so the
+      # caller skips rather than marking a transaction with no Transfer behind it.
+      existing_transfer(match)
     rescue ActiveRecord::RecordInvalid => e
-      # The same race can surface through the uniqueness validation when the rival
-      # row is already committed. Swallow only that case; re-raise anything else.
+      # The same race surfaces through the per-column uniqueness validation. Re-raise
+      # anything that is not a :taken on the transfer's transaction ids...
       raise unless %i[inflow_transaction_id outflow_transaction_id].any? { |attr| e.record.errors.of_kind?(attr, :taken) }
+      # ...and even for :taken, only accept it once the exact (inflow, outflow) row is
+      # confirmed present; otherwise the :taken came from a different pairing.
+      existing_transfer(match)
+    end
+
+    # The committed transfer for this exact candidate pair, or nil if none exists.
+    def existing_transfer(match)
+      Transfer.find_by(
+        inflow_transaction_id: match.inflow_transaction_id,
+        outflow_transaction_id: match.outflow_transaction_id,
+      )
     end
 
     def coerce_transfer_match_date_window!(value)

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -40,7 +40,7 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     original = Transfer.method(:find_or_create_by!)
     Transfer.singleton_class.send(:define_method, :find_or_create_by!) do |attributes|
       if attributes[:inflow_transaction_id] == inflow_id
-        insert!(inflow_transaction_id: rival.inflow_transaction_id, outflow_transaction_id: rival.outflow_transaction_id)
+        insert!({ inflow_transaction_id: rival.inflow_transaction_id, outflow_transaction_id: rival.outflow_transaction_id })
       else
         original.call(attributes)
       end

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -32,6 +32,11 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     rival_in = create_transaction(date: Date.current, account: @credit_card, amount: -250)
     rival = Transfer.create!(inflow_transaction_id: rival_in.entryable_id, outflow_transaction_id: rival_out.entryable_id)
 
+    # A second, non-conflicting candidate: matching must CONTINUE past the skipped
+    # collision and still create this transfer.
+    good_out = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 700)
+    good_in = create_transaction(date: Date.current, account: @credit_card, amount: -700)
+
     original = Transfer.method(:find_or_create_by!)
     Transfer.singleton_class.send(:define_method, :find_or_create_by!) do |attributes|
       if attributes[:inflow_transaction_id] == inflow_id
@@ -55,6 +60,14 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     # transaction healthy (no abort asserted above).
     assert_nil Transfer.find_by(inflow_transaction_id: inflow_id, outflow_transaction_id: outflow_entry.entryable_id)
     refute_equal "funds_movement", inflow_entry.entryable.kind
+
+    # ...and matching did not stop at the skip: the non-conflicting candidate was
+    # still created and both its entries marked.
+    good_in.reload
+    good_out.reload
+    assert Transfer.exists?(inflow_transaction_id: good_in.entryable_id, outflow_transaction_id: good_out.entryable_id)
+    assert_equal "funds_movement", good_in.entryable.kind
+    assert_equal "cc_payment", good_out.entryable.kind
   end
 
   test "a :taken on one column from a different pairing is skipped, not marked" do

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -19,6 +19,73 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
+  test "concurrent unique-index race does not abort the surrounding transaction" do
+    outflow_entry = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: @credit_card, amount: -500)
+    inflow_id = inflow_entry.entryable_id
+
+    # A separate matched pair whose transfer already exists, standing in for the
+    # row a concurrent sync committed first. Colliding with its unique index gives
+    # us a genuine failing INSERT (not a synthetic raise) -- only that aborts the
+    # PostgreSQL transaction, so only that reproduces the bug.
+    rival_out = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 250)
+    rival_in = create_transaction(date: Date.current, account: @credit_card, amount: -250)
+    rival = Transfer.create!(inflow_transaction_id: rival_in.entryable_id, outflow_transaction_id: rival_out.entryable_id)
+
+    original = Transfer.method(:find_or_create_by!)
+    Transfer.singleton_class.send(:define_method, :find_or_create_by!) do |attributes|
+      if attributes[:inflow_transaction_id] == inflow_id
+        insert!(inflow_transaction_id: rival.inflow_transaction_id, outflow_transaction_id: rival.outflow_transaction_id)
+      else
+        original.call(attributes)
+      end
+    end
+
+    begin
+      assert_nothing_raised { @family.auto_match_transfers! }
+    ensure
+      Transfer.singleton_class.send(:remove_method, :find_or_create_by!)
+    end
+
+    inflow_entry.reload
+    outflow_entry.reload
+
+    # The surrounding transaction stayed healthy, so the kinds were still written.
+    assert_equal "funds_movement", inflow_entry.entryable.kind
+    assert_equal "cc_payment", outflow_entry.entryable.kind
+  end
+
+  test "validation-path race during matching does not abort the run" do
+    outflow_entry = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    # A concurrent job already committed the rival row, so the uniqueness
+    # validation rejects the insert with :taken before any SQL is issued.
+    invalid = Transfer.new(inflow_transaction_id: inflow_entry.entryable_id, outflow_transaction_id: outflow_entry.entryable_id)
+    invalid.errors.add(:inflow_transaction_id, :taken)
+    Transfer.stubs(:find_or_create_by!).raises(ActiveRecord::RecordInvalid.new(invalid))
+
+    assert_nothing_raised { @family.auto_match_transfers! }
+
+    inflow_entry.reload
+    outflow_entry.reload
+
+    assert_equal "funds_movement", inflow_entry.entryable.kind
+    assert_equal "cc_payment", outflow_entry.entryable.kind
+  end
+
+  test "non-uniqueness validation failure during matching is not swallowed" do
+    create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -500)
+
+    # A genuine (non-race) validation failure must surface, not be skipped silently.
+    invalid = Transfer.new
+    invalid.errors.add(:base, :different_accounts)
+    Transfer.stubs(:find_or_create_by!).raises(ActiveRecord::RecordInvalid.new(invalid))
+
+    assert_raises(ActiveRecord::RecordInvalid) { @family.auto_match_transfers! }
+  end
+
   test "auto-matches multi-currency transfers" do
     load_exchange_prices
     create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -50,17 +50,20 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     inflow_entry.reload
     outflow_entry.reload
 
-    # The surrounding transaction stayed healthy, so the kinds were still written.
-    assert_equal "funds_movement", inflow_entry.entryable.kind
-    assert_equal "cc_payment", outflow_entry.entryable.kind
+    # The collision was with a DIFFERENT pair (the rival), so no Transfer exists for
+    # THIS pair: the match is skipped, not marked. The savepoint kept the surrounding
+    # transaction healthy (no abort asserted above).
+    assert_nil Transfer.find_by(inflow_transaction_id: inflow_id, outflow_transaction_id: outflow_entry.entryable_id)
+    refute_equal "funds_movement", inflow_entry.entryable.kind
   end
 
-  test "validation-path race during matching does not abort the run" do
+  test "a :taken on one column from a different pairing is skipped, not marked" do
     outflow_entry = create_transaction(date: 1.day.ago.to_date, account: @depository, amount: 500)
     inflow_entry = create_transaction(date: Date.current, account: @credit_card, amount: -500)
 
-    # A concurrent job already committed the rival row, so the uniqueness
-    # validation rejects the insert with :taken before any SQL is issued.
+    # A concurrent sync matched this inflow to a DIFFERENT outflow, so the per-column
+    # uniqueness validation raises :taken on inflow_transaction_id -- but no Transfer
+    # exists for THIS (inflow, outflow) pair.
     invalid = Transfer.new(inflow_transaction_id: inflow_entry.entryable_id, outflow_transaction_id: outflow_entry.entryable_id)
     invalid.errors.add(:inflow_transaction_id, :taken)
     Transfer.stubs(:find_or_create_by!).raises(ActiveRecord::RecordInvalid.new(invalid))
@@ -70,8 +73,10 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     inflow_entry.reload
     outflow_entry.reload
 
-    assert_equal "funds_movement", inflow_entry.entryable.kind
-    assert_equal "cc_payment", outflow_entry.entryable.kind
+    # No Transfer was created for this pair, so neither transaction may be marked.
+    assert_nil Transfer.find_by(inflow_transaction_id: inflow_entry.entryable_id, outflow_transaction_id: outflow_entry.entryable_id)
+    refute_equal "funds_movement", inflow_entry.entryable.kind
+    refute_equal "cc_payment", outflow_entry.entryable.kind
   end
 
   test "non-uniqueness validation failure during matching is not swallowed" do


### PR DESCRIPTION
## Summary

Under concurrent syncs of the same family, `Family#auto_match_transfers!` could abort its own PostgreSQL transaction and silently skip the remaining candidates. This makes a lost unique-index race harmless again.

Fixes #2471.

## Root cause

`auto_match_transfers!` opens one `Transfer.transaction` and, for each candidate pair, calls `Transfer.find_or_create_by!` while rescuing `ActiveRecord::RecordNotUnique`. The `transfers` table has a composite unique index on `(inflow_transaction_id, outflow_transaction_id)`, so when two syncs of the same family run at once, the losing insert raises the unique violation.

On PostgreSQL a failed statement aborts the entire surrounding transaction. Rescuing the Ruby exception does not clear that aborted state, so the next `update!` raises `PG::InFailedSqlTransaction` and every following candidate in the loop is dropped.

## Fix

The per-candidate insert now runs inside its own savepoint via `Transfer.transaction(requires_new: true)`, extracted into a small private `find_or_create_transfer!` helper. When the race is lost, only that statement rolls back to the savepoint; the `RecordNotUnique` is rescued and the surrounding transaction stays healthy, so the loop keeps matching the remaining candidates.

The same race can also surface through the model's uniqueness validation (a `RecordInvalid` with a `:taken` error on `inflow_transaction_id`/`outflow_transaction_id`) when the rival row is already committed. That case is treated as "already created" too, while any other validation failure is re-raised so genuine errors are never swallowed.

## Testing

Added regression tests in `test/models/family/auto_transfer_matchable_test.rb`:

- a genuine unique-index collision during matching (a real failing insert, since only that aborts the transaction) — asserts the run completes and still writes the transfer kinds;
- a validation-path race (`RecordInvalid` with `:taken`) — asserts the run is not aborted;
- a non-uniqueness validation failure — asserts it still propagates and is not silently swallowed.

```bash
bin/rails test test/models/family/auto_transfer_matchable_test.rb
```

<details><summary>Notes I made while reviewing this</summary>

- **minor** `test/models/family/auto_transfer_matchable_test.rb:35` — Test 1 redefines Transfer.find_or_create_by! via singleton_class define_method/remove_method rather than a mocha stub. This is necessary here (it must conditionally call a real insert! to produce a genuine DB unique violation), and remove_method in the ensure block correctly restores the inherited method, so it is safe — just stylistically heavier than the rest of the suite.
- **minor** `app/models/family/auto_transfer_matchable.rb:95` — The RecordInvalid(:taken) rescue path is broader than the issue described (which is only about the RecordNotUnique/SAVEPOINT-abort scenario). It is a legitimate variant of the same race — find_or_create_by! can hit the uniqueness validation if the rival commits between its SELECT and INSERT — but note that a pure validation failure issues no SQL and therefore never aborts the PG transaction, so this rescue is defensive rather than strictly required by the reported bug.
- **minor** `app/models/family/auto_transfer_matchable.rb:95` — Swallowing RecordInvalid(:taken) subtly widens behavior vs the original (which only caught RecordNotUnique): a pair like (A,B) vs (A,C) where A is already in another transfer will now be silently treated as 'already created' even though no DB-level composite-index collision occurred. This is arguably correct (the inflow already belongs to a transfer), but it is broader than the DB unique constraint and worth a conscious nod.
- **minor** `test/models/family/auto_transfer_matchable_test.rb:36` — The 'concurrent unique-index race' test redefines Transfer.find_or_create_by! on the singleton class and relies on an ensure block to remove it. This is more fragile than the mocha stubbing used in the sibling tests, but it is the one path that produces a genuine failing INSERT (RecordNotUnique) needed to reproduce the PG abort, so a plain stub could not cover it.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic transfer matching to better handle concurrent duplicate creation, so the overall matching run continues without disruption.
  * Matching now avoids marking transactions as matched when a corresponding transfer record can’t be created.
  * Gracefully handles uniqueness-related “taken” validation failures for the relevant inflow/outflow pairing, while still surfacing other validation issues.

* **Tests**
  * Added regression tests covering concurrent unique-index races, “taken” errors caused by other pairings, and non-uniqueness validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->