### PR TITLE
feat(insights): acknowledge instead of dismiss, on both surfaces

### DIFF
--- a/app/controllers/insights_controller.rb
+++ b/app/controllers/insights_controller.rb
@@ -1,5 +1,5 @@
 class InsightsController < ApplicationController
-  before_action :set_insight, only: %i[dismiss undismiss]
+  before_action :set_insight, only: %i[acknowledge unacknowledge]
 
   def index
     load_feed
@@ -14,8 +14,9 @@ class InsightsController < ApplicationController
     end
   end
 
-  def dismiss
-    @insight.dismiss!
+  def acknowledge
+    @insight.acknowledge!
+    load_widget_feed
 
     respond_to do |format|
       format.turbo_stream
@@ -23,9 +24,10 @@ class InsightsController < ApplicationController
     end
   end
 
-  def undismiss
-    @insight.undismiss!
+  def unacknowledge
+    @insight.unacknowledge!
     load_feed
+    load_widget_feed
 
     respond_to do |format|
       format.turbo_stream
@@ -52,6 +54,13 @@ class InsightsController < ApplicationController
     def load_feed
       @insights = Current.family.insights.visible.ordered.to_a
       @unread_ids = @insights.select(&:active?).map(&:id).to_set
+    end
+
+    # Acknowledging is reachable from the dashboard widget as well as this page,
+    # so the response re-renders the widget's top three. Removing a row there
+    # should promote the next insight into the freed slot, not leave a gap.
+    def load_widget_feed
+      @feed_insights = Current.family.insights.visible.ordered.limit(Insight::FEED_LIMIT).to_a
     end
 
     # Turbo sends X-Sec-Purpose (the fetch spec forbids setting Sec-Purpose

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -51,7 +51,7 @@ class PagesController < ApplicationController
 
     @cashflow_sankey_data = build_cashflow_sankey_data(net_totals, income_totals, expense_totals, family_currency)
     @outflows_data = build_outflows_donut_data(net_totals)
-    @feed_insights = Current.family.insights.visible.ordered.limit(3)
+    @feed_insights = Current.family.insights.visible.ordered.limit(Insight::FEED_LIMIT)
 
     @money_flow_accounts = income_statement.eligible_accounts
     @money_flow_month = money_flow_month_param

--- a/app/models/insight.rb
+++ b/app/models/insight.rb
@@ -3,9 +3,17 @@
 # the LLM (when configured) only writes the `body` prose from pre-computed
 # numbers, so rows are safe to render verbatim.
 #
-# Status semantics: `read` and `dismissed` are user actions; `expired` is the
+# Status semantics: `read` and `acknowledged` are user actions; `expired` is the
 # system's — set when a signal stops being generated (the condition cleared).
-# A returning condition reactivates an expired row but never a dismissed one.
+#
+# "Acknowledged" rather than "dismissed" because that is what the state has
+# always actually meant. GenerateInsightsJob resurfaces a row whose bucketed
+# metadata changes materially even if the user acknowledged the stale version,
+# and 6 of 8 generators scope `dedup_key` to a month, so acknowledging July's
+# budget card says nothing about August's. The contract is: acknowledgement
+# covers the numbers you saw; new numbers are a new insight. The DB value stays
+# `"dismissed"` (and the `dismissed_at` column keeps its name) so this needed no
+# migration — only the vocabulary the code and the UI speak was wrong.
 class Insight < ApplicationRecord
   belongs_to :family
 
@@ -20,7 +28,11 @@ class Insight < ApplicationRecord
     budget_on_track
   ].freeze
 
-  enum :status, { active: "active", read: "read", dismissed: "dismissed", expired: "expired" }
+  # How many the dashboard widget shows. Shared so PagesController (first render)
+  # and InsightsController (re-render after acknowledging) can't drift apart.
+  FEED_LIMIT = 3
+
+  enum :status, { active: "active", read: "read", acknowledged: "dismissed", expired: "expired" }
   enum :priority, { high: "high", medium: "medium", low: "low" }, prefix: true
 
   validates :insight_type, presence: true, inclusion: { in: TYPES }
@@ -29,7 +41,7 @@ class Insight < ApplicationRecord
   # instead of ActiveRecord::RecordNotUnique; races still hit the index.
   validates :dedup_key, uniqueness: { scope: :family_id }
 
-  # Everything the user hasn't dismissed; what the feed renders.
+  # Everything the user hasn't acknowledged; what the feed renders.
   scope :visible, -> { where(status: [ :active, :read ]) }
   scope :ordered, -> {
     order(Arel.sql("CASE insights.priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END"))
@@ -42,13 +54,13 @@ class Insight < ApplicationRecord
     update!(status: :read, read_at: Time.current)
   end
 
-  def dismiss!
-    update!(status: :dismissed, dismissed_at: Time.current)
+  def acknowledge!
+    update!(status: :acknowledged, dismissed_at: Time.current)
   end
 
-  # Undoes a dismissal without re-badging the insight as new — the user has
-  # obviously seen it, so it returns as read.
-  def undismiss!
+  # Undoes an acknowledgement without re-badging the insight as new — the user
+  # has obviously seen it, so it returns as read.
+  def unacknowledge!
     update!(status: :read, dismissed_at: nil, read_at: read_at || Time.current)
   end
 end

--- a/app/views/insights/_insight_card.html.erb
+++ b/app/views/insights/_insight_card.html.erb
@@ -1,50 +1,62 @@
 <%# locals: (insight:, unread: false) %>
 
-<div id="<%= dom_id(insight) %>" class="bg-container rounded-xl shadow-border-xs p-4 flex gap-3">
-  <div class="shrink-0 mt-0.5">
-    <%= icon(insight_icon_key(insight), color: insight_icon_color(insight)) %>
-  </div>
+<div id="<%= dom_id(insight) %>" class="bg-container rounded-xl shadow-border-xs">
+  <div class="p-4 flex gap-3">
+    <div class="shrink-0 mt-0.5">
+      <%= icon(insight_icon_key(insight), color: insight_icon_color(insight)) %>
+    </div>
 
-  <div class="min-w-0 grow space-y-1">
-    <p class="text-xs text-secondary"><%= insight_meta_line(insight) %></p>
+    <div class="min-w-0 grow space-y-1">
+      <p class="text-xs text-secondary"><%= insight_meta_line(insight) %></p>
 
-    <div class="flex items-start justify-between gap-3">
-      <h3 class="text-sm font-medium text-primary inline-flex items-center gap-2 min-w-0">
-        <%= insight.title %>
-        <% if unread %>
-          <%# A dot, not a labelled chip. Visiting this page marks every insight
-              read in one go, so at first paint the badge is on *every* row and
-              differentiates nothing — an uppercase tracked chip that heavy just
-              steals weight from the title it sits beside. %>
-          <%= render DS::Pill.new(label: t("insights.card.new"), tone: :info, dot_only: true) %>
-        <% end %>
-      </h3>
+      <div class="flex items-start justify-between gap-3">
+        <h3 class="text-sm font-medium text-primary inline-flex items-center gap-2 min-w-0">
+          <%= insight.title %>
+          <% if unread %>
+            <%# A dot, not a labelled chip. Visiting this page marks every insight
+                read in one go, so at first paint the badge is on *every* row and
+                differentiates nothing — an uppercase tracked chip that heavy just
+                steals weight from the title it sits beside. %>
+            <%= render DS::Pill.new(label: t("insights.card.new"), tone: :info, dot_only: true) %>
+          <% end %>
+        </h3>
 
-      <div class="flex items-start gap-1 shrink-0">
+        <%# The figure now owns this corner outright. It used to share it with the
+            acknowledge control, so the card's data and its escape hatch competed
+            for the same spot. %>
         <% if (figure = insight_key_figure(insight)) %>
-          <div class="text-right mr-1">
+          <div class="text-right shrink-0">
             <p class="text-sm font-mono font-medium privacy-sensitive <%= insight_sentiment(insight) == :positive ? "text-success" : "text-primary" %>"><%= figure.first %></p>
             <p class="text-xs text-subdued"><%= figure.last %></p>
           </div>
         <% end %>
-
-        <%= render DS::Button.new(
-          variant: "icon",
-          icon: "x",
-          href: dismiss_insight_path(insight),
-          method: :patch,
-          title: t("insights.card.dismiss"),
-          aria_label: t("insights.card.dismiss")
-        ) %>
       </div>
+
+      <p class="text-sm text-secondary"><%= insight.body %></p>
     </div>
+  </div>
 
-    <p class="text-sm text-secondary"><%= insight.body %></p>
-
+  <%# Both actions in a footer strip, which fixes an inverted action pyramid: the
+      escape hatch used to be a chromed icon button in the top-right corner while
+      the card's actual purpose ("View budget") was a borderless ghost link
+      buried under the body text. The subject action gets the chrome now, and
+      acknowledging is labelled text beside it — quieter, and honest about being
+      an acknowledgement rather than a deletion. %>
+  <div class="px-4 py-2.5 bg-container-inset rounded-b-xl flex items-center justify-between gap-3">
     <% if (action = insight_action(insight)) %>
-      <div class="pt-1">
-        <%= render DS::Link.new(text: action[:text], href: action[:href], variant: "ghost", size: "sm") %>
-      </div>
+      <%= render DS::Link.new(text: action[:text], href: action[:href], variant: "outline", size: "sm") %>
+    <% else %>
+      <span></span>
     <% end %>
+
+    <%= render DS::Button.new(
+      text: t("insights.card.acknowledge"),
+      icon: "check",
+      variant: "ghost",
+      size: "sm",
+      href: acknowledge_insight_path(insight),
+      method: :patch,
+      title: t("insights.card.acknowledge_title")
+    ) %>
   </div>
 </div>

--- a/app/views/insights/_undo_toast.html.erb
+++ b/app/views/insights/_undo_toast.html.erb
@@ -8,14 +8,18 @@
      aria-live="polite"
      class="relative flex items-center gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-xs"
      data-controller="element-removal">
-  <p class="text-primary text-sm font-medium grow"><%= t("insights.card.dismissed") %></p>
+  <p class="text-primary text-sm font-medium grow"><%= t("insights.card.acknowledged") %></p>
 
+  <%# autofocus so Undo is one keystroke away: the acknowledged card is gone from
+      the DOM, which drops focus to <body>, and Turbo focuses the first
+      [autofocus] element in stream-rendered content. %>
   <%= render DS::Button.new(
     text: t("insights.card.undo"),
     variant: "ghost",
     size: "sm",
-    href: undismiss_insight_path(insight),
-    method: :patch
+    href: unacknowledge_insight_path(insight),
+    method: :patch,
+    autofocus: true
   ) %>
 
   <%# A real button, not a bare icon with a click action: the glyph alone is

--- a/app/views/insights/acknowledge.turbo_stream.erb
+++ b/app/views/insights/acknowledge.turbo_stream.erb
@@ -1,0 +1,16 @@
+<%# Acknowledging is reachable from two surfaces now, so this response carries
+    the update for both and each applies only the streams whose targets it has —
+    Turbo silently ignores a stream whose target is absent. %>
+
+<%# /insights: drop the card. %>
+<%= turbo_stream.remove dom_id(@insight) %>
+
+<%# Dashboard: re-render the well rather than removing a row, so the next
+    insight is promoted into the freed slot instead of leaving a gap. %>
+<%= turbo_stream.replace "insights-feed" do %>
+  <%= render "pages/dashboard/insights_feed", insights: @feed_insights %>
+<% end %>
+
+<%= turbo_stream.append "notification-tray" do %>
+  <%= render "insights/undo_toast", insight: @insight %>
+<% end %>

--- a/app/views/insights/dismiss.turbo_stream.erb
+++ b/app/views/insights/dismiss.turbo_stream.erb
@@ -1,5 +1,0 @@
-<%= turbo_stream.remove dom_id(@insight) %>
-
-<%= turbo_stream.append "notification-tray" do %>
-  <%= render "insights/undo_toast", insight: @insight %>
-<% end %>

--- a/app/views/insights/unacknowledge.turbo_stream.erb
+++ b/app/views/insights/unacknowledge.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.remove dom_id(@insight, :undo) %>
+
+<%= turbo_stream.replace "insights-list" do %>
+  <%= render "insights/list", insights: @insights, unread_ids: @unread_ids %>
+<% end %>
+
+<%# Undo can be pressed from the dashboard, where the toast is the only part of
+    this flow on screen — so the well needs restoring there too. %>
+<%= turbo_stream.replace "insights-feed" do %>
+  <%= render "pages/dashboard/insights_feed", insights: @feed_insights %>
+<% end %>

--- a/app/views/insights/undismiss.turbo_stream.erb
+++ b/app/views/insights/undismiss.turbo_stream.erb
@@ -1,5 +1,0 @@
-<%= turbo_stream.remove dom_id(@insight, :undo) %>
-
-<%= turbo_stream.replace "insights-list" do %>
-  <%= render "insights/list", insights: @insights, unread_ids: @unread_ids %>
-<% end %>

--- a/app/views/pages/dashboard/_insights_feed.html.erb
+++ b/app/views/pages/dashboard/_insights_feed.html.erb
@@ -2,8 +2,8 @@
 
 <%# Mirrors the outflows/balance-sheet list idiom: an inset well with an
     uppercase mini-header, white rows inside, tinted icon circles, and
-    right-aligned figures. Dismissal lives on /insights; here each row just
-    links through. Prefetch is disabled because Turbo would serve the
+    right-aligned figures. Each row links through to /insights and carries its
+    own acknowledge control. Prefetch is disabled because Turbo would serve the
     hover-prefetched response on click, skipping the mark-as-read in
     InsightsController#index (it deliberately ignores prefetch requests). %>
 <%# -mt-2 evens the frame: the section shell gives 24px above the content but
@@ -31,12 +31,18 @@
 
     <div class="py-1.5 shadow-border-xs rounded-lg bg-container text-sm">
       <% insights.each do |insight| %>
-        <%# No hover background, matching the outflows rows — the affordance is
-            the cursor plus the icon's gentle scale. %>
-        <%= link_to insights_path,
-              data: { turbo_prefetch: false },
-              class: "flex items-center mx-3 px-3 py-2.5 rounded-lg gap-3 cursor-pointer group" do %>
-          <div class="h-7 w-7 shrink-0 rounded-full flex justify-center items-center group-hover:scale-105 transition-all duration-300"
+        <%# Stretched link rather than a link wrapping the row, because the
+            acknowledge control is a button_to — a <form>, which cannot be
+            nested inside an <a>. Same idiom as the outflows rows. %>
+        <div class="relative flex items-center mx-3 px-3 py-2.5 rounded-lg gap-3 group/insight">
+          <%# Empty body with an aria-label: the visible title is a sibling, and
+              passing a name would render it as link text on top of the row. %>
+          <%= link_to "", insights_path,
+                class: "absolute inset-0 rounded-lg cursor-pointer",
+                aria: { label: insight.title },
+                data: { turbo_prefetch: false } %>
+
+          <div class="h-7 w-7 shrink-0 rounded-full flex justify-center items-center group-hover/insight:scale-105 transition-all duration-300"
                style="background-color: color-mix(in oklab, <%= insight_icon_css_color(insight) %> 10%, transparent); color: <%= insight_icon_css_color(insight) %>;">
             <%= icon(insight_icon_key(insight), color: "current", size: "sm") %>
           </div>
@@ -56,7 +62,30 @@
               <p class="text-xs text-secondary whitespace-nowrap"><%= figure.last %></p>
             </div>
           <% end %>
-        <% end %>
+
+          <%# Acknowledging used to be possible only on /insights, so the surface
+              people actually look at couldn't clear anything. `relative z-10`
+              lifts this above the stretched link. Visibility is progressive and
+              never hover-only: pointer hover, keyboard focus, and always shown
+              on touch, where there is no hover to reveal it. No gesture, so the
+              section's drag-to-reorder handlers are untouched.
+
+              The group is *named*: the dashboard <section> wrapping this widget
+              is itself a `.group` (for its header controls), and a bare
+              `group-hover:` matches any ancestor group — so hovering one row, or
+              even the section header, revealed the control on every row. %>
+          <div class="relative z-10 shrink-0 opacity-0 group-hover/insight:opacity-100 group-focus-within/insight:opacity-100 pointer-coarse:opacity-100 transition-opacity">
+            <%= render DS::Button.new(
+              variant: "icon",
+              size: "sm",
+              icon: "check",
+              href: acknowledge_insight_path(insight),
+              method: :patch,
+              title: t("insights.card.acknowledge"),
+              aria_label: t("insights.feed.acknowledge_aria", title: insight.title)
+            ) %>
+          </div>
+        </div>
       <% end %>
     </div>
   </div>

--- a/config/locales/views/insights/en.yml
+++ b/config/locales/views/insights/en.yml
@@ -12,14 +12,16 @@ en:
       queued: We're generating fresh insights. Check back in a minute.
       checking: Checking…
     card:
-      dismiss: Dismiss
+      acknowledge: Got it
+      acknowledge_title: Hide this until the numbers change
       new: New
-      dismissed: Insight dismissed
+      acknowledged: Got it — hidden until this changes
       undo: Undo
     feed:
       view_all: View all insights
       header: Latest
       header_new: New
+      acknowledge_aria: "Got it: %{title}"
     types:
       spending_anomaly: Spending
       cash_flow_warning: Cash flow

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -498,8 +498,8 @@ Rails.application.routes.draw do
     end
 
     member do
-      patch :dismiss
-      patch :undismiss
+      patch :acknowledge
+      patch :unacknowledge
     end
   end
 

--- a/test/controllers/insights_controller_test.rb
+++ b/test/controllers/insights_controller_test.rb
@@ -48,25 +48,62 @@ class InsightsControllerTest < ActionDispatch::IntegrationTest
       "insights_feed should be prepended, not appended, for saved orders that predate it"
   end
 
-  test "dismiss removes the insight from the feed and offers undo via turbo stream" do
-    patch dismiss_insight_url(@insight), as: :turbo_stream
+  test "acknowledge removes the insight from the feed and offers undo via turbo stream" do
+    patch acknowledge_insight_url(@insight), as: :turbo_stream
 
     assert_response :success
     assert_match "turbo-stream", response.body
-    assert_match undismiss_insight_path(@insight), response.body
-    assert @insight.reload.dismissed?
+    assert_match unacknowledge_insight_path(@insight), response.body
+    assert @insight.reload.acknowledged?
   end
 
-  test "undismiss restores the insight as read and re-renders the list" do
-    @insight.dismiss!
+  test "unacknowledge restores the insight as read and re-renders the list" do
+    @insight.acknowledge!
 
-    patch undismiss_insight_url(@insight), as: :turbo_stream
+    patch unacknowledge_insight_url(@insight), as: :turbo_stream
 
     assert_response :success
     assert_match "insights-list", response.body
     assert_match CGI.escapeHTML(@insight.title), response.body
     assert @insight.reload.read?
     assert_nil @insight.dismissed_at
+  end
+
+  # Acknowledging used to be reachable only from /insights, so the dashboard —
+  # the surface people actually look at — could show an insight but not clear it.
+  test "dashboard feed rows carry an acknowledge control" do
+    get root_url
+
+    assert_response :success
+    assert_select "#insights-feed form[action=?]", acknowledge_insight_path(@insight)
+  end
+
+  # The widget shows the top N, so clearing one has to promote the next into the
+  # freed slot rather than leave a gap — hence a re-render, not a row removal.
+  test "acknowledge re-renders the dashboard feed so the next insight backfills" do
+    family = @user.family
+    family.insights.destroy_all
+
+    # One more than the well holds, same priority so `ordered` falls through to
+    # generated_at and the sequence is predictable.
+    rows = (Insight::FEED_LIMIT + 1).times.map do |i|
+      family.insights.create!(
+        insight_type: "idle_cash",
+        priority: "high",
+        status: "active",
+        title: "Test insight #{i}",
+        body: "body",
+        dedup_key: "idle_cash:test:#{i}",
+        generated_at: (i + 1).minutes.ago
+      )
+    end
+
+    patch acknowledge_insight_url(rows.first), as: :turbo_stream
+
+    assert_response :success
+    assert_match "insights-feed", response.body
+    assert_no_match(/Test insight 0/, response.body)
+    assert_match(/Test insight #{Insight::FEED_LIMIT}/, response.body)
   end
 
   test "refresh swaps the button into a pending state via turbo stream" do
@@ -79,7 +116,7 @@ class InsightsControllerTest < ActionDispatch::IntegrationTest
     assert_match CGI.escapeHTML(I18n.t("insights.refresh.checking")), response.body
   end
 
-  test "cannot dismiss another family's insight" do
+  test "cannot acknowledge another family's insight" do
     other_insight = families(:empty).insights.create!(
       insight_type: "idle_cash",
       priority: "low",
@@ -88,7 +125,7 @@ class InsightsControllerTest < ActionDispatch::IntegrationTest
       dedup_key: "idle_cash:other:2026-07"
     )
 
-    patch dismiss_insight_url(other_insight), as: :turbo_stream
+    patch acknowledge_insight_url(other_insight), as: :turbo_stream
 
     assert_response :not_found
     assert other_insight.reload.active?

--- a/test/jobs/generate_insights_job_test.rb
+++ b/test/jobs/generate_insights_job_test.rb
@@ -77,24 +77,24 @@ class GenerateInsightsJobTest < ActiveJob::TestCase
     assert insight.read?
   end
 
-  test "dismissed insight stays dismissed when numbers are unchanged" do
+  test "acknowledged insight stays acknowledged when numbers are unchanged" do
     stub_generated([ generated_insight ])
     GenerateInsightsJob.perform_now(family_id: @family.id)
 
     insight = @family.insights.find_by(dedup_key: "idle_cash:test-account:2026-07")
-    insight.dismiss!
+    insight.acknowledge!
 
     GenerateInsightsJob.perform_now(family_id: @family.id)
 
-    assert insight.reload.dismissed?
+    assert insight.reload.acknowledged?
   end
 
-  test "dismissed insight reactivates when numbers change materially" do
+  test "acknowledged insight reactivates when numbers change materially" do
     stub_generated([ generated_insight ])
     GenerateInsightsJob.perform_now(family_id: @family.id)
 
     insight = @family.insights.find_by(dedup_key: "idle_cash:test-account:2026-07")
-    insight.dismiss!
+    insight.acknowledge!
 
     stub_generated([ generated_insight(balance: 9000.0) ])
     GenerateInsightsJob.perform_now(family_id: @family.id)
@@ -125,14 +125,14 @@ class GenerateInsightsJobTest < ActiveJob::TestCase
     assert insight.reload.active?
   end
 
-  test "does not touch dismissed insights when their condition clears" do
+  test "does not touch acknowledged insights when their condition clears" do
     insight = insights(:cash_flow_warning)
-    insight.dismiss!
+    insight.acknowledge!
     stub_generated([], succeeded_types: [ "cash_flow_warning" ])
 
     GenerateInsightsJob.perform_now(family_id: @family.id)
 
-    assert insight.reload.dismissed?
+    assert insight.reload.acknowledged?
   end
 
   test "expired insight reactivates without a body rewrite when the condition returns unchanged" do

--- a/test/models/insight_test.rb
+++ b/test/models/insight_test.rb
@@ -14,28 +14,28 @@ class InsightTest < ActiveSupport::TestCase
     assert @insight.read_at.present?
   end
 
-  test "mark_read! does not touch dismissed insights" do
-    @insight.dismiss!
+  test "mark_read! does not touch acknowledged insights" do
+    @insight.acknowledge!
 
     @insight.mark_read!
 
-    assert @insight.reload.dismissed?
+    assert @insight.reload.acknowledged?
     assert_nil @insight.read_at
   end
 
-  test "dismiss! removes insight from visible scope" do
+  test "acknowledge! removes insight from visible scope" do
     assert_includes Insight.visible, @insight
 
-    @insight.dismiss!
+    @insight.acknowledge!
 
     assert_not_includes Insight.visible, @insight
     assert @insight.dismissed_at.present?
   end
 
-  test "undismiss! restores a dismissed insight as read, not new" do
-    @insight.dismiss!
+  test "unacknowledge! restores an acknowledged insight as read, not new" do
+    @insight.acknowledge!
 
-    @insight.undismiss!
+    @insight.unacknowledge!
 
     assert @insight.reload.read?
     assert_nil @insight.dismissed_at


### PR DESCRIPTION
> **Stacked on #2799.** Base that first; this branch contains its commit. Review the second commit only.

## Summary

Two complaints about the insight feed: the close (`×`) control felt wrong, and clearing an insight was only possible on `/insights` — not on the dashboard widget, which is the surface people actually look at.

## The `×` was lying

Dismissal has never been permanent. `GenerateInsightsJob` resurfaces a row whose bucketed metadata changes materially — its own comment says "even if the user had read or **dismissed** the stale version" — and 6 of 8 generators scope `dedup_key` to a month token, so dismissing July's budget card says nothing about August's.

So a destructive-looking control was performing a non-destructive act. It is now **"Got it"**, which makes the real contract statable: *acknowledgement covers the numbers you saw; new numbers are a new insight.*

**No migration.** The DB value stays `"dismissed"` and `dismissed_at` keeps its name — only the enum key and the vocabulary the code speaks change. Existing rows stay hidden and become undoable under an honest label.

```ruby
enum :status, { active: "active", read: "read", acknowledged: "dismissed", expired: "expired" }
```

## The action pyramid was inverted

The escape hatch was a chromed icon button in the card's top-right — the strongest secondary scan position — while the card's actual purpose ("View budget") was a borderless ghost link buried under the body text.

Both now sit in a footer strip: the subject action gets the chrome, acknowledging is quiet labelled text beside it, and the key figure gets the corner to itself instead of competing with a control.

<img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/insights-ack-card.png" width="860" alt="Insights page: each card has a footer strip with an outlined action button on the left and a quiet Got it on the right">

## The widget can clear its own rows

Each row gains an acknowledge control, revealed on pointer hover, on keyboard focus (`group-focus-within`), and shown unconditionally on touch where there is no hover to reveal it. **No gesture**, so the section's drag-to-reorder handlers are untouched — a tap resolves well inside the hold-to-drag threshold, exactly as the existing collapse chevron does.

<img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/insights-ack-widget.png" width="860" alt="Dashboard insights widget with the acknowledge check revealed on the hovered row only">

The row becomes a stretched link plus a sibling button, because `button_to` renders a `<form>` and a form cannot nest inside an `<a>`.

Acknowledging **re-renders the well** rather than removing a row, so the next insight is promoted into the freed slot. `Insight::FEED_LIMIT` is now shared between the two controllers that render the widget so they cannot drift apart.

<img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/insights-ack-toast.png" width="860" alt="Undo toast reading Got it — hidden until this changes, with Undo and a close button">

## Two traps worth knowing about

**The group had to be named.** The dashboard `<section>` is itself a `.group` (for its header controls), and Tailwind's bare `group-hover:` matches *any* ancestor group. Hovering one row — or the section header — revealed the control on every row. It's `group/insight` now. Caught by measuring computed opacity per row, not by reading the markup.

**`link_to insights_path, class: …` renders the path as link text.** The stretched link needs an explicit empty name: `link_to "", insights_path, …`. Without it every row showed a literal "/insights".

## Notes

- No new design-system styles or tokens.
- Undo carries `autofocus`, so it is one keystroke away after the acknowledged card leaves the DOM and focus would otherwise fall to `<body>`.
- Routes renamed `dismiss`/`undismiss` → `acknowledge`/`unacknowledge`. Nothing external references them — there is no `api/v1` insights controller.
- `mark_read!` remains unused in `app/` (`index` uses `update_all`). Left alone here rather than widening the diff.
- Conflicts with #2788 on `_insights_feed.html.erb` and `insights/index.html.erb` are likely, since that PR adds Preview pills to both. Trivial to resolve either way round.

## Test plan

- [x] `bin/rails test` on the insights surface — 66 runs, 0 failures (`insights_controller_test`, `insight_test`, `insights_helper_test`, `pages_controller_test`, `generate_insights_job_test`)
- [x] `bin/rubocop` — 617 files, no offenses
- [x] `bundle exec erb_lint` clean on all six templates
- [x] Verified in a browser, both surfaces: card footer layout, acknowledge from the page, acknowledge from the widget with the next insight backfilling, undo restoring the row on both surfaces
- [x] Verified by measuring computed style rather than eyeballing: hover reveals only the hovered row (`row 0: 1, row 1: 0, row 2: 0`), keyboard focus reveals only the focused row, toast is `role="status" aria-live="polite"` with two real buttons, and focus lands on Undo after acknowledging

New coverage: the widget carries an acknowledge form per row, and acknowledging re-renders the well so the next insight backfills.
