### PR TITLE
Add markdown-driven public roadmap page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,7 +29,9 @@ class PagesController < ApplicationController
   DASHBOARD_HEIGHT_PRESETS = { "compact" => 208, "auto" => 288, "tall" => 416 }.freeze
   DEFAULT_HEIGHT_PRESET = "auto"
 
-  skip_authentication only: %i[redis_configuration_error privacy terms]
+  # Roadmap is a public project page, so it uses the same guest-accessible
+  # convention as the legal pages and the shared blank shell.
+  skip_authentication only: %i[redis_configuration_error privacy terms roadmap]
   before_action :ensure_intro_guest!, only: :intro
 
   def dashboard
@@ -107,6 +109,11 @@ class PagesController < ApplicationController
   end
 
   def terms
+    render layout: "blank"
+  end
+
+  def roadmap
+    @roadmap = RoadmapPresenter.new
     render layout: "blank"
   end
 

--- a/app/presenters/roadmap_markdown.rb
+++ b/app/presenters/roadmap_markdown.rb
@@ -1,0 +1,94 @@
+require "uri"
+
+class RoadmapMarkdown
+  FORMAT_MARKER = "<!-- roadmap:v1 -->"
+  STATUSES = %w[in_progress planned exploring].freeze
+
+  Item = Data.define(:title, :description, :status, :issue_url)
+  Phase = Data.define(:name, :description, :items)
+
+  def self.load(path, logger: Rails.logger)
+    new(File.read(path), logger: logger).parse
+  rescue SystemCallError => error
+    logger&.warn("RoadmapMarkdown could not read #{path}: #{error.message}")
+    []
+  end
+
+  def initialize(markdown, logger: Rails.logger)
+    @markdown = markdown
+    @logger = logger
+  end
+
+  def parse
+    unless @markdown.include?(FORMAT_MARKER)
+      warn("missing #{FORMAT_MARKER}")
+      return []
+    end
+
+    phases = []
+    phase = nil
+    item = nil
+
+    @markdown.each_line do |line|
+      line = line.strip
+
+      if (match = line.match(/\A## Phase: (.+)\z/))
+        item = finish_item(item, phase)
+        phase = { name: match[1].strip, description: nil, items: [] }
+        phases << phase
+      elsif (match = line.match(/\A### Item: (.+)\z/))
+        item = finish_item(item, phase)
+        if phase
+          item = { title: match[1].strip, description: nil, status: nil, issue_url: nil }
+        else
+          warn("item #{match[1].strip.inspect} appears before a phase; skipped")
+        end
+      elsif phase && (match = line.match(/\ADescription: (.+)\z/))
+        (item || phase)[:description] = match[1].strip
+      elsif item && (match = line.match(/\AStatus: (.+)\z/))
+        item[:status] = match[1].strip
+      elsif item && (match = line.match(/\AIssue: \[[^\]]+\]\(([^)]+)\)\z/))
+        item[:issue_url] = valid_issue_url(match[1].strip)
+      elsif line.match?(/\A(?:Status|Issue):/) || line.match?(/\A(?:##|###)\s/)
+        warn("unrecognized roadmap metadata: #{line.inspect}") unless line.empty?
+      end
+    end
+
+    finish_item(item, phase)
+    phases.filter_map do |candidate|
+      if candidate[:name].present? && candidate[:description].present?
+        Phase.new(candidate[:name], candidate[:description], candidate[:items].freeze)
+      else
+        warn("phase #{candidate[:name].inspect} is missing a description; skipped")
+        nil
+      end
+    end.freeze
+  end
+
+  private
+    def finish_item(item, phase)
+      return nil unless item
+
+      if phase && item[:title].present? && item[:description].present? && STATUSES.include?(item[:status])
+        phase[:items] << Item.new(item[:title], item[:description], item[:status].to_sym, item[:issue_url])
+      else
+        warn("item #{item[:title].inspect} is missing valid metadata; skipped")
+      end
+      nil
+    end
+
+    def valid_issue_url(url)
+      uri = URI.parse(url)
+      return url if uri.is_a?(URI::HTTP) && uri.scheme == "https" && uri.host == "github.com"
+
+      warn("invalid GitHub issue URL #{url.inspect}; omitted")
+      nil
+    rescue URI::InvalidURIError
+      warn("invalid GitHub issue URL #{url.inspect}; omitted")
+      nil
+    end
+
+    def warn(message)
+      @logger&.warn("RoadmapMarkdown: #{message}")
+    end
+end

--- a/app/presenters/roadmap_presenter.rb
+++ b/app/presenters/roadmap_presenter.rb
@@ -1,0 +1,13 @@
+class RoadmapPresenter
+  def initialize(path: Rails.root.join("docs/roadmap.md"))
+    @path = path
+  end
+
+  def phases
+    @phases ||= RoadmapMarkdown.load(@path)
+  end
+
+  def status_counts
+    phases.flat_map(&:items).group_by(&:status).transform_values(&:count)
+  end
+end

--- a/app/views/pages/roadmap.html.erb
+++ b/app/views/pages/roadmap.html.erb
@@ -1,0 +1,82 @@
+<% content_for :title, t("pages.roadmap.title") %>
+
+<div class="h-full overflow-y-auto">
+  <div class="mx-auto w-full max-w-6xl px-5 py-6 sm:px-8 lg:px-12">
+    <header class="flex items-center justify-between border-b border-divider pb-5">
+    <%= link_to root_path, class: "inline-flex items-center gap-3 focus-ring rounded-lg", aria: { label: t("pages.roadmap.back_to_sure") } do %>
+      <%= image_tag "logomark-color.svg", class: "h-9 w-9", alt: "" %>
+      <span class="text-sm font-semibold text-primary"><%= brand_name %></span>
+    <% end %>
+    <%= render DS::Link.new(text: t("pages.roadmap.back_to_app"), href: root_path) %>
+    </header>
+
+    <main id="main" class="py-16 sm:py-20">
+    <div class="mx-auto max-w-3xl text-center">
+      <p class="text-xs font-semibold uppercase tracking-widest text-secondary"><%= t("pages.roadmap.eyebrow") %></p>
+      <h1 class="mt-4 text-4xl font-semibold tracking-tight text-primary sm:text-5xl"><%= t("pages.roadmap.heading") %></h1>
+      <p class="mx-auto mt-5 max-w-2xl text-base leading-7 text-secondary sm:text-lg"><%= t("pages.roadmap.subtitle") %></p>
+    </div>
+
+    <div class="mt-14 grid gap-12 lg:grid-cols-4 lg:gap-16">
+      <aside class="self-start lg:col-span-1 lg:sticky lg:top-8" aria-labelledby="roadmap-status-heading">
+        <%= render DS::Card.new(class: "gap-5") do %>
+          <div>
+            <h2 id="roadmap-status-heading" class="text-sm font-semibold text-primary"><%= t("pages.roadmap.status.heading") %></h2>
+            <p class="mt-2 text-sm leading-6 text-secondary"><%= t("pages.roadmap.status.description") %></p>
+          </div>
+          <dl class="divide-y divide-tertiary border-y border-divider">
+            <% %i[in_progress planned exploring].each do |status| %>
+              <div class="flex items-center justify-between gap-3 py-3">
+                <dt class="flex items-center gap-2 text-sm text-secondary">
+                  <%= render DS::Pill.new(label: t("pages.roadmap.statuses.#{status}"), tone: status == :in_progress ? :success : :neutral, marker: false, show_dot: true) %>
+                </dt>
+                <dd class="text-sm font-semibold tabular-nums text-primary"><%= @roadmap.status_counts.fetch(status, 0) %></dd>
+              </div>
+            <% end %>
+          </dl>
+          <p class="text-xs leading-5 text-subdued"><%= t("pages.roadmap.status.note") %></p>
+        <% end %>
+      </aside>
+
+      <section class="lg:col-span-3" aria-labelledby="roadmap-phases-heading">
+        <h2 id="roadmap-phases-heading" class="sr-only"><%= t("pages.roadmap.phases_heading") %></h2>
+        <div class="border-l border-divider">
+          <% @roadmap.phases.each do |phase| %>
+            <div class="relative -ml-px border-b border-divider pb-8 pl-7 pt-1 first:pt-0 last:border-b-0">
+              <span class="absolute -left-[0.4375rem] top-2 h-3 w-3 rounded-full border-2 border-primary bg-surface first:top-1" aria-hidden="true"></span>
+              <%= render DS::Disclosure.new(body_class: "mt-5", summary_class: "list-none cursor-pointer rounded-lg focus-ring") do |disclosure| %>
+                <% disclosure.with_summary_content do %>
+                  <div class="flex w-full items-start justify-between gap-4">
+                    <div>
+                      <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+                        <h3 class="text-lg font-semibold text-primary"><%= phase.name %></h3>
+                        <span class="text-xs text-secondary"><%= t("pages.roadmap.item_count", count: phase.items.size) %></span>
+                      </div>
+                      <p class="mt-2 max-w-xl text-sm leading-6 text-secondary"><%= phase.description %></p>
+                    </div>
+                    <%= icon("chevron-down", class: "mt-1 shrink-0 text-secondary transition-transform group-open:rotate-180", size: "sm") %>
+                  </div>
+                <% end %>
+                <div class="divide-y divide-tertiary border-t border-divider">
+                  <% phase.items.each do |item| %>
+                    <article class="py-4 first:pt-5 last:pb-1">
+                      <div class="flex flex-wrap items-center justify-between gap-3">
+                        <h4 class="text-sm font-medium text-primary"><%= item.title %></h4>
+                        <%= render DS::Pill.new(label: t("pages.roadmap.statuses.#{item.status}"), tone: item.status == :in_progress ? :success : :neutral, marker: false) %>
+                      </div>
+                      <p class="mt-1.5 text-sm leading-6 text-secondary"><%= item.description %></p>
+                      <% if item.issue_url %>
+                        <%= link_to "GitHub issue for #{item.title}", item.issue_url, class: "mt-2 inline-flex text-sm text-secondary underline focus-ring rounded", target: "_blank", rel: "noopener", aria: { label: "View GitHub issue for #{item.title}" } %>
+                      <% end %>
+                    </article>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </section>
+    </div>
+    </main>
+  </div>
+</div>

--- a/app/views/pages/roadmap.html.erb
+++ b/app/views/pages/roadmap.html.erb
@@ -66,7 +66,8 @@
                       </div>
                       <p class="mt-1.5 text-sm leading-6 text-secondary"><%= item.description %></p>
                       <% if item.issue_url %>
-                        <%= link_to "GitHub issue for #{item.title}", item.issue_url, class: "mt-2 inline-flex text-sm text-secondary underline focus-ring rounded", target: "_blank", rel: "noopener", aria: { label: "View GitHub issue for #{item.title}" } %>
+                        <% issue_link_text = t("pages.roadmap.issue_link", title: item.title) %>
+                        <%= link_to issue_link_text, item.issue_url, class: "mt-2 inline-flex text-sm text-secondary underline focus-ring rounded", target: "_blank", rel: "noopener", aria: { label: issue_link_text } %>
                       <% end %>
                     </article>
                   <% end %>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -56,6 +56,7 @@ en:
         heading: Roadmap status
         description: Our priorities are guided by real-world use and community feedback.
         note: Timelines can change as we learn. Follow the project to stay up to date.
+      issue_link: GitHub issue for %{title}
     dashboard:
       welcome: "Welcome back, %{name}"
       subtitle: "Here's what's happening with your finances"

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -37,6 +37,25 @@ en:
       title: Terms of Service
       heading: Terms of Service
       placeholder: Terms of service content will be displayed here.
+    roadmap:
+      title: Sure roadmap
+      back_to_sure: Back to Sure
+      back_to_app: Open app
+      eyebrow: Building Sure together
+      heading: The Sure roadmap
+      subtitle: A transparent view of what we’re improving, what’s next, and where the community can help shape the future of personal finance.
+      phases_heading: Roadmap phases
+      item_count:
+        one: "%{count} item"
+        other: "%{count} items"
+      statuses:
+        in_progress: In progress
+        planned: Planned
+        exploring: Exploring
+      status:
+        heading: Roadmap status
+        description: Our priorities are guided by real-world use and community feedback.
+        note: Timelines can change as we learn. Follow the project to stay up to date.
     dashboard:
       welcome: "Welcome back, %{name}"
       subtitle: "Here's what's happening with your finances"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -820,6 +820,7 @@ Rails.application.routes.draw do
   terms_url = ENV["LEGAL_TERMS_URL"].presence
   get "privacy", to: privacy_url ? redirect(privacy_url) : "pages#privacy"
   get "terms", to: terms_url ? redirect(terms_url) : "pages#terms"
+  get "roadmap", to: "pages#roadmap"
   get "intro", to: "pages#intro"
 
   # Admin namespace for super admin functionality

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,59 @@
+<!-- roadmap:v1 -->
+
+# Sure roadmap
+
+This file is the curation and triage source for the public roadmap page. Keep
+the phases and items in the order they should appear publicly. GitHub issues
+and pull requests are supporting workflow links, not the roadmap source of
+truth; a pull request review controls changes to this file and therefore to
+the public roadmap.
+
+The page reads this deliberately small Markdown format:
+
+- Each phase starts with `## Phase: Name`, followed by one `Description:` line.
+- Each item starts with `### Item: Name`, followed by `Status:`, `Description:`,
+  and optionally `Issue: [label](https://github.com/...)` lines.
+- Status must be one of `in_progress`, `planned`, or `exploring`.
+- Keep metadata on one line. Unknown or incomplete items are omitted safely.
+
+## Phase: Strengthen the foundation
+
+Description: Make the everyday experience faster, clearer, and more dependable.
+
+### Item: Reliable account syncing
+
+Status: in_progress
+Description: Keep connections healthy and make sync status easier to understand.
+
+### Item: Better financial data
+
+Status: in_progress
+Description: Improve the accuracy and context of balances, transactions, and holdings.
+
+## Phase: Turn data into insight
+
+Description: Help you understand your money and make confident decisions.
+
+### Item: Clearer cash flow planning
+
+Status: planned
+Description: See what is coming in, what is going out, and what you can safely plan for.
+
+### Item: Goals that fit real life
+
+Status: planned
+Description: Make it easier to plan for the things that matter without losing flexibility.
+
+## Phase: The bigger picture
+
+Description: Explore the ideas that could make financial planning feel more human.
+
+### Item: Shared financial context
+
+Status: exploring
+Description: Explore thoughtful ways to plan with the people you trust.
+
+### Item: Less financial busywork
+
+Status: exploring
+Description: Reduce repetitive tasks while keeping you in control of your data.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,44 +16,99 @@ The page reads this deliberately small Markdown format:
 - Status must be one of `in_progress`, `planned`, or `exploring`.
 - Keep metadata on one line. Unknown or incomplete items are omitted safely.
 
-## Phase: Strengthen the foundation
+## Phase: Stabilize and polish the core
 
-Description: Make the everyday experience faster, clearer, and more dependable.
+Description: Establish a stable, secure, polished foundation for the web product.
 
-### Item: Reliable account syncing
-
-Status: in_progress
-Description: Keep connections healthy and make sync status easier to understand.
-
-### Item: Better financial data
+### Item: Reliability, performance, and technical-debt reduction
 
 Status: in_progress
-Description: Improve the accuracy and context of balances, transactions, and holdings.
+Description: Refactor duplicated code, improve provider abstractions, fix balance and sign inconsistencies, improve security, and establish a stable v1.0 foundation.
 
-## Phase: Turn data into insight
+### Item: Web UX/UI polish and consistency
 
-Description: Help you understand your money and make confident decisions.
+Status: in_progress
+Description: Improve responsiveness, animations, optimistic UI, copy quality, wording, visual consistency, and general polish.
 
-### Item: Clearer cash flow planning
+### Item: AI controls and transparency
+
+Status: in_progress
+Description: Add a first-class AI settings area with a master on/off switch and granular controls, keeping AI optional rather than forcing it on users.
+
+### Item: Documentation and onboarding
+
+Status: in_progress
+Description: Improve generic and advanced guides, surface the documentation better, reorganize outdated material, and eventually support localized guidance.
+
+### Item: Mobile app planning and delivery
 
 Status: planned
-Description: See what is coming in, what is going out, and what you can safely plan for.
+Description: Build toward a polished iOS and Android app, while resolving the right timing and delivery approach after web stabilization.
 
-### Item: Goals that fit real life
+### Item: Release cadence focused on quality
+
+Status: in_progress
+Description: Alternate stability, performance, and polish periods with feature-focused periods on a roughly quarterly or monthly rhythm.
+
+## Phase: Expand personal-finance capability
+
+Description: Add better tools for understanding money, planning decisions, and building long-term financial confidence.
+
+### Item: Better AI integration and a first-class AI experience
 
 Status: planned
-Description: Make it easier to plan for the things that matter without losing flexibility.
+Description: Make AI chat a dedicated page or workspace, allow it to navigate Sure’s UI, generate useful visualizations, and act as an assistant without replacing the traditional interface.
 
-## Phase: The bigger picture
+### Item: Transaction intelligence
 
-Description: Explore the ideas that could make financial planning feel more human.
+Status: planned
+Description: Use small, local, non-LLM machine-learning models to predict or categorize transactions.
 
-### Item: Shared financial context
+### Item: Savings, retirement, and investment improvements
+
+Status: planned
+Description: Better separate everyday accounts from long-term savings with projections, fee impact, diversification and portfolio-health indicators, graphs, and retirement tooling.
+
+### Item: Scenario simulation and sandbox mode
+
+Status: planned
+Description: Let users model hypothetical decisions, such as a major trip, and preview their short- and long-term financial effects.
+
+### Item: Localization and country-specific finance support
+
+Status: planned
+Description: Add country-aware onboarding, categories, providers, account types, taxation, translations, and an international or multi-country mode.
+
+### Item: Themes and customization
+
+Status: planned
+Description: Add additional themes and thoughtful customization as a lower-priority quality-of-life improvement.
+
+## Phase: Open the platform carefully
+
+Description: Extend Sure while keeping it understandable, controlled, and centered on user ownership.
+
+### Item: External-agent integration and financial execution
 
 Status: exploring
-Description: Explore thoughtful ways to plan with the people you trust.
+Description: Keep Sure as the system of record while approved external AI agents use its data and, with explicit approval, request or execute actions such as transfers or trades with strong opt-in controls, audit logs, and security.
 
-### Item: Less financial busywork
+### Item: Agent-assisted financial cleanup and memory
 
 Status: exploring
-Description: Reduce repetitive tasks while keeping you in control of your data.
+Description: Support workflows such as reading receipts or email, reconciling purchases, and splitting transactions, while letting an external agent harness handle long-term memory and orchestration where appropriate.
+
+### Item: Polished mobile ecosystem
+
+Status: exploring
+Description: Complete mobile parity and explore widgets, notifications, and Siri integration.
+
+### Item: Improved macOS and desktop experience
+
+Status: exploring
+Description: Add native notifications and widgets while evaluating whether desktop belongs alongside web and mobile or should remain a separate effort.
+
+### Item: Business finance support
+
+Status: exploring
+Description: Explore business finance only after personal finance is stable, likely as a separate app or product with different workflows, tax treatment, integrations, support expectations, and hosted or SMB offerings.

--- a/test/controllers/pages_roadmap_test.rb
+++ b/test/controllers/pages_roadmap_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class PagesRoadmapTest < ActionDispatch::IntegrationTest
+  test "roadmap is public and renders collapsed roadmap phases" do
+    get roadmap_path
+
+    assert_response :ok
+    assert_select "h1", text: "The Sure roadmap"
+    assert_select "aside[aria-labelledby='roadmap-status-heading']"
+    assert_select "main section details", count: 3
+    assert_select "main section details:not([open])", count: 3
+    assert_select "main section summary", count: 3
+    assert_select "main section summary", text: /2 items/, count: 3
+    assert_select "main section details article", count: 6
+    assert_select "h3", text: [
+      "Strengthen the foundation",
+      "Turn data into insight",
+      "The bigger picture"
+    ]
+    assert_select "h4", text: "Reliable account syncing"
+    assert_select "h4", text: "Less financial busywork"
+    assert_select "dd", text: "2", count: 2
+    assert_select "dd", text: "0", count: 1
+  end
+
+  test "renders an accessible GitHub issue link when the Markdown item has one" do
+    item = RoadmapMarkdown::Item.new("Linked item", "Item description.", :planned, "https://github.com/we-promise/sure/issues/42")
+    phase = RoadmapMarkdown::Phase.new("Linked phase", "Phase description.", [ item ])
+
+    RoadmapMarkdown.stubs(:load).returns([ phase ])
+    get roadmap_path
+
+    assert_response :ok
+    assert_select "a[href='https://github.com/we-promise/sure/issues/42'][aria-label='View GitHub issue for Linked item']", text: "GitHub issue for Linked item"
+  end
+end

--- a/test/controllers/pages_roadmap_test.rb
+++ b/test/controllers/pages_roadmap_test.rb
@@ -33,6 +33,6 @@ class PagesRoadmapTest < ActionDispatch::IntegrationTest
     get roadmap_path
 
     assert_response :ok
-    assert_select "a[href='https://github.com/we-promise/sure/issues/42'][aria-label='View GitHub issue for Linked item']", text: "GitHub issue for Linked item"
+    assert_select "a[href='https://github.com/we-promise/sure/issues/42'][aria-label='GitHub issue for Linked item']", text: "GitHub issue for Linked item"
   end
 end

--- a/test/controllers/pages_roadmap_test.rb
+++ b/test/controllers/pages_roadmap_test.rb
@@ -10,17 +10,19 @@ class PagesRoadmapTest < ActionDispatch::IntegrationTest
     assert_select "main section details", count: 3
     assert_select "main section details:not([open])", count: 3
     assert_select "main section summary", count: 3
-    assert_select "main section summary", text: /2 items/, count: 3
-    assert_select "main section details article", count: 6
+    assert_select "main section summary", text: /6 items/, count: 2
+    assert_select "main section summary", text: /5 items/, count: 1
+    assert_select "main section details article", count: 17
     assert_select "h3", text: [
-      "Strengthen the foundation",
-      "Turn data into insight",
-      "The bigger picture"
+      "Stabilize and polish the core",
+      "Expand personal-finance capability",
+      "Open the platform carefully"
     ]
-    assert_select "h4", text: "Reliable account syncing"
-    assert_select "h4", text: "Less financial busywork"
-    assert_select "dd", text: "2", count: 2
-    assert_select "dd", text: "0", count: 1
+    assert_select "h4", text: "Reliability, performance, and technical-debt reduction"
+    assert_select "h4", text: "Business finance support"
+    assert_select "dd", text: "5", count: 1
+    assert_select "dd", text: "7", count: 1
+    assert_select "dd", text: "5", count: 1
   end
 
   test "renders an accessible GitHub issue link when the Markdown item has one" do

--- a/test/presenters/roadmap_markdown_test.rb
+++ b/test/presenters/roadmap_markdown_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class RoadmapMarkdownTest < ActiveSupport::TestCase
+  test "parses phases and items in document order with statuses and issue links" do
+    markdown = <<~MARKDOWN
+      <!-- roadmap:v1 -->
+      ## Phase: First phase
+      Description: First phase description.
+      ### Item: First item
+      Status: in_progress
+      Description: First item description.
+      Issue: [#42](https://github.com/we-promise/sure/issues/42)
+      ### Item: Second item
+      Status: planned
+      Description: Second item description.
+      ## Phase: Second phase
+      Description: Second phase description.
+      ### Item: Third item
+      Status: exploring
+      Description: Third item description.
+    MARKDOWN
+
+    phases = RoadmapMarkdown.new(markdown, logger: nil).parse
+
+    assert_equal [ "First phase", "Second phase" ], phases.map(&:name)
+    assert_equal [ "First item", "Second item" ], phases.first.items.map(&:title)
+    assert_equal [ :in_progress, :planned ], phases.first.items.map(&:status)
+    assert_equal "https://github.com/we-promise/sure/issues/42", phases.first.items.first.issue_url
+  end
+
+  test "skips malformed metadata and rejects non-GitHub issue links" do
+    markdown = <<~MARKDOWN
+      <!-- roadmap:v1 -->
+      ## Phase: Safe phase
+      Description: Safe description.
+      ### Item: Missing status
+      Description: Omitted.
+      ### Item: Unsafe link
+      Status: planned
+      Description: Kept without its link.
+      Issue: [bad](http://example.com/item)
+    MARKDOWN
+
+    items = RoadmapMarkdown.new(markdown, logger: nil).parse.flat_map(&:items)
+
+    assert_equal [ "Unsafe link" ], items.map(&:title)
+    assert_nil items.first.issue_url
+  end
+
+  test "returns no phases when the format marker is missing" do
+    assert_empty RoadmapMarkdown.new("## Phase: Not a roadmap", logger: nil).parse
+  end
+end


### PR DESCRIPTION
## Summary

- add a public `/roadmap` page using Sure’s existing design-system components and tokens
- keep status triage on the left and collapsed phase disclosures on the right
- make `docs/roadmap.md` the reviewed source of truth for public roadmap phases, ordering, copy, and statuses
- allow optional links to supporting GitHub issues
- add parser and controller coverage

## Notes

This intentionally does not add a GitHub Projects integration. GitHub issues/PRs remain supporting workflow objects; roadmap changes happen through PR review of `docs/roadmap.md`.

Rails tests could not be run in the development environment because Ruby is unavailable; `git diff --check` passes.
