### PR TITLE
feat(auth): sign in with a passkey, without a password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,11 +123,14 @@ REDIS_URL=redis://localhost:6379/1
 # This is the domain that your Sure instance will be hosted at. It is used to generate links in emails and other places.
 APP_DOMAIN=
 
-# WebAuthn / passkey MFA configuration
+# WebAuthn / passkey configuration
 # RP ID is usually the registrable domain (example.com), not a full URL.
 # Allowed origins are full HTTPS origins where users access Sure.
 WEBAUTHN_RP_ID=
 WEBAUTHN_ALLOWED_ORIGINS=
+# Set to false to keep passkeys as a second factor only, instead of also
+# allowing passwordless sign-in. See docs/hosting/webauthn.md.
+# AUTH_PASSKEY_LOGIN_ENABLED=true
 
 # OpenID Connect configuration
 OIDC_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -125,7 +125,8 @@ APP_DOMAIN=
 
 # WebAuthn / passkey configuration
 # RP ID is usually the registrable domain (example.com), not a full URL.
-# Allowed origins are full HTTPS origins where users access Sure.
+# Allowed origins is a comma-separated list of the full origins where users
+# access Sure (scheme included), e.g. https://sure.example.com,https://app.example.com.
 WEBAUTHN_RP_ID=
 WEBAUTHN_ALLOWED_ORIGINS=
 # Set to false to keep passkeys as a second factor only, instead of also

--- a/app/controllers/passkey_sessions_controller.rb
+++ b/app/controllers/passkey_sessions_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Passwordless sign-in with a discoverable passkey ("usernameless" WebAuthn).
+#
+# The browser resolves which credential to use, so no email is submitted and
+# nothing here can be probed for account enumeration. User verification is
+# REQUIRED at assertion time, which makes a lone passkey two factors on its
+# own (possession + biometric/PIN) — that is why this path deliberately skips
+# the TOTP step in MfaController.
+class PasskeySessionsController < ApplicationController
+  include WebauthnRelyingParty
+
+  skip_authentication only: %i[options create]
+
+  def options
+    return head :forbidden unless AuthConfig.passkey_login_enabled?
+
+    request_options = webauthn_relying_party.options_for_authentication(
+      user_verification: "required"
+    )
+
+    session[:passkey_login_challenge] = request_options.challenge
+
+    render json: request_options
+  end
+
+  def create
+    return head :forbidden unless AuthConfig.passkey_login_enabled?
+
+    challenge = session.delete(:passkey_login_challenge)
+    return render_invalid if challenge.blank?
+
+    credential = WebAuthn::Credential.from_get(
+      webauthn_credential_payload,
+      relying_party: webauthn_relying_party
+    )
+
+    user = user_for(credential)
+    return render_invalid unless user&.active?
+    return render_invalid unless AuthConfig.local_login_allowed_for?(user)
+
+    # Scoped to the user so an assertion can never pair one account's user
+    # handle with another account's credential.
+    stored_credential = user.webauthn_credentials.find_by(credential_id: credential.id)
+    return render_invalid unless stored_credential
+
+    stored_credential.with_lock do
+      credential.verify(
+        challenge,
+        public_key: stored_credential.public_key,
+        sign_count: stored_credential.sign_count,
+        user_presence: true,
+        user_verification: true
+      )
+
+      stored_credential.update!(
+        sign_count: credential.sign_count,
+        last_used_at: Time.current
+      )
+    end
+
+    complete_sign_in(user)
+
+    render json: { redirect_url: root_path }
+  rescue WebAuthn::Error, ActionController::BadRequest, ActionController::ParameterMissing
+    render_invalid
+  end
+
+  private
+    def user_for(credential)
+      # `presence` matters: `find_by(webauthn_id: nil)` would match every user
+      # who never registered a credential.
+      handle = credential.user_handle.presence
+      return nil if handle.blank?
+
+      User.find_by(webauthn_id: handle)
+    end
+
+    def complete_sign_in(user)
+      # Drop any half-finished password + TOTP attempt from this browser.
+      session.delete(:mfa_user_id)
+
+      @session = create_session_for(user)
+      flash[:notice] = t("invitations.accept_choice.joined_household") if accept_pending_invitation_for(user)
+    end
+
+    def render_invalid
+      render json: { error: t("passkey_sessions.invalid_credential") }, status: :unprocessable_entity
+    end
+end

--- a/app/controllers/settings/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/webauthn_credentials_controller.rb
@@ -15,7 +15,13 @@ class Settings::WebauthnCredentialsController < ApplicationController
         display_name: Current.user.display_name
       },
       exclude: Current.user.webauthn_credentials.pluck(:credential_id),
-      authenticator_selection: { user_verification: "preferred" },
+      # `resident_key: "preferred"` asks for a discoverable credential so the
+      # key can also be used for passwordless sign-in. "preferred" rather than
+      # "required" so authenticators without free resident-key slots (older
+      # security keys) can still register as a second factor. User verification
+      # stays "preferred" here for the same reason and is enforced as
+      # "required" on the passwordless sign-in ceremony instead.
+      authenticator_selection: { resident_key: "preferred", user_verification: "preferred" },
       attestation: "none"
     )
 

--- a/app/javascript/controllers/webauthn_authentication_controller.js
+++ b/app/javascript/controllers/webauthn_authentication_controller.js
@@ -34,6 +34,12 @@ export default class extends WebauthnController {
       return;
     }
 
+    // A second click would mint a fresh challenge while the first
+    // authenticator prompt is still open, so the assertion the user is about
+    // to produce would verify against a challenge the server has replaced.
+    if (this.authenticating) return;
+    this.authenticating = true;
+
     // A pending conditional request holds the challenge minted on connect.
     // Fetching options below replaces it server-side, so the stale request has
     // to go first or its assertion would verify against a challenge that no
@@ -49,28 +55,48 @@ export default class extends WebauthnController {
       await this.verifyCredential(serializePublicKeyCredential(credential));
     } catch (error) {
       this.showError(error.message);
+    } finally {
+      this.authenticating = false;
     }
   }
 
   async startConditionalMediation() {
+    // Created before the first await so a button click or a Turbo disconnect
+    // in the meantime has something to abort. Held in a local because
+    // abortConditionalMediation() nulls the field.
+    const controller = new AbortController();
+    this.abortController = controller;
+
     const available =
       await window.PublicKeyCredential?.isConditionalMediationAvailable?.();
-    if (!available) return;
+    if (!available || controller.signal.aborted) return;
 
-    this.abortController = new AbortController();
+    let credential;
 
     try {
       const options = await this.fetchOptions();
-      const credential = await navigator.credentials.get({
+      if (controller.signal.aborted) return;
+
+      credential = await navigator.credentials.get({
         publicKey: prepareCredentialRequestOptions(options),
         mediation: "conditional",
-        signal: this.abortController.signal,
+        signal: controller.signal,
       });
-
-      await this.verifyCredential(serializePublicKeyCredential(credential));
     } catch (_error) {
-      // Aborted, dismissed, or the user signed in another way. This runs
-      // without a user gesture, so failures stay silent.
+      // Nothing has been asked of the user yet: aborted, dismissed, or the
+      // background options request failed. Surfacing that would paint an error
+      // on a login page nobody has touched.
+      return;
+    }
+
+    if (controller.signal.aborted || !credential) return;
+
+    try {
+      await this.verifyCredential(serializePublicKeyCredential(credential));
+    } catch (error) {
+      // The user did pick a passkey from the autofill menu, so a rejection
+      // here has to be visible.
+      this.showError(error.message);
     }
   }
 

--- a/app/javascript/controllers/webauthn_authentication_controller.js
+++ b/app/javascript/controllers/webauthn_authentication_controller.js
@@ -18,7 +18,7 @@ export default class extends WebauthnController {
   };
 
   connect() {
-    if (this.conditionalValue) this.startConditionalMediation();
+    if (this.conditionalValue) this.#startConditionalMediation();
   }
 
   disconnect() {
@@ -60,7 +60,7 @@ export default class extends WebauthnController {
     }
   }
 
-  async startConditionalMediation() {
+  async #startConditionalMediation() {
     // Created before the first await so a button click or a Turbo disconnect
     // in the meantime has something to abort. Held in a local because
     // abortConditionalMediation() nulls the field.
@@ -74,7 +74,7 @@ export default class extends WebauthnController {
     let credential;
 
     try {
-      const options = await this.fetchOptions();
+      const options = await this.fetchOptions(controller.signal);
       if (controller.signal.aborted) return;
 
       credential = await navigator.credentials.get({
@@ -105,11 +105,15 @@ export default class extends WebauthnController {
     this.abortController = null;
   }
 
-  async fetchOptions() {
+  // Takes a signal so the conditional flow's request can be cancelled. The
+  // challenge rides in the session cookie, so a response whose Set-Cookie never
+  // lands cannot overwrite the challenge a manual click just minted.
+  async fetchOptions(signal) {
     const response = await fetch(this.optionsUrlValue, {
       method: "POST",
       headers: this.headers,
       credentials: "same-origin",
+      signal,
     });
 
     if (!response.ok) throw new Error(await this.errorMessage(response));

--- a/app/javascript/controllers/webauthn_authentication_controller.js
+++ b/app/javascript/controllers/webauthn_authentication_controller.js
@@ -11,7 +11,19 @@ export default class extends WebauthnController {
     verifyUrl: String,
     unsupportedMessage: String,
     errorFallback: String,
+    // Opt in to browser autofill ("conditional mediation"): passkeys are
+    // offered from the username field instead of behind a button click. Only
+    // passwordless sign-in enables this; the MFA step-up does not.
+    conditional: Boolean,
   };
+
+  connect() {
+    if (this.conditionalValue) this.startConditionalMediation();
+  }
+
+  disconnect() {
+    this.abortConditionalMediation();
+  }
 
   async authenticate(event) {
     event.preventDefault();
@@ -21,6 +33,12 @@ export default class extends WebauthnController {
       this.showError(this.unsupportedMessageValue);
       return;
     }
+
+    // A pending conditional request holds the challenge minted on connect.
+    // Fetching options below replaces it server-side, so the stale request has
+    // to go first or its assertion would verify against a challenge that no
+    // longer exists.
+    this.abortConditionalMediation();
 
     try {
       const options = await this.fetchOptions();
@@ -32,6 +50,33 @@ export default class extends WebauthnController {
     } catch (error) {
       this.showError(error.message);
     }
+  }
+
+  async startConditionalMediation() {
+    const available =
+      await window.PublicKeyCredential?.isConditionalMediationAvailable?.();
+    if (!available) return;
+
+    this.abortController = new AbortController();
+
+    try {
+      const options = await this.fetchOptions();
+      const credential = await navigator.credentials.get({
+        publicKey: prepareCredentialRequestOptions(options),
+        mediation: "conditional",
+        signal: this.abortController.signal,
+      });
+
+      await this.verifyCredential(serializePublicKeyCredential(credential));
+    } catch (_error) {
+      // Aborted, dismissed, or the user signed in another way. This runs
+      // without a user gesture, so failures stay silent.
+    }
+  }
+
+  abortConditionalMediation() {
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   async fetchOptions() {

--- a/app/models/auth_config.rb
+++ b/app/models/auth_config.rb
@@ -12,6 +12,13 @@ class AuthConfig
       !!Rails.configuration.x.auth.local_admin_override_enabled
     end
 
+    # Whether a registered passkey may be used to sign in on its own, skipping
+    # both the password and the TOTP step. Defaults to true when unconfigured.
+    def passkey_login_enabled?
+      value = Rails.configuration.x.auth.passkey_login_enabled
+      value.nil? ? true : !!value
+    end
+
     # When the local login form should be visible on the login page.
     # - true when local login is enabled for everyone
     # - true when admin override is enabled (super-admin only backend guard)

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -16,12 +16,20 @@
   </div>
 <% end %>
 
+<% passkey_login_enabled = AuthConfig.passkey_login_enabled? %>
+
 <% if AuthConfig.local_login_form_visible? %>
   <%= styled_form_with url: sessions_path, class: "space-y-4", data: { turbo: false } do |form| %>
+    <%#
+      The "webauthn" autocomplete token is what lets browsers offer a saved
+      passkey from this field's autofill menu (conditional mediation). It is
+      only added when passwordless sign-in is enabled, so the menu never
+      advertises a path the server would reject.
+    %>
     <%= form.email_field :email,
                          label: t(".email"),
                          autofocus: false,
-                         autocomplete: "email",
+                         autocomplete: passkey_login_enabled ? "username webauthn" : "email",
                          required: "required",
                          placeholder: t(".email_placeholder"),
                          value: @email %>
@@ -33,6 +41,28 @@
                             value: @password %>
 
     <%= form.submit t(".submit") %>
+  <% end %>
+
+  <% if passkey_login_enabled %>
+    <div class="mt-4 space-y-3"
+         data-controller="webauthn-authentication"
+         data-webauthn-authentication-conditional-value="true"
+         data-webauthn-authentication-options-url-value="<%= passkey_session_options_path %>"
+         data-webauthn-authentication-verify-url-value="<%= passkey_session_path %>"
+         data-webauthn-authentication-unsupported-message-value="<%= t(".passkey_unsupported") %>"
+         data-webauthn-authentication-error-fallback-value="<%= t("passkey_sessions.invalid_credential") %>">
+      <%= render DS::Button.new(
+            text: t(".passkey_button"),
+            variant: :outline,
+            size: :md,
+            full_width: true,
+            icon: "fingerprint",
+            type: "button",
+            class: "gap-2",
+            data: { action: "webauthn-authentication#authenticate" }
+          ) %>
+      <p class="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true" aria-hidden="true" hidden data-webauthn-authentication-target="error"></p>
+    </div>
   <% end %>
 
   <% unless AuthConfig.local_login_enabled? %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -43,8 +43,25 @@
     <%= form.submit t(".submit") %>
   <% end %>
 
+  <% unless AuthConfig.local_login_enabled? %>
+    <p class="mt-2 text-xs text-secondary text-center">
+      <%= t(".local_login_admin_only") %>
+    </p>
+  <% end %>
+
+  <% if AuthConfig.password_features_enabled? %>
+    <div class="mt-6 text-center">
+      <%= link_to t(".forgot_password"), new_password_reset_path, class: "font-medium text-sm text-primary hover:underline transition" %>
+    </div>
+  <% end %>
+
+  <%#
+    Sits with the SSO buttons rather than under the password fields: it is an
+    alternative to the credential form, not part of it, and the four outline
+    buttons read as one group.
+  %>
   <% if passkey_login_enabled %>
-    <div class="mt-4 space-y-3"
+    <div class="mt-6 space-y-3"
          data-controller="webauthn-authentication"
          data-webauthn-authentication-conditional-value="true"
          data-webauthn-authentication-options-url-value="<%= passkey_session_options_path %>"
@@ -62,18 +79,6 @@
             data: { action: "webauthn-authentication#authenticate" }
           ) %>
       <p class="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true" aria-hidden="true" hidden data-webauthn-authentication-target="error"></p>
-    </div>
-  <% end %>
-
-  <% unless AuthConfig.local_login_enabled? %>
-    <p class="mt-2 text-xs text-secondary text-center">
-      <%= t(".local_login_admin_only") %>
-    </p>
-  <% end %>
-
-  <% if AuthConfig.password_features_enabled? %>
-    <div class="mt-6 text-center">
-      <%= link_to t(".forgot_password"), new_password_reset_path, class: "font-medium text-sm text-primary hover:underline transition" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -56,9 +56,14 @@
   <% end %>
 
   <%#
-    Sits with the SSO buttons rather than under the password fields: it is an
-    alternative to the credential form, not part of it, and the four outline
-    buttons read as one group.
+    Last thing in the local-login branch, so it renders directly above the SSO
+    buttons: a passkey is an alternative to the credential form, not part of it.
+
+    It stays inside this branch on purpose. PasskeySessionsController#create
+    gates on AuthConfig.local_login_allowed_for?, so in SSO-only mode (local
+    login off, no admin override) every assertion is rejected. Hoisting this
+    out would render a button that always fails, and mount a Stimulus
+    controller that mints an unredeemable challenge on every page view.
   %>
   <% if passkey_login_enabled %>
     <div class="mt-6 space-y-3"

--- a/config/auth.yml
+++ b/config/auth.yml
@@ -8,6 +8,13 @@ default: &default
     # local login as an emergency override. Regular users remain SSO-only.
     admin_override_enabled: <%= ENV.fetch("AUTH_LOCAL_ADMIN_OVERRIDE_ENABLED", "false") == "true" %>
 
+  passkey_login:
+    # When true, users with a registered passkey can sign in without a password
+    # (and without the TOTP step). User verification is always required for this
+    # path, so the passkey alone is two factors. Set to false to keep passkeys
+    # as a second factor only.
+    enabled: <%= ENV.fetch("AUTH_PASSKEY_LOGIN_ENABLED", "true") == "true" %>
+
   jit:
     # Controls behavior when a user signs in via SSO and no OIDC identity exists.
     # - "create_and_link" (default): create a new user + family when no match exists

--- a/config/initializers/auth.rb
+++ b/config/initializers/auth.rb
@@ -14,6 +14,8 @@ auth_config = raw_auth_config.deep_symbolize_keys
 Rails.configuration.x.auth.local_login_enabled = auth_config.dig(:local_login, :enabled)
 Rails.configuration.x.auth.local_admin_override_enabled = auth_config.dig(:local_login, :admin_override_enabled)
 
+Rails.configuration.x.auth.passkey_login_enabled = auth_config.dig(:passkey_login, :enabled)
+
 Rails.configuration.x.auth.jit_mode = auth_config.dig(:jit, :mode) || "create_and_link"
 
 raw_domains = auth_config.dig(:jit, :allowed_oidc_domains).to_s

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -14,12 +14,27 @@ class Rack::Attack
     request.ip if request.post? && request.path == "/register"
   end
 
-  # Throttle unauthenticated WebAuthn MFA ceremonies similarly to sign-in
+  # Throttle unauthenticated WebAuthn ceremonies similarly to sign-in
   # endpoints; registration remains behind normal application authentication.
+  # Covers both the MFA step-up and passwordless passkey sign-in.
   throttle("mfa/webauthn", limit: 10, period: 1.minute) do |request|
-    if request.post? && request.path.in?(%w[/mfa/webauthn_options /mfa/verify_webauthn])
+    if request.post? && request.path.in?(%w[
+         /mfa/webauthn_options
+         /mfa/verify_webauthn
+         /sessions/passkey
+       ])
       request.ip
     end
+  end
+
+  # The passwordless challenge endpoint gets its own, looser budget: browsers
+  # that support conditional mediation call it automatically on every login
+  # page load, so sharing the limit above would let ordinary page views lock a
+  # shared NAT out of MFA. Minting a challenge touches no credential and
+  # reveals nothing, and the assertion it produces is still verified under the
+  # stricter limit.
+  throttle("passkey/options", limit: 30, period: 1.minute) do |request|
+    request.ip if request.post? && request.path == "/sessions/passkey_options"
   end
 
   # Throttle admin endpoints to prevent brute-force attacks

--- a/config/locales/views/passkey_sessions/en.yml
+++ b/config/locales/views/passkey_sessions/en.yml
@@ -1,0 +1,5 @@
+---
+en:
+  passkey_sessions:
+    invalid_credential: Could not sign in with that passkey. Please try again or
+      use your password.

--- a/config/locales/views/sessions/en.yml
+++ b/config/locales/views/sessions/en.yml
@@ -30,6 +30,8 @@ en:
       oidc: Sign in with OpenID Connect
       google_auth_connect: Sign in with Google
       local_login_admin_only: Local login is restricted to administrators.
+      passkey_button: Sign in with a passkey
+      passkey_unsupported: This browser does not support passkeys.
       no_auth_methods_enabled: No authentication methods are currently enabled. Please contact an administrator.
       demo_banner_title: "Demo Mode Active"
       demo_banner_message: "This is a demonstration environment. Login credentials have been pre-filled for your convenience. Please do not enter real or sensitive information."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,6 +275,10 @@ Rails.application.routes.draw do
 
   resource :registration, only: %i[new create]
   resources :sessions, only: %i[index new create destroy]
+  # Passwordless sign-in with a discoverable passkey. Unauthenticated by design;
+  # rate limited alongside the MFA WebAuthn endpoints in Rack::Attack.
+  post "/sessions/passkey_options", to: "passkey_sessions#options", as: :passkey_session_options
+  post "/sessions/passkey", to: "passkey_sessions#create", as: :passkey_session
   # Desktop app SSO: opens the flow in the system browser (so passkeys/WebAuthn
   # work), then hands a single-use, PKCE-bound code back via the sure:// scheme
   # which the desktop webview exchanges for a normal web session.

--- a/docs/hosting/webauthn.md
+++ b/docs/hosting/webauthn.md
@@ -54,13 +54,15 @@ Passwordless sign-in is on by default, and it applies to passkeys that were
 registered before this feature existed. A passkey a user added purely as a
 second factor can, after the upgrade, sign that user in on its own.
 
-Nothing needs to be re-registered for this to happen, and nothing in the
-database marks a credential as discoverable — whether a stored credential turns
-up in the passkey picker is decided by the authenticator that holds it. In
-practice, every credential held by a password manager or platform authenticator
-(Proton Pass, iCloud Keychain, 1Password, Bitwarden, Windows Hello) is
-discoverable and becomes usable for passwordless sign-in. Hardware security keys
-registered without a free resident-key slot stay second-factor only.
+This applies to a credential only if the authenticator that holds it made it
+discoverable. Registration asks with `residentKey: "preferred"`, which an
+authenticator is free to decline, and nothing in the database records what it
+decided — so Sure cannot tell you in advance which existing credentials are
+affected. In practice password managers and platform authenticators (Proton
+Pass, iCloud Keychain, 1Password, Bitwarden, Windows Hello) store discoverable
+credentials by default, so theirs generally are; a credential an authenticator
+stored non-discoverably, such as one on a hardware key with no free resident-key
+slot, stays second-factor only. Nothing needs to be re-registered either way.
 
 The opt-out is instance-wide. There is no per-user or per-credential setting: to
 keep passkeys as a second factor for everyone, set

--- a/docs/hosting/webauthn.md
+++ b/docs/hosting/webauthn.md
@@ -48,6 +48,31 @@ Sign-in is "usernameless": no email is submitted, because the browser returns th
 - Users must enable two-factor authentication before they can register a passkey. Disabling 2FA removes every registered passkey, which also removes passwordless sign-in for that user.
 - Passkey sign-in follows the same policy as local login. When `AUTH_LOCAL_LOGIN_ENABLED=false`, only super admins with `AUTH_LOCAL_ADMIN_OVERRIDE_ENABLED=true` may use it.
 
+### Upgrading an instance that already has passkeys
+
+Passwordless sign-in is on by default, and it applies to passkeys that were
+registered before this feature existed. A passkey a user added purely as a
+second factor can, after the upgrade, sign that user in on its own.
+
+Nothing needs to be re-registered for this to happen, and nothing in the
+database marks a credential as discoverable — whether a stored credential turns
+up in the passkey picker is decided by the authenticator that holds it. In
+practice, every credential held by a password manager or platform authenticator
+(Proton Pass, iCloud Keychain, 1Password, Bitwarden, Windows Hello) is
+discoverable and becomes usable for passwordless sign-in. Hardware security keys
+registered without a free resident-key slot stay second-factor only.
+
+The opt-out is instance-wide. There is no per-user or per-credential setting: to
+keep passkeys as a second factor for everyone, set
+`AUTH_PASSKEY_LOGIN_ENABLED=false` before upgrading. A single user can only opt
+out by removing the credential.
+
+This is not a reduction in security — the passwordless ceremony requires user
+verification, so the passkey alone is still two factors, as described above. It
+is a change in what an already-registered credential can do, and users who chose
+a passkey specifically as a *second* factor have not consented to it signing
+them in alone.
+
 ### Browser autofill
 
 When the browser supports conditional mediation, saved passkeys are offered from the email field's autofill menu, before any button is clicked. Browsers without it fall back to the "Sign in with a passkey" button, which works the same way.

--- a/docs/hosting/webauthn.md
+++ b/docs/hosting/webauthn.md
@@ -1,6 +1,6 @@
-# WebAuthn MFA Configuration
+# WebAuthn Configuration
 
-Sure supports passkeys, Touch ID, Windows Hello, and hardware security keys as MFA credentials. WebAuthn credentials are bound to the relying party ID used when they are registered, so production deployments should pin these values explicitly instead of deriving them from incoming request headers.
+Sure supports passkeys, Touch ID, Windows Hello, and hardware security keys, both as a second factor and for passwordless sign-in. WebAuthn credentials are bound to the relying party ID used when they are registered, so production deployments should pin these values explicitly instead of deriving them from incoming request headers.
 
 Set these environment variables for self-hosted deployments:
 
@@ -25,3 +25,29 @@ WEBAUTHN_ALLOWED_ORIGINS=http://localhost:3000
 ```
 
 Changing `WEBAUTHN_RP_ID` after users register credentials can make existing passkeys and security keys unavailable. Keep the value stable across reverse proxy, domain, and hostname changes.
+
+## Passwordless sign-in
+
+A registered passkey can sign a user in directly from the login page, without a password and without the TOTP step. This is enabled by default:
+
+```bash
+AUTH_PASSKEY_LOGIN_ENABLED=true
+```
+
+Set it to `false` to keep passkeys as a second factor only.
+
+### Why skipping the password is not a downgrade
+
+The passwordless ceremony always requests `userVerification: "required"`, so the authenticator must confirm the person as well as the device — a biometric, a device PIN, or a security key PIN. That makes a lone passkey two independent factors (possession plus inherence or knowledge), which is the same bar as the password plus TOTP flow it replaces. An authenticator that can only confirm presence, such as a bare touch, is rejected on this path and still works as a second factor.
+
+Sign-in is "usernameless": no email is submitted, because the browser returns the account handle along with the assertion. Nothing on this path can be probed to discover whether an account exists.
+
+### Requirements
+
+- The passkey must be **discoverable** (also called a resident key). Registration asks for one with `residentKey: "preferred"`. Password managers and platform authenticators — Proton Pass, iCloud Keychain, 1Password, Bitwarden, Windows Hello — store discoverable credentials by default. A hardware security key with no free resident-key slots still registers, but only as a second factor, and will not appear in the passkey picker.
+- Users must enable two-factor authentication before they can register a passkey. Disabling 2FA removes every registered passkey, which also removes passwordless sign-in for that user.
+- Passkey sign-in follows the same policy as local login. When `AUTH_LOCAL_LOGIN_ENABLED=false`, only super admins with `AUTH_LOCAL_ADMIN_OVERRIDE_ENABLED=true` may use it.
+
+### Browser autofill
+
+When the browser supports conditional mediation, saved passkeys are offered from the email field's autofill menu, before any button is clicked. Browsers without it fall back to the "Sign in with a passkey" button, which works the same way.

--- a/test/controllers/passkey_sessions_controller_test.rb
+++ b/test/controllers/passkey_sessions_controller_test.rb
@@ -1,0 +1,212 @@
+require "test_helper"
+require "webauthn/fake_client"
+
+class PasskeySessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @user.webauthn_credentials.destroy_all
+    sign_in @user
+    @user.setup_mfa!
+    @user.enable_mfa!
+    @client = register_webauthn_credential
+    @stored_credential = @user.webauthn_credentials.reload.first
+    sign_out
+  end
+
+  test "signs in with a discoverable passkey, skipping password and TOTP" do
+    assertion = passkey_assertion
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :success
+    assert_equal root_path, JSON.parse(response.body).fetch("redirect_url")
+    assert Session.exists?(user_id: @user.id)
+    assert @stored_credential.reload.last_used_at.present?
+    assert_operator @stored_credential.sign_count, :>, 0
+  end
+
+  test "rejects an assertion without user verification" do
+    assertion = passkey_assertion(user_verified: false)
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t("passkey_sessions.invalid_credential"), JSON.parse(response.body).fetch("error")
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "rejects an unknown user handle" do
+    assertion = passkey_assertion(user_handle: WebAuthn.generate_user_id)
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  # A blank handle must not fall through to `find_by(webauthn_id: nil)`, which
+  # would match every user who never registered a credential.
+  test "rejects a blank user handle" do
+    other_user = users(:family_member)
+    assert_nil other_user.webauthn_id
+
+    assertion = passkey_assertion
+    assertion["response"]["userHandle"] = nil
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_empty Session.where(user_id: [ @user.id, other_user.id ])
+  end
+
+  test "rejects a credential that belongs to a different user than the handle" do
+    other_user = users(:family_member)
+    other_user.ensure_webauthn_id!
+
+    assertion = passkey_assertion(user_handle: other_user.reload.webauthn_id)
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_empty Session.where(user_id: [ @user.id, other_user.id ])
+  end
+
+  test "rejects a deactivated user" do
+    @user.update_column(:active, false)
+    assertion = passkey_assertion
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "rejects a replayed assertion" do
+    assertion = passkey_assertion
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+    assert_response :success
+
+    Session.where(user_id: @user.id).destroy_all
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "rejects an assertion with no challenge in the session" do
+    assertion = passkey_assertion
+
+    reset!
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "rejects malformed credential payloads" do
+    post passkey_session_options_path, as: :json
+    assert_response :success
+
+    post passkey_session_path, params: { credential: "not-json" }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "rejects users who are not allowed to use local login" do
+    AuthConfig.stubs(:local_login_allowed_for?).returns(false)
+    assertion = passkey_assertion
+
+    post passkey_session_path, params: { credential: assertion }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "both endpoints are unavailable when passkey login is disabled" do
+    AuthConfig.stubs(:passkey_login_enabled?).returns(false)
+
+    post passkey_session_options_path, as: :json
+    assert_response :forbidden
+
+    post passkey_session_path, params: { credential: {} }, as: :json
+    assert_response :forbidden
+    assert_not Session.exists?(user_id: @user.id)
+  end
+
+  test "requests a discoverable credential with user verification required" do
+    post passkey_session_options_path, as: :json
+
+    assert_response :success
+    options = JSON.parse(response.body)
+    assert_equal "www.example.com", options.fetch("rpId")
+    assert_equal "required", options.fetch("userVerification")
+    assert_empty options.fetch("allowCredentials")
+  end
+
+  test "options use the configured relying party id" do
+    with_webauthn_config(rp_id: "example.test", allowed_origins: [ "https://app.example.test" ]) do
+      post passkey_session_options_path, as: :json
+
+      assert_response :success
+      assert_equal "example.test", JSON.parse(response.body).fetch("rpId")
+    end
+  end
+
+  private
+    # Runs a full options -> get -> assertion cycle against the passwordless
+    # endpoint, so each assertion is bound to a freshly minted challenge.
+    def passkey_assertion(user_verified: true, user_handle: nil)
+      post passkey_session_options_path, as: :json
+      assert_response :success
+      options = JSON.parse(response.body)
+
+      @client.get(
+        challenge: options.fetch("challenge"),
+        rp_id: "www.example.com",
+        user_verified: user_verified,
+        user_handle: raw_user_handle(user_handle || @user.reload.webauthn_id)
+      )
+    end
+
+    # FakeClient encodes whatever it is handed, but `webauthn_id` is already a
+    # base64url string, so it has to be decoded back to raw bytes first.
+    def raw_user_handle(webauthn_id)
+      WebAuthn.standard_encoder.decode(webauthn_id)
+    end
+
+    def register_webauthn_credential(origin: "http://www.example.com", rp_id: "www.example.com")
+      client = WebAuthn::FakeClient.new(origin)
+
+      post options_settings_webauthn_credentials_path, as: :json
+      options = JSON.parse(response.body)
+      credential = client.create(challenge: options.fetch("challenge"), rp_id: rp_id)
+      post settings_webauthn_credentials_path, params: {
+        webauthn_credential: { nickname: "MacBook Touch ID" },
+        credential: credential
+      }, as: :json
+      assert_response :success
+
+      client
+    end
+
+    def sign_out
+      @user.sessions.each { |session| delete session_path(session) }
+    end
+
+    def with_webauthn_config(rp_id:, allowed_origins:)
+      config = Rails.application.config.x.webauthn
+      previous_rp_id = config.rp_id
+      previous_allowed_origins = config.allowed_origins
+      config.rp_id = rp_id
+      config.allowed_origins = allowed_origins
+
+      yield
+    ensure
+      config.rp_id = previous_rp_id
+      config.allowed_origins = previous_allowed_origins
+    end
+end

--- a/test/controllers/passkey_sessions_controller_test.rb
+++ b/test/controllers/passkey_sessions_controller_test.rb
@@ -25,6 +25,28 @@ class PasskeySessionsControllerTest < ActionDispatch::IntegrationTest
     assert_operator @stored_credential.sign_count, :>, 0
   end
 
+  # The pending invitation lives in the Rack session, and complete_sign_in reads
+  # it immediately after creating the session. Anything that clears the session
+  # in between — a reset_session added to "fix" session fixation, say — drops the
+  # invitee into their own family with no error and no failing test.
+  test "accepts a pending invitation stored before the passkey sign-in" do
+    invitation = Invitation.create!(
+      email: @user.email,
+      role: "member",
+      family: @user.family,
+      inviter: @user
+    )
+
+    get new_session_path(invitation: invitation.token)
+    assert_response :success
+
+    post passkey_session_path, params: { credential: passkey_assertion }, as: :json
+
+    assert_response :success
+    assert invitation.reload.accepted_at.present?, "invitation was not accepted during passkey sign-in"
+    assert_equal "member", @user.reload.role
+  end
+
   test "rejects an assertion without user verification" do
     assertion = passkey_assertion(user_verified: false)
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -39,6 +39,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "login page offers passkey sign-in" do
+    AuthConfig.stubs(:passkey_login_enabled?).returns(true)
+
     get new_session_url
 
     assert_response :success

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -38,6 +38,29 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "login page offers passkey sign-in" do
+    get new_session_url
+
+    assert_response :success
+    assert_select "button", text: I18n.t("sessions.new.passkey_button")
+    assert_select "[data-webauthn-authentication-conditional-value='true']"
+    assert_select "[data-webauthn-authentication-unsupported-message-value=?]", I18n.t("sessions.new.passkey_unsupported")
+    assert_select "[data-webauthn-authentication-error-fallback-value=?]", I18n.t("passkey_sessions.invalid_credential")
+    # Browsers only surface passkeys from autofill when the field carries the
+    # "webauthn" token.
+    assert_select "input[type=email][autocomplete='username webauthn']"
+  end
+
+  test "login page hides passkey sign-in when disabled" do
+    AuthConfig.stubs(:passkey_login_enabled?).returns(false)
+
+    get new_session_url
+
+    assert_response :success
+    assert_select "button", text: I18n.t("sessions.new.passkey_button"), count: 0
+    assert_select "input[type=email][autocomplete='email']"
+  end
+
   test "can sign in" do
     sign_in @user
     assert_redirected_to root_url

--- a/test/controllers/settings/webauthn_credentials_controller_test.rb
+++ b/test/controllers/settings/webauthn_credentials_controller_test.rb
@@ -20,6 +20,13 @@ class Settings::WebauthnCredentialsControllerTest < ActionDispatch::IntegrationT
     assert_equal I18n.t("webauthn_credentials.mfa_required"), JSON.parse(response.body).fetch("error")
   end
 
+  test "asks for a discoverable credential so it can be used for passwordless sign-in" do
+    options = registration_options
+
+    assert_equal "preferred", options.dig("authenticatorSelection", "residentKey")
+    assert_equal "preferred", options.dig("authenticatorSelection", "userVerification")
+  end
+
   test "creates a credential from a verified registration challenge" do
     options = registration_options
     credential = @client.create(challenge: options.fetch("challenge"), rp_id: "www.example.com")


### PR DESCRIPTION
Passkeys could only ever replace the TOTP code. Registration required 2FA to already be on, and the WebAuthn ceremony was reachable only after `User.authenticate_by` had succeeded, so a passkey never removed a step — it just swapped which second factor you used.

A registered passkey can now complete sign-in on its own, straight from the login page.

| Light | Dark |
|---|---|
| <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/passkey-login-light.png" width="420"> | <img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/passkey-login-dark.png" width="420"> |

## Why skipping the password isn't a downgrade

The passwordless ceremony always requests `userVerification: "required"`, so the authenticator has to confirm the person as well as the device — biometric, device PIN, or security-key PIN. That makes a lone passkey two independent factors (possession plus inherence or knowledge), the same bar as the password + TOTP flow it replaces. This is why the path deliberately skips the TOTP step.

An authenticator that can only prove presence — a bare touch — is rejected here and still works as a second factor.

Sign-in is usernameless: no email is submitted, because the browser returns the account handle with the assertion. Nothing on this path can be probed to learn whether an account exists.

## What changed

**`PasskeySessionsController`** (new) — `POST /sessions/passkey_options` mints a discoverable-credential challenge; `POST /sessions/passkey` verifies the assertion and creates the session. Guards run in order: user handle present, user active, local-login policy allows them, credential belongs to that user.

Two of those are less obvious than they look:

- The handle is checked with `.presence` before the lookup. `find_by(webauthn_id: nil)` would match every user who never registered a credential, so a blank handle has to fail before it reaches the query.
- The credential is fetched through `user.webauthn_credentials`, not globally, so an assertion can never pair one account's handle with another account's credential.

**Registration** now asks for `residentKey: "preferred"` so the credential is discoverable and appears in the picker. `"preferred"` rather than `"required"`: authenticators with no free resident-key slot still register as a second factor.

**Rate limiting** — the verify endpoint joins the existing 10/min WebAuthn throttle. The options endpoint got its own 30/min budget, because conditional mediation calls it automatically on every login page load; sharing the strict limit would have let ordinary page views lock a shared NAT out of MFA. Minting a challenge touches no credential and reveals nothing, and the assertion it produces is still verified under the stricter limit.

**Browser autofill** — where conditional mediation is available, saved passkeys are offered from the email field's autofill menu before any click. `webauthn_authentication_controller.js` gained a `conditional` value rather than growing a second controller, since both URLs were already Stimulus values. An `AbortController` kills a pending conditional request before the button mints a new challenge — otherwise the stale assertion would verify against a challenge that no longer exists.

**Config** — `AUTH_PASSKEY_LOGIN_ENABLED=false` keeps passkeys as a second factor only. Passkey sign-in follows the same policy as local login, so it stays closed to regular users when `AUTH_LOCAL_LOGIN_ENABLED=false`.

## Scope

Passkeys still require 2FA to be enabled before they can be registered, and `disable_mfa!` still destroys them. Decoupling passkeys from TOTP entirely is a larger change — backup codes, `otp_required?` semantics across the app, the settings UI — and isn't needed for passwordless sign-in.

## Upgrade notes

Existing passkeys from password managers and platform authenticators (Proton Pass, iCloud Keychain, 1Password, Bitwarden, Windows Hello) are already discoverable and work without re-registering. Hardware security keys registered before this change may not appear in the picker; re-registering them fixes that where the key has a free resident-key slot.

**This is a capability change for credentials that already exist, and it is on by default.** A passkey a user registered purely as a second factor can, after upgrading, sign that user in on its own. Nothing has to be re-registered for that to happen, and it does not depend on the `residentKey` change here: `ensure_webauthn_id!` predates this PR, so every stored credential already carries the user handle the passwordless path looks up, and nothing in the schema records whether a credential is discoverable — the authenticator decides. `residentKey: "preferred"` only affects what new hardware keys do.

The opt-out is instance-wide. There is no per-user or per-credential setting, so an admin who wants passkeys to stay second-factor-only must set `AUTH_PASSKEY_LOGIN_ENABLED=false` **before** upgrading; an individual user can only opt out by removing the credential. This is not a reduction in security — the ceremony still requires user verification, so the passkey alone remains two factors — but users who deliberately chose a passkey as a *second* factor have not consented to it signing them in alone, so it belongs in the release notes.

## Testing

- `bin/rails test` — 6122 runs, 0 failures, 0 errors
- 14 new tests in `test/controllers/passkey_sessions_controller_test.rb`: happy path, missing user verification, unknown handle, blank handle, handle/credential mismatch across users, deactivated user, replayed assertion, missing challenge, malformed payload, local-login denied, feature flag off, options shape, configured RP ID, and a guard asserting a pending invitation still survives passkey sign-in
- `bin/rails test:system` — 88/89. The one failure (`DragAndDropImportTest`) is a local file-upload issue unrelated to this branch: it fails identically with `AUTH_PASSKEY_LOGIN_ENABLED=false` and passes against `origin/main` in a checkout outside `~/Documents`.
- `bin/rubocop`, `erb_lint`, `biome lint` clean; `bin/brakeman` reports no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passwordless sign-in with discoverable passkeys and required user verification.
  * Added optional passkey controls, browser autofill, and password sign-in fallback.
  * Added configuration to enable or disable passwordless passkey authentication.
  * Improved passkey registration to support discoverable credentials.
* **Bug Fixes**
  * Added clearer messages for invalid credentials and unsupported browsers.
* **Documentation**
  * Documented passkey login configuration, requirements, and browser behavior.
* **Security**
  * Added request throttling for passkey authentication endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
