### PR TITLE
test(i18n): stop gating CI on German coverage

### DIFF
--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -1,6 +1,5 @@
 require "i18n/tasks"
 require "pathname"
-require "set"
 require "yaml"
 
 # We're currently skipping some i18n tests to speed up development.  Eventually, we'll make a dedicated
@@ -25,36 +24,6 @@ class I18nTest < ActiveSupport::TestCase
         YAML.load_file(path, aliases: true)
       end
     end
-  end
-
-  def test_german_app_locale_covers_english_keys
-    missing_keys = english_app_locale_leaves.keys.filter_map do |key|
-      key unless translation_present?(german_app_locale_tree, key)
-    end
-
-    assert_empty missing_keys.sort, "Missing German i18n keys:\n#{missing_keys.sort.join("\n")}"
-  end
-
-  def test_german_app_locale_interpolations_match_english
-    mismatches = english_app_locale_leaves.filter_map do |key, english_value|
-      next unless english_value.is_a?(String)
-
-      german_value = translation_at(german_app_locale_tree, key)
-      next if german_value.nil?
-
-      expected_interpolations = interpolation_keys(english_value)
-      german_values =
-        if german_value.is_a?(Hash)
-          flatten_leaves(german_value).values.grep(String)
-        else
-          [ german_value ]
-        end
-
-      bad_values = german_values.reject { |value| interpolation_keys(value) == expected_interpolations }
-      "#{key}: expected #{expected_interpolations.to_a.sort}, got #{bad_values.map { |value| interpolation_keys(value).to_a.sort }.uniq}" if bad_values.any?
-    end
-
-    assert_empty mismatches, "German i18n interpolation mismatches:\n#{mismatches.join("\n")}"
   end
 
   def test_no_missing_keys
@@ -89,72 +58,11 @@ class I18nTest < ActiveSupport::TestCase
   end
 
   private
-    def english_app_locale_leaves
-      @english_app_locale_leaves ||= flatten_leaves(english_app_locale_tree)
-    end
-
-    def english_app_locale_tree
-      @english_app_locale_tree ||= locale_tree("en")
-    end
-
-    def german_app_locale_tree
-      @german_app_locale_tree ||= locale_tree("de")
-    end
-
     def german_locale_paths
       @german_locale_paths ||= locale_paths.select { |path| path.basename.to_s.match?(/(^|[._-])de\.yml\z/) }
     end
 
-    def locale_tree(locale)
-      locale_paths.each_with_object({}) do |path, tree|
-        data = YAML.load_file(path, aliases: true) || {}
-        deep_merge!(tree, data.fetch(locale, {}))
-      end
-    end
-
     def locale_paths
       @locale_paths ||= GERMAN_COVERAGE_GLOBS.flat_map { |glob| Pathname.pwd.glob(glob) }.uniq
-    end
-
-    def deep_merge!(target, source)
-      source.each do |key, value|
-        if target[key].is_a?(Hash) && value.is_a?(Hash)
-          deep_merge!(target[key], value)
-        else
-          target[key] = value
-        end
-      end
-
-      target
-    end
-
-    def flatten_leaves(value, prefix = [], result = {})
-      case value
-      when Hash
-        value.each { |key, child| flatten_leaves(child, prefix + [ key.to_s ], result) }
-      else
-        result[prefix.join(".")] = value
-      end
-
-      result
-    end
-
-    def translation_at(tree, key)
-      key.split(".").reduce(tree) do |current, segment|
-        return nil unless current.is_a?(Hash) && current.key?(segment)
-
-        current[segment]
-      end
-    end
-
-    def translation_present?(tree, key)
-      value = translation_at(tree, key)
-      return false if value.nil?
-
-      true
-    end
-
-    def interpolation_keys(value)
-      value.scan(/%\{([^}]+)\}/).flatten.to_set
     end
 end


### PR DESCRIPTION
## Summary

- Remove the German locale completeness test that required every English app locale key to exist in German.
- Remove the German interpolation parity test and the helper code only those assertions used.
- Keep the German YAML parse test so malformed German locale files still fail fast.

## Tests

- `bin/rails test test/i18n_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed obsolete German and English locale comparison tests.
  * Retained coverage for locale path discovery and YAML parsing.
* **Chores**
  * Removed an unused dependency and related test helper code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->