### PR TITLE
fix(goals): stop the days-left phrase splitting across lines

### DIFF
--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -507,7 +507,11 @@ class Goal < ApplicationRecord
   # Header copy under the goal title on show. Used to live as a multi-line
   # if/elsif block in show.html.erb. Keeps the view template free of date
   # math + i18n key picking.
-  def header_summary
+  # The dot-separated segments of the header line, kept as separate strings so
+  # the view can stop a short one breaking mid-phrase. Joined into a single
+  # string, "184 days left" could wrap after "days" and orphan "left" on the
+  # next line — which is what a phone did.
+  def header_summary_parts
     parts = []
     if target_date
       days = (target_date - Date.current).to_i
@@ -528,7 +532,7 @@ class Goal < ApplicationRecord
       parts << I18n.t("goals.show.header.target",
                       amount: target_amount_money.format(precision: 0))
     end
-    parts.join(" · ")
+    parts
   end
 
   # Single source of truth for the projection-chart subtitle / chart-aria

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -5,7 +5,18 @@
     </div>
     <div class="min-w-0 flex-1">
       <h1 class="text-2xl font-semibold text-primary break-words"><%= @goal.name %></h1>
-      <p class="text-sm text-secondary mt-1 privacy-sensitive"><%= @goal.header_summary %></p>
+      <%# Each segment is its own nowrap span so a short trailing one — "184 days
+          left" — moves to the next line whole instead of breaking after "days".
+          The first segment carries the target and a long-format date, so it is
+          left free to wrap; pinning it would overflow a narrow screen. %>
+      <p class="text-sm text-secondary mt-1 privacy-sensitive">
+        <%= safe_join(
+              @goal.header_summary_parts.map.with_index { |part, i|
+                tag.span(part, class: ("whitespace-nowrap" unless i.zero?))
+              },
+              " · "
+            ) %>
+      </p>
       <% last_days = @goal.last_matched_pledge_days_ago %>
       <% unless last_days.nil? %>
         <p class="text-xs text-subdued mt-0.5">

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -14,6 +14,34 @@ class GoalTest < ActiveSupport::TestCase
     assert @goal.valid?
   end
 
+  # The days-left segment is returned separately so the view can keep it
+  # unbroken; joined into one string it wrapped after "days" on a phone.
+  test "header_summary_parts keeps the days-left phrase in its own segment" do
+    # Target well above the linked account's balance, or the goal reads as
+    # :reached and drops the days-left segment on purpose.
+    @goal.target_amount = 1_000_000
+    @goal.target_date = 184.days.from_now.to_date
+
+    parts = @goal.header_summary_parts
+
+    assert_equal 2, parts.size
+    assert_match(/184 days left/, parts.last)
+    assert_no_match(/days left/, parts.first)
+  end
+
+  test "header_summary_parts omits days left once the target is reached" do
+    @goal.target_date = 184.days.from_now.to_date
+    @goal.complete!
+
+    assert_equal 1, @goal.header_summary_parts.size
+  end
+
+  test "header_summary_parts is a single segment without a target date" do
+    @goal.target_date = nil
+
+    assert_equal 1, @goal.header_summary_parts.size
+  end
+
   test "name is required" do
     @goal.name = ""
     assert_not @goal.valid?

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -17,16 +17,20 @@ class GoalTest < ActiveSupport::TestCase
   # The days-left segment is returned separately so the view can keep it
   # unbroken; joined into one string it wrapped after "days" on a phone.
   test "header_summary_parts keeps the days-left phrase in its own segment" do
-    # Target well above the linked account's balance, or the goal reads as
-    # :reached and drops the days-left segment on purpose.
-    @goal.target_amount = 1_000_000
-    @goal.target_date = 184.days.from_now.to_date
+    # Pinned: the count is `target_date - Date.current`, so a suite that crossed
+    # midnight between setting the date and reading it would report 183.
+    travel_to Date.new(2026, 6, 1) do
+      # Target well above the linked account's balance, or the goal reads as
+      # :reached and drops the days-left segment on purpose.
+      @goal.target_amount = 1_000_000
+      @goal.target_date = Date.current + 184
 
-    parts = @goal.header_summary_parts
+      parts = @goal.header_summary_parts
 
-    assert_equal 2, parts.size
-    assert_match(/184 days left/, parts.last)
-    assert_no_match(/days left/, parts.first)
+      assert_equal 2, parts.size
+      assert_match(/184 days left/, parts.last)
+      assert_no_match(/days left/, parts.first)
+    end
   end
 
   test "header_summary_parts omits days left once the target is reached" do


### PR DESCRIPTION
The goal header rendered as a single text node:

```
Target 700 € by 08 de Febrer de 2027 · 184 days left
```

so on a phone it wrapped wherever it ran out of room — "184 days" on the first line, "left" orphaned on the second.

## Fix

`Goal#header_summary_parts` now returns the dot-separated segments instead of a joined string, and the view renders each as its own span.

Only the segments **after the first** get `whitespace-nowrap`. The first carries the target amount and a long-format date, so it has to stay free to wrap — pinning it would overflow a narrow screen. Verified at 320px: the first segment takes two lines while "675 days left" still moves down whole, and nothing overflows the paragraph or scrolls the page.

Measured at 390px:

```
before   one text node, "days left" breaks after "675"
after    span 1 (wraps freely)  top 97
         span 2 (nowrap)        top 117   -> moved down intact
```

## Before / after

<img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/goal-header-wrap.png" width="400">

## Testing

Three cases in `test/models/goal_test.rb` covering the segment split: days-left kept in its own segment, dropped once the goal is reached, and a single segment when there is no target date.

Worth noting for review: the days-left segment is deliberately absent when the goal is already at 100% — the first version of the test missed this because the `vacation_italy` fixture is fully funded, so it read as `:reached` and returned one segment. The test now raises the target so the case it claims to cover is actually exercised.

Full suite 6205 runs / 0 failures · `rubocop` clean · `erb_lint` clean.

## Note

Touches `app/models/goal.rb`, as does #2963, but a different method — they merge in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Goal headers now display summary details as separate segments, clearly divided by middle dots.
  * Additional summary details remain on one line to improve readability.

* **Bug Fixes**
  * Completed goals no longer display an irrelevant days-left message.
  * Goals without target dates now show a concise single-part summary.

* **Tests**
  * Added coverage for goal summaries across active, completed, and undated goals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->