### PR TITLE
fix(design-system): resolve DS Drift Patrol findings (#2836)

### DIFF
--- a/app/assets/tailwind/sure-design-system/_generated.css
+++ b/app/assets/tailwind/sure-design-system/_generated.css
@@ -258,6 +258,14 @@
   }
 }
 
+@utility bg-subdued {
+  @apply bg-gray-400;
+
+  @variant theme-dark {
+    @apply bg-gray-400;
+  }
+}
+
 @utility bg-overlay {
   background-color: --alpha(var(--color-gray-100) / 50%);
 

--- a/app/views/pages/dashboard/_money_flow.html.erb
+++ b/app/views/pages/dashboard/_money_flow.html.erb
@@ -81,7 +81,7 @@
             <%= t(".income") %>
           </span>
           <span class="flex items-center gap-1.5 text-xs text-secondary">
-            <span class="w-2 h-2 rounded-full bg-gray-400"></span>
+            <span class="w-2 h-2 rounded-full bg-subdued"></span>
             <%= t(".expenses") %>
           </span>
         </div>
@@ -124,7 +124,7 @@
             class: "flex items-center justify-between p-3 border border-secondary rounded-lg hover:bg-container-inset-hover transition-colors group",
             data: { turbo_frame: "_top" } do %>
         <span class="flex items-center gap-2 text-sm text-primary">
-          <span class="w-2.5 h-2.5 rounded-full bg-gray-400"></span>
+          <span class="w-2.5 h-2.5 rounded-full bg-subdued"></span>
           <%= t(".expenses") %>
         </span>
         <span class="flex items-center gap-2">

--- a/app/views/redbark_items/_redbark_item.html.erb
+++ b/app/views/redbark_items/_redbark_item.html.erb
@@ -1,81 +1,83 @@
 <%# locals: (redbark_item:) %>
 
 <%= tag.div id: dom_id(redbark_item) do %>
-  <details open class="group bg-container p-4 shadow-border-xs rounded-xl">
-    <summary class="flex items-center justify-between gap-2 focus-visible:outline-hidden">
-      <div class="flex items-center gap-2">
-        <%= icon "chevron-right", class: "group-open:transform group-open:rotate-90" %>
+  <%= render DS::Disclosure.new(variant: :card, open: true) do |disclosure| %>
+    <% disclosure.with_summary_content do %>
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex items-center gap-2">
+          <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-        <div class="flex items-center justify-center h-8 w-8 bg-primary/10 rounded-full">
-          <div class="flex items-center justify-center">
-            <%= tag.p redbark_item.name.first.upcase, class: "text-primary text-xs font-medium" %>
+          <div class="flex items-center justify-center h-8 w-8 bg-primary/10 rounded-full">
+            <div class="flex items-center justify-center">
+              <%= tag.p redbark_item.name.first.upcase, class: "text-primary text-xs font-medium" %>
+            </div>
+          </div>
+
+          <div class="pl-1 text-sm">
+            <div class="flex items-center gap-2">
+              <%= tag.p redbark_item.name, class: "font-medium text-primary" %>
+              <% if redbark_item.scheduled_for_deletion? %>
+                <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
+              <% end %>
+            </div>
+            <p class="text-xs text-secondary"><%= t(".provider_name") %></p>
+            <% if redbark_item.syncing? %>
+              <div class="text-secondary flex items-center gap-1">
+                <%= icon "loader", size: "sm", class: "animate-spin" %>
+                <%= tag.span t(".syncing") %>
+              </div>
+            <% elsif redbark_item.requires_update? %>
+              <div class="text-warning flex items-center gap-1">
+                <%= icon "alert-triangle", size: "sm", color: "warning" %>
+                <%= tag.span t(".requires_update") %>
+              </div>
+            <% else %>
+              <p class="text-secondary">
+                <% if redbark_item.last_synced_at %>
+                  <% if redbark_item.sync_status_summary %>
+                    <%= t(".status_with_summary", timestamp: time_ago_in_words(redbark_item.last_synced_at), summary: redbark_item.sync_status_summary) %>
+                  <% else %>
+                    <%= t(".status", timestamp: time_ago_in_words(redbark_item.last_synced_at)) %>
+                  <% end %>
+                <% else %>
+                  <%= t(".status_never") %>
+                <% end %>
+              </p>
+            <% end %>
           </div>
         </div>
 
-        <div class="pl-1 text-sm">
-          <div class="flex items-center gap-2">
-            <%= tag.p redbark_item.name, class: "font-medium text-primary" %>
-            <% if redbark_item.scheduled_for_deletion? %>
-              <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
-            <% end %>
-          </div>
-          <p class="text-xs text-secondary"><%= t(".provider_name") %></p>
-          <% if redbark_item.syncing? %>
-            <div class="text-secondary flex items-center gap-1">
-              <%= icon "loader", size: "sm", class: "animate-spin" %>
-              <%= tag.span t(".syncing") %>
-            </div>
-          <% elsif redbark_item.requires_update? %>
-            <div class="text-warning flex items-center gap-1">
-              <%= icon "alert-triangle", size: "sm", color: "warning" %>
-              <%= tag.span t(".requires_update") %>
-            </div>
+        <div class="flex items-center gap-2">
+          <% if redbark_item.requires_update? %>
+            <%= render DS::Link.new(
+              text: t(".update_credentials"),
+              icon: "refresh-cw",
+              variant: "secondary",
+              href: settings_providers_path,
+              frame: "_top"
+            ) %>
           <% else %>
-            <p class="text-secondary">
-              <% if redbark_item.last_synced_at %>
-                <% if redbark_item.sync_status_summary %>
-                  <%= t(".status_with_summary", timestamp: time_ago_in_words(redbark_item.last_synced_at), summary: redbark_item.sync_status_summary) %>
-                <% else %>
-                  <%= t(".status", timestamp: time_ago_in_words(redbark_item.last_synced_at)) %>
-                <% end %>
-              <% else %>
-                <%= t(".status_never") %>
-              <% end %>
-            </p>
+            <%= icon(
+              "refresh-cw",
+              as_button: true,
+              href: sync_redbark_item_path(redbark_item),
+              disabled: redbark_item.syncing?
+            ) %>
+          <% end %>
+
+          <%= render DS::Menu.new do |menu| %>
+            <% menu.with_item(
+              variant: "button",
+              text: t(".delete"),
+              icon: "trash-2",
+              href: redbark_item_path(redbark_item),
+              method: :delete,
+              confirm: CustomConfirm.for_resource_deletion(redbark_item.name, high_severity: true)
+            ) %>
           <% end %>
         </div>
       </div>
-
-      <div class="flex items-center gap-2">
-        <% if redbark_item.requires_update? %>
-          <%= render DS::Link.new(
-            text: t(".update_credentials"),
-            icon: "refresh-cw",
-            variant: "secondary",
-            href: settings_providers_path,
-            frame: "_top"
-          ) %>
-        <% else %>
-          <%= icon(
-            "refresh-cw",
-            as_button: true,
-            href: sync_redbark_item_path(redbark_item),
-            disabled: redbark_item.syncing?
-          ) %>
-        <% end %>
-
-        <%= render DS::Menu.new do |menu| %>
-          <% menu.with_item(
-            variant: "button",
-            text: t(".delete"),
-            icon: "trash-2",
-            href: redbark_item_path(redbark_item),
-            method: :delete,
-            confirm: CustomConfirm.for_resource_deletion(redbark_item.name, high_severity: true)
-          ) %>
-        <% end %>
-      </div>
-    </summary>
+    <% end %>
 
     <% unless redbark_item.scheduled_for_deletion? %>
       <div class="space-y-4 mt-4">
@@ -129,5 +131,5 @@
         <% end %>
       </div>
     <% end %>
-  </details>
+  <% end %>
 <% end %>

--- a/app/views/redbark_items/select_existing_account.html.erb
+++ b/app/views/redbark_items/select_existing_account.html.erb
@@ -14,7 +14,13 @@
         <%= icon "alert-circle", class: "text-warning mx-auto mb-4", size: "lg" %>
         <p class="text-secondary"><%= t("redbark_items.select_existing_account.no_accounts") %></p>
         <p class="text-sm text-secondary mt-2"><%= t("redbark_items.select_existing_account.connect_hint") %></p>
-        <%= link_to t("redbark_items.select_existing_account.settings_link"), settings_providers_path, class: "btn btn--primary btn--sm mt-4" %>
+        <%= render DS::Link.new(
+          text: t("redbark_items.select_existing_account.settings_link"),
+          variant: "primary",
+          size: "sm",
+          href: settings_providers_path,
+          class: "mt-4"
+        ) %>
       </div>
     <% else %>
       <div class="space-y-4">

--- a/app/views/settings/providers/_redbark_panel.html.erb
+++ b/app/views/settings/providers/_redbark_panel.html.erb
@@ -42,8 +42,11 @@
                         value: nil %>
 
     <div class="flex justify-end">
-      <%= form.submit is_new_record ? t("redbark_items.panel.save_button") : t("redbark_items.panel.update_button"),
-                      class: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium btn btn--primary" %>
+      <%= render DS::Button.new(
+        text: is_new_record ? t("redbark_items.panel.save_button") : t("redbark_items.panel.update_button"),
+        variant: "primary",
+        type: "submit"
+      ) %>
     </div>
   <% end %>
 

--- a/design/tokens/sure.tokens.json
+++ b/design/tokens/sure.tokens.json
@@ -274,6 +274,7 @@
   "utility": {
     "bg-inverse":             { "$type": "utility", "$value": "{color.gray.800}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.white}" } },
     "bg-inverse-hover":       { "$type": "utility", "$value": "{color.gray.700}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.100}" } },
+    "bg-subdued":             { "$type": "utility", "$value": "{color.gray.400}", "$extensions": { "sure.utility": { "prefix": "bg" }, "sure.dark": "{color.gray.400}" } },
     "bg-overlay": {
       "$type": "utility",
       "$value": "{color.gray.100|50%}",


### PR DESCRIPTION
Resolves the three findings from the DS Drift Patrol scan in #2836.

## Findings addressed

**1 — raw `<details>` bypassing `DS::Disclosure`** (`app/views/redbark_items/_redbark_item.html.erb`)
The partial hand-rolled the exact `:card`-variant output of `DS::Disclosure`. Rewrote it to `render DS::Disclosure.new(variant: :card, open: true)` with a `with_summary_content` slot, matching the sibling `lunchflow_items/_lunchflow_item.html.erb` pattern. Body/logic/i18n unchanged; modernized the chevron transition class to match.

**2 — hand-rolled buttons using undefined CSS classes** (`select_existing_account.html.erb`, `settings/providers/_redbark_panel.html.erb`)
`btn` / `btn--primary` / `btn--sm` are defined nowhere in the repo (dead classes). Replaced with `DS::Link.new(variant: "primary", size: "sm", …)` for the settings link and `DS::Button.new(variant: "primary", type: "submit")` for the form submit — consistent with the `DS::Button`/`DS::Link` already used elsewhere in those files.

**3 — non-functional `bg-gray-400`** (`app/views/pages/dashboard/_money_flow.html.erb`)
The expense legend dots used literal `bg-gray-400`. This gray is intentional — `bar_chart_controller.js` deliberately renders expense bars as `var(--color-gray-400)` ("not destructive red"), and the design system had no functional `bg-` token equal to gray-400. Added a `bg-subdued` token (mirroring the existing `text-subdued`/`border-subdued`, = gray-400, regenerated into `_generated.css`) and used it for both dots, so they stay a functional token *and* stay in sync with the chart bars.

## Testing
- `bin/rails test` — 6059 runs, 24140 assertions, **0 failures, 0 errors**, 30 skips
- `DISABLE_PARALLELIZATION=true bin/rails test:system` (remote Selenium/Chromium) — 89 runs, 351 assertions, **0 failures, 0 errors**, 0 skips
- `bundle exec erb_lint` on the changed views — no errors
- `npm run tokens:build` is idempotent; `_generated.css` diff is only the `bg-subdued` utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a subdued background style for consistent light and dark theme support.
  * Updated expense indicators and transaction links to use the new styling.
  * Improved disclosure controls with updated styling and motion.
  * Standardized settings navigation and provider form actions with refreshed interface controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->