### PR TITLE
feat(hosting): universal headless rclone backup sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,3 +209,22 @@ POSTHOG_HOST=
 # ========
 SKYLIGHT_AUTHENTICATION=
 SKYLIGHT_ENABLED=
+
+# ======================================================================================================
+# Database Backup Configuration (Optional)
+# ======================================================================================================
+#
+# When using the "backup" container profile, these settings control how backups are saved.
+# Uses rclone to sync to any storage provider (S3, Cloudflare R2, Google Drive, SFTP, etc).
+#
+# BACKUP_SCHEDULE="0 2 * * *"          # Cron schedule (default: every day at 2am)
+# BACKUP_OVERWRITE="false"             # true = backup_latest.sql.gz, false = backup_YYYY-MM-DD_HH-MM-SS.sql.gz
+# BACKUP_KEEP_DAYS="7"                 # Delete backups older than this many days (when BACKUP_OVERWRITE is false)
+# BACKUP_DESTINATION="s3:my-bucket"    # Rclone remote format (remote:bucket/path)
+#
+# Example Rclone configuration for an S3 compatible provider (e.g., Cloudflare R2):
+# RCLONE_CONFIG_S3_TYPE=s3
+# RCLONE_CONFIG_S3_PROVIDER=Cloudflare
+# RCLONE_CONFIG_S3_ACCESS_KEY_ID=
+# RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=
+# RCLONE_CONFIG_S3_ENDPOINT=

--- a/bin/db-backup.sh
+++ b/bin/db-backup.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+# Configuration
+BACKUP_OVERWRITE=${BACKUP_OVERWRITE:-false}
+BACKUP_KEEP_DAYS=${BACKUP_KEEP_DAYS:-7}
+BACKUP_DESTINATION=${BACKUP_DESTINATION}
+
+if [ -z "$BACKUP_DESTINATION" ]; then
+  echo "Error: BACKUP_DESTINATION is not set."
+  exit 1
+fi
+
+if [ -z "$POSTGRES_DB" ] || [ -z "$POSTGRES_USER" ] || [ -z "$POSTGRES_PASSWORD" ] || [ -z "$POSTGRES_HOST" ]; then
+  echo "Error: Database connection variables are not fully set."
+  exit 1
+fi
+
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+
+if [ "$BACKUP_OVERWRITE" = "true" ]; then
+  FILENAME="backup_latest.sql.gz"
+else
+  FILENAME="backup_${TIMESTAMP}.sql.gz"
+fi
+
+TEMP_FILE="/tmp/${FILENAME}"
+
+trap 'rm -f "${TEMP_FILE}"' EXIT
+
+echo "Starting backup for ${POSTGRES_DB} to ${TEMP_FILE}..."
+set -o pipefail
+PGPASSWORD="${POSTGRES_PASSWORD}" pg_dump -h "${POSTGRES_HOST}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" | gzip > "${TEMP_FILE}"
+set +o pipefail
+
+echo "Uploading ${TEMP_FILE} to ${BACKUP_DESTINATION}/${FILENAME} via rclone..."
+rclone copy "${TEMP_FILE}" "${BACKUP_DESTINATION}"
+
+if [ "$BACKUP_OVERWRITE" != "true" ] && [ -n "$BACKUP_KEEP_DAYS" ]; then
+  echo "Pruning remote backups older than ${BACKUP_KEEP_DAYS} days..."
+  rclone delete "${BACKUP_DESTINATION}" --min-age "${BACKUP_KEEP_DAYS}d" --include "backup_*.sql.gz"
+fi
+
+echo "Cleaning up..."
+rm "${TEMP_FILE}"
+
+echo "Backup complete!"

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -338,19 +338,21 @@ services:
   backup:
     profiles:
       - backup
-    image: prodrigestivill/postgres-backup-local
+    image: alpine:3.20
     restart: unless-stopped
     volumes:
-      - /opt/sure-data/backups:/backups # Change this path to your desired backup location on the host machine
+      - ./bin/db-backup.sh:/usr/local/bin/db-backup.sh:ro
+    env_file:
+      - .env
     environment:
       - POSTGRES_HOST=db
       - POSTGRES_DB=${POSTGRES_DB:-sure_production}
       - POSTGRES_USER=${POSTGRES_USER:-sure_user}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sure_password} # pipelock:ignore
-      - SCHEDULE=@daily # Runs once a day at midnight
-      - BACKUP_KEEP_DAYS=7 # Keeps the last 7 days of backups
-      - BACKUP_KEEP_WEEKS=4 # Keeps 4 weekly backups
-      - BACKUP_KEEP_MONTHS=6 # Keeps 6 monthly backups
+    command: >
+      sh -c "apk add --no-cache postgresql16-client~=16 rclone~=1.66 gzip~=1 &&
+             echo \"$$BACKUP_SCHEDULE /usr/local/bin/db-backup.sh\" > /etc/crontabs/root &&
+             crond -f -d 8"
     depends_on:
       - db
     networks:

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -126,19 +126,21 @@ services:
   backup:
     profiles:
       - backup
-    image: prodrigestivill/postgres-backup-local
+    image: alpine:3.20
     restart: unless-stopped
     volumes:
-      - /opt/sure-data/backups:/backups # Change this path to your desired backup location on the host machine
+      - ./bin/db-backup.sh:/usr/local/bin/db-backup.sh:ro
+    env_file:
+      - .env
     environment:
       - POSTGRES_HOST=db
       - POSTGRES_DB=${POSTGRES_DB:-sure_production}
       - POSTGRES_USER=${POSTGRES_USER:-sure_user}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sure_password} # pipelock:ignore
-      - SCHEDULE=@daily # Runs once a day at midnight
-      - BACKUP_KEEP_DAYS=7 # Keeps the last 7 days of backups
-      - BACKUP_KEEP_WEEKS=4 # Keeps 4 weekly backups
-      - BACKUP_KEEP_MONTHS=6 # Keeps 6 monthly backups
+    command: >
+      sh -c "apk add --no-cache postgresql16-client~=16 rclone~=1.66 gzip~=1 &&
+             echo \"$$BACKUP_SCHEDULE /usr/local/bin/db-backup.sh\" > /etc/crontabs/root &&
+             crond -f -d 8"
     depends_on:
       - db
     networks:

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -40,12 +40,18 @@ Make sure you are in the directory you just created and run the following comman
 ```bash
 # Download the sample compose.yml file from the GitHub repository
 curl -o compose.yml https://raw.githubusercontent.com/we-promise/sure/main/compose.example.yml
+
+# (Optional) If you plan to use the automated database backups feature:
+mkdir -p bin
+curl -o bin/db-backup.sh https://raw.githubusercontent.com/we-promise/sure/main/bin/db-backup.sh
+chmod +x bin/db-backup.sh
 ```
 
 This command will do the following:
 
 1. Fetch the sample docker compose file from our public Github repository
 2. Creates a file in your current directory called `compose.yml` with the contents of the example file
+3. (Optionally) Fetches the backup script and makes it executable.
 
 At this point, the only file in your current working directory should be `compose.yml`.
 


### PR DESCRIPTION
This PR replaces the `prodrigestivill/postgres-backup-local` backup service with a custom, ultra-lightweight `alpine` container running `rclone` and `pg_dump`.

### Why?
- **Universal Compatibility**: Rclone supports 70+ cloud storage providers out of the box (S3, Cloudflare R2, Google Drive, Backblaze B2, SFTP, WebDAV, etc.).
- **Minimal Footprint**: Runs completely headless without any Web UI surface area, minimizing resource usage and improving security.
- **Customizable**: Introduces a `BACKUP_OVERWRITE` environment variable (defaults to `false`), allowing users to choose whether they want their backups to coexist with timestamps (`backup_YYYY-MM-DD_HH-MM-SS.sql.gz`) or overwrite a single file (`backup_latest.sql.gz`) to save storage space.

### Changes
- Updated `compose.example.yml` and `compose.example.ai.yml` to utilize `alpine:latest` and configure the cron job.
- Created `bin/db-backup.sh` to securely execute `pg_dump` (with pipefail) and `rclone copy`, with a guaranteed trap cleanup.
- Documented new environment variables in `.env.example`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable PostgreSQL backups with scheduled execution, retention controls, and optional filename overwriting.
  * Added support for compressed backup uploads to local or S3-compatible destinations.
  * Added configuration guidance for scheduling, retention, destinations, overwrite behavior, and credentials.
* **Chores**
  * Updated example deployment configurations to use the new backup workflow and required tools.
  * Added automatic cleanup of temporary files and expired backups.
* **Documentation**
  * Added guidance for optionally enabling database backups in Docker hosting setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->