### PR TITLE
feat(rules): add "Swap deposit and withdraw" transaction rule

### DIFF
--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -346,6 +346,7 @@ class Family::DataExporter
           created_at: transaction.created_at,
           updated_at: transaction.updated_at
         }
+        add_amount_inversion_state(transaction_data, transaction)
         split_lines = serialize_split_lines_for_export(transaction.entry)
         transaction_data[:split_lines] = split_lines if split_lines.any?
 
@@ -497,7 +498,7 @@ class Family::DataExporter
 
       child_entries.map do |child_entry|
         transaction = child_entry.entryable
-        {
+        data = {
           id: transaction.id,
           entry_id: child_entry.id,
           amount: child_entry.amount,
@@ -512,7 +513,14 @@ class Family::DataExporter
           created_at: transaction.created_at,
           updated_at: transaction.updated_at
         }
+        add_amount_inversion_state(data, transaction)
+        data
       end
+    end
+
+    def add_amount_inversion_state(data, transaction)
+      state = transaction.amount_inversion_state
+      data[:amount_inversion_state] = state if state
     end
 
     def split_child_entries_for_export(parent_entry)

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -587,7 +587,10 @@ class Family::DataImporter
           merchant_id: new_merchant_id,
           kind: data["kind"] || "standard"
         )
-        transaction.restore_amount_inversion_state(data["amount_inversion_state"]) if data.key?("amount_inversion_state")
+        if data.key?("amount_inversion_state")
+          restored = transaction.restore_amount_inversion_state(data["amount_inversion_state"])
+          log_rejected_amount_inversion_state(data["amount_inversion_state"], old_id) unless restored
+        end
 
         entry ||= Entry.new(entryable: transaction)
         entry.assign_attributes(
@@ -677,8 +680,12 @@ class Family::DataImporter
           merchant_id: row[:merchant_id_provided] ? row[:merchant_id] : transaction.merchant_id,
           kind: row[:kind].presence || transaction.kind
         )
-        if row[:amount_inversion_state].present? && transaction.restore_amount_inversion_state(row[:amount_inversion_state])
-          transaction.save!
+        if row[:amount_inversion_state].present?
+          if transaction.restore_amount_inversion_state(row[:amount_inversion_state])
+            transaction.save!
+          else
+            log_rejected_amount_inversion_state(row[:amount_inversion_state], row[:old_id])
+          end
         end
         child_entry.update!(notes: row[:notes]) if row[:notes].present?
 
@@ -945,6 +952,21 @@ class Family::DataImporter
 
       max_allowed_date = @oldest_import_entry_dates_by_account[old_id]&.prev_day
       [ explicit_date, max_allowed_date ].compact.min
+    end
+
+    # A rejected watermark is silent but consequential: the transaction imports
+    # with the corrected amount and no record that it was corrected, so the next
+    # rule run inverts it again and flips the sign back. The import itself still
+    # reports success, so surface it where support can see it.
+    def log_rejected_amount_inversion_state(state, old_id)
+      DebugLogEntry.capture(
+        category: "data_import",
+        level: "warn",
+        message: "Rejected malformed amount inversion state during import",
+        source: self.class.name,
+        family: @family,
+        metadata: { source_transaction_id: old_id, state: state }
+      )
     end
 
     def log_failed_opening_balance_import(account, old_id, result)

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -587,6 +587,7 @@ class Family::DataImporter
           merchant_id: new_merchant_id,
           kind: data["kind"] || "standard"
         )
+        transaction.restore_amount_inversion_state(data["amount_inversion_state"]) if data.key?("amount_inversion_state")
 
         entry ||= Entry.new(entryable: transaction)
         entry.assign_attributes(
@@ -652,7 +653,8 @@ class Family::DataImporter
           excluded: boolean_import_value(row, "excluded", default: false),
           tag_ids: mapped_tag_ids(row["tag_ids"], record_type: "Transaction"),
           tag_ids_provided: row.key?("tag_ids"),
-          kind: row["kind"]
+          kind: row["kind"],
+          amount_inversion_state: row["amount_inversion_state"]
         }
       end
     end
@@ -675,6 +677,9 @@ class Family::DataImporter
           merchant_id: row[:merchant_id_provided] ? row[:merchant_id] : transaction.merchant_id,
           kind: row[:kind].presence || transaction.kind
         )
+        if row[:amount_inversion_state].present? && transaction.restore_amount_inversion_state(row[:amount_inversion_state])
+          transaction.save!
+        end
         child_entry.update!(notes: row[:notes]) if row[:notes].present?
 
         tag_ids = row[:tag_ids_provided] ? row[:tag_ids] : fallback_tag_ids

--- a/app/models/rule/action_executor/invert_transaction_amount.rb
+++ b/app/models/rule/action_executor/invert_transaction_amount.rb
@@ -1,0 +1,61 @@
+class Rule::ActionExecutor::InvertTransactionAmount < Rule::ActionExecutor
+  def label
+    I18n.t("rules.action_executors.invert_transaction_amount")
+  end
+
+  def execute(transaction_scope, value: nil, ignore_attribute_locks: false, rule_run: nil)
+    scope = transaction_scope.with_entry
+    unless ignore_attribute_locks
+      scope = scope.where.not(Arel.sql("entries.locked_attributes ? 'amount'"))
+    end
+
+    modified_entries = scope.filter_map do |transaction|
+      invert_amount_once(transaction, ignore_attribute_locks: ignore_attribute_locks)
+    end
+
+    schedule_account_recalculations(modified_entries)
+    modified_entries.size
+  end
+
+  private
+    def invert_amount_once(transaction, ignore_attribute_locks:)
+      entry = transaction.entry
+
+      # Entry#transaction is the delegated Transaction accessor, so use an
+      # explicit class transaction before locking the Entry row.
+      Entry.transaction do
+        entry.lock!
+        transaction.reload
+
+        if entry.amount.zero? || transaction.amount_inversion_corrected_amount == entry.amount
+          false
+        else
+          source_amount = entry.amount
+          corrected_amount = entry.amount * -1
+          modified = entry.enrich_attribute(
+            :amount,
+            corrected_amount,
+            source: "rule",
+            metadata: { rule_id: rule.id, action_type: key },
+            ignore_locks: ignore_attribute_locks
+          )
+
+          if modified
+            transaction.record_amount_inversion!(source_amount:, corrected_amount:)
+            entry
+          else
+            false
+          end
+        end
+      end
+    end
+
+    def schedule_account_recalculations(entries)
+      entries.group_by(&:account_id).each_value do |account_entries|
+        earliest_date = account_entries.filter_map(&:date).min
+        # Account sync rematerializes persisted balances; its post-sync hook
+        # also reruns transfer matching against the corrected direction.
+        account_entries.first.account.sync_later(window_start_date: earliest_date)
+      end
+    end
+end

--- a/app/models/rule/action_executor/invert_transaction_amount.rb
+++ b/app/models/rule/action_executor/invert_transaction_amount.rb
@@ -18,7 +18,7 @@ class Rule::ActionExecutor::InvertTransactionAmount < Rule::ActionExecutor
   end
 
   private
-    # Flipping a sign is only self-contained for a standalone transaction. Two
+    # Flipping a sign is only self-contained for a standalone transaction. Three
     # shapes carry a cross-record sum invariant that nothing re-checks when an
     # Entry amount changes, so inverting one leaves persistent corruption:
     #
@@ -27,15 +27,23 @@ class Rule::ActionExecutor::InvertTransactionAmount < Rule::ActionExecutor
     #   written, so the row survives in an invalid state. It cannot self-heal,
     #   because auto transfer matching only considers transactions that are not
     #   already attached to a transfer.
+    # - Transfer fees. These hang off the transfer through transfer_id rather
+    #   than either leg association, and they are ordinary standard-kind rows,
+    #   so nothing else filters them out. Transfer#derived_source_fee_amount
+    #   sums them by account, so flipping one turns a reported fee negative and
+    #   moves the account balance. No validation covers fees, so the transfer
+    #   still reports itself as valid.
     # - Split children. Entry#split! enforces sum(children) == parent.amount
     #   only at split time, and the excluded parent means balances derive from
     #   the children, so flipping one child silently moves the account balance.
     #
-    # Both are skipped rather than corrected. They are reported as blocked in
-    # the rule run counts, which is the same treatment a locked amount gets.
+    # All three are skipped rather than corrected. They are reported as blocked
+    # in the rule run counts, the same treatment a locked amount gets.
     def invertible_scope(transaction_scope)
       transaction_scope
         .with_entry
+        .preload(entry: :account)
+        .where(transactions: { transfer_id: nil })
         .where(entries: { parent_entry_id: nil })
         .where.missing(:transfer_as_inflow, :transfer_as_outflow)
     end

--- a/app/models/rule/action_executor/invert_transaction_amount.rb
+++ b/app/models/rule/action_executor/invert_transaction_amount.rb
@@ -4,7 +4,7 @@ class Rule::ActionExecutor::InvertTransactionAmount < Rule::ActionExecutor
   end
 
   def execute(transaction_scope, value: nil, ignore_attribute_locks: false, rule_run: nil)
-    scope = transaction_scope.with_entry
+    scope = invertible_scope(transaction_scope)
     unless ignore_attribute_locks
       scope = scope.where.not(Arel.sql("entries.locked_attributes ? 'amount'"))
     end
@@ -18,6 +18,28 @@ class Rule::ActionExecutor::InvertTransactionAmount < Rule::ActionExecutor
   end
 
   private
+    # Flipping a sign is only self-contained for a standalone transaction. Two
+    # shapes carry a cross-record sum invariant that nothing re-checks when an
+    # Entry amount changes, so inverting one leaves persistent corruption:
+    #
+    # - Transfer legs. Transfer validates that its legs have opposite signs and
+    #   sum to zero, but no callback re-validates the transfer when an entry is
+    #   written, so the row survives in an invalid state. It cannot self-heal,
+    #   because auto transfer matching only considers transactions that are not
+    #   already attached to a transfer.
+    # - Split children. Entry#split! enforces sum(children) == parent.amount
+    #   only at split time, and the excluded parent means balances derive from
+    #   the children, so flipping one child silently moves the account balance.
+    #
+    # Both are skipped rather than corrected. They are reported as blocked in
+    # the rule run counts, which is the same treatment a locked amount gets.
+    def invertible_scope(transaction_scope)
+      transaction_scope
+        .with_entry
+        .where(entries: { parent_entry_id: nil })
+        .where.missing(:transfer_as_inflow, :transfer_as_outflow)
+    end
+
     def invert_amount_once(transaction, ignore_attribute_locks:)
       entry = transaction.entry
 
@@ -53,8 +75,9 @@ class Rule::ActionExecutor::InvertTransactionAmount < Rule::ActionExecutor
     def schedule_account_recalculations(entries)
       entries.group_by(&:account_id).each_value do |account_entries|
         earliest_date = account_entries.filter_map(&:date).min
-        # Account sync rematerializes persisted balances; its post-sync hook
-        # also reruns transfer matching against the corrected direction.
+        # Account sync rematerializes persisted balances. Its post-sync hook
+        # also reruns transfer matching, which can now pair a corrected
+        # transaction that previously had the wrong sign to match against.
         account_entries.first.account.sync_later(window_start_date: earliest_date)
       end
     end

--- a/app/models/rule/registry/transaction_resource.rb
+++ b/app/models/rule/registry/transaction_resource.rb
@@ -23,6 +23,7 @@ class Rule::Registry::TransactionResource < Rule::Registry
       Rule::ActionExecutor::SetTransactionMerchant.new(rule),
       Rule::ActionExecutor::SetTransactionName.new(rule),
       Rule::ActionExecutor::SetInvestmentActivityLabel.new(rule),
+      Rule::ActionExecutor::InvertTransactionAmount.new(rule),
       Rule::ActionExecutor::ExcludeTransaction.new(rule),
       Rule::ActionExecutor::SetAsTransferOrPayment.new(rule),
       Rule::ActionExecutor::SendEmailNotification.new(rule)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -163,6 +163,46 @@ class Transaction < ApplicationRecord
     false
   end
 
+  # A direction correction is transaction state, not rule state. Multiple
+  # matching inversion rules must therefore share one watermark so they cannot
+  # cancel each other by each multiplying the same amount by -1.
+  def amount_inversion_state
+    raw_state = extra.is_a?(Hash) ? extra.dig("rules", "invert_transaction_amount") : nil
+    normalize_amount_inversion_state(raw_state)
+  end
+
+  def amount_inversion_corrected_amount
+    value = amount_inversion_state&.fetch("corrected_amount", nil)
+    BigDecimal(value) if value
+  end
+
+  def record_amount_inversion!(source_amount:, corrected_amount:)
+    state = normalize_amount_inversion_state(
+      "source_amount" => source_amount,
+      "corrected_amount" => corrected_amount
+    )
+    raise ArgumentError, "invalid amount inversion state" unless state
+
+    updated_extra = extra.is_a?(Hash) ? extra.deep_dup : {}
+    updated_extra["rules"] = {} unless updated_extra["rules"].is_a?(Hash)
+    updated_extra["rules"]["invert_transaction_amount"] = state
+    update!(extra: updated_extra)
+  end
+
+  # Used by the family backup importer. Only this narrowly-scoped rule state is
+  # restored; provider metadata and any unrelated Transaction#extra keys are
+  # neither accepted from nor overwritten by the portable export field.
+  def restore_amount_inversion_state(state)
+    normalized_state = normalize_amount_inversion_state(state)
+    return false unless normalized_state
+
+    updated_extra = extra.is_a?(Hash) ? extra.deep_dup : {}
+    updated_extra["rules"] = {} unless updated_extra["rules"].is_a?(Hash)
+    updated_extra["rules"]["invert_transaction_amount"] = normalized_state
+    self.extra = updated_extra
+    true
+  end
+
   def activity_security_id
     extra&.dig("security_id").presence || extra&.dig("security", "id").presence
   end
@@ -384,6 +424,21 @@ class Transaction < ApplicationRecord
     def potential_posted_match_data
       return nil unless extra.is_a?(Hash)
       extra["potential_posted_match"]
+    end
+
+    def normalize_amount_inversion_state(state)
+      return unless state.is_a?(Hash)
+
+      source_amount = BigDecimal(state["source_amount"].to_s)
+      corrected_amount = BigDecimal(state["corrected_amount"].to_s)
+      return if source_amount.zero? || corrected_amount != -source_amount
+
+      {
+        "source_amount" => source_amount.to_s("F"),
+        "corrected_amount" => corrected_amount.to_s("F")
+      }
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def clear_merchant_unlinked_association

--- a/config/locales/views/rules/en.yml
+++ b/config/locales/views/rules/en.yml
@@ -52,6 +52,8 @@ en:
       confirm_changes: Confirm changes
     actions:
       value_placeholder: Enter a value
+    action_executors:
+      invert_transaction_amount: Swap deposit and withdrawal
     update:
       success: Rule updated
     destroy:

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -635,6 +635,52 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal false, restored_named.manual
   end
 
+  test "round trips an inverted transaction without applying the correction twice" do
+    source_family = Family.create!(name: "Inversion Source", currency: "USD")
+    source_account = source_family.accounts.create!(
+      name: "Fidelity",
+      accountable: Depository.new,
+      balance: 1000,
+      currency: "USD"
+    )
+    source_entry = source_account.entries.create!(
+      name: "FIDELITY DEPOSIT",
+      amount: -100,
+      currency: "USD",
+      date: Date.current,
+      entryable: Transaction.new(extra: { "simplefin" => { "pending" => false } })
+    )
+    source_rule = source_family.rules.create!(
+      name: "Correct Fidelity direction",
+      resource_type: "transaction",
+      active: true,
+      effective_date: 1.day.ago.to_date,
+      conditions: [ Rule::Condition.new(condition_type: "transaction_name", operator: "like", value: "fidelity") ],
+      actions: [ Rule::Action.new(action_type: "invert_transaction_amount") ]
+    )
+    Account.any_instance.stubs(:sync_later)
+
+    assert_equal 1, source_rule.apply
+    assert_equal 100, source_entry.reload.amount
+
+    ndjson = nil
+    Zip::File.open_buffer(Family::DataExporter.new(source_family).generate_export) do |zip|
+      ndjson = zip.read("all.ndjson")
+    end
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    restored_entry = @family.entries.find_by!(name: "FIDELITY DEPOSIT")
+    restored_rule = @family.rules.find_by!(name: "Correct Fidelity direction")
+    restored_state = restored_entry.transaction.amount_inversion_state
+
+    assert_equal 100, restored_entry.amount
+    assert_equal({ "source_amount" => "-100.0", "corrected_amount" => "100.0" }, restored_state)
+    assert_nil restored_entry.transaction.extra["simplefin"]
+    assert_equal 0, restored_rule.apply
+    assert_equal 100, restored_entry.reload.amount
+  end
+
   test "imports recurring transactions with unknown status fallback" do
     ndjson = build_ndjson([
       {

--- a/test/models/rule/action_test.rb
+++ b/test/models/rule/action_test.rb
@@ -332,6 +332,24 @@ class Rule::ActionTest < ActiveSupport::TestCase
     assert_equal 500, outflow.reload.entry.amount
   end
 
+  test "invert_transaction_amount skips transfer fees so reported fees keep their sign" do
+    stub_account_sync
+    other_account = @family.accounts.create!(name: "Fee target", balance: 1000, currency: "USD", accountable: Depository.new)
+    outflow = create_transaction(date: Date.current, account: @account, amount: 500, name: "Fee transfer out").transaction
+    inflow = create_transaction(date: Date.current, account: other_account, amount: -500, name: "Fee transfer in").transaction
+    fee = create_transaction(date: Date.current, account: @account, amount: 5, name: "Transfer fee").transaction
+    transfer = Transfer.create!(inflow_transaction: inflow, outflow_transaction: outflow, status: "confirmed")
+    transfer.fee_transactions << fee
+
+    action = Rule::Action.new(rule: @transaction_rule, action_type: "invert_transaction_amount")
+
+    # A fee hangs off transfer_id, not either leg association, and is an
+    # ordinary standard-kind row, so nothing else would filter it out.
+    assert_equal 0, action.apply(Transaction.where(id: fee.id))
+    assert_equal 5, fee.reload.entry.amount
+    assert_equal 5, transfer.reload.derived_source_fee_amount
+  end
+
   test "invert_transaction_amount skips split children so the split still sums to its parent" do
     stub_account_sync
     parent_entry = create_transaction(date: Date.current, account: @account, amount: 300, name: "Split parent")

--- a/test/models/rule/action_test.rb
+++ b/test/models/rule/action_test.rb
@@ -17,6 +17,7 @@ class Rule::ActionTest < ActiveSupport::TestCase
     @txn3 = create_transaction(date: 1.day.ago.to_date, account: @account, amount: 50, name: "Rule test transaction3").transaction
 
     @rule_scope = @account.transactions
+    Account.any_instance.stubs(:sync_later)
   end
 
   test "set_transaction_category" do
@@ -218,6 +219,103 @@ class Rule::ActionTest < ActiveSupport::TestCase
 
     category = @family.investment_contributions_category
     assert_equal category, transfer.outflow_transaction.category
+  end
+
+  test "invert_transaction_amount swaps deposits and withdrawals once" do
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "invert_transaction_amount"
+    )
+    scope = Transaction.where(id: [ @txn1.id, @txn2.id ])
+
+    assert_equal 2, action.apply(scope)
+    assert_equal(-100, @txn1.reload.entry.amount)
+    assert_equal 200, @txn2.reload.entry.amount
+
+    assert_equal 0, action.apply(scope)
+    assert_equal(-100, @txn1.reload.entry.amount)
+    assert_equal 200, @txn2.reload.entry.amount
+  end
+
+  test "invert_transaction_amount corrects an amount restored by provider sync" do
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "invert_transaction_amount"
+    )
+    scope = Transaction.where(id: @txn2.id)
+
+    assert_equal 1, action.apply(scope)
+    assert_equal 200, @txn2.reload.entry.amount
+    assert_equal(
+      { "source_amount" => "-200.0", "corrected_amount" => "200.0" },
+      @txn2.amount_inversion_state
+    )
+
+    @txn2.entry.update!(amount: -200)
+
+    assert_equal 1, action.apply(scope)
+    assert_equal 200, @txn2.reload.entry.amount
+    assert_equal 0, action.apply(scope)
+  end
+
+  test "invert_transaction_amount preserves provider metadata" do
+    @txn2.update!(extra: { "simplefin" => { "pending" => true } })
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "invert_transaction_amount"
+    )
+
+    action.apply(Transaction.where(id: @txn2.id))
+
+    assert_equal true, @txn2.reload.extra.dig("simplefin", "pending")
+    assert_equal "200.0", @txn2.extra.dig("rules", "invert_transaction_amount", "corrected_amount")
+  end
+
+  test "invert_transaction_amount schedules one recalculation per affected account from the earliest date" do
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "invert_transaction_amount"
+    )
+
+    Account.any_instance.expects(:sync_later).with(window_start_date: 1.day.ago.to_date).once
+
+    assert_equal 2, action.apply(Transaction.where(id: [ @txn1.id, @txn3.id ]))
+  end
+
+  test "overlapping invert actions share transaction state instead of cancelling each other" do
+    other_rule = Rule.create!(
+      family: @family,
+      resource_type: "transaction",
+      actions: [ Rule::Action.new(action_type: "invert_transaction_amount") ]
+    )
+    first_action = Rule::Action.new(rule: @transaction_rule, action_type: "invert_transaction_amount")
+    second_action = other_rule.actions.first
+    scope = Transaction.where(id: @txn2.id)
+
+    assert_equal 1, first_action.apply(scope)
+    assert_equal 0, second_action.apply(scope)
+    assert_equal 200, @txn2.reload.entry.amount
+
+    @txn2.entry.update!(amount: -200)
+
+    assert_equal 1, second_action.apply(scope)
+    assert_equal 0, first_action.apply(scope)
+    assert_equal 200, @txn2.reload.entry.amount
+  end
+
+  test "invert_transaction_amount respects amount locks unless explicitly reapplied" do
+    @txn1.entry.lock_attr!(:amount)
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "invert_transaction_amount"
+    )
+    scope = Transaction.where(id: @txn1.id)
+
+    assert_equal 0, action.apply(scope)
+    assert_equal 100, @txn1.reload.entry.amount
+
+    assert_equal 1, action.apply(scope, ignore_attribute_locks: true)
+    assert_equal(-100, @txn1.reload.entry.amount)
   end
 
   test "set_investment_activity_label ignores invalid values" do

--- a/test/models/rule/action_test.rb
+++ b/test/models/rule/action_test.rb
@@ -17,6 +17,12 @@ class Rule::ActionTest < ActiveSupport::TestCase
     @txn3 = create_transaction(date: 1.day.ago.to_date, account: @account, amount: 50, name: "Rule test transaction3").transaction
 
     @rule_scope = @account.transactions
+  end
+
+  # The inversion action schedules a balance resync per affected account. Stub
+  # it only where it is incidental, so the surrounding tests keep exercising
+  # their own real sync behavior.
+  def stub_account_sync
     Account.any_instance.stubs(:sync_later)
   end
 
@@ -222,6 +228,7 @@ class Rule::ActionTest < ActiveSupport::TestCase
   end
 
   test "invert_transaction_amount swaps deposits and withdrawals once" do
+    stub_account_sync
     action = Rule::Action.new(
       rule: @transaction_rule,
       action_type: "invert_transaction_amount"
@@ -238,6 +245,7 @@ class Rule::ActionTest < ActiveSupport::TestCase
   end
 
   test "invert_transaction_amount corrects an amount restored by provider sync" do
+    stub_account_sync
     action = Rule::Action.new(
       rule: @transaction_rule,
       action_type: "invert_transaction_amount"
@@ -259,6 +267,7 @@ class Rule::ActionTest < ActiveSupport::TestCase
   end
 
   test "invert_transaction_amount preserves provider metadata" do
+    stub_account_sync
     @txn2.update!(extra: { "simplefin" => { "pending" => true } })
     action = Rule::Action.new(
       rule: @transaction_rule,
@@ -283,6 +292,7 @@ class Rule::ActionTest < ActiveSupport::TestCase
   end
 
   test "overlapping invert actions share transaction state instead of cancelling each other" do
+    stub_account_sync
     other_rule = Rule.create!(
       family: @family,
       resource_type: "transaction",
@@ -303,7 +313,59 @@ class Rule::ActionTest < ActiveSupport::TestCase
     assert_equal 200, @txn2.reload.entry.amount
   end
 
+  test "invert_transaction_amount skips transfer legs so the transfer keeps opposite amounts" do
+    stub_account_sync
+    other_account = @family.accounts.create!(name: "Transfer target", balance: 1000, currency: "USD", accountable: Depository.new)
+    outflow = create_transaction(date: Date.current, account: @account, amount: 500, name: "Transfer out").transaction
+    inflow = create_transaction(date: Date.current, account: other_account, amount: -500, name: "Transfer in").transaction
+    transfer = Transfer.create!(inflow_transaction: inflow, outflow_transaction: outflow, status: "confirmed")
+
+    action = Rule::Action.new(rule: @transaction_rule, action_type: "invert_transaction_amount")
+
+    assert_equal 0, action.apply(Transaction.where(id: [ inflow.id, outflow.id ]))
+    assert_equal 500, outflow.reload.entry.amount
+    assert_equal(-500, inflow.reload.entry.amount)
+    assert transfer.reload.valid?, "transfer must remain valid: #{transfer.errors.full_messages.inspect}"
+
+    # An explicit re-apply must not be an escape hatch around the invariant.
+    assert_equal 0, action.apply(Transaction.where(id: [ inflow.id, outflow.id ]), ignore_attribute_locks: true)
+    assert_equal 500, outflow.reload.entry.amount
+  end
+
+  test "invert_transaction_amount skips split children so the split still sums to its parent" do
+    stub_account_sync
+    parent_entry = create_transaction(date: Date.current, account: @account, amount: 300, name: "Split parent")
+    parent_entry.split!([
+      { amount: 100, name: "Split child A" },
+      { amount: 200, name: "Split child B" }
+    ])
+    child_ids = parent_entry.reload.child_entries.map(&:entryable_id)
+
+    action = Rule::Action.new(rule: @transaction_rule, action_type: "invert_transaction_amount")
+
+    assert_equal 0, action.apply(Transaction.where(id: child_ids))
+
+    children = parent_entry.reload.child_entries
+    assert_equal [ 100, 200 ], children.map(&:amount).map(&:to_i).sort
+    assert_equal parent_entry.amount, children.sum(&:amount)
+  end
+
+  test "invert_transaction_amount still corrects a standalone transaction alongside skipped ones" do
+    stub_account_sync
+    other_account = @family.accounts.create!(name: "Transfer target 2", balance: 1000, currency: "USD", accountable: Depository.new)
+    outflow = create_transaction(date: Date.current, account: @account, amount: 500, name: "Transfer out").transaction
+    inflow = create_transaction(date: Date.current, account: other_account, amount: -500, name: "Transfer in").transaction
+    Transfer.create!(inflow_transaction: inflow, outflow_transaction: outflow, status: "confirmed")
+
+    action = Rule::Action.new(rule: @transaction_rule, action_type: "invert_transaction_amount")
+
+    assert_equal 1, action.apply(Transaction.where(id: [ @txn2.id, inflow.id, outflow.id ]))
+    assert_equal 200, @txn2.reload.entry.amount
+    assert_equal 500, outflow.reload.entry.amount
+  end
+
   test "invert_transaction_amount respects amount locks unless explicitly reapplied" do
+    stub_account_sync
     @txn1.entry.lock_attr!(:amount)
     action = Rule::Action.new(
       rule: @transaction_rule,

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -55,6 +55,32 @@ class RuleTest < ActiveSupport::TestCase
     assert_equal @groceries_category, transaction_entry2.transaction.category
   end
 
+  test "invert amount action uses existing account and name conditions with effective date" do
+    other_account = @family.accounts.create!(name: "Other account", balance: 1000, currency: "USD", accountable: Depository.new)
+    matching_deposit = create_transaction(date: Date.current, account: @account, name: "FIDELITY DEPOSIT", amount: -100)
+    unrelated_fidelity_transaction = create_transaction(date: Date.current, account: @account, name: "FIDELITY PURCHASE", amount: 25)
+    old_fidelity_deposit = create_transaction(date: 2.months.ago.to_date, account: @account, name: "FIDELITY DEPOSIT", amount: -75)
+    other_account_deposit = create_transaction(date: Date.current, account: other_account, name: "FIDELITY DEPOSIT", amount: -50)
+
+    rule = Rule.create!(
+      family: @family,
+      resource_type: "transaction",
+      effective_date: 1.month.ago.to_date,
+      conditions: [
+        Rule::Condition.new(condition_type: "transaction_account", operator: "=", value: @account.id),
+        Rule::Condition.new(condition_type: "transaction_name", operator: "like", value: "deposit")
+      ],
+      actions: [ Rule::Action.new(action_type: "invert_transaction_amount") ]
+    )
+
+    assert_equal 1, rule.apply
+    assert_equal 100, matching_deposit.reload.amount
+    assert_equal 25, unrelated_fidelity_transaction.reload.amount
+    assert_equal(-75, old_fidelity_deposit.reload.amount)
+    assert_equal(-50, other_account_deposit.reload.amount)
+    assert_equal 0, rule.apply
+  end
+
   test "exclude transaction rule" do
     transaction_entry = create_transaction(date: Date.current, account: @account, merchant: @whole_foods_merchant)
 

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -219,4 +219,77 @@ class TransactionTest < ActiveSupport::TestCase
 
     assert_nil category.reload.last_used_at
   end
+
+  test "restore_amount_inversion_state accepts a well-formed inverted pair" do
+    transaction = Transaction.new
+
+    assert transaction.restore_amount_inversion_state(
+      "source_amount" => "-100.0", "corrected_amount" => "100.0"
+    )
+    assert_equal(
+      { "source_amount" => "-100.0", "corrected_amount" => "100.0" },
+      transaction.amount_inversion_state
+    )
+  end
+
+  test "restore_amount_inversion_state normalizes numeric and BigDecimal payloads to strings" do
+    transaction = Transaction.new
+
+    assert transaction.restore_amount_inversion_state(
+      "source_amount" => 250, "corrected_amount" => BigDecimal("-250")
+    )
+    assert_equal(
+      { "source_amount" => "250.0", "corrected_amount" => "-250.0" },
+      transaction.amount_inversion_state
+    )
+  end
+
+  test "restore_amount_inversion_state rejects malformed payloads" do
+    # Each of these must leave the transaction with no watermark rather than a
+    # half-valid one. A bad watermark would let a later rule run invert an
+    # already-corrected amount a second time and flip the sign back.
+    rejected_payloads = {
+      "non-numeric source" => { "source_amount" => "abc", "corrected_amount" => "100.0" },
+      "non-numeric corrected" => { "source_amount" => "-100.0", "corrected_amount" => "not a number" },
+      "nil source" => { "source_amount" => nil, "corrected_amount" => "100.0" },
+      "nil corrected" => { "source_amount" => "-100.0", "corrected_amount" => nil },
+      "missing keys" => {},
+      "zero source" => { "source_amount" => "0.0", "corrected_amount" => "0.0" },
+      "pair does not negate" => { "source_amount" => "-100.0", "corrected_amount" => "50.0" },
+      "same sign pair" => { "source_amount" => "-100.0", "corrected_amount" => "-100.0" },
+      "nested hash value" => { "source_amount" => { "a" => 1 }, "corrected_amount" => "100.0" },
+      "not a hash" => "-100.0",
+      "nil state" => nil,
+      "array state" => [ "-100.0", "100.0" ]
+    }
+
+    rejected_payloads.each do |description, payload|
+      transaction = Transaction.new
+
+      assert_not transaction.restore_amount_inversion_state(payload),
+        "expected #{description} to be rejected"
+      assert_nil transaction.amount_inversion_state,
+        "expected #{description} to leave no inversion state"
+    end
+  end
+
+  test "restore_amount_inversion_state preserves unrelated extra keys" do
+    transaction = Transaction.new(extra: { "simplefin" => { "pending" => true } })
+
+    assert transaction.restore_amount_inversion_state(
+      "source_amount" => "-100.0", "corrected_amount" => "100.0"
+    )
+
+    assert_equal true, transaction.extra.dig("simplefin", "pending")
+    assert_equal "100.0", transaction.extra.dig("rules", "invert_transaction_amount", "corrected_amount")
+  end
+
+  test "amount_inversion_state ignores a stored watermark that no longer normalizes" do
+    transaction = Transaction.new(
+      extra: { "rules" => { "invert_transaction_amount" => { "source_amount" => "-100.0", "corrected_amount" => "37.0" } } }
+    )
+
+    assert_nil transaction.amount_inversion_state
+    assert_nil transaction.amount_inversion_corrected_amount
+  end
 end

--- a/test/system/rules_test.rb
+++ b/test/system/rules_test.rb
@@ -5,6 +5,15 @@ class RulesTest < ApplicationSystemTestCase
     sign_in @user = users(:family_admin)
   end
 
+  test "offers swap deposit and withdrawal as a then action" do
+    visit new_rule_path
+
+    click_on "Add action"
+
+    assert_selector "select[name*='[actions_attributes]'] option", text: "Swap deposit and withdrawal"
+    assert_text "FOR"
+  end
+
   test "shows queued processed modified and blocked counts for recent rule runs" do
     rule = @user.family.rules.create!(
       name: "Whole Foods Testing",


### PR DESCRIPTION
## Summary

- Adds a transaction rule action, **Swap deposit and withdrawal**, that multiplies a matched transaction's amount by `-1`. Fixes #2926.
- Motivation is provider-side sign reversal. Fidelity transactions imported over SimpleFIN currently arrive with the wrong direction, so deposits and withdrawals appear swapped. This gives users a scoped, self-service workaround while the provider fixes the upstream data.
- The action composes with existing rule conditions, so it can be narrowed to a single account, name pattern, or effective date.
- Correction state is recorded on the transaction rather than on the rule, under `extra["rules"]["invert_transaction_amount"]`. Idempotency therefore holds three ways: re-running a rule is a no-op, two overlapping inversion rules cannot cancel each other out, and a later provider sync that restores the original sign is re-corrected on the next rule run.
- Each row is corrected under a row lock so concurrent syncs cannot interleave a partial flip.
- Amount locks are respected. A user who has manually edited an amount is not overwritten unless the rule is explicitly re-applied with locks ignored.
- Transfer legs and split children are deliberately skipped, even on an explicit re-apply. Both carry a cross-record sum invariant that nothing re-checks when an entry amount is written: `Transfer` requires its two legs to have opposite signs and sum to zero, and a split requires its children to sum to the excluded parent. Flipping one side of either would leave a silently invalid row that cannot self-heal, since auto transfer matching only considers transactions not already attached to a transfer. Skipped transactions are reported as blocked in the rule run counts, the same treatment a locked amount gets.
- Affected accounts are re-synced once each from the earliest changed date so persisted balances are rematerialized.
- The correction state round-trips through family export and import, so restoring a backup does not re-apply the correction and double-flip the amount. Only this one narrowly scoped key is carried in the portable format; provider metadata under `extra` is neither exported nor overwritten.

## Verification

Run against the branch tip:

- `bin/rails test`: 6213 runs, 24715 assertions, 0 failures, 0 errors
- `bin/rails test:system test/system/rules_test.rb`: 90 runs, 0 failures
- `bin/rubocop` and `bin/brakeman`: clean, 0 warnings

Automated coverage includes idempotency on re-apply, two overlapping inversion rules not cancelling each other, amount locks, the export and re-import round trip, and the transfer-leg and split-child skips. The skip tests were confirmed to fail without the guard rather than passing vacuously.

One gap worth knowing: the account resync is stubbed in these tests, so the balance rematerialization path has no automated coverage and is worth confirming by hand.

## Test plan

- [ ] Create the rule through the UI and confirm a `-100.00` withdrawal becomes a `100.00` deposit.
- [ ] Confirm the account balance and the balance chart update to match.
- [ ] Re-sync the provider so it restores the original sign, then confirm the next rule run re-corrects it.

## Notes

- No migration and no schema change. Correction state reuses the existing `transactions.extra` jsonb column.
- `Family::DataExporter` gains one optional field. The importer guards on its presence, so older backups import unchanged.
- English locale string only, consistent with how other strings land in this repo before translation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a rule action to swap deposit and withdrawal amounts.
  * The action skips transfers, split entries, zero amounts, and locked amounts when applicable.
  * Account balances are recalculated after eligible transactions are updated.
* **Improvements**
  * Amount-swap corrections persist through export and import.
  * Transaction metadata is preserved, and corrections are not repeated.
* **Bug Fixes**
  * Invalid inversion states are rejected without overwriting unrelated metadata.
  * Malformed imported inversion data is safely ignored and logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->