### PR TITLE
fix(enable-banking): preserve manual card limit when provider reports zero

### DIFF
--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -103,8 +103,8 @@ class EnableBankingAccount::Processor
         # limit: the API-provided one, or a user-entered value when the API
         # omits it. Writing the limit back (never the reported balance) keeps
         # the field stable across syncs so a manual limit is never clobbered.
-        credit_limit = positive_amount(enable_banking_account.credit_limit) ||
-                       positive_amount(account.accountable&.available_credit)
+        credit_limit = positive_credit_limit(enable_banking_account.credit_limit) ||
+                       positive_credit_limit(account.accountable&.available_credit)
 
         unless account.accountable.present?
           capture_debug_log("CreditCard accountable missing for account", account)
@@ -128,11 +128,12 @@ class EnableBankingAccount::Processor
         end
       else
         # Default behavior: API returns outstanding debt
-        provider_credit_limit = positive_amount(enable_banking_account.credit_limit)
+        provider_credit_limit = positive_credit_limit(enable_banking_account.credit_limit)
         available_credit = if provider_credit_limit
           [ provider_credit_limit - reported_balance, 0 ].max
         else
-          # A missing or zero API limit must not erase user-entered metadata.
+          # In this mode available_credit is the actual remaining credit, not a
+          # limit, so zero is valid and must be preserved intentionally.
           account.accountable&.available_credit
         end
 
@@ -140,8 +141,9 @@ class EnableBankingAccount::Processor
       end
     end
 
-    # Returns the amount only when it is positive, otherwise nil.
-    def positive_amount(value)
+    # Credit limits must be positive. Non-positive provider or manual values
+    # mean that no usable limit is known.
+    def positive_credit_limit(value)
       value if value&.positive?
     end
 

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -103,8 +103,8 @@ class EnableBankingAccount::Processor
         # limit: the API-provided one, or a user-entered value when the API
         # omits it. Writing the limit back (never the reported balance) keeps
         # the field stable across syncs so a manual limit is never clobbered.
-        credit_limit = enable_banking_account.credit_limit.presence ||
-                       account.accountable&.available_credit
+        credit_limit = positive_amount(enable_banking_account.credit_limit) ||
+                       positive_amount(account.accountable&.available_credit)
 
         unless account.accountable.present?
           capture_debug_log("CreditCard accountable missing for account", account)
@@ -128,15 +128,20 @@ class EnableBankingAccount::Processor
         end
       else
         # Default behavior: API returns outstanding debt
-        available_credit = if enable_banking_account.credit_limit.present?
-          [ enable_banking_account.credit_limit - reported_balance, 0 ].max
-        elsif account.accountable&.available_credit.present?
-          # No limit from API, but we have stored available_credit metadata
-          account.accountable.available_credit
+        provider_credit_limit = positive_amount(enable_banking_account.credit_limit)
+        available_credit = if provider_credit_limit
+          [ provider_credit_limit - reported_balance, 0 ].max
+        else
+          # A missing or zero API limit must not erase user-entered metadata.
+          account.accountable&.available_credit
         end
 
         [ reported_balance, available_credit, false ]
       end
+    end
+
+    def positive_amount(value)
+      value if value&.positive?
     end
 
     def capture_debug_log(message, account)

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -140,6 +140,7 @@ class EnableBankingAccount::Processor
       end
     end
 
+    # Returns the amount only when it is positive, otherwise nil.
     def positive_amount(value)
       value if value&.positive?
     end

--- a/test/models/enable_banking_account/processor_test.rb
+++ b/test/models/enable_banking_account/processor_test.rb
@@ -71,21 +71,23 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
-  test "available credit mode uses manual limit when provider reports a zero limit" do
+  test "available credit mode uses manual limit when provider reports a non-positive limit" do
     cc_account = accounts(:credit_card)
     cc_account.accountable.update!(available_credit: 3000.00)
-
-    @enable_banking_account.update!(
-      current_balance: 2995.32,
-      credit_limit: 0,
-      treat_balance_as_available_credit: true
-    )
     relink_provider_to(cc_account)
 
-    EnableBankingAccount::Processor.new(@enable_banking_account).process
+    [ 0, -1 ].each do |provider_credit_limit|
+      @enable_banking_account.update!(
+        current_balance: 2995.32,
+        credit_limit: provider_credit_limit,
+        treat_balance_as_available_credit: true
+      )
 
-    assert_equal 4.68, cc_account.reload.cash_balance
-    assert_equal 3000.0, cc_account.accountable.reload.available_credit
+      EnableBankingAccount::Processor.new(@enable_banking_account).process
+
+      assert_equal 4.68, cc_account.reload.cash_balance
+      assert_equal 3000.0, cc_account.accountable.reload.available_credit
+    end
   end
 
   test "when treat_balance_as_available_credit is true and card is overpaid, floors debt at zero" do

--- a/test/models/enable_banking_account/processor_test.rb
+++ b/test/models/enable_banking_account/processor_test.rb
@@ -71,6 +71,23 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "available credit mode uses manual limit when provider reports a zero limit" do
+    cc_account = accounts(:credit_card)
+    cc_account.accountable.update!(available_credit: 3000.00)
+
+    @enable_banking_account.update!(
+      current_balance: 2995.32,
+      credit_limit: 0,
+      treat_balance_as_available_credit: true
+    )
+    relink_provider_to(cc_account)
+
+    EnableBankingAccount::Processor.new(@enable_banking_account).process
+
+    assert_equal 4.68, cc_account.reload.cash_balance
+    assert_equal 3000.0, cc_account.accountable.reload.available_credit
+  end
+
   test "when treat_balance_as_available_credit is true and card is overpaid, floors debt at zero" do
     cc_account = accounts(:credit_card)
 

--- a/test/models/enable_banking_account/processor_test.rb
+++ b/test/models/enable_banking_account/processor_test.rb
@@ -174,6 +174,25 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "default balance mode preserves remaining credit when provider limit is non-positive" do
+    cc_account = accounts(:credit_card)
+    cc_account.accountable.update!(available_credit: 3000.00)
+    relink_provider_to(cc_account)
+
+    [ 0, -1 ].each do |provider_credit_limit|
+      @enable_banking_account.update!(
+        current_balance: 100.00,
+        credit_limit: provider_credit_limit,
+        treat_balance_as_available_credit: false
+      )
+
+      EnableBankingAccount::Processor.new(@enable_banking_account).process
+
+      assert_equal 100.0, cc_account.reload.cash_balance
+      assert_equal 3000.0, cc_account.accountable.reload.available_credit
+    end
+  end
+
   test "sets CC balance to absolute debt when both limit and stored available_credit are absent" do
     cc_account = accounts(:credit_card)
     cc_account.accountable.update!(available_credit: nil)


### PR DESCRIPTION
## Summary

This fixes Enable Banking credit card synchronization when the provider reports a credit limit of `0`.

In available-credit mode, Sure uses either the provider-reported credit limit or the manually entered Available credit value to derive the outstanding debt. Rails considers numeric zero present, so a provider limit of `0` was previously preferred over the manual value.

This caused the manual card limit to be overwritten with zero and prevented the correct debt from being calculated.

## Changes

- Treat zero and negative provider credit limits as unavailable.
- Fall back to the manually entered card limit when the provider limit is unusable.
- Preserve manually entered available-credit metadata during normal balance synchronization.
- Add regression coverage for the observed scenario.

## Example

Given:

- Provider balance: `€2,995.32`
- Provider credit limit: `€0`
- Manually entered card limit: `€3,000`
- “Balance is available credit” enabled

Sure now preserves the manual `€3,000` limit and derives:

`€3,000.00 - €2,995.32 = €4.68` outstanding debt.

## Why

Some Enable Banking institutions return a zero credit limit even though the limit is unavailable rather than genuinely zero.

A non-positive provider limit should not overwrite a valid user-entered value.

## Validation

Focused model test:

```text
bin/rails test test/models/enable_banking_account/processor_test.rb
```

Results:

- 12 tests
- 22 assertions
- 0 failures
- 0 errors
- 0 skips

The change was also tested against the affected staging account. The manual `€3,000` value remains after synchronization.

A temporary upstream `ASPSP_ERROR: Service unavailable` prevented the latest bank balance request from completing, so the existing account balance was correctly preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved manually configured available credit when the provider returns a missing, zero, or negative credit limit.
  * Corrected cash balance/debt calculations to treat non-positive provider limits as “absent,” ensuring stored available credit is retained appropriately.
  * Updated behavior consistency between available-credit mode and default balance mode for non-positive credit limits.
* **Tests**
  * Added test cases covering provider `credit_limit` values of `0` and `-1` in both operating modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->