### PR TITLE
fix(schema): remove duplicate enable_banking_accounts columns breaking the test suite

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -577,12 +577,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120000) do
     t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
+    t.boolean "treat_balance_as_available_credit", default: false, null: false
     t.string "uid"
     t.datetime "updated_at", null: false
-    t.string "product"
-    t.decimal "credit_limit", precision: 19, scale: 4
-    t.jsonb "identification_hashes", default: []
-    t.boolean "treat_balance_as_available_credit", default: false, null: false
     t.index ["account_id"], name: "index_enable_banking_accounts_on_account_id"
     t.index ["enable_banking_item_id"], name: "index_enable_banking_accounts_on_enable_banking_item_id"
     t.index ["identification_hashes"], name: "index_enable_banking_accounts_on_identification_hashes", using: :gin


### PR DESCRIPTION
## Problem

`db/schema.rb` currently defines three columns **twice** in the `enable_banking_accounts` table — `product`, `credit_limit`, and `identification_hashes` (introduced as a merge artifact in `565e049f`). Loading the schema raises:

```
ArgumentError: you can't define an already defined column 'product' on 'enable_banking_accounts'.
```

Because `db:schema:load` runs during test setup, this aborts **before any test executes**. On `main` right now, CI's `test_unit` and `test_system` jobs both fail for every open PR — e.g. run [29971335670](https://github.com/we-promise/sure/actions/runs/29971335670) (`ci / test_unit: failure`, `ci / test_system: failure`, both with the ArgumentError above). This is a repo-wide CI outage, not a per-PR issue.

## Root cause

Each of the three columns is added exactly once, by `db/migrate/20260405120000_add_aspsp_metadata_to_enable_banking.rb`:

```ruby
add_column :enable_banking_accounts, :product, :string
add_column :enable_banking_accounts, :credit_limit, :decimal, precision: 19, scale: 4
add_column :enable_banking_accounts, :identification_hashes, :jsonb, default: []
```

The second copies in `schema.rb` have no backing migration — they're stray duplicate lines from a merge conflict resolution that also left `treat_balance_as_available_credit` out of alphabetical order.

## Fix

Remove the three duplicate lines and place `treat_balance_as_available_credit` (from migration `20260627101954`) in its correct alphabetical position, exactly as a clean `rails db:schema:dump` would produce. The table now has 19 unique columns, each backed by a migration. No migration changes are needed — the DDL was always correct; only the checked-in schema dump was corrupted.

## Validation

- Static scan of the full `schema.rb`: no remaining duplicate column in any table.
- Reproduced Rails' exact `TableDefinition` dup-column guard against the `enable_banking_accounts` block: previously raised on `product`, now executes cleanly with 19 unique columns.

## Impact & risk

- Unblocks the test suite (`test_unit` / `test_system`) for the whole repository — CI can go green again for all open PRs.
- Zero runtime/behavior change: schema dump only, matching the existing migrations; no data model or API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the generated database schema column ordering for banking account records.
  * No data types, constraints, indexes, or functionality were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->