### PR TITLE
fix(goals): keep the projection chart's saved line inside the plot

### DIFF
--- a/app/javascript/controllers/goal_projection_chart_controller.js
+++ b/app/javascript/controllers/goal_projection_chart_controller.js
@@ -15,6 +15,18 @@ import {
 //
 // Data shape passed via `data-goal-projection-chart-data-value`
 // matches Goal#projection_payload.
+
+// Ceiling on how far the y-axis may stretch past the goal's own scale to fit a
+// taller savings history, as a multiple of that scale.
+//
+// Every value the chart reasons about — the target, the projection, the
+// required path, today's balance — sits at or below that scale, so any headroom
+// above it is spent purely on historical peaks. Keep it small: at 2 the target
+// line never falls below half the plot height, while a history that overshoots
+// the target up to twofold (having saved past it, the ordinary case) still
+// shows in full.
+const SAVED_HEADROOM_FACTOR = 2;
+
 export default class extends Controller {
   static values = {
     data: Object,
@@ -159,7 +171,26 @@ export default class extends Controller {
         ]
       : [];
 
-    const yMax = Math.max(targetAmount * 1.05, projectionEnd, requiredEnd, currentAmount, 1);
+    // The scale the goal's own content needs: target, projection, required path
+    // and where the balance stands today.
+    const goalBand = Math.max(targetAmount * 1.05, projectionEnd, requiredEnd, currentAmount, 1);
+
+    // The saved history used to be left out of the domain entirely, so a
+    // balance that ever rose above the target was drawn above the plot — the
+    // line escaped the chart and painted over the legend before the SVG edge
+    // cut it off. Include it, with headroom so the peak's stroke isn't shaved
+    // in half at the top.
+    //
+    // But do not let it set the scale without limit. A goal funded from a
+    // current account sees the whole balance as "saved", so a 700 target
+    // against a salary that lands and clears can be an order of magnitude
+    // apart; scaled to that peak, the target line and both projection lines
+    // collapse into the floor and the chart stops answering "am I on track".
+    // Past SAVED_HEADROOM_FACTOR the history is clipped instead — deliberately,
+    // inside the plot (see the clip path below), rather than bleeding out of
+    // it. Clipped peaks are still readable on hover.
+    const savedMax = d3.max(savedSeries, (d) => d.value) || 0;
+    const yMax = Math.min(Math.max(goalBand, savedMax * 1.05), goalBand * SAVED_HEADROOM_FACTOR);
 
     const x = d3.scaleTime().domain([start, endDate]).range([margin.left, margin.left + innerWidth]);
     const y = d3.scaleLinear().domain([0, yMax]).range([margin.top + innerHeight, margin.top]);
@@ -186,6 +217,24 @@ export default class extends Controller {
       .attr("x1", 0).attr("y1", 0).attr("x2", 0).attr("y2", 1);
     gradient.append("stop").attr("offset", "0%").attr("stop-color", textPrimary).attr("stop-opacity", 0.22);
     gradient.append("stop").attr("offset", "100%").attr("stop-color", textPrimary).attr("stop-opacity", 0);
+
+    // Everything driven by the saved series is confined to the plot box. The
+    // domain above already covers the common case, but this is the structural
+    // guarantee: a value outside it — a balance past the headroom ceiling, or a
+    // linked current account that went overdrawn and dipped below zero — stops
+    // at the plot edge instead of painting over the legend above or the date
+    // axis below. Bounds are exact vertically; a couple of pixels of horizontal
+    // bleed keep the stroke's round cap from being shaved at the left edge.
+    const clipId = `plot-clip-${this._id()}`;
+    defs
+      .append("clipPath")
+      .attr("id", clipId)
+      .append("rect")
+      .attr("x", margin.left - 2)
+      .attr("y", margin.top)
+      .attr("width", innerWidth + 4)
+      .attr("height", innerHeight);
+    const plotClip = `url(#${clipId})`;
 
     const COLLISION_PX = 18;
     const targetY = targetAmount > 0 ? y(targetAmount) : null;
@@ -270,6 +319,7 @@ export default class extends Controller {
       .append("path")
       .datum(savedSeries)
       .attr("fill", `url(#saved-fill-${this._id()})`)
+      .attr("clip-path", plotClip)
       .attr("d", area);
 
     svg
@@ -280,6 +330,7 @@ export default class extends Controller {
       .attr("stroke-width", 2)
       .attr("stroke-linejoin", "round")
       .attr("stroke-linecap", "round")
+      .attr("clip-path", plotClip)
       .attr("d", line);
 
     if (requiredSeries.length) {
@@ -421,6 +472,10 @@ export default class extends Controller {
       .attr("pointer-events", "none")
       .style("display", "none");
 
+    // Clipped like the line it rides on: hovering a point above the headroom
+    // ceiling would otherwise park the dot outside the plot. The tooltip still
+    // reports that point's real amount, which is how a clipped peak stays
+    // readable.
     const hoverSavedDot = svg
       .append("circle")
       .attr("r", 4)
@@ -428,6 +483,7 @@ export default class extends Controller {
       .attr("stroke", containerBg)
       .attr("stroke-width", 2)
       .attr("pointer-events", "none")
+      .attr("clip-path", plotClip)
       .style("display", "none");
 
     const hoverProjDot = svg


### PR DESCRIPTION
## What's wrong

Two defects, one visible and one structural.

**The y-domain ignored the series it draws.** It was built from the target, the projection end, the required path and today's balance — but not the saved history:

```js
const yMax = Math.max(targetAmount * 1.05, projectionEnd, requiredEnd, currentAmount, 1);
```

So a goal whose linked account ever held more than the target mapped that history above the top of the scale.

**Nothing was clipped.** Paths are appended straight to the `<svg>`, so out-of-domain values painted over the legend and out of the plot until the SVG edge cut them off. That is the black smear in the report.

Reproduced with the reported shape — €700 target, €27 balance today, history peaking at €8,000 (a current account that fills and drains): the y-axis topped out at **$600** while the line reached **8,000**, a 11× overshoot drawn outside the plot.

## The judgment call

The obvious fix — put the saved max in the domain — is wrong on its own. Every value the chart reasons about (target, projection end, required end, today) sits at or below the goal's own scale, so **any headroom above it buys nothing but taller spikes**. Scaled to an 8,000 peak, a €700 target line and both projection lines collapse into the bottom 9% of the plot and the chart stops answering "am I on track?".

So the domain follows the history, but only so far. Past `SAVED_HEADROOM_FACTOR` (2) times the goal's scale it clips instead, which keeps the target line at or above half the plot height. Two covers the ordinary overshoot — having saved past your target — in full.

| history peak vs goal scale | domain | clipped |
|---|---|---|
| 0.6× | 1050 | no |
| 1.4× | 1470 | no (autoscaled) |
| 2.0× | 2100 | no (at the ceiling) |
| 8.0× | 2100 | **yes**, inside the plot |

Clipping is now deliberate and contained rather than a bleed: the line rises, leaves at the plot edge and comes back — which reads as off-scale, not as a plateau — and the tooltip still reports the real amount at any point.

## The clip region

The structural half, and worth having regardless of the domain. Series paths and the hover dot are confined to the plot box, so anything outside the domain stops at the edge instead of painting over the legend above or the date axis below. It also covers a case the domain does not: a linked current account that goes **overdrawn** produces negative values, which would otherwise paint below the baseline into the date labels.

## Before / after

Same injected payload in both.

<img src="https://raw.githubusercontent.com/we-promise/sure/assets/ds-screenshots/goal-projection-overflow.png" width="600">

## Testing

Full suite 6202 runs / 0 failures · `rubocop` clean · `biome lint` clean (542 files).

Chart walked in a browser across the overshoot range above, checking the rendered y-ticks and the clip region each time. Note for anyone verifying: `getBoundingClientRect()` on an SVG path reports geometry and **ignores `clip-path`**, so it cannot be used to confirm this — I checked the rendered output instead.

## Follow-ups, not done here

The deeper oddity is upstream: for a whole-balance link, `Goal#projection_payload` uses the linked account's raw balance history as "Saved", so a current account's salary cycle shows up as goal progress. Two things worth considering separately — starting the series at the goal's `created_at` rather than a flat 90 days (a goal cannot have been funded before it existed), and smoothing the series so transient peaks don't dominate. Both change what the line means, so they belong in their own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved goal projection charts so saved history, goals, and projections remain clearly visible within the chart area.
  * Prevented out-of-range chart values and hover indicators from extending beyond the plot boundaries.
  * Preserved accurate amounts in tooltips, even when values are clipped visually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->