### PR TITLE
feat(budgets): support multiple budgets per month via budget plans

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -170,6 +170,8 @@ class AccountsController < ApplicationController
   def destroy
     if @account.linked?
       redirect_to account_path(@account), alert: t("accounts.destroy.cannot_delete_linked")
+    elsif (plan_names = @account.solely_scoped_budget_plans.pluck(:name)).any?
+      redirect_to account_path(@account), alert: t("accounts.destroy.cannot_delete_last_budget_plan_account", plans: plan_names.to_sentence)
     else
       begin
         @account.destroy_later

--- a/app/controllers/api/v1/budget_plans_controller.rb
+++ b/app/controllers/api/v1/budget_plans_controller.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # API v1 endpoint for budget plans — the named, optionally account-scoped
+    # budgets a family keeps side by side (e.g. "Personal" vs "Joint", or a
+    # test budget observed next to the live one). Monthly budget rows belong
+    # to a plan; see Api::V1::BudgetsController's budget_plan_id filter.
+    #
+    # @example Create an account-scoped plan
+    #   POST /api/v1/budget_plans
+    #   { "budget_plan": { "name": "Joint", "account_ids": ["<uuid>", "<uuid>"] } }
+    #
+    class BudgetPlansController < BaseController
+      before_action -> { authorize_scope!(:read) }, only: %i[index show]
+      before_action -> { authorize_scope!(:read_write) }, only: %i[create update destroy]
+      before_action :set_budget_plan, only: %i[show update destroy]
+
+      def index
+        plans = family.budget_plans.default_first.includes(:budget_plan_accounts)
+
+        render json: plans.map { |plan| budget_plan_json(plan) }
+      end
+
+      def show
+        render json: budget_plan_json(@budget_plan)
+      end
+
+      def create
+        @budget_plan = family.budget_plans.new(name: budget_plan_params[:name])
+        return unless assign_accounts(@budget_plan)
+
+        if @budget_plan.save
+          render json: budget_plan_json(@budget_plan), status: :created
+        else
+          render json: { error: @budget_plan.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        @budget_plan.name = budget_plan_params[:name] if budget_plan_params.key?(:name)
+        return unless assign_accounts(@budget_plan)
+
+        if @budget_plan.save
+          render json: budget_plan_json(@budget_plan)
+        else
+          render json: { error: @budget_plan.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        if @budget_plan.destroy
+          head :no_content
+        else
+          render json: { error: @budget_plan.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+        def family
+          current_resource_owner.family
+        end
+
+        def set_budget_plan
+          @budget_plan = family.budget_plans.find(params[:id])
+        rescue ActiveRecord::RecordNotFound
+          render json: { error: "Budget plan not found" }, status: :not_found
+        end
+
+        def budget_plan_params
+          params.require(:budget_plan).permit(:name, account_ids: [])
+        end
+
+        # Replaces the plan's scoped accounts when the account_ids key is
+        # present ([] clears the scope back to all-accounts); leaves the
+        # scope untouched when the key is omitted. Ids are re-scoped through
+        # the family; unknown ids are a 422, not silently dropped.
+        def assign_accounts(plan)
+          return true unless budget_plan_params.key?(:account_ids)
+
+          ids = Array(budget_plan_params[:account_ids]).reject(&:blank?).uniq
+          accounts = family.accounts.where(id: ids)
+          missing = ids - accounts.pluck(:id)
+
+          if missing.any?
+            render json: { error: "Unknown account ids: #{missing.join(', ')}" }, status: :unprocessable_entity
+            return false
+          end
+
+          plan.account_ids = accounts.map(&:id)
+          true
+        end
+
+        def budget_plan_json(plan)
+          {
+            id: plan.id,
+            name: plan.name,
+            slug: plan.slug,
+            is_default: plan.is_default,
+            # [] means the plan tracks all of the family's accounts.
+            account_ids: plan.budget_plan_accounts.map(&:account_id),
+            created_at: plan.created_at,
+            updated_at: plan.updated_at
+          }
+        end
+    end
+  end
+end

--- a/app/controllers/api/v1/budget_plans_controller.rb
+++ b/app/controllers/api/v1/budget_plans_controller.rb
@@ -72,23 +72,30 @@ module Api
           params.require(:budget_plan).permit(:name, account_ids: [])
         end
 
+        def accessible_account_ids
+          @accessible_account_ids ||= current_resource_owner.accessible_accounts.pluck(:id).to_set
+        end
+
         # Replaces the plan's scoped accounts when the account_ids key is
         # present ([] clears the scope back to all-accounts); leaves the
         # scope untouched when the key is omitted. Ids are re-scoped through
-        # the family; unknown ids are a 422, not silently dropped.
+        # the resource owner's accessible accounts; unknown or inaccessible
+        # ids are a 422, not silently dropped. Links to accounts the owner
+        # can't see are preserved — their absence from the submitted set is
+        # not an intentional removal (mirrors the web controller's sync).
         def assign_accounts(plan)
           return true unless budget_plan_params.key?(:account_ids)
 
           ids = Array(budget_plan_params[:account_ids]).reject(&:blank?).uniq
-          accounts = family.accounts.where(id: ids)
-          missing = ids - accounts.pluck(:id)
+          missing = ids.reject { |id| accessible_account_ids.include?(id) }
 
           if missing.any?
             render json: { error: "Unknown account ids: #{missing.join(', ')}" }, status: :unprocessable_entity
             return false
           end
 
-          plan.account_ids = accounts.map(&:id)
+          preserved = plan.account_ids.reject { |id| accessible_account_ids.include?(id) }
+          plan.account_ids = preserved + ids
           true
         end
 
@@ -98,8 +105,9 @@ module Api
             name: plan.name,
             slug: plan.slug,
             is_default: plan.is_default,
-            # [] means the plan tracks all of the family's accounts.
-            account_ids: plan.budget_plan_accounts.map(&:account_id),
+            # [] means the plan tracks all of the family's accounts. Only
+            # accounts visible to the API key's owner are listed.
+            account_ids: plan.budget_plan_accounts.map(&:account_id).select { |id| accessible_account_ids.include?(id) },
             created_at: plan.created_at,
             updated_at: plan.updated_at
           }

--- a/app/controllers/api/v1/budgets_controller.rb
+++ b/app/controllers/api/v1/budgets_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::BudgetsController < Api::V1::BaseController
   before_action :set_budget, only: :show
 
   def index
-    budgets_query = apply_filters(budgets_scope).order(start_date: :desc)
+    budgets_query = apply_filters(budgets_scope).order(start_date: :desc, created_at: :asc, id: :asc)
     @per_page = safe_per_page_param
 
     @pagy, @budgets = pagy(
@@ -38,10 +38,14 @@ class Api::V1::BudgetsController < Api::V1::BaseController
     def apply_filters(query)
       query = query.where("budgets.start_date >= ?", parse_date_param(:start_date)) if params[:start_date].present?
       query = query.where("budgets.end_date <= ?", parse_date_param(:end_date)) if params[:end_date].present?
+      if params[:budget_plan_id].present?
+        raise ActiveRecord::RecordNotFound unless valid_uuid?(params[:budget_plan_id])
+        query = query.where(budget_plan_id: params[:budget_plan_id])
+      end
       query
     end
 
     def budgets_scope
-      current_resource_owner.family.budgets.includes(budget_categories: :category)
+      current_resource_owner.family.budgets.includes({ budget_plan: :budget_plan_accounts }, budget_categories: :category)
     end
 end

--- a/app/controllers/budget_categories_controller.rb
+++ b/app/controllers/budget_categories_controller.rb
@@ -21,7 +21,7 @@ class BudgetCategoriesController < ApplicationController
       @budget_category = @budget.uncategorized_budget_category
       @recent_transactions = @recent_transactions.where(transactions: { category_id: nil })
     else
-      @budget_category = Current.family.budget_categories.find(params[:id])
+      @budget_category = @budget.budget_categories.find(params[:id])
       @recent_transactions = @recent_transactions.joins("LEFT JOIN categories ON categories.id = transactions.category_id")
                                                  .where("categories.id = ? OR categories.parent_id = ?", @budget_category.category.id, @budget_category.category.id)
     end
@@ -30,7 +30,7 @@ class BudgetCategoriesController < ApplicationController
   end
 
   def update
-    @budget_category = Current.family.budget_categories.find(params[:id])
+    @budget_category = @budget.budget_categories.find(params[:id])
     @budget_category.update_budgeted_spending!(budgeted_spending_param)
 
     respond_to do |format|
@@ -50,7 +50,10 @@ class BudgetCategoriesController < ApplicationController
     end
 
     def set_budget
-      start_date = Budget.param_to_date(params[:budget_month_year], family: Current.family)
-      @budget = Current.family.budgets.find_by!(start_date: start_date)
+      plan, start_date = Budget.resolve_param(params[:budget_month_year], family: Current.family)
+      @budget = Current.family.budgets.find_by!(budget_plan: plan, start_date: start_date)
+      # Same per-user account visibility the budget page applies via
+      # Budget.find_or_bootstrap, so the drilldown shows matching numbers.
+      @budget.current_user = Current.user
     end
 end

--- a/app/controllers/budget_plans_controller.rb
+++ b/app/controllers/budget_plans_controller.rb
@@ -1,0 +1,104 @@
+class BudgetPlansController < ApplicationController
+  before_action :set_budget_plan, only: %i[edit update destroy]
+
+  def new
+    @budget_plan = Current.family.budget_plans.new
+    @selectable_accounts = selectable_accounts
+  end
+
+  def create
+    @budget_plan = Current.family.budget_plans.new(budget_plan_params)
+    accounts = lookup_accounts(params.dig(:budget_plan, :account_ids))
+
+    BudgetPlan.transaction do
+      accounts.each { |account| @budget_plan.budget_plan_accounts.build(account: account) }
+      @budget_plan.save!
+    end
+
+    redirect_to_plan_budget(@budget_plan, notice: t(".success"))
+  rescue ActiveRecord::RecordInvalid
+    @selectable_accounts = selectable_accounts
+    render :new, status: :unprocessable_entity
+  end
+
+  def edit
+    @selectable_accounts = selectable_accounts
+    @scoped_account_ids = @budget_plan.budget_plan_accounts.pluck(:account_id).map(&:to_s)
+  end
+
+  def update
+    account_ids = params.dig(:budget_plan, :account_ids)
+    accounts_supplied = !account_ids.nil?
+    accounts = accounts_supplied ? lookup_accounts(account_ids) : []
+
+    BudgetPlan.transaction do
+      @budget_plan.update!(budget_plan_params)
+      sync_scoped_accounts!(@budget_plan, accounts) if accounts_supplied
+    end
+
+    redirect_to_plan_budget(@budget_plan, notice: t(".success"))
+  rescue ActiveRecord::RecordInvalid
+    @selectable_accounts = selectable_accounts
+    @scoped_account_ids = @budget_plan.budget_plan_accounts.pluck(:account_id).map(&:to_s)
+    render :edit, status: :unprocessable_entity
+  end
+
+  def destroy
+    if @budget_plan.is_default?
+      redirect_to budgets_path, alert: t(".cannot_delete_default")
+      return
+    end
+
+    @budget_plan.destroy!
+    redirect_to budgets_path, notice: t(".success")
+  end
+
+  private
+    def set_budget_plan
+      @budget_plan = Current.family.budget_plans.find(params[:id])
+    end
+
+    def budget_plan_params
+      params.require(:budget_plan).permit(:name)
+    end
+
+    def redirect_to_plan_budget(plan, notice:)
+      budget = Budget.find_or_bootstrap(Current.family, start_date: Date.current, user: Current.user, plan: plan)
+      target = budget ? budget_path(budget) : budgets_path
+
+      flash[:notice] = notice
+      respond_to do |format|
+        format.html { redirect_to target }
+        format.turbo_stream { render turbo_stream: turbo_stream.action(:redirect, target) }
+      end
+    end
+
+    # Submitted ids are re-scoped through the user's accessible accounts —
+    # never trusted raw. Unknown ids simply drop out of the checkbox set.
+    def lookup_accounts(ids)
+      return [] if ids.blank?
+
+      ids = Array(ids).reject(&:blank?)
+      Current.user.accessible_accounts.visible.where(id: ids).to_a
+    end
+
+    def selectable_accounts
+      Current.user.accessible_accounts.visible.alphabetically.to_a
+    end
+
+    # Goals-style sync: only unlink accounts the current user can see in the
+    # picker. Another member's private account never renders as a checkbox,
+    # so its absence from the submitted set is not an intentional removal.
+    def sync_scoped_accounts!(plan, accounts)
+      desired_ids = accounts.map(&:id).to_set
+      current_ids = plan.budget_plan_accounts.pluck(:account_id).to_set
+      removable_ids = Current.user.accessible_accounts.where(id: current_ids.to_a).pluck(:id).to_set
+
+      plan.budget_plan_accounts.where(account_id: ((current_ids & removable_ids) - desired_ids).to_a).destroy_all
+      plan.budget_plan_accounts.reload
+
+      (desired_ids - current_ids).each do |account_id|
+        plan.budget_plan_accounts.create!(account_id: account_id)
+      end
+    end
+end

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -36,9 +36,16 @@ class BudgetsController < ApplicationController
   end
 
   def picker
+    plan = if params[:plan].present?
+      Current.family.budget_plans.find_by!(slug: params[:plan])
+    else
+      Current.family.default_budget_plan
+    end
+
     render partial: "budgets/picker", locals: {
       family: Current.family,
-      year: params[:year].to_i || Date.current.year
+      year: params[:year].to_i || Date.current.year,
+      plan: plan
     }
   end
 
@@ -53,8 +60,8 @@ class BudgetsController < ApplicationController
     end
 
     def set_budget
-      start_date = Budget.param_to_date(params[:month_year], family: Current.family)
-      @budget = Budget.find_or_bootstrap(Current.family, start_date: start_date, user: Current.user)
+      plan, start_date = Budget.resolve_param(params[:month_year], family: Current.family)
+      @budget = Budget.find_or_bootstrap(Current.family, start_date: start_date, user: Current.user, plan: plan)
       raise ActiveRecord::RecordNotFound unless @budget
     end
 

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -44,7 +44,7 @@ class BudgetsController < ApplicationController
 
     render partial: "budgets/picker", locals: {
       family: Current.family,
-      year: params[:year].to_i || Date.current.year,
+      year: params[:year].to_i.nonzero? || Date.current.year,
       plan: plan
     }
   end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -8,6 +8,7 @@ class PlansController < ApplicationController
   def show
     @budget = Budget.find_or_bootstrap(Current.family, start_date: Date.current, user: Current.user)
     @top_budget_categories = @budget.initialized? ? @budget.top_spending_categories : []
+    @other_budget_plans = Current.family.budget_plans.where(is_default: false).order(:name)
 
     @goals = Goal.active_prepared_for(Current.family)
     @goals_summary = Goal.summary_for(@goals, currency: Current.family.primary_currency_code)

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -1,4 +1,9 @@
 module BudgetsHelper
+  # Plans offered by the switcher menu on the budget page.
+  def budget_plan_switcher_plans
+    Current.family.budget_plans.default_first
+  end
+
   def budget_has_over_budget?(budget)
     return false unless budget.initialized?
 

--- a/app/helpers/insights_helper.rb
+++ b/app/helpers/insights_helper.rb
@@ -86,7 +86,10 @@ module InsightsHelper
       { text: t("insights.actions.net_worth_milestone"), href: reports_path }
     when "budget_at_risk", "budget_on_track"
       return nil unless insight.period_start
-      { text: t("insights.actions.budget"), href: budget_path(Budget.date_to_param(insight.period_start)) }
+      # Insights created before budget plans existed carry no budget_param;
+      # the bare month param resolves to the default plan's budget.
+      param = insight.metadata&.dig("budget_param").presence || Budget.date_to_param(insight.period_start)
+      { text: t("insights.actions.budget"), href: budget_path(param) }
     end
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -501,6 +501,14 @@ class Account < ApplicationRecord
     end
   end
 
+  # Budget plans whose scope is exactly this account. Deleting the account
+  # would empty their account list, silently flipping them from "track one
+  # account" to "track every account" (see BudgetPlan#scoped?).
+  def solely_scoped_budget_plans
+    BudgetPlan.where(id: budget_plan_accounts.select(:budget_plan_id))
+      .where.not(id: BudgetPlanAccount.where.not(account_id: id).select(:budget_plan_id))
+  end
+
   def destroy_later
     transaction do
       mark_for_deletion!

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -27,6 +27,7 @@ class Account < ApplicationRecord
   has_many :recurring_transactions, dependent: :destroy
   has_many :goal_accounts, dependent: :destroy
   has_many :goals, through: :goal_accounts
+  has_many :budget_plan_accounts, dependent: :destroy
   has_many :goal_pledges, dependent: :destroy
   # Inverse for recurring transfers where this account is the destination.
   # Account#recurring_transactions only matches account_id; without this

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -52,7 +52,8 @@ module Assistant
         Function::GetCategories,
         Function::CreateCategory,
         Function::UpdateCategory,
-        Function::UpdateTransaction
+        Function::UpdateTransaction,
+        Function::UpdateBudget
       ]
 
       classes += PREVIEW_FUNCTION_CLASSES if user&.preview_features_enabled?

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -53,7 +53,10 @@ module Assistant
         Function::CreateCategory,
         Function::UpdateCategory,
         Function::UpdateTransaction,
-        Function::UpdateBudget
+        Function::UpdateBudget,
+        Function::ListBudgets,
+        Function::CreateBudget,
+        Function::DeleteBudget
       ]
 
       classes += PREVIEW_FUNCTION_CLASSES if user&.preview_features_enabled?

--- a/app/models/assistant/function.rb
+++ b/app/models/assistant/function.rb
@@ -79,6 +79,19 @@ class Assistant::Function
       user.family
     end
 
+    # Resolves a budget-plan reference (slug or case-insensitive name) from a
+    # function's optional `budget` param; blank means the default plan.
+    def find_budget_plan!(ref)
+      return family.default_budget_plan if ref.blank?
+
+      normalized = ref.to_s.strip.downcase
+      plan = family.budget_plans.find_by(slug: normalized) ||
+             family.budget_plans.where("LOWER(name) = ?", normalized).first
+
+      plan || raise(Assistant::Error,
+        "Budget '#{ref}' not found. Available budgets: #{family.budget_plans.pluck(:name).join(', ')}. Use list_budgets to see them.")
+    end
+
     def valid_uuid?(str)
       UuidFormat.valid?(str)
     end

--- a/app/models/assistant/function/create_budget.rb
+++ b/app/models/assistant/function/create_budget.rb
@@ -1,0 +1,130 @@
+class Assistant::Function::CreateBudget < Assistant::Function
+  class << self
+    def name
+      "create_budget"
+    end
+
+    def description
+      <<~INSTRUCTIONS
+        Creates an additional budget for the user's family, alongside the ones
+        they already have (see list_budgets).
+
+        Use when the user wants to budget a subset of their accounts separately
+        (e.g. "personal" vs "joint" accounts) or to try out a test budget next
+        to their live one.
+
+        Before calling, confirm the name and — if the budget should only track
+        certain accounts — which accounts, by paraphrasing back to the user.
+        Only call once they've confirmed.
+
+        Parameters:
+        - `name` (required): budget name, e.g. "Joint" or "Test".
+        - `accounts` (optional): account names (exact) or account ids to scope
+          the budget to. Omit to track all of the family's accounts.
+
+        After creating, target the new budget by passing its name or slug as
+        the `budget` parameter of get_budget and update_budget.
+
+        On a soft failure (e.g. an account name doesn't match), the response
+        includes the available account list so you can re-ask.
+      INSTRUCTIONS
+    end
+  end
+
+  def strict_mode?
+    false
+  end
+
+  def params_schema
+    build_schema(
+      required: %w[name],
+      properties: {
+        name: {
+          type: "string",
+          description: "Budget name, e.g. 'Personal', 'Joint', or 'Test'."
+        },
+        accounts: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional account names (exact) or account ids to scope this budget to. Omit to track all of the family's accounts."
+        }
+      }
+    )
+  end
+
+  def call(params = {})
+    name = params["name"].to_s.strip
+    return error("name_required", "Please provide a name for the budget.") if name.blank?
+
+    refs = Array(params["accounts"]).map { |r| r.to_s.strip }.reject(&:blank?)
+    resolution = resolve_accounts(refs)
+    return resolution if resolution.is_a?(Hash) && resolution[:success] == false
+
+    plan = nil
+    BudgetPlan.transaction do
+      plan = family.budget_plans.new(name: name)
+      resolution.each { |account| plan.budget_plan_accounts.build(account: account) }
+      plan.save!
+    end
+
+    {
+      success: true,
+      name: plan.name,
+      slug: plan.slug,
+      accounts: plan.scoped? ? plan.accounts.order(:name).pluck(:name) : "all_accounts",
+      message: "Budget '#{plan.name}' created. Use budget: \"#{plan.slug}\" with get_budget or update_budget to work with it."
+    }
+  rescue ActiveRecord::RecordInvalid => e
+    error("validation_failed", e.record.errors.full_messages.join("; "))
+  end
+
+  private
+    # Resolves account references (uuid or exact name) through the family —
+    # raw ids are never trusted. Returns an Array of accounts on success or
+    # an error payload Hash on failure.
+    def resolve_accounts(refs)
+      return [] if refs.empty?
+
+      accounts = []
+      unknown = []
+      ambiguous = []
+
+      refs.each do |ref|
+        if valid_uuid?(ref)
+          account = family.accounts.visible.find_by(id: ref)
+          account ? accounts << account : unknown << ref
+        else
+          matches = family.accounts.visible.where(name: ref).to_a
+          case matches.size
+          when 0 then unknown << ref
+          when 1 then accounts << matches.first
+          else ambiguous << ref
+          end
+        end
+      end
+
+      if unknown.any?
+        return error(
+          "unknown_accounts",
+          "Some accounts didn't match the family's accounts.",
+          unknown_accounts: unknown,
+          available_accounts: family_account_names
+        )
+      end
+
+      if ambiguous.any?
+        return error(
+          "ambiguous_accounts",
+          "Multiple accounts share a name. Ask the user which one to use.",
+          ambiguous_names: ambiguous,
+          available_accounts: family_account_names
+        )
+      end
+
+      accounts.uniq
+    end
+
+    def error(key, message, extra = {})
+      { success: false, error: key, message: message }.merge(extra)
+    end
+end

--- a/app/models/assistant/function/create_budget.rb
+++ b/app/models/assistant/function/create_budget.rb
@@ -71,7 +71,7 @@ class Assistant::Function::CreateBudget < Assistant::Function
       success: true,
       name: plan.name,
       slug: plan.slug,
-      accounts: plan.scoped? ? plan.accounts.order(:name).pluck(:name) : "all_accounts",
+      accounts: plan.scoped_account_names(user: user),
       message: "Budget '#{plan.name}' created. Use budget: \"#{plan.slug}\" with get_budget or update_budget to work with it."
     }
   rescue ActiveRecord::RecordInvalid => e
@@ -79,9 +79,10 @@ class Assistant::Function::CreateBudget < Assistant::Function
   end
 
   private
-    # Resolves account references (uuid or exact name) through the family —
-    # raw ids are never trusted. Returns an Array of accounts on success or
-    # an error payload Hash on failure.
+    # Resolves account references (uuid or exact name) through the user's
+    # accessible accounts — raw ids are never trusted, and another member's
+    # private accounts are never linkable. Returns an Array of accounts on
+    # success or an error payload Hash on failure.
     def resolve_accounts(refs)
       return [] if refs.empty?
 
@@ -91,10 +92,10 @@ class Assistant::Function::CreateBudget < Assistant::Function
 
       refs.each do |ref|
         if valid_uuid?(ref)
-          account = family.accounts.visible.find_by(id: ref)
+          account = user.accessible_accounts.visible.find_by(id: ref)
           account ? accounts << account : unknown << ref
         else
-          matches = family.accounts.visible.where(name: ref).to_a
+          matches = user.accessible_accounts.visible.where(name: ref).to_a
           case matches.size
           when 0 then unknown << ref
           when 1 then accounts << matches.first

--- a/app/models/assistant/function/delete_budget.rb
+++ b/app/models/assistant/function/delete_budget.rb
@@ -1,0 +1,61 @@
+class Assistant::Function::DeleteBudget < Assistant::Function
+  class << self
+    def name
+      "delete_budget"
+    end
+
+    def description
+      <<~INSTRUCTIONS
+        Deletes one of the family's budgets (see list_budgets), including all
+        of its monthly budget data. The primary budget cannot be deleted.
+
+        This is destructive and cannot be undone — only call after the user has
+        explicitly confirmed which budget to delete.
+
+        Parameters:
+        - `budget` (required): the budget's name or slug.
+      INSTRUCTIONS
+    end
+  end
+
+  def strict_mode?
+    false
+  end
+
+  def params_schema
+    build_schema(
+      required: %w[budget],
+      properties: {
+        budget: {
+          type: "string",
+          description: "Name or slug of the budget to delete (see list_budgets)."
+        }
+      }
+    )
+  end
+
+  def call(params = {})
+    plan = find_budget_plan!(params["budget"])
+
+    if plan.is_default?
+      return error("cannot_delete_default", "The primary budget can't be deleted.")
+    end
+
+    months = plan.budgets.count
+    plan.destroy!
+
+    {
+      success: true,
+      deleted_budget: plan.name,
+      months_deleted: months,
+      message: "Budget '#{plan.name}' and #{months} month(s) of budget data deleted."
+    }
+  rescue Assistant::Error => e
+    error("invalid_params", e.message)
+  end
+
+  private
+    def error(key, message)
+      { success: false, error: key, message: message }
+    end
+end

--- a/app/models/assistant/function/get_budget.rb
+++ b/app/models/assistant/function/get_budget.rb
@@ -1,5 +1,6 @@
 class Assistant::Function::GetBudget < Assistant::Function
   include ActiveSupport::NumberHelper
+  include Assistant::Function::MonthResolvable
 
   MAX_PRIOR_MONTHS = 11
 
@@ -155,30 +156,6 @@ class Assistant::Function::GetBudget < Assistant::Function
       return "near_limit" if bc.budgeted? && bc.near_limit?
       return "on_track" if bc.on_track?
       "no_activity"
-    end
-
-    def resolve_month_start(raw)
-      base = parse_month(raw)
-      return (base || Date.current).beginning_of_month unless family.uses_custom_month_start?
-
-      # Match Budget.param_to_date for explicit slugs so the input round-trips with the response.
-      base ? Date.new(base.year, base.month, family.month_start_day) : family.custom_month_start_for(Date.current)
-    end
-
-    def parse_month(raw)
-      return nil if raw.blank?
-
-      # Date.strptime ignores trailing characters, so guard with strict anchors first.
-      fmt = case raw
-      when /\A\d{4}-\d{2}\z/         then "%Y-%m"
-      when /\A[A-Za-z]{3}-\d{4}\z/   then "%b-%Y"
-      end
-
-      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY." if fmt.nil?
-
-      Date.strptime(raw, fmt)
-    rescue ArgumentError
-      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY."
     end
 
     def shift_months(date, n)

--- a/app/models/assistant/function/get_budget.rb
+++ b/app/models/assistant/function/get_budget.rb
@@ -23,6 +23,8 @@ class Assistant::Function::GetBudget < Assistant::Function
         - `month` (optional): "YYYY-MM" or "MMM-YYYY". Defaults to the current month.
         - `prior_months` (optional): integer 0..#{MAX_PRIOR_MONTHS}. Number of months
           preceding the target month to include for trend comparison. Default 0.
+        - `budget` (optional): which budget to read when the family keeps more than
+          one (name or slug — see list_budgets). Defaults to the primary budget.
 
         Example (current month only):
 
@@ -55,12 +57,17 @@ class Assistant::Function::GetBudget < Assistant::Function
           description: "Number of months before the target month to also return for trend comparison.",
           minimum: 0,
           maximum: MAX_PRIOR_MONTHS
+        },
+        budget: {
+          type: "string",
+          description: "Which budget to read when the family keeps more than one (name or slug — see list_budgets). Defaults to the primary budget."
         }
       }
     )
   end
 
   def call(params = {})
+    plan = find_budget_plan!(params["budget"])
     target_start = resolve_month_start(params["month"])
     prior = [ params["prior_months"].to_i, 0 ].max
     prior = [ prior, MAX_PRIOR_MONTHS ].min
@@ -70,11 +77,12 @@ class Assistant::Function::GetBudget < Assistant::Function
 
     months = month_starts.filter_map do |start_date|
       next unless Budget.budget_date_valid?(start_date, family: family)
-      build_month_payload(start_date, bootstrap: start_date == target_start)
+      build_month_payload(start_date, plan: plan, bootstrap: start_date == target_start)
     end
 
     result = {
       currency: family.currency,
+      budget: { name: plan.name, slug: plan.slug, is_default: plan.is_default },
       months: months
     }
     unavailable = requested - months.length
@@ -83,12 +91,12 @@ class Assistant::Function::GetBudget < Assistant::Function
   end
 
   private
-    def build_month_payload(start_date, bootstrap:)
+    def build_month_payload(start_date, plan:, bootstrap:)
       budget = if bootstrap
-        Budget.find_or_bootstrap(family, start_date: start_date, user: user)
+        Budget.find_or_bootstrap(family, start_date: start_date, user: user, plan: plan)
       else
         budget_start, budget_end = Budget.period_for(start_date, family: family)
-        family.budgets.find_by(start_date: budget_start, end_date: budget_end)
+        plan.budgets.find_by(start_date: budget_start, end_date: budget_end)
       end
       return nil unless budget
 

--- a/app/models/assistant/function/list_budgets.rb
+++ b/app/models/assistant/function/list_budgets.rb
@@ -1,0 +1,35 @@
+class Assistant::Function::ListBudgets < Assistant::Function
+  class << self
+    def name
+      "list_budgets"
+    end
+
+    def description
+      <<~INSTRUCTIONS
+        Lists the family's budgets. Most families have just one (the primary
+        budget), but a family can keep several side by side — e.g. a "Personal"
+        budget scoped to some accounts and a "Joint" one scoped to others, or a
+        test budget observed next to the live one.
+
+        Use the returned name or slug as the `budget` parameter of get_budget
+        and update_budget to read or edit a specific budget. A budget with
+        accounts "all_accounts" tracks every account in the family; otherwise
+        it only counts transactions from the listed accounts.
+      INSTRUCTIONS
+    end
+  end
+
+  def call(params = {})
+    {
+      budgets: family.budget_plans.default_first.includes(:accounts).map do |plan|
+        {
+          name: plan.name,
+          slug: plan.slug,
+          is_default: plan.is_default,
+          accounts: plan.scoped? ? plan.accounts.order(:name).pluck(:name) : "all_accounts",
+          initialized_months: plan.budgets.where.not(budgeted_spending: nil).count
+        }
+      end
+    }
+  end
+end

--- a/app/models/assistant/function/list_budgets.rb
+++ b/app/models/assistant/function/list_budgets.rb
@@ -21,12 +21,12 @@ class Assistant::Function::ListBudgets < Assistant::Function
 
   def call(params = {})
     {
-      budgets: family.budget_plans.default_first.includes(:accounts).map do |plan|
+      budgets: family.budget_plans.default_first.map do |plan|
         {
           name: plan.name,
           slug: plan.slug,
           is_default: plan.is_default,
-          accounts: plan.scoped? ? plan.accounts.order(:name).pluck(:name) : "all_accounts",
+          accounts: plan.scoped_account_names(user: user),
           initialized_months: plan.budgets.where.not(budgeted_spending: nil).count
         }
       end

--- a/app/models/assistant/function/list_budgets.rb
+++ b/app/models/assistant/function/list_budgets.rb
@@ -21,7 +21,7 @@ class Assistant::Function::ListBudgets < Assistant::Function
 
   def call(params = {})
     {
-      budgets: family.budget_plans.default_first.map do |plan|
+      budgets: family.budget_plans.default_first.includes(:budget_plan_accounts).map do |plan|
         {
           name: plan.name,
           slug: plan.slug,

--- a/app/models/assistant/function/month_resolvable.rb
+++ b/app/models/assistant/function/month_resolvable.rb
@@ -1,0 +1,29 @@
+# Shared month handling for budget-facing assistant tools so month slugs
+# round-trip between get_budget and update_budget, including families with a
+# custom month start day.
+module Assistant::Function::MonthResolvable
+  private
+    def resolve_month_start(raw)
+      base = parse_month(raw)
+      return (base || Date.current).beginning_of_month unless family.uses_custom_month_start?
+
+      # Match Budget.param_to_date for explicit slugs so the input round-trips with the response.
+      base ? Date.new(base.year, base.month, family.month_start_day) : family.custom_month_start_for(Date.current)
+    end
+
+    def parse_month(raw)
+      return nil if raw.blank?
+
+      # Date.strptime ignores trailing characters, so guard with strict anchors first.
+      fmt = case raw
+      when /\A\d{4}-\d{2}\z/         then "%Y-%m"
+      when /\A[A-Za-z]{3}-\d{4}\z/   then "%b-%Y"
+      end
+
+      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY." if fmt.nil?
+
+      Date.strptime(raw, fmt)
+    rescue ArgumentError
+      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY."
+    end
+end

--- a/app/models/assistant/function/update_budget.rb
+++ b/app/models/assistant/function/update_budget.rb
@@ -20,6 +20,8 @@ class Assistant::Function::UpdateBudget < Assistant::Function
 
         Parameters:
         - `month` (optional): "YYYY-MM" or "MMM-YYYY". Defaults to the current month.
+        - `budget` (optional): which budget to update when the family keeps more than
+          one (name or slug — see list_budgets). Defaults to the primary budget.
         - `budgeted_spending` (optional): total planned spending for the month.
         - `expected_income` (optional): expected income for the month.
         - `categories` (optional): array of { category: <name or id>, amount: <number> }.
@@ -52,6 +54,10 @@ class Assistant::Function::UpdateBudget < Assistant::Function
         month: {
           type: "string",
           description: "Target month in YYYY-MM or MMM-YYYY format. Defaults to the current month."
+        },
+        budget: {
+          type: "string",
+          description: "Which budget to update when the family keeps more than one (name or slug — see list_budgets). Defaults to the primary budget."
         },
         budgeted_spending: {
           type: "number",
@@ -93,6 +99,7 @@ class Assistant::Function::UpdateBudget < Assistant::Function
       return error("no_changes", "Provide at least one of budgeted_spending, expected_income, or categories.")
     end
 
+    plan = find_budget_plan!(params["budget"])
     start_date = resolve_month_start(params["month"])
     unless Budget.budget_date_valid?(start_date, family: family)
       return error("invalid_month", "No budget exists (or can be created) for that month — it is outside the valid budget range.")
@@ -107,7 +114,7 @@ class Assistant::Function::UpdateBudget < Assistant::Function
     # Bootstrap and all writes share one transaction so a bad entry can't
     # leave a newly created (or half-updated) budget behind.
     Budget.transaction do
-      budget = Budget.find_or_bootstrap(family, start_date: start_date, user: user)
+      budget = Budget.find_or_bootstrap(family, start_date: start_date, user: user, plan: plan)
 
       budget.update!(attrs) if attrs.any?
 
@@ -136,7 +143,7 @@ class Assistant::Function::UpdateBudget < Assistant::Function
         available_to_allocate: format_money(budget.available_to_allocate)
       },
       updated_categories: updated,
-      message: "Budget for #{budget.start_date.strftime('%B %Y')} updated."
+      message: "#{budget.budget_plan.is_default? ? 'Budget' : "#{budget.budget_plan.name} budget"} for #{budget.start_date.strftime('%B %Y')} updated."
     }
   rescue Assistant::Error => e
     error("invalid_params", e.message)

--- a/app/models/assistant/function/update_budget.rb
+++ b/app/models/assistant/function/update_budget.rb
@@ -1,0 +1,186 @@
+class Assistant::Function::UpdateBudget < Assistant::Function
+  class << self
+    def name
+      "update_budget"
+    end
+
+    def description
+      <<~INSTRUCTIONS
+        Updates the user's monthly budget: total budgeted spending, expected income,
+        and/or per-category budgeted amounts.
+
+        Call get_budget first to see current amounts and exact category names.
+        Amounts are plain non-negative numbers in the family's currency. Only the
+        fields and categories you pass are changed. Setting a subcategory's amount
+        keeps its parent's total in sync automatically. The "Uncategorized" bucket
+        cannot be set directly — it is the unallocated remainder of total budgeted
+        spending.
+
+        Parameters:
+        - `month` (optional): "YYYY-MM" or "MMM-YYYY". Defaults to the current month.
+        - `budgeted_spending` (optional): total planned spending for the month.
+        - `expected_income` (optional): expected income for the month.
+        - `categories` (optional): array of { category: <name or id>, amount: <number> }.
+
+        At least one of budgeted_spending, expected_income, or categories is required.
+
+        Example (set the total and two category allocations for August 2026):
+
+        ```
+        update_budget({
+          month: "2026-08",
+          budgeted_spending: 6500,
+          categories: [
+            { category: "Groceries", amount: 900 },
+            { category: "Dining Out", amount: 250 }
+          ]
+        })
+        ```
+      INSTRUCTIONS
+    end
+  end
+
+  def strict_mode?
+    false
+  end
+
+  def params_schema
+    build_schema(
+      properties: {
+        month: {
+          type: "string",
+          description: "Target month in YYYY-MM or MMM-YYYY format. Defaults to the current month."
+        },
+        budgeted_spending: {
+          type: "number",
+          minimum: 0,
+          description: "Total planned spending for the month, in the family currency."
+        },
+        expected_income: {
+          type: "number",
+          minimum: 0,
+          description: "Expected income for the month, in the family currency."
+        },
+        categories: {
+          type: "array",
+          description: "Per-category budget allocations to set.",
+          items: {
+            type: "object",
+            properties: {
+              category: {
+                type: "string",
+                description: "Category name (exact match, case-insensitive) or category id (use get_categories)."
+              },
+              amount: {
+                type: "number",
+                minimum: 0,
+                description: "New budgeted amount for this category."
+              }
+            },
+            required: [ "category", "amount" ],
+            additionalProperties: false
+          }
+        }
+      }
+    )
+  end
+
+  def call(params = {})
+    category_changes = Array(params["categories"])
+    unless params.key?("budgeted_spending") || params.key?("expected_income") || category_changes.any?
+      return error("no_changes", "Provide at least one of budgeted_spending, expected_income, or categories.")
+    end
+
+    budget = find_budget(params["month"])
+    return error("invalid_month", "No budget exists (or can be created) for that month — it is outside the valid budget range.") unless budget
+
+    attrs = {}
+    attrs[:budgeted_spending] = parse_amount!(params["budgeted_spending"], "budgeted_spending") if params.key?("budgeted_spending")
+    attrs[:expected_income] = parse_amount!(params["expected_income"], "expected_income") if params.key?("expected_income")
+
+    updated = []
+    Budget.transaction do
+      budget.update!(attrs) if attrs.any?
+
+      category_changes.each do |change|
+        budget_category = find_budget_category!(budget, change.is_a?(Hash) ? change["category"] : nil)
+        amount = parse_amount!(change["amount"], "amount for '#{budget_category.name}'")
+        budget_category.update_budgeted_spending!(amount)
+        updated << { category: budget_category.name, budgeted_spending: format_money(budget_category.reload.budgeted_spending) }
+      end
+    end
+
+    budget.reload
+    {
+      success: true,
+      month: budget.to_param,
+      totals: {
+        budgeted_spending: format_money(budget.budgeted_spending),
+        expected_income: format_money(budget.expected_income),
+        allocated_spending: format_money(budget.allocated_spending),
+        available_to_allocate: format_money(budget.available_to_allocate)
+      },
+      updated_categories: updated,
+      message: "Budget for #{budget.start_date.strftime('%B %Y')} updated."
+    }
+  rescue Assistant::Error => e
+    error("invalid_params", e.message)
+  rescue ActiveRecord::RecordInvalid => e
+    error("validation_failed", e.record.errors.full_messages.join("; "))
+  end
+
+  private
+    def find_budget(raw_month)
+      base = raw_month.present? ? parse_month!(raw_month) : nil
+
+      # Mirrors GetBudget#resolve_month_start so month slugs round-trip between
+      # the two tools even when the family uses a custom month start day.
+      start_date = if family.uses_custom_month_start?
+        base ? Date.new(base.year, base.month, family.month_start_day) : family.custom_month_start_for(Date.current)
+      else
+        (base || Date.current).beginning_of_month
+      end
+
+      Budget.find_or_bootstrap(family, start_date: start_date, user: user)
+    end
+
+    def parse_month!(raw)
+      fmt = case raw
+      when /\A\d{4}-\d{2}\z/         then "%Y-%m"
+      when /\A[A-Za-z]{3}-\d{4}\z/   then "%b-%Y"
+      end
+      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY." if fmt.nil?
+
+      Date.strptime(raw, fmt)
+    rescue ArgumentError
+      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY."
+    end
+
+    def parse_amount!(raw, label)
+      value = Float(raw)
+      raise Assistant::Error, "#{label} must be a non-negative number." if value.negative?
+      value
+    rescue ArgumentError, TypeError
+      raise Assistant::Error, "#{label} must be a non-negative number."
+    end
+
+    def find_budget_category!(budget, ref)
+      ref = ref.to_s.strip
+      raise Assistant::Error, "Each categories entry needs a category name or id." if ref.blank?
+
+      category = valid_uuid?(ref) ? family.categories.find_by(id: ref) : nil
+      category ||= family.categories.where("LOWER(name) = ?", ref.downcase).first
+      raise Assistant::Error, "Category '#{ref}' not found. Use get_categories to list categories." unless category
+
+      budget.budget_categories.find_by(category_id: category.id) ||
+        raise(Assistant::Error, "No budget row exists for category '#{category.name}' in #{budget.to_param}.")
+    end
+
+    def format_money(value)
+      Money.new(value || 0, family.currency).format
+    end
+
+    def error(key, message)
+      { success: false, error: key, message: message }
+    end
+end

--- a/app/models/assistant/function/update_budget.rb
+++ b/app/models/assistant/function/update_budget.rb
@@ -1,4 +1,6 @@
 class Assistant::Function::UpdateBudget < Assistant::Function
+  include Assistant::Function::MonthResolvable
+
   class << self
     def name
       "update_budget"
@@ -91,20 +93,33 @@ class Assistant::Function::UpdateBudget < Assistant::Function
       return error("no_changes", "Provide at least one of budgeted_spending, expected_income, or categories.")
     end
 
-    budget = find_budget(params["month"])
-    return error("invalid_month", "No budget exists (or can be created) for that month — it is outside the valid budget range.") unless budget
+    start_date = resolve_month_start(params["month"])
+    unless Budget.budget_date_valid?(start_date, family: family)
+      return error("invalid_month", "No budget exists (or can be created) for that month — it is outside the valid budget range.")
+    end
 
     attrs = {}
     attrs[:budgeted_spending] = parse_amount!(params["budgeted_spending"], "budgeted_spending") if params.key?("budgeted_spending")
     attrs[:expected_income] = parse_amount!(params["expected_income"], "expected_income") if params.key?("expected_income")
 
+    budget = nil
     updated = []
+    # Bootstrap and all writes share one transaction so a bad entry can't
+    # leave a newly created (or half-updated) budget behind.
     Budget.transaction do
+      budget = Budget.find_or_bootstrap(family, start_date: start_date, user: user)
+
       budget.update!(attrs) if attrs.any?
 
-      category_changes.each do |change|
+      changes = category_changes.map do |change|
         budget_category = find_budget_category!(budget, change.is_a?(Hash) ? change["category"] : nil)
-        amount = parse_amount!(change["amount"], "amount for '#{budget_category.name}'")
+        [ budget_category, parse_amount!(change["amount"], "amount for '#{budget_category.name}'") ]
+      end
+
+      # Subcategory updates sync their parent's total, so explicit parent
+      # amounts apply last to keep results independent of the array order.
+      subcategories, parents = changes.partition { |budget_category, _amount| budget_category.subcategory? }
+      (subcategories + parents).each do |budget_category, amount|
         budget_category.update_budgeted_spending!(amount)
         updated << { category: budget_category.name, budgeted_spending: format_money(budget_category.reload.budgeted_spending) }
       end
@@ -130,35 +145,9 @@ class Assistant::Function::UpdateBudget < Assistant::Function
   end
 
   private
-    def find_budget(raw_month)
-      base = raw_month.present? ? parse_month!(raw_month) : nil
-
-      # Mirrors GetBudget#resolve_month_start so month slugs round-trip between
-      # the two tools even when the family uses a custom month start day.
-      start_date = if family.uses_custom_month_start?
-        base ? Date.new(base.year, base.month, family.month_start_day) : family.custom_month_start_for(Date.current)
-      else
-        (base || Date.current).beginning_of_month
-      end
-
-      Budget.find_or_bootstrap(family, start_date: start_date, user: user)
-    end
-
-    def parse_month!(raw)
-      fmt = case raw
-      when /\A\d{4}-\d{2}\z/         then "%Y-%m"
-      when /\A[A-Za-z]{3}-\d{4}\z/   then "%b-%Y"
-      end
-      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY." if fmt.nil?
-
-      Date.strptime(raw, fmt)
-    rescue ArgumentError
-      raise Assistant::Error, "Invalid month: #{raw}. Use YYYY-MM or MMM-YYYY."
-    end
-
     def parse_amount!(raw, label)
       value = Float(raw)
-      raise Assistant::Error, "#{label} must be a non-negative number." if value.negative?
+      raise Assistant::Error, "#{label} must be a non-negative number." if !value.finite? || value.negative?
       value
     rescue ArgumentError, TypeError
       raise Assistant::Error, "#{label} must be a non-negative number."
@@ -170,7 +159,13 @@ class Assistant::Function::UpdateBudget < Assistant::Function
 
       category = valid_uuid?(ref) ? family.categories.find_by(id: ref) : nil
       category ||= family.categories.where("LOWER(name) = ?", ref.downcase).first
-      raise Assistant::Error, "Category '#{ref}' not found. Use get_categories to list categories." unless category
+
+      if category.nil?
+        if Category.all_uncategorized_names.any? { |name| name.casecmp?(ref) }
+          raise Assistant::Error, "'#{ref}' is the unallocated remainder of budgeted_spending and cannot be set directly. Adjust budgeted_spending or category amounts instead."
+        end
+        raise Assistant::Error, "Category '#{ref}' not found. Use get_categories to list categories."
+      end
 
       budget.budget_categories.find_by(category_id: category.id) ||
         raise(Assistant::Error, "No budget row exists for category '#{category.name}' in #{budget.to_param}.")

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -2,15 +2,21 @@ class Budget < ApplicationRecord
   include Monetizable
 
   PARAM_DATE_FORMAT = "%b-%Y"
+  # Optional plan-slug prefix ahead of the strict month token, so
+  # "aug-2026" (default plan) and "joint-aug-2026" both parse unambiguously.
+  PARAM_FORMAT = /\A(?:(?<plan>.+)-)?(?<month>[a-z]{3}-\d{4})\z/
 
   attr_accessor :current_user
 
   belongs_to :family
+  belongs_to :budget_plan
 
   has_many :budget_categories, -> { includes(:category) }, dependent: :destroy
 
   validates :start_date, :end_date, presence: true
-  validates :start_date, :end_date, uniqueness: { scope: :family_id }
+  validates :start_date, uniqueness: { scope: :budget_plan_id }
+
+  before_validation :ensure_budget_plan, on: :create
 
   monetize :budgeted_spending, :expected_income, :allocated_spending,
            :actual_spending, :available_to_spend, :available_to_allocate,
@@ -30,6 +36,28 @@ class Budget < ApplicationRecord
       end
     end
 
+    # Month param, prefixed with the plan slug for non-default plans:
+    # param_for(default_plan, aug) => "aug-2026"; param_for(joint, aug) => "joint-aug-2026".
+    def param_for(plan, date)
+      month = date_to_param(date)
+      plan.nil? || plan.is_default? ? month : "#{plan.slug}-#{month}"
+    end
+
+    # Inverse of param_for: "joint-aug-2026" => [joint plan, 2026-08-01].
+    # Raises RecordNotFound for malformed params or unknown plan slugs.
+    def resolve_param(param, family:)
+      match = PARAM_FORMAT.match(param.to_s.downcase)
+      raise ActiveRecord::RecordNotFound unless match
+
+      plan = if match[:plan].present?
+        family.budget_plans.find_by!(slug: match[:plan])
+      else
+        family.default_budget_plan
+      end
+
+      [ plan, param_to_date(match[:month], family: family) ]
+    end
+
     def budget_date_valid?(date, family:)
       budget_start, _ = period_for(date, family: family)
       budget_start >= oldest_valid_budget_date(family) &&
@@ -44,14 +72,18 @@ class Budget < ApplicationRecord
       end
     end
 
-    def find_or_bootstrap(family, start_date:, user: nil)
+    def find_or_bootstrap(family, start_date:, user: nil, plan: nil)
       return nil unless budget_date_valid?(start_date, family: family)
+
+      plan ||= family.default_budget_plan
+      raise ArgumentError, "plan must belong to the same family" unless plan.family_id == family.id
 
       Budget.transaction do
         budget_start, budget_end = period_for(start_date, family: family)
 
         budget = Budget.find_or_create_by!(
           family: family,
+          budget_plan: plan,
           start_date: budget_start,
           end_date: budget_end
         ) do |b|
@@ -86,7 +118,7 @@ class Budget < ApplicationRecord
   end
 
   def to_param
-    self.class.date_to_param(start_date)
+    self.class.param_for(budget_plan, start_date)
   end
 
   def sync_budget_categories
@@ -122,10 +154,30 @@ class Budget < ApplicationRecord
     if current_user
       scope = scope.joins(:entry).where(entries: { account_id: family.accounts.accessible_by(current_user).included_in_reports.select(:id) })
     end
+    if budget_plan&.scoped?
+      scope = scope.joins(:entry).where(entries: { account_id: budget_plan.account_ids })
+    end
     scope
   end
 
   def name
+    if budget_plan.is_default?
+      period_name
+    elsif family.uses_custom_month_start?
+      I18n.t(
+        "budgets.name.plan_custom_range",
+        plan: budget_plan.name,
+        start: I18n.l(start_date, format: :short),
+        end_date: I18n.l(end_date, format: :long)
+      )
+    else
+      I18n.t("budgets.name.plan_month_year", plan: budget_plan.name, month: I18n.l(start_date, format: :month_year))
+    end
+  end
+
+  # The period alone, without the plan prefix — for surfaces that show the
+  # plan name separately (e.g. the header's month button next to the switcher).
+  def period_name
     if family.uses_custom_month_start?
       I18n.t(
         "budgets.name.custom_range",
@@ -142,7 +194,7 @@ class Budget < ApplicationRecord
   end
 
   def most_recent_initialized_budget
-    family.budgets
+    budget_plan.budgets
       .includes(:budget_categories)
       .where("start_date < ?", start_date)
       .where.not(budgeted_spending: nil)
@@ -151,7 +203,7 @@ class Budget < ApplicationRecord
   end
 
   def copy_from!(source_budget)
-    raise ArgumentError, "source budget must belong to the same family" unless source_budget.family_id == family_id
+    raise ArgumentError, "source budget must belong to the same budget plan" unless source_budget.budget_plan_id == budget_plan_id
     raise ArgumentError, "source budget must precede target budget" unless source_budget.start_date < start_date
 
     Budget.transaction do
@@ -211,14 +263,14 @@ class Budget < ApplicationRecord
     previous_date = start_date - 1.month
     return nil unless self.class.budget_date_valid?(previous_date, family: family)
 
-    self.class.date_to_param(previous_date)
+    self.class.param_for(budget_plan, previous_date)
   end
 
   def next_budget_param
     next_date = start_date + 1.month
     return nil unless self.class.budget_date_valid?(next_date, family: family)
 
-    self.class.date_to_param(next_date)
+    self.class.param_for(budget_plan, next_date)
   end
 
   def to_donut_segments_json
@@ -316,11 +368,11 @@ class Budget < ApplicationRecord
   # Income: How much user earned relative to what they expected to earn
   # =============================================================================
   def estimated_income
-    family.income_statement.median_income(interval: "month")
+    income_statement.median_income(interval: "month")
   end
 
   def actual_income
-    family.income_statement.income_totals(period: self.period).total
+    income_statement.income_totals(period: self.period).total
   end
 
   def actual_income_percent
@@ -340,8 +392,12 @@ class Budget < ApplicationRecord
   end
 
   private
+    def ensure_budget_plan
+      self.budget_plan ||= family&.default_budget_plan
+    end
+
     def income_statement
-      @income_statement ||= family.income_statement(user: current_user)
+      @income_statement ||= IncomeStatement.new(family, user: current_user, account_ids: budget_plan&.scoped_account_ids)
     end
 
     def net_totals

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -17,6 +17,7 @@ class Budget < ApplicationRecord
   validates :start_date, uniqueness: { scope: :budget_plan_id }
 
   before_validation :ensure_budget_plan, on: :create
+  validate :budget_plan_must_match_family
 
   monetize :budgeted_spending, :expected_income, :allocated_spending,
            :actual_spending, :available_to_spend, :available_to_allocate,
@@ -56,6 +57,10 @@ class Budget < ApplicationRecord
       end
 
       [ plan, param_to_date(match[:month], family: family) ]
+    rescue Date::Error
+      # A well-shaped but impossible month token ("abc-2026") is a bad URL,
+      # not a server error.
+      raise ActiveRecord::RecordNotFound
     end
 
     def budget_date_valid?(date, family:)
@@ -394,6 +399,13 @@ class Budget < ApplicationRecord
   private
     def ensure_budget_plan
       self.budget_plan ||= family&.default_budget_plan
+    end
+
+    def budget_plan_must_match_family
+      return if budget_plan.nil? || family.nil?
+      return if budget_plan.family_id == family_id
+
+      errors.add(:budget_plan, :must_belong_to_family)
     end
 
     def income_statement

--- a/app/models/budget_plan.rb
+++ b/app/models/budget_plan.rb
@@ -36,7 +36,32 @@ class BudgetPlan < ApplicationRecord
     (user ? accounts.accessible_by(user) : accounts).map(&:name).sort
   end
 
+  # generate_slug checks existing slugs before the INSERT, so two concurrent
+  # saves of the same name can both pass the check and collide on the unique
+  # index. Rescue the race like Family#default_budget_plan: the winner's row
+  # is visible by then, so one regeneration picks the next free suffix.
+  def save(**options, &block)
+    with_slug_collision_retry { super(**options, &block) }
+  end
+
+  def save!(**options, &block)
+    with_slug_collision_retry { super(**options, &block) }
+  end
+
   private
+    def with_slug_collision_retry
+      retried = false
+      begin
+        yield
+      rescue ActiveRecord::RecordNotUnique => e
+        raise if retried || !e.message.include?("index_budget_plans_on_family_id_and_slug")
+
+        retried = true
+        generate_slug
+        retry
+      end
+    end
+
     def generate_slug
       base = name.to_s.parameterize
       base = "plan" if base.blank?

--- a/app/models/budget_plan.rb
+++ b/app/models/budget_plan.rb
@@ -1,0 +1,63 @@
+class BudgetPlan < ApplicationRecord
+  # A month-shaped slug ("jan-2025") would collide with the bare month params
+  # that address the default plan's budgets (see Budget.resolve_param).
+  MONTH_SLUG_FORMAT = /\A[a-z]{3}-\d{4}\z/
+
+  belongs_to :family
+
+  has_many :budgets, dependent: :destroy
+  has_many :budget_plan_accounts, dependent: :destroy
+  has_many :accounts, through: :budget_plan_accounts
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :slug, presence: true, uniqueness: { scope: :family_id }
+  validate :accounts_must_belong_to_family
+
+  before_validation :generate_slug, if: -> { slug.blank? || will_save_change_to_name? }
+  before_destroy :prevent_destroying_default
+
+  scope :default_first, -> { order(is_default: :desc).order(Arel.sql("LOWER(budget_plans.name) ASC")) }
+
+  # A plan with no linked accounts covers all of the family's accounts.
+  def scoped?
+    budget_plan_accounts.any?
+  end
+
+  def scoped_account_ids
+    scoped? ? account_ids : nil
+  end
+
+  private
+    def generate_slug
+      base = name.to_s.parameterize
+      base = "plan" if base.blank?
+      base = "#{base}-plan" if base.match?(MONTH_SLUG_FORMAT)
+
+      candidate = base
+      sequence = 2
+      while family.budget_plans.where.not(id: id).exists?(slug: candidate)
+        candidate = "#{base}-#{sequence}"
+        sequence += 1
+      end
+
+      self.slug = candidate
+    end
+
+    def accounts_must_belong_to_family
+      return if family.nil?
+
+      foreign = budget_plan_accounts.reject(&:marked_for_destruction?).reject do |bpa|
+        bpa.account.nil? || bpa.account.family_id == family_id
+      end
+      return if foreign.empty?
+
+      errors.add(:accounts, :must_belong_to_family)
+    end
+
+    def prevent_destroying_default
+      return unless is_default?
+
+      errors.add(:base, :cannot_destroy_default)
+      throw :abort
+    end
+end

--- a/app/models/budget_plan.rb
+++ b/app/models/budget_plan.rb
@@ -27,6 +27,15 @@ class BudgetPlan < ApplicationRecord
     scoped? ? account_ids : nil
   end
 
+  # Account-name payload shared by the assistant budget tools. "all_accounts"
+  # means the plan tracks every account in the family; pass user: to hide
+  # accounts that aren't shared with that member.
+  def scoped_account_names(user: nil)
+    return "all_accounts" unless scoped?
+
+    (user ? accounts.accessible_by(user) : accounts).map(&:name).sort
+  end
+
   private
     def generate_slug
       base = name.to_s.parameterize

--- a/app/models/budget_plan_account.rb
+++ b/app/models/budget_plan_account.rb
@@ -3,4 +3,13 @@ class BudgetPlanAccount < ApplicationRecord
   belongs_to :account
 
   validates :account_id, uniqueness: { scope: :budget_plan_id }
+  validate :account_must_belong_to_plan_family
+
+  private
+    def account_must_belong_to_plan_family
+      return if budget_plan.nil? || account.nil?
+      return if account.family_id == budget_plan.family_id
+
+      errors.add(:account, :must_belong_to_family)
+    end
 end

--- a/app/models/budget_plan_account.rb
+++ b/app/models/budget_plan_account.rb
@@ -1,0 +1,6 @@
+class BudgetPlanAccount < ApplicationRecord
+  belongs_to :budget_plan
+  belongs_to :account
+
+  validates :account_id, uniqueness: { scope: :budget_plan_id }
+end

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -368,7 +368,7 @@ class Demo::Generator
 
       spend_per_cat = txns.group("categories.id").sum("entries.amount")
 
-      budget = family.budgets.where(start_date: current_month).first_or_initialize
+      budget = family.budgets.where(budget_plan: family.default_budget_plan, start_date: current_month).first_or_initialize
       budget.update!(
         end_date: current_month.end_of_month,
         currency: "USD",

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -50,6 +50,10 @@ class Family < ApplicationRecord
 
   has_many :budgets, dependent: :destroy
   has_many :budget_categories, through: :budgets
+  # Declared after :budgets so budgets destroy first and the plans' own
+  # dependent budgets are already gone.
+  has_many :budget_plans, dependent: :destroy
+  has_many :budget_plan_accounts, through: :budget_plans
 
   has_many :goals, dependent: :destroy
 
@@ -312,6 +316,16 @@ class Family < ApplicationRecord
 
   def income_statement(user: Current.user)
     IncomeStatement.new(self, user: user)
+  end
+
+  # The plan behind bare month params ("aug-2026") and every budget created
+  # before plans existed. Lazily created so families without budgets don't
+  # carry an empty plan row.
+  def default_budget_plan
+    budget_plans.find_or_create_by!(is_default: true) { |plan| plan.name = "Primary" }
+  rescue ActiveRecord::RecordNotUnique
+    # Concurrent bootstrap lost the partial-unique-index race; the winner's row exists.
+    budget_plans.find_by!(is_default: true)
   end
 
   # Returns the Investment Contributions category for this family, creating it if it doesn't exist.

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -455,6 +455,22 @@ class Family::DataExporter
         }.to_json
       end
 
+      # Export budget plans (before budgets, which reference them)
+      @family.budget_plans.find_each do |budget_plan|
+        lines << {
+          type: "BudgetPlan",
+          data: budget_plan.as_json
+        }.to_json
+      end
+
+      # Export budget plan account scopes
+      @family.budget_plan_accounts.find_each do |budget_plan_account|
+        lines << {
+          type: "BudgetPlanAccount",
+          data: budget_plan_account.as_json
+        }.to_json
+      end
+
       # Export budgets
       @family.budgets.find_each do |budget|
         lines << {

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -31,7 +31,7 @@ class Family::DataImporter
     end
   end
 
-  SUPPORTED_TYPES = %w[Account Balance Category Tag Merchant RecurringTransaction Transaction Transfer RejectedTransfer Trade Holding Valuation Budget BudgetCategory Rule].freeze
+  SUPPORTED_TYPES = %w[Account Balance Category Tag Merchant RecurringTransaction Transaction Transfer RejectedTransfer Trade Holding Valuation BudgetPlan BudgetPlanAccount Budget BudgetCategory Rule].freeze
   ACCOUNTABLE_TYPE_CLASSES = {
     "Depository" => Depository, "Investment" => Investment, "Crypto" => Crypto,
     "Property" => Property, "Vehicle" => Vehicle, "OtherAsset" => OtherAsset,
@@ -49,6 +49,7 @@ class Family::DataImporter
     merchants: "Merchant",
     recurring_transactions: "RecurringTransaction",
     transactions: "Transaction",
+    budget_plans: "BudgetPlan",
     budgets: "Budget",
     securities: "Security",
     rules: "Rule"
@@ -66,6 +67,8 @@ class Family::DataImporter
     "Trade" => "trades",
     "Holding" => "holdings",
     "Valuation" => "valuations",
+    "BudgetPlan" => "budget_plans",
+    "BudgetPlanAccount" => "budget_plan_accounts",
     "Budget" => "budgets",
     "BudgetCategory" => "budget_categories",
     "Rule" => "rules"
@@ -84,6 +87,7 @@ class Family::DataImporter
       merchants: {},
       recurring_transactions: {},
       transactions: {},
+      budget_plans: {},
       budgets: {},
       securities: {},
       rules: {}
@@ -113,6 +117,8 @@ class Family::DataImporter
       import_trades(records["Trade"] || [])
       import_holdings(records["Holding"] || [])
       import_valuations(records["Valuation"] || [])
+      import_budget_plans(records["BudgetPlan"] || [])
+      import_budget_plan_accounts(records["BudgetPlanAccount"] || [])
       import_budgets(records["Budget"] || [])
       import_budget_categories(records["BudgetCategory"] || [])
       import_rules(records["Rule"] || [])
@@ -961,6 +967,54 @@ class Family::DataImporter
       nil
     end
 
+    def import_budget_plans(records)
+      records.each do |record|
+        data = record["data"]
+        old_id = data["id"]
+
+        require_source_id!("BudgetPlan", old_id)
+
+        budget_plan = mapped_record(:budget_plans, old_id, @family.budget_plans, record_type: "BudgetPlan")
+        created = budget_plan.blank?
+
+        # The default plan is a per-family singleton — imports remap onto it
+        # rather than creating a second one (the partial unique index forbids it).
+        if budget_plan.blank? && truthy?(data["is_default"])
+          budget_plan = @family.default_budget_plan
+          created = false
+        end
+
+        budget_plan ||= @family.budget_plans.build
+
+        budget_plan.name = data["name"] if data["name"].present?
+        # Slug is regenerated (and uniquified) locally rather than imported.
+
+        budget_plan.save!
+        map_source!(:budget_plans, old_id, budget_plan)
+        increment_summary("BudgetPlan", created ? :created : :updated)
+      end
+    end
+
+    def import_budget_plan_accounts(records)
+      records.each do |record|
+        data = record["data"]
+
+        new_plan_id = mapped_id(:budget_plans, data["budget_plan_id"], record_type: "BudgetPlanAccount")
+        next unless new_plan_id
+
+        new_account_id = mapped_id(:accounts, data["account_id"], record_type: "BudgetPlanAccount")
+        next unless new_account_id
+
+        budget_plan = @family.budget_plans.find(new_plan_id)
+
+        budget_plan_account = budget_plan.budget_plan_accounts.find_or_initialize_by(account_id: new_account_id)
+        created = budget_plan_account.new_record?
+
+        budget_plan_account.save!
+        increment_summary("BudgetPlanAccount", created ? :created : :updated)
+      end
+    end
+
     def import_budgets(records)
       records.each do |record|
         data = record["data"]
@@ -972,7 +1026,14 @@ class Family::DataImporter
         created = budget.blank?
         budget ||= @family.budgets.build
 
+        # Exports predating budget plans have no budget_plan_id; those
+        # budgets land on the family's default plan.
+        budget_plan_id = if data["budget_plan_id"].present?
+          mapped_id(:budget_plans, data["budget_plan_id"], record_type: "Budget", required: false)
+        end
+
         budget.assign_attributes(
+          budget_plan_id: budget_plan_id || @family.default_budget_plan.id,
           start_date: Date.parse(data["start_date"].to_s),
           end_date: Date.parse(data["end_date"].to_s),
           budgeted_spending: data["budgeted_spending"]&.to_d,

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -1015,6 +1015,18 @@ class Family::DataImporter
       end
     end
 
+    # The first legacy budget implicitly creates the family default plan,
+    # which must show up in the summary (and the import readback) like any
+    # other created plan.
+    def fallback_budget_plan_id
+      @fallback_budget_plan_id ||= begin
+        existed = @family.budget_plans.exists?(is_default: true)
+        plan = @family.default_budget_plan
+        increment_summary("BudgetPlan", :created) unless existed
+        plan.id
+      end
+    end
+
     def import_budgets(records)
       records.each do |record|
         data = record["data"]
@@ -1033,7 +1045,7 @@ class Family::DataImporter
         end
 
         budget.assign_attributes(
-          budget_plan_id: budget_plan_id || @family.default_budget_plan.id,
+          budget_plan_id: budget_plan_id || fallback_budget_plan_id,
           start_date: Date.parse(data["start_date"].to_s),
           end_date: Date.parse(data["end_date"].to_s),
           budgeted_spending: data["budgeted_spending"]&.to_d,

--- a/app/models/family/financial_data_reset.rb
+++ b/app/models/family/financial_data_reset.rb
@@ -29,6 +29,8 @@ class Family::FinancialDataReset
     rule_runs
     budgets
     budget_categories
+    budget_plans
+    budget_plan_accounts
     categories
     tags
     taggings
@@ -153,6 +155,10 @@ class Family::FinancialDataReset
       scope(:recurring_transactions).destroy_all
       scope(:rules).destroy_all
       scope(:budgets).destroy_all
+      # Plans go after their budgets (budgets FK-reference plans). delete_all
+      # bypasses the default plan's destroy guard — a full reset removes it too.
+      scope(:budget_plan_accounts).delete_all
+      scope(:budget_plans).delete_all
       scope(:categories).destroy_all
       scope(:tags).destroy_all
       scope(:merchants).destroy_all
@@ -252,6 +258,7 @@ class Family::FinancialDataReset
         rule_ids = rule_scope.select(:id)
         budget_scope = Budget.where(family_id: family.id)
         budget_ids = budget_scope.select(:id)
+        budget_plan_scope = BudgetPlan.where(family_id: family.id)
         transaction_scope = Transaction.joins(:entry).where(entries: { account_id: account_ids })
         transaction_ids = transaction_scope.select(:id)
         tag_scope = Tag.where(family_id: family.id)
@@ -284,6 +291,8 @@ class Family::FinancialDataReset
           rule_runs: RuleRun.where(rule_id: rule_ids),
           budgets: budget_scope,
           budget_categories: BudgetCategory.where(budget_id: budget_ids),
+          budget_plans: budget_plan_scope,
+          budget_plan_accounts: BudgetPlanAccount.where(budget_plan_id: budget_plan_scope.select(:id)),
           categories: Category.where(family_id: family.id),
           tags: tag_scope,
           taggings: Tagging.where(tag_id: tag_scope.select(:id)),

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -7,9 +7,13 @@ class IncomeStatement
 
   attr_reader :family, :user
 
-  def initialize(family, user: nil)
+  # account_ids: optional explicit scope (e.g. a budget plan's linked
+  # accounts). Intersected with the user-derived account set when both are
+  # present; nil keeps today's user-or-whole-family behavior.
+  def initialize(family, user: nil, account_ids: nil)
     @family = family
     @user = user || Current.user
+    @scoped_account_ids = account_ids&.map(&:to_s)
   end
 
   def totals(transactions_scope: nil, date_range:)
@@ -239,7 +243,15 @@ class IncomeStatement
     end
 
     def included_account_ids
-      @included_account_ids ||= user ? user.finance_accounts.pluck(:id) : nil
+      return @included_account_ids if defined?(@included_account_ids)
+
+      user_ids = user ? user.finance_accounts.pluck(:id) : nil
+      @included_account_ids =
+        if user_ids && @scoped_account_ids
+          user_ids & @scoped_account_ids
+        else
+          @scoped_account_ids || user_ids
+        end
     end
 
     def included_account_ids_hash

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -135,6 +135,9 @@ class IncomeStatement
       tax_advantaged_ids = family.tax_advantaged_account_ids
       scope = scope.where.not(id: tax_advantaged_ids) if tax_advantaged_ids.present?
       scope = scope.merge(Account.included_in_finances_for(user)) if user
+      # Keep the offered accounts consistent with the totals: an explicit
+      # scope (e.g. a budget plan's linked accounts) excludes everything else.
+      scope = scope.where(id: @scoped_account_ids) if @scoped_account_ids
       scope
     end
   end

--- a/app/models/insight/generators/budget_insight_generator.rb
+++ b/app/models/insight/generators/budget_insight_generator.rb
@@ -1,7 +1,8 @@
-# Reads the family's current budget (if they've set one up) and produces
-# either a warning — categories over or near their limit — or, once the month
-# is at least half over, a quiet positive signal that everything is on track.
-# Reuses BudgetCategory's own health checks rather than re-deriving pace math.
+# Reads the family's current budgets (if they've set any up) and produces,
+# per budget, either a warning — categories over or near their limit — or,
+# once the month is at least half over, a quiet positive signal that
+# everything is on track. Reuses BudgetCategory's own health checks rather
+# than re-deriving pace math.
 class Insight::Generators::BudgetInsightGenerator < Insight::Generator
   produces "budget_at_risk", "budget_on_track"
 
@@ -10,28 +11,29 @@ class Insight::Generators::BudgetInsightGenerator < Insight::Generator
   MAX_LISTED_CATEGORIES = 3
 
   def generate
-    budget = current_budget
-    return [] unless budget&.initialized?
+    current_budgets.flat_map do |budget|
+      next [] unless budget.initialized?
 
-    parent_categories = budget.budget_categories.reject(&:subcategory?)
-    over = parent_categories.select(&:over_budget_with_budget?)
-    near = parent_categories.select { |bc| bc.budgeted? && bc.near_limit? }
+      parent_categories = budget.budget_categories.reject(&:subcategory?)
+      over = parent_categories.select(&:over_budget_with_budget?)
+      near = parent_categories.select { |bc| bc.budgeted? && bc.near_limit? }
 
-    if over.any? || near.any?
-      [ at_risk_insight(budget, over, near) ]
-    elsif on_track_eligible?(budget, parent_categories)
-      [ on_track_insight(budget) ]
-    else
-      []
+      if over.any? || near.any?
+        [ at_risk_insight(budget, over, near) ]
+      elsif on_track_eligible?(budget, parent_categories)
+        [ on_track_insight(budget) ]
+      else
+        []
+      end
     end
   end
 
   private
-    def current_budget
+    def current_budgets
       family.budgets
-        .includes(budget_categories: :category)
+        .includes(:budget_plan, budget_categories: :category)
         .where("start_date <= ? AND end_date >= ?", Date.current, Date.current)
-        .first
+        .order(:created_at)
     end
 
     def at_risk_insight(budget, over, near)
@@ -41,7 +43,7 @@ class Insight::Generators::BudgetInsightGenerator < Insight::Generator
       build_insight(
         insight_type: "budget_at_risk",
         priority: over.any? ? "high" : "medium",
-        title: I18n.t("insights.titles.budget_at_risk", count: flagged.size),
+        title: insight_title("budget_at_risk", budget, count: flagged.size),
         template_key: over.any? ? "budget_at_risk.over" : "budget_at_risk.near",
         facts: {
           categories: category_names.to_sentence,
@@ -53,10 +55,11 @@ class Insight::Generators::BudgetInsightGenerator < Insight::Generator
         metadata: {
           over_category_ids: over.map { |bc| bc.category.id }.sort,
           near_category_ids: near.map { |bc| bc.category.id }.sort,
-          budget_spent_pct_bucket: (round(budget.percent_of_budget_spent, 0).to_i / 10) * 10
+          budget_spent_pct_bucket: (round(budget.percent_of_budget_spent, 0).to_i / 10) * 10,
+          budget_param: budget.to_param
         },
         period: budget.period,
-        dedup_key: "budget_at_risk:#{month_token(budget.start_date)}"
+        dedup_key: "budget_at_risk:#{dedup_scope(budget)}#{month_token(budget.start_date)}"
       )
     end
 
@@ -64,7 +67,7 @@ class Insight::Generators::BudgetInsightGenerator < Insight::Generator
       build_insight(
         insight_type: "budget_on_track",
         priority: "low",
-        title: I18n.t("insights.titles.budget_on_track"),
+        title: insight_title("budget_on_track", budget),
         template_key: "budget_on_track",
         facts: {
           spent: format_money(budget.actual_spending),
@@ -74,11 +77,26 @@ class Insight::Generators::BudgetInsightGenerator < Insight::Generator
         # Bucketed to damp nightly churn: a one-point move shouldn't count as
         # a material change that rewrites the body or reactivates a dismissal.
         metadata: {
-          budget_spent_pct_bucket: (round(budget.percent_of_budget_spent, 0).to_i / 10) * 10
+          budget_spent_pct_bucket: (round(budget.percent_of_budget_spent, 0).to_i / 10) * 10,
+          budget_param: budget.to_param
         },
         period: budget.period,
-        dedup_key: "budget_on_track:#{month_token(budget.start_date)}"
+        dedup_key: "budget_on_track:#{dedup_scope(budget)}#{month_token(budget.start_date)}"
       )
+    end
+
+    # The default plan keeps the legacy month-only key so existing insights
+    # don't duplicate after upgrade; sibling budgets get their plan id.
+    def dedup_scope(budget)
+      budget.budget_plan.is_default? ? "" : "#{budget.budget_plan_id}:"
+    end
+
+    def insight_title(insight_type, budget, count: nil)
+      if budget.budget_plan.is_default?
+        I18n.t("insights.titles.#{insight_type}", count: count)
+      else
+        I18n.t("insights.titles.#{insight_type}_named", budget: budget.budget_plan.name, count: count)
+      end
     end
 
     def on_track_eligible?(budget, parent_categories)

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -18,6 +18,8 @@ class SureImport < Import
     "Trade" => :trades,
     "Holding" => :holdings,
     "Valuation" => :valuations,
+    "BudgetPlan" => :budget_plans,
+    "BudgetPlanAccount" => :budget_plan_accounts,
     "Budget" => :budgets,
     "BudgetCategory" => :budget_categories,
     "Rule" => :rules
@@ -335,6 +337,8 @@ class SureImport < Import
         trades: family.entries.where(entryable_type: "Trade").count,
         holdings: family.holdings.count,
         valuations: family.entries.where(entryable_type: "Valuation").count,
+        budget_plans: family.budget_plans.count,
+        budget_plan_accounts: family.budget_plan_accounts.count,
         budgets: family.budgets.count,
         budget_categories: family.budget_categories.count,
         rules: family.rules.count

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -151,7 +151,7 @@ class SureImport < Import
       update!(summary: result[:summary]) if has_attribute?(:summary)
     end
 
-    record_readback_verification!(before_counts:)
+    record_readback_verification!(before_counts:, import_summary: result[:summary])
     result
   rescue => error
     record_failed_readback_verification!(before_counts:, error:)
@@ -273,9 +273,9 @@ class SureImport < Import
       )
     end
 
-    def record_readback_verification!(before_counts:)
+    def record_readback_verification!(before_counts:, import_summary: nil)
       update_columns(
-        readback_verification: build_readback_verification(before_counts:, status_for_mismatch: "mismatch"),
+        readback_verification: build_readback_verification(before_counts:, status_for_mismatch: "mismatch", import_summary:),
         updated_at: Time.current
       )
     end
@@ -294,12 +294,21 @@ class SureImport < Import
       Rails.logger.warn("Failed to record Sure import readback verification for import #{id}: #{verification_error.message}")
     end
 
-    def build_readback_verification(before_counts:, status_for_mismatch:)
+    def build_readback_verification(before_counts:, status_for_mismatch:, import_summary: nil)
       after_counts = readback_count_snapshot
       actual_delta_counts = delta_counts(before_counts, after_counts)
       expected_counts = normalized_expected_record_counts
       checked_counts = (actual_delta_counts.keys | expected_counts.keys).index_with do |key|
         expected_counts.fetch(key, 0).to_i
+      end
+
+      # Budget-plan NDJSON lines legitimately diverge from the DB delta: an
+      # imported default plan remaps onto the family's existing default, and
+      # a legacy budget-only export creates one implicitly. The importer's
+      # created-count is the true expected delta for this type — comparing
+      # it to the observed delta still catches lost writes.
+      if import_summary && (plan_summary = import_summary.deep_stringify_keys["budget_plans"])
+        checked_counts["budget_plans"] = plan_summary.fetch("created", 0).to_i
       end
       mismatches = checked_counts.each_with_object({}) do |(key, expected_count), result|
         actual_count = actual_delta_counts.fetch(key, 0)

--- a/app/models/sure_import/preflight.rb
+++ b/app/models/sure_import/preflight.rb
@@ -23,6 +23,8 @@ class SureImport::Preflight
     "Trade" => %w[account_id date amount qty price ticker],
     "Holding" => %w[account_id date amount qty price ticker],
     "Valuation" => %w[account_id date amount],
+    "BudgetPlan" => %w[id name],
+    "BudgetPlanAccount" => %w[budget_plan_id account_id],
     "Budget" => %w[id start_date end_date],
     "BudgetCategory" => %w[budget_id category_id],
     "Rule" => %w[name]
@@ -34,6 +36,7 @@ class SureImport::Preflight
     "Account" => :accounts,
     "RecurringTransaction" => :recurring_transactions,
     "Transaction" => :transactions,
+    "BudgetPlan" => :budget_plans,
     "Budget" => :budgets
   ).freeze
 
@@ -47,6 +50,8 @@ class SureImport::Preflight
     "Trade" => { accounts: %w[account_id] },
     "Holding" => { accounts: %w[account_id] },
     "Valuation" => { accounts: %w[account_id] },
+    "BudgetPlanAccount" => { budget_plans: %w[budget_plan_id], accounts: %w[account_id] },
+    "Budget" => { budget_plans: %w[budget_plan_id] },
     "BudgetCategory" => { budgets: %w[budget_id], categories: %w[category_id] }
   }.freeze
 

--- a/app/views/api/v1/budgets/_budget.json.jbuilder
+++ b/app/views/api/v1/budgets/_budget.json.jbuilder
@@ -14,6 +14,15 @@ json.currency budget.currency
 json.initialized budget.initialized?
 json.current budget.current?
 
+json.budget_plan do
+  json.id budget.budget_plan_id
+  json.name budget.budget_plan.name
+  json.slug budget.budget_plan.slug
+  json.is_default budget.budget_plan.is_default
+  # [] means the plan tracks all of the family's accounts.
+  json.account_ids budget.budget_plan.budget_plan_accounts.map(&:account_id)
+end
+
 json.budgeted_spending budget.budgeted_spending_money&.format
 json.budgeted_spending_cents money_to_minor_units.call(budget.budgeted_spending_money)
 json.expected_income budget.expected_income_money&.format

--- a/app/views/budget_plans/_form.html.erb
+++ b/app/views/budget_plans/_form.html.erb
@@ -24,7 +24,7 @@
     <div class="bg-container-inset rounded-lg p-1">
       <% grouped = selectable_accounts.group_by(&:accountable_type) %>
       <% grouped.each_with_index do |(type, accounts), group_idx| %>
-        <div class="px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-secondary"><%= type.titleize %></div>
+        <div class="px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-secondary"><%= Accountable.from_type(type)&.display_name || type.titleize %></div>
         <div class="bg-container rounded-md <%= "mb-1" if group_idx < grouped.size - 1 %>">
           <% accounts.each_with_index do |account, idx| %>
             <label class="flex items-center gap-3 px-3 py-2.5 hover:bg-surface-hover cursor-pointer <%= "border-t border-subdued" if idx > 0 %>">

--- a/app/views/budget_plans/_form.html.erb
+++ b/app/views/budget_plans/_form.html.erb
@@ -1,0 +1,59 @@
+<%# locals: (budget_plan:, selectable_accounts:, scoped_account_ids: []) %>
+
+<%= styled_form_with model: budget_plan,
+                     url: budget_plan.persisted? ? budget_plan_path(budget_plan) : budget_plans_path,
+                     method: budget_plan.persisted? ? :patch : :post,
+                     class: "space-y-5" do |f| %>
+  <%= f.text_field :name,
+                   label: t("budget_plans.form.fields.name"),
+                   placeholder: t("budget_plans.form.fields.name_placeholder"),
+                   autofocus: true,
+                   required: true %>
+
+  <div>
+    <div class="mb-2">
+      <span class="block text-sm font-medium text-primary"><%= t("budget_plans.form.fields.accounts") %></span>
+      <p class="text-xs text-secondary mt-0.5"><%= t("budget_plans.form.fields.accounts_hint") %></p>
+    </div>
+
+    <%# Always-present blank entry so unchecking every box still submits
+        budget_plan[account_ids] (= "track all accounts") instead of
+        omitting the key (= "leave the scope unchanged"). %>
+    <%= hidden_field_tag "budget_plan[account_ids][]", "" %>
+
+    <div class="bg-container-inset rounded-lg p-1">
+      <% grouped = selectable_accounts.group_by(&:accountable_type) %>
+      <% grouped.each_with_index do |(type, accounts), group_idx| %>
+        <div class="px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-secondary"><%= type.titleize %></div>
+        <div class="bg-container rounded-md <%= "mb-1" if group_idx < grouped.size - 1 %>">
+          <% accounts.each_with_index do |account, idx| %>
+            <label class="flex items-center gap-3 px-3 py-2.5 hover:bg-surface-hover cursor-pointer <%= "border-t border-subdued" if idx > 0 %>">
+              <%= check_box_tag "budget_plan[account_ids][]",
+                                account.id,
+                                scoped_account_ids.include?(account.id.to_s),
+                                id: "budget_plan_account_ids_#{account.id}",
+                                class: "checkbox checkbox--light shrink-0" %>
+              <div class="min-w-0">
+                <p class="text-sm font-medium text-primary truncate"><%= account.name %></p>
+                <p class="text-xs text-secondary tabular-nums privacy-sensitive"><%= Money.new(account.balance, account.currency).format %></p>
+              </div>
+            </label>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-between pt-2">
+    <% if budget_plan.persisted? && !budget_plan.is_default? %>
+      <%= button_to t("budget_plans.form.delete"),
+                    budget_plan_path(budget_plan),
+                    method: :delete,
+                    class: "text-sm text-destructive hover:underline cursor-pointer",
+                    form: { data: { turbo_frame: :_top, turbo_confirm: t("budget_plans.form.delete_confirm") } } %>
+    <% end %>
+    <div class="ml-auto">
+      <%= f.submit budget_plan.persisted? ? t("budget_plans.form.save") : t("budget_plans.form.create") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/budget_plans/edit.html.erb
+++ b/app/views/budget_plans/edit.html.erb
@@ -1,0 +1,15 @@
+<% if turbo_frame_request? %>
+  <%= render DS::Dialog.new(width: "lg") do |dialog| %>
+    <% dialog.with_header(title: t(".heading")) %>
+    <% dialog.with_body do %>
+      <%= render "form", budget_plan: @budget_plan, selectable_accounts: @selectable_accounts, scoped_account_ids: @scoped_account_ids %>
+    <% end %>
+  <% end %>
+<% else %>
+  <div class="max-w-2xl mx-auto py-8 px-4">
+    <header class="mb-6">
+      <h1 class="text-xl font-medium text-primary"><%= t(".heading") %></h1>
+    </header>
+    <%= render "form", budget_plan: @budget_plan, selectable_accounts: @selectable_accounts, scoped_account_ids: @scoped_account_ids %>
+  </div>
+<% end %>

--- a/app/views/budget_plans/new.html.erb
+++ b/app/views/budget_plans/new.html.erb
@@ -1,0 +1,30 @@
+<% if turbo_frame_request? %>
+  <%= render DS::Dialog.new(width: "lg") do |dialog| %>
+    <% dialog.with_header(custom_header: true) do %>
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-start gap-3">
+          <%= render DS::FilledIcon.new(variant: :container, icon: "map", size: "md", rounded: true) %>
+          <div>
+            <h2 class="text-base font-medium text-primary"><%= t(".heading") %></h2>
+            <p class="text-sm text-secondary mt-0.5"><%= t(".subtitle") %></p>
+          </div>
+        </div>
+        <%= render DS::Button.new(variant: "icon", icon: "x", title: t("defaults.common.close"), aria_label: t("defaults.common.close"), data: { action: "DS--dialog#close" }) %>
+      </div>
+    <% end %>
+    <% dialog.with_body do %>
+      <%= render "form", budget_plan: @budget_plan, selectable_accounts: @selectable_accounts %>
+    <% end %>
+  <% end %>
+<% else %>
+  <div class="max-w-2xl mx-auto py-8 px-4">
+    <header class="mb-6 flex items-start gap-3">
+      <%= render DS::FilledIcon.new(variant: :container, icon: "map", size: "md", rounded: true) %>
+      <div>
+        <h1 class="text-xl font-medium text-primary"><%= t(".heading") %></h1>
+        <p class="text-sm text-secondary mt-0.5"><%= t(".subtitle") %></p>
+      </div>
+    </header>
+    <%= render "form", budget_plan: @budget_plan, selectable_accounts: @selectable_accounts %>
+  </div>
+<% end %>

--- a/app/views/budgets/_budget_header.html.erb
+++ b/app/views/budgets/_budget_header.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (budget:, previous_budget:, next_budget:, latest_budget:) %>
+<%# locals: (budget:) %>
 
 <div class="flex items-center gap-1 mb-4">
   <div class="flex items-center gap-2">
@@ -29,20 +29,24 @@
 
   <%= render DS::Popover.new(variant: "button") do |popover| %>
     <% popover.with_button class: "flex items-center gap-1 hover:bg-surface-hover cursor-pointer rounded-md p-2"  do %>
-      <span class="text-primary font-medium text-lg lg:text-base"><%= @budget.name %></span>
+      <span class="text-primary font-medium text-lg lg:text-base"><%= budget.period_name %></span>
       <%= icon("chevron-down") %>
     <% end %>
 
     <% popover.with_custom_content do %>
-      <%= render "budgets/picker", family: Current.family, year: budget.start_date.year %>
+      <%= render "budgets/picker", family: Current.family, year: budget.start_date.year, plan: budget.budget_plan %>
     <% end %>
+  <% end %>
+
+  <% if Current.family.budget_plans.many? %>
+    <%= render "budgets/plan_switcher", budget: budget %>
   <% end %>
 
   <div class="ml-auto">
     <%= render DS::Link.new(
         text: t(".today"),
         variant: "outline",
-        href: budget_path(Budget.date_to_param(Date.current)),
+        href: budget_path(Budget.param_for(budget.budget_plan, Date.current)),
     ) %>
   </div>
 </div>

--- a/app/views/budgets/_budget_nav.html.erb
+++ b/app/views/budgets/_budget_nav.html.erb
@@ -1,8 +1,8 @@
 <%# locals: (budget:) %>
 
 <% steps = [
-  { name: "Setup", path: edit_budget_path(budget), is_complete: budget.initialized?, step_number: 1 },
-  { name: "Categories", path: budget_budget_categories_path(budget), is_complete: budget.allocations_valid?, step_number: 2 },
+  { name: t("budgets.budget_nav.setup"), path: edit_budget_path(budget), is_complete: budget.initialized?, step_number: 1 },
+  { name: t("budgets.budget_nav.categories"), path: budget_budget_categories_path(budget), is_complete: budget.allocations_valid?, step_number: 2 },
 ] %>
 
 <ul class="flex items-center gap-2">

--- a/app/views/budgets/_picker.html.erb
+++ b/app/views/budgets/_picker.html.erb
@@ -1,12 +1,13 @@
-<%# locals: (family:, year:) %>
+<%# locals: (family:, year:, plan:) %>
 
 <%= turbo_frame_tag "budget_picker" do %>
   <div class="p-3 space-y-4">
     <div class="flex items-center gap-2 justify-between">
       <% last_month_of_previous_year = Date.new(year - 1, 12, 1) %>
+      <% picker_plan_param = plan.is_default? ? nil : plan.slug %>
 
       <% if Budget.budget_date_valid?(last_month_of_previous_year, family: family) %>
-        <%= link_to picker_budgets_path(year: year - 1), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-surface-hover rounded-md" do %>
+        <%= link_to picker_budgets_path(year: year - 1, plan: picker_plan_param), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-surface-hover rounded-md" do %>
           <%= icon "chevron-left" %>
         <% end %>
       <% else %>
@@ -22,7 +23,7 @@
       <% first_month_of_next_year = Date.new(year + 1, 1, 1) %>
 
       <% if Budget.budget_date_valid?(first_month_of_next_year, family: family) %>
-        <%= link_to picker_budgets_path(year: year + 1), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-surface-hover rounded-md" do %>
+        <%= link_to picker_budgets_path(year: year + 1, plan: picker_plan_param), data: { turbo_frame: "budget_picker" }, class: "p-2 flex items-center justify-center hover:bg-surface-hover rounded-md" do %>
           <%= icon "chevron-right" %>
         <% end %>
       <% else %>
@@ -35,7 +36,7 @@
     <div class="grid grid-cols-3 gap-2 text-sm text-center font-medium">
       <% Date::ABBR_MONTHNAMES.compact.each do |month_name| %>
         <% date = Date.strptime("#{month_name}-#{year}", "%b-%Y") %>
-        <% param_key = Budget.date_to_param(date) %>
+        <% param_key = Budget.param_for(plan, date) %>
 
         <% if Budget.budget_date_valid?(date, family: family) %>
           <%= render DS::Link.new(
@@ -49,6 +50,17 @@
           <span class="px-3 py-2 text-subdued rounded-md"><%= month_name %></span>
         <% end %>
       <% end %>
+    </div>
+
+    <div class="border-t border-tertiary pt-2">
+      <%= render DS::Link.new(
+        variant: "ghost",
+        icon: "plus",
+        text: t(".new_plan"),
+        href: new_budget_plan_path,
+        full_width: true,
+        frame: :modal
+      ) %>
     </div>
   </div>
 <% end %>

--- a/app/views/budgets/_plan_switcher.html.erb
+++ b/app/views/budgets/_plan_switcher.html.erb
@@ -1,0 +1,31 @@
+<%# locals: (budget:) %>
+
+<% plans = Current.family.budget_plans.default_first %>
+
+<%= render DS::Menu.new(variant: :button, placement: "bottom-start") do |menu| %>
+  <% menu.with_button(
+       type: "button",
+       class: "inline-flex items-center gap-1.5 bg-container border border-secondary font-medium rounded-lg pl-3 pr-2 py-2 text-sm cursor-pointer text-primary hover:bg-container-inset-hover focus:outline-hidden focus:ring-0",
+       aria: { label: t(".aria_label", plan: budget.budget_plan.name) }
+     ) do %>
+    <span class="whitespace-nowrap"><%= budget.budget_plan.name %></span>
+    <%= icon("chevron-down", size: "sm") %>
+  <% end %>
+
+  <% plans.each do |plan| %>
+    <% menu.with_item(
+         variant: :link,
+         text: plan.name,
+         href: budget_path(Budget.param_for(plan, budget.start_date)),
+         selected: plan.id == budget.budget_plan_id
+       ) %>
+  <% end %>
+
+  <% menu.with_item(variant: :divider) %>
+  <% menu.with_item(variant: :link, icon: "pencil", text: t(".edit_plan"),
+                    href: edit_budget_plan_path(budget.budget_plan),
+                    frame: :modal) %>
+  <% menu.with_item(variant: :link, icon: "plus", text: t(".new_plan"),
+                    href: new_budget_plan_path,
+                    frame: :modal) %>
+<% end %>

--- a/app/views/budgets/_plan_switcher.html.erb
+++ b/app/views/budgets/_plan_switcher.html.erb
@@ -1,11 +1,11 @@
 <%# locals: (budget:) %>
 
-<% plans = Current.family.budget_plans.default_first %>
+<% plans = budget_plan_switcher_plans %>
 
 <%= render DS::Menu.new(variant: :button, placement: "bottom-start") do |menu| %>
   <% menu.with_button(
        type: "button",
-       class: "inline-flex items-center gap-1.5 bg-container border border-secondary font-medium rounded-lg pl-3 pr-2 py-2 text-sm cursor-pointer text-primary hover:bg-container-inset-hover focus:outline-hidden focus:ring-0",
+       class: "inline-flex items-center gap-1.5 bg-container border border-secondary font-medium rounded-lg pl-3 pr-2 py-2 text-sm cursor-pointer text-primary hover:bg-container-inset-hover",
        aria: { label: t(".aria_label", plan: budget.budget_plan.name) }
      ) do %>
     <span class="whitespace-nowrap"><%= budget.budget_plan.name %></span>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -1,9 +1,5 @@
 <div class="pb-6 lg:pb-12">
-  <%= render "budgets/budget_header",
-            budget: @budget,
-            previous_budget: @previous_budget,
-            next_budget: @next_budget,
-            latest_budget: @latest_budget %>
+  <%= render "budgets/budget_header", budget: @budget %>
 
   <div class="space-y-4">
     <%# Top Section: Donut and Summary side by side %>

--- a/app/views/plans/_budget_card.html.erb
+++ b/app/views/plans/_budget_card.html.erb
@@ -115,7 +115,7 @@
         <%= render DS::Link.new(
           text: plan.name,
           variant: "ghost",
-          href: budget_path(Budget.param_for(plan, Date.current)),
+          href: budget_path(Budget.param_for(plan, budget.start_date)),
           icon: "chevron-right",
           icon_position: :right,
           full_width: true

--- a/app/views/plans/_budget_card.html.erb
+++ b/app/views/plans/_budget_card.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (budget:, top_budget_categories:) %>
+<%# locals: (budget:, top_budget_categories:, other_plans: []) %>
 
 <%= render DS::Card.new do %>
   <div class="flex flex-wrap items-center gap-2 mb-4">
@@ -107,4 +107,20 @@
     full_width: true,
     class: "mt-5"
   ) %>
+
+  <% if other_plans.any? %>
+    <div class="mt-3 border-t border-tertiary pt-3">
+      <p class="mb-1 text-[11px] font-medium uppercase tracking-wide text-secondary"><%= t(".other_plans") %></p>
+      <% other_plans.each do |plan| %>
+        <%= render DS::Link.new(
+          text: plan.name,
+          variant: "ghost",
+          href: budget_path(Budget.param_for(plan, Date.current)),
+          icon: "chevron-right",
+          icon_position: :right,
+          full_width: true
+        ) %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -11,7 +11,7 @@
   </header>
 
   <div class="grid grid-cols-1 @3xl:grid-cols-2 gap-4 items-stretch">
-    <%= render "plans/budget_card", budget: @budget, top_budget_categories: @top_budget_categories %>
+    <%= render "plans/budget_card", budget: @budget, top_budget_categories: @top_budget_categories, other_plans: @other_budget_plans %>
     <%= render "plans/goals_card", goals: @goals, summary: @goals_summary, linkable_account_count: @linkable_account_count, family_has_goals: @family_has_goals %>
   </div>
 </div>

--- a/config/locales/models/budget_plan/en.yml
+++ b/config/locales/models/budget_plan/en.yml
@@ -3,8 +3,16 @@ en:
   activerecord:
     errors:
       models:
+        budget:
+          attributes:
+            budget_plan:
+              must_belong_to_family: must belong to the same family
         budget_plan:
           attributes:
             accounts:
               must_belong_to_family: must belong to the same family
           cannot_destroy_default: The default budget can't be deleted
+        budget_plan_account:
+          attributes:
+            account:
+              must_belong_to_family: must belong to the same family

--- a/config/locales/models/budget_plan/en.yml
+++ b/config/locales/models/budget_plan/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        budget_plan:
+          attributes:
+            accounts:
+              must_belong_to_family: must belong to the same family
+          cannot_destroy_default: The default budget can't be deleted

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -32,6 +32,7 @@ en:
       depository_only: "Only cash and credit card accounts can be set as default."
     destroy:
       success: "%{type} account scheduled for deletion"
+      cannot_delete_last_budget_plan_account: "This account is the only one tracked by the %{plans} budget. Update or delete that budget first."
       cannot_delete_linked: "Cannot delete a linked account. Please unlink it first."
       failed: "Resource deletion failed. Try again later."
     empty:

--- a/config/locales/views/budget_plans/en.yml
+++ b/config/locales/views/budget_plans/en.yml
@@ -1,0 +1,28 @@
+---
+en:
+  budget_plans:
+    create:
+      success: Budget created
+    destroy:
+      cannot_delete_default: The default budget can't be deleted
+      success: Budget deleted
+    edit:
+      heading: Edit budget
+    form:
+      create: Create budget
+      delete: Delete budget
+      delete_confirm: Delete this budget and all of its monthly data? This cannot
+        be undone.
+      fields:
+        accounts: Accounts
+        accounts_hint: This budget only counts transactions from the checked accounts.
+          Leave all unchecked to include every account.
+        name: Name
+        name_placeholder: e.g. Personal, Joint, Test
+      save: Save
+    new:
+      heading: New budget
+      subtitle: Budget a subset of your accounts, or run a separate budget alongside
+        your main one.
+    update:
+      success: Budget updated

--- a/config/locales/views/budgets/en.yml
+++ b/config/locales/views/budgets/en.yml
@@ -35,6 +35,14 @@ en:
     name:
       custom_range: "%{start} - %{end_date}"
       month_year: "%{month}"
+      plan_custom_range: "%{plan} · %{start} - %{end_date}"
+      plan_month_year: "%{plan} · %{month}"
+    picker:
+      new_plan: "New budget"
+    plan_switcher:
+      aria_label: "Budget: %{plan}"
+      edit_plan: "Edit budget"
+      new_plan: "New budget"
     show:
       categories:
         amount: Amount

--- a/config/locales/views/insights/en.yml
+++ b/config/locales/views/insights/en.yml
@@ -75,7 +75,11 @@ en:
       budget_at_risk:
         one: One category needs attention in your budget
         other: "%{count} categories need attention in your budget"
+      budget_at_risk_named:
+        one: One category needs attention in your %{budget} budget
+        other: "%{count} categories need attention in your %{budget} budget"
       budget_on_track: Your budget is on track
+      budget_on_track_named: Your %{budget} budget is on track
     templates:
       spending_anomaly:
         above: You're on pace to spend %{projected_spend} on %{category} this month, about %{deviation_pct}% more than your recent monthly average of %{baseline_spend}.

--- a/config/locales/views/plans/en.yml
+++ b/config/locales/views/plans/en.yml
@@ -14,6 +14,7 @@ en:
       percent_used: "%{percent}% used"
       top_categories: Top categories
       view_budget: View full budget
+      other_plans: Other budgets
       empty_body: Set a monthly spending target and per-category limits to see how this month is tracking.
       set_up: Set up this month's budget
     goals_card:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,6 +389,8 @@ Rails.application.routes.draw do
     resources :budget_categories, only: %i[index show update]
   end
 
+  resources :budget_plans, only: %i[new create edit update destroy]
+
   resources :goals do
     member do
       patch :pause
@@ -614,6 +616,7 @@ Rails.application.routes.draw do
       resources :balances, only: [ :index, :show ]
       resources :budgets, only: [ :index, :show ]
       resources :budget_categories, only: [ :index, :show ]
+      resources :budget_plans, only: [ :index, :show, :create, :update, :destroy ]
       resources :categories, only: [ :index, :show, :create ]
       resources :merchants, only: [ :index, :show, :create ]
       resources :rules, only: [ :index, :show ]

--- a/db/migrate/20260804000000_create_budget_plans.rb
+++ b/db/migrate/20260804000000_create_budget_plans.rb
@@ -50,10 +50,8 @@ class CreateBudgetPlans < ActiveRecord::Migration[7.2]
   end
 
   def down
-    add_index :budgets, [ :family_id, :start_date, :end_date ], unique: true,
-              name: "index_budgets_on_family_id_and_start_date_and_end_date"
-    remove_column :budgets, :budget_plan_id
-    drop_table :budget_plan_accounts
-    drop_table :budget_plans
+    # Sibling plans can hold budgets for the same family and period, which the
+    # former (family_id, start_date, end_date) unique index cannot represent.
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260804000000_create_budget_plans.rb
+++ b/db/migrate/20260804000000_create_budget_plans.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class CreateBudgetPlans < ActiveRecord::Migration[7.2]
+  def up
+    create_table :budget_plans, id: :uuid do |t|
+      t.references :family, null: false, foreign_key: { on_delete: :cascade }, type: :uuid
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.boolean :is_default, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :budget_plans, [ :family_id, :slug ], unique: true
+    add_index :budget_plans, :family_id, unique: true, where: "is_default",
+              name: "index_budget_plans_one_default_per_family"
+
+    create_table :budget_plan_accounts, id: :uuid do |t|
+      t.references :budget_plan, null: false, foreign_key: { on_delete: :cascade }, type: :uuid
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }, type: :uuid
+
+      t.timestamps
+    end
+
+    add_index :budget_plan_accounts, [ :budget_plan_id, :account_id ], unique: true,
+              name: "index_budget_plan_accounts_on_plan_and_account"
+
+    add_column :budgets, :budget_plan_id, :uuid
+    add_foreign_key :budgets, :budget_plans
+
+    # One default plan per family that already has budgets; existing budgets attach to it.
+    execute <<~SQL
+      INSERT INTO budget_plans (id, family_id, name, slug, is_default, created_at, updated_at)
+      SELECT gen_random_uuid(), family_id, 'Primary', 'primary', true, NOW(), NOW()
+      FROM budgets
+      GROUP BY family_id
+    SQL
+
+    execute <<~SQL
+      UPDATE budgets
+      SET budget_plan_id = budget_plans.id
+      FROM budget_plans
+      WHERE budget_plans.family_id = budgets.family_id AND budget_plans.is_default
+    SQL
+
+    change_column_null :budgets, :budget_plan_id, false
+    add_index :budgets, [ :budget_plan_id, :start_date, :end_date ], unique: true,
+              name: "index_budgets_on_plan_and_start_date_and_end_date"
+    remove_index :budgets, name: "index_budgets_on_family_id_and_start_date_and_end_date"
+  end
+
+  def down
+    add_index :budgets, [ :family_id, :start_date, :end_date ], unique: true,
+              name: "index_budgets_on_family_id_and_start_date_and_end_date"
+    remove_column :budgets, :budget_plan_id
+    drop_table :budget_plan_accounts
+    drop_table :budget_plans
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_04_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -372,8 +372,31 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
     t.index ["category_id"], name: "index_budget_categories_on_category_id"
   end
 
+  create_table "budget_plan_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "budget_plan_id", null: false
+    t.uuid "account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_budget_plan_accounts_on_account_id"
+    t.index ["budget_plan_id", "account_id"], name: "index_budget_plan_accounts_on_plan_and_account", unique: true
+    t.index ["budget_plan_id"], name: "index_budget_plan_accounts_on_budget_plan_id"
+  end
+
+  create_table "budget_plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "family_id", null: false
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.boolean "is_default", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_id", "slug"], name: "index_budget_plans_on_family_id_and_slug", unique: true
+    t.index ["family_id"], name: "index_budget_plans_on_family_id"
+    t.index ["family_id"], name: "index_budget_plans_one_default_per_family", unique: true, where: "is_default"
+  end
+
   create_table "budgets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "family_id", null: false
+    t.uuid "budget_plan_id", null: false
     t.date "start_date", null: false
     t.date "end_date", null: false
     t.decimal "budgeted_spending", precision: 19, scale: 4
@@ -381,7 +404,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
     t.string "currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["family_id", "start_date", "end_date"], name: "index_budgets_on_family_id_and_start_date_and_end_date", unique: true
+    t.index ["budget_plan_id", "start_date", "end_date"], name: "index_budgets_on_plan_and_start_date_and_end_date", unique: true
     t.index ["family_id"], name: "index_budgets_on_family_id"
   end
 
@@ -2341,6 +2364,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_27_111051) do
   add_foreign_key "brex_items", "families"
   add_foreign_key "budget_categories", "budgets"
   add_foreign_key "budget_categories", "categories"
+  add_foreign_key "budget_plan_accounts", "accounts", on_delete: :cascade
+  add_foreign_key "budget_plan_accounts", "budget_plans", on_delete: :cascade
+  add_foreign_key "budget_plans", "families", on_delete: :cascade
+  add_foreign_key "budgets", "budget_plans"
   add_foreign_key "budgets", "families"
   add_foreign_key "categories", "families"
   add_foreign_key "chats", "users"

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -460,6 +460,62 @@ components:
         updated_at:
           type: string
           format: date-time
+    BudgetPlan:
+      type: object
+      required:
+      - id
+      - name
+      - slug
+      - is_default
+      - account_ids
+      - created_at
+      - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        is_default:
+          type: boolean
+        account_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Accounts this plan is scoped to; empty means all of the family's
+            accounts
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    BudgetPlanRef:
+      type: object
+      required:
+      - id
+      - name
+      - slug
+      - is_default
+      - account_ids
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        is_default:
+          type: boolean
+        account_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
     BudgetSummary:
       type: object
       required:
@@ -470,6 +526,7 @@ components:
       - currency
       - initialized
       - current
+      - budget_plan
       - created_at
       - updated_at
       properties:
@@ -490,6 +547,8 @@ components:
           type: boolean
         current:
           type: boolean
+        budget_plan:
+          "$ref": "#/components/schemas/BudgetPlanRef"
         budgeted_spending:
           type: string
           nullable: true
@@ -522,6 +581,7 @@ components:
       - currency
       - initialized
       - current
+      - budget_plan
       - created_at
       - updated_at
       properties:
@@ -542,6 +602,8 @@ components:
           type: boolean
         current:
           type: boolean
+        budget_plan:
+          "$ref": "#/components/schemas/BudgetPlanRef"
         budgeted_spending:
           type: string
           nullable: true
@@ -1005,6 +1067,23 @@ components:
         updated_at:
           type: string
           format: date-time
+    MerchantImportResult:
+      type: object
+      required:
+      - imported
+      - skipped
+      - merchants
+      properties:
+        imported:
+          type: integer
+          description: Number of merchants successfully created
+        skipped:
+          type: integer
+          description: Number of rows skipped (duplicates or invalid)
+        merchants:
+          type: array
+          items:
+            "$ref": "#/components/schemas/MerchantDetail"
     Tag:
       type: object
       required:
@@ -1564,6 +1643,20 @@ components:
           - liability_payment
           - loan_payment
         notes:
+          type: string
+          nullable: true
+        source_fee_amount:
+          type: string
+          nullable: true
+          description: Fee charged to the source account
+        source_fee_currency:
+          type: string
+          nullable: true
+        destination_fee_amount:
+          type: string
+          nullable: true
+          description: Fee deducted from the destination account
+        destination_fee_currency:
           type: string
           nullable: true
         inflow_transaction:
@@ -3075,6 +3168,8 @@ components:
           - rule_runs
           - budgets
           - budget_categories
+          - budget_plans
+          - budget_plan_accounts
           - categories
           - tags
           - taggings
@@ -3160,6 +3255,12 @@ components:
               type: integer
               minimum: 0
             budget_categories:
+              type: integer
+              minimum: 0
+            budget_plans:
+              type: integer
+              minimum: 0
+            budget_plan_accounts:
               type: integer
               minimum: 0
             categories:
@@ -4056,6 +4157,153 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/budget_plans":
+    get:
+      summary: List budget plans
+      tags:
+      - Budget Plans
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: budget plans listed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/BudgetPlan"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    post:
+      summary: Create a budget plan
+      tags:
+      - Budget Plans
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '201':
+          description: budget plan created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BudgetPlan"
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - budget_plan
+              properties:
+                budget_plan:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    name:
+                      type: string
+                    account_ids:
+                      type: array
+                      items:
+                        type: string
+                        format: uuid
+                      description: Accounts to scope the plan to; omit or send []
+                        to track all accounts
+  "/api/v1/budget_plans/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      description: Budget plan ID
+      schema:
+        type: string
+        format: uuid
+    get:
+      summary: Retrieve a budget plan
+      tags:
+      - Budget Plans
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: budget plan retrieved
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BudgetPlan"
+        '404':
+          description: budget plan not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update a budget plan
+      tags:
+      - Budget Plans
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '200':
+          description: budget plan updated
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BudgetPlan"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - budget_plan
+              properties:
+                budget_plan:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    account_ids:
+                      type: array
+                      items:
+                        type: string
+                        format: uuid
+                      description: Replaces the plan's account scope; [] clears it
+                        back to all accounts. Omit to leave unchanged.
+    delete:
+      summary: Delete a budget plan
+      tags:
+      - Budget Plans
+      security:
+      - apiKeyAuth: []
+      responses:
+        '204':
+          description: budget plan deleted
+        '422':
+          description: cannot delete the default plan
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v1/budgets":
     get:
       summary: List budgets
@@ -4090,6 +4338,13 @@ paths:
           type: string
           format: date
         description: Filter budgets ending on or before this date
+      - name: budget_plan_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+        description: Filter budgets belonging to a specific budget plan
       responses:
         '200':
           description: budgets listed
@@ -5723,6 +5978,39 @@ paths:
                 type: array
                 items:
                   "$ref": "#/components/schemas/MerchantDetail"
+    post:
+      summary: Import merchants from CSV
+      tags:
+      - Merchants
+      security:
+      - apiKeyAuth: []
+      parameters: []
+      responses:
+        '201':
+          description: merchants imported
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MerchantImportResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: missing file or invalid CSV
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: file
+        required: true
+        description: 'CSV file with columns: name* (required), color, website_url'
   "/api/v1/merchants/{id}":
     parameters:
     - name: id

--- a/spec/requests/api/v1/budget_plans_spec.rb
+++ b/spec/requests/api/v1/budget_plans_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'API V1 Budget Plans', type: :request do
+  let(:family) do
+    Family.create!(
+      name: 'API Family',
+      currency: 'USD',
+      locale: 'en',
+      date_format: '%m-%d-%Y'
+    )
+  end
+
+  let(:user) do
+    family.users.create!(
+      email: 'api-user@example.com',
+      password: 'password123',
+      password_confirmation: 'password123'
+    )
+  end
+
+  let(:api_key) do
+    key = ApiKey.generate_secure_key
+    ApiKey.create!(
+      user: user,
+      name: 'API Docs Key',
+      key: key,
+      display_key: key,
+      scopes: %w[read_write],
+      source: 'web'
+    )
+  end
+
+  let(:read_only_api_key) do
+    key = ApiKey.generate_secure_key
+    ApiKey.create!(
+      user: user,
+      name: 'Read Only Docs Key',
+      key: key,
+      display_key: key,
+      scopes: %w[read],
+      source: 'web'
+    )
+  end
+
+  let(:'X-Api-Key') { api_key.plain_key }
+
+  let!(:budget_plan) { family.budget_plans.create!(name: 'Joint') }
+
+  path '/api/v1/budget_plans' do
+    get 'List budget plans' do
+      tags 'Budget Plans'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+
+      response '200', 'budget plans listed' do
+        schema type: :array, items: { '$ref' => '#/components/schemas/BudgetPlan' }
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { nil }
+
+        run_test!
+      end
+    end
+
+    post 'Create a budget plan' do
+      tags 'Budget Plans'
+      security [ { apiKeyAuth: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: %w[budget_plan],
+        properties: {
+          budget_plan: {
+            type: :object,
+            required: %w[name],
+            properties: {
+              name: { type: :string },
+              account_ids: {
+                type: :array,
+                items: { type: :string, format: :uuid },
+                description: 'Accounts to scope the plan to; omit or send [] to track all accounts'
+              }
+            }
+          }
+        }
+      }
+
+      response '201', 'budget plan created' do
+        schema '$ref' => '#/components/schemas/BudgetPlan'
+
+        let(:body) { { budget_plan: { name: 'Personal' } } }
+
+        run_test!
+      end
+
+      response '403', 'insufficient scope' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:'X-Api-Key') { read_only_api_key.plain_key }
+        let(:body) { { budget_plan: { name: 'Personal' } } }
+
+        run_test!
+      end
+
+      response '422', 'validation failed' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:body) { { budget_plan: { name: '' } } }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/budget_plans/{id}' do
+    parameter name: :id, in: :path, required: true, description: 'Budget plan ID',
+              schema: { type: :string, format: :uuid }
+
+    get 'Retrieve a budget plan' do
+      tags 'Budget Plans'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+
+      let(:id) { budget_plan.id }
+
+      response '200', 'budget plan retrieved' do
+        schema '$ref' => '#/components/schemas/BudgetPlan'
+
+        run_test!
+      end
+
+      response '404', 'budget plan not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+
+    patch 'Update a budget plan' do
+      tags 'Budget Plans'
+      security [ { apiKeyAuth: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: %w[budget_plan],
+        properties: {
+          budget_plan: {
+            type: :object,
+            properties: {
+              name: { type: :string },
+              account_ids: {
+                type: :array,
+                items: { type: :string, format: :uuid },
+                description: 'Replaces the plan\'s account scope; [] clears it back to all accounts. Omit to leave unchanged.'
+              }
+            }
+          }
+        }
+      }
+
+      let(:id) { budget_plan.id }
+
+      response '200', 'budget plan updated' do
+        schema '$ref' => '#/components/schemas/BudgetPlan'
+
+        let(:body) { { budget_plan: { name: 'Renamed' } } }
+
+        run_test!
+      end
+    end
+
+    delete 'Delete a budget plan' do
+      tags 'Budget Plans'
+      security [ { apiKeyAuth: [] } ]
+      produces 'application/json'
+
+      let(:id) { budget_plan.id }
+
+      response '204', 'budget plan deleted' do
+        run_test!
+      end
+
+      response '422', 'cannot delete the default plan' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { family.default_budget_plan.id }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/budgets_spec.rb
+++ b/spec/requests/api/v1/budgets_spec.rb
@@ -70,6 +70,9 @@ RSpec.describe 'API V1 Budgets', type: :request do
       parameter name: :end_date, in: :query, required: false,
                 schema: { type: :string, format: :date },
                 description: 'Filter budgets ending on or before this date'
+      parameter name: :budget_plan_id, in: :query, required: false,
+                schema: { type: :string, format: :uuid },
+                description: 'Filter budgets belonging to a specific budget plan'
 
       response '200', 'budgets listed' do
         schema '$ref' => '#/components/schemas/BudgetCollection'

--- a/spec/requests/api/v1/budgets_spec.rb
+++ b/spec/requests/api/v1/budgets_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'API V1 Budgets', type: :request do
       name: 'API Docs Key',
       key: key,
       display_key: key,
-      scopes: %w[read],
+      scopes: %w[read_write],
       source: 'web'
     )
   end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -298,9 +298,40 @@ RSpec.configure do |config|
               updated_at: { type: :string, format: :'date-time' }
             }
           },
+          BudgetPlan: {
+            type: :object,
+            required: %w[id name slug is_default account_ids created_at updated_at],
+            properties: {
+              id: { type: :string, format: :uuid },
+              name: { type: :string },
+              slug: { type: :string },
+              is_default: { type: :boolean },
+              account_ids: {
+                type: :array,
+                items: { type: :string, format: :uuid },
+                description: 'Accounts this plan is scoped to; empty means all of the family\'s accounts'
+              },
+              created_at: { type: :string, format: :'date-time' },
+              updated_at: { type: :string, format: :'date-time' }
+            }
+          },
+          BudgetPlanRef: {
+            type: :object,
+            required: %w[id name slug is_default account_ids],
+            properties: {
+              id: { type: :string, format: :uuid },
+              name: { type: :string },
+              slug: { type: :string },
+              is_default: { type: :boolean },
+              account_ids: {
+                type: :array,
+                items: { type: :string, format: :uuid }
+              }
+            }
+          },
           BudgetSummary: {
             type: :object,
-            required: %w[id start_date end_date name currency initialized current created_at updated_at],
+            required: %w[id start_date end_date name currency initialized current budget_plan created_at updated_at],
             properties: {
               id: { type: :string, format: :uuid },
               start_date: { type: :string, format: :date },
@@ -309,6 +340,7 @@ RSpec.configure do |config|
               currency: { type: :string },
               initialized: { type: :boolean },
               current: { type: :boolean },
+              budget_plan: { '$ref' => '#/components/schemas/BudgetPlanRef' },
               budgeted_spending: { type: :string, nullable: true },
               budgeted_spending_cents: { type: :integer, nullable: true },
               expected_income: { type: :string, nullable: true },
@@ -321,7 +353,7 @@ RSpec.configure do |config|
           },
           Budget: {
             type: :object,
-            required: %w[id start_date end_date name currency initialized current created_at updated_at],
+            required: %w[id start_date end_date name currency initialized current budget_plan created_at updated_at],
             properties: {
               id: { type: :string, format: :uuid },
               start_date: { type: :string, format: :date },
@@ -330,6 +362,7 @@ RSpec.configure do |config|
               currency: { type: :string },
               initialized: { type: :boolean },
               current: { type: :boolean },
+              budget_plan: { '$ref' => '#/components/schemas/BudgetPlanRef' },
               budgeted_spending: { type: :string, nullable: true },
               budgeted_spending_cents: { type: :integer, nullable: true },
               expected_income: { type: :string, nullable: true },

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -492,6 +492,17 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     ActionView::Base.logger = original_view_logger
     Rails.logger = original_rails_logger
   end
+
+  test "destroy is refused while the account is a budget plan's only scoped account" do
+    plan = @user.family.budget_plans.create!(name: "Solo")
+    plan.budget_plan_accounts.create!(account: @account)
+
+    delete account_url(@account)
+
+    assert_redirected_to account_path(@account)
+    assert_match plan.name, flash[:alert]
+    assert Account.exists?(@account.id)
+  end
 end
 
 class AccountsControllerSimplefinCtaTest < ActionDispatch::IntegrationTest

--- a/test/controllers/api/v1/budget_plans_controller_test.rb
+++ b/test/controllers/api/v1/budget_plans_controller_test.rb
@@ -7,22 +7,22 @@ class Api::V1::BudgetPlansControllerTest < ActionDispatch::IntegrationTest
     @user = users(:family_admin)
     @family = @user.family
 
-    @oauth_app = Doorkeeper::Application.create!(
-      name: "Test App",
-      redirect_uri: "https://example.com/callback",
-      scopes: "read read_write"
+    @user.api_keys.active.destroy_all
+
+    @read_key = ApiKey.create!(
+      user: @user,
+      name: "Test Read Key",
+      scopes: [ "read" ],
+      source: "web",
+      display_key: "test_read_#{SecureRandom.hex(8)}"
     )
 
-    @read_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read"
-    )
-
-    @read_write_token = Doorkeeper::AccessToken.create!(
-      application: @oauth_app,
-      resource_owner_id: @user.id,
-      scopes: "read_write"
+    @read_write_key = ApiKey.create!(
+      user: @user,
+      name: "Test Read Write Key",
+      scopes: [ "read_write" ],
+      source: "web",
+      display_key: "test_rw_#{SecureRandom.hex(8)}"
     )
   end
 
@@ -159,10 +159,10 @@ class Api::V1::BudgetPlansControllerTest < ActionDispatch::IntegrationTest
   private
 
     def read_headers
-      { "Authorization" => "Bearer #{@read_token.token}" }
+      { "X-Api-Key" => @read_key.plain_key }
     end
 
     def read_write_headers
-      { "Authorization" => "Bearer #{@read_write_token.token}" }
+      { "X-Api-Key" => @read_write_key.plain_key }
     end
 end

--- a/test/controllers/api/v1/budget_plans_controller_test.rb
+++ b/test/controllers/api/v1/budget_plans_controller_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::BudgetPlansControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+
+    @oauth_app = Doorkeeper::Application.create!(
+      name: "Test App",
+      redirect_uri: "https://example.com/callback",
+      scopes: "read read_write"
+    )
+
+    @read_token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read"
+    )
+
+    @read_write_token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read_write"
+    )
+  end
+
+  test "index requires authentication" do
+    get api_v1_budget_plans_url
+
+    assert_response :unauthorized
+  end
+
+  test "index lists the family's plans, default first" do
+    get api_v1_budget_plans_url, headers: read_headers
+
+    assert_response :success
+    plans = JSON.parse(response.body)
+    assert_equal @family.budget_plans.count, plans.length
+    assert plans.first["is_default"]
+    assert_includes plans.map { |p| p["slug"] }, "personal"
+  end
+
+  test "show returns a plan with its account ids" do
+    plan = budget_plans(:dylan_personal)
+    account = accounts(:depository)
+    plan.budget_plan_accounts.create!(account: account)
+
+    get api_v1_budget_plan_url(plan), headers: read_headers
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal plan.name, body["name"]
+    assert_equal [ account.id ], body["account_ids"]
+  end
+
+  test "show 404s for another family's plan" do
+    foreign_plan = families(:empty).budget_plans.create!(name: "Foreign")
+
+    get api_v1_budget_plan_url(foreign_plan), headers: read_headers
+
+    assert_response :not_found
+  end
+
+  test "create requires read_write scope" do
+    post api_v1_budget_plans_url, params: { budget_plan: { name: "Joint" } }, headers: read_headers, as: :json
+
+    assert_response :forbidden
+  end
+
+  test "create builds an unscoped plan from a name" do
+    assert_difference "BudgetPlan.count", 1 do
+      post api_v1_budget_plans_url, params: { budget_plan: { name: "Joint" } }, headers: read_write_headers, as: :json
+    end
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal "joint", body["slug"]
+    assert_equal [], body["account_ids"]
+    assert_not body["is_default"]
+  end
+
+  test "create with account_ids scopes the plan" do
+    account = accounts(:depository)
+
+    post api_v1_budget_plans_url,
+         params: { budget_plan: { name: "Scoped", account_ids: [ account.id ] } },
+         headers: read_write_headers, as: :json
+
+    assert_response :created
+    assert_equal [ account.id ], JSON.parse(response.body)["account_ids"]
+  end
+
+  test "create rejects unknown or foreign account ids" do
+    foreign_account = Account.create!(
+      family: families(:empty),
+      accountable: Depository.new,
+      name: "Foreign",
+      status: "active",
+      currency: "USD",
+      balance: 0
+    )
+
+    assert_no_difference "BudgetPlan.count" do
+      post api_v1_budget_plans_url,
+           params: { budget_plan: { name: "Sneaky", account_ids: [ foreign_account.id ] } },
+           headers: read_write_headers, as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_match foreign_account.id, JSON.parse(response.body)["error"]
+  end
+
+  test "update renames a plan and regenerates its slug" do
+    plan = budget_plans(:dylan_personal)
+
+    patch api_v1_budget_plan_url(plan), params: { budget_plan: { name: "Solo" } }, headers: read_write_headers, as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal "Solo", body["name"]
+    assert_equal "solo", body["slug"]
+  end
+
+  test "update with empty account_ids clears the scope, omitting the key leaves it" do
+    plan = budget_plans(:dylan_personal)
+    plan.budget_plan_accounts.create!(account: accounts(:depository))
+
+    patch api_v1_budget_plan_url(plan), params: { budget_plan: { name: "Personal" } }, headers: read_write_headers, as: :json
+    assert_response :success
+    assert plan.reload.scoped?
+
+    patch api_v1_budget_plan_url(plan), params: { budget_plan: { name: "Personal", account_ids: [] } }, headers: read_write_headers, as: :json
+    assert_response :success
+    assert_not plan.reload.scoped?
+  end
+
+  test "destroy removes a non-default plan" do
+    plan = budget_plans(:dylan_personal)
+
+    assert_difference "BudgetPlan.count", -1 do
+      delete api_v1_budget_plan_url(plan), headers: read_write_headers
+    end
+
+    assert_response :no_content
+  end
+
+  test "destroy refuses the default plan" do
+    plan = budget_plans(:dylan_default)
+
+    assert_no_difference "BudgetPlan.count" do
+      delete api_v1_budget_plan_url(plan), headers: read_write_headers
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  private
+
+    def read_headers
+      { "Authorization" => "Bearer #{@read_token.token}" }
+    end
+
+    def read_write_headers
+      { "Authorization" => "Bearer #{@read_write_token.token}" }
+    end
+end

--- a/test/controllers/api/v1/budgets_controller_test.rb
+++ b/test/controllers/api/v1/budgets_controller_test.rb
@@ -66,6 +66,58 @@ class Api::V1::BudgetsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "budget payload includes its budget plan" do
+    get api_v1_budget_url(@budget.id), headers: api_headers(@api_key)
+
+    assert_response :success
+    plan = JSON.parse(response.body)["budget_plan"]
+    assert_equal @budget.budget_plan_id, plan["id"]
+    assert_equal "Primary", plan["name"]
+    assert plan["is_default"]
+    assert_equal [], plan["account_ids"]
+  end
+
+  test "filters budgets by budget_plan_id" do
+    sibling_plan = @family.budget_plans.create!(name: "Test")
+    sibling_budget = @family.budgets.create!(
+      budget_plan: sibling_plan,
+      start_date: @budget.start_date,
+      end_date: @budget.end_date,
+      budgeted_spending: 100,
+      currency: "USD"
+    )
+
+    get api_v1_budgets_url, params: { budget_plan_id: sibling_plan.id }, headers: api_headers(@api_key)
+
+    assert_response :success
+    ids = JSON.parse(response.body)["budgets"].map { |b| b["id"] }
+    assert_equal [ sibling_budget.id ], ids
+  end
+
+  test "rejects a malformed budget_plan_id filter" do
+    get api_v1_budgets_url, params: { budget_plan_id: "not-a-uuid" }, headers: api_headers(@api_key)
+
+    assert_response :not_found
+  end
+
+  test "orders same-month sibling budgets deterministically" do
+    sibling_plan = @family.budget_plans.create!(name: "Test")
+    sibling_budget = @family.budgets.create!(
+      budget_plan: sibling_plan,
+      start_date: @budget.start_date,
+      end_date: @budget.end_date,
+      budgeted_spending: 100,
+      currency: "USD"
+    )
+
+    get api_v1_budgets_url, headers: api_headers(@api_key)
+
+    assert_response :success
+    ids = JSON.parse(response.body)["budgets"].map { |b| b["id"] }
+    assert_equal ids.index(@budget.id) + 1, ids.index(sibling_budget.id),
+      "sibling budgets for the same month should sort by creation order"
+  end
+
   test "shows a budget" do
     get api_v1_budget_url(@budget.id), headers: api_headers(@api_key)
 

--- a/test/controllers/budget_categories_controller_test.rb
+++ b/test/controllers/budget_categories_controller_test.rb
@@ -162,4 +162,27 @@ class BudgetCategoriesControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, "MORTGAGE_REPRO_OUTFLOW",
       "loan_payment outflow remains visible (kind is not BUDGET_EXCLUDED)"
   end
+
+  test "index resolves a sibling plan's budget from its plan-qualified param" do
+    plan = budget_plans(:dylan_personal)
+    sibling_budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+
+    get budget_budget_categories_path(sibling_budget)
+
+    assert_response :success
+  end
+
+  test "update rejects a budget category belonging to a sibling plan's budget" do
+    plan = budget_plans(:dylan_personal)
+    sibling_budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+    sibling_bc = sibling_budget.budget_categories.find_by!(category: @parent_category)
+    sibling_bc.update!(budgeted_spending: 111)
+
+    patch budget_budget_category_path(@budget, sibling_bc),
+          params: { budget_category: { budgeted_spending: 999 } },
+          as: :turbo_stream
+
+    assert_response :not_found
+    assert_equal 111, sibling_bc.reload.budgeted_spending
+  end
 end

--- a/test/controllers/budget_plans_controller_test.rb
+++ b/test/controllers/budget_plans_controller_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class BudgetPlansControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    sign_in @user
+    ensure_tailwind_build
+  end
+
+  test "new renders as a standalone page" do
+    get new_budget_plan_url
+
+    assert_response :success
+    assert_select "form[action=?]", budget_plans_path
+  end
+
+  test "new renders inside the modal frame" do
+    get new_budget_plan_url, headers: { "Turbo-Frame" => "modal" }
+
+    assert_response :success
+    assert_select "form[action=?]", budget_plans_path
+  end
+
+  test "create with no accounts builds an all-accounts plan" do
+    assert_difference "BudgetPlan.count", 1 do
+      post budget_plans_url, params: { budget_plan: { name: "Test Drive", account_ids: [ "" ] } }
+    end
+
+    plan = @family.budget_plans.find_by!(slug: "test-drive")
+    assert_not plan.scoped?
+    assert_redirected_to budget_path("test-drive-#{Budget.date_to_param(Date.current)}")
+  end
+
+  test "create with checked accounts scopes the plan" do
+    account = accounts(:depository)
+
+    post budget_plans_url, params: { budget_plan: { name: "Scoped", account_ids: [ "", account.id ] } }
+
+    plan = @family.budget_plans.find_by!(slug: "scoped")
+    assert_equal [ account.id ], plan.scoped_account_ids
+  end
+
+  test "create ignores accounts outside the user's accessible accounts" do
+    foreign_account = Account.create!(
+      family: families(:empty),
+      accountable: Depository.new,
+      name: "Foreign",
+      status: "active",
+      currency: "USD",
+      balance: 0
+    )
+
+    post budget_plans_url, params: { budget_plan: { name: "Sneaky", account_ids: [ "", foreign_account.id ] } }
+
+    plan = @family.budget_plans.find_by!(slug: "sneaky")
+    assert_not plan.scoped?
+  end
+
+  test "create with a blank name re-renders the form" do
+    assert_no_difference "BudgetPlan.count" do
+      post budget_plans_url, params: { budget_plan: { name: "" } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "update renames the plan and replaces its accounts" do
+    plan = budget_plans(:dylan_personal)
+    plan.budget_plan_accounts.create!(account: accounts(:depository))
+    other_account = accounts(:credit_card)
+
+    patch budget_plan_url(plan), params: { budget_plan: { name: "Solo", account_ids: [ "", other_account.id ] } }
+
+    plan.reload
+    assert_equal "Solo", plan.name
+    assert_equal "solo", plan.slug
+    assert_equal [ other_account.id ], plan.scoped_account_ids
+  end
+
+  test "update with all boxes unchecked clears the account scope" do
+    plan = budget_plans(:dylan_personal)
+    plan.budget_plan_accounts.create!(account: accounts(:depository))
+
+    patch budget_plan_url(plan), params: { budget_plan: { name: plan.name, account_ids: [ "" ] } }
+
+    assert_not plan.reload.scoped?
+  end
+
+  test "destroy removes a non-default plan and its budgets" do
+    plan = budget_plans(:dylan_personal)
+    Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+
+    assert_difference "BudgetPlan.count", -1 do
+      delete budget_plan_url(plan)
+    end
+
+    assert_redirected_to budgets_path
+    assert_not Budget.exists?(budget_plan_id: plan.id)
+  end
+
+  test "destroy refuses the default plan" do
+    plan = budget_plans(:dylan_default)
+
+    assert_no_difference "BudgetPlan.count" do
+      delete budget_plan_url(plan)
+    end
+
+    assert_redirected_to budgets_path
+    assert flash[:alert].present?
+  end
+
+  test "cannot touch another family's plan" do
+    foreign_plan = families(:empty).budget_plans.create!(name: "Foreign")
+
+    patch budget_plan_url(foreign_plan), params: { budget_plan: { name: "Hacked" } }
+
+    assert_response :not_found
+    assert_equal "Foreign", foreign_plan.reload.name
+  end
+end

--- a/test/controllers/budgets_controller_test.rb
+++ b/test/controllers/budgets_controller_test.rb
@@ -42,7 +42,9 @@ class BudgetsControllerTest < ActionDispatch::IntegrationTest
     get budget_url("#{plan.slug}-#{Budget.date_to_param(Date.current)}")
 
     assert_response :success
-    assert_match plan.name, response.body
+    # The switcher marks only the resolved plan as the active menu selection,
+    # so a default-plan fallback can't satisfy this.
+    assert_select "[aria-checked='true']", text: /#{Regexp.escape(plan.name)}/
   end
 
   test "show 404s for an unknown plan slug" do

--- a/test/controllers/budgets_controller_test.rb
+++ b/test/controllers/budgets_controller_test.rb
@@ -35,4 +35,49 @@ class BudgetsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", plan_path, count: 0
     assert_select "a[href=?]", budgets_path, minimum: 1
   end
+
+  test "show renders a budget addressed by a plan-qualified param" do
+    plan = budget_plans(:dylan_personal)
+
+    get budget_url("#{plan.slug}-#{Budget.date_to_param(Date.current)}")
+
+    assert_response :success
+    assert_match plan.name, response.body
+  end
+
+  test "show 404s for an unknown plan slug" do
+    get budget_url("ghost-#{Budget.date_to_param(Date.current)}")
+
+    assert_response :not_found
+  end
+
+  test "header shows the plan switcher listing every plan" do
+    plan = budget_plans(:dylan_personal)
+
+    get budget_url(Budget.date_to_param(Date.current))
+
+    assert_response :success
+    assert_select "a[href=?]", budget_path("#{plan.slug}-#{Budget.date_to_param(Date.current)}")
+    assert_select "a[href=?]", new_budget_plan_path, minimum: 1
+  end
+
+  test "header omits the plan switcher for single-plan families" do
+    budget_plans(:dylan_personal).destroy!
+
+    get budget_url(Budget.date_to_param(Date.current))
+
+    assert_response :success
+    assert_select "a[href=?]", edit_budget_plan_path(budget_plans(:dylan_default)), count: 0
+    # The picker footer still offers plan creation.
+    assert_select "a[href=?]", new_budget_plan_path, minimum: 1
+  end
+
+  test "picker preserves plan context across year navigation" do
+    plan = budget_plans(:dylan_personal)
+
+    get picker_budgets_url(year: Date.current.year, plan: plan.slug)
+
+    assert_response :success
+    assert_select "a[href=?]", budget_path("#{plan.slug}-#{Budget.date_to_param(Date.current.beginning_of_year)}")
+  end
 end

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -289,6 +289,7 @@ class McpControllerTest < ActionDispatch::IntegrationTest
       assert_includes tool_names, "get_balance_sheet"
       assert_includes tool_names, "get_income_statement"
       assert_includes tool_names, "update_transaction"
+      assert_includes tool_names, "update_budget"
 
       # Each tool has required fields
       tools.each do |tool|
@@ -460,6 +461,30 @@ class McpControllerTest < ActionDispatch::IntegrationTest
       assert_equal true, inner["success"]
       assert_equal category.id, transaction.reload.category_id
       assert_equal "Updated through MCP", transaction.entry.notes
+    end
+  end
+
+  test "tools/call executes update_budget" do
+    with_mcp_env do
+      budget = budgets(:one)
+
+      post "/mcp", params: jsonrpc_request("tools/call", {
+        name: "update_budget",
+        arguments: {
+          budgeted_spending: 6200,
+          expected_income: 8800
+        }
+      }).to_json, headers: mcp_headers(@token)
+
+      assert_response :ok
+      body = JSON.parse(response.body)
+      result = body["result"]
+      inner = JSON.parse(result["content"][0]["text"])
+
+      assert_equal true, inner["success"]
+      budget.reload
+      assert_equal 6200, budget.budgeted_spending
+      assert_equal 8800, budget.expected_income
     end
   end
 

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -290,6 +290,9 @@ class McpControllerTest < ActionDispatch::IntegrationTest
       assert_includes tool_names, "get_income_statement"
       assert_includes tool_names, "update_transaction"
       assert_includes tool_names, "update_budget"
+      assert_includes tool_names, "list_budgets"
+      assert_includes tool_names, "create_budget"
+      assert_includes tool_names, "delete_budget"
 
       # Each tool has required fields
       tools.each do |tool|
@@ -485,6 +488,41 @@ class McpControllerTest < ActionDispatch::IntegrationTest
       budget.reload
       assert_equal 6200, budget.budgeted_spending
       assert_equal 8800, budget.expected_income
+    end
+  end
+
+  test "tools/call runs the create/update/delete budget lifecycle" do
+    with_mcp_env do
+      family = users(:family_admin).family
+
+      post "/mcp", params: jsonrpc_request("tools/call", {
+        name: "create_budget",
+        arguments: { name: "Joint", accounts: [ accounts(:depository).name ] }
+      }).to_json, headers: mcp_headers(@token)
+
+      inner = JSON.parse(JSON.parse(response.body)["result"]["content"][0]["text"])
+      assert_equal true, inner["success"]
+      assert_equal "joint", inner["slug"]
+
+      post "/mcp", params: jsonrpc_request("tools/call", {
+        name: "update_budget",
+        arguments: { budget: "joint", budgeted_spending: 900 }
+      }).to_json, headers: mcp_headers(@token)
+
+      inner = JSON.parse(JSON.parse(response.body)["result"]["content"][0]["text"])
+      assert_equal true, inner["success"]
+      plan = family.budget_plans.find_by!(slug: "joint")
+      assert_equal 900, plan.budgets.sole.budgeted_spending
+      assert_equal 5000, budgets(:one).reload.budgeted_spending
+
+      post "/mcp", params: jsonrpc_request("tools/call", {
+        name: "delete_budget",
+        arguments: { budget: "joint" }
+      }).to_json, headers: mcp_headers(@token)
+
+      inner = JSON.parse(JSON.parse(response.body)["result"]["content"][0]["text"])
+      assert_equal true, inner["success"]
+      assert_not family.budget_plans.exists?(slug: "joint")
     end
   end
 

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -64,4 +64,14 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     assert_match I18n.t("plans.budget_card.empty_body"), response.body
     assert_select "a[href=?]", edit_budget_path(Budget.date_to_param(Date.current))
   end
+
+  test "budget card links to the other plans' current-month budgets" do
+    plan = budget_plans(:dylan_personal)
+
+    get plan_url
+
+    assert_response :success
+    assert_match I18n.t("plans.budget_card.other_plans"), response.body
+    assert_select "a[href=?]", budget_path("#{plan.slug}-#{Budget.date_to_param(Date.current)}")
+  end
 end

--- a/test/fixtures/budget_plans.yml
+++ b/test/fixtures/budget_plans.yml
@@ -1,0 +1,10 @@
+dylan_default:
+  family: dylan_family
+  name: Primary
+  slug: primary
+  is_default: true
+
+dylan_personal:
+  family: dylan_family
+  name: Personal
+  slug: personal

--- a/test/fixtures/budgets.yml
+++ b/test/fixtures/budgets.yml
@@ -1,5 +1,6 @@
 one:
   family: dylan_family
+  budget_plan: dylan_default
   start_date: <%= Date.current.beginning_of_month %>
   end_date: <%= Date.current.end_of_month %>
   budgeted_spending: 5000

--- a/test/helpers/insights_helper_test.rb
+++ b/test/helpers/insights_helper_test.rb
@@ -150,6 +150,23 @@ class InsightsHelperTest < ActionView::TestCase
     assert_nil insight_action(dangling)
   end
 
+  test "budget insight CTA uses the stored budget param" do
+    param = "personal-#{Budget.date_to_param(Date.current)}"
+    insight = build_insight(
+      "budget_at_risk",
+      metadata: { "budget_param" => param },
+      period_start: Date.current.beginning_of_month
+    )
+
+    assert_equal budget_path(param), insight_action(insight)[:href]
+  end
+
+  test "budget insight CTA falls back to the month param for legacy rows" do
+    insight = build_insight("budget_on_track", period_start: Date.current.beginning_of_month)
+
+    assert_equal budget_path(Budget.date_to_param(Date.current.beginning_of_month)), insight_action(insight)[:href]
+  end
+
   private
     def build_insight(insight_type, priority: "medium", metadata: {}, facts: {}, period_start: nil, period_end: nil)
       Insight.new(

--- a/test/models/assistant/function/create_budget_test.rb
+++ b/test/models/assistant/function/create_budget_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class Assistant::Function::CreateBudgetTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @function = Assistant::Function::CreateBudget.new(@user)
+  end
+
+  test "has correct name" do
+    assert_equal "create_budget", @function.name
+  end
+
+  test "requires a name" do
+    result = @function.call({ "name" => "  " })
+
+    assert_equal false, result[:success]
+    assert_equal "name_required", result[:error]
+  end
+
+  test "creates an unscoped budget from a name" do
+    assert_difference "BudgetPlan.count", 1 do
+      result = @function.call({ "name" => "Test" })
+
+      assert result[:success]
+      assert_equal "test", result[:slug]
+      assert_equal "all_accounts", result[:accounts]
+    end
+  end
+
+  test "creates a scoped budget from account names and ids" do
+    depository = accounts(:depository)
+    credit_card = accounts(:credit_card)
+
+    result = @function.call({ "name" => "Scoped", "accounts" => [ depository.name, credit_card.id ] })
+
+    assert result[:success]
+    plan = @family.budget_plans.find_by!(slug: "scoped")
+    assert_equal [ credit_card.id, depository.id ].sort, plan.scoped_account_ids.sort
+  end
+
+  test "reports unknown accounts with the available list" do
+    result = @function.call({ "name" => "Bad", "accounts" => [ "No Such Account" ] })
+
+    assert_equal false, result[:success]
+    assert_equal "unknown_accounts", result[:error]
+    assert_includes result[:unknown_accounts], "No Such Account"
+    assert result[:available_accounts].any?
+    assert_not @family.budget_plans.exists?(slug: "bad")
+  end
+
+  test "reports ambiguous account names" do
+    account = accounts(:depository)
+    @family.accounts.create!(
+      name: account.name,
+      accountable: Depository.new,
+      status: "active",
+      currency: "USD",
+      balance: 0
+    )
+
+    result = @function.call({ "name" => "Ambiguous", "accounts" => [ account.name ] })
+
+    assert_equal false, result[:success]
+    assert_equal "ambiguous_accounts", result[:error]
+    assert_includes result[:ambiguous_names], account.name
+  end
+
+  test "rejects foreign account ids as unknown" do
+    foreign_account = Account.create!(
+      family: families(:empty),
+      accountable: Depository.new,
+      name: "Foreign",
+      status: "active",
+      currency: "USD",
+      balance: 0
+    )
+
+    result = @function.call({ "name" => "Sneaky", "accounts" => [ foreign_account.id ] })
+
+    assert_equal false, result[:success]
+    assert_equal "unknown_accounts", result[:error]
+  end
+
+  test "duplicate names succeed with a uniquified slug" do
+    @family.budget_plans.create!(name: "Dup")
+
+    result = @function.call({ "name" => "Dup" })
+
+    assert result[:success]
+    assert_equal "dup-2", result[:slug]
+  end
+end

--- a/test/models/assistant/function/create_budget_test.rb
+++ b/test/models/assistant/function/create_budget_test.rb
@@ -90,4 +90,20 @@ class Assistant::Function::CreateBudgetTest < ActiveSupport::TestCase
     assert result[:success]
     assert_equal "dup-2", result[:slug]
   end
+  test "cannot scope a budget to an account that isn't shared with the caller" do
+    private_account = users(:family_admin).family.accounts.create!(
+      accountable: Depository.new,
+      name: "Admin Private",
+      status: "active",
+      currency: "USD",
+      balance: 0,
+      owner: users(:family_admin)
+    )
+    function = Assistant::Function::CreateBudget.new(users(:family_member))
+
+    result = function.call("name" => "Sneaky", "accounts" => [ private_account.name ])
+
+    assert_equal false, result[:success]
+    assert_equal "unknown_accounts", result[:error]
+  end
 end

--- a/test/models/assistant/function/delete_budget_test.rb
+++ b/test/models/assistant/function/delete_budget_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class Assistant::Function::DeleteBudgetTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @function = Assistant::Function::DeleteBudget.new(@user)
+  end
+
+  test "has correct name" do
+    assert_equal "delete_budget", @function.name
+  end
+
+  test "deletes a named budget and its monthly data" do
+    plan = budget_plans(:dylan_personal)
+    Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+
+    result = @function.call({ "budget" => "personal" })
+
+    assert result[:success]
+    assert_equal "Personal", result[:deleted_budget]
+    assert_equal 1, result[:months_deleted]
+    assert_not BudgetPlan.exists?(plan.id)
+    assert_not Budget.exists?(budget_plan_id: plan.id)
+  end
+
+  test "refuses to delete the primary budget" do
+    result = @function.call({ "budget" => "Primary" })
+
+    assert_equal false, result[:success]
+    assert_equal "cannot_delete_default", result[:error]
+    assert BudgetPlan.exists?(budget_plans(:dylan_default).id)
+  end
+
+  test "reports unknown budgets" do
+    result = @function.call({ "budget" => "Ghost" })
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_params", result[:error]
+    assert_match "Ghost", result[:message]
+  end
+end

--- a/test/models/assistant/function/get_budget_test.rb
+++ b/test/models/assistant/function/get_budget_test.rb
@@ -168,4 +168,45 @@ class Assistant::Function::GetBudgetTest < ActiveSupport::TestCase
       assert totals.key?(key), "totals should include #{key}"
     end
   end
+
+  test "defaults to the primary budget and says so in the response" do
+    result = @function.call({})
+
+    assert result[:budget][:is_default]
+    assert_equal "primary", result[:budget][:slug]
+  end
+
+  test "reads a named budget by name or slug with plan-qualified month slugs" do
+    plan = budget_plans(:dylan_personal)
+    budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+    budget.update!(budgeted_spending: 1234)
+
+    [ "Personal", "personal" ].each do |ref|
+      result = @function.call({ "budget" => ref })
+
+      assert_equal "personal", result[:budget][:slug]
+      month = result[:months].first
+      assert_equal "personal-#{Budget.date_to_param(Date.current)}", month[:month]
+      assert month[:initialized]
+    end
+  end
+
+  test "named budget months do not leak into the primary budget" do
+    plan = budget_plans(:dylan_personal)
+    Budget.find_or_bootstrap(@family, start_date: 1.month.ago, plan: plan)
+
+    result = @function.call({ "prior_months" => 1 })
+
+    # The primary budget has no row last month and priors don't bootstrap.
+    assert_equal [ true ], result[:months].map { |m| m[:is_current] }
+  end
+
+  test "unknown budget raises a helpful error listing available budgets" do
+    error = assert_raises Assistant::Error do
+      @function.call({ "budget" => "Ghost" })
+    end
+
+    assert_match "Ghost", error.message
+    assert_match "Personal", error.message
+  end
 end

--- a/test/models/assistant/function/list_budgets_test.rb
+++ b/test/models/assistant/function/list_budgets_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Assistant::Function::ListBudgetsTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @function = Assistant::Function::ListBudgets.new(@user)
+  end
+
+  test "has correct name" do
+    assert_equal "list_budgets", @function.name
+  end
+
+  test "lists plans default-first with account scope and initialized month count" do
+    plan = budget_plans(:dylan_personal)
+    plan.budget_plan_accounts.create!(account: accounts(:depository))
+    Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan).update!(budgeted_spending: 100)
+
+    result = @function.call({})
+
+    assert_equal @family.budget_plans.count, result[:budgets].length
+
+    primary = result[:budgets].first
+    assert primary[:is_default]
+    assert_equal "all_accounts", primary[:accounts]
+    assert_equal 1, primary[:initialized_months] # budgets(:one)
+
+    personal = result[:budgets].find { |b| b[:slug] == "personal" }
+    assert_equal [ accounts(:depository).name ], personal[:accounts]
+    assert_equal 1, personal[:initialized_months]
+  end
+end

--- a/test/models/assistant/function/list_budgets_test.rb
+++ b/test/models/assistant/function/list_budgets_test.rb
@@ -29,4 +29,21 @@ class Assistant::Function::ListBudgetsTest < ActiveSupport::TestCase
     assert_equal [ accounts(:depository).name ], personal[:accounts]
     assert_equal 1, personal[:initialized_months]
   end
+  test "hides linked accounts that aren't shared with the caller" do
+    private_account = @family.accounts.create!(
+      accountable: Depository.new,
+      name: "Admin Private",
+      status: "active",
+      currency: "USD",
+      balance: 0,
+      owner: users(:family_admin)
+    )
+    plan = budget_plans(:dylan_personal)
+    plan.budget_plan_accounts.create!(account: private_account)
+
+    result = Assistant::Function::ListBudgets.new(users(:family_member)).call({})
+    personal = result[:budgets].find { |b| b[:slug] == plan.slug }
+
+    assert_equal [], personal[:accounts]
+  end
 end

--- a/test/models/assistant/function/update_budget_test.rb
+++ b/test/models/assistant/function/update_budget_test.rb
@@ -23,6 +23,7 @@ class Assistant::Function::UpdateBudgetTest < ActiveSupport::TestCase
   test "params_schema declares month totals and categories as optional" do
     schema = @function.params_schema
     assert schema[:properties].key?(:month)
+    assert schema[:properties].key?(:budget)
     assert schema[:properties].key?(:budgeted_spending)
     assert schema[:properties].key?(:expected_income)
     assert schema[:properties].key?(:categories)

--- a/test/models/assistant/function/update_budget_test.rb
+++ b/test/models/assistant/function/update_budget_test.rb
@@ -1,0 +1,151 @@
+require "test_helper"
+
+class Assistant::Function::UpdateBudgetTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @budget = budgets(:one)
+    @function = Assistant::Function::UpdateBudget.new(@user)
+  end
+
+  test "has correct name" do
+    assert_equal "update_budget", @function.name
+  end
+
+  test "has a description" do
+    assert_not_empty @function.description
+  end
+
+  test "is not in strict mode" do
+    refute @function.strict_mode?
+  end
+
+  test "params_schema declares month totals and categories as optional" do
+    schema = @function.params_schema
+    assert schema[:properties].key?(:month)
+    assert schema[:properties].key?(:budgeted_spending)
+    assert schema[:properties].key?(:expected_income)
+    assert schema[:properties].key?(:categories)
+    assert_empty schema[:required]
+  end
+
+  test "updates totals for the current month by default" do
+    result = @function.call(
+      "budgeted_spending" => 6500,
+      "expected_income" => 9000
+    )
+
+    assert_equal true, result[:success]
+    assert_equal @budget.to_param, result[:month]
+
+    @budget.reload
+    assert_equal 6500, @budget.budgeted_spending
+    assert_equal 9000, @budget.expected_income
+  end
+
+  test "sets a category allocation by case-insensitive name" do
+    @budget.sync_budget_categories
+
+    result = @function.call(
+      "categories" => [ { "category" => "food & drink", "amount" => 450 } ]
+    )
+
+    assert_equal true, result[:success]
+    assert_equal 1, result[:updated_categories].length
+    assert_equal "Food & Drink", result[:updated_categories].first[:category]
+
+    budget_category = @budget.budget_categories
+      .joins(:category).find_by(categories: { name: "Food & Drink" })
+    assert_equal 450, budget_category.reload.budgeted_spending
+  end
+
+  test "sets a category allocation by id and keeps a subcategory's parent in sync" do
+    @budget.sync_budget_categories
+    subcategory = categories(:subcategory)
+    parent = subcategory.parent
+
+    result = @function.call(
+      "categories" => [ { "category" => subcategory.id, "amount" => 120 } ]
+    )
+
+    assert_equal true, result[:success]
+
+    sub_bc = @budget.budget_categories.find_by(category_id: subcategory.id)
+    parent_bc = @budget.budget_categories.find_by(category_id: parent.id)
+    assert_equal 120, sub_bc.reload.budgeted_spending
+    assert_operator parent_bc.reload.budgeted_spending, :>=, 120
+  end
+
+  test "bootstraps a budget when targeting a valid month with no budget row" do
+    target = Date.current.beginning_of_month << 1
+    assert_nil @family.budgets.find_by(start_date: target)
+
+    result = @function.call(
+      "month" => target.strftime("%Y-%m"),
+      "budgeted_spending" => 1000
+    )
+
+    assert_equal true, result[:success]
+    created = @family.budgets.find_by(start_date: target)
+    assert_equal 1000, created.budgeted_spending
+  end
+
+  test "rejects a category outside the family and rolls back totals from the same call" do
+    other_family_category = Category.create!(
+      family: families(:empty),
+      name: "Elsewhere",
+      color: "#e99537",
+      lucide_icon: "tag"
+    )
+    original = @budget.budgeted_spending
+
+    result = @function.call(
+      "budgeted_spending" => 9999,
+      "categories" => [ { "category" => other_family_category.id, "amount" => 10 } ]
+    )
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_params", result[:error]
+    assert_equal original, @budget.reload.budgeted_spending
+  end
+
+  test "rejects unknown category names" do
+    result = @function.call(
+      "categories" => [ { "category" => "No Such Category", "amount" => 10 } ]
+    )
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_params", result[:error]
+    assert_match(/not found/i, result[:message])
+  end
+
+  test "rejects negative amounts" do
+    result = @function.call("expected_income" => -5)
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_params", result[:error]
+  end
+
+  test "rejects malformed months" do
+    result = @function.call("month" => "never", "budgeted_spending" => 1)
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_params", result[:error]
+  end
+
+  test "rejects months outside the valid budget range" do
+    far_future = (Date.current + 10.years).strftime("%Y-%m")
+
+    result = @function.call("month" => far_future, "budgeted_spending" => 1)
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_month", result[:error]
+  end
+
+  test "rejects calls with nothing to change" do
+    result = @function.call({})
+
+    assert_equal false, result[:success]
+    assert_equal "no_changes", result[:error]
+  end
+end

--- a/test/models/assistant/function/update_budget_test.rb
+++ b/test/models/assistant/function/update_budget_test.rb
@@ -109,6 +109,52 @@ class Assistant::Function::UpdateBudgetTest < ActiveSupport::TestCase
     assert_equal original, @budget.reload.budgeted_spending
   end
 
+  test "does not leave a bootstrapped budget behind when a later entry is invalid" do
+    target = Date.current.beginning_of_month << 2
+    assert_nil @family.budgets.find_by(start_date: target)
+
+    result = @function.call(
+      "month" => target.strftime("%Y-%m"),
+      "budgeted_spending" => 1000,
+      "categories" => [ { "category" => "No Such Category", "amount" => 10 } ]
+    )
+
+    assert_equal false, result[:success]
+    assert_nil @family.budgets.find_by(start_date: target)
+  end
+
+  test "applies explicit parent amounts after subcategory updates regardless of order" do
+    @budget.sync_budget_categories
+    subcategory = categories(:subcategory)
+    parent = subcategory.parent
+
+    result = @function.call(
+      "categories" => [
+        { "category" => parent.id, "amount" => 1000 },
+        { "category" => subcategory.id, "amount" => 300 }
+      ]
+    )
+
+    assert_equal true, result[:success]
+
+    sub_bc = @budget.budget_categories.find_by(category_id: subcategory.id)
+    parent_bc = @budget.budget_categories.find_by(category_id: parent.id)
+    assert_equal 300, sub_bc.reload.budgeted_spending
+    assert_equal 1000, parent_bc.reload.budgeted_spending
+  end
+
+  test "explains that Uncategorized cannot be set directly" do
+    @budget.sync_budget_categories
+
+    result = @function.call(
+      "categories" => [ { "category" => "Uncategorized", "amount" => 50 } ]
+    )
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_params", result[:error]
+    assert_match(/cannot be set directly/i, result[:message])
+  end
+
   test "rejects unknown category names" do
     result = @function.call(
       "categories" => [ { "category" => "No Such Category", "amount" => 10 } ]
@@ -124,6 +170,20 @@ class Assistant::Function::UpdateBudgetTest < ActiveSupport::TestCase
 
     assert_equal false, result[:success]
     assert_equal "invalid_params", result[:error]
+  end
+
+  test "rejects non-finite amounts" do
+    @budget.sync_budget_categories
+
+    [ Float::NAN, Float::INFINITY ].each do |value|
+      result = @function.call("budgeted_spending" => value)
+      assert_equal false, result[:success]
+      assert_equal "invalid_params", result[:error]
+
+      result = @function.call("categories" => [ { "category" => "Food & Drink", "amount" => value } ])
+      assert_equal false, result[:success]
+      assert_equal "invalid_params", result[:error]
+    end
   end
 
   test "rejects malformed months" do

--- a/test/models/assistant/function/update_budget_test.rb
+++ b/test/models/assistant/function/update_budget_test.rb
@@ -208,4 +208,27 @@ class Assistant::Function::UpdateBudgetTest < ActiveSupport::TestCase
     assert_equal false, result[:success]
     assert_equal "no_changes", result[:error]
   end
+
+  test "updates a named budget without touching the primary budget" do
+    plan = budget_plans(:dylan_personal)
+    primary_before = budgets(:one).budgeted_spending
+
+    result = @function.call({ "budget" => "Personal", "budgeted_spending" => 750 })
+
+    assert result[:success]
+    assert_equal "personal-#{Budget.date_to_param(Date.current)}", result[:month]
+    assert_match "Personal budget", result[:message]
+
+    plan_budget = plan.budgets.find_by!(start_date: Date.current.beginning_of_month)
+    assert_equal 750, plan_budget.budgeted_spending
+    assert_equal primary_before, budgets(:one).reload.budgeted_spending
+  end
+
+  test "rejects an unknown budget with a helpful error" do
+    result = @function.call({ "budget" => "Ghost", "budgeted_spending" => 100 })
+
+    assert_equal false, result[:success]
+    assert_equal "invalid_params", result[:error]
+    assert_match "Ghost", result[:message]
+  end
 end

--- a/test/models/budget_plan_test.rb
+++ b/test/models/budget_plan_test.rb
@@ -44,6 +44,17 @@ class BudgetPlanTest < ActiveSupport::TestCase
     assert_equal "household", plan.slug
   end
 
+  test "save retries with a fresh slug after losing the unique-index race" do
+    @family.budget_plans.create!(name: "Joint")
+
+    # Simulate the race: the loser computed "joint" before the winner's row
+    # was visible, so neither the existence check nor the uniqueness
+    # validation caught it and the INSERT hits the unique index.
+    loser = @family.budget_plans.new(name: "Joint", slug: "joint")
+    assert loser.save(validate: false)
+    assert_equal "joint-2", loser.slug
+  end
+
   test "cannot destroy the default plan" do
     plan = budget_plans(:dylan_default)
     assert_not plan.destroy

--- a/test/models/budget_plan_test.rb
+++ b/test/models/budget_plan_test.rb
@@ -113,4 +113,19 @@ class BudgetPlanTest < ActiveSupport::TestCase
     assert_equal plan, family.default_budget_plan
     assert_equal 1, family.budget_plans.count
   end
+  test "budget plan account rejects direct creation with another family's account" do
+    foreign_account = Account.create!(
+      family: families(:empty),
+      accountable: Depository.new,
+      name: "Foreign",
+      status: "active",
+      currency: "USD",
+      balance: 0
+    )
+
+    budget_plan_account = BudgetPlanAccount.new(budget_plan: budget_plans(:dylan_default), account: foreign_account)
+
+    assert_not budget_plan_account.valid?
+    assert budget_plan_account.errors[:account].any?
+  end
 end

--- a/test/models/budget_plan_test.rb
+++ b/test/models/budget_plan_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+class BudgetPlanTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "requires a name" do
+    plan = @family.budget_plans.new(name: "")
+    assert_not plan.valid?
+    assert plan.errors[:name].any?
+  end
+
+  test "generates slug from name" do
+    plan = @family.budget_plans.create!(name: "Joint Accounts")
+    assert_equal "joint-accounts", plan.slug
+  end
+
+  test "uniquifies slug within the family" do
+    @family.budget_plans.create!(name: "Joint")
+    second = @family.budget_plans.create!(name: "Joint!")
+    assert_equal "joint-2", second.slug
+  end
+
+  test "same slug is allowed across families" do
+    @family.budget_plans.create!(name: "Joint")
+    other = families(:empty).budget_plans.create!(name: "Joint")
+    assert_equal "joint", other.slug
+  end
+
+  test "month-shaped names get a -plan suffix so they cannot shadow month params" do
+    plan = @family.budget_plans.create!(name: "Jan 2025")
+    assert_equal "jan-2025-plan", plan.slug
+  end
+
+  test "names that parameterize to blank fall back to plan" do
+    plan = @family.budget_plans.create!(name: "!!!")
+    assert_equal "plan", plan.slug
+  end
+
+  test "slug regenerates on rename" do
+    plan = @family.budget_plans.create!(name: "Joint")
+    plan.update!(name: "Household")
+    assert_equal "household", plan.slug
+  end
+
+  test "cannot destroy the default plan" do
+    plan = budget_plans(:dylan_default)
+    assert_not plan.destroy
+    assert plan.errors[:base].any?
+    assert BudgetPlan.exists?(plan.id)
+  end
+
+  test "only one default plan per family" do
+    assert_raises ActiveRecord::RecordNotUnique do
+      @family.budget_plans.create!(name: "Another Default", is_default: true)
+    end
+  end
+
+  test "scoped accounts must belong to the family" do
+    plan = @family.budget_plans.new(name: "Joint")
+    foreign_account = Account.create!(
+      family: families(:empty),
+      accountable: Depository.new,
+      name: "Foreign",
+      status: "active",
+      currency: "USD",
+      balance: 0
+    )
+    plan.budget_plan_accounts.build(account: foreign_account)
+
+    assert_not plan.valid?
+    assert plan.errors[:accounts].any?
+  end
+
+  test "scoped_account_ids is nil when no accounts are linked" do
+    plan = @family.budget_plans.create!(name: "Everything")
+    assert_not plan.scoped?
+    assert_nil plan.scoped_account_ids
+  end
+
+  test "scoped_account_ids returns linked account ids" do
+    account = accounts(:depository)
+    plan = @family.budget_plans.create!(name: "Scoped")
+    plan.budget_plan_accounts.create!(account: account)
+
+    assert plan.scoped?
+    assert_equal [ account.id ], plan.scoped_account_ids
+  end
+
+  test "destroying a plan destroys its budgets and account links" do
+    plan = @family.budget_plans.create!(name: "Doomed")
+    plan.budget_plan_accounts.create!(account: accounts(:depository))
+    budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+
+    assert_difference [ "Budget.count", "BudgetPlanAccount.count" ], -1 do
+      plan.destroy!
+    end
+    assert_not Budget.exists?(budget.id)
+  end
+
+  test "default_budget_plan finds the existing default" do
+    assert_equal budget_plans(:dylan_default), @family.default_budget_plan
+  end
+
+  test "default_budget_plan lazily creates one for families without plans" do
+    family = families(:empty)
+    assert_equal 0, family.budget_plans.count
+
+    plan = family.default_budget_plan
+    assert plan.is_default?
+    assert_equal "Primary", plan.name
+    assert_equal plan, family.default_budget_plan
+    assert_equal 1, family.budget_plans.count
+  end
+end

--- a/test/models/budget_test.rb
+++ b/test/models/budget_test.rb
@@ -523,4 +523,155 @@ class BudgetTest < ActiveSupport::TestCase
       assert_equal 0, budget.days_remaining
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Budget plans (multiple budgets per month)
+  # ---------------------------------------------------------------------------
+
+  test "creating a budget without a plan attaches it to the family's default plan" do
+    budget = Budget.create!(
+      family: @family,
+      start_date: Date.current.beginning_of_month,
+      end_date: Date.current.end_of_month,
+      currency: "USD"
+    )
+
+    assert_equal @family.default_budget_plan, budget.budget_plan
+  end
+
+  test "two plans can hold budgets for the same month but one plan cannot" do
+    plan_a = @family.default_budget_plan
+    plan_b = @family.budget_plans.create!(name: "Test")
+
+    Budget.create!(family: @family, budget_plan: plan_a, start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month, currency: "USD")
+    sibling = Budget.create!(family: @family, budget_plan: plan_b, start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month, currency: "USD")
+    assert sibling.persisted?
+
+    duplicate = Budget.new(family: @family, budget_plan: plan_b, start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month, currency: "USD")
+    assert_not duplicate.valid?
+    assert duplicate.errors[:start_date].any?
+  end
+
+  test "find_or_bootstrap with a plan returns that plan's budget" do
+    plan = @family.budget_plans.create!(name: "Test")
+
+    default_budget = Budget.find_or_bootstrap(@family, start_date: Date.current)
+    plan_budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+
+    assert_not_equal default_budget.id, plan_budget.id
+    assert_equal plan.id, plan_budget.budget_plan_id
+    assert_equal plan_budget.id, Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan).id
+  end
+
+  test "find_or_bootstrap rejects a plan from another family" do
+    other_plan = families(:dylan_family).budget_plans.create!(name: "Foreign")
+
+    assert_raises ArgumentError do
+      Budget.find_or_bootstrap(@family, start_date: Date.current, plan: other_plan)
+    end
+  end
+
+  test "to_param is the bare month slug for the default plan and plan-qualified otherwise" do
+    default_budget = Budget.find_or_bootstrap(@family, start_date: Date.current)
+    assert_equal Budget.date_to_param(Date.current), default_budget.to_param
+
+    plan = @family.budget_plans.create!(name: "Joint Accounts")
+    plan_budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+    assert_equal "joint-accounts-#{Budget.date_to_param(Date.current)}", plan_budget.to_param
+  end
+
+  test "resolve_param round-trips both param shapes including multi-dash slugs" do
+    plan = @family.budget_plans.create!(name: "Side Hustle Fund")
+    date = Date.current.beginning_of_month
+
+    resolved_plan, resolved_date = Budget.resolve_param(Budget.date_to_param(date), family: @family)
+    assert resolved_plan.is_default?
+    assert_equal date, resolved_date
+
+    resolved_plan, resolved_date = Budget.resolve_param("side-hustle-fund-#{Budget.date_to_param(date)}", family: @family)
+    assert_equal plan, resolved_plan
+    assert_equal date, resolved_date
+  end
+
+  test "resolve_param raises RecordNotFound for malformed params and unknown slugs" do
+    assert_raises ActiveRecord::RecordNotFound do
+      Budget.resolve_param("not-a-real-param", family: @family)
+    end
+
+    assert_raises ActiveRecord::RecordNotFound do
+      Budget.resolve_param("ghost-#{Budget.date_to_param(Date.current)}", family: @family)
+    end
+  end
+
+  test "previous and next budget params carry the plan slug" do
+    plan = @family.budget_plans.create!(name: "Test")
+    budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+
+    assert_equal "test-#{Budget.date_to_param(Date.current - 1.month)}", budget.previous_budget_param
+    assert_equal "test-#{Budget.date_to_param(Date.current + 1.month)}", budget.next_budget_param
+  end
+
+  test "most_recent_initialized_budget stays within the budget's plan" do
+    plan = @family.budget_plans.create!(name: "Test")
+
+    Budget.create!(
+      family: @family,
+      start_date: 1.month.ago.beginning_of_month.to_date,
+      end_date: 1.month.ago.end_of_month.to_date,
+      budgeted_spending: 1000,
+      currency: "USD"
+    )
+
+    plan_budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+    assert_nil plan_budget.most_recent_initialized_budget
+
+    default_budget = Budget.find_or_bootstrap(@family, start_date: Date.current)
+    assert_not_nil default_budget.most_recent_initialized_budget
+  end
+
+  test "copy_from! rejects a source budget from another plan" do
+    plan = @family.budget_plans.create!(name: "Test")
+
+    source = Budget.create!(
+      family: @family,
+      start_date: 1.month.ago.beginning_of_month.to_date,
+      end_date: 1.month.ago.end_of_month.to_date,
+      budgeted_spending: 1000,
+      currency: "USD"
+    )
+    target = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+
+    assert_raises ArgumentError do
+      target.copy_from!(source)
+    end
+  end
+
+  test "a plan scoped to accounts only counts those accounts' transactions" do
+    scoped_account = Account.create!(family: @family, accountable: Depository.new, name: "Scoped", status: "active", currency: "USD", balance: 1000)
+    other_account = Account.create!(family: @family, accountable: Depository.new, name: "Unscoped", status: "active", currency: "USD", balance: 1000)
+
+    category = Category.create!(name: "Food", family: @family, color: "#e74c3c")
+
+    [ scoped_account, other_account ].each do |account|
+      Entry.create!(
+        account: account,
+        entryable: Transaction.create!(category: category),
+        date: Date.current,
+        name: "Spend from #{account.name}",
+        amount: 100,
+        currency: "USD"
+      )
+    end
+
+    plan = @family.budget_plans.create!(name: "Scoped")
+    plan.budget_plan_accounts.create!(account: scoped_account)
+
+    scoped_budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+    default_budget = Budget.find_or_bootstrap(@family, start_date: Date.current)
+
+    assert_equal 100, scoped_budget.actual_spending
+    assert_equal 200, default_budget.actual_spending
+    assert_equal 1, scoped_budget.transactions.count
+    assert_equal 2, default_budget.transactions.count
+  end
 end

--- a/test/models/budget_test.rb
+++ b/test/models/budget_test.rb
@@ -603,6 +603,32 @@ class BudgetTest < ActiveSupport::TestCase
     end
   end
 
+  test "resolve_param raises RecordNotFound for well-shaped but impossible month tokens" do
+    plan = @family.budget_plans.create!(name: "Real")
+
+    assert_raises ActiveRecord::RecordNotFound do
+      Budget.resolve_param("abc-2026", family: @family)
+    end
+
+    assert_raises ActiveRecord::RecordNotFound do
+      Budget.resolve_param("real-abc-2026", family: @family)
+    end
+  end
+
+  test "rejects direct creation against another family's plan" do
+    foreign_plan = budget_plans(:dylan_default)
+
+    budget = @family.budgets.build(
+      start_date: Date.current.beginning_of_month,
+      end_date: Date.current.end_of_month,
+      currency: "USD",
+      budget_plan: foreign_plan
+    )
+
+    assert_not budget.valid?
+    assert budget.errors[:budget_plan].any?
+  end
+
   test "previous and next budget params carry the plan slug" do
     plan = @family.budget_plans.create!(name: "Test")
     budget = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -371,6 +371,32 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     end
   end
 
+  test "exports budget plans with their account scopes before budgets" do
+    plan = budget_plans(:dylan_personal)
+    plan.budget_plan_accounts.create!(account: @account)
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      lines = zip.read("all.ndjson").split("\n").map { |line| JSON.parse(line) }
+      types = lines.map { |line| line["type"] }
+
+      assert_includes types, "BudgetPlan"
+      assert_includes types, "BudgetPlanAccount"
+      assert types.index("BudgetPlanAccount") < types.index("Budget"), "plan lines must precede budgets"
+
+      plan_line = lines.find { |line| line["type"] == "BudgetPlan" && line["data"]["slug"] == "personal" }
+      assert_not_nil plan_line
+
+      scope_line = lines.find { |line| line["type"] == "BudgetPlanAccount" }
+      assert_equal plan.id, scope_line["data"]["budget_plan_id"]
+      assert_equal @account.id, scope_line["data"]["account_id"]
+
+      budget_line = lines.find { |line| line["type"] == "Budget" }
+      assert budget_line["data"].key?("budget_plan_id")
+    end
+  end
+
   test "only exports data from the specified family" do
     # Create data for another family that should NOT be exported
     other_account = @other_family.accounts.create!(

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -1748,6 +1748,87 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal 5000.0, budget.expected_income.to_f
   end
 
+  test "legacy budget exports without plans land on the default plan" do
+    ndjson = build_ndjson([
+      {
+        type: "Budget",
+        data: {
+          id: "budget-1",
+          start_date: "2024-01-01",
+          end_date: "2024-01-31",
+          budgeted_spending: "3000.00",
+          currency: "USD"
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    assert_equal @family.default_budget_plan, @family.budgets.first.budget_plan
+  end
+
+  test "imports budget plans with account scopes and remaps the default plan" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "old-account-1",
+          name: "Scoped Checking",
+          balance: "100.00",
+          currency: "USD",
+          accountable_type: "Depository",
+          accountable: { subtype: "checking" }
+        }
+      },
+      {
+        type: "BudgetPlan",
+        data: { id: "plan-default", name: "Primary", slug: "primary", is_default: true }
+      },
+      {
+        type: "BudgetPlan",
+        data: { id: "plan-joint", name: "Joint", slug: "joint", is_default: false }
+      },
+      {
+        type: "BudgetPlanAccount",
+        data: { id: "bpa-1", budget_plan_id: "plan-joint", account_id: "old-account-1" }
+      },
+      {
+        type: "Budget",
+        data: {
+          id: "budget-1",
+          budget_plan_id: "plan-joint",
+          start_date: "2024-01-01",
+          end_date: "2024-01-31",
+          budgeted_spending: "900.00",
+          currency: "USD"
+        }
+      },
+      {
+        type: "Budget",
+        data: {
+          id: "budget-2",
+          budget_plan_id: "plan-default",
+          start_date: "2024-01-01",
+          end_date: "2024-01-31",
+          budgeted_spending: "3000.00",
+          currency: "USD"
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    assert_equal 2, @family.budget_plans.count
+
+    joint = @family.budget_plans.find_by!(slug: "joint")
+    assert_not joint.is_default?
+    assert_equal [ "Scoped Checking" ], joint.accounts.pluck(:name)
+    assert_equal 900.0, joint.budgets.sole.budgeted_spending.to_f
+
+    default = @family.default_budget_plan
+    assert_equal 3000.0, default.budgets.sole.budgeted_spending.to_f
+  end
+
   test "imports budget_categories" do
     ndjson = build_ndjson([
       {

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -787,4 +787,10 @@ class IncomeStatementTest < ActiveSupport::TestCase
     assert_equal unscoped.totals(date_range: Period.last_30_days.date_range),
                  scoped.totals(date_range: Period.last_30_days.date_range)
   end
+  test "eligible_accounts honors an explicit account scope" do
+    scoped = IncomeStatement.new(@family, account_ids: [ @checking_account.id ])
+
+    assert_equal [ @checking_account.id ], scoped.eligible_accounts.pluck(:id)
+    assert_includes IncomeStatement.new(@family).eligible_accounts.pluck(:id), @credit_card_account.id
+  end
 end

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -746,4 +746,45 @@ class IncomeStatementTest < ActiveSupport::TestCase
 
     assert_equal 1, totals_query_calls
   end
+
+  test "account_ids scopes totals to the given accounts" do
+    income_statement = IncomeStatement.new(@family, account_ids: [ @credit_card_account.id ])
+    totals = income_statement.totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal Money.new(0, @family.currency), totals.income_money
+    assert_equal Money.new(300 + 400, @family.currency), totals.expense_money
+  end
+
+  test "account_ids intersects with the user's finance accounts" do
+    user = users(:empty)
+    # The credit card belongs to another member (unowned accounts count as
+    # everyone's), so it drops out of user's finance accounts.
+    @credit_card_account.update!(owner: users(:sure_support_staff))
+
+    # User's finances exclude the credit card; explicit scope asks for both.
+    income_statement = IncomeStatement.new(@family, user: user, account_ids: [ @checking_account.id, @credit_card_account.id ])
+    totals = income_statement.totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal Money.new(1000, @family.currency), totals.income_money
+    assert_equal Money.new(200, @family.currency), totals.expense_money
+  end
+
+  test "disjoint account_ids and user accounts yield zero totals" do
+    user = users(:empty)
+    @credit_card_account.update!(owner: users(:sure_support_staff))
+
+    income_statement = IncomeStatement.new(@family, user: user, account_ids: [ @credit_card_account.id ])
+    totals = income_statement.totals(date_range: Period.last_30_days.date_range)
+
+    assert_equal Money.new(0, @family.currency), totals.income_money
+    assert_equal Money.new(0, @family.currency), totals.expense_money
+  end
+
+  test "nil account_ids preserves the unscoped totals" do
+    scoped = IncomeStatement.new(@family, account_ids: nil)
+    unscoped = IncomeStatement.new(@family)
+
+    assert_equal unscoped.totals(date_range: Period.last_30_days.date_range),
+                 scoped.totals(date_range: Period.last_30_days.date_range)
+  end
 end

--- a/test/models/insight/generators/budget_insight_generator_test.rb
+++ b/test/models/insight/generators/budget_insight_generator_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Insight::Generators::BudgetInsightGeneratorTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @category = Category.create!(name: "Insight Groceries", family: @family, color: "#e74c3c")
+  end
+
+  test "default plan keeps the legacy month-only dedup key" do
+    make_over_budget!(budgets(:one))
+
+    insights = Insight::Generators::BudgetInsightGenerator.new(@family).generate
+
+    assert_equal 1, insights.size
+    insight = insights.first
+    assert_equal "budget_at_risk", insight.insight_type
+    assert_equal "budget_at_risk:#{Date.current.strftime('%Y-%m')}", insight.dedup_key
+    assert_equal budgets(:one).to_param, insight.metadata[:budget_param]
+  end
+
+  test "sibling plans get their own insight with a plan-scoped dedup key and named title" do
+    make_over_budget!(budgets(:one))
+
+    plan = budget_plans(:dylan_personal)
+    sibling = Budget.find_or_bootstrap(@family, start_date: Date.current, plan: plan)
+    make_over_budget!(sibling)
+
+    insights = Insight::Generators::BudgetInsightGenerator.new(@family).generate
+
+    assert_equal 2, insights.size
+    sibling_insight = insights.find { |i| i.metadata[:budget_param] == sibling.to_param }
+    assert_not_nil sibling_insight
+    assert_equal "budget_at_risk:#{plan.id}:#{Date.current.strftime('%Y-%m')}", sibling_insight.dedup_key
+    assert_match plan.name, sibling_insight.title
+  end
+
+  test "uninitialized sibling budgets produce no insight" do
+    make_over_budget!(budgets(:one))
+    Budget.find_or_bootstrap(@family, start_date: Date.current, plan: budget_plans(:dylan_personal))
+
+    insights = Insight::Generators::BudgetInsightGenerator.new(@family).generate
+
+    assert_equal 1, insights.size
+  end
+
+  private
+    # Gives the budget an over-limit category: $100 budgeted, $200 spent.
+    def make_over_budget!(budget)
+      budget.update!(budgeted_spending: budget.budgeted_spending || 1000)
+      budget.sync_budget_categories
+      budget.budget_categories.find_by!(category: @category).update!(budgeted_spending: 100)
+
+      Entry.create!(
+        account: accounts(:depository),
+        entryable: Transaction.create!(category: @category),
+        date: budget.start_date,
+        name: "Overspend for #{budget.id}",
+        amount: 200,
+        currency: "USD"
+      )
+    end
+end


### PR DESCRIPTION
## Summary

Allows a family to keep **multiple budgets side by side** — e.g. a budget scoped to personal accounts next to one for joint accounts, or a test budget observed alongside the live one.

> **Stacked on #2908** (`feat/mcp-update-budget-tool`) — it extends the `update_budget` tool added there. Only the last commit (`feat(budgets): support multiple budgets per month via budget plans`) is new to review; GitHub will drop the shared commit from the diff once #2908 merges.

## Design

- New **`BudgetPlan`** model (`name`, `slug`, `is_default`) owns the monthly `budgets` rows. A `budget_plan_accounts` join optionally scopes a plan to a subset of accounts — **no rows = all accounts** (today's behavior).
- **Zero behavior change for existing users**: a migration backfills existing budgets onto a per-family default plan (lazily created for families without budgets). Bare month URLs (`/budgets/aug-2026`), exports, insights, and the API are byte-identical until a second plan exists.
- **URL scheme**: `Budget#to_param` stays the bare month slug for the default plan and becomes `<plan-slug>-aug-2026` for siblings. The month token is strict (`/[a-z]{3}-\d{4}$/`), so parsing is unambiguous; slug generation appends `-plan` to month-shaped names (`"Jan 2025"` → `jan-2025-plan`) so a plan slug can never shadow a month param.
- **Scoped actuals** reuse `IncomeStatement`'s existing `included_account_ids` machinery via a new explicit `account_ids:` param, intersected with the per-user finance-account visibility that already existed. Cache keys already carried the account-set hash, so no caching changes were needed.

## Surfaces

- **Web**: budget plan CRUD (modal form with grouped account checkboxes, mirroring the goals form), a plan switcher in the budget header (hidden for single-plan families — header is pixel-identical until a second plan exists), plan-aware month picker/prev-next/"Today" navigation, and sibling-budget links on the Plan hub card.
- **API v1**: new `budget_plans` resource (index/show/create/update/destroy, `read`/`read_write` scopes); `/api/v1/budgets` gains a `budget_plan_id` filter, a deterministic ordering tiebreaker, and an embedded `budget_plan` node; rswag specs + schemas included.
- **Assistant / MCP**: `get_budget` and `update_budget` accept an optional `budget` (name or slug, defaults to the primary); new `list_budgets`, `create_budget` (with family-scoped account resolution), and `delete_budget` (refuses the default plan) functions.
- **Data lifecycle**: family export/import (`BudgetPlan` + `BudgetPlanAccount` NDJSON types; legacy exports import onto the default plan), sure_import preflight, financial data reset, and the demo generator are plan-aware.
- **Insights**: the budget insight generator iterates all current budgets. The default plan keeps its legacy month-only dedup key (no duplicate insights after upgrade); sibling budgets get plan-scoped keys and named titles. CTAs carry the plan-qualified budget param with a fallback for pre-existing rows.

## Fixes folded in (become real bugs with sibling budgets)

- `BudgetCategoriesController` looked up budget categories family-wide instead of scoping to the addressed budget — a cross-budget read/write leak once two budgets share a month (regression test included). It also never set `current_user`, so drilldown actuals ignored the per-user account visibility the budget page applies.
- `Budget#estimated_income`/`#actual_income` bypassed the budget's own income statement and always computed family-wide.

## Notes for reviewers

- `db/schema.rb` was edited by hand in the existing 7.2-dump format: the repo is on Rails 8.1 but `schema.rb` hasn't been re-dumped since the bump (#2849), so a regenerated dump would rewrite the whole file. Happy to re-dump instead if you prefer.
- New locale keys are en-only, matching recent feature PRs; other locales fall back to English until coverage PRs catch up.
- Migration is reversible (`down` restores the old unique index) and was tested through a migrate → rollback → re-migrate cycle.

## Testing

- ~60 new/extended minitest cases: `BudgetPlan` model (slug guards, default-destroy protection, cascade), `Budget` (param round-trips, per-plan uniqueness/bootstrap/copy/scoping), `IncomeStatement` intersection semantics, web + API controllers (including the leak regression), all five MCP functions plus an MCP create→update→delete lifecycle test, exporter/importer round-trips incl. legacy imports, insight generator dedup back-compat.
- Full suite: **6214 runs, 0 failures** (1 pre-existing env-only error in `ActiveStorageAuthorizationTest` without libvips installed; passes with it). Rubocop and erb_lint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, edit, delete, and switch between multiple budget plans with optional account scoping.
  * Added API and assistant support for managing budget plans and budgets.
* **Improvements**
  * Budgets, categories, insights, income calculations, exports, and imports now respect plan-specific scopes.
  * Budget responses and navigation include plan details.
* **Bug Fixes**
  * Improved validation and authorization for accounts and plan-specific categories.
  * Prevented deletion of default plans and accounts exclusively used by a budget plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->