### PR TITLE
Fix preview cleanup over-firing on PR close

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -39,17 +39,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: "24"
-
-      - name: Install Wrangler
-        run: npm install -g wrangler
-
       - name: Delete preview Worker
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
@@ -63,14 +55,22 @@ jobs:
           fi
 
           # Delete the worker (this also stops any running containers)
-          delete_output="$(mktemp)"
-          if wrangler delete --name "$WORKER_NAME" --force >"$delete_output" 2>&1; then
-            cat "$delete_output"
-          elif grep -Eiq 'not found|does not exist|could not find' "$delete_output"; then
-            cat "$delete_output"
+          response="$(curl -sS -X DELETE \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json")" || {
+              echo "Failed to delete preview Worker via Cloudflare API"
+              exit 1
+            }
+
+          if echo "$response" | jq -e '.success == true' >/dev/null; then
+            echo "Deleted Worker: $WORKER_NAME"
+          elif echo "$response" | jq -e '[.errors[]?.code] | index(10007)' >/dev/null; then
+            echo "$response" | jq -c '.errors'
             echo "Worker may not exist"
           else
-            cat "$delete_output"
+            echo "Cloudflare API failed to delete preview Worker"
+            echo "$response" | jq -c '.errors // .'
             exit 1
           fi
 

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -55,22 +55,30 @@ jobs:
           fi
 
           # Delete the worker (this also stops any running containers)
-          response="$(curl -sS -X DELETE \
-            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME" \
+          response_file="$(mktemp)"
+          http_status="$(curl -sS -o "$response_file" -w "%{http_code}" -X DELETE \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME?force=true" \
             -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
             -H "Content-Type: application/json")" || {
               echo "Failed to delete preview Worker via Cloudflare API"
               exit 1
             }
+          response="$(cat "$response_file")"
 
-          if echo "$response" | jq -e '.success == true' >/dev/null; then
+          if [ -z "$response" ] && [[ "$http_status" =~ ^2 ]]; then
             echo "Deleted Worker: $WORKER_NAME"
-          elif echo "$response" | jq -e '[.errors[]?.code] | index(10007)' >/dev/null; then
+          elif [ -n "$response" ] && echo "$response" | jq -e '.success == true' >/dev/null; then
+            echo "Deleted Worker: $WORKER_NAME"
+          elif [ -n "$response" ] && echo "$response" | jq -e '[.errors[]?.code] | index(10007)' >/dev/null; then
             echo "$response" | jq -c '.errors'
             echo "Worker may not exist"
           else
-            echo "Cloudflare API failed to delete preview Worker"
-            echo "$response" | jq -c '.errors // .'
+            echo "Cloudflare API failed to delete preview Worker (HTTP $http_status)"
+            if [ -n "$response" ]; then
+              echo "$response" | jq -c '.errors // .' || printf '%s\n' "$response"
+            else
+              echo "No response body"
+            fi
             exit 1
           fi
 

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -24,7 +24,12 @@ permissions:
 jobs:
   cleanup-on-close:
     name: Cleanup closed PR preview
-    if: github.event_name == 'pull_request' && (github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'preview-cf'))
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview-cf')) ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'preview-cf')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -47,11 +52,27 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
+          set -euo pipefail
+
           WORKER_NAME="sure-preview-${{ github.event.pull_request.number }}"
           echo "Deleting Worker: $WORKER_NAME"
 
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "Missing Cloudflare credentials; refusing to mark preview cleanup as successful"
+            exit 1
+          fi
+
           # Delete the worker (this also stops any running containers)
-          wrangler delete --name "$WORKER_NAME" --force || echo "Worker may not exist"
+          delete_output="$(mktemp)"
+          if wrangler delete --name "$WORKER_NAME" --force >"$delete_output" 2>&1; then
+            cat "$delete_output"
+          elif grep -Eiq 'not found|does not exist|could not find' "$delete_output"; then
+            cat "$delete_output"
+            echo "Worker may not exist"
+          else
+            cat "$delete_output"
+            exit 1
+          fi
 
       - name: Delete GitHub Deployment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
## Summary
- only run immediate PR-close cleanup when the PR still has the `preview-cf` label, or when that label is removed
- fail the close-path cleanup when Cloudflare credentials are missing
- stop masking Wrangler delete failures except for worker-not-found cases

## Context
The cleanup workflow was running green on ordinary closed PRs with no preview. In those runs Cloudflare secrets were empty and `wrangler delete` failed, but the failure was hidden behind `|| echo "Worker may not exist"`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/preview-cleanup.yml"); puts "yaml ok"'
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of preview deployments when pull requests are closed.
  * Hardened preview worker deletion by directly calling the Cloudflare Workers API, adding required-credential validation, more reliable success/failure detection, and treating “worker not found” as non-fatal while surfacing unexpected errors.
* **Chores**
  * Refined the preview cleanup job condition formatting into an equivalent, more readable boolean expression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->