### PR TITLE
fix(splits): let category selector size to its content instead of clipping names

### DIFF
--- a/app/javascript/controllers/category_badge_select_controller.js
+++ b/app/javascript/controllers/category_badge_select_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
     const option = this.element.querySelector(`[role="option"][data-value="${CSS.escape(value)}"]`)
     if (!option) return
 
-    const badge = option.querySelector("span.flex.items-center")
+    const badge = option.querySelector("span.inline-flex.items-center")
     if (badge) {
       this.buttonTarget.innerHTML = badge.outerHTML
     } else {

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -370,7 +370,7 @@ export default class extends Controller {
     const shouldOpenUp = placement === "up" || (placement === "auto" && spaceBelow < menuHeight && spaceAbove > spaceBelow)
 
     this.menuTarget.style.left = "0"
-    this.menuTarget.style.width = "100%"
+    this.menuTarget.style.right = ""
     this.menuTarget.style.top = ""
     this.menuTarget.style.bottom = ""
     this.menuTarget.style.overflowY = "auto"
@@ -381,6 +381,15 @@ export default class extends Controller {
     } else {
       this.menuTarget.style.top = "100%"
       this.menuTarget.style.maxHeight = `${Math.max(0, spaceBelow - this.offsetValue)}px`
+    }
+
+    // A menu wider than its anchor (e.g. the split dialog's category select)
+    // can spill past the scroll container's right edge and force a horizontal
+    // scrollbar; anchor it to the right edge of the button instead.
+    const menuRect = this.menuTarget.getBoundingClientRect()
+    if (menuRect.right > containerRect.right) {
+      this.menuTarget.style.left = "auto"
+      this.menuTarget.style.right = "0"
     }
   }
 }

--- a/app/javascript/controllers/split_transaction_controller.js
+++ b/app/javascript/controllers/split_transaction_controller.js
@@ -71,7 +71,7 @@ export default class extends Controller {
 
     row.innerHTML = `
       <div class="flex flex-wrap md:flex-nowrap items-end gap-2">
-        <div class="w-full md:flex-1 md:w-auto min-w-0">
+        <div class="w-full md:flex-1 md:w-auto min-w-0 md:min-w-28">
           <label class="text-xs font-medium text-secondary uppercase tracking-wide block mb-1">Name</label>
           <input type="text"
                  name="split[splits][${index}][name]"

--- a/app/views/splits/_category_select.html.erb
+++ b/app/views/splits/_category_select.html.erb
@@ -4,7 +4,7 @@
   default_color = "#737373"
 %>
 
-<div class="category-select-container relative flex-1 md:flex-none md:w-44" data-controller="select list-filter form-dropdown category-badge-select" data-action="dropdown:select->form-dropdown#onSelect dropdown:select->category-badge-select#updateButton">
+<div class="category-select-container relative flex-1 md:flex-initial md:w-auto md:min-w-44 md:max-w-72" data-controller="select list-filter form-dropdown category-badge-select" data-action="dropdown:select->form-dropdown#onSelect dropdown:select->category-badge-select#updateButton">
   <label class="text-xs font-medium text-secondary uppercase tracking-wide block mb-1"><%= t("splits.new.category_label") %></label>
   <input type="hidden"
          name="<%= name %>"
@@ -19,20 +19,21 @@
           aria-expanded="false">
     <% if selected_category %>
       <% hex_color = selected_category.color.presence || default_color %>
-      <span class="flex items-center gap-2 text-sm font-medium rounded-full px-3 py-1 border truncate"
+      <span class="flex items-center gap-2 text-sm font-medium rounded-full px-3 py-1 border min-w-0 max-w-64"
+            title="<%= selected_category.display_name %>"
             style="background-color: color-mix(in oklab, <%= hex_color %> 10%, transparent); border-color: color-mix(in oklab, <%= hex_color %> 20%, transparent); color: <%= hex_color %>;">
         <% if selected_category.lucide_icon.present? %>
           <%= icon selected_category.lucide_icon, size: "sm", color: "current" %>
         <% else %>
-          <span class="size-1.5 rounded-full" style="background-color: <%= hex_color %>;"></span>
+          <span class="size-1.5 rounded-full shrink-0" style="background-color: <%= hex_color %>;"></span>
         <% end %>
-        <%= selected_category.display_name %>
+        <span class="truncate"><%= selected_category.display_name %></span>
       </span>
     <% else %>
       <%= t("splits.new.uncategorized") %>
     <% end %>
   </button>
-  <div class="absolute z-50 p-1.5 w-full min-w-48 rounded-lg shadow-lg shadow-border-xs bg-container mt-1.5 transition duration-150 ease-out -translate-y-1 opacity-0 hidden" data-select-target="menu">
+  <div class="absolute z-50 p-1.5 w-full min-w-48 md:w-80 rounded-lg shadow-lg shadow-border-xs bg-container mt-1.5 transition duration-150 ease-out -translate-y-1 opacity-0 hidden" data-select-target="menu">
     <div class="flex items-center bg-container border border-secondary rounded-lg mb-1 focus-within:ring-4 focus-within:ring-alpha-black-200 theme-dark:focus-within:ring-alpha-white-300 transition-shadow">
       <%= render DS::SearchInput.new(
         variant: :embedded,
@@ -72,14 +73,15 @@
           <span class="check-icon <%= "hidden" unless is_selected %>">
             <%= icon("check") %>
           </span>
-          <span class="flex items-center gap-2 text-sm font-medium rounded-full px-3 py-1 border truncate"
+          <span class="flex items-center gap-2 text-sm font-medium rounded-full px-3 py-1 border min-w-0 max-w-64"
+                title="<%= category.display_name %>"
                 style="background-color: color-mix(in oklab, <%= hex_color %> 10%, transparent); border-color: color-mix(in oklab, <%= hex_color %> 20%, transparent); color: <%= hex_color %>;">
             <% if category.lucide_icon.present? %>
               <%= icon category.lucide_icon, size: "sm", color: "current" %>
             <% else %>
-              <span class="size-1.5 rounded-full" style="background-color: <%= hex_color %>;"></span>
+              <span class="size-1.5 rounded-full shrink-0" style="background-color: <%= hex_color %>;"></span>
             <% end %>
-            <%= category.display_name %>
+            <span class="truncate"><%= category.display_name %></span>
           </span>
         </div>
       <% end %>

--- a/app/views/splits/_category_select.html.erb
+++ b/app/views/splits/_category_select.html.erb
@@ -1,7 +1,6 @@
 <%# locals: (name:, categories:, selected_id: nil) %>
 <%
   selected_category = categories.find { |c| c.id == selected_id }
-  default_color = "#737373"
 %>
 
 <div class="category-select-container relative flex-1 md:flex-initial md:w-auto md:min-w-44 md:max-w-72" data-controller="select list-filter form-dropdown category-badge-select" data-action="dropdown:select->form-dropdown#onSelect dropdown:select->category-badge-select#updateButton">
@@ -18,17 +17,19 @@
           aria-haspopup="listbox"
           aria-expanded="false">
     <% if selected_category %>
-      <% hex_color = selected_category.color.presence || default_color %>
-      <span class="flex items-center gap-2 text-sm font-medium rounded-full px-3 py-1 border min-w-0 max-w-64"
-            title="<%= selected_category.display_name %>"
-            style="background-color: color-mix(in oklab, <%= hex_color %> 10%, transparent); border-color: color-mix(in oklab, <%= hex_color %> 20%, transparent); color: <%= hex_color %>;">
-        <% if selected_category.lucide_icon.present? %>
-          <%= icon selected_category.lucide_icon, size: "sm", color: "current" %>
-        <% else %>
-          <span class="size-1.5 rounded-full shrink-0" style="background-color: <%= hex_color %>;"></span>
-        <% end %>
-        <span class="truncate"><%= selected_category.display_name %></span>
-      </span>
+      <%# Same DS::Pill shape as the canonical categories/badge partial; rendered
+          directly (without its div wrapper) because a button only allows
+          phrasing content. category-badge-select clones the option's pill into
+          this button on selection, so both must stay the same markup. %>
+      <%= render DS::Pill.new(
+            label: selected_category.display_name,
+            custom_color: selected_category.color,
+            icon: selected_category.lucide_icon.presence,
+            icon_size: "sm",
+            marker: false,
+            size: :md,
+            truncate: true,
+            title: selected_category.display_name) %>
     <% else %>
       <%= t("splits.new.uncategorized") %>
     <% end %>
@@ -62,7 +63,6 @@
 
       <% categories.each do |category| %>
         <% is_selected = category.id == selected_id %>
-        <% hex_color = category.color.presence || default_color %>
         <div class="filterable-item text-sm cursor-pointer flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-container-inset-hover <%= "bg-container-inset" if is_selected %>"
              role="option"
              tabindex="0"
@@ -73,16 +73,7 @@
           <span class="check-icon <%= "hidden" unless is_selected %>">
             <%= icon("check") %>
           </span>
-          <span class="flex items-center gap-2 text-sm font-medium rounded-full px-3 py-1 border min-w-0 max-w-64"
-                title="<%= category.display_name %>"
-                style="background-color: color-mix(in oklab, <%= hex_color %> 10%, transparent); border-color: color-mix(in oklab, <%= hex_color %> 20%, transparent); color: <%= hex_color %>;">
-            <% if category.lucide_icon.present? %>
-              <%= icon category.lucide_icon, size: "sm", color: "current" %>
-            <% else %>
-              <span class="size-1.5 rounded-full shrink-0" style="background-color: <%= hex_color %>;"></span>
-            <% end %>
-            <span class="truncate"><%= category.display_name %></span>
-          </span>
+          <%= render partial: "categories/badge", locals: { category: category } %>
         </div>
       <% end %>
     </div>

--- a/app/views/splits/edit.html.erb
+++ b/app/views/splits/edit.html.erb
@@ -38,7 +38,7 @@
         <% @children.each_with_index do |child, index| %>
           <div class="p-3 rounded-lg border border-secondary bg-container" data-split-transaction-target="row">
             <div class="flex flex-wrap md:flex-nowrap items-end gap-2">
-              <div class="w-full md:flex-1 md:w-auto min-w-0">
+              <div class="w-full md:flex-1 md:w-auto min-w-0 md:min-w-28">
                 <label class="text-xs font-medium text-secondary uppercase tracking-wide block mb-1"><%= t("splits.new.name_label") %></label>
                 <input type="text"
                        name="split[splits][<%= index %>][name]"

--- a/app/views/splits/new.html.erb
+++ b/app/views/splits/new.html.erb
@@ -36,7 +36,7 @@
       <div data-split-transaction-target="rowsContainer" class="space-y-3">
         <div class="p-3 rounded-lg border border-secondary bg-container" data-split-transaction-target="row">
           <div class="flex flex-wrap md:flex-nowrap items-end gap-2">
-            <div class="w-full md:flex-1 md:w-auto min-w-0">
+            <div class="w-full md:flex-1 md:w-auto min-w-0 md:min-w-28">
               <label class="text-xs font-medium text-secondary uppercase tracking-wide block mb-1"><%= t("splits.new.name_label") %></label>
               <input type="text"
                      name="split[splits][0][name]"


### PR DESCRIPTION
Fixes #2934

## Problem

In the split-transaction dialog, the category selector is a fixed 176px column (`md:w-44`) and the selected badge carries a hard `truncate`, so any category name longer than a few words is clipped to an ellipsis — in the closed button *and* in the dropdown option list. There is no way to read the full name.

## What changed

`app/views/splits/_category_select.html.erb`
- The container is now `md:flex-initial md:w-auto md:min-w-44 md:max-w-72`, so the button sizes to the selected category name (bounded on both ends) instead of a fixed 176px.
- The badge truncates an inner `<span class="truncate">` label instead of the whole pill, caps at `max-w-64`, keeps the color dot from being squashed (`shrink-0`), and exposes the full name as a native `title` tooltip — in both the button and the option list.
- The dropdown menu widens to `md:w-80` so option badges stay readable.

`app/javascript/controllers/select_controller.js`
- `updatePosition()` no longer forces the menu to `width: 100%` inline — that override clobbered any width classes on the menu markup. Width now comes from the markup (`DS::Select` already declares `w-full min-w-32`, so every existing select renders identically).
- When a menu is wider than its anchor and would spill past the scroll container's right edge (forcing a horizontal scrollbar in the dialog), it now anchors to the button's right edge instead.

`app/views/splits/new.html.erb`, `app/views/splits/edit.html.erb`
- The name field gets `md:min-w-28` so a wide category selector can't crush it to zero on desktop.

## Testing

- Verified visually with a long category name ("Groceries & Household Supplies Monthly") in the split dialog: button badge truncates with tooltip and no overflow; dropdown shows the full name.
- Full local CI parity: biome, rubocop (2198 files, no offenses), brakeman, importmap audit, preview-deploy security check, unit suite (6202 runs, 0 failures), and the system suite — all green.

## Note

This touches the same partial as #2845 (option-list loop); happy to rebase whichever lands second.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Category dropdowns now reposition automatically to remain visible within their scroll area.
  * Improved menu sizing to prevent dropdown overflow.

* **UI Improvements**
  * Updated category badges and dropdown options for more consistent styling.
  * Improved responsive sizing for category selectors and split name fields on medium and larger screens.
  * Category selector layouts now better accommodate icons and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->