### PR TITLE
fix(dashboard): add hover state to section header controls

### DIFF
--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -66,7 +66,7 @@
           <div class="flex items-center gap-2">
             <button
               type="button"
-              class="text-secondary hover:text-primary transition-colors p-0.5"
+              class="flex items-center justify-center w-6 h-6 rounded-md text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors"
               data-action="click->dashboard-section#toggle keydown->dashboard-section#handleToggleKeydown"
               data-dashboard-section-target="button"
               aria-label="<%= t("pages.dashboard.toggle_section") %>"
@@ -81,7 +81,7 @@
             <% if section[:key] == "cashflow_sankey" && section[:locals][:sankey_data][:links].present? %>
               <button
                 type="button"
-                class="text-secondary hover:text-primary transition-colors opacity-100 lg:opacity-0 lg:group-hover:opacity-100 flex items-center justify-center w-5 h-5 ml-auto lg:ml-0"
+                class="flex items-center justify-center w-6 h-6 rounded-md text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors opacity-100 lg:opacity-0 lg:group-hover:opacity-100 ml-auto lg:ml-0"
                 data-action="click->cashflow-expand#open"
                 aria-label="<%= t("global.expand") %>">
                 <%= icon("maximize-2", size: "sm", class: "!w-3.5 !h-3.5") %>
@@ -96,7 +96,7 @@
                 data-dashboard-widget-size-section-key-value="<%= section[:key] %>"
                 data-action="keydown->dashboard-widget-size#stopKeydown">
                 <summary
-                  class="focus-ring list-none cursor-pointer text-secondary hover:text-primary transition-colors p-0.5 opacity-0 group-hover:opacity-100 [&::-webkit-details-marker]:hidden"
+                  class="focus-ring list-none cursor-pointer flex items-center justify-center w-6 h-6 rounded-md text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors opacity-0 group-hover:opacity-100 [&::-webkit-details-marker]:hidden"
                   aria-label="<%= t("pages.dashboard.widget_size.label") %>">
                   <%= icon("sliders-horizontal", size: "sm", class: "!w-3.5 !h-3.5") %>
                 </summary>
@@ -140,7 +140,7 @@
             <% end %>
             <button
               type="button"
-              class="cursor-grab active:cursor-grabbing text-secondary hover:text-primary transition-colors p-0.5 opacity-0 group-hover:opacity-100 hidden lg:block"
+              class="cursor-grab active:cursor-grabbing hidden lg:flex items-center justify-center w-6 h-6 rounded-md text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors opacity-0 group-hover:opacity-100"
               aria-label="<%= t("pages.dashboard.drag_to_reorder") %>">
               <%= icon("grip-vertical", size: "sm") %>
             </button>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -138,9 +138,14 @@
                 </div>
               </details>
             <% end %>
+            <%# A grab surface, not a button — clicking it does nothing. It keeps
+                cursor-grab and the colour shift, and deliberately skips the hover
+                background the other header controls use: a filled hover state
+                reads as "clickable" and would promise a click that never lands.
+                Still sized to the same 24px box so the icons stay aligned. %>
             <button
               type="button"
-              class="cursor-grab active:cursor-grabbing hidden lg:flex items-center justify-center w-6 h-6 rounded-md text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors opacity-0 group-hover:opacity-100"
+              class="cursor-grab active:cursor-grabbing hidden lg:flex items-center justify-center w-6 h-6 text-secondary hover:text-primary transition-colors opacity-0 group-hover:opacity-100"
               aria-label="<%= t("pages.dashboard.drag_to_reorder") %>">
               <%= icon("grip-vertical", size: "sm") %>
             </button>


### PR DESCRIPTION
## Summary

The clickable controls in a dashboard section header — collapse chevron, widget-size settings, and the cashflow expand button — signalled hover with a colour shift alone (`text-secondary` → `text-primary`). On 14–16px glyphs that reads as almost nothing, so hovering the settings and drag controls (which sit 4px apart) gave no usable feedback about which one was about to be clicked.

This adds the icon-control recipe already used for the top bar in `layouts/application.html.erb:63`: `hover:bg-container-inset-hover` plus a radius, alongside the existing colour shift. Deliberately subtle — a background tint, no shape or size change on hover.

| | |
|---|---|
| Light, settings hovered | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/dashboard-header-hover-light.png" width="208" alt="Widget settings control with a subtle grey rounded hover background; the drag handle beside it is untinted"> |
| Dark, settings hovered | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/dashboard-header-hover-dark.png" width="208" alt="Widget settings control with a subtle dark hover background; the drag handle beside it is untinted"> |

Shown at 4× so the tint is visible; each control is 24px in reality.

## Notes

- **No design system change.** `--color-container-inset-hover` already resolves to `gray-100` / `gray-700`, so both themes are covered by the existing token.
- **The drag handle deliberately gets no hover fill.** It's a grab surface, not a button — clicking it does nothing. A filled hover state reads as "clickable" and would promise a click that never lands, so it keeps `cursor-grab` and the colour shift only. It still uses the same 24px box so the icons stay aligned with the control beside it. There's a comment in the template so the inconsistency doesn't get "fixed" later.
- **Uniform sizing.** The four controls each carried their own ad-hoc box — `p-0.5` around a 16px icon, `p-0.5` around a 14px icon, `w-5 h-5` — which meant three different hover target sizes and three different tint areas once a background exists. They now share a centred 24px box. 24px matches the header's `text-base` line-height, so the row height is unchanged.
- **The drag handle still goes to `hidden lg:flex`,** not `hidden lg:block` plus a bare `flex` — needed for the 24px box. The latter would have overridden `hidden` below `lg` depending on utility order in the compiled sheet, leaking the handle onto mobile.
- The chevron is included even though it's always visible, rather than left as the only control in the header without a hover background.

## Test plan

- [x] `bin/rails test test/controllers/pages_controller_test.rb` — 20 runs, 0 failures
- [x] `bin/rails test test/controllers/insights_controller_test.rb` — 9 runs, 0 failures (only test asserting on section header markup)
- [x] `bundle exec erb_lint app/views/pages/dashboard.html.erb`
- [x] Verified in a browser at both themes: tint appears on the hovered clickable control only, row height unchanged, `<summary>` still toggles the widget-size popover with `display: flex` applied, drag-to-reorder still works
- [x] Confirmed via computed style with the pointer on the grip: `background-color: rgba(0, 0, 0, 0)`, `cursor: grab`, colour still shifts, box still `24x24` and aligned with its neighbour

## Follow-up worth a separate look

These controls are `opacity-0 group-hover:opacity-100`, so a keyboard user can Tab to the drag handle and widget-size control while they're fully transparent — the focused control is invisible. A `focus-visible:opacity-100` on each would fix it. Left out here to keep this to the hover state; happy to fold it in if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined dashboard section header controls with standardized icon sizing (`w-6 h-6`), added consistent rounding (`rounded-md`), and improved responsive visibility/opacity behavior.
  * Updated hover/breakpoint styling for collapse/expand toggles, cashflow expand controls, widget-size summary toggles, and drag-to-reorder grab surfaces (now explicitly hidden on small screens and aligned consistently on large screens).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->