### PR TITLE
Preserve gross income and expenses in budgets

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -172,11 +172,11 @@ class Budget < ApplicationRecord
   end
 
   def income_category_totals
-    net_totals.net_income_categories.reject { |ct| ct.total.zero? }.sort_by(&:weight).reverse
+    income_totals.category_totals.reject { |ct| ct.total.zero? }.sort_by(&:weight).reverse
   end
 
   def expense_category_totals
-    net_totals.net_expense_categories.reject { |ct| ct.total.zero? }.sort_by(&:weight).reverse
+    expense_totals.category_totals.reject { |ct| ct.total.zero? }.sort_by(&:weight).reverse
   end
 
   def current?
@@ -257,14 +257,12 @@ class Budget < ApplicationRecord
   end
 
   def actual_spending
-    net_totals.total_net_expense
+    expense_totals.total
   end
 
   def budget_category_actual_spending(budget_category)
     key = budget_category.category_id || stable_synthetic_key(budget_category.category)
-    expense = expense_totals_by_category[key]&.total || 0
-    refund = income_totals_by_category[key]&.total || 0
-    [ expense - refund, 0 ].max
+    expense_totals_by_category[key]&.total || 0
   end
 
   def category_median_monthly_expense(category)
@@ -344,10 +342,6 @@ class Budget < ApplicationRecord
       @income_statement ||= family.income_statement(user: current_user)
     end
 
-    def net_totals
-      @net_totals ||= income_statement.net_category_totals(period: period)
-    end
-
     def expense_totals
       @expense_totals ||= income_statement.expense_totals(period: period)
     end
@@ -358,10 +352,6 @@ class Budget < ApplicationRecord
 
     def expense_totals_by_category
       @expense_totals_by_category ||= expense_totals.category_totals.index_by { |ct| ct.category.id || stable_synthetic_key(ct.category) }
-    end
-
-    def income_totals_by_category
-      @income_totals_by_category ||= income_totals.category_totals.index_by { |ct| ct.category.id || stable_synthetic_key(ct.category) }
     end
 
     def stable_synthetic_key(category)

--- a/test/models/budget_test.rb
+++ b/test/models/budget_test.rb
@@ -145,7 +145,7 @@ class BudgetTest < ActiveSupport::TestCase
     end
   end
 
-  test "actual_spending nets refunds against expenses in same category" do
+  test "budget actuals preserve gross expenses and income in the same category" do
     family = families(:dylan_family)
     budget = Budget.find_or_bootstrap(family, start_date: Date.current.beginning_of_month)
 
@@ -185,13 +185,16 @@ class BudgetTest < ActiveSupport::TestCase
     budget = Budget.find(budget.id)
     budget.sync_budget_categories
 
-    # Budget category should show net spending: $500 - $200 = $300
-    assert_equal 300, budget.budget_category_actual_spending(
+    # Budget actuals should preserve the gross expense and income amounts.
+    assert_equal 500, budget.budget_category_actual_spending(
       budget.budget_categories.find_by(category: healthcare)
     )
+    assert_equal 500, budget.actual_spending
+    assert_equal 500, budget.expense_category_totals.find { |ct| ct.category == healthcare }.total
+    assert_equal 200, budget.income_category_totals.find { |ct| ct.category == healthcare }.total
   end
 
-  test "budget_category_actual_spending does not go below zero" do
+  test "budget_category_actual_spending does not count income as spending" do
     family = families(:dylan_family)
     budget = Budget.find_or_bootstrap(family, start_date: Date.current.beginning_of_month)
 


### PR DESCRIPTION
## Summary

- preserve gross expense totals in budget actuals
- preserve gross income totals and category breakdowns
- avoid netting same-category income against expenses
- add regression coverage for mixed income and expense transactions in one category

## Context

A positive expense and negative/income transaction in the same category were displayed as a net expense (for example, $5,000 expense + $1,000 income displayed as $4,000 expenses). This made ordinary revenue look like a refund.

## Testing

- `git diff --check` ✅
- Rails tests not run: Ruby/Bundler are unavailable in the execution environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Budget category expense totals now show gross expenses without reducing them by income or refunds in the same category.
  * Income and expense totals are tracked separately for clearer budget reporting.
  * Category breakdowns now exclude categories and subcategories with zero totals.

* **Tests**
  * Updated budget calculation coverage to verify gross expense totals, separate income tracking, refund handling, and category breakdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->