### PR TITLE
Add origin-scoped custom CA support to the mobile app

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -19,6 +19,7 @@ For more detailed technical documentation, see [docs/TECHNICAL_GUIDE.md](docs/TE
 - 🎨 Material Design 3 with light/dark theme support
 - 🔄 Token refresh for persistent sessions
 - 🔒 Two-factor authentication (MFA) support
+- 🛡️ Origin-scoped custom CA support for private HTTPS servers
 
 ## Requirements
 

--- a/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -26,6 +26,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin connectivity_plus, dev.fluttercommunity.plus.connectivity.ConnectivityPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new com.mr.flutter.plugin.filepicker.FilePickerPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin file_picker, com.mr.flutter.plugin.filepicker.FilePickerPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new io.flutter.plugins.flutter_plugin_android_lifecycle.FlutterAndroidLifecyclePlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin flutter_plugin_android_lifecycle, io.flutter.plugins.flutter_plugin_android_lifecycle.FlutterAndroidLifecyclePlugin", e);

--- a/mobile/docs/TECHNICAL_GUIDE.md
+++ b/mobile/docs/TECHNICAL_GUIDE.md
@@ -316,6 +316,22 @@ class User {
 - Production environment enforces HTTPS
 - Development environment supports HTTP (local testing only)
 
+### 5. Private Certificate Authorities
+- Users may import one PEM or DER root CA for a private Sure server, such as a
+  server using Caddy's internal issuer.
+- The imported CA is additive: public servers continue to use the platform
+  trust store, and TLS hostname verification remains enabled.
+- Custom trust is restricted to the configured server's exact scheme, host,
+  and port. Requests to any other origin use platform trust only.
+- Automatic redirects are disabled on the custom-trust transport so a redirect
+  cannot carry that trust decision to another origin.
+- The app never enables Android's complete user certificate store and never
+  accepts all certificates. Certificate files are validated before saving and
+  their SHA-256 fingerprint is displayed for verification.
+- CA certificates are public trust material, so the selected certificate and
+  filename are stored in `shared_preferences`; private keys are not accepted or
+  stored.
+
 ## Theme & UI
 
 ### Material Design 3

--- a/mobile/ios/Runner/GeneratedPluginRegistrant.m
+++ b/mobile/ios/Runner/GeneratedPluginRegistrant.m
@@ -18,6 +18,12 @@
 @import connectivity_plus;
 #endif
 
+#if __has_include(<file_picker/FilePickerPlugin.h>)
+#import <file_picker/FilePickerPlugin.h>
+#else
+@import file_picker;
+#endif
+
 #if __has_include(<flutter_secure_storage_darwin/FlutterSecureStorageDarwinPlugin.h>)
 #import <flutter_secure_storage_darwin/FlutterSecureStorageDarwinPlugin.h>
 #else
@@ -71,6 +77,7 @@
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
   [AppLinksIosPlugin registerWithRegistrar:[registry registrarForPlugin:@"AppLinksIosPlugin"]];
   [ConnectivityPlusPlugin registerWithRegistrar:[registry registrarForPlugin:@"ConnectivityPlusPlugin"]];
+  [FilePickerPlugin registerWithRegistrar:[registry registrarForPlugin:@"FilePickerPlugin"]];
   [FlutterSecureStorageDarwinPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterSecureStorageDarwinPlugin"]];
   [LocalAuthPlugin registerWithRegistrar:[registry registrarForPlugin:@"LocalAuthPlugin"]];
   [FPPPackageInfoPlusPlugin registerWithRegistrar:[registry registrarForPlugin:@"FPPPackageInfoPlusPlugin"]];

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -471,6 +471,23 @@
 
   "backendConfigChangeHint": "You can change this later in the settings.",
   "@backendConfigChangeHint": { "description": "Helper text below the config form." },
+  "backendConfigCertificateLabel": "Custom CA certificate",
+  "@backendConfigCertificateLabel": { "description": "Label for the custom CA certificate section." },
+  "backendConfigCertificateSubtitle": "Optional certificate for a private HTTPS server",
+  "@backendConfigCertificateSubtitle": { "description": "Subtitle when no custom CA certificate is selected." },
+  "backendConfigCertificateChoose": "Choose certificate",
+  "@backendConfigCertificateChoose": { "description": "Button label for selecting a CA certificate." },
+  "backendConfigCertificateRemove": "Remove certificate",
+  "@backendConfigCertificateRemove": { "description": "Tooltip for removing the selected CA certificate." },
+  "backendConfigCertificateHelp": "Select the root CA certificate used by your server (for example Caddy's root.crt). PEM and DER certificates are supported. Hostname verification remains enabled.",
+  "@backendConfigCertificateHelp": { "description": "Help text for custom CA certificate configuration." },
+  "backendConfigCertificateInvalid": "Select a file containing one valid X.509 certificate (maximum 64 KB).",
+  "@backendConfigCertificateInvalid": { "description": "Error shown when a selected certificate cannot be parsed." },
+  "backendConfigCertificateFingerprint": "SHA-256: {fingerprint}",
+  "@backendConfigCertificateFingerprint": {
+    "description": "SHA-256 fingerprint of the selected custom CA certificate.",
+    "placeholders": { "fingerprint": { "type": "String" } }
+  },
 
   "recentTransactionsTitle": "Recent Transactions",
   "@recentTransactionsTitle": { "description": "App bar title for the recent transactions screen." },

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -1006,6 +1006,48 @@ abstract class AppLocalizations {
   /// **'You can change this later in the settings.'**
   String get backendConfigChangeHint;
 
+  /// Label for the custom CA certificate section.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom CA certificate'**
+  String get backendConfigCertificateLabel;
+
+  /// Subtitle when no custom CA certificate is selected.
+  ///
+  /// In en, this message translates to:
+  /// **'Optional certificate for a private HTTPS server'**
+  String get backendConfigCertificateSubtitle;
+
+  /// Button label for selecting a CA certificate.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose certificate'**
+  String get backendConfigCertificateChoose;
+
+  /// Tooltip for removing the selected CA certificate.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove certificate'**
+  String get backendConfigCertificateRemove;
+
+  /// Help text for custom CA certificate configuration.
+  ///
+  /// In en, this message translates to:
+  /// **'Select the root CA certificate used by your server (for example Caddy\'s root.crt). PEM and DER certificates are supported. Hostname verification remains enabled.'**
+  String get backendConfigCertificateHelp;
+
+  /// Error shown when a selected certificate cannot be parsed.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a file containing one valid X.509 certificate (maximum 64 KB).'**
+  String get backendConfigCertificateInvalid;
+
+  /// SHA-256 fingerprint of the selected custom CA certificate.
+  ///
+  /// In en, this message translates to:
+  /// **'SHA-256: {fingerprint}'**
+  String backendConfigCertificateFingerprint(String fingerprint);
+
   /// App bar title for the recent transactions screen.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -498,6 +498,32 @@ class AppLocalizationsEn extends AppLocalizations {
       'You can change this later in the settings.';
 
   @override
+  String get backendConfigCertificateLabel => 'Custom CA certificate';
+
+  @override
+  String get backendConfigCertificateSubtitle =>
+      'Optional certificate for a private HTTPS server';
+
+  @override
+  String get backendConfigCertificateChoose => 'Choose certificate';
+
+  @override
+  String get backendConfigCertificateRemove => 'Remove certificate';
+
+  @override
+  String get backendConfigCertificateHelp =>
+      'Select the root CA certificate used by your server (for example Caddy\'s root.crt). PEM and DER certificates are supported. Hostname verification remains enabled.';
+
+  @override
+  String get backendConfigCertificateInvalid =>
+      'Select a file containing one valid X.509 certificate (maximum 64 KB).';
+
+  @override
+  String backendConfigCertificateFingerprint(String fingerprint) {
+    return 'SHA-256: $fingerprint';
+  }
+
+  @override
   String get recentTransactionsTitle => 'Recent Transactions';
 
   @override

--- a/mobile/lib/screens/backend_config_screen.dart
+++ b/mobile/lib/screens/backend_config_screen.dart
@@ -1,10 +1,15 @@
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:http/http.dart' as http;
 import '../models/custom_proxy_header.dart';
+import '../services/api_http_client.dart';
 import '../services/api_config.dart';
+import '../services/custom_certificate_service.dart';
 import '../services/custom_proxy_headers_service.dart';
 import '../services/log_service.dart';
+import '../utils/certificate_fingerprint.dart';
 import '../widgets/custom_proxy_headers_editor.dart';
 import '../l10n/app_localizations.dart';
 
@@ -26,6 +31,8 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
   String? _errorMessage;
   String? _successMessage;
   List<CustomProxyHeader> _customHeaders = [];
+  Uint8List? _certificateBytes;
+  String? _certificateName;
 
   @override
   void initState() {
@@ -46,6 +53,10 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
       final prefs = await SharedPreferences.getInstance();
       final savedUrl = prefs.getString('backend_url');
       headers = await CustomProxyHeadersService.instance.loadHeaders();
+      _certificateBytes =
+          await CustomCertificateService.instance.loadCertificate();
+      _certificateName =
+          await CustomCertificateService.instance.loadCertificateName();
       if (savedUrl != null && savedUrl.isNotEmpty) {
         urlToShow = savedUrl;
       }
@@ -67,6 +78,56 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
     }
   }
 
+  Future<void> _pickCertificate() async {
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['pem', 'crt', 'cer', 'der'],
+        withData: true,
+      );
+      if (result == null) return;
+      final file = result.files.single;
+      final bytes = file.bytes;
+      if (bytes == null ||
+          bytes.isEmpty ||
+          bytes.length > CustomCertificateService.maxCertificateBytes) {
+        throw const FormatException('Certificate is empty');
+      }
+
+      // Building the client validates that Dart can parse the selected file.
+      ApiHttpClient.instance.configure(
+        trustedCertificateBytes: bytes,
+        trustedOrigin: Uri.parse(ApiConfig.baseUrl),
+      );
+      ApiHttpClient.instance.configure(
+        trustedCertificateBytes: ApiConfig.customCertificateBytes,
+        trustedOrigin: ApiConfig.customCertificateBytes == null
+            ? null
+            : Uri.parse(ApiConfig.baseUrl),
+      );
+      if (mounted) {
+        setState(() {
+          _certificateBytes = bytes;
+          _certificateName = file.name;
+          _errorMessage = null;
+        });
+      }
+    } catch (e) {
+      ApiHttpClient.instance.configure(
+        trustedCertificateBytes: ApiConfig.customCertificateBytes,
+        trustedOrigin: ApiConfig.customCertificateBytes == null
+            ? null
+            : Uri.parse(ApiConfig.baseUrl),
+      );
+      if (mounted) {
+        setState(() {
+          _errorMessage =
+              AppLocalizations.of(context).backendConfigCertificateInvalid;
+        });
+      }
+    }
+  }
+
   Future<void> _testConnection() async {
     if (!_formKey.currentState!.validate()) return;
 
@@ -79,6 +140,7 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
     });
 
     final previousHeaders = ApiConfig.customProxyHeaders;
+    final previousCertificate = ApiConfig.customCertificateBytes;
     try {
       // Normalize base URL by removing trailing slashes
       final normalizedUrl = _urlController.text.trim().replaceAll(
@@ -89,11 +151,17 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
       // Apply the unsaved edits only for the duration of this probe so the
       // test reflects what the user is about to save. Restored in `finally`.
       ApiConfig.setCustomProxyHeaders(_customHeaders);
+      ApiHttpClient.instance.configure(
+        trustedCertificateBytes: _certificateBytes,
+        trustedOrigin:
+            _certificateBytes == null ? null : Uri.parse(normalizedUrl),
+      );
 
       // Check /sessions/new page to verify it's a Sure backend
       final sessionsUrl = Uri.parse('$normalizedUrl/sessions/new');
-      final sessionsResponse =
-          await http.get(sessionsUrl, headers: ApiConfig.htmlHeaders()).timeout(
+      final sessionsResponse = await ApiHttpClient.instance
+          .get(sessionsUrl, headers: ApiConfig.htmlHeaders())
+          .timeout(
         const Duration(seconds: 10),
         onTimeout: () {
           throw Exception(l.backendConfigTimeout);
@@ -123,6 +191,11 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
       }
     } finally {
       ApiConfig.setCustomProxyHeaders(previousHeaders);
+      ApiHttpClient.instance.configure(
+        trustedCertificateBytes: previousCertificate,
+        trustedOrigin:
+            previousCertificate == null ? null : Uri.parse(ApiConfig.baseUrl),
+      );
       if (mounted) {
         setState(() {
           _isTesting = false;
@@ -155,6 +228,19 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
       // Save custom proxy headers
       await CustomProxyHeadersService.instance.saveHeaders(_customHeaders);
       ApiConfig.setCustomProxyHeaders(_customHeaders);
+
+      if (_certificateBytes == null) {
+        await CustomCertificateService.instance.clearCertificate();
+      } else {
+        await CustomCertificateService.instance.saveCertificate(
+          _certificateBytes!,
+          _certificateName ?? 'certificate',
+        );
+      }
+      ApiConfig.setCustomCertificate(
+        _certificateBytes,
+        name: _certificateName,
+      );
 
       // Update ApiConfig
       ApiConfig.setBaseUrl(normalizedUrl);
@@ -374,7 +460,8 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
                   subtitle: Text(
                     _customHeaders.isEmpty
                         ? l.backendConfigProxyHeadersSubtitle
-                        : l.backendConfigProxyHeadersCount(_customHeaders.length),
+                        : l.backendConfigProxyHeadersCount(
+                            _customHeaders.length),
                   ),
                   children: [
                     const SizedBox(height: 8),
@@ -403,6 +490,64 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
                 ),
                 const SizedBox(height: 16),
 
+                ExpansionTile(
+                  tilePadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.verified_user_outlined),
+                  title: Text(l.backendConfigCertificateLabel),
+                  subtitle: Text(
+                    _certificateName ?? l.backendConfigCertificateSubtitle,
+                  ),
+                  children: [
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: _isLoading || _isTesting
+                                ? null
+                                : _pickCertificate,
+                            icon: const Icon(Icons.upload_file_outlined),
+                            label: Text(l.backendConfigCertificateChoose),
+                          ),
+                        ),
+                        if (_certificateBytes != null) ...[
+                          const SizedBox(width: 8),
+                          IconButton(
+                            tooltip: l.backendConfigCertificateRemove,
+                            onPressed: _isLoading || _isTesting
+                                ? null
+                                : () => setState(() {
+                                      _certificateBytes = null;
+                                      _certificateName = null;
+                                    }),
+                            icon: const Icon(Icons.delete_outline),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      l.backendConfigCertificateHelp,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                    if (_certificateBytes != null) ...[
+                      const SizedBox(height: 12),
+                      SelectableText(
+                        l.backendConfigCertificateFingerprint(
+                          certificateSha256Fingerprint(_certificateBytes!),
+                        ),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                              fontFamily: 'monospace',
+                            ),
+                      ),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: 16),
+
                 // Test Connection Button
                 OutlinedButton.icon(
                   onPressed: _isTesting || _isLoading ? null : _testConnection,
@@ -413,7 +558,9 @@ class _BackendConfigScreenState extends State<BackendConfigScreen> {
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
                       : const Icon(Icons.cable),
-                  label: Text(_isTesting ? l.backendConfigTesting : l.backendConfigTestButton),
+                  label: Text(_isTesting
+                      ? l.backendConfigTesting
+                      : l.backendConfigTestButton),
                 ),
 
                 const SizedBox(height: 12),

--- a/mobile/lib/services/account_detail_service.dart
+++ b/mobile/lib/services/account_detail_service.dart
@@ -5,6 +5,7 @@ import '../models/account_balance.dart';
 import '../models/account_holding.dart';
 import '../utils/json_parsing.dart';
 import 'api_config.dart';
+import 'api_http_client.dart';
 import 'log_service.dart';
 
 class AccountDetailService {
@@ -14,7 +15,7 @@ class AccountDetailService {
   final bool _ownsClient;
 
   AccountDetailService({http.Client? client})
-      : _client = client ?? http.Client(),
+      : _client = client ?? ApiHttpClient.instance,
         _ownsClient = client == null;
 
   void close() {

--- a/mobile/lib/services/accounts_service.dart
+++ b/mobile/lib/services/accounts_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import '../models/account.dart';
 import 'api_config.dart';
+import 'api_http_client.dart';
 
 class AccountsService {
   Future<Map<String, dynamic>> getAccounts({
@@ -14,7 +14,7 @@ class AccountsService {
         '${ApiConfig.baseUrl}/api/v1/accounts?page=$page&per_page=$perPage',
       );
 
-      final response = await http.get(
+      final response = await ApiHttpClient.instance.get(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));

--- a/mobile/lib/services/api_config.dart
+++ b/mobile/lib/services/api_config.dart
@@ -1,6 +1,8 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/custom_proxy_header.dart';
+import 'api_http_client.dart';
+import 'custom_certificate_service.dart';
 import 'custom_proxy_headers_service.dart';
 
 class ApiConfig {
@@ -15,8 +17,30 @@ class ApiConfig {
   static String get baseUrl => _baseUrl;
   static String get defaultBaseUrl => _defaultBaseUrl;
 
+  static List<int>? _customCertificateBytes;
+  static String? _customCertificateName;
+
+  static List<int>? get customCertificateBytes => _customCertificateBytes;
+  static String? get customCertificateName => _customCertificateName;
+
+  static void setCustomCertificate(List<int>? bytes, {String? name}) {
+    // Validate and install the trust material before publishing it as the
+    // active configuration.
+    ApiHttpClient.instance.configure(
+      trustedCertificateBytes: bytes,
+      trustedOrigin: bytes == null ? null : Uri.parse(_baseUrl),
+    );
+    _customCertificateBytes = bytes == null ? null : List.unmodifiable(bytes);
+    _customCertificateName = name;
+  }
+
   static void setBaseUrl(String url) {
     _baseUrl = url;
+    ApiHttpClient.instance.configure(
+      trustedCertificateBytes: _customCertificateBytes,
+      trustedOrigin:
+          _customCertificateBytes == null ? null : Uri.parse(_baseUrl),
+    );
   }
 
   // API key authentication mode
@@ -90,10 +114,17 @@ class ApiConfig {
     try {
       final prefs = await SharedPreferences.getInstance();
       final savedUrl = prefs.getString(_backendUrlKey);
+      _baseUrl =
+          savedUrl != null && savedUrl.isNotEmpty ? savedUrl : _defaultBaseUrl;
+      final certificate =
+          await CustomCertificateService.instance.loadCertificate();
+      final certificateName =
+          await CustomCertificateService.instance.loadCertificateName();
+      setCustomCertificate(certificate, name: certificateName);
 
       if (savedUrl != null && savedUrl.isNotEmpty) {
-        _baseUrl = savedUrl;
-        _customProxyHeaders = await CustomProxyHeadersService.instance.loadHeaders();
+        _customProxyHeaders =
+            await CustomProxyHeadersService.instance.loadHeaders();
         return true;
       }
 
@@ -101,7 +132,8 @@ class ApiConfig {
       // go straight to login while still letting users override it later.
       _baseUrl = _defaultBaseUrl;
       await prefs.setString(_backendUrlKey, _defaultBaseUrl);
-      _customProxyHeaders = await CustomProxyHeadersService.instance.loadHeaders();
+      _customProxyHeaders =
+          await CustomProxyHeadersService.instance.loadHeaders();
       return true;
     } catch (e) {
       // If initialization fails, keep the default URL

--- a/mobile/lib/services/api_http_client.dart
+++ b/mobile/lib/services/api_http_client.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'http_client_factory.dart';
+
+/// Shared API client whose trust store can include the user's private CA.
+///
+/// Platform trust roots remain enabled, and hostname verification is not
+/// bypassed when a custom certificate is configured.
+class ApiHttpClient extends http.BaseClient {
+  ApiHttpClient._()
+      : _systemDelegate = createHttpClient(null),
+        _customClientFactory = createHttpClient;
+
+  @visibleForTesting
+  ApiHttpClient.forTesting({
+    required http.Client systemDelegate,
+    required http.Client Function(List<int>) customClientFactory,
+  })  : _systemDelegate = systemDelegate,
+        _customClientFactory = customClientFactory;
+
+  static final ApiHttpClient instance = ApiHttpClient._();
+
+  final http.Client _systemDelegate;
+  final http.Client Function(List<int>) _customClientFactory;
+  http.Client? _customDelegate;
+  Uri? _trustedOrigin;
+
+  void configure({
+    List<int>? trustedCertificateBytes,
+    Uri? trustedOrigin,
+  }) {
+    if (trustedCertificateBytes != null && trustedOrigin == null) {
+      throw ArgumentError(
+        'A trusted origin is required with a custom certificate.',
+      );
+    }
+
+    final replacement = trustedCertificateBytes == null
+        ? null
+        : _customClientFactory(trustedCertificateBytes);
+    final previous = _customDelegate;
+    _customDelegate = replacement;
+    _trustedOrigin = trustedCertificateBytes == null ? null : trustedOrigin;
+    previous?.close();
+  }
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    final customDelegate = _customDelegate;
+    final trustedOrigin = _trustedOrigin;
+    if (customDelegate != null &&
+        trustedOrigin != null &&
+        sameOrigin(request.url, trustedOrigin)) {
+      // Prevent the custom trust context from following redirects to another
+      // origin. A later request to another host uses system trust instead.
+      request.followRedirects = false;
+      return customDelegate.send(request);
+    }
+    return _systemDelegate.send(request);
+  }
+
+  @override
+  void close() {
+    // This process-wide client must not be closed by an individual service.
+  }
+}
+
+bool sameOrigin(Uri first, Uri second) {
+  return first.scheme.toLowerCase() == second.scheme.toLowerCase() &&
+      first.host.toLowerCase() == second.host.toLowerCase() &&
+      first.port == second.port;
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'package:http/http.dart' as http;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../models/auth_tokens.dart';
 import '../models/user.dart';
 import 'api_config.dart';
+import 'api_http_client.dart';
 import 'log_service.dart';
 
 class AuthService {
@@ -103,7 +103,7 @@ class AuthService {
         body['otp_code'] = otpCode;
       }
 
-      final response = await http
+      final response = await ApiHttpClient.instance
           .post(
             url,
             headers: ApiConfig.jsonHeaders(),
@@ -206,7 +206,7 @@ class AuthService {
         body['invite_code'] = inviteCode;
       }
 
-      final response = await http
+      final response = await ApiHttpClient.instance
           .post(
             url,
             headers: ApiConfig.jsonHeaders(),
@@ -279,7 +279,7 @@ class AuthService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/auth/refresh');
 
-      final response = await http
+      final response = await ApiHttpClient.instance
           .post(
             url,
             headers: ApiConfig.jsonHeaders(),
@@ -351,7 +351,7 @@ class AuthService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/accounts');
 
-      final response = await http.get(
+      final response = await ApiHttpClient.instance.get(
         url,
         headers: {
           ...ApiConfig.customProxyHeaderMap,
@@ -451,7 +451,7 @@ class AuthService {
     // Exchange authorization code for tokens via secure POST
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/auth/sso_exchange');
-      final response = await http
+      final response = await ApiHttpClient.instance
           .post(
             url,
             headers: ApiConfig.jsonHeaders(),
@@ -517,7 +517,7 @@ class AuthService {
   }) async {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/auth/sso_link');
-      final response = await http
+      final response = await ApiHttpClient.instance
           .post(
             url,
             headers: ApiConfig.jsonHeaders(),
@@ -575,7 +575,7 @@ class AuthService {
       if (firstName != null) body['first_name'] = firstName;
       if (lastName != null) body['last_name'] = lastName;
 
-      final response = await http
+      final response = await ApiHttpClient.instance
           .post(
             url,
             headers: ApiConfig.jsonHeaders(),
@@ -620,7 +620,7 @@ class AuthService {
   }) async {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/auth/enable_ai');
-      final response = await http.patch(
+      final response = await ApiHttpClient.instance.patch(
         url,
         headers: {
           ...ApiConfig.getAuthHeaders(accessToken),

--- a/mobile/lib/services/balance_sheet_service.dart
+++ b/mobile/lib/services/balance_sheet_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import 'api_config.dart';
+import 'api_http_client.dart';
 
 /// Service for fetching balance sheet data (net worth, assets, liabilities)
 /// from the Sure API.
@@ -15,7 +15,7 @@ class BalanceSheetService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/balance_sheet');
 
-      final response = await http.get(
+      final response = await ApiHttpClient.instance.get(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));

--- a/mobile/lib/services/categories_service.dart
+++ b/mobile/lib/services/categories_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import '../models/category.dart';
 import 'api_config.dart';
+import 'api_http_client.dart';
 
 class CategoriesService {
   Future<Map<String, dynamic>> getCategories({
@@ -32,7 +32,7 @@ class CategoriesService {
         : baseUri;
 
     try {
-      final response = await http.get(
+      final response = await ApiHttpClient.instance.get(
         url,
         headers: {
           ...ApiConfig.getAuthHeaders(accessToken),

--- a/mobile/lib/services/chat_service.dart
+++ b/mobile/lib/services/chat_service.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import '../models/chat.dart';
 import '../models/message.dart';
 import 'api_config.dart';
+import 'api_http_client.dart';
 
 class ChatService {
   /// Get list of chats with pagination
@@ -16,7 +16,7 @@ class ChatService {
         '${ApiConfig.baseUrl}/api/v1/chats?page=$page&per_page=$perPage',
       );
 
-      final response = await http.get(
+      final response = await ApiHttpClient.instance.get(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));
@@ -73,7 +73,7 @@ class ChatService {
         '${ApiConfig.baseUrl}/api/v1/chats/$chatId?page=$page&per_page=$perPage',
       );
 
-      final response = await http.get(
+      final response = await ApiHttpClient.instance.get(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));
@@ -132,7 +132,7 @@ class ChatService {
         body['message'] = initialMessage;
       }
 
-      final response = await http.post(
+      final response = await ApiHttpClient.instance.post(
         url,
         headers: {
           ...ApiConfig.getAuthHeaders(accessToken),
@@ -186,7 +186,7 @@ class ChatService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/chats/$chatId/messages');
 
-      final response = await http.post(
+      final response = await ApiHttpClient.instance.post(
         url,
         headers: {
           ...ApiConfig.getAuthHeaders(accessToken),
@@ -241,7 +241,7 @@ class ChatService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/chats/$chatId');
 
-      final response = await http.patch(
+      final response = await ApiHttpClient.instance.patch(
         url,
         headers: {
           ...ApiConfig.getAuthHeaders(accessToken),
@@ -295,7 +295,7 @@ class ChatService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/chats/$chatId');
 
-      final response = await http.delete(
+      final response = await ApiHttpClient.instance.delete(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));
@@ -367,7 +367,7 @@ class ChatService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/chats/$chatId/messages/retry');
 
-      final response = await http.post(
+      final response = await ApiHttpClient.instance.post(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));

--- a/mobile/lib/services/custom_certificate_service.dart
+++ b/mobile/lib/services/custom_certificate_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CustomCertificateService {
+  CustomCertificateService._();
+
+  static final CustomCertificateService instance = CustomCertificateService._();
+  static const String _certificateKey = 'custom_ca_certificate';
+  static const String _certificateNameKey = 'custom_ca_certificate_name';
+  static const int maxCertificateBytes = 64 * 1024;
+
+  Future<Uint8List?> loadCertificate() async {
+    final prefs = await SharedPreferences.getInstance();
+    final encoded = prefs.getString(_certificateKey);
+    if (encoded == null || encoded.isEmpty) return null;
+    return base64Decode(encoded);
+  }
+
+  Future<String?> loadCertificateName() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_certificateNameKey);
+  }
+
+  Future<void> saveCertificate(Uint8List bytes, String name) async {
+    if (bytes.isEmpty || bytes.length > maxCertificateBytes) {
+      throw const FormatException('Invalid certificate file size.');
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_certificateKey, base64Encode(bytes));
+    await prefs.setString(_certificateNameKey, name);
+  }
+
+  Future<void> clearCertificate() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_certificateKey);
+    await prefs.remove(_certificateNameKey);
+  }
+}

--- a/mobile/lib/services/http_client_factory.dart
+++ b/mobile/lib/services/http_client_factory.dart
@@ -1,0 +1,7 @@
+import 'package:http/http.dart' as http;
+
+import 'http_client_factory_stub.dart'
+    if (dart.library.io) 'http_client_factory_io.dart' as platform;
+
+http.Client createHttpClient(List<int>? trustedCertificateBytes) =>
+    platform.createHttpClient(trustedCertificateBytes);

--- a/mobile/lib/services/http_client_factory_io.dart
+++ b/mobile/lib/services/http_client_factory_io.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+
+import '../utils/certificate_bytes.dart';
+
+http.Client createHttpClient(List<int>? trustedCertificateBytes) {
+  final context = SecurityContext(withTrustedRoots: true);
+  if (trustedCertificateBytes != null && trustedCertificateBytes.isNotEmpty) {
+    context.setTrustedCertificatesBytes(
+      singleCertificateDerBytes(trustedCertificateBytes),
+    );
+  }
+  return IOClient(HttpClient(context: context));
+}

--- a/mobile/lib/services/http_client_factory_stub.dart
+++ b/mobile/lib/services/http_client_factory_stub.dart
@@ -1,0 +1,4 @@
+import 'package:http/http.dart' as http;
+
+http.Client createHttpClient(List<int>? trustedCertificateBytes) =>
+    http.Client();

--- a/mobile/lib/services/response_list_parser.dart
+++ b/mobile/lib/services/response_list_parser.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
-
 import 'api_config.dart';
+import 'api_http_client.dart';
 
 List<Map<String, dynamic>> extractJsonObjectList(
   dynamic responseData, {
@@ -38,7 +37,7 @@ Future<Map<String, dynamic>> fetchApiList<T>({
   final url = Uri.parse('${ApiConfig.baseUrl}$path');
 
   try {
-    final response = await http.get(
+    final response = await ApiHttpClient.instance.get(
       url,
       headers: {
         ...ApiConfig.getAuthHeaders(accessToken),

--- a/mobile/lib/services/transactions_service.dart
+++ b/mobile/lib/services/transactions_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/transaction.dart';
 import 'api_config.dart';
+import 'api_http_client.dart';
 
 class TransactionsService {
   static const String mobileIdempotencySource = 'sure_mobile';
@@ -9,7 +10,7 @@ class TransactionsService {
   final http.Client _client;
 
   TransactionsService({http.Client? client})
-      : _client = client ?? http.Client();
+      : _client = client ?? ApiHttpClient.instance;
 
   Future<Map<String, dynamic>> createTransaction({
     required String accessToken,

--- a/mobile/lib/services/user_service.dart
+++ b/mobile/lib/services/user_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import 'api_config.dart';
+import 'api_http_client.dart';
 
 class UserService {
   Future<Map<String, dynamic>> resetAccount({
@@ -9,7 +9,7 @@ class UserService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/users/reset');
 
-      final response = await http.delete(
+      final response = await ApiHttpClient.instance.delete(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));
@@ -42,7 +42,7 @@ class UserService {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}/api/v1/users/me');
 
-      final response = await http.delete(
+      final response = await ApiHttpClient.instance.delete(
         url,
         headers: ApiConfig.getAuthHeaders(accessToken),
       ).timeout(const Duration(seconds: 30));

--- a/mobile/lib/utils/certificate_bytes.dart
+++ b/mobile/lib/utils/certificate_bytes.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+final _pemCertificatePattern = RegExp(
+  r'-----BEGIN CERTIFICATE-----([\s\S]*?)-----END CERTIFICATE-----',
+);
+
+/// Returns one DER-encoded certificate, rejecting PEM bundles and extra data.
+Uint8List singleCertificateDerBytes(List<int> bytes) {
+  String text;
+  try {
+    text = utf8.decode(bytes);
+  } on FormatException {
+    return Uint8List.fromList(bytes);
+  }
+
+  final matches = _pemCertificatePattern.allMatches(text).toList();
+  if (matches.isEmpty) return Uint8List.fromList(bytes);
+  if (matches.length != 1 ||
+      text.replaceFirst(_pemCertificatePattern, '').trim().isNotEmpty) {
+    throw const FormatException(
+      'Select a file containing exactly one CA certificate.',
+    );
+  }
+
+  final encoded = matches.single.group(1)!.replaceAll(RegExp(r'\s'), '');
+  return base64Decode(encoded);
+}

--- a/mobile/lib/utils/certificate_fingerprint.dart
+++ b/mobile/lib/utils/certificate_fingerprint.dart
@@ -1,0 +1,11 @@
+import 'package:crypto/crypto.dart';
+
+import 'certificate_bytes.dart';
+
+String certificateSha256Fingerprint(List<int> bytes) {
+  return sha256
+      .convert(singleCertificateDerBytes(bytes))
+      .bytes
+      .map((byte) => byte.toRadixString(16).padLeft(2, '0').toUpperCase())
+      .join(':');
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -121,8 +121,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  crypto:
+  cross_file:
     dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
+  crypto:
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
@@ -177,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.3"
   fixnum:
     dependency: transitive
     description:
@@ -353,26 +369,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -433,26 +449,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -766,10 +782,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -886,10 +902,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   version:
     dependency: transitive
     description:
@@ -947,5 +963,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.32.0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.6
   http: ^1.1.0
+  crypto: ^3.0.7
+  file_picker: ^11.0.3
   provider: ^6.1.1
   shared_preferences: ^2.2.2
   flutter_secure_storage: ^10.0.0

--- a/mobile/test/services/api_http_client_test.dart
+++ b/mobile/test/services/api_http_client_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:sure_mobile/services/api_http_client.dart';
+
+void main() {
+  group('sameOrigin', () {
+    test('matches the same HTTPS host and effective port', () {
+      expect(
+        sameOrigin(
+          Uri.parse('https://sure.example/api/v1/accounts'),
+          Uri.parse('https://SURE.example:443'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a different host, scheme, or port', () {
+      final origin = Uri.parse('https://sure.example:8443');
+
+      expect(
+        sameOrigin(Uri.parse('https://other.example:8443'), origin),
+        isFalse,
+      );
+      expect(
+        sameOrigin(Uri.parse('http://sure.example:8443'), origin),
+        isFalse,
+      );
+      expect(
+        sameOrigin(Uri.parse('https://sure.example:443'), origin),
+        isFalse,
+      );
+    });
+  });
+
+  group('ApiHttpClient', () {
+    test('uses custom trust only for the configured origin', () async {
+      var systemRequests = 0;
+      var customRequests = 0;
+      final client = ApiHttpClient.forTesting(
+        systemDelegate: MockClient((request) async {
+          systemRequests += 1;
+          return http.Response('system', 200);
+        }),
+        customClientFactory: (_) => MockClient((request) async {
+          customRequests += 1;
+          return http.Response('custom', 200);
+        }),
+      );
+      client.configure(
+        trustedCertificateBytes: [1],
+        trustedOrigin: Uri.parse('https://sure.example'),
+      );
+
+      final trusted = await client.get(
+        Uri.parse('https://sure.example/api/v1/accounts'),
+      );
+      final other = await client.get(
+        Uri.parse('https://other.example/api/v1/accounts'),
+      );
+
+      expect(trusted.body, 'custom');
+      expect(other.body, 'system');
+      expect(customRequests, 1);
+      expect(systemRequests, 1);
+    });
+
+    test('disables automatic redirects on the custom-trust transport',
+        () async {
+      bool? followsRedirects;
+      final client = ApiHttpClient.forTesting(
+        systemDelegate: MockClient((_) async => http.Response('', 500)),
+        customClientFactory: (_) => MockClient((request) async {
+          followsRedirects = request.followRedirects;
+          return http.Response('', 302,
+              headers: {'location': 'https://evil.test'});
+        }),
+      );
+      client.configure(
+        trustedCertificateBytes: [1],
+        trustedOrigin: Uri.parse('https://sure.example'),
+      );
+
+      final response = await client.get(Uri.parse('https://sure.example'));
+
+      expect(response.statusCode, 302);
+      expect(followsRedirects, isFalse);
+    });
+
+    test('requires an origin whenever custom trust is configured', () {
+      final client = ApiHttpClient.forTesting(
+        systemDelegate: MockClient((_) async => http.Response('', 200)),
+        customClientFactory: (_) => MockClient(
+          (_) async => http.Response('', 200),
+        ),
+      );
+
+      expect(
+        () => client.configure(trustedCertificateBytes: [1]),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/mobile/test/services/custom_certificate_service_test.dart
+++ b/mobile/test/services/custom_certificate_service_test.dart
@@ -1,0 +1,64 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sure_mobile/services/custom_certificate_service.dart';
+import 'package:sure_mobile/services/http_client_factory.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('saves and loads a custom CA certificate and its name', () async {
+    final bytes = Uint8List.fromList([1, 2, 3, 4]);
+
+    await CustomCertificateService.instance.saveCertificate(
+      bytes,
+      'root.crt',
+    );
+
+    expect(
+      await CustomCertificateService.instance.loadCertificate(),
+      orderedEquals(bytes),
+    );
+    expect(
+      await CustomCertificateService.instance.loadCertificateName(),
+      'root.crt',
+    );
+  });
+
+  test('clears a saved custom CA certificate', () async {
+    await CustomCertificateService.instance.saveCertificate(
+      Uint8List.fromList([1, 2, 3]),
+      'root.crt',
+    );
+
+    await CustomCertificateService.instance.clearCertificate();
+
+    expect(await CustomCertificateService.instance.loadCertificate(), isNull);
+    expect(
+      await CustomCertificateService.instance.loadCertificateName(),
+      isNull,
+    );
+  });
+
+  test('rejects bytes that are not an X.509 certificate', () {
+    expect(
+      () => createHttpClient([1, 2, 3]),
+      throwsA(anything),
+    );
+  });
+
+  test('rejects oversized certificate storage', () async {
+    expect(
+      () => CustomCertificateService.instance.saveCertificate(
+        Uint8List(CustomCertificateService.maxCertificateBytes + 1),
+        'root.crt',
+      ),
+      throwsFormatException,
+    );
+  });
+}

--- a/mobile/test/utils/certificate_fingerprint_test.dart
+++ b/mobile/test/utils/certificate_fingerprint_test.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sure_mobile/utils/certificate_bytes.dart';
+import 'package:sure_mobile/utils/certificate_fingerprint.dart';
+
+void main() {
+  test('formats a SHA-256 certificate fingerprint', () {
+    expect(
+      certificateSha256Fingerprint([1, 2, 3]),
+      '03:90:58:C6:F2:C0:CB:49:2C:53:3B:0A:4D:14:EF:77:'
+      'CC:0F:78:AB:CC:CE:D5:28:7D:84:A1:A2:01:1C:FB:81',
+    );
+  });
+
+  test('PEM and DER representations have the same fingerprint', () {
+    final der = [1, 2, 3];
+    final pem = utf8.encode(
+      '-----BEGIN CERTIFICATE-----\n'
+      '${base64Encode(der)}\n'
+      '-----END CERTIFICATE-----\n',
+    );
+
+    expect(
+      certificateSha256Fingerprint(pem),
+      certificateSha256Fingerprint(der),
+    );
+  });
+
+  test('rejects certificate bundles', () {
+    const certificate =
+        '-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n';
+
+    expect(
+      () => singleCertificateDerBytes(utf8.encode('$certificate$certificate')),
+      throwsFormatException,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #888.

Adds support for importing one custom CA certificate in the Flutter mobile app so self-hosted Sure instances using private HTTPS certificates, including Caddy's internal CA, can be reached on Android and iOS.

This takes a safer approach than #892. That PR enabled Android's entire user certificate store globally through `network_security_config`, which prompted MITM concerns. Instead, this implementation:

- lets the user explicitly select one PEM or DER certificate
- keeps the platform trust store enabled
- keeps TLS hostname verification enabled
- applies custom trust only to the configured server's exact scheme, host, and port
- disables automatic redirects on the custom-trust transport so trust cannot cross origins
- rejects certificate bundles, malformed certificates, and files over 64 KB
- shows the certificate's SHA-256 fingerprint for verification
- does not enable Android's global user certificate store or accept all certificates

## Implementation

- Adds a centralized API HTTP client and routes all mobile API services through it.
- Persists the selected CA certificate and filename alongside backend configuration.
- Adds the certificate picker and removal controls to the backend configuration screen.
- Registers the file picker for Android and iOS.
- Keeps a browser-compatible client stub; browser TLS remains managed by the browser.
- Documents the trust model and storage behavior.

## Validation

- `flutter test`: 193 tests passed
- `flutter build apk --debug`: passed
- `flutter build apk --release`: passed
- `git diff --check`: passed
- `flutter analyze`: no feature errors or warnings; 14 pre-existing info-level deprecation notices remain
