### PR TITLE
fix: cascade parent category color changes to subcategories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,6 +19,7 @@ class Category < ApplicationRecord
   validate :category_level_limit
 
   before_save :inherit_color_from_parent
+  after_update :sync_subcategory_colors, if: :saved_change_to_color?
 
   scope :alphabetically, -> { order(:name) }
   scope :alphabetically_by_hierarchy, -> {
@@ -296,6 +297,13 @@ class Category < ApplicationRecord
 
   def inherit_color_from_parent
     self.color = parent.color if subcategory? && parent
+  end
+
+  # Subcategories inherit their parent's color on their own save, but changing
+  # a parent's color must also cascade to already-saved subcategories, or their
+  # stored color goes stale and mismatches the parent (#2816).
+  def sync_subcategory_colors
+    subcategories.where.not(color: color).update_all(color: color)
   end
 
   def replace_and_destroy!(replacement)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,6 +19,7 @@ class Category < ApplicationRecord
   validate :category_level_limit
 
   before_save :inherit_color_from_parent
+  after_update :sync_subcategory_colors, if: :saved_change_to_color?
 
   scope :alphabetically, -> { order(:name) }
   scope :recently_used, -> { where.not(last_used_at: nil).order(last_used_at: :desc) }
@@ -332,6 +333,13 @@ class Category < ApplicationRecord
 
   def inherit_color_from_parent
     self.color = parent.color if subcategory? && parent
+  end
+
+  # Subcategories inherit their parent's color on their own save, but changing
+  # a parent's color must also cascade to already-saved subcategories, or their
+  # stored color goes stale and mismatches the parent (#2816).
+  def sync_subcategory_colors
+    subcategories.where.not(color: color).update_all(color: color)
   end
 
   def replace_and_destroy!(replacement)

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -21,6 +21,22 @@ class CategoryTest < ActiveSupport::TestCase
     assert_nil transactions.map { |t| t.reload.category }.uniq.first
   end
 
+  test "changing a parent's color cascades to its subcategories" do
+    parent = @family.categories.create!(name: "Travel", color: "#000000", lucide_icon: "plane")
+    subcategory = @family.categories.create!(name: "Flights", color: "#000000", lucide_icon: "plane", parent: parent)
+
+    parent.update!(color: "#123456")
+
+    assert_equal "#123456", subcategory.reload.color
+  end
+
+  test "changing a category color without subcategories does not error" do
+    category = @family.categories.create!(name: "Standalone", color: "#000000", lucide_icon: "tag")
+
+    assert_nothing_raised { category.update!(color: "#654321") }
+    assert_equal "#654321", category.reload.color
+  end
+
   test "destroying parent category preserves subcategory transaction assignments" do
     parent = @family.categories.create!(
       name: "Parent With Child Transactions",


### PR DESCRIPTION
Fixes #2816

## Problem

A subcategory's color does not follow its parent. After you change a parent category's color, the subcategory keeps its old color, so the two visibly mismatch and there's no way to correct the subcategory from the UI (subcategory colors are driven by the parent).

## Root cause

`Category` already forces a subcategory to adopt its parent's color, but only via a `before_save` hook on the **subcategory**:

```ruby
before_save :inherit_color_from_parent   # self.color = parent.color if subcategory?
```

Changing a parent's color saves only the parent record — the subcategories are never re-saved, so their stored `color` column stays at the old value.

## Fix

Add an `after_update` hook so a parent's color change cascades to its subcategories:

```ruby
after_update :sync_subcategory_colors, if: :saved_change_to_color?

def sync_subcategory_colors
  subcategories.where.not(color: color).update_all(color: color)
end
```

- Runs only when `color` actually changed (`saved_change_to_color?`).
- `where.not(color: color)` skips rows already in sync, so it's a no-op when nothing changes.
- Leaf categories have no subcategories, so it's a harmless no-op for them.
- `update_all` is a single UPDATE — no per-row callbacks or N extra saves.

Combined with the existing `before_save`, subcategory colors now stay consistent with their parent in both directions.

## Tests

Added to `test/models/category_test.rb`:
- changing a parent's color cascades to its subcategories;
- changing the color of a category with no subcategories does not error.

## Impact / risk

- Fixes the visible color mismatch; no schema or API changes.
- Scoped to `Category` (+1 hook, +1 method, +2 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a category’s color now automatically applies the new color to its existing subcategories, keeping related colors consistent.
  * Categories without subcategories can be updated without errors, and their new colors are saved correctly.

* **Tests**
  * Added coverage for cascading color updates to subcategories.
  * Added coverage confirming standalone category color changes are saved successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->