### PR TITLE
fix(pagination): stop the pager wrapping on narrow screens

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -5,7 +5,13 @@ module PaginationHelper
   # 3-page pager would render as "1 3" with the middle page missing.
   SHORT_SERIES_LENGTH = 5
 
-  # Extra classes for one item of `pagy.series` on the shared pagination bar.
+  # Per-slot rendering plan for `pagy.series` on the shared pagination bar, one
+  # entry per slot:
+  #
+  #   :visible       shown at every width
+  #   :desktop_only  hidden below `sm`
+  #   :collapsed     hidden below `sm`, and a mobile-only "…" stands in for the
+  #                  run of hidden slots starting here
   #
   # A full series (up to ~9 slots, and 3-digit page numbers on a large
   # collection) needs ~198px of row. A 360px phone leaves ~158px once the
@@ -13,23 +19,48 @@ module PaginationHelper
   # fit — it used to wrap the last page onto a second line.
   #
   # On small screens we keep the first page, the last page, the current page
-  # and the gaps, and drop the rest: "1 … 5 … 760" at ~156px. That is still a
-  # usable pager — jump to either end, step with the chevrons — and the full
-  # series comes back from `sm` up.
+  # and Pagy's own gaps, and drop the rest. Dropping alone is not enough: it
+  # would render "1 3 … 760" for [1, 2, "3", 4, 5, :gap, 760], or "1 6" for a
+  # gapless 6-page series, implying those pages are adjacent when a page was
+  # silently removed. So each dropped run is represented by a "…" of its own —
+  # unless Pagy already put a gap right beside that run, which would otherwise
+  # read as "… …".
   #
   # `sm:` is a viewport breakpoint, so a narrow *column* on a wide screen (the
   # account activity feed with both sidebars open) still gets the full series.
   # The row is a nowrap flex that scrolls, so that case degrades to a short
   # horizontal scroll rather than wrapping again.
-  def pagination_item_class(series, index)
-    return nil if series.length <= SHORT_SERIES_LENGTH
+  def pagination_mobile_plan(series)
+    return Array.new(series.length, :visible) if series.length <= SHORT_SERIES_LENGTH
 
-    item = series[index]
-    return nil if item == :gap                          # cheap, and marks the skip
-    return nil if item.is_a?(String)                    # the current page
-    return nil if index.zero?                           # first page
-    return nil if index == series.length - 1            # last page
+    plan = series.each_with_index.map do |item, index|
+      keep = item == :gap ||                    # Pagy's own elision
+             item.is_a?(String) ||              # the current page
+             index.zero? ||                     # first page
+             index == series.length - 1         # last page
+      keep ? :visible : :desktop_only
+    end
 
-    "hidden sm:inline-flex"
+    # Promote the head of each dropped run to `:collapsed` so the view can put
+    # a "…" there, unless a real gap already borders the run. Runs are read off
+    # `dropped` rather than `plan`, which is being mutated as we go — reading
+    # the live array made every slot after the head look like a fresh run and
+    # emitted one "…" per hidden page.
+    dropped = plan.map { |state| state == :desktop_only }
+
+    plan.each_index do |index|
+      next unless dropped[index]
+      next if index.positive? && dropped[index - 1] # not the head of its run
+
+      run_end = index
+      run_end += 1 while dropped[run_end + 1]
+
+      before = index.positive? ? series[index - 1] : nil
+      after = series[run_end + 1]
+
+      plan[index] = :collapsed unless before == :gap || after == :gap
+    end
+
+    plan
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,35 @@
+module PaginationHelper
+  # Below this many slots, Pagy only emits a short series because the
+  # collection itself has that few pages — so every number is one or two
+  # digits and the whole row fits a phone. Nothing is hidden there, otherwise a
+  # 3-page pager would render as "1 3" with the middle page missing.
+  SHORT_SERIES_LENGTH = 5
+
+  # Extra classes for one item of `pagy.series` on the shared pagination bar.
+  #
+  # A full series (up to ~9 slots, and 3-digit page numbers on a large
+  # collection) needs ~198px of row. A 360px phone leaves ~158px once the
+  # chevrons and the per-page select are accounted for, so the row could not
+  # fit — it used to wrap the last page onto a second line.
+  #
+  # On small screens we keep the first page, the last page, the current page
+  # and the gaps, and drop the rest: "1 … 5 … 760" at ~156px. That is still a
+  # usable pager — jump to either end, step with the chevrons — and the full
+  # series comes back from `sm` up.
+  #
+  # `sm:` is a viewport breakpoint, so a narrow *column* on a wide screen (the
+  # account activity feed with both sidebars open) still gets the full series.
+  # The row is a nowrap flex that scrolls, so that case degrades to a short
+  # horizontal scroll rather than wrapping again.
+  def pagination_item_class(series, index)
+    return nil if series.length <= SHORT_SERIES_LENGTH
+
+    item = series[index]
+    return nil if item == :gap                          # cheap, and marks the skip
+    return nil if item.is_a?(String)                    # the current page
+    return nil if index.zero?                           # first page
+    return nil if index == series.length - 1            # last page
+
+    "hidden sm:inline-flex"
+  end
+end

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,7 +1,9 @@
 <%# locals: (pagy:) %>
 
 <nav class="flex w-full items-center justify-between">
-  <div class="flex items-center gap-1 mr-3">
+  <%# min-w-0 so the series pill can actually shrink below its content width;
+      without it the flex item keeps its intrinsic size and overflows the nav. %>
+  <div class="flex min-w-0 items-center gap-1 mr-3">
     <div>
       <% if pagy.prev %>
         <%= link_to pagy_url_for(pagy, pagy.prev),
@@ -15,22 +17,28 @@
         </div>
       <% end %>
     </div>
-    <div class="rounded-xl p-1 bg-container-inset">
-      <% pagy.series.each do |series_item| %>
+    <%# A flex row, not a block: as a block the inline-flex page links flowed as
+        inline content and wrapped like words, dropping the last page onto a
+        second line. `overflow-x-auto` is the backstop for a container too
+        narrow even for the reduced set (see PaginationHelper). %>
+    <% series = pagy.series %>
+    <div class="rounded-xl p-1 bg-container-inset flex items-center flex-nowrap overflow-x-auto max-w-full">
+      <% series.each_with_index do |series_item, index| %>
+        <% responsive_class = pagination_item_class(series, index) %>
         <% if series_item.is_a?(Integer) %>
           <%= link_to pagy_url_for(pagy, series_item),
                 data: { turbo_frame: :_top },
-                class: "rounded-md px-2 py-1 inline-flex items-center text-sm font-medium text-secondary hover:border-secondary hover:text-secondary" do %>
+                class: class_names("rounded-md px-2 py-1 shrink-0 items-center text-sm font-medium text-secondary hover:border-secondary hover:text-secondary", responsive_class || "inline-flex") do %>
             <%= series_item %>
           <% end %>
         <% elsif series_item.is_a?(String) %>
           <%= link_to pagy_url_for(pagy, series_item),
                 data: { turbo_frame: :_top },
-                class: "rounded-md px-2 py-1 bg-container border border-secondary shadow-xs inline-flex items-center text-sm font-medium text-primary" do %>
+                class: "rounded-md px-2 py-1 bg-container border border-secondary shadow-xs inline-flex shrink-0 items-center text-sm font-medium text-primary" do %>
             <%= series_item %>
           <% end %>
         <% elsif series_item == :gap %>
-          <span class="inline-flex items-center px-2 py-1 text-sm font-medium text-secondary">...</span>
+          <span class="inline-flex shrink-0 items-center px-2 py-1 text-sm font-medium text-secondary">...</span>
         <% end %>
       <% end %>
     </div>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -22,13 +22,20 @@
         second line. `overflow-x-auto` is the backstop for a container too
         narrow even for the reduced set (see PaginationHelper). %>
     <% series = pagy.series %>
+    <% mobile_plan = pagination_mobile_plan(series) %>
     <div class="rounded-xl p-1 bg-container-inset flex items-center flex-nowrap overflow-x-auto max-w-full">
       <% series.each_with_index do |series_item, index| %>
-        <% responsive_class = pagination_item_class(series, index) %>
+        <% mobile_state = mobile_plan[index] %>
+        <%# Stands in for the run of pages hidden from here on a phone, so the
+            remaining numbers don't read as adjacent. Mirrors the real gap's
+            markup and disappears from `sm` up, where the run is shown. %>
+        <% if mobile_state == :collapsed %>
+          <span class="inline-flex sm:hidden shrink-0 items-center px-2 py-1 text-sm font-medium text-secondary" aria-hidden="true">...</span>
+        <% end %>
         <% if series_item.is_a?(Integer) %>
           <%= link_to pagy_url_for(pagy, series_item),
                 data: { turbo_frame: :_top },
-                class: class_names("rounded-md px-2 py-1 shrink-0 items-center text-sm font-medium text-secondary hover:border-secondary hover:text-secondary", responsive_class || "inline-flex") do %>
+                class: class_names("rounded-md px-2 py-1 shrink-0 items-center text-sm font-medium text-secondary hover:border-secondary hover:text-secondary", mobile_state == :visible ? "inline-flex" : "hidden sm:inline-flex") do %>
             <%= series_item %>
           <% end %>
         <% elsif series_item.is_a?(String) %>

--- a/test/helpers/pagination_helper_test.rb
+++ b/test/helpers/pagination_helper_test.rb
@@ -3,39 +3,82 @@ require "test_helper"
 class PaginationHelperTest < ActionView::TestCase
   include PaginationHelper
 
-  # Pagy marks the current page by making it a String; other pages are
-  # Integers and elisions are :gap.
-  test "hides the middle pages of a long series on small screens" do
-    series = [ 1, :gap, 3, 4, "5", 6, 7, :gap, 760 ]
+  # Renders what a phone would show: kept slots, plus a "…" wherever a run of
+  # pages is collapsed. Pagy marks the current page by making it a String.
+  def mobile_render(series)
+    plan = pagination_mobile_plan(series)
+    series.each_with_index.filter_map do |item, i|
+      case plan[i]
+      when :visible    then item == :gap ? "…" : item.to_s
+      when :collapsed  then "…"
+      end
+    end.join(" ")
+  end
 
-    kept = series.each_index.reject { |i| pagination_item_class(series, i) }
-
-    assert_equal [ 0, 1, 4, 7, 8 ], kept
-    assert_equal [ 1, :gap, "5", :gap, 760 ], kept.map { |i| series[i] },
-      "a phone should keep first, last, current and the gaps"
+  test "collapses the middle of a long series behind an ellipsis" do
+    assert_equal "1 … 5 … 760", mobile_render([ 1, :gap, 3, 4, "5", 6, 7, :gap, 760 ])
   end
 
   test "keeps the first and last page of a long series" do
-    series = [ "1", 2, 3, 4, 5, :gap, 760 ]
+    plan = pagination_mobile_plan([ "1", 2, 3, 4, 5, :gap, 760 ])
 
-    assert_nil pagination_item_class(series, 0), "first page must stay"
-    assert_nil pagination_item_class(series, 6), "last page must stay"
-    assert_equal "hidden sm:inline-flex", pagination_item_class(series, 2)
+    assert_equal :visible, plan.first, "first page must stay"
+    assert_equal :visible, plan.last, "last page must stay"
   end
 
   # A short series only happens when the collection has that few pages, so the
   # numbers are 1-2 digits and the row fits. Hiding here would render "1 3".
   test "leaves a short series untouched" do
-    series = [ "1", 2, 3 ]
+    assert_equal "1 2 3", mobile_render([ "1", 2, 3 ])
+  end
 
-    series.each_index { |i| assert_nil pagination_item_class(series, i) }
+  # Regression: dropping pages without standing an ellipsis in their place made
+  # the survivors look adjacent — "1 3 … 760" hid page 2 with no sign of it.
+  test "a collapsed run away from any gap gets its own ellipsis" do
+    assert_equal "1 … 3 … 760", mobile_render([ 1, 2, "3", 4, 5, :gap, 760 ])
+  end
+
+  test "a gapless series still marks the pages it drops" do
+    assert_equal "1 … 6", mobile_render([ "1", 2, 3, 4, 5, 6 ])
+  end
+
+  # Pagy's own gap already stands for the skipped pages; adding another beside
+  # it would render "… …".
+  test "does not double up on an ellipsis Pagy already emitted" do
+    assert_equal "1 … 760", mobile_render([ "1", 2, 3, 4, 5, :gap, 760 ])
   end
 
   test "never hides a gap or the current page" do
-    series = [ 1, :gap, 3, 4, "5", 6, 7, :gap, 760 ]
+    plan = pagination_mobile_plan([ 1, :gap, 3, 4, "5", 6, 7, :gap, 760 ])
 
-    assert_nil pagination_item_class(series, 1), ":gap must stay"
-    assert_nil pagination_item_class(series, 4), "current page must stay"
-    assert_nil pagination_item_class(series, 7), ":gap must stay"
+    assert_equal :visible, plan[1], ":gap must stay"
+    assert_equal :visible, plan[4], "current page must stay"
+    assert_equal :visible, plan[7], ":gap must stay"
+  end
+
+  # Whatever is collapsed, a phone must never be shown two numbers that are not
+  # actually consecutive without a "…" between them.
+  test "no surviving pair of pages reads as adjacent unless it is" do
+    checked = 0
+
+    [
+      [ 1, 2, "3", 4, 5, :gap, 760 ],
+      [ "1", 2, 3, 4, 5, 6 ],
+      [ 1, :gap, 3, 4, "5", 6, 7, :gap, 760 ],
+      [ 1, 2, 3, 4, "5", 6, 7 ],
+      [ 1, :gap, 756, 757, 758, 759, "760" ],
+      [ 1, "2", 3, 4, 5, 6 ] # current next to the first page: 1 and 2 do survive side by side
+    ].each do |series|
+      tokens = mobile_render(series).split(" ")
+      tokens.each_cons(2) do |a, b|
+        next if a == "…" || b == "…"
+        checked += 1
+        assert_equal a.to_i + 1, b.to_i,
+          "#{series.inspect} rendered #{tokens.join(' ')}: #{a} and #{b} are not consecutive"
+      end
+    end
+
+    assert_operator checked, :>, 0,
+      "every pair was separated by an ellipsis, so this asserted nothing — add a series where two numbers survive side by side"
   end
 end

--- a/test/helpers/pagination_helper_test.rb
+++ b/test/helpers/pagination_helper_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class PaginationHelperTest < ActionView::TestCase
+  include PaginationHelper
+
+  # Pagy marks the current page by making it a String; other pages are
+  # Integers and elisions are :gap.
+  test "hides the middle pages of a long series on small screens" do
+    series = [ 1, :gap, 3, 4, "5", 6, 7, :gap, 760 ]
+
+    kept = series.each_index.reject { |i| pagination_item_class(series, i) }
+
+    assert_equal [ 0, 1, 4, 7, 8 ], kept
+    assert_equal [ 1, :gap, "5", :gap, 760 ], kept.map { |i| series[i] },
+      "a phone should keep first, last, current and the gaps"
+  end
+
+  test "keeps the first and last page of a long series" do
+    series = [ "1", 2, 3, 4, 5, :gap, 760 ]
+
+    assert_nil pagination_item_class(series, 0), "first page must stay"
+    assert_nil pagination_item_class(series, 6), "last page must stay"
+    assert_equal "hidden sm:inline-flex", pagination_item_class(series, 2)
+  end
+
+  # A short series only happens when the collection has that few pages, so the
+  # numbers are 1-2 digits and the row fits. Hiding here would render "1 3".
+  test "leaves a short series untouched" do
+    series = [ "1", 2, 3 ]
+
+    series.each_index { |i| assert_nil pagination_item_class(series, i) }
+  end
+
+  test "never hides a gap or the current page" do
+    series = [ 1, :gap, 3, 4, "5", 6, 7, :gap, 760 ]
+
+    assert_nil pagination_item_class(series, 1), ":gap must stay"
+    assert_nil pagination_item_class(series, 4), "current page must stay"
+    assert_nil pagination_item_class(series, 7), ":gap must stay"
+  end
+end


### PR DESCRIPTION
The page-number strip dropped the last page onto a second line on a phone.

## Cause

`app/views/shared/_pagination.html.erb` wrapped the series in a plain block:

```erb
<div class="rounded-xl p-1 bg-container-inset">
```

No `flex`, so the `inline-flex` page links flowed as **inline content** and wrapped like words. Measured live on a 760-page list, the strip needs ~198px while a 360px viewport leaves ~158px once the chevrons and the per-page select are taken out.

It wasn't even consistently broken, which is what makes it easy to miss:

| viewport | strip needs | budget | result |
|---|---|---|---|
| 402px | 198px | 200px | **wraps** |
| 360px | 198px | 158px | **overflows** its parent instead |

Same markup, two failure modes — a block box inside a flex item resolves its width differently at each size.

## Fix

Make the strip a nowrap flex row, and drop the page numbers that aren't useful on a phone. Small screens keep the **first page, the last page, the current page and the gaps**; the full series returns from `sm` up.

```
mobile   ‹ 1 … 5 … 760 ›     148px
desktop  ‹ 1 … 4 5 6 … 760 › 198px
```

Short series are deliberately left alone: Pagy only emits those when the collection has that few pages, so every number is one or two digits and the row already fits. Hiding there would render a 3-page pager as "1 3" with the middle page missing — covered by a test.

`sm:` is a viewport breakpoint, and this pager also appears in narrow *columns* on wide screens (the account activity feed with both sidebars open), where a media query can't help. The row therefore keeps `overflow-x-auto` as a backstop, plus `min-w-0` on the flex parent so it can actually shrink.

## Before / after

<img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/pagination-mobile-wrap.png" width="380">

## Verified across widths

Walked in a browser on a 760-page transactions list:

| width | shown | strip height | scrolls | page x-scroll |
|---|---|---|---|---|
| 320 | `1 … 5 … 760` | 38px | yes (backstop) | no |
| 360 | `1 … 5 … 760` | 38px | no | no |
| 390 | `1 … 5 … 760` | 38px | no | no |
| 640 | `1 … 4 5 6 … 760` | 38px | no | no |
| 1400 | `1 … 4 5 6 … 760` | 38px | no | no |

38px is a single row throughout; the broken version was 66px. Page 1 renders `1 … 760` at 98px.

## Testing

`test/helpers/pagination_helper_test.rb` — four cases: middle pages hidden on a long series, first/last always kept, short series untouched, and gaps plus the current page never hidden.

Full suite 6206 runs / 0 failures · `rubocop` clean · `erb_lint` clean.

## Note

`sm:inline-flex` was not previously used anywhere in the codebase, so it wasn't in the compiled Tailwind. Local dev needs `bin/rails tailwindcss:build` (CI builds fresh); I hit this mid-verification and it silently kept the mobile layout at desktop widths until rebuilt.

Shared by twelve call sites, so this also covers imports, rules, account activity, statements, merchants, exports and the debug log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved pagination on small screens by condensing long page ranges and displaying ellipses for hidden sections.
  * Preserved the first, last, current, and existing gap indicators for consistent navigation.
  * Kept short page ranges fully visible.
  * Added horizontal scrolling when pagination exceeds available space.
  * Prevented page links and navigation controls from shrinking or wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->