### PR TITLE
fix: update Claude MCP connector instructions

### DIFF
--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -293,8 +293,8 @@ en:
         copy_url: Copy
         copied: Copied!
         how_to_connect_title: How to connect Claude
-        step_1: "Open Claude.ai and go to Settings → Integrations."
-        step_2: Click "Add integration" and paste the MCP server URL above.
+        step_1: "Open Claude.ai and go to Settings → Customize → Connectors."
+        step_2: Click "Add connector" and paste the MCP server URL above.
         step_3: Click Connect — you'll be redirected to Sure to sign in and authorize access.
         step_4: Once authorized, Claude can read your accounts, transactions, and balance data.
         connected_title: Connected clients

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -113,8 +113,8 @@ fr:
         page_title: Serveur MCP
         revoke: Révoquer
         revoke_confirm: Révoquer l'accès pour ce client ?
-        step_1: Ouvrez Claude.ai et allez dans Paramètres → Intégrations.
-        step_2: Cliquez sur "Ajouter l'intégration" et collez l'URL du serveur MCP ci-dessus.
+        step_1: Ouvrez Claude.ai et allez dans Paramètres → Personnaliser → Connecteurs.
+        step_2: Cliquez sur "Ajouter un connecteur" et collez l'URL du serveur MCP ci-dessus.
         step_3: Cliquez sur Connecter — vous serez redirigé vers Sure pour vous connecter et autoriser l'accès.
         step_4: Une fois autorisé, Claude peut lire vos comptes, transactions et données de solde.
         unknown_client: Client inconnu

--- a/config/locales/views/settings/it.yml
+++ b/config/locales/views/settings/it.yml
@@ -248,8 +248,8 @@ it:
         copy_url: Copia
         copied: Copiato!
         how_to_connect_title: Come connettere Claude
-        step_1: "Apri Claude.ai e vai su Impostazioni → Integrazioni."
-        step_2: Clicca "Aggiungi integrazione" e incolla l'URL del server MCP sopra.
+        step_1: "Apri Claude.ai e vai su Impostazioni → Personalizza → Connettori."
+        step_2: Clicca "Aggiungi connettore" e incolla l'URL del server MCP sopra.
         step_3: Clicca Connetti — verrai reindirizzato a Sure per accedere e autorizzare l'accesso.
         step_4: Una volta autorizzato, Claude può leggere i tuoi conti, transazioni e dati di saldo.
         connected_title: Client connessi

--- a/config/locales/views/settings/ru.yml
+++ b/config/locales/views/settings/ru.yml
@@ -126,8 +126,8 @@ ru:
         page_title: MCP-сервер
         revoke: Отозвать
         revoke_confirm: Отозвать доступ для этого клиента?
-        step_1: Откройте Claude.ai и перейдите в Settings → Integrations.
-        step_2: Нажмите «Add integration» и вставьте URL MCP-сервера выше.
+        step_1: Откройте Claude.ai и перейдите в Settings → Customize → Connectors.
+        step_2: Нажмите «Add connector» и вставьте URL MCP-сервера выше.
         step_3: Нажмите Connect — вы будете перенаправлены в Sure для входа и 
           подтверждения доступа.
         step_4: После авторизации Claude сможет читать ваши счета, операции и данные 

--- a/config/locales/views/settings/tr.yml
+++ b/config/locales/views/settings/tr.yml
@@ -128,8 +128,8 @@ tr:
         page_title: MCP Sunucusu
         revoke: İptal Et
         revoke_confirm: Bu istemcinin erişimi iptal edilsin mi?
-        step_1: Claude.ai'yi açın ve Ayarlar → Entegrasyonlar'a gidin.
-        step_2: '"Entegrasyon ekle"ye tıklayın ve yukarıdaki MCP sunucu URL''sini
+        step_1: Claude.ai'yi açın ve Ayarlar → Özelleştir → Bağlayıcılar'a gidin.
+        step_2: '"Bağlayıcı ekle"ye tıklayın ve yukarıdaki MCP sunucu URL''sini
           yapıştırın.'
         step_3: Bağlan'a tıklayın — giriş yapmak ve erişimi yetkilendirmek için Sure'a
           yönlendirileceksiniz.


### PR DESCRIPTION
## Summary

- update the MCP settings instructions for Claude.ai's current Settings > Customize > Connectors path
- rename the Add integration step to Add connector across the MCP settings locale copy

## Validation

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' config/locales/views/settings/en.yml config/locales/views/settings/fr.yml config/locales/views/settings/it.yml config/locales/views/settings/ru.yml config/locales/views/settings/tr.yml
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP connection instructions to match Claude.ai’s current **Connectors** navigation and setup terminology.
  * Revised instructions in English, French, Italian, Russian, and Turkish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->