### PR TITLE
docs: use wealth history wording

### DIFF
--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -7,8 +7,8 @@ module Assistant
   }.freeze
 
   # Statement Vault + provenance tools, for users who opted into preview features
-  # in Settings -> Preferences. They back the patrimonial agent-harness workflow
-  # documented in docs/llm-guides/patrimonial-agent-harness.md.
+  # in Settings -> Preferences. They back the wealth agent-harness workflow
+  # documented in docs/llm-guides/wealth-agent-harness.md.
   PREVIEW_FUNCTION_CLASSES = [
     Function::UploadAccountStatement,
     Function::ListAccountStatements,

--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -461,8 +461,8 @@ the model and the compiler — rather than a feature inside Sure. Sure exposes a
 set of preview MCP tools for it (the Statement Vault, coverage gaps, and
 valuations that require a source citation).
 
-See [Patrimonial history with an external agent harness](../llm-guides/patrimonial-agent-harness.md)
-for which side owns what, and [the blueprint](../llm-guides/patrimonial-blueprint.md)
+See [Wealth history with an external agent harness](../llm-guides/wealth-agent-harness.md)
+for which side owns what, and [the blueprint](../llm-guides/wealth-blueprint.md)
 it implements.
 
 ### Security with Pipelock

--- a/docs/hosting/mcp.md
+++ b/docs/hosting/mcp.md
@@ -132,7 +132,7 @@ permissions enforced in the web UI.
 
 They exist for agents that maintain a document-backed record of a family's
 wealth over time. See
-[Patrimonial history with an external agent harness](../llm-guides/patrimonial-agent-harness.md).
+[Wealth history with an external agent harness](../llm-guides/wealth-agent-harness.md).
 
 ## Example Requests
 

--- a/docs/llm-guides/wealth-agent-harness.md
+++ b/docs/llm-guides/wealth-agent-harness.md
@@ -5,7 +5,7 @@ back to the document it came from — on top of Sure, without putting that model
 inside Sure.
 
 The model itself is specified by
-[the wealth + tax blueprint](patrimonial-blueprint.md). This guide is the seam:
+[the wealth + tax blueprint](wealth-blueprint.md). This guide is the seam:
 which half owns what, which MCP tool serves which layer of the blueprint, and
 which invariants Sure cannot enforce for you.
 
@@ -213,7 +213,7 @@ Worth knowing before you promise the user something:
 
 ## See also
 
-- [The wealth + tax blueprint](patrimonial-blueprint.md) — the full spec.
+- [The wealth + tax blueprint](wealth-blueprint.md) — the full spec.
 - [MCP Server for External AI Assistants](../hosting/mcp.md) — endpoint,
   authentication, tool list.
 - [External AI Assistant configuration](../hosting/ai.md#openclaw-gateway-example)

--- a/docs/llm-guides/wealth-blueprint.md
+++ b/docs/llm-guides/wealth-blueprint.md
@@ -8,7 +8,7 @@
 >
 > For how the two halves fit together — which layer Sure owns, which MCP tools
 > serve which section, and what the harness must own itself — read
-> [the patrimonial agent harness guide](patrimonial-agent-harness.md) first.
+> [the wealth agent harness guide](wealth-agent-harness.md) first.
 >
 > The document is reproduced verbatim as supplied. It contains no real names,
 > institutions, positions, amounts or identifiers.


### PR DESCRIPTION
## Summary
- rename the English wealth-history guide files away from `patrimonial-*`
- update hosting docs and assistant comments to use wealth-history wording
- leave localized accounting strings untouched

## Checks
- `rg -n -i "patrimonial|patrimony" docs app test .github`