### PR TITLE
feat(hosting): universal headless rclone backup sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -247,3 +247,23 @@ POSTHOG_HOST=
 # ========
 SKYLIGHT_AUTHENTICATION=
 SKYLIGHT_ENABLED=
+
+# ======================================================================================================
+# Database Backup Configuration (Optional)
+# ======================================================================================================
+#
+# When using the "backup" container profile, these settings control how backups are saved.
+# Uses rclone to sync to any storage provider (S3, Cloudflare R2, Google Drive, SFTP, etc).
+#
+# BACKUP_SCHEDULE="0 2 * * *"          # Cron schedule (default: every day at 2am)
+# BACKUP_OVERWRITE="false"             # true = backup_latest.sql.gz, false = backup_YYYY-MM-DD_HH-MM-SS.sql.gz
+# BACKUP_KEEP_DAYS="7"                 # Delete backups older than this many days (when BACKUP_OVERWRITE is false)
+# BACKUP_DESTINATION="s3:my-bucket"    # Rclone remote format (remote:bucket/path)
+# INSTANCE_ID="default"                # Scopes backups under BACKUP_DESTINATION/<INSTANCE_ID> to isolate retention lifecycle operations per deployment
+#
+# Example Rclone configuration for an S3 compatible provider (e.g., Cloudflare R2):
+# RCLONE_CONFIG_S3_TYPE=s3
+# RCLONE_CONFIG_S3_PROVIDER=Cloudflare
+# RCLONE_CONFIG_S3_ACCESS_KEY_ID=
+# RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=
+# RCLONE_CONFIG_S3_ENDPOINT=

--- a/.env.example
+++ b/.env.example
@@ -209,3 +209,23 @@ POSTHOG_HOST=
 # ========
 SKYLIGHT_AUTHENTICATION=
 SKYLIGHT_ENABLED=
+
+# ======================================================================================================
+# Database Backup Configuration (Optional)
+# ======================================================================================================
+#
+# When using the "backup" container profile, these settings control how backups are saved.
+# Uses rclone to sync to any storage provider (S3, Cloudflare R2, Google Drive, SFTP, etc).
+#
+# BACKUP_SCHEDULE="0 2 * * *"          # Cron schedule (default: every day at 2am)
+# BACKUP_OVERWRITE="false"             # true = backup_latest.sql.gz, false = backup_YYYY-MM-DD_HH-MM-SS.sql.gz
+# BACKUP_KEEP_DAYS="7"                 # Delete backups older than this many days (when BACKUP_OVERWRITE is false)
+# BACKUP_DESTINATION="s3:my-bucket"    # Rclone remote format (remote:bucket/path)
+# INSTANCE_ID="default"                # Scopes backups under BACKUP_DESTINATION/<INSTANCE_ID> to isolate retention lifecycle operations per deployment
+#
+# Example Rclone configuration for an S3 compatible provider (e.g., Cloudflare R2):
+# RCLONE_CONFIG_S3_TYPE=s3
+# RCLONE_CONFIG_S3_PROVIDER=Cloudflare
+# RCLONE_CONFIG_S3_ACCESS_KEY_ID=
+# RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=
+# RCLONE_CONFIG_S3_ENDPOINT=

--- a/bin/db-backup.sh
+++ b/bin/db-backup.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -e
+
+# shellcheck disable=SC3040
+if (set -o pipefail 2>/dev/null); then
+  set -o pipefail
+fi
+
+# Configuration
+BACKUP_OVERWRITE=${BACKUP_OVERWRITE:-false}
+BACKUP_KEEP_DAYS=${BACKUP_KEEP_DAYS:-7}
+BACKUP_DESTINATION=${BACKUP_DESTINATION:-}
+INSTANCE_ID=${INSTANCE_ID:-default}
+POSTGRES_PORT=${POSTGRES_PORT:-5432}
+
+if [ -z "$BACKUP_DESTINATION" ]; then
+  echo "Error: BACKUP_DESTINATION is not set."
+  exit 1
+fi
+
+if [ -z "$POSTGRES_DB" ] || [ -z "$POSTGRES_USER" ] || [ -z "$POSTGRES_PASSWORD" ] || [ -z "$POSTGRES_HOST" ]; then
+  echo "Error: Database connection variables are not fully set."
+  exit 1
+fi
+
+case "${POSTGRES_HOST}${POSTGRES_PORT}${POSTGRES_DB}${POSTGRES_USER}${POSTGRES_PASSWORD}" in
+  *"
+"*)
+    echo "Error: Database connection parameters must not contain newlines."
+    exit 1
+    ;;
+esac
+
+if [ "$BACKUP_OVERWRITE" != "true" ] && [ -n "$BACKUP_KEEP_DAYS" ]; then
+  if ! [ "$BACKUP_KEEP_DAYS" -gt 0 ] 2>/dev/null; then
+    echo "Error: BACKUP_KEEP_DAYS must be a positive integer (got: ${BACKUP_KEEP_DAYS})."
+    exit 1
+  fi
+fi
+
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+
+if [ "$BACKUP_OVERWRITE" = "true" ]; then
+  FILENAME="backup_latest.sql.gz"
+else
+  FILENAME="backup_${TIMESTAMP}_$$.sql.gz"
+fi
+
+TMP_DIR=$(umask 077 && mktemp -d)
+TEMP_FILE="${TMP_DIR}/${FILENAME}"
+PGPASS_FILE="${TMP_DIR}/.pgpass"
+
+# POSIX trap handler to guarantee cleanup of temporary workspace on exit or termination signal
+trap 'rm -rf "${TMP_DIR}"' EXIT INT TERM
+
+# Securely generate .pgpass file with strict permissions (0600) and escaped fields
+PG_HOST_ESC=$(printf '%s' "${POSTGRES_HOST}" | sed -e 's/\\/\\\\/g' -e 's/:/\\:/g')
+PG_PORT_ESC=$(printf '%s' "${POSTGRES_PORT}" | sed -e 's/\\/\\\\/g' -e 's/:/\\:/g')
+PG_DB_ESC=$(printf '%s' "${POSTGRES_DB}" | sed -e 's/\\/\\\\/g' -e 's/:/\\:/g')
+PG_USER_ESC=$(printf '%s' "${POSTGRES_USER}" | sed -e 's/\\/\\\\/g' -e 's/:/\\:/g')
+PG_PASS_ESC=$(printf '%s' "${POSTGRES_PASSWORD}" | sed -e 's/\\/\\\\/g' -e 's/:/\\:/g')
+
+(umask 077 && printf '%s:%s:%s:%s:%s\n' "${PG_HOST_ESC}" "${PG_PORT_ESC}" "${PG_DB_ESC}" "${PG_USER_ESC}" "${PG_PASS_ESC}" > "${PGPASS_FILE}")
+chmod 0600 "${PGPASS_FILE}"
+export PGPASSFILE="${PGPASS_FILE}"
+
+# Create temp output file with restricted permissions before pg_dump execution
+(umask 077 && touch "${TEMP_FILE}")
+chmod 0600 "${TEMP_FILE}"
+
+echo "Starting backup for ${POSTGRES_DB} to ${TEMP_FILE}..."
+pg_dump -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" | gzip > "${TEMP_FILE}"
+
+DEST_PATH="${BACKUP_DESTINATION%/}/${INSTANCE_ID}"
+echo "Uploading ${TEMP_FILE} to ${DEST_PATH}/${FILENAME} via rclone..."
+rclone copy "${TEMP_FILE}" "${DEST_PATH}"
+
+if [ "$BACKUP_OVERWRITE" != "true" ] && [ -n "$BACKUP_KEEP_DAYS" ]; then
+  echo "Pruning remote backups older than ${BACKUP_KEEP_DAYS} days in ${DEST_PATH}..."
+  rclone delete "${DEST_PATH}" --min-age "${BACKUP_KEEP_DAYS}d" --include "backup_*.sql.gz"
+fi
+
+echo "Cleaning up..."
+rm -rf "${TMP_DIR}"
+
+echo "Backup complete!"

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -368,19 +368,32 @@ services:
   backup:
     profiles:
       - backup
-    image: prodrigestivill/postgres-backup-local
+    image: alpine:3.20
     restart: unless-stopped
     volumes:
-      - /opt/sure-data/backups:/backups # Change this path to your desired backup location on the host machine
+      - ./bin/db-backup.sh:/usr/local/bin/db-backup.sh:ro
     environment:
       - POSTGRES_HOST=db
-      - POSTGRES_DB=${POSTGRES_DB:-sure_production}
-      - POSTGRES_USER=${POSTGRES_USER:-sure_user}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sure_password} # pipelock:ignore
-      - SCHEDULE=@daily # Runs once a day at midnight
-      - BACKUP_KEEP_DAYS=7 # Keeps the last 7 days of backups
-      - BACKUP_KEEP_WEEKS=4 # Keeps 4 weekly backups
-      - BACKUP_KEEP_MONTHS=6 # Keeps 6 monthly backups
+      - POSTGRES_DB
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD # pipelock:ignore
+      - BACKUP_SCHEDULE
+      - BACKUP_OVERWRITE
+      - BACKUP_KEEP_DAYS
+      - BACKUP_DESTINATION
+      - INSTANCE_ID
+      # Rclone Provider Config
+      # By default we map the S3 variables. If you use a different provider (e.g., gdrive), 
+      # replace these with the equivalent variables you added to your .env file.
+      - RCLONE_CONFIG_S3_TYPE
+      - RCLONE_CONFIG_S3_PROVIDER
+      - RCLONE_CONFIG_S3_ACCESS_KEY_ID
+      - RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+      - RCLONE_CONFIG_S3_ENDPOINT
+    command: >
+      sh -c "apk add --no-cache postgresql16-client~=16 rclone~=1.66 gzip~=1 &&
+             echo \"$${BACKUP_SCHEDULE:-0 2 * * *} /usr/local/bin/db-backup.sh\" > /etc/crontabs/root &&
+             crond -f -d 8"
     depends_on:
       - db
     networks:

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -338,19 +338,32 @@ services:
   backup:
     profiles:
       - backup
-    image: prodrigestivill/postgres-backup-local
+    image: alpine:3.20
     restart: unless-stopped
     volumes:
-      - /opt/sure-data/backups:/backups # Change this path to your desired backup location on the host machine
+      - ./bin/db-backup.sh:/usr/local/bin/db-backup.sh:ro
     environment:
       - POSTGRES_HOST=db
-      - POSTGRES_DB=${POSTGRES_DB:-sure_production}
-      - POSTGRES_USER=${POSTGRES_USER:-sure_user}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sure_password} # pipelock:ignore
-      - SCHEDULE=@daily # Runs once a day at midnight
-      - BACKUP_KEEP_DAYS=7 # Keeps the last 7 days of backups
-      - BACKUP_KEEP_WEEKS=4 # Keeps 4 weekly backups
-      - BACKUP_KEEP_MONTHS=6 # Keeps 6 monthly backups
+      - POSTGRES_DB
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD # pipelock:ignore
+      - BACKUP_SCHEDULE
+      - BACKUP_OVERWRITE
+      - BACKUP_KEEP_DAYS
+      - BACKUP_DESTINATION
+      - INSTANCE_ID
+      # Rclone Provider Config
+      # By default we map the S3 variables. If you use a different provider (e.g., gdrive), 
+      # replace these with the equivalent variables you added to your .env file.
+      - RCLONE_CONFIG_S3_TYPE
+      - RCLONE_CONFIG_S3_PROVIDER
+      - RCLONE_CONFIG_S3_ACCESS_KEY_ID
+      - RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+      - RCLONE_CONFIG_S3_ENDPOINT
+    command: >
+      sh -c "apk add --no-cache postgresql16-client~=16 rclone~=1.66 gzip~=1 &&
+             echo \"$${BACKUP_SCHEDULE:-0 2 * * *} /usr/local/bin/db-backup.sh\" > /etc/crontabs/root &&
+             crond -f -d 8"
     depends_on:
       - db
     networks:

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -126,19 +126,32 @@ services:
   backup:
     profiles:
       - backup
-    image: prodrigestivill/postgres-backup-local
+    image: alpine:3.20
     restart: unless-stopped
     volumes:
-      - /opt/sure-data/backups:/backups # Change this path to your desired backup location on the host machine
+      - ./bin/db-backup.sh:/usr/local/bin/db-backup.sh:ro
     environment:
       - POSTGRES_HOST=db
-      - POSTGRES_DB=${POSTGRES_DB:-sure_production}
-      - POSTGRES_USER=${POSTGRES_USER:-sure_user}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sure_password} # pipelock:ignore
-      - SCHEDULE=@daily # Runs once a day at midnight
-      - BACKUP_KEEP_DAYS=7 # Keeps the last 7 days of backups
-      - BACKUP_KEEP_WEEKS=4 # Keeps 4 weekly backups
-      - BACKUP_KEEP_MONTHS=6 # Keeps 6 monthly backups
+      - POSTGRES_DB
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD # pipelock:ignore
+      - BACKUP_SCHEDULE
+      - BACKUP_OVERWRITE
+      - BACKUP_KEEP_DAYS
+      - BACKUP_DESTINATION
+      - INSTANCE_ID
+      # Rclone Provider Config
+      # By default we map the S3 variables. If you use a different provider (e.g., gdrive), 
+      # replace these with the equivalent variables you added to your .env file.
+      - RCLONE_CONFIG_S3_TYPE
+      - RCLONE_CONFIG_S3_PROVIDER
+      - RCLONE_CONFIG_S3_ACCESS_KEY_ID
+      - RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+      - RCLONE_CONFIG_S3_ENDPOINT
+    command: >
+      sh -c "apk add --no-cache postgresql16-client~=16 rclone~=1.66 gzip~=1 &&
+             echo \"$${BACKUP_SCHEDULE:-0 2 * * *} /usr/local/bin/db-backup.sh\" > /etc/crontabs/root &&
+             crond -f -d 8"
     depends_on:
       - db
     networks:

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -135,19 +135,32 @@ services:
   backup:
     profiles:
       - backup
-    image: prodrigestivill/postgres-backup-local
+    image: alpine:3.20
     restart: unless-stopped
     volumes:
-      - /opt/sure-data/backups:/backups # Change this path to your desired backup location on the host machine
+      - ./bin/db-backup.sh:/usr/local/bin/db-backup.sh:ro
     environment:
       - POSTGRES_HOST=db
-      - POSTGRES_DB=${POSTGRES_DB:-sure_production}
-      - POSTGRES_USER=${POSTGRES_USER:-sure_user}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sure_password} # pipelock:ignore
-      - SCHEDULE=@daily # Runs once a day at midnight
-      - BACKUP_KEEP_DAYS=7 # Keeps the last 7 days of backups
-      - BACKUP_KEEP_WEEKS=4 # Keeps 4 weekly backups
-      - BACKUP_KEEP_MONTHS=6 # Keeps 6 monthly backups
+      - POSTGRES_DB
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD # pipelock:ignore
+      - BACKUP_SCHEDULE
+      - BACKUP_OVERWRITE
+      - BACKUP_KEEP_DAYS
+      - BACKUP_DESTINATION
+      - INSTANCE_ID
+      # Rclone Provider Config
+      # By default we map the S3 variables. If you use a different provider (e.g., gdrive), 
+      # replace these with the equivalent variables you added to your .env file.
+      - RCLONE_CONFIG_S3_TYPE
+      - RCLONE_CONFIG_S3_PROVIDER
+      - RCLONE_CONFIG_S3_ACCESS_KEY_ID
+      - RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+      - RCLONE_CONFIG_S3_ENDPOINT
+    command: >
+      sh -c "apk add --no-cache postgresql16-client~=16 rclone~=1.66 gzip~=1 &&
+             echo \"$${BACKUP_SCHEDULE:-0 2 * * *} /usr/local/bin/db-backup.sh\" > /etc/crontabs/root &&
+             crond -f -d 8"
     depends_on:
       - db
     networks:

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -39,15 +39,21 @@ Make sure you are in the directory you just created and run the following comman
 
 ```bash
 # Download the sample compose.yml file from the GitHub repository
-curl -o compose.yml https://raw.githubusercontent.com/we-promise/sure/main/compose.example.yml
+curl --fail --location --silent --show-error --output compose.yml https://raw.githubusercontent.com/we-promise/sure/main/compose.example.yml
+
+# (Optional) If you plan to use the automated database backups feature:
+mkdir -p bin
+curl --fail --location --silent --show-error --output bin/db-backup.sh https://raw.githubusercontent.com/we-promise/sure/main/bin/db-backup.sh
+chmod +x bin/db-backup.sh
 ```
 
 This command will do the following:
 
 1. Fetch the sample docker compose file from our public Github repository
 2. Creates a file in your current directory called `compose.yml` with the contents of the example file
+3. (Optionally) Fetches the backup script to `bin/db-backup.sh` and makes it executable.
 
-At this point, the only file in your current working directory should be `compose.yml`.
+At this point, you should have `compose.yml` in your directory (and optionally `bin/db-backup.sh` generated alongside `compose.yml` when using backups).
 
 ### Step 3 (optional): Configure your environment
 
@@ -63,7 +69,7 @@ In order to configure the app, you will need to create a file called `.env`, whi
 To do this, you should get our .env.example as a starting point:
 
 ```bash
-curl -o .env https://raw.githubusercontent.com/we-promise/sure/main/.env.example
+curl --fail --location --silent --show-error --output .env https://raw.githubusercontent.com/we-promise/sure/main/.env.example
 ```
 
 #### Generate the app secret key
@@ -221,9 +227,9 @@ Sure ships with a separate compose file for AI-related features: `compose.exampl
 
 ```bash
 # Download both compose files
-curl -o compose.yml https://raw.githubusercontent.com/we-promise/sure/main/compose.example.yml
-curl -o compose.ai.yml https://raw.githubusercontent.com/we-promise/sure/main/compose.example.ai.yml
-curl -o pipelock.example.yaml https://raw.githubusercontent.com/we-promise/sure/main/pipelock.example.yaml
+curl --fail --location --silent --show-error --output compose.yml https://raw.githubusercontent.com/we-promise/sure/main/compose.example.yml
+curl --fail --location --silent --show-error --output compose.ai.yml https://raw.githubusercontent.com/we-promise/sure/main/compose.example.ai.yml
+curl --fail --location --silent --show-error --output pipelock.example.yaml https://raw.githubusercontent.com/we-promise/sure/main/pipelock.example.yaml
 
 # Run with Pipelock (no local LLM)
 docker compose -f compose.ai.yml up -d


### PR DESCRIPTION
This PR replaces the `prodrigestivill/postgres-backup-local` backup service with a custom, ultra-lightweight `alpine` container running `rclone` and `pg_dump`.

### Why?
- **Universal Compatibility**: Rclone supports 70+ cloud storage providers out of the box (S3, Cloudflare R2, Google Drive, Backblaze B2, SFTP, WebDAV, etc.).
- **Minimal Footprint**: Runs completely headless without any Web UI surface area, minimizing resource usage and improving security.
- **Customizable**: Introduces a `BACKUP_OVERWRITE` environment variable (defaults to `false`), allowing users to choose whether they want their backups to coexist with timestamps (`backup_YYYY-MM-DD_HH-MM-SS.sql.gz`) or overwrite a single file (`backup_latest.sql.gz`) to save storage space.

### Changes
- Updated `compose.example.yml` and `compose.example.ai.yml` to utilize `alpine:3.20` and configure the cron job.
- Created `bin/db-backup.sh` to securely execute `pg_dump` (with pipefail) and `rclone copy`, with a guaranteed trap cleanup and a `BACKUP_KEEP_DAYS` retention policy using `rclone delete --min-age`.
- Documented new environment variables in `.env.example` and added self-contained script download instructions to `docs/hosting/docker.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional scheduled PostgreSQL backups with timestamped or overwrite modes.
  * Added configurable remote storage uploads, retention cleanup, and S3-compatible destinations.
  * Added instance-specific backup destinations for improved isolation.
  * Added Docker Compose support with configurable cron scheduling.
  * Added configuration validation and secure cleanup for more reliable backups.

* **Documentation**
  * Documented backup settings, storage credentials, and Docker deployment configuration.
  * Added instructions for downloading and enabling the backup script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->