### PR TITLE
test: pin Sankey income and expense directions

### DIFF
--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -124,6 +124,30 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert sankey_data.fetch("nodes").any? { |node| node.fetch("id").start_with?("expense_") }
   end
 
+  test "dashboard puts positive transactions on the expense side of the Sankey" do
+    expense_category = @family.categories.create!(name: "Sankey Expense", color: "#FF5733")
+    income_category = @family.categories.create!(name: "Sankey Income", color: "#33FF57")
+
+    create_transaction(account: @family.accounts.first, name: "Sankey purchase", amount: 125, category: expense_category)
+    create_transaction(account: @family.accounts.first, name: "Sankey deposit", amount: -300, category: income_category)
+
+    get root_path
+
+    assert_response :ok
+    chart = css_select("[data-controller='sankey-chart']").first
+    sankey_data = JSON.parse(chart["data-sankey-chart-data-value"])
+    nodes = sankey_data.fetch("nodes")
+    links = sankey_data.fetch("links")
+    cash_flow_index = nodes.index { |node| node.fetch("id") == "cash_flow_node" }
+    expense_index = nodes.index { |node| node.fetch("id") == "expense_#{expense_category.id}" }
+    income_index = nodes.index { |node| node.fetch("id") == "income_#{income_category.id}" }
+
+    assert_not_nil expense_index
+    assert_not_nil income_index
+    assert links.any? { |link| link["source"] == cash_flow_index && link["target"] == expense_index && link["value"] == 125.0 }
+    assert links.any? { |link| link["source"] == income_index && link["target"] == cash_flow_index && link["value"] == 300.0 }
+  end
+
   test "dashboard renders money flow widget" do
     get root_path
 


### PR DESCRIPTION
## Summary
- add an end-to-end dashboard regression test for Sankey direction
- verify positive entries flow from Cash Flow to an expense node
- verify negative entries flow from an income node to Cash Flow

## Investigation
The current main branch already classifies ordinary positive entries as expenses and negative entries as income. This test makes that contract explicit and should distinguish a real classification regression from provider-side sign normalization issues.

## Testing
- `git diff --check` passed
- Rails tests could not run in this environment: Ruby is not installed (`/usr/bin/env: ruby: No such file or directory`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify Sankey charts display transaction flows in the correct direction.
  * Confirmed expense transactions flow from cash flow to expense nodes, while income transactions flow from income nodes to cash flow.
  * Verified each expected connection appears exactly once, with accurate values, and reversed connections are not displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->