### PR TITLE
fix(devcontainer): use configured session key in Codespaces

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,10 @@ require "rails/all"
 Bundler.require(*Rails.groups)
 
 module Sure
+  # Matches Rails::Application::Finisher#setup_default_session_store for Sure::Application
+  # ("_#{railtie_name.chomp("_application")}_session" → "_sure_session").
+  SESSION_COOKIE_KEY = "_sure_session"
+
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1
@@ -23,6 +27,9 @@ module Sure
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Explicit source of truth for the session cookie name (also used by Codespaces).
+    config.session_store :cookie_store, key: SESSION_COOKIE_KEY
 
     # TODO: This is here for incremental adoption of localization.  This can be removed when all translations are implemented.
     config.i18n.fallbacks = true

--- a/config/initializers/codespaces.rb
+++ b/config/initializers/codespaces.rb
@@ -15,11 +15,14 @@ if Rails.env.development? && ENV["CODESPACES"] == "true"
 
   # If you use the VS Code "Preview" (iframe), you need SameSite=None; Secure
   # Codespaces serves over HTTPS, so secure: true is OK here.
-  # Prefer the configured session key when present; this initializer is the
-  # only session_store call, so session_options may still be unset on a fresh
-  # Codespaces boot — fall back to the previous literal key.
+  # Re-declare the cookie store so we can set Codespaces-only cookie flags, but
+  # keep Sure::SESSION_COOKIE_KEY (set in config/application.rb) so the cookie
+  # name stays consistent with non-Codespaces boots. Do not read
+  # session_options[:key] here as the "source of truth" — calling session_store
+  # replaces those options, and this file used to hardcode "_app_session", which
+  # diverged from Rails' default "_sure_session".
   Rails.application.config.session_store :cookie_store,
-    key: Rails.application.config.session_options&.[](:key).presence || "_app_session",
+    key: Sure::SESSION_COOKIE_KEY,
     same_site: :none,
     secure: true
 

--- a/config/initializers/codespaces.rb
+++ b/config/initializers/codespaces.rb
@@ -16,7 +16,7 @@ if Rails.env.development? && ENV["CODESPACES"] == "true"
   # If you use the VS Code "Preview" (iframe), you need SameSite=None; Secure
   # Codespaces serves over HTTPS, so secure: true is OK here.
   Rails.application.config.session_store :cookie_store,
-    key: "_app_session",
+    key: Rails.application.config.session_options[:key],
     same_site: :none,
     secure: true
 

--- a/config/initializers/codespaces.rb
+++ b/config/initializers/codespaces.rb
@@ -15,8 +15,11 @@ if Rails.env.development? && ENV["CODESPACES"] == "true"
 
   # If you use the VS Code "Preview" (iframe), you need SameSite=None; Secure
   # Codespaces serves over HTTPS, so secure: true is OK here.
+  # Prefer the configured session key when present; this initializer is the
+  # only session_store call, so session_options may still be unset on a fresh
+  # Codespaces boot — fall back to the previous literal key.
   Rails.application.config.session_store :cookie_store,
-    key: Rails.application.config.session_options[:key],
+    key: Rails.application.config.session_options&.[](:key).presence || "_app_session",
     same_site: :none,
     secure: true
 


### PR DESCRIPTION
## Summary
* Closes #98: stop using a Codespaces-only hardcoded `_app_session` cookie name.
* Introduce `Sure::SESSION_COOKIE_KEY` (`_sure_session`, matching Rails' default finisher key) in `config/application.rb` as the shared source of truth.
* Codespaces re-declares the cookie store only to set `same_site: :none` / `secure: true`, while keeping that same key so preview cookies stay consistent with non-Codespaces boots.

## Test plan
* [ ] Boot locally (non-Codespaces) — session cookie name remains `_sure_session`
* [ ] Boot with `CODESPACES=true` — session cookie name is `_sure_session` (not `_app_session`), with `SameSite=None; Secure`
* [ ] VS Code simple browser / HTTPS preview still accepts the session

Closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Improved session handling in Codespaces environments by consistently using the application’s configured session cookie key.
- Standardized session cookie behavior across the application and Codespaces.
- Preserved secure cookie settings and cross-site compatibility for reliable authenticated sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->