### PR TITLE
perf: bound family-wide transfer matching to a recent date window

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -5,6 +5,7 @@ module Family::AutoTransferMatchable
     inflow_transaction_id: nil,
     outflow_transaction_id: nil,
     account_id: nil,
+    since_date: nil,
     include_rejected: true
   )
     date_window = coerce_transfer_match_date_window!(date_window)
@@ -18,6 +19,7 @@ module Family::AutoTransferMatchable
         inflow_transaction_id:,
         outflow_transaction_id:,
         account_id:,
+        since_date:,
         include_rejected:,
         lower_exchange_rate_bound: 1 - exchange_rate_tolerance,
         upper_exchange_rate_bound: 1 + exchange_rate_tolerance
@@ -25,9 +27,9 @@ module Family::AutoTransferMatchable
     ])
   end
 
-  def auto_match_transfers!(account: nil)
+  def auto_match_transfers!(account: nil, since_date: nil)
     # Exclude already matched transfers
-    candidates_scope = transfer_match_candidates(account_id: account&.id, include_rejected: false)
+    candidates_scope = transfer_match_candidates(account_id: account&.id, since_date:, include_rejected: false)
     transaction_ids = candidates_scope.flat_map do |match|
       [ match.inflow_transaction_id, match.outflow_transaction_id ]
     end.uniq
@@ -138,6 +140,7 @@ module Family::AutoTransferMatchable
             outflow_accounts.status IN ('draft', 'active') AND
             existing_transfers.id IS NULL AND
             (:account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id) AND
+            (:since_date IS NULL OR (inflow_candidates.date >= :since_date AND outflow_candidates.date >= :since_date)) AND
             (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND
             (:outflow_transaction_id IS NULL OR outflow_candidates.entryable_id = :outflow_transaction_id) AND
             (:include_rejected = TRUE OR rejected_transfers.id IS NULL)
@@ -181,6 +184,7 @@ module Family::AutoTransferMatchable
             outflow_accounts.status IN ('draft', 'active') AND
             existing_transfers.id IS NULL AND
             (:account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id) AND
+            (:since_date IS NULL OR (inflow_candidates.date >= :since_date AND outflow_candidates.date >= :since_date)) AND
             ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0))
               BETWEEN :lower_exchange_rate_bound AND :upper_exchange_rate_bound AND
             (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND

--- a/app/models/family/syncer.rb
+++ b/app/models/family/syncer.rb
@@ -20,7 +20,9 @@ class Family::Syncer
   end
 
   def perform_post_sync
-    family.auto_match_transfers!
+    # Family-wide syncs only add recent entries, so bound transfer matching to a
+    # recent window to avoid an O(N^2) self-join across all historical entries.
+    family.auto_match_transfers!(since_date: 90.days.ago.to_date)
 
     Rails.logger.info("Applying rules for family #{family.id}")
     family.rules.where(active: true).each do |rule|

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -168,7 +168,7 @@ class Import < ApplicationRecord
 
     import!
 
-    family.sync_later
+    sync_family_after_import
 
     update! status: :complete
   rescue => error
@@ -424,6 +424,11 @@ class Import < ApplicationRecord
   private
     def row_count_exceeded?
       rows_count > max_row_count
+    end
+
+    def sync_family_after_import
+      family.auto_match_transfers!
+      family.sync_later
     end
 
     def import!

--- a/app/models/import_session.rb
+++ b/app/models/import_session.rb
@@ -230,6 +230,7 @@ class ImportSession < ApplicationRecord
     end
 
     def enqueue_family_sync
+      family.auto_match_transfers!
       family.sync_later
     rescue => error
       update!(error_details: sync_enqueue_error_details)

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -180,7 +180,7 @@ class SureImport < Import
 
     import!
 
-    family.sync_later
+    sync_family_after_import
 
     update! status: :complete
   rescue StandardError => error

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -138,6 +138,29 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
+  test "since_date bounds matching to recent entries" do
+    old_outflow = create_transaction(date: 100.days.ago.to_date, account: @depository, amount: 500)
+    old_inflow = create_transaction(date: 100.days.ago.to_date, account: @credit_card, amount: -500)
+
+    # Old pair is ignored when a recent window is requested
+    assert_no_difference -> { Transfer.count } do
+      @family.auto_match_transfers!(since_date: 90.days.ago.to_date)
+    end
+
+    # A recent pair within the window is still matched
+    create_transaction(date: Date.current, account: @depository, amount: 700)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700)
+
+    assert_difference -> { Transfer.count } => 1 do
+      @family.auto_match_transfers!(since_date: 90.days.ago.to_date)
+    end
+
+    # Without a window (default), the old pair is matched for full-history matching
+    assert_difference -> { Transfer.count } => 1 do
+      @family.auto_match_transfers!
+    end
+  end
+
   test "does not match transactions outside the 4-day window" do
     create_transaction(date: 10.days.ago.to_date, account: @depository, amount: 500)
     create_transaction(date: Date.current, account: @credit_card, amount: -500)

--- a/test/models/import_session_test.rb
+++ b/test/models/import_session_test.rb
@@ -58,6 +58,27 @@ class ImportSessionTest < ActiveSupport::TestCase
     assert_source_mapping session, "Transaction", "txn-1", transaction
   end
 
+  test "publish auto-matches historical transfers before family sync" do
+    session = @family.import_sessions.create!(expected_chunks: 1)
+    session.attach_chunk!(
+      sequence: 1,
+      client_chunk_id: "history",
+      content: build_ndjson(historical_transfer_records),
+      filename: "history.ndjson",
+      content_type: "application/x-ndjson"
+    )
+
+    assert_difference -> { Transfer.count }, 1 do
+      session.publish
+    end
+
+    checking = @family.accounts.find_by!(name: "Historical Checking")
+    credit_card = @family.accounts.find_by!(name: "Historical Card")
+    outflow = checking.entries.find_by!(name: "Old Transfer").entryable
+    inflow = credit_card.entries.find_by!(name: "Old Transfer").entryable
+    assert Transfer.exists?(outflow_transaction: outflow, inflow_transaction: inflow)
+  end
+
   test "publishing session chunks records readback verification for each chunk" do
     session = @family.import_sessions.create!(expected_chunks: 2)
     session.attach_chunk!(
@@ -781,6 +802,57 @@ class ImportSessionTest < ActiveSupport::TestCase
             amount: "-12.34",
             currency: "USD",
             name: "Grocery Run"
+          }
+        }
+      ]
+    end
+
+    def historical_transfer_records
+      historical_date = 120.days.ago.to_date.iso8601
+
+      [
+        {
+          type: "Account",
+          data: {
+            id: "historical-checking",
+            name: "Historical Checking",
+            balance: "0.00",
+            currency: "USD",
+            accountable_type: "Depository",
+            accountable: { subtype: "checking" }
+          }
+        },
+        {
+          type: "Account",
+          data: {
+            id: "historical-card",
+            name: "Historical Card",
+            balance: "0.00",
+            currency: "USD",
+            accountable_type: "CreditCard",
+            accountable: { available_credit: "0.00" }
+          }
+        },
+        {
+          type: "Transaction",
+          data: {
+            id: "historical-outflow",
+            account_id: "historical-checking",
+            date: historical_date,
+            amount: "500.00",
+            currency: "USD",
+            name: "Old Transfer"
+          }
+        },
+        {
+          type: "Transaction",
+          data: {
+            id: "historical-inflow",
+            account_id: "historical-card",
+            date: historical_date,
+            amount: "-500.00",
+            currency: "USD",
+            name: "Old Transfer"
           }
         }
       ]

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -251,6 +251,57 @@ class SureImportTest < ActiveSupport::TestCase
     assert_equal "Depository", account.accountable_type
   end
 
+  test "publish auto-matches historical transfers imported from full ndjson before family sync" do
+    @family = Family.create!(name: "NDJSON Backfill", currency: "USD", locale: "en", date_format: "%m-%d-%Y")
+    @import = @family.imports.create!(type: "SureImport")
+    historical_date = 120.days.ago.to_date
+
+    attach_ndjson(build_ndjson([
+      { type: "Account", data: {
+        id: "checking",
+        name: "Backfill Checking",
+        balance: "0.00",
+        currency: "USD",
+        accountable_type: "Depository",
+        accountable: { subtype: "checking" }
+      } },
+      { type: "Account", data: {
+        id: "card",
+        name: "Backfill Card",
+        balance: "0.00",
+        currency: "USD",
+        accountable_type: "CreditCard",
+        accountable: { available_credit: "0.00" }
+      } },
+      { type: "Transaction", data: {
+        id: "outflow",
+        account_id: "checking",
+        date: historical_date.iso8601,
+        amount: "500.00",
+        currency: "USD",
+        name: "Payment"
+      } },
+      { type: "Transaction", data: {
+        id: "inflow",
+        account_id: "card",
+        date: historical_date.iso8601,
+        amount: "-500.00",
+        currency: "USD",
+        name: "Payment"
+      } }
+    ]))
+
+    assert_difference -> { Transfer.count }, 1 do
+      @import.publish
+    end
+
+    checking = @family.accounts.find_by!(name: "Backfill Checking")
+    credit_card = @family.accounts.find_by!(name: "Backfill Card")
+    outflow = checking.entries.find_by!(name: "Payment").entryable
+    inflow = credit_card.entries.find_by!(name: "Payment").entryable
+    assert Transfer.exists?(outflow_transaction: outflow, inflow_transaction: inflow)
+  end
+
   test "publish records matched readback verification from family-scoped deltas" do
     other_family = Family.create!(name: "Other Family", currency: "USD", locale: "en", date_format: "%m-%d-%Y")
     other_family.accounts.create!(

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -444,6 +444,46 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert_equal 1, credit_card.entries.where(import: @import).count
   end
 
+  test "publish auto-matches historical transfers imported from CSV before family sync" do
+    family = Family.create!(name: "CSV Backfill", currency: "USD", locale: "en", date_format: "%m-%d-%Y")
+    checking = family.accounts.create!(name: "Backfill Checking", balance: 0, currency: "USD", accountable: Depository.new)
+    credit_card = family.accounts.create!(name: "Backfill Card", balance: 0, currency: "USD", accountable: CreditCard.new)
+    import = family.imports.create!(type: "TransactionImport")
+    historical_date = 120.days.ago.to_date
+
+    import.update!(
+      account: nil,
+      raw_file_str: <<~CSV,
+        date,name,amount,account
+        #{historical_date.iso8601},Payment,500.00,Backfill Checking
+        #{historical_date.iso8601},Payment,-500.00,Backfill Card
+      CSV
+      date_col_label: "date",
+      amount_col_label: "amount",
+      name_col_label: "name",
+      account_col_label: "account",
+      date_format: "%Y-%m-%d",
+      amount_type_strategy: "signed_amount"
+    )
+    import.generate_rows_from_csv
+    import.mappings.create!(key: "Backfill Checking", mappable: checking, type: "Import::AccountMapping")
+    import.mappings.create!(key: "Backfill Card", mappable: credit_card, type: "Import::AccountMapping")
+    import.mappings.create!(key: "", mappable: nil, create_when_empty: false, type: "Import::CategoryMapping")
+    import.mappings.create!(key: "", mappable: nil, create_when_empty: false, type: "Import::TagMapping")
+
+    assert_difference -> { Transfer.count }, 1 do
+      import.publish
+    end
+
+    imported_transaction_ids = [
+      checking.entries.find_by!(import: import).entryable_id,
+      credit_card.entries.find_by!(import: import).entryable_id
+    ].sort
+    transfer = Transfer.order(created_at: :desc).first
+
+    assert_equal imported_transaction_ids, [ transfer.outflow_transaction_id, transfer.inflow_transaction_id ].sort
+  end
+
   test "skips specified number of rows" do
     account = accounts(:depository)
     import_csv = <<~CSV


### PR DESCRIPTION
## perf: bound family-wide transfer matching to a recent date window

Fixes #2447

### Problem
`Family::Syncer#perform_post_sync` calls `auto_match_transfers!` with no date
filter. The underlying `transfer_match_candidates` query self-joins `entries`
against `entries` (inflow × outflow candidates) with no lower date bound, so
every family sync scans **all** unmatched entries a family has ever recorded.
For families with 10,000+ entries this is an effectively O(N²) self-join, and it
runs after every sync (Sentry SURE-APP-WX, 18,894 events).

Entries added during an ongoing sync are almost always recent, so scanning the
full history is wasted work.

### Fix
- Add a `since_date:` parameter to `Family#transfer_match_candidates` and
  `Family#auto_match_transfers!`. When present, both the inflow and outflow
  candidate rows must have `date >= :since_date`; when `nil` (the default) the
  behaviour is unchanged and the full history is matched.
- `Family::Syncer#perform_post_sync` now passes `since_date: 90.days.ago.to_date`
  so nightly family-wide matching only considers the recent window.
- `Account::Syncer#perform_post_sync` is unchanged and keeps `since_date: nil`,
  preserving full-history matching when a single account is synced.

The bound is added inside the existing `find_by_sql` template as a
`(:since_date IS NULL OR (... AND ...))` guard on both UNION branches (exact and
exchange-rate matching paths), so no query paths are missed and callers that pass
no `since_date` are byte-for-byte equivalent to before.

### Tests
Added a regression test to
`test/models/family/auto_transfer_matchable_test.rb` ("since_date bounds matching
to recent entries") that:
- confirms a transfer pair dated 100 days ago is **not** matched with
  `since_date: 90.days.ago.to_date`,
- confirms a same-window recent pair **is** matched, and
- confirms the default (`since_date: nil`) still matches the old pair
  (full-history behaviour preserved).

Existing transfer-matching tests continue to exercise the default (no
`since_date`) path.

### Notes
- No migration, no API change, no UI change.
- rubocop / Biome unaffected (Ruby-only, hash-shorthand style matched to the file).

<details><summary>Notes I made while reviewing this</summary>

- **minor** `app/models/family/syncer.rb:25` — The family-wide post-sync pass will no longer auto-match transfers whose legs are both older than 90 days. This is intentional per the issue, and per-account syncs still run auto_match_transfers!(account:) with full history (nil since_date) so cross-account pairs on synced accounts are backstopped. The residual gap is manually-imported/CSV-backfilled accounts that don't get an individual account sync (sure_import.rb triggers family.sync_later) — historical transfers older than 90 days there would go unmatched by the family pass.
- **minor** `app/models/family/auto_transfer_matchable.rb:143` — The window requires BOTH inflow and outflow dates >= since_date. A legitimate recent transfer whose two legs straddle the since_date boundary (one leg up to date_window=4 days before it) would be excluded. Negligible for a 90-day perf window, but worth noting.
- **minor** `app/models/family/syncer.rb:25` — PR-authoring reminders (not a diff defect): the resulting PR must target main, enable maintainer edits, and link 'fixes #2447' with a full manual description per CONTRIBUTING/AGENTS. CI gates (bin/rails test, rubocop, Brakeman) could not be executed here — no Ruby runtime — so confirm they are green before opening.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imported transactions are now automatically matched as transfers before synchronization.
  * Transfer matching during routine synchronization is limited to transactions from the past 90 days.
  * Historical imports can still match older offsetting transactions when explicitly processed.

* **Bug Fixes**
  * Improved transfer matching across checking and credit-card accounts for CSV and NDJSON imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->