### PR TITLE
Add Ethereum as a currency

### DIFF
--- a/config/currencies.yml
+++ b/config/currencies.yml
@@ -894,6 +894,20 @@ doge:
   delimiter: ","
   default_format: "%u%n"
   default_precision: 8
+eth:
+  name: Ethereum
+  priority: 100
+  iso_code: ETH
+  iso_numeric: ""
+  html_code: "&#926;"
+  symbol: "Ξ"
+  minor_unit: Ethereum
+  minor_unit_conversion: 100000000
+  smallest_denomination: 1
+  separator: "."
+  delimiter: ","
+  default_format: "%u%n"
+  default_precision: 8
 jep:
   name: Jersey Pound
   priority: 100


### PR DESCRIPTION
This simple addition to the `currencies.yml` resolves an issue that prevents SimpleFin from completing its sync job if the user has a cryptocurrency account. This has been tested with a coinbase account through the SimpleFin integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ethereum (ETH), including the Ξ symbol.
  * Added Ethereum denomination and conversion settings.
  * Enabled display precision of up to eight decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->