### PR TITLE
Add “Is not equal to” operator for transaction amount rules

### DIFF
--- a/app/models/rule/condition_filter.rb
+++ b/app/models/rule/condition_filter.rb
@@ -5,7 +5,7 @@ class Rule::ConditionFilter
 
   OPERATORS_MAP = {
     "text" => [ [ "Contains", "like" ], [ "Equal to", "=" ], [ "Is empty", "is_null" ] ],
-    "number" => [ [ "Greater than", ">" ], [ "Greater or equal to", ">=" ], [ "Less than", "<" ], [ "Less than or equal to", "<=" ], [ "Is equal to", "=" ] ],
+    "number" => [ [ "Greater than", ">" ], [ "Greater or equal to", ">=" ], [ "Less than", "<" ], [ "Less than or equal to", "<=" ], [ "Is equal to", "=" ], [ "Is not equal to", "!=" ] ],
     "select" => [ [ "Equal to", "=" ], [ "Is empty", "is_null" ] ]
   }
 

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -57,7 +57,8 @@ class Rule::ConditionTest < ActiveSupport::TestCase
   end
 
   test "applies transaction_amount not equal operator using absolute values" do
-    scope = @rule_scope
+    create_transaction(date: Date.current, account: @account, amount: -100, name: "Rule test transaction negative 100")
+    scope = @account.transactions
 
     condition = Rule::Condition.new(
       rule: @transaction_rule,
@@ -69,7 +70,7 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     scope = condition.prepare(scope)
 
     filtered = condition.apply(scope)
-    # Absolute amounts: 100, 200, 50, 10, 1000 — exclude 100
+    # Absolute amounts: 100, -100, 200, 50, 10, 1000 — exclude both ±100
     assert_equal 4, filtered.count
     assert_not filtered.any? { |txn| txn.entry.amount.abs == 100 }
   end

--- a/test/models/rule/condition_test.rb
+++ b/test/models/rule/condition_test.rb
@@ -56,6 +56,24 @@ class Rule::ConditionTest < ActiveSupport::TestCase
     assert_equal 3, filtered.count
   end
 
+  test "applies transaction_amount not equal operator using absolute values" do
+    scope = @rule_scope
+
+    condition = Rule::Condition.new(
+      rule: @transaction_rule,
+      condition_type: "transaction_amount",
+      operator: "!=",
+      value: "100"
+    )
+
+    scope = condition.prepare(scope)
+
+    filtered = condition.apply(scope)
+    # Absolute amounts: 100, 200, 50, 10, 1000 — exclude 100
+    assert_equal 4, filtered.count
+    assert_not filtered.any? { |txn| txn.entry.amount.abs == 100 }
+  end
+
   test "applies transaction_merchant condition" do
     scope = @rule_scope
 


### PR DESCRIPTION
## Summary
- Adds **Is not equal to** (`!=`) to number condition operators used by Transaction amount rules ([#2882](https://github.com/we-promise/sure/issues/2882))
- Evaluation already uses `ABS(entries.amount)` via the shared SQL builder; no schema or UI wiring changes needed
- Regression test covers absolute-amount not-equal matching

## Test plan
- [ ] Open New transaction rule → Transaction amount → confirm **Is not equal to** appears in the operator dropdown
- [ ] Create a rule with amount ≠ a known value; run/apply and confirm matching transactions exclude that amount
- [ ] `bin/rails test test/models/rule/condition_test.rb`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added an “Is not equal to” operator for numeric rule conditions.
- Transaction amount rules can now exclude matching positive and negative amounts using absolute-value comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->