### PR TITLE
fix(imports): don't require Rule name in Sure NDJSON import preflight

### DIFF
--- a/app/models/sure_import/preflight.rb
+++ b/app/models/sure_import/preflight.rb
@@ -25,7 +25,11 @@ class SureImport::Preflight
     "Valuation" => %w[account_id date amount],
     "Budget" => %w[id start_date end_date],
     "BudgetCategory" => %w[budget_id category_id],
-    "Rule" => %w[name]
+    # Rule#name is nullable (validated with allow_nil: true) and the exporter
+    # emits null names, so it must not be a required import field — requiring it
+    # aborts the whole import on a valid export. resource_type is defaulted by
+    # the importer, so Rule has no import-required fields.
+    "Rule" => %w[]
   }.freeze
 
   TAXONOMY_TYPES = { "Category" => :categories, "Tag" => :tags, "Merchant" => :merchants }.freeze

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -611,6 +611,26 @@ class SureImportTest < ActiveSupport::TestCase
     assert_includes codes, "missing_reference"
   end
 
+  test "preflight accepts rules with a null name" do
+    # Rule#name is nullable (allow_nil: true) and the exporter emits null names,
+    # so a null-named Rule must not abort the import. Regression for #2721.
+    attach_ndjson(build_ndjson([
+      { type: "Rule", data: {
+        id: "rule-1",
+        name: nil,
+        resource_type: "transaction",
+        active: true,
+        conditions: [],
+        actions: []
+      } }
+    ]))
+
+    result = @import.sure_preflight
+
+    assert result.valid?, result.error_message
+    assert_empty result.errors.select { |error| error[:code] == "missing_required_fields" }
+  end
+
   test "preflight rejects invalid accountable types through explicit allowlist" do
     attach_ndjson(build_ndjson([
       { type: "Account", data: {


### PR DESCRIPTION
## Problem

Importing a full `all.ndjson` export via the Raw Data / Full NDJSON import flow aborts at preflight when any exported rule has a null name:

```
Line 10459 Rule is missing required field(s): name.
```

`SureImport::Preflight::REQUIRED_FIELDS` lists `name` as required for `Rule`, and the preflight is all-or-nothing — a single such row fails the whole import before any record is written. Reported in #2721, where the user had to hand-edit the export file to get past it.

## Root cause

`Rule#name` is genuinely optional:

- The model validates it with `validates :name, length: { minimum: 1 }, allow_nil: true` — a null name is explicitly valid.
- The `rules.name` column is nullable (no `NOT NULL`), and `normalize_name` actively converts blank names to `nil`.
- `Family::DataExporter` exports `name` as-is, so valid exports legitimately contain null rule names.
- `Family::DataImporter#import_rules` assigns `name: data["name"]` directly — `nil` imports fine.

So the preflight requirement contradicts the model, the schema, the exporter, and the importer. `RecurringTransaction`, whose name is also nullable, is already not required — this just makes `Rule` consistent.

## Fix

Remove `name` from `REQUIRED_FIELDS["Rule"]`. `resource_type` is defaulted by the importer (`data["resource_type"] || "transaction"`), so `Rule` has no import-required fields.

## Tests

Added a preflight regression test: an NDJSON `Rule` record with `name: nil` now passes preflight with no `missing_required_fields` error.

## Scope / note

This resolves the **first** blocker in #2721 (the `Rule.name` preflight abort). The issue also mentions orphaned `RejectedTransfer` rows referencing deleted transactions. On current `main` the exporter already scopes transfers to `family_transaction_ids` (both endpoints must be exported family transactions), so I could not reproduce new exports emitting dangling references; making the importer tolerate pre-existing broken export files is a separate, policy-level change (skip-with-warning vs hard-fail) better handled on its own. Happy to follow up on that if maintainers want it.

Partially addresses #2721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Imports now accept Rule records with blank or missing names when the source data permits them.
  * Preflight validation no longer incorrectly reports missing required fields for these Rule records.

* **Tests**
  * Added coverage to verify valid imports with unnamed Rule records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->