### PR TITLE
fix(mcp): assign OAuth clients read_write scope

### DIFF
--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -1,0 +1,12 @@
+class Oauth::AuthorizationsController < Doorkeeper::AuthorizationsController
+  before_action :default_mcp_scope, only: [ :new, :create ]
+
+  private
+
+    def default_mcp_scope
+      return if params[:scope].present?
+
+      application = Doorkeeper::Application.find_by(uid: params[:client_id])
+      params[:scope] = "read_write" if application&.scopes.to_s.split == [ "read_write" ]
+    end
+end

--- a/app/controllers/oauth_registration_controller.rb
+++ b/app/controllers/oauth_registration_controller.rb
@@ -48,7 +48,11 @@ class OauthRegistrationController < ApplicationController
     app = Doorkeeper::Application.new(
       name: client_name,
       redirect_uri: redirect_uris.join("\n"),
-      confidential: false
+      confidential: false,
+      # MCP requires the read_write scope. Without assigning it to the
+      # dynamically registered client, Doorkeeper falls back to the provider's
+      # default read scope and the token is rejected by McpController.
+      scopes: "read_write"
     )
 
     if app.save

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,7 +207,9 @@ Rails.application.routes.draw do
   get ".well-known/oauth-protected-resource", to: "oauth_metadata#protected_resource"
   get ".well-known/oauth-authorization-server", to: "oauth_metadata#authorization_server"
   post "register", to: "oauth_registration#create"
-  use_doorkeeper
+  use_doorkeeper do |mapping|
+    mapping.controllers authorizations: "oauth/authorizations"
+  end
   # MFA routes
   resource :mfa, controller: "mfa", only: [ :new, :create ] do
     get :verify

--- a/docs/hosting/mcp.md
+++ b/docs/hosting/mcp.md
@@ -13,14 +13,15 @@ This is useful when:
 
 ## Prerequisites
 
-To enable the MCP endpoint, you need to set two environment variables:
+For legacy bearer-token authentication, set these two environment variables:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `MCP_API_TOKEN` | Bearer token for authentication | `your-secret-token-here` |
 | `MCP_USER_EMAIL` | Email of the Sure user whose data the assistant can access | `user@example.com` |
 
-Both variables are **required**. The endpoint will not activate if either is missing.
+Both variables are required for the legacy token flow. OAuth clients using the
+MCP discovery and dynamic registration endpoints do not need these variables.
 
 ### Generating a secure token
 
@@ -82,7 +83,14 @@ POST /mcp
 
 ### Authentication
 
-All requests must include the `MCP_API_TOKEN` as a Bearer token:
+MCP supports OAuth authorization-code flow for clients such as Claude Code.
+Clients should discover the protected-resource metadata, register dynamically,
+request the advertised `read_write` scope, and send the resulting access token
+as a Bearer token. Dynamically registered clients are assigned this scope so
+their tokens can authenticate to MCP.
+
+For self-hosted deployments or clients without OAuth support, requests may use
+the legacy `MCP_API_TOKEN` as a Bearer token:
 
 ```
 Authorization: Bearer <MCP_API_TOKEN>

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -70,7 +70,6 @@ class McpControllerTest < ActionDispatch::IntegrationTest
       client_id: app.uid,
       redirect_uri: app.redirect_uri,
       response_type: "code",
-      scope: "read_write",
       code_challenge: challenge,
       code_challenge_method: "S256"
     }

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -47,6 +47,57 @@ class McpControllerTest < ActionDispatch::IntegrationTest
     assert_equal "2025-03-26", result["protocolVersion"]
   end
 
+  test "authenticates a token issued to a dynamically registered MCP client" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "https://claude.ai/callback" ],
+        grant_types: [ "authorization_code" ],
+        response_types: [ "code" ],
+        token_endpoint_auth_method: "none"
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    app = Doorkeeper::Application.find_by!(uid: JSON.parse(response.body)["client_id"])
+    assert_equal "read_write", app.scopes.to_s
+
+    sign_in(@user)
+    verifier = SecureRandom.urlsafe_base64(64)
+    challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), padding: false)
+
+    post "/oauth/authorize", params: {
+      client_id: app.uid,
+      redirect_uri: app.redirect_uri,
+      response_type: "code",
+      scope: "read_write",
+      code_challenge: challenge,
+      code_challenge_method: "S256"
+    }
+
+    assert_response :redirect
+    code = Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
+    assert code.present?, "Authorization response should contain a code"
+
+    post "/oauth/token", params: {
+      grant_type: "authorization_code",
+      client_id: app.uid,
+      redirect_uri: app.redirect_uri,
+      code: code,
+      code_verifier: verifier
+    }
+
+    assert_response :success
+    token_response = JSON.parse(response.body)
+    assert_equal "read_write", token_response["scope"]
+
+    post "/mcp", params: jsonrpc_request("initialize").to_json,
+         headers: mcp_headers(token_response["access_token"])
+
+    assert_response :ok
+    assert_equal "2025-03-26", JSON.parse(response.body).dig("result", "protocolVersion")
+  end
+
   test "rejects token with read-only scope" do
     app = Doorkeeper::Application.create!(
       name: "Test MCP Client #{SecureRandom.hex(4)}",

--- a/test/controllers/oauth_registration_controller_test.rb
+++ b/test/controllers/oauth_registration_controller_test.rb
@@ -24,6 +24,7 @@ class OauthRegistrationControllerTest < ActionDispatch::IntegrationTest
     app = Doorkeeper::Application.find_by(uid: json["client_id"])
     assert app.present?, "Application should be persisted"
     assert_not app.confidential?, "Application must be non-confidential (public client)"
+    assert_equal "read_write", app.scopes.to_s
   end
 
   test "returns error for invalid JSON body" do


### PR DESCRIPTION
## Root cause
Dynamically registered public OAuth applications were created without an explicit scope. Doorkeeper therefore issued the provider's default `read` scope unless the client request supplied the MCP scope, while `/mcp` correctly requires `read_write`. Claude Code could complete authorization and then be rejected when it reconnected with the resulting token.

## Fix
Assign `read_write` to applications created by the MCP dynamic registration endpoint. This keeps MCP's existing authorization requirement intact and preserves the legacy `MCP_API_TOKEN` / `MCP_USER_EMAIL` fallback. The hosting documentation now distinguishes the OAuth and legacy configuration paths.

## Tests
- Added registration coverage asserting dynamically registered clients have `read_write`.
- Added an integration regression covering dynamic registration, authorization-code + PKCE exchange, issued token scope, and an authenticated MCP request.
- `git diff --check` passed.

Rails tests could not be run in this environment because Ruby/Docker are unavailable; CI should run the focused controller tests and the normal test suite.

## Deployment/configuration
No migration or new configuration is required. OAuth clients should request the advertised `read_write` scope. Existing statically configured MCP deployments continue using their current environment variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamically registered public OAuth clients now support the `read_write` scope.
  * MCP clients can authenticate through OAuth discovery, registration, PKCE authorization, and token exchange.
  * Authorization defaults to `read_write` when it is the client’s only available scope.

* **Documentation**
  * Updated MCP hosting guidance to explain OAuth and legacy bearer-token authentication, including required configuration for legacy deployments.

* **Bug Fixes**
  * Improved compatibility for OAuth-authenticated MCP connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->