### PR TITLE
Make report income/expense categories clickable

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -398,12 +398,30 @@ class ReportsController < ApplicationController
 
       # Helper to initialize a category group hash
       init_category_group = ->(id, name, color, icon, type) do
-        { category_id: id, category_name: name, category_color: color, category_icon: icon, type: type, total: 0, count: 0, subcategories: {} }
+        {
+          category_id: id,
+          category_name: name,
+          category_color: color,
+          category_icon: icon,
+          type: type,
+          total: 0,
+          count: 0,
+          has_transactions: false,
+          subcategories: {}
+        }
       end
 
       # Helper to initialize a subcategory hash
       init_subcategory = ->(category) do
-        { category_id: category.id, category_name: category.name, category_color: category.color, category_icon: category.lucide_icon, total: 0, count: 0 }
+        {
+          category_id: category.id,
+          category_name: category.name,
+          category_color: category.color,
+          category_icon: category.lucide_icon,
+          total: 0,
+          count: 0,
+          has_transactions: false
+        }
       end
 
       # Helper to process an entry (transaction or trade)
@@ -434,6 +452,7 @@ class ReportsController < ApplicationController
           grouped_data[parent_key][:subcategories][category.id] ||= init_subcategory.call(category)
           grouped_data[parent_key][:subcategories][category.id][:count] += 1
           grouped_data[parent_key][:subcategories][category.id][:total] += converted_amount
+          grouped_data[parent_key][:subcategories][category.id][:has_transactions] = true unless is_trade
         else
           # This is a root category (no parent)
           parent_key = [ category.id, type ]
@@ -442,6 +461,7 @@ class ReportsController < ApplicationController
 
         grouped_data[parent_key][:count] += 1
         grouped_data[parent_key][:total] += converted_amount
+        grouped_data[parent_key][:has_transactions] = true unless is_trade
       end
 
       # Process transactions

--- a/app/views/reports/_breakdown_table.html.erb
+++ b/app/views/reports/_breakdown_table.html.erb
@@ -1,5 +1,5 @@
 <%# Renders a breakdown table for income or expense groups %>
-<%# Local variables: groups, total, type (:income or :expense), amount_sort_params, current_sort_by, current_sort_direction %>
+<%# Local variables: groups, total, type (:income or :expense), amount_sort_params, current_sort_by, current_sort_direction, start_date, end_date %>
 
 <%
   color_class = type == :income ? "text-success" : "text-primary"
@@ -38,6 +38,8 @@
             total: total,
             color_class: color_class,
             level: :category,
+            start_date: start_date,
+            end_date: end_date,
             show_border: idx < groups.size - 1 || group[:subcategories].present? %>
           <%# Render subcategories if present %>
           <% if group[:subcategories].present? && group[:subcategories].any? %>
@@ -47,6 +49,8 @@
                 total: total,
                 color_class: color_class,
                 level: :subcategory,
+                start_date: start_date,
+                end_date: end_date,
                 show_border: sub_idx < group[:subcategories].size - 1 %>
             <% end %>
           <% end %>

--- a/app/views/reports/_category_row.html.erb
+++ b/app/views/reports/_category_row.html.erb
@@ -7,9 +7,11 @@
   # /transactions only lists Transaction rows. Skip trade-only buckets (e.g. Other
   # Investments) so the destination is not empty relative to the report row.
   clickable = item[:has_transactions] && row_start_date.present? && row_end_date.present?
+  transactions_href = clickable ? transactions_path(q: { categories: [ item[:category_name] ], start_date: row_start_date, end_date: row_end_date }) : nil
 %>
 
-<tr data-category="category-<%= item[:category_id] %>" class="text-secondary text-sm <%= show_border ? "table-divider" : "" %>">
+<tr data-category="category-<%= item[:category_id] %>"
+    class="text-secondary text-sm <%= show_border ? "table-divider" : "" %> <%= clickable ? "relative group/category-row" : "" %>">
   <td colspan="2" class="py-3 px-4 lg:px-6 <%= is_sub ? "pl-7 lg:pl-9" : "" %>">
     <div class="flex items-center gap-2">
       <% if is_sub %>
@@ -18,7 +20,7 @@
         </div>
       <% end %>
       <% if item[:category_icon] %>
-        <div class="h-7 w-7 flex-shrink-0 rounded-full flex justify-center items-center"
+        <div class="h-7 w-7 flex-shrink-0 rounded-full flex justify-center items-center <%= clickable ? "group-hover/category-row:scale-105 transition-all duration-300" : "" %>"
           style="
             background-color: color-mix(in oklab, <%= item[:category_color] %> 10%, transparent);
             border-color: color-mix(in oklab, <%= item[:category_color] %> 10%, transparent);
@@ -36,9 +38,11 @@
         ) %>
       <% end %>
       <% if clickable %>
+        <%# Stretched link covers the full row (mirrors dashboard outflows).
+            `before:absolute before:inset-0` is positioned against the relative <tr>. %>
         <%= link_to item[:category_name],
-              transactions_path(q: { categories: [ item[:category_name] ], start_date: row_start_date, end_date: row_end_date }),
-              class: "font-medium text-primary hover:underline",
+              transactions_href,
+              class: "font-medium text-primary hover:underline before:absolute before:inset-0 before:content-['']",
               data: { turbo_frame: "_top", turbo_prefetch: false } %>
       <% else %>
         <span class="font-medium text-primary">

--- a/app/views/reports/_category_row.html.erb
+++ b/app/views/reports/_category_row.html.erb
@@ -4,8 +4,9 @@
   show_border = local_assigns.fetch(:show_border, false)
   row_start_date = local_assigns[:start_date]
   row_end_date = local_assigns[:end_date]
-  # Synthetic "Other Investments" is not a real category filter target (same as dashboard).
-  clickable = item[:category_id] != :other_investments && row_start_date.present? && row_end_date.present?
+  # /transactions only lists Transaction rows. Skip trade-only buckets (e.g. Other
+  # Investments) so the destination is not empty relative to the report row.
+  clickable = item[:has_transactions] && row_start_date.present? && row_end_date.present?
 %>
 
 <tr data-category="category-<%= item[:category_id] %>" class="text-secondary text-sm <%= show_border ? "table-divider" : "" %>">

--- a/app/views/reports/_category_row.html.erb
+++ b/app/views/reports/_category_row.html.erb
@@ -2,6 +2,10 @@
   percentage = total.zero? ? 0 : (item[:total].to_f / total * 100).round(1)
   is_sub = level == :subcategory
   show_border = local_assigns.fetch(:show_border, false)
+  row_start_date = local_assigns[:start_date]
+  row_end_date = local_assigns[:end_date]
+  # Synthetic "Other Investments" is not a real category filter target (same as dashboard).
+  clickable = item[:category_id] != :other_investments && row_start_date.present? && row_end_date.present?
 %>
 
 <tr data-category="category-<%= item[:category_id] %>" class="text-secondary text-sm <%= show_border ? "table-divider" : "" %>">
@@ -30,9 +34,16 @@
           rounded: true
         ) %>
       <% end %>
-      <span class="font-medium text-primary">
-        <%= item[:category_name] %>
-      </span>
+      <% if clickable %>
+        <%= link_to item[:category_name],
+              transactions_path(q: { categories: [ item[:category_name] ], start_date: row_start_date, end_date: row_end_date }),
+              class: "font-medium text-primary hover:underline",
+              data: { turbo_frame: "_top", turbo_prefetch: false } %>
+      <% else %>
+        <span class="font-medium text-primary">
+          <%= item[:category_name] %>
+        </span>
+      <% end %>
       <span class="text-xs text-subdued whitespace-nowrap">
         (<%= t("reports.transactions_breakdown.table.entries", count: item[:count]) %>)
       </span>

--- a/app/views/reports/_transactions_breakdown.html.erb
+++ b/app/views/reports/_transactions_breakdown.html.erb
@@ -59,7 +59,9 @@
               type: :income,
               amount_sort_params: amount_sort_params,
               current_sort_by: current_sort_by,
-              current_sort_direction: current_sort_direction %>
+              current_sort_direction: current_sort_direction,
+              start_date: start_date,
+              end_date: end_date %>
       <% end %>
 
       <%# Expenses Section %>
@@ -70,7 +72,9 @@
               type: :expense,
               amount_sort_params: amount_sort_params,
               current_sort_by: current_sort_by,
-              current_sort_direction: current_sort_direction %>
+              current_sort_direction: current_sort_direction,
+              start_date: start_date,
+              end_date: end_date %>
       <% end %>
     </div>
 

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -433,26 +433,6 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr[data-category='category-#{category.id}'] a[href=?]", expected_href, text: category.name
   end
 
-  test "index does not link trade-only Other Investments rows to transactions" do
-    @family.accounts.each { |account| account.entries.destroy_all }
-
-    brokerage = @family.accounts.create!(
-      owner: @user,
-      name: "Reports Trade Only Brokerage",
-      balance: 0,
-      currency: "USD",
-      accountable: Investment.new(subtype: "brokerage")
-    )
-    create_trade(securities(:aapl), account: brokerage, qty: 1, date: Date.current, price: 100)
-
-    get reports_path(period_type: :monthly)
-    assert_response :ok
-
-    other_investments_row = css_select("tr[data-category='category-other_investments']").first
-    assert_not_nil other_investments_row
-    assert_equal 0, other_investments_row.css("a").size
-  end
-
   test "index excludes tax-advantaged account transactions from activity breakdown" do
     @family.accounts.each { |account| account.entries.destroy_all }
 

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -433,6 +433,26 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr[data-category='category-#{category.id}'] a[href=?]", expected_href, text: category.name
   end
 
+  test "index does not link trade-only Other Investments rows to transactions" do
+    @family.accounts.each { |account| account.entries.destroy_all }
+
+    brokerage = @family.accounts.create!(
+      owner: @user,
+      name: "Reports Trade Only Brokerage",
+      balance: 0,
+      currency: "USD",
+      accountable: Investment.new(subtype: "brokerage")
+    )
+    create_trade(securities(:aapl), account: brokerage, qty: 1, date: Date.current, price: 100)
+
+    get reports_path(period_type: :monthly)
+    assert_response :ok
+
+    other_investments_row = css_select("tr[data-category='category-other_investments']").first
+    assert_not_nil other_investments_row
+    assert_equal 0, other_investments_row.css("a").size
+  end
+
   test "index excludes tax-advantaged account transactions from activity breakdown" do
     @family.accounts.each { |account| account.entries.destroy_all }
 

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -423,14 +423,24 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
   test "index links income and expense categories to filtered transactions" do
     start_date = Date.current.beginning_of_month
     end_date = Date.current.end_of_month
-    category = @family.categories.create!(name: "Reports Clickable Groceries", color: "#ABCDEF")
-    create_transaction(account: @family.accounts.first, name: "Groceries", amount: 42, category: category, date: Date.current)
+    expense_category = @family.categories.create!(name: "Reports Clickable Groceries", color: "#ABCDEF")
+    income_category = @family.categories.create!(name: "Reports Clickable Salary", color: "#FEDCBA")
+    account = @family.accounts.first
+
+    create_transaction(account: account, name: "Groceries", amount: 42, category: expense_category, date: Date.current)
+    create_transaction(account: account, name: "Salary", amount: -100, category: income_category, date: Date.current)
+    create_transaction(account: account, name: "Uncategorized cash", amount: 25, date: Date.current)
 
     get reports_path(period_type: :monthly, start_date: start_date, end_date: end_date)
     assert_response :ok
 
-    expected_href = transactions_path(q: { categories: [ category.name ], start_date: start_date, end_date: end_date })
-    assert_select "tr[data-category='category-#{category.id}'] a[href=?]", expected_href, text: category.name
+    expense_href = transactions_path(q: { categories: [ expense_category.name ], start_date: start_date, end_date: end_date })
+    income_href = transactions_path(q: { categories: [ income_category.name ], start_date: start_date, end_date: end_date })
+    uncategorized_href = transactions_path(q: { categories: [ Category.uncategorized.name ], start_date: start_date, end_date: end_date })
+
+    assert_select "tr[data-category='category-#{expense_category.id}'] a[href=?]", expense_href, text: expense_category.name
+    assert_select "tr[data-category='category-#{income_category.id}'] a[href=?]", income_href, text: income_category.name
+    assert_select "tr[data-category='category-uncategorized'] a[href=?]", uncategorized_href, text: Category.uncategorized.name
   end
 
   test "index excludes tax-advantaged account transactions from activity breakdown" do
@@ -464,12 +474,14 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr[data-category='category-#{taxable_category.id}']", text: /Reports Taxable Income/
     assert_select "tr[data-category='category-#{retirement_category.id}']", count: 0
 
-    other_investments_row = css_select("tr[data-category='category-other_investments']").first
-    assert_not_nil other_investments_row
-    assert_match(/#{Regexp.escape(Category.other_investments.name)}/, other_investments_row.text)
-    assert_match(/#{Regexp.escape(I18n.t("reports.transactions_breakdown.table.entries", count: 1))}/, other_investments_row.text)
-    assert_match(/\$100\.00/, other_investments_row.text)
-    assert_equal 0, other_investments_row.css("a").size
+    other_investments_rows = css_select("tr[data-category='category-other_investments']")
+    assert_operator other_investments_rows.size, :>=, 1
+    other_investments_rows.each do |row|
+      assert_match(/#{Regexp.escape(Category.other_investments.name)}/, row.text)
+      assert_equal 0, row.css("a").size
+    end
+    assert_match(/#{Regexp.escape(I18n.t("reports.transactions_breakdown.table.entries", count: 1))}/, other_investments_rows.first.text)
+    assert_match(/\$100\.00/, other_investments_rows.first.text)
   end
 
   test "monthly period navigation shows previous month link" do

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -441,6 +441,26 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr[data-category='category-#{expense_category.id}'] a[href=?]", expense_href, text: expense_category.name
     assert_select "tr[data-category='category-#{income_category.id}'] a[href=?]", income_href, text: income_category.name
     assert_select "tr[data-category='category-uncategorized'] a[href=?]", uncategorized_href, text: Category.uncategorized.name
+
+    # Full-row hit target via stretched ::before (mirrors dashboard outflows)
+    assert_select "tr.relative.group\\/category-row[data-category='category-#{expense_category.id}'] a[class*='before:absolute'][class*='before:inset-0']"
+  end
+
+  test "index uncategorized category link uses localized name that Search accepts" do
+    start_date = Date.current.beginning_of_month
+    end_date = Date.current.end_of_month
+    account = @family.accounts.first
+    create_transaction(account: account, name: "Uncategorized cash", amount: 25, date: Date.current)
+
+    @user.update!(locale: "zh-CN")
+    localized_name = I18n.with_locale(:"zh-CN") { Category.uncategorized.name }
+    assert_includes Category.all_uncategorized_names, localized_name
+
+    get reports_path(period_type: :monthly, start_date: start_date, end_date: end_date)
+    assert_response :ok
+
+    href = transactions_path(q: { categories: [ localized_name ], start_date: start_date, end_date: end_date })
+    assert_select "tr[data-category='category-uncategorized'] a[href=?]", href, text: localized_name
   end
 
   test "index excludes tax-advantaged account transactions from activity breakdown" do

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -420,6 +420,19 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr[data-category='category-#{subcategory_games.id}']", text: /^Games/
   end
 
+  test "index links income and expense categories to filtered transactions" do
+    start_date = Date.current.beginning_of_month
+    end_date = Date.current.end_of_month
+    category = @family.categories.create!(name: "Reports Clickable Groceries", color: "#ABCDEF")
+    create_transaction(account: @family.accounts.first, name: "Groceries", amount: 42, category: category, date: Date.current)
+
+    get reports_path(period_type: :monthly, start_date: start_date, end_date: end_date)
+    assert_response :ok
+
+    expected_href = transactions_path(q: { categories: [ category.name ], start_date: start_date, end_date: end_date })
+    assert_select "tr[data-category='category-#{category.id}'] a[href=?]", expected_href, text: category.name
+  end
+
   test "index excludes tax-advantaged account transactions from activity breakdown" do
     @family.accounts.each { |account| account.entries.destroy_all }
 
@@ -456,6 +469,7 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/#{Regexp.escape(Category.other_investments.name)}/, other_investments_row.text)
     assert_match(/#{Regexp.escape(I18n.t("reports.transactions_breakdown.table.entries", count: 1))}/, other_investments_row.text)
     assert_match(/\$100\.00/, other_investments_row.text)
+    assert_equal 0, other_investments_row.css("a").size
   end
 
   test "monthly period navigation shows previous month link" do


### PR DESCRIPTION
## Summary
- Links report breakdown category names to filtered `/transactions` for the selected period, matching dashboard outflows behavior ([#2850](https://github.com/we-promise/sure/issues/2850))
- Keeps synthetic **Other Investments** non-clickable (same as dashboard) because it is not a persisted category filter target
- Clarifies investigation from the issue: **Other Investments** ≠ **Investment Contributions** — the former is a reporting bucket for uncategorized investment activity; the latter is a real auto-category for transfers into investment accounts

## Test plan
- [ ] Open Reports → income/expense breakdown → click a real category → lands on Transactions filtered by that category + report date range
- [ ] Confirm Uncategorized (if present) is clickable
- [ ] Confirm Other Investments (uncategorized taxable trade) has no link
- [ ] `bin/rails test test/controllers/reports_controller_test.rb -n "/links income|excludes tax-advantaged/"`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category, subcategory, and breakdown names in income, expense, and uncategorized reports are now clickable when date filters are set and matching transactions exist.
  * Links open filtered transactions for the selected category within the reporting period.
  * Rows without transactions or complete date filters remain non-clickable.
  * Uncategorized links support localized category names.

* **Bug Fixes**
  * Prevented links from appearing on investment (“Other Investments”) rows without eligible transactions.

* **Tests**
  * Added coverage for filtered transaction links, localized uncategorized links, and investment rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->