### PR TITLE
fix(import): tolerate null Rule names and orphaned rejected transfers

### DIFF
--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -735,9 +735,15 @@ class Family::DataImporter
     def import_rejected_transfers(records)
       records.each do |record|
         data = record["data"]
-        inflow_transaction_id = mapped_id(:transactions, data["inflow_transaction_id"], record_type: "RejectedTransfer")
-        outflow_transaction_id = mapped_id(:transactions, data["outflow_transaction_id"], record_type: "RejectedTransfer")
-        next unless inflow_transaction_id && outflow_transaction_id
+        # A rejected transfer is an advisory hint that stops two transactions from
+        # being re-matched. When either side is missing (e.g. the transaction was
+        # deleted after the rejection), skip the row instead of failing the import.
+        inflow_transaction_id = mapped_id(:transactions, data["inflow_transaction_id"], record_type: "RejectedTransfer", required: false)
+        outflow_transaction_id = mapped_id(:transactions, data["outflow_transaction_id"], record_type: "RejectedTransfer", required: false)
+        unless inflow_transaction_id && outflow_transaction_id
+          increment_summary("RejectedTransfer", :skipped)
+          next
+        end
 
         rejected_transfer = RejectedTransfer.find_or_create_by!(
           inflow_transaction_id: inflow_transaction_id,

--- a/app/models/import/preflight.rb
+++ b/app/models/import/preflight.rb
@@ -237,7 +237,11 @@ class Import::Preflight
         content: content
       ).call
       stats = result.stats
-      warnings = result.warnings.dup
+      # result.warnings are {code, message} hashes internally, but the published
+      # OpenAPI contract documents preflight warnings as strings. Surface the
+      # human-readable message at the API boundary so the array stays homogeneous and
+      # contract-generated clients can still deserialize it.
+      warnings = result.warnings.map { |warning| warning.is_a?(Hash) ? warning[:message] : warning }
       warnings << "No importable records were found." if stats[:rows_count].positive? && (stats[:entity_counts] || {}).values.sum.zero?
       warnings << "Row count exceeds this import type's publish limit." if stats[:rows_count] > SureImport.max_row_count
 

--- a/app/models/sure_import/preflight.rb
+++ b/app/models/sure_import/preflight.rb
@@ -25,8 +25,13 @@ class SureImport::Preflight
     "Valuation" => %w[account_id date amount],
     "Budget" => %w[id start_date end_date],
     "BudgetCategory" => %w[budget_id category_id],
-    "Rule" => %w[name]
+    "Rule" => %w[id]
   }.freeze
+
+  # Record types whose references are advisory: the importer skips rows whose
+  # referenced records are absent instead of failing, so a dangling reference is
+  # a warning rather than a blocking error.
+  SOFT_REFERENCE_TYPES = %w[RejectedTransfer].freeze
 
   TAXONOMY_TYPES = { "Category" => :categories, "Tag" => :tags, "Merchant" => :merchants }.freeze
 
@@ -265,7 +270,12 @@ class SureImport::Preflight
     def validate_reference(record, type, mapping_key, field, value)
       return if value.blank?
       return if @source_ids[mapping_key].include?(value.to_s)
-      add_error(:missing_reference, "Line #{record[:line_number]} #{type} references missing #{field} #{value.inspect}.")
+      message = "Line #{record[:line_number]} #{type} references missing #{field} #{value.inspect}."
+      if SOFT_REFERENCE_TYPES.include?(type)
+        add_warning(:skipped_missing_reference, "#{message} It will be skipped during import.")
+      else
+        add_error(:missing_reference, message)
+      end
     end
 
     def validate_tag_references(record, type)
@@ -309,4 +319,6 @@ class SureImport::Preflight
     def blank_required_value?(value) = value.blank?
 
     def add_error(code, message) = @errors << { code: code.to_s, message: message }
+
+    def add_warning(code, message) = @warnings << { code: code.to_s, message: message }
 end

--- a/app/models/sure_import/preflight.rb
+++ b/app/models/sure_import/preflight.rb
@@ -270,11 +270,16 @@ class SureImport::Preflight
     def validate_reference(record, type, mapping_key, field, value)
       return if value.blank?
       return if @source_ids[mapping_key].include?(value.to_s)
-      message = "Line #{record[:line_number]} #{type} references missing #{field} #{value.inspect}."
+      interpolations = {
+        line: record[:line_number],
+        type: type,
+        field: field,
+        value: value.inspect
+      }
       if SOFT_REFERENCE_TYPES.include?(type)
-        add_warning(:skipped_missing_reference, "#{message} It will be skipped during import.")
+        add_warning(:skipped_missing_reference, I18n.t("sure_import.preflight.skipped_missing_reference", **interpolations))
       else
-        add_error(:missing_reference, message)
+        add_error(:missing_reference, I18n.t("sure_import.preflight.missing_reference", **interpolations))
       end
     end
 

--- a/config/locales/models/sure_import/preflight/en.yml
+++ b/config/locales/models/sure_import/preflight/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  sure_import:
+    preflight:
+      missing_reference: "Line %{line} %{type} references missing %{field} %{value}."
+      skipped_missing_reference: "Line %{line} %{type} references missing %{field} %{value}. It will be skipped during import."

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -1636,6 +1636,45 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal "Candidate outflow", rejected_transfer.outflow_transaction.entry.name
   end
 
+  test "skips rejected transfers with missing transactions under strict import" do
+    session = @family.import_sessions.create!(expected_chunks: 1)
+
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: { id: "checking", name: "Checking", balance: "1000", currency: "USD", accountable_type: "Depository" }
+      },
+      {
+        type: "Account",
+        data: { id: "savings", name: "Savings", balance: "2500", currency: "USD", accountable_type: "Depository" }
+      },
+      {
+        type: "Transaction",
+        data: { id: "rejected-outflow", account_id: "checking", date: "2024-01-20", amount: "25.00", name: "Candidate outflow", currency: "USD", kind: "standard" }
+      },
+      {
+        type: "Transaction",
+        data: { id: "rejected-inflow", account_id: "savings", date: "2024-01-20", amount: "-25.00", name: "Candidate inflow", currency: "USD", kind: "standard" }
+      },
+      {
+        type: "RejectedTransfer",
+        data: { id: "rejected-valid", inflow_transaction_id: "rejected-inflow", outflow_transaction_id: "rejected-outflow" }
+      },
+      {
+        type: "RejectedTransfer",
+        data: { id: "rejected-orphan", inflow_transaction_id: "rejected-inflow", outflow_transaction_id: "missing-outflow" }
+      }
+    ])
+
+    result = nil
+    assert_difference -> { RejectedTransfer.count }, 1 do
+      result = Family::DataImporter.new(@family, ndjson, import_session: session).import!
+    end
+
+    assert_equal 1, result[:summary].dig("rejected_transfers", "created")
+    assert_equal 1, result[:summary].dig("rejected_transfers", "skipped")
+  end
+
   test "imports duplicate transfer decisions idempotently with unknown status fallback" do
     ndjson = build_ndjson([
       {

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -611,6 +611,23 @@ class SureImportTest < ActiveSupport::TestCase
     assert_includes codes, "missing_reference"
   end
 
+  test "preflight allows null rule names and treats orphaned rejected transfers as warnings" do
+    attach_ndjson(build_ndjson([
+      { type: "Rule", data: { id: "rule-1", name: nil, resource_type: "transaction" } },
+      { type: "RejectedTransfer", data: {
+        id: "rejected-1",
+        inflow_transaction_id: "missing-inflow",
+        outflow_transaction_id: "missing-outflow"
+      } }
+    ]))
+
+    result = @import.sure_preflight
+
+    assert result.valid?, result.error_message
+    assert_empty result.errors
+    assert_includes result.warnings.map { |warning| warning[:code] }, "skipped_missing_reference"
+  end
+
   test "preflight rejects invalid accountable types through explicit allowlist" do
     attach_ndjson(build_ndjson([
       { type: "Account", data: {

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -865,6 +865,30 @@ class Import::PreflightTest < ActiveSupport::TestCase
     assert_includes payload[:warnings], "No importable records were found."
   end
 
+  test "SureImport preflight serializes hash warnings as strings at the API boundary" do
+    result = Struct.new(:stats, :errors, :warnings, keyword_init: true) do
+      def valid?
+        true
+      end
+    end.new(
+      stats: { rows_count: 2, valid_rows_count: 2, invalid_rows_count: 0, entity_counts: { accounts: 2 } },
+      errors: [],
+      warnings: [ { code: "skipped_missing_reference", message: "Skipped an orphaned rejected transfer." } ]
+    )
+    SureImport::Preflight.stubs(:new).returns(stub(call: result))
+
+    response = Import::Preflight.new(
+      family: @family,
+      params: { type: "SureImport", raw_file_content: "{}" }
+    ).call
+    payload = response.payload[:data]
+
+    # The contract documents warnings as strings, so the {code, message} hash must
+    # surface as its message -- never leak the hash into the response.
+    assert payload[:warnings].all? { |warning| warning.is_a?(String) }, "preflight warnings must be strings"
+    assert_includes payload[:warnings], "Skipped an orphaned rejected transfer."
+  end
+
   private
 
     def build_ndjson(records)


### PR DESCRIPTION
Fixes #2721

## Problem

Importing a full `all.ndjson` export through the Raw Data / Full `.ndjson` import
flow aborted on exports that are perfectly valid data, for two reasons:

1. **`Rule.name` was treated as required.** The Sure preflight listed `name` as a
   required field for `Rule`, but `rules.name` is nullable (`db/schema.rb`) and the
   model explicitly allows it (`validates :name, length: { minimum: 1 }, allow_nil: true`).
   A single rule with `"name": null` failed preflight and blocked the entire import.

2. **Dangling `RejectedTransfer` rows aborted the import.** A `RejectedTransfer` is
   an advisory hint that stops two transactions from being re-matched. When one of
   the referenced transactions is gone (e.g. deleted after the rejection), the
   preflight raised a hard `missing_reference` error, and — even past preflight — the
   importer raised `MissingReferenceError` in strict (session) mode instead of taking
   the `next unless inflow && outflow` skip path that was already written for it.

## Fix

- `SureImport::Preflight`: require `Rule.id` (the field the importer actually needs,
  consistent with every other record type) instead of the optional `Rule.name`.
- `SureImport::Preflight`: treat `RejectedTransfer` references as advisory — a missing
  referenced transaction is now a **warning** (`skipped_missing_reference`) rather than
  a blocking error, matching the importer's skip behaviour.
- `Family::DataImporter#import_rejected_transfers`: resolve the transaction references
  with `required: false` so an orphaned rejected transfer is skipped (and counted as
  `skipped`) instead of raising under strict imports.

The exporter already filters rejected transfers to family transactions and the DB
enforces `on_delete: :cascade`, so new exports cannot contain these rows; this change
makes the importer resilient to existing exports that predate those guarantees.

## Tests

- `test/models/sure_import_test.rb` — preflight accepts a null `Rule.name` and reports
  an orphaned `RejectedTransfer` as a warning rather than an error.
- `test/models/family/data_importer_test.rb` — a strict (session) import skips a
  rejected transfer whose transaction is missing while still importing the valid one.

## Migration notes

None.

<details><summary>Notes I made while reviewing this</summary>

- **minor** `app/models/sure_import/preflight.rb:28` — Dropping `name` from Rule required fields means an empty-string ("") name — as opposed to null — now passes preflight but would raise ActiveRecord::RecordInvalid during import (Rule validates name length minimum:1 for non-nil values), aborting the whole import transaction instead of surfacing a clean preflight error. Real exports serialize null rather than empty string, so low likelihood.
- **minor** `app/models/sure_import/preflight.rb:274` — A RejectedTransfer that references a transaction which SHOULD exist but is genuinely missing now degrades silently to a warning + skip rather than surfacing loudly. This is the intended advisory semantics and matches the importer's skip behavior, but it does slightly reduce the diagnostic signal for a malformed export.
- **minor** `app/models/family/data_importer.rb:736` — In non-strict mode (import_session nil) the old code skipped orphaned rejected transfers silently; now they increment the 'skipped' summary. This is a slight behavior change to the summary counts, but it is more accurate and harmless.
- **minor** `app/models/import/preflight.rb:240` — sure_import_preflight_payload appends plain-string warnings (lines 241-242) into the same array that now receives {code:, message:} hash warnings from SureImport::Preflight. Previously preflight warnings were always empty, so this heterogeneous mix is newly created and is exposed in the /api/v1/imports/preflight JSON response. No crash, but inconsistent shape for any consumer.
- **minor** `app/models/sure_import/preflight.rb:275` — The new warning message string is hardcoded English (not t()), consistent with every other message in this preflight file. Not a new violation, but the repo's i18n rule technically covers user-facing strings and these warnings surface via the import UI/API.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Imports no longer fail when rejected transfers reference missing transactions.
  * Orphaned rejected transfers are skipped and surfaced as warnings during preflight validation.
  * Validation now supports Rule records when only an ID is provided.
  * Preflight warning messages are now returned in the expected (string) format for the API response.

* **Tests**
  * Added strict-import and preflight scenarios covering skipped/reported missing references and unnamed rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->