### PR TITLE
fix(insights): respect recurring_transactions_disabled in subscription_audit

### DIFF
--- a/app/models/insight/generators/cash_flow_warning_generator.rb
+++ b/app/models/insight/generators/cash_flow_warning_generator.rb
@@ -78,6 +78,17 @@ class Insight::Generators::CashFlowWarningGenerator < Insight::Generator
     # Projected occurrences of known recurring transactions within the horizon.
     # Transfers are internal moves, and cross-currency amounts can't be applied
     # to a family-currency balance without a rate lookup, so both are skipped.
+    #
+    # Deliberately NOT gated on family.recurring_transactions_disabled?, unlike
+    # SubscriptionAuditGenerator. That generator's entire subject is "your
+    # recurring transactions" — with detection off, there's nothing left to
+    # report. Here, recurring transactions are one input refining a cash-flow
+    # projection whose subject (will your balance dip low in the next 30 days)
+    # stays meaningful either way. Disabling the setting only stops the
+    # identification job from finding NEW recurring transactions
+    # (IdentifyRecurringTransactionsJob) — it doesn't clear out ones already
+    # identified, so this keeps using that last-known set rather than silently
+    # degrading to the flatter median-only baseline.
     def upcoming_recurring_entries
       family.recurring_transactions
         .expected_soon

--- a/app/models/insight/generators/subscription_audit_generator.rb
+++ b/app/models/insight/generators/subscription_audit_generator.rb
@@ -8,6 +8,8 @@ class Insight::Generators::SubscriptionAuditGenerator < Insight::Generator
   MAX_INSIGHTS = 3
 
   def generate
+    return [] if family.recurring_transactions_disabled?
+
     overdue_recurring.map do |recurring|
       name = recurring.merchant&.name.presence || recurring.name
       amount = Money.new(recurring.amount, recurring.currency).format

--- a/test/models/insight/generators/subscription_audit_generator_test.rb
+++ b/test/models/insight/generators/subscription_audit_generator_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Insight::Generators::SubscriptionAuditGeneratorTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @overdue = recurring_transactions(:netflix_subscription)
+    @overdue.update!(next_expected_date: 50.days.ago.to_date)
+  end
+
+  test "generates an insight for an overdue recurring transaction" do
+    insights = Insight::Generators::SubscriptionAuditGenerator.new(@family).generate
+
+    assert_equal 1, insights.size
+    assert_equal "subscription_audit:#{@overdue.id}", insights.first.dedup_key
+  end
+
+  test "returns nothing when recurring transaction detection is disabled" do
+    @family.update!(recurring_transactions_disabled: true)
+
+    insights = Insight::Generators::SubscriptionAuditGenerator.new(@family).generate
+
+    assert_empty insights
+  end
+end


### PR DESCRIPTION
## Summary

Disabling recurring-transaction detection (Settings -> Recurring Transactions -> toggle off) didn't stop the Insights feed from showing "recurring charge overdue" nudges sourced from rows identified before the toggle was flipped.

- `Insight::Generators::SubscriptionAuditGenerator#generate` queried `family.recurring_transactions` directly and never checked `family.recurring_transactions_disabled?` — unlike both existing call sites in `IdentifyRecurringTransactionsJob`, which already gate on that same family-wide flag. Disabling the feature correctly stopped *new* identification, but did nothing about insights built from rows already sitting in the table.
- Fix is a one-line early return in the generator when the flag is set.
- Existing insights self-clean up on the next nightly run without any separate cleanup path: `produced_types` is a class-level declaration (not tied to what a given run actually returns), so `GenerateInsightsJob` still counts `subscription_audit` as a succeeded type and expires any visible insight whose `dedup_key` wasn't regenerated — exactly the mechanism already in place for a condition that clears.

## Test plan
- [x] `Insight::Generators::SubscriptionAuditGenerator` — generates an insight for a genuinely overdue recurring transaction (baseline, previously untested); returns nothing when `recurring_transactions_disabled` is set, even with an overdue row present (`test/models/insight/generators/subscription_audit_generator_test.rb`).
- [x] Full `bin/rails test` — 6024 runs, 0 failures, 0 errors.
- [x] `bin/rubocop` on touched/new Ruby files — clean.
- [x] `bin/brakeman` — 0 warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped overdue recurring transaction alerts from being generated when recurring transaction tracking is disabled.
  * Kept existing overdue recurring alerts intact when tracking is enabled.
* **Tests**
  * Added automated coverage for both disabled and enabled recurring tracking scenarios.
* **Documentation**
  * Clarified expected behavior of cash-flow warning generation when recurring transaction tracking is disabled, to reflect how prior identified items are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->