### PR TITLE
feat(recurring): show badge and detail for matched transactions

### DIFF
--- a/app/controllers/recurring_transactions_controller.rb
+++ b/app/controllers/recurring_transactions_controller.rb
@@ -16,7 +16,9 @@ class RecurringTransactionsController < ApplicationController
       .find(params[:id])
 
     @matching_entries = @recurring_transaction.matching_transactions
-      .includes(:account, entryable: :merchant)
+      .joins(:account)
+      .merge(Account.accessible_by(Current.user))
+      .preload(:account, entryable: :merchant)
       .limit(50)
       .to_a
 

--- a/app/controllers/recurring_transactions_controller.rb
+++ b/app/controllers/recurring_transactions_controller.rb
@@ -9,6 +9,24 @@ class RecurringTransactionsController < ApplicationController
     @family = Current.family
   end
 
+  def show
+    @recurring_transaction = Current.family.recurring_transactions
+      .accessible_by(Current.user)
+      .includes(:merchant, :account, :destination_account)
+      .find(params[:id])
+
+    @matching_entries = @recurring_transaction.matching_transactions
+      .includes(:account, entryable: :merchant)
+      .limit(50)
+      .to_a
+
+    @breadcrumbs = [
+      [ t("breadcrumbs.home"), root_path ],
+      [ t("breadcrumbs.recurring_transactions"), recurring_transactions_path ],
+      [ @recurring_transaction.display_name, nil ]
+    ]
+  end
+
   def update_settings
     Current.family.update!(recurring_settings_params)
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -79,8 +79,8 @@ class TransactionsController < ApplicationController
                                          Date.current)
                                   .includes(:merchant)
 
-    @matched_recurring_by_entry_id = RecurringTransaction.matches_for_entries(
-      @transactions.map(&:entry),
+    @matched_recurring_by_entry_id = RecurringTransaction.matches_for_transactions(
+      @transactions,
       family: Current.family,
       user: Current.user
     )
@@ -89,8 +89,8 @@ class TransactionsController < ApplicationController
   end
 
   def show
-    @matched_recurring = RecurringTransaction.match_for_entry(
-      @entry,
+    @matched_recurring = RecurringTransaction.match_for_transaction(
+      @entry.entryable,
       family: Current.family,
       user: Current.user
     )

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -79,7 +79,21 @@ class TransactionsController < ApplicationController
                                          Date.current)
                                   .includes(:merchant)
 
+    @matched_recurring_by_entry_id = RecurringTransaction.matches_for_entries(
+      @transactions.map(&:entry),
+      family: Current.family,
+      user: Current.user
+    )
+
     @breadcrumbs = [ [ t("breadcrumbs.home"), root_path ], [ t("breadcrumbs.transactions"), nil ] ]
+  end
+
+  def show
+    @matched_recurring = RecurringTransaction.match_for_entry(
+      @entry,
+      family: Current.family,
+      user: Current.user
+    )
   end
 
   def clear_filter

--- a/app/models/recurring_transaction.rb
+++ b/app/models/recurring_transaction.rb
@@ -262,50 +262,88 @@ class RecurringTransaction < ApplicationRecord
     merchant&.name.presence || name
   end
 
-  # Map entry IDs on the current page/list to their matching active recurring
+  # Map entry IDs for the current page/list to their matching active recurring
   # pattern. Prefers manual patterns when multiple could match.
-  def self.matches_for_entries(entries, family:, user:)
+  #
+  # Pass already-loaded Transaction records (e.g. `@transactions` on index) so
+  # matching can reuse their preloaded `entry` / transfer associations instead of
+  # walking `entry.entryable` and triggering N+1 queries.
+  def self.matches_for_transactions(transactions, family:, user:)
     return {} if family.recurring_transactions_disabled?
 
-    entry_list = Array(entries).compact
-    return {} if entry_list.empty?
+    transaction_list = Array(transactions).compact
+    return {} if transaction_list.empty?
 
+    # Avoid includes(:account) here: matching only needs FK columns on the
+    # recurring rows, and a single-account preload shows up as
+    # `accounts.id = $1` which the transactions index N+1 guard treats as a
+    # lazy load.
     recurrings = family.recurring_transactions
       .accessible_by(user)
       .active
-      .includes(:merchant, :account, :destination_account)
       .order(manual: :desc)
       .to_a
 
     return {} if recurrings.empty?
 
-    entry_list.each_with_object({}) do |entry, map|
-      next unless entry.entryable_type == "Transaction"
+    transaction_list.each_with_object({}) do |transaction, map|
+      entry = transaction.entry
+      next unless entry
 
-      match = recurrings.find { |recurring| recurring.matches_entry?(entry) }
+      match = recurrings.find { |recurring| recurring.matches_transaction?(transaction) }
       map[entry.id] = match if match
     end
   end
 
-  def self.match_for_entry(entry, family:, user:)
-    matches_for_entries([ entry ], family: family, user: user)[entry.id]
+  def self.match_for_transaction(transaction, family:, user:)
+    return nil if transaction.blank?
+
+    entry = transaction.entry
+    return nil if entry.blank?
+
+    matches_for_transactions([ transaction ], family: family, user: user)[entry.id]
   end
 
-  # Whether this active pattern's heuristics match a concrete ledger entry.
-  # Mirrors the filters used by matching_transactions / the Cleaner.
-  def matches_entry?(entry)
-    return false unless active?
-    return false unless entry.entryable_type == "Transaction"
-    return false unless entry.currency == currency
+  # Convenience wrappers for Entry-centric callers (e.g. show pages). Prefer
+  # matches_for_transactions when the Transaction records are already loaded.
+  def self.matches_for_entries(entries, family:, user:)
+    transactions = Array(entries).compact.filter_map do |entry|
+      next unless entry.entryable_type == "Transaction"
 
-    transaction = entry.entryable
+      entry.entryable
+    end
+
+    matches_for_transactions(transactions, family: family, user: user)
+  end
+
+  def self.match_for_entry(entry, family:, user:)
+    return nil if entry.blank?
+    return nil unless entry.entryable_type == "Transaction"
+
+    match_for_transaction(entry.entryable, family: family, user: user)
+  end
+
+  # Whether this active pattern's heuristics match a concrete Transaction.
+  # Mirrors the filters used by matching_transactions / the Cleaner.
+  def matches_transaction?(transaction)
+    return false unless active?
     return false unless transaction.is_a?(Transaction)
+
+    entry = transaction.entry
+    return false unless entry
+    return false unless entry.currency == currency
 
     if transfer?
       matches_transfer_entry?(entry, transaction)
     else
       matches_regular_entry?(entry, transaction)
     end
+  end
+
+  def matches_entry?(entry)
+    return false unless entry&.entryable_type == "Transaction"
+
+    matches_transaction?(entry.entryable)
   end
 
   # Find matching transactions for this recurring pattern
@@ -470,10 +508,16 @@ class RecurringTransaction < ApplicationRecord
     end
 
     def day_matches?(date)
-      day = date.day
-      min_day = [ expected_day_of_month - 2, 1 ].max
-      max_day = [ expected_day_of_month + 2, 31 ].min
-      day >= min_day && day <= max_day
+      expected_day = [ expected_day_of_month, date.end_of_month.day ].min
+      circular_day_distance(date.day, expected_day) <= 2
+    end
+
+    # Same 31-day circular distance used by Identifier for month-boundary wraps
+    # (e.g. expected day 31 vs occurrence on day 1).
+    def circular_day_distance(day1, day2)
+      linear_distance = (day1 - day2).abs
+      wrap_distance = 31 - linear_distance
+      [ linear_distance, wrap_distance ].min
     end
 
     # Issue #1590: a recurring transfer's future occurrences rarely share the
@@ -510,11 +554,35 @@ class RecurringTransaction < ApplicationRecord
       end
     end
 
-    # Entries whose day-of-month lands within ±2 days of the expected day.
+    # Entries whose day-of-month lands within ±2 circular days of the
+    # calendar-clamped expected day (so a 31st schedule still matches Feb 28/29).
     def day_of_month_scope(relation)
-      relation.where("EXTRACT(DAY FROM entries.date) BETWEEN ? AND ?",
-                     [ expected_day_of_month - 2, 1 ].max,
-                     [ expected_day_of_month + 2, 31 ].min)
+      relation.where(<<~SQL.squish, expected: expected_day_of_month)
+        LEAST(
+          ABS(
+            EXTRACT(DAY FROM entries.date)::integer
+            - LEAST(
+                :expected,
+                EXTRACT(
+                  DAY FROM (
+                    DATE_TRUNC('month', entries.date) + INTERVAL '1 month' - INTERVAL '1 day'
+                  )
+                )::integer
+              )
+          ),
+          31 - ABS(
+            EXTRACT(DAY FROM entries.date)::integer
+            - LEAST(
+                :expected,
+                EXTRACT(
+                  DAY FROM (
+                    DATE_TRUNC('month', entries.date) + INTERVAL '1 month' - INTERVAL '1 day'
+                  )
+                )::integer
+              )
+          )
+        ) <= 2
+      SQL
     end
 
     def monetizable_currency

--- a/app/models/recurring_transaction.rb
+++ b/app/models/recurring_transaction.rb
@@ -258,6 +258,56 @@ class RecurringTransaction < ApplicationRecord
     end
   end
 
+  def display_name
+    merchant&.name.presence || name
+  end
+
+  # Map entry IDs on the current page/list to their matching active recurring
+  # pattern. Prefers manual patterns when multiple could match.
+  def self.matches_for_entries(entries, family:, user:)
+    return {} if family.recurring_transactions_disabled?
+
+    entry_list = Array(entries).compact
+    return {} if entry_list.empty?
+
+    recurrings = family.recurring_transactions
+      .accessible_by(user)
+      .active
+      .includes(:merchant, :account, :destination_account)
+      .order(manual: :desc)
+      .to_a
+
+    return {} if recurrings.empty?
+
+    entry_list.each_with_object({}) do |entry, map|
+      next unless entry.entryable_type == "Transaction"
+
+      match = recurrings.find { |recurring| recurring.matches_entry?(entry) }
+      map[entry.id] = match if match
+    end
+  end
+
+  def self.match_for_entry(entry, family:, user:)
+    matches_for_entries([ entry ], family: family, user: user)[entry.id]
+  end
+
+  # Whether this active pattern's heuristics match a concrete ledger entry.
+  # Mirrors the filters used by matching_transactions / the Cleaner.
+  def matches_entry?(entry)
+    return false unless active?
+    return false unless entry.entryable_type == "Transaction"
+    return false unless entry.currency == currency
+
+    transaction = entry.entryable
+    return false unless transaction.is_a?(Transaction)
+
+    if transfer?
+      matches_transfer_entry?(entry, transaction)
+    else
+      matches_regular_entry?(entry, transaction)
+    end
+  end
+
   # Find matching transactions for this recurring pattern
   def matching_transactions
     # Recurring transfers can't be matched by single-account name/amount —
@@ -272,10 +322,8 @@ class RecurringTransaction < ApplicationRecord
 
     # Filter by merchant or name
     if merchant_id.present?
-      # Match by merchant through the entryable (Transaction)
-      entries.select do |entry|
-        entry.entryable.is_a?(Transaction) && entry.entryable.merchant_id == merchant_id
-      end
+      entries.joins("INNER JOIN transactions ON transactions.id = entries.entryable_id AND entries.entryable_type = 'Transaction'")
+             .where(transactions: { merchant_id: merchant_id })
     else
       # Match by entry name
       entries.where(name: name)
@@ -387,6 +435,47 @@ class RecurringTransaction < ApplicationRecord
   end
 
   private
+    def matches_regular_entry?(entry, transaction)
+      return false if account_id.present? && entry.account_id != account_id
+      return false unless amount_matches?(entry.amount)
+      return false unless day_matches?(entry.date)
+
+      if merchant_id.present?
+        transaction.merchant_id == merchant_id
+      else
+        entry.name == name
+      end
+    end
+
+    def matches_transfer_entry?(entry, transaction)
+      return false if account_id.blank? || destination_account_id.blank?
+      return false unless entry.account_id == account_id
+      return false unless amount_matches?(entry.amount)
+      return false unless day_matches?(entry.date)
+
+      transfer = transaction.transfer
+      return false unless transfer
+      return false unless transfer.outflow_transaction_id == transaction.id
+
+      inflow_entry = transfer.inflow_transaction&.entry
+      inflow_entry&.account_id == destination_account_id
+    end
+
+    def amount_matches?(entry_amount)
+      if manual? && has_amount_variance?
+        entry_amount >= expected_amount_min && entry_amount <= expected_amount_max
+      else
+        entry_amount == amount
+      end
+    end
+
+    def day_matches?(date)
+      day = date.day
+      min_day = [ expected_day_of_month - 2, 1 ].max
+      max_day = [ expected_day_of_month + 2, 31 ].min
+      day >= min_day && day <= max_day
+    end
+
     # Issue #1590: a recurring transfer's future occurrences rarely share the
     # seed's name (user free-text, importer wording, the auto-matcher's
     # "Transfer to ..."), so name-based matching returns [] and the Cleaner

--- a/app/views/recurring_transactions/index.html.erb
+++ b/app/views/recurring_transactions/index.html.erb
@@ -98,7 +98,7 @@
             <% @recurring_transactions.each do |recurring_transaction| %>
               <tr class="border-b border-subdued hover:bg-surface-hover <%= "opacity-60" unless recurring_transaction.active? %>">
                 <td class="py-3 px-2 text-sm">
-                  <div class="flex items-center gap-2">
+                  <%= link_to recurring_transaction_path(recurring_transaction), class: "flex items-center gap-2 hover:opacity-80" do %>
                     <% if recurring_transaction.merchant.present? %>
                       <% if recurring_transaction.merchant.logo_url.present? %>
                         <%= image_tag recurring_transaction.merchant.logo_url,
@@ -127,7 +127,7 @@
                         <%= t("recurring_transactions.badges.manual") %>
                       </span>
                     <% end %>
-                  </div>
+                  <% end %>
                 </td>
                 <% if recurring_transaction.transfer? %>
                   <td class="py-3 px-2 text-sm font-medium privacy-sensitive text-secondary">

--- a/app/views/recurring_transactions/show.html.erb
+++ b/app/views/recurring_transactions/show.html.erb
@@ -43,18 +43,25 @@
           <div class="flex items-center gap-2 flex-wrap">
             <h2 class="text-lg font-medium text-primary truncate"><%= @recurring_transaction.display_name %></h2>
             <% if @recurring_transaction.manual? %>
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-tint-10 text-link">
-                <%= t("recurring_transactions.badges.manual") %>
-              </span>
+              <%= render DS::Pill.new(
+                label: t("recurring_transactions.badges.manual"),
+                tone: :info,
+                marker: false
+              ) %>
             <% end %>
             <% if @recurring_transaction.active? %>
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-50 text-success theme-dark:bg-green-tint-10">
-                <%= t("recurring_transactions.status.active") %>
-              </span>
+              <%= render DS::Pill.new(
+                label: t("recurring_transactions.status.active"),
+                tone: :success,
+                marker: false,
+                show_dot: true
+              ) %>
             <% else %>
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-inset text-primary">
-                <%= t("recurring_transactions.status.inactive") %>
-              </span>
+              <%= render DS::Pill.new(
+                label: t("recurring_transactions.status.inactive"),
+                tone: :neutral,
+                marker: false
+              ) %>
             <% end %>
           </div>
           <p class="text-sm text-secondary mt-1">

--- a/app/views/recurring_transactions/show.html.erb
+++ b/app/views/recurring_transactions/show.html.erb
@@ -1,0 +1,146 @@
+<%= content_for :page_title, @recurring_transaction.display_name %>
+<%= content_for :page_actions do %>
+  <%= render DS::Link.new(
+    text: t("recurring_transactions.show.back"),
+    icon: "arrow-left",
+    variant: "outline",
+    href: recurring_transactions_path
+  ) %>
+  <%= render DS::Button.new(
+    text: @recurring_transaction.active? ? t("recurring_transactions.show.pause") : t("recurring_transactions.show.resume"),
+    variant: "outline",
+    icon: @recurring_transaction.active? ? "pause" : "play",
+    href: toggle_status_recurring_transaction_path(@recurring_transaction),
+    method: :post
+  ) %>
+  <%= render DS::Button.new(
+    text: t("recurring_transactions.show.delete"),
+    variant: "outline_destructive",
+    icon: "trash-2",
+    href: recurring_transaction_path(@recurring_transaction),
+    method: :delete,
+    confirm: t("recurring_transactions.confirm_delete")
+  ) %>
+<% end %>
+
+<div class="space-y-4 flex flex-col">
+  <div class="bg-container rounded-xl shadow-border-xs p-4 space-y-4">
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex items-center gap-3 min-w-0">
+        <% if @recurring_transaction.merchant&.logo_url.present? %>
+          <%= image_tag @recurring_transaction.merchant.logo_url,
+              class: "w-10 h-10 rounded-full shrink-0",
+              loading: "lazy" %>
+        <% else %>
+          <%= render DS::FilledIcon.new(
+            variant: :text,
+            text: @recurring_transaction.display_name,
+            size: "lg",
+            rounded: true
+          ) %>
+        <% end %>
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <h2 class="text-lg font-medium text-primary truncate"><%= @recurring_transaction.display_name %></h2>
+            <% if @recurring_transaction.manual? %>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-tint-10 text-link">
+                <%= t("recurring_transactions.badges.manual") %>
+              </span>
+            <% end %>
+            <% if @recurring_transaction.active? %>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-50 text-success theme-dark:bg-green-tint-10">
+                <%= t("recurring_transactions.status.active") %>
+              </span>
+            <% else %>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-inset text-primary">
+                <%= t("recurring_transactions.status.inactive") %>
+              </span>
+            <% end %>
+          </div>
+          <p class="text-sm text-secondary mt-1">
+            <%= t("recurring_transactions.day_of_month", day: @recurring_transaction.expected_day_of_month) %>
+          </p>
+        </div>
+      </div>
+
+      <div class="text-right shrink-0">
+        <% if @recurring_transaction.transfer? %>
+          <p class="text-lg font-medium text-secondary privacy-sensitive">
+            <%= format_money(@recurring_transaction.amount_money.abs) %>
+          </p>
+        <% elsif @recurring_transaction.manual? && @recurring_transaction.has_amount_variance? %>
+          <p class="text-lg font-medium privacy-sensitive <%= @recurring_transaction.amount.negative? ? "text-success" : "text-primary" %>">
+            ~<%= format_money(-@recurring_transaction.expected_amount_avg_money) %>
+          </p>
+        <% else %>
+          <p class="text-lg font-medium privacy-sensitive <%= @recurring_transaction.amount.negative? ? "text-success" : "text-primary" %>">
+            <%= format_money(-@recurring_transaction.amount_money) %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <div class="rounded-lg bg-container-inset p-3">
+        <p class="text-xs text-secondary uppercase"><%= t("recurring_transactions.table.next_date") %></p>
+        <p class="text-sm font-medium text-primary mt-1"><%= l(@recurring_transaction.next_expected_date, format: :short) %></p>
+      </div>
+      <div class="rounded-lg bg-container-inset p-3">
+        <p class="text-xs text-secondary uppercase"><%= t("recurring_transactions.table.last_occurrence") %></p>
+        <p class="text-sm font-medium text-primary mt-1"><%= l(@recurring_transaction.last_occurrence_date, format: :short) %></p>
+      </div>
+      <div class="rounded-lg bg-container-inset p-3">
+        <p class="text-xs text-secondary uppercase"><%= t("recurring_transactions.show.occurrences") %></p>
+        <p class="text-sm font-medium text-primary mt-1"><%= @matching_entries.size %><%= "+" if @matching_entries.size >= 50 %></p>
+      </div>
+      <% if @recurring_transaction.account.present? %>
+        <div class="rounded-lg bg-container-inset p-3">
+          <p class="text-xs text-secondary uppercase"><%= t("recurring_transactions.show.account") %></p>
+          <p class="text-sm font-medium text-primary mt-1 truncate">
+            <%= @recurring_transaction.account.name %>
+            <% if @recurring_transaction.transfer? && @recurring_transaction.destination_account.present? %>
+              → <%= @recurring_transaction.destination_account.name %>
+            <% end %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="bg-container rounded-xl shadow-border-xs p-4">
+    <div class="flex items-center gap-1.5 px-1 pb-3 text-xs font-medium text-secondary uppercase">
+      <p><%= t("recurring_transactions.show.history_title") %></p>
+      <span class="text-subdued">&middot;</span>
+      <p><%= @matching_entries.size %></p>
+    </div>
+
+    <% if @matching_entries.empty? %>
+      <%= render DS::EmptyState.new(
+        icon: "repeat",
+        title: t("recurring_transactions.show.history_empty_title"),
+        description: t("recurring_transactions.show.history_empty_description")
+      ) %>
+    <% else %>
+      <div class="bg-container-inset rounded-lg divide-y divide-alpha-black-200 theme-dark:divide-alpha-white-200">
+        <% @matching_entries.each do |entry| %>
+          <%= link_to entry_path(entry),
+                data: { turbo_frame: "drawer" },
+                class: "flex items-center justify-between gap-3 p-3 hover:bg-surface-hover first:rounded-t-lg last:rounded-b-lg" do %>
+            <div class="min-w-0">
+              <p class="text-sm font-medium text-primary truncate"><%= entry.name %></p>
+              <p class="text-xs text-secondary mt-0.5">
+                <%= l(entry.date, format: :short) %>
+                <% if entry.account.present? %>
+                  · <%= entry.account.name %>
+                <% end %>
+              </p>
+            </div>
+            <p class="text-sm font-medium privacy-sensitive shrink-0 <%= entry.amount.negative? ? "text-success" : "text-primary" %>">
+              <%= format_money(-entry.amount_money) %>
+            </p>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -96,6 +96,22 @@
                       </span>
                     <% end %>
 
+                    <% matched_recurring = @matched_recurring_by_entry_id&.[](entry.id) %>
+                    <% if matched_recurring %>
+                      <%= link_to recurring_transaction_path(matched_recurring),
+                            data: { turbo_frame: "_top" },
+                            class: "inline-flex",
+                            title: t("transactions.transaction.recurring_tooltip") do %>
+                        <%= render DS::Pill.new(
+                          label: t("transactions.transaction.recurring"),
+                          tone: :info,
+                          marker: false,
+                          icon: "repeat",
+                          title: t("transactions.transaction.recurring_tooltip")
+                        ) %>
+                      <% end %>
+                    <% end %>
+
                     <%# Pending indicator %>
                     <% if transaction.pending? %>
                       <%= render DS::Pill.new(

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -397,20 +397,35 @@
               ) %>
             </div>
           <% end %>
-          <!-- Mark as Recurring Form -->
+          <!-- Recurring Transaction -->
           <div class="flex items-center justify-between gap-2 p-3">
             <div class="text-sm space-y-1">
-              <h4 class="text-primary"><%= t(".mark_recurring_title") %></h4>
-              <p class="text-secondary"><%= t(".mark_recurring_subtitle") %></p>
+              <% if @matched_recurring %>
+                <h4 class="text-primary"><%= t(".view_recurring_title") %></h4>
+                <p class="text-secondary"><%= t(".view_recurring_subtitle") %></p>
+              <% else %>
+                <h4 class="text-primary"><%= t(".mark_recurring_title") %></h4>
+                <p class="text-secondary"><%= t(".mark_recurring_subtitle") %></p>
+              <% end %>
             </div>
-            <%= render DS::Button.new(
-              text: t(".mark_recurring"),
-              variant: "outline",
-              icon: "repeat",
-              href: mark_as_recurring_transaction_path(@entry.transaction),
-              method: :post,
-              frame: "_top"
-            ) %>
+            <% if @matched_recurring %>
+              <%= render DS::Button.new(
+                text: t(".view_recurring"),
+                variant: "outline",
+                icon: "repeat",
+                href: recurring_transaction_path(@matched_recurring),
+                frame: "_top"
+              ) %>
+            <% else %>
+              <%= render DS::Button.new(
+                text: t(".mark_recurring"),
+                variant: "outline",
+                icon: "repeat",
+                href: mark_as_recurring_transaction_path(@entry.transaction),
+                method: :post,
+                frame: "_top"
+              ) %>
+            <% end %>
           </div>
         <% end %>
         <%# Delete Transaction Form - hidden for split children %>

--- a/config/locales/views/recurring_transactions/ca.yml
+++ b/config/locales/views/recurring_transactions/ca.yml
@@ -5,7 +5,16 @@ ca:
     amount_range: 'Rang: %{min} a %{max}'
     badges:
       manual: Manual
-    cleaned_up: S'han netejat %{count} transaccions recurrents obsoletes
+    show:
+      back: Enrere
+      pause: Posa en pausa
+      resume: Reprèn
+      delete: Suprimeix
+      occurrences: Ocurrències
+      account: Compte
+      history_title: Transaccions coincidents
+      history_empty_title: Cap transacció coincident
+      history_empty_description: "Ara mateix no hi ha transaccions passades que coincideixin amb aquest patró recurrent."
     cleanup_stale: Neteja obsoletes
     confirm_delete: Segur que vols eliminar aquesta transacció recurrent?
     creation_failed: No s'ha pogut crear la transacció recurrent. Comprova els detalls

--- a/config/locales/views/recurring_transactions/de.yml
+++ b/config/locales/views/recurring_transactions/de.yml
@@ -50,3 +50,13 @@ de:
       inactive: Inaktiv
     badges:
       manual: Manuell
+    show:
+      back: Zurück
+      pause: Pausieren
+      resume: Fortsetzen
+      delete: Löschen
+      occurrences: Vorkommen
+      account: Konto
+      history_title: Übereinstimmende Transaktionen
+      history_empty_title: Keine übereinstimmenden Transaktionen
+      history_empty_description: "Derzeit passen keine vergangenen Transaktionen zu diesem wiederkehrenden Muster."

--- a/config/locales/views/recurring_transactions/en.yml
+++ b/config/locales/views/recurring_transactions/en.yml
@@ -50,6 +50,16 @@ en:
       inactive: Inactive
     badges:
       manual: Manual
+    show:
+      back: Back
+      pause: Pause
+      resume: Resume
+      delete: Delete
+      occurrences: Occurrences
+      account: Account
+      history_title: Matching transactions
+      history_empty_title: No matching transactions
+      history_empty_description: No past transactions currently match this recurring pattern.
     transfer_marked_as_recurring: Transfer marked as recurring
     transfer_already_exists: A recurring transfer already exists for this account pair
     transfer_creation_failed: Failed to create recurring transfer. Please check the transfer details and try again.

--- a/config/locales/views/recurring_transactions/es.yml
+++ b/config/locales/views/recurring_transactions/es.yml
@@ -51,3 +51,13 @@ es:
       inactive: Inactiva
     badges:
       manual: Manual
+    show:
+      back: Volver
+      pause: Pausar
+      resume: Reanudar
+      delete: Eliminar
+      occurrences: Ocurrencias
+      account: Cuenta
+      history_title: Transacciones coincidentes
+      history_empty_title: No hay transacciones coincidentes
+      history_empty_description: "Ninguna transacción pasada coincide actualmente con este patrón recurrente."

--- a/config/locales/views/recurring_transactions/fr.yml
+++ b/config/locales/views/recurring_transactions/fr.yml
@@ -5,6 +5,16 @@ fr:
     amount_range: 'Plage : %{min} à %{max}'
     badges:
       manual: Manuel
+    show:
+      back: Retour
+      pause: Pause
+      resume: Reprendre
+      delete: Supprimer
+      occurrences: Occurrences
+      account: Compte
+      history_title: Transactions correspondantes
+      history_empty_title: Aucune transaction correspondante
+      history_empty_description: Aucune transaction passée ne correspond actuellement à ce modèle récurrent.
     cleaned_up: "%{count} transactions récurrentes obsolètes nettoyées"
     cleanup_stale: Nettoyer les obsolètes
     confirm_delete: Êtes-vous sûr(e) de vouloir supprimer cette transaction récurrente

--- a/config/locales/views/recurring_transactions/hu.yml
+++ b/config/locales/views/recurring_transactions/hu.yml
@@ -50,7 +50,16 @@ hu:
       inactive: Inaktív
     badges:
       manual: Manuális
-    transfer_marked_as_recurring: Átutalás ismétlődőként jelölve
+    show:
+      back: Vissza
+      pause: Szüneteltetés
+      resume: Folytatás
+      delete: Törlés
+      occurrences: Előfordulások
+      account: Számla
+      history_title: Egyező tranzakciók
+      history_empty_title: Nincs egyező tranzakció
+      history_empty_description: "Jelenleg egyetlen korábbi tranzakció sem egyezik ezzel az ismétlődő mintával."
     transfer_already_exists: Ehhez a számlápárhoz már létezik ismétlődő átutalás
     transfer_creation_failed: Nem sikerült létrehozni az ismétlődő átutalást. Kérlek ellenőrizd az átutalás adatait, és próbáld újra.
     transfer_feature_disabled: Az ismétlődő tranzakciók le vannak tiltva ennél a háztartásnál

--- a/config/locales/views/recurring_transactions/it.yml
+++ b/config/locales/views/recurring_transactions/it.yml
@@ -50,7 +50,16 @@ it:
       inactive: Inattiva
     badges:
       manual: Manuale
-    transfer_marked_as_recurring: Bonifico contrassegnato come ricorrente
+    show:
+      back: Indietro
+      pause: Metti in pausa
+      resume: Riprendi
+      delete: Elimina
+      occurrences: Occorrenze
+      account: Conto
+      history_title: Transazioni corrispondenti
+      history_empty_title: Nessuna transazione corrispondente
+      history_empty_description: "Nessuna transazione passata corrisponde attualmente a questo modello ricorrente."
     transfer_already_exists: Esiste già un bonifico ricorrente per questa coppia di conti
     transfer_creation_failed: Impossibile creare il bonifico ricorrente. Verifica i dettagli e riprova.
     transfer_feature_disabled: Le transazioni ricorrenti sono disabilitate per questa famiglia

--- a/config/locales/views/recurring_transactions/nl.yml
+++ b/config/locales/views/recurring_transactions/nl.yml
@@ -47,3 +47,13 @@ nl:
       inactive: Inactief
     badges:
       manual: Handmatig
+    show:
+      back: Terug
+      pause: Pauzeren
+      resume: Hervatten
+      delete: Verwijderen
+      occurrences: Voorkomens
+      account: Rekening
+      history_title: Overeenkomende transacties
+      history_empty_title: Geen overeenkomende transacties
+      history_empty_description: "Er komen momenteel geen eerdere transacties overeen met dit terugkerende patroon."

--- a/config/locales/views/recurring_transactions/pl.yml
+++ b/config/locales/views/recurring_transactions/pl.yml
@@ -52,3 +52,13 @@ pl:
       inactive: Nieaktywna
     badges:
       manual: Ręczna
+    show:
+      back: Wstecz
+      pause: Wstrzymaj
+      resume: Wznów
+      delete: Usuń
+      occurrences: Wystąpienia
+      account: Konto
+      history_title: Pasujące transakcje
+      history_empty_title: Brak pasujących transakcji
+      history_empty_description: "Żadne wcześniejsze transakcje nie pasują obecnie do tego cyklicznego wzorca."

--- a/config/locales/views/recurring_transactions/pt-BR.yml
+++ b/config/locales/views/recurring_transactions/pt-BR.yml
@@ -43,3 +43,13 @@ pt-BR:
       inactive: Inativa
     badges:
       manual: Manual
+    show:
+      back: Voltar
+      pause: Pausar
+      resume: Retomar
+      delete: Excluir
+      occurrences: Ocorrências
+      account: Conta
+      history_title: Transações correspondentes
+      history_empty_title: Nenhuma transação correspondente
+      history_empty_description: "Nenhuma transação anterior corresponde atualmente a este padrão recorrente."

--- a/config/locales/views/recurring_transactions/ro.yml
+++ b/config/locales/views/recurring_transactions/ro.yml
@@ -36,3 +36,15 @@ ro:
     status:
       active: Activ
       inactive: Inactiv
+    badges:
+      manual: Manual
+    show:
+      back: Înapoi
+      pause: Întrerupe
+      resume: Reia
+      delete: Șterge
+      occurrences: Apariții
+      account: Cont
+      history_title: Tranzacții corespunzătoare
+      history_empty_title: Nicio tranzacție corespunzătoare
+      history_empty_description: "Nicio tranzacție anterioară nu corespunde momentan acestui tipar recurent."

--- a/config/locales/views/recurring_transactions/ru.yml
+++ b/config/locales/views/recurring_transactions/ru.yml
@@ -5,6 +5,16 @@ ru:
     amount_range: 'Диапазон: от %{min} до %{max}'
     badges:
       manual: Вручную
+    show:
+      back: Назад
+      pause: Приостановить
+      resume: Возобновить
+      delete: Удалить
+      occurrences: Вхождения
+      account: Счёт
+      history_title: Совпадающие операции
+      history_empty_title: Нет совпадающих операций
+      history_empty_description: "На данный момент ни одна прошедшая операция не соответствует этому повторяющемуся шаблону."
     cleaned_up: Очищено %{count} устаревших регулярных операций
     cleanup_stale: Очистить устаревшие
     confirm_delete: Вы уверены, что хотите удалить эту регулярную операцию?

--- a/config/locales/views/recurring_transactions/tr.yml
+++ b/config/locales/views/recurring_transactions/tr.yml
@@ -5,7 +5,16 @@ tr:
     amount_range: 'Aralık: %{min} - %{max}'
     badges:
       manual: Manuel
-    cleaned_up: "%{count} eski yinelenen işlem temizlendi"
+    show:
+      back: Geri
+      pause: Duraklat
+      resume: Sürdür
+      delete: Sil
+      occurrences: Oluşumlar
+      account: Hesap
+      history_title: Eşleşen işlemler
+      history_empty_title: Eşleşen işlem yok
+      history_empty_description: "Şu anda bu yinelenen kalıpla eşleşen geçmiş işlem yok."
     cleanup_stale: Eskileri Temizle
     confirm_delete: Bu yinelenen işlemi silmek istediğinizden emin misiniz?
     creation_failed: Yinelenen işlem oluşturulamadı. Lütfen işlem bilgilerini kontrol

--- a/config/locales/views/recurring_transactions/vi.yml
+++ b/config/locales/views/recurring_transactions/vi.yml
@@ -50,7 +50,16 @@ vi:
       inactive: Không hoạt động
     badges:
       manual: Thủ công
-    transfer_marked_as_recurring: Chuyển khoản đã được đánh dấu là định kỳ
+    show:
+      back: Quay lại
+      pause: Tạm dừng
+      resume: Tiếp tục
+      delete: Xóa
+      occurrences: Lần xuất hiện
+      account: Tài khoản
+      history_title: Giao dịch khớp
+      history_empty_title: Không có giao dịch khớp
+      history_empty_description: "Hiện không có giao dịch trước đây nào khớp với mẫu định kỳ này."
     transfer_already_exists: Đã tồn tại chuyển khoản định kỳ cho cặp tài khoản này
     transfer_creation_failed: Không thể tạo chuyển khoản định kỳ. Vui lòng kiểm tra thông tin và thử lại.
     transfer_feature_disabled: Chuyển khoản định kỳ đã bị tắt cho hộ gia đình này

--- a/config/locales/views/recurring_transactions/zh-CN.yml
+++ b/config/locales/views/recurring_transactions/zh-CN.yml
@@ -50,7 +50,16 @@ zh-CN:
       inactive: 停用
     badges:
       manual: 手动
-    transfer_marked_as_recurring: 转账已标记为循环
+    show:
+      back: 返回
+      pause: 暂停
+      resume: 恢复
+      delete: 删除
+      occurrences: 发生次数
+      account: 账户
+      history_title: 匹配的交易
+      history_empty_title: 没有匹配的交易
+      history_empty_description: "目前没有过去的交易匹配此循环模式。"
     transfer_already_exists: 此账户对已存在循环转账
     transfer_creation_failed: 创建循环转账失败。请检查转账详情后重试。
     transfer_feature_disabled: 此家庭已禁用循环交易

--- a/config/locales/views/recurring_transactions/zh-TW.yml
+++ b/config/locales/views/recurring_transactions/zh-TW.yml
@@ -47,3 +47,13 @@ zh-TW:
       inactive: 已停用
     badges:
       manual: 手動
+    show:
+      back: 返回
+      pause: 暫停
+      resume: 繼續
+      delete: 刪除
+      occurrences: 發生次數
+      account: 帳戶
+      history_title: 相符交易
+      history_empty_title: 沒有相符交易
+      history_empty_description: "目前沒有過去的交易符合此定期模式。"

--- a/config/locales/views/transactions/ca.yml
+++ b/config/locales/views/transactions/ca.yml
@@ -305,6 +305,9 @@ ca:
         d'import es calcula automàticament a partir dels últims 6 mesos de transaccions
         similars.
       mark_recurring_title: Transacció recurrent
+      view_recurring: "Veure la recurrència"
+      view_recurring_subtitle: "Aquesta transacció coincideix amb un patró recurrent actiu."
+      view_recurring_title: "Transacció recurrent"
       memo: Memo
       merchant_label: Comerç
       merge_duplicate: Sí, fusiona-les
@@ -354,6 +357,8 @@ ca:
       total_transactions: Total de transaccions
     toggle_recurring_section: Mostra/Amaga les transaccions recurrents properes
     transaction:
+      recurring: "Recurrent"
+      recurring_tooltip: "Forma part d'un patró recurrent — veure'n els detalls"
       activity_type_tooltip: Tipus d'activitat d'inversió
       linked_with_provider: Vinculat amb %{provider}
       pending: Pendent

--- a/config/locales/views/transactions/de.yml
+++ b/config/locales/views/transactions/de.yml
@@ -24,6 +24,9 @@ de:
     new:
       new_transaction: Neue Transaktion
     show:
+      view_recurring: "Wiederkehrende anzeigen"
+      view_recurring_subtitle: "Diese Transaktion entspricht einem aktiven wiederkehrenden Muster."
+      view_recurring_title: "Wiederkehrende Transaktion"
       account_label: Konto
       amount: Betrag
       category_label: Kategorie
@@ -75,6 +78,8 @@ de:
     merge_duplicate: Ja, zusammenführen
     keep_both: Nein, beide behalten
     transaction:
+      recurring: "Wiederkehrend"
+      recurring_tooltip: "Teil eines wiederkehrenden Musters — Details anzeigen"
       pending: Ausstehend
       pending_tooltip: Ausstehende Transaktion — kann sich bei Buchung ändern
       linked_with_provider: Mit %{provider} verknüpft

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -58,6 +58,9 @@ en:
       mark_recurring: Mark as Recurring
       mark_recurring_subtitle: Track this as a recurring transaction. Amount variance is automatically calculated from past 6 months of similar transactions.
       mark_recurring_title: Recurring Transaction
+      view_recurring: View Recurring
+      view_recurring_subtitle: This transaction matches an active recurring pattern.
+      view_recurring_title: Recurring Transaction
       merge_duplicate: Yes, merge them
       potential_duplicate_description: This pending transaction may be the same as the posted transaction below. If so, merge them to avoid double-counting.
       potential_duplicate_title: Possible duplicate detected
@@ -136,6 +139,8 @@ en:
       reject_match: Reject match
       transfer_confirmed: Transfer is confirmed
     transaction:
+      recurring: Recurring
+      recurring_tooltip: Part of a recurring pattern — view details
       pending: Pending
       pending_tooltip: Pending transaction — may change when posted
       linked_with_provider: Linked with %{provider}

--- a/config/locales/views/transactions/es.yml
+++ b/config/locales/views/transactions/es.yml
@@ -24,6 +24,9 @@ es:
     new:
       new_transaction: Nueva transacción
     show:
+      view_recurring: "Ver recurrente"
+      view_recurring_subtitle: "Esta transacción coincide con un patrón recurrente activo."
+      view_recurring_title: "Transacción recurrente"
       account_label: Cuenta
       amount: Importe
       category_label: Categoría
@@ -76,6 +79,8 @@ es:
       merge_duplicate: Sí, combinarlas
       keep_both: No, mantener ambas
     transaction:
+      recurring: "Recurrente"
+      recurring_tooltip: "Forma parte de un patrón recurrente — ver detalles"
       pending: Pendiente
       pending_tooltip: Transacción pendiente — puede cambiar al confirmarse
       linked_with_provider: Vinculado con %{provider}

--- a/config/locales/views/transactions/fr.yml
+++ b/config/locales/views/transactions/fr.yml
@@ -289,6 +289,9 @@ fr:
       mark_recurring: Marquer comme récurrent
       mark_recurring_subtitle: Suivez cela comme une transaction récurrente. L’écart de montant est automatiquement calculé à partir des 6 derniers mois de transactions similaires.
       mark_recurring_title: Transaction récurrente
+      view_recurring: Voir la récurrence
+      view_recurring_subtitle: Cette transaction correspond à un modèle récurrent actif.
+      view_recurring_title: Transaction récurrente
       memo: Mémo
       merchant_label: Marchand
       merge_duplicate: Oui, fusionne-les
@@ -328,6 +331,8 @@ fr:
     transaction:
       activity_type_tooltip: Type d'activité d'investissement
       linked_with_provider: Lié avec %{provider}
+      recurring: Récurrent
+      recurring_tooltip: Fait partie d'un modèle récurrent — voir les détails
       pending: En attente
       pending_tooltip: Transaction en attente — peut changer une fois validée
       possible_duplicate: Doublon ?

--- a/config/locales/views/transactions/hu.yml
+++ b/config/locales/views/transactions/hu.yml
@@ -58,6 +58,9 @@ hu:
       mark_recurring: Ismétlődőként jelölés
       mark_recurring_subtitle: Kövesd ezt ismétlődő tranzakcióként. Az összegeltérés automatikusan kiszámításra kerül az elmúlt 6 hónap hasonló tranzakcióiból.
       mark_recurring_title: Ismétlődő tranzakció
+      view_recurring: "Ismétlődő megtekintése"
+      view_recurring_subtitle: "Ez a tranzakció egy aktív ismétlődő mintához illeszkedik."
+      view_recurring_title: "Ismétlődő tranzakció"
       merge_duplicate: Igen, egyesítsd őket
       potential_duplicate_description: Ez a függőben lévő tranzakció megegyezhet az alábbi közzétett tranzakcióval. Ha igen, egyesítsd őket a kettős könyvelés elkerülése érdekében.
       potential_duplicate_title: Lehetséges duplikátum észlelve
@@ -128,6 +131,8 @@ hu:
     split_parent_row:
       split_label: "Felosztva"
     transaction:
+      recurring: "Ismétlődő"
+      recurring_tooltip: "Ismétlődő minta része — részletek megtekintése"
       pending: Függőben
       pending_tooltip: Függőben lévő tranzakció — közzétételkor változhat
       linked_with_provider: "Összekapcsolva: %{provider}"

--- a/config/locales/views/transactions/it.yml
+++ b/config/locales/views/transactions/it.yml
@@ -58,6 +58,9 @@ it:
       mark_recurring: Segna come ricorrente
       mark_recurring_subtitle: Monitora questa come transazione ricorrente. La varianza dell'importo viene calcolata automaticamente dagli ultimi 6 mesi di transazioni simili.
       mark_recurring_title: Transazione ricorrente
+      view_recurring: "Vedi ricorrente"
+      view_recurring_subtitle: "Questa transazione corrisponde a un modello ricorrente attivo."
+      view_recurring_title: "Transazione ricorrente"
       merge_duplicate: Sì, uniscile
       potential_duplicate_description: Questa transazione in attesa potrebbe essere la stessa di quella registrata qui sotto. In caso affermativo, uniscile per evitare il doppio conteggio.
       potential_duplicate_title: Possibile duplicato rilevato
@@ -134,6 +137,8 @@ it:
       reject_match: Rifiuta abbinamento
       transfer_confirmed: Bonifico confermato
     transaction:
+      recurring: "Ricorrente"
+      recurring_tooltip: "Fa parte di un modello ricorrente — vedi i dettagli"
       pending: In attesa
       pending_tooltip: Transazione in attesa — potrebbe cambiare alla registrazione
       linked_with_provider: Collegata con %{provider}

--- a/config/locales/views/transactions/nb.yml
+++ b/config/locales/views/transactions/nb.yml
@@ -23,6 +23,9 @@ nb:
     new:
       new_transaction: Ny transaksjon
     show:
+      view_recurring: "Vis gjentakende"
+      view_recurring_subtitle: "Denne transaksjonen matcher et aktivt gjentakende mønster."
+      view_recurring_title: "Gjentakende transaksjon"
       account_label: Konto
       amount: Beløp
       category_label: Kategori
@@ -49,6 +52,8 @@ nb:
       edit_tags: Rediger tagger
       import: Importer
     transaction:
+      recurring: "Gjentakende"
+      recurring_tooltip: "Del av et gjentakende mønster — se detaljer"
       linked_with_provider: Koblet med %{provider}
     index:
       transaction: transaksjon

--- a/config/locales/views/transactions/nl.yml
+++ b/config/locales/views/transactions/nl.yml
@@ -24,6 +24,9 @@ nl:
     new:
       new_transaction: Nieuwe transactie
     show:
+      view_recurring: "Terugkerende bekijken"
+      view_recurring_subtitle: "Deze transactie komt overeen met een actief terugkerend patroon."
+      view_recurring_title: "Terugkerende transactie"
       account_label: Account
       amount: Bedrag
       category_label: Categorie
@@ -74,6 +77,8 @@ nl:
     merge_duplicate: Ja, voeg ze samen
     keep_both: Nee, bewaar beide
     transaction:
+      recurring: "Terugkerend"
+      recurring_tooltip: "Onderdeel van een terugkerend patroon — bekijk details"
       pending: Wachtend
       pending_tooltip: Wachtende transactie — kan wijzigen bij posting
       linked_with_provider: Gekoppeld met %{provider}

--- a/config/locales/views/transactions/pl.yml
+++ b/config/locales/views/transactions/pl.yml
@@ -28,6 +28,9 @@ pl:
     new:
       new_transaction: Nowa transakcja
     show:
+      view_recurring: "Zobacz cykliczną"
+      view_recurring_subtitle: "Ta transakcja pasuje do aktywnego wzorca cyklicznego."
+      view_recurring_title: "Transakcja cykliczna"
       account_label: Konto
       amount: Kwota
       category_label: Kategoria
@@ -87,6 +90,8 @@ pl:
     split_parent_row:
       split_label: Podział
     transaction:
+      recurring: "Cykliczna"
+      recurring_tooltip: "Część wzorca cyklicznego — zobacz szczegóły"
       pending: Oczekująca
       pending_tooltip: Transakcja oczekująca — może się zmienić po zaksięgowaniu
       linked_with_provider: Połączono z %{provider}

--- a/config/locales/views/transactions/pt-BR.yml
+++ b/config/locales/views/transactions/pt-BR.yml
@@ -35,6 +35,9 @@ pt-BR:
       mark_recurring: Marcar como Recorrente
       mark_recurring_subtitle: Acompanhe como uma transação recorrente. A variação de valor é calculada automaticamente com base nos últimos 6 meses de transações similares.
       mark_recurring_title: Transação Recorrente
+      view_recurring: "Ver recorrente"
+      view_recurring_subtitle: "Esta transação corresponde a um padrão recorrente ativo."
+      view_recurring_title: "Transação recorrente"
       merchant_label: Comerciante
       name_label: Nome
       nature: Tipo
@@ -52,6 +55,8 @@ pt-BR:
       edit_tags: Editar tags
       import: Importar
     transaction:
+      recurring: "Recorrente"
+      recurring_tooltip: "Faz parte de um padrão recorrente — ver detalhes"
       linked_with_provider: Vinculado com %{provider}
     index:
       transaction: transação

--- a/config/locales/views/transactions/ro.yml
+++ b/config/locales/views/transactions/ro.yml
@@ -23,6 +23,9 @@ ro:
     new:
       new_transaction: Tranzacție nouă
     show:
+      view_recurring: "Vezi recurenta"
+      view_recurring_subtitle: "Această tranzacție corespunde unui tipar recurent activ."
+      view_recurring_title: "Tranzacție recurentă"
       account_label: Cont
       amount: Sumă
       category_label: Categorie
@@ -48,6 +51,8 @@ ro:
       edit_tags: Editează etichete
       import: Importă
     transaction:
+      recurring: "Recurentă"
+      recurring_tooltip: "Face parte dintr-un tipar recurent — vezi detaliile"
       linked_with_provider: Conectat cu %{provider}
     index:
       transaction: tranzacție

--- a/config/locales/views/transactions/ru.yml
+++ b/config/locales/views/transactions/ru.yml
@@ -324,6 +324,9 @@ ru:
         в сумме автоматически рассчитывается на основе последних 6 месяцев аналогичных
         операций.
       mark_recurring_title: Повторяющаяся операция
+      view_recurring: "Открыть повторяющуюся"
+      view_recurring_subtitle: "Эта операция соответствует активному повторяющемуся шаблону."
+      view_recurring_title: "Повторяющаяся операция"
       memo: Заметка
       merchant_label: Продавец
       merge_duplicate: Да, объединить их
@@ -365,6 +368,8 @@ ru:
       total_transactions: Всего операций
     toggle_recurring_section: Переключить предстоящие повторяющиеся операции
     transaction:
+      recurring: "Повторяющаяся"
+      recurring_tooltip: "Часть повторяющегося шаблона — открыть подробности"
       activity_type_tooltip: Тип инвестиционной активности
       linked_with_provider: Связано с %{provider}
       pending: В ожидании

--- a/config/locales/views/transactions/tr.yml
+++ b/config/locales/views/transactions/tr.yml
@@ -312,6 +312,9 @@ tr:
       mark_recurring_subtitle: Bunu yinelenen bir işlem olarak takip edin. Tutar farkı,
         geçmiş 6 aydaki benzer işlemlerden otomatik olarak hesaplanır.
       mark_recurring_title: Yinelenen İşlem
+      view_recurring: "Yineleneni gör"
+      view_recurring_subtitle: "Bu işlem etkin bir yinelenen kalıpla eşleşiyor."
+      view_recurring_title: "Yinelenen işlem"
       memo: Not
       merchant_label: Satıcı
       merge_duplicate: Evet, birleştir
@@ -352,6 +355,8 @@ tr:
       total_transactions: Toplam işlem
     toggle_recurring_section: Yaklaşan yinelenen işlemleri aç/kapat
     transaction:
+      recurring: "Yinelenen"
+      recurring_tooltip: "Yinelenen bir kalıbın parçası — ayrıntıları gör"
       activity_type_tooltip: Yatırım aktivite türü
       linked_with_provider: "%{provider} ile bağlantılı"
       pending: Beklemede

--- a/config/locales/views/transactions/vi.yml
+++ b/config/locales/views/transactions/vi.yml
@@ -56,6 +56,9 @@ vi:
       mark_recurring: Đánh dấu là định kỳ
       mark_recurring_subtitle: Theo dõi giao dịch định kỳ này. Mức biến động được tự động tính từ 6 tháng giao dịch tương tự.
       mark_recurring_title: Giao dịch định kỳ
+      view_recurring: "Xem định kỳ"
+      view_recurring_subtitle: "Giao dịch này khớp với một mẫu định kỳ đang hoạt động."
+      view_recurring_title: "Giao dịch định kỳ"
       merge_duplicate: Có, gộp lại
       potential_duplicate_description: Giao dịch đang chờ này có thể giống với giao dịch đã đăng bên dưới. Nếu vậy, hãy gộp lại để tránh tính hai lần.
       potential_duplicate_title: Phát hiện trùng lặp có thể
@@ -133,6 +136,8 @@ vi:
       reject_match: Từ chối khớp
       transfer_confirmed: Chuyển khoản đã được xác nhận
     transaction:
+      recurring: "Định kỳ"
+      recurring_tooltip: "Thuộc một mẫu định kỳ — xem chi tiết"
       pending: Đang chờ
       pending_tooltip: Giao dịch đang chờ — có thể thay đổi khi được đăng
       linked_with_provider: Liên kết với %{provider}

--- a/config/locales/views/transactions/zh-CN.yml
+++ b/config/locales/views/transactions/zh-CN.yml
@@ -58,6 +58,9 @@ zh-CN:
       mark_recurring: 标记为循环
       mark_recurring_subtitle: 将此交易跟踪为循环交易。金额差异会根据过去 6 个月的相似交易自动计算。
       mark_recurring_title: 循环交易
+      view_recurring: "查看循环"
+      view_recurring_subtitle: "此交易匹配一个有效的循环模式。"
+      view_recurring_title: "循环交易"
       merge_duplicate: 是，合并它们
       potential_duplicate_description: 这笔待处理交易可能与下方已入账交易相同。如果是这样，请合并以避免重复计算。
       potential_duplicate_title: 检测到可能的重复项
@@ -336,6 +339,8 @@ zh-CN:
       max_reached: 已达到最大文件数（%{count}/%{max}）。删除现有文件后才能上传另一个。
     potential_duplicate_description: 这笔待处理交易可能与下方已入账交易相同。如是，请合并以避免重复计算。
     transaction:
+      recurring: "循环"
+      recurring_tooltip: "属于循环模式 — 查看详情"
       pending: 待处理
       pending_tooltip: 待处理交易，入账后可能变化
       linked_with_provider: 已关联 %{provider}

--- a/config/locales/views/transactions/zh-TW.yml
+++ b/config/locales/views/transactions/zh-TW.yml
@@ -34,6 +34,9 @@ zh-TW:
       mark_recurring: 標記為定期交易
       mark_recurring_subtitle: 將此筆交易追蹤為定期交易。系統會根據過去 6 個月的類似交易自動計算金額變動範圍。
       mark_recurring_title: 定期交易
+      view_recurring: "查看定期"
+      view_recurring_subtitle: "此交易符合一個有效的定期模式。"
+      view_recurring_title: "定期交易"
       merchant_label: 商家
       name_label: 名稱
       nature: 類型
@@ -51,6 +54,8 @@ zh-TW:
       edit_tags: 編輯標籤
       import: 匯入
     transaction:
+      recurring: "定期"
+      recurring_tooltip: "屬於定期模式 — 查看詳情"
       linked_with_provider: 已與 %{provider} 連結
     index:
       transaction: 筆交易

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -491,7 +491,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :recurring_transactions, only: %i[index destroy] do
+  resources :recurring_transactions, only: %i[index show destroy] do
     collection do
       match :identify, via: [ :get, :post ]
       match :cleanup, via: [ :get, :post ]

--- a/test/controllers/recurring_transactions_controller_test.rb
+++ b/test/controllers/recurring_transactions_controller_test.rb
@@ -37,4 +37,47 @@ class RecurringTransactionsControllerTest < ActionDispatch::IntegrationTest
     get recurring_transaction_url(other_recurring)
     assert_response :not_found
   end
+
+  test "show hides matching entries from inaccessible accounts" do
+    sign_in users(:family_member)
+
+    family = families(:dylan_family)
+    accessible_account = accounts(:depository)
+    inaccessible_account = accounts(:investment)
+
+    recurring = family.recurring_transactions.create!(
+      account: nil,
+      name: "Accountless Access Pattern",
+      amount: 66.66,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3,
+      manual: true
+    )
+
+    accessible_account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 66.66,
+      currency: "USD",
+      name: "Accountless Access Pattern",
+      entryable: Transaction.create!(category: categories(:food_and_drink))
+    )
+
+    inaccessible_account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 66.66,
+      currency: "USD",
+      name: "Accountless Access Pattern",
+      entryable: Transaction.create!(category: categories(:food_and_drink))
+    )
+
+    get recurring_transaction_url(recurring)
+
+    assert_response :success
+    assert_select "p", text: /#{Regexp.escape(accessible_account.name)}/
+    assert_select "p", text: /#{Regexp.escape(inaccessible_account.name)}/, count: 0
+  end
 end

--- a/test/controllers/recurring_transactions_controller_test.rb
+++ b/test/controllers/recurring_transactions_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class RecurringTransactionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in @user = users(:family_admin)
+    @recurring = recurring_transactions(:netflix_subscription)
+  end
+
+  test "show renders recurring detail for accessible pattern" do
+    get recurring_transaction_url(@recurring)
+
+    assert_response :success
+    assert_select "h1", text: @recurring.display_name
+  end
+
+  test "show returns not found for another family recurring" do
+    other = families(:empty)
+    other_account = other.accounts.create!(
+      name: "Other Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    other_recurring = other.recurring_transactions.create!(
+      account: other_account,
+      name: "Other Sub",
+      amount: 10,
+      currency: "USD",
+      expected_day_of_month: 1,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 1,
+      manual: true
+    )
+
+    get recurring_transaction_url(other_recurring)
+    assert_response :not_found
+  end
+end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -722,6 +722,85 @@ end
     assert_nil created_entry.transaction.extra["exchange_rate"]
   end
 
+  test "index and show render recurring pill for matched transactions" do
+    account = accounts(:depository)
+    expected_day = Date.current.day.clamp(1, 28)
+    recurring = @user.family.recurring_transactions.create!(
+      account: account,
+      name: "Unique Recurring Pill Pattern",
+      amount: 77.77,
+      currency: "USD",
+      expected_day_of_month: expected_day,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3,
+      manual: true
+    )
+
+    entry = create_transaction(
+      account: account,
+      name: "Unique Recurring Pill Pattern",
+      amount: 77.77,
+      date: Date.current,
+      currency: "USD"
+    )
+    transaction = entry.entryable
+
+    assert_equal recurring, RecurringTransaction.match_for_transaction(
+      transaction,
+      family: @user.family,
+      user: @user
+    )
+
+    get transaction_url(entry)
+    assert_response :success
+    assert_select "h4", text: I18n.t("transactions.show.view_recurring_title")
+    assert_select "form[action=?]", recurring_transaction_path(recurring)
+
+    get transactions_url(q: { search: entry.name }, per_page: 50)
+    assert_response :success
+    assert_select "#" + dom_id(transaction)
+    assert_select "#" + dom_id(transaction) + " a[href=?]", recurring_transaction_path(recurring)
+    assert_select "#" + dom_id(transaction) + " span", text: I18n.t("transactions.transaction.recurring")
+  end
+
+  test "index does not match recurring patterns from another family" do
+    other_family = families(:empty)
+    other_account = other_family.accounts.create!(
+      name: "Other Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+    expected_day = Date.current.day.clamp(1, 28)
+    other_recurring = other_family.recurring_transactions.create!(
+      account: other_account,
+      name: "Cross Family Netflix Match",
+      amount: 88.88,
+      currency: "USD",
+      expected_day_of_month: expected_day,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3,
+      manual: true
+    )
+
+    entry = accounts(:depository).entries.create!(
+      date: Date.current,
+      amount: 88.88,
+      currency: "USD",
+      name: "Cross Family Netflix Match",
+      entryable: Transaction.create!(category: categories(:food_and_drink))
+    )
+
+    get transactions_url(q: { search: entry.name })
+    assert_response :success
+    assert_select "a[href=?]", recurring_transaction_path(other_recurring), count: 0
+    assert_select "#" + dom_id(entry.entryable) + " a[href*='recurring_transactions']", count: 0
+  end
+
   test "index preloads transfer counterparty entry and account to avoid N+1" do
     family = @user.family
     from_account = family.accounts.visible.first

--- a/test/models/recurring_transaction_test.rb
+++ b/test/models/recurring_transaction_test.rb
@@ -1106,4 +1106,134 @@ class RecurringTransactionTest < ActiveSupport::TestCase
       @family.recurring_transactions.create!(base_attrs)
     end
   end
+
+  test "matches_entry? matches merchant amount day and account" do
+    recurring = @family.recurring_transactions.create!(
+      account: @account,
+      merchant: @merchant,
+      amount: 15.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    matching_entry = @account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 15.99,
+      currency: "USD",
+      name: "Netflix",
+      entryable: Transaction.create!(merchant: @merchant, category: categories(:food_and_drink))
+    )
+
+    other_amount = @account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 20.00,
+      currency: "USD",
+      name: "Netflix",
+      entryable: Transaction.create!(merchant: @merchant, category: categories(:food_and_drink))
+    )
+
+    assert recurring.matches_entry?(matching_entry)
+    assert_not recurring.matches_entry?(other_amount)
+  end
+
+  test "matches_for_entries maps page entries to active recurring patterns" do
+    recurring = @family.recurring_transactions.create!(
+      account: @account,
+      merchant: @merchant,
+      amount: 15.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+    user = users(:family_admin)
+
+    matching_entry = @account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 15.99,
+      currency: "USD",
+      name: "Netflix Subscription",
+      entryable: Transaction.create!(merchant: @merchant, category: categories(:food_and_drink))
+    )
+
+    unmatched_entry = @account.entries.create!(
+      date: Date.current,
+      amount: 42.00,
+      currency: "USD",
+      name: "Coffee",
+      entryable: Transaction.create!(category: categories(:food_and_drink))
+    )
+
+    matches = RecurringTransaction.matches_for_entries(
+      [ matching_entry, unmatched_entry ],
+      family: @family,
+      user: user
+    )
+
+    assert_equal recurring, matches[matching_entry.id]
+    assert_nil matches[unmatched_entry.id]
+  end
+
+  test "matches_for_entries returns empty when recurring feature is disabled" do
+    recurring = @family.recurring_transactions.create!(
+      account: @account,
+      merchant: @merchant,
+      amount: 15.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+    @family.update!(recurring_transactions_disabled: true)
+    user = users(:family_admin)
+
+    entry = @account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: recurring.amount,
+      currency: recurring.currency,
+      name: "Netflix Subscription",
+      entryable: Transaction.create!(merchant: @merchant, category: categories(:food_and_drink))
+    )
+
+    assert_empty RecurringTransaction.matches_for_entries([ entry ], family: @family, user: user)
+  ensure
+    @family.update!(recurring_transactions_disabled: false)
+  end
+
+  test "display_name prefers merchant name" do
+    recurring = @family.recurring_transactions.create!(
+      account: @account,
+      merchant: @merchant,
+      amount: 15.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+    assert_equal @merchant.name, recurring.display_name
+
+    named = @family.recurring_transactions.create!(
+      account: @account,
+      name: "Gym Membership",
+      amount: 40,
+      currency: "USD",
+      expected_day_of_month: 1,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 1,
+      manual: true
+    )
+    assert_equal "Gym Membership", named.display_name
+  end
 end

--- a/test/models/recurring_transaction_test.rb
+++ b/test/models/recurring_transaction_test.rb
@@ -1137,10 +1137,43 @@ class RecurringTransactionTest < ActiveSupport::TestCase
     )
 
     assert recurring.matches_entry?(matching_entry)
+    assert recurring.matches_transaction?(matching_entry.entryable)
     assert_not recurring.matches_entry?(other_amount)
   end
 
-  test "matches_for_entries maps page entries to active recurring patterns" do
+  test "matches_entry? clamps end-of-month schedules to February" do
+    [ 29, 30, 31 ].each do |expected_day|
+      recurring = @family.recurring_transactions.create!(
+        account: @account,
+        merchant: @merchant,
+        amount: 15.99,
+        currency: "USD",
+        expected_day_of_month: expected_day,
+        last_occurrence_date: Date.new(2024, 1, 31),
+        next_expected_date: Date.new(2024, 2, 29),
+        status: "active",
+        occurrence_count: 3
+      )
+
+      feb_entry = @account.entries.create!(
+        date: Date.new(2024, 2, 29),
+        amount: 15.99,
+        currency: "USD",
+        name: "Netflix",
+        entryable: Transaction.create!(merchant: @merchant, category: categories(:food_and_drink))
+      )
+
+      assert recurring.matches_entry?(feb_entry),
+             "expected day #{expected_day} should match Feb 29"
+
+      assert_includes recurring.matching_transactions.map(&:id), feb_entry.id
+
+      recurring.destroy!
+      feb_entry.destroy!
+    end
+  end
+
+  test "matches_for_transactions maps page transactions to active recurring patterns" do
     recurring = @family.recurring_transactions.create!(
       account: @account,
       merchant: @merchant,
@@ -1170,8 +1203,8 @@ class RecurringTransactionTest < ActiveSupport::TestCase
       entryable: Transaction.create!(category: categories(:food_and_drink))
     )
 
-    matches = RecurringTransaction.matches_for_entries(
-      [ matching_entry, unmatched_entry ],
+    matches = RecurringTransaction.matches_for_transactions(
+      [ matching_entry.entryable, unmatched_entry.entryable ],
       family: @family,
       user: user
     )
@@ -1204,8 +1237,48 @@ class RecurringTransactionTest < ActiveSupport::TestCase
     )
 
     assert_empty RecurringTransaction.matches_for_entries([ entry ], family: @family, user: user)
+    assert_nil RecurringTransaction.match_for_entry(nil, family: @family, user: user)
   ensure
     @family.update!(recurring_transactions_disabled: false)
+  end
+
+  test "matches_for_transactions ignores patterns from another family" do
+    user = users(:family_admin)
+    other_family = families(:empty)
+    other_account = other_family.accounts.create!(
+      name: "Other Checking",
+      balance: 0,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    other_family.recurring_transactions.create!(
+      account: other_account,
+      name: "Netflix Subscription",
+      amount: 15.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    matching_entry = @account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 15.99,
+      currency: "USD",
+      name: "Netflix Subscription",
+      entryable: Transaction.create!(category: categories(:food_and_drink))
+    )
+
+    matches = RecurringTransaction.matches_for_transactions(
+      [ matching_entry.entryable ],
+      family: @family,
+      user: user
+    )
+
+    assert_empty matches
   end
 
   test "display_name prefers merchant name" do


### PR DESCRIPTION
## Summary
- Show a Recurring badge on transaction list/show rows that match an active recurring pattern, linking to Settings detail
- Add a recurring transaction show page with schedule summary, matching history, pause/resume, and delete
- Match via existing heuristics (no FK); prefer manual patterns; SQL merchant matching for history

## Test plan
- [ ] Enable recurring transactions and run Identify Patterns on demo data
- [ ] Confirm Netflix/Spotify/etc. rows show a Recurring pill that opens the detail page
- [ ] On a matched transaction drawer, confirm View Recurring (not Mark as Recurring)
- [ ] On Settings → Recurring, click a name → detail with matching history; pause/delete work
- [ ] With recurring disabled, no badges appear
- [ ] `bin/rails test test/models/recurring_transaction_test.rb test/controllers/recurring_transactions_controller_test.rb`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed recurring transaction pages with status, schedule, account, amount, and transaction history information.
  * Transactions now identify matching recurring patterns and link directly to their details.
  * Added actions to pause, resume, and delete recurring transactions.
  * Added support for matching recurring transactions across regular entries and transfers.

* **Bug Fixes**
  * Improved matching accuracy using account, amount, date, merchant, currency, and transfer details.

* **Accessibility & Localization**
  * Added English and French translations for recurring transaction details and indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->