### PR TITLE
fix(ai): drop empty data-driven enums from assistant function schemas

### DIFF
--- a/app/models/assistant/function.rb
+++ b/app/models/assistant/function.rb
@@ -49,10 +49,41 @@ class Assistant::Function
     def build_schema(properties: {}, required: [])
       {
         type: "object",
-        properties: properties,
+        properties: prune_empty_enums(properties),
         required: required,
         additionalProperties: false
       }
+    end
+
+    # Enum values are built from user data (account names, tags, merchants, etc.)
+    # and can be empty for a new family. An empty enum is invalid JSON Schema and
+    # strict providers (e.g. xAI) reject the entire request, so drop the
+    # constraint and fall back to a plain string.
+    def prune_empty_enums(node)
+      case node
+      when Hash
+        pruned = {}
+        dropped_enum = false
+
+        node.each do |key, value|
+          if key.to_sym == :enum && value.is_a?(Array) && value.empty?
+            dropped_enum = true
+            next
+          end
+
+          pruned[key] = prune_empty_enums(value)
+        end
+
+        if dropped_enum && !pruned.key?(:type) && !pruned.key?("type")
+          pruned[:type] = "string"
+        end
+
+        pruned
+      when Array
+        node.map { |item| prune_empty_enums(item) }
+      else
+        node
+      end
     end
 
     def family_account_names

--- a/app/models/assistant/function.rb
+++ b/app/models/assistant/function.rb
@@ -66,8 +66,13 @@ class Assistant::Function
         dropped_enum = false
 
         node.each do |key, value|
-          if key.to_sym == :enum && value.is_a?(Array) && value.empty?
-            dropped_enum = true
+          # Enum members are literal values, not subschemas; keep them verbatim
+          if key.to_sym == :enum && value.is_a?(Array)
+            if value.empty?
+              dropped_enum = true
+            else
+              pruned[key] = value
+            end
             next
           end
 

--- a/test/models/assistant/function_test.rb
+++ b/test/models/assistant/function_test.rb
@@ -64,10 +64,27 @@ class Assistant::FunctionTest < ActiveSupport::TestCase
     assert_equal "object", schema[:type]
   end
 
+  test "keeps populated enum values verbatim, including literal objects and arrays" do
+    schema = {
+      status: { enum: [ { enum: [] }, [ "nested" ] ] },
+      order: { enum: [ "asc" ] }
+    }
+
+    pruned = @function.send(:prune_empty_enums, schema)
+
+    assert_equal [ { enum: [] }, [ "nested" ] ], pruned[:status][:enum]
+    assert_equal [ "asc" ], pruned[:order][:enum]
+  end
+
   test "no registered function emits an empty enum" do
     user = users(:family_admin)
+    user.update!(preferences: (user.preferences || {}).merge("preview_features_enabled" => true))
 
-    Assistant.function_classes(user).each do |function_class|
+    function_classes = Assistant.function_classes(user)
+    assert_empty Assistant::PREVIEW_FUNCTION_CLASSES - function_classes,
+      "expected preview functions to be included in the assertion"
+
+    function_classes.each do |function_class|
       definition = function_class.new(user).to_definition
       assert_no_empty_enums definition[:params_schema], function_class.name
     end

--- a/test/models/assistant/function_test.rb
+++ b/test/models/assistant/function_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+
+class Assistant::FunctionTest < ActiveSupport::TestCase
+  class EmptyEnumFunction < Assistant::Function
+    class << self
+      def name
+        "empty_enum_function"
+      end
+
+      def description
+        "Test function with data-driven enums"
+      end
+    end
+
+    def call(params = {})
+      {}
+    end
+
+    def params_schema
+      build_schema(
+        required: [ "name" ],
+        properties: {
+          name: {
+            type: "string",
+            description: "Property-level enum built from empty user data",
+            enum: []
+          },
+          accounts: {
+            type: "array",
+            description: "Items-level enum built from empty user data",
+            items: { enum: [] },
+            minItems: 1,
+            uniqueItems: true
+          },
+          order: {
+            enum: [ "asc", "desc" ],
+            description: "Static enum that must be preserved"
+          }
+        }
+      )
+    end
+  end
+
+  setup do
+    @function = EmptyEnumFunction.new(users(:family_admin))
+  end
+
+  test "drops empty enums so strict providers accept the schema" do
+    properties = @function.to_definition[:params_schema][:properties]
+
+    refute properties[:name].key?(:enum)
+    assert_equal "string", properties[:name][:type]
+
+    refute properties[:accounts][:items].key?(:enum)
+    assert_equal "string", properties[:accounts][:items][:type]
+    assert_equal 1, properties[:accounts][:minItems]
+  end
+
+  test "preserves populated enums and surrounding schema" do
+    schema = @function.to_definition[:params_schema]
+
+    assert_equal [ "asc", "desc" ], schema[:properties][:order][:enum]
+    assert_equal [ "name" ], schema[:required]
+    assert_equal "object", schema[:type]
+  end
+
+  test "no registered function emits an empty enum" do
+    user = users(:family_admin)
+
+    Assistant.function_classes(user).each do |function_class|
+      definition = function_class.new(user).to_definition
+      assert_no_empty_enums definition[:params_schema], function_class.name
+    end
+  end
+
+  private
+    def assert_no_empty_enums(node, function_name, path = "params_schema")
+      case node
+      when Hash
+        node.each do |key, value|
+          refute key.to_sym == :enum && value == [],
+            "#{function_name} emits an empty enum at #{path}.#{key}, which is invalid JSON Schema"
+          assert_no_empty_enums(value, function_name, "#{path}.#{key}")
+        end
+      when Array
+        node.each_with_index do |value, index|
+          assert_no_empty_enums(value, function_name, "#{path}[#{index}]")
+        end
+      end
+    end
+end


### PR DESCRIPTION
## Problem

Assistant tool schemas build enum values from family data: account names, categories, merchants, tags, and security tickers. A family that has none of these gets `enum: []`, which is invalid JSON Schema (`enum` requires at least one entry).

OpenAI tolerates this, but strict OpenAI-compatible providers do not. xAI rejects the entire chat request with a 400, so the assistant is broken for every fresh family until they happen to create a tag or merchant:

```
{"code": "invalid-argument", "error": "Invalid request content: Schema validation failed: [standard_violation] /properties/merchants/items/enum: [] has less than 1 item; [standard_violation] /properties/tags/items/enum: [] has less than 1 item"}
```

Repro: fresh self-hosted install, custom provider pointed at xAI (`OPENAI_URI_BASE=https://api.x.ai/v1`), send any chat message.

Affected schema sites: `get_transactions` (accounts, categories, merchants, tags), `get_holdings` (accounts, tickers), `update_tag` (name).

## Fix

Prune empty enums in `Assistant::Function#build_schema`, falling back to a plain string type. One choke point covers every function (the default `params_schema` also routes through it) and both consumers of these schemas: chat tool definitions for all providers, and the `/mcp` endpoint's `tools/list`, which serves `params_schema` directly.

Populated enums are untouched.

## Tests

- Unit coverage for the pruning: property-level and items-level empty enums are dropped with a string fallback, populated enums and surrounding schema keys are preserved
- Regression test that walks every function in `Assistant.function_classes` and asserts no emitted schema contains an empty enum, so future data-driven enums are covered automatically

Verified against live xAI (grok-4.3): before the fix every chat request 400s; after it, the full tool-call round trip completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of assistant function schemas with empty enumerations.
  * Empty enum values are removed while preserving valid types, constraints, required fields, and populated enums.
  * Nested schema objects and arrays are sanitized consistently.
  * Schema fields affected by removed empty enums receive an appropriate string type when needed.

* **Tests**
  * Added coverage to verify schema cleanup across registered assistant functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->