### PR TITLE
Fix Wise profile session payload size

### DIFF
--- a/app/controllers/wise_items_controller.rb
+++ b/app/controllers/wise_items_controller.rb
@@ -35,7 +35,7 @@ class WiseItemsController < ApplicationController
       return render_provider_panel_error
     end
 
-    session[:wise_pending_profiles] = pending_profile_session_payload(profiles)
+    session[:wise_pending_profiles] = Provider::Wise.pending_profile_session_payload(profiles)
     session[:wise_pending_encrypted_token] = encrypt_pending_token(token)
 
     redirect_to select_profiles_wise_items_path
@@ -78,14 +78,11 @@ class WiseItemsController < ApplicationController
       next unless selected_ids.include?(profile_id)
       next if Current.family.wise_items.exists?(profile_id: profile_id)
 
-      profile_type = profile["type"] == "business" ? "business" : "personal"
-      display_name = profile_display_name(profile)
-
       Current.family.create_wise_item!(
         token: token,
         profile_id: profile_id,
-        profile_type: profile_type,
-        item_name: display_name
+        profile_type: profile["type"] == "business" ? "business" : "personal",
+        item_name: Provider::Wise.profile_label(profile)
       )
       created += 1
     end
@@ -251,33 +248,6 @@ class WiseItemsController < ApplicationController
       WiseAccount.joins(:wise_item)
                  .merge(Current.family.wise_items.active)
                  .find_by(id: wise_account_id)
-    end
-
-    def profile_display_name(profile)
-      type_key = profile["type"] == "business" ? :business : :personal
-      type_label = I18n.t("wise_items.profile_types.#{type_key}")
-      details = profile["details"] || {}
-      name = details["name"].presence ||
-             [ details["firstName"], details["lastName"] ].compact.join(" ").presence
-
-      name.present? ? "#{name} (#{type_label})" : "Wise #{type_label}"
-    end
-
-    def pending_profile_session_payload(profiles)
-      profiles.map do |profile|
-        details = profile["details"].is_a?(Hash) ? profile["details"] : {}
-
-        {
-          "id" => profile["id"].to_s,
-          "type" => profile["type"].to_s,
-          "details" => {
-            "name" => details["name"].to_s,
-            "firstName" => details["firstName"].to_s,
-            "lastName" => details["lastName"].to_s,
-            "email" => details["email"].to_s
-          }.compact_blank
-        }.compact_blank
-      end
     end
 
     def render_provider_panel_success(message)

--- a/app/controllers/wise_items_controller.rb
+++ b/app/controllers/wise_items_controller.rb
@@ -35,7 +35,7 @@ class WiseItemsController < ApplicationController
       return render_provider_panel_error
     end
 
-    session[:wise_pending_profiles] = profiles
+    session[:wise_pending_profiles] = pending_profile_session_payload(profiles)
     session[:wise_pending_encrypted_token] = encrypt_pending_token(token)
 
     redirect_to select_profiles_wise_items_path
@@ -261,6 +261,23 @@ class WiseItemsController < ApplicationController
              [ details["firstName"], details["lastName"] ].compact.join(" ").presence
 
       name.present? ? "#{name} (#{type_label})" : "Wise #{type_label}"
+    end
+
+    def pending_profile_session_payload(profiles)
+      profiles.map do |profile|
+        details = profile["details"].is_a?(Hash) ? profile["details"] : {}
+
+        {
+          "id" => profile["id"].to_s,
+          "type" => profile["type"].to_s,
+          "details" => {
+            "name" => details["name"].to_s,
+            "firstName" => details["firstName"].to_s,
+            "lastName" => details["lastName"].to_s,
+            "email" => details["email"].to_s
+          }.compact_blank
+        }.compact_blank
+      end
     end
 
     def render_provider_panel_success(message)

--- a/app/models/provider/wise.rb
+++ b/app/models/provider/wise.rb
@@ -6,6 +6,8 @@ class Provider::Wise
 
   LIVE_BASE_URL = "https://api.wise.com"
   SANDBOX_BASE_URL = "https://api.sandbox.transferwise.tech"
+  MAX_PENDING_PROFILES = 10
+  MAX_PENDING_PROFILE_FIELD_LENGTH = 64
 
   headers "User-Agent" => "Sure Finance Wise Client"
   default_options.merge!({ timeout: 120 }.merge(httparty_ssl_options))
@@ -23,6 +25,29 @@ class Provider::Wise
 
   def get_profiles
     get("/v1/profiles")
+  end
+
+  def self.pending_profile_session_payload(profiles)
+    Array(profiles).first(MAX_PENDING_PROFILES).filter_map do |profile|
+      next unless profile.is_a?(Hash)
+
+      profile_id = truncate_session_field(profile["id"])
+      next if profile_id.blank?
+
+      {
+        "id" => profile_id,
+        "type" => profile_type(profile),
+        "display_name" => truncate_session_field(profile_display_name(profile))
+      }.compact_blank
+    end
+  end
+
+  def self.profile_label(profile)
+    type_key = profile_type(profile).to_sym
+    type_label = I18n.t("wise_items.profile_types.#{type_key}")
+    display_name = truncate_session_field(profile["display_name"].presence || profile_display_name(profile))
+
+    display_name.present? ? "#{display_name} (#{type_label})" : "Wise #{type_label}"
   end
 
   def get_balances(profile_id)
@@ -113,5 +138,20 @@ class Provider::Wise
         super(message)
         @error_type = error_type
       end
+    end
+
+    def self.profile_type(profile)
+      profile["type"] == "business" ? "business" : "personal"
+    end
+
+    def self.profile_display_name(profile)
+      details = profile["details"].is_a?(Hash) ? profile["details"] : {}
+
+      details["name"].presence ||
+        [ details["firstName"], details["lastName"] ].compact.join(" ").presence
+    end
+
+    def self.truncate_session_field(value)
+      value.to_s.first(MAX_PENDING_PROFILE_FIELD_LENGTH)
     end
 end

--- a/app/views/wise_items/select_profiles.html.erb
+++ b/app/views/wise_items/select_profiles.html.erb
@@ -24,8 +24,7 @@
           <% profile_id = profile["id"].to_s %>
           <% already_connected = @existing_profile_ids.include?(profile_id) %>
           <% profile_type = profile["type"] == "business" ? "business" : "personal" %>
-          <% details = profile["details"] || {} %>
-          <% display_name = details["name"].presence || [ details["firstName"], details["lastName"] ].compact.join(" ") %>
+          <% display_name = profile["display_name"] %>
 
           <label class="flex items-start gap-3 p-3 border <%= already_connected ? "border-secondary opacity-60 cursor-not-allowed" : "border-primary hover:bg-subtle cursor-pointer" %> rounded-lg transition-colors">
             <%= check_box_tag "profile_ids[]", profile_id, !already_connected, disabled: already_connected, class: "mt-1" %>
@@ -39,9 +38,6 @@
                   <span class="text-xs text-secondary"><%= t(".already_connected_label") %></span>
                 <% end %>
               </div>
-              <% if details["email"].present? %>
-                <p class="text-xs text-secondary mt-0.5"><%= details["email"] %></p>
-              <% end %>
             </div>
           </label>
         <% end %>

--- a/test/controllers/wise_items_controller_test.rb
+++ b/test/controllers/wise_items_controller_test.rb
@@ -30,6 +30,41 @@ class WiseItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='encrypted_pending_token']"
   end
 
+  test "create keeps only display profile fields in the session" do
+    profiles = [
+      {
+        "id" => "99999999",
+        "type" => "personal",
+        "details" => {
+          "firstName" => "Jane",
+          "lastName" => "Doe",
+          "email" => "jane@example.com",
+          "address" => "x" * 3.kilobytes,
+          "avatar" => "y" * 3.kilobytes
+        },
+        "extra" => "z" * 3.kilobytes
+      }
+    ]
+    Provider::Wise.any_instance.stubs(:get_profiles).returns(profiles)
+
+    post wise_items_url, params: { wise_item: { token: "live_token_abc" } }
+
+    pending_profile = session[:wise_pending_profiles].first
+    assert_equal(
+      {
+        "id" => "99999999",
+        "type" => "personal",
+        "details" => {
+          "firstName" => "Jane",
+          "lastName" => "Doe",
+          "email" => "jane@example.com"
+        }
+      },
+      pending_profile
+    )
+    assert_operator session[:wise_pending_profiles].to_json.bytesize, :<, 500
+  end
+
   test "create stores an encrypted token that round-trips to the original value" do
     Provider::Wise.any_instance.stubs(:get_profiles).returns(@valid_profiles)
 

--- a/test/controllers/wise_items_controller_test.rb
+++ b/test/controllers/wise_items_controller_test.rb
@@ -30,21 +30,21 @@ class WiseItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='encrypted_pending_token']"
   end
 
-  test "create keeps only display profile fields in the session" do
-    profiles = [
+  test "create keeps only bounded display profile fields in the session" do
+    profiles = 25.times.map do |index|
       {
-        "id" => "99999999",
-        "type" => "personal",
+        "id" => "#{index}-#{"i" * 500}",
+        "type" => index.even? ? "personal" : "business",
         "details" => {
           "firstName" => "Jane",
-          "lastName" => "Doe",
-          "email" => "jane@example.com",
+          "lastName" => "Doe #{"n" * 500}",
+          "email" => "jane-#{index}@example.com",
           "address" => "x" * 3.kilobytes,
           "avatar" => "y" * 3.kilobytes
         },
         "extra" => "z" * 3.kilobytes
       }
-    ]
+    end
     Provider::Wise.any_instance.stubs(:get_profiles).returns(profiles)
 
     post wise_items_url, params: { wise_item: { token: "live_token_abc" } }
@@ -52,17 +52,14 @@ class WiseItemsControllerTest < ActionDispatch::IntegrationTest
     pending_profile = session[:wise_pending_profiles].first
     assert_equal(
       {
-        "id" => "99999999",
+        "id" => "0-#{"i" * 62}",
         "type" => "personal",
-        "details" => {
-          "firstName" => "Jane",
-          "lastName" => "Doe",
-          "email" => "jane@example.com"
-        }
+        "display_name" => "Jane Doe #{"n" * 55}"
       },
       pending_profile
     )
-    assert_operator session[:wise_pending_profiles].to_json.bytesize, :<, 500
+    assert_equal 10, session[:wise_pending_profiles].size
+    assert_operator session[:wise_pending_profiles].to_json.bytesize, :<, 2.kilobytes
   end
 
   test "create stores an encrypted token that round-trips to the original value" do


### PR DESCRIPTION
## Summary
- store only the Wise profile fields needed for the linking screen in the cookie-backed session
- keep bulky Wise profile response fields out of `wise_pending_profiles`
- add a regression test with oversized profile data

## Test
- `bin/rails tailwindcss:build`
- `bin/rails test test/controllers/wise_items_controller_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wise profile handling during setup by retaining only relevant, sanitized display information.
  * Limited saved profiles and field lengths to prevent oversized session data and improve reliability.
  * Updated profile selection labels for clearer, more consistent display.

* **Tests**
  * Added coverage confirming profile data is truncated, capped at 10 profiles, and remains within session-size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->