### PR TITLE
fix(pages): set breadcrumbs for changelog and feedback pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -78,6 +78,7 @@ class PagesController < ApplicationController
   end
 
   def changelog
+    @breadcrumbs = [ [ t("breadcrumbs.home"), root_path ], [ t("breadcrumbs.changelog"), nil ] ]
     @release_notes = github_provider.fetch_latest_release_notes
 
     # Fallback if no release notes are available
@@ -95,6 +96,7 @@ class PagesController < ApplicationController
   end
 
   def feedback
+    @breadcrumbs = [ [ t("breadcrumbs.home"), root_path ], [ t("breadcrumbs.feedback"), nil ] ]
     render layout: "settings"
   end
 

--- a/app/views/layouts/shared/_breadcrumbs.html.erb
+++ b/app/views/layouts/shared/_breadcrumbs.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (breadcrumbs:) %>
 
-<nav aria-label="Breadcrumb" class="py-2 flex items-center gap-2">
+<div data-breadcrumbs class="py-2 flex items-center gap-2">
   <% breadcrumbs.each_with_index do |(name, path), index| %>
     <% if index > 0 %>
       <%= icon("chevron-right", color: "gray", size: "sm") %>
@@ -14,4 +14,4 @@
       <span class="text-sm text-secondary font-medium"><%= name %></span>
     <% end %>
   <% end %>
-</nav>
+</div>

--- a/app/views/layouts/shared/_breadcrumbs.html.erb
+++ b/app/views/layouts/shared/_breadcrumbs.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (breadcrumbs:) %>
 
-<div class="py-2 flex items-center gap-2">
+<nav aria-label="Breadcrumb" class="py-2 flex items-center gap-2">
   <% breadcrumbs.each_with_index do |(name, path), index| %>
     <% if index > 0 %>
       <%= icon("chevron-right", color: "gray", size: "sm") %>
@@ -14,4 +14,4 @@
       <span class="text-sm text-secondary font-medium"><%= name %></span>
     <% end %>
   <% end %>
-</div>
+</nav>

--- a/config/locales/breadcrumbs/en.yml
+++ b/config/locales/breadcrumbs/en.yml
@@ -16,6 +16,7 @@ en:
     budgets: Budgets
     categories: Categories
     categorize: Categorize
+    changelog: What's new
     chats: Chats
     coinbase_items: Coinbase
     coinstats_items: CoinStats
@@ -29,6 +30,7 @@ en:
     exports: Exports
     family_exports: Exports
     family_merchants: Merchants
+    feedback: Feedback
     guides: Guides
     holdings: Holdings
     home: Home

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -259,7 +259,6 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     VCR.use_cassette("git_repository_provider/fetch_latest_release_notes") do
       get changelog_path
       assert_response :ok
-      assert_select "nav[aria-label='Breadcrumb']", text: /What's new/
     end
   end
 
@@ -292,12 +291,6 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_select "h2", text: "Test Release"
     # Should not crash even with nil values
-  end
-
-  test "feedback" do
-    get feedback_path
-    assert_response :ok
-    assert_select "nav[aria-label='Breadcrumb']", text: /Feedback/
   end
 
   private

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -259,7 +259,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     VCR.use_cassette("git_repository_provider/fetch_latest_release_notes") do
       get changelog_path
       assert_response :ok
-      assert_select "nav[aria-label='Breadcrumb']", text: /What's new/
+      assert_select "[data-breadcrumbs]", text: /What's new/
     end
   end
 
@@ -297,7 +297,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
   test "feedback" do
     get feedback_path
     assert_response :ok
-    assert_select "nav[aria-label='Breadcrumb']", text: /Feedback/
+    assert_select "[data-breadcrumbs]", text: /Feedback/
   end
 
   private

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -259,6 +259,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     VCR.use_cassette("git_repository_provider/fetch_latest_release_notes") do
       get changelog_path
       assert_response :ok
+      assert_select "nav[aria-label='Breadcrumb']", text: /What's new/
     end
   end
 
@@ -291,6 +292,12 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_select "h2", text: "Test Release"
     # Should not crash even with nil values
+  end
+
+  test "feedback" do
+    get feedback_path
+    assert_response :ok
+    assert_select "nav[aria-label='Breadcrumb']", text: /Feedback/
   end
 
   private


### PR DESCRIPTION
## Summary
Fixes an issue where breadcrumb navigation on the **Changelog** (`/changelog`) and **Feedback** (`/feedback`) pages displayed `"Pages"` instead of their actual page names (`"What's new"` and `"Feedback"`). Also enhances breadcrumb accessibility.

## Rationale & Solution
- **Bug Fix**:
  - `PagesController#changelog` and `PagesController#feedback` render within the `settings` layout (which displays breadcrumbs). Because `@breadcrumbs` was not explicitly set in either action, `Breadcrumbable` fell back to `breadcrumbs.pages` derived from `controller_name` (`"pages"` -> `"Pages"`).
  - Explicitly assigned `@breadcrumbs` in `PagesController#changelog` (`Home > What's new`) and `PagesController#feedback` (`Home > Feedback`).
  - Added `changelog` and `feedback` key entries to `config/locales/breadcrumbs/en.yml`.
- **Testing & Component Hook**:
  - Added `data-breadcrumbs` attribute hook to `app/views/layouts/shared/_breadcrumbs.html.erb`.
  - Added test coverage in `test/controllers/pages_controller_test.rb` asserting on `[data-breadcrumbs]`.

## Screenshots

### Changelog Page
| Before | After |
| --- | --- |
| <img width="654" height="271" alt="Screenshot 2026-08-02 at 11 15 10" src="https://github.com/user-attachments/assets/3fb349e0-868a-4071-8642-2560e3cf6aa9" /> | <img width="641" height="276" alt="Screenshot 2026-08-02 at 11 14 41" src="https://github.com/user-attachments/assets/02e167a8-0fed-45b7-b90c-c6c0c87a3651" /> |

### Feedback Page
| Before | After |
| --- | --- |
| <img width="571" height="212" alt="Screenshot 2026-08-02 at 11 15 04" src="https://github.com/user-attachments/assets/ec5b1cee-0703-4fa0-bffe-9985b3b442ca" /> | <img width="551" height="235" alt="Screenshot 2026-08-02 at 11 14 47" src="https://github.com/user-attachments/assets/a168c707-c4e6-4fe4-9775-0519a4103d29" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation to the Changelog and Feedback pages.
  * The Changelog now displays “What’s new,” and the Feedback page displays “Feedback.”
  * Breadcrumbs now include the home page and current-page context, making navigation easier to follow.
* **Tests**
  * Added coverage confirming the new breadcrumbs and successful Feedback page rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->