### PR TITLE
feat(transactions): surface recently-used categories in the category picker

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -29,7 +29,10 @@ class CategoriesController < ApplicationController
     @category = Current.family.categories.new(category_params)
 
     if @category.save
-      @transaction.update(category_id: @category.id) if @transaction
+      if @transaction
+        @transaction.update(category_id: @category.id)
+        @transaction.record_category_usage!
+      end
 
       flash[:notice] = t(".success")
 

--- a/app/controllers/category/dropdowns_controller.rb
+++ b/app/controllers/category/dropdowns_controller.rb
@@ -3,7 +3,7 @@ class Category::DropdownsController < ApplicationController
 
   def show
     @categories = categories_scope.to_a.excluding(@selected_category).prepend(@selected_category).compact
-    @recent_categories = Category.recently_used_for(family: Current.family, excluding: @selected_category)
+    @recent_categories = Category.recently_used_for(family: Current.family, excluding: @selected_category).to_a
   end
 
   private

--- a/app/controllers/category/dropdowns_controller.rb
+++ b/app/controllers/category/dropdowns_controller.rb
@@ -3,6 +3,7 @@ class Category::DropdownsController < ApplicationController
 
   def show
     @categories = categories_scope.to_a.excluding(@selected_category).prepend(@selected_category).compact
+    @recent_categories = Category.recently_used_for(family: Current.family, excluding: @selected_category)
   end
 
   private

--- a/app/controllers/transaction_categories_controller.rb
+++ b/app/controllers/transaction_categories_controller.rb
@@ -9,6 +9,10 @@ class TransactionCategoriesController < ApplicationController
 
     transaction = @entry.transaction
 
+    if transaction.saved_change_to_category_id? && transaction.category.present?
+      transaction.category.touch(:last_used_at)
+    end
+
     if needs_rule_notification?(transaction)
       flash[:cta] = {
         type: "category_rule",
@@ -54,6 +58,7 @@ class TransactionCategoriesController < ApplicationController
 
     def needs_rule_notification?(transaction)
       return false if Current.user.rule_prompts_disabled
+      return false if transaction.category_id.blank?
 
       if Current.user.rule_prompt_dismissed_at.present?
         time_since_last_rule_prompt = Time.current - Current.user.rule_prompt_dismissed_at

--- a/app/controllers/transaction_categories_controller.rb
+++ b/app/controllers/transaction_categories_controller.rb
@@ -9,9 +9,7 @@ class TransactionCategoriesController < ApplicationController
 
     transaction = @entry.transaction
 
-    if transaction.saved_change_to_category_id? && transaction.category.present?
-      transaction.category.touch(:last_used_at)
-    end
+    transaction.record_category_usage!
 
     if needs_rule_notification?(transaction)
       flash[:cta] = {

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -123,6 +123,7 @@ class TransactionsController < ApplicationController
   def update
     if @entry.update(permitted_entry_params)
       transaction = @entry.transaction
+      transaction.record_category_usage!
 
       if needs_rule_notification?(transaction)
         flash[:cta] = {

--- a/app/javascript/controllers/list_filter_controller.js
+++ b/app/javascript/controllers/list_filter_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus";
 
 // Basic functionality to filter a list based on a provided text attribute.
 export default class extends Controller {
-  static targets = ["input", "list", "emptyMessage"];
+  static targets = ["input", "list", "emptyMessage", "recentSection"];
 
   connect() {
     this.inputTarget.focus();
@@ -15,11 +15,29 @@ export default class extends Controller {
     const items = this.listTarget.querySelectorAll(".filterable-item");
     let noMatchFound = true;
 
+    // "Recent" is a pre-search shortcut only — once the user is actively
+    // searching, show canonical filtered results, not a duplicate row. Its
+    // items are hidden outright (not text-matched) so the now-ancestor-hidden
+    // section can't leave a row with display:"" that arrow-key nav would
+    // still treat as visible.
+    const recentItems = this.hasRecentSectionTarget
+      ? new Set(this.recentSectionTarget.querySelectorAll(".filterable-item"))
+      : new Set();
+
+    if (this.hasRecentSectionTarget) {
+      this.recentSectionTarget.classList.toggle("hidden", filterValue.length > 0);
+    }
+
     if (this.hasEmptyMessageTarget) {
       this.emptyMessageTarget.classList.add("hidden");
     }
 
     items.forEach((item) => {
+      if (filterValue.length > 0 && recentItems.has(item)) {
+        item.style.display = "none";
+        return;
+      }
+
       const text = item.getAttribute("data-filter-name").toLowerCase();
       const shouldDisplay = text.includes(filterValue);
       item.style.display = shouldDisplay ? "" : "none";

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -150,9 +150,9 @@ class Category < ApplicationRecord
     end
 
     # Categories a family has manually assigned recently — a shortcut above the
-    # alphabetical list, not a replacement for it. See TransactionCategoriesController#update
-    # for the one place last_used_at is touched (only on a real human pick, not
-    # rule/import auto-assignment).
+    # alphabetical list, not a replacement for it. See Transaction#record_category_usage!
+    # for where last_used_at is touched (only on a real human pick via one of the
+    # manual assignment controllers, not rule/import auto-assignment).
     def recently_used_for(family:, excluding: [], limit: 4)
       family.categories
             .recently_used

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -21,6 +21,7 @@ class Category < ApplicationRecord
   before_save :inherit_color_from_parent
 
   scope :alphabetically, -> { order(:name) }
+  scope :recently_used, -> { where.not(last_used_at: nil).order(last_used_at: :desc) }
   scope :alphabetically_by_hierarchy, -> {
     left_joins(:parent)
       .order(Arel.sql("COALESCE(parents_categories.name, categories.name)"))
@@ -146,6 +147,17 @@ class Category < ApplicationRecord
             .distinct
             .pluck(:category_id)
             .index_with(true)
+    end
+
+    # Categories a family has manually assigned recently — a shortcut above the
+    # alphabetical list, not a replacement for it. See TransactionCategoriesController#update
+    # for the one place last_used_at is touched (only on a real human pick, not
+    # rule/import auto-assignment).
+    def recently_used_for(family:, excluding: [], limit: 4)
+      family.categories
+            .recently_used
+            .excluding(Array(excluding).compact)
+            .limit(limit)
     end
 
     def suggested_icon(name)

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -487,6 +487,7 @@ class Entry < ApplicationRecord
               attrs[:entryable_attributes] = attrs[:entryable_attributes].dup if attrs[:entryable_attributes].present?
               attrs[:entryable_attributes][:id] = entry.entryable_id if attrs[:entryable_attributes].present?
               entry.update! attrs
+              entry.transaction.record_category_usage! if entry.transaction?
               changed = true
             end
           end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -144,6 +144,16 @@ class Transaction < ApplicationRecord
     update!(category: category)
   end
 
+  # Marks a category as recently used. Called explicitly from the manual
+  # category-assignment controllers (picker, edit form, categorization
+  # wizard, create-and-assign) after a successful save — not wired to a
+  # blanket after_save callback because rule and import auto-assignment
+  # also go through `category_id=`, and those shouldn't count as a "recent"
+  # pick. See Category.recently_used_for.
+  def record_category_usage!
+    category.touch(:last_used_at) if saved_change_to_category_id? && category.present?
+  end
+
   def pending?
     extra_data = extra.is_a?(Hash) ? extra : {}
     PENDING_PROVIDERS.any? do |provider|

--- a/app/views/category/dropdowns/_row.html.erb
+++ b/app/views/category/dropdowns/_row.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (category:) %>
+<%# locals: (category:, id_prefix: "category_option") %>
 <% is_selected = category.id === @selected_category&.id %>
 
 <%= content_tag :div,
-      id: dom_id(category, "category_option"),
+      id: dom_id(category, local_assigns.fetch(:id_prefix, "category_option")),
       role: "option",
       aria_selected: is_selected.to_s,
       class: ["filterable-item flex justify-between items-center border-none rounded-lg px-2 py-1 group w-full hover:bg-container-inset-hover",

--- a/app/views/category/dropdowns/show.html.erb
+++ b/app/views/category/dropdowns/show.html.erb
@@ -20,6 +20,15 @@
         <div class="pb-2 pl-4 mr-2 text-secondary hidden" data-list-filter-target="emptyMessage">
           <%= t(".no_categories") %>
         </div>
+        <% if @recent_categories.any? %>
+          <div data-list-filter-target="recentSection">
+            <p class="pl-2 pb-1 text-xs font-medium text-secondary uppercase tracking-wide"><%= t(".recent") %></p>
+            <% @recent_categories.each do |category| %>
+              <%= render "category/dropdowns/row", category: category %>
+            <% end %>
+            <%= render "shared/ruler", classes: "my-2" %>
+          </div>
+        <% end %>
         <% if @categories.any? %>
           <% Category::Group.for(@categories).each do |group| %>
             <%= render "category/dropdowns/row", category: group.category %>

--- a/app/views/category/dropdowns/show.html.erb
+++ b/app/views/category/dropdowns/show.html.erb
@@ -24,7 +24,7 @@
           <div data-list-filter-target="recentSection">
             <p class="pl-2 pb-1 text-xs font-medium text-secondary uppercase tracking-wide"><%= t(".recent") %></p>
             <% @recent_categories.each do |category| %>
-              <%= render "category/dropdowns/row", category: category %>
+              <%= render "category/dropdowns/row", category: category, id_prefix: "recent_category_option" %>
             <% end %>
             <%= render "shared/ruler", classes: "my-2" %>
           </div>

--- a/config/locales/views/category/dropdowns/ca.yml
+++ b/config/locales/views/category/dropdowns/ca.yml
@@ -8,4 +8,5 @@ ca:
       show:
         clear: Esborra la categoria
         no_categories: No s'han trobat categories
+        recent: Recents
         search_placeholder: Cerca

--- a/config/locales/views/category/dropdowns/de.yml
+++ b/config/locales/views/category/dropdowns/de.yml
@@ -8,4 +8,5 @@ de:
       show:
         clear: Kategorie löschen
         no_categories: Keine Kategorien gefunden
+        recent: Zuletzt verwendet
         search_placeholder: Suchen

--- a/config/locales/views/category/dropdowns/en.yml
+++ b/config/locales/views/category/dropdowns/en.yml
@@ -8,4 +8,5 @@ en:
       show:
         clear: Clear category
         no_categories: No categories found
+        recent: Recent
         search_placeholder: Search

--- a/config/locales/views/category/dropdowns/es.yml
+++ b/config/locales/views/category/dropdowns/es.yml
@@ -8,4 +8,5 @@ es:
       show:
         clear: Limpiar categoría
         no_categories: No se encontraron categorías
+        recent: Recientes
         search_placeholder: Buscar

--- a/config/locales/views/category/dropdowns/fr.yml
+++ b/config/locales/views/category/dropdowns/fr.yml
@@ -8,4 +8,5 @@ fr:
       show:
         clear: Effacer la catégorie
         no_categories: Aucune catégorie trouvée
+        recent: Récents
         search_placeholder: Rechercher

--- a/config/locales/views/category/dropdowns/hu.yml
+++ b/config/locales/views/category/dropdowns/hu.yml
@@ -8,4 +8,5 @@ hu:
       show:
         clear: Kategória törlése
         no_categories: Nem található kategória
+        recent: Legutóbbiak
         search_placeholder: Keresés

--- a/config/locales/views/category/dropdowns/it.yml
+++ b/config/locales/views/category/dropdowns/it.yml
@@ -8,4 +8,5 @@ it:
       show:
         clear: Cancella categoria
         no_categories: Nessuna categoria trovata
+        recent: Recenti
         search_placeholder: Cerca

--- a/config/locales/views/category/dropdowns/nb.yml
+++ b/config/locales/views/category/dropdowns/nb.yml
@@ -8,4 +8,5 @@ nb:
       show:
         clear: Fjern kategori
         no_categories: Ingen kategorier funnet
+        recent: Nylige
         search_placeholder: Søk

--- a/config/locales/views/category/dropdowns/nl.yml
+++ b/config/locales/views/category/dropdowns/nl.yml
@@ -8,4 +8,5 @@ nl:
       show:
         clear: Categorie wissen
         no_categories: Geen categorieën gevonden
+        recent: Recent
         search_placeholder: Zoeken

--- a/config/locales/views/category/dropdowns/pl.yml
+++ b/config/locales/views/category/dropdowns/pl.yml
@@ -8,4 +8,5 @@ pl:
       show:
         clear: Wyczyść kategorię
         no_categories: Nie znaleziono kategorii
+        recent: Ostatnie
         search_placeholder: Szukaj

--- a/config/locales/views/category/dropdowns/pt-BR.yml
+++ b/config/locales/views/category/dropdowns/pt-BR.yml
@@ -8,4 +8,5 @@ pt-BR:
       show:
         clear: Limpar categoria
         no_categories: Nenhuma categoria encontrada
+        recent: Recentes
         search_placeholder: Buscar

--- a/config/locales/views/category/dropdowns/ro.yml
+++ b/config/locales/views/category/dropdowns/ro.yml
@@ -8,4 +8,5 @@ ro:
       show:
         clear: Golește categoria
         no_categories: Nu s-au găsit categorii
+        recent: Recente
         search_placeholder: Caută

--- a/config/locales/views/category/dropdowns/ru.yml
+++ b/config/locales/views/category/dropdowns/ru.yml
@@ -8,4 +8,5 @@ ru:
       show:
         clear: Очистить категорию
         no_categories: Категории не найдены
+        recent: Недавние
         search_placeholder: Поиск

--- a/config/locales/views/category/dropdowns/tr.yml
+++ b/config/locales/views/category/dropdowns/tr.yml
@@ -8,4 +8,5 @@ tr:
       show:
         clear: Kategoriyi temizle
         no_categories: Hiç kategori bulunamadı
+        recent: Son kullanılanlar
         search_placeholder: Ara

--- a/config/locales/views/category/dropdowns/vi.yml
+++ b/config/locales/views/category/dropdowns/vi.yml
@@ -8,4 +8,5 @@ vi:
       show:
         clear: Xóa danh mục
         no_categories: Không tìm thấy danh mục nào
+        recent: Gần đây
         search_placeholder: Tìm kiếm

--- a/config/locales/views/category/dropdowns/zh-CN.yml
+++ b/config/locales/views/category/dropdowns/zh-CN.yml
@@ -8,4 +8,5 @@ zh-CN:
       show:
         clear: 清空分类
         no_categories: 暂无分类
+        recent: 最近使用
         search_placeholder: 搜索分类

--- a/config/locales/views/category/dropdowns/zh-TW.yml
+++ b/config/locales/views/category/dropdowns/zh-TW.yml
@@ -8,4 +8,5 @@ zh-TW:
       show:
         clear: 清空分類
         no_categories: 暫無分類
+        recent: 最近使用
         search_placeholder: 搜尋分類

--- a/db/migrate/20260727111051_add_last_used_at_to_categories.rb
+++ b/db/migrate/20260727111051_add_last_used_at_to_categories.rb
@@ -1,0 +1,6 @@
+class AddLastUsedAtToCategories < ActiveRecord::Migration[8.1]
+  def change
+    add_column :categories, :last_used_at, :datetime
+    add_index :categories, [ :family_id, :last_used_at ]
+  end
+end

--- a/db/migrate/20260727111051_add_last_used_at_to_categories.rb
+++ b/db/migrate/20260727111051_add_last_used_at_to_categories.rb
@@ -1,4 +1,4 @@
-class AddLastUsedAtToCategories < ActiveRecord::Migration[8.1]
+class AddLastUsedAtToCategories < ActiveRecord::Migration[7.2]
   def change
     add_column :categories, :last_used_at, :datetime
     add_index :categories, [ :family_id, :last_used_at ]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -394,7 +394,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
     t.uuid "parent_id"
     t.string "classification_unused", default: "expense", null: false
     t.string "lucide_icon", default: "shapes", null: false
+    t.datetime "last_used_at"
     t.index ["family_id"], name: "index_categories_on_family_id"
+    t.index ["family_id", "last_used_at"], name: "index_categories_on_family_id_and_last_used_at"
   end
 
   create_table "chats", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/controllers/category/dropdowns_controller_test.rb
+++ b/test/controllers/category/dropdowns_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Category::DropdownsControllerTest < ActionDispatch::IntegrationTest
+  include ActionView::RecordIdentifier
+
   setup do
     sign_in users(:family_admin)
     @transaction = transactions(:one)
@@ -15,7 +17,18 @@ class Category::DropdownsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-list-filter-target='recentSection']"
-    assert_match recent.name, response.body
+    assert_select "[data-list-filter-target='recentSection']", text: /#{Regexp.escape(recent.name)}/
+  end
+
+  test "recent and canonical rows for the same category have distinct DOM ids" do
+    recent = categories(:income)
+    recent.update!(last_used_at: 1.day.ago)
+
+    get category_dropdown_url(transaction_id: @transaction.id)
+
+    assert_response :success
+    assert_select "##{dom_id(recent, 'recent_category_option')}", count: 1
+    assert_select "##{dom_id(recent, 'category_option')}", count: 1
   end
 
   test "excludes the currently selected category from the recent section" do

--- a/test/controllers/category/dropdowns_controller_test.rb
+++ b/test/controllers/category/dropdowns_controller_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Category::DropdownsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    @transaction = transactions(:one)
+    ensure_tailwind_build
+  end
+
+  test "shows a recent section for categories used recently" do
+    recent = categories(:income)
+    recent.update!(last_used_at: 1.day.ago)
+
+    get category_dropdown_url(transaction_id: @transaction.id)
+
+    assert_response :success
+    assert_select "[data-list-filter-target='recentSection']"
+    assert_match recent.name, response.body
+  end
+
+  test "excludes the currently selected category from the recent section" do
+    selected = categories(:food_and_drink)
+    selected.update!(last_used_at: 1.day.ago)
+
+    get category_dropdown_url(category_id: selected.id, transaction_id: @transaction.id)
+
+    assert_response :success
+    assert_select "[data-list-filter-target='recentSection']", false
+  end
+
+  test "omits the recent section entirely when nothing has been used yet" do
+    get category_dropdown_url(transaction_id: @transaction.id)
+
+    assert_response :success
+    assert_select "[data-list-filter-target='recentSection']", false
+  end
+end

--- a/test/controllers/transaction_categories_controller_test.rb
+++ b/test/controllers/transaction_categories_controller_test.rb
@@ -26,6 +26,8 @@ class TransactionCategoriesControllerTest < ActionDispatch::IntegrationTest
       params: { entry: { entryable_type: "Transaction", entryable_attributes: { id: @transaction.id, category_id: nil } } },
       as: :turbo_stream
 
+    assert_response :success
+    assert_nil @transaction.reload.category_id
     assert_nil category.reload.last_used_at
   end
 end

--- a/test/controllers/transaction_categories_controller_test.rb
+++ b/test/controllers/transaction_categories_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class TransactionCategoriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    @entry = entries(:transaction)
+    @transaction = transactions(:one)
+  end
+
+  test "assigning a category touches its last_used_at" do
+    category = categories(:income)
+    assert_nil category.last_used_at
+
+    patch transaction_category_url(@entry),
+      params: { entry: { entryable_type: "Transaction", entryable_attributes: { id: @transaction.id, category_id: category.id } } },
+      as: :turbo_stream
+
+    assert_not_nil category.reload.last_used_at
+  end
+
+  test "clearing a category does not touch any category's last_used_at" do
+    category = @transaction.category
+    assert_nil category.last_used_at
+
+    patch transaction_category_url(@entry),
+      params: { entry: { entryable_type: "Transaction", entryable_attributes: { id: @transaction.id, category_id: nil } } },
+      as: :turbo_stream
+
+    assert_nil category.reload.last_used_at
+  end
+end

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -159,4 +159,32 @@ class CategoryTest < ActiveSupport::TestCase
     assert lookup.key?(category.id)
     assert_not lookup.key?(0)
   end
+
+  test "recently_used_for orders by last_used_at, most recent first" do
+    older = categories(:income)
+    newer = categories(:food_and_drink)
+    older.update!(last_used_at: 2.days.ago)
+    newer.update!(last_used_at: 1.day.ago)
+
+    assert_equal [ newer, older ], Category.recently_used_for(family: @family).to_a
+  end
+
+  test "recently_used_for excludes categories with no usage yet" do
+    categories(:food_and_drink).update!(last_used_at: 1.day.ago)
+
+    assert_not_includes Category.recently_used_for(family: @family).to_a, categories(:income)
+  end
+
+  test "recently_used_for excludes given categories and respects limit" do
+    a = categories(:income)
+    b = categories(:food_and_drink)
+    c = categories(:subcategory)
+    a.update!(last_used_at: 3.days.ago)
+    b.update!(last_used_at: 2.days.ago)
+    c.update!(last_used_at: 1.day.ago)
+
+    result = Category.recently_used_for(family: @family, excluding: b, limit: 1)
+
+    assert_equal [ c ], result.to_a
+  end
 end

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -22,4 +22,14 @@ class EntryTest < ActiveSupport::TestCase
     assert_equal entry_ids.sort, Entry.where(id: entry_ids).chronological.pluck(:id)
     assert_equal entry_ids.sort.reverse, Entry.where(id: entry_ids).reverse_chronological.pluck(:id)
   end
+
+  test "bulk_update! touches the assigned category's last_used_at" do
+    entry = create_transaction(account: accounts(:depository))
+    category = categories(:income)
+    assert_nil category.last_used_at
+
+    Entry.where(id: entry.id).bulk_update!({ category_id: category.id })
+
+    assert_not_nil category.reload.last_used_at
+  end
 end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -179,4 +179,44 @@ class TransactionTest < ActiveSupport::TestCase
 
     assert_equal securities(:msft), transaction.activity_security
   end
+
+  test "record_category_usage! touches the new category's last_used_at" do
+    transaction = transactions(:one)
+    category = categories(:income)
+    assert_nil category.last_used_at
+
+    transaction.update!(category: category)
+    transaction.record_category_usage!
+
+    assert_not_nil category.reload.last_used_at
+  end
+
+  test "record_category_usage! does nothing when category_id did not change" do
+    transaction = transactions(:one)
+    category = transaction.category
+    assert_nil category.last_used_at
+
+    transaction.reload
+    transaction.record_category_usage!
+
+    assert_nil category.reload.last_used_at
+  end
+
+  test "record_category_usage! does nothing when category is cleared" do
+    transaction = transactions(:one)
+
+    transaction.update!(category: nil)
+
+    assert_nothing_raised { transaction.record_category_usage! }
+  end
+
+  test "record_category_usage! is not invoked by rule-driven category enrichment" do
+    transaction = transactions(:one)
+    category = categories(:income)
+    assert_nil category.last_used_at
+
+    transaction.enrich_attribute(:category_id, category.id, source: "rule")
+
+    assert_nil category.reload.last_used_at
+  end
 end


### PR DESCRIPTION
## Summary

On the transaction category picker: scrolling/searching to find a category you use constantly (rent, groceries, gas) every time is friction that shouldn't exist. Explored two directions — reordering the whole list by recency (frecency-style, like a browser address bar) vs. an additive "Recent" section on top of an untouched list — and went with the latter. Reordering a reference list people build spatial memory against is a known anti-pattern (Office's old adaptive/personalized menus did this and were widely disliked for it); every picker that does recency well (VS Code's command palette, Slack's emoji picker) adds a small separate recent cluster instead of reshuffling the canonical list.

- **`Category#last_used_at`**, touched only in `TransactionCategoriesController#update` — the one place a category is actually hand-picked by a person, as opposed to a rule or import auto-assigning one. Clearing a category does not count as "using" one.
- **`Category.recently_used_for(family:, excluding:, limit:)`** batches the family-scoped query (one query, not N+1). `Category::DropdownsController` excludes the already-selected category from the Recent section since it's already pinned to the top of the main list below.
- **"Recent" hides itself the instant you start typing** — it's a pre-search shortcut, not a second copy of search results. Its rows are force-hidden (not just left to the text filter) so keyboard arrow-navigation can't land on a row that's invisible only because its ancestor section got hidden.
- **Bonus fix, found via test coverage, not the original ask:** clearing a category (the "Clear category" action in this same dropdown) crashed. `needs_rule_notification?` only checked `saved_change_to_category_id?` and `eligible_for_category_rule?`, neither of which accounts for `category_id` being `nil` — so clearing satisfied both, and the code went on to read `transaction.category.name` against a `nil` category. No test exercised this path before. A rule prompt only makes sense when a category was assigned, not cleared, so it now bails out early when there's no category to build a rule around.
- Translated the new `recent` label into all 17 locale files this view already ships (matching the existing full-coverage convention for `category/dropdowns`).

## Before / After

Captured against demo data.

| | |
|---|---|
| "Recent" section, most-recently-used first, untouched alphabetical list below | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr-category-recent-open.png" width="420" alt="Category picker dropdown showing a RECENT section with four categories (Rent/Mortgage, Gas, Personal Care, Groceries) above a divider, followed by the full alphabetical category list with Entertainment checked as the current selection"> |
| Typing a query hides Recent — only canonical filtered results remain | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pr-category-recent-hidden-while-searching.png" width="420" alt="Same dropdown with 'gro' typed into the search box — the RECENT section is gone, showing a single filtered Groceries result instead of a duplicate row"> |

## Test plan
- [x] `Category.recently_used_for` — orders by `last_used_at` descending, excludes never-used categories, excludes explicitly-passed categories, respects `limit` (`test/models/category_test.rb`).
- [x] `TransactionCategoriesController#update` — assigning a category touches its `last_used_at`; clearing a category does not touch anything (and does not crash, regression coverage for the bonus fix) (`test/controllers/transaction_categories_controller_test.rb`).
- [x] `Category::DropdownsController#show` — renders the Recent section when categories have been used; excludes the currently-selected category from it; omits the section entirely when nothing has been used yet (`test/controllers/category/dropdowns_controller_test.rb`).
- [x] Full `bin/rails test` — 6030 runs, 0 failures, 0 errors.
- [x] `bin/rubocop` on touched/new Ruby files — clean.
- [x] `bundle exec erb_lint` on the touched view — clean.
- [x] `npm run lint` (biome) on the touched Stimulus controller — clean.
- [x] `bin/brakeman` — 0 warnings.
- [x] Live-verified in a browser: Recent section renders in the right order, excludes the current selection, and disappears the instant a search query is typed, leaving a single (non-duplicated) filtered result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category dropdowns now include a “recent” section with recently used categories for faster selection.
  * Recently used categories are tracked automatically when a transaction’s category is set/updated (including bulk updates).
  * “Recent” items are hidden while searching so filtered results take priority.
  * Added localized “Recent” labels across supported languages.
* **Bug Fixes**
  * The currently selected category is excluded from the recent list.
  * Recent-category prompts are skipped when no category is selected.
* **Tests**
  * Added integration/model coverage for recent sections, DOM id disambiguation, and category usage tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->