### PR TITLE
Automatic principal/interest splitting for manual loan payments

### DIFF
--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -2,6 +2,18 @@ class LoansController < ApplicationController
   include AccountableResource
 
   permitted_accountable_attributes(
-    :id, :subtype, :rate_type, :interest_rate, :term_months, :initial_balance
+    :id, :subtype, :rate_type, :interest_rate, :term_months, :initial_balance, :auto_split_payments
   )
+
+  # NOTE: AccountableResource already registers set_manageable_account for
+  # :edit/:update. Re-declaring the same callback replaces its action filter, so
+  # we must list those actions here too (not just :resplit_payments).
+  before_action :set_manageable_account, only: [ :edit, :update, :resplit_payments ]
+
+  # Retroactively re-splits loan payments that were linked before automatic
+  # splitting was enabled, so historical interest/principal is corrected.
+  def resplit_payments
+    Loan::PaymentResplitter.new(@account).call
+    redirect_back_or_to @account, notice: t(".success")
+  end
 end

--- a/app/controllers/transfer_matches_controller.rb
+++ b/app/controllers/transfer_matches_controller.rb
@@ -12,6 +12,16 @@ class TransferMatchesController < ApplicationController
     target_account = resolve_target_account
     return unless require_account_permission!(target_account, redirect_path: transactions_path)
 
+    # Loans with automatic payment splitting enabled record the interest portion
+    # as an expense and only apply the principal against the loan balance.
+    splitter = loan_payment_splitter(target_account)
+    if splitter&.applicable?
+      @transfer = splitter.split!
+      @transfer&.sync_account_later
+      redirect_back_or_to transactions_path, notice: t(".success")
+      return
+    end
+
     @transfer = build_transfer
     Transfer.transaction do
       @transfer.save!
@@ -42,6 +52,16 @@ class TransferMatchesController < ApplicationController
 
     def transfer_match_params
       params.require(:transfer_match).permit(:method, :matched_entry_id, :target_account_id)
+    end
+
+    # Returns a PaymentSplitter for the "link to a new loan entry" case, or nil
+    # when splitting doesn't apply (only the "new" method creates the loan-side
+    # entry; matching an existing transaction is left untouched).
+    def loan_payment_splitter(target_account)
+      return nil unless transfer_match_params[:method] == "new"
+      return nil unless target_account.loan?
+
+      Loan::PaymentSplitter.new(payment_entry: @entry, loan_account: target_account)
     end
 
     def resolve_target_account

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -93,6 +93,7 @@ class Category < ApplicationRecord
   UNCATEGORIZED_NAME_KEY = "models.category.uncategorized"
   OTHER_INVESTMENTS_NAME_KEY = "models.category.other_investments"
   INVESTMENT_CONTRIBUTIONS_NAME_KEY = "models.category.investment_contributions"
+  LOAN_INTEREST_NAME_KEY = "models.category.loan_interest"
   DEFAULT_CATEGORY_TRANSLATION_KEYS = %w[
     income
     food_and_drink
@@ -226,6 +227,11 @@ class Category < ApplicationRecord
       I18n.t(INVESTMENT_CONTRIBUTIONS_NAME_KEY)
     end
 
+    # Helper to get the localized name for the loan interest category
+    def loan_interest_name
+      I18n.t(LOAN_INTEREST_NAME_KEY)
+    end
+
     # Returns all possible investment contributions names across all supported locales
     # Used to detect investment contributions category regardless of locale
     def all_investment_contributions_names
@@ -289,7 +295,8 @@ class Category < ApplicationRecord
           [ I18n.t("models.category.defaults.services"),              "#7c3aed", "briefcase" ],
           [ I18n.t("models.category.defaults.fees"),                  "#6b7280", "receipt" ],
           [ I18n.t("models.category.defaults.savings_and_investments"), "#059669", "piggy-bank" ],
-          [ investment_contributions_name,                       "#0d9488", "trending-up" ]
+          [ investment_contributions_name,                       "#0d9488", "trending-up" ],
+          [ loan_interest_name,                                  "#be123c", "percent" ]
         ]
       end
   end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -356,6 +356,21 @@ class Family < ApplicationRecord
     end
   end
 
+  # The category used to record the interest portion of automatically-split
+  # loan payments. Created on demand using the family's locale.
+  def loan_interest_category
+    I18n.with_locale(locale) do
+      categories.find_or_create_by!(name: Category.loan_interest_name) do |cat|
+        cat.color = "#be123c"
+        cat.lucide_icon = "percent"
+      end
+    end
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+    I18n.with_locale(locale) do
+      categories.find_by!(name: Category.loan_interest_name)
+    end
+  end
+
   # Returns account IDs for tax-advantaged accounts (401k, IRA, HSA, etc.)
   # Used to exclude these accounts from budget/cashflow calculations.
   # Tax-advantaged accounts are retirement savings, not daily expenses.

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -13,6 +13,51 @@ class Loan < ApplicationRecord
 
   validates :subtype, inclusion: { in: SUBTYPES.keys }, allow_blank: true
 
+  # Standard amortizing loans accrue interest monthly.
+  PAYMENT_PERIODS_PER_YEAR = 12
+
+  # True when payments linked to this loan should be automatically split into
+  # a principal portion (which reduces the loan balance via a transfer) and an
+  # interest portion (recorded as an expense). Requires a usable interest rate.
+  def splits_payments?
+    auto_split_payments? && interest_rate.present? && interest_rate.to_d.positive?
+  end
+
+  # Interest portion of a single payment, computed from the outstanding balance
+  # and the loan's annual rate (simple monthly accrual: balance * rate/100 / 12).
+  # Clamped to the range [0, payment]. The outstanding balance defaults to the
+  # most recent materialized balance before +as_of_date+; callers replaying a
+  # payment history (see PaymentResplitter) can pass an explicit
+  # +outstanding_balance+ so each period uses the balance left by the prior one.
+  def interest_portion(payment_amount:, as_of_date:, outstanding_balance: nil)
+    zero = Money.new(0, account.currency)
+    return zero unless interest_rate.present? && interest_rate.to_d.positive?
+
+    outstanding = outstanding_balance || outstanding_balance_before(as_of_date)
+    return zero unless outstanding.positive?
+
+    payment = payment_amount.to_d.abs
+    monthly_rate = interest_rate.to_d / 100 / PAYMENT_PERIODS_PER_YEAR
+    interest = (outstanding * monthly_rate).round(2).clamp(0, payment)
+
+    Money.new(interest, account.currency)
+  end
+
+  # Principal portion of a single payment (payment minus interest).
+  def principal_portion(payment_amount:, as_of_date:, outstanding_balance: nil)
+    Money.new(payment_amount.to_d.abs, account.currency) -
+      interest_portion(payment_amount: payment_amount, as_of_date: as_of_date, outstanding_balance: outstanding_balance)
+  end
+
+  # Outstanding principal balance immediately before +date+, taken from the most
+  # recent materialized balance strictly before that date. Falls back to the
+  # loan's original balance when no prior balance has been materialized yet
+  # (e.g. the first payment).
+  def outstanding_balance_before(date)
+    prior = account.balances.where("date < ?", date).order(:date).last
+    prior&.balance || original_balance.amount
+  end
+
   def monthly_payment
     return nil if term_months.nil? || interest_rate.nil? || rate_type.nil? || rate_type != "fixed"
     return Money.new(0, account.currency) if account.loan.original_balance.amount.zero? || term_months.zero?

--- a/app/models/loan/payment_resplitter.rb
+++ b/app/models/loan/payment_resplitter.rb
@@ -20,26 +20,40 @@ class Loan::PaymentResplitter
     resplittable_transfers.each do |transfer|
       cash_entry = transfer.outflow_transaction.entry
       loan_entry = transfer.inflow_transaction.entry
-      payment_amount = cash_entry.amount
+      payment_amount = cash_entry.amount.to_d.abs
       as_of_date = cash_entry.date
 
-      Transfer.transaction do
+      interest = loan.interest_portion(
+        payment_amount: payment_amount, as_of_date: as_of_date, outstanding_balance: outstanding
+      ).amount
+
+      new_transfer = Transfer.transaction do
         # Full (non-split) transfer: destroying it just unlinks and resets kinds.
         transfer.destroy!
         # Remove the full-amount principal reduction on the loan.
         loan_entry.destroy!
 
-        Loan::PaymentSplitter.new(
+        split = Loan::PaymentSplitter.new(
           payment_entry: cash_entry.reload,
           loan_account: @loan_account,
           outstanding_balance: outstanding
         ).split!
+
+        # split! is a no-op (returns nil) when the payment isn't splittable at
+        # this point in the replay — a payoff-sized or interest-heavy payment
+        # whose interest would consume the whole amount (principal <= 0), or a
+        # currency mismatch. Roll the destroys back so the original full-amount
+        # transfer survives, rather than committing a destroy with nothing to
+        # replace it, which would leave the payment unlinked and silently drop
+        # the loan's principal reduction.
+        raise ActiveRecord::Rollback if split.nil?
+
+        split
       end
 
-      interest = loan.interest_portion(
-        payment_amount: payment_amount, as_of_date: as_of_date, outstanding_balance: outstanding
-      )
-      outstanding -= (payment_amount.to_d.abs - interest.amount)
+      # Advance the running balance: by principal only when the split landed, by
+      # the full payment when it was left as its original full-amount transfer.
+      outstanding -= new_transfer ? (payment_amount - interest) : payment_amount
     end
 
     @loan_account.sync_later

--- a/app/models/loan/payment_resplitter.rb
+++ b/app/models/loan/payment_resplitter.rb
@@ -23,6 +23,12 @@ class Loan::PaymentResplitter
       payment_amount = cash_entry.amount.to_d.abs
       as_of_date = cash_entry.date
 
+      # Loan-side amount of the existing full transfer, in the loan's currency.
+      # For a cross-currency payment this differs from the cash-side
+      # +payment_amount+ by the FX conversion, and it is what actually reduces
+      # the loan balance when the transfer is left intact.
+      loan_side_amount = loan_entry.amount.to_d.abs
+
       interest = loan.interest_portion(
         payment_amount: payment_amount, as_of_date: as_of_date, outstanding_balance: outstanding
       ).amount
@@ -51,9 +57,11 @@ class Loan::PaymentResplitter
         split
       end
 
-      # Advance the running balance: by principal only when the split landed, by
-      # the full payment when it was left as its original full-amount transfer.
-      outstanding -= new_transfer ? (payment_amount - interest) : payment_amount
+      # Advance the running balance: by principal only when the split landed
+      # (same-currency by definition, so cash and loan amounts agree), and by the
+      # transfer's loan-side amount when it was left as its original full-amount
+      # transfer (correct even across currencies).
+      outstanding -= new_transfer ? (payment_amount - interest) : loan_side_amount
     end
 
     @loan_account.sync_later

--- a/app/models/loan/payment_resplitter.rb
+++ b/app/models/loan/payment_resplitter.rb
@@ -1,0 +1,65 @@
+# Retroactively re-splits loan payments that were linked to the loan BEFORE
+# automatic splitting was enabled (i.e. applied as a full-amount transfer that
+# reduced the whole balance).
+#
+# Payments are replayed in chronological order because each period's interest
+# depends on the outstanding balance left by the prior payment. The running
+# balance is tracked analytically from the loan's original balance rather than
+# from materialized balances, so the result is deterministic and independent of
+# sync timing. Already-split payments are skipped, so this is idempotent.
+class Loan::PaymentResplitter
+  def initialize(loan_account)
+    @loan_account = loan_account
+  end
+
+  def call
+    return unless loan.splits_payments?
+
+    outstanding = loan.original_balance.amount
+
+    resplittable_transfers.each do |transfer|
+      cash_entry = transfer.outflow_transaction.entry
+      loan_entry = transfer.inflow_transaction.entry
+      payment_amount = cash_entry.amount
+      as_of_date = cash_entry.date
+
+      Transfer.transaction do
+        # Full (non-split) transfer: destroying it just unlinks and resets kinds.
+        transfer.destroy!
+        # Remove the full-amount principal reduction on the loan.
+        loan_entry.destroy!
+
+        Loan::PaymentSplitter.new(
+          payment_entry: cash_entry.reload,
+          loan_account: @loan_account,
+          outstanding_balance: outstanding
+        ).split!
+      end
+
+      interest = loan.interest_portion(
+        payment_amount: payment_amount, as_of_date: as_of_date, outstanding_balance: outstanding
+      )
+      outstanding -= (payment_amount.to_d.abs - interest.amount)
+    end
+
+    @loan_account.sync_later
+  end
+
+  private
+    def loan
+      @loan ||= @loan_account.accountable
+    end
+
+    # Loan-payment transfers into this loan whose cash side is a plain, full
+    # payment (not already split).
+    def resplittable_transfers
+      loan_transaction_ids = @loan_account.entries.where(entryable_type: "Transaction").pluck(:entryable_id)
+
+      Transfer
+        .where(inflow_transaction_id: loan_transaction_ids)
+        .includes(inflow_transaction: :entry, outflow_transaction: :entry)
+        .select { |t| t.outflow_transaction&.entry.present? }
+        .reject { |t| t.outflow_transaction.entry.split_child? }
+        .sort_by { |t| t.outflow_transaction.entry.date }
+    end
+end

--- a/app/models/loan/payment_splitter.rb
+++ b/app/models/loan/payment_splitter.rb
@@ -1,0 +1,111 @@
+# Splits a single loan payment (an existing entry on a cash account that is
+# being linked to a loan) into two parts:
+#
+#   1. the principal portion, linked to the loan as a transfer so it reduces
+#      the loan's balance, and
+#   2. the interest portion, recorded as a categorized expense on the cash
+#      account (it does not reduce the loan balance).
+#
+# This mirrors what a user would otherwise do by hand each month via a manual
+# split transaction. The interest/principal breakdown is derived from the
+# loan's outstanding balance and rate at the time of the payment, so it changes
+# every period as the loan amortizes.
+class Loan::PaymentSplitter
+  def initialize(payment_entry:, loan_account:, outstanding_balance: nil)
+    @payment_entry = payment_entry
+    @loan_account = loan_account
+    @outstanding_balance = outstanding_balance
+  end
+
+  # Whether this payment should be split. Requires the loan to have automatic
+  # splitting enabled with a usable rate, a same-currency cash payment, a plain
+  # (non-transfer, non-split) source entry, and a positive interest AND
+  # principal portion (a payment smaller than the accrued interest, or against a
+  # paid-off loan, falls back to the normal full-amount transfer).
+  def applicable?
+    @loan_account.loan? &&
+      loan&.splits_payments? &&
+      same_currency? &&
+      splittable_source? &&
+      @payment_entry.amount.to_d.positive? &&
+      interest.amount.positive? &&
+      principal.amount.positive?
+  end
+
+  # Performs the split and links the principal portion to the loan. Returns the
+  # created Transfer, or nil when the payment is not applicable for splitting
+  # (callers should fall back to a normal full-amount transfer).
+  def split!
+    return nil unless applicable?
+
+    Transfer.transaction do
+      principal_child, _interest_child = @payment_entry.split!([
+        { name: principal_name, amount: principal.amount, category_id: nil },
+        { name: interest_name, amount: interest.amount, category_id: interest_category.id }
+      ])
+
+      loan_transaction = Transaction.new(
+        kind: "funds_movement",
+        entry: @loan_account.entries.build(
+          amount: principal.amount * -1,
+          currency: @loan_account.currency,
+          date: @payment_entry.date,
+          name: "Payment from #{@payment_entry.account.name}",
+          user_modified: true
+        )
+      )
+
+      transfer = Transfer.create!(
+        inflow_transaction: loan_transaction,
+        outflow_transaction: principal_child.transaction,
+        status: "confirmed"
+      )
+
+      principal_child.transaction.update!(kind: Transfer.kind_for_account(@loan_account))
+
+      transfer
+    end
+  end
+
+  private
+    def loan
+      @loan ||= @loan_account.accountable
+    end
+
+    def interest
+      @interest ||= loan.interest_portion(
+        payment_amount: @payment_entry.amount, as_of_date: @payment_entry.date, outstanding_balance: @outstanding_balance
+      )
+    end
+
+    def principal
+      @principal ||= loan.principal_portion(
+        payment_amount: @payment_entry.amount, as_of_date: @payment_entry.date, outstanding_balance: @outstanding_balance
+      )
+    end
+
+    def interest_category
+      @interest_category ||= @loan_account.family.loan_interest_category
+    end
+
+    def same_currency?
+      @payment_entry.currency == @loan_account.currency
+    end
+
+    def splittable_source?
+      txn = @payment_entry.transaction
+      txn.present? &&
+        !txn.transfer? &&
+        !@payment_entry.split_parent? &&
+        !@payment_entry.split_child? &&
+        !@payment_entry.excluded?
+    end
+
+    def principal_name
+      "Principal — Payment to #{@loan_account.name}"
+    end
+
+    def interest_name
+      "Interest — Payment to #{@loan_account.name}"
+    end
+end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -104,6 +104,12 @@ class Transfer < ApplicationRecord
 
   def destroy!
     Transfer.transaction do
+      # If this was an auto-split loan payment, capture the pieces to reverse
+      # (the checking-side split parent and the loan-side principal entry) so the
+      # original single payment is restored once the transfer is gone.
+      split_parent = loan_payment_split_parent
+      loan_entry = split_parent ? inflow_transaction&.entry : nil
+
       [ inflow_transaction, outflow_transaction ].each do |transaction|
         next if transaction.nil?
         next unless Transaction.exists?(transaction.id)
@@ -115,7 +121,22 @@ class Transfer < ApplicationRecord
         end
       end
       super
+
+      if split_parent
+        loan_entry&.destroy!
+        split_parent.unsplit!
+      end
     end
+  end
+
+  # When a linked loan payment was auto-split into principal + interest, the
+  # outflow (cash) side is a split child and the inflow side is the loan. Returns
+  # the split parent entry to reverse in that case, otherwise nil.
+  def loan_payment_split_parent
+    return nil unless outflow_transaction&.entry&.split_child?
+    return nil unless to_account&.loan?
+
+    outflow_transaction.entry.parent_entry
   end
 
   def confirm!

--- a/app/views/loans/_form.html.erb
+++ b/app/views/loans/_form.html.erb
@@ -34,6 +34,14 @@
                   Loan.subtype_options_for_select,
                   { label: true, prompt: t("loans.form.subtype_prompt"), include_blank: t("loans.form.none") } %>
       </div>
+
+      <div class="flex items-center justify-between gap-2 pt-2">
+        <div>
+          <p class="text-sm text-primary"><%= t("loans.form.auto_split_payments") %></p>
+          <p class="text-xs text-secondary"><%= t("loans.form.auto_split_payments_description") %></p>
+        </div>
+        <%= loan_form.toggle :auto_split_payments %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/loans/tabs/_overview.html.erb
+++ b/app/views/loans/tabs/_overview.html.erb
@@ -52,3 +52,13 @@
     frame: :modal
   ) %>
 </div>
+
+<% if account.loan.splits_payments? %>
+  <div class="flex justify-center pb-8">
+    <%= button_to t(".resplit_payments"),
+          resplit_payments_loan_path(account),
+          method: :post,
+          class: "text-sm text-secondary underline",
+          data: { turbo_confirm: t(".resplit_payments_confirm") } %>
+  </div>
+<% end %>

--- a/config/locales/models/category/en.yml
+++ b/config/locales/models/category/en.yml
@@ -5,6 +5,7 @@ en:
       uncategorized: Uncategorized
       other_investments: Other Investments
       investment_contributions: Investment Contributions
+      loan_interest: Loan Interest
       defaults:
         income: Income
         food_and_drink: Food & Drink

--- a/config/locales/views/loans/en.yml
+++ b/config/locales/views/loans/en.yml
@@ -13,6 +13,8 @@ en:
       none: None
       subtype_prompt: Select loan type
       subtype_none: None
+      auto_split_payments: Auto-split payments into principal & interest
+      auto_split_payments_description: When a payment is linked to this loan, only the principal reduces the balance and the interest is recorded as an expense. Requires an interest rate.
     new:
       title: Enter loan details
     overview:
@@ -35,3 +37,7 @@ en:
         type: Type
         unknown: Unknown
         edit_loan_details: "Edit loan details"
+        resplit_payments: "Recalculate past payments"
+        resplit_payments_confirm: "This will re-split payments already linked to this loan into principal and interest, correcting historical balances. Continue?"
+    resplit_payments:
+      success: "Past payments are being recalculated into principal and interest."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,7 +579,11 @@ Rails.application.routes.draw do
   end
   resources :vehicles, only: %i[new create edit update]
   resources :credit_cards, only: %i[new create edit update]
-  resources :loans, only: %i[new create edit update]
+  resources :loans, only: %i[new create edit update] do
+    member do
+      post :resplit_payments
+    end
+  end
   resources :cryptos, only: %i[new create edit update]
   resources :other_assets, only: %i[new create edit update]
   resources :other_liabilities, only: %i[new create edit update]

--- a/db/migrate/20260726000000_add_auto_split_payments_to_loans.rb
+++ b/db/migrate/20260726000000_add_auto_split_payments_to_loans.rb
@@ -1,0 +1,5 @@
+class AddAutoSplitPaymentsToLoans < ActiveRecord::Migration[7.2]
+  def change
+    add_column :loans, :auto_split_payments, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_26_000000) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
-  enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
@@ -23,9 +23,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
 
   create_table "account_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
-    t.string "provider_type", null: false
-    t.uuid "provider_id", null: false
     t.datetime "created_at", null: false
+    t.uuid "provider_id", null: false
+    t.string "provider_type", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id", "provider_type"], name: "index_account_providers_on_account_and_provider_type", unique: true
     t.index ["provider_type", "provider_id"], name: "index_account_providers_on_provider_type_and_provider_id", unique: true
@@ -33,43 +33,43 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
 
   create_table "account_shares", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
-    t.uuid "user_id", null: false
-    t.string "permission", default: "read_only", null: false
-    t.boolean "include_in_finances", default: true, null: false
     t.datetime "created_at", null: false
+    t.boolean "include_in_finances", default: true, null: false
+    t.string "permission", default: "read_only", null: false
     t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
     t.index ["account_id", "user_id"], name: "index_account_shares_on_account_id_and_user_id", unique: true
     t.index ["account_id"], name: "index_account_shares_on_account_id"
     t.index ["user_id", "include_in_finances"], name: "index_account_shares_on_user_id_and_include_in_finances"
     t.index ["user_id"], name: "index_account_shares_on_user_id"
-    t.check_constraint "permission::text = ANY (ARRAY['full_control'::character varying, 'read_write'::character varying, 'read_only'::character varying]::text[])", name: "chk_account_shares_permission"
+    t.check_constraint "permission::text = ANY (ARRAY['full_control'::character varying::text, 'read_write'::character varying::text, 'read_only'::character varying::text])", name: "chk_account_shares_permission"
   end
 
   create_table "account_statements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
     t.uuid "account_id"
-    t.uuid "suggested_account_id"
-    t.string "filename", limit: 255, null: false
-    t.string "content_type", limit: 100, null: false
+    t.string "account_last4_hint", limit: 4
+    t.string "account_name_hint", limit: 200
     t.bigint "byte_size", null: false
     t.string "checksum", limit: 64, null: false
-    t.string "source", default: "manual_upload", null: false
-    t.string "upload_status", default: "stored", null: false
-    t.string "institution_name_hint", limit: 200
-    t.string "account_name_hint", limit: 200
-    t.string "account_last4_hint", limit: 4
-    t.date "period_start_on"
-    t.date "period_end_on"
-    t.decimal "opening_balance", precision: 19, scale: 4
     t.decimal "closing_balance", precision: 19, scale: 4
+    t.string "content_sha256"
+    t.string "content_type", limit: 100, null: false
+    t.datetime "created_at", null: false
     t.string "currency", limit: 3
-    t.decimal "parser_confidence", precision: 5, scale: 4
+    t.uuid "family_id", null: false
+    t.string "filename", limit: 255, null: false
+    t.string "institution_name_hint", limit: 200
     t.decimal "match_confidence", precision: 5, scale: 4
+    t.decimal "opening_balance", precision: 19, scale: 4
+    t.decimal "parser_confidence", precision: 5, scale: 4
+    t.date "period_end_on"
+    t.date "period_start_on"
     t.string "review_status", default: "unmatched", null: false
     t.jsonb "sanitized_parser_output", default: {}, null: false
-    t.datetime "created_at", null: false
+    t.string "source", default: "manual_upload", null: false
+    t.uuid "suggested_account_id"
     t.datetime "updated_at", null: false
-    t.string "content_sha256"
+    t.string "upload_status", default: "stored", null: false
     t.index ["account_id", "period_start_on", "period_end_on"], name: "index_account_statements_on_account_period"
     t.index ["account_id"], name: "index_account_statements_on_account_id"
     t.index ["family_id", "checksum"], name: "index_account_statements_on_family_checksum"
@@ -91,44 +91,44 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
     t.check_constraint "match_confidence IS NULL OR match_confidence >= 0::numeric AND match_confidence <= 1::numeric", name: "chk_account_statements_match_confidence"
     t.check_constraint "parser_confidence IS NULL OR parser_confidence >= 0::numeric AND parser_confidence <= 1::numeric", name: "chk_account_statements_parser_confidence"
     t.check_constraint "period_start_on IS NULL OR period_end_on IS NULL OR period_start_on <= period_end_on", name: "chk_account_statements_period_order"
-    t.check_constraint "review_status::text = ANY (ARRAY['unmatched'::character varying, 'linked'::character varying, 'rejected'::character varying]::text[])", name: "chk_account_statements_review_status"
+    t.check_constraint "review_status::text = ANY (ARRAY['unmatched'::character varying::text, 'linked'::character varying::text, 'rejected'::character varying::text])", name: "chk_account_statements_review_status"
     t.check_constraint "source::text = 'manual_upload'::text", name: "chk_account_statements_source"
-    t.check_constraint "upload_status::text = ANY (ARRAY['stored'::character varying, 'failed'::character varying]::text[])", name: "chk_account_statements_upload_status"
+    t.check_constraint "upload_status::text = ANY (ARRAY['stored'::character varying::text, 'failed'::character varying::text])", name: "chk_account_statements_upload_status"
   end
 
   create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "subtype"
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "accountable_type"
+    t.integer "account_providers_count", default: 0, null: false
     t.uuid "accountable_id"
+    t.string "accountable_type"
     t.decimal "balance", precision: 19, scale: 4
-    t.string "currency"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
-    t.uuid "import_id"
-    t.uuid "plaid_account_id"
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
-    t.jsonb "locked_attributes", default: {}
-    t.string "status", default: "active"
-    t.uuid "simplefin_account_id"
-    t.string "institution_name"
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.datetime "disabled_at"
+    t.boolean "enable_category_matcher", default: true, null: false
+    t.boolean "exclude_from_reports", default: false, null: false
+    t.uuid "family_id", null: false
+    t.uuid "import_id"
     t.string "institution_domain"
+    t.string "institution_name"
+    t.jsonb "locked_attributes", default: {}
+    t.string "name"
     t.text "notes"
     t.uuid "owner_id"
-    t.datetime "disabled_at"
-    t.boolean "exclude_from_reports", default: false, null: false
-    t.integer "account_providers_count", default: 0, null: false
-    t.boolean "enable_category_matcher", default: true, null: false
+    t.uuid "plaid_account_id"
+    t.uuid "simplefin_account_id"
+    t.string "status", default: "active"
+    t.string "subtype"
+    t.datetime "updated_at", null: false
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"
     t.index ["family_id", "accountable_type"], name: "index_accounts_on_family_id_and_accountable_type"
+    t.index ["family_id", "exclude_from_reports"], name: "index_accounts_on_family_id_and_exclude_from_reports"
     t.index ["family_id", "id"], name: "index_accounts_on_family_id_and_id"
     t.index ["family_id", "status", "accountable_type"], name: "index_accounts_on_family_id_status_accountable_type"
     t.index ["family_id", "status"], name: "index_accounts_on_family_id_and_status"
-    t.index ["family_id", "exclude_from_reports"], name: "index_accounts_on_family_id_and_exclude_from_reports"
     t.index ["family_id"], name: "index_accounts_on_family_id"
     t.index ["import_id"], name: "index_accounts_on_import_id"
     t.index ["owner_id"], name: "index_accounts_on_owner_id"
@@ -138,24 +138,24 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.uuid "record_id", null: false
     t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.uuid "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -166,37 +166,37 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "addressable_type"
     t.uuid "addressable_id"
+    t.string "addressable_type"
+    t.string "country"
+    t.string "county"
+    t.datetime "created_at", null: false
     t.string "line1"
     t.string "line2"
-    t.string "county"
     t.string "locality"
-    t.string "region"
-    t.string "country"
     t.string "postal_code"
-    t.datetime "created_at", null: false
+    t.string "region"
     t.datetime "updated_at", null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable"
   end
 
   create_table "akahu_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "akahu_item_id", null: false
-    t.string "name"
     t.string "account_id"
-    t.string "formatted_account"
-    t.string "currency"
-    t.decimal "current_balance", precision: 19, scale: 4
-    t.decimal "available_balance", precision: 19, scale: 4
-    t.decimal "balance_limit", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.uuid "akahu_item_id", null: false
+    t.decimal "available_balance", precision: 19, scale: 4
+    t.decimal "balance_limit", precision: 19, scale: 4
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
+    t.string "formatted_account"
     t.jsonb "institution_metadata"
+    t.string "name"
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
     t.date "sync_start_date"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_akahu_accounts_on_account_id"
     t.index ["akahu_item_id", "account_id"], name: "index_akahu_accounts_on_item_and_account_id", unique: true, where: "(account_id IS NOT NULL)"
@@ -204,38 +204,38 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "akahu_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "app_token"
+    t.datetime "created_at", null: false
     t.uuid "family_id", null: false
-    t.string "name"
+    t.string "institution_color"
+    t.string "institution_domain"
     t.string "institution_id"
     t.string "institution_name"
-    t.string "institution_domain"
     t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good", null: false
-    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "name"
     t.boolean "pending_account_setup", default: false, null: false
-    t.date "sync_start_date"
-    t.jsonb "raw_payload"
     t.jsonb "raw_institution_payload"
-    t.text "app_token"
-    t.text "user_token"
-    t.datetime "created_at", null: false
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
+    t.date "sync_start_date"
     t.datetime "updated_at", null: false
+    t.text "user_token"
     t.index ["family_id"], name: "index_akahu_items_on_family_id"
     t.index ["status"], name: "index_akahu_items_on_status"
   end
 
   create_table "api_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name"
-    t.uuid "user_id", null: false
-    t.json "scopes"
-    t.datetime "last_used_at"
-    t.datetime "expires_at"
-    t.datetime "revoked_at"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "display_key", null: false
+    t.datetime "expires_at"
+    t.datetime "last_used_at"
+    t.string "name"
+    t.datetime "revoked_at"
+    t.json "scopes"
     t.string "source", default: "web"
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
     t.index ["display_key"], name: "index_api_keys_on_display_key", unique: true
     t.index ["revoked_at"], name: "index_api_keys_on_revoked_at"
     t.index ["user_id", "source"], name: "index_api_keys_on_user_id_and_source"
@@ -243,11 +243,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "archived_exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "email", null: false
-    t.string "family_name"
-    t.string "download_token_digest", null: false
-    t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
+    t.string "download_token_digest", null: false
+    t.string "email", null: false
+    t.datetime "expires_at", null: false
+    t.string "family_name"
     t.datetime "updated_at", null: false
     t.index ["download_token_digest"], name: "index_archived_exports_on_download_token_digest", unique: true
     t.index ["expires_at"], name: "index_archived_exports_on_expires_at"
@@ -255,42 +255,42 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
 
   create_table "balances", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
-    t.date "date", null: false
     t.decimal "balance", precision: 19, scale: 4, null: false
-    t.string "currency", default: "USD", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.decimal "cash_adjustments", precision: 19, scale: 4, default: "0.0", null: false
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
-    t.decimal "start_cash_balance", precision: 19, scale: 4, default: "0.0", null: false
-    t.decimal "start_non_cash_balance", precision: 19, scale: 4, default: "0.0", null: false
     t.decimal "cash_inflows", precision: 19, scale: 4, default: "0.0", null: false
     t.decimal "cash_outflows", precision: 19, scale: 4, default: "0.0", null: false
-    t.decimal "non_cash_inflows", precision: 19, scale: 4, default: "0.0", null: false
-    t.decimal "non_cash_outflows", precision: 19, scale: 4, default: "0.0", null: false
-    t.decimal "net_market_flows", precision: 19, scale: 4, default: "0.0", null: false
-    t.decimal "cash_adjustments", precision: 19, scale: 4, default: "0.0", null: false
-    t.decimal "non_cash_adjustments", precision: 19, scale: 4, default: "0.0", null: false
-    t.integer "flows_factor", default: 1, null: false
-    t.virtual "start_balance", type: :decimal, precision: 19, scale: 4, as: "(start_cash_balance + start_non_cash_balance)", stored: true
+    t.datetime "created_at", null: false
+    t.string "currency", default: "USD", null: false
+    t.date "date", null: false
+    t.virtual "end_balance", type: :decimal, precision: 19, scale: 4, as: "(((start_cash_balance + ((cash_inflows - cash_outflows) * (flows_factor)::numeric)) + cash_adjustments) + (((start_non_cash_balance + ((non_cash_inflows - non_cash_outflows) * (flows_factor)::numeric)) + net_market_flows) + non_cash_adjustments))", stored: true
     t.virtual "end_cash_balance", type: :decimal, precision: 19, scale: 4, as: "((start_cash_balance + ((cash_inflows - cash_outflows) * (flows_factor)::numeric)) + cash_adjustments)", stored: true
     t.virtual "end_non_cash_balance", type: :decimal, precision: 19, scale: 4, as: "(((start_non_cash_balance + ((non_cash_inflows - non_cash_outflows) * (flows_factor)::numeric)) + net_market_flows) + non_cash_adjustments)", stored: true
-    t.virtual "end_balance", type: :decimal, precision: 19, scale: 4, as: "(((start_cash_balance + ((cash_inflows - cash_outflows) * (flows_factor)::numeric)) + cash_adjustments) + (((start_non_cash_balance + ((non_cash_inflows - non_cash_outflows) * (flows_factor)::numeric)) + net_market_flows) + non_cash_adjustments))", stored: true
+    t.integer "flows_factor", default: 1, null: false
+    t.decimal "net_market_flows", precision: 19, scale: 4, default: "0.0", null: false
+    t.decimal "non_cash_adjustments", precision: 19, scale: 4, default: "0.0", null: false
+    t.decimal "non_cash_inflows", precision: 19, scale: 4, default: "0.0", null: false
+    t.decimal "non_cash_outflows", precision: 19, scale: 4, default: "0.0", null: false
+    t.virtual "start_balance", type: :decimal, precision: 19, scale: 4, as: "(start_cash_balance + start_non_cash_balance)", stored: true
+    t.decimal "start_cash_balance", precision: 19, scale: 4, default: "0.0", null: false
+    t.decimal "start_non_cash_balance", precision: 19, scale: 4, default: "0.0", null: false
+    t.datetime "updated_at", null: false
     t.index ["account_id", "date", "currency"], name: "index_account_balances_on_account_id_date_currency_unique", unique: true
     t.index ["account_id", "date"], name: "index_balances_on_account_id_and_date", order: { date: :desc }
     t.index ["account_id"], name: "index_balances_on_account_id"
   end
 
   create_table "binance_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "binance_item_id", null: false
-    t.string "name"
     t.string "account_type"
+    t.uuid "binance_item_id", null: false
+    t.datetime "created_at", null: false
     t.string "currency"
     t.decimal "current_balance", precision: 19, scale: 4
+    t.jsonb "extra", default: {}, null: false
     t.jsonb "institution_metadata"
+    t.string "name"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.jsonb "extra", default: {}, null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_type"], name: "index_binance_accounts_on_account_type"
     t.index ["binance_item_id", "account_type"], name: "index_binance_accounts_on_item_and_type", unique: true
@@ -298,63 +298,63 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "binance_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good", null: false
-    t.boolean "scheduled_for_deletion", default: false, null: false
-    t.boolean "pending_account_setup", default: false, null: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
     t.text "api_key"
     t.text "api_secret"
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false, null: false
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
+    t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_binance_items_on_family_id"
     t.index ["status"], name: "index_binance_items_on_status"
   end
 
   create_table "brex_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "brex_item_id", null: false
-    t.string "name"
     t.string "account_id", null: false
     t.string "account_kind", default: "cash", null: false
-    t.string "currency", default: "USD", null: false
-    t.decimal "current_balance", precision: 19, scale: 4
-    t.decimal "available_balance", precision: 19, scale: 4
     t.decimal "account_limit", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.decimal "available_balance", precision: 19, scale: 4
+    t.uuid "brex_item_id", null: false
+    t.datetime "created_at", null: false
+    t.string "currency", default: "USD", null: false
+    t.decimal "current_balance", precision: 19, scale: 4
     t.jsonb "institution_metadata"
+    t.string "name"
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["brex_item_id", "account_id"], name: "index_brex_accounts_on_item_and_account_id", unique: true
     t.index ["brex_item_id"], name: "index_brex_accounts_on_brex_item_id"
   end
 
   create_table "brex_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name", null: false
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good", null: false
-    t.boolean "scheduled_for_deletion", default: false, null: false
-    t.boolean "pending_account_setup", default: false, null: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
-    t.text "token", null: false
     t.string "base_url"
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name", null: false
+    t.boolean "pending_account_setup", default: false, null: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
+    t.datetime "sync_start_date"
+    t.text "token", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_brex_items_on_family_id"
     t.index ["status"], name: "index_brex_items_on_status"
@@ -362,10 +362,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
 
   create_table "budget_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "budget_id", null: false
-    t.uuid "category_id", null: false
     t.decimal "budgeted_spending", precision: 19, scale: 4, null: false
-    t.string "currency", null: false
+    t.uuid "category_id", null: false
     t.datetime "created_at", null: false
+    t.string "currency", null: false
     t.datetime "updated_at", null: false
     t.index ["budget_id", "category_id"], name: "index_budget_categories_on_budget_id_and_category_id", unique: true
     t.index ["budget_id"], name: "index_budget_categories_on_budget_id"
@@ -373,54 +373,54 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "budgets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.decimal "budgeted_spending", precision: 19, scale: 4
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.date "end_date", null: false
+    t.decimal "expected_income", precision: 19, scale: 4
     t.uuid "family_id", null: false
     t.date "start_date", null: false
-    t.date "end_date", null: false
-    t.decimal "budgeted_spending", precision: 19, scale: 4
-    t.decimal "expected_income", precision: 19, scale: 4
-    t.string "currency", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id", "start_date", "end_date"], name: "index_budgets_on_family_id_and_start_date_and_end_date", unique: true
     t.index ["family_id"], name: "index_budgets_on_family_id"
   end
 
   create_table "categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", null: false
-    t.string "color", default: "#6172F3", null: false
-    t.uuid "family_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.uuid "parent_id"
     t.string "classification_unused", default: "expense", null: false
+    t.string "color", default: "#6172F3", null: false
+    t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
     t.string "lucide_icon", default: "shapes", null: false
+    t.string "name", null: false
+    t.uuid "parent_id"
+    t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_categories_on_family_id"
   end
 
   create_table "chats", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.string "title", null: false
-    t.string "instructions"
-    t.jsonb "error"
-    t.string "latest_assistant_response_id"
     t.datetime "created_at", null: false
+    t.jsonb "error"
+    t.string "instructions"
+    t.string "latest_assistant_response_id"
+    t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
     t.index ["user_id"], name: "index_chats_on_user_id"
   end
 
   create_table "coinbase_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "coinbase_item_id", null: false
-    t.string "name"
     t.string "account_id"
-    t.string "currency"
-    t.decimal "current_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.uuid "coinbase_item_id", null: false
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
     t.jsonb "institution_metadata"
+    t.string "name"
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_coinbase_accounts_on_account_id"
     t.index ["coinbase_item_id", "account_id"], name: "index_coinbase_accounts_on_item_and_account_id", unique: true, where: "(account_id IS NOT NULL)"
@@ -428,40 +428,40 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "coinbase_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
     t.text "api_key"
     t.text "api_secret"
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
+    t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_coinbase_items_on_family_id"
     t.index ["status"], name: "index_coinbase_items_on_status"
   end
 
   create_table "coinstats_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "coinstats_item_id", null: false
-    t.string "name"
     t.string "account_id"
-    t.string "currency"
-    t.decimal "current_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.uuid "coinstats_item_id", null: false
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
     t.jsonb "institution_metadata"
+    t.string "name"
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "wallet_address"
     t.index ["coinstats_item_id", "account_id", "wallet_address"], name: "index_coinstats_accounts_on_item_account_and_wallet", unique: true
@@ -469,24 +469,24 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "coinstats_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
     t.string "api_key", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "exchange_portfolio_id"
     t.string "exchange_connection_id"
+    t.string "exchange_portfolio_id"
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
+    t.datetime "sync_start_date"
+    t.datetime "updated_at", null: false
     t.index ["exchange_connection_id"], name: "index_coinstats_items_on_exchange_connection_id"
     t.index ["family_id", "exchange_portfolio_id"], name: "index_coinstats_items_on_family_id_and_exchange_portfolio_id", unique: true, where: "(exchange_portfolio_id IS NOT NULL)"
     t.index ["family_id"], name: "index_coinstats_items_on_family_id"
@@ -494,51 +494,51 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "credit_cards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.decimal "available_credit", precision: 10, scale: 2
-    t.decimal "minimum_payment", precision: 10, scale: 2
-    t.decimal "apr", precision: 10, scale: 2
-    t.date "expiration_date"
     t.decimal "annual_fee", precision: 10, scale: 2
+    t.decimal "apr", precision: 10, scale: 2
+    t.decimal "available_credit", precision: 10, scale: 2
+    t.datetime "created_at", null: false
+    t.date "expiration_date"
     t.jsonb "locked_attributes", default: {}
+    t.decimal "minimum_payment", precision: 10, scale: 2
     t.string "subtype"
+    t.datetime "updated_at", null: false
   end
 
   create_table "cryptos", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.jsonb "locked_attributes", default: {}
     t.string "subtype"
     t.string "tax_treatment", default: "taxable", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "data_enrichments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "enrichable_type", null: false
-    t.uuid "enrichable_id", null: false
-    t.string "source"
     t.string "attribute_name"
-    t.jsonb "value"
-    t.jsonb "metadata"
     t.datetime "created_at", null: false
+    t.uuid "enrichable_id", null: false
+    t.string "enrichable_type", null: false
+    t.jsonb "metadata"
+    t.string "source"
     t.datetime "updated_at", null: false
+    t.jsonb "value"
     t.index ["enrichable_id", "enrichable_type", "source", "attribute_name"], name: "idx_on_enrichable_id_enrichable_type_source_attribu_5be5f63e08", unique: true
     t.index ["enrichable_type", "enrichable_id"], name: "index_data_enrichments_on_enrichable"
   end
 
   create_table "debug_log_entries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id"
+    t.uuid "account_provider_id"
     t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.uuid "family_id"
     t.string "level", null: false
     t.text "message", null: false
-    t.string "source", null: false
     t.jsonb "metadata", default: {}, null: false
-    t.uuid "family_id"
-    t.uuid "account_id"
-    t.uuid "user_id"
-    t.uuid "account_provider_id"
     t.string "provider_key"
-    t.datetime "created_at", null: false
+    t.string "source", null: false
     t.datetime "updated_at", null: false
+    t.uuid "user_id"
     t.index ["account_id"], name: "index_debug_log_entries_on_account_id"
     t.index ["account_provider_id"], name: "index_debug_log_entries_on_account_provider_id"
     t.index ["category", "created_at"], name: "index_debug_log_entries_on_category_and_created_at"
@@ -550,95 +550,95 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
     t.index ["provider_key"], name: "index_debug_log_entries_on_provider_key"
     t.index ["source"], name: "index_debug_log_entries_on_source"
     t.index ["user_id"], name: "index_debug_log_entries_on_user_id"
-    t.check_constraint "level::text = ANY (ARRAY['debug'::character varying, 'info'::character varying, 'warn'::character varying, 'error'::character varying]::text[])", name: "chk_debug_log_entries_level"
+    t.check_constraint "level::text = ANY (ARRAY['debug'::character varying::text, 'info'::character varying::text, 'warn'::character varying::text, 'error'::character varying::text])", name: "chk_debug_log_entries_level"
   end
 
   create_table "depositories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.jsonb "locked_attributes", default: {}
     t.string "subtype"
+    t.datetime "updated_at", null: false
   end
 
   create_table "enable_banking_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "enable_banking_item_id", null: false
-    t.string "name"
     t.string "account_id"
-    t.string "currency"
-    t.decimal "current_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.datetime "created_at", null: false
+    t.decimal "credit_limit", precision: 19, scale: 4
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
+    t.uuid "enable_banking_item_id", null: false
     t.string "iban"
-    t.string "uid"
+    t.jsonb "identification_hashes", default: []
     t.jsonb "institution_metadata"
+    t.string "name"
+    t.string "product"
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "product"
-    t.decimal "credit_limit", precision: 19, scale: 4
-    t.jsonb "identification_hashes", default: []
     t.boolean "treat_balance_as_available_credit", default: false, null: false
+    t.string "uid"
+    t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_enable_banking_accounts_on_account_id"
     t.index ["enable_banking_item_id"], name: "index_enable_banking_accounts_on_enable_banking_item_id"
     t.index ["identification_hashes"], name: "index_enable_banking_accounts_on_identification_hashes", using: :gin
   end
 
   create_table "enable_banking_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "application_id"
+    t.string "aspsp_auth_approach"
+    t.string "aspsp_id"
+    t.integer "aspsp_maximum_consent_validity"
+    t.string "aspsp_name"
+    t.jsonb "aspsp_psu_types", default: []
+    t.jsonb "aspsp_required_psu_headers", default: []
+    t.string "authorization_id"
+    t.text "client_certificate"
+    t.string "country_code"
+    t.datetime "created_at", null: false
     t.uuid "family_id", null: false
-    t.string "name"
+    t.string "institution_color"
+    t.string "institution_domain"
     t.string "institution_id"
     t.string "institution_name"
-    t.string "institution_domain"
     t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.date "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
-    t.string "country_code"
-    t.string "application_id"
-    t.text "client_certificate"
-    t.string "session_id"
-    t.datetime "session_expires_at"
-    t.string "aspsp_name"
-    t.string "aspsp_id"
-    t.string "authorization_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.jsonb "aspsp_required_psu_headers", default: []
-    t.integer "aspsp_maximum_consent_validity"
-    t.string "aspsp_auth_approach"
-    t.jsonb "aspsp_psu_types", default: []
     t.string "last_psu_ip"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false
     t.string "psu_type"
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.datetime "session_expires_at"
+    t.string "session_id"
+    t.string "status", default: "good"
+    t.date "sync_start_date"
+    t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_enable_banking_items_on_family_id"
     t.index ["status"], name: "index_enable_banking_items_on_status"
   end
 
   create_table "entries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
-    t.string "entryable_type"
-    t.uuid "entryable_id"
     t.decimal "amount", precision: 19, scale: 4, null: false
+    t.datetime "created_at", null: false
     t.string "currency"
     t.date "date"
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.uuid "import_id"
-    t.text "notes"
+    t.uuid "entryable_id"
+    t.string "entryable_type"
     t.boolean "excluded", default: false
-    t.string "plaid_id"
-    t.jsonb "locked_attributes", default: {}
     t.string "external_id"
-    t.string "source"
-    t.boolean "user_modified", default: false, null: false
+    t.uuid "import_id"
     t.boolean "import_locked", default: false, null: false
+    t.jsonb "locked_attributes", default: {}
+    t.string "name", null: false
+    t.text "notes"
     t.uuid "parent_entry_id"
+    t.string "plaid_id"
+    t.string "source"
+    t.datetime "updated_at", null: false
+    t.boolean "user_modified", default: false, null: false
     t.index "lower((name)::text)", name: "index_entries_on_lower_name"
     t.index ["account_id", "date", "entryable_id"], name: "index_entries_on_investment_totals_lookup", where: "(((entryable_type)::text = 'Trade'::text) AND (excluded = false))"
     t.index ["account_id", "date"], name: "index_entries_on_account_id_and_date"
@@ -654,57 +654,57 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", null: false
-    t.string "description"
-    t.string "eval_type", null: false
-    t.string "version", default: "1.0", null: false
-    t.integer "sample_count", default: 0
-    t.jsonb "metadata", default: {}
     t.boolean "active", default: true
     t.datetime "created_at", null: false
+    t.string "description"
+    t.string "eval_type", null: false
+    t.jsonb "metadata", default: {}
+    t.string "name", null: false
+    t.integer "sample_count", default: 0
     t.datetime "updated_at", null: false
+    t.string "version", default: "1.0", null: false
     t.index ["eval_type", "active"], name: "index_eval_datasets_on_eval_type_and_active"
     t.index ["name"], name: "index_eval_datasets_on_name", unique: true
   end
 
   create_table "eval_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "actual_output", null: false
+    t.boolean "alternative_match", default: false
+    t.integer "completion_tokens"
+    t.boolean "correct", null: false
+    t.decimal "cost", precision: 10, scale: 6
+    t.datetime "created_at", null: false
     t.uuid "eval_run_id", null: false
     t.uuid "eval_sample_id", null: false
-    t.jsonb "actual_output", null: false
-    t.boolean "correct", null: false
     t.boolean "exact_match", default: false
+    t.float "fuzzy_score"
     t.boolean "hierarchical_match", default: false
+    t.integer "latency_ms"
+    t.jsonb "metadata", default: {}
     t.boolean "null_expected", default: false
     t.boolean "null_returned", default: false
-    t.float "fuzzy_score"
-    t.integer "latency_ms"
     t.integer "prompt_tokens"
-    t.integer "completion_tokens"
-    t.decimal "cost", precision: 10, scale: 6
-    t.jsonb "metadata", default: {}
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "alternative_match", default: false
     t.index ["eval_run_id", "correct"], name: "index_eval_results_on_eval_run_id_and_correct"
     t.index ["eval_run_id"], name: "index_eval_results_on_eval_run_id"
     t.index ["eval_sample_id"], name: "index_eval_results_on_eval_sample_id"
   end
 
   create_table "eval_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.text "error_message"
     t.uuid "eval_dataset_id", null: false
-    t.string "name"
-    t.string "status", default: "pending", null: false
-    t.string "provider", null: false
-    t.string "model", null: false
-    t.jsonb "provider_config", default: {}
     t.jsonb "metrics", default: {}
-    t.integer "total_prompt_tokens", default: 0
+    t.string "model", null: false
+    t.string "name"
+    t.string "provider", null: false
+    t.jsonb "provider_config", default: {}
+    t.datetime "started_at"
+    t.string "status", default: "pending", null: false
     t.integer "total_completion_tokens", default: 0
     t.decimal "total_cost", precision: 10, scale: 6, default: "0.0"
-    t.datetime "started_at"
-    t.datetime "completed_at"
-    t.text "error_message"
-    t.datetime "created_at", null: false
+    t.integer "total_prompt_tokens", default: 0
     t.datetime "updated_at", null: false
     t.index ["eval_dataset_id", "model"], name: "index_eval_runs_on_eval_dataset_id_and_model"
     t.index ["eval_dataset_id"], name: "index_eval_runs_on_eval_dataset_id"
@@ -713,14 +713,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "eval_samples", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "eval_dataset_id", null: false
-    t.jsonb "input_data", null: false
-    t.jsonb "expected_output", null: false
     t.jsonb "context_data", default: {}
-    t.string "difficulty", default: "medium"
-    t.string "tags", default: [], array: true
-    t.jsonb "metadata", default: {}
     t.datetime "created_at", null: false
+    t.string "difficulty", default: "medium"
+    t.uuid "eval_dataset_id", null: false
+    t.jsonb "expected_output", null: false
+    t.jsonb "input_data", null: false
+    t.jsonb "metadata", default: {}
+    t.string "tags", default: [], array: true
     t.datetime "updated_at", null: false
     t.index ["eval_dataset_id", "difficulty"], name: "index_eval_samples_on_eval_dataset_id_and_difficulty"
     t.index ["eval_dataset_id"], name: "index_eval_samples_on_eval_dataset_id"
@@ -728,21 +728,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "exchange_rate_pairs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "from_currency", null: false
-    t.string "to_currency", null: false
-    t.date "first_provider_rate_on"
-    t.string "provider_name"
     t.datetime "created_at", null: false
+    t.date "first_provider_rate_on"
+    t.string "from_currency", null: false
+    t.string "provider_name"
+    t.string "to_currency", null: false
     t.datetime "updated_at", null: false
     t.index ["from_currency", "to_currency"], name: "index_exchange_rate_pairs_on_pair_unique", unique: true
   end
 
   create_table "exchange_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "from_currency", null: false
-    t.string "to_currency", null: false
-    t.decimal "rate", null: false
-    t.date "date", null: false
     t.datetime "created_at", null: false
+    t.date "date", null: false
+    t.string "from_currency", null: false
+    t.decimal "rate", null: false
+    t.string "to_currency", null: false
     t.datetime "updated_at", null: false
     t.index ["from_currency", "to_currency", "date"], name: "index_exchange_rates_on_base_converted_date_unique", unique: true
     t.index ["from_currency"], name: "index_exchange_rates_on_from_currency"
@@ -750,41 +750,41 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "families", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "currency", default: "USD"
-    t.string "locale", default: "en"
-    t.string "stripe_customer_id"
-    t.string "date_format", default: "%m-%d-%Y"
-    t.string "country", default: "US"
-    t.string "timezone"
-    t.boolean "data_enrichment_enabled", default: false
-    t.boolean "early_access", default: false
-    t.boolean "auto_sync_on_login", default: true, null: false
-    t.datetime "latest_sync_activity_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.datetime "latest_sync_completed_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.boolean "recurring_transactions_disabled", default: false, null: false
-    t.integer "month_start_day", default: 1, null: false
-    t.string "moniker", default: "Family", null: false
-    t.string "vector_store_id"
     t.string "assistant_type", default: "builtin", null: false
+    t.boolean "auto_sync_on_login", default: true, null: false
+    t.string "country", default: "US"
+    t.datetime "created_at", null: false
+    t.string "currency", default: "USD"
+    t.boolean "data_enrichment_enabled", default: false
+    t.string "date_format", default: "%m-%d-%Y"
     t.string "default_account_sharing", default: "shared", null: false
+    t.boolean "early_access", default: false
     t.string "enabled_currencies", array: true
     t.datetime "last_sync_all_attempted_at"
-    t.check_constraint "default_account_sharing::text = ANY (ARRAY['shared'::character varying, 'private'::character varying]::text[])", name: "chk_families_default_account_sharing"
+    t.datetime "latest_sync_activity_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "latest_sync_completed_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.string "locale", default: "en"
+    t.string "moniker", default: "Family", null: false
+    t.integer "month_start_day", default: 1, null: false
+    t.string "name"
+    t.boolean "recurring_transactions_disabled", default: false, null: false
+    t.string "stripe_customer_id"
+    t.string "timezone"
+    t.datetime "updated_at", null: false
+    t.string "vector_store_id"
+    t.check_constraint "default_account_sharing::text = ANY (ARRAY['shared'::character varying::text, 'private'::character varying::text])", name: "chk_families_default_account_sharing"
     t.check_constraint "month_start_day >= 1 AND month_start_day <= 28", name: "month_start_day_range"
   end
 
   create_table "family_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "filename", null: false
     t.string "content_type"
+    t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
     t.integer "file_size"
+    t.string "filename", null: false
+    t.jsonb "metadata", default: {}
     t.string "provider_file_id"
     t.string "status", default: "pending", null: false
-    t.jsonb "metadata", default: {}
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_family_documents_on_family_id"
     t.index ["provider_file_id"], name: "index_family_documents_on_provider_file_id"
@@ -792,18 +792,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "family_exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.uuid "family_id", null: false
     t.string "status", default: "pending", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_family_exports_on_family_id"
   end
 
   create_table "family_merchant_associations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.uuid "family_id", null: false
     t.uuid "merchant_id", null: false
     t.datetime "unlinked_at"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id", "merchant_id"], name: "idx_on_family_id_merchant_id_23e883e08f", unique: true
     t.index ["family_id"], name: "index_family_merchant_associations_on_family_id"
@@ -811,11 +811,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "goal_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "goal_id", null: false
     t.uuid "account_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.decimal "allocated_amount", precision: 19, scale: 4
+    t.datetime "created_at", null: false
+    t.uuid "goal_id", null: false
+    t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_goal_accounts_on_account_id"
     t.index ["goal_id", "account_id"], name: "index_savings_goal_accounts_on_goal_and_account", unique: true
     t.index ["goal_id"], name: "index_goal_accounts_on_goal_id"
@@ -823,15 +823,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "goal_pledges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "goal_id", null: false
     t.uuid "account_id", null: false
     t.decimal "amount", precision: 19, scale: 4, null: false
-    t.string "currency", null: false
-    t.enum "kind", null: false, enum_type: "goal_pledge_kind"
-    t.enum "status", default: "open", null: false, enum_type: "goal_pledge_status"
-    t.datetime "expires_at", null: false
-    t.uuid "matched_transaction_id"
     t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.datetime "expires_at", null: false
+    t.uuid "goal_id", null: false
+    t.enum "kind", null: false, enum_type: "goal_pledge_kind"
+    t.uuid "matched_transaction_id"
+    t.enum "status", default: "open", null: false, enum_type: "goal_pledge_status"
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_goal_pledges_on_account_id"
     t.index ["goal_id", "status"], name: "index_goal_pledges_on_goal_id_and_status"
@@ -842,43 +842,43 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "goals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name", null: false
-    t.decimal "target_amount", precision: 19, scale: 4, null: false
-    t.string "currency", null: false
-    t.date "target_date"
     t.string "color"
-    t.text "notes"
-    t.string "state", default: "active", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "currency", null: false
+    t.uuid "family_id", null: false
     t.string "icon"
+    t.string "name", null: false
+    t.text "notes"
     t.string "progress_basis", default: "balance", null: false
+    t.string "state", default: "active", null: false
+    t.decimal "target_amount", precision: 19, scale: 4, null: false
+    t.date "target_date"
+    t.datetime "updated_at", null: false
     t.index ["family_id", "state"], name: "index_goals_on_family_id_and_state"
     t.index ["family_id"], name: "index_goals_on_family_id"
     t.check_constraint "char_length(name::text) <= 255", name: "chk_savings_goals_name_length"
-    t.check_constraint "progress_basis::text = ANY (ARRAY['balance'::character varying, 'contributions'::character varying]::text[])", name: "chk_goals_progress_basis_enum"
-    t.check_constraint "state::text = ANY (ARRAY['active'::character varying, 'paused'::character varying, 'completed'::character varying, 'archived'::character varying]::text[])", name: "chk_savings_goals_state_enum"
+    t.check_constraint "progress_basis::text = ANY (ARRAY['balance'::character varying::text, 'contributions'::character varying::text])", name: "chk_goals_progress_basis_enum"
+    t.check_constraint "state::text = ANY (ARRAY['active'::character varying::text, 'paused'::character varying::text, 'completed'::character varying::text, 'archived'::character varying::text])", name: "chk_savings_goals_state_enum"
     t.check_constraint "target_amount > 0::numeric", name: "chk_savings_goals_target_amount_positive"
   end
 
   create_table "holdings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
-    t.uuid "security_id", null: false
-    t.date "date", null: false
-    t.decimal "qty", precision: 24, scale: 8, null: false
-    t.decimal "price", precision: 19, scale: 4, null: false
-    t.decimal "amount", precision: 19, scale: 4, null: false
-    t.string "currency", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "external_id"
-    t.decimal "cost_basis", precision: 19, scale: 4
     t.uuid "account_provider_id"
-    t.string "cost_basis_source"
+    t.decimal "amount", precision: 19, scale: 4, null: false
+    t.decimal "cost_basis", precision: 19, scale: 4
     t.boolean "cost_basis_locked", default: false, null: false
+    t.string "cost_basis_source"
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.date "date", null: false
+    t.string "external_id"
+    t.decimal "price", precision: 19, scale: 4, null: false
     t.uuid "provider_security_id"
+    t.decimal "qty", precision: 24, scale: 8, null: false
+    t.uuid "security_id", null: false
     t.boolean "security_locked", default: false, null: false
+    t.datetime "updated_at", null: false
     t.index ["account_id", "external_id"], name: "idx_holdings_on_account_id_external_id_unique", unique: true, where: "(external_id IS NOT NULL)"
     t.index ["account_id", "security_id", "date", "currency"], name: "idx_on_account_id_security_id_date_currency_5323e39f8b", unique: true
     t.index ["account_id"], name: "index_holdings_on_account_id"
@@ -888,121 +888,121 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "ibkr_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "ibkr_item_id", null: false
-    t.string "name"
-    t.string "ibkr_account_id"
+    t.decimal "cash_balance", precision: 19, scale: 4
+    t.datetime "created_at", null: false
     t.string "currency"
     t.decimal "current_balance", precision: 19, scale: 4
-    t.decimal "cash_balance", precision: 19, scale: 4
+    t.string "ibkr_account_id"
+    t.uuid "ibkr_item_id", null: false
     t.jsonb "institution_metadata"
-    t.jsonb "raw_holdings_payload", default: []
+    t.datetime "last_activities_sync"
+    t.datetime "last_holdings_sync"
+    t.string "name"
     t.jsonb "raw_activities_payload", default: {}
     t.jsonb "raw_cash_report_payload", default: []
-    t.date "report_date"
-    t.datetime "last_holdings_sync"
-    t.datetime "last_activities_sync"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.jsonb "raw_equity_summary_payload", default: [], null: false
+    t.jsonb "raw_holdings_payload", default: []
+    t.date "report_date"
+    t.datetime "updated_at", null: false
     t.index ["ibkr_item_id", "ibkr_account_id"], name: "index_ibkr_accounts_on_item_and_ibkr_account_id", unique: true, where: "(ibkr_account_id IS NOT NULL)"
     t.index ["ibkr_item_id"], name: "index_ibkr_accounts_on_ibkr_item_id"
   end
 
   create_table "ibkr_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.uuid "family_id", null: false
     t.string "name"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
     t.boolean "pending_account_setup", default: false, null: false
-    t.jsonb "raw_payload"
     t.string "query_id"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
     t.string "token"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_ibkr_items_on_family_id"
     t.index ["status"], name: "index_ibkr_items_on_status"
   end
 
   create_table "impersonation_session_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "impersonation_session_id", null: false
-    t.string "controller"
     t.string "action"
-    t.text "path"
-    t.string "method"
-    t.string "ip_address"
-    t.text "user_agent"
+    t.string "controller"
     t.datetime "created_at", null: false
+    t.uuid "impersonation_session_id", null: false
+    t.string "ip_address"
+    t.string "method"
+    t.text "path"
     t.datetime "updated_at", null: false
+    t.text "user_agent"
     t.index ["impersonation_session_id"], name: "index_impersonation_session_logs_on_impersonation_session_id"
   end
 
   create_table "impersonation_sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "impersonator_id", null: false
-    t.uuid "impersonated_id", null: false
-    t.string "status", default: "pending", null: false
     t.datetime "created_at", null: false
+    t.uuid "impersonated_id", null: false
+    t.uuid "impersonator_id", null: false
+    t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
     t.index ["impersonated_id"], name: "index_impersonation_sessions_on_impersonated_id"
     t.index ["impersonator_id"], name: "index_impersonation_sessions_on_impersonator_id"
   end
 
   create_table "import_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "type", null: false
-    t.string "key"
-    t.string "value"
     t.boolean "create_when_empty", default: true
-    t.uuid "import_id", null: false
-    t.string "mappable_type"
-    t.uuid "mappable_id"
     t.datetime "created_at", null: false
+    t.uuid "import_id", null: false
+    t.string "key"
+    t.uuid "mappable_id"
+    t.string "mappable_type"
+    t.string "type", null: false
     t.datetime "updated_at", null: false
+    t.string "value"
     t.index ["import_id"], name: "index_import_mappings_on_import_id"
     t.index ["mappable_type", "mappable_id"], name: "index_import_mappings_on_mappable"
   end
 
   create_table "import_rows", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "import_id", null: false
     t.string "account"
-    t.string "date"
-    t.string "qty"
-    t.string "ticker"
-    t.string "price"
-    t.string "amount"
-    t.string "currency"
-    t.string "name"
-    t.string "category"
-    t.string "tags"
-    t.string "entity_type"
-    t.text "notes"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "category_parent"
-    t.string "category_color"
-    t.string "category_classification"
-    t.string "category_icon"
-    t.string "exchange_operating_mic"
-    t.string "resource_type"
-    t.boolean "active"
-    t.string "effective_date"
-    t.text "conditions"
     t.text "actions"
-    t.integer "source_row_number", null: false
+    t.boolean "active"
+    t.string "amount"
+    t.string "category"
+    t.string "category_classification"
+    t.string "category_color"
+    t.string "category_icon"
+    t.string "category_parent"
+    t.text "conditions"
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.string "date"
+    t.string "effective_date"
+    t.string "entity_type"
+    t.string "exchange_operating_mic"
+    t.uuid "import_id", null: false
     t.string "merchant_color"
     t.string "merchant_website"
+    t.string "name"
+    t.text "notes"
+    t.string "price"
+    t.string "qty"
+    t.string "resource_type"
+    t.integer "source_row_number", null: false
+    t.string "tags"
+    t.string "ticker"
+    t.datetime "updated_at", null: false
     t.index ["import_id", "source_row_number"], name: "index_import_rows_on_import_id_and_source_row_number", unique: true
     t.index ["import_id"], name: "index_import_rows_on_import_id"
     t.check_constraint "source_row_number > 0", name: "chk_import_rows_source_row_number_positive"
   end
 
   create_table "import_sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "client_session_id", limit: 255
+    t.datetime "created_at", null: false
+    t.jsonb "error_details", default: {}, null: false
+    t.integer "expected_chunks"
     t.uuid "family_id", null: false
     t.string "import_type", default: "SureImport", null: false
     t.string "status", default: "pending", null: false
-    t.string "client_session_id", limit: 255
-    t.integer "expected_chunks"
     t.jsonb "summary", default: {}, null: false
-    t.jsonb "error_details", default: {}, null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id", "client_session_id"], name: "idx_import_sessions_on_family_client_session", unique: true, where: "(client_session_id IS NOT NULL)"
     t.index ["family_id", "status"], name: "index_import_sessions_on_family_id_and_status"
@@ -1010,20 +1010,20 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
     t.index ["id", "family_id"], name: "idx_import_sessions_on_id_family", unique: true
     t.check_constraint "client_session_id IS NULL OR btrim(client_session_id::text) <> ''::text", name: "chk_import_sessions_client_session_id_present"
     t.check_constraint "expected_chunks IS NULL OR expected_chunks > 0", name: "chk_import_sessions_expected_chunks_positive"
-    t.check_constraint "jsonb_typeof(error_details) = 'object'::text", name: "chk_import_sessions_error_details_object"
     t.check_constraint "import_type::text = 'SureImport'::text", name: "chk_import_sessions_import_type"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'importing'::character varying, 'complete'::character varying, 'failed'::character varying]::text[])", name: "chk_import_sessions_status"
+    t.check_constraint "jsonb_typeof(error_details) = 'object'::text", name: "chk_import_sessions_error_details_object"
     t.check_constraint "jsonb_typeof(summary) = 'object'::text", name: "chk_import_sessions_summary_object"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'importing'::character varying::text, 'complete'::character varying::text, 'failed'::character varying::text])", name: "chk_import_sessions_status"
   end
 
   create_table "import_source_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.uuid "family_id", null: false
     t.uuid "import_session_id", null: false
-    t.string "source_type", limit: 64, null: false
     t.string "source_id", limit: 255, null: false
-    t.string "target_type", null: false
+    t.string "source_type", limit: 64, null: false
     t.uuid "target_id", null: false
-    t.datetime "created_at", null: false
+    t.string "target_type", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id", "source_type", "source_id"], name: "idx_import_source_mappings_on_family_source"
     t.index ["family_id"], name: "index_import_source_mappings_on_family_id"
@@ -1031,57 +1031,57 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
     t.index ["import_session_id"], name: "index_import_source_mappings_on_import_session_id"
     t.index ["target_type", "target_id"], name: "idx_import_source_mappings_on_target"
     t.check_constraint "btrim(source_id::text) <> ''::text", name: "chk_import_source_mappings_source_id_present"
-    t.check_constraint "source_type::text = ANY (ARRAY['Account'::character varying, 'Category'::character varying, 'Tag'::character varying, 'Merchant'::character varying, 'RecurringTransaction'::character varying, 'Transaction'::character varying, 'Budget'::character varying, 'Security'::character varying, 'Rule'::character varying]::text[])", name: "chk_import_source_mappings_source_type"
     t.check_constraint "btrim(source_type::text) <> ''::text", name: "chk_import_source_mappings_source_type_present"
-    t.check_constraint "target_type::text = ANY (ARRAY['Account'::character varying, 'Category'::character varying, 'Tag'::character varying, 'Merchant'::character varying, 'RecurringTransaction'::character varying, 'Transaction'::character varying, 'Budget'::character varying, 'Security'::character varying, 'Rule'::character varying]::text[])", name: "chk_import_source_mappings_target_type"
     t.check_constraint "btrim(target_type::text) <> ''::text", name: "chk_import_source_mappings_target_type_present"
+    t.check_constraint "source_type::text = ANY (ARRAY['Account'::character varying::text, 'Category'::character varying::text, 'Tag'::character varying::text, 'Merchant'::character varying::text, 'RecurringTransaction'::character varying::text, 'Transaction'::character varying::text, 'Budget'::character varying::text, 'Security'::character varying::text, 'Rule'::character varying::text])", name: "chk_import_source_mappings_source_type"
+    t.check_constraint "target_type::text = ANY (ARRAY['Account'::character varying::text, 'Category'::character varying::text, 'Tag'::character varying::text, 'Merchant'::character varying::text, 'RecurringTransaction'::character varying::text, 'Transaction'::character varying::text, 'Budget'::character varying::text, 'Security'::character varying::text, 'Rule'::character varying::text])", name: "chk_import_source_mappings_target_type"
   end
 
   create_table "imports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.jsonb "column_mappings"
-    t.string "status"
-    t.string "raw_file_str"
-    t.string "normalized_csv_str"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "col_sep", default: ","
-    t.uuid "family_id", null: false
-    t.uuid "account_id"
-    t.string "type", null: false
-    t.string "date_col_label"
-    t.string "amount_col_label"
-    t.string "name_col_label"
-    t.string "category_col_label"
-    t.string "tags_col_label"
     t.string "account_col_label"
-    t.string "qty_col_label"
-    t.string "ticker_col_label"
-    t.string "price_col_label"
-    t.string "entity_type_col_label"
-    t.string "notes_col_label"
-    t.string "currency_col_label"
-    t.string "date_format", default: "%m/%d/%Y"
-    t.string "signage_convention", default: "inflows_positive"
-    t.string "error"
-    t.string "number_format"
-    t.string "exchange_operating_mic_col_label"
-    t.string "amount_type_strategy", default: "signed_amount"
-    t.string "amount_type_inflow_value"
-    t.integer "rows_count", default: 0, null: false
-    t.string "amount_type_identifier_value"
-    t.integer "rows_to_skip", default: 0, null: false
-    t.text "ai_summary"
-    t.string "document_type"
-    t.jsonb "extracted_data"
+    t.uuid "account_id"
     t.uuid "account_statement_id"
-    t.jsonb "expected_record_counts", default: {}, null: false
-    t.jsonb "readback_verification", default: {}, null: false
-    t.uuid "import_session_id"
-    t.integer "sequence"
-    t.string "client_chunk_id", limit: 255
+    t.text "ai_summary"
+    t.string "amount_col_label"
+    t.string "amount_type_identifier_value"
+    t.string "amount_type_inflow_value"
+    t.string "amount_type_strategy", default: "signed_amount"
+    t.string "category_col_label"
     t.string "checksum", limit: 64
-    t.jsonb "summary", default: {}, null: false
+    t.string "client_chunk_id", limit: 255
+    t.string "col_sep", default: ","
+    t.jsonb "column_mappings"
+    t.datetime "created_at", null: false
+    t.string "currency_col_label"
+    t.string "date_col_label"
+    t.string "date_format", default: "%m/%d/%Y"
+    t.string "document_type"
+    t.string "entity_type_col_label"
+    t.string "error"
     t.jsonb "error_details", default: {}, null: false
+    t.string "exchange_operating_mic_col_label"
+    t.jsonb "expected_record_counts", default: {}, null: false
+    t.jsonb "extracted_data"
+    t.uuid "family_id", null: false
+    t.uuid "import_session_id"
+    t.string "name_col_label"
+    t.string "normalized_csv_str"
+    t.string "notes_col_label"
+    t.string "number_format"
+    t.string "price_col_label"
+    t.string "qty_col_label"
+    t.string "raw_file_str"
+    t.jsonb "readback_verification", default: {}, null: false
+    t.integer "rows_count", default: 0, null: false
+    t.integer "rows_to_skip", default: 0, null: false
+    t.integer "sequence"
+    t.string "signage_convention", default: "inflows_positive"
+    t.string "status"
+    t.jsonb "summary", default: {}, null: false
+    t.string "tags_col_label"
+    t.string "ticker_col_label"
+    t.string "type", null: false
+    t.datetime "updated_at", null: false
     t.index ["account_statement_id"], name: "index_imports_on_account_statement_id"
     t.index ["family_id"], name: "index_imports_on_family_id"
     t.index ["import_session_id", "client_chunk_id"], name: "idx_imports_on_session_client_chunk", unique: true, where: "((import_session_id IS NOT NULL) AND (client_chunk_id IS NOT NULL))"
@@ -1089,34 +1089,34 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
     t.index ["import_session_id"], name: "index_imports_on_import_session_id"
     t.check_constraint "checksum IS NULL OR length(checksum::text) = 64", name: "chk_imports_checksum_sha256_length"
     t.check_constraint "client_chunk_id IS NULL OR btrim(client_chunk_id::text) <> ''::text", name: "chk_imports_client_chunk_id_present"
-    t.check_constraint "jsonb_typeof(error_details) = 'object'::text", name: "chk_imports_error_details_object"
     t.check_constraint "import_session_id IS NULL OR checksum IS NOT NULL", name: "chk_imports_session_checksum_present"
     t.check_constraint "import_session_id IS NULL OR sequence IS NOT NULL", name: "chk_imports_session_sequence_present"
+    t.check_constraint "jsonb_typeof(error_details) = 'object'::text", name: "chk_imports_error_details_object"
     t.check_constraint "jsonb_typeof(summary) = 'object'::text", name: "chk_imports_summary_object"
     t.check_constraint "sequence IS NULL OR sequence > 0", name: "chk_imports_session_sequence_positive"
   end
 
   create_table "indexa_capital_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "indexa_capital_item_id", null: false
-    t.string "name"
-    t.string "indexa_capital_account_id"
     t.string "account_number"
-    t.string "currency"
-    t.decimal "current_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
-    t.jsonb "institution_metadata"
-    t.jsonb "raw_payload"
-    t.string "indexa_capital_authorization_id"
-    t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
-    t.jsonb "raw_holdings_payload", default: []
-    t.jsonb "raw_activities_payload", default: []
-    t.datetime "last_holdings_sync"
-    t.datetime "last_activities_sync"
     t.boolean "activities_fetch_pending", default: false
-    t.date "sync_start_date"
+    t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
     t.datetime "created_at", null: false
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
+    t.string "indexa_capital_account_id"
+    t.string "indexa_capital_authorization_id"
+    t.uuid "indexa_capital_item_id", null: false
+    t.jsonb "institution_metadata"
+    t.datetime "last_activities_sync"
+    t.datetime "last_holdings_sync"
+    t.string "name"
+    t.string "provider"
+    t.jsonb "raw_activities_payload", default: []
+    t.jsonb "raw_holdings_payload", default: []
+    t.jsonb "raw_payload"
+    t.date "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["indexa_capital_authorization_id"], name: "idx_on_indexa_capital_authorization_id_58db208d52"
     t.index ["indexa_capital_item_id", "indexa_capital_account_id"], name: "index_indexa_capital_accounts_on_item_and_account_id", unique: true, where: "(indexa_capital_account_id IS NOT NULL)"
@@ -1124,34 +1124,27 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "indexa_capital_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "api_token"
+    t.datetime "created_at", null: false
+    t.string "document"
     t.uuid "family_id", null: false
-    t.string "name"
+    t.string "institution_color"
+    t.string "institution_domain"
     t.string "institution_id"
     t.string "institution_name"
-    t.string "institution_domain"
     t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
-    t.string "username"
-    t.string "document"
+    t.string "name"
     t.text "password"
-    t.datetime "created_at", null: false
+    t.boolean "pending_account_setup", default: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
+    t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
-    t.text "api_token"
+    t.string "username"
     t.index ["family_id"], name: "index_indexa_capital_items_on_family_id"
     t.index ["status"], name: "index_indexa_capital_items_on_status"
-  end
-
-  create_table "investments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.jsonb "locked_attributes", default: {}
-    t.string "subtype"
   end
 
   create_table "insights", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1175,21 +1168,28 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
     t.index ["family_id", "dedup_key"], name: "index_insights_on_family_id_and_dedup_key", unique: true
     t.index ["family_id", "generated_at"], name: "index_insights_on_family_id_and_generated_at"
     t.index ["family_id", "status"], name: "index_insights_on_family_id_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['high'::character varying, 'medium'::character varying, 'low'::character varying]::text[])", name: "chk_insights_priority"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'read'::character varying, 'dismissed'::character varying, 'expired'::character varying]::text[])", name: "chk_insights_status"
+    t.check_constraint "priority::text = ANY (ARRAY['high'::character varying::text, 'medium'::character varying::text, 'low'::character varying::text])", name: "chk_insights_priority"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'read'::character varying::text, 'dismissed'::character varying::text, 'expired'::character varying::text])", name: "chk_insights_status"
+  end
+
+  create_table "investments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.jsonb "locked_attributes", default: {}
+    t.string "subtype"
+    t.datetime "updated_at", null: false
   end
 
   create_table "invitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "accepted_at"
+    t.datetime "created_at", null: false
     t.string "email"
-    t.string "role"
-    t.string "token"
+    t.datetime "expires_at"
     t.uuid "family_id", null: false
     t.uuid "inviter_id", null: false
-    t.datetime "accepted_at"
-    t.datetime "expires_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "role"
+    t.string "token"
     t.string "token_digest"
+    t.datetime "updated_at", null: false
     t.index ["email", "family_id"], name: "index_invitations_on_email_and_family_id_pending", unique: true, where: "(accepted_at IS NULL)"
     t.index ["email"], name: "index_invitations_on_email"
     t.index ["family_id"], name: "index_invitations_on_family_id"
@@ -1199,26 +1199,26 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "invite_codes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "token", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "token", null: false
     t.string "token_digest"
+    t.datetime "updated_at", null: false
     t.index ["token"], name: "index_invite_codes_on_token", unique: true
     t.index ["token_digest"], name: "index_invite_codes_on_token_digest", unique: true, where: "(token_digest IS NOT NULL)"
   end
 
   create_table "kraken_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "kraken_item_id", null: false
-    t.string "name"
     t.string "account_id", null: false
     t.string "account_type"
+    t.datetime "created_at", null: false
     t.string "currency"
     t.decimal "current_balance", precision: 19, scale: 4
+    t.jsonb "extra", default: {}, null: false
     t.jsonb "institution_metadata"
+    t.uuid "kraken_item_id", null: false
+    t.string "name"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.jsonb "extra", default: {}, null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_type"], name: "index_kraken_accounts_on_account_type"
     t.index ["kraken_item_id", "account_id"], name: "index_kraken_accounts_on_item_and_account_id", unique: true
@@ -1226,40 +1226,40 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "kraken_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good", null: false
-    t.boolean "scheduled_for_deletion", default: false, null: false
-    t.boolean "pending_account_setup", default: false, null: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
     t.text "api_key"
     t.text "api_secret"
-    t.bigint "last_nonce", default: 0, null: false
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.bigint "last_nonce", default: 0, null: false
+    t.string "name"
+    t.boolean "pending_account_setup", default: false, null: false
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
+    t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_kraken_items_on_family_id"
     t.index ["status"], name: "index_kraken_items_on_status"
   end
 
   create_table "llm_usages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "cache_creation_tokens"
+    t.integer "cache_read_tokens"
+    t.integer "completion_tokens", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.decimal "estimated_cost", precision: 10, scale: 6
     t.uuid "family_id", null: false
-    t.string "provider", null: false
+    t.jsonb "metadata", default: {}
     t.string "model", null: false
     t.string "operation", null: false
     t.integer "prompt_tokens", default: 0, null: false
-    t.integer "completion_tokens", default: 0, null: false
+    t.string "provider", null: false
     t.integer "total_tokens", default: 0, null: false
-    t.decimal "estimated_cost", precision: 10, scale: 6
-    t.jsonb "metadata", default: {}
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "cache_creation_tokens"
-    t.integer "cache_read_tokens"
     t.index ["family_id", "created_at"], name: "index_llm_usages_on_family_id_and_created_at"
     t.index ["family_id", "operation"], name: "index_llm_usages_on_family_id_and_operation"
     t.index ["family_id"], name: "index_llm_usages_on_family_id"
@@ -1268,70 +1268,71 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "loans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "auto_split_payments", default: false, null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "rate_type"
-    t.decimal "interest_rate", precision: 10, scale: 3
-    t.integer "term_months"
     t.decimal "initial_balance", precision: 19, scale: 4
+    t.decimal "interest_rate", precision: 10, scale: 3
     t.jsonb "locked_attributes", default: {}
+    t.string "rate_type"
     t.string "subtype"
+    t.integer "term_months"
+    t.datetime "updated_at", null: false
   end
 
   create_table "lunchflow_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "lunchflow_item_id", null: false
-    t.string "name"
     t.string "account_id"
+    t.string "account_status"
+    t.string "account_type"
+    t.datetime "created_at", null: false
     t.string "currency"
     t.decimal "current_balance", precision: 19, scale: 4
-    t.string "account_status"
-    t.string "provider"
-    t.string "account_type"
+    t.boolean "holdings_supported", default: true, null: false
     t.jsonb "institution_metadata"
+    t.uuid "lunchflow_item_id", null: false
+    t.string "name"
+    t.string "provider"
+    t.jsonb "raw_holdings_payload"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "holdings_supported", default: true, null: false
-    t.jsonb "raw_holdings_payload"
     t.index ["account_id"], name: "index_lunchflow_accounts_on_account_id"
     t.index ["lunchflow_item_id", "account_id"], name: "index_lunchflow_accounts_on_item_and_account_id", unique: true, where: "(account_id IS NOT NULL)"
     t.index ["lunchflow_item_id"], name: "index_lunchflow_accounts_on_lunchflow_item_id"
   end
 
   create_table "lunchflow_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.text "api_key"
     t.string "base_url"
+    t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
+    t.datetime "sync_start_date"
+    t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_lunchflow_items_on_family_id"
     t.index ["status"], name: "index_lunchflow_items_on_status"
   end
 
   create_table "merchants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", null: false
     t.string "color"
-    t.uuid "family_id"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.uuid "family_id"
     t.string "logo_url"
-    t.string "website_url"
-    t.string "type", null: false
-    t.string "source"
+    t.string "name", null: false
     t.string "provider_merchant_id"
+    t.string "source"
+    t.string "type", null: false
+    t.datetime "updated_at", null: false
+    t.string "website_url"
     t.index ["family_id", "name"], name: "index_merchants_on_family_id_and_name", unique: true, where: "((type)::text = 'FamilyMerchant'::text)"
     t.index ["family_id"], name: "index_merchants_on_family_id"
     t.index ["provider_merchant_id", "source"], name: "index_merchants_on_provider_merchant_id_and_source", unique: true, where: "((provider_merchant_id IS NOT NULL) AND ((type)::text = 'ProviderMerchant'::text))"
@@ -1340,77 +1341,77 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "mercury_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "mercury_item_id", null: false
-    t.string "name"
     t.string "account_id", null: false
-    t.string "currency"
-    t.decimal "current_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
     t.jsonb "institution_metadata"
+    t.uuid "mercury_item_id", null: false
+    t.string "name"
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["mercury_item_id", "account_id"], name: "index_mercury_accounts_on_item_and_account_id", unique: true
     t.index ["mercury_item_id"], name: "index_mercury_accounts_on_mercury_item_id"
   end
 
   create_table "mercury_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
-    t.text "token"
     t.string "base_url"
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
+    t.datetime "sync_start_date"
+    t.text "token"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_mercury_items_on_family_id"
     t.index ["status"], name: "index_mercury_items_on_status"
   end
 
   create_table "messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "chat_id", null: false
-    t.string "type", null: false
-    t.string "status", default: "complete", null: false
-    t.text "content"
     t.string "ai_model"
+    t.uuid "chat_id", null: false
+    t.text "content"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "debug", default: false
     t.string "provider_id"
     t.boolean "reasoning", default: false
+    t.string "status", default: "complete", null: false
+    t.string "type", null: false
+    t.datetime "updated_at", null: false
     t.index ["chat_id"], name: "index_messages_on_chat_id"
   end
 
   create_table "mobile_devices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
+    t.string "app_version"
+    t.datetime "created_at", null: false
     t.string "device_id"
     t.string "device_name"
     t.string "device_type"
-    t.string "os_version"
-    t.string "app_version"
     t.datetime "last_seen_at"
-    t.datetime "created_at", null: false
+    t.string "os_version"
     t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
     t.index ["user_id", "device_id"], name: "index_mobile_devices_on_user_id_and_device_id", unique: true
     t.index ["user_id"], name: "index_mobile_devices_on_user_id"
   end
 
   create_table "notification_deliveries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.uuid "rule_id", null: false
     t.uuid "transaction_id", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["rule_id", "transaction_id"], name: "index_notification_deliveries_on_rule_and_transaction", unique: true
     t.index ["rule_id"], name: "index_notification_deliveries_on_rule_id"
@@ -1418,30 +1419,30 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
-    t.string "resource_owner_id", null: false
     t.bigint "application_id", null: false
-    t.string "token", null: false
+    t.datetime "created_at", null: false
     t.integer "expires_in", null: false
     t.text "redirect_uri", null: false
-    t.string "scopes", default: "", null: false
-    t.datetime "created_at", null: false
+    t.string "resource_owner_id", null: false
     t.datetime "revoked_at"
+    t.string "scopes", default: "", null: false
+    t.string "token", null: false
     t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
     t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
   create_table "oauth_access_tokens", force: :cascade do |t|
-    t.string "resource_owner_id"
     t.bigint "application_id", null: false
-    t.string "token", null: false
-    t.string "refresh_token"
-    t.integer "expires_in"
-    t.string "scopes"
     t.datetime "created_at", null: false
-    t.datetime "revoked_at"
-    t.string "previous_refresh_token", default: "", null: false
+    t.integer "expires_in"
     t.uuid "mobile_device_id"
+    t.string "previous_refresh_token", default: "", null: false
+    t.string "refresh_token"
+    t.string "resource_owner_id"
+    t.datetime "revoked_at"
+    t.string "scopes"
+    t.string "token", null: false
     t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
     t.index ["mobile_device_id"], name: "index_oauth_access_tokens_on_mobile_device_id"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
@@ -1450,29 +1451,29 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "oauth_applications", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "uid", null: false
-    t.string "secret", null: false
-    t.text "redirect_uri", null: false
-    t.string "scopes", default: "", null: false
     t.boolean "confidential", default: true, null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "name", null: false
     t.uuid "owner_id"
     t.string "owner_type"
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.string "secret", null: false
+    t.string "uid", null: false
+    t.datetime "updated_at", null: false
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
   create_table "oidc_identities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
+    t.datetime "created_at", null: false
+    t.jsonb "info", default: {}
+    t.string "issuer"
+    t.datetime "last_authenticated_at"
     t.string "provider", null: false
     t.string "uid", null: false
-    t.jsonb "info", default: {}
-    t.datetime "last_authenticated_at"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "issuer"
+    t.uuid "user_id", null: false
     t.index ["issuer"], name: "index_oidc_identities_on_issuer"
     t.index ["provider", "uid"], name: "index_oidc_identities_on_provider_and_uid", unique: true
     t.index ["user_id"], name: "index_oidc_identities_on_user_id"
@@ -1480,72 +1481,72 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
 
   create_table "other_assets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.jsonb "locked_attributes", default: {}
     t.string "subtype"
+    t.datetime "updated_at", null: false
   end
 
   create_table "other_liabilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.jsonb "locked_attributes", default: {}
     t.string "subtype"
+    t.datetime "updated_at", null: false
   end
 
   create_table "plaid_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "plaid_item_id", null: false
-    t.string "plaid_id", null: false
-    t.string "plaid_type", null: false
-    t.string "plaid_subtype"
-    t.decimal "current_balance", precision: 19, scale: 4
     t.decimal "available_balance", precision: 19, scale: 4
-    t.string "currency", null: false
-    t.string "name", null: false
-    t.string "mask"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.jsonb "raw_payload", default: {}
-    t.jsonb "raw_transactions_payload", default: {}
+    t.string "currency", null: false
+    t.decimal "current_balance", precision: 19, scale: 4
+    t.string "mask"
+    t.string "name", null: false
+    t.string "plaid_id", null: false
+    t.uuid "plaid_item_id", null: false
+    t.string "plaid_subtype"
+    t.string "plaid_type", null: false
     t.jsonb "raw_holdings_payload", default: {}
     t.jsonb "raw_liabilities_payload", default: {}
+    t.jsonb "raw_payload", default: {}
+    t.jsonb "raw_transactions_payload", default: {}
+    t.datetime "updated_at", null: false
     t.index ["plaid_item_id", "plaid_id"], name: "index_plaid_accounts_on_item_and_plaid_id", unique: true
     t.index ["plaid_item_id"], name: "index_plaid_accounts_on_plaid_item_id"
   end
 
   create_table "plaid_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
     t.string "access_token"
-    t.string "plaid_id", null: false
-    t.string "name"
-    t.string "next_cursor"
-    t.boolean "scheduled_for_deletion", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "available_products", default: [], array: true
     t.string "billed_products", default: [], array: true
-    t.string "plaid_region", default: "us", null: false
-    t.string "institution_url"
-    t.string "institution_id"
+    t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
     t.string "institution_color"
-    t.string "status", default: "good", null: false
-    t.jsonb "raw_payload", default: {}
+    t.string "institution_id"
+    t.string "institution_url"
+    t.string "name"
+    t.string "next_cursor"
+    t.string "plaid_id", null: false
+    t.string "plaid_region", default: "us", null: false
     t.jsonb "raw_institution_payload", default: {}
+    t.jsonb "raw_payload", default: {}
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good", null: false
+    t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_plaid_items_on_family_id"
     t.index ["plaid_id"], name: "index_plaid_items_on_plaid_id", unique: true
   end
 
   create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "year_built"
-    t.integer "area_value"
     t.string "area_unit"
+    t.integer "area_value"
+    t.date "avm_last_synced_on"
+    t.string "avm_provider"
+    t.datetime "created_at", null: false
     t.jsonb "locked_attributes", default: {}
     t.string "subtype"
-    t.string "avm_provider"
-    t.date "avm_last_synced_on"
+    t.datetime "updated_at", null: false
+    t.integer "year_built"
     t.index ["avm_last_synced_on"], name: "index_properties_on_avm_provider_sync", order: "NULLS FIRST", where: "(avm_provider IS NOT NULL)"
-    t.check_constraint "avm_provider IS NULL OR (avm_provider::text = ANY (ARRAY['rentcast'::character varying, 'realie'::character varying]::text[]))", name: "properties_avm_provider_check"
+    t.check_constraint "avm_provider IS NULL OR (avm_provider::text = ANY (ARRAY['rentcast'::character varying::text, 'realie'::character varying::text]))", name: "properties_avm_provider_check"
   end
 
   create_table "provider_request_counts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1608,24 +1609,24 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "recurring_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.uuid "merchant_id"
-    t.decimal "amount", precision: 19, scale: 4, null: false
-    t.string "currency", null: false
-    t.integer "expected_day_of_month", null: false
-    t.date "last_occurrence_date", null: false
-    t.date "next_expected_date", null: false
-    t.string "status", default: "active", null: false
-    t.integer "occurrence_count", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "name"
-    t.boolean "manual", default: false, null: false
-    t.decimal "expected_amount_min", precision: 19, scale: 4
-    t.decimal "expected_amount_max", precision: 19, scale: 4
-    t.decimal "expected_amount_avg", precision: 19, scale: 4
     t.uuid "account_id"
+    t.decimal "amount", precision: 19, scale: 4, null: false
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
     t.uuid "destination_account_id"
+    t.decimal "expected_amount_avg", precision: 19, scale: 4
+    t.decimal "expected_amount_max", precision: 19, scale: 4
+    t.decimal "expected_amount_min", precision: 19, scale: 4
+    t.integer "expected_day_of_month", null: false
+    t.uuid "family_id", null: false
+    t.date "last_occurrence_date", null: false
+    t.boolean "manual", default: false, null: false
+    t.uuid "merchant_id"
+    t.string "name"
+    t.date "next_expected_date", null: false
+    t.integer "occurrence_count", default: 0, null: false
+    t.string "status", default: "active", null: false
+    t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_recurring_transactions_on_account_id"
     t.index ["destination_account_id"], name: "index_recurring_transactions_on_destination_account_id"
     t.index ["family_id", "account_id", "destination_account_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_pair_merchant", unique: true, where: "((destination_account_id IS NOT NULL) AND (merchant_id IS NOT NULL))"
@@ -1641,52 +1642,52 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "redbark_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "redbark_item_id", null: false
-    t.string "name", null: false
-    t.string "redbark_account_id", null: false
-    t.string "connection_id"
     t.string "account_number"
-    t.string "currency", null: false
-    t.decimal "current_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.string "connection_id"
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.decimal "current_balance", precision: 19, scale: 4
     t.boolean "ignored", default: false, null: false
     t.jsonb "institution_metadata"
+    t.string "name", null: false
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
+    t.string "redbark_account_id", null: false
+    t.uuid "redbark_item_id", null: false
     t.date "sync_start_date"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["redbark_item_id", "redbark_account_id"], name: "index_redbark_accounts_on_item_and_account_id", unique: true
     t.index ["redbark_item_id"], name: "index_redbark_accounts_on_redbark_item_id"
   end
 
   create_table "redbark_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name", null: false
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good", null: false
-    t.boolean "scheduled_for_deletion", default: false, null: false
-    t.boolean "pending_account_setup", default: false, null: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
     t.text "api_key", null: false
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name", null: false
+    t.boolean "pending_account_setup", default: false, null: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
+    t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_redbark_items_on_family_id"
     t.index ["status"], name: "index_redbark_items_on_status"
   end
 
   create_table "rejected_transfers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.uuid "inflow_transaction_id", null: false
     t.uuid "outflow_transaction_id", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["inflow_transaction_id", "outflow_transaction_id"], name: "idx_on_inflow_transaction_id_outflow_transaction_id_412f8e7e26", unique: true
     t.index ["inflow_transaction_id"], name: "index_rejected_transfers_on_inflow_transaction_id"
@@ -1694,38 +1695,38 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "rule_actions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "rule_id", null: false
     t.string "action_type", null: false
-    t.string "value"
     t.datetime "created_at", null: false
+    t.uuid "rule_id", null: false
     t.datetime "updated_at", null: false
+    t.string "value"
     t.index ["rule_id"], name: "index_rule_actions_on_rule_id"
   end
 
   create_table "rule_conditions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "rule_id"
-    t.uuid "parent_id"
     t.string "condition_type", null: false
-    t.string "operator", null: false
-    t.string "value"
     t.datetime "created_at", null: false
+    t.string "operator", null: false
+    t.uuid "parent_id"
+    t.uuid "rule_id"
     t.datetime "updated_at", null: false
+    t.string "value"
     t.index ["parent_id"], name: "index_rule_conditions_on_parent_id"
     t.index ["rule_id"], name: "index_rule_conditions_on_rule_id"
   end
 
   create_table "rule_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error_message"
+    t.datetime "executed_at", null: false
+    t.string "execution_type", null: false
+    t.integer "pending_jobs_count", default: 0, null: false
     t.uuid "rule_id", null: false
     t.string "rule_name"
-    t.string "execution_type", null: false
     t.string "status", null: false
-    t.integer "transactions_queued", default: 0, null: false
-    t.integer "transactions_processed", default: 0, null: false
     t.integer "transactions_modified", default: 0, null: false
-    t.integer "pending_jobs_count", default: 0, null: false
-    t.datetime "executed_at", null: false
-    t.text "error_message"
-    t.datetime "created_at", null: false
+    t.integer "transactions_processed", default: 0, null: false
+    t.integer "transactions_queued", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["executed_at"], name: "index_rule_runs_on_executed_at"
     t.index ["rule_id", "executed_at"], name: "index_rule_runs_on_rule_id_and_executed_at"
@@ -1733,119 +1734,119 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "resource_type", null: false
-    t.date "effective_date"
     t.boolean "active", default: false, null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.date "effective_date"
+    t.uuid "family_id", null: false
     t.string "name"
+    t.string "resource_type", null: false
+    t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_rules_on_family_id"
   end
 
   create_table "securities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "ticker", null: false
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "country_code"
-    t.string "exchange_mic"
+    t.datetime "created_at", null: false
     t.string "exchange_acronym"
-    t.string "logo_url"
+    t.string "exchange_mic"
     t.string "exchange_operating_mic"
-    t.boolean "offline", default: false, null: false
     t.datetime "failed_fetch_at"
     t.integer "failed_fetch_count", default: 0, null: false
-    t.datetime "last_health_check_at"
-    t.string "website_url"
-    t.string "kind", default: "standard", null: false
-    t.string "price_provider"
-    t.string "offline_reason"
     t.date "first_provider_price_on"
+    t.string "kind", default: "standard", null: false
+    t.datetime "last_health_check_at"
+    t.string "logo_url"
+    t.string "name"
+    t.boolean "offline", default: false, null: false
+    t.string "offline_reason"
+    t.string "price_provider"
+    t.string "ticker", null: false
+    t.datetime "updated_at", null: false
+    t.string "website_url"
     t.index "upper((ticker)::text), COALESCE(upper((exchange_operating_mic)::text), ''::text)", name: "index_securities_on_ticker_and_exchange_operating_mic_unique", unique: true
     t.index ["country_code"], name: "index_securities_on_country_code"
     t.index ["exchange_operating_mic"], name: "index_securities_on_exchange_operating_mic"
     t.index ["kind"], name: "index_securities_on_kind"
     t.index ["price_provider", "offline_reason"], name: "index_securities_on_price_provider_and_offline_reason"
     t.index ["price_provider"], name: "index_securities_on_price_provider"
-    t.check_constraint "kind::text = ANY (ARRAY['standard'::character varying, 'cash'::character varying]::text[])", name: "chk_securities_kind"
+    t.check_constraint "kind::text = ANY (ARRAY['standard'::character varying::text, 'cash'::character varying::text])", name: "chk_securities_kind"
   end
 
   create_table "security_prices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "currency", default: "USD", null: false
     t.date "date", null: false
     t.decimal "price", precision: 19, scale: 4, null: false
-    t.string "currency", default: "USD", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.uuid "security_id"
     t.boolean "provisional", default: false, null: false
+    t.uuid "security_id"
+    t.datetime "updated_at", null: false
     t.index ["security_id", "date", "currency"], name: "index_security_prices_on_security_id_and_date_and_currency", unique: true
     t.index ["security_id"], name: "index_security_prices_on_security_id"
   end
 
   create_table "sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.string "user_agent"
-    t.string "ip_address"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.uuid "active_impersonator_session_id"
-    t.datetime "subscribed_at"
-    t.jsonb "prev_transaction_page_params", default: {}
+    t.datetime "created_at", null: false
     t.jsonb "data", default: {}
+    t.string "ip_address"
     t.string "ip_address_digest"
+    t.jsonb "prev_transaction_page_params", default: {}
+    t.datetime "subscribed_at"
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.uuid "user_id", null: false
     t.index ["active_impersonator_session_id"], name: "index_sessions_on_active_impersonator_session_id"
     t.index ["ip_address_digest"], name: "index_sessions_on_ip_address_digest"
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "settings", force: :cascade do |t|
-    t.string "var", null: false
-    t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "value"
+    t.string "var", null: false
     t.index ["var"], name: "index_settings_on_var", unique: true
   end
 
   create_table "simplefin_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "simplefin_item_id", null: false
-    t.string "name"
     t.string "account_id"
+    t.string "account_subtype"
+    t.string "account_type"
+    t.decimal "available_balance", precision: 19, scale: 4
+    t.datetime "balance_date"
+    t.datetime "created_at", null: false
     t.string "currency"
     t.decimal "current_balance", precision: 19, scale: 4
-    t.decimal "available_balance", precision: 19, scale: 4
-    t.string "account_type"
-    t.string "account_subtype"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_transactions_payload"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "balance_date"
     t.jsonb "extra"
+    t.string "name"
     t.jsonb "org_data"
     t.jsonb "raw_holdings_payload"
+    t.jsonb "raw_payload"
+    t.jsonb "raw_transactions_payload"
+    t.uuid "simplefin_item_id", null: false
+    t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_simplefin_accounts_on_account_id"
     t.index ["simplefin_item_id", "account_id"], name: "idx_unique_sfa_per_item_and_upstream", unique: true, where: "(account_id IS NOT NULL)"
     t.index ["simplefin_item_id"], name: "index_simplefin_accounts_on_simplefin_item_id"
   end
 
   create_table "simplefin_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
     t.text "access_url"
-    t.string "name"
+    t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
     t.string "institution_id"
     t.string "institution_name"
     t.string "institution_url"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "name"
     t.boolean "pending_account_setup", default: false, null: false
-    t.string "institution_domain"
-    t.string "institution_color"
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
     t.date "sync_start_date"
+    t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_simplefin_items_on_family_id"
     t.index ["institution_domain"], name: "index_simplefin_items_on_institution_domain"
     t.index ["institution_id"], name: "index_simplefin_items_on_institution_id"
@@ -1854,118 +1855,118 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "snaptrade_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "snaptrade_item_id", null: false
-    t.string "name"
-    t.string "snaptrade_account_id"
-    t.string "snaptrade_authorization_id"
     t.string "account_number"
-    t.string "brokerage_name"
-    t.string "currency"
-    t.decimal "current_balance", precision: 19, scale: 4
-    t.decimal "cash_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "provider"
+    t.boolean "activities_fetch_pending", default: false
+    t.string "brokerage_name"
+    t.decimal "cash_balance", precision: 19, scale: 4
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.decimal "current_balance", precision: 19, scale: 4
     t.jsonb "institution_metadata"
+    t.datetime "last_activities_sync"
+    t.datetime "last_holdings_sync"
+    t.string "name"
+    t.string "provider"
+    t.jsonb "raw_activities_payload", default: []
+    t.jsonb "raw_balances_payload", default: []
+    t.jsonb "raw_holdings_payload", default: []
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.jsonb "raw_holdings_payload", default: []
-    t.jsonb "raw_activities_payload", default: []
-    t.datetime "last_holdings_sync"
-    t.datetime "last_activities_sync"
-    t.boolean "activities_fetch_pending", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "snaptrade_account_id"
+    t.string "snaptrade_authorization_id"
+    t.uuid "snaptrade_item_id", null: false
     t.date "sync_start_date"
-    t.jsonb "raw_balances_payload", default: []
+    t.datetime "updated_at", null: false
     t.index ["snaptrade_item_id", "snaptrade_account_id"], name: "index_snaptrade_accounts_on_item_and_snaptrade_account_id", unique: true, where: "(snaptrade_account_id IS NOT NULL)"
     t.index ["snaptrade_item_id"], name: "index_snaptrade_accounts_on_snaptrade_item_id"
   end
 
   create_table "snaptrade_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.datetime "sync_start_date"
-    t.datetime "last_synced_at"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
     t.string "client_id"
     t.string "consumer_key"
-    t.string "snaptrade_user_id"
-    t.string "snaptrade_user_secret"
+    t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.datetime "last_synced_at"
+    t.string "name"
     t.text "oauth_access_token"
     t.text "oauth_refresh_token"
-    t.string "oauth_token_type"
     t.string "oauth_scope"
     t.datetime "oauth_token_expires_at"
-    t.datetime "created_at", null: false
+    t.string "oauth_token_type"
+    t.boolean "pending_account_setup", default: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "snaptrade_user_id"
+    t.string "snaptrade_user_secret"
+    t.string "status", default: "good"
+    t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_snaptrade_items_on_family_id"
     t.index ["status"], name: "index_snaptrade_items_on_status"
   end
 
   create_table "sophtron_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "sophtron_item_id", null: false
-    t.string "name", null: false
     t.string "account_id", null: false
-    t.string "currency"
-    t.decimal "balance", precision: 19, scale: 4
-    t.decimal "available_balance", precision: 19, scale: 4
+    t.string "account_number_mask"
     t.string "account_status"
-    t.string "account_type"
     t.string "account_sub_type"
-    t.datetime "last_updated"
+    t.string "account_type"
+    t.decimal "available_balance", precision: 19, scale: 4
+    t.decimal "balance", precision: 19, scale: 4
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.string "customer_id"
     t.jsonb "institution_metadata"
+    t.datetime "last_updated"
+    t.boolean "manual_sync", default: false, null: false
+    t.string "member_id"
+    t.string "name", null: false
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
-    t.string "customer_id"
-    t.string "member_id"
-    t.datetime "created_at", null: false
+    t.uuid "sophtron_item_id", null: false
     t.datetime "updated_at", null: false
-    t.string "account_number_mask"
-    t.boolean "manual_sync", default: false, null: false
     t.index ["account_id"], name: "index_sophtron_accounts_on_account_id"
     t.index ["sophtron_item_id", "account_id"], name: "idx_unique_sophtron_accounts_per_item", unique: true
     t.index ["sophtron_item_id"], name: "index_sophtron_accounts_on_sophtron_item_id"
   end
 
   create_table "sophtron_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good"
-    t.boolean "scheduled_for_deletion", default: false
-    t.boolean "pending_account_setup", default: false
-    t.datetime "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
-    t.string "user_id", null: false
     t.string "access_key", null: false
     t.string "base_url"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "current_job_id"
+    t.uuid "current_job_sophtron_account_id"
     t.string "customer_id"
     t.string "customer_name"
-    t.jsonb "raw_customer_payload"
-    t.string "user_institution_id"
-    t.string "current_job_id"
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
     t.string "job_status"
-    t.jsonb "raw_job_payload"
     t.text "last_connection_error"
     t.boolean "manual_sync", default: false, null: false
-    t.uuid "current_job_sophtron_account_id"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false
+    t.jsonb "raw_customer_payload"
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_job_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
+    t.datetime "sync_start_date"
+    t.datetime "updated_at", null: false
+    t.string "user_id", null: false
+    t.string "user_institution_id"
     t.index ["current_job_sophtron_account_id"], name: "index_sophtron_items_on_current_job_sophtron_account_id"
     t.index ["customer_id"], name: "index_sophtron_items_on_customer_id"
     t.index ["family_id"], name: "index_sophtron_items_on_family_id"
@@ -1974,14 +1975,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "sso_audit_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id"
-    t.string "event_type", null: false
-    t.string "provider"
-    t.string "ip_address"
-    t.string "user_agent"
-    t.jsonb "metadata", default: {}, null: false
     t.datetime "created_at", null: false
+    t.string "event_type", null: false
+    t.string "ip_address"
+    t.jsonb "metadata", default: {}, null: false
+    t.string "provider"
     t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.uuid "user_id"
     t.index ["created_at"], name: "index_sso_audit_logs_on_created_at"
     t.index ["event_type"], name: "index_sso_audit_logs_on_event_type"
     t.index ["user_id", "created_at"], name: "index_sso_audit_logs_on_user_id_and_created_at"
@@ -1989,54 +1990,54 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "sso_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "strategy", null: false
-    t.string "name", null: false
-    t.string "label", null: false
-    t.string "icon"
-    t.boolean "enabled", default: true, null: false
-    t.string "issuer"
     t.string "client_id"
     t.string "client_secret"
+    t.datetime "created_at", null: false
+    t.boolean "enabled", default: true, null: false
+    t.string "icon"
+    t.string "issuer"
+    t.string "label", null: false
+    t.string "name", null: false
     t.string "redirect_uri"
     t.jsonb "settings", default: {}, null: false
-    t.datetime "created_at", null: false
+    t.string "strategy", null: false
     t.datetime "updated_at", null: false
     t.index ["enabled"], name: "index_sso_providers_on_enabled"
     t.index ["name"], name: "index_sso_providers_on_name", unique: true
   end
 
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.decimal "amount", precision: 19, scale: 4
+    t.boolean "cancel_at_period_end", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.datetime "current_period_ends_at"
     t.uuid "family_id", null: false
+    t.string "interval"
     t.string "status", null: false
     t.string "stripe_id"
-    t.decimal "amount", precision: 19, scale: 4
-    t.string "currency"
-    t.string "interval"
-    t.datetime "current_period_ends_at"
     t.datetime "trial_ends_at"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "cancel_at_period_end", default: false, null: false
     t.index ["family_id"], name: "index_subscriptions_on_family_id", unique: true
   end
 
   create_table "syncs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "syncable_type", null: false
-    t.uuid "syncable_id", null: false
-    t.string "status", default: "pending"
-    t.string "error"
-    t.jsonb "data"
+    t.datetime "cancel_requested_at"
+    t.datetime "completed_at"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.jsonb "data"
+    t.string "error"
+    t.datetime "failed_at"
     t.uuid "parent_id"
     t.datetime "pending_at"
-    t.datetime "syncing_at"
-    t.datetime "completed_at"
-    t.datetime "failed_at"
-    t.date "window_start_date"
-    t.date "window_end_date"
+    t.string "status", default: "pending"
     t.text "sync_stats"
-    t.datetime "cancel_requested_at"
+    t.uuid "syncable_id", null: false
+    t.string "syncable_type", null: false
+    t.datetime "syncing_at"
+    t.datetime "updated_at", null: false
+    t.date "window_end_date"
+    t.date "window_start_date"
     t.index ["parent_id"], name: "index_syncs_on_parent_id"
     t.index ["status"], name: "index_syncs_on_status"
     t.index ["syncable_type", "syncable_id", "created_at", "id"], name: "index_syncs_on_syncable_and_created_at_and_id", order: { created_at: :desc, id: :desc }
@@ -2044,48 +2045,48 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "taggings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "tag_id", null: false
-    t.string "taggable_type"
-    t.uuid "taggable_id"
     t.datetime "created_at", null: false
+    t.uuid "tag_id", null: false
+    t.uuid "taggable_id"
+    t.string "taggable_type"
     t.datetime "updated_at", null: false
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
     t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable"
   end
 
   create_table "tags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name"
     t.string "color", default: "#e99537", null: false
-    t.uuid "family_id", null: false
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "name"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_tags_on_family_id"
   end
 
   create_table "tool_calls", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "message_id", null: false
-    t.string "provider_id", null: false
-    t.string "provider_call_id"
-    t.string "type", null: false
-    t.string "function_name"
-    t.jsonb "function_arguments"
-    t.jsonb "function_result"
     t.datetime "created_at", null: false
+    t.jsonb "function_arguments"
+    t.string "function_name"
+    t.jsonb "function_result"
+    t.uuid "message_id", null: false
+    t.string "provider_call_id"
+    t.string "provider_id", null: false
+    t.string "type", null: false
     t.datetime "updated_at", null: false
     t.index ["message_id"], name: "index_tool_calls_on_message_id"
   end
 
   create_table "trades", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "security_id", null: false
-    t.decimal "qty", precision: 24, scale: 8
-    t.decimal "price", precision: 19, scale: 10
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "currency"
-    t.jsonb "locked_attributes", default: {}
-    t.string "investment_activity_label"
-    t.decimal "fee", precision: 19, scale: 4, default: "0.0", null: false
     t.jsonb "extra", default: {}, null: false
+    t.decimal "fee", precision: 19, scale: 4, default: "0.0", null: false
+    t.string "investment_activity_label"
+    t.jsonb "locked_attributes", default: {}
+    t.decimal "price", precision: 19, scale: 10
+    t.decimal "qty", precision: 24, scale: 8
+    t.uuid "security_id", null: false
+    t.datetime "updated_at", null: false
     t.index ["extra"], name: "index_trades_on_extra", using: :gin
     t.index ["investment_activity_label"], name: "index_trades_on_investment_activity_label"
     t.index ["security_id"], name: "index_trades_on_security_id"
@@ -2129,16 +2130,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.uuid "category_id"
-    t.uuid "merchant_id"
-    t.jsonb "locked_attributes", default: {}
-    t.string "kind", default: "standard", null: false
+    t.datetime "created_at", null: false
     t.string "external_id"
     t.jsonb "extra", default: {}, null: false
     t.string "investment_activity_label"
+    t.string "kind", default: "standard", null: false
+    t.jsonb "locked_attributes", default: {}
+    t.uuid "merchant_id"
     t.uuid "transfer_id"
+    t.datetime "updated_at", null: false
     t.index "(((extra -> 'goal'::text) ->> 'pledge_id'::text))", name: "ix_transactions_extra_goal_pledge_id", unique: true, where: "(((extra -> 'goal'::text) ->> 'pledge_id'::text) IS NOT NULL)"
     t.index ["category_id"], name: "index_transactions_on_category_id"
     t.index ["external_id"], name: "index_transactions_on_external_id"
@@ -2151,11 +2152,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
 
   create_table "transfers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.decimal "amount", precision: 19, scale: 4, default: "0.0", null: false
+    t.datetime "created_at", null: false
     t.uuid "inflow_transaction_id", null: false
+    t.text "notes"
     t.uuid "outflow_transaction_id", null: false
     t.string "status", default: "pending", null: false
-    t.text "notes"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["inflow_transaction_id", "outflow_transaction_id"], name: "idx_on_inflow_transaction_id_outflow_transaction_id_8cd07a28bd", unique: true
     t.index ["inflow_transaction_id"], name: "index_transfers_on_inflow_transaction_id"
@@ -2165,21 +2166,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "up_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "up_item_id", null: false
-    t.string "name", null: false
     t.string "account_id"
-    t.string "currency", null: false
-    t.decimal "current_balance", precision: 19, scale: 4
     t.string "account_status"
     t.string "account_type"
-    t.string "ownership_type"
-    t.string "provider"
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.decimal "current_balance", precision: 19, scale: 4
     t.boolean "ignored", default: false, null: false
     t.jsonb "institution_metadata"
+    t.string "name", null: false
+    t.string "ownership_type"
+    t.string "provider"
     t.jsonb "raw_payload"
     t.jsonb "raw_transactions_payload"
     t.date "sync_start_date"
-    t.datetime "created_at", null: false
+    t.uuid "up_item_id", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_up_accounts_on_account_id"
     t.index ["up_item_id", "account_id"], name: "index_up_accounts_on_item_and_account_id", unique: true, where: "(account_id IS NOT NULL)"
@@ -2187,57 +2188,57 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   end
 
   create_table "up_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.string "name"
-    t.string "institution_id"
-    t.string "institution_name"
-    t.string "institution_domain"
-    t.string "institution_url"
-    t.string "institution_color"
-    t.string "status", default: "good", null: false
-    t.boolean "scheduled_for_deletion", default: false, null: false
-    t.boolean "pending_account_setup", default: false, null: false
-    t.date "sync_start_date"
-    t.jsonb "raw_payload"
-    t.jsonb "raw_institution_payload"
     t.text "access_token"
     t.datetime "created_at", null: false
+    t.uuid "family_id", null: false
+    t.string "institution_color"
+    t.string "institution_domain"
+    t.string "institution_id"
+    t.string "institution_name"
+    t.string "institution_url"
+    t.string "name"
+    t.boolean "pending_account_setup", default: false, null: false
+    t.jsonb "raw_institution_payload"
+    t.jsonb "raw_payload"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
+    t.date "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_up_items_on_family_id"
     t.index ["status"], name: "index_up_items_on_status"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.boolean "ai_enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.uuid "default_account_id"
+    t.string "default_account_order", default: "name_asc"
+    t.string "default_period", default: "last_30_days", null: false
+    t.string "email"
     t.uuid "family_id", null: false
     t.string "first_name"
-    t.string "last_name"
-    t.string "email"
-    t.string "password_digest"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "role", default: "member", null: false
-    t.boolean "active", default: true, null: false
-    t.datetime "onboarded_at"
-    t.string "unconfirmed_email"
-    t.string "otp_secret"
-    t.boolean "otp_required", default: false, null: false
-    t.string "otp_backup_codes", default: [], array: true
-    t.boolean "show_sidebar", default: true
-    t.string "default_period", default: "last_30_days", null: false
-    t.uuid "last_viewed_chat_id"
-    t.boolean "show_ai_sidebar", default: true
-    t.boolean "ai_enabled", default: false, null: false
-    t.string "theme", default: "system"
-    t.boolean "rule_prompts_disabled", default: false
-    t.datetime "rule_prompt_dismissed_at"
     t.text "goals", default: [], array: true
-    t.datetime "set_onboarding_preferences_at"
-    t.datetime "set_onboarding_goals_at"
-    t.string "default_account_order", default: "name_asc"
-    t.string "ui_layout"
-    t.jsonb "preferences", default: {}, null: false
+    t.string "last_name"
+    t.uuid "last_viewed_chat_id"
     t.string "locale"
-    t.uuid "default_account_id"
+    t.datetime "onboarded_at"
+    t.string "otp_backup_codes", default: [], array: true
+    t.boolean "otp_required", default: false, null: false
+    t.string "otp_secret"
+    t.string "password_digest"
+    t.jsonb "preferences", default: {}, null: false
+    t.string "role", default: "member", null: false
+    t.datetime "rule_prompt_dismissed_at"
+    t.boolean "rule_prompts_disabled", default: false
+    t.datetime "set_onboarding_goals_at"
+    t.datetime "set_onboarding_preferences_at"
+    t.boolean "show_ai_sidebar", default: true
+    t.boolean "show_sidebar", default: true
+    t.string "theme", default: "system"
+    t.string "ui_layout"
+    t.string "unconfirmed_email"
+    t.datetime "updated_at", null: false
     t.string "webauthn_id"
     t.index ["default_account_id"], name: "index_users_on_default_account_id"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -2251,33 +2252,33 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
 
   create_table "valuations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.jsonb "locked_attributes", default: {}
     t.string "kind", default: "reconciliation", null: false
+    t.jsonb "locked_attributes", default: {}
+    t.datetime "updated_at", null: false
   end
 
   create_table "vehicles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.jsonb "locked_attributes", default: {}
+    t.string "make"
+    t.string "mileage_unit"
+    t.integer "mileage_value"
+    t.string "model"
+    t.string "subtype"
     t.datetime "updated_at", null: false
     t.integer "year"
-    t.integer "mileage_value"
-    t.string "mileage_unit"
-    t.string "make"
-    t.string "model"
-    t.jsonb "locked_attributes", default: {}
-    t.string "subtype"
   end
 
   create_table "webauthn_credentials", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.string "nickname", null: false
+    t.datetime "created_at", null: false
     t.string "credential_id", null: false
+    t.datetime "last_used_at"
+    t.string "nickname", null: false
     t.text "public_key", null: false
     t.bigint "sign_count", default: 0, null: false
     t.string "transports", default: [], null: false, array: true
-    t.datetime "last_used_at"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
     t.index ["credential_id"], name: "index_webauthn_credentials_on_credential_id", unique: true
     t.index ["user_id"], name: "index_webauthn_credentials_on_user_id"
     t.check_constraint "sign_count >= 0", name: "chk_webauthn_credentials_sign_count_non_negative"
@@ -2442,7 +2443,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_25_000000) do
   add_foreign_key "trading212_items", "families"
   add_foreign_key "transactions", "categories", on_delete: :nullify
   add_foreign_key "transactions", "merchants"
-  add_foreign_key "transactions", "transfers", column: "transfer_id"
+  add_foreign_key "transactions", "transfers"
   add_foreign_key "transfers", "transactions", column: "inflow_transaction_id", on_delete: :cascade
   add_foreign_key "transfers", "transactions", column: "outflow_transaction_id", on_delete: :cascade
   add_foreign_key "up_accounts", "up_items"

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -123,8 +123,8 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "bootstrap" do
-    # 22 default categories minus 2 that already exist in fixtures (Income, Food & Drink)
-    assert_difference "Category.count", 20 do
+    # 23 default categories minus 2 that already exist in fixtures (Income, Food & Drink)
+    assert_difference "Category.count", 21 do
       post bootstrap_categories_url
     end
 

--- a/test/models/loan/payment_resplitter_test.rb
+++ b/test/models/loan/payment_resplitter_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Loan::PaymentResplitterTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @checking = accounts(:depository)
+    @loan_account = Account.create! \
+      family: @family,
+      name: "Auto Loan",
+      balance: 10000,
+      currency: "USD",
+      accountable: Loan.create!(subtype: "auto", interest_rate: 6, rate_type: "fixed", auto_split_payments: true)
+  end
+
+  test "retroactively splits existing full-amount payments in chronological order" do
+    # Two legacy payments applied as full-amount transfers (pre-feature).
+    create_full_payment(amount: 300, date: 2.months.ago.to_date)
+    create_full_payment(amount: 300, date: 1.month.ago.to_date)
+
+    Loan::PaymentResplitter.new(@loan_account).call
+
+    # Each payment now records interest as an expense, principal against the loan.
+    interest_entries = @checking.entries
+                                .joins("JOIN transactions t ON t.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+                                .where(t: { category_id: @family.loan_interest_category.id })
+                                .order(:date)
+
+    # Month 1: 10000 * 6% / 12 = 50.00
+    # Month 2: (10000 - 250) * 6% / 12 = 48.75  <- reflects the prior principal
+    assert_equal [ 50.0, 48.75 ], interest_entries.map { |e| e.amount.to_f }
+
+    # Loan now holds two principal entries (250.00 and 251.25), not the full 600.
+    loan_principals = @loan_account.entries.order(:date).map { |e| e.amount.to_f }
+    assert_equal [ -250.0, -251.25 ], loan_principals
+  end
+
+  test "is idempotent - already-split payments are not touched again" do
+    create_full_payment(amount: 300, date: 1.month.ago.to_date)
+
+    Loan::PaymentResplitter.new(@loan_account).call
+    loan_entries_after_first = @loan_account.entries.order(:date).map { |e| e.amount.to_f }
+
+    Loan::PaymentResplitter.new(@loan_account).call
+    loan_entries_after_second = @loan_account.entries.order(:date).map { |e| e.amount.to_f }
+
+    assert_equal loan_entries_after_first, loan_entries_after_second
+  end
+
+  private
+    def create_full_payment(amount:, date:)
+      Transfer::Creator.new(
+        family: @family,
+        source_account_id: @checking.id,
+        destination_account_id: @loan_account.id,
+        date: date,
+        amount: amount
+      ).create
+    end
+end

--- a/test/models/loan/payment_resplitter_test.rb
+++ b/test/models/loan/payment_resplitter_test.rb
@@ -34,6 +34,30 @@ class Loan::PaymentResplitterTest < ActiveSupport::TestCase
     assert_equal [ -250.0, -251.25 ], loan_principals
   end
 
+  test "leaves an interest-heavy payment as a full transfer instead of silently dropping it" do
+    # Monthly interest on the opening balance is 10000 * 6% / 12 = 50.00, so a
+    # $40 payment is entirely interest: principal would be <= 0 and the split is
+    # not applicable. The original full-amount transfer must survive rather than
+    # be destroyed with nothing to replace it, which would leave the payment
+    # unlinked and drop the loan's principal reduction with no error.
+    transfer = create_full_payment(amount: 40, date: 1.month.ago.to_date)
+    loan_entry_id = transfer.inflow_transaction.entry.id
+
+    Loan::PaymentResplitter.new(@loan_account).call
+
+    assert Transfer.exists?(transfer.id), "original transfer was destroyed with no replacement"
+    assert Entry.exists?(loan_entry_id), "loan principal reduction was dropped"
+
+    # The loan still carries its single full-amount principal reduction...
+    assert_equal [ -40.0 ], @loan_account.entries.map { |e| e.amount.to_f }
+
+    # ...and no interest expense leaked onto the checking account.
+    interest_entries = @checking.entries
+                                .joins("JOIN transactions t ON t.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+                                .where(t: { category_id: @family.loan_interest_category.id })
+    assert_empty interest_entries
+  end
+
   test "is idempotent - already-split payments are not touched again" do
     create_full_payment(amount: 300, date: 1.month.ago.to_date)
 

--- a/test/models/loan/payment_resplitter_test.rb
+++ b/test/models/loan/payment_resplitter_test.rb
@@ -58,6 +58,37 @@ class Loan::PaymentResplitterTest < ActiveSupport::TestCase
     assert_empty interest_entries
   end
 
+  test "retained multi-currency payment reduces the running balance by its loan-side amount" do
+    # A EUR payment into a USD loan can't be split (currency mismatch), so it is
+    # left as a full-amount transfer. The replay's running balance must fall by
+    # the transfer's USD loan-side amount (100 EUR * 1.1 = 110 USD), not the raw
+    # EUR cash figure, so a later same-currency payment prices interest correctly.
+    eur_checking = Account.create! \
+      family: @family, name: "EUR Checking", balance: 1000, currency: "EUR",
+      accountable: Depository.new
+
+    Transfer::Creator.new(
+      family: @family,
+      source_account_id: eur_checking.id,
+      destination_account_id: @loan_account.id,
+      date: 2.months.ago.to_date,
+      amount: 100,
+      exchange_rate: 1.1
+    ).create
+
+    create_full_payment(amount: 300, date: 1.month.ago.to_date)
+
+    Loan::PaymentResplitter.new(@loan_account).call
+
+    # Interest on the USD payment reflects 10000 - 110 = 9890 outstanding:
+    # 9890 * 6% / 12 = 49.45 (it would be 49.50 if the EUR cash amount were used).
+    interest = @checking.entries
+                        .joins("JOIN transactions t ON t.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+                        .where(t: { category_id: @family.loan_interest_category.id })
+                        .sole
+    assert_equal 49.45, interest.amount.to_f
+  end
+
   test "is idempotent - already-split payments are not touched again" do
     create_full_payment(amount: 300, date: 1.month.ago.to_date)
 

--- a/test/models/loan/payment_splitter_test.rb
+++ b/test/models/loan/payment_splitter_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class Loan::PaymentSplitterTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:dylan_family)
+    @checking = accounts(:depository)
+    @loan_account = Account.create! \
+      family: @family,
+      name: "Auto Loan",
+      balance: 10000,
+      currency: "USD",
+      accountable: Loan.create!(subtype: "auto", interest_rate: 6, rate_type: "fixed", auto_split_payments: true)
+  end
+
+  test "splits a payment into a principal transfer and an interest expense" do
+    payment = create_transaction(account: @checking, amount: 300, name: "Bridgecrest Payment")
+
+    splitter = Loan::PaymentSplitter.new(payment_entry: payment, loan_account: @loan_account)
+    assert splitter.applicable?
+
+    transfer = nil
+    assert_difference -> { @checking.entries.count } => 2, -> { @loan_account.entries.count } => 1 do
+      transfer = splitter.split!
+    end
+
+    assert transfer.persisted?
+
+    # Original payment becomes an excluded split parent with two children.
+    payment.reload
+    assert payment.excluded?
+    assert_equal 2, payment.child_entries.count
+
+    interest_child = payment.child_entries.find { |e| e.amount == 50 }
+    principal_child = payment.child_entries.find { |e| e.amount == 250 }
+    assert interest_child.present?
+    assert principal_child.present?
+
+    # Interest portion is a categorized expense, NOT part of the transfer.
+    assert_equal @family.loan_interest_category, interest_child.transaction.category
+    assert_not interest_child.transaction.transfer?
+
+    # Principal portion is the outflow side of a loan-payment transfer.
+    assert_equal "loan_payment", principal_child.transaction.kind
+    assert_equal principal_child.transaction, transfer.outflow_transaction
+
+    # Loan receives only the principal (negative reduces the liability balance).
+    loan_entry = transfer.inflow_transaction.entry
+    assert_equal @loan_account, loan_entry.account
+    assert_equal(-250, loan_entry.amount)
+    assert_equal "funds_movement", transfer.inflow_transaction.kind
+  end
+
+  test "reversing the transfer restores the original payment and removes the loan entry" do
+    payment = create_transaction(account: @checking, amount: 300, name: "Bridgecrest Payment")
+    transfer = Loan::PaymentSplitter.new(payment_entry: payment, loan_account: @loan_account).split!
+
+    assert_difference -> { @loan_account.entries.count } => -1,
+                      -> { Entry.where(parent_entry_id: payment.id).count } => -2 do
+      transfer.destroy!
+    end
+
+    payment.reload
+    assert_not payment.excluded?
+    assert_equal 0, payment.child_entries.count
+    assert_equal 300, payment.amount
+  end
+
+  test "is not applicable when auto-splitting is disabled" do
+    @loan_account.loan.update!(auto_split_payments: false)
+    payment = create_transaction(account: @checking, amount: 300)
+
+    splitter = Loan::PaymentSplitter.new(payment_entry: payment, loan_account: @loan_account)
+
+    assert_not splitter.applicable?
+    assert_nil splitter.split!
+  end
+
+  test "is not applicable when the loan has no interest rate" do
+    @loan_account.loan.update!(interest_rate: nil)
+    payment = create_transaction(account: @checking, amount: 300)
+
+    splitter = Loan::PaymentSplitter.new(payment_entry: payment, loan_account: @loan_account)
+
+    assert_not splitter.applicable?
+  end
+
+  test "is not applicable for an entry already involved in a transfer or split" do
+    payment = create_transaction(account: @checking, amount: 300)
+    payment.update!(excluded: true)
+
+    splitter = Loan::PaymentSplitter.new(payment_entry: payment, loan_account: @loan_account)
+
+    assert_not splitter.applicable?
+  end
+end

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -23,4 +23,44 @@ class LoanTest < ActiveSupport::TestCase
 
     assert_equal 2245, loan_account.loan.monthly_payment.amount
   end
+
+  test "splits_payments? requires the toggle and a positive rate" do
+    loan = Loan.new(auto_split_payments: true, interest_rate: 6)
+    assert loan.splits_payments?
+
+    assert_not Loan.new(auto_split_payments: false, interest_rate: 6).splits_payments?
+    assert_not Loan.new(auto_split_payments: true, interest_rate: nil).splits_payments?
+    assert_not Loan.new(auto_split_payments: true, interest_rate: 0).splits_payments?
+  end
+
+  test "computes interest and principal portions from outstanding balance and rate" do
+    loan_account = Account.create! \
+      family: families(:dylan_family),
+      name: "Auto Loan",
+      balance: 10000,
+      currency: "USD",
+      accountable: Loan.create!(subtype: "auto", interest_rate: 6, rate_type: "fixed", auto_split_payments: true)
+
+    loan = loan_account.loan
+
+    # No materialized balances yet -> falls back to original balance (10000).
+    # Monthly interest = 10000 * 6% / 12 = 50; principal = payment - interest.
+    assert_equal 50, loan.interest_portion(payment_amount: 300, as_of_date: Date.current).amount
+    assert_equal 250, loan.principal_portion(payment_amount: 300, as_of_date: Date.current).amount
+  end
+
+  test "interest portion is clamped to the payment amount for tiny payments" do
+    loan_account = Account.create! \
+      family: families(:dylan_family),
+      name: "Auto Loan",
+      balance: 10000,
+      currency: "USD",
+      accountable: Loan.create!(subtype: "auto", interest_rate: 6, rate_type: "fixed", auto_split_payments: true)
+
+    loan = loan_account.loan
+
+    # Accrued interest would be 50, but the payment is only 30.
+    assert_equal 30, loan.interest_portion(payment_amount: 30, as_of_date: Date.current).amount
+    assert_equal 0, loan.principal_portion(payment_amount: 30, as_of_date: Date.current).amount
+  end
 end


### PR DESCRIPTION
## What & why

Manual loan accounts (e.g. a subprime auto loan that Plaid can't sync) receive a single monthly payment from a linked checking account. Today, linking that payment to the loan applies the **entire amount** against the balance as a transfer. For an amortizing loan that's wrong: only the **principal** portion should reduce the balance; the **interest** portion is a cost and should be recorded as an expense.

This PR adds an opt-in, per-loan setting that automatically splits each linked payment into principal (a transfer that reduces the loan) and interest (a categorized expense), recomputing the breakdown every period from the outstanding balance and rate — so it tracks the amortization schedule as the balance falls.

## Behavior

- New per-loan toggle **Auto-split payments** (`loans.auto_split_payments`, default off). Only active when an interest rate is set.
- When a payment is linked to such a loan, `Loan::PaymentSplitter`:
  - computes `interest = outstanding_balance × rate/100 ÷ 12` (clamped to `0..payment`), `principal = payment − interest`;
  - splits the cash-side entry into a principal child (linked to the loan as a `loan_payment` transfer) and an interest child (categorized **Loan Interest**);
  - leaves the loan reduced by principal only.
- Unmatching the transfer fully reverses the split (restores the original single payment) — handled in `Transfer#destroy!`.
- **Historical fix:** `Loan::PaymentResplitter` (exposed via a "Recalculate past payments" action on the loan) replays already-linked full-amount payments oldest→newest, re-splitting each using the balance left by the prior one. Idempotent (already-split payments are skipped).
- Adds **Loan Interest** to the default categories; `Family#loan_interest_category` creates it on demand for existing families.

## Design notes

- No new "service" layer — logic lives in POROs under `app/models/loan/` (mirroring `Transfer::Creator`) and on the `Loan` model.
- Balance handling is unchanged: a loan's balance is the sum of its entries, so making the loan-side entry principal-only is sufficient. The `Transfer` opposite-amounts invariant is why the interest must live on the cash side rather than inside the transfer.
- Interest uses simple monthly accrual (rate ÷ 12). Non-monthly frequencies and alternate day-count conventions are out of scope here (monthly covers standard amortizing consumer loans); the accrual is centralized in `Loan#interest_portion` if that's extended later.
- Multi-currency payments (cash currency ≠ loan currency) fall back to the normal full-amount transfer.

## Tests

- `Loan` math incl. clamping; `Loan::PaymentSplitter` (split shape, categories, not-applicable cases, unmatch teardown); `Loan::PaymentResplitter` (chronological interest across periods, idempotency); updated the default-category bootstrap count.
- Full suite green; `rubocop`, `erb_lint`, `brakeman` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic splitting of eligible loan payments into principal transfers and loan interest expenses.
  * Added a loan setting to enable automatic payment splitting.
  * Added support for retroactively resplitting existing eligible payments.
  * Added a dedicated “Loan Interest” category.
  * Deleting a split transfer now restores the original payment.

* **Bug Fixes**
  * Improved handling of loan payment transfers and balance calculations.

* **Documentation**
  * Added labels, descriptions, confirmations, and success messages for payment splitting and resplitting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->