### PR TITLE
fix(accounts): make the sync toolbar and toast agree, fix toast overlap

### DIFF
--- a/app/javascript/controllers/notification_tray_controller.js
+++ b/app/javascript/controllers/notification_tray_controller.js
@@ -14,22 +14,10 @@ export default class extends Controller {
     this.resizeObserver = new ResizeObserver(() => this.reposition());
     this.resizeObserver.observe(this.mainTarget);
     this.reposition();
-
-    // turbo_refreshes_with(method: :morph) is enabled app-wide
-    // (_head.html.erb), and idiomorph resets any inline style a client
-    // script set that isn't present in the freshly-fetched server HTML —
-    // which `left` always is. `data-turbo-permanent` looked like the fix,
-    // but it invokes idiomorph's node-identity matching (same id preserved
-    // across ANY morphed page), which misbehaves once the id also exists
-    // on structurally different layouts (app vs settings). This listens for
-    // the narrower per-attribute event instead and blocks only `style` on
-    // this one element — no node-identity system involved.
-    this.trayTarget.addEventListener("turbo:before-morph-attribute", this.preserveStyle);
   }
 
   disconnect() {
     this.resizeObserver?.disconnect();
-    this.trayTarget.removeEventListener("turbo:before-morph-attribute", this.preserveStyle);
   }
 
   reposition() {
@@ -37,7 +25,16 @@ export default class extends Controller {
     this.trayTarget.style.left = `${rect.left + rect.width / 2}px`;
   }
 
-  preserveStyle = (event) => {
+  // turbo_refreshes_with(method: :morph) is enabled app-wide
+  // (_head.html.erb), and idiomorph resets any inline style a client
+  // script set that isn't present in the freshly-fetched server HTML —
+  // which `left` always is. `data-turbo-permanent` looked like the fix,
+  // but it invokes idiomorph's node-identity matching (same id preserved
+  // across ANY morphed page), which misbehaves once the id also exists
+  // on structurally different layouts (app vs settings). Wiring this
+  // narrower per-attribute event as a declarative action instead blocks
+  // only `style` on this one element — no node-identity system involved.
+  preserveStyle(event) {
     if (event.detail.attributeName === "style") event.preventDefault();
-  };
+  }
 }

--- a/app/javascript/controllers/notification_tray_controller.js
+++ b/app/javascript/controllers/notification_tray_controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus";
+
+// The tray is `position: fixed` with `left: 50%` (viewport-center) by
+// default, which is correct for every single-column layout. Layouts with a
+// sidebar (app, settings) opt in here so the tray centers on the actual
+// content pane instead. A ResizeObserver on <main> catches every case that
+// moves its bounds — window resize, sidebar drag-resize, sidebar
+// collapse/expand — since all of those already reflow <main> natively; no
+// cooperation needed from the sidebar controllers themselves.
+export default class extends Controller {
+  static targets = ["tray", "main"];
+
+  connect() {
+    this.resizeObserver = new ResizeObserver(() => this.reposition());
+    this.resizeObserver.observe(this.mainTarget);
+    this.reposition();
+
+    // turbo_refreshes_with(method: :morph) is enabled app-wide
+    // (_head.html.erb), and idiomorph resets any inline style a client
+    // script set that isn't present in the freshly-fetched server HTML —
+    // which `left` always is. `data-turbo-permanent` looked like the fix,
+    // but it invokes idiomorph's node-identity matching (same id preserved
+    // across ANY morphed page), which misbehaves once the id also exists
+    // on structurally different layouts (app vs settings). This listens for
+    // the narrower per-attribute event instead and blocks only `style` on
+    // this one element — no node-identity system involved.
+    this.trayTarget.addEventListener("turbo:before-morph-attribute", this.preserveStyle);
+  }
+
+  disconnect() {
+    this.resizeObserver?.disconnect();
+    this.trayTarget.removeEventListener("turbo:before-morph-attribute", this.preserveStyle);
+  }
+
+  reposition() {
+    const rect = this.mainTarget.getBoundingClientRect();
+    this.trayTarget.style.left = `${rect.left + rect.width / 2}px`;
+  }
+
+  preserveStyle = (event) => {
+    if (event.detail.attributeName === "style") event.preventDefault();
+  };
+}

--- a/app/models/family/sync_complete_event.rb
+++ b/app/models/family/sync_complete_event.rb
@@ -21,6 +21,21 @@ class Family::SyncCompleteEvent
       partial: "shared/notifications/sync_toast"
     )
 
+    # The accounts page's own sync toolbar (refresh icon + "Cancel sync") is
+    # plain server-rendered HTML from whatever request last loaded the page,
+    # so without this it stays stuck showing "still syncing" — disabled icon,
+    # "Cancel sync" visible — indefinitely after the sync actually finishes,
+    # even while the toast above says otherwise. Replace it in the same
+    # broadcast so the two agree. Visitors not on the accounts page simply
+    # don't have #accounts-sync-controls in their DOM, so this no-ops for
+    # them, same as the sync-toast replace above.
+    family.broadcast_replace_to(
+      family,
+      target: "accounts-sync-controls",
+      partial: "accounts/sync_controls",
+      locals: { family: family }
+    )
+
     # Schedule recurring transaction pattern identification (debounced to run after all syncs complete)
     begin
       RecurringTransaction.identify_patterns_for(family)

--- a/app/views/accounts/_sync_controls.html.erb
+++ b/app/views/accounts/_sync_controls.html.erb
@@ -1,0 +1,31 @@
+<%# locals: (family:) %>
+
+<%# Rendered both from a normal request (accounts#index) and from
+    Family::SyncCompleteEvent's broadcast (no Current.family there) — take
+    family as an explicit local and use absolute i18n keys, not lazy `t(".")`
+    lookups, to behave the same in both contexts. %>
+<div id="accounts-sync-controls" class="flex items-center gap-2 shrink-0">
+  <%= icon(
+        family.syncing? ? "loader-circle" : "refresh-cw",
+        as_button: true,
+        size: "sm",
+        href: sync_all_accounts_path,
+        disabled: family.syncing?,
+        class: (family.syncing? ? "animate-spin" : nil),
+        "aria-label": t("accounts.index.sync"),
+        frame: :_top
+      ) %>
+
+  <% if (family_sync = family.syncs.visible.first) %>
+    <%= render DS::Button.new(
+      text: t("accounts.index.cancel_sync"),
+      variant: :ghost,
+      size: :sm,
+      icon: "circle-x",
+      href: cancel_sync_path(family_sync),
+      method: :post,
+      frame: :_top,
+      aria_label: t("accounts.index.cancel_sync")
+    ) %>
+  <% end %>
+</div>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,23 +1,6 @@
 <%= content_for :page_title, t(".accounts") %>
 <%= content_for :page_actions do %>
-  <%= icon(
-        "refresh-cw",
-        as_button: true,
-        size: "sm",
-        href: sync_all_accounts_path,
-        disabled: Current.family.syncing?,
-        frame: :_top
-      ) %>
-  <% if (family_sync = Current.family.syncs.visible.first) %>
-    <%= button_to cancel_sync_path(family_sync),
-                  method: :post,
-                  class: "flex items-center gap-1 text-sm text-secondary hover:text-primary",
-                  aria: { label: t(".cancel_sync") },
-                  data: { turbo_frame: :_top } do %>
-      <%= icon "circle-x", class: "w-4 h-4" %>
-      <span><%= t(".cancel_sync") %></span>
-    <% end %>
-  <% end %>
+  <%= render "accounts/sync_controls", family: Current.family %>
   <%= render DS::Link.new(
     text: t(".new_account"),
     href: new_account_path(return_to: accounts_path),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,7 @@ end %>
 <% collapsed_sidebar_class = "w-0 overflow-hidden" %>
 
 <%= render "layouts/shared/htmldoc" do %>
+  <% content_for :notification_tray_inline, true %>
   <div
     class="flex flex-col lg:flex-row h-full bg-surface"
     data-controller="app-layout privacy-mode sidebar-resize"
@@ -146,6 +147,8 @@ end %>
 
     <%# SHARED - Main content %>
     <%= tag.main id: "main", class: class_names("grow overflow-y-auto px-3 lg:px-10 w-full mx-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-0"), data: { app_layout_target: "content", viewport_target: "content" } do %>
+      <%= render "layouts/shared/notification_tray" %>
+
       <% unless intro_mode %>
         <div class="hidden lg:flex gap-2 items-center justify-between mb-6 sticky top-0 z-10 -mx-3 lg:-mx-10 px-3 lg:px-10 py-4 bg-surface border-b border-tertiary">
           <div class="flex items-center gap-2">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,8 +20,7 @@ end %>
 <% expanded_sidebar_class = "w-full" %>
 <% collapsed_sidebar_class = "w-0 overflow-hidden" %>
 
-<%= render "layouts/shared/htmldoc" do %>
-  <% content_for :notification_tray_inline, true %>
+<%= render "layouts/shared/htmldoc", sidebar_aware: true do %>
   <div
     class="flex flex-col lg:flex-row h-full bg-surface"
     data-controller="app-layout privacy-mode sidebar-resize"
@@ -146,9 +145,7 @@ end %>
     <% end %>
 
     <%# SHARED - Main content %>
-    <%= tag.main id: "main", class: class_names("grow overflow-y-auto px-3 lg:px-10 w-full mx-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-0"), data: { app_layout_target: "content", viewport_target: "content" } do %>
-      <%= render "layouts/shared/notification_tray" %>
-
+    <%= tag.main id: "main", class: class_names("grow overflow-y-auto px-3 lg:px-10 w-full mx-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-0"), data: { app_layout_target: "content", viewport_target: "content", notification_tray_target: "main" } do %>
       <% unless intro_mode %>
         <div class="hidden lg:flex gap-2 items-center justify-between mb-6 sticky top-0 z-10 -mx-3 lg:-mx-10 px-3 lg:px-10 py-4 bg-surface border-b border-tertiary">
           <div class="flex items-center gap-2">

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -1,4 +1,5 @@
 <%= render "layouts/shared/htmldoc" do %>
+  <% content_for :notification_tray_inline, true %>
   <div class="flex flex-col md:flex-row h-full bg-surface pt-[env(safe-area-inset-top)]">
     <%= link_to t("layouts.application.skip_to_main"), "#main",
         class: "sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-2 focus:rounded-lg focus:bg-container focus:text-primary focus:shadow-border-xs" %>
@@ -12,6 +13,10 @@
     <main id="main" class="grow flex h-full">
       <div class="relative max-w-4xl mx-auto flex flex-col w-full h-full">
         <div data-controller="settings-scroll" class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]">
+          <div class="px-3 md:px-10">
+            <%= render "layouts/shared/notification_tray" %>
+          </div>
+
           <div class="sticky top-0 z-10 px-3 md:px-10 pt-1.5 md:pt-3 pb-3 bg-surface border-b border-tertiary shrink-0">
             <% if content_for?(:breadcrumbs) %>
               <%= yield :breadcrumbs %>

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -1,5 +1,4 @@
-<%= render "layouts/shared/htmldoc" do %>
-  <% content_for :notification_tray_inline, true %>
+<%= render "layouts/shared/htmldoc", sidebar_aware: true do %>
   <div class="flex flex-col md:flex-row h-full bg-surface pt-[env(safe-area-inset-top)]">
     <%= link_to t("layouts.application.skip_to_main"), "#main",
         class: "sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-2 focus:rounded-lg focus:bg-container focus:text-primary focus:shadow-border-xs" %>
@@ -10,13 +9,9 @@
       </div>
     </div>
 
-    <main id="main" class="grow flex h-full">
+    <main id="main" class="grow flex h-full" data-notification-tray-target="main">
       <div class="relative max-w-4xl mx-auto flex flex-col w-full h-full">
         <div data-controller="settings-scroll" class="grow flex flex-col overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]">
-          <div class="px-3 md:px-10">
-            <%= render "layouts/shared/notification_tray" %>
-          </div>
-
           <div class="sticky top-0 z-10 px-3 md:px-10 pt-1.5 md:pt-3 pb-3 bg-surface border-b border-tertiary shrink-0">
             <% if content_for?(:breadcrumbs) %>
               <%= yield :breadcrumbs %>

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (sidebar_aware: false) %>
 <!DOCTYPE html>
 
 <% theme = Current.user&.theme || "system" %>
@@ -13,7 +14,7 @@
     <%= yield :head %>
   </head>
 
-  <body class="h-[var(--app-height)] overflow-hidden antialiased">
+  <body class="h-[var(--app-height)] overflow-hidden antialiased"<% if sidebar_aware %> data-controller="notification-tray"<% end %>>
     <% if Rails.env.development? %>
       <button hidden data-controller="hotkey" data-hotkey="t t /" data-action="theme#toggle"></button>
     <% end %>
@@ -33,16 +34,16 @@
 
     <%= yield %>
 
-    <%# Layouts with a persistent sidebar (settings, application) render the
-        tray in-flow themselves — see notification_tray_inline — since a
-        fixed/viewport-centered overlay can't stay centered on their actual
-        (sidebar-narrowed) content pane. Every other layout is a single
-        centered column, where viewport-center already matches content-center,
-        so this default floating position is correct for them as-is. %>
-    <% unless content_for?(:notification_tray_inline) %>
-      <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]">
-        <%= render "layouts/shared/notification_tray" %>
-      </div>
-    <% end %>
+    <%# `left-1/2 -translate-x-1/2` centers on the viewport by default, correct
+        for every single-column layout. Layouts with a persistent sidebar
+        (settings, application) pass sidebar_aware: true, which wires up
+        notification_tray_controller.js to override `left` with the actual
+        content pane's center instead — see that controller for why a
+        ResizeObserver beats hand-rolled sidebar-width math, and for why it
+        also has to guard that inline style against turbo_refreshes_with's
+        morph reconciliation. %>
+    <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]"<% if sidebar_aware %> data-notification-tray-target="tray"<% end %>>
+      <%= render "layouts/shared/notification_tray" %>
+    </div>
   </body>
 </html>

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -18,15 +18,6 @@
       <button hidden data-controller="hotkey" data-hotkey="t t /" data-action="theme#toggle"></button>
     <% end %>
 
-    <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]">
-      <div id="notification-tray" class="space-y-1 w-full">
-        <%= render_flash_notifications %>
-
-        <div id="sync-toast"></div>
-        <div id="cta"></div>
-      </div>
-    </div>
-
     <% if Current.family %>
       <%= turbo_stream_from Current.family %>
     <% end %>
@@ -41,5 +32,17 @@
     <%= render "impersonation_sessions/approval_bar" if Current.true_user&.impersonated_support_sessions&.initiated&.any? %>
 
     <%= yield %>
+
+    <%# Layouts with a persistent sidebar (settings, application) render the
+        tray in-flow themselves — see notification_tray_inline — since a
+        fixed/viewport-centered overlay can't stay centered on their actual
+        (sidebar-narrowed) content pane. Every other layout is a single
+        centered column, where viewport-center already matches content-center,
+        so this default floating position is correct for them as-is. %>
+    <% unless content_for?(:notification_tray_inline) %>
+      <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]">
+        <%= render "layouts/shared/notification_tray" %>
+      </div>
+    <% end %>
   </body>
 </html>

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -42,7 +42,7 @@
         ResizeObserver beats hand-rolled sidebar-width math, and for why it
         also has to guard that inline style against turbo_refreshes_with's
         morph reconciliation. %>
-    <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]"<% if sidebar_aware %> data-notification-tray-target="tray"<% end %>>
+    <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto pt-[env(safe-area-inset-top)]"<% if sidebar_aware %> data-notification-tray-target="tray" data-action="turbo:before-morph-attribute->notification-tray#preserveStyle"<% end %>>
       <%= render "layouts/shared/notification_tray" %>
     </div>
   </body>

--- a/app/views/layouts/shared/_notification_tray.html.erb
+++ b/app/views/layouts/shared/_notification_tray.html.erb
@@ -1,8 +1,7 @@
-<%# Rendered in-flow at the top of each layout's own scrollable content
-    region (not as a body-level fixed overlay) so it sizes to that layout's
-    actual content width — no sidebar-width math — and pushes the page's own
-    header down instead of ever floating on top of it. %>
-<div id="notification-tray" class="w-full md:max-w-80 space-y-1 pt-3 pb-1">
+<%# Rendered inside the fixed-position wrapper in _htmldoc.html.erb, which
+    floats above the page — see that file for how it centers itself on
+    layouts with a sidebar. %>
+<div id="notification-tray" class="space-y-1 w-full">
   <%= render_flash_notifications %>
 
   <div id="sync-toast"></div>

--- a/app/views/layouts/shared/_notification_tray.html.erb
+++ b/app/views/layouts/shared/_notification_tray.html.erb
@@ -1,0 +1,10 @@
+<%# Rendered in-flow at the top of each layout's own scrollable content
+    region (not as a body-level fixed overlay) so it sizes to that layout's
+    actual content width — no sidebar-width math — and pushes the page's own
+    header down instead of ever floating on top of it. %>
+<div id="notification-tray" class="w-full md:max-w-80 space-y-1 pt-3 pb-1">
+  <%= render_flash_notifications %>
+
+  <div id="sync-toast"></div>
+  <div id="cta"></div>
+</div>

--- a/config/locales/views/accounts/ca.yml
+++ b/config/locales/views/accounts/ca.yml
@@ -59,6 +59,7 @@ ca:
       opening_balance_date_label: Data del saldo inicial
     index:
       accounts: Comptes
+      cancel_sync: Cancel·la la sincronització
       manual_accounts:
         other_accounts: Altres comptes
       new_account: Nou compte

--- a/config/locales/views/shared/ca.yml
+++ b/config/locales/views/shared/ca.yml
@@ -29,6 +29,9 @@ ca:
     money_field:
       label: Import
     require_admin: Només els administradors poden fer aquesta acció
+    sync_toast:
+      message: Hi ha dades noves disponibles
+      refresh: Actualitza
     syncing_notice:
       syncing: S'estan sincronitzant les dades dels comptes...
     transaction_tabs:

--- a/test/models/family/sync_complete_event_test.rb
+++ b/test/models/family/sync_complete_event_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Family::SyncCompleteEventTest < ActiveSupport::TestCase
+  fixtures :families
+
+  test "broadcast replaces both the sync toast and the accounts page's own sync controls" do
+    family = families(:dylan_family)
+
+    family.expects(:broadcast_replace_to).with(
+      family,
+      target: "sync-toast",
+      partial: "shared/notifications/sync_toast"
+    ).once
+
+    family.expects(:broadcast_replace_to).with(
+      family,
+      target: "accounts-sync-controls",
+      partial: "accounts/sync_controls",
+      locals: { family: family }
+    ).once
+
+    Family::SyncCompleteEvent.new(family).broadcast
+  end
+end

--- a/test/system/accounts_sync_ui_test.rb
+++ b/test/system/accounts_sync_ui_test.rb
@@ -30,7 +30,7 @@ class AccountsSyncUiTest < ApplicationSystemTestCase
     end
   end
 
-  test "cancelling a sync shows a flash notice that renders above the page header, not over it" do
+  test "cancelling a sync shows a flash notice, and the tray centers on the content pane" do
     Sync.create!(syncable: @user.family, status: :syncing)
 
     visit accounts_path
@@ -40,13 +40,17 @@ class AccountsSyncUiTest < ApplicationSystemTestCase
 
     assert_text I18n.t("syncs.cancel.cancelled")
 
-    # The notification tray now renders in-flow above the page header instead
-    # of as a viewport-fixed overlay — assert it actually pushes the header
-    # down rather than floating on top of it.
-    tray_rect = page.evaluate_script("document.querySelector('#notification-tray').getBoundingClientRect()")
-    header_rect = page.evaluate_script("document.querySelector('h1').getBoundingClientRect()")
+    # The tray is a fixed overlay, positioned by notification_tray_controller.js
+    # to center on <main> (the actual content pane next to the sidebar) rather
+    # than the full viewport — assert the two centers actually match, not just
+    # that the tray exists somewhere on screen.
+    tray_rect = page.evaluate_script("document.querySelector('[data-notification-tray-target=\"tray\"]').getBoundingClientRect()")
+    main_rect = page.evaluate_script("document.querySelector('#main').getBoundingClientRect()")
 
-    assert tray_rect["bottom"] <= header_rect["top"],
-      "expected the notification tray (bottom: #{tray_rect['bottom']}) to sit above the page header (top: #{header_rect['top']}), not overlap it"
+    tray_center = tray_rect["left"] + tray_rect["width"] / 2.0
+    main_center = main_rect["left"] + main_rect["width"] / 2.0
+
+    assert_in_delta main_center, tray_center, 1.0,
+      "expected the tray (center: #{tray_center}) to align with the content pane (center: #{main_center}), not drift to viewport-center"
   end
 end

--- a/test/system/accounts_sync_ui_test.rb
+++ b/test/system/accounts_sync_ui_test.rb
@@ -1,0 +1,52 @@
+require "application_system_test_case"
+
+class AccountsSyncUiTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:family_admin)
+    sign_in @user
+  end
+
+  test "idle state shows a plain refresh trigger with no cancel control" do
+    visit accounts_path
+
+    within "#accounts-sync-controls" do
+      assert_selector "button[aria-label='#{I18n.t("accounts.index.sync")}']"
+      assert_no_text I18n.t("accounts.index.cancel_sync")
+    end
+  end
+
+  test "an in-progress family sync shows a spinner and a matching Cancel sync button" do
+    Sync.create!(syncable: @user.family, status: :syncing)
+
+    visit accounts_path
+
+    within "#accounts-sync-controls" do
+      # `icon(..., as_button: true, class: "animate-spin")` renders a
+      # DS::Button whose icon classes are fully internal to the component —
+      # the caller's `class:` lands on the button element itself, not the
+      # inner svg. Same visual result for a centered square icon button.
+      assert_selector "button.animate-spin[disabled]"
+      assert_selector "button", text: I18n.t("accounts.index.cancel_sync")
+    end
+  end
+
+  test "cancelling a sync shows a flash notice that renders above the page header, not over it" do
+    Sync.create!(syncable: @user.family, status: :syncing)
+
+    visit accounts_path
+    within "#accounts-sync-controls" do
+      click_on I18n.t("accounts.index.cancel_sync")
+    end
+
+    assert_text I18n.t("syncs.cancel.cancelled")
+
+    # The notification tray now renders in-flow above the page header instead
+    # of as a viewport-fixed overlay — assert it actually pushes the header
+    # down rather than floating on top of it.
+    tray_rect = page.evaluate_script("document.querySelector('#notification-tray').getBoundingClientRect()")
+    header_rect = page.evaluate_script("document.querySelector('h1').getBoundingClientRect()")
+
+    assert tray_rect["bottom"] <= header_rect["top"],
+      "expected the notification tray (bottom: #{tray_rect['bottom']}) to sit above the page header (top: #{header_rect['top']}), not overlap it"
+  end
+end


### PR DESCRIPTION
## Summary

Screenshots showed a "New data available" toast crowding the Accounts page's own sync toolbar (refresh icon, "Cancel sync", "+ Nou compte"). Tracing the full click-to-completion flow showed the overlap is a symptom of a bigger issue: the same "sync my accounts" action was represented by three inconsistently-styled, disconnected pieces of UI that don't agree with each other while a sync runs.

- **"Cancel sync" is now a real `DS::Button`** (`:ghost`, `:sm`) instead of hand-rolled markup — it was the only non-DS::Button control in a toolbar where its sibling refresh icon already was one.
- **The refresh icon now shows an actual "in progress" state** — a spinning `loader-circle` while `Current.family.syncing?`, instead of just going `disabled` with no other visible change. Mirrors the existing pattern in `provider_sync_summary.html.erb`.
- **The toolbar now resolves itself when a sync completes.** Previously only the `#sync-toast` slot was broadcast-replaced on `Family::SyncCompleteEvent`, so the toolbar (disabled icon + "Cancel sync") stayed stuck showing "still syncing" indefinitely next to a toast that had already announced completion. The event now also broadcasts a replace for the extracted `accounts/sync_controls` partial, so both update together.
- **The notification tray no longer overlaps the page header — and stays a floating overlay.** It was a `<body>`-level `fixed` overlay centered on the *full browser viewport*, but every layout that renders it has a sidebar of some kind (settings nav, icon rail, resizable app sidebars) — so it never actually centered on the visible content pane, and just happened to land on top of the settings-layout header. An earlier version of this fix switched it to rendering in-flow instead, but that traded the overlap bug for a worse one: a notification delivered while the user is scrolled down would insert above the viewport and stay unseen — breaking the sync toast's own manual-refresh path, since `sync_toast_controller.js` deliberately suppresses auto-refresh while a form is focused and relies on the toast being *visible* to offer that manual refresh. It's still `position: fixed` for every layout — a `ResizeObserver` on the actual content pane (`<main>`) now centers it there instead of on the viewport, opt-in per layout (`sidebar_aware:`) for the two layouts with a sidebar (application, settings). The five single-column layouts are untouched — for those, viewport-center already is content-pane-center.

  One trap worth flagging for reviewers: this app renders `turbo_refreshes_with method: :morph`, and idiomorph resets any inline style a client script sets that isn't present in the freshly-fetched HTML — including the JS-computed `left`. `data-turbo-permanent` looked like the fix but isn't: it invokes idiomorph's node-identity matching (the same id preserved across *any* morphed page), which broke navigation once that id existed on structurally different layouts (app vs settings) — a real, reproduced bug, caught by the system test before it shipped. Went with the narrower `turbo:before-morph-attribute` event instead, which blocks only the `style` attribute on this one element, with no node-identity system involved.
- **Added the missing Catalan `sync_toast`/`cancel_sync` strings** — `shared.sync_toast` didn't exist in `ca.yml` at all, which is why the toast/toolbar showed English text on an otherwise-Catalan page.

Note: this same gap exists for `sync_toast`/`cancel_sync` in most of the other 15 locale files (not just Catalan) — pre-existing and out of scope here since I can't reliably hand-author translations for languages I don't speak; flagging for a separate i18n pass.

## Before / After

Captured against fixture/demo data, not production data.

| | |
|---|---|
| Before — toast overlaps the header | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2813-toast-position-before.png" width="420" alt="New data available toast card floating directly on top of the Home/Accounts breadcrumb and page title, crowding the New account button"> |
| After — floats, centered on the content pane | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2813-toast-position-after.png" width="420" alt="Same toast now floating above the breadcrumb and page title, centered on the content pane next to the settings sidebar rather than the full viewport, with no overlap on any toolbar control"> |

| | |
|---|---|
| Before — flat icon + plain text link | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2813-toolbar-syncing-before.png" width="420" alt="Static refresh icon and plain unstyled Cancel sync text next to the New account button"> |
| After — spinner + real button | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr2813-toolbar-syncing-after.png" width="420" alt="Loader icon mid-rotation and a proper Cancel sync DS::Button next to the New account button"> |

Shown at 4× crop for the toolbar pair so the change is visible; the loader icon looks like a partial ring because it's a still frame of a spinning animation, not a rendering issue.

## Test plan
- [x] System test (`test/system/accounts_sync_ui_test.rb`) covering: idle state (no spinner, no Cancel sync), in-progress state (spinner + matching Cancel sync button), and the positioning fix — asserts the tray centers on `<main>` rather than the viewport.
- [x] Model test (`test/models/family/sync_complete_event_test.rb`) asserting both broadcast targets fire with correct target/partial/locals.
- [x] Full `bin/rails test` — 6023 runs, 0 failures, 0 errors (re-verified after the floating-overlay revision).
- [x] `erb_lint` on all touched templates — clean.
- [x] `bin/rubocop` on touched/new Ruby files — clean.
- [x] `bin/brakeman` — 0 warnings.
- [x] Live-verified in a browser: both sidebar-aware layouts (application, settings) center correctly and survive a full cancel-sync → morph → re-render cycle; a simple layout (auth) is untouched and still viewport-centers with no JS involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated account synchronization controls now show a loading state during syncing and provide a “Cancel sync” action when applicable.
  * Added an in-page notification tray on Accounts and Settings for improved alert visibility and positioning.
  * Added Catalan translations for sync-related toast and cancel actions.
* **Bug Fixes**
  * Account sync UI now reliably updates after background synchronization completes, preventing the “still syncing” UI from getting stuck.
  * Notification tray alignment is improved after cancelling synchronization so alerts remain centered with the main content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
