### PR TITLE
fix: pass .env variables through to containers in compose.example.yml

### DIFF
--- a/compose.example.yml
+++ b/compose.example.yml
@@ -75,6 +75,13 @@ services:
       # "Binding to IPv6" for details.
       # - "[::]:${PORT:-3000}:3000"
     restart: unless-stopped
+    # Inject any variables you set in .env (ONBOARDING_STATE, APP_DOMAIN,
+    # SMTP_*, etc.). The explicit `environment` values below take precedence
+    # over .env, so container-critical settings (DB_HOST, REDIS_URL, ...) stay
+    # correct. `required: false` keeps this working when no .env file exists.
+    env_file:
+      - path: .env
+        required: false
     environment:
       <<: *rails_env
       # BINDING: "::"  # Uncomment for IPv6 dual-stack inside the container
@@ -95,6 +102,10 @@ services:
     volumes:
       - app-storage:/rails/storage
     restart: unless-stopped
+    # Same as `web`: pass through .env while keeping explicit values authoritative.
+    env_file:
+      - path: .env
+        required: false
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Fixes #2773

## Problem

Self-hosters following the documented setup put variables like `ONBOARDING_STATE`, `APP_DOMAIN`, `SMTP_*`, and `EMAIL_SENDER` in their `.env`, but the app never sees them — onboarding stays open and email doesn't work. `printenv` inside the container shows only the handful of variables hardcoded in the compose file. Same root cause reported earlier in #2489 (APP_DOMAIN + SMTP).

## Root cause

`compose.example.yml` declares container environment **only** via the `x-rails-env` anchor, which lists just DB / Redis / SSL / OpenAI variables, and sets no `env_file`.

Docker Compose automatically reads a `.env` file for `${VAR}` **interpolation inside the compose file**, but that does **not** inject those values into the container's environment unless they're referenced somewhere. Since the documented self-hosting variables aren't in the anchor, they're silently dropped.

## Fix

Add `env_file` to the `web` and `worker` services so the user's `.env` is passed through to the containers:

```yaml
    env_file:
      - path: .env
        required: false
```

- `required: false` keeps the "runs without any configuration" promise (docs `docker.md` line 54) — the out-of-the-box run with no `.env` still works.
- The explicit `environment:` anchor **takes precedence over `env_file`** in Docker Compose, so container-critical settings (`DB_HOST: db`, `REDIS_URL`, `SELF_HOSTED`) remain authoritative and can't be clobbered by a stray `.env` value.
- `env_file` injects **only** the variables the user actually set, so absent variables stay truly unset and the app's `ENV[...].presence`/`ENV.fetch(..., default)` fallbacks keep working (verified for `ONBOARDING_STATE` in `app/models/setting.rb` and `APP_DOMAIN` in `config/environments/production.rb`).

This resolves **all** documented self-hosting variables at once, not just the handful in the report.

## Why not enumerate vars in the anchor instead

Listing each variable as `KEY: ${KEY:-}` would force an **empty string** for every unset variable, which differs from "unset" and can defeat `ENV.fetch(key, default)` for enum-style vars (e.g. provider selection). `env_file` avoids that footgun by only passing what's present.

## Compatibility

The `required: false` long form needs Docker Compose ≥ 2.24 (Jan 2024); the setup guide already uses the `docker compose` v2 CLI throughout. Happy to fall back to enumerating specific variables in the anchor if the team prefers to support older Compose.

## Validation

- YAML parses; `environment` precedence + `env_file` behavior confirmed against the Docker Compose spec.
- Ran the repo's full `Pull Request` CI on a fork — all jobs green (the change is config-only, no Ruby impact).

## Risk / scope

- Single file, +11 lines, comments included. No app code changes.
- `compose.example.ai.yml` has the same pattern; happy to apply the same fix there in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added optional `.env` file support for web and worker services.
  * Explicit service environment settings take precedence over values in `.env`.
  * The setup continues to work when no `.env` file is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->