### PR TITLE
fix: prevent AddAmountToTransfers migration from aborting the upgrade on legacy transfer data

### DIFF
--- a/db/migrate/20260628171409_add_amount_to_transfers.rb
+++ b/db/migrate/20260628171409_add_amount_to_transfers.rb
@@ -5,9 +5,14 @@ class AddAmountToTransfers < ActiveRecord::Migration[8.1]
     reversible do |dir|
       dir.up do
         # Backfill principal from outflow entries: amount = outflow_entry.amount - source_fee_amount
+        # Historical rows can violate the modern sign convention (negative
+        # outflow amounts) or carry fees larger than the entry amount, which
+        # would produce a negative principal and trip the check constraint
+        # below — aborting the migration and blocking the whole upgrade.
+        # Normalize with ABS and clamp at zero instead (#2653).
         execute <<~SQL
           UPDATE transfers
-          SET amount = e.amount - COALESCE(transfers.source_fee_amount, 0)
+          SET amount = GREATEST(ABS(e.amount) - COALESCE(transfers.source_fee_amount, 0), 0)
           FROM entries e
           WHERE e.entryable_id = transfers.outflow_transaction_id
             AND e.entryable_type = 'Transaction';


### PR DESCRIPTION
Fixes #2653

## Problem

Upgrading to the latest image aborts for some self-hosters:

```
== 20260628171409 AddAmountToTransfers: migrating =============================
PG::CheckViolation: ERROR:  check constraint "check_transfer_amount_non_negative"
  of relation "transfers" is violated by some row
```

`db:prepare` dies, all later migrations are canceled, and the instance is left down — with no self-service way to recover short of manual SQL.

## Root cause

The migration backfills `transfers.amount = outflow_entry.amount - COALESCE(source_fee_amount, 0)` and then adds a `amount >= 0` check constraint.

`Transfer#transfer_has_opposite_amounts` enforces positive outflow amounts **today**, but historical rows can predate that validation or come from imports — a sign-flipped outflow entry (negative amount) or a `source_fee_amount` larger than the entry amount produces a **negative** computed principal, and the constraint kills the migration.

## Fix

Normalize with `ABS` and clamp at zero in the backfill:

```sql
SET amount = GREATEST(ABS(e.amount) - COALESCE(transfers.source_fee_amount, 0), 0)
```

- Rows that already satisfied the old expression are byte-identical (`ABS` is a no-op for positive amounts, `GREATEST` never triggers).
- Sign-flipped rows recover their actual principal instead of a negative value.
- Fee-exceeds-amount rows clamp to 0 rather than aborting the upgrade.

Editing the shipped migration is safe here: users who already ran it are recorded in `schema_migrations` and never re-run it; users stuck on the `CheckViolation` re-run the migration from scratch on next upgrade (PostgreSQL rolled the failed one back atomically) and now get the fixed backfill. Repo precedent: eee0ca89 ("Fix migration: add missing add_column…").

## Validation

Reproduced both behaviors against PostgreSQL 17 with a fixture covering a normal row, a sign-flipped row, a fee-exceeds-amount row, and an orphan transfer:

- **Old backfill + constraint** → `ERROR: check constraint … is violated by some row` (exactly the #2653 failure)
- **Fixed backfill + constraint** → succeeds; normal row `95.0` (unchanged), sign-flipped `50.0`, fee-exceeds `0.0`, orphan `0.0`

## Impact / risk

- Unblocks upgrades for affected self-hosters; no-op for everyone else.
- 1-file, migration-only change; no schema or model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer amount backfilling during upgrades.
  * Prevented invalid negative transfer amounts when historical fee or transaction values use nonstandard signs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->