### PR TITLE
fix: omit SimpleFin pending param when pending transactions are disabled

### DIFF
--- a/app/models/provider/simplefin.rb
+++ b/app/models/provider/simplefin.rb
@@ -66,7 +66,11 @@ class Provider::Simplefin
       query_params["end-date"] = end_timestamp.to_s
     end
 
-    query_params["pending"] = pending ? "1" : "0" unless pending.nil?
+    # Per the SimpleFIN protocol, pending transactions are excluded by default
+    # and only included when `pending=1` is present. Bridges presence-check the
+    # param, so sending `pending=0` behaves like `pending=1` — the only
+    # spec-compliant way to exclude pending is to omit the param entirely.
+    query_params["pending"] = "1" if pending
 
     accounts_url = "#{access_url}/accounts"
     accounts_url += "?#{URI.encode_www_form(query_params)}" unless query_params.empty?

--- a/test/models/provider/simplefin_test.rb
+++ b/test/models/provider/simplefin_test.rb
@@ -102,6 +102,39 @@ class Provider::SimplefinTest < ActiveSupport::TestCase
     assert_equal :server_error, error.error_type
   end
 
+  test "get_accounts sends pending=1 when pending is enabled" do
+    mock_response = OpenStruct.new(code: 200, body: '{"accounts": []}')
+
+    Provider::Simplefin.expects(:get)
+      .with { |url| url.include?("pending=1") }
+      .returns(mock_response)
+
+    @provider.get_accounts(@access_url, pending: true)
+  end
+
+  test "get_accounts omits the pending param when pending is disabled" do
+    # The SimpleFIN protocol has no pending=0 — bridges presence-check the
+    # param, so pending=0 behaves like pending=1. Disabling pending must omit
+    # the param entirely.
+    mock_response = OpenStruct.new(code: 200, body: '{"accounts": []}')
+
+    Provider::Simplefin.expects(:get)
+      .with { |url| !url.include?("pending") }
+      .returns(mock_response)
+
+    @provider.get_accounts(@access_url, pending: false)
+  end
+
+  test "get_accounts omits the pending param when pending is nil" do
+    mock_response = OpenStruct.new(code: 200, body: '{"accounts": []}')
+
+    Provider::Simplefin.expects(:get)
+      .with { |url| !url.include?("pending") }
+      .returns(mock_response)
+
+    @provider.get_accounts(@access_url, pending: nil)
+  end
+
   test "claim_access_url retries on network errors" do
     setup_token = Base64.encode64("https://example.com/claim")
     mock_response = OpenStruct.new(code: 200, body: "https://example.com/access")


### PR DESCRIPTION
Fixes #2440

## Problem

Disabling pending transactions for SimpleFin — via the **Include pending transactions** setting or `SIMPLEFIN_INCLUDE_PENDING=0` — has no effect: pending transactions keep being downloaded, so users stay exposed to the pending/posted duplication and "appear then disappear" churn described in #2440.

## Root cause

`Provider::Simplefin#get_accounts` built the query param as:

```ruby
query_params["pending"] = pending ? "1" : "0" unless pending.nil?
```

But the [SimpleFIN protocol](https://www.simplefin.org/protocol.html) only defines `pending=1` ("If pending=1 is provided, pending transactions will be included… By default, pending transactions are NOT included"). There is no `pending=0` in the spec — bridges presence-check the param, so `pending=0` behaves **identically to `pending=1`**. The issue reporter confirmed this empirically against `beta-bridge.simplefin.org`: `pending=0` and `pending=1` both returned 4 pending transactions; only omitting the param returned 0.

## Fix

One line in [`app/models/provider/simplefin.rb`](../blob/main/app/models/provider/simplefin.rb) (plus a spec-reference comment): only send `pending=1` when pending is enabled, and **omit the param entirely** otherwise — the only spec-compliant way to exclude pending.

```ruby
query_params["pending"] = "1" if pending
```

## Tests

Added three targeted tests in `test/models/provider/simplefin_test.rb` (existing mocha style):

- `pending: true` → request URL contains `pending=1`
- `pending: false` → request URL contains no `pending` param (the regression)
- `pending: nil` → request URL contains no `pending` param

## Impact / risk

- The "Include pending transactions" setting and `SIMPLEFIN_INCLUDE_PENDING=0` now actually stop pending transactions from being downloaded.
- Enabled/default behavior is unchanged (`pending=1` still sent when the setting is on).
- No change for institutions that ignore the param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated account retrieval requests to follow SimpleFIN’s handling of pending transactions.
  * Pending transactions are explicitly requested when enabled; otherwise, the option is omitted.

* **Tests**
  * Added coverage for enabled, disabled, and unspecified pending transaction settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->