### PR TITLE
Add tags support for transfer transactions

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -89,7 +89,10 @@ class TransfersController < ApplicationController
 
   def update_tags
     outflow_account = @transfer.outflow_transaction.entry.account
-    return unless require_account_permission!(outflow_account, redirect_path: transactions_url)
+    inflow_account = @transfer.inflow_transaction.entry.account
+
+    return unless require_account_permission!(outflow_account, :annotate, redirect_path: transactions_url)
+    return unless require_account_permission!(inflow_account, :annotate, redirect_path: transactions_url)
 
     resolved_ids = Current.family.tags.where(id: Array(params[:tag_ids]).reject(&:blank?)).pluck(:id)
 

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -59,12 +59,14 @@ class TransfersController < ApplicationController
     end
   rescue Money::ConversionError
     @transfer ||= Transfer.new
+    @transfer.tag_ids = transfer_params[:tag_ids]
     @transfer.errors.add(:base, "Exchange rate unavailable for selected currencies and date")
     set_accounts
     @tags = Current.family.tags.alphabetically
     render :new, status: :unprocessable_entity
   rescue ArgumentError
     @transfer ||= Transfer.new
+    @transfer.tag_ids = transfer_params[:tag_ids]
     @transfer.errors.add(:date, "is invalid")
     set_accounts
     @tags = Current.family.tags.alphabetically

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -60,14 +60,14 @@ class TransfersController < ApplicationController
   rescue Money::ConversionError
     @transfer ||= Transfer.new
     @transfer.tag_ids = transfer_params[:tag_ids]
-    @transfer.errors.add(:base, "Exchange rate unavailable for selected currencies and date")
+    @transfer.errors.add(:base, t(".exchange_rate_unavailable"))
     set_accounts
     @tags = Current.family.tags.alphabetically
     render :new, status: :unprocessable_entity
   rescue ArgumentError
     @transfer ||= Transfer.new
     @transfer.tag_ids = transfer_params[:tag_ids]
-    @transfer.errors.add(:date, "is invalid")
+    @transfer.errors.add(:date, t(".date_invalid"))
     set_accounts
     @tags = Current.family.tags.alphabetically
     render :new, status: :unprocessable_entity

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -1,16 +1,18 @@
 class TransfersController < ApplicationController
   include StreamExtensions
 
-  before_action :set_transfer, only: %i[show destroy update mark_as_recurring]
+  before_action :set_transfer, only: %i[show destroy update update_tags mark_as_recurring]
   before_action :set_accounts, only: %i[new create]
 
   def new
     @transfer = Transfer.new
     @from_account_id = params[:from_account_id]
+    @tags = Current.family.tags.alphabetically
   end
 
   def show
     @categories = Current.family.categories.alphabetically
+    @tags = Current.family.tags.alphabetically
 
     # Whether the current user can hit `mark_as_recurring`: feature flag on,
     # AND they have write access to BOTH transfer endpoints. Gating the
@@ -40,7 +42,8 @@ class TransfersController < ApplicationController
       amount: transfer_params[:amount].to_d,
       exchange_rate: transfer_params[:exchange_rate].presence&.to_d,
       source_fee_amount: transfer_params[:source_fee_amount],
-      destination_fee_amount: transfer_params[:destination_fee_amount]
+      destination_fee_amount: transfer_params[:destination_fee_amount],
+      tag_ids: transfer_params[:tag_ids]
     ).create
 
     if @transfer.persisted?
@@ -51,17 +54,20 @@ class TransfersController < ApplicationController
       end
     else
       @from_account_id = transfer_params[:from_account_id]
+      @tags = Current.family.tags.alphabetically
       render :new, status: :unprocessable_entity
     end
   rescue Money::ConversionError
     @transfer ||= Transfer.new
     @transfer.errors.add(:base, "Exchange rate unavailable for selected currencies and date")
     set_accounts
+    @tags = Current.family.tags.alphabetically
     render :new, status: :unprocessable_entity
   rescue ArgumentError
     @transfer ||= Transfer.new
     @transfer.errors.add(:date, "is invalid")
     set_accounts
+    @tags = Current.family.tags.alphabetically
     render :new, status: :unprocessable_entity
   end
 
@@ -79,6 +85,22 @@ class TransfersController < ApplicationController
       format.html { redirect_back_or_to transactions_url, notice: t(".success") }
       format.turbo_stream
     end
+  end
+
+  def update_tags
+    outflow_account = @transfer.outflow_transaction.entry.account
+    return unless require_account_permission!(outflow_account, redirect_path: transactions_url)
+
+    resolved_ids = Current.family.tags.where(id: Array(params[:tag_ids]).reject(&:blank?)).pluck(:id)
+
+    Transfer.transaction do
+      [ @transfer.outflow_transaction, @transfer.inflow_transaction ].each do |transaction|
+        transaction.tag_ids = resolved_ids
+        transaction.lock_attr!(:tag_ids)
+      end
+    end
+
+    render json: { tag_ids: @transfer.outflow_transaction.reload.tag_ids }
   end
 
   def destroy
@@ -163,7 +185,7 @@ class TransfersController < ApplicationController
     end
 
     def transfer_params
-      params.require(:transfer).permit(:from_account_id, :to_account_id, :amount, :date, :name, :excluded, :exchange_rate, :source_fee_amount, :destination_fee_amount)
+      params.require(:transfer).permit(:from_account_id, :to_account_id, :amount, :date, :name, :excluded, :exchange_rate, :source_fee_amount, :destination_fee_amount, tag_ids: [])
     end
 
     def set_accounts

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -4,7 +4,7 @@ class Transfer < ApplicationRecord
 
   has_many :fee_transactions, class_name: "Transaction", dependent: :destroy
 
-  attr_accessor :source_fee_amount, :destination_fee_amount
+  attr_accessor :source_fee_amount, :destination_fee_amount, :tag_ids
 
   enum :status, { pending: "pending", confirmed: "confirmed" }
 

--- a/app/models/transfer/creator.rb
+++ b/app/models/transfer/creator.rb
@@ -1,5 +1,5 @@
 class Transfer::Creator
-  def initialize(family:, source_account_id:, destination_account_id:, date:, amount:, exchange_rate: nil, source_fee_amount: nil, destination_fee_amount: nil)
+  def initialize(family:, source_account_id:, destination_account_id:, date:, amount:, exchange_rate: nil, source_fee_amount: nil, destination_fee_amount: nil, tag_ids: nil)
     @family = family
     @source_account = family.accounts.find(source_account_id) # early throw if not found
     @destination_account = family.accounts.find(destination_account_id) # early throw if not found
@@ -7,6 +7,7 @@ class Transfer::Creator
     @amount = amount.to_d
     @source_fee_amount = source_fee_amount.to_d
     @destination_fee_amount = destination_fee_amount.to_d
+    @tag_ids = Array(tag_ids).reject(&:blank?)
 
     if exchange_rate.present?
       rate_value = exchange_rate.to_d
@@ -36,6 +37,7 @@ class Transfer::Creator
         transfer.fee_transactions << build_destination_fee_transaction
       end
       transfer.save!
+      apply_tags!(transfer) if tag_ids.any?
     end
 
     source_account.sync_later
@@ -45,7 +47,16 @@ class Transfer::Creator
   end
 
   private
-    attr_reader :family, :source_account, :destination_account, :date, :amount, :exchange_rate, :source_fee_amount, :destination_fee_amount
+    attr_reader :family, :source_account, :destination_account, :date, :amount, :exchange_rate, :source_fee_amount, :destination_fee_amount, :tag_ids
+
+    def apply_tags!(transfer)
+      resolved_ids = family.tags.where(id: tag_ids).pluck(:id)
+      return if resolved_ids.empty?
+
+      [ transfer.outflow_transaction, transfer.inflow_transaction ].each do |transaction|
+        transaction.tag_ids = resolved_ids
+      end
+    end
 
     def outflow_transaction
       name = "#{name_prefix} to #{destination_account.name}"

--- a/app/views/transfers/_form.html.erb
+++ b/app/views/transfers/_form.html.erb
@@ -35,6 +35,12 @@
 
     <%= f.number_field :amount, label: t(".source_amount"), required: true, min: 0, placeholder: "100", step: 0.00000001, data: { transfer_form_target: "amount", action: "input->transfer-form#onSourceAmountChange" } %>
 
+    <%= render DS::TagSelect.new(
+          form: f,
+          tags: @tags,
+          selected_ids: Array(f.object.tag_ids)
+        ) %>
+
     <% convert_input = capture do %>
       <%= f.number_field :exchange_rate,
         label: t("shared.exchange_rate_tabs.exchange_rate"),

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -86,6 +86,13 @@
         <% if @transfer.categorizable? %>
           <%= f.collection_select :category_id, @categories.alphabetically, :id, :name, { label: t(".category"), include_blank: t(".uncategorized"), selected: @transfer.outflow_transaction.category&.id, variant: :badge, searchable: true }, "data-auto-submit-form-target": "auto" %>
         <% end %>
+        <%= render DS::TagSelect.new(
+              form: f,
+              tags: @tags,
+              selected_ids: @transfer.outflow_transaction.tag_ids,
+              auto_submit: true,
+              update_url: tags_transfer_path(@transfer)
+            ) %>
         <%= f.text_area :notes,
                   label: t(".note_label"),
                   placeholder: t(".note_placeholder"),

--- a/config/locales/views/transfers/en.yml
+++ b/config/locales/views/transfers/en.yml
@@ -3,6 +3,8 @@ en:
   transfers:
     create:
       success: Transfer created
+      exchange_rate_unavailable: Exchange rate unavailable for selected currencies and date
+      date_invalid: is invalid
     destroy:
       success: Transfer removed
     form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -419,6 +419,7 @@ Rails.application.routes.draw do
   resources :transfers, only: %i[new create destroy show update] do
     member do
       post :mark_as_recurring
+      patch :tags, action: :update_tags
     end
   end
 

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -285,6 +285,66 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "can create transfer with tags on both sides" do
+    tag = tags(:one)
+
+    assert_difference "Transfer.count", 1 do
+      post transfers_url, params: {
+        transfer: {
+          from_account_id: accounts(:depository).id,
+          to_account_id: accounts(:credit_card).id,
+          date: Date.current,
+          amount: 100,
+          tag_ids: [ tag.id ]
+        }
+      }
+    end
+
+    transfer = Transfer.order(:created_at).last
+    assert_equal [ tag.id ], transfer.outflow_transaction.tag_ids
+    assert_equal [ tag.id ], transfer.inflow_transaction.tag_ids
+  end
+
+  test "can update transfer tags on both sides" do
+    transfer = transfers(:one)
+    tag = tags(:one)
+
+    patch tags_transfer_url(transfer), params: { tag_ids: [ tag.id ] }, as: :json
+
+    assert_response :success
+    assert_equal [ tag.id ], transfer.outflow_transaction.reload.tag_ids
+    assert_equal [ tag.id ], transfer.inflow_transaction.reload.tag_ids
+    assert_equal [ tag.id ], JSON.parse(response.body)["tag_ids"]
+  end
+
+  test "update transfer tags ignores tags from other families" do
+    transfer = transfers(:one)
+    family_tag = tags(:one)
+    other_family = Family.create!(name: "Other Family", currency: "USD")
+    other_tag = other_family.tags.create!(name: "Foreign")
+
+    patch tags_transfer_url(transfer), params: {
+      tag_ids: [ family_tag.id, other_tag.id ]
+    }, as: :json
+
+    assert_response :success
+    assert_equal [ family_tag.id ], transfer.outflow_transaction.reload.tag_ids
+    assert_equal [ family_tag.id ], transfer.inflow_transaction.reload.tag_ids
+  end
+
+  test "can clear transfer tags" do
+    transfer = transfers(:one)
+    tag = tags(:one)
+    transfer.outflow_transaction.update!(tag_ids: [ tag.id ])
+    transfer.inflow_transaction.update!(tag_ids: [ tag.id ])
+
+    patch tags_transfer_url(transfer), params: { tag_ids: [] }, as: :json
+
+    assert_response :success
+    assert_empty transfer.outflow_transaction.reload.tag_ids
+    assert_empty transfer.inflow_transaction.reload.tag_ids
+  end
+
   test "can add notes to transfer" do
     transfer = transfers(:one)
     assert_nil transfer.notes

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -345,6 +345,22 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     assert_empty transfer.inflow_transaction.reload.tag_ids
   end
 
+  test "update tags requires annotate permission on both transfer sides" do
+    # family_member: full_control on depository (outflow), read_only on credit_card (inflow)
+    sign_in users(:family_member)
+    transfer = transfers(:one)
+    tag = tags(:one)
+    original_outflow_tags = transfer.outflow_transaction.tag_ids
+    original_inflow_tags = transfer.inflow_transaction.tag_ids
+
+    patch tags_transfer_url(transfer), params: { tag_ids: [ tag.id ] }, as: :json
+
+    assert_response :forbidden
+    assert_equal I18n.t("accounts.not_authorized"), JSON.parse(response.body)["error"]
+    assert_equal original_outflow_tags, transfer.outflow_transaction.reload.tag_ids
+    assert_equal original_inflow_tags, transfer.inflow_transaction.reload.tag_ids
+  end
+
   test "can add notes to transfer" do
     transfer = transfers(:one)
     assert_nil transfer.notes

--- a/test/models/transfer/creator_test.rb
+++ b/test/models/transfer/creator_test.rb
@@ -318,4 +318,23 @@ class Transfer::CreatorTest < ActiveSupport::TestCase
     assert transfer.persisted?
     assert_in_delta(-0.0001, transfer.inflow_transaction.entry.amount, 0.0001)
   end
+
+  test "creates transfer with tags applied to both transactions" do
+    other_depository = @family.accounts.create!(name: "Savings", balance: 1000, currency: "USD", accountable: Depository.new)
+    tag = tags(:one)
+
+    creator = Transfer::Creator.new(
+      family: @family,
+      source_account_id: @source_account.id,
+      destination_account_id: other_depository.id,
+      date: @date,
+      amount: @amount,
+      tag_ids: [ tag.id ]
+    )
+
+    transfer = creator.create
+
+    assert_equal [ tag.id ], transfer.outflow_transaction.tag_ids
+    assert_equal [ tag.id ], transfer.inflow_transaction.tag_ids
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `DS::TagSelect` to the New transfer form and transfer details drawer ([#2900](https://github.com/we-promise/sure/issues/2900))
- Applies family-scoped tags to **both** inflow and outflow transactions on create and via `PATCH /transfers/:id/tags`
- No schema migration — tagging already works on `Transaction` at the model layer

## Test plan
- [ ] Create a transfer with one or more tags; confirm both sides show the tags
- [ ] Edit tags on an existing transfer in the drawer; confirm auto-save updates both sides
- [ ] Clear tags and confirm both sides are cleared
- [ ] Attempt to assign a tag from another family (should be ignored)
- [ ] `bin/rails test test/controllers/transfers_controller_test.rb test/models/transfer/creator_test.rb`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added tag selection when creating transfers.
  * Added tag management on transfer details, with updates applied to both sides of the transfer.
  * Tags can be cleared, while invalid or unrelated tags are ignored.

* **Bug Fixes**
  * Selected tags are preserved when transfer creation fails validation.
  * Tag updates are restricted when annotation access is missing for either side of a transfer.
  * Added localized messages for invalid transfer dates and unavailable exchange rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->