### PR TITLE
fix(ci): avoid bumping prerelease versions on PR branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -426,6 +426,8 @@ jobs:
     steps:
       - name: Determine source branch for tag
         id: source_branch
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           # Fetch all branches to find which one contains this tag's commit
           git init --quiet
@@ -439,7 +441,7 @@ jobs:
           # Prefer the matching release branch over main. Do not select arbitrary
           # feature or PR branches that happen to contain the tagged commit.
           SOURCE_BRANCH="main"
-          RELEASE_BRANCH="$(echo "${{ github.ref_name }}" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/v\1.\2-release-branch/')"
+          RELEASE_BRANCH="$(printf '%s\n' "$TAG_NAME" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/v\1.\2-release-branch/')"
 
           for branch in $BRANCHES; do
             if [ "$branch" = "$RELEASE_BRANCH" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -436,14 +436,26 @@ jobs:
           BRANCHES=$(git branch -r --contains ${{ github.sha }} | grep -v HEAD | sed 's/origin\///' | xargs)
           echo "Branches containing commit: $BRANCHES"
 
-          # Prefer non-main branches (release branches) over main
+          # Prefer the matching release branch over main. Do not select arbitrary
+          # feature or PR branches that happen to contain the tagged commit.
           SOURCE_BRANCH="main"
+          RELEASE_BRANCH="$(echo "${{ github.ref_name }}" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/v\1.\2-release-branch/')"
+
           for branch in $BRANCHES; do
-            if [ "$branch" != "main" ] && [ "$branch" != "master" ]; then
+            if [ "$branch" = "$RELEASE_BRANCH" ]; then
               SOURCE_BRANCH="$branch"
               break
             fi
           done
+
+          if [ "$SOURCE_BRANCH" = "main" ]; then
+            for branch in $BRANCHES; do
+              if [[ "$branch" =~ ^v[0-9]+\.[0-9]+-release-branch$ ]]; then
+                SOURCE_BRANCH="$branch"
+                break
+              fi
+            done
+          fi
 
           echo "Selected source branch: $SOURCE_BRANCH"
           echo "branch=$SOURCE_BRANCH" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- restrict prerelease version bump source-branch selection to the matching release branch
- fall back to main when no release branch contains the tag commit
- avoid choosing arbitrary feature/PR branches that happen to contain the released commit

## Why
The v0.7.4-alpha.1 publish run saw these branches containing the tag commit:

- claude/ci-test-performance-6d95pc-10-rate-limit-tests
- claude/sure-patrimonial-history-c8s7am
- feature/bank-statement-reconciliation
- fix/insights-privacy-mode-prose
- main

The old loop picked the first non-main branch, so it pushed the post-release version bump onto PR #2565.

## Validation
- Replayed the bad branch list locally: new logic selects main.
- Replayed a matching release branch list locally: new logic selects v0.7-release-branch.
- actionlint is not installed in this environment, so workflow syntax was reviewed by inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-release versioning to select the appropriate release branch based on the tag version.
  * Added safer fallback behavior to use a versioned release branch or `main`, avoiding unrelated branches.
  * Release preparation is now more consistent and predictable when creating pre-release versions from tagged builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->