### PR TITLE
fix(ui): use DS::Tooltip and DS::Pill for the insights nav badge

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -166,12 +166,16 @@ end %>
                   response served on click would never clear the badge. %>
               <%= link_to insights_path,
                     class: "relative inline-flex items-center justify-center w-9 h-9 pointer-coarse:w-11 pointer-coarse:h-11 rounded-lg text-secondary hover:text-primary hover:bg-container-inset-hover transition-colors focus-ring",
-                    title: t("layouts.application.insights"),
                     aria: { label: t("layouts.application.insights") },
                     data: { turbo_prefetch: false } do %>
-                <%= icon("lightbulb", size: "sm") %>
+                <%# `as: :span` because the trigger sits inside this already-
+                    focusable link — the tooltip replaces the raw title=
+                    attribute; the link keeps its aria-label. %>
+                <%= render DS::Tooltip.new(text: t("layouts.application.insights"), icon: "lightbulb", size: "sm", as: :span) %>
                 <% if unread_insights_count.positive? %>
-                  <span class="absolute top-1 right-1 min-w-4 h-4 px-1 rounded-full bg-inverse text-inverse text-[10px] font-medium flex items-center justify-center pointer-events-none"><%= unread_insights_count > 9 ? "9+" : unread_insights_count %></span>
+                  <span class="absolute -top-1 -right-1 pointer-events-none">
+                    <%= render DS::Pill.new(label: unread_insights_count > 9 ? "9+" : unread_insights_count.to_s, tone: :neutral, style: :filled, marker: false) %>
+                  </span>
                 <% end %>
               <% end %>
             <% end %>


### PR DESCRIPTION
# PR body — we-promise/sure — account: tryeverything24 (PR #2 on this repo)

**Branch:** `fix/ds-tooltip-pill-insights-nav-badge` (in WSL clone `/root/sure`, commit `961b3898`, based on `origin/main` @ `6b6ae0ca`)
**Title:** `fix(ds): use DS::Tooltip and DS::Pill for the insights nav badge`

---

## Summary

Addresses **Finding 2** of the DS Drift Patrol report in #2745.

The insights nav icon (added in #2550, `app/views/layouts/application.html.erb`) hand-rolled both of its affordances:

1. a raw `title:` attribute on the icon-only link as its tooltip, and
2. a raw `rounded-full` span with fixed sizing as the unread-count badge.

## What changed

- **Tooltip:** the raw `title=` is replaced by `DS::Tooltip` with `as: :span` — the component's documented mode for triggers inside an already-focusable interactive ancestor (here, the nav link). Same conversion the repo already merged for the accounts eye-off indicator. The link keeps its `aria: { label: }`, so the accessible name is unchanged.
- **Badge:** the unread count renders through `DS::Pill` (badge mode, `style: :filled`, `:neutral` tone → dark chip with white label, closest DS equivalent to the previous `bg-inverse`/`text-inverse`). Positioned via an absolute wrapper span at the icon corner, following the `layouts/shared/_nav_item.html.erb` precedent (which wraps its preview `DS::Pill` the same way); nudged to `-top-1 -right-1` so the DS-scale pill doesn't cover the lightbulb.
- The "9+" overflow cap and the `unread_insights_count.positive?` guard are untouched; the turbo-prefetch opt-out and its explanatory comment are untouched.

## Notes for review

- Hover shows the DS tooltip anchored to the icon (floating-ui), replacing the browser-native title bubble. Keyboard focus behavior is unchanged from `title=` (native titles never showed on focus either; screen readers get the retained `aria-label`).
- No new locale keys: the tooltip reuses `layouts.application.insights`.

## Test plan

- `bin/rails test` — full suite green (5,920 runs, 23,808 assertions, 0 failures, 0 errors).
- `bin/rails test test/controllers/insights_controller_test.rb` — green (covers the layout's unread-badge path).
- `bundle exec erb_lint app/views/layouts/application.html.erb` — no offenses.
- `bin/rubocop` — clean; `bin/brakeman` — no warnings.

---

*Checklist for opening: base = `main`, allow edits from maintainers ON. Do NOT use closing keywords (#2745's Finding 1 is covered separately) — reference it as "Addresses Finding 2 of #2745".*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the desktop Insights navigation control with an improved lightbulb tooltip.
  * Refined the unread insights indicator with a consistent pill-style badge, displaying the exact count or `9+` for larger totals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->