### PR TITLE
Roll up Investments panel holdings by security with portfolio weight

### DIFF
--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -80,34 +80,39 @@ class InvestmentStatement
       .includes(:security, :account)
   end
 
-  # Top holdings by family-currency value
+  # Top investments rolled up by security across accounts, ranked by
+  # family-currency value. Weight is % of total portfolio (including cash).
   def top_holdings(limit: 5)
-    current_holdings
-      .to_a
-      .sort_by { |h| -convert_to_family_currency(h.amount, h.currency) }
-      .first(limit)
-  end
-
-  # Portfolio allocation by security. Weights and amounts are computed in the
-  # family's currency so cross-currency holdings compare correctly.
-  def allocation
-    converted = current_holdings.to_a.map do |holding|
-      [ holding, convert_to_family_currency(holding.amount, holding.currency) ]
-    end
-
-    total = converted.sum { |_, value| value }
+    total = portfolio_value
     return [] if total.zero?
 
-    converted
-      .sort_by { |_, value| -value }
-      .map do |holding, value|
+    holdings_rolled_up_by_security
+      .first(limit)
+      .map do |security, value, trend|
         HoldingAllocation.new(
-          security: holding.security,
+          security: security,
           amount: Money.new(value, family.currency),
           weight: (value / total * 100).round(2),
-          trend: holding.trend
+          trend: trend
         )
       end
+  end
+
+  # Portfolio allocation by security (rolled up across accounts). Weights are
+  # relative to total holdings value (excludes cash) so they sum to ~100%.
+  def allocation
+    rolled_up = holdings_rolled_up_by_security
+    total = rolled_up.sum { |_, value, _| value }
+    return [] if total.zero?
+
+    rolled_up.map do |security, value, trend|
+      HoldingAllocation.new(
+        security: security,
+        amount: Money.new(value, family.currency),
+        weight: (value / total * 100).round(2),
+        trend: trend
+      )
+    end
   end
 
   # Unrealized gains across all holdings, summed in family currency
@@ -297,7 +302,48 @@ class InvestmentStatement
       end
     end
 
-    HoldingAllocation = Data.define(:security, :amount, :weight, :trend)
+    HoldingAllocation = Data.define(:security, :amount, :weight, :trend) do
+      def ticker = security.ticker
+      def name = security.name.presence || ticker
+      def amount_money = amount
+    end
+
+    # Groups current holdings by security, summing family-currency value and
+    # combining cost-basis trends. Returns [[security, value, trend], ...]
+    # sorted by value descending.
+    def holdings_rolled_up_by_security
+      current_holdings
+        .to_a
+        .group_by(&:security_id)
+        .filter_map do |_security_id, holdings|
+          security = holdings.first.security
+          value = holdings.sum { |h| convert_to_family_currency(h.amount, h.currency) }
+          next if value.zero?
+
+          [ security, value, combined_holding_trend(holdings) ]
+        end
+        .sort_by { |_, value, _| -value }
+    end
+
+    def combined_holding_trend(holdings)
+      currents = []
+      previouses = []
+
+      holdings.each do |holding|
+        trend = holding.trend
+        next unless trend
+
+        currents << convert_to_family_currency(trend.current, holding.currency)
+        previouses << convert_to_family_currency(trend.previous, holding.currency)
+      end
+
+      return nil if currents.empty?
+
+      Trend.new(
+        current: Money.new(currents.sum, family.currency),
+        previous: Money.new(previouses.sum, family.currency)
+      )
+    end
 
     def investment_account_ids
       @investment_account_ids ||= investment_accounts.pluck(:id)

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -86,14 +86,16 @@ class InvestmentStatement
     total = portfolio_value
     return [] if total.zero?
 
+    # Rank/limit on value first; only then compute cost-basis trends for the
+    # rows that will be rendered (avoids avg_cost/trade lookups for the rest).
     holdings_rolled_up_by_security
       .first(limit)
-      .map do |security, value, trend|
+      .map do |security, value, holdings|
         HoldingAllocation.new(
           security: security,
           amount: Money.new(value, family.currency),
           weight: (value / total * 100).round(2),
-          trend: trend
+          trend: combined_holding_trend(holdings)
         )
       end
   end
@@ -105,12 +107,12 @@ class InvestmentStatement
     total = rolled_up.sum { |_, value, _| value }
     return [] if total.zero?
 
-    rolled_up.map do |security, value, trend|
+    rolled_up.map do |security, value, holdings|
       HoldingAllocation.new(
         security: security,
         amount: Money.new(value, family.currency),
         weight: (value / total * 100).round(2),
-        trend: trend
+        trend: combined_holding_trend(holdings)
       )
     end
   end
@@ -308,9 +310,10 @@ class InvestmentStatement
       def amount_money = amount
     end
 
-    # Groups current holdings by security, summing family-currency value and
-    # combining cost-basis trends. Returns [[security, value, trend], ...]
-    # sorted by value descending.
+    # Groups current holdings by security and sums family-currency value.
+    # Returns [[security, value, holdings], ...] sorted by value descending.
+    # Callers that need return trends should call combined_holding_trend only
+    # for rows they will render (e.g. after top_holdings applies its limit).
     def holdings_rolled_up_by_security
       current_holdings
         .to_a
@@ -320,7 +323,7 @@ class InvestmentStatement
           value = holdings.sum { |h| convert_to_family_currency(h.amount, h.currency) }
           next if value.zero?
 
-          [ security, value, combined_holding_trend(holdings) ]
+          [ security, value, holdings ]
         end
         .sort_by { |_, value, _| -value }
     end

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -82,13 +82,23 @@ class InvestmentStatement
 
   # Top investments rolled up by security across accounts, ranked by
   # family-currency value. Weight is % of total portfolio (including cash).
+  # Presence is gated on holdings totals — not Account#balance — so a stale
+  # zero portfolio_value still surfaces real positions.
   def top_holdings(limit: 5)
+    rolled_up = holdings_rolled_up_by_security
+    return [] if rolled_up.empty?
+
+    holdings_total = rolled_up.sum { |_, value, _| value }
+    return [] if holdings_total.zero?
+
+    # Prefer portfolio_value (includes cash) for weight; fall back to holdings
+    # total when cached account balances are stale/zero.
     total = portfolio_value
-    return [] if total.zero?
+    total = holdings_total if total.zero?
 
     # Rank/limit on value first; only then compute cost-basis trends for the
     # rows that will be rendered (avoids avg_cost/trade lookups for the rest).
-    holdings_rolled_up_by_security
+    rolled_up
       .first(limit)
       .map do |security, value, holdings|
         HoldingAllocation.new(

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -91,10 +91,7 @@ class InvestmentStatement
     holdings_total = rolled_up.sum { |_, value, _| value }
     return [] if holdings_total.zero?
 
-    # Prefer portfolio_value (includes cash) for weight; fall back to holdings
-    # total when cached account balances are stale/zero.
-    total = portfolio_value
-    total = holdings_total if total.zero?
+    total = weight_denominator(holdings_total)
 
     # Rank/limit on value first; only then compute cost-basis trends for the
     # rows that will be rendered (avoids avg_cost/trade lookups for the rest).
@@ -110,12 +107,16 @@ class InvestmentStatement
       end
   end
 
-  # Portfolio allocation by security (rolled up across accounts). Weights are
-  # relative to total holdings value (excludes cash) so they sum to ~100%.
+  # Portfolio allocation by security (rolled up across accounts). Shares the
+  # weight denominator with top_holdings so the same security never reports two
+  # different percentages. Weights therefore sum to the invested share of the
+  # portfolio, not to 100 — cash is the residual.
   def allocation
     rolled_up = holdings_rolled_up_by_security
-    total = rolled_up.sum { |_, value, _| value }
-    return [] if total.zero?
+    holdings_total = rolled_up.sum { |_, value, _| value }
+    return [] if holdings_total.zero?
+
+    total = weight_denominator(holdings_total)
 
     rolled_up.map do |security, value, holdings|
       HoldingAllocation.new(
@@ -324,6 +325,18 @@ class InvestmentStatement
     # Returns [[security, value, holdings], ...] sorted by value descending.
     # Callers that need return trends should call combined_holding_trend only
     # for rows they will render (e.g. after top_holdings applies its limit).
+    # Shared by top_holdings and allocation so one security cannot report two
+    # different percentages.
+    #
+    # max(portfolio_value, holdings_total) rather than portfolio_value alone:
+    # portfolio_value includes cash, which goes negative on margin or an
+    # unsettled buy and would push a weight past 100%. The holdings total acts
+    # as a floor. It also covers a stale-zero portfolio_value, where the cached
+    # Account#balance lags behind the Holding rows.
+    def weight_denominator(holdings_total)
+      [ portfolio_value, holdings_total ].max
+    end
+
     def holdings_rolled_up_by_security
       current_holdings
         .to_a
@@ -331,7 +344,7 @@ class InvestmentStatement
         .filter_map do |_security_id, holdings|
           security = holdings.first.security
           value = holdings.sum { |h| convert_to_family_currency(h.amount, h.currency) }
-          next if value.zero?
+          next unless value.positive?
 
           [ security, value, holdings ]
         end

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -342,11 +342,20 @@ class InvestmentStatement
         .to_a
         .group_by(&:security_id)
         .filter_map do |_security_id, holdings|
-          security = holdings.first.security
-          value = holdings.sum { |h| convert_to_family_currency(h.amount, h.currency) }
-          next unless value.positive?
+          # Filter row by row rather than on the netted total. current_holdings
+          # is DISTINCT ON (account_id, security_id), so one security held in two
+          # accounts yields two rows; a negative row in one would otherwise net
+          # against the good row in the other and understate the position.
+          positive_holdings = holdings.select do |holding|
+            convert_to_family_currency(holding.amount, holding.currency).positive?
+          end
+          next if positive_holdings.empty?
 
-          [ security, value, holdings ]
+          security = positive_holdings.first.security
+          value = positive_holdings.sum { |h| convert_to_family_currency(h.amount, h.currency) }
+
+          # positive_holdings, not holdings, so the trend excludes the bad row too.
+          [ security, value, positive_holdings ]
         end
         .sort_by { |_, value, _| -value }
     end

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -134,6 +134,32 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_in_delta 60.0, top.first.weight, 0.01
   end
 
+  test "top_holdings computes trends only for the selected limit" do
+    large = create_investment_account(balance: 5000, cash_balance: 0)
+    small = create_investment_account(balance: 1000, cash_balance: 0)
+
+    top_security = Security.create!(ticker: "TOP1", name: "Top One")
+    skipped_security = Security.create!(ticker: "SKIP", name: "Skipped")
+
+    Holding.create!(
+      account: large, security: top_security, date: Date.current,
+      qty: 50, price: 100, amount: 5000, currency: "USD",
+      cost_basis: 90, cost_basis_locked: true
+    )
+    Holding.create!(
+      account: small, security: skipped_security, date: Date.current,
+      qty: 10, price: 100, amount: 1000, currency: "USD",
+      cost_basis: 90, cost_basis_locked: true
+    )
+
+    # Only the one holding in the selected top security should ask for a trend
+    Holding.any_instance.expects(:trend).once.returns(nil)
+
+    top = @statement.top_holdings(limit: 1)
+
+    assert_equal %w[TOP1], top.map(&:ticker)
+  end
+
   test "allocation rolls up duplicate securities and weights sum to 100%" do
     ira = create_investment_account(balance: 3000, currency: "USD")
     taxable = create_investment_account(balance: 2000, currency: "USD")

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -134,6 +134,28 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_in_delta 60.0, top.first.weight, 0.01
   end
 
+  test "top_holdings still lists positions when portfolio_value is stale zero" do
+    # Cached Account#balance can lag behind Holding rows; presence must not
+    # depend on portfolio_value alone.
+    account = create_investment_account(balance: 0, cash_balance: 0, currency: "USD")
+    security = Security.create!(ticker: "AAPL", name: "Apple")
+
+    Holding.create!(
+      account: account, security: security, date: Date.current,
+      qty: 10, price: 200, amount: 2000, currency: "USD"
+    )
+
+    assert_equal 0, @statement.portfolio_value
+
+    top = @statement.top_holdings(limit: 5)
+
+    assert_equal 1, top.size
+    assert_equal "AAPL", top.first.ticker
+    assert_equal Money.new(2000, "USD"), top.first.amount_money
+    # Falls back to holdings total as weight denominator when portfolio is 0
+    assert_in_delta 100.0, top.first.weight, 0.01
+  end
+
   test "top_holdings computes trends only for the selected limit" do
     large = create_investment_account(balance: 5000, cash_balance: 0)
     small = create_investment_account(balance: 1000, cash_balance: 0)

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -87,6 +87,81 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_equal %w[ASML AAPL], top.map(&:ticker)
   end
 
+  test "top_holdings rolls up the same security across accounts" do
+    ira = create_investment_account(balance: 5000, cash_balance: 0, currency: "USD")
+    taxable = create_investment_account(balance: 3000, cash_balance: 0, currency: "USD")
+    other = create_investment_account(balance: 2000, cash_balance: 0, currency: "USD")
+
+    aapl = Security.create!(ticker: "AAPL", name: "Apple")
+    msft = Security.create!(ticker: "MSFT", name: "Microsoft")
+
+    Holding.create!(
+      account: ira, security: aapl, date: Date.current,
+      qty: 10, price: 200, amount: 2000, currency: "USD"
+    )
+    Holding.create!(
+      account: taxable, security: aapl, date: Date.current,
+      qty: 15, price: 200, amount: 3000, currency: "USD"
+    )
+    Holding.create!(
+      account: other, security: msft, date: Date.current,
+      qty: 10, price: 200, amount: 2000, currency: "USD"
+    )
+
+    top = @statement.top_holdings(limit: 5)
+
+    assert_equal %w[AAPL MSFT], top.map(&:ticker)
+    assert_equal 1, top.count { |row| row.ticker == "AAPL" }
+    assert_equal Money.new(5000, "USD"), top.first.amount_money
+    # Portfolio total = 5000 + 3000 + 2000 = 10000; AAPL = 50%, MSFT = 20%
+    assert_in_delta 50.0, top.first.weight, 0.01
+    assert_in_delta 20.0, top.second.weight, 0.01
+  end
+
+  test "top_holdings weight is percent of total portfolio including cash" do
+    account = create_investment_account(balance: 10_000, cash_balance: 4000, currency: "USD")
+    security = Security.create!(ticker: "VOO", name: "Vanguard S&P 500")
+
+    Holding.create!(
+      account: account, security: security, date: Date.current,
+      qty: 30, price: 200, amount: 6000, currency: "USD"
+    )
+
+    top = @statement.top_holdings(limit: 1)
+
+    assert_equal 1, top.size
+    # 6000 / 10000 portfolio = 60% (not 100% of holdings)
+    assert_in_delta 60.0, top.first.weight, 0.01
+  end
+
+  test "allocation rolls up duplicate securities and weights sum to 100%" do
+    ira = create_investment_account(balance: 3000, currency: "USD")
+    taxable = create_investment_account(balance: 2000, currency: "USD")
+
+    aapl = Security.create!(ticker: "AAPL", name: "Apple")
+    msft = Security.create!(ticker: "MSFT", name: "Microsoft")
+
+    Holding.create!(
+      account: ira, security: aapl, date: Date.current,
+      qty: 10, price: 100, amount: 1000, currency: "USD"
+    )
+    Holding.create!(
+      account: taxable, security: aapl, date: Date.current,
+      qty: 5, price: 100, amount: 500, currency: "USD"
+    )
+    Holding.create!(
+      account: ira, security: msft, date: Date.current,
+      qty: 20, price: 100, amount: 2000, currency: "USD"
+    )
+
+    allocation = @statement.allocation
+
+    assert_equal 2, allocation.size
+    assert_equal %w[MSFT AAPL], allocation.map(&:ticker)
+    assert_equal Money.new(1500, "USD"), allocation.find { |a| a.ticker == "AAPL" }.amount
+    assert_in_delta 100.0, allocation.sum(&:weight), 0.01
+  end
+
   test "allocation weights sum to 100% with mixed currencies" do
     usd_account = create_investment_account(balance: 2100, currency: "USD")
     eur_account = create_investment_account(balance: 2000, currency: "EUR")

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -196,6 +196,43 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_in_delta 100.0, top.first.weight, 0.01
   end
 
+  test "top_holdings ignores a negative row sharing a security with a good one" do
+    # current_holdings is DISTINCT ON (account_id, security_id), so one security
+    # held in two accounts yields two rows. A negative row in one account must
+    # not net against the good row in the other before the value is taken.
+    ira = create_investment_account(balance: 1000, cash_balance: 0, currency: "USD")
+    taxable = create_investment_account(balance: 0, cash_balance: 0, currency: "USD")
+    security = Security.create!(ticker: "AAPL", name: "Apple")
+
+    Holding.create!(
+      account: ira, security: security, date: Date.current,
+      qty: 5, price: 200, amount: 1000, currency: "USD"
+    )
+
+    negative = Holding.new(
+      account: taxable, security: security, date: Date.current,
+      qty: 2, price: 250, amount: -500, currency: "USD"
+    )
+    negative.save!(validate: false)
+
+    # Trades give both rows a cost basis, so combined_holding_trend actually has
+    # something to combine — without them Holding#trend is nil and the trend
+    # half of the filtering would go unexercised.
+    create_trade_for(account: ira, security: security, qty: 5, price: 200)
+    create_trade_for(account: taxable, security: security, qty: 2, price: 250)
+
+    top = @statement.top_holdings(limit: 5)
+
+    assert_equal [ "AAPL" ], top.map(&:ticker)
+    assert_equal Money.new(1000, "USD"), top.first.amount_money
+    assert_in_delta 100.0, top.first.weight, 0.01
+
+    # The bad row must not reach the trend either: netting it in would give
+    # current 500 (1000 + -500) against previous 1500.
+    assert_equal Money.new(1000, "USD"), top.first.trend.current
+    assert_equal Money.new(1000, "USD"), top.first.trend.previous
+  end
+
   test "top_holdings computes trends only for the selected limit" do
     large = create_investment_account(balance: 5000, cash_balance: 0)
     small = create_investment_account(balance: 1000, cash_balance: 0)
@@ -467,6 +504,21 @@ class InvestmentStatementTest < ActiveSupport::TestCase
         cash_balance: cash_balance,
         currency: currency,
         accountable: Investment.new
+      )
+    end
+
+    def create_trade_for(account:, security:, qty:, price:, date: Date.current)
+      account.entries.create!(
+        name: "Trade #{SecureRandom.hex(3)}",
+        amount: qty * price,
+        date: date,
+        currency: account.currency,
+        entryable: Trade.new(
+          security: security,
+          qty: qty,
+          price: price,
+          currency: account.currency
+        )
       )
     end
 

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -156,6 +156,46 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_in_delta 100.0, top.first.weight, 0.01
   end
 
+  test "top_holdings weight stays within 100 when cash is negative" do
+    # Margin or an unsettled buy: balance 960 = holdings 1000 + cash -40.
+    account = create_investment_account(balance: 960, cash_balance: -40, currency: "USD")
+    security = Security.create!(ticker: "VTI", name: "Vanguard Total Market")
+
+    Holding.create!(
+      account: account, security: security, date: Date.current,
+      qty: 5, price: 200, amount: 1000, currency: "USD"
+    )
+
+    top = @statement.top_holdings(limit: 1)
+
+    assert_equal 1, top.size
+    assert_in_delta 100.0, top.first.weight, 0.01
+  end
+
+  test "top_holdings ignores a negative holding row when weighting" do
+    # Holding validates amount >= 0, but Holding::Materializer writes via
+    # upsert_all, which skips validations — an over-sell can land a negative row.
+    account = create_investment_account(balance: 500, cash_balance: 0, currency: "USD")
+    good = Security.create!(ticker: "AAPL", name: "Apple")
+    bad = Security.create!(ticker: "MSFT", name: "Microsoft")
+
+    Holding.create!(
+      account: account, security: good, date: Date.current,
+      qty: 5, price: 200, amount: 1000, currency: "USD"
+    )
+
+    negative = Holding.new(
+      account: account, security: bad, date: Date.current,
+      qty: 2, price: 250, amount: -500, currency: "USD"
+    )
+    negative.save!(validate: false)
+
+    top = @statement.top_holdings(limit: 5)
+
+    assert_equal [ "AAPL" ], top.map(&:ticker)
+    assert_in_delta 100.0, top.first.weight, 0.01
+  end
+
   test "top_holdings computes trends only for the selected limit" do
     large = create_investment_account(balance: 5000, cash_balance: 0)
     small = create_investment_account(balance: 1000, cash_balance: 0)
@@ -182,9 +222,13 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_equal %w[TOP1], top.map(&:ticker)
   end
 
-  test "allocation rolls up duplicate securities and weights sum to 100%" do
-    ira = create_investment_account(balance: 3000, currency: "USD")
-    taxable = create_investment_account(balance: 2000, currency: "USD")
+  # allocation shares top_holdings' denominator, so its weights sum to the
+  # invested share of the portfolio and cash is the visible residual.
+  test "allocation rolls up duplicate securities and weights leave cash as the residual" do
+    # Coherent balances: each account's balance is its holdings plus its cash,
+    # so the weight residual is genuinely cash and not stale balance data.
+    ira = create_investment_account(balance: 3000, cash_balance: 0, currency: "USD")
+    taxable = create_investment_account(balance: 2000, cash_balance: 1500, currency: "USD")
 
     aapl = Security.create!(ticker: "AAPL", name: "Apple")
     msft = Security.create!(ticker: "MSFT", name: "Microsoft")
@@ -207,7 +251,31 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_equal 2, allocation.size
     assert_equal %w[MSFT AAPL], allocation.map(&:ticker)
     assert_equal Money.new(1500, "USD"), allocation.find { |a| a.ticker == "AAPL" }.amount
-    assert_in_delta 100.0, allocation.sum(&:weight), 0.01
+
+    # 3500 of holdings against a 5000 portfolio: 70% invested, 30% cash.
+    assert_in_delta 70.0, allocation.sum(&:weight), 0.01
+
+    cash_share = @statement.cash_balance / @statement.portfolio_value * 100
+    assert_in_delta 100.0, allocation.sum(&:weight) + cash_share, 0.01
+  end
+
+  # The latent bug behind the divergence: the two methods used different
+  # denominators, so one security could report two percentages. Nothing renders
+  # allocation today, so this guards whoever wires it up.
+  test "top_holdings and allocation report the same weight for a security" do
+    account = create_investment_account(balance: 10_000, cash_balance: 4000, currency: "USD")
+    security = Security.create!(ticker: "VOO", name: "Vanguard S&P 500")
+
+    Holding.create!(
+      account: account, security: security, date: Date.current,
+      qty: 30, price: 200, amount: 6000, currency: "USD"
+    )
+
+    top_weight = @statement.top_holdings(limit: 1).first.weight
+    allocation_weight = @statement.allocation.find { |a| a.ticker == "VOO" }.weight
+
+    assert_in_delta top_weight, allocation_weight, 0.01
+    assert_in_delta 60.0, top_weight, 0.01
   end
 
   test "allocation weights sum to 100% with mixed currencies" do


### PR DESCRIPTION
## Summary
- Fixes #2291 by rolling up holdings by security across investment accounts in `InvestmentStatement#top_holdings` / `#allocation`
- Weight on the dashboard/reports Investments panel is now % of total portfolio value (including cash), not account-level `Holding#weight`
- Each investment appears once; top 5 are ranked by aggregated family-currency value
- `HoldingAllocation` duck-types `ticker` / `name` / `amount_money` so existing dashboard and reports views keep working without template changes

## Test plan
- [x] `bin/rails test test/models/investment_statement_test.rb`
- [ ] Dashboard Investments panel: same ticker in two accounts appears once with combined value
- [ ] Weight reflects share of total portfolio (cash dilutes holding %)
- [ ] Reports investment performance / print top holdings still render


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* **Portfolio Insights**
  * Top holdings and portfolio allocation now combine positions in the same security across accounts.
  * Holdings are ranked and weighted using consolidated portfolio values, with fallback handling when portfolio value is unavailable.
  * Allocation percentages remain capped at 100% when negative cash or other adjustments are present.
  * Non-positive holding rows are excluded from reported values, trends, and allocation calculations.
  * Allocation uses cash as the residual.
  * Holding details now include ticker, display name, and monetary value.
  * Trends reflect the selected top holdings using combined account data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->