### PR TITLE
fix: add Schwab to SimpleFIN total-basis cost_basis allowlist

### DIFF
--- a/app/models/simplefin_account/investments/holdings_processor.rb
+++ b/app/models/simplefin_account/investments/holdings_processor.rb
@@ -132,9 +132,10 @@ class SimplefinAccount::Investments::HoldingsProcessor
     #   - cost_basis / basis: the spec calls this per-share, and most
     #     brokerages comply. Keep these values unchanged by default.
     #
-    # Exception: a small allowlist of brokerages (Vanguard, Fidelity) is
-    # known to populate cost_basis with the total position cost in violation
-    # of the spec (#1718, #1182). For those connections only, divide by qty.
+    # Exception: a small allowlist of brokerages (Vanguard, Fidelity, Schwab)
+    # is known to populate cost_basis with the total position cost in
+    # violation of the spec (#1718, #1182, #2626). For those connections
+    # only, divide by qty.
     #
     # An earlier revision of this fix used a magnitude heuristic
     # (share_price × √qty midpoint). It was withdrawn because a legitimate
@@ -158,7 +159,7 @@ class SimplefinAccount::Investments::HoldingsProcessor
     # field with the total position cost rather than the per-share value the
     # spec requires. Matched as case-insensitive substrings against the
     # account's stored org name and domain.
-    TOTAL_BASIS_INSTITUTIONS = %w[vanguard fidelity].freeze
+    TOTAL_BASIS_INSTITUTIONS = %w[vanguard fidelity schwab].freeze
 
     def institution_reports_total_basis?
       org = simplefin_account.respond_to?(:org_data) ? simplefin_account.org_data : nil

--- a/test/models/simplefin_account/investments/holdings_processor_test.rb
+++ b/test/models/simplefin_account/investments/holdings_processor_test.rb
@@ -122,14 +122,14 @@ class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::Test
     assert_equal BigDecimal("100.00"), cost_basis
   end
 
-  test "institution_reports_total_basis? matches Vanguard and Fidelity org metadata" do
+  test "institution_reports_total_basis? matches Vanguard, Fidelity, and Schwab org metadata" do
     cases = {
       { "name" => "Vanguard" }                          => true,
       { "name" => "VANGUARD BROKERAGE" }                => true,
       { "name" => "Fidelity Investments" }              => true,
       { "domain" => "vanguard.com" }                    => true,
       { "domain" => "401k.fidelity.com" }               => true,
-      { "name" => "Charles Schwab", "domain" => "schwab.com" } => false,
+      { "name" => "Charles Schwab", "domain" => "schwab.com" } => true,
       { "name" => "Chase" }                             => false,
       {}                                                => false
     }
@@ -141,6 +141,28 @@ class SimplefinAccount::Investments::HoldingsProcessorTest < ActiveSupport::Test
         processor.send(:institution_reports_total_basis?),
         "org_data #{org.inspect} expected #{expected}"
     end
+  end
+
+  test "cost_basis from Charles Schwab is divided by qty (#2626)" do
+    # Schwab reports `cost_basis` as the total position cost, not per-share,
+    # in violation of the SimpleFIN spec — same failure mode as Vanguard
+    # (#1182) and Fidelity (#1718). Observed on two independent Sure
+    # instances via raw SimpleFIN payloads, e.g.:
+    #   { "shares" => "651.00", "cost_basis" => "30162.36", "purchase_price" => "46.33235" }
+    # Left uncorrected, Holding#calculate_trend later multiplies this
+    # (mislabeled-as-per-share) total by qty again when reconstructing the
+    # position's original cost, inflating a holding's unrealized loss by
+    # roughly qty× — e.g. a $46,950 position showing a -99.8% / -$19.6M
+    # "return" instead of its true +55.7% gain.
+    cost_basis = @processor.send(
+      :normalize_cost_basis,
+      BigDecimal("30162.36"),
+      BigDecimal("651"),
+      "cost_basis",
+      true # institution_reports_total_basis?
+    )
+
+    assert_in_delta 46.33, cost_basis.to_f, 0.01
   end
 
   test "missing cost basis fields return nil" do


### PR DESCRIPTION
## Problem

Charles Schwab's SimpleFIN feed reports `cost_basis` as the **total position cost**, not per-share — violating the SimpleFIN spec the same way Vanguard (#1182) and Fidelity (#1718) already do. Schwab isn't on the `TOTAL_BASIS_INSTITUTIONS` allowlist in `holdings_processor.rb`, so the raw total gets stored directly into `holdings.cost_basis`, which the rest of the app treats as a genuine per-share average cost.

`Holding#calculate_trend` then multiplies `avg_cost` by `qty` again when reconstructing the position's original cost. For a correctly-normalized per-share value this is correct — but for Schwab's unadjusted total, it squares the share count into the "cost basis," producing a wildly inflated phantom loss. Concretely, on a real Schwab-linked 401(k):

| field | value |
|---|---|
| shares | 651 |
| `cost_basis` (raw, from Schwab) | $30,162.36 |
| `purchase_price` (same payload, unused) | $46.33/share |
| current value | $46,950.12 |
| true return | **+55.7%** |
| displayed return | **-99.8% (-$19,588,746.24)** |

Every Schwab holding in the account is affected the same way — visible on both the dashboard "Investment Performance" widget and the per-account Holdings tab, where the UI literally labels the (actually-total) figure "per share."

## Fix

This picks up where #2626 left off — same core idea (add `schwab` to the allowlist) — but that PR stalled on review feedback: a test it broke, and a doc comment that needed updating. Credit to @malewpro for the original diagnosis and payload evidence.

- Add `schwab` to `TOTAL_BASIS_INSTITUTIONS`
- Update the doc comment to reflect the third allowlisted institution
- Fix `institution_reports_total_basis? matches Vanguard and Fidelity org metadata` — it hardcoded `"Charles Schwab" => false`, which is exactly the incorrect assumption this PR corrects
- Add a dedicated regression test using the real observed Schwab payload shape (`cost_basis` / `shares` / `purchase_price`) so this can't silently regress

## Verification

No local Rails dev environment available for this change, so the two pure methods under test (`normalize_cost_basis`, `institution_reports_total_basis?`) were extracted into a standalone Ruby script and checked against all existing + new test cases — all pass, including the corrected Schwab case and the new regression test. CI will run the full suite on this PR.

Fixes #2626