### PR TITLE
Fix SnapTrade holdings by using the /positions/all endpoint

### DIFF
--- a/app/models/provider/snaptrade.rb
+++ b/app/models/provider/snaptrade.rb
@@ -207,7 +207,8 @@ class Provider::Snaptrade
 
   # Returns Array<Hash> of positions
   def get_positions(account_id:)
-    get_json("/api/v1/accounts/#{account_id}/positions")
+    response = get_json("/api/v1/accounts/#{account_id}/positions/all")
+    response.is_a?(Hash) ? Array(response["results"]) : []
   end
 
   # Returns raw JSON: paginated form is {"data" => [...]}, may also be a plain Array

--- a/app/models/provider/snaptrade.rb
+++ b/app/models/provider/snaptrade.rb
@@ -32,6 +32,13 @@ class Provider::Snaptrade
   DASHBOARD_URL = "https://dashboard.snaptrade.com".freeze
   TOKEN_EXPIRY_LEEWAY = 60 # seconds; refresh this long before actual expiry
 
+  # Filtered out of get_positions so they never reach raw_holdings_payload:
+  # units are per-contract and symbols OCC-style, which neither
+  # SnaptradeAccount::HoldingsProcessor nor the units * price sum in
+  # SnaptradeAccount::Processor#calculate_holdings_value models. A denylist, so
+  # equity-like kinds added later still import rather than being dropped.
+  UNSUPPORTED_INSTRUMENT_KINDS = %w[option future cfd].freeze
+
   class << self
     def oauth_configured?
       oauth_client_id.present? && oauth_client_secret.present?
@@ -208,7 +215,19 @@ class Provider::Snaptrade
   # Returns Array<Hash> of positions
   def get_positions(account_id:)
     response = get_json("/api/v1/accounts/#{account_id}/positions/all")
-    response.is_a?(Hash) ? Array(response["results"]) : []
+    results = response["results"] if response.is_a?(Hash)
+
+    # An empty `results` is a legitimately empty account, but a missing one is
+    # a partial or schema-changed response. Raising leaves the previous
+    # snapshot in place rather than overwriting it with nothing.
+    unless results.is_a?(Array)
+      raise ApiError.new(
+        "SnapTrade positions response has no results array " \
+        "(keys: #{response.is_a?(Hash) ? response.keys.inspect : response.class})"
+      )
+    end
+
+    results.reject { |position| unsupported_instrument?(position) }
   end
 
   # Returns raw JSON: paginated form is {"data" => [...]}, may also be a plain Array
@@ -248,6 +267,15 @@ class Provider::Snaptrade
   end
 
   private
+
+    def unsupported_instrument?(position)
+      return false unless position.is_a?(Hash)
+
+      instrument = position["instrument"]
+      return false unless instrument.is_a?(Hash)
+
+      UNSUPPORTED_INSTRUMENT_KINDS.include?(instrument["kind"].to_s.downcase)
+    end
 
     def get_json(path, params = {})
       request_json(:get, path, params: params)

--- a/app/models/snaptrade_account/data_helpers.rb
+++ b/app/models/snaptrade_account/data_helpers.rb
@@ -105,6 +105,7 @@ module SnaptradeAccount::DataHelpers
 
     def extract_exchange(symbol_data)
       exchange = symbol_data[:exchange] || symbol_data["exchange"]
+      return exchange.presence if exchange.is_a?(String)
       return nil unless exchange.is_a?(Hash)
 
       exchange.with_indifferent_access[:mic_code] || exchange.with_indifferent_access[:id]
@@ -129,8 +130,13 @@ module SnaptradeAccount::DataHelpers
       end
     end
 
-    # SnapTrade positions nest the security data as holding.symbol.symbol
+    # Security metadata sits under `instrument`, or under `symbol.symbol` in
+    # payloads persisted to raw_holdings_payload before the /positions/all
+    # migration, which are re-read until the next sync overwrites them.
     def extract_symbol_data(data)
+      instrument = data[:instrument] || data["instrument"]
+      return instrument.with_indifferent_access if instrument.is_a?(Hash)
+
       symbol_wrapper = data[:symbol].is_a?(Hash) ? data[:symbol].with_indifferent_access : {}
       raw_symbol_data = symbol_wrapper[:symbol]
 

--- a/app/models/snaptrade_account/holdings_processor.rb
+++ b/app/models/snaptrade_account/holdings_processor.rb
@@ -1,6 +1,11 @@
 class SnaptradeAccount::HoldingsProcessor
   include SnaptradeAccount::DataHelpers
 
+  # Units are per-contract and symbols OCC-style, neither of which this
+  # processor models. A denylist, so equity-like kinds added later still
+  # import rather than being silently dropped.
+  UNSUPPORTED_INSTRUMENT_KINDS = %w[option future cfd].freeze
+
   def initialize(snaptrade_account)
     @snaptrade_account = snaptrade_account
   end
@@ -84,18 +89,9 @@ class SnaptradeAccount::HoldingsProcessor
     end
 
     def process_holding(data)
-      # Extract security info from the holding
-      # SnapTrade has DEEPLY NESTED structure:
-      #   holding.symbol.symbol.symbol = ticker (e.g., "TSLA")
-      #   holding.symbol.symbol.description = name (e.g., "Tesla Inc")
-      raw_symbol_wrapper = data["symbol"] || data[:symbol] || {}
-      symbol_wrapper = raw_symbol_wrapper.is_a?(Hash) ? raw_symbol_wrapper.with_indifferent_access : {}
+      return if unsupported_instrument?(data)
 
-      # The actual security data is nested inside symbol.symbol
-      raw_symbol_data = symbol_wrapper["symbol"] || symbol_wrapper[:symbol] || {}
-      symbol_data = raw_symbol_data.is_a?(Hash) ? raw_symbol_data.with_indifferent_access : {}
-
-      # Get the ticker - it's at symbol.symbol.symbol
+      symbol_data = extract_symbol_data(data)
       ticker = symbol_data["symbol"] || symbol_data[:symbol]
 
       # If that's still a hash, we need to go deeper or use raw_symbol
@@ -122,15 +118,9 @@ class SnaptradeAccount::HoldingsProcessor
       # Get the holding date (use current date if not provided)
       holding_date = Date.current
 
-      # Extract currency - it can be at the holding level or in symbol_data
-      currency_data = data["currency"] || data[:currency] || symbol_data["currency"] || symbol_data[:currency]
-      currency = if currency_data.is_a?(Hash)
-        currency_data.with_indifferent_access["code"]
-      elsif currency_data.is_a?(String)
-        currency_data
-      else
-        account.currency
-      end
+      # Must resolve to the same bucket as cash_equivalent_position_value, or
+      # cash-equivalent positions stop cancelling out (#2729).
+      currency = extract_currency(data, symbol_data, account.currency)
 
       Rails.logger.info "SnaptradeAccount::HoldingsProcessor - Importing holding: #{ticker} qty=#{quantity} price=#{price} currency=#{currency}"
 
@@ -147,11 +137,23 @@ class SnaptradeAccount::HoldingsProcessor
         delete_future_holdings: false
       )
 
-      # Store cost basis if available
-      avg_price = data["average_purchase_price"] || data[:average_purchase_price]
+      # Store cost basis if available. Both fields are per-share, which is
+      # what update_holding_cost_basis expects.
+      avg_price = data["average_purchase_price"] || data[:average_purchase_price] ||
+                  data["cost_basis"] || data[:cost_basis]
       if avg_price.present?
         update_holding_cost_basis(security, avg_price)
       end
+    end
+
+    def unsupported_instrument?(data)
+      instrument = data[:instrument] || data["instrument"]
+      return false unless instrument.is_a?(Hash)
+
+      kind = instrument.with_indifferent_access[:kind]
+      return false if kind.blank?
+
+      UNSUPPORTED_INSTRUMENT_KINDS.include?(kind.to_s.downcase)
     end
 
     def update_holding_cost_basis(security, avg_cost)

--- a/app/models/snaptrade_account/holdings_processor.rb
+++ b/app/models/snaptrade_account/holdings_processor.rb
@@ -1,11 +1,6 @@
 class SnaptradeAccount::HoldingsProcessor
   include SnaptradeAccount::DataHelpers
 
-  # Units are per-contract and symbols OCC-style, neither of which this
-  # processor models. A denylist, so equity-like kinds added later still
-  # import rather than being silently dropped.
-  UNSUPPORTED_INSTRUMENT_KINDS = %w[option future cfd].freeze
-
   def initialize(snaptrade_account)
     @snaptrade_account = snaptrade_account
   end
@@ -89,8 +84,6 @@ class SnaptradeAccount::HoldingsProcessor
     end
 
     def process_holding(data)
-      return if unsupported_instrument?(data)
-
       symbol_data = extract_symbol_data(data)
       ticker = symbol_data["symbol"] || symbol_data[:symbol]
 
@@ -138,22 +131,13 @@ class SnaptradeAccount::HoldingsProcessor
       )
 
       # Store cost basis if available. Both fields are per-share, which is
-      # what update_holding_cost_basis expects.
+      # what update_holding_cost_basis expects — unlike the identically named
+      # tax_lots[].cost_basis, which SnapTrade documents as a whole-lot total.
       avg_price = data["average_purchase_price"] || data[:average_purchase_price] ||
                   data["cost_basis"] || data[:cost_basis]
       if avg_price.present?
         update_holding_cost_basis(security, avg_price)
       end
-    end
-
-    def unsupported_instrument?(data)
-      instrument = data[:instrument] || data["instrument"]
-      return false unless instrument.is_a?(Hash)
-
-      kind = instrument.with_indifferent_access[:kind]
-      return false if kind.blank?
-
-      UNSUPPORTED_INSTRUMENT_KINDS.include?(kind.to_s.downcase)
     end
 
     def update_holding_cost_basis(security, avg_cost)

--- a/test/models/provider/snaptrade_oauth_test.rb
+++ b/test/models/provider/snaptrade_oauth_test.rb
@@ -128,6 +128,40 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
     assert_equal [ { "id" => "acct-1" } ], accounts
   end
 
+  test "get_positions calls /positions/all and unwraps results" do
+    configure_oauth!
+    provider = Provider::Snaptrade.new(fake_item)
+
+    request = OpenStruct.new(headers: {}, params: {})
+    body = {
+      results: [ { instrument: { kind: "stock", symbol: "AAPL" }, units: "10", price: "1.5" } ],
+      data_freshness: { as_of: "2026-08-14T18:12:18Z" }
+    }.to_json
+
+    connection = mock("faraday")
+    connection.expects(:get)
+      .with("#{Provider::Snaptrade::API_BASE_URL}/api/v1/accounts/acct-1/positions/all")
+      .yields(request).returns(faraday_response(status: 200, body: body))
+    provider.stubs(:api_connection).returns(connection)
+
+    positions = provider.get_positions(account_id: "acct-1")
+
+    assert_equal 1, positions.size
+    assert_equal "AAPL", positions.first.dig("instrument", "symbol")
+  end
+
+  test "get_positions returns an empty array when results are absent" do
+    configure_oauth!
+    provider = Provider::Snaptrade.new(fake_item)
+
+    connection = mock("faraday")
+    connection.expects(:get).yields(OpenStruct.new(headers: {}, params: {}))
+      .returns(faraday_response(status: 200, body: { data_freshness: {} }.to_json))
+    provider.stubs(:api_connection).returns(connection)
+
+    assert_equal [], provider.get_positions(account_id: "acct-1")
+  end
+
   test "expired token is refreshed before the data call and rotation persisted" do
     configure_oauth!
     item = fake_item(expires_at: 1.minute.ago)

--- a/test/models/provider/snaptrade_oauth_test.rb
+++ b/test/models/provider/snaptrade_oauth_test.rb
@@ -150,7 +150,19 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
     assert_equal "AAPL", positions.first.dig("instrument", "symbol")
   end
 
-  test "get_positions returns an empty array when results are absent" do
+  test "get_positions returns an empty array for an account holding nothing" do
+    configure_oauth!
+    provider = Provider::Snaptrade.new(fake_item)
+
+    connection = mock("faraday")
+    connection.expects(:get).yields(OpenStruct.new(headers: {}, params: {}))
+      .returns(faraday_response(status: 200, body: { results: [] }.to_json))
+    provider.stubs(:api_connection).returns(connection)
+
+    assert_equal [], provider.get_positions(account_id: "acct-1")
+  end
+
+  test "get_positions raises rather than reporting no positions when results are absent" do
     configure_oauth!
     provider = Provider::Snaptrade.new(fake_item)
 
@@ -159,7 +171,34 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
       .returns(faraday_response(status: 200, body: { data_freshness: {} }.to_json))
     provider.stubs(:api_connection).returns(connection)
 
-    assert_equal [], provider.get_positions(account_id: "acct-1")
+    error = assert_raises(Provider::Snaptrade::ApiError) do
+      provider.get_positions(account_id: "acct-1")
+    end
+    assert_match "no results array", error.message
+  end
+
+  test "get_positions filters out instrument kinds the holdings pipeline cannot model" do
+    configure_oauth!
+    provider = Provider::Snaptrade.new(fake_item)
+
+    body = {
+      results: [
+        { instrument: { kind: "stock", symbol: "AAPL" }, units: "10", price: "1.5" },
+        { instrument: { kind: "option", symbol: "AAPL 240119C00150000" }, units: "2", price: "5.1" },
+        { instrument: { kind: "future", symbol: "ESZ4" }, units: "1", price: "10" },
+        { instrument: { kind: "cfd", symbol: "CFD1" }, units: "1", price: "10" },
+        { instrument: { kind: "somethingnew", symbol: "NEW" }, units: "3", price: "2" }
+      ]
+    }.to_json
+
+    connection = mock("faraday")
+    connection.expects(:get).yields(OpenStruct.new(headers: {}, params: {}))
+      .returns(faraday_response(status: 200, body: body))
+    provider.stubs(:api_connection).returns(connection)
+
+    positions = provider.get_positions(account_id: "acct-1")
+
+    assert_equal %w[AAPL NEW], positions.map { |p| p.dig("instrument", "symbol") }
   end
 
   test "expired token is refreshed before the data call and rotation persisted" do

--- a/test/models/snaptrade_account_processor_test.rb
+++ b/test/models/snaptrade_account_processor_test.rb
@@ -214,47 +214,6 @@ class SnaptradeAccountProcessorTest < ActiveSupport::TestCase
     assert_equal "provider", holding.cost_basis_source
   end
 
-  test "holdings processor skips derivative positions from positions/all" do
-    @snaptrade_account.update!(
-      raw_holdings_payload: [
-        {
-          "instrument" => {
-            "kind" => "option",
-            "symbol" => "AAPL 240119C00150000",
-            "currency" => "USD"
-          },
-          "units" => "2",
-          "price" => "5.10",
-          "currency" => "USD"
-        }
-      ]
-    )
-
-    assert_nothing_raised do
-      SnaptradeAccount::HoldingsProcessor.new(@snaptrade_account).process
-    end
-    assert_equal 0, @account.holdings.count
-  end
-
-  test "holdings processor imports unrecognised instrument kinds" do
-    security = securities(:aapl)
-
-    @snaptrade_account.update!(
-      raw_holdings_payload: [
-        {
-          "instrument" => { "kind" => "somethingnew", "symbol" => security.ticker, "currency" => "USD" },
-          "units" => "5",
-          "price" => "100.00",
-          "currency" => "USD"
-        }
-      ]
-    )
-
-    SnaptradeAccount::HoldingsProcessor.new(@snaptrade_account).process
-
-    assert_not_nil @account.holdings.find_by(security: security)
-  end
-
   test "cash-equivalent positions are recognised in a positions/all payload" do
     security = securities(:aapl)
 

--- a/test/models/snaptrade_account_processor_test.rb
+++ b/test/models/snaptrade_account_processor_test.rb
@@ -159,6 +159,122 @@ class SnaptradeAccountProcessorTest < ActiveSupport::TestCase
     assert_equal "CHF", @account.currency
   end
 
+  # === /positions/all payload shape ===
+
+  test "holdings processor creates holdings from a positions/all payload" do
+    security = securities(:aapl)
+
+    @snaptrade_account.update!(
+      raw_holdings_payload: [
+        {
+          "instrument" => {
+            "kind" => "stock",
+            "symbol" => security.ticker,
+            "raw_symbol" => security.ticker,
+            "description" => security.name,
+            "currency" => "USD",
+            "exchange" => "XNAS"
+          },
+          "units" => "10",
+          "price" => "77.885",
+          "cost_basis" => "30",
+          "currency" => "USD"
+        }
+      ]
+    )
+
+    SnaptradeAccount::HoldingsProcessor.new(@snaptrade_account).process
+
+    holding = @account.holdings.find_by(security: security)
+    assert_not_nil holding
+    assert_equal BigDecimal("10"), holding.qty
+    assert_equal BigDecimal("77.885"), holding.price
+  end
+
+  test "holdings processor reads cost_basis as a per-share value" do
+    security = securities(:aapl)
+
+    @snaptrade_account.update!(
+      raw_holdings_payload: [
+        {
+          "instrument" => { "kind" => "stock", "symbol" => security.ticker, "currency" => "USD" },
+          "units" => "10",
+          "price" => "77.885",
+          "cost_basis" => "30",
+          "currency" => "USD"
+        }
+      ]
+    )
+
+    SnaptradeAccount::HoldingsProcessor.new(@snaptrade_account).process
+
+    holding = @account.holdings.find_by(security: security)
+    assert_not_nil holding
+    assert_equal BigDecimal("30"), holding.cost_basis
+    assert_equal "provider", holding.cost_basis_source
+  end
+
+  test "holdings processor skips derivative positions from positions/all" do
+    @snaptrade_account.update!(
+      raw_holdings_payload: [
+        {
+          "instrument" => {
+            "kind" => "option",
+            "symbol" => "AAPL 240119C00150000",
+            "currency" => "USD"
+          },
+          "units" => "2",
+          "price" => "5.10",
+          "currency" => "USD"
+        }
+      ]
+    )
+
+    assert_nothing_raised do
+      SnaptradeAccount::HoldingsProcessor.new(@snaptrade_account).process
+    end
+    assert_equal 0, @account.holdings.count
+  end
+
+  test "holdings processor imports unrecognised instrument kinds" do
+    security = securities(:aapl)
+
+    @snaptrade_account.update!(
+      raw_holdings_payload: [
+        {
+          "instrument" => { "kind" => "somethingnew", "symbol" => security.ticker, "currency" => "USD" },
+          "units" => "5",
+          "price" => "100.00",
+          "currency" => "USD"
+        }
+      ]
+    )
+
+    SnaptradeAccount::HoldingsProcessor.new(@snaptrade_account).process
+
+    assert_not_nil @account.holdings.find_by(security: security)
+  end
+
+  test "cash-equivalent positions are recognised in a positions/all payload" do
+    security = securities(:aapl)
+
+    @snaptrade_account.update!(
+      currency: "USD",
+      cash_balance: BigDecimal("1000.00"),
+      raw_holdings_payload: [
+        {
+          "instrument" => { "kind" => "mutualfund", "symbol" => security.ticker, "currency" => "USD" },
+          "units" => "100",
+          "price" => "1.00",
+          "currency" => "USD",
+          "cash_equivalent" => true
+        }
+      ]
+    )
+
+    assert_equal BigDecimal("100"), @snaptrade_account.cash_equivalent_position_value("USD")
+  end
+
   # === ActivitiesProcessor Tests ===
 
   test "activities processor maps BUY type to Buy label" do


### PR DESCRIPTION
Fixes #3029

### Problem

A newly connected SnapTrade account imports its balance correctly but shows **zero holdings**, with no error surfaced anywhere in the UI.

SnapTrade has retired the endpoints this provider calls. They return `410 Gone` for any SnapTrade app registered after their 2026 cutoff:

> `{"detail":"This endpoint is no longer available for your account."}`

Verified against the live API with a valid OAuth bearer token:

| Endpoint | Status |
|---|---|
| `GET /api/v1/accounts` | 200 |
| `GET /api/v1/accounts/{id}` | 200 |
| `GET /api/v1/accounts/{id}/balances` | 200 |
| `GET /api/v1/accounts/{id}/activities` | 200 |
| `GET /api/v1/accounts/{id}/positions` | **410** |
| `GET /api/v1/accounts/{id}/holdings` | **410** |
| `GET /api/v1/accounts/{id}/options` | **410** |
| `GET /api/v1/accounts/{id}/positions/all` | **200** |

Because `/balances` still works, the account and its balance import fine and the failure is indistinguishable from an account that genuinely holds nothing.

### Why this hasn't shown up before

The deprecation is applied by **signup date**, not globally — apps registered before the cutoff keep working on `/positions` indefinitely. The OAuth work (#2494, #2523, #2747) all landed after that cutoff but was presumably tested with pre-cutoff credentials, so `/positions` kept returning 200 for the developers.

This means every self-hoster registering a new SnapTrade app from now on hits it, and it will **not** reproduce for anyone using older credentials. Verifying this fix requires a SnapTrade app registered after the cutoff.

### What changed

**`app/models/provider/snaptrade.rb`** — `get_positions` calls `/api/v1/accounts/{id}/positions/all` and unwraps the `results` array, filtering out instrument kinds the holdings pipeline cannot model (see below). It raises if `results` is missing or not an array, so a partial or schema-changed response leaves the previous snapshot in place instead of overwriting it with nothing; an empty `results` remains a legitimately empty account.

**`app/models/snaptrade_account/data_helpers.rb`** — `extract_symbol_data` returns the flat `instrument` object when present, falling back to the legacy nested `symbol.symbol` path. `extract_exchange` accepts a bare MIC string (`"XNAS"`) in addition to the old nested object, so newly created securities keep their `exchange_mic`.

**`app/models/snaptrade_account/holdings_processor.rb`** — `process_holding` now uses the shared `extract_symbol_data`/`extract_currency` helpers instead of duplicating the traversal inline, and reads `cost_basis` alongside the legacy `average_purchase_price`.

### Notes for reviewers

**`cost_basis` is per-share**, so it maps onto `average_purchase_price` with no conversion. From SnapTrade's OpenAPI spec (`AccountPosition.cost_basis`):

> "Book price or average purchase price for the position. For options, this is per-share." — example `118.2` against a `price` of `123.45`

The legacy field is documented as "Cost basis _per share_ of this position", and `update_holding_cost_basis` stores a per-share value, so the semantics line up.

**The fix goes through `extract_symbol_data`, not just the holdings processor.** That helper is also used by `SnaptradeAccount#cash_equivalent_position_value`. Patching only `HoldingsProcessor` would leave that method walking the old nested path, silently returning `0` for the new payload and regressing the cash-equivalent double-counting fix from #2696 (issues #2729/#2731). For the same reason `process_holding` now shares `extract_currency` — if the two disagree about which currency bucket a position belongs to, cash-equivalent positions stop cancelling out.

**Backward compatibility is load-bearing, not defensive.** `raw_holdings_payload` is persisted, so every existing install has old-shape rows in the database that are read back before the next sync overwrites them. Both shapes must work during that window. The existing old-shape tests are unchanged and still pass.

**Derivative positions are filtered out in `get_positions`, not further downstream.** The legacy `/positions` covered stocks, ETFs, crypto and mutual funds only; `/positions/all` also returns options, futures and CFDs, which carry OCC-style symbols (`AAPL 240119C00150000`) and per-contract units that the holdings pipeline doesn't model.

Filtering has to happen before the payload is persisted, not just before a holding is created. `SnaptradeAccount::Processor#calculate_holdings_value` sums `units * price` over every entry in `raw_holdings_payload`, and `calculate_total_balance` prefers that sum over SnapTrade's own figure whenever it is non-zero — so a derivative left in the payload would displace the API total with a number derived from contract counts, even with the holding itself suppressed. `holdings_currencies` walks the same payload to decide `use_api_total_balance?`. Filtering once at the provider keeps all of those consistent by construction rather than requiring each to re-apply the same exclusion.

`UNSUPPORTED_INSTRUMENT_KINDS` is a denylist rather than an allowlist so equity-like kinds SnapTrade adds later aren't silently dropped. Proper options/futures support seems worth its own PR.

**No fallback to `/positions` on 410.** `/positions/all` is the documented replacement for all accounts, not just post-cutoff ones, so a fallback would only mask real errors. Happy to add one if maintainers would rather be cautious here.

### Deliberately out of scope

The sync reports `total_errors: 0` even though the 410 was raised and logged, which is what makes this failure silent. There are two independent causes, both pre-existing and neither specific to SnapTrade:

1. `SnaptradeItem::Importer#persist_stats!` is only called at the end of `import_accounts`, *before* the holdings loop runs — so errors registered during holdings import never reach `sync.sync_stats` at all.
2. `SnaptradeItem::Syncer` calls `collect_health_stats(sync, errors: nil)` on the happy path, and `SyncStats::Collector` unconditionally writes `"total_errors" => 0` when `errors` is nil, which a flat `Hash#merge` then applies over anything the importer did persist.

Fixing (2) touches the shared collector used by every provider, so it belongs in its own PR. Relatedly, `AGENTS.md` asks that recoverable provider-sync errors go to `DebugLogEntry.capture(...)` rather than `Rails.logger` — the 410 path currently uses `Rails.logger.error`, which is worth revisiting as part of that same follow-up. Happy to open a separate issue for both if useful.

### Testing

Seven tests added, none of the existing ones modified:

`test/models/provider/snaptrade_oauth_test.rb`
- `get_positions` calls `/positions/all` and unwraps `results`
- returns `[]` for an account holding nothing
- raises rather than reporting no positions when `results` is absent
- filters out instrument kinds the holdings pipeline cannot model (asserting `option`/`future`/`cfd` are dropped while an unrecognised kind passes through, so the denylist doesn't behave like an allowlist)

`test/models/snaptrade_account_processor_test.rb`
- creates holdings from a `/positions/all` payload
- reads `cost_basis` as a per-share value
- recognises cash-equivalent positions in the new shape

Stashing the `app/` changes and re-running makes 6 of the 7 fail, confirming they exercise the fix. The remaining one (cash-equivalent recognition) passes either way — it is a regression guard for behaviour that must not change.

Separately, the verbatim `/positions/all` response captured from a live Robinhood connection was run through the patched path, to check the fixtures above aren't just agreeing with themselves. It resolves the security ("Netflix, Inc.", `exchange_mic` `XNAS`, `country_code` `US`) and produces `qty=10 price=77.885 amount=778.85 cost_basis=30 cost_basis_source=provider`.

### Checklist

- [x] `bin/rails test` — 6313 runs, 25522 assertions, 0 failures, 0 errors, 30 skips
- [x] `bin/rubocop` — 2214 files inspected, no offenses
- [x] `bin/brakeman --no-pager` — 0 security warnings, 0 errors
- [x] Tests added (7)
- [x] Branch targets `main`
- [ ] `bundle exec erb_lint` — not applicable, no `.erb` changes
- [ ] Screenshots — not applicable, no UI changes
- [ ] Migration notes — not applicable, no migrations

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)