### PR TITLE
Log LLM provider failures to debug events

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -63,12 +63,14 @@ class Provider
       provider_error = transformed_error || original_error
       attributes = debug_log.respond_to?(:call) ? debug_log.call(original_error, provider_error) : debug_log
       attributes = attributes.to_h.symbolize_keys
-      metadata = (attributes[:metadata] || {}).merge(provider_error_metadata(original_error, provider_error))
+      metadata = sanitized_provider_debug_value(attributes[:metadata] || {})
+                   .merge(provider_error_metadata(original_error, provider_error))
 
       DebugLogEntry.capture(
         category: attributes.fetch(:category, "provider_error"),
         level: attributes.fetch(:level, "error"),
-        message: attributes[:message].presence || "#{self.class.name} request failed: #{safe_provider_error_message(provider_error)}",
+        message: sanitized_debug_message(attributes[:message]) ||
+                 "#{self.class.name} request failed: #{sanitized_provider_error_message(provider_error)}",
         source: attributes.fetch(:source, self.class.name),
         provider_key: attributes[:provider_key],
         family: attributes[:family],
@@ -89,10 +91,17 @@ class Provider
       {
         error_class: original_error.class.name,
         provider_error_class: provider_error.class.name,
-        error_message: safe_provider_error_message(provider_error),
+        error_message: sanitized_provider_error_message(provider_error),
         http_status_code: provider_http_status_code(original_error) || provider_http_status_code(provider_error),
-        details: provider_error.respond_to?(:details) ? sanitized_provider_debug_value(provider_error.details) : nil
+        details: provider_error_details(original_error, provider_error)
       }
+    end
+
+    def provider_error_details(original_error, provider_error)
+      details = provider_error.details if provider_error.respond_to?(:details)
+      details = original_error.details if details.blank? && original_error.respond_to?(:details)
+
+      sanitized_provider_debug_value(details)
     end
 
     def provider_http_status_code(error)
@@ -120,7 +129,7 @@ class Provider
       when Array
         value.map { |nested_value| sanitized_provider_debug_value(nested_value) }
       when String
-        value.truncate(1_000)
+        scrub_provider_debug_string(value).truncate(1_000)
       when NilClass, Numeric, TrueClass, FalseClass
         value
       else
@@ -130,6 +139,36 @@ class Provider
 
     def sensitive_debug_key?(key)
       key.match?(/token|secret|password|authorization|api[_-]?key|credential/i)
+    end
+
+    def sanitized_provider_error_message(error)
+      scrub_provider_debug_string(safe_provider_error_message(error).to_s).truncate(1_000)
+    end
+
+    def sanitized_debug_message(message)
+      return if message.blank?
+
+      scrub_provider_debug_string(message.to_s).truncate(1_000)
+    end
+
+    def scrub_provider_debug_string(value)
+      value.to_s
+           .gsub(/\b(Bearer)\s+[^\s,"'}\]]+/i, '\1 [FILTERED]')
+           .gsub(/\b(api[_-]?key|token|secret|password|authorization|credential)(\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,"'}\]]+)/i, '\1\2[FILTERED]')
+           .gsub(/("(?:api[_-]?key|token|secret|password|authorization|credential)"\s*:\s*)"[^"]*"/i, '\1"[FILTERED]"')
+           .gsub(/'(?:api[_-]?key|token|secret|password|authorization|credential)'\s*:\s*'[^']*'/i) { |match| match.sub(/:\s*'[^']*'\z/, ": '[FILTERED]'") }
+           .gsub(/\bsk-[A-Za-z0-9_-]{12,}\b/, "sk-[FILTERED]")
+    end
+
+    def sanitized_provider_debug_url(url)
+      uri = URI.parse(url.to_s)
+      uri.user = nil if uri.respond_to?(:user=)
+      uri.password = nil if uri.respond_to?(:password=)
+      uri.query = nil
+      uri.fragment = nil
+      uri.to_s
+    rescue URI::InvalidURIError
+      scrub_provider_debug_string(url.to_s)
     end
 
     def safe_provider_error_message(error)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -21,7 +21,7 @@ class Provider
     PaginatedData = Data.define(:paginated, :first_page, :total_pages)
     UsageData = Data.define(:used, :limit, :utilization, :plan)
 
-    def with_provider_response(error_transformer: nil, &block)
+    def with_provider_response(error_transformer: nil, debug_log: nil, &block)
       data = yield
 
       Response.new(
@@ -41,6 +41,8 @@ class Provider
         data: nil,
         error: transformed_error
       )
+    ensure
+      capture_provider_debug_log(debug_log, error, transformed_error) if defined?(error) && error
     end
 
     # Override to set class-level error transformation for methods using `with_provider_response`
@@ -53,5 +55,86 @@ class Provider
       else
         self.class::Error.new(error.message)
       end
+    end
+
+    def capture_provider_debug_log(debug_log, original_error, transformed_error)
+      return if debug_log.blank?
+
+      provider_error = transformed_error || original_error
+      attributes = debug_log.respond_to?(:call) ? debug_log.call(original_error, provider_error) : debug_log
+      attributes = attributes.to_h.symbolize_keys
+      metadata = (attributes[:metadata] || {}).merge(provider_error_metadata(original_error, provider_error))
+
+      DebugLogEntry.capture(
+        category: attributes.fetch(:category, "provider_error"),
+        level: attributes.fetch(:level, "error"),
+        message: attributes[:message].presence || "#{self.class.name} request failed: #{safe_provider_error_message(provider_error)}",
+        source: attributes.fetch(:source, self.class.name),
+        provider_key: attributes[:provider_key],
+        family: attributes[:family],
+        family_id: attributes[:family_id],
+        account: attributes[:account],
+        account_id: attributes[:account_id],
+        user: attributes[:user],
+        user_id: attributes[:user_id],
+        account_provider: attributes[:account_provider],
+        account_provider_id: attributes[:account_provider_id],
+        metadata: metadata.compact
+      )
+    rescue => capture_error
+      Rails.logger.error("Provider debug log capture failed: #{capture_error.class}: #{capture_error.message}")
+    end
+
+    def provider_error_metadata(original_error, provider_error)
+      {
+        error_class: original_error.class.name,
+        provider_error_class: provider_error.class.name,
+        error_message: safe_provider_error_message(provider_error),
+        http_status_code: provider_http_status_code(original_error) || provider_http_status_code(provider_error),
+        details: provider_error.respond_to?(:details) ? sanitized_provider_debug_value(provider_error.details) : nil
+      }
+    end
+
+    def provider_http_status_code(error)
+      if error.respond_to?(:status)
+        error.status
+      elsif error.respond_to?(:http_status)
+        error.http_status
+      elsif error.respond_to?(:response)
+        response = error.response
+        response[:status] if response.respond_to?(:[])
+      elsif safe_provider_error_message(error) =~ /\b([1-5]\d{2})\b/
+        $1.to_i
+      end
+    rescue
+      nil
+    end
+
+    def sanitized_provider_debug_value(value)
+      case value
+      when Hash
+        value.each_with_object({}) do |(key, nested_value), sanitized|
+          key_string = key.to_s
+          sanitized[key_string] = sensitive_debug_key?(key_string) ? "[FILTERED]" : sanitized_provider_debug_value(nested_value)
+        end
+      when Array
+        value.map { |nested_value| sanitized_provider_debug_value(nested_value) }
+      when String
+        value.truncate(1_000)
+      when NilClass, Numeric, TrueClass, FalseClass
+        value
+      else
+        value.to_s.truncate(1_000)
+      end
+    end
+
+    def sensitive_debug_key?(key)
+      key.match?(/token|secret|password|authorization|api[_-]?key|credential/i)
+    end
+
+    def safe_provider_error_message(error)
+      error&.message
+    rescue => message_error
+      "(message unavailable: #{message_error.class})"
     end
 end

--- a/app/models/provider/anthropic.rb
+++ b/app/models/provider/anthropic.rb
@@ -215,7 +215,7 @@ class Provider::Anthropic < Provider
     user_identifier: nil,
     family: nil
   )
-    with_provider_response do
+    with_provider_response(debug_log: llm_debug_log_attributes(operation: "chat", model: model, family: family, endpoint: "messages")) do
       chat_config = ChatConfig.new(
         prompt: prompt,
         instructions: instructions,
@@ -286,6 +286,24 @@ class Provider::Anthropic < Provider
 
     def default_max_tokens
       ENV.fetch("ANTHROPIC_MAX_TOKENS", 4096).to_i
+    end
+
+    def llm_debug_log_attributes(operation:, model:, family:, endpoint:)
+      {
+        category: "llm_provider_error",
+        level: "error",
+        message: "Anthropic-compatible LLM #{operation} request failed",
+        source: self.class.name,
+        provider_key: "anthropic",
+        family: family,
+        metadata: {
+          operation: operation,
+          model: model,
+          endpoint: endpoint,
+          base_url: @base_url.presence || "https://api.anthropic.com",
+          custom_provider: custom_endpoint?
+        }
+      }
     end
 
     def sync_chat_response(request_params:)

--- a/app/models/provider/anthropic.rb
+++ b/app/models/provider/anthropic.rb
@@ -15,7 +15,8 @@ class Provider::Anthropic < Provider
     # Use ENV[].presence rather than ENV.fetch(KEY, default) so the Setting
     # lookup is only performed when the ENV var is actually absent — otherwise
     # the default arg is evaluated eagerly on every call.
-    configured_model = ENV["ANTHROPIC_MODEL"].presence || Setting.anthropic_model
+    configured_model = ENV["ANTHROPIC_MODEL"].to_s.strip.presence ||
+                       Setting.anthropic_model.to_s.strip.presence
     configured_model.presence || DEFAULT_MODEL
   end
 

--- a/app/models/provider/anthropic.rb
+++ b/app/models/provider/anthropic.rb
@@ -301,7 +301,7 @@ class Provider::Anthropic < Provider
           operation: operation,
           model: model,
           endpoint: endpoint,
-          base_url: @base_url.presence || "https://api.anthropic.com",
+          base_url: sanitized_provider_debug_url(@base_url.presence || "https://api.anthropic.com"),
           custom_provider: custom_endpoint?
         }
       }

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -11,7 +11,9 @@ class Provider::Openai < Provider
   # Returns the effective model that would be used by the provider.
   # Priority: explicit ENV > Setting > DEFAULT_MODEL.
   def self.effective_model
-    ENV.fetch("OPENAI_MODEL") { Setting.openai_model }.presence || DEFAULT_MODEL
+    ENV["OPENAI_MODEL"].to_s.strip.presence ||
+      Setting.openai_model.to_s.strip.presence ||
+      DEFAULT_MODEL
   end
 
   def self.configured?

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -316,6 +316,24 @@ class Provider::Openai < Provider
       default
     end
 
+    def llm_debug_log_attributes(operation:, model:, family:, endpoint:)
+      {
+        category: "llm_provider_error",
+        level: "error",
+        message: "OpenAI-compatible LLM #{operation} request failed",
+        source: self.class.name,
+        provider_key: "openai",
+        family: family,
+        metadata: {
+          operation: operation,
+          model: model,
+          endpoint: endpoint,
+          uri_base: @uri_base.presence || "https://api.openai.com",
+          custom_provider: custom_provider?
+        }
+      }
+    end
+
     # Routes one-shot (non-chat) inputs through the BatchSlicer so large
     # caller batches are split to fit the model's context window. `fixed` is
     # the portion of the prompt that stays constant across every sub-batch
@@ -341,7 +359,7 @@ class Provider::Openai < Provider
       user_identifier: nil,
       family: nil
     )
-      with_provider_response do
+      with_provider_response(debug_log: llm_debug_log_attributes(operation: "chat", model: model, family: family, endpoint: "responses")) do
         chat_config = ChatConfig.new(
           functions: functions,
           function_results: function_results
@@ -444,7 +462,7 @@ class Provider::Openai < Provider
       user_identifier: nil,
       family: nil
     )
-      with_provider_response do
+      with_provider_response(debug_log: llm_debug_log_attributes(operation: "chat", model: model, family: family, endpoint: "chat.completions")) do
         messages = build_generic_messages(
           prompt: prompt,
           instructions: instructions,

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -330,7 +330,7 @@ class Provider::Openai < Provider
           operation: operation,
           model: model,
           endpoint: endpoint,
-          uri_base: @uri_base.presence || "https://api.openai.com",
+          uri_base: sanitized_provider_debug_url(@uri_base.presence || "https://api.openai.com"),
           custom_provider: custom_provider?
         }
       }

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -81,8 +81,8 @@ class Provider::Registry
 
         return nil unless access_token.present?
 
-        uri_base = ENV["OPENAI_URI_BASE"].presence || Setting.openai_uri_base
-        model = ENV["OPENAI_MODEL"].presence || Setting.openai_model
+        uri_base = ENV["OPENAI_URI_BASE"].to_s.strip.presence || Setting.openai_uri_base.to_s.strip.presence
+        model = ENV["OPENAI_MODEL"].to_s.strip.presence || Setting.openai_model.to_s.strip.presence
 
         if uri_base.present? && model.blank?
           Rails.logger.error("Custom OpenAI provider configured without a model; please set OPENAI_MODEL or Setting.openai_model")
@@ -99,8 +99,8 @@ class Provider::Registry
 
         return nil unless access_token.present?
 
-        base_url = ENV["ANTHROPIC_BASE_URL"].presence || Setting.anthropic_base_url
-        model = ENV["ANTHROPIC_MODEL"].presence || Setting.anthropic_model
+        base_url = ENV["ANTHROPIC_BASE_URL"].to_s.strip.presence || Setting.anthropic_base_url.to_s.strip.presence
+        model = ENV["ANTHROPIC_MODEL"].to_s.strip.presence || Setting.anthropic_model.to_s.strip.presence
 
         Provider::Anthropic.new(access_token, base_url: base_url, model: model)
       end

--- a/test/models/provider/anthropic_test.rb
+++ b/test/models/provider/anthropic_test.rb
@@ -62,6 +62,14 @@ class Provider::AnthropicTest < ActiveSupport::TestCase
     end
   end
 
+  test "effective_model ignores blank env model and falls back to setting" do
+    ClimateControl.modify("ANTHROPIC_MODEL" => "   ") do
+      Setting.stubs(:anthropic_model).returns(" claude-opus-4-7 ")
+
+      assert_equal "claude-opus-4-7", Provider::Anthropic.effective_model
+    end
+  end
+
   test "configured? reflects ENV and Setting presence" do
     ClimateControl.modify("ANTHROPIC_ACCESS_TOKEN" => nil, "ANTHROPIC_API_KEY" => nil) do
       Setting.stubs(:anthropic_access_token).returns(nil)

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -36,7 +36,7 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
   test "custom OpenAI-compatible chat failures are captured in debug log" do
     provider = Provider::Openai.new(
       "test-openai-token",
-      uri_base: "http://ollama.example.test/v1",
+      uri_base: "http://user:secret@ollama.example.test/v1?api_key=leak#frag",
       model: "gpt-oss:20b"
     )
 
@@ -44,7 +44,7 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     provider.stubs(:client).returns(fake_client)
     fake_client.expects(:chat).raises(
       Faraday::ResourceNotFound.new(
-        "the server responded with status 404",
+        "the server responded with status 404 Authorization: Bearer sk-shouldnotlog123456",
         {
           status: 404,
           body: {
@@ -77,6 +77,37 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     assert_equal true, entry.metadata["custom_provider"]
     assert_equal 404, entry.metadata["http_status_code"]
     assert_equal "[FILTERED]", entry.metadata.dig("details", "error", "api_key")
+    assert_no_match(/sk-shouldnotlog/, entry.metadata["error_message"])
+  end
+
+  test "custom OpenAI-compatible debug log scrubs raw string details" do
+    provider = Provider::Openai.new(
+      "test-openai-token",
+      uri_base: "http://ollama.example.test/v1",
+      model: "gpt-oss:20b"
+    )
+
+    fake_client = mock
+    provider.stubs(:client).returns(fake_client)
+    fake_client.expects(:chat).raises(
+      Faraday::BadRequestError.new(
+        "api_key=sk-rawmessage123456 was rejected",
+        {
+          status: 400,
+          body: '{"error":{"message":"Authorization: Bearer sk-rawbody123456","api_key":"raw-secret"}}'
+        }
+      )
+    )
+
+    assert_difference "DebugLogEntry.count", 1 do
+      provider.chat_response("hi", model: "gpt-oss:20b", family: families(:dylan_family))
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_no_match(/sk-rawmessage/, entry.metadata["error_message"])
+    assert_no_match(/sk-rawbody/, entry.metadata["details"])
+    assert_no_match(/raw-secret/, entry.metadata["details"])
+    assert_match(/\[FILTERED\]/, entry.metadata["details"])
   end
 
   test "auto categorizes transactions by various attributes" do
@@ -524,16 +555,22 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
       true
     end.returns(nil)
 
-    response = @subject.chat_response(
-      "hi",
-      model: @subject_model,
-      streamer: proc { |_| }
-    )
+    assert_difference "DebugLogEntry.count", 1 do
+      response = @subject.chat_response(
+        "hi",
+        model: @subject_model,
+        streamer: proc { |_| },
+        family: families(:dylan_family)
+      )
 
-    assert_not response.success?
-    assert_kind_of Provider::Openai::Error, response.error
-    assert_match(/Previous response not found/, response.error.message)
-    assert_match(/previous_response_not_found/, response.error.message)
+      assert_not response.success?
+      assert_kind_of Provider::Openai::Error, response.error
+      assert_match(/Previous response not found/, response.error.message)
+      assert_match(/previous_response_not_found/, response.error.message)
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "previous_response_not_found", entry.metadata.dig("details", "error", "code")
   end
 
   test "streaming surfaces a useful error when the stream ends with no response and no error event" do

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -17,6 +17,22 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     end
   end
 
+  test "effective_model ignores blank env model and falls back to setting" do
+    ClimateControl.modify("OPENAI_MODEL" => "   ") do
+      Setting.stubs(:openai_model).returns(" gpt-oss:20b ")
+
+      assert_equal "gpt-oss:20b", Provider::Openai.effective_model
+    end
+  end
+
+  test "effective_model falls back to default when env and setting are blank" do
+    ClimateControl.modify("OPENAI_MODEL" => "") do
+      Setting.stubs(:openai_model).returns(" ")
+
+      assert_equal Provider::Openai::DEFAULT_MODEL, Provider::Openai.effective_model
+    end
+  end
+
   test "custom OpenAI-compatible chat failures are captured in debug log" do
     provider = Provider::Openai.new(
       "test-openai-token",

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -17,6 +17,52 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     end
   end
 
+  test "custom OpenAI-compatible chat failures are captured in debug log" do
+    provider = Provider::Openai.new(
+      "test-openai-token",
+      uri_base: "http://ollama.example.test/v1",
+      model: "gpt-oss:20b"
+    )
+
+    fake_client = mock
+    provider.stubs(:client).returns(fake_client)
+    fake_client.expects(:chat).raises(
+      Faraday::ResourceNotFound.new(
+        "the server responded with status 404",
+        {
+          status: 404,
+          body: {
+            error: {
+              message: "not found",
+              api_key: "should-not-be-persisted"
+            }
+          }
+        }
+      )
+    )
+
+    assert_difference "DebugLogEntry.count", 1 do
+      response = provider.chat_response("hi", model: "gpt-oss:20b", family: families(:dylan_family))
+
+      assert_not response.success?
+      assert_kind_of Provider::Openai::Error, response.error
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "llm_provider_error", entry.category
+    assert_equal "error", entry.level
+    assert_equal "Provider::Openai", entry.source
+    assert_equal "openai", entry.provider_key
+    assert_equal families(:dylan_family), entry.family
+    assert_equal "chat", entry.metadata["operation"]
+    assert_equal "gpt-oss:20b", entry.metadata["model"]
+    assert_equal "chat.completions", entry.metadata["endpoint"]
+    assert_equal "http://ollama.example.test/v1", entry.metadata["uri_base"]
+    assert_equal true, entry.metadata["custom_provider"]
+    assert_equal 404, entry.metadata["http_status_code"]
+    assert_equal "[FILTERED]", entry.metadata.dig("details", "error", "api_key")
+  end
+
   test "auto categorizes transactions by various attributes" do
     VCR.use_cassette("openai/auto_categorize") do
       input_transactions = [


### PR DESCRIPTION
## Summary

- add optional `debug_log:` capture support to `Provider#with_provider_response`
- log OpenAI-compatible and Anthropic chat failures as `llm_provider_error` debug events
- include sanitized endpoint/model/status/details metadata for custom OpenAI-compatible endpoints such as Ollama

## Tests

- `bin/rubocop app/models/provider.rb app/models/provider/openai.rb app/models/provider/anthropic.rb test/models/provider/openai_test.rb`
- `bin/rails test test/models/provider/openai_test.rb test/models/provider/anthropic_test.rb test/models/debug_log_entry_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider model settings now ignore accidental surrounding whitespace and correctly fall back to configured defaults.
  * Improved handling of failed OpenAI-compatible and Anthropic requests, including clearer error details and HTTP status information.
  * Sensitive or oversized diagnostic values are sanitized before being recorded.
* **Reliability**
  * Provider failures are logged more safely, helping troubleshoot connection and configuration issues without exposing sensitive data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->