### PR TITLE
fix(wise): add missing sync button to Wise account group header

### DIFF
--- a/app/views/wise_items/_wise_item.html.erb
+++ b/app/views/wise_items/_wise_item.html.erb
@@ -45,6 +45,13 @@
 
         <% if Current.user&.admin? %>
           <div class="flex items-center gap-2">
+            <%= icon(
+              "refresh-cw",
+              as_button: true,
+              href: sync_wise_item_path(wise_item),
+              disabled: wise_item.syncing?
+            ) %>
+
             <%= render DS::Menu.new do |menu| %>
               <% menu.with_item(
                 variant: "button",


### PR DESCRIPTION
Wise is missing the sync action, similar to other sync providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refresh button for administrators to manually synchronize individual Wise items.
  * The button is disabled while synchronization is in progress to prevent duplicate actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->