### PR TITLE
fix(dashboard): fit money-flow month labels and put its figures on scale

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -473,6 +473,12 @@ class PagesController < ApplicationController
         {
           date: month_start,
           label: I18n.l(month_start, format: :short_month_year),
+          # Fallback for the axis when the full label does not fit its band.
+          # `short_month_year` is only short in some locales — "Mar 2026" in
+          # English, but "Mar de 2026" in ca/es/pt, which is wide enough to
+          # collide with its neighbours on a phone. The bar chart measures the
+          # rendered labels and drops to this when they overlap.
+          short_label: I18n.l(month_start, format: "%b"),
           income: totals.income_money.amount.to_f.round(2),
           expense: totals.expense_money.amount.to_f.round(2),
           highlighted: month_start == selected_month,

--- a/app/javascript/controllers/bar_chart_controller.js
+++ b/app/javascript/controllers/bar_chart_controller.js
@@ -7,6 +7,10 @@ import { CHART_TOOLTIP_CLASSES } from "utils/chart_tooltip";
 // Modeled after time_series_chart_controller's lifecycle (install/teardown,
 // ResizeObserver, turbo:load reinstall, page-relative tooltip positioning)
 // but with scaleBand/scaleLinear instead of a line.
+
+// Breathing room between neighbouring month labels before they read as touching.
+const LABEL_GAP_PX = 8;
+
 export default class extends Controller {
   static values = {
     data: Array,
@@ -120,7 +124,7 @@ export default class extends Controller {
       .on("mousemove", (event, d) => showTooltip(event, d.month, d.key))
       .on("mouseleave", hideTooltip);
 
-    group
+    const axisLabels = group
       .append("g")
       .attr("transform", `translate(0,${innerHeight})`)
       .call(d3.axisBottom(x0).tickSize(0))
@@ -129,6 +133,29 @@ export default class extends Controller {
       .attr("class", (_d, i) => (data[i].highlighted ? "text-primary fill-current" : "text-secondary fill-current"))
       .style("font-size", "12px")
       .style("font-weight", (_d, i) => (data[i].highlighted ? 600 : 500));
+
+    this._fitAxisLabels(axisLabels, data, x0.step());
+  }
+
+  // The month labels are sized by the locale, not by the chart: "Mar 2026" fits
+  // a phone, "Mar de 2026" (ca/es/pt) does not and overlaps its neighbours.
+  // Measure what actually rendered and step down until it fits — full label,
+  // then the abbreviated month, then every other tick. Measuring beats guessing
+  // at a character width, which varies by locale, font and zoom.
+  _fitAxisLabels(labels, data, step) {
+    if (labels.empty()) return;
+
+    const widest = () => d3.max(labels.nodes(), (node) => node.getComputedTextLength()) || 0;
+    const fits = () => widest() <= step - LABEL_GAP_PX;
+
+    if (fits()) return;
+
+    labels.text((_d, i) => data[i].short_label ?? data[i].label);
+    if (fits()) return;
+
+    // Still too wide (a very narrow column): thin out rather than overlap,
+    // always keeping the highlighted month visible.
+    labels.style("display", (_d, i) => (i % 2 === 0 || data[i].highlighted ? null : "none"));
   }
 
   _tooltipTemplate(month, key) {

--- a/app/javascript/controllers/bar_chart_controller.js
+++ b/app/javascript/controllers/bar_chart_controller.js
@@ -153,9 +153,15 @@ export default class extends Controller {
     labels.text((_d, i) => data[i].short_label ?? data[i].label);
     if (fits()) return;
 
-    // Still too wide (a very narrow column): thin out rather than overlap,
-    // always keeping the highlighted month visible.
-    labels.style("display", (_d, i) => (i % 2 === 0 || data[i].highlighted ? null : "none"));
+    // Still too wide (a very narrow column): thin out rather than overlap.
+    // The parity is taken from the highlighted month rather than fixed at even,
+    // so that month survives without being an exception to the pattern — it
+    // sits last (build_money_flow_data counts down to the selected month), and
+    // keeping it on top of every even index left the final two labels one step
+    // apart, the very spacing that had just been measured as too tight.
+    const highlightedIndex = data.findIndex((d) => d.highlighted);
+    const keepParity = highlightedIndex >= 0 ? highlightedIndex % 2 : 0;
+    labels.style("display", (_d, i) => (i % 2 === keepParity ? null : "none"));
   }
 
   _tooltipTemplate(month, key) {

--- a/app/views/pages/dashboard/_money_flow.html.erb
+++ b/app/views/pages/dashboard/_money_flow.html.erb
@@ -114,8 +114,12 @@
           <span class="w-2.5 h-2.5 rounded-full bg-success"></span>
           <%= t(".income") %>
         </span>
+        <%# text-sm to match the row's own label and the equivalent figure in the
+            outflows widget. Without it these inherited the 16px base, which is
+            off the scale the dashboard uses (sm for rows, lg for a total, 3xl
+            for a hero) and left the amount larger than the label beside it. %>
         <span class="flex items-center gap-2">
-          <span class="font-medium tabular-nums text-success privacy-sensitive"><%= format_money money_flow_data[:income] %></span>
+          <span class="text-sm font-medium tabular-nums text-success privacy-sensitive"><%= format_money money_flow_data[:income] %></span>
           <%= icon("chevron-right", size: "sm", class: "text-secondary group-hover:text-primary transition-colors") %>
         </span>
       <% end %>
@@ -128,7 +132,7 @@
           <%= t(".expenses") %>
         </span>
         <span class="flex items-center gap-2">
-          <span class="font-medium tabular-nums text-primary privacy-sensitive"><%= format_money money_flow_data[:expense] %></span>
+          <span class="text-sm font-medium tabular-nums text-primary privacy-sensitive"><%= format_money money_flow_data[:expense] %></span>
           <%= icon("chevron-right", size: "sm", class: "text-secondary group-hover:text-primary transition-colors") %>
         </span>
       <% end %>


### PR DESCRIPTION
Two problems in the Money In / Out widget, reported from a phone.

## 1 — month labels collide

The axis rendered whatever `short_month_year` produced, with no regard for the width each band actually has. That format is only *short* in some locales:

```
en  short_month_year: "%b %Y"      -> "Mar 2026"
ca  short_month_year: "%b de %Y"   -> "Mar de 2026"
```

Measured on a 390px viewport in Catalan: labels are **62–71px against a 56px band step — 5 overlapping pairs, worst overlap 15px**. That is the reported screenshot.

English isn't immune, it's just closer to the edge:

| locale | viewport | label width | step | overlapping pairs |
|---|---|---|---|---|
| en | 390 | 45–53px | 53px | 0 (clears by 2px) |
| en | 360 | 45–53px | 49px | **4** |
| ca | 390 | 62–71px | 56px | **5** |

The chart now measures what it actually rendered (`getComputedTextLength`) and steps down until it fits — full label, then an abbreviated month, then every other tick with the highlighted month always kept. Measuring beats assuming a character width, which changes with locale, font and zoom.

Verified across widths in Catalan:

| viewport | labels shown | overlapping pairs |
|---|---|---|
| 1512 | `Mar de 2026 … Ago de 2026` (full) | 0 |
| 390 | `Mar Abr Mai Jun Jul Ago` | 0 |
| 320 | `Mar Abr Mai Jun Jul Ago` | 0 |
| 240 | `Mar Mai Jul Ago` (thinned, highlighted kept) | 0 |

## 2 — the figures were off the type scale

`income` and `expense` carried **no size class**, so they inherited the 16px base. The dashboard's scale is `text-sm` for a repeated row, `text-lg` for a section total, `text-3xl` for a hero — 16px is none of those, and it left each amount *larger than the label beside it*:

```
before   label 14px   income 16px   expense 16px   balance 18px
after    label 14px   income 14px   expense 14px   balance 18px
```

`text-sm` matches both their own labels and the equivalent amount in the outflows widget (`text-sm font-medium text-primary`).

The balance keeps `text-lg` — that matches the balance sheet's group total, and with the two rows corrected it now reads as their summary rather than one more oversized number. Happy to flatten it to `text-sm` as well if you'd rather the block had no hierarchy at all.

## Before / after

Catalan at 390px.

<img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/money-flow-labels.png" width="700">

## Testing

Full suite 6202 runs / 0 failures · `rubocop` clean · `erb_lint` clean · `biome lint` clean (542 files).

Chart behaviour walked in a browser at 1512 / 390 / 320 / 240px in both `en` and `ca`, including the thin-out tier, which fires without error and keeps the highlighted month.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Money-flow charts now adapt month labels to available space, using localized abbreviated or alternating labels to prevent overlap while keeping highlighted months visible.
  * Chart labels remain readable across different screen sizes and data ranges.

* **Style**
  * Updated income and expense amount text sizing for improved consistency with dashboard row labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->