### PR TITLE
fix(ui): use DS::Pill for the background-jobs queue chip

### DIFF
--- a/app/views/settings/background_jobs/show.html.erb
+++ b/app/views/settings/background_jobs/show.html.erb
@@ -30,9 +30,11 @@
 
           <div class="flex flex-wrap gap-2">
             <% @console.stats.queues.each do |queue| %>
-              <span class="rounded-full bg-container-inset px-3 py-1 text-xs text-secondary font-mono">
-                <%= queue[:name] %>: <%= queue[:size] %> · <%= t(".stats.latency", value: queue[:latency]) %>
-              </span>
+              <%= render DS::Pill.new(
+                label: "#{queue[:name]}: #{queue[:size]} · #{t(".stats.latency", value: queue[:latency])}",
+                tone: :neutral,
+                marker: false
+              ) %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
# PR body — we-promise/sure — account: rsnetworkinginc (PR #2 on this repo)

**Branch:** `fix/ds-pill-background-jobs-queue-chip` (in WSL clone `/root/sure`, commit `58053fe4`, based on `origin/main` @ `6b6ae0ca`)
**Title:** `fix(ds): render background-jobs queue chips with DS::Pill`

---

## Summary

Addresses **Finding 1** of the DS Drift Patrol report in #2745.

The queue-status chips on the super-admin background jobs console (`app/views/settings/background_jobs/show.html.erb:33`, added in #2682) hand-roll the pill pattern with a raw `rounded-full bg-container-inset px-3 py-1` span. That same PR's review cycle already fixed two other Drift Patrol comments before merge — this chip was the instance that slipped through.

## What changed

- The chip now renders through `DS::Pill` (badge mode — `marker: false` — with the `:neutral` semantic tone), replacing the hand-rolled span. One template, 1 chip block, no logic changes.
- Text stays on the `text-xs` DS scale. The chip picks up the pill primitive's standard border/palette treatment (soft gray) instead of the raw `bg-container-inset`; the bespoke `font-mono` styling is dropped since the pill primitive owns typography — this is the intended DS conformance.

## Test plan

- `bin/rails test` — full suite green (5,920 runs, 23,808 assertions, 0 failures, 0 errors).
- `bin/rails test test/controllers/settings/background_jobs_controller_test.rb` — green (renders this view with stubbed Sidekiq queues).
- `bundle exec erb_lint app/views/settings/background_jobs/show.html.erb` — no offenses.
- `bin/rubocop` — clean; `bin/brakeman` — no warnings.

---

*Checklist for opening: base = `main`, allow edits from maintainers ON. Do NOT use closing keywords (#2745 has a second finding covered separately) — reference it as "Addresses Finding 1 of #2745".*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated background job queue indicators to use a consistent pill-style presentation.
  * Preserved queue names, sizes, and latency details while improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->