### PR TITLE
fix(oidc): honor http issuer scheme during OIDC discovery

### DIFF
--- a/config/initializers/openid_connect_http_discovery.rb
+++ b/config/initializers/openid_connect_http_discovery.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Patch: honor the issuer's scheme during OIDC discovery.
+#
+# The openid_connect/swd gems hardcode discovery to HTTPS (SWD.url_builder defaults to
+# URI::HTTPS, and Config::Resource drops the issuer's scheme), so an http:// issuer -
+# a self-hosted IdP without SSL - is upgraded to https:443 and fails to connect.
+#
+# Only the discovery request is affected: the endpoints it returns are absolute, and
+# rack-oauth2 keeps a scheme that is already present, so the rest of the flow follows.
+#
+# Verified against openid_connect 2.3.1 / swd 2.0.3 - revisit if those are upgraded.
+# See https://github.com/we-promise/sure/issues/2844.
+require "openid_connect"
+
+module OpenIDConnect
+  module Discovery
+    module Provider
+      class Config
+        class Resource
+          def initialize(uri)
+            @scheme = uri.scheme
+            @host = uri.host
+            @port = uri.port unless [ 80, 443 ].include?(uri.port)
+            @path = File.join uri.path, ".well-known/openid-configuration"
+            attr_missing!
+          end
+
+          def endpoint
+            url_builder = @scheme == "http" ? URI::HTTP : URI::HTTPS
+            url_builder.build [ nil, host, port, path, nil, nil ]
+          rescue URI::Error => e
+            raise SWD::Exception.new(e.message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/openid_connect_http_discovery.rb
+++ b/config/initializers/openid_connect_http_discovery.rb
@@ -8,6 +8,8 @@
 #
 # Only the discovery request is affected: the endpoints it returns are absolute, and
 # rack-oauth2 keeps a scheme that is already present, so the rest of the flow follows.
+# The port and cache-key handling below are also made scheme-aware so an http:// issuer
+# never drops an explicit port or reuses an https:// issuer's cached metadata.
 #
 # Verified against openid_connect 2.3.1 / swd 2.0.3 - revisit if those are upgraded.
 # See https://github.com/we-promise/sure/issues/2844.
@@ -21,7 +23,9 @@ module OpenIDConnect
           def initialize(uri)
             @scheme = uri.scheme
             @host = uri.host
-            @port = uri.port unless [ 80, 443 ].include?(uri.port)
+            # Only omit the scheme's own default port, so an explicitly configured
+            # non-default port (e.g. http on 443, https on 80) is preserved.
+            @port = uri.port unless uri.port == uri.default_port
             @path = File.join uri.path, ".well-known/openid-configuration"
             attr_missing!
           end
@@ -32,6 +36,16 @@ module OpenIDConnect
           rescue URI::Error => e
             raise SWD::Exception.new(e.message)
           end
+
+          private
+
+            # The gem keys the discovery cache on host alone. Now that a single host
+            # can be reached over more than one scheme/port/path, include those so an
+            # http:// issuer never reuses an https:// issuer's cached metadata.
+            def cache_key
+              digest = OpenSSL::Digest::SHA256.hexdigest [ @scheme, host, port, path ].join(" ")
+              "swd:resource:opneid-conf:#{digest}"
+            end
         end
       end
     end

--- a/test/initializers/openid_connect_http_discovery_test.rb
+++ b/test/initializers/openid_connect_http_discovery_test.rb
@@ -25,6 +25,21 @@ class OpenIDConnectHttpDiscoveryTest < ActiveSupport::TestCase
     assert_equal "http://auth.example:9000/.well-known/openid-configuration", endpoint.to_s
   end
 
+  test "explicit non-default port is preserved per scheme" do
+    http_443 = Resource.new(URI.parse("http://auth.example:443")).endpoint
+    https_80 = Resource.new(URI.parse("https://auth.example:80")).endpoint
+
+    assert_equal "http://auth.example:443/.well-known/openid-configuration", http_443.to_s
+    assert_equal "https://auth.example:80/.well-known/openid-configuration", https_80.to_s
+  end
+
+  test "cache key distinguishes scheme on the same host" do
+    http = Resource.new(URI.parse("http://auth.example"))
+    https = Resource.new(URI.parse("https://auth.example"))
+
+    refute_equal http.send(:cache_key), https.send(:cache_key)
+  end
+
   test "issuer path prefix is preserved" do
     endpoint = Resource.new(URI.parse("http://auth.example/application/o/sure")).endpoint
 

--- a/test/initializers/openid_connect_http_discovery_test.rb
+++ b/test/initializers/openid_connect_http_discovery_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression coverage for https://github.com/we-promise/sure/issues/2844 - a
+# self-hosted IdP served over plain HTTP was upgraded to https:443 during discovery.
+class OpenIDConnectHttpDiscoveryTest < ActiveSupport::TestCase
+  Resource = OpenIDConnect::Discovery::Provider::Config::Resource
+
+  test "http issuer builds an http discovery endpoint" do
+    endpoint = Resource.new(URI.parse("http://auth.example")).endpoint
+
+    assert_equal "http://auth.example/.well-known/openid-configuration", endpoint.to_s
+  end
+
+  test "https issuer still builds an https discovery endpoint" do
+    endpoint = Resource.new(URI.parse("https://auth.example")).endpoint
+
+    assert_equal "https://auth.example/.well-known/openid-configuration", endpoint.to_s
+  end
+
+  test "custom http port is preserved" do
+    endpoint = Resource.new(URI.parse("http://auth.example:9000")).endpoint
+
+    assert_equal "http://auth.example:9000/.well-known/openid-configuration", endpoint.to_s
+  end
+
+  test "issuer path prefix is preserved" do
+    endpoint = Resource.new(URI.parse("http://auth.example/application/o/sure")).endpoint
+
+    assert_equal "http://auth.example/application/o/sure/.well-known/openid-configuration", endpoint.to_s
+  end
+end

--- a/test/initializers/openid_connect_http_discovery_test.rb
+++ b/test/initializers/openid_connect_http_discovery_test.rb
@@ -33,11 +33,14 @@ class OpenIDConnectHttpDiscoveryTest < ActiveSupport::TestCase
     assert_equal "https://auth.example:80/.well-known/openid-configuration", https_80.to_s
   end
 
-  test "cache key distinguishes scheme on the same host" do
-    http = Resource.new(URI.parse("http://auth.example"))
-    https = Resource.new(URI.parse("https://auth.example"))
+  test "cache key varies by scheme, port, and path on the same host" do
+    baseline = cache_key_for("http://auth.example")
+    other_scheme = cache_key_for("https://auth.example")
+    other_port = cache_key_for("http://auth.example:9000")
+    other_path = cache_key_for("http://auth.example/application/o/sure")
 
-    refute_equal http.send(:cache_key), https.send(:cache_key)
+    keys = [ baseline, other_scheme, other_port, other_path ]
+    assert_equal keys.length, keys.uniq.length, "each of scheme/port/path must produce a distinct cache key"
   end
 
   test "issuer path prefix is preserved" do
@@ -45,4 +48,9 @@ class OpenIDConnectHttpDiscoveryTest < ActiveSupport::TestCase
 
     assert_equal "http://auth.example/application/o/sure/.well-known/openid-configuration", endpoint.to_s
   end
+
+  private
+    def cache_key_for(issuer)
+      Resource.new(URI.parse(issuer)).send(:cache_key)
+    end
 end


### PR DESCRIPTION
## Summary

Fixes #2844 — self-hosted OIDC providers served over plain **HTTP** (no SSL) fail login with:

```
Failed to open TCP connection to <issuer>:443 (Connection refused) — OpenIDConnect::Discovery::DiscoveryFailed
```

even though the issuer is `http://…`.

## Root cause

OIDC discovery is hardcoded to HTTPS in the underlying gems, not in Sure's config:

- `swd` (2.0.3): `SWD.url_builder` defaults to `URI::HTTPS`.
- `openid_connect` (2.3.1): `OpenIDConnect::Discovery::Provider::Config::Resource#initialize` keeps only host/port/path and **discards the issuer's scheme**, then `#endpoint` rebuilds the `.well-known/openid-configuration` URL as `https://…`.

So an `http://auth.host` issuer is upgraded to `https://auth.host:443` and the connection is refused. This also explains why the in-app **"Test connection"** succeeds while real login fails — the tester (`SsoProviderTester`) uses Faraday against the raw issuer URL and never goes through the gem's discovery path.

## Fix

A small initializer reopens `Config::Resource` to remember `uri.scheme` and build the discovery endpoint with `URI::HTTP` or `URI::HTTPS` accordingly.

- Per-request; **no global mutable state** (avoids `SWD.url_builder =` which would break mixed http/https providers).
- `https://` issuers and default-port normalization are unchanged.
- Custom ports and issuer path prefixes (e.g. Authentik's `/application/o/<slug>`) are preserved.

Only discovery needs patching: the endpoints it returns are absolute, and `rack-oauth2`'s `absolute_uri_for` keeps an already-present scheme (`scheme ||= …`), so the token/userinfo/jwks calls follow over http automatically.

Before vs. after:

```
BEFORE: http://auth.internal  -> https://auth.internal/.well-known/openid-configuration   ← the bug
AFTER:  http://auth.internal  -> http://auth.internal/.well-known/openid-configuration
        https://auth.internal -> https://auth.internal/.well-known/openid-configuration    ← unchanged
        http://auth.internal:9000 -> http://auth.internal:9000/.well-known/openid-configuration
```

## Testing

- New `test/initializers/openid_connect_http_discovery_test.rb` (http, https-unchanged, custom port, path-prefixed issuer).
- Full suite: **6026 runs, 24058 assertions, 0 failures, 0 errors**.
- `bin/rubocop` clean; `bin/brakeman` 0 warnings.

> Verified against `openid_connect 2.3.1` / `swd 2.0.3` — the patch notes this so it can be revisited if those gems are upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenID Connect discovery to respect the issuer’s scheme (HTTP stays HTTP; HTTPS stays HTTPS) instead of upgrading during discovery.
  * Preserved issuer ports, including non-default ports, and any issuer path prefix when constructing discovery requests.
  * Prevented cached discovery metadata from being reused across different schemes, ports, or issuer paths for the same host.

* **Tests**
  * Expanded regression coverage to verify cache keys vary by scheme, port, and path, ensuring distinct issuers don’t share cached metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->