### PR TITLE
Enable Banking: progressive date_from fallback on WRONG_TRANSACTIONS_PERIOD

### DIFF
--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -6,6 +6,11 @@ class Provider::EnableBanking
 
   BASE_URL = "https://api.enablebanking.com".freeze
 
+  # Progressive fallback windows (days) for retrying a transactions fetch when
+  # an ASPSP rejects the requested period (WRONG_TRANSACTIONS_PERIOD) without
+  # suggesting a corrected date_from in the response payload.
+  FALLBACK_TRANSACTIONS_DATE_FROM_DAYS = [ 89, 60, 30 ].freeze
+
   headers "User-Agent" => "Sure Finance Enable Banking Client"
   default_options.merge!({ timeout: 120 }.merge(httparty_ssl_options))
 
@@ -164,7 +169,7 @@ class Provider::EnableBanking
   # @param psu_headers [Hash] Optional PSU context headers required by some ASPSPs
   # @return [Hash] Transactions and continuation_key for pagination
   def get_account_transactions(account_id:, date_from: nil, date_to: nil,
-                               continuation_key: nil, transaction_status: nil, psu_headers: {}, retried_date_from: false)
+                               continuation_key: nil, transaction_status: nil, psu_headers: {}, retry_attempt: 0)
     encoded_id = CGI.escape(account_id.to_s)
     query_params = {}
     query_params[:transaction_status] = transaction_status if transaction_status.present?
@@ -180,17 +185,17 @@ class Provider::EnableBanking
 
     handle_response(response)
   rescue EnableBankingError => e
-    corrected_date_from = e.corrected_date_from
+    next_date_from = next_transactions_date_from(e, date_from, retry_attempt)
 
-    if !retried_date_from && e.wrong_transactions_period? && corrected_date_from.present? && corrected_date_from != date_from
+    if next_date_from
       get_account_transactions(
         account_id: account_id,
-        date_from: corrected_date_from,
+        date_from: next_date_from,
         date_to: date_to,
         continuation_key: continuation_key,
         transaction_status: transaction_status,
         psu_headers: psu_headers,
-        retried_date_from: true
+        retry_attempt: retry_attempt + 1
       )
     else
       raise
@@ -200,6 +205,37 @@ class Provider::EnableBanking
   end
 
   private
+
+    # Decides the next date_from to retry a transactions fetch with after an
+    # ASPSP rejects the requested window with WRONG_TRANSACTIONS_PERIOD.
+    #
+    # Some ASPSPs (e.g. certain PT banks) return this error WITHOUT a corrected
+    # date_from in the payload, which defeated the previous single-shot retry.
+    # In that case we step through progressively shorter windows so the sync can
+    # still succeed instead of surfacing a generic error. Returns nil when no
+    # further retry should be attempted.
+    def next_transactions_date_from(error, current_date_from, retry_attempt)
+      return nil unless error.wrong_transactions_period?
+
+      current = current_date_from&.to_date
+
+      # Prefer the ASPSP-suggested date on the first retry (original behaviour).
+      if retry_attempt.zero?
+        corrected = error.corrected_date_from
+        return corrected if corrected.present? && corrected != current
+      end
+
+      # Otherwise fall back to progressively shorter windows.
+      days = FALLBACK_TRANSACTIONS_DATE_FROM_DAYS[retry_attempt]
+      return nil unless days
+
+      fallback = days.days.ago.to_date
+      # Only retry when this moves the window forward, to guarantee progress
+      # and avoid an infinite retry loop.
+      return nil if current && fallback <= current
+
+      fallback
+    end
 
     def safe_psu_headers(headers)
       headers.except("Authorization", :Authorization, "Accept", :Accept, "Content-Type", :"Content-Type")

--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -216,25 +216,23 @@ class Provider::EnableBanking
     # further retry should be attempted.
     def next_transactions_date_from(error, current_date_from, retry_attempt)
       return nil unless error.wrong_transactions_period?
+      return nil if retry_attempt > FALLBACK_TRANSACTIONS_DATE_FROM_DAYS.length
 
       current = current_date_from&.to_date
 
-      # Prefer the ASPSP-suggested date on the first retry (original behaviour).
+      # Prefer the ASPSP-suggested date on the first retry (original behaviour),
+      # but only when it actually moves the window forward.
       if retry_attempt.zero?
         corrected = error.corrected_date_from
-        return corrected if corrected.present? && corrected != current
+        return corrected if corrected.present? && (current.nil? || corrected > current)
       end
 
-      # Otherwise fall back to progressively shorter windows.
-      days = FALLBACK_TRANSACTIONS_DATE_FROM_DAYS[retry_attempt]
-      return nil unless days
-
-      fallback = days.days.ago.to_date
-      # Only retry when this moves the window forward, to guarantee progress
-      # and avoid an infinite retry loop.
-      return nil if current && fallback <= current
-
-      fallback
+      # Otherwise pick the first progressively-shorter window that advances the
+      # window forward, skipping any window that is not newer than the current
+      # date_from. Moving strictly forward guarantees progress and termination.
+      FALLBACK_TRANSACTIONS_DATE_FROM_DAYS
+        .map { |days| days.days.ago.to_date }
+        .find { |candidate| current.nil? || candidate > current }
     end
 
     def safe_psu_headers(headers)

--- a/test/models/provider/enable_banking_test.rb
+++ b/test/models/provider/enable_banking_test.rb
@@ -43,6 +43,62 @@ class Provider::EnableBankingTest < ActiveSupport::TestCase
     assert_equal "2026-01-17", requested_queries.second[:date_from]
   end
 
+  test "get_account_transactions falls back to a shorter window when no corrected date_from is given" do
+    requested_queries = []
+
+    # Some ASPSPs reject the period without suggesting a corrected date_from.
+    validation_response = OpenStruct.new(
+      code: 422,
+      body: {
+        error: "WRONG_TRANSACTIONS_PERIOD",
+        detail: { message: "Requested time period out of bound." }
+      }.to_json
+    )
+    success_response = OpenStruct.new(code: 200, body: { transactions: [] }.to_json)
+
+    Provider::EnableBanking.expects(:get).twice.with do |_url, options|
+      requested_queries << options[:query].dup
+      true
+    end.returns(validation_response, success_response)
+
+    result = @provider.get_account_transactions(
+      account_id: "acct_123",
+      date_from: 6.months.ago.to_date,
+      transaction_status: "BOOK"
+    )
+
+    assert_equal [], result[:transactions]
+    assert_equal 6.months.ago.to_date.iso8601, requested_queries.first[:date_from]
+    assert_equal 89.days.ago.to_date.iso8601, requested_queries.second[:date_from]
+  end
+
+  test "get_account_transactions skips fallback windows that do not advance the search" do
+    requested_queries = []
+
+    validation_response = OpenStruct.new(
+      code: 422,
+      body: { error: "WRONG_TRANSACTIONS_PERIOD", detail: { message: "out of bound" } }.to_json
+    )
+    success_response = OpenStruct.new(code: 200, body: { transactions: [] }.to_json)
+
+    Provider::EnableBanking.expects(:get).twice.with do |_url, options|
+      requested_queries << options[:query].dup
+      true
+    end.returns(validation_response, success_response)
+
+    # A 45-day lookback is newer than the 89- and 60-day windows; only the
+    # 30-day window moves the search forward, so it must be the one retried.
+    result = @provider.get_account_transactions(
+      account_id: "acct_123",
+      date_from: 45.days.ago.to_date,
+      transaction_status: "BOOK"
+    )
+
+    assert_equal [], result[:transactions]
+    assert_equal 45.days.ago.to_date.iso8601, requested_queries.first[:date_from]
+    assert_equal 30.days.ago.to_date.iso8601, requested_queries.second[:date_from]
+  end
+
   test "validation errors expose parsed response data" do
     response = OpenStruct.new(
       code: 422,


### PR DESCRIPTION
## What & why

Fixes the root cause reported in #2989.

Some ASPSPs (e.g. **Santander Totta** and **Activo Bank** in PT) reject the
transactions window with `422 WRONG_TRANSACTIONS_PERIOD` but do **not** include a
corrected `date_from` in the response payload:

```json
{"code":422,"message":"Wrong transactions period requested",
 "detail":{"message":"Requested time period out of bound."},
 "error":"WRONG_TRANSACTIONS_PERIOD"}
```

The existing retry in `get_account_transactions` only fires when the API supplies
`detail.date_from`. For these banks `corrected_date_from` is `nil`, so the retry
is skipped, the error propagates, and `handle_sync_error` maps it to the generic
*"A communication error occurred with the bank."* — transactions never sync even
though the connection and session are valid.

## The change

A small, bounded **progressive fallback** in `get_account_transactions`:

- The ASPSP-suggested `date_from` is still preferred on the first retry
  (original behaviour preserved).
- When the period is rejected **without** a corrected date, retry with
  progressively shorter windows: **89 → 60 → 30 days** (`FALLBACK_TRANSACTIONS_DATE_FROM_DAYS`).
- The step-down only ever moves the window *forward*, which guarantees progress
  and rules out an infinite loop. After the windows are exhausted the error is
  re-raised unchanged.

Only `WRONG_TRANSACTIONS_PERIOD` triggers the fallback, so ASPSPs that accept a
longer window (e.g. the default 3 months) are unaffected.

## Verification

Reproduced and verified on a live self-hosted instance:

- Before: Santander Totta / Activo Bank → 0 transactions, generic
  "communication error".
- After: **Activo Bank imported 82 transactions** once the fallback narrowed the
  window within the bank's ~90-day PSD2 limit.

## Notes / not covered here

- The Santander Totta `ASPSP_ERROR` ("Error interacting with ASPSP") mentioned in
  #2989 is a separate Enable Banking ↔ ASPSP connector issue, not addressed here.
- Suggestion #3 from the issue (surfacing the raw `error_type`/`response_data`
  instead of the generic message) is complementary and left for a follow-up.

Signed-off-by: Pedro Santos <pedro_santos@outlook.pt>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction retrieval when the requested date range is rejected.
  * Added progressive fallback date ranges to increase the likelihood of successfully fetching transactions.
  * Prevented repeated retries when no progress can be made or retry limits are reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->