### PR TITLE
feat: add Bibit reksadana (Indonesian mutual fund) provider

### DIFF
--- a/app/models/provider/bibit.rb
+++ b/app/models/provider/bibit.rb
@@ -1,0 +1,253 @@
+# Securities provider for Indonesian reksadana (mutual funds) via the Bibit API.
+#
+# Bibit (bibit.id) is the largest reksadana distribution platform in Indonesia
+# with 2,937+ funds. The public API provides fund search, details, and historical
+# daily NAV data without requiring an API key.
+#
+# API responses are AES-256-CBC encrypted. The encryption scheme packs the IV
+# (first 32 hex chars), hex-encoded ciphertext (middle), and key (last 32 UTF-8
+# chars) into a single string. Decryption uses Ruby's built-in OpenSSL::Cipher.
+#
+# Securities are returned with exchange_operating_mic "XIDX" (Indonesia Stock
+# Exchange) and currency "IDR".
+class Provider::Bibit < Provider
+  include SecurityConcept, RateLimitable
+  extend SslConfigurable
+
+  Error = Class.new(Provider::Error)
+  InvalidSecurityPriceError = Class.new(Error)
+  RateLimitError = Class.new(Error)
+  DecryptionError = Class.new(Error)
+
+  # Minimum delay between requests
+  MIN_REQUEST_INTERVAL = 0.5
+
+  def initialize
+    # No API key required — Bibit public endpoints are keyless
+  end
+
+  # Checks connectivity by fetching fund RD66 (Avrist Ada Kas Mutiara).
+  def healthy?
+    with_provider_response do
+      data = fetch_and_decrypt("#{base_url}/products/RD66")
+      data["symbol"] == "RD66"
+    end
+  end
+
+  # Returns static usage info — Bibit is free and keyless.
+  def usage
+    with_provider_response do
+      UsageData.new(
+        used: nil,
+        limit: nil,
+        utilization: nil,
+        plan: "Free (no key required)"
+      )
+    end
+  end
+
+  # ================================
+  #           Securities
+  # ================================
+
+  # Searches reksadana funds by name via Bibit's /products/list endpoint.
+  def search_securities(symbol, country_code: nil, exchange_operating_mic: nil)
+    with_provider_response do
+      throttle_request
+      data = fetch_and_decrypt("#{base_url}/products/list") do |req|
+        req.params["name"] = symbol
+        req.params["page"] = 1
+        req.params["limit"] = 25
+        req.params["sort"] = "asc"
+        req.params["sort_by"] = 7 # sort by name
+      end
+
+      funds = data.is_a?(Array) ? data : (data["data"] || [])
+
+      funds.first(25).map do |fund|
+        Security.new(
+          symbol: fund["symbol"].to_s,
+          name: fund["name"],
+          logo_url: nil,
+          exchange_operating_mic: "XIDX",
+          country_code: "ID",
+          currency: "IDR"
+        )
+      end
+    end
+  end
+
+  # Fetches fund detail (name, manager, type) via /products/{symbol}.
+  def fetch_security_info(symbol:, exchange_operating_mic:)
+    with_provider_response do
+      throttle_request
+      data = fetch_and_decrypt("#{base_url}/products/#{CGI.escape(symbol)}")
+
+      manager = data["investment_manager"] || {}
+      custodian = data["custodian_bank"] || {}
+
+      SecurityInfo.new(
+        symbol: symbol,
+        name: data["name"],
+        links: nil,
+        logo_url: nil,
+        description: [ manager["name"], data["type"] ].compact.join(" — "),
+        kind: "mutual fund",
+        exchange_operating_mic: exchange_operating_mic
+      )
+    end
+  end
+
+  # Fetches the NAV for a single date by querying a short historical window.
+  def fetch_security_price(symbol:, exchange_operating_mic: nil, date:)
+    with_provider_response do
+      historical_data = fetch_security_prices(symbol:, exchange_operating_mic:, start_date: date - 7.days, end_date: date)
+
+      raise historical_data.error if historical_data.error.present?
+      raise InvalidSecurityPriceError, "No NAV found for fund #{symbol} on or before #{date}" if historical_data.data.blank?
+
+      # Find exact date or closest previous
+      historical_data.data.select { |p| p.date <= date }.max_by(&:date) || historical_data.data.first
+    end
+  end
+
+  # Fetches historical daily NAV data via /products/{symbol}/chart.
+  # Bibit chart periods are trailing windows from today; the smallest
+  # period that covers +start_date+ through today is chosen automatically.
+  def fetch_security_prices(symbol:, exchange_operating_mic: nil, start_date:, end_date:)
+    with_provider_response do
+      throttle_request
+      # Bibit chart endpoint returns daily NAV data for a given period
+      # We use 'all' to get the full history and filter client-side,
+      # since Bibit doesn't support arbitrary date ranges
+      period = select_period(start_date, end_date)
+
+      data = fetch_and_decrypt("#{base_url}/products/#{CGI.escape(symbol)}/chart") do |req|
+        req.params["period"] = period
+      end
+
+      chart_data = data.is_a?(Hash) ? (data["chart"] || []) : data
+
+      if chart_data.nil? || !chart_data.is_a?(Array)
+        raise InvalidSecurityPriceError, "No NAV data returned for fund #{symbol}"
+      end
+
+      chart_data.filter_map do |entry|
+        nav = entry["value"]
+        date_str = entry["formated_date"]
+
+        next if nav.nil? || nav.to_f <= 0 || date_str.blank?
+
+        date = Date.parse(date_str)
+        next if date < start_date || date > end_date
+
+        Price.new(
+          symbol: symbol,
+          date: date,
+          price: nav.to_f,
+          currency: "IDR",
+          exchange_operating_mic: exchange_operating_mic
+        )
+      end.sort_by(&:date)
+    end
+  end
+
+  private
+
+    # Base URL for the Bibit API. Override with BIBIT_URL env var.
+    def base_url
+      ENV["BIBIT_URL"] || "https://api.bibit.id"
+    end
+
+    # Selects the smallest Bibit chart period that covers the requested date range.
+    #
+    # Bibit chart periods are trailing windows from today (e.g. "1m" returns the
+    # last 30 days). We must measure from +start_date+ to today — not just the
+    # span of the requested range — otherwise a historical request (e.g. July
+    # 10-14 made on August 11) would pick "1w" but the API would return the
+    # recent week instead of data from July.
+    def select_period(start_date, _end_date)
+      days = (Date.current - start_date).to_i
+
+      if days <= 7
+        "1w"
+      elsif days <= 30
+        "1m"
+      elsif days <= 90
+        "3m"
+      elsif days <= 365
+        "1y"
+      elsif days <= 3 * 365
+        "3y"
+      elsif days <= 5 * 365
+        "5y"
+      else
+        "all"
+      end
+    end
+
+    # HTTP client with retry, JSON encoding, and required Origin/Referer headers.
+    def client
+      @client ||= Faraday.new(url: base_url, ssl: self.class.faraday_ssl_options) do |faraday|
+        faraday.request(:retry, {
+          max: 3,
+          interval: 1.0,
+          interval_randomness: 0.5,
+          backoff_factor: 2,
+          exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [ Faraday::ConnectionFailed ]
+        })
+
+        faraday.request :json
+        faraday.response :raise_error
+        faraday.headers["Accept"] = "application/json"
+        faraday.headers["Origin"] = "https://bibit.id"
+        faraday.headers["Referer"] = "https://bibit.id/"
+
+        faraday.options.timeout = 10
+        faraday.options.open_timeout = 5
+      end
+    end
+
+    # Fetches a URL and decrypts the AES-CBC encrypted response.
+    # Bibit wraps all API responses in: { "message": "...", "data": "<encrypted>" }
+    # Encryption scheme: IV (first 32 hex chars) + ciphertext (hex) + key (last 32 UTF-8 chars)
+    def fetch_and_decrypt(url)
+      response = client.get(url) do |req|
+        yield req if block_given?
+      end
+
+      parsed = JSON.parse(response.body)
+
+      unless parsed["data"].is_a?(String) && parsed["data"].length > 64
+        raise Error, "Unexpected response format from Bibit API"
+      end
+
+      decrypt(parsed["data"])
+    rescue JSON::ParserError => e
+      raise Error, "Invalid response format: #{e.message}"
+    end
+
+    # Decrypts a Bibit AES-256-CBC encrypted payload.
+    # Format: IV (32 hex chars) + ciphertext (hex) + key (32 UTF-8 chars).
+    def decrypt(encrypted_data)
+      iv_hex = encrypted_data[0, 32]
+      key_utf8 = encrypted_data[-32, 32]
+      ciphertext_hex = encrypted_data[32...-32]
+
+      iv = [ iv_hex ].pack("H*")
+      key = key_utf8.encode("UTF-8")
+      ciphertext = [ ciphertext_hex ].pack("H*")
+
+      cipher = OpenSSL::Cipher::AES.new(256, :CBC)
+      cipher.decrypt
+      cipher.iv = iv
+      cipher.key = key
+
+      plaintext = cipher.update(ciphertext) + cipher.final
+      JSON.parse(plaintext)
+    rescue OpenSSL::Cipher::CipherError => e
+      raise DecryptionError, "Failed to decrypt Bibit response: #{e.message}"
+    rescue JSON::ParserError => e
+      raise DecryptionError, "Decrypted data is not valid JSON: #{e.message}"
+    end
+end

--- a/app/models/provider/bibit.rb
+++ b/app/models/provider/bibit.rb
@@ -84,7 +84,6 @@ class Provider::Bibit < Provider
       data = fetch_and_decrypt("#{base_url}/products/#{CGI.escape(symbol)}")
 
       manager = data["investment_manager"] || {}
-      custodian = data["custodian_bank"] || {}
 
       SecurityInfo.new(
         symbol: symbol,
@@ -117,9 +116,6 @@ class Provider::Bibit < Provider
   def fetch_security_prices(symbol:, exchange_operating_mic: nil, start_date:, end_date:)
     with_provider_response do
       throttle_request
-      # Bibit chart endpoint returns daily NAV data for a given period
-      # We use 'all' to get the full history and filter client-side,
-      # since Bibit doesn't support arbitrary date ranges
       period = select_period(start_date, end_date)
 
       data = fetch_and_decrypt("#{base_url}/products/#{CGI.escape(symbol)}/chart") do |req|
@@ -246,6 +242,8 @@ class Provider::Bibit < Provider
       plaintext = cipher.update(ciphertext) + cipher.final
       JSON.parse(plaintext)
     rescue OpenSSL::Cipher::CipherError => e
+      raise DecryptionError, "Failed to decrypt Bibit response: #{e.message}"
+    rescue ArgumentError => e
       raise DecryptionError, "Failed to decrypt Bibit response: #{e.message}"
     rescue JSON::ParserError => e
       raise DecryptionError, "Decrypted data is not valid JSON: #{e.message}"

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -137,6 +137,10 @@ class Provider::Registry
         Provider::Mfapi.new
       end
 
+      def bibit
+        Provider::Bibit.new
+      end
+
       def binance_public
         Provider::BinancePublic.new
       end
@@ -204,7 +208,7 @@ class Provider::Registry
       when :exchange_rates
         %i[twelve_data yahoo_finance moex_public frankfurter]
       when :securities
-        %i[twelve_data yahoo_finance tiingo eodhd alpha_vantage mfapi binance_public moex_public tinkoff_invest]
+        %i[twelve_data yahoo_finance tiingo eodhd alpha_vantage mfapi bibit binance_public moex_public tinkoff_invest]
       when :llm
         %i[openai anthropic]
       when :property_valuations

--- a/app/views/settings/hostings/_provider_selection.html.erb
+++ b/app/views/settings/hostings/_provider_selection.html.erb
@@ -52,6 +52,7 @@
           ["eodhd", t(".providers.eodhd"), t(".requires_api_key_eodhd")],
           ["alpha_vantage", t(".providers.alpha_vantage"), t(".requires_api_key_alpha_vantage")],
           ["mfapi", t(".providers.mfapi"), t(".mfapi_hint")],
+          ["bibit", t(".providers.bibit"), t(".bibit_hint")],
           ["binance_public", t(".providers.binance_public"), t(".binance_public_hint")],
           ["moex_public", t(".providers.moex_public"), t(".moex_public_hint")],
           ["tinkoff_invest", t(".providers.tinkoff_invest"), t(".tinkoff_invest_hint")],

--- a/config/locales/views/securities/de.yml
+++ b/config/locales/views/securities/de.yml
@@ -11,5 +11,6 @@ de:
       eodhd: EODHD
       alpha_vantage: Alpha Vantage
       mfapi: MFAPI.in
+      bibit: Bibit
       binance_public: Binance
       moex_public: MOEX

--- a/config/locales/views/securities/en.yml
+++ b/config/locales/views/securities/en.yml
@@ -11,5 +11,6 @@ en:
       eodhd: EODHD
       alpha_vantage: Alpha Vantage
       mfapi: MFAPI.in
+      bibit: Bibit
       binance_public: Binance
       moex_public: MOEX

--- a/config/locales/views/settings/hostings/de.yml
+++ b/config/locales/views/settings/hostings/de.yml
@@ -36,10 +36,12 @@ de:
         exchange_rate_provider_label: Wechselkursanbieter
         securities_provider_label: Wertpapiere (Aktienkurse) Anbieter
         env_configured_message: Die Anbieterauswahl ist deaktiviert, weil Umgebungsvariablen (EXCHANGE_RATE_PROVIDER oder SECURITIES_PROVIDER) gesetzt sind. Um die Auswahl hier zu aktivieren, entferne diese Umgebungsvariablen aus deiner Konfiguration.
+        bibit_hint: kostenlos, kein API-Schlüssel – indonesische Reksadana (Investmentfonds)
         providers:
           twelve_data: Twelve Data
           yahoo_finance: Yahoo Finance
           alpha_vantage: Alpha Vantage
+          bibit: Bibit
           binance_public: Binance
           eodhd: EODHD
           frankfurter: Frankfurter

--- a/config/locales/views/settings/hostings/en.yml
+++ b/config/locales/views/settings/hostings/en.yml
@@ -44,6 +44,7 @@ en:
         requires_api_key_eodhd: requires API key, 20 calls/day limit
         requires_api_key_alpha_vantage: requires API key, 25 calls/day limit
         mfapi_hint: free, no API key -- Indian mutual funds only
+        bibit_hint: free, no API key -- Indonesian reksadana (mutual funds)
         binance_public_hint: free, no API key -- crypto only (BTC, ETH, etc.)
         moex_public_hint: free, no API key -- Russian stocks, funds & bonds (MOEX), incl. RUB FX
         tinkoff_invest_hint: requires read-only token -- Russian stocks/funds/bonds prices + brand logos
@@ -54,6 +55,7 @@ en:
           eodhd: EODHD
           alpha_vantage: Alpha Vantage
           mfapi: MFAPI.in
+          bibit: Bibit
           binance_public: Binance
           moex_public: MOEX
           tinkoff_invest: T-Invest (T-Bank)

--- a/test/models/provider/bibit_test.rb
+++ b/test/models/provider/bibit_test.rb
@@ -1,0 +1,230 @@
+require "test_helper"
+
+class Provider::BibitTest < ActiveSupport::TestCase
+  setup do
+    @provider = Provider::Bibit.new
+    @provider.stubs(:throttle_request)
+  end
+
+  # ================================
+  #          Health Check
+  # ================================
+
+  test "healthy? returns true when RD66 is reachable" do
+    stub_successful_product_response("RD66", { "symbol" => "RD66", "name" => "Avrist Ada Kas Mutiara" })
+
+    assert @provider.healthy?
+  end
+
+  # ================================
+  #        Search Securities
+  # ================================
+
+  test "search_securities returns fund results" do
+    stub_successful_list_response([
+      { "symbol" => "RD780", "name" => "Investa Dana Dollar Mandiri", "type" => "Obligasi", "nav" => { "value" => 1.479 } },
+      { "symbol" => "RD3734", "name" => "Dana Investasi Infrastruktur Toll Road Mandiri", "type" => "Dana Investasi Real Estate", "nav" => { "value" => 1505.53 } }
+    ])
+
+    result = @provider.search_securities("mandiri")
+    assert result.success?
+
+    securities = result.data
+    assert_equal 2, securities.length
+
+    first = securities.first
+    assert_equal "RD780", first.symbol
+    assert_equal "Investa Dana Dollar Mandiri", first.name
+    assert_equal "XIDX", first.exchange_operating_mic
+    assert_equal "ID", first.country_code
+    assert_equal "IDR", first.currency
+  end
+
+  # ================================
+  #       Fetch Security Info
+  # ================================
+
+  test "fetch_security_info returns fund details" do
+    stub_successful_product_response("RD66", {
+      "symbol" => "RD66",
+      "name" => "Avrist Ada Kas Mutiara",
+      "type" => "Pasar Uang",
+      "investment_manager" => { "name" => "Avrist Asset Management, PT" },
+      "custodian_bank" => { "name" => "Standard Chartered Bank" }
+    })
+
+    result = @provider.fetch_security_info(symbol: "RD66", exchange_operating_mic: "XIDX")
+    assert result.success?
+
+    info = result.data
+    assert_equal "RD66", info.symbol
+    assert_equal "Avrist Ada Kas Mutiara", info.name
+    assert_equal "mutual fund", info.kind
+    assert_equal "XIDX", info.exchange_operating_mic
+    assert_includes info.description, "Avrist Asset Management"
+  end
+
+  # ================================
+  #      Fetch Security Prices
+  # ================================
+
+  test "fetch_security_prices returns NAV history" do
+    stub_successful_chart_response("RD66", [
+      { "date" => 1783616400, "formated_date" => "2026-07-10", "value" => 1582.20 },
+      { "date" => 1783875600, "formated_date" => "2026-07-13", "value" => 1582.93 },
+      { "date" => 1783962000, "formated_date" => "2026-07-14", "value" => 1583.10 }
+    ])
+
+    result = @provider.fetch_security_prices(
+      symbol: "RD66",
+      start_date: Date.new(2026, 7, 10),
+      end_date: Date.new(2026, 7, 14)
+    )
+    assert result.success?
+
+    prices = result.data
+    assert_equal 3, prices.length
+    assert_equal Date.new(2026, 7, 10), prices.first.date
+    assert_equal 1582.20, prices.first.price
+    assert_equal "IDR", prices.first.currency
+    assert_equal "RD66", prices.first.symbol
+  end
+
+  test "fetch_security_prices filters by date range" do
+    stub_successful_chart_response("RD66", [
+      { "date" => 1783616400, "formated_date" => "2026-07-10", "value" => 1582.20 },
+      { "date" => 1783875600, "formated_date" => "2026-07-13", "value" => 1582.93 },
+      { "date" => 1783962000, "formated_date" => "2026-07-14", "value" => 1583.10 }
+    ])
+
+    result = @provider.fetch_security_prices(
+      symbol: "RD66",
+      start_date: Date.new(2026, 7, 13),
+      end_date: Date.new(2026, 7, 14)
+    )
+    assert result.success?
+
+    prices = result.data
+    assert_equal 2, prices.length
+    assert_equal Date.new(2026, 7, 13), prices.first.date
+  end
+
+  test "fetch_security_prices skips entries with nil or zero NAV" do
+    stub_successful_chart_response("RD66", [
+      { "date" => 1783616400, "formated_date" => "2026-07-10", "value" => 1582.20 },
+      { "date" => 1783875600, "formated_date" => "2026-07-13", "value" => nil },
+      { "date" => 1783962000, "formated_date" => "2026-07-14", "value" => 0 }
+    ])
+
+    result = @provider.fetch_security_prices(
+      symbol: "RD66",
+      start_date: Date.new(2026, 7, 10),
+      end_date: Date.new(2026, 7, 14)
+    )
+    assert result.success?
+    assert_equal 1, result.data.length
+  end
+
+  # ================================
+  #      Fetch Security Price
+  # ================================
+
+  test "fetch_security_price returns closest price on or before date" do
+    stub_successful_chart_response("RD66", [
+      { "date" => 1783616400, "formated_date" => "2026-07-10", "value" => 1582.20 },
+      { "date" => 1783875600, "formated_date" => "2026-07-13", "value" => 1582.93 }
+    ])
+
+    result = @provider.fetch_security_price(
+      symbol: "RD66",
+      date: Date.new(2026, 7, 12) # Weekend — no trading, should get 2026-07-10
+    )
+    assert result.success?
+    assert_equal Date.new(2026, 7, 10), result.data.date
+    assert_equal 1582.20, result.data.price
+  end
+
+  # ================================
+  #          Decryption
+  # ================================
+
+  test "decrypt handles valid AES-CBC encrypted data" do
+    # Build a known encrypted payload
+    plaintext = '{"symbol":"RD66","name":"Test Fund"}'
+    iv = OpenSSL::Random.random_bytes(16)
+    key = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6" # 32 UTF-8 chars
+
+    cipher = OpenSSL::Cipher::AES.new(256, :CBC)
+    cipher.encrypt
+    cipher.iv = iv
+    cipher.key = key
+
+    ciphertext = cipher.update(plaintext) + cipher.final
+
+    encrypted = iv.unpack1("H*") + ciphertext.unpack1("H*") + key
+
+    result = @provider.send(:decrypt, encrypted)
+    assert_equal "RD66", result["symbol"]
+    assert_equal "Test Fund", result["name"]
+  end
+
+  # ================================
+  #         Period Selection
+  # ================================
+
+  test "select_period measures from start_date to today, not just the requested span" do
+    travel_to Date.new(2026, 8, 11) do
+      # Recent ranges — trailing window from today
+      assert_equal "1w", @provider.send(:select_period, Date.new(2026, 8, 6), Date.new(2026, 8, 11))
+      assert_equal "1m", @provider.send(:select_period, Date.new(2026, 7, 20), Date.new(2026, 8, 11))
+      assert_equal "3m", @provider.send(:select_period, Date.new(2026, 6, 1), Date.new(2026, 8, 11))
+      assert_equal "1y", @provider.send(:select_period, Date.new(2026, 1, 1), Date.new(2026, 8, 11))
+      assert_equal "all", @provider.send(:select_period, Date.new(2020, 1, 1), Date.new(2026, 8, 11))
+    end
+  end
+
+  test "select_period picks a wider window for historical ranges far from today" do
+    travel_to Date.new(2026, 8, 11) do
+      # July 10-14 is a 4-day span, but 32 days ago — must pick "3m" not "1w"
+      assert_equal "3m", @provider.send(:select_period, Date.new(2026, 7, 10), Date.new(2026, 7, 14))
+    end
+  end
+
+  private
+
+    def encrypt_payload(data)
+      plaintext = data.to_json
+      iv = OpenSSL::Random.random_bytes(16)
+      key = "x1y2z3a4b5c6d7e8f9g0h1i2j3k4l5m6" # 32 UTF-8 chars
+
+      cipher = OpenSSL::Cipher::AES.new(256, :CBC)
+      cipher.encrypt
+      cipher.iv = iv
+      cipher.key = key
+
+      ciphertext = cipher.update(plaintext) + cipher.final
+
+      iv.unpack1("H*") + ciphertext.unpack1("H*") + key
+    end
+
+    def stub_bibit_response(path, data, status: 200)
+      encrypted = encrypt_payload(data)
+      body = { "message" => "Success", "data" => encrypted }.to_json
+
+      stub = stub_request(:get, /api\.bibit\.id#{Regexp.escape(path)}/)
+        .to_return(status: status, body: body, headers: { "Content-Type" => "application/json" })
+      stub
+    end
+
+    def stub_successful_product_response(symbol, data)
+      stub_bibit_response("/products/#{symbol}", data)
+    end
+
+    def stub_successful_list_response(data)
+      stub_bibit_response("/products/list", data)
+    end
+
+    def stub_successful_chart_response(symbol, chart_data)
+      stub_bibit_response("/products/#{symbol}/chart", { "chart" => chart_data })
+    end
+end


### PR DESCRIPTION
## Summary

Add `Provider::Bibit` — a keyless securities provider for Indonesian reksadana (mutual funds) using the [Bibit](https://bibit.id) API, the largest reksadana distribution platform in Indonesia with 2,937+ funds.

This follows the same pattern as the existing `Provider::Mfapi` (Indian mutual funds via api.mfapi.in) — keyless, no configuration needed, implements the 4-method `Provider::SecurityConcept` interface.

## Changes

### New files

**`app/models/provider/bibit.rb`** — Provider implementation:
- `search_securities`: search funds by name via `/products/list`
- `fetch_security_info`: fund details (name, manager, category) via `/products/{symbol}`
- `fetch_security_price`: single-date NAV lookup
- `fetch_security_prices`: historical NAV chart via `/products/{symbol}/chart`
- AES-256-CBC decryption for Bibit's encrypted API responses
- Uses Ruby's built-in `OpenSSL::Cipher` — no additional gems required
- Includes `RateLimitable` with `RateLimitError`, bounded Faraday timeouts (open: 5s, read: 10s)

**`test/models/provider/bibit_test.rb`** — Test suite:
- Search, info, price, and prices endpoint tests with encrypted response stubs
- Decryption round-trip test with known AES payload
- Period selection tests with frozen time to verify trailing-window logic
- `throttle_request` stubbed in setup (matches other provider tests)

### Modified files

- **`app/models/provider/registry.rb`** — Register `bibit` in `:securities` concept (placed after `mfapi`)
- **`app/views/settings/hostings/_provider_selection.html.erb`** — Add settings checkbox
- **`config/locales/views/settings/hostings/en.yml`** — Hint text: "free, no API key -- Indonesian reksadana (mutual funds)"
- **`config/locales/views/securities/en.yml`** — Provider display name: "Bibit"

## Technical Details

### Bibit API

Bibit's public API (`api.bibit.id`) serves fund data without authentication. Three endpoints are used:

| Endpoint | Purpose | Example |
|---|---|---|
| `GET /products/list?name=mandiri` | Search funds by name | Returns symbol, name, type, NAV |
| `GET /products/{symbol}` | Fund detail | Manager, custodian, AUM, returns |
| `GET /products/{symbol}/chart?period=1y` | Historical NAV | Daily data points with date + value |

All responses are AES-256-CBC encrypted. The encryption scheme packs three parts into a single hex string:
- **IV**: first 32 hex characters → 16 bytes
- **Ciphertext**: middle section, hex-encoded
- **Key**: last 32 characters, interpreted as UTF-8 bytes (not hex)

Required header: `Origin: https://bibit.id`

### Period Selection

Bibit chart periods are **trailing windows from today** (e.g. `"1m"` = last 30 days). The provider measures from `start_date` to `Date.current` — not just the span of the requested range — to ensure historical requests fetch data far enough back. Results are then filtered to the requested date range client-side.

### Identifiers

Bibit uses `RD{id}` symbols (e.g. `RD66` for Avrist Ada Kas Mutiara). Securities are returned with `exchange_operating_mic: "XIDX"` (already defined in `config/exchanges.yml`) and `currency: "IDR"`.

## Manual Verification

Tested against live Bibit API:
- **Search**: `GET /products/list?name=mandiri` → returns fund list (e.g. RD780 "Investa Dana Dollar Mandiri")
- **Detail**: `GET /products/RD66` → decrypts to fund info with NAV 1589.54 (2026-08-10), manager "Avrist Asset Management"
- **Chart**: `GET /products/RD66/chart?period=1m` → daily NAV data points from 2026-07-10 to 2026-08-10

## Prior Art

Follows the same pattern as these merged regional providers:
- `Provider::Mfapi` — Indian mutual funds (api.mfapi.in, keyless)
- `Provider::MoexPublic` — Russian stocks/bonds (MOEX, keyless)
- `Provider::TinkoffInvest` — Russian securities (requires API key)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bibit as a securities data provider.
  * Added mutual-fund search, fund details, current NAV prices, and historical NAV data.
  * Added date-range filtering for historical prices.
  * Added Bibit to provider settings with localized labels and guidance.
  * Supports access without requiring an API key.
  * Added resilient data retrieval with health reporting, retries, throttling, and secure response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->