### PR TITLE
fix(snaptrade): sign bare TRANSFER activities by provider direction (#2756)

### DIFF
--- a/app/models/snaptrade_account/activities_processor.rb
+++ b/app/models/snaptrade_account/activities_processor.rb
@@ -250,6 +250,15 @@ class SnaptradeAccount::ActivitiesProcessor
         amount.abs   # Money out should be positive in Sure
       when "CONTRIBUTION", "TRANSFER_IN", "DIVIDEND", "DIV", "INTEREST", "CASH"
         -amount.abs  # Money in should be negative in Sure
+      when "TRANSFER"
+        # Direction is not encoded in the type (unlike TRANSFER_IN/TRANSFER_OUT), so the
+        # provider's sign is the only directional signal available. SnapTrade signs these
+        # from the account's perspective (positive = money in), which is the inverse of
+        # Sure's convention, so invert it rather than passing it through unchanged.
+        # Passing it through stored a 401k contribution as a positive amount, which
+        # Entry#classification reads as an expense and ReverseCalculator reads as a
+        # value decrease — a correct current balance with a declining history (issue #2756).
+        -amount
       else
         amount
       end

--- a/test/models/snaptrade_account/activities_processor_test.rb
+++ b/test/models/snaptrade_account/activities_processor_test.rb
@@ -161,6 +161,37 @@ class SnaptradeAccount::ActivitiesProcessorTest < ActiveSupport::TestCase
     assert_equal "Transfer", transfer_out.entryable.investment_activity_label
   end
 
+  test "normalizes bare TRANSFER from the provider sign" do
+    # Regression test for issue #2756. Unlike TRANSFER_IN/TRANSFER_OUT, a bare "TRANSFER"
+    # carries no direction in the type, so SnapTrade's sign is the only directional signal
+    # available and must be inverted into Sure's convention rather than passed through.
+    @snaptrade_account.update!(raw_activities_payload: [
+      build_cash_activity(
+        id: "transfer_generic_in",
+        type: "TRANSFER",
+        amount: 1320.75,
+        settlement_date: Date.current.to_s
+      ),
+      build_cash_activity(
+        id: "transfer_generic_out",
+        type: "TRANSFER",
+        amount: -500.00,
+        settlement_date: Date.current.to_s
+      )
+    ])
+
+    processor = SnaptradeAccount::ActivitiesProcessor.new(@snaptrade_account)
+    processor.process
+
+    inbound = @account.entries.find_by(external_id: "transfer_generic_in", source: "snaptrade")
+    outbound = @account.entries.find_by(external_id: "transfer_generic_out", source: "snaptrade")
+
+    assert_not_nil inbound
+    assert_not_nil outbound
+    assert_equal(-1320.75, inbound.amount.to_f, "money in must be stored negative on an asset account")
+    assert_equal 500.00, outbound.amount.to_f, "money out must be stored positive on an asset account"
+  end
+
   test "maps all known activity types correctly" do
     type_mappings = {
       "BUY" => "Buy",


### PR DESCRIPTION
Fixes #2756.

## Problem

A SnapTrade activity with `type: "TRANSFER"` (bare, not `TRANSFER_IN`/`TRANSFER_OUT`) and a positive `amount` was stored **verbatim**. Sure's convention requires inflows to an asset account to be stored **negative**, so a positive stored amount:

- renders as an expense (`Entry#classification`: `amount.negative? ? "income" : "expense"`), showing `-$1,320.75` where the broker shows `+$1,320.75`; and
- on a linked account (which uses `Balance::ReverseCalculator`) produces a **correct current balance but a monotonically declining history** — the ~−14.6%/yr chart in the report.

## Root cause

`SnaptradeAccount::ActivitiesProcessor#normalize_cash_amount` handled `TRANSFER_IN` and `TRANSFER_OUT` but not bare `TRANSFER`, which fell through the `else` branch and was passed through unchanged.

## Fix

Add a `when "TRANSFER"` branch. The principle: **types that encode direction (`TRANSFER_IN`/`TRANSFER_OUT`/`WITHDRAWAL`/`CONTRIBUTION`) can force the sign with `.abs`; bare `TRANSFER` does not encode direction, so the provider's sign is the only directional signal and must be translated into Sure's convention** (SnapTrade signs from the account's perspective — positive = money in — which is the inverse of Sure's), rather than passed through.

```ruby
when "TRANSFER"
  -amount
```

I deliberately did **not** widen the `else` default: `process_activity` dispatches every non-trade type to `normalize_cash_amount` (the `CASH_TYPES` constant that looks like a gate is actually unreferenced dead code), so touching `else` would silently flip the sign on `SPLIT`, `MERGER`, `JOURNAL`, `OTHER`, etc.

## Test

Added `test "normalizes bare TRANSFER from the provider sign"` covering both directions (inbound `+1320.75 → -1320.75`, outbound `-500 → +500`). The full `activities_processor_test.rb` file passes (11 runs, 48 assertions, 0 failures). `bin/brakeman` reports 0 warnings.

## Caveat worth a maintainer's eye

All real samples in the issue are **inbound** (positive). The fix assumes SnapTrade also *signs* outbound `TRANSFER` (i.e. sends it negative). If SnapTrade instead sends an unsigned magnitude for outbound transfers, those would be inverted incorrectly. An outbound `TRANSFER` sample from any SnapTrade connection would close this question; if maintainers prefer a safety net, a `DebugLogEntry.capture` on this branch would surface direction-less types in `/settings/debug`.

## Note on existing rows

The amount is assigned unconditionally on each sync, so untouched imported rows self-heal on the next sync. Rows the reporter manually edited are `user_modified` and won't self-heal until unlocked via the transaction detail page (`POST /transactions/:id/unlock`).

---

The unrelated inverted-sign finding in `IndexaCapitalAccount::ActivitiesProcessor` is tracked separately per @jjmata's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the handling of generic transfer amounts so inbound and outbound transfers use the proper sign convention.
  * Improved balance and transaction classification for transfer activity, including retirement account contributions.

* **Tests**
  * Added coverage to verify correct processing of positive and negative transfer amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->