### PR TITLE
fix(ui): satisfy DS Drift Patrol Rule 4 in redbark disclosure

### DIFF
--- a/app/views/redbark_items/_redbark_item.html.erb
+++ b/app/views/redbark_items/_redbark_item.html.erb
@@ -3,7 +3,7 @@
 <%= tag.div id: dom_id(redbark_item) do %>
   <%= render DS::Disclosure.new(variant: :card, open: true) do |disclosure| %>
     <% disclosure.with_summary_content do %>
-      <div class="flex items-center justify-between gap-2">
+      <div class="w-full flex items-center justify-between gap-2">
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 


### PR DESCRIPTION
## Summary
- Wraps the Redbark `DS::Disclosure(variant: :card)` summary flex row in `w-full`, matching DS Drift Patrol Rule 4.
- Resolves the sole merged finding tracked in #2912 (introduced when #2867 landed).

Closes #2912

## Test plan
- [ ] Open Settings → Providers → Redbark connection card; confirm disclosure summary layout still stretches (title left, actions right)
- [ ] Toggle open/closed; chevron and actions remain aligned
- [ ] Visual check matches other provider cards (Plaid/Lunchflow-style row)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the disclosure summary layout to use the full available width while preserving its alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->