### PR TITLE
fix(ds): resolve remaining DS Drift findings (#1951)

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -53,7 +53,7 @@
           <% pending_invitations = @invitations_by_family[family.id] || [] %>
           <%= render DS::Disclosure.new(
                 variant: :bare,
-                summary_class: "list-none flex items-center justify-between gap-4 px-4 py-3 cursor-pointer select-none hover:bg-surface-hover",
+                summary_class: "list-none focus-ring flex items-center justify-between gap-4 px-4 py-3 cursor-pointer select-none hover:bg-surface-hover",
                 class: "bg-container-inset rounded-lg overflow-hidden",
                 data: {
                   controller: "admin-invitation-delete",

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -51,10 +51,16 @@
       <div class="space-y-4">
         <% @families_with_users.each do |family, users| %>
           <% pending_invitations = @invitations_by_family[family.id] || [] %>
-          <details class="bg-container-inset rounded-lg overflow-hidden group"
-                   data-controller="admin-invitation-delete"
-                   data-admin-invitation-delete-delete-all-label-value="<%= t(".invitations.delete_all") %>">
-            <summary class="flex items-center justify-between gap-4 px-4 py-3 cursor-pointer select-none hover:bg-surface-hover">
+          <%= render DS::Disclosure.new(
+                variant: :bare,
+                summary_class: "list-none flex items-center justify-between gap-4 px-4 py-3 cursor-pointer select-none hover:bg-surface-hover",
+                class: "bg-container-inset rounded-lg overflow-hidden",
+                data: {
+                  controller: "admin-invitation-delete",
+                  admin_invitation_delete_delete_all_label_value: t(".invitations.delete_all")
+                }
+              ) do |disclosure| %>
+            <% disclosure.with_summary_content do %>
               <div class="flex items-center gap-3">
                 <%= icon "users", class: "w-5 h-5 text-secondary shrink-0" %>
                 <div>
@@ -80,7 +86,7 @@
                 <% end %>
                 <%= icon "chevron-down", class: "w-4 h-4 text-secondary transition-transform group-open:rotate-180" %>
               </div>
-            </summary>
+            <% end %>
 
             <div class="border-t border-primary">
               <table class="w-full">
@@ -154,12 +160,16 @@
                         </td>
                         <td class="px-4 py-3 text-right">
                           <%= form_with url: admin_invitation_path(invitation), method: :delete, class: "inline" do |f| %>
-                            <button type="submit"
-                                    data-admin-invitation-delete-target="button"
-                                    data-action="click->admin-invitation-delete#handleClick"
-                                    class="text-sm text-destructive border border-destructive rounded-lg px-2 py-1 hover:bg-destructive/10 transition-colors">
-                              <%= t(".invitations.delete") %>
-                            </button>
+                            <%= render DS::Button.new(
+                                  text: t(".invitations.delete"),
+                                  type: "submit",
+                                  variant: :outline_destructive,
+                                  size: :sm,
+                                  data: {
+                                    admin_invitation_delete_target: "button",
+                                    action: "click->admin-invitation-delete#handleClick"
+                                  }
+                                ) %>
                           <% end %>
                         </td>
                       </tr>
@@ -174,7 +184,7 @@
                 <% end %>
               <% end %>
             </div>
-          </details>
+          <% end %>
         <% end %>
       </div>
     <% else %>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -28,12 +28,12 @@
 <% end %>
 
 <% unless Current.user.ui_layout_intro? %>
-  <%= settings_section title: Current.family&.moniker == "Group" ? t(".group_title", default: "Group") : t(".household_title"), subtitle: t(".household_subtitle", moniker_plural: family_moniker_plural_downcase, moniker: family_moniker_downcase) do %>
+  <%= settings_section title: Current.family&.moniker == "Group" ? t(".group_title") : t(".household_title"), subtitle: t(".household_subtitle", moniker_plural: family_moniker_plural_downcase, moniker: family_moniker_downcase) do %>
     <div class="space-y-4">
       <%= styled_form_with model: Current.user, class: "space-y-4", data: { controller: "auto-submit-form" } do |form| %>
         <%= form.fields_for :family do |family_fields| %>
-          <% name_label = Current.family&.moniker == "Group" ? t(".group_form_label", default: "Group name") : t(".household_form_label") %>
-          <% name_placeholder = Current.family&.moniker == "Group" ? t(".group_form_input_placeholder", default: "Enter group name") : t(".household_form_input_placeholder") %>
+          <% name_label = Current.family&.moniker == "Group" ? t(".group_form_label") : t(".household_form_label") %>
+          <% name_placeholder = Current.family&.moniker == "Group" ? t(".group_form_input_placeholder") : t(".household_form_input_placeholder") %>
           <%= family_fields.text_field :name,
                 placeholder: name_placeholder,
                 label: name_label,


### PR DESCRIPTION
## Summary
Closes still-open findings from [#1951](https://github.com/we-promise/sure/issues/1951):

- **Admin users family rows** → `DS::Disclosure` (`variant: :bare`) instead of raw `<details>`
- **Admin invitation delete** → `DS::Button` (`outline_destructive`) instead of a hand-rolled destructive button
- **Profile settings** → remove redundant `t(..., default:)` for group title/label/placeholder (keys already in locale)

### Skipped (already fixed on `main`)
- Admin green/red palette badges → already `DS::Pill` / `bg-destructive/5`
- Invalid `bg-surface-default` → already gone
- Imports `bg-gray-tint-5` → already replaced
- Debug view findings → noted as fixed in the issue
- Profile `role_descriptions.member` default → no longer present in that view

## Test plan
- [ ] Admin → Users: expand/collapse family groups; subscription pill still shows
- [ ] Pending invitation delete works; Alt-click still triggers delete-all flow
- [ ] Settings → Profile with Group moniker: group name field label/placeholder/title resolve from locale

Closes #1951


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## UI Improvements
- Updated family user sections with a consistent expandable interface.
- Invitation removal actions now use standard destructive button styling while preserving existing behavior.
- Improved the consistency and accessibility of controls for managing invitations.

## Localization
- Group-specific profile settings now rely on configured translations for section titles, form labels, and placeholders.
- Prevented unintended fallback text from appearing when localized content is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->