### PR TITLE
Stabilize net worth breakdown series tests

### DIFF
--- a/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
+++ b/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
@@ -12,12 +12,12 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilderTest < ActiveSupport::TestCase
   end
 
   test "builds monthly points with group breakdown that sums to net worth" do
-    period = Period.custom(start_date: 3.months.ago.to_date, end_date: Date.current)
+    period = Period.custom(start_date: Date.new(2026, 4, 15), end_date: Date.new(2026, 7, 15))
 
     create_balance(account: @asset_account, date: period.start_date, balance: 5000)
-    create_balance(account: @asset_account, date: Date.current, balance: 6000)
+    create_balance(account: @asset_account, date: period.end_date, balance: 6000)
     create_balance(account: @liability_account, date: period.start_date, balance: 1000)
-    create_balance(account: @liability_account, date: Date.current, balance: 1500)
+    create_balance(account: @liability_account, date: period.end_date, balance: 1500)
 
     series = builder.breakdown_series(period: period)
 
@@ -47,10 +47,10 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilderTest < ActiveSupport::TestCase
   end
 
   test "includes group metadata and excludes groups with no balances" do
-    period = Period.custom(start_date: 1.month.ago.to_date, end_date: Date.current)
+    period = Period.custom(start_date: Date.new(2026, 6, 15), end_date: Date.new(2026, 7, 15))
 
-    create_balance(account: @asset_account, date: Date.current, balance: 5000)
-    create_balance(account: @liability_account, date: Date.current, balance: 1000)
+    create_balance(account: @asset_account, date: period.end_date, balance: 5000)
+    create_balance(account: @liability_account, date: period.end_date, balance: 1000)
 
     series = builder.breakdown_series(period: period)
     groups = series[:values].last[:groups]


### PR DESCRIPTION
## Summary
- replace relative date setup in `BalanceSheet::NetWorthBreakdownSeriesBuilderTest` with fixed calendar dates
- keep the monthly series expectations stable across month-end CI runs
- update the sibling metadata test to avoid `Date.current` too

## Testing
- `bin/rails test test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated net-worth breakdown test scenarios to use fixed 2026 date ranges.
  * Improved balance data coverage for custom reporting periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->