### PR TITLE
fix(import): move opening anchor for CSV txs that predate it

### DIFF
--- a/app/models/transaction_import.rb
+++ b/app/models/transaction_import.rb
@@ -79,6 +79,11 @@ class TransactionImport < Import
 
       # Bulk import new transactions
       Transaction.import!(new_transactions, recursive: true) if new_transactions.any?
+
+      # Existing accounts often have an opening_anchor valuation. Forward balance
+      # calc resets absolute balance on that date, wiping effects of imported txs
+      # that predate it (same fix QIF already applies — #2826).
+      adjust_opening_anchors_if_needed!
     end
   end
 
@@ -116,4 +121,33 @@ class TransactionImport < Import
     csv.delete("account") if account.present?
     csv
   end
+
+  private
+    def adjust_opening_anchors_if_needed!
+      earliest_date_by_account.each do |mapped_account, earliest|
+        manager = Account::OpeningBalanceManager.new(mapped_account)
+        next unless manager.has_opening_anchor?
+        next unless earliest < manager.opening_date
+
+        manager.set_opening_balance(
+          balance: manager.opening_balance,
+          date: earliest - 1.day
+        )
+      end
+    end
+
+    def earliest_date_by_account
+      rows.each_with_object({}) do |row, earliest_by_account|
+        mapped_account = if account
+          account
+        else
+          mappings.accounts.mappable_for(row.account)
+        end
+        next if mapped_account.nil?
+
+        date = Date.iso8601(row.date_iso)
+        current = earliest_by_account[mapped_account]
+        earliest_by_account[mapped_account] = current.nil? || date < current ? date : current
+      end
+    end
 end

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -478,4 +478,65 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert_equal "Transaction 1", rows.first.name
     assert_equal "100", rows.first.amount
   end
+
+  test "import! moves opening anchor back when transactions predate it" do
+    account = accounts(:depository)
+    account.entries.create!(
+      date: 2.years.ago.to_date,
+      name: "Opening balance",
+      amount: 0,
+      currency: account.currency,
+      entryable: Valuation.new(kind: "opening_anchor")
+    )
+
+    @import.update!(
+      account: account,
+      raw_file_str: <<~CSV,
+        date,name,amount
+        01/15/2020,Old grocery,50
+        01/20/2020,Old coffee,10
+      CSV
+      date_col_label: "date",
+      amount_col_label: "amount",
+      name_col_label: "name",
+      date_format: "%m/%d/%Y"
+    )
+
+    @import.generate_rows_from_csv
+    @import.import!
+
+    manager = Account::OpeningBalanceManager.new(account.reload)
+    assert_equal Date.new(2020, 1, 14), manager.opening_date
+    assert_equal 0, manager.opening_balance
+  end
+
+  test "import! does not move opening anchor when transactions do not predate it" do
+    account = accounts(:depository)
+    anchor_date = Date.new(2020, 1, 1)
+    account.entries.create!(
+      date: anchor_date,
+      name: "Opening balance",
+      amount: 0,
+      currency: account.currency,
+      entryable: Valuation.new(kind: "opening_anchor")
+    )
+
+    @import.update!(
+      account: account,
+      raw_file_str: <<~CSV,
+        date,name,amount
+        06/04/2020,Later grocery,50
+      CSV
+      date_col_label: "date",
+      amount_col_label: "amount",
+      name_col_label: "name",
+      date_format: "%m/%d/%Y"
+    )
+
+    @import.generate_rows_from_csv
+    @import.import!
+
+    manager = Account::OpeningBalanceManager.new(account.reload)
+    assert_equal anchor_date, manager.opening_date
+  end
 end


### PR DESCRIPTION
## Summary
- CSV transaction imports into existing accounts left balances/graphs unchanged because an `opening_anchor` valuation reset absolute balance on that date, wiping earlier imported history.
- Mirror the existing QIF import behavior: when imported rows predate the account's opening anchor, move the anchor to the day before the earliest imported transaction (preserving the anchor balance).
- Adds regression tests covering both the adjust and no-op cases.

Fixes #2826

## Test plan
- [ ] Import a CSV into an existing account that already has an opening anchor dated after some imported rows
- [ ] Confirm account balance/graph reflects the imported history after sync
- [ ] Confirm an anchor that already predates all imported rows is left unchanged
- [ ] `bin/rails test test/models/transaction_import_test.rb`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Imported transactions dated before an account’s existing opening balance are now preserved.
  * Opening balance dates automatically adjust earlier when needed, while remaining unchanged when no adjustment is necessary.

* **Tests**
  * Added coverage for both adjusted and unchanged opening balance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->