### PR TITLE
fix(ds): keep DS::Menu/Popover panels anchored across Turbo morphs

### DIFF
--- a/app/components/DS/menu.html.erb
+++ b/app/components/DS/menu.html.erb
@@ -5,7 +5,7 @@
     <%= button %>
   <% end %>
 
-  <div id="<%= menu_id %>" data-DS--menu-target="content" class="px-2 lg:px-0 max-w-full hidden z-50" role="menu">
+  <div id="<%= menu_id %>" data-DS--menu-target="content" class="fixed px-2 lg:px-0 max-w-full hidden z-50" role="menu">
     <%= tag.div class: "mx-auto min-w-[200px] shadow-border-lg bg-container rounded-lg", style: ("max-width: #{max_width}" if max_width) do %>
       <%= tag.div class: class_names("py-1" => !no_padding, "overflow-y-auto" => max_height), style: ("max-height: #{max_height}" if max_height) do %>
         <% items.each do |item| %>

--- a/app/components/DS/menu_controller.js
+++ b/app/components/DS/menu_controller.js
@@ -24,10 +24,19 @@ export default class extends Controller {
   };
 
   connect() {
-    this.show = this.showValue;
     this.boundUpdate = this.update.bind(this);
     this.addEventListeners();
     this.startAutoUpdate();
+  }
+
+  // Derived from the content element's own class rather than tracked as
+  // separate state. A Turbo morph (e.g. the same-page refresh after this
+  // menu's own "disable account" action) re-renders the content element
+  // closed without going through toggle()/close(), which would otherwise
+  // leave a plain instance property out of sync with the DOM — swallowing
+  // the next click because toggle() would think it still needs to close.
+  get show() {
+    return !this.contentTarget.classList.contains("hidden");
   }
 
   disconnect() {
@@ -103,17 +112,16 @@ export default class extends Controller {
   };
 
   toggle = () => {
-    this.show = !this.show;
-    this.contentTarget.classList.toggle("hidden", !this.show);
-    this.buttonTarget.setAttribute("aria-expanded", this.show.toString());
-    if (this.show) {
+    const nextShow = !this.show;
+    this.contentTarget.classList.toggle("hidden", !nextShow);
+    this.buttonTarget.setAttribute("aria-expanded", nextShow.toString());
+    if (nextShow) {
       this.update();
       this.#focusFirstMenuItem();
     }
   };
 
   close() {
-    this.show = false;
     this.contentTarget.classList.add("hidden");
     this.buttonTarget.setAttribute("aria-expanded", "false");
   }

--- a/app/components/DS/popover.html.erb
+++ b/app/components/DS/popover.html.erb
@@ -20,7 +20,7 @@
     </button>
   <% end %>
 
-  <div id="<%= panel_id %>" data-DS--popover-target="content" class="px-2 lg:px-0 max-w-full hidden z-50">
+  <div id="<%= panel_id %>" data-DS--popover-target="content" class="fixed px-2 lg:px-0 max-w-full hidden z-50">
     <%= tag.div class: "mx-auto min-w-[200px] shadow-border-lg bg-container rounded-lg", style: ("max-width: #{max_width}" if max_width) do %>
       <%= header %>
 

--- a/app/components/DS/popover_controller.js
+++ b/app/components/DS/popover_controller.js
@@ -25,10 +25,19 @@ export default class extends Controller {
   };
 
   connect() {
-    this.show = this.showValue;
     this.boundUpdate = this.update.bind(this);
     this.addEventListeners();
     this.startAutoUpdate();
+  }
+
+  // Derived from the content element's own class rather than tracked as
+  // separate state. A Turbo morph (e.g. a same-page refresh while this
+  // popover is mounted) re-renders the content element closed without
+  // going through toggle()/close(), which would otherwise leave a plain
+  // instance property out of sync with the DOM — swallowing the next
+  // click because toggle() would think it still needs to close.
+  get show() {
+    return !this.contentTarget.classList.contains("hidden");
   }
 
   disconnect() {
@@ -67,17 +76,16 @@ export default class extends Controller {
   };
 
   toggle = () => {
-    this.show = !this.show;
-    this.contentTarget.classList.toggle("hidden", !this.show);
-    this.buttonTarget.setAttribute("aria-expanded", this.show.toString());
-    if (this.show) {
+    const nextShow = !this.show;
+    this.contentTarget.classList.toggle("hidden", !nextShow);
+    this.buttonTarget.setAttribute("aria-expanded", nextShow.toString());
+    if (nextShow) {
       this.update();
       this.focusFirstElement();
     }
   };
 
   close() {
-    this.show = false;
     this.contentTarget.classList.add("hidden");
     this.buttonTarget.setAttribute("aria-expanded", "false");
   }

--- a/test/system/ds_overlay_morph_test.rb
+++ b/test/system/ds_overlay_morph_test.rb
@@ -1,0 +1,65 @@
+require "application_system_test_case"
+
+# Regression coverage for the bug fixed alongside DS::Menu / DS::Popover's
+# `fixed`-in-static-class change: a Turbo morph re-renders an open panel's
+# content element back to its server-rendered (closed) state without going
+# through the controller's own open/close methods. `show` used to be a plain
+# instance property that a morph couldn't touch, so the next click toggled
+# off an already-closed panel — swallowing the click. Deriving `show` from
+# the content element's own `hidden` class (rather than tracked state) means
+# it can't desync from what the DOM actually shows.
+class DsOverlayMorphTest < ApplicationSystemTestCase
+  setup do
+    sign_in @user = users(:family_admin)
+  end
+
+  test "DS::Menu reopens correctly after a morph resets it to hidden" do
+    visit tags_url
+
+    trigger = find("[aria-haspopup='menu']", match: :first)
+    content_id = trigger["aria-controls"]
+
+    trigger.click
+    assert_selector "##{content_id}", visible: true
+    assert_equal "true", trigger["aria-expanded"]
+
+    simulate_morph_reset(content_id)
+
+    trigger.click
+    assert_selector "##{content_id}", visible: true
+    assert_equal "true", trigger["aria-expanded"]
+  end
+
+  test "DS::Popover reopens correctly after a morph resets it to hidden" do
+    visit root_url
+
+    within_testid "user-menu" do
+      trigger = find("[aria-haspopup='dialog']")
+      content_id = trigger["aria-controls"]
+
+      trigger.click
+      assert_selector "##{content_id}", visible: true
+      assert_equal "true", trigger["aria-expanded"]
+
+      simulate_morph_reset(content_id)
+
+      trigger.click
+      assert_selector "##{content_id}", visible: true
+      assert_equal "true", trigger["aria-expanded"]
+    end
+  end
+
+  private
+    # Mimics what idiomorph does to an open panel on a same-page Turbo morph:
+    # the content element's class list is reconciled back to the always-hidden
+    # server-rendered markup, and any inline style the controller applied
+    # (position coordinates) is stripped — all without calling the Stimulus
+    # controller's toggle()/close().
+    def simulate_morph_reset(content_id)
+      page.execute_script(<<~JS, content_id)
+        const el = document.getElementById(arguments[0]);
+        el.classList.add("hidden");
+        el.removeAttribute("style");
+      JS
+    end
+end


### PR DESCRIPTION
## Summary
- After any same-page account action (disable, exclude from reports, set default, etc.), the accounts page does a Turbo **morph** refresh (`turbo_refreshes_with method: :morph`). Idiomorph resets every `DS::Menu`/`DS::Popover` content panel's `style` attribute back to the bare server-rendered value, silently stripping the JS-applied `position: fixed`. The next dropdown opened (any row, not just the one acted on) briefly renders in normal flex flow before floating-ui's async recompute lands, shoving its own trigger button sideways — so the panel ends up anchored to a phantom position instead of the real button.
- Related bug found in the same investigation: `this.show` was tracked as a plain instance property, which the morph can leave desynced from the DOM (menu closed in the DOM, but the controller still thinks it's open), silently swallowing the first click on a dropdown right after it caused the morph.
- `DS::Popover` mirrors `DS::Menu`'s implementation and has the identical issue, so it's fixed the same way.

## Fix
- `menu.html.erb` / `popover.html.erb`: add `fixed` to the content panel's static class list, so `position: fixed` survives a morph resetting the inline style (only `left`/`top` remain JS-driven).
- `menu_controller.js` / `popover_controller.js`: derive `show` from `contentTarget.classList.contains("hidden")` instead of tracking it separately, so it can never desync from the DOM.

## Before / After

Real app, fixture/demo data (not production data): disable "Checking Account" from its own dropdown, then open the unrelated "Credit Card" row's dropdown, which was never touched.

| | |
|---|---|
| Before | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2812-dropdown-anchor-before.png" width="480" alt="Credit Card row's dropdown menu (Edit, Sharing, Link with provider, Disable account, ...) rendered near the top of the page, nowhere near the Credit Card row's own trigger button at the bottom of the viewport"> |
| After | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2812-dropdown-anchor-after.png" width="480" alt="Same dropdown menu now anchored directly above the Credit Card row's trigger button, flipped upward since there wasn't room below"> |

## Test plan
- [x] Reproduced against the real Turbo 8.0.13 + Stimulus + floating-ui pipeline (pulled from the project's own `turbo-rails`/`stimulus-rails` gems and `vendor/javascript`) in an isolated harness, confirmed the exact failure mode, then confirmed it's resolved with the patched controller (panel lands pixel-exact on its trigger; previously-swallowed first click now opens on click 1).
- [x] `erb_lint` clean on both templates.
- [x] `node --check` clean on both controllers.
- [x] Full `bin/rails test` — 6022 runs, 0 failures, 0 errors.
- [x] Reproduced live in a real browser against fixture data (screenshots below), confirming both the anchor bug on `main` and the fix on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu and popover open/close behavior after page updates or navigation.
  - Kept expanded/collapsed state synchronized with what’s displayed.
  - Updated accessibility attributes for expandable menus and popovers to remain accurate after Turbo-driven DOM changes.
- **Style**
  - Adjusted menu and popover panel positioning to use fixed layout for more consistent rendering.
- **Tests**
  - Added system coverage to prevent regressions with Turbo morphs for menu and popover reopen behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
