### PR TITLE
Allow setting merchant and tags per split row

### DIFF
--- a/app/controllers/splits_controller.rb
+++ b/app/controllers/splits_controller.rb
@@ -4,6 +4,8 @@ class SplitsController < ApplicationController
 
   def new
     @categories = Current.family.categories.alphabetically
+    @merchants = Current.family.available_merchants_for(Current.user).alphabetically
+    @tags = Current.family.tags.alphabetically
   end
 
   def create
@@ -12,12 +14,7 @@ class SplitsController < ApplicationController
       return
     end
 
-    raw_splits = split_params[:splits]
-    raw_splits = raw_splits.values if raw_splits.respond_to?(:values)
-
-    splits = raw_splits.map do |s|
-      { name: s[:name], amount: s[:amount].to_d * -1, category_id: s[:category_id].presence, excluded: s[:excluded] }
-    end
+    splits = build_splits(split_params[:splits])
 
     @entry.split!(splits)
     @entry.sync_account_later
@@ -36,6 +33,8 @@ class SplitsController < ApplicationController
     end
 
     @categories = Current.family.categories.alphabetically
+    @merchants = Current.family.available_merchants_for(Current.user).alphabetically
+    @tags = Current.family.tags.alphabetically
     @children = @entry.child_entries.includes(:entryable)
   end
 
@@ -47,12 +46,7 @@ class SplitsController < ApplicationController
       return
     end
 
-    raw_splits = split_params[:splits]
-    raw_splits = raw_splits.values if raw_splits.respond_to?(:values)
-
-    splits = raw_splits.map do |s|
-      { name: s[:name], amount: s[:amount].to_d * -1, category_id: s[:category_id].presence, excluded: s[:excluded] }
-    end
+    splits = build_splits(split_params[:splits])
 
     Entry.transaction do
       @entry.unsplit!
@@ -95,6 +89,29 @@ class SplitsController < ApplicationController
     end
 
     def split_params
-      params.require(:split).permit(splits: [ :name, :amount, :category_id, :excluded ])
+      params.require(:split).permit(splits: [ :name, :amount, :category_id, :merchant_id, :excluded, tag_ids: [] ])
+    end
+
+    # Maps raw split params into `Entry#split!` input, scoping merchant_id and
+    # tag_ids to the current family so a crafted request can't attribute a
+    # split to another family's merchant or tag.
+    def build_splits(raw_splits)
+      raw_splits = raw_splits.values if raw_splits.respond_to?(:values)
+      family_merchant_ids = Current.family.available_merchants_for(Current.user).ids.map(&:to_s)
+
+      raw_splits.map do |s|
+        tag_ids = Current.family.tags.where(id: Array(s[:tag_ids]).reject(&:blank?)).ids
+        merchant_id = s[:merchant_id].presence
+        merchant_id = nil unless family_merchant_ids.include?(merchant_id.to_s)
+
+        {
+          name: s[:name],
+          amount: s[:amount].to_d * -1,
+          category_id: s[:category_id].presence,
+          merchant_id: merchant_id,
+          tag_ids: tag_ids,
+          excluded: s[:excluded]
+        }
+      end
     end
 end

--- a/app/helpers/splits_helper.rb
+++ b/app/helpers/splits_helper.rb
@@ -1,0 +1,22 @@
+module SplitsHelper
+  # Minimal stand-in for a Rails FormBuilder, providing just enough (an
+  # `object_name` for field naming and a `label` helper) for DS::TagSelect to
+  # render inside a dynamically-indexed split row that has no real bound
+  # model/form builder of its own.
+  class SplitFieldProxy
+    attr_reader :object_name
+
+    def initialize(template, object_name)
+      @template = template
+      @object_name = object_name
+    end
+
+    def label(method, text = nil, options = {}, &block)
+      @template.label(object_name, method, text, options, &block)
+    end
+  end
+
+  def split_field_proxy(index)
+    SplitFieldProxy.new(self, "split[splits][#{index}]")
+  end
+end

--- a/app/javascript/controllers/split_transaction_controller.js
+++ b/app/javascript/controllers/split_transaction_controller.js
@@ -20,54 +20,9 @@ export default class extends Controller {
     row.classList.add("p-3", "rounded-lg", "border", "border-secondary", "bg-container")
     row.dataset.splitTransactionTarget = "row"
 
-    // Clone category select from the first row
-    const existingCategorySelect = container.querySelector(".category-select-container")
-    let categorySelectHTML = ""
-    if (existingCategorySelect) {
-      const cloned = existingCategorySelect.cloneNode(true)
-
-      // Reset hidden input value and update name
-      const hiddenInput = cloned.querySelector("input[type='hidden']")
-      if (hiddenInput) {
-        hiddenInput.value = ""
-        hiddenInput.name = `split[splits][${index}][category_id]`
-      }
-
-      // Reset button to show placeholder text (uncategorized)
-      const button = cloned.querySelector("[data-select-target='button']")
-      if (button) {
-        // Find the uncategorized option text from the menu
-        const uncategorizedOption = cloned.querySelector("[data-value='']")
-        const placeholderText = uncategorizedOption ? uncategorizedOption.dataset.filterName : "(uncategorized)"
-        button.innerHTML = placeholderText
-        button.setAttribute("aria-expanded", "false")
-      }
-
-      // Reset selected states in menu
-      cloned.querySelectorAll("[role='option']").forEach(option => {
-        option.setAttribute("aria-selected", "false")
-        option.classList.remove("bg-container-inset")
-        const checkIcon = option.querySelector(".check-icon")
-        if (checkIcon) checkIcon.classList.add("hidden")
-      })
-
-      // Select the blank/uncategorized option
-      const blankOption = cloned.querySelector("[data-value='']")
-      if (blankOption) {
-        blankOption.setAttribute("aria-selected", "true")
-        blankOption.classList.add("bg-container-inset")
-        const checkIcon = blankOption.querySelector(".check-icon")
-        if (checkIcon) checkIcon.classList.remove("hidden")
-      }
-
-      // Ensure menu is hidden
-      const menu = cloned.querySelector("[data-select-target='menu']")
-      if (menu && !menu.classList.contains("hidden")) {
-        menu.classList.add("hidden")
-      }
-
-      categorySelectHTML = cloned.outerHTML
-    }
+    const categorySelectHTML = this.cloneDropdownSelect(container, ".category-select-container", "category_id", index, "(uncategorized)")
+    const merchantSelectHTML = this.cloneDropdownSelect(container, ".merchant-select-container", "merchant_id", index, "(none)")
+    const tagSelectHTML = this.cloneTagSelect(container, index)
 
     row.innerHTML = `
       <div class="flex flex-wrap md:flex-nowrap items-end gap-2">
@@ -100,10 +55,103 @@ export default class extends Controller {
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
         </button>
       </div>
+      <div class="flex flex-wrap md:flex-nowrap items-end gap-2 mt-2">
+        ${merchantSelectHTML}
+        <div class="w-full md:flex-1 md:w-auto min-w-0">
+          ${tagSelectHTML}
+        </div>
+      </div>
     `
 
     container.appendChild(row)
     this.updateRemaining()
+  }
+
+  // Clones a single-select dropdown (category/merchant select) from the first
+  // row, resetting its hidden input, indexed field name, and selected state
+  // back to blank — otherwise the clone would resubmit row 0's selection.
+  cloneDropdownSelect(container, selector, fieldKey, index, blankLabelFallback) {
+    const existing = container.querySelector(selector)
+    if (!existing) return ""
+
+    const cloned = existing.cloneNode(true)
+
+    const hiddenInput = cloned.querySelector("input[type='hidden']")
+    if (hiddenInput) {
+      hiddenInput.value = ""
+      hiddenInput.name = `split[splits][${index}][${fieldKey}]`
+    }
+
+    const button = cloned.querySelector("[data-select-target='button']")
+    if (button) {
+      const blankOption = cloned.querySelector("[data-value='']")
+      button.innerHTML = blankOption ? blankOption.dataset.filterName : blankLabelFallback
+      button.setAttribute("aria-expanded", "false")
+    }
+
+    cloned.querySelectorAll("[role='option']").forEach(option => {
+      option.setAttribute("aria-selected", "false")
+      option.classList.remove("bg-container-inset")
+      const checkIcon = option.querySelector(".check-icon")
+      if (checkIcon) checkIcon.classList.add("hidden")
+    })
+
+    const blankOption = cloned.querySelector("[data-value='']")
+    if (blankOption) {
+      blankOption.setAttribute("aria-selected", "true")
+      blankOption.classList.add("bg-container-inset")
+      const checkIcon = blankOption.querySelector(".check-icon")
+      if (checkIcon) checkIcon.classList.remove("hidden")
+    }
+
+    const menu = cloned.querySelector("[data-select-target='menu']")
+    if (menu && !menu.classList.contains("hidden")) {
+      menu.classList.add("hidden")
+    }
+
+    return cloned.outerHTML
+  }
+
+  // Clones the DS::TagSelect widget from the first row, clearing all
+  // selections and pointing its hidden inputs at the new row's index.
+  cloneTagSelect(container, index) {
+    const existing = container.querySelector("[data-controller~='tag-select']")
+    if (!existing) return ""
+
+    const cloned = existing.cloneNode(true)
+
+    const fieldName = `split[splits][${index}][tag_ids][]`
+    cloned.dataset.tagSelectFieldNameValue = fieldName
+
+    const hiddenInputsContainer = cloned.querySelector("[data-tag-select-hidden-inputs]")
+    if (hiddenInputsContainer) {
+      hiddenInputsContainer.innerHTML = ""
+      const emptyInput = document.createElement("input")
+      emptyInput.type = "hidden"
+      emptyInput.name = fieldName
+      emptyInput.value = ""
+      hiddenInputsContainer.appendChild(emptyInput)
+    }
+
+    const selectionContainer = cloned.querySelector("[data-tag-select-target='selectionContainer']")
+    if (selectionContainer) {
+      const placeholder = selectionContainer.dataset.placeholder || "None"
+      selectionContainer.innerHTML = `<span class="text-secondary">${placeholder}</span>`
+    }
+
+    cloned.querySelectorAll("[role='option']").forEach(option => {
+      option.setAttribute("aria-selected", "false")
+      option.classList.remove("bg-container-inset")
+      const checkIcon = option.querySelector(".check-icon")
+      if (checkIcon) checkIcon.classList.add("hidden")
+    })
+
+    const menu = cloned.querySelector("[data-tag-select-target='menu']")
+    if (menu && !menu.classList.contains("hidden")) {
+      menu.classList.add("hidden")
+    }
+
+    return cloned.outerHTML
   }
 
   removeRow(event) {
@@ -118,9 +166,16 @@ export default class extends Controller {
 
   reindexRows() {
     this.rowTargets.forEach((row, index) => {
-      // Update input names (including hidden inputs inside category select)
+      // Update input names (including hidden inputs inside category/merchant
+      // selects and the tag select's dynamically-built hidden inputs)
       row.querySelectorAll("[name]").forEach(input => {
         input.name = input.name.replace(/splits\[\d+\]/, `splits[${index}]`)
+      })
+
+      // The tag select's hidden input names are rebuilt from this Stimulus
+      // value on every selection change, so it must be reindexed too.
+      row.querySelectorAll("[data-tag-select-field-name-value]").forEach(el => {
+        el.dataset.tagSelectFieldNameValue = el.dataset.tagSelectFieldNameValue.replace(/splits\[\d+\]/, `splits[${index}]`)
       })
     })
   }

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -390,7 +390,7 @@ class Entry < ApplicationRecord
 
   # Splits this entry into child entries. Marks parent as excluded.
   #
-  # @param splits [Array<Hash>] array of { name:, amount:, category_id:, excluded: } hashes
+  # @param splits [Array<Hash>] array of { name:, amount:, category_id:, merchant_id:, tag_ids:, excluded: } hashes
   # @return [Array<Entry>] the created child entries
   def split!(splits)
     total = splits.sum { |s| s[:amount].to_d }
@@ -402,11 +402,13 @@ class Entry < ApplicationRecord
       children = splits.map do |split_attrs|
         child_transaction = Transaction.new(
           category_id: split_attrs[:category_id],
-          merchant_id: entryable.try(:merchant_id),
+          # Falls back to the parent's merchant when a row doesn't set its own,
+          # preserving pre-#2958 behavior for rows that leave merchant blank.
+          merchant_id: split_attrs[:merchant_id].presence || entryable.try(:merchant_id),
           kind: entryable.try(:kind)
         )
 
-        child_entries.create!(
+        child = child_entries.create!(
           account: account,
           date: date,
           name: split_attrs[:name],
@@ -415,6 +417,10 @@ class Entry < ApplicationRecord
           excluded: TRUTHY_VALUES.include?(split_attrs[:excluded]),
           entryable: child_transaction
         )
+
+        child_transaction.tag_ids = split_attrs[:tag_ids] if split_attrs[:tag_ids].present?
+
+        child
       end
 
       update!(excluded: true)

--- a/app/views/splits/_merchant_select.html.erb
+++ b/app/views/splits/_merchant_select.html.erb
@@ -1,0 +1,64 @@
+<%# locals: (name:, merchants:, selected_id: nil) %>
+<%
+  selected_merchant = merchants.find { |m| m.id == selected_id }
+%>
+
+<div class="merchant-select-container relative flex-1 md:flex-initial md:w-auto md:min-w-44 md:max-w-72" data-controller="select list-filter form-dropdown" data-action="dropdown:select->form-dropdown#onSelect">
+  <label class="text-xs font-medium text-secondary uppercase tracking-wide block mb-1"><%= t("splits.new.merchant_label") %></label>
+  <input type="hidden"
+         name="<%= name %>"
+         value="<%= selected_id %>"
+         data-form-dropdown-target="input">
+  <button type="button"
+          class="form-field__input w-full overflow-hidden border border-secondary rounded-md pl-2.5 pr-7 py-1.5 text-sm text-primary bg-container truncate"
+          data-select-target="button"
+          data-action="click->select#toggle"
+          aria-haspopup="listbox"
+          aria-expanded="false">
+    <%= selected_merchant&.name || t("splits.new.no_merchant") %>
+  </button>
+  <div class="absolute z-50 p-1.5 w-full min-w-48 md:w-80 rounded-lg shadow-lg shadow-border-xs bg-container mt-1.5 transition duration-150 ease-out -translate-y-1 opacity-0 hidden" data-select-target="menu">
+    <div class="flex items-center bg-container border border-secondary rounded-lg mb-1 focus-within:ring-4 focus-within:ring-alpha-black-200 theme-dark:focus-within:ring-alpha-white-300 transition-shadow">
+      <%= render DS::SearchInput.new(
+        variant: :embedded,
+        placeholder: t("helpers.select.search_placeholder"),
+        data: {
+          list_filter_target: "input",
+          action: "list-filter#filter"
+        }
+      ) %>
+    </div>
+    <div data-list-filter-target="list" data-select-target="content" class="flex flex-col gap-0.5 max-h-64 overflow-auto" role="listbox" tabindex="-1">
+      <%# No merchant option %>
+      <% is_blank_selected = selected_id.blank? %>
+      <div class="filterable-item text-sm cursor-pointer flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-container-inset-hover <%= "bg-container-inset" if is_blank_selected %>"
+           role="option"
+           tabindex="0"
+           aria-selected="<%= is_blank_selected %>"
+           data-action="click->select#select"
+           data-value=""
+           data-filter-name="<%= t("splits.new.no_merchant") %>">
+        <span class="check-icon <%= "hidden" unless is_blank_selected %>">
+          <%= icon("check") %>
+        </span>
+        <%= t("splits.new.no_merchant") %>
+      </div>
+
+      <% merchants.each do |merchant| %>
+        <% is_selected = merchant.id == selected_id %>
+        <div class="filterable-item text-sm cursor-pointer flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-container-inset-hover <%= "bg-container-inset" if is_selected %>"
+             role="option"
+             tabindex="0"
+             aria-selected="<%= is_selected %>"
+             data-action="click->select#select"
+             data-value="<%= merchant.id %>"
+             data-filter-name="<%= merchant.name %>">
+          <span class="check-icon <%= "hidden" unless is_selected %>">
+            <%= icon("check") %>
+          </span>
+          <span class="truncate"><%= merchant.name %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/splits/edit.html.erb
+++ b/app/views/splits/edit.html.erb
@@ -73,6 +73,19 @@
                 <%= icon "x", size: "sm" %>
               </button>
             </div>
+            <div class="flex flex-wrap md:flex-nowrap items-end gap-2 mt-2">
+              <%= render "splits/merchant_select",
+                         name: "split[splits][#{index}][merchant_id]",
+                         merchants: @merchants,
+                         selected_id: child.entryable.try(:merchant_id) %>
+              <div class="w-full md:flex-1 md:w-auto min-w-0">
+                <%= render DS::TagSelect.new(
+                      form: split_field_proxy(index),
+                      tags: @tags,
+                      selected_ids: child.entryable.try(:tag_ids) || []
+                    ) %>
+              </div>
+            </div>
           </div>
         <% end %>
       </div>

--- a/app/views/splits/new.html.erb
+++ b/app/views/splits/new.html.erb
@@ -65,6 +65,19 @@
                        selected_id: nil %>
             <div class="w-8 shrink-0 hidden md:block"></div>
           </div>
+          <div class="flex flex-wrap md:flex-nowrap items-end gap-2 mt-2">
+            <%= render "splits/merchant_select",
+                       name: "split[splits][0][merchant_id]",
+                       merchants: @merchants,
+                       selected_id: nil %>
+            <div class="w-full md:flex-1 md:w-auto min-w-0">
+              <%= render DS::TagSelect.new(
+                    form: split_field_proxy(0),
+                    tags: @tags,
+                    selected_ids: []
+                  ) %>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/config/locales/views/splits/en.yml
+++ b/config/locales/views/splits/en.yml
@@ -15,6 +15,8 @@ en:
       amount_label: Amount
       category_label: Category
       uncategorized: "(uncategorized)"
+      merchant_label: Merchant
+      no_merchant: "(none)"
       original_name: "Name:"
       original_date: "Date:"
       original_amount: "Amount"

--- a/test/controllers/splits_controller_test.rb
+++ b/test/controllers/splits_controller_test.rb
@@ -140,6 +140,47 @@ class SplitsControllerTest < ActionDispatch::IntegrationTest
     assert children.last.excluded?
   end
 
+  test "create with merchant_id and tag_ids assigns them to the split" do
+    assert_difference "Entry.count", 2 do
+      post transaction_split_path(@entry), params: {
+        split: {
+          splits: [
+            { name: "Groceries", amount: "-70", category_id: "", merchant_id: merchants(:netflix).id, tag_ids: [ tags(:one).id, tags(:two).id ] },
+            { name: "Household", amount: "-30", category_id: "" }
+          ]
+        }
+      }
+    end
+
+    children = @entry.child_entries.includes(:entryable).order(:amount)
+    household, groceries = children
+    assert_equal merchants(:netflix).id, groceries.entryable.merchant_id
+    assert_equal [ tags(:one).id, tags(:two).id ].sort, groceries.entryable.tag_ids.sort
+    assert_nil household.entryable.merchant_id
+    assert_empty household.entryable.tag_ids
+  end
+
+  test "create ignores merchant_id and tag_ids belonging to another family" do
+    other_family = families(:empty)
+    other_merchant = FamilyMerchant.create!(name: "Other Family Merchant", family: other_family)
+    other_tag = Tag.create!(name: "Other Family Tag", family: other_family)
+
+    assert_difference "Entry.count", 2 do
+      post transaction_split_path(@entry), params: {
+        split: {
+          splits: [
+            { name: "Groceries", amount: "-70", category_id: "", merchant_id: other_merchant.id, tag_ids: [ other_tag.id ] },
+            { name: "Household", amount: "-30", category_id: "" }
+          ]
+        }
+      }
+    end
+
+    groceries = @entry.child_entries.includes(:entryable).order(:amount).last
+    assert_nil groceries.entryable.merchant_id
+    assert_empty groceries.entryable.tag_ids
+  end
+
   # Edit action tests
   test "edit renders with existing children pre-filled" do
     @entry.split!([

--- a/test/models/entry_split_test.rb
+++ b/test/models/entry_split_test.rb
@@ -165,6 +165,32 @@ class EntrySplitTest < ActiveSupport::TestCase
     assert @entry.split_parent?
   end
 
+  test "split! assigns per-row merchant, falling back to parent's merchant when blank" do
+    @entry.entryable.update!(merchant: merchants(:netflix))
+
+    splits = [
+      { name: "Part 1", amount: 60, category_id: nil, merchant_id: merchants(:amazon).id },
+      { name: "Part 2", amount: 40, category_id: nil, merchant_id: nil }
+    ]
+
+    children = @entry.split!(splits)
+
+    assert_equal merchants(:amazon).id, children.first.entryable.merchant_id
+    assert_equal merchants(:netflix).id, children.last.entryable.merchant_id
+  end
+
+  test "split! assigns per-row tags" do
+    splits = [
+      { name: "Part 1", amount: 60, category_id: nil, tag_ids: [ tags(:one).id, tags(:two).id ] },
+      { name: "Part 2", amount: 40, category_id: nil }
+    ]
+
+    children = @entry.split!(splits)
+
+    assert_equal [ tags(:one).id, tags(:two).id ].sort, children.first.entryable.tag_ids.sort
+    assert_empty children.last.entryable.tag_ids
+  end
+
   test "split_child? returns true for child entries" do
     children = @entry.split!([
       { name: "Part 1", amount: 50, category_id: nil },


### PR DESCRIPTION
## Summary
- Each split row in the transaction split dialog can now optionally set its own **merchant** and **tags**, in addition to the existing name/amount/category.
- A row that leaves merchant blank still falls back to the parent transaction's merchant, so existing splits behave exactly as before.
- `merchant_id`/`tag_ids` are scoped to `Current.family` server-side before being passed to `Entry#split!`, so a crafted request can't attribute a split to another family's merchant or tag.

Fixes #2958

## Implementation
- `Entry#split!`: accepts `merchant_id:`/`tag_ids:` per split hash, falling back to the parent's merchant when a row's is blank.
- `SplitsController`: loads `@merchants`/`@tags` for `new`/`edit`, and scopes both new params to the family in a new `build_splits` helper (mirrors the family-scoping pattern already used for tags on the main transaction form).
- New `splits/_merchant_select` partial, modeled on the existing `splits/_category_select` single-select dropdown pattern.
- Tag selection reuses the existing `DS::TagSelect` component (search, keyboard nav, inline tag creation) via a small `SplitsHelper::SplitFieldProxy` that gives it just enough of a form-builder interface (`object_name`, `label`) to work inside a dynamically-indexed split row that has no real bound form object.
- `split_transaction_controller.js`'s `addRow()` now also clones/reset the merchant select and tag select when a new row is added dynamically, and `reindexRows()` was extended to also fix up the tag select's `data-tag-select-field-name-value` Stimulus value (not just plain `[name]` attributes) when rows are removed/reindexed.

## Test plan
- [x] `bin/rails test test/models/entry_split_test.rb test/controllers/splits_controller_test.rb` — 36 runs, 117 assertions, 0 failures/errors (run against the project's NAS test-stack container, no local Ruby available)
- [x] `bin/rubocop` on changed Ruby files — no offenses
- [x] `bin/brakeman --no-pager` (full app scan) — 0 new security warnings
- [ ] erb_lint could not be run in this session due to an unrelated container permission issue (root-owned `/rails` in the test container blocking tempfile creation) — views were reviewed manually for consistency with the existing `_category_select` pattern instead
- [ ] Manual browser check of the split dialog (add/edit rows, dynamic "Add split") not performed in this session — no running dev server available; would appreciate a manual smoke test before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assign a merchant and tags to each split transaction.
  * Search and select merchants, including a “No merchant” option.
  * Preserve merchant and tag selections when adding or reordering split rows.
  * Existing splits now display their assigned merchants and tags.

* **Bug Fixes**
  * Split associations are limited to valid items within the current family.
  * Split merchants correctly fall back to the parent transaction when unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->