### PR TITLE
feat(yahoo_finance): add Indonesia Stock Exchange (XIDX) support

### DIFF
--- a/app/models/provider/yahoo_finance.rb
+++ b/app/models/provider/yahoo_finance.rb
@@ -570,7 +570,8 @@ class Provider::YahooFinance < Provider
     EXCHANGE_CONFIG = {
       "XNSE" => { yahoo_suffix: ".NS", default_currency: "INR", dual_list_group: :india, preference_rank: 0 },
       "XBOM" => { yahoo_suffix: ".BO", default_currency: "INR", dual_list_group: :india, preference_rank: 1 },
-      "XBOG" => { yahoo_suffix: ".CL", default_currency: "COP" }
+      "XBOG" => { yahoo_suffix: ".CL", default_currency: "COP" },
+      "XIDX" => { yahoo_suffix: ".JK", default_currency: "IDR" }
     }.freeze
 
     # Yahoo Finance sometimes returns currencies in minor units (pence, cents)
@@ -1056,6 +1057,8 @@ class Provider::YahooFinance < Provider
         "MX"
       when /JSE|JOHANNESBURG/
         "ZA"
+      when /JAKARTA|IDX/
+        "ID"
       else
         nil
       end
@@ -1108,6 +1111,8 @@ class Provider::YahooFinance < Provider
         "XBOM" # BSE (Bombay Stock Exchange)
       when "BVC"
         "XBOG" # Colombian Securities Exchange
+      when "JKT"
+        "XIDX" # Indonesia Stock Exchange (IDX)
       else
         exchange_code.upcase
       end

--- a/test/models/provider/yahoo_finance_test.rb
+++ b/test/models/provider/yahoo_finance_test.rb
@@ -745,6 +745,11 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     assert_nil @provider.send(:map_exchange_mic, "")
   end
 
+  test "map_exchange_mic returns XIDX for JKT" do
+    assert_equal "XIDX", @provider.send(:map_exchange_mic, "JKT")
+    assert_equal "XIDX", @provider.send(:map_exchange_mic, "jkt")
+  end
+
   test "map_security_type returns correct types" do
     assert_equal "common stock", @provider.send(:map_security_type, "equity")
     assert_equal "etf", @provider.send(:map_security_type, "etf")
@@ -823,6 +828,11 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     assert_equal "IN", @provider.send(:map_country_code, "MUMBAI")
   end
 
+  test "map_country_code returns ID for Indonesian exchanges" do
+    assert_equal "ID", @provider.send(:map_country_code, "JAKARTA")
+    assert_equal "ID", @provider.send(:map_country_code, "IDX")
+  end
+
   # ================================
   #   normalize_symbol Tests
   # ================================
@@ -831,11 +841,13 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     assert_equal "RELIANCE.NS", @provider.send(:normalize_symbol, "RELIANCE", "XNSE")
     assert_equal "INFY.NS",     @provider.send(:normalize_symbol, "INFY", "XNSE")
     assert_equal "500325.BO",   @provider.send(:normalize_symbol, "500325", "XBOM")
+    assert_equal "BBCA.JK",     @provider.send(:normalize_symbol, "BBCA", "XIDX")
   end
 
   test "normalize_symbol does not double-suffix already suffixed symbols" do
     assert_equal "RELIANCE.NS", @provider.send(:normalize_symbol, "RELIANCE.NS", "XNSE")
     assert_equal "500325.BO",   @provider.send(:normalize_symbol, "500325.BO", "XBOM")
+    assert_equal "BBCA.JK",     @provider.send(:normalize_symbol, "BBCA.JK", "XIDX")
   end
 
   test "normalize_symbol leaves unconfigured MIC symbols unchanged" do
@@ -856,6 +868,7 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
   test "default_currency_for_exchange returns configured currency for known Yahoo exchange names" do
     assert_equal "INR", @provider.send(:default_currency_for_exchange, "NSE")
     assert_equal "INR", @provider.send(:default_currency_for_exchange, "BSE")
+    assert_equal "IDR", @provider.send(:default_currency_for_exchange, "JKT")
   end
 
   test "default_currency_for_exchange returns nil for unknown exchanges" do


### PR DESCRIPTION
## Summary

Add Indonesia Stock Exchange (IDX / XIDX) support to the Yahoo Finance provider, enabling search and pricing for Indonesian equities (e.g. `BBCA.JK` — PT Bank Central Asia Tbk).

## Changes

**`app/models/provider/yahoo_finance.rb`:**
- Add `"XIDX" => { yahoo_suffix: ".JK", default_currency: "IDR" }` to `EXCHANGE_CONFIG` — enables `.JK` symbol suffix normalization and IDR default currency
- Add `"JKT" => "XIDX"` to `map_exchange_mic` — Yahoo Finance returns Indonesian stocks with exchange code `JKT`; this maps it to the XIDX MIC already defined in `config/exchanges.yml`
- Add `JAKARTA|IDX` pattern to `map_country_code` — returns `"ID"` for Indonesian exchange names

**`test/models/provider/yahoo_finance_test.rb`:**
- Add test cases for `map_exchange_mic` (JKT → XIDX)
- Add test cases for `map_country_code` (JAKARTA/IDX → ID)
- Extend `normalize_symbol` tests (BBCA → BBCA.JK for XIDX)
- Extend `default_currency_for_exchange` test (JKT → IDR)

## Context

Indonesia Stock Exchange (IDX) is the sole securities exchange in Indonesia with ~900 listed companies. Yahoo Finance already indexes IDX stocks under the `.JK` suffix (e.g. `BBCA.JK`, `TLKM.JK`, `BBRI.JK`) and `config/exchanges.yml` already defines `XIDX` — but the Yahoo Finance provider lacked the exchange code mapping to connect them.

Manually verified against Yahoo Finance endpoints:
- **Search**: `v1/finance/search?q=BBCA` returns `{ exchange: "JKT", symbol: "BBCA.JK", exchDisp: "Jakarta" }`
- **Chart**: `v8/finance/chart/BBCA.JK` returns price data with `currency: "IDR"`, `exchangeName: "JKT"`, `timezone: "WIB"`

Follows the same pattern as the existing India (XNSE/XBOM) and Colombia (XBOG) exchange mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Indonesian market data through Yahoo Finance.
  * Indonesian securities now use the `.JK` ticker suffix and IDR currency.
  * Jakarta and IDX exchanges are correctly identified as Indonesia.

* **Bug Fixes**
  * Prevented duplicate `.JK` suffixes on Indonesian ticker symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->