### PR TITLE
fix(providers): separate booking dates from bank entry dates

### DIFF
--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -627,8 +627,9 @@ class Account::ProviderImportAdapter
   # @param source [String] Provider name
   # @param activity_label [String, nil] Investment activity label (e.g., "Buy", "Sell", "Reinvestment")
   # @param exchange_rate [BigDecimal, Numeric, nil] Optional provider-supplied FX rate into the account currency
+  # @param extra [Hash, nil] Optional provider metadata merged into trade.extra (e.g. trade_date / settlement_date)
   # @return [Entry] The created entry with trade
-  def import_trade(security:, quantity:, price:, amount:, currency:, date:, name: nil, external_id: nil, source:, activity_label: nil, exchange_rate: nil)
+  def import_trade(security:, quantity:, price:, amount:, currency:, date:, name: nil, external_id: nil, source:, activity_label: nil, exchange_rate: nil, extra: nil)
     raise ArgumentError, "security is required" if security.nil?
     raise ArgumentError, "source is required" if source.blank?
 
@@ -671,6 +672,12 @@ class Account::ProviderImportAdapter
       trade_attributes[:exchange_rate] = exchange_rate unless exchange_rate.nil?
 
       entry.entryable.assign_attributes(trade_attributes)
+
+      if extra.present?
+        existing = entry.entryable.extra || {}
+        incoming = extra.is_a?(Hash) ? extra.deep_stringify_keys : {}
+        entry.entryable.extra = existing.deep_merge(incoming)
+      end
 
       entry.assign_attributes(
         date: date,

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -145,7 +145,13 @@ class BrexEntry::Processor
       selected = Provider::BankEntryDate.select([
         [ "posted_at_date", parse_provider_date(data[:posted_at_date]) ],
         [ "initiated_at_date", parse_provider_date(data[:initiated_at_date]) ]
-      ], as_of: Provider::BankEntryDate.family_today(account&.family))
+      ],
+        as_of: Provider::BankEntryDate.family_today(account&.family),
+        existing_date: Provider::BankEntryDate.existing_entry_date(
+          account: account,
+          external_id: external_id,
+          source: "brex"
+        ))
 
       return selected if selected
 

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -142,7 +142,18 @@ class BrexEntry::Processor
     end
 
     def date
-      date_value = data[:posted_at_date].presence || data[:initiated_at_date].presence
+      selected = Provider::BankEntryDate.select([
+        [ "posted_at_date", parse_provider_date(data[:posted_at_date]) ],
+        [ "initiated_at_date", parse_provider_date(data[:initiated_at_date]) ]
+      ])
+
+      return selected if selected
+
+      raise ArgumentError, "Invalid date format: #{[ data[:posted_at_date], data[:initiated_at_date] ].inspect}"
+    end
+
+    def parse_provider_date(date_value)
+      return nil if date_value.blank?
 
       case date_value
       when String
@@ -158,11 +169,11 @@ class BrexEntry::Processor
       when Date
         date_value
       else
-        raise ArgumentError, "Invalid date format: #{date_value.inspect}"
+        nil
       end
     rescue ArgumentError, TypeError => e
       Rails.logger.error("Failed to parse Brex transaction date '#{date_value}': #{e.message}")
-      raise ArgumentError, "Unable to parse transaction date: #{date_value.inspect}"
+      nil
     end
 
     def extra

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -145,7 +145,7 @@ class BrexEntry::Processor
       selected = Provider::BankEntryDate.select([
         [ "posted_at_date", parse_provider_date(data[:posted_at_date]) ],
         [ "initiated_at_date", parse_provider_date(data[:initiated_at_date]) ]
-      ])
+      ], as_of: Provider::BankEntryDate.family_today(account&.family))
 
       return selected if selected
 

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -266,7 +266,7 @@ class EnableBankingEntry::Processor
         [ "booking_date", parse_provider_date(data[:booking_date]) ],
         [ "value_date", parse_provider_date(data[:value_date]) ],
         [ "transaction_date", parse_provider_date(data[:transaction_date]) ]
-      ])
+      ], as_of: Provider::BankEntryDate.family_today(account&.family))
 
       return selected if selected
 

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -266,7 +266,13 @@ class EnableBankingEntry::Processor
         [ "booking_date", parse_provider_date(data[:booking_date]) ],
         [ "value_date", parse_provider_date(data[:value_date]) ],
         [ "transaction_date", parse_provider_date(data[:transaction_date]) ]
-      ], as_of: Provider::BankEntryDate.family_today(account&.family))
+      ],
+        as_of: Provider::BankEntryDate.family_today(account&.family),
+        existing_date: Provider::BankEntryDate.existing_entry_date(
+          account: account,
+          external_id: self.class.compute_external_id(data),
+          source: "enable_banking"
+        ))
 
       return selected if selected
 

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -169,6 +169,11 @@ class EnableBankingEntry::Processor
 
       eb[:merchant_category_code] = data[:merchant_category_code] if data[:merchant_category_code].present?
       eb[:pending] = true if data[:_pending] == true
+      eb.merge!(Provider::BankEntryDate.provenance([
+        [ :booking_date, data[:booking_date] ],
+        [ :value_date, data[:value_date] ],
+        [ :transaction_date, data[:transaction_date] ]
+      ]))
 
       eb.compact!
       eb.empty? ? nil : { enable_banking: eb }
@@ -252,9 +257,25 @@ class EnableBankingEntry::Processor
       Rails.logger.warn("Invalid currency code '#{currency_value}' in Enable Banking transaction #{safe_id}, falling back to account currency")
     end
 
+    # Prefer booking_date, then value_date, then transaction_date — but never use a
+    # future booking/posting date as entries.date when an earlier non-future
+    # candidate exists (see #2907). Content-based external IDs still fingerprint
+    # the raw provider dates above and are intentionally unchanged.
     def date
-      # Prefer booking_date, fall back to value_date, then transaction_date
-      date_value = data[:booking_date] || data[:value_date] || data[:transaction_date]
+      selected = Provider::BankEntryDate.select([
+        [ "booking_date", parse_provider_date(data[:booking_date]) ],
+        [ "value_date", parse_provider_date(data[:value_date]) ],
+        [ "transaction_date", parse_provider_date(data[:transaction_date]) ]
+      ])
+
+      return selected if selected
+
+      Rails.logger.error("Enable Banking transaction has invalid date value: #{[ data[:booking_date], data[:value_date], data[:transaction_date] ].inspect}")
+      raise ArgumentError, "Invalid date format: #{[ data[:booking_date], data[:value_date], data[:transaction_date] ].inspect}"
+    end
+
+    def parse_provider_date(date_value)
+      return nil if date_value.blank?
 
       case date_value
       when String
@@ -270,11 +291,10 @@ class EnableBankingEntry::Processor
       when Date
         date_value
       else
-        Rails.logger.error("Enable Banking transaction has invalid date value: #{date_value.inspect}")
-        raise ArgumentError, "Invalid date format: #{date_value.inspect}"
+        nil
       end
     rescue ArgumentError, TypeError => e
       Rails.logger.error("Failed to parse Enable Banking transaction date '#{date_value}': #{e.message}")
-      raise ArgumentError, "Unable to parse transaction date: #{date_value.inspect}"
+      nil
     end
 end

--- a/app/models/mercury_entry/processor.rb
+++ b/app/models/mercury_entry/processor.rb
@@ -162,7 +162,13 @@ class MercuryEntry::Processor
       selected = Provider::BankEntryDate.select([
         [ "postedAt", parse_provider_date(data[:postedAt]) ],
         [ "createdAt", parse_provider_date(data[:createdAt]) ]
-      ], as_of: Provider::BankEntryDate.family_today(account&.family))
+      ],
+        as_of: Provider::BankEntryDate.family_today(account&.family),
+        existing_date: Provider::BankEntryDate.existing_entry_date(
+          account: account,
+          external_id: external_id,
+          source: "mercury"
+        ))
 
       return selected if selected
 

--- a/app/models/mercury_entry/processor.rb
+++ b/app/models/mercury_entry/processor.rb
@@ -119,6 +119,10 @@ class MercuryEntry::Processor
       meta = { "pending" => pending? }
       meta["kind"]           = data[:kind] if data[:kind].present?
       meta["counterparty_id"] = data[:counterpartyId] if data[:counterpartyId].present?
+      meta.merge!(Provider::BankEntryDate.provenance([
+        [ :postedAt, data[:postedAt] ],
+        [ :createdAt, data[:createdAt] ]
+      ]))
       { "mercury" => meta }
     end
 
@@ -153,8 +157,21 @@ class MercuryEntry::Processor
     end
 
     def date
-      # Mercury provides createdAt and postedAt - use postedAt if available, otherwise createdAt
-      date_value = data[:postedAt].presence || data[:createdAt].presence
+      # Prefer postedAt, fall back to createdAt — but avoid a future postedAt as
+      # entries.date when createdAt (or clamping) yields a non-future date (#2907).
+      selected = Provider::BankEntryDate.select([
+        [ "postedAt", parse_provider_date(data[:postedAt]) ],
+        [ "createdAt", parse_provider_date(data[:createdAt]) ]
+      ])
+
+      return selected if selected
+
+      Rails.logger.error("Mercury transaction has invalid date value: #{[ data[:postedAt], data[:createdAt] ].inspect}")
+      raise ArgumentError, "Invalid date format: #{[ data[:postedAt], data[:createdAt] ].inspect}"
+    end
+
+    def parse_provider_date(date_value)
+      return nil if date_value.blank?
 
       case date_value
       when String
@@ -170,11 +187,10 @@ class MercuryEntry::Processor
       when Date
         date_value
       else
-        Rails.logger.error("Mercury transaction has invalid date value: #{date_value.inspect}")
-        raise ArgumentError, "Invalid date format: #{date_value.inspect}"
+        nil
       end
     rescue ArgumentError, TypeError => e
       Rails.logger.error("Failed to parse Mercury transaction date '#{date_value}': #{e.message}")
-      raise ArgumentError, "Unable to parse transaction date: #{date_value.inspect}"
+      nil
     end
 end

--- a/app/models/mercury_entry/processor.rb
+++ b/app/models/mercury_entry/processor.rb
@@ -162,7 +162,7 @@ class MercuryEntry::Processor
       selected = Provider::BankEntryDate.select([
         [ "postedAt", parse_provider_date(data[:postedAt]) ],
         [ "createdAt", parse_provider_date(data[:createdAt]) ]
-      ])
+      ], as_of: Provider::BankEntryDate.family_today(account&.family))
 
       return selected if selected
 

--- a/app/models/plaid_entry/processor.rb
+++ b/app/models/plaid_entry/processor.rb
@@ -67,7 +67,13 @@ class PlaidEntry::Processor
         [ "authorized_date", parse_provider_date(plaid_transaction["authorized_date"]) ],
         [ "datetime", parse_provider_date(plaid_transaction["datetime"]) ],
         [ "authorized_datetime", parse_provider_date(plaid_transaction["authorized_datetime"]) ]
-      ], as_of: Provider::BankEntryDate.family_today(account&.family))
+      ],
+        as_of: Provider::BankEntryDate.family_today(account&.family),
+        existing_date: Provider::BankEntryDate.existing_entry_date(
+          account: account,
+          external_id: external_id,
+          source: "plaid"
+        ))
 
       return selected if selected
 

--- a/app/models/plaid_entry/processor.rb
+++ b/app/models/plaid_entry/processor.rb
@@ -20,8 +20,14 @@ class PlaidEntry::Processor
       extra: {
         plaid: {
           pending: plaid_transaction["pending"],
-          pending_transaction_id: pending_transaction_id # Also store for reference
-        }
+          pending_transaction_id: pending_transaction_id, # Also store for reference
+          **Provider::BankEntryDate.provenance([
+            [ :date, plaid_transaction["date"] ],
+            [ :authorized_date, plaid_transaction["authorized_date"] ],
+            [ :datetime, plaid_transaction["datetime"] ],
+            [ :authorized_datetime, plaid_transaction["authorized_datetime"] ]
+          ])
+        }.compact
       }
     )
   end
@@ -53,8 +59,40 @@ class PlaidEntry::Processor
       plaid_transaction["iso_currency_code"]
     end
 
+    # Prefer Plaid's posted `date`, then authorized/datetime fields when needed to
+    # avoid a future display date (#2907).
     def date
-      plaid_transaction["date"]
+      selected = Provider::BankEntryDate.select([
+        [ "date", parse_provider_date(plaid_transaction["date"]) ],
+        [ "authorized_date", parse_provider_date(plaid_transaction["authorized_date"]) ],
+        [ "datetime", parse_provider_date(plaid_transaction["datetime"]) ],
+        [ "authorized_datetime", parse_provider_date(plaid_transaction["authorized_datetime"]) ]
+      ])
+
+      return selected if selected
+
+      raise ArgumentError, "Invalid date format: #{plaid_transaction["date"].inspect}"
+    end
+
+    def parse_provider_date(date_value)
+      return nil if date_value.blank?
+
+      case date_value
+      when String
+        if date_value.include?("T") || date_value.include?(":")
+          Time.parse(date_value).in_time_zone(account&.family&.timezone).to_date
+        else
+          Date.parse(date_value)
+        end
+      when Time, DateTime, ActiveSupport::TimeWithZone
+        date_value.in_time_zone(account&.family&.timezone).to_date
+      when Date
+        date_value
+      else
+        nil
+      end
+    rescue ArgumentError, TypeError
+      nil
     end
 
     # Plaid provides this linking ID when a posted transaction matches a pending one

--- a/app/models/plaid_entry/processor.rb
+++ b/app/models/plaid_entry/processor.rb
@@ -67,7 +67,7 @@ class PlaidEntry::Processor
         [ "authorized_date", parse_provider_date(plaid_transaction["authorized_date"]) ],
         [ "datetime", parse_provider_date(plaid_transaction["datetime"]) ],
         [ "authorized_datetime", parse_provider_date(plaid_transaction["authorized_datetime"]) ]
-      ])
+      ], as_of: Provider::BankEntryDate.family_today(account&.family))
 
       return selected if selected
 

--- a/app/models/provider/bank_entry_date.rb
+++ b/app/models/provider/bank_entry_date.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Selects the user-facing `entries.date` for bank/provider transaction imports.
+#
+# Provider booking/posting/settlement fields are provenance — they should live
+# in `transaction.extra[source]` — and must not always become the Sure entry date
+# when they fall in the future (see #2907).
+#
+# Preference order is caller-defined. Among present Date values, the first that
+# is on or before `as_of` wins. If every candidate is in the future, clamp to
+# `as_of` so activity/budgets/transfer matching stay current. Investment
+# processors should not use this helper blindly (future settlement can be valid).
+class Provider::BankEntryDate
+  def self.select(candidates, as_of: Date.current)
+    dates = Array(candidates).filter_map do |candidate|
+      date = candidate.is_a?(Array) ? candidate.last : candidate
+      date if date.is_a?(Date)
+    end
+
+    return nil if dates.empty?
+
+    dates.find { |date| date <= as_of } || as_of
+  end
+
+  # Compact string provenance for nesting under transaction.extra[source].
+  # Accepts [[key, raw_or_date], ...] and skips blanks.
+  def self.provenance(fields)
+    Array(fields).each_with_object({}) do |(key, value), hash|
+      next if value.blank?
+
+      hash[key.to_s] = value.respond_to?(:iso8601) ? value.iso8601 : value.to_s
+    end
+  end
+end

--- a/app/models/provider/bank_entry_date.rb
+++ b/app/models/provider/bank_entry_date.rb
@@ -8,9 +8,15 @@
 #
 # Preference order is caller-defined. Among present Date values, the first that
 # is on or before `as_of` wins. If every candidate is in the future, clamp to
-# `as_of` so activity/budgets/transfer matching stay current. Investment
-# processors should not use this helper blindly (future settlement can be valid).
+# `as_of` so activity/budgets/transfer matching stay current. Pass
+# `as_of: family_today(family)` so "future" is judged in the family's timezone,
+# not the server/UTC calendar date. Investment processors should not use this
+# helper blindly (future settlement can be valid).
 class Provider::BankEntryDate
+  def self.family_today(family = nil)
+    Time.current.in_time_zone(family&.timezone).to_date
+  end
+
   def self.select(candidates, as_of: Date.current)
     dates = Array(candidates).filter_map do |candidate|
       date = candidate.is_a?(Array) ? candidate.last : candidate

--- a/app/models/provider/bank_entry_date.rb
+++ b/app/models/provider/bank_entry_date.rb
@@ -8,16 +8,24 @@
 #
 # Preference order is caller-defined. Among present Date values, the first that
 # is on or before `as_of` wins. If every candidate is in the future, clamp to
-# `as_of` so activity/budgets/transfer matching stay current. Pass
-# `as_of: family_today(family)` so "future" is judged in the family's timezone,
-# not the server/UTC calendar date. Investment processors should not use this
-# helper blindly (future settlement can be valid).
+# `as_of` on first import so activity/budgets/transfer matching stay current.
+# On resync, pass `existing_date:` so a still-all-future payload does not advance
+# the clamped date day-by-day; once a real ≤-as_of candidate appears, it wins.
+# Pass `as_of: family_today(family)` so "future" is judged in the family's
+# timezone, not the server/UTC calendar date. Investment processors should not
+# use this helper blindly (future settlement can be valid).
 class Provider::BankEntryDate
   def self.family_today(family = nil)
     Time.current.in_time_zone(family&.timezone).to_date
   end
 
-  def self.select(candidates, as_of: Date.current)
+  def self.existing_entry_date(account:, external_id:, source:)
+    return nil if account.nil? || external_id.blank? || source.blank?
+
+    account.entries.where(external_id: external_id, source: source).pick(:date)
+  end
+
+  def self.select(candidates, as_of: Date.current, existing_date: nil)
     dates = Array(candidates).filter_map do |candidate|
       date = candidate.is_a?(Array) ? candidate.last : candidate
       date if date.is_a?(Date)
@@ -25,7 +33,8 @@ class Provider::BankEntryDate
 
     return nil if dates.empty?
 
-    dates.find { |date| date <= as_of } || as_of
+    dates.find { |date| date <= as_of } ||
+      (existing_date.is_a?(Date) && existing_date <= as_of ? existing_date : as_of)
   end
 
   # Compact string provenance for nesting under transaction.extra[source].

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -179,7 +179,10 @@ class SimplefinEntry::Processor
         [ [ "posted", posted_date ], [ "transacted_at", transacted_date ] ]
       end
 
-      selected = Provider::BankEntryDate.select(candidates)
+      selected = Provider::BankEntryDate.select(
+        candidates,
+        as_of: Provider::BankEntryDate.family_today(account&.family)
+      )
       return selected if selected
 
       Rails.logger.error("SimpleFin transaction missing posted/transacted date: #{data.inspect}")

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -181,7 +181,12 @@ class SimplefinEntry::Processor
 
       selected = Provider::BankEntryDate.select(
         candidates,
-        as_of: Provider::BankEntryDate.family_today(account&.family)
+        as_of: Provider::BankEntryDate.family_today(account&.family),
+        existing_date: Provider::BankEntryDate.existing_entry_date(
+          account: account,
+          external_id: external_id,
+          source: "simplefin"
+        )
       )
       return selected if selected
 

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -84,6 +84,11 @@ class SimplefinEntry::Processor
         sf["pending"] = false
       end
 
+      sf.merge!(Provider::BankEntryDate.provenance([
+        [ :posted, data[:posted] ],
+        [ :transacted_at, data[:transacted_at] ]
+      ]))
+
       # FX metadata: when tx currency differs from account currency
       tx_currency = parse_currency(data[:currency])
       acct_currency = account.currency
@@ -164,21 +169,19 @@ class SimplefinEntry::Processor
     # UI/entry date selection by account type:
     # - Credit cards/loans: prefer transaction date (matches statements), then posted
     # - Others: prefer posted date, then transaction date
-    # Epochs parsed as UTC timestamps via DateUtils
+    # Epochs parsed as UTC timestamps via DateUtils. A future preferred date falls
+    # back to the next non-future candidate (or clamps to today) per #2907.
     def date
-      # Prefer transaction date for revolving debt (credit cards/loans); otherwise prefer posted date
       acct_type = simplefin_account&.account_type.to_s.strip.downcase.tr(" ", "_")
-      if %w[credit_card credit loan mortgage].include?(acct_type)
-        t = transacted_date
-        return t if t
-        p = posted_date
-        return p if p
+      candidates = if %w[credit_card credit loan mortgage].include?(acct_type)
+        [ [ "transacted_at", transacted_date ], [ "posted", posted_date ] ]
       else
-        p = posted_date
-        return p if p
-        t = transacted_date
-        return t if t
+        [ [ "posted", posted_date ], [ "transacted_at", transacted_date ] ]
       end
+
+      selected = Provider::BankEntryDate.select(candidates)
+      return selected if selected
+
       Rails.logger.error("SimpleFin transaction missing posted/transacted date: #{data.inspect}")
       raise ArgumentError, "Invalid date format: #{data[:posted].inspect} / #{data[:transacted_at].inspect}"
     end

--- a/docs/api/rails_provider_generator.md
+++ b/docs/api/rails_provider_generator.md
@@ -599,6 +599,16 @@ end
 
 After generation, you'll typically want to customize three files:
 
+### Bank transaction dates (important)
+
+Generated bank `Transactions::Processor` classes use `Provider::BankEntryDate` to:
+
+1. Parse provider date candidates separately (`transaction_date`, `authorized_date`, `initiated_at`, `posted_at`/`posted_date`, `booking_date`, `date`)
+2. Choose `entries.date` from the first non-future candidate in preference order (clamp to today if every candidate is future)
+3. Store raw provider dates under `transaction.extra["<provider>"]` for provenance
+
+Reorder the candidate list to match your provider’s preferred display date. Do **not** apply this banking clamp to investment activity processors — prefer `trade_date` for display and leave future `settlement_date` values unclamped (store both when available).
+
 ### 1. Customize the Adapter
 
 Implement the `build_provider` method in `app/models/provider/my_bank_adapter.rb`:

--- a/docs/api/rails_provider_generator.md
+++ b/docs/api/rails_provider_generator.md
@@ -604,8 +604,9 @@ After generation, you'll typically want to customize three files:
 Generated bank `Transactions::Processor` classes use `Provider::BankEntryDate` to:
 
 1. Parse provider date candidates separately (`transaction_date`, `authorized_date`, `initiated_at`, `posted_at`/`posted_date`, `booking_date`, `date`)
-2. Choose `entries.date` from the first non-future candidate in preference order (clamp to family-local today via `as_of: Provider::BankEntryDate.family_today(account&.family)` if every candidate is future)
-3. Store raw provider dates under `transaction.extra["<provider>"]` for provenance
+2. Choose `entries.date` from the first non-future candidate in preference order (clamp to family-local today via `as_of: Provider::BankEntryDate.family_today(account&.family)` if every candidate is future on first import)
+3. On resync, pass `existing_date: Provider::BankEntryDate.existing_entry_date(...)` so an all-future payload does not advance the clamped date day-by-day; once a real ≤-as_of candidate appears, it wins
+4. Store raw provider dates under `transaction.extra["<provider>"]` for provenance
 
 Reorder the candidate list to match your provider’s preferred display date. Do **not** apply this banking clamp to investment activity processors — prefer `trade_date` for display and leave future `settlement_date` values unclamped. Pass raw `trade_date` / `settlement_date` via `extra:` on both `import_trade` and `import_transaction` so provenance survives while `entries.date` stays the selected display date.
 

--- a/docs/api/rails_provider_generator.md
+++ b/docs/api/rails_provider_generator.md
@@ -604,7 +604,7 @@ After generation, you'll typically want to customize three files:
 Generated bank `Transactions::Processor` classes use `Provider::BankEntryDate` to:
 
 1. Parse provider date candidates separately (`transaction_date`, `authorized_date`, `initiated_at`, `posted_at`/`posted_date`, `booking_date`, `date`)
-2. Choose `entries.date` from the first non-future candidate in preference order (clamp to today if every candidate is future)
+2. Choose `entries.date` from the first non-future candidate in preference order (clamp to family-local today via `as_of: Provider::BankEntryDate.family_today(account&.family)` if every candidate is future)
 3. Store raw provider dates under `transaction.extra["<provider>"]` for provenance
 
 Reorder the candidate list to match your provider’s preferred display date. Do **not** apply this banking clamp to investment activity processors — prefer `trade_date` for display and leave future `settlement_date` values unclamped. Pass raw `trade_date` / `settlement_date` via `extra:` on both `import_trade` and `import_transaction` so provenance survives while `entries.date` stays the selected display date.

--- a/docs/api/rails_provider_generator.md
+++ b/docs/api/rails_provider_generator.md
@@ -607,7 +607,7 @@ Generated bank `Transactions::Processor` classes use `Provider::BankEntryDate` t
 2. Choose `entries.date` from the first non-future candidate in preference order (clamp to today if every candidate is future)
 3. Store raw provider dates under `transaction.extra["<provider>"]` for provenance
 
-Reorder the candidate list to match your provider’s preferred display date. Do **not** apply this banking clamp to investment activity processors — prefer `trade_date` for display and leave future `settlement_date` values unclamped (store both when available).
+Reorder the candidate list to match your provider’s preferred display date. Do **not** apply this banking clamp to investment activity processors — prefer `trade_date` for display and leave future `settlement_date` values unclamped. Pass raw `trade_date` / `settlement_date` via `extra:` on both `import_trade` and `import_transaction` so provenance survives while `entries.date` stays the selected display date.
 
 ### 1. Customize the Adapter
 

--- a/lib/generators/provider/family/templates/activities_processor.rb.tt
+++ b/lib/generators/provider/family/templates/activities_processor.rb.tt
@@ -141,6 +141,13 @@ class <%= class_name %>Account::ActivitiesProcessor
 
       currency = extract_currency(data, fallback: account.currency)
       description = data[:description] || "#{activity_type} #{ticker}"
+      date_provenance = {
+        "<%= file_name %>" => Provider::BankEntryDate.provenance([
+          [ :trade_date, data[:trade_date] ],
+          [ :settlement_date, data[:settlement_date] ],
+          [ :date, data[:date] ]
+        ])
+      }
 
       Rails.logger.info "<%= class_name %>Account::ActivitiesProcessor - Importing trade: #{ticker} qty=#{quantity} price=#{price} date=#{activity_date}"
 
@@ -154,7 +161,8 @@ class <%= class_name %>Account::ActivitiesProcessor
         date: activity_date,
         name: description,
         source: "<%= file_name %>",
-        activity_label: label_from_type(activity_type)
+        activity_label: label_from_type(activity_type),
+        extra: date_provenance
       )
       @trades_count += 1 if result
     end
@@ -182,6 +190,13 @@ class <%= class_name %>Account::ActivitiesProcessor
       amount = normalize_cash_amount(amount, activity_type)
 
       currency = extract_currency(data, fallback: account.currency)
+      date_provenance = {
+        "<%= file_name %>" => Provider::BankEntryDate.provenance([
+          [ :trade_date, data[:trade_date] ],
+          [ :settlement_date, data[:settlement_date] ],
+          [ :date, data[:date] ]
+        ])
+      }
 
       Rails.logger.info "<%= class_name %>Account::ActivitiesProcessor - Importing cash activity: type=#{activity_type} amount=#{amount} date=#{activity_date}"
 
@@ -192,7 +207,8 @@ class <%= class_name %>Account::ActivitiesProcessor
         date: activity_date,
         name: description,
         source: "<%= file_name %>",
-        investment_activity_label: label_from_type(activity_type)
+        investment_activity_label: label_from_type(activity_type),
+        extra: date_provenance
       )
       @transactions_count += 1 if result
     end

--- a/lib/generators/provider/family/templates/activities_processor.rb.tt
+++ b/lib/generators/provider/family/templates/activities_processor.rb.tt
@@ -129,10 +129,13 @@ class <%= class_name %>Account::ActivitiesProcessor
         return
       end
 
-      # Get the activity date
-      # TODO: Customize date field names
-      activity_date = parse_date(data[:settlement_date], family: account&.family) ||
-                      parse_date(data[:trade_date], family: account&.family) ||
+      # Activity dates: prefer trade_date for display when available; preserve
+      # settlement_date as provenance. Do NOT clamp future settlement dates —
+      # investment settlement in the future can be legitimate (#2907).
+      trade_date = parse_date(data[:trade_date], family: account&.family)
+      settlement_date = parse_date(data[:settlement_date], family: account&.family)
+      activity_date = trade_date ||
+                      settlement_date ||
                       parse_date(data[:date], family: account&.family) ||
                       Date.current
 
@@ -163,10 +166,11 @@ class <%= class_name %>Account::ActivitiesProcessor
       return if amount.nil?
       # Note: Zero-amount transactions (splits, free shares) are allowed
 
-      # Get the activity date
-      # TODO: Customize date field names
-      activity_date = parse_date(data[:settlement_date], family: account&.family) ||
-                      parse_date(data[:trade_date], family: account&.family) ||
+      # Prefer trade_date for display; keep settlement_date unclamped (#2907).
+      trade_date = parse_date(data[:trade_date], family: account&.family)
+      settlement_date = parse_date(data[:settlement_date], family: account&.family)
+      activity_date = trade_date ||
+                      settlement_date ||
                       parse_date(data[:date], family: account&.family) ||
                       Date.current
 

--- a/lib/generators/provider/family/templates/transactions_processor.rb.tt
+++ b/lib/generators/provider/family/templates/transactions_processor.rb.tt
@@ -108,7 +108,10 @@ class <%= class_name %>Account::Transactions::Processor
         [ "date", parse_date(data[:date], family: account&.family) ]
       ]
       # TODO: Reorder candidates to match your provider's preferred display date
-      date = Provider::BankEntryDate.select(date_candidates)
+      date = Provider::BankEntryDate.select(
+        date_candidates,
+        as_of: Provider::BankEntryDate.family_today(account&.family)
+      )
       return nil if date.nil?
 
       name = data[:name] || data[:description] || data[:merchant_name] || "Transaction"

--- a/lib/generators/provider/family/templates/transactions_processor.rb.tt
+++ b/lib/generators/provider/family/templates/transactions_processor.rb.tt
@@ -95,8 +95,20 @@ class <%= class_name %>Account::Transactions::Processor
       amount = parse_transaction_amount(data)
       return nil if amount.nil?
 
-      # TODO: Customize date field names based on your provider
-      date = parse_date(data[:date] || data[:transaction_date] || data[:posted_at], family: account&.family)
+      # Parse provider date candidates separately. Store all raw dates in
+      # transaction.extra for provenance; choose entries.date from the best
+      # non-future bank date (do not blindly use a future booking/posted date).
+      # See Provider::BankEntryDate and issue #2907.
+      date_candidates = [
+        [ "transaction_date", parse_date(data[:transaction_date], family: account&.family) ],
+        [ "authorized_date", parse_date(data[:authorized_date], family: account&.family) ],
+        [ "initiated_at", parse_date(data[:initiated_at], family: account&.family) ],
+        [ "posted_at", parse_date(data[:posted_at] || data[:posted_date], family: account&.family) ],
+        [ "booking_date", parse_date(data[:booking_date], family: account&.family) ],
+        [ "date", parse_date(data[:date], family: account&.family) ]
+      ]
+      # TODO: Reorder candidates to match your provider's preferred display date
+      date = Provider::BankEntryDate.select(date_candidates)
       return nil if date.nil?
 
       name = data[:name] || data[:description] || data[:merchant_name] || "Transaction"
@@ -141,7 +153,16 @@ class <%= class_name %>Account::Transactions::Processor
           "pending" => data[:pending] || data[:is_pending],
           "merchant" => data[:merchant] || data[:merchant_name],
           "category" => data[:category]
-        }.compact
+        }.compact.merge(
+          Provider::BankEntryDate.provenance([
+            [ :transaction_date, data[:transaction_date] ],
+            [ :authorized_date, data[:authorized_date] ],
+            [ :initiated_at, data[:initiated_at] ],
+            [ :posted_at, data[:posted_at] || data[:posted_date] ],
+            [ :booking_date, data[:booking_date] ],
+            [ :date, data[:date] ]
+          ])
+        )
       }
     end
 end

--- a/lib/generators/provider/family/templates/transactions_processor.rb.tt
+++ b/lib/generators/provider/family/templates/transactions_processor.rb.tt
@@ -110,7 +110,12 @@ class <%= class_name %>Account::Transactions::Processor
       # TODO: Reorder candidates to match your provider's preferred display date
       date = Provider::BankEntryDate.select(
         date_candidates,
-        as_of: Provider::BankEntryDate.family_today(account&.family)
+        as_of: Provider::BankEntryDate.family_today(account&.family),
+        existing_date: Provider::BankEntryDate.existing_entry_date(
+          account: account,
+          external_id: external_id,
+          source: "<%= file_name %>"
+        )
       )
       return nil if date.nil?
 

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -351,9 +351,12 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
       }
     )
 
+    entry.reload
+    trade = entry.entryable.reload
+
     assert_equal Date.new(2026, 8, 4), entry.date
-    assert_equal "2026-08-04", entry.entryable.extra.dig("example_broker", "trade_date")
-    assert_equal "2026-08-08", entry.entryable.extra.dig("example_broker", "settlement_date")
+    assert_equal "2026-08-04", trade.extra.dig("example_broker", "trade_date")
+    assert_equal "2026-08-08", trade.extra.dig("example_broker", "settlement_date")
   end
 
   test "raises error when security is missing for trade import" do

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -330,6 +330,32 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
     assert_equal 0.91, entry.entryable.exchange_rate
   end
 
+  test "imports trade with provider date provenance in extra" do
+    investment_account = accounts(:investment)
+    adapter = Account::ProviderImportAdapter.new(investment_account)
+    security = securities(:aapl)
+
+    entry = adapter.import_trade(
+      security: security,
+      quantity: 5,
+      price: 150.00,
+      amount: 750.00,
+      currency: "USD",
+      date: Date.new(2026, 8, 4),
+      source: "example_broker",
+      extra: {
+        "example_broker" => {
+          "trade_date" => "2026-08-04",
+          "settlement_date" => "2026-08-08"
+        }
+      }
+    )
+
+    assert_equal Date.new(2026, 8, 4), entry.date
+    assert_equal "2026-08-04", entry.entryable.extra.dig("example_broker", "trade_date")
+    assert_equal "2026-08-08", entry.entryable.extra.dig("example_broker", "settlement_date")
+  end
+
   test "raises error when security is missing for trade import" do
     exception = assert_raises(ArgumentError) do
       @adapter.import_trade(

--- a/test/models/brex_account/transactions/processor_test.rb
+++ b/test/models/brex_account/transactions/processor_test.rb
@@ -75,7 +75,7 @@ class BrexAccount::Transactions::ProcessorTest < ActiveSupport::TestCase
     assert_equal 1, result[:failed]
     assert_empty result[:skipped_transactions]
     assert_equal "tx_failure", result[:errors].first[:transaction_id]
-    assert_match(/Unable to parse transaction date/, result[:errors].first[:error])
+    assert_match(/Invalid date format/, result[:errors].first[:error])
   end
 
   private

--- a/test/models/brex_entry/processor_test.rb
+++ b/test/models/brex_entry/processor_test.rb
@@ -109,6 +109,38 @@ class BrexEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal "USD", entry.currency
   end
 
+  test "uses non-future initiated_at_date when posted_at_date is in the future" do
+    travel_to Date.new(2026, 8, 5) do
+      transaction = card_transaction(id: "tx_future_posted", amount: 12_34).merge(
+        posted_at_date: "2026-08-08",
+        initiated_at_date: "2026-08-04"
+      )
+
+      entry = BrexEntry::Processor.new(transaction, brex_account: @brex_account).process
+
+      assert_equal Date.new(2026, 8, 4), entry.date
+      assert_equal "2026-08-08", entry.transaction.extra.dig("brex", "posted_at_date")
+      assert_equal "2026-08-04", entry.transaction.extra.dig("brex", "initiated_at_date")
+    end
+  end
+
+  test "all-future date clamp stays put across daily resyncs" do
+    transaction = card_transaction(id: "tx_future_clamp", amount: 40_00).merge(
+      posted_at_date: "2026-08-10",
+      initiated_at_date: "2026-08-09"
+    )
+
+    travel_to Date.new(2026, 8, 5) do
+      entry = BrexEntry::Processor.new(transaction, brex_account: @brex_account).process
+      assert_equal Date.new(2026, 8, 5), entry.date
+    end
+
+    travel_to Date.new(2026, 8, 6) do
+      entry = BrexEntry::Processor.new(transaction, brex_account: @brex_account).process
+      assert_equal Date.new(2026, 8, 5), entry.date
+    end
+  end
+
   private
 
     def card_transaction(id: "tx_1", amount:, type: "CARD_EXPENSE")

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -518,4 +518,33 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal expected, EnableBankingEntry::Processor.compute_external_id(tx.merge(value_date: "2026-08-01"))
     refute_equal expected, EnableBankingEntry::Processor.compute_external_id(tx.merge(booking_date: "2026-08-09"))
   end
+
+  test "all-future booking clamp stays put across daily resyncs until a real date arrives" do
+    tx = {
+      transaction_id: "future_clamp_resync",
+      booking_date: "2026-08-10",
+      value_date: "2026-08-09",
+      transaction_amount: { amount: "40.00", currency: "EUR" },
+      creditor: { name: "Future Clamp Shop" },
+      credit_debit_indicator: "DBIT",
+      status: "BOOK"
+    }
+
+    travel_to Date.new(2026, 8, 5) do
+      result = EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+      assert_equal Date.new(2026, 8, 5), result.date
+    end
+
+    travel_to Date.new(2026, 8, 6) do
+      result = EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+      assert_equal Date.new(2026, 8, 5), result.date,
+        "clamped entries.date must not advance with each daily sync while booking stays future"
+    end
+
+    travel_to Date.new(2026, 8, 10) do
+      result = EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+      assert_equal Date.new(2026, 8, 10), result.date,
+        "once booking_date is on or before as_of, entries.date should adopt it"
+    end
+  end
 end

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -451,4 +451,44 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     assert_not_nil result
     assert_equal Date.new(2025, 7, 15), result.date
   end
+
+  test "uses non-future value_date when booking_date is in the future" do
+    travel_to Date.new(2026, 8, 5) do
+      tx = {
+        transaction_id: "future_booking_1",
+        booking_date: "2026-08-08",
+        value_date: "2026-08-04",
+        transaction_date: "2026-08-03",
+        transaction_amount: { amount: "25.00", currency: "EUR" },
+        creditor: { name: "Future Booked Shop" },
+        credit_debit_indicator: "DBIT",
+        status: "BOOK"
+      }
+
+      result = EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+
+      assert_not_nil result
+      assert_equal Date.new(2026, 8, 4), result.date
+      assert_equal "2026-08-08", result.entryable.extra.dig("enable_banking", "booking_date")
+      assert_equal "2026-08-04", result.entryable.extra.dig("enable_banking", "value_date")
+      assert_equal "2026-08-03", result.entryable.extra.dig("enable_banking", "transaction_date")
+    end
+  end
+
+  test "content-based external_id still fingerprints raw provider booking_date" do
+    tx = {
+      transaction_id: nil,
+      entry_reference: nil,
+      booking_date: "2026-08-08",
+      value_date: "2026-08-04",
+      transaction_amount: { amount: "11.00", currency: "EUR" },
+      credit_debit_indicator: "DBIT",
+      creditor: { name: "Fingerprint Shop" },
+      remittance_information: [ "idempotent" ]
+    }
+
+    expected = EnableBankingEntry::Processor.compute_external_id(tx)
+    assert_equal expected, EnableBankingEntry::Processor.compute_external_id(tx.merge(value_date: "2026-08-01"))
+    refute_equal expected, EnableBankingEntry::Processor.compute_external_id(tx.merge(booking_date: "2026-08-09"))
+  end
 end

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -266,7 +266,7 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal true, eb_extra["pending"]
   end
 
-  test "does not add enable_banking extra key when no extra data present" do
+  test "stores booking_date provenance when no other enable_banking extras present" do
     tx = {
       entry_reference: "ref_noextra",
       transaction_id: nil,
@@ -278,7 +278,9 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
 
     EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
     entry = @account.entries.find_by!(external_id: "enable_banking_ref_noextra")
-    assert_nil entry.transaction&.extra&.dig("enable_banking")
+    eb_extra = entry.transaction&.extra&.dig("enable_banking")
+
+    assert_equal({ "booking_date" => Date.current.to_s }, eb_extra)
   end
 
   def build_processor(data)

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -475,6 +475,31 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "uses family-local as_of near UTC midnight when booking_date is tomorrow locally" do
+    # 2026-08-05 02:00 UTC == 2026-08-04 19:00 PDT — UTC Date.current is Aug 5,
+    # but family-local "today" is still Aug 4, so booking_date Aug 5 is future.
+    @family.update!(timezone: "America/Los_Angeles")
+
+    travel_to Time.utc(2026, 8, 5, 2, 0, 0) do
+      tx = {
+        transaction_id: "tz_as_of_future_booking",
+        booking_date: "2026-08-05",
+        value_date: "2026-08-04",
+        transaction_date: "2026-08-03",
+        transaction_amount: { amount: "25.00", currency: "EUR" },
+        creditor: { name: "Near Midnight Shop" },
+        credit_debit_indicator: "DBIT",
+        status: "BOOK"
+      }
+
+      result = EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+
+      assert_not_nil result
+      assert_equal Date.new(2026, 8, 4), result.date
+      assert_equal "2026-08-05", result.entryable.extra.dig("enable_banking", "booking_date")
+    end
+  end
+
   test "content-based external_id still fingerprints raw provider booking_date" do
     tx = {
       transaction_id: nil,

--- a/test/models/mercury_entry/processor_test.rb
+++ b/test/models/mercury_entry/processor_test.rb
@@ -78,6 +78,39 @@ class MercuryEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal Date.new(2024, 3, 10), @account.entries.last.date
   end
 
+  test "uses non-future createdAt when postedAt is in the future" do
+    travel_to Date.new(2026, 8, 5) do
+      process(tx(
+        id: "tx_future_posted",
+        posted_at: "2026-08-08",
+        created_at: "2026-08-04"
+      ))
+
+      entry = @account.entries.find_by!(external_id: "mercury_tx_future_posted", source: "mercury")
+      assert_equal Date.new(2026, 8, 4), entry.date
+      assert_equal "2026-08-08", entry.transaction.extra.dig("mercury", "postedAt")
+      assert_equal "2026-08-04", entry.transaction.extra.dig("mercury", "createdAt")
+    end
+  end
+
+  test "all-future date clamp stays put across daily resyncs" do
+    payload = tx(
+      id: "tx_future_clamp",
+      posted_at: "2026-08-10",
+      created_at: "2026-08-09"
+    )
+
+    travel_to Date.new(2026, 8, 5) do
+      process(payload)
+      assert_equal Date.new(2026, 8, 5), @account.entries.find_by!(external_id: "mercury_tx_future_clamp").date
+    end
+
+    travel_to Date.new(2026, 8, 6) do
+      process(payload)
+      assert_equal Date.new(2026, 8, 5), @account.entries.find_by!(external_id: "mercury_tx_future_clamp").date
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # notes
   # ---------------------------------------------------------------------------

--- a/test/models/plaid_entry/processor_test.rb
+++ b/test/models/plaid_entry/processor_test.rb
@@ -120,4 +120,60 @@ class PlaidEntry::ProcessorTest < ActiveSupport::TestCase
     entry = Entry.order(created_at: :desc).first
     assert_nil entry.transaction.category_id
   end
+
+  test "uses non-future authorized_date when posted date is in the future" do
+    travel_to Date.new(2026, 8, 5) do
+      plaid_transaction = {
+        "transaction_id" => "plaid_future_posted",
+        "merchant_name" => "Future Shop",
+        "amount" => 25,
+        "date" => "2026-08-08",
+        "authorized_date" => "2026-08-04",
+        "iso_currency_code" => "USD"
+      }
+
+      @category_matcher.expects(:match).never
+
+      entry = PlaidEntry::Processor.new(
+        plaid_transaction,
+        plaid_account: @plaid_account,
+        category_matcher: @category_matcher
+      ).process
+
+      assert_equal Date.new(2026, 8, 4), entry.date
+      assert_equal "2026-08-08", entry.transaction.extra.dig("plaid", "date")
+      assert_equal "2026-08-04", entry.transaction.extra.dig("plaid", "authorized_date")
+    end
+  end
+
+  test "all-future date clamp stays put across daily resyncs" do
+    plaid_transaction = {
+      "transaction_id" => "plaid_future_clamp",
+      "merchant_name" => "Clamp Shop",
+      "amount" => 40,
+      "date" => "2026-08-10",
+      "authorized_date" => "2026-08-09",
+      "iso_currency_code" => "USD"
+    }
+
+    @category_matcher.stubs(:match).returns(nil)
+
+    travel_to Date.new(2026, 8, 5) do
+      entry = PlaidEntry::Processor.new(
+        plaid_transaction,
+        plaid_account: @plaid_account,
+        category_matcher: @category_matcher
+      ).process
+      assert_equal Date.new(2026, 8, 5), entry.date
+    end
+
+    travel_to Date.new(2026, 8, 6) do
+      entry = PlaidEntry::Processor.new(
+        plaid_transaction,
+        plaid_account: @plaid_account,
+        category_matcher: @category_matcher
+      ).process
+      assert_equal Date.new(2026, 8, 5), entry.date
+    end
+  end
 end

--- a/test/models/provider/bank_entry_date_test.rb
+++ b/test/models/provider/bank_entry_date_test.rb
@@ -62,4 +62,13 @@ class Provider::BankEntryDateTest < ActiveSupport::TestCase
       provenance
     )
   end
+
+  test "family_today uses family timezone near UTC midnight" do
+    family = OpenStruct.new(timezone: "America/Los_Angeles")
+
+    travel_to Time.utc(2026, 8, 5, 2, 0, 0) do
+      assert_equal Date.new(2026, 8, 5), Time.now.utc.to_date
+      assert_equal Date.new(2026, 8, 4), Provider::BankEntryDate.family_today(family)
+    end
+  end
 end

--- a/test/models/provider/bank_entry_date_test.rb
+++ b/test/models/provider/bank_entry_date_test.rb
@@ -43,6 +43,35 @@ class Provider::BankEntryDateTest < ActiveSupport::TestCase
     assert_equal as_of, selected
   end
 
+  test "preserves existing clamped date when every candidate is still in the future" do
+    as_of = Date.new(2026, 8, 6)
+    existing = Date.new(2026, 8, 5)
+    selected = Provider::BankEntryDate.select(
+      [
+        [ "booking_date", Date.new(2026, 8, 9) ],
+        [ "value_date", Date.new(2026, 8, 8) ]
+      ],
+      as_of: as_of,
+      existing_date: existing
+    )
+
+    assert_equal existing, selected
+  end
+
+  test "updates from existing clamp once a non-future candidate appears" do
+    as_of = Date.new(2026, 8, 8)
+    selected = Provider::BankEntryDate.select(
+      [
+        [ "booking_date", Date.new(2026, 8, 8) ],
+        [ "value_date", Date.new(2026, 8, 4) ]
+      ],
+      as_of: as_of,
+      existing_date: Date.new(2026, 8, 5)
+    )
+
+    assert_equal Date.new(2026, 8, 8), selected
+  end
+
   test "returns nil when no date candidates are present" do
     assert_nil Provider::BankEntryDate.select([ [ "booking_date", nil ], [ "value_date", nil ] ])
   end

--- a/test/models/provider/bank_entry_date_test.rb
+++ b/test/models/provider/bank_entry_date_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Provider::BankEntryDateTest < ActiveSupport::TestCase
+  test "prefers first non-future candidate in order" do
+    as_of = Date.new(2026, 8, 5)
+    selected = Provider::BankEntryDate.select(
+      [
+        [ "booking_date", Date.new(2026, 8, 7) ],
+        [ "value_date", Date.new(2026, 8, 4) ],
+        [ "transaction_date", Date.new(2026, 8, 3) ]
+      ],
+      as_of: as_of
+    )
+
+    assert_equal Date.new(2026, 8, 4), selected
+  end
+
+  test "keeps preferred date when it is not in the future" do
+    as_of = Date.new(2026, 8, 5)
+    selected = Provider::BankEntryDate.select(
+      [
+        [ "booking_date", Date.new(2026, 8, 5) ],
+        [ "value_date", Date.new(2026, 8, 1) ]
+      ],
+      as_of: as_of
+    )
+
+    assert_equal Date.new(2026, 8, 5), selected
+  end
+
+  test "clamps to as_of when every candidate is in the future" do
+    as_of = Date.new(2026, 8, 5)
+    selected = Provider::BankEntryDate.select(
+      [
+        [ "booking_date", Date.new(2026, 8, 9) ],
+        [ "value_date", Date.new(2026, 8, 8) ]
+      ],
+      as_of: as_of
+    )
+
+    assert_equal as_of, selected
+  end
+
+  test "returns nil when no date candidates are present" do
+    assert_nil Provider::BankEntryDate.select([ [ "booking_date", nil ], [ "value_date", nil ] ])
+  end
+
+  test "provenance stores compact string values" do
+    provenance = Provider::BankEntryDate.provenance(
+      [
+        [ :booking_date, Date.new(2026, 8, 7) ],
+        [ :value_date, "2026-08-04" ],
+        [ :transaction_date, nil ],
+        [ :posted_at, "" ]
+      ]
+    )
+
+    assert_equal(
+      { "booking_date" => "2026-08-07", "value_date" => "2026-08-04" },
+      provenance
+    )
+  end
+end

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -279,4 +279,49 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
     sf = entry.transaction.extra.fetch("simplefin")
     assert_equal false, sf["pending"], "expected a non-numeric posted value to not be inferred as pending"
   end
+
+  test "uses non-future transacted_at when posted is in the future" do
+    travel_to Date.new(2026, 8, 5) do
+      tx = {
+        id: "tx_future_posted",
+        amount: "-25.00",
+        currency: "USD",
+        payee: "Future Shop",
+        description: "Auth",
+        posted: "2026-08-08",
+        transacted_at: "2026-08-04"
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_future_posted", source: "simplefin")
+      assert_equal Date.new(2026, 8, 4), entry.date
+      assert_equal "2026-08-08", entry.transaction.extra.dig("simplefin", "posted")
+      assert_equal "2026-08-04", entry.transaction.extra.dig("simplefin", "transacted_at")
+    end
+  end
+
+  test "all-future date clamp stays put across daily resyncs" do
+    tx = {
+      id: "tx_future_clamp",
+      amount: "-40.00",
+      currency: "USD",
+      payee: "Clamp Shop",
+      description: "Hold",
+      posted: "2026-08-10",
+      transacted_at: "2026-08-09"
+    }
+
+    travel_to Date.new(2026, 8, 5) do
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+      assert_equal Date.new(2026, 8, 5),
+        @account.entries.find_by!(external_id: "simplefin_tx_future_clamp").date
+    end
+
+    travel_to Date.new(2026, 8, 6) do
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+      assert_equal Date.new(2026, 8, 5),
+        @account.entries.find_by!(external_id: "simplefin_tx_future_clamp").date
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `Provider::BankEntryDate` to choose a non-future `entries.date` while storing raw provider booking/posted/authorized dates in `transaction.extra[source]`.
- Updates the family provider generator (bank transactions + investment activity guidance) and docs so new providers follow the pattern by default.
- Retrofits high/medium-priority bank processors: Enable Banking, Brex, Mercury, SimpleFIN, and Plaid.
- Enable Banking content-based external IDs still fingerprint raw provider dates (idempotency preserved).
- Investment processors are intentionally not clamped (future settlement can be legitimate); generator now prefers `trade_date` for display.

Closes #2907

## Test plan
- [ ] `bin/rails test test/models/provider/bank_entry_date_test.rb test/models/enable_banking_entry/processor_test.rb`
- [ ] Confirm Enable Banking fixture with future `booking_date` + past `value_date` lands on the non-future entry date and keeps all three dates in `extra["enable_banking"]`
- [ ] Spot-check Brex/Mercury/SimpleFIN/Plaid imports still sync and pending→posted reconciliation still works
- [ ] Generate a sample family provider and confirm transaction processor uses `Provider::BankEntryDate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transaction date selection across providers using valid, non-future dates and reliable fallbacks.
  * Added date provenance and raw provider date details to transaction and trade metadata.
  * Enhanced trade and cash activity date handling, including trade and settlement-date tracking.
  * Preserved account-specific date ordering and timezone-aware handling during imports.

* **Bug Fixes**
  * Invalid, missing, or future dates now fall back safely without unnecessary processing failures.

* **Documentation**
  * Documented date precedence, fallback behavior, future-date handling, and provenance metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->