### PR TITLE
fix(insights): blur amounts in insight prose under privacy mode

### DIFF
--- a/app/helpers/insights_helper.rb
+++ b/app/helpers/insights_helper.rb
@@ -14,6 +14,30 @@ module InsightsHelper
     INSIGHT_ICONS.fetch(insight.insight_type, "lightbulb")
   end
 
+  # Matches the numeric fragments inside insight prose: currency amounts
+  # ("€288.59", "1 234,56 €"), percentages ("142%"), and bare counts. Digit
+  # groups may be separated by ".", ",", or the (narrow) no-break spaces some
+  # locales format with, but must start and end on a digit so sentence
+  # punctuation stays outside the match.
+  INSIGHT_NUMERIC_FRAGMENT = /
+    (?:\p{Sc}[\s\u00A0\u202F]?)?          # currency symbol prefix
+    \d(?:[\d.,\s\u00A0\u202F]*\d)?        # digits with grouping separators
+    (?:[\s\u00A0\u202F]?(?:%|\p{Sc}))?    # percent or currency symbol suffix
+  /x
+
+  # Insight titles and bodies are stored as finished prose with the amounts
+  # already interpolated (by the i18n template or the LLM writer), so unlike
+  # the rest of the app the figures can't be tagged where they're formatted.
+  # This wraps each numeric fragment in a privacy-sensitive span at render
+  # time so privacy mode blurs the numbers but the sentence stays readable.
+  def insight_privacy_text(text)
+    safe_join(
+      text.to_s.split(/(#{INSIGHT_NUMERIC_FRAGMENT})/o).map.with_index do |part, index|
+        index.odd? ? tag.span(part, class: "privacy-sensitive") : part
+      end
+    )
+  end
+
   # "Savings rate · June" / "Cash flow · Next 30 days" — the card's meta line.
   # Uses the insight's stored period; falls back to the subject (account or
   # merchant name from facts) for insights without one.

--- a/app/views/insights/_insight_card.html.erb
+++ b/app/views/insights/_insight_card.html.erb
@@ -11,7 +11,7 @@
 
       <div class="flex items-start justify-between gap-3">
         <h3 class="text-sm font-medium text-primary inline-flex items-center gap-2 min-w-0">
-          <%= insight.title %>
+          <%= insight_privacy_text(insight.title) %>
           <% if unread %>
             <%# A dot, not a labelled chip. Visiting this page marks every insight
                 read in one go, so at first paint the badge is on *every* row and
@@ -32,7 +32,7 @@
         <% end %>
       </div>
 
-      <p class="text-sm text-secondary"><%= insight.body %></p>
+      <p class="text-sm text-secondary"><%= insight_privacy_text(insight.body) %></p>
     </div>
   </div>
 

--- a/app/views/pages/dashboard/_insights_feed.html.erb
+++ b/app/views/pages/dashboard/_insights_feed.html.erb
@@ -55,8 +55,8 @@
                 unread ones ("New · 3"), and with only three rows the pill was
                 usually on all of them — saying the same thing twice while
                 crowding the title. %>
-            <span class="text-sm font-medium text-primary truncate block"><%= insight.title %></span>
-            <p class="text-sm text-secondary truncate"><%= insight.body %></p>
+            <span class="text-sm font-medium text-primary truncate block"><%= insight_privacy_text(insight.title) %></span>
+            <p class="text-sm text-secondary truncate"><%= insight_privacy_text(insight.body) %></p>
           </div>
 
           <% if (figure = insight_key_figure(insight)) %>

--- a/test/helpers/insights_helper_test.rb
+++ b/test/helpers/insights_helper_test.rb
@@ -141,6 +141,34 @@ class InsightsHelperTest < ActionView::TestCase
     assert_equal "of budget", caption
   end
 
+  test "privacy text wraps amounts, percentages and counts in privacy-sensitive spans" do
+    body = "Your grocery spending is at €288.59, which is 142% above your usual €119.01."
+
+    rendered = insight_privacy_text(body)
+
+    assert_predicate rendered, :html_safe?
+    assert_equal <<~HTML.strip, rendered
+      Your grocery spending is at <span class="privacy-sensitive">€288.59</span>, which is <span class="privacy-sensitive">142%</span> above your usual <span class="privacy-sensitive">€119.01</span>.
+    HTML
+  end
+
+  test "privacy text handles locale formats with suffix currency and no-break-space grouping" do
+    rendered = insight_privacy_text("Checking holds 1 234,56 € with no activity in the last 45 days.")
+
+    assert_includes rendered, %(<span class="privacy-sensitive">1 234,56 €</span>)
+    assert_includes rendered, %(<span class="privacy-sensitive">45</span> days)
+  end
+
+  test "privacy text leaves numberless prose untouched and escapes HTML" do
+    assert_equal "Is Netflix still active?", insight_privacy_text("Is Netflix still active?")
+    assert_equal "", insight_privacy_text(nil)
+
+    rendered = insight_privacy_text("It's <b>big</b>: $1,200.50")
+
+    assert_includes rendered, "It&#39;s &lt;b&gt;big&lt;/b&gt;:"
+    assert_includes rendered, %(<span class="privacy-sensitive">$1,200.50</span>)
+  end
+
   test "action link resolves the stored subject and disappears when it cannot" do
     account = families(:dylan_family).accounts.visible.first
     resolvable = build_insight("idle_cash", metadata: { "account_id" => account.id })


### PR DESCRIPTION
## Bug

With the hide-numbers (privacy mode) toggle active, the proactive insights on the dashboard — and the cards on `/insights` — still showed every amount in plain text:

> Your grocery spending is at €288.59, which is 142% above your usual €119.01.

Only the right-aligned key figure was tagged `privacy-sensitive`, so it blurred while the sentence next to it leaked the same numbers.

## Why it happens

Insight titles and bodies are stored as finished prose with the amounts already interpolated (by the i18n template or the LLM `Insight::BodyWriter`). Unlike the rest of the app, the figures can't be tagged `privacy-sensitive` where they're formatted — by the time the view sees them they're just part of a string.

## Fix

- New `InsightsHelper#insight_privacy_text` wraps each numeric fragment in the stored prose in a `<span class="privacy-sensitive">` at render time. The regex covers currency-prefix amounts (`€288.59`), percentages (`142%`), bare counts (`45`), and suffix-currency locale formats with (narrow) no-break-space grouping (`1 234,56 €`), and must start/end on a digit so sentence punctuation stays outside the blur.
- Applied to the title and body in `app/views/pages/dashboard/_insights_feed.html.erb` and `app/views/insights/_insight_card.html.erb`. Titles matter too: the net-worth-milestone title interpolates an amount ("Net worth milestone: €100,000").
- The sentence stays readable — only the figures blur — matching how the toggle behaves elsewhere in the app.

Escaping note: the helper splits the **raw** text and reassembles with `safe_join`, so stored prose is still HTML-escaped. Escaping first and regexing after would corrupt digit-bearing entities (an apostrophe becomes `&#39;`, whose `39` would get wrapped mid-entity).

## Screenshots

Both captured with privacy mode on. Note in the "before" shots that the right-aligned key figure is already blurred while the sentence beside it spells out the same numbers.

**`/insights` cards**

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/insights-privacy-prose-before-cards.png" alt="Insight cards with privacy mode on: the body prose shows -5.4%, 50.6 percentage points, 45.2%, $152.40, 78%, $683.67 in plain text"> | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/insights-privacy-prose-after-cards.png" alt="The same insight cards with every numeric fragment in the prose blurred, the surrounding sentence still readable"> |

**Dashboard insights feed**

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/insights-privacy-prose-before-dashboard.png" alt="Dashboard insights feed with privacy mode on: amounts and percentages visible in each row's body line"> | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/insights-privacy-prose-after-dashboard.png" alt="Dashboard insights feed with the numbers in each row's body line blurred"> |

The lone `-` still visible before a blurred `5.4%` is the regex boundary working as intended: matches start and end on a digit so sentence punctuation isn't swallowed into the span.

## Tests

- 3 new tests in `test/helpers/insights_helper_test.rb`: span wrapping for amounts/percents/counts, suffix-currency + no-break-space locale format, and numberless-prose/nil/HTML-escaping behavior.
- Full suite: 6062 runs, 0 failures, 0 errors, 30 pre-existing skips.
- `bin/rubocop`, `erb_lint`, `bin/brakeman` clean (brakeman's 7 warnings are all in untracked local scratch copies, not app code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-aware formatting for insights, highlighting currency amounts, percentages, and counts.
  * Applied numeric privacy formatting to insight titles and descriptions across insight cards and dashboard feeds.
  * Improved insight card controls with clearer footer actions and button styling.

* **Bug Fixes**
  * Ensured insight content is safely escaped while preserving privacy formatting across supported number formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->