### PR TITLE
fix: require paired accounts for transfers

### DIFF
--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -202,32 +202,32 @@ class Account::ProviderImportAdapter
         entry.transaction.save!
       end
 
-      # Auto-detect investment activity labels for investment accounts
+      # Auto-detect investment activity labels for investment accounts. A label
+      # from a previous sync is metadata, not proof that this transaction is an
+      # internal transfer, so do not reuse it for classification.
       detected_label = investment_activity_label
       if account.investment? && detected_label.nil? && entry.entryable.is_a?(Transaction)
         detected_label = detect_activity_label(name, amount)
       end
 
-      # Determine the transaction kind. Activity-label and account-type classification
-      # take precedence; an explicit kind supplied by the provider is used as a fallback
-      # for the standard case. A provider such as Up flags internal transfers and
-      # round-ups (via relationships.transferAccount) and passes funds_movement, but a
-      # repayment imported onto a linked Loan/CreditCard account must stay
-      # loan_payment/cc_payment (a budgeted expense) rather than being reclassified, so
-      # the account-type branches below win over the provider hint.
+      # Determine the transaction kind. A provider's transfer/contribution label or
+      # transfer kind is not enough to establish an internal transfer: only a real
+      # Sure Transfer record can do that. The family matcher assigns transfer kinds
+      # once it has both accounts. Account-type branches below still classify loan and
+      # credit-card payments, which are budgeted expenses rather than transfers.
+      previous_kind = entry.transaction.kind
       auto_kind = nil
-      auto_category = nil
-      if Transaction::INTERNAL_MOVEMENT_LABELS.include?(detected_label)
-        auto_kind = "funds_movement"
-      elsif detected_label == "Contribution"
-        auto_kind = "investment_contribution"
-        auto_category = account.family.investment_contributions_category
-      elsif account.accountable_type == "Loan" && amount.negative?
+      if account.accountable_type == "Loan" && amount.negative?
         auto_kind = "loan_payment"
       elsif account.accountable_type == "CreditCard" && amount.negative?
         auto_kind = "cc_payment"
+      elsif kind.present? && !Transaction::TRANSFER_KINDS.include?(kind)
+        auto_kind = kind
+      elsif Transaction::TRANSFER_KINDS.include?(previous_kind) && !transfer_record_exists?(entry.transaction)
+        # Clear a stale provider classification when a later import no longer
+        # supplies an internal counterpart or transfer relationship.
+        auto_kind = "standard"
       end
-      auto_kind ||= kind.presence
 
       # Set investment activity label, kind, and category if detected
       if entry.entryable.is_a?(Transaction)
@@ -239,8 +239,10 @@ class Account::ProviderImportAdapter
           entry.transaction.assign_attributes(kind: auto_kind)
         end
 
-        if auto_category.present? && entry.transaction.category_id.blank?
-          entry.transaction.assign_attributes(category: auto_category)
+        if category_id.blank? &&
+              previous_kind == "investment_contribution" &&
+              entry.transaction.category == account.family.investment_contributions_category
+          entry.transaction.assign_attributes(category: nil)
         end
       end
 
@@ -1017,6 +1019,12 @@ class Account::ProviderImportAdapter
   end
 
   private
+
+    def transfer_record_exists?(transaction)
+      Transfer.where(inflow_transaction_id: transaction.id)
+        .or(Transfer.where(outflow_transaction_id: transaction.id))
+        .exists?
+    end
 
     # Memoized per adapter instance (which is per-account). Membership in
     # goal_accounts is stable across a sync batch.

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -55,7 +55,7 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
     end
   end
 
-  test "applies an explicit provider kind on a depository account" do
+  test "does not apply an orphaned provider transfer kind" do
     entry = @adapter.import_transaction(
       external_id: "up_transfer_1",
       amount: -50.00,
@@ -66,7 +66,7 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
       kind: "funds_movement"
     )
 
-    assert_equal "funds_movement", entry.transaction.kind
+    assert_equal "standard", entry.transaction.kind
   end
 
   test "account-type kind takes precedence over an explicit provider kind" do
@@ -84,6 +84,81 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
 
     assert_equal "loan_payment", entry.transaction.kind,
                  "a repayment on a Loan account must stay loan_payment, not the provider's funds_movement"
+  end
+
+  test "preserves the matched transfer kind despite a provider contribution label" do
+    investment_account = accounts(:investment)
+    adapter = Account::ProviderImportAdapter.new(investment_account)
+    brokerage_entry = adapter.import_transaction(
+      external_id: "matched_contribution_inflow",
+      amount: -1750,
+      currency: "USD",
+      date: Date.current,
+      name: "Electronic Funds Transfer Received",
+      source: "plaid",
+      investment_activity_label: "Contribution"
+    )
+    checking_entry = accounts(:depository).entries.create!(
+      entryable: Transaction.new(kind: "investment_contribution"),
+      amount: 1750,
+      currency: "USD",
+      date: Date.current,
+      name: "Brokerage contribution"
+    )
+    Transfer.create!(
+      outflow_transaction: checking_entry.transaction,
+      inflow_transaction: brokerage_entry.transaction,
+      amount: 1750,
+      status: "confirmed"
+    )
+    brokerage_entry.transaction.update!(kind: "funds_movement")
+
+    adapter.import_transaction(
+      external_id: "matched_contribution_inflow",
+      amount: -1750,
+      currency: "USD",
+      date: Date.current,
+      name: "Electronic Funds Transfer Received",
+      source: "plaid",
+      investment_activity_label: "Contribution"
+    )
+
+    assert_equal "funds_movement", brokerage_entry.transaction.reload.kind
+  end
+
+  test "keeps orphaned provider contributions as standard transactions" do
+    investment_account = accounts(:investment)
+    adapter = Account::ProviderImportAdapter.new(investment_account)
+    category = investment_account.family.investment_contributions_category
+
+    entry = adapter.import_transaction(
+      external_id: "orphaned_cashback_1",
+      amount: -25,
+      currency: "USD",
+      date: Date.current,
+      name: "Robinhood Gold cashback",
+      source: "robinhood",
+      investment_activity_label: "Contribution"
+    )
+
+    assert_equal "standard", entry.transaction.kind
+    assert_nil entry.transaction.category
+    assert_equal "Contribution", entry.transaction.investment_activity_label
+
+    entry.transaction.update!(kind: "investment_contribution", category: category)
+    adapter.import_transaction(
+      external_id: "orphaned_cashback_1",
+      amount: -25,
+      currency: "USD",
+      date: Date.current,
+      name: "Robinhood Gold cashback",
+      source: "robinhood"
+    )
+
+    entry.transaction.reload
+    assert_equal "standard", entry.transaction.kind
+    assert_nil entry.transaction.category
+    assert_equal "Contribution", entry.transaction.investment_activity_label
   end
 
   test "updates existing transaction instead of creating duplicate" do


### PR DESCRIPTION
## Summary

- require a real Sure `Transfer` relationship before provider transfer/contribution classifications are applied
- keep orphaned provider credits such as cashback as standard transactions while preserving activity labels
- clear stale provider transfer classification and auto-assigned investment-contribution category
- preserve existing loan/card payment classification and add focused regression coverage

## Testing

- `git diff --check`
- Rails tests blocked in this environment: Ruby is not installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction classification during provider imports.
  * Preserved valid provider-supplied transaction types while prioritizing loan and credit-card payment details.
  * Prevented investment labels from incorrectly changing transaction categories.
  * Cleared outdated transfer or investment classifications when supporting account relationships are no longer present.
  * Ensured orphaned investment contributions remain uncategorized standard transactions.
  * Normalized orphaned provider transaction types while retaining account-specific classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->