### PR TITLE
fix(settings): give API key copy buttons success feedback

### DIFF
--- a/app/views/settings/api_keys/_key_reveal.html.erb
+++ b/app/views/settings/api_keys/_key_reveal.html.erb
@@ -3,7 +3,7 @@
   <h4 class="font-medium text-primary mb-3"><%= heading %></h4>
   <p class="text-secondary text-sm mb-3"><%= description %></p>
 
-  <div class="@container bg-container rounded-lg p-3 border border-primary" data-controller="clipboard">
+  <div class="@container bg-container rounded-lg p-3 border border-primary" data-controller="clipboard" data-clipboard-copied-text-value="<%= t(".copied") %>">
     <div class="flex flex-col items-start gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
       <code class="font-mono text-sm text-primary break-all min-w-0" data-clipboard-target="source"><%= api_key.plain_key %></code>
       <%= render DS::Button.new(

--- a/config/locales/views/settings/api_keys/en.yml
+++ b/config/locales/views/settings/api_keys/en.yml
@@ -26,6 +26,8 @@ en:
         empty_description: "Create an API key to access your data programmatically."
         revoke_key: "Revoke"
         revoke_confirmation: "Are you sure you want to revoke \"%{name}\"? This will immediately disable any application using this key."
+      key_reveal:
+        copied: "Copied!"
       show:
         title: "API Key Management"
         newly_created:


### PR DESCRIPTION
Fixes #2329

## Problem

The API key reveal partial (`settings/api_keys/_key_reveal.html.erb`, rendered for both the newly-created and current-key blocks) binds `clipboard#copy` on a `DS::Button`, but never sets `data-clipboard-copied-text-value`. The clipboard controller's `flashLabel` path returns early without it, so clicking copies the key with **no visible confirmation** — the same gap #2314 closed for the MCP copy button.

## Fix

Mirror #2314 exactly:
- add `data-clipboard-copied-text-value="<%= t(".copied") %>"` to the partial's `data-controller="clipboard"` element
- add the `settings.api_keys.key_reveal.copied` key (`"Copied!"`) to `config/locales/views/settings/api_keys/en.yml`

No JS changes needed — the shared controller already ships the label-flash behaviour since #2314. Both render sites of the partial (create flow and settings page) get the feedback.

## Testing

- Full unit suite: 6201 runs, 0 failures
- Full system suite via remote selenium: 89 runs, 0 failures (one unrelated `PropertyTest` flake errored in-suite and passes in isolation)
- `rubocop`, `erb_lint`, `biome lint`, `brakeman`, `importmap audit` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key reveal interactions by displaying a localized “Copied!” confirmation after copying a key.

* **Localization**
  * Added support for the copied confirmation message in English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->