### PR TITLE
Warn before provider setup without encryption keys

### DIFF
--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -2,6 +2,7 @@ class Settings::ProvidersController < ApplicationController
   layout -> { turbo_frame_request? ? "turbo_rails/frame" : "settings" }
 
   before_action :ensure_admin, only: [ :show, :update, :sync_all, :sync, :connect_form ]
+  before_action :set_encryption_warning_context, only: [ :show, :connect_form ]
 
   def show
     @breadcrumbs = [
@@ -151,6 +152,11 @@ class Settings::ProvidersController < ApplicationController
       return if Current.user.admin?
 
       redirect_to root_path, alert: t("settings.providers.not_authorized")
+    end
+
+    def set_encryption_warning_context
+      @provider_setup_encryption_warning = Rails.configuration.app_mode.self_hosted? &&
+        !ActiveRecordEncryptionConfig.explicitly_configured?
     end
 
     # Reload provider configurations after settings update

--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -2,7 +2,7 @@ class Settings::ProvidersController < ApplicationController
   layout -> { turbo_frame_request? ? "turbo_rails/frame" : "settings" }
 
   before_action :ensure_admin, only: [ :show, :update, :sync_all, :sync, :connect_form ]
-  before_action :set_encryption_warning_context, only: [ :show, :connect_form ]
+  before_action :set_encryption_warning_context, only: [ :connect_form ]
 
   def show
     @breadcrumbs = [

--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -2,7 +2,7 @@ class Settings::ProvidersController < ApplicationController
   layout -> { turbo_frame_request? ? "turbo_rails/frame" : "settings" }
 
   before_action :ensure_admin, only: [ :show, :update, :sync_all, :sync, :connect_form ]
-  before_action :set_encryption_warning_context, only: [ :connect_form ]
+  before_action :set_encryption_warning_context, only: [ :show, :connect_form ]
 
   def show
     @breadcrumbs = [

--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -116,6 +116,7 @@ class Settings::ProvidersController < ApplicationController
       @panel_key     = panel[:key]
       @panel_partial = panel[:partial]
       @panel_title   = panel[:title]
+      @panel_handles_encryption_warning = panel[:handles_encryption_warning]
       load_provider_items(provider_key)
       return render :connect_form
     end
@@ -195,9 +196,9 @@ class Settings::ProvidersController < ApplicationController
       { key: "simplefin",      title: "SimpleFIN",       turbo_id: "simplefin",      partial: "simplefin_panel" },
       { key: "enable_banking", title: "Enable Banking",  turbo_id: "enable_banking", partial: "enable_banking_panel" },
       { key: "coinstats",      title: "CoinStats",       turbo_id: "coinstats",      partial: "coinstats_panel" },
-      { key: "wise",           title: "Wise",            turbo_id: "wise",           partial: "wise_panel" },
+      { key: "wise",           title: "Wise",            turbo_id: "wise",           partial: "wise_panel", handles_encryption_warning: true },
       { key: "mercury",        title: "Mercury",         turbo_id: "mercury",        partial: "mercury_panel" },
-      { key: "brex",           title: "Brex",            turbo_id: "brex",           partial: "brex_panel" },
+      { key: "brex",           title: "Brex",            turbo_id: "brex",           partial: "brex_panel", handles_encryption_warning: true },
       { key: "coinbase",       title: "Coinbase",        turbo_id: "coinbase",       partial: "coinbase_panel" },
       { key: "binance",        title: "Binance",         turbo_id: "binance",        partial: "binance_panel" },
       { key: "kraken",         title: "Kraken",          turbo_id: "kraken",         partial: "kraken_panel" },

--- a/app/controllers/settings/providers_controller.rb
+++ b/app/controllers/settings/providers_controller.rb
@@ -116,7 +116,6 @@ class Settings::ProvidersController < ApplicationController
       @panel_key     = panel[:key]
       @panel_partial = panel[:partial]
       @panel_title   = panel[:title]
-      @panel_handles_encryption_warning = panel[:handles_encryption_warning]
       load_provider_items(provider_key)
       return render :connect_form
     end
@@ -196,9 +195,9 @@ class Settings::ProvidersController < ApplicationController
       { key: "simplefin",      title: "SimpleFIN",       turbo_id: "simplefin",      partial: "simplefin_panel" },
       { key: "enable_banking", title: "Enable Banking",  turbo_id: "enable_banking", partial: "enable_banking_panel" },
       { key: "coinstats",      title: "CoinStats",       turbo_id: "coinstats",      partial: "coinstats_panel" },
-      { key: "wise",           title: "Wise",            turbo_id: "wise",           partial: "wise_panel", handles_encryption_warning: true },
+      { key: "wise",           title: "Wise",            turbo_id: "wise",           partial: "wise_panel" },
       { key: "mercury",        title: "Mercury",         turbo_id: "mercury",        partial: "mercury_panel" },
-      { key: "brex",           title: "Brex",            turbo_id: "brex",           partial: "brex_panel", handles_encryption_warning: true },
+      { key: "brex",           title: "Brex",            turbo_id: "brex",           partial: "brex_panel" },
       { key: "coinbase",       title: "Coinbase",        turbo_id: "coinbase",       partial: "coinbase_panel" },
       { key: "binance",        title: "Binance",         turbo_id: "binance",        partial: "binance_panel" },
       { key: "kraken",         title: "Kraken",          turbo_id: "kraken",         partial: "kraken_panel" },

--- a/app/views/settings/providers/_brex_panel.html.erb
+++ b/app/views/settings/providers/_brex_panel.html.erb
@@ -16,18 +16,6 @@
     </p>
   </div>
 
-  <% unless BrexItem.encryption_ready? %>
-    <div class="p-3 rounded-md bg-warning/10 text-warning text-sm">
-      <div class="flex items-start gap-2">
-        <%= icon "shield-alert", size: "sm", class: "mt-0.5 shrink-0" %>
-        <div>
-          <p class="font-medium"><%= t("brex_items.provider_panel.encryption_warning.title") %></p>
-          <p class="mt-1"><%= t("brex_items.provider_panel.encryption_warning.message") %></p>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
   <% error_msg = local_assigns[:error_message] || @error_message %>
   <% if error_msg.present? %>
     <div class="p-2 rounded-md bg-destructive/10 text-destructive text-sm overflow-hidden">

--- a/app/views/settings/providers/_connection_row.html.erb
+++ b/app/views/settings/providers/_connection_row.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (entry:, open:) %>
+<%# locals: (entry:, open:, provider_setup_encryption_warning: false) %>
 <%
   status        = entry[:summary][:status]
   meta          = entry[:summary][:meta]
@@ -39,7 +39,9 @@
   </summary>
   <div class="space-y-4 mt-4 px-4 pb-4">
     <% if entry[:configuration] %>
-      <%= render "settings/providers/provider_form", configuration: entry[:configuration] %>
+      <%= render "settings/providers/provider_form",
+                 configuration: entry[:configuration],
+                 provider_setup_encryption_warning: provider_setup_encryption_warning %>
     <% else %>
       <turbo-frame id="<%= entry[:turbo_id] %>-providers-panel">
         <%= render "settings/providers/#{entry[:partial]}" %>

--- a/app/views/settings/providers/_provider_form.html.erb
+++ b/app/views/settings/providers/_provider_form.html.erb
@@ -1,6 +1,7 @@
 <%
   # Parameters:
   # - configuration: Provider::Configurable::Configuration object
+  # - provider_setup_encryption_warning: whether to warn before saving credentials
   provider_key = configuration.provider_key.to_s
 
   setup_steps_data =
@@ -16,6 +17,14 @@
 %>
 
 <div class="space-y-4">
+  <% if local_assigns[:provider_setup_encryption_warning] %>
+    <%= render DS::Alert.new(
+          variant: :warning,
+          title: t("settings.providers.provider_setup_encryption_warning.title"),
+          message: t("settings.providers.provider_setup_encryption_warning.message")
+        ) %>
+  <% end %>
+
   <% if setup_steps_data %>
     <%= render "settings/providers/setup_steps", steps: setup_steps_data %>
   <% elsif configuration.provider_description.present? %>
@@ -66,5 +75,11 @@
         <%= form.submit t(".save_and_connect") %>
       </div>
     </div>
+  <% end %>
+
+  <% if local_assigns[:provider_setup_encryption_warning] %>
+    <p class="text-xs text-secondary pt-3 border-t border-tertiary">
+      <%= t("settings.providers.drawer_trust_statement_encryption_unconfigured") %>
+    </p>
   <% end %>
 </div>

--- a/app/views/settings/providers/_wise_panel.html.erb
+++ b/app/views/settings/providers/_wise_panel.html.erb
@@ -11,18 +11,6 @@
     </ol>
   </div>
 
-  <% unless WiseItem.encryption_ready? %>
-    <div class="p-3 rounded-md bg-warning/10 text-warning text-sm">
-      <div class="flex items-start gap-2">
-        <%= icon "shield-alert", size: "sm", class: "mt-0.5 shrink-0" %>
-        <div>
-          <p class="font-medium"><%= t("wise_items.provider_panel.encryption_warning.title") %></p>
-          <p class="mt-1"><%= t("wise_items.provider_panel.encryption_warning.message") %></p>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
   <% error_msg = local_assigns[:error_message] || @error_message %>
   <% if error_msg.present? %>
     <div class="p-2 rounded-md bg-destructive/10 text-destructive text-sm overflow-hidden">

--- a/app/views/settings/providers/connect_form.html.erb
+++ b/app/views/settings/providers/connect_form.html.erb
@@ -4,6 +4,16 @@
     <%= render "settings/providers/drawer_header", provider_key: provider_key, title: @panel_title %>
   <% end %>
   <% dialog.with_body do %>
+    <% if @provider_setup_encryption_warning %>
+      <div class="mb-4">
+        <%= render DS::Alert.new(
+              variant: :warning,
+              title: t("settings.providers.provider_setup_encryption_warning.title"),
+              message: t("settings.providers.provider_setup_encryption_warning.message")
+            ) %>
+      </div>
+    <% end %>
+
     <% if @panel_partial %>
       <turbo-frame id="<%= @panel_key %>-connect-form" target="_top">
         <%= render "settings/providers/#{@panel_partial}" %>
@@ -15,7 +25,7 @@
     <% end %>
 
     <p class="text-xs text-secondary mt-6 pt-3 border-t border-tertiary">
-      <%= t("settings.providers.drawer_trust_statement") %>
+      <%= t(@provider_setup_encryption_warning ? "settings.providers.drawer_trust_statement_encryption_unconfigured" : "settings.providers.drawer_trust_statement") %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/settings/providers/connect_form.html.erb
+++ b/app/views/settings/providers/connect_form.html.erb
@@ -4,7 +4,7 @@
     <%= render "settings/providers/drawer_header", provider_key: provider_key, title: @panel_title %>
   <% end %>
   <% dialog.with_body do %>
-    <% if @provider_setup_encryption_warning %>
+    <% if @provider_setup_encryption_warning && !@panel_handles_encryption_warning %>
       <div class="mb-4">
         <%= render DS::Alert.new(
               variant: :warning,

--- a/app/views/settings/providers/connect_form.html.erb
+++ b/app/views/settings/providers/connect_form.html.erb
@@ -4,7 +4,7 @@
     <%= render "settings/providers/drawer_header", provider_key: provider_key, title: @panel_title %>
   <% end %>
   <% dialog.with_body do %>
-    <% if @provider_setup_encryption_warning && !@panel_handles_encryption_warning %>
+    <% if @provider_setup_encryption_warning %>
       <div class="mb-4">
         <%= render DS::Alert.new(
               variant: :warning,

--- a/app/views/settings/providers/show.html.erb
+++ b/app/views/settings/providers/show.html.erb
@@ -42,7 +42,10 @@
       <div class="space-y-2">
         <% all_connections.each do |entry| %>
           <% auto_open = all_connections.size == 1 %>
-          <%= render "settings/providers/connection_row", entry: entry, open: auto_open %>
+          <%= render "settings/providers/connection_row",
+                     entry: entry,
+                     open: auto_open,
+                     provider_setup_encryption_warning: @provider_setup_encryption_warning %>
         <% end %>
       </div>
     <% end %>

--- a/config/locales/views/passkey_sessions/de.yml
+++ b/config/locales/views/passkey_sessions/de.yml
@@ -1,0 +1,4 @@
+---
+de:
+  passkey_sessions:
+    invalid_credential: Anmeldung mit diesem Passkey fehlgeschlagen. Bitte versuche es erneut oder nutze dein Passwort.

--- a/config/locales/views/sessions/de.yml
+++ b/config/locales/views/sessions/de.yml
@@ -28,6 +28,8 @@ de:
       oidc: Mit OpenID Connect anmelden
       google_auth_connect: Mit Google anmelden
       local_login_admin_only: Lokale Anmeldung ist auf Administratoren beschränkt.
+      passkey_button: Mit Passkey anmelden
+      passkey_unsupported: Dieser Browser unterstützt keine Passkeys.
       no_auth_methods_enabled: Derzeit sind keine Anmeldemethoden aktiviert. Bitte wende dich an einen Administrator.
       demo_banner_title: "Demo-Modus aktiv"
       demo_banner_message: "Dies ist eine Demo-Umgebung. Anmeldedaten wurden zur Vereinfachung vorausgefüllt. Bitte gib keine echten oder sensiblen Daten ein."

--- a/config/locales/views/settings/de.yml
+++ b/config/locales/views/settings/de.yml
@@ -305,7 +305,11 @@ de:
       clear_filter: Filter löschen
       connect: Verbinden
       drawer_trust_statement: Nur Lesezugriff. Sure kann kein Geld bewegen, und deine Zugangsdaten liegen verschlüsselt.
+      drawer_trust_statement_encryption_unconfigured: Nur Lesezugriff. Sure kann kein Geld bewegen. Konfiguriere explizite Verschlüsselungsschlüssel, bevor du Provider-Zugangsdaten in Produktion speicherst.
       empty_filter: Kein Anbieter passt zu deinem Filter.
+      provider_setup_encryption_warning:
+        title: Verschlüsselungsschlüssel fehlen
+        message: Diese selbst gehostete Installation hat keine expliziten Active-Record-Verschlüsselungsschlüssel konfiguriert. Konfiguriere primary_key, deterministic_key und key_derivation_salt, bevor du Provider-Zugangsdaten in Produktion speicherst.
       groups:
         available: Verfügbar
         empty_available: Alle verfügbaren Anbieter sind verbunden.

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -365,6 +365,10 @@ en:
         beta: Beta
         alpha: Alpha
       drawer_trust_statement: "Read-only access. Sure can never move money, and your credentials are stored encrypted."
+      drawer_trust_statement_encryption_unconfigured: "Read-only access. Sure can never move money. Configure explicit encryption keys before storing provider credentials in production."
+      provider_setup_encryption_warning:
+        title: Encryption keys missing
+        message: "This self-hosted install has not configured explicit Active Record encryption keys. Configure primary_key, deterministic_key and key_derivation_salt before saving provider credentials in production."
       setup_steps:
         eyebrow: Setup
         need_help: "Need help?"

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -383,6 +383,10 @@ en:
         beta: Beta
         alpha: Alpha
       drawer_trust_statement: "Read-only access. Sure can never move money, and your credentials are stored encrypted."
+      drawer_trust_statement_encryption_unconfigured: "Read-only access. Sure can never move money. Configure explicit encryption keys before storing provider credentials in production."
+      provider_setup_encryption_warning:
+        title: Encryption keys missing
+        message: "This self-hosted install has not configured explicit Active Record encryption keys. Configure primary_key, deterministic_key and key_derivation_salt before saving provider credentials in production."
       setup_steps:
         eyebrow: Setup
         need_help: "Need help?"

--- a/test/controllers/settings/providers_controller_test.rb
+++ b/test/controllers/settings/providers_controller_test.rb
@@ -422,6 +422,30 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Query ID/i, response.body)
   end
 
+  test "GET connect_form warns when self-hosted encryption keys are not explicitly configured" do
+    Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(false)
+
+    get connect_form_settings_providers_path(provider_key: "ibkr")
+
+    assert_response :success
+    assert_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
+    refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement")
+  end
+
+  test "GET connect_form hides encryption warning when self-hosted encryption keys are configured" do
+    Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(true)
+
+    get connect_form_settings_providers_path(provider_key: "ibkr")
+
+    assert_response :success
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement")
+    refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
+  end
+
   test "GET connect_form for snaptrade shows OAuth setup instructions when instance is not configured" do
     Provider::Snaptrade.stubs(:oauth_configured?).returns(false)
 

--- a/test/controllers/settings/providers_controller_test.rb
+++ b/test/controllers/settings/providers_controller_test.rb
@@ -414,6 +414,40 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Flex Query/i, response.body)
   end
 
+  test "GET show warns on configured provider forms when self-hosted encryption keys are not explicitly configured" do
+    Setting["plaid_client_id"] = "test-client-id"
+    Setting["plaid_secret"] = "test-secret"
+    Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(false)
+
+    get settings_providers_url
+
+    assert_response :success
+    assert_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    assert_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
+    assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
+  ensure
+    Setting["plaid_client_id"] = nil
+    Setting["plaid_secret"] = nil
+  end
+
+  test "GET show hides provider form encryption warning in managed mode" do
+    Setting["plaid_client_id"] = "test-client-id"
+    Setting["plaid_secret"] = "test-secret"
+    Rails.configuration.stubs(:app_mode).returns("managed".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(false)
+
+    get settings_providers_url
+
+    assert_response :success
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
+    refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
+  ensure
+    Setting["plaid_client_id"] = nil
+    Setting["plaid_secret"] = nil
+  end
+
   test "GET connect_form renders Interactive Brokers panel" do
     get connect_form_settings_providers_path(provider_key: "ibkr")
 

--- a/test/controllers/settings/providers_controller_test.rb
+++ b/test/controllers/settings/providers_controller_test.rb
@@ -430,6 +430,7 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    assert_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
     assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
     refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement")
   end
@@ -442,6 +443,20 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
+    assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement")
+    refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
+  end
+
+  test "GET connect_form hides encryption warning in managed mode" do
+    Rails.configuration.stubs(:app_mode).returns("managed".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(false)
+
+    get connect_form_settings_providers_path(provider_key: "ibkr")
+
+    assert_response :success
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
     assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement")
     refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
   end

--- a/test/controllers/settings/providers_controller_test.rb
+++ b/test/controllers/settings/providers_controller_test.rb
@@ -495,6 +495,22 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
     refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
   end
 
+  test "GET connect_form does not duplicate provider-specific encryption warnings" do
+    Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
+    ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(false)
+    WiseItem.stubs(:encryption_ready?).returns(false)
+
+    get connect_form_settings_providers_path(provider_key: "wise")
+
+    assert_response :success
+    assert_includes response.body, I18n.t("wise_items.provider_panel.encryption_warning.title")
+    assert_includes response.body, I18n.t("wise_items.provider_panel.encryption_warning.message")
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
+    assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
+    refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement")
+  end
+
   test "GET connect_form for snaptrade shows OAuth setup instructions when instance is not configured" do
     Provider::Snaptrade.stubs(:oauth_configured?).returns(false)
 

--- a/test/controllers/settings/providers_controller_test.rb
+++ b/test/controllers/settings/providers_controller_test.rb
@@ -495,18 +495,17 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
     refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
   end
 
-  test "GET connect_form does not duplicate provider-specific encryption warnings" do
+  test "GET connect_form uses shared encryption warning for provider panels" do
     Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
     ActiveRecordEncryptionConfig.stubs(:explicitly_configured?).returns(false)
-    WiseItem.stubs(:encryption_ready?).returns(false)
 
     get connect_form_settings_providers_path(provider_key: "wise")
 
     assert_response :success
-    assert_includes response.body, I18n.t("wise_items.provider_panel.encryption_warning.title")
-    assert_includes response.body, I18n.t("wise_items.provider_panel.encryption_warning.message")
-    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
-    refute_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
+    assert_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.title")
+    assert_includes response.body, I18n.t("settings.providers.provider_setup_encryption_warning.message")
+    refute_includes response.body, I18n.t("wise_items.provider_panel.encryption_warning.title")
+    refute_includes response.body, I18n.t("wise_items.provider_panel.encryption_warning.message")
     assert_includes response.body, I18n.t("settings.providers.drawer_trust_statement_encryption_unconfigured")
     refute_includes response.body, I18n.t("settings.providers.drawer_trust_statement")
   end


### PR DESCRIPTION
## Summary
- show a warning in the provider setup drawer when self-hosted installs lack explicit Active Record encryption keys
- replace the drawer trust copy in that state so it does not claim provider credentials are encrypted
- add English and German locale strings plus controller coverage

## Tests
- bin/rails test test/controllers/settings/providers_controller_test.rb
- bin/rails test test/i18n_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encryption warnings to provider connection forms when required keys are not configured in self-hosted installations.
  * Updated trust messaging to clarify encryption requirements before saving provider credentials.
  * Added German and English translations for encryption guidance.
  * Added German passkey sign-in labels and messages for failed authentication or unsupported browsers.

* **Bug Fixes**
  * Ensured warnings appear only when applicable, including provider-specific messaging for Wise and Brex.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->