### PR TITLE
fix(providers): capture API error response body in PDF processor span output

### DIFF
--- a/app/models/provider/anthropic/concerns/usage_recorder.rb
+++ b/app/models/provider/anthropic/concerns/usage_recorder.rb
@@ -76,10 +76,26 @@ module Provider::Anthropic::Concerns::UsageRecorder
     end
 
     # Anthropic::Errors::APIStatusError carries the parsed response body
-    # directly on the error, unlike Faraday-based providers.
-    def safe_error_body(error)
-      error.respond_to?(:body) ? error.body : nil
+    # directly on the error. The body can echo request content (potentially
+    # sensitive, since these calls process user-uploaded financial documents),
+    # so only allowlisted fields are extracted rather than forwarded whole.
+    def safe_error_detail(error)
+      body = error.respond_to?(:body) ? error.body : nil
+      request_id = error.respond_to?(:headers) ? error.headers&.[]("request-id") : nil
+      extract_error_detail(body, request_id)
     rescue => e
-      "(body unavailable: #{e.class})"
+      "(detail unavailable: #{e.class})"
+    end
+
+    def extract_error_detail(body, request_id)
+      body = body.with_indifferent_access if body.respond_to?(:with_indifferent_access)
+      nested = body.is_a?(Hash) ? body[:error] : nil
+      nested = nested.with_indifferent_access if nested.respond_to?(:with_indifferent_access)
+
+      detail = {}
+      detail[:type] = nested[:type] if nested.is_a?(Hash) && nested[:type].present?
+      detail[:message] = nested[:message] if nested.is_a?(Hash) && nested[:message].present?
+      detail[:request_id] = request_id if request_id.present?
+      detail.presence
     end
 end

--- a/app/models/provider/anthropic/concerns/usage_recorder.rb
+++ b/app/models/provider/anthropic/concerns/usage_recorder.rb
@@ -74,4 +74,12 @@ module Provider::Anthropic::Concerns::UsageRecorder
     rescue => e
       "(message unavailable: #{e.class})"
     end
+
+    # Anthropic::Errors::APIStatusError carries the parsed response body
+    # directly on the error, unlike Faraday-based providers.
+    def safe_error_body(error)
+      error.respond_to?(:body) ? error.body : nil
+    rescue => e
+      "(body unavailable: #{e.class})"
+    end
 end

--- a/app/models/provider/anthropic/pdf_processor.rb
+++ b/app/models/provider/anthropic/pdf_processor.rb
@@ -53,7 +53,7 @@ class Provider::Anthropic::PdfProcessor
     span&.end(output: result.to_h, usage: usage_hash(response.usage))
     result
   rescue => e
-    span&.end(output: { error: e.message }, level: "ERROR")
+    span&.end(output: { error: e.message, response_body: safe_error_body(e) }, level: "ERROR")
     record_usage_error(model, operation: "process_pdf", error: e, metadata: { pdf_size: pdf_content&.bytesize })
     raise
   end

--- a/app/models/provider/anthropic/pdf_processor.rb
+++ b/app/models/provider/anthropic/pdf_processor.rb
@@ -53,7 +53,7 @@ class Provider::Anthropic::PdfProcessor
     span&.end(output: result.to_h, usage: usage_hash(response.usage))
     result
   rescue => e
-    span&.end(output: { error: e.message, response_body: safe_error_body(e) }, level: "ERROR")
+    span&.end(output: { error: e.message, error_detail: safe_error_detail(e) }, level: "ERROR")
     record_usage_error(model, operation: "process_pdf", error: e, metadata: { pdf_size: pdf_content&.bytesize })
     raise
   end

--- a/app/models/provider/openai/concerns/usage_recorder.rb
+++ b/app/models/provider/openai/concerns/usage_recorder.rb
@@ -101,10 +101,27 @@ module Provider::Openai::Concerns::UsageRecorder
     end
 
     # ruby-openai raises Faraday::Error, which carries the parsed response
-    # body via response_body rather than exposing it directly.
-    def safe_error_body(error)
-      error.respond_to?(:response_body) ? error.response_body : nil
+    # body via response_body. The body can echo request content (potentially
+    # sensitive, since these calls process user-uploaded financial documents),
+    # so only allowlisted fields are extracted rather than forwarded whole.
+    def safe_error_detail(error)
+      body = error.respond_to?(:response_body) ? error.response_body : nil
+      request_id = error.respond_to?(:response_headers) ? error.response_headers&.[]("x-request-id") : nil
+      extract_error_detail(body, request_id)
     rescue => e
-      "(body unavailable: #{e.class})"
+      "(detail unavailable: #{e.class})"
+    end
+
+    def extract_error_detail(body, request_id)
+      body = body.with_indifferent_access if body.respond_to?(:with_indifferent_access)
+      nested = body.is_a?(Hash) ? body[:error] : nil
+      nested = nested.with_indifferent_access if nested.respond_to?(:with_indifferent_access)
+
+      detail = {}
+      detail[:type] = nested[:type] if nested.is_a?(Hash) && nested[:type].present?
+      detail[:message] = nested[:message] if nested.is_a?(Hash) && nested[:message].present?
+      detail[:code] = nested[:code] if nested.is_a?(Hash) && nested[:code].present?
+      detail[:request_id] = request_id if request_id.present?
+      detail.presence
     end
 end

--- a/app/models/provider/openai/concerns/usage_recorder.rb
+++ b/app/models/provider/openai/concerns/usage_recorder.rb
@@ -99,4 +99,12 @@ module Provider::Openai::Concerns::UsageRecorder
     rescue => e
       "(message unavailable: #{e.class})"
     end
+
+    # ruby-openai raises Faraday::Error, which carries the parsed response
+    # body via response_body rather than exposing it directly.
+    def safe_error_body(error)
+      error.respond_to?(:response_body) ? error.response_body : nil
+    rescue => e
+      "(body unavailable: #{e.class})"
+    end
 end

--- a/app/models/provider/openai/pdf_processor.rb
+++ b/app/models/provider/openai/pdf_processor.rb
@@ -31,7 +31,7 @@ class Provider::Openai::PdfProcessor
     span&.end(output: response.to_h)
     response
   rescue => e
-    span&.end(output: { error: e.message, response_body: safe_error_body(e) }, level: "ERROR")
+    span&.end(output: { error: e.message, error_detail: safe_error_detail(e) }, level: "ERROR")
     raise
   end
 

--- a/app/models/provider/openai/pdf_processor.rb
+++ b/app/models/provider/openai/pdf_processor.rb
@@ -31,7 +31,7 @@ class Provider::Openai::PdfProcessor
     span&.end(output: response.to_h)
     response
   rescue => e
-    span&.end(output: { error: e.message }, level: "ERROR")
+    span&.end(output: { error: e.message, response_body: safe_error_body(e) }, level: "ERROR")
     raise
   end
 

--- a/test/models/provider/anthropic/pdf_processor_test.rb
+++ b/test/models/provider/anthropic/pdf_processor_test.rb
@@ -99,7 +99,86 @@ class Provider::Anthropic::PdfProcessorTest < ActiveSupport::TestCase
     assert_match(/32 MB request limit/i, err.message)
   end
 
+  test "captures the error response body in span output when the API call fails" do
+    error = StandardError.new("boom")
+    def error.body
+      { "type" => "error", "error" => { "message" => "invalid request" } }
+    end
+
+    client = stub_failing_client(error)
+    captured_output = nil
+    trace = stub_trace { |output| captured_output = output }
+
+    assert_raises(StandardError) do
+      Provider::Anthropic::PdfProcessor.new(
+        client,
+        model: "claude-sonnet-4-6",
+        pdf_content: @pdf_content,
+        langfuse_trace: trace
+      ).process
+    end
+
+    assert_equal({ "type" => "error", "error" => { "message" => "invalid request" } }, captured_output[:response_body])
+  end
+
+  test "response_body is nil in span output when the error exposes no body" do
+    error = StandardError.new("boom")
+
+    client = stub_failing_client(error)
+    captured_output = nil
+    trace = stub_trace { |output| captured_output = output }
+
+    assert_raises(StandardError) do
+      Provider::Anthropic::PdfProcessor.new(
+        client,
+        model: "claude-sonnet-4-6",
+        pdf_content: @pdf_content,
+        langfuse_trace: trace
+      ).process
+    end
+
+    assert_nil captured_output[:response_body]
+  end
+
+  test "response_body falls back to a placeholder when reading the body itself raises" do
+    error = StandardError.new("boom")
+    def error.body
+      raise "body accessor exploded"
+    end
+
+    client = stub_failing_client(error)
+    captured_output = nil
+    trace = stub_trace { |output| captured_output = output }
+
+    assert_raises(StandardError) do
+      Provider::Anthropic::PdfProcessor.new(
+        client,
+        model: "claude-sonnet-4-6",
+        pdf_content: @pdf_content,
+        langfuse_trace: trace
+      ).process
+    end
+
+    assert_match(/body unavailable/i, captured_output[:response_body])
+  end
+
   private
+    def stub_failing_client(error)
+      messages = mock
+      messages.expects(:create).raises(error)
+      client = mock
+      client.stubs(:messages).returns(messages)
+      client
+    end
+
+    def stub_trace
+      span = mock
+      span.expects(:end).with { |args| yield(args[:output]); true }
+      trace = mock
+      trace.stubs(:span).returns(span)
+      trace
+    end
+
     def stub_client(response)
       messages = mock
       messages.expects(:create).with do |params|

--- a/test/models/provider/anthropic/pdf_processor_test.rb
+++ b/test/models/provider/anthropic/pdf_processor_test.rb
@@ -99,10 +99,14 @@ class Provider::Anthropic::PdfProcessorTest < ActiveSupport::TestCase
     assert_match(/32 MB request limit/i, err.message)
   end
 
-  test "captures the error response body in span output when the API call fails" do
+  test "extracts only allowlisted error fields into span output when the API call fails" do
     error = StandardError.new("boom")
     def error.body
-      { "type" => "error", "error" => { "message" => "invalid request" } }
+      {
+        "type" => "error",
+        "error" => { "type" => "invalid_request_error", "message" => "invalid request" },
+        "request" => { "document" => "base64-pdf-contents-that-should-never-leak" }
+      }
     end
 
     client = stub_failing_client(error)
@@ -118,10 +122,10 @@ class Provider::Anthropic::PdfProcessorTest < ActiveSupport::TestCase
       ).process
     end
 
-    assert_equal({ "type" => "error", "error" => { "message" => "invalid request" } }, captured_output[:response_body])
+    assert_equal({ type: "invalid_request_error", message: "invalid request" }, captured_output[:error_detail])
   end
 
-  test "response_body is nil in span output when the error exposes no body" do
+  test "error_detail is nil in span output when the error exposes no body" do
     error = StandardError.new("boom")
 
     client = stub_failing_client(error)
@@ -137,10 +141,10 @@ class Provider::Anthropic::PdfProcessorTest < ActiveSupport::TestCase
       ).process
     end
 
-    assert_nil captured_output[:response_body]
+    assert_nil captured_output[:error_detail]
   end
 
-  test "response_body falls back to a placeholder when reading the body itself raises" do
+  test "error_detail falls back to a placeholder when reading the body itself raises" do
     error = StandardError.new("boom")
     def error.body
       raise "body accessor exploded"
@@ -159,7 +163,7 @@ class Provider::Anthropic::PdfProcessorTest < ActiveSupport::TestCase
       ).process
     end
 
-    assert_match(/body unavailable/i, captured_output[:response_body])
+    assert_match(/detail unavailable/i, captured_output[:error_detail])
   end
 
   private

--- a/test/models/provider/openai/pdf_processor_test.rb
+++ b/test/models/provider/openai/pdf_processor_test.rb
@@ -13,6 +13,9 @@ class Provider::Openai::PdfProcessorTest < ActiveSupport::TestCase
         "request" => { "messages" => "statement text that should never leak" }
       }
     end
+    def error.response_headers
+      { "x-request-id" => "req_abc123" }
+    end
 
     captured_output = nil
     trace = stub_trace { |output| captured_output = output }
@@ -22,7 +25,7 @@ class Provider::Openai::PdfProcessorTest < ActiveSupport::TestCase
     end
 
     assert_equal(
-      { type: "invalid_request_error", message: "invalid request", code: "bad_pdf" },
+      { type: "invalid_request_error", message: "invalid request", code: "bad_pdf", request_id: "req_abc123" },
       captured_output[:error_detail]
     )
   end

--- a/test/models/provider/openai/pdf_processor_test.rb
+++ b/test/models/provider/openai/pdf_processor_test.rb
@@ -5,10 +5,13 @@ class Provider::Openai::PdfProcessorTest < ActiveSupport::TestCase
     @pdf_content = "%PDF-1.4 fake bytes".b
   end
 
-  test "captures the error response body in span output when the API call fails" do
+  test "extracts only allowlisted error fields into span output when the API call fails" do
     error = StandardError.new("boom")
     def error.response_body
-      { "error" => { "message" => "invalid request" } }
+      {
+        "error" => { "type" => "invalid_request_error", "message" => "invalid request", "code" => "bad_pdf" },
+        "request" => { "messages" => "statement text that should never leak" }
+      }
     end
 
     captured_output = nil
@@ -18,10 +21,13 @@ class Provider::Openai::PdfProcessorTest < ActiveSupport::TestCase
       build_processor(error, trace).process
     end
 
-    assert_equal({ "error" => { "message" => "invalid request" } }, captured_output[:response_body])
+    assert_equal(
+      { type: "invalid_request_error", message: "invalid request", code: "bad_pdf" },
+      captured_output[:error_detail]
+    )
   end
 
-  test "response_body is nil in span output when the error exposes no response_body" do
+  test "error_detail is nil in span output when the error exposes no response_body" do
     error = StandardError.new("boom")
 
     captured_output = nil
@@ -31,10 +37,10 @@ class Provider::Openai::PdfProcessorTest < ActiveSupport::TestCase
       build_processor(error, trace).process
     end
 
-    assert_nil captured_output[:response_body]
+    assert_nil captured_output[:error_detail]
   end
 
-  test "response_body falls back to a placeholder when reading response_body itself raises" do
+  test "error_detail falls back to a placeholder when reading response_body itself raises" do
     error = StandardError.new("boom")
     def error.response_body
       raise "response_body accessor exploded"
@@ -47,7 +53,7 @@ class Provider::Openai::PdfProcessorTest < ActiveSupport::TestCase
       build_processor(error, trace).process
     end
 
-    assert_match(/body unavailable/i, captured_output[:response_body])
+    assert_match(/detail unavailable/i, captured_output[:error_detail])
   end
 
   private

--- a/test/models/provider/openai/pdf_processor_test.rb
+++ b/test/models/provider/openai/pdf_processor_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class Provider::Openai::PdfProcessorTest < ActiveSupport::TestCase
+  setup do
+    @pdf_content = "%PDF-1.4 fake bytes".b
+  end
+
+  test "captures the error response body in span output when the API call fails" do
+    error = StandardError.new("boom")
+    def error.response_body
+      { "error" => { "message" => "invalid request" } }
+    end
+
+    captured_output = nil
+    trace = stub_trace { |output| captured_output = output }
+
+    assert_raises(StandardError) do
+      build_processor(error, trace).process
+    end
+
+    assert_equal({ "error" => { "message" => "invalid request" } }, captured_output[:response_body])
+  end
+
+  test "response_body is nil in span output when the error exposes no response_body" do
+    error = StandardError.new("boom")
+
+    captured_output = nil
+    trace = stub_trace { |output| captured_output = output }
+
+    assert_raises(StandardError) do
+      build_processor(error, trace).process
+    end
+
+    assert_nil captured_output[:response_body]
+  end
+
+  test "response_body falls back to a placeholder when reading response_body itself raises" do
+    error = StandardError.new("boom")
+    def error.response_body
+      raise "response_body accessor exploded"
+    end
+
+    captured_output = nil
+    trace = stub_trace { |output| captured_output = output }
+
+    assert_raises(StandardError) do
+      build_processor(error, trace).process
+    end
+
+    assert_match(/body unavailable/i, captured_output[:response_body])
+  end
+
+  private
+    def build_processor(error, trace)
+      client = mock
+      client.expects(:chat).raises(error)
+
+      processor = Provider::Openai::PdfProcessor.new(
+        client,
+        model: "gpt-4.1",
+        pdf_content: @pdf_content,
+        langfuse_trace: trace,
+        max_response_tokens: 1000
+      )
+      processor.stubs(:extract_text_from_pdf).returns("Statement text")
+      processor
+    end
+
+    def stub_trace
+      span = mock
+      span.expects(:end).with { |args| yield(args[:output]); true }
+      trace = mock
+      trace.stubs(:span).returns(span)
+      trace
+    end
+end


### PR DESCRIPTION
Anthropic and OpenAI PDF processing errors only logged the exception message, dropping the parsed response body that usually explains the failure. Add safe_error_body to both providers' UsageRecorder concerns and include it in the langfuse span output on failure, with tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error details captured when PDF processing fails through supported AI providers.
  * API response details now include only relevant, sanitized fields when available.
  * Errors remain safely handled when response details are unavailable or cannot be accessed.

* **Tests**
  * Added coverage for available, missing, and inaccessible error response details across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->