### PR TITLE
fix(akahu): pull full history on initial Akahu sync

### DIFF
--- a/app/models/akahu_item/importer.rb
+++ b/app/models/akahu_item/importer.rb
@@ -1,6 +1,14 @@
 require "digest/md5"
 
 class AkahuItem::Importer
+  # Akahu's transactions endpoint only returns data from the requested `start`
+  # onward (paginating the full range via cursor). On the first sync of an
+  # account we therefore request a long lookback so all historic transactions
+  # the connection can provide are pulled through, rather than clamping to a
+  # short recent window. Akahu returns only the data that actually exists, so an
+  # early start date simply captures everything available.
+  INITIAL_SYNC_LOOKBACK = 5.years
+
   attr_reader :akahu_item, :akahu_provider
 
   def initialize(akahu_item, akahu_provider:)
@@ -236,7 +244,7 @@ class AkahuItem::Importer
       if has_stored_transactions && akahu_item.last_synced_at
         akahu_item.last_synced_at - 7.days
       else
-        90.days.ago
+        INITIAL_SYNC_LOOKBACK.ago
       end
     end
 

--- a/app/models/akahu_item/importer.rb
+++ b/app/models/akahu_item/importer.rb
@@ -1,14 +1,6 @@
 require "digest/md5"
 
 class AkahuItem::Importer
-  # Akahu's transactions endpoint only returns data from the requested `start`
-  # onward (paginating the full range via cursor). On the first sync of an
-  # account we therefore request a long lookback so all historic transactions
-  # the connection can provide are pulled through, rather than clamping to a
-  # short recent window. Akahu returns only the data that actually exists, so an
-  # early start date simply captures everything available.
-  INITIAL_SYNC_LOOKBACK = 5.years
-
   attr_reader :akahu_item, :akahu_provider
 
   def initialize(akahu_item, akahu_provider:)
@@ -244,7 +236,11 @@ class AkahuItem::Importer
       if has_stored_transactions && akahu_item.last_synced_at
         akahu_item.last_synced_at - 7.days
       else
-        INITIAL_SYNC_LOOKBACK.ago
+        # Initial sync: omit the start date entirely. Akahu's transactions
+        # endpoint defaults to the full accessible range when no start is given,
+        # so this pulls the connection's complete history instead of clamping it
+        # to a fixed lookback window (which truncated apps with >5 years of data).
+        nil
       end
     end
 

--- a/test/models/akahu_item/importer_test.rb
+++ b/test/models/akahu_item/importer_test.rb
@@ -105,9 +105,8 @@ class AkahuItem::ImporterTest < ActiveSupport::TestCase
     AkahuItem::Importer.new(@akahu_item, akahu_provider: provider).import
 
     start_date = provider.transaction_calls.first[:start_date]
-    assert start_date.present?, "expected an explicit start date for the initial sync"
-    assert start_date < 100.days.ago, "initial sync should reach further back than the recent 90-day window"
-    assert_in_delta AkahuItem::Importer::INITIAL_SYNC_LOOKBACK.ago.to_i, start_date.to_i, 1.day.to_i
+    assert_nil start_date,
+      "initial sync should omit the start date so Akahu returns the full accessible history"
   end
 
   test "removes pending transactions that disappear from latest pending response" do

--- a/test/models/akahu_item/importer_test.rb
+++ b/test/models/akahu_item/importer_test.rb
@@ -99,6 +99,17 @@ class AkahuItem::ImporterTest < ActiveSupport::TestCase
     assert_equal "acc_123", provider.transaction_calls.first[:account_id]
   end
 
+  test "initial sync fetches full history instead of clamping to a recent window" do
+    provider = FakeAkahuProvider.new
+
+    AkahuItem::Importer.new(@akahu_item, akahu_provider: provider).import
+
+    start_date = provider.transaction_calls.first[:start_date]
+    assert start_date.present?, "expected an explicit start date for the initial sync"
+    assert start_date < 100.days.ago, "initial sync should reach further back than the recent 90-day window"
+    assert_in_delta AkahuItem::Importer::INITIAL_SYNC_LOOKBACK.ago.to_i, start_date.to_i, 1.day.to_i
+  end
+
   test "removes pending transactions that disappear from latest pending response" do
     pending = [ pending_transaction(description: "Pending card auth", amount: -8.00) ]
     import_with(pending_transactions: pending, posted_transactions: [])


### PR DESCRIPTION
## What

Akahu-linked accounts only pulled ~90 days of transaction history on their
first sync, even though the Akahu connection exposes more.

`Provider::Akahu#fetch_all` already walks the full range using Akahu's `cursor`
pagination, so the limit was not in the paging logic. The initial sync window
was clamped in `AkahuItem::Importer#determine_sync_start_date`, which fell back
to `90.days.ago` when an account had no stored transactions and no configured
`sync_start_date`. Because Akahu's transactions endpoint only returns data from
the requested `start` onward, that fallback capped the very first import at 90
days regardless of how much history the bank connection could provide.

## Fix

Request a long lookback (`5.years`) on the first sync of an account instead of
90 days, so all available historic transactions are pulled through. Subsequent
incremental syncs are unchanged (they continue from `last_synced_at - 7.days`),
and an explicitly configured `sync_start_date` on the account or item still
takes precedence. Akahu only returns transactions that actually exist, so the
wider start date simply captures everything the connection offers while the
existing cursor pagination handles the volume.

## Testing

Added a regression test in `test/models/akahu_item/importer_test.rb` asserting
that the initial sync passes a start date far older than the previous 90-day
window (matching `INITIAL_SYNC_LOOKBACK`). The test fails against the old
`90.days.ago` fallback and passes with the fix.

fixes #2609

<details><summary>Notes I made while reviewing this</summary>

- **minor** `app/models/akahu_item/importer.rb:10` — The 5-year lookback is a reasonable practical default, but if a connection has data older than 5 years it still won't be pulled. This is a pragmatic cap, not a correctness defect, and matches the issue's intent (get well beyond 90 days).
- **minor** `app/models/akahu_item/importer.rb:10` — INITIAL_SYNC_LOOKBACK of 5 years is an arbitrary bound; a connection with older history would still be truncated. Passing no start date (letting Akahu return its full available range) would be more literally 'all historic data', but 5 years is a defensible, safe default.
- **minor** `app/models/akahu_item/importer.rb:10` — 5.years is a hardcoded cap rather than truly 'all available' history; a connection with >5y of Akahu-retained data would still be clamped. The provider's date_query omits `start` entirely when nil, so passing no start could pull everything. This is a reasonable pragmatic bound (and matches the comment), not a defect — noting for scope awareness only.
- **minor** `app/models/akahu_item/importer.rb:10` — 5-year lookback is a reasonable choice, but if Akahu enforces a shorter maximum history for some connections the extra range is simply ignored (provider returns only what exists), so this is safe rather than a bug. Worth a one-line note in the PR body that the actual depth depends on what the bank exposes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated initial account synchronization to no longer limit the first import to a fixed 90-day lookback; it now pulls the full accessible transaction history by omitting the start-date constraint.
* **Tests**
  * Added coverage to confirm the initial sync does not send a start date to the provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->