### PR TITLE
fix(plaid): pace investment transaction pagination to avoid rate limits

### DIFF
--- a/app/models/provider/plaid.rb
+++ b/app/models/provider/plaid.rb
@@ -3,6 +3,12 @@ class Provider::Plaid
 
   SUPPORTED_PLAID_PRODUCTS = %w[transactions investments liabilities].freeze
   MAX_HISTORY_DAYS = Rails.env.development? ? 90 : 730
+  # Plaid's documented max for investments/transactions/get. Omitting count defaults to 100 and
+  # forces many rapid pages — the path that trips INVESTMENTS_LIMIT (#2827).
+  INVESTMENTS_TRANSACTIONS_PAGE_SIZE = 500
+  INVESTMENTS_PAGE_INTERVAL_SECONDS = 1.0
+  INVESTMENTS_RATE_LIMIT_MAX_RETRIES = 5
+  INVESTMENTS_RATE_LIMIT_ERROR_CODES = %w[INVESTMENTS_LIMIT RATE_LIMIT_EXCEEDED].freeze
 
   def initialize(config, region: :us)
     @client = Plaid::PlaidApi.new(
@@ -119,7 +125,28 @@ class Provider::Plaid
   def get_item_investments(access_token, start_date: nil, end_date: Date.current)
     start_date = start_date || MAX_HISTORY_DAYS.days.ago.to_date
     holdings, holding_securities = get_item_holdings(access_token: access_token)
-    transactions, transaction_securities = get_item_investment_transactions(access_token: access_token, start_date:, end_date:)
+
+    begin
+      transactions, transaction_securities = get_item_investment_transactions(access_token: access_token, start_date:, end_date:)
+    rescue Plaid::ApiError => e
+      # Holdings already succeeded. Prefer returning what we have over failing the whole Item sync
+      # (which previously left "No accounts found" despite a healthy Item — #2827).
+      raise unless investments_rate_limited?(e)
+
+      DebugLogEntry.capture(
+        category: "provider_sync",
+        level: "warn",
+        message: "Plaid investments/transactions/get rate-limited; continuing with holdings only",
+        source: "Provider::Plaid#get_item_investments",
+        provider_key: "plaid",
+        metadata: {
+          error_code: plaid_error_code(e),
+          http_status: e.respond_to?(:code) ? e.code : nil
+        }
+      )
+
+      return InvestmentsResponse.new(holdings:, transactions: [], securities: holding_securities || [])
+    end
 
     merged_securities = ((holding_securities || []) + (transaction_securities || [])).uniq { |s| s.security_id }
 
@@ -164,19 +191,51 @@ class Provider::Plaid
           access_token: access_token,
           start_date: start_date.to_s,
           end_date: end_date.to_s,
-          options: { offset: offset }
+          options: {
+            count: INVESTMENTS_TRANSACTIONS_PAGE_SIZE,
+            offset: offset
+          }
         )
 
-        response = client.investments_transactions_get(request)
+        response = fetch_investments_transactions_page(request)
 
         transactions += response.investment_transactions
         securities += response.securities
 
         break if transactions.length >= response.total_investment_transactions
         offset = transactions.length
+        sleep INVESTMENTS_PAGE_INTERVAL_SECONDS
       end
 
       [ transactions, securities ]
+    end
+
+    def fetch_investments_transactions_page(request)
+      attempts = 0
+
+      begin
+        client.investments_transactions_get(request)
+      rescue Plaid::ApiError => e
+        attempts += 1
+        raise unless investments_rate_limited?(e) && attempts <= INVESTMENTS_RATE_LIMIT_MAX_RETRIES
+
+        sleep(2**attempts)
+        retry
+      end
+    end
+
+    def investments_rate_limited?(error)
+      return true if error.respond_to?(:code) && error.code.to_i == 429
+
+      INVESTMENTS_RATE_LIMIT_ERROR_CODES.include?(plaid_error_code(error))
+    end
+
+    def plaid_error_code(error)
+      return nil unless error.respond_to?(:response_body) && error.response_body.present?
+
+      JSON.parse(error.response_body)["error_code"]
+    rescue JSON::ParserError
+      nil
     end
 
     def get_primary_product(accountable_type)

--- a/test/models/provider/plaid_test.rb
+++ b/test/models/provider/plaid_test.rb
@@ -80,6 +80,61 @@ class Provider::PlaidTest < ActiveSupport::TestCase
     end
   end
 
+  test "get_item_investment_transactions requests page size 500 and paces pages" do
+    page1 = OpenStruct.new(
+      investment_transactions: [ Object.new ],
+      securities: [],
+      total_investment_transactions: 2
+    )
+    page2 = OpenStruct.new(
+      investment_transactions: [ Object.new ],
+      securities: [],
+      total_investment_transactions: 2
+    )
+
+    seen_counts = []
+    @plaid.client.expects(:investments_transactions_get).twice.with do |request|
+      opts = request.options
+      seen_counts << (opts.is_a?(Hash) ? opts[:count] || opts["count"] : opts.try(:count))
+      true
+    end.returns(page1).then.returns(page2)
+
+    @plaid.expects(:sleep).with(Provider::Plaid::INVESTMENTS_PAGE_INTERVAL_SECONDS).once
+
+    transactions, _securities = @plaid.send(
+      :get_item_investment_transactions,
+      access_token: "access-token",
+      start_date: Date.new(2024, 1, 1),
+      end_date: Date.new(2024, 1, 31)
+    )
+
+    assert_equal 2, transactions.size
+    assert_equal [ 500, 500 ], seen_counts
+  end
+
+  test "get_item_investments returns holdings when investment transactions are rate-limited" do
+    holding = Object.new
+    security = OpenStruct.new(security_id: "sec-1")
+
+    @plaid.stubs(:get_item_holdings).returns([ [ holding ], [ security ] ])
+    @plaid.stubs(:sleep)
+
+    rate_limit_error = Plaid::ApiError.new(
+      code: 429,
+      response_headers: {},
+      response_body: { error_code: "INVESTMENTS_LIMIT", error_message: "rate limited" }.to_json
+    )
+    @plaid.client.stubs(:investments_transactions_get).raises(rate_limit_error)
+
+    DebugLogEntry.stubs(:capture)
+
+    response = @plaid.get_item_investments("access-token", start_date: Date.new(2024, 1, 1), end_date: Date.new(2024, 1, 31))
+
+    assert_equal [ holding ], response.holdings
+    assert_equal [], response.transactions
+    assert_equal [ security ], response.securities
+  end
+
   private
     def get_access_token
       VCR.use_cassette("plaid/access_token") do


### PR DESCRIPTION
## Summary
- Plaid investment sync paginated `/investments/transactions/get` with the default page size (100) and no pacing, which quickly hit `INVESTMENTS_LIMIT` (HTTP 429) and aborted the Item import transaction — leaving “No accounts found” while the Item stayed `good`.
- Request the documented max page size (500), sleep between pages, retry rate-limit errors with backoff, and soft-fail to holdings-only so accounts can still import when transaction history is rate-limited.
- Adds unit coverage for paging/pacing and the holdings-only soft-fail path.

Fixes #2827

## Test plan
- [ ] Sync a Plaid investment Item with multi-page transaction history and confirm sync completes without 429 abort
- [ ] Confirm accounts/holdings still import if transactions endpoint is rate-limited after retries
- [ ] `bin/rails test test/models/provider/plaid_test.rb`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved investment transaction syncing when Plaid applies rate limits.
  * Preserves investment holdings and securities even when transaction retrieval is temporarily unavailable.
  * Added paginated transaction retrieval with pacing and automatic retries for rate-limited requests.
  * Non-rate-limit API errors continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->