### PR TITLE
fix: tolerate Trade Republic Enable Banking pagination/PDNG errors (#392)

### DIFF
--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -652,8 +652,12 @@ class EnableBankingItem::Importer
           # succeeded, treat a validation error as "pagination exhausted" and keep
           # the partial result. A validation error on the very first page has no
           # prior data to fall back on and is a real failure, so it still propagates.
-          # (Issue #392)
-          raise if e.error_type != :validation_error || page_count == 1
+          # WRONG_TRANSACTIONS_PERIOD is excluded even mid-pagination: it means the
+          # date range itself is invalid (already retried once with a corrected
+          # date_from in Provider::EnableBanking#get_account_transactions), not that
+          # pagination is exhausted, so swallowing it here would silently drop the
+          # remaining pages instead of surfacing a retryable failure. (Issue #392)
+          raise if e.error_type != :validation_error || page_count == 1 || e.wrong_transactions_period?
           Rails.logger.warn "EnableBankingItem::Importer - Validation error mid-pagination for account #{enable_banking_account.uid} (status=#{transaction_status}), keeping #{all_transactions.count} transaction(s) from #{page_count - 1} page(s). #{e.message}"
           capture_pagination_truncation_debug_log(
             enable_banking_account,

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -382,6 +382,8 @@ class EnableBankingItem::Importer
         # (e.g. ImaginV2 returns WRONG_REQUEST_PARAMETERS; others mention "transactionStatus" verbatim),
         # so we treat every validation_error on PDNG as "ASPSP doesn't support pending" and continue with
         # the booked transactions only. (Issue #1805)
+        # Trade Republic rejects the same request with a 400 (:bad_request) instead of a
+        # 422 (:validation_error), so both error types are treated as "PDNG unsupported". (Issue #392)
         begin
           pending_transactions = fetch_paginated_transactions(
             enable_banking_account,
@@ -390,7 +392,7 @@ class EnableBankingItem::Importer
             psu_headers: enable_banking_item.build_psu_headers
           )
         rescue Provider::EnableBanking::EnableBankingError => e
-          raise unless e.error_type == :validation_error
+          raise unless [ :validation_error, :bad_request ].include?(e.error_type)
           api_error = e.response_data.is_a?(Hash) ? (e.response_data[:error] || e.response_data["error"]) : nil
           Rails.logger.warn "EnableBankingItem::Importer - ASPSP does not support PDNG transaction status for account #{enable_banking_account.uid}, skipping pending transactions. API error: #{api_error || e.message}"
         end
@@ -581,13 +583,28 @@ class EnableBankingItem::Importer
           raise PaginationTruncatedError, msg
         end
 
-        transactions_data = enable_banking_provider.get_account_transactions(
-          account_id: enable_banking_account.api_account_id,
-          date_from: start_date,
-          continuation_key: continuation_key,
-          transaction_status: transaction_status,
-          psu_headers: psu_headers
-        )
+        begin
+          transactions_data = enable_banking_provider.get_account_transactions(
+            account_id: enable_banking_account.api_account_id,
+            date_from: start_date,
+            continuation_key: continuation_key,
+            transaction_status: transaction_status,
+            psu_headers: psu_headers
+          )
+        rescue Provider::EnableBanking::EnableBankingError => e
+          # Some ASPSPs (e.g. Trade Republic via Enable Banking) issue a continuation_key
+          # that their own API then rejects on the next page as mismatched with
+          # transaction_status (422 WRONG_REQUEST_PARAMETERS: "transactionStatus in
+          # request is not the same as in continuationKey"). Failing outright would
+          # discard every page already fetched, so once at least one page has
+          # succeeded, treat a validation error as "pagination exhausted" and keep
+          # the partial result. A validation error on the very first page has no
+          # prior data to fall back on and is a real failure, so it still propagates.
+          # (Issue #392)
+          raise if e.error_type != :validation_error || page_count == 1
+          Rails.logger.warn "EnableBankingItem::Importer - Validation error mid-pagination for account #{enable_banking_account.uid} (status=#{transaction_status}), keeping #{all_transactions.count} transaction(s) from #{page_count - 1} page(s). #{e.message}"
+          break
+        end
 
         transactions = transactions_data[:transactions] || []
         all_transactions.concat(transactions)

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -335,6 +335,29 @@ class EnableBankingItem::Importer
       )
     end
 
+    # Surfaces "ASPSP doesn't support PDNG" as a support-visible diagnostic, same
+    # rationale as capture_pagination_truncation_debug_log: this is a partial
+    # degradation (booked transactions still sync, pending transactions are
+    # silently skipped) that was previously only visible via Rails.logger.
+    def capture_pdng_unsupported_debug_log(enable_banking_account, error:)
+      DebugLogEntry.capture(
+        category: "provider_sync_error",
+        level: "warn",
+        message: "ASPSP does not support the PDNG transaction status; skipping pending transactions and continuing with booked transactions only",
+        source: self.class.name,
+        provider_key: "enable_banking",
+        family: enable_banking_item.family,
+        account_provider: enable_banking_account.account_provider,
+        metadata: {
+          enable_banking_item_id: enable_banking_item.id,
+          enable_banking_account_id: enable_banking_account.id,
+          uid: enable_banking_account.uid,
+          error_type: error.error_type.to_s,
+          provider_error: sanitized_provider_error(error)
+        }
+      )
+    end
+
     def sanitized_error_message(error)
       return error.message unless error.is_a?(Provider::EnableBanking::EnableBankingError)
 
@@ -423,6 +446,7 @@ class EnableBankingItem::Importer
           raise unless [ :validation_error, :bad_request ].include?(e.error_type)
           api_error = e.response_data.is_a?(Hash) ? (e.response_data[:error] || e.response_data["error"]) : nil
           Rails.logger.warn "EnableBankingItem::Importer - ASPSP does not support PDNG transaction status for account #{enable_banking_account.uid}, skipping pending transactions. API error: #{api_error || e.message}"
+          capture_pdng_unsupported_debug_log(enable_banking_account, error: e)
         end
       end
 

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -307,6 +307,34 @@ class EnableBankingItem::Importer
       )
     end
 
+    # Surfaces a pagination truncation as a support-visible diagnostic (rather than
+    # only a Rails log line) so the /settings/debug UI shows when a sync silently
+    # dropped pages beyond a validation error, in case the account ever has more
+    # transactions in the requested window than the ASPSP's broken pagination can
+    # actually deliver (currently harmless for narrow incremental sync windows, but
+    # a wider historical resync could otherwise lose data without any visible sign).
+    def capture_pagination_truncation_debug_log(enable_banking_account, transaction_status:, pages_kept:, transactions_kept:, error:)
+      DebugLogEntry.capture(
+        category: "provider_sync_error",
+        level: "warn",
+        message: "Enable Banking transaction pagination truncated by a validation error mid-fetch; kept partial results instead of failing the sync",
+        source: self.class.name,
+        provider_key: "enable_banking",
+        family: enable_banking_item.family,
+        account_provider: enable_banking_account.account_provider,
+        metadata: {
+          enable_banking_item_id: enable_banking_item.id,
+          enable_banking_account_id: enable_banking_account.id,
+          uid: enable_banking_account.uid,
+          transaction_status: transaction_status,
+          pages_kept: pages_kept,
+          transactions_kept: transactions_kept,
+          error_type: error.error_type.to_s,
+          provider_error: sanitized_provider_error(error)
+        }
+      )
+    end
+
     def sanitized_error_message(error)
       return error.message unless error.is_a?(Provider::EnableBanking::EnableBankingError)
 
@@ -603,6 +631,13 @@ class EnableBankingItem::Importer
           # (Issue #392)
           raise if e.error_type != :validation_error || page_count == 1
           Rails.logger.warn "EnableBankingItem::Importer - Validation error mid-pagination for account #{enable_banking_account.uid} (status=#{transaction_status}), keeping #{all_transactions.count} transaction(s) from #{page_count - 1} page(s). #{e.message}"
+          capture_pagination_truncation_debug_log(
+            enable_banking_account,
+            transaction_status: transaction_status,
+            pages_kept: page_count - 1,
+            transactions_kept: all_transactions.count,
+            error: e
+          )
           break
         end
 

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -316,7 +316,7 @@ class EnableBankingItem::Importer
     def capture_pagination_truncation_debug_log(enable_banking_account, transaction_status:, pages_kept:, transactions_kept:, error:)
       DebugLogEntry.capture(
         category: "provider_sync_error",
-        level: "warn",
+        level: "error",
         message: "Enable Banking transaction pagination truncated by a validation error mid-fetch; kept partial results instead of failing the sync",
         source: self.class.name,
         provider_key: "enable_banking",
@@ -647,18 +647,25 @@ class EnableBankingItem::Importer
           # Some ASPSPs (e.g. Trade Republic via Enable Banking) issue a continuation_key
           # that their own API then rejects on the next page as mismatched with
           # transaction_status (422 WRONG_REQUEST_PARAMETERS: "transactionStatus in
-          # request is not the same as in continuationKey"). Failing outright would
-          # discard every page already fetched, so once at least one page has
-          # succeeded, treat a validation error as "pagination exhausted" and keep
-          # the partial result. A validation error on the very first page has no
-          # prior data to fall back on and is a real failure, so it still propagates.
+          # request is not the same as in continuationKey", surfaced as :validation_error;
+          # Trade Republic's PDNG fetch specifically surfaces the same underlying issue as
+          # a plain 400/:bad_request instead). Failing outright would discard every page
+          # already fetched, so once at least one page has succeeded, treat either error
+          # type as "pagination exhausted" and keep the partial result — symmetric with the
+          # PDNG-unsupported handling below, which already tolerates both types for the same
+          # reason. A validation error on the very first page has no prior data to fall back
+          # on and is a real failure, so it still propagates.
           # WRONG_TRANSACTIONS_PERIOD is excluded even mid-pagination: it means the
           # date range itself is invalid (already retried once with a corrected
           # date_from in Provider::EnableBanking#get_account_transactions), not that
           # pagination is exhausted, so swallowing it here would silently drop the
           # remaining pages instead of surfacing a retryable failure. (Issue #392)
-          raise if e.error_type != :validation_error || page_count == 1 || e.wrong_transactions_period?
-          Rails.logger.warn "EnableBankingItem::Importer - Validation error mid-pagination for account #{enable_banking_account.uid} (status=#{transaction_status}), keeping #{all_transactions.count} transaction(s) from #{page_count - 1} page(s). #{e.message}"
+          raise if ![ :validation_error, :bad_request ].include?(e.error_type) || page_count == 1 || e.wrong_transactions_period?
+          # error (not warn): this discards data for any ASPSP/scenario matching this
+          # error_type mid-pagination, not just the specific Trade Republic continuationKey
+          # mismatch this was written for — worth surfacing prominently in case a future
+          # ASPSP hits this path for a genuinely different reason.
+          Rails.logger.error "EnableBankingItem::Importer - Validation error mid-pagination for account #{enable_banking_account.uid} (status=#{transaction_status}), keeping #{all_transactions.count} transaction(s) from #{page_count - 1} page(s). #{e.message}"
           capture_pagination_truncation_debug_log(
             enable_banking_account,
             transaction_status: transaction_status,

--- a/test/models/enable_banking_item/importer_error_handling_test.rb
+++ b/test/models/enable_banking_item/importer_error_handling_test.rb
@@ -209,10 +209,40 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
 
     debug_log = DebugLogEntry.last
     assert_equal "provider_sync_error", debug_log.category
-    assert_equal "warn", debug_log.level
+    assert_equal "error", debug_log.level
     assert_equal "enable_banking", debug_log.provider_key
     assert_equal 1, debug_log.metadata["pages_kept"]
     assert_equal 1, debug_log.metadata["transactions_kept"]
+  end
+
+  # Regression for we-promise/sure#2828 review feedback (jjmata): the PDNG-unsupported
+  # rescue in fetch_and_store_transactions already tolerates both :validation_error and
+  # :bad_request, but fetch_paginated_transactions is the shared method behind both the
+  # BOOK and PDNG fetches — without this, a :bad_request mid-PDNG-pagination would raise
+  # here, propagate past the PDNG-unsupported rescue's partial-keep logic, and discard
+  # the already-fetched PDNG page 1 entirely instead of keeping it like the BOOK path
+  # does. Trade Republic only 400s on PDNG page 1 today, so this is currently latent,
+  # but the two error types must stay symmetric for ASPSPs that don't.
+  test "fetch_paginated_transactions keeps partial results when a bad_request interrupts a later PDNG page" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+    page1_tx = { transaction_id: "tx1" }
+    page1_response = { transactions: [ page1_tx ], continuation_key: "next-page-key" }
+    error = Provider::EnableBanking::EnableBankingError.new(
+      "Bad request to Enable Banking API: {\"error\":\"WRONG_REQUEST_PARAMETERS\"}",
+      :bad_request,
+      response_data: { error: "WRONG_REQUEST_PARAMETERS" }
+    )
+
+    @mock_provider.expects(:get_account_transactions).twice.returns(page1_response).then.raises(error)
+
+    result = @importer.send(
+      :fetch_paginated_transactions,
+      enable_banking_account,
+      start_date: Date.today,
+      transaction_status: "PDNG"
+    )
+
+    assert_equal [ page1_tx ], result
   end
 
   # A validation error on the very first page has no prior page to fall back on, so it

--- a/test/models/enable_banking_item/importer_error_handling_test.rb
+++ b/test/models/enable_banking_item/importer_error_handling_test.rb
@@ -128,9 +128,15 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
     @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "BOOK")).returns([])
     @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "PDNG")).raises(trade_republic_pdng_error)
 
-    result = @importer.send(:fetch_and_store_transactions, enable_banking_account)
+    result = nil
+    assert_difference "DebugLogEntry.count", 1 do
+      result = @importer.send(:fetch_and_store_transactions, enable_banking_account)
+    end
 
     assert result[:success]
+    debug_log = DebugLogEntry.last
+    assert_equal "provider_sync_error", debug_log.category
+    assert_equal "bad_request", debug_log.metadata["error_type"]
   end
 
   # Regression for #1805: ImaginV2 (and other Enable Banking connectors) reject PDNG with
@@ -182,19 +188,13 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
   test "fetch_paginated_transactions keeps partial results when a validation error interrupts a later page" do
     enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
     page1_tx = { transaction_id: "tx1" }
-    call_count = 0
+    page1_response = { transactions: [ page1_tx ], continuation_key: "next-page-key" }
+    error = Provider::EnableBanking::EnableBankingError.new(
+      "Validation error from Enable Banking API: transactionStatus in request is not the same as in continuationKey",
+      :validation_error
+    )
 
-    @mock_provider.define_singleton_method(:get_account_transactions) do |**args|
-      call_count += 1
-      if call_count == 1
-        { transactions: [ page1_tx ], continuation_key: "next-page-key" }
-      else
-        raise Provider::EnableBanking::EnableBankingError.new(
-          "Validation error from Enable Banking API: transactionStatus in request is not the same as in continuationKey",
-          :validation_error
-        )
-      end
-    end
+    @mock_provider.expects(:get_account_transactions).twice.returns(page1_response).then.raises(error)
 
     assert_difference "DebugLogEntry.count", 1 do
       result = @importer.send(
@@ -205,7 +205,6 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
       )
 
       assert_equal [ page1_tx ], result
-      assert_equal 2, call_count
     end
 
     debug_log = DebugLogEntry.last
@@ -220,10 +219,9 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
   # is a real failure (not ASPSP pagination quirk) and must still propagate.
   test "fetch_paginated_transactions propagates a validation error on the very first page" do
     enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+    error = Provider::EnableBanking::EnableBankingError.new("Bad request parameters", :validation_error)
 
-    @mock_provider.define_singleton_method(:get_account_transactions) do |**args|
-      raise Provider::EnableBanking::EnableBankingError.new("Bad request parameters", :validation_error)
-    end
+    @mock_provider.expects(:get_account_transactions).once.raises(error)
 
     assert_raises(Provider::EnableBanking::EnableBankingError) do
       @importer.send(
@@ -241,16 +239,10 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
   test "fetch_paginated_transactions propagates a non-validation error mid-pagination" do
     enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
     page1_tx = { transaction_id: "tx1" }
-    call_count = 0
+    page1_response = { transactions: [ page1_tx ], continuation_key: "next-page-key" }
+    error = Provider::EnableBanking::EnableBankingError.new("Rate limit exceeded. Please try again later.", :rate_limited)
 
-    @mock_provider.define_singleton_method(:get_account_transactions) do |**args|
-      call_count += 1
-      if call_count == 1
-        { transactions: [ page1_tx ], continuation_key: "next-page-key" }
-      else
-        raise Provider::EnableBanking::EnableBankingError.new("Rate limit exceeded. Please try again later.", :rate_limited)
-      end
-    end
+    @mock_provider.expects(:get_account_transactions).twice.returns(page1_response).then.raises(error)
 
     assert_raises(Provider::EnableBanking::EnableBankingError) do
       @importer.send(

--- a/test/models/enable_banking_item/importer_error_handling_test.rb
+++ b/test/models/enable_banking_item/importer_error_handling_test.rb
@@ -196,15 +196,24 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
       end
     end
 
-    result = @importer.send(
-      :fetch_paginated_transactions,
-      enable_banking_account,
-      start_date: Date.today,
-      transaction_status: "BOOK"
-    )
+    assert_difference "DebugLogEntry.count", 1 do
+      result = @importer.send(
+        :fetch_paginated_transactions,
+        enable_banking_account,
+        start_date: Date.today,
+        transaction_status: "BOOK"
+      )
 
-    assert_equal [ page1_tx ], result
-    assert_equal 2, call_count
+      assert_equal [ page1_tx ], result
+      assert_equal 2, call_count
+    end
+
+    debug_log = DebugLogEntry.last
+    assert_equal "provider_sync_error", debug_log.category
+    assert_equal "warn", debug_log.level
+    assert_equal "enable_banking", debug_log.provider_key
+    assert_equal 1, debug_log.metadata["pages_kept"]
+    assert_equal 1, debug_log.metadata["transactions_kept"]
   end
 
   # A validation error on the very first page has no prior page to fall back on, so it

--- a/test/models/enable_banking_item/importer_error_handling_test.rb
+++ b/test/models/enable_banking_item/importer_error_handling_test.rb
@@ -233,6 +233,32 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
     end
   end
 
+  # WRONG_TRANSACTIONS_PERIOD means the date range itself is invalid, not that
+  # pagination is exhausted (unlike the continuation-key mismatch above). It must
+  # still propagate mid-pagination instead of being swallowed as a truncated-but-
+  # successful result, otherwise the remaining pages are silently dropped.
+  test "fetch_paginated_transactions propagates a WRONG_TRANSACTIONS_PERIOD validation error mid-pagination" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+    page1_tx = { transaction_id: "tx1" }
+    page1_response = { transactions: [ page1_tx ], continuation_key: "next-page-key" }
+    error = Provider::EnableBanking::EnableBankingError.new(
+      "Validation error from Enable Banking API: invalid transaction period",
+      :validation_error,
+      response_data: { error: "WRONG_TRANSACTIONS_PERIOD" }
+    )
+
+    @mock_provider.expects(:get_account_transactions).twice.returns(page1_response).then.raises(error)
+
+    assert_raises(Provider::EnableBanking::EnableBankingError) do
+      @importer.send(
+        :fetch_paginated_transactions,
+        enable_banking_account,
+        start_date: Date.today,
+        transaction_status: "BOOK"
+      )
+    end
+  end
+
   # Non-validation errors (e.g. rate limiting, network failures) mid-pagination are
   # real failures regardless of how many pages already succeeded, and must propagate
   # so the sync is retried rather than silently importing a truncated result.

--- a/test/models/enable_banking_item/importer_error_handling_test.rb
+++ b/test/models/enable_banking_item/importer_error_handling_test.rb
@@ -112,6 +112,27 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
     assert result[:success]
   end
 
+  # Regression for #392: Trade Republic (via Enable Banking) rejects the PDNG request
+  # with a plain 400 (:bad_request) instead of the 422 (:validation_error) other ASPSPs use.
+  test "fetch_and_store_transactions succeeds and skips pending when ASPSP rejects PDNG with a bad_request error" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+    @importer.stubs(:determine_sync_start_date).returns(Date.today)
+    @importer.stubs(:include_pending?).returns(true)
+
+    trade_republic_pdng_error = Provider::EnableBanking::EnableBankingError.new(
+      "Bad request to Enable Banking API: {\"error\":\"WRONG_REQUEST_PARAMETERS\"}",
+      :bad_request,
+      response_data: { error: "WRONG_REQUEST_PARAMETERS" }
+    )
+
+    @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "BOOK")).returns([])
+    @importer.stubs(:fetch_paginated_transactions).with(enable_banking_account, has_entries(transaction_status: "PDNG")).raises(trade_republic_pdng_error)
+
+    result = @importer.send(:fetch_and_store_transactions, enable_banking_account)
+
+    assert result[:success]
+  end
+
   # Regression for #1805: ImaginV2 (and other Enable Banking connectors) reject PDNG with
   # a generic WRONG_REQUEST_PARAMETERS body whose message does not mention "transactionStatus".
   # The sync must still succeed and import booked transactions.
@@ -150,6 +171,86 @@ class EnableBankingItem::ImporterErrorHandlingTest < ActiveSupport::TestCase
     result = @importer.send(:fetch_and_store_transactions, enable_banking_account)
 
     assert_not result[:success]
+  end
+
+  # Regression for #392: Trade Republic (via Enable Banking) issues a continuation_key
+  # on page 1 that its own API then rejects on page 2 as mismatched with
+  # transaction_status (422 WRONG_REQUEST_PARAMETERS). Failing outright would discard
+  # the page already fetched, so once at least one page has succeeded, a validation
+  # error mid-pagination must be treated as "pagination exhausted" and keep the partial
+  # result instead of raising.
+  test "fetch_paginated_transactions keeps partial results when a validation error interrupts a later page" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+    page1_tx = { transaction_id: "tx1" }
+    call_count = 0
+
+    @mock_provider.define_singleton_method(:get_account_transactions) do |**args|
+      call_count += 1
+      if call_count == 1
+        { transactions: [ page1_tx ], continuation_key: "next-page-key" }
+      else
+        raise Provider::EnableBanking::EnableBankingError.new(
+          "Validation error from Enable Banking API: transactionStatus in request is not the same as in continuationKey",
+          :validation_error
+        )
+      end
+    end
+
+    result = @importer.send(
+      :fetch_paginated_transactions,
+      enable_banking_account,
+      start_date: Date.today,
+      transaction_status: "BOOK"
+    )
+
+    assert_equal [ page1_tx ], result
+    assert_equal 2, call_count
+  end
+
+  # A validation error on the very first page has no prior page to fall back on, so it
+  # is a real failure (not ASPSP pagination quirk) and must still propagate.
+  test "fetch_paginated_transactions propagates a validation error on the very first page" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+
+    @mock_provider.define_singleton_method(:get_account_transactions) do |**args|
+      raise Provider::EnableBanking::EnableBankingError.new("Bad request parameters", :validation_error)
+    end
+
+    assert_raises(Provider::EnableBanking::EnableBankingError) do
+      @importer.send(
+        :fetch_paginated_transactions,
+        enable_banking_account,
+        start_date: Date.today,
+        transaction_status: "BOOK"
+      )
+    end
+  end
+
+  # Non-validation errors (e.g. rate limiting, network failures) mid-pagination are
+  # real failures regardless of how many pages already succeeded, and must propagate
+  # so the sync is retried rather than silently importing a truncated result.
+  test "fetch_paginated_transactions propagates a non-validation error mid-pagination" do
+    enable_banking_account = EnableBankingAccount.new(uid: "test_uid")
+    page1_tx = { transaction_id: "tx1" }
+    call_count = 0
+
+    @mock_provider.define_singleton_method(:get_account_transactions) do |**args|
+      call_count += 1
+      if call_count == 1
+        { transactions: [ page1_tx ], continuation_key: "next-page-key" }
+      else
+        raise Provider::EnableBanking::EnableBankingError.new("Rate limit exceeded. Please try again later.", :rate_limited)
+      end
+    end
+
+    assert_raises(Provider::EnableBanking::EnableBankingError) do
+      @importer.send(
+        :fetch_paginated_transactions,
+        enable_banking_account,
+        start_date: Date.today,
+        transaction_status: "BOOK"
+      )
+    end
   end
 
   test "fetch_and_update_balance does not flip whole connection on per-account unauthorized error" do


### PR DESCRIPTION
Fixes the two Trade Republic sync errors reported in #392:

1. **BOOK pagination**: the transaction fetch issues a `continuation_key` on page 1 that Enable Banking's own API then rejects on page 2 as mismatched with `transaction_status` (`422 WRONG_REQUEST_PARAMETERS`: *"transactionStatus in request is not the same as in continuationKey"*). Previously this discarded every page already fetched. Once at least one page has succeeded, a validation error is now treated as "pagination exhausted" and the partial result is kept instead of raising. A validation error on the very first page still propagates as a real failure.
2. **PDNG (pending) fetch**: rejected with a plain `400`/`:bad_request` instead of the `422`/`:validation_error` other ASPSPs use for "transaction status not supported". Both error types are now treated as "ASPSP doesn't support pending transactions", consistent with the existing handling added for #1805.

Also adds a `DebugLogEntry` when pagination gets truncated by (1), so a truncated sync is visible in `/settings/debug` instead of only in container logs — relevant if an account's sync window ever needs more than one page (currently harmless for narrow incremental windows, since transaction volume stays under a page, but a wider historical resync could otherwise lose data past page 1 with no visible sign).

## Testing
- Full test suite green (`bin/rails test`), no regressions.
- `bin/rubocop` clean.
- Verified against a live Trade Republic connection through Enable Banking (self-hosted instance): sync went from consistently failing with the errors above to completing successfully and importing new transactions.

## Disclosure
This code was 100% written by Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction syncing when some providers reject pending transactions, allowing booked transactions to continue importing.
  * Improved resilience during interrupted transaction pagination by retaining successfully retrieved transactions when safe.
  * Added clearer diagnostics for partial imports and provider limitations.
* **Tests**
  * Added regression coverage for pending-transaction rejection and interrupted pagination scenarios, including cases that must fail immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->