### PR TITLE
Use confirmed transfers for reporting

### DIFF
--- a/app/controllers/budget_categories_controller.rb
+++ b/app/controllers/budget_categories_controller.rb
@@ -16,6 +16,7 @@ class BudgetCategoriesController < ApplicationController
     # category -- even though the aggregate ignores it. See issue #1059.
     @recent_transactions = @budget.transactions
                                   .where.not(transactions: { kind: Transaction::BUDGET_EXCLUDED_KINDS })
+                                  .excluding_reporting_transfers
 
     if params[:id] == BudgetCategory.uncategorized.id
       @budget_category = @budget.uncategorized_budget_category

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -365,6 +365,7 @@ class ReportsController < ApplicationController
         .merge(Account.included_in_reports)
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
         .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
+        .excluding_reporting_transfers
         .includes(entry: :account, category: :parent)
       transactions = exclude_tax_advantaged_accounts(transactions)
 
@@ -687,6 +688,7 @@ class ReportsController < ApplicationController
         .merge(Account.included_in_reports)
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
         .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
+        .excluding_reporting_transfers
         .includes(entry: :account, category: [])
       transactions = exclude_tax_advantaged_accounts(transactions)
 
@@ -726,6 +728,7 @@ class ReportsController < ApplicationController
         .merge(Account.included_in_reports)
         .where(entries: { entryable_type: "Transaction", excluded: false, date: @period.date_range })
         .where.not(kind: Transaction::BUDGET_EXCLUDED_KINDS)
+        .excluding_reporting_transfers
         .includes(entry: :account, category: [])
       transactions = exclude_tax_advantaged_accounts(transactions)
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -89,14 +89,14 @@ class Entry < ApplicationRecord
     joins(:account).where(accounts: { family_id: family.id })
   end
 
-  # Uncategorized, non-transfer transaction entries on draft or active accounts.
+  # Uncategorized transaction entries that are not part of a confirmed Transfer.
   # Caller is responsible for scoping to accessible entries before applying this scope.
   scope :uncategorized_transactions, -> {
     joins(:account)
       .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
       .where(accounts: { status: %w[draft active] })
       .where(transactions: { category_id: nil })
-      .where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
+      .where.not(Transfer.confirmed_transaction_sql("transactions"))
       .where(entries: { excluded: false })
   }
 

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -458,6 +458,17 @@ class Family < ApplicationRecord
     end
   end
 
+  # Transfer-aware reporting caches must change for creates, updates, and
+  # deletes. COUNT prevents deleting an older (non-MAX) row from leaving the
+  # version stale.
+  def transfers_cache_version
+    @transfers_cache_version ||= begin
+      scope = Transfer.joins(outflow_transaction: { entry: :account })
+                      .where(accounts: { family_id: id })
+      "#{scope.maximum(:updated_at)&.to_i || 0}-#{scope.count}"
+    end
+  end
+
   def self_hoster?
     Rails.application.config.app_mode.self_hosted?
   end

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -227,14 +227,14 @@ class IncomeStatement
     def family_stats(interval: "month")
       @family_stats ||= {}
       @family_stats[interval] ||= Rails.cache.fetch([
-        "income_statement", "family_stats", family.id, user&.id, interval, included_account_ids_hash, family.entries_cache_version
+        "income_statement", "family_stats", family.id, user&.id, interval, included_account_ids_hash, family.entries_cache_version, family.transfers_cache_version
       ]) { FamilyStats.new(family, interval:, account_ids: included_account_ids).call }
     end
 
     def category_stats(interval: "month")
       @category_stats ||= {}
       @category_stats[interval] ||= Rails.cache.fetch([
-        "income_statement", "category_stats", family.id, user&.id, interval, included_account_ids_hash, family.entries_cache_version
+        "income_statement", "category_stats", family.id, user&.id, interval, included_account_ids_hash, family.entries_cache_version, family.transfers_cache_version
       ]) { CategoryStats.new(family, interval:, account_ids: included_account_ids).call }
     end
 
@@ -250,7 +250,7 @@ class IncomeStatement
       sql_hash = Digest::MD5.hexdigest(transactions_scope.to_sql)
 
       Rails.cache.fetch([
-        "income_statement", "totals_query", "v2", family.id, user&.id, included_account_ids_hash, sql_hash, date_range.begin, date_range.end, family.entries_cache_version, family.accounts.maximum(:updated_at)&.to_i
+        "income_statement", "totals_query", "v3", family.id, user&.id, included_account_ids_hash, sql_hash, date_range.begin, date_range.end, family.entries_cache_version, family.transfers_cache_version, family.accounts.maximum(:updated_at)&.to_i
       ]) { Totals.new(family, transactions_scope: transactions_scope, date_range: date_range, included_account_ids: included_account_ids).call }
     end
 

--- a/app/models/income_statement/category_stats.rb
+++ b/app/models/income_statement/category_stats.rb
@@ -79,6 +79,7 @@ class IncomeStatement::CategoryStats
           )
           WHERE a.family_id = :family_id
             AND t.kind NOT IN (#{budget_excluded_kinds_sql})
+            AND NOT (#{Transfer.confirmed_transaction_sql("t")})
             AND ae.excluded = false
             AND a.exclude_from_reports = false
             #{pending_providers_sql}

--- a/app/models/income_statement/family_stats.rb
+++ b/app/models/income_statement/family_stats.rb
@@ -76,6 +76,7 @@ class IncomeStatement::FamilyStats
           )
           WHERE a.family_id = :family_id
             AND t.kind NOT IN (#{budget_excluded_kinds_sql})
+            AND NOT (#{Transfer.confirmed_transaction_sql("t")})
             AND ae.excluded = false
             AND a.exclude_from_reports = false
             #{pending_providers_sql}

--- a/app/models/income_statement/totals.rb
+++ b/app/models/income_statement/totals.rb
@@ -74,6 +74,7 @@ class IncomeStatement::Totals
           er.to_currency = :target_currency
         )
         WHERE at.kind NOT IN (#{budget_excluded_kinds_sql})
+          AND NOT (#{Transfer.confirmed_transaction_sql("at")})
           AND ae.excluded = false
           AND a.family_id = :family_id
           AND a.status IN ('draft', 'active')
@@ -103,6 +104,7 @@ class IncomeStatement::Totals
           er.to_currency = :target_currency
         )
         WHERE at.kind NOT IN (#{budget_excluded_kinds_sql})
+          AND NOT (#{Transfer.confirmed_transaction_sql("at")})
           AND (
             at.investment_activity_label IS NULL
             OR at.investment_activity_label NOT IN ('Transfer', 'Sweep In', 'Sweep Out', 'Exchange')

--- a/app/models/recurring_transaction/identifier.rb
+++ b/app/models/recurring_transaction/identifier.rb
@@ -10,8 +10,8 @@ class RecurringTransaction
     def identify_recurring_patterns
       three_months_ago = 3.months.ago.to_date
 
-      # Skip transfer-kind transactions: they're one half of a Transfer pair, so grouping them
-      # under their single account would produce incoherent recurring "patterns" that don't
+      # Skip confirmed Transfer legs: grouping either half under its single account
+      # would produce incoherent recurring "patterns" that don't
       # represent the underlying account-pair flow. Recurring transfers are tracked on a
       # different shape (RecurringTransaction with destination_account_id). Filtering at the
       # SQL level avoids loading and discarding transfer entries for a busy family.
@@ -19,7 +19,7 @@ class RecurringTransaction
         .joins("INNER JOIN transactions ON transactions.id = entries.entryable_id")
         .where(entryable_type: "Transaction")
         .where("entries.date >= ?", three_months_ago)
-        .where.not("transactions.kind": Transaction::TRANSFER_KINDS)
+        .where.not(Transfer.confirmed_transaction_sql("transactions"))
         .includes(:entryable)
         .to_a
 

--- a/app/models/rule/condition_filter/transaction_type.rb
+++ b/app/models/rule/condition_filter/transaction_type.rb
@@ -24,12 +24,12 @@ class Rule::ConditionFilter::TransactionType < Rule::ConditionFilter
     case value
     when "income"
       scope.where("entries.amount < 0")
-           .where.not(kind: Transaction::TRANSFER_KINDS)
+           .excluding_reporting_transfers
     when "expense"
       scope.where("entries.amount >= 0")
-           .where.not(kind: Transaction::TRANSFER_KINDS)
+           .excluding_reporting_transfers
     when "transfer"
-      scope.where(kind: Transaction::TRANSFER_KINDS)
+      scope.reporting_transfers
     else
       scope
     end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -76,8 +76,10 @@ class Transaction < ApplicationRecord
     investment_contribution: "investment_contribution" # Transfer to investment/crypto account, treated as an expense in budgets
   }
 
-  # All kinds where money moves between accounts (transfer? returns true).
-  # Used for search filters, rule conditions, and UI display.
+  # Provider/UI hints for money movement (Transaction#transfer? remains a kind
+  # predicate for presentation and import workflows). Reporting, search totals,
+  # rule transaction types, and recurring detection use confirmed Transfer rows
+  # through Transfer.confirmed_transaction_sql instead.
   TRANSFER_KINDS = %w[funds_movement cc_payment loan_payment investment_contribution].freeze
 
   # Kinds excluded from budget/income-statement analytics.

--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -62,20 +62,16 @@ class Transaction::Search
         result = scope
                   .select(
                     ActiveRecord::Base.sanitize_sql_array([
-                      "COALESCE(SUM(CASE WHEN entries.amount >= 0 AND transactions.kind NOT IN (?) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as expense_total",
-                      Transaction::TRANSFER_KINDS
+                      "COALESCE(SUM(CASE WHEN entries.amount >= 0 AND NOT (#{Transfer.confirmed_transaction_sql}) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as expense_total"
                     ]),
                     ActiveRecord::Base.sanitize_sql_array([
-                      "COALESCE(SUM(CASE WHEN entries.amount < 0 AND transactions.kind NOT IN (?) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as income_total",
-                      Transaction::TRANSFER_KINDS
+                      "COALESCE(SUM(CASE WHEN entries.amount < 0 AND NOT (#{Transfer.confirmed_transaction_sql}) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as income_total"
                     ]),
                     ActiveRecord::Base.sanitize_sql_array([
-                      "COALESCE(SUM(CASE WHEN entries.amount < 0 AND transactions.kind IN (?) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as transfer_inflow_total",
-                      Transaction::TRANSFER_KINDS
+                      "COALESCE(SUM(CASE WHEN entries.amount < 0 AND (#{Transfer.confirmed_transaction_sql}) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as transfer_inflow_total"
                     ]),
                     ActiveRecord::Base.sanitize_sql_array([
-                      "COALESCE(SUM(CASE WHEN entries.amount >= 0 AND transactions.kind IN (?) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as transfer_outflow_total",
-                      Transaction::TRANSFER_KINDS
+                      "COALESCE(SUM(CASE WHEN entries.amount >= 0 AND (#{Transfer.confirmed_transaction_sql}) THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as transfer_outflow_total"
                     ]),
                     "COUNT(entries.id) as transactions_count"
                   )
@@ -103,6 +99,7 @@ class Transaction::Search
       family.id,
       Digest::SHA256.hexdigest(attributes.sort.to_h.to_json), # cached by filters
       family.entries_cache_version,
+      family.transfers_cache_version,
       Digest::SHA256.hexdigest(family.tax_advantaged_account_ids.sort.to_json), # stable across processes
       accessible_account_ids ? Digest::SHA256.hexdigest(accessible_account_ids.sort.to_json) : "all"
     ].join("/")
@@ -131,14 +128,14 @@ class Transaction::Search
       # Get parent category IDs for the given category names
       parent_category_ids = family.categories.where(name: real_categories).pluck(:id)
 
-      uncategorized_condition = "categories.id IS NULL AND transactions.kind NOT IN (?)"
+      uncategorized_condition = "categories.id IS NULL AND NOT (#{Transfer.confirmed_transaction_sql})"
 
       # Build condition based on whether parent_category_ids is empty
       if parent_category_ids.empty?
         if include_uncategorized
           query = query.left_joins(:category).where(
             "categories.name IN (?) OR (#{uncategorized_condition})",
-            real_categories.presence || [], Transaction::TRANSFER_KINDS
+            real_categories.presence || []
           )
         else
           query = query.left_joins(:category).where(categories: { name: real_categories })
@@ -147,7 +144,7 @@ class Transaction::Search
         if include_uncategorized
           query = query.left_joins(:category).where(
             "categories.name IN (?) OR categories.parent_id IN (?) OR (#{uncategorized_condition})",
-            real_categories, parent_category_ids, Transaction::TRANSFER_KINDS
+            real_categories, parent_category_ids
           )
         else
           query = query.left_joins(:category).where(
@@ -166,17 +163,17 @@ class Transaction::Search
 
       case types.sort
       when [ "transfer" ]
-        query.where(kind: Transaction::TRANSFER_KINDS)
+        query.reporting_transfers
       when [ "expense" ]
-        query.where("entries.amount >= 0").where.not(kind: Transaction::TRANSFER_KINDS)
+        query.where("entries.amount >= 0").excluding_reporting_transfers
       when [ "income" ]
-        query.where("entries.amount < 0").where.not(kind: Transaction::TRANSFER_KINDS)
+        query.where("entries.amount < 0").excluding_reporting_transfers
       when [ "expense", "transfer" ]
-        query.where("entries.amount >= 0 OR transactions.kind IN (?)", Transaction::TRANSFER_KINDS)
+        query.where("entries.amount >= 0 OR (#{Transfer.confirmed_transaction_sql})")
       when [ "income", "transfer" ]
-        query.where("entries.amount < 0 OR transactions.kind IN (?)", Transaction::TRANSFER_KINDS)
+        query.where("entries.amount < 0 OR (#{Transfer.confirmed_transaction_sql})")
       when [ "expense", "income" ]
-        query.where.not(kind: Transaction::TRANSFER_KINDS)
+        query.excluding_reporting_transfers
       else
         query
       end

--- a/app/models/transaction/transferable.rb
+++ b/app/models/transaction/transferable.rb
@@ -8,6 +8,13 @@ module Transaction::Transferable
     # We keep track of rejected transfers to avoid auto-matching them again
     has_one :rejected_transfer_as_inflow, class_name: "RejectedTransfer", foreign_key: "inflow_transaction_id", dependent: :destroy
     has_one :rejected_transfer_as_outflow, class_name: "RejectedTransfer", foreign_key: "outflow_transaction_id", dependent: :destroy
+
+    scope :reporting_transfers, -> { where(Transfer.confirmed_transaction_sql(table_name)) }
+    scope :excluding_reporting_transfers, -> { where.not(Transfer.confirmed_transaction_sql(table_name)) }
+  end
+
+  def reporting_transfer?
+    transfer_as_inflow&.confirmed? || transfer_as_outflow&.confirmed? || false
   end
 
   def transfer

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -1,4 +1,25 @@
 class Transfer < ApplicationRecord
+  # Reporting treats a confirmed persisted Transfer as the sole authority for
+  # whether a transaction is an internal transfer. Transaction#kind remains a
+  # provider/UI classification hint and may be overwritten during re-sync.
+  def self.confirmed_transaction_sql(transaction_alias = "transactions")
+    unless transaction_alias.match?(/\A[a-zA-Z_][a-zA-Z0-9_]*\z/)
+      raise ArgumentError, "invalid transaction table alias"
+    end
+
+    <<~SQL.squish
+      EXISTS (
+        SELECT 1
+        FROM transfers reporting_transfers
+        WHERE reporting_transfers.status = 'confirmed'
+          AND (
+            reporting_transfers.inflow_transaction_id = #{transaction_alias}.id
+            OR reporting_transfers.outflow_transaction_id = #{transaction_alias}.id
+          )
+      )
+    SQL
+  end
+
   belongs_to :inflow_transaction, class_name: "Transaction"
   belongs_to :outflow_transaction, class_name: "Transaction"
 

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -22,4 +22,21 @@ class EntryTest < ActiveSupport::TestCase
     assert_equal entry_ids.sort, Entry.where(id: entry_ids).chronological.pluck(:id)
     assert_equal entry_ids.sort.reverse, Entry.where(id: entry_ids).reverse_chronological.pluck(:id)
   end
+
+  test "uncategorized reporting follows confirmed transfers instead of kind" do
+    source = accounts(:depository)
+    destination = source.family.accounts.where.not(id: source.id).first
+    kind_hint = create_transaction(account: source, kind: "funds_movement", category: nil)
+    transfer = create_transfer(from_account: source, to_account: destination, amount: 100)
+    transfer.inflow_transaction.update!(kind: "standard")
+    transfer.outflow_transaction.update!(kind: "standard")
+
+    result_ids = Entry.where(id: [ kind_hint.id, transfer.inflow_transaction.entry.id, transfer.outflow_transaction.entry.id ])
+                      .uncategorized_transactions
+                      .pluck(:id)
+
+    assert_includes result_ids, kind_hint.id
+    assert_not_includes result_ids, transfer.inflow_transaction.entry.id
+    assert_not_includes result_ids, transfer.outflow_transaction.entry.id
+  end
 end

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -2,9 +2,26 @@ require "test_helper"
 
 class FamilyTest < ActiveSupport::TestCase
   include SyncableInterfaceTest
+  include EntriesTestHelper
 
   def setup
     @syncable = families(:dylan_family)
+  end
+
+  test "transfers cache version changes when a non-latest transfer is deleted" do
+    family = families(:empty)
+    source = family.accounts.create!(name: "Source", balance: 0, currency: "USD", accountable: Depository.new)
+    destination = family.accounts.create!(name: "Destination", balance: 0, currency: "USD", accountable: Depository.new)
+    older = create_transfer(from_account: source, to_account: destination, amount: 10, date: 2.days.ago.to_date)
+    latest = create_transfer(from_account: source, to_account: destination, amount: 20, date: 1.day.ago.to_date)
+    older.update_column(:updated_at, 2.days.ago)
+    latest.update_column(:updated_at, 1.day.ago)
+    family.reload
+    version_before_delete = family.transfers_cache_version
+
+    older.destroy!
+
+    assert_not_equal version_before_delete, family.reload.transfers_cache_version
   end
 
   test "investment_contributions_category creates category when missing" do

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -385,6 +385,34 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_equal Money.new(1400, @family.currency), totals.expense_money # 900 + 500 (abs of -500)
   end
 
+  test "provider re-sync cannot double count a confirmed transfer" do
+    investment_account = @family.accounts.create!(
+      name: "Brokerage",
+      currency: @family.currency,
+      balance: 0,
+      accountable: Investment.new
+    )
+    transfer = create_transfer(
+      from_account: @checking_account,
+      to_account: investment_account,
+      amount: 500
+    )
+
+    before_sync = IncomeStatement.new(@family).totals(date_range: Period.last_30_days.date_range)
+
+    # Providers may rewrite either hint on a subsequent sync. The confirmed
+    # Transfer remains authoritative for reporting classification.
+    transfer.inflow_transaction.update!(kind: "investment_contribution")
+    transfer.outflow_transaction.update!(kind: "standard")
+
+    after_sync = IncomeStatement.new(@family).totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal before_sync, after_sync
+    assert_equal 4, after_sync.transactions_count
+    assert_equal Money.new(1000, @family.currency), after_sync.income_money
+    assert_equal Money.new(900, @family.currency), after_sync.expense_money
+  end
+
   # Tax-Advantaged Account Exclusion Tests
   test "excludes transactions from tax-advantaged Roth IRA accounts" do
     # Create a Roth IRA (tax-exempt) investment account

--- a/test/models/recurring_transaction/identifier_test.rb
+++ b/test/models/recurring_transaction/identifier_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class RecurringTransaction::IdentifierTest < ActiveSupport::TestCase
+  include EntriesTestHelper
   def setup
     @family = families(:dylan_family)
     @identifier = RecurringTransaction::Identifier.new(@family)
@@ -464,6 +465,24 @@ class RecurringTransaction::IdentifierTest < ActiveSupport::TestCase
   test "days_cluster_together returns false for widely spread days" do
     days = [ 1, 15, 30 ]
     assert_not @identifier.send(:days_cluster_together?, days)
+  end
+
+  test "confirmed transfers are excluded even after their kinds change" do
+    source = @family.accounts.first
+    destination = @family.accounts.where.not(id: source.id).first
+
+    [ 0, 1, 2 ].each do |months_ago|
+      transfer = create_transfer(
+        from_account: source,
+        to_account: destination,
+        amount: 75,
+        date: months_ago.months.ago.beginning_of_month + 4.days
+      )
+      transfer.inflow_transaction.update!(kind: "standard")
+      transfer.outflow_transaction.update!(kind: "standard")
+    end
+
+    assert_equal 0, @identifier.identify_recurring_patterns
   end
 
   private

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -7,6 +7,7 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     @family = families(:empty)
     @transaction_rule = rules(:one)
     @account = @family.accounts.create!(name: "Rule test", balance: 1000, currency: "USD", accountable: Depository.new)
+    @transfer_account = @family.accounts.create!(name: "Transfer target", balance: 0, currency: "USD", accountable: Depository.new)
 
     @grocery_category = @family.categories.create!(name: "Grocery")
     @whole_foods_merchant = @family.merchants.create!(name: "Whole Foods", type: "FamilyMerchant")
@@ -372,13 +373,7 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     scope = @rule_scope
 
     # Create a transfer transaction
-    transfer_entry = create_transaction(
-      date: Date.current,
-      account: @account,
-      amount: 500,
-      name: "Transfer to savings"
-    )
-    transfer_entry.transaction.update!(kind: "funds_movement")
+    transfer_entry = create_transfer(from_account: @account, to_account: @transfer_account, amount: 500).outflow_transaction.entry
 
     condition = Rule::Condition.new(
       rule: @transaction_rule,
@@ -399,13 +394,7 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     scope = @rule_scope
 
     # Create a transfer with positive amount (would look like expense)
-    transfer_entry = create_transaction(
-      date: Date.current,
-      account: @account,
-      amount: 500,
-      name: "Transfer to savings"
-    )
-    transfer_entry.transaction.update!(kind: "funds_movement")
+    transfer_entry = create_transfer(from_account: @account, to_account: @transfer_account, amount: 500).outflow_transaction.entry
 
     condition = Rule::Condition.new(
       rule: @transaction_rule,
@@ -425,13 +414,7 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     scope = @rule_scope
 
     # Create a transfer inflow (negative amount)
-    transfer_entry = create_transaction(
-      date: Date.current,
-      account: @account,
-      amount: -500,
-      name: "Transfer from savings"
-    )
-    transfer_entry.transaction.update!(kind: "funds_movement")
+    transfer_entry = create_transfer(from_account: @transfer_account, to_account: @account, amount: 500).inflow_transaction.entry
 
     condition = Rule::Condition.new(
       rule: @transaction_rule,
@@ -447,7 +430,7 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_not filtered.map(&:id).include?(transfer_entry.transaction.id)
   end
 
-  test "transaction_type transfer includes investment_contribution" do
+  test "transaction_type transfer ignores an unconfirmed kind hint" do
     scope = @rule_scope
 
     # Create investment contribution with negative amount (inflow from provider)
@@ -469,24 +452,22 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     scope = condition.prepare(scope)
     filtered = condition.apply(scope)
 
-    # investment_contribution is a transfer kind
-    assert filtered.map(&:id).include?(contribution_entry.transaction.id)
+    assert_not_includes filtered.map(&:id), contribution_entry.transaction.id
 
-    # Should NOT match expense filter
-    expense_condition = Rule::Condition.new(
+    income_condition = Rule::Condition.new(
       rule: @transaction_rule,
       condition_type: "transaction_type",
       operator: "=",
-      value: "expense"
+      value: "income"
     )
 
-    expense_scope = expense_condition.prepare(@rule_scope)
-    expense_filtered = expense_condition.apply(expense_scope)
+    income_scope = income_condition.prepare(@rule_scope)
+    income_filtered = income_condition.apply(income_scope)
 
-    assert_not expense_filtered.map(&:id).include?(contribution_entry.transaction.id)
+    assert_includes income_filtered.map(&:id), contribution_entry.transaction.id
   end
 
-  test "transaction_type income excludes investment_contribution" do
+  test "transaction_type income excludes confirmed transfer after kind changes" do
     scope = @rule_scope
 
     # Create investment contribution with negative amount
@@ -497,6 +478,13 @@ class Rule::ConditionTest < ActiveSupport::TestCase
       name: "401k contribution"
     )
     contribution_entry.transaction.update!(kind: "investment_contribution")
+    counterpart = create_transaction(date: Date.current, account: @transfer_account, amount: 1000, name: "Contribution source")
+    Transfer.create!(
+      inflow_transaction: contribution_entry.transaction,
+      outflow_transaction: counterpart.transaction,
+      status: "confirmed",
+      amount: 1000
+    )
 
     condition = Rule::Condition.new(
       rule: @transaction_rule,

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -13,7 +13,7 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     @family.accounts.each { |account| account.entries.delete_all }
   end
 
-  test "search filters by transaction types using kind enum" do
+  test "search does not treat kind hints as persisted transfers" do
     # Create different types of transactions using the helper method
     standard_entry = create_transaction(
       account: @checking_account,
@@ -50,9 +50,9 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     transfer_results = Transaction::Search.new(@family, filters: { types: [ "transfer" ] }).transactions_scope
     transfer_ids = transfer_results.pluck(:id)
 
-    assert_includes transfer_ids, transfer_entry.entryable.id
-    assert_includes transfer_ids, payment_entry.entryable.id
-    assert_includes transfer_ids, loan_payment_entry.entryable.id
+    assert_not_includes transfer_ids, transfer_entry.entryable.id
+    assert_not_includes transfer_ids, payment_entry.entryable.id
+    assert_not_includes transfer_ids, loan_payment_entry.entryable.id
     assert_not_includes transfer_ids, one_time_entry.entryable.id
     assert_not_includes transfer_ids, standard_entry.entryable.id
 
@@ -62,8 +62,8 @@ class Transaction::SearchTest < ActiveSupport::TestCase
 
     assert_includes expense_ids, standard_entry.entryable.id
     assert_includes expense_ids, one_time_entry.entryable.id
-    assert_not_includes expense_ids, loan_payment_entry.entryable.id
-    assert_not_includes expense_ids, transfer_entry.entryable.id
+    assert_includes expense_ids, loan_payment_entry.entryable.id
+    assert_includes expense_ids, transfer_entry.entryable.id
     assert_not_includes expense_ids, payment_entry.entryable.id
 
     # Test income type filter
@@ -77,6 +77,7 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     income_ids = income_results.pluck(:id)
 
     assert_includes income_ids, income_entry.entryable.id
+    assert_includes income_ids, payment_entry.entryable.id
     assert_not_includes income_ids, standard_entry.entryable.id
     assert_not_includes income_ids, loan_payment_entry.entryable.id
     assert_not_includes income_ids, transfer_entry.entryable.id
@@ -88,9 +89,9 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     assert_includes non_transfer_ids, standard_entry.entryable.id
     assert_includes non_transfer_ids, income_entry.entryable.id
     assert_includes non_transfer_ids, one_time_entry.entryable.id
-    assert_not_includes non_transfer_ids, loan_payment_entry.entryable.id
-    assert_not_includes non_transfer_ids, transfer_entry.entryable.id
-    assert_not_includes non_transfer_ids, payment_entry.entryable.id
+    assert_includes non_transfer_ids, loan_payment_entry.entryable.id
+    assert_includes non_transfer_ids, transfer_entry.entryable.id
+    assert_includes non_transfer_ids, payment_entry.entryable.id
   end
 
   test "search category filter handles uncategorized transactions correctly with kind filtering" do
@@ -120,9 +121,8 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     # Should include standard uncategorized transactions
     assert_includes uncategorized_ids, uncategorized_standard.entryable.id
 
-    # Should exclude all transfer kinds (TRANSFER_KINDS) even if uncategorized
-    assert_not_includes uncategorized_ids, uncategorized_transfer.entryable.id
-    assert_not_includes uncategorized_ids, uncategorized_loan_payment.entryable.id
+    assert_includes uncategorized_ids, uncategorized_transfer.entryable.id
+    assert_includes uncategorized_ids, uncategorized_loan_payment.entryable.id
   end
 
   test "filtering for only Uncategorized returns only uncategorized transactions" do
@@ -230,16 +230,15 @@ class Transaction::SearchTest < ActiveSupport::TestCase
 
     # Should include expense transactions
     assert_includes result_ids, transaction1.entryable.id
-    # Should exclude transfer transactions
-    assert_not_includes result_ids, transaction2.entryable.id
+    assert_includes result_ids, transaction2.entryable.id
 
     # Test that the relation builds from family.transactions correctly
-    assert_equal @family.transactions.joins(entry: :account).where(
-      "entries.amount >= 0 AND NOT (transactions.kind IN (?))", Transaction::TRANSFER_KINDS
-    ).count, results.count
+    assert_equal @family.transactions.joins(entry: :account)
+                        .where("entries.amount >= 0")
+                        .excluding_reporting_transfers.count, results.count
   end
 
-  test "transfer filter includes investment_contribution transactions" do
+  test "transfer filter ignores unpersisted transfer kinds" do
     investment_contribution = create_transaction(
       account: @checking_account,
       amount: 500,
@@ -255,11 +254,11 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     search = Transaction::Search.new(@family, filters: { types: [ "transfer" ] })
     result_ids = search.transactions_scope.pluck(:id)
 
-    assert_includes result_ids, investment_contribution.entryable.id
-    assert_includes result_ids, funds_movement.entryable.id
+    assert_not_includes result_ids, investment_contribution.entryable.id
+    assert_not_includes result_ids, funds_movement.entryable.id
   end
 
-  test "expense filter excludes investment_contribution transactions" do
+  test "expense filter includes unpersisted investment contribution kind" do
     investment_contribution = create_transaction(
       account: @checking_account,
       amount: 500,
@@ -275,7 +274,7 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     search = Transaction::Search.new(@family, filters: { types: [ "expense" ] })
     result_ids = search.transactions_scope.pluck(:id)
 
-    assert_not_includes result_ids, investment_contribution.entryable.id
+    assert_includes result_ids, investment_contribution.entryable.id
     assert_includes result_ids, standard_expense.entryable.id
   end
 
@@ -669,5 +668,27 @@ class Transaction::SearchTest < ActiveSupport::TestCase
 
     assert_includes confirmed_ids, confirmed.entryable.id
     assert_not_includes pending_ids, confirmed.entryable.id
+  end
+
+  test "confirmed transfer remains classified after provider kind re-sync" do
+    transfer = create_transfer(
+      from_account: @checking_account,
+      to_account: @credit_card_account,
+      amount: 250
+    )
+    search = Transaction::Search.new(@family)
+
+    transfer.inflow_transaction.update!(kind: "investment_contribution")
+    transfer.outflow_transaction.update!(kind: "standard")
+
+    transfer_ids = Transaction::Search.new(@family, filters: { types: [ "transfer" ] }).transactions_scope.pluck(:id)
+    totals = search.totals
+
+    assert_includes transfer_ids, transfer.inflow_transaction_id
+    assert_includes transfer_ids, transfer.outflow_transaction_id
+    assert_equal Money.new(250, @family.currency), totals.transfer_inflow_money
+    assert_equal Money.new(250, @family.currency), totals.transfer_outflow_money
+    assert_equal Money.new(0, @family.currency), totals.income_money
+    assert_equal Money.new(0, @family.currency), totals.expense_money
   end
 end

--- a/test/support/entries_test_helper.rb
+++ b/test/support/entries_test_helper.rb
@@ -59,7 +59,8 @@ module EntriesTestHelper
     transfer = Transfer.create!(
       outflow_transaction: outflow_transaction,
       inflow_transaction: inflow_transaction,
-      amount: amount.abs
+      amount: amount.abs,
+      status: "confirmed"
     )
 
     from_account.entries.create!(


### PR DESCRIPTION
## Summary

- make confirmed persisted `Transfer` rows the documented reporting authority while retaining transaction `kind` as an import/UI hint
- migrate entry categorization, transaction search/totals, recurring detection, rule transaction-type filters, and income-statement/report queries to that authority
- invalidate transfer-aware caches on transfer creates, updates, and non-latest deletes by including both `MAX(updated_at)` and row count
- add regressions proving provider kind rewrites cannot reintroduce reporting double counting

## Root cause

Reporting classified transfers from mutable transaction kinds. Provider re-syncs can rewrite those hints after matching, causing the two legs of a persisted transfer to be reported inconsistently or counted twice.

## Validation

- `git diff --check` — passed
- focused Rails tests — not run because this worktree image has no Ruby executable (`/usr/bin/env: ruby: No such file or directory`)
- focused RuboCop — not run for the same missing Ruby runtime

Closes #2860.
