### PR TITLE
Use moniker interpolation for user family labels

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,21 @@ class User < ApplicationRecord
     User.exists? ? fallback_role : :super_admin
   end
 
+  class << self
+    def human_attribute_name(attribute, options = {})
+      locale = options[:locale] || I18n.locale
+      moniker = I18n.with_locale(locale) do
+        Current.family&.moniker_label || I18n.t("shared.family_moniker.singular", default: "Family")
+      end
+
+      options = {
+        moniker: moniker
+      }.merge(options)
+
+      super(attribute, options)
+    end
+  end
+
   has_one_attached :profile_image, dependent: :purge_later do |attachable|
     attachable.variant :thumbnail, resize_to_fill: [ 300, 300 ], convert: :webp, saver: { quality: 80 }
     attachable.variant :small, resize_to_fill: [ 72, 72 ], convert: :webp, saver: { quality: 80 }, preprocessed: true

--- a/config/locales/models/user/es.yml
+++ b/config/locales/models/user/es.yml
@@ -4,8 +4,8 @@ es:
     attributes:
       user:
         email: Correo electrónico
-        family: Familia
-        family_id: Familia
+        family: "%{moniker}"
+        family_id: "%{moniker}"
         first_name: Nombre
         last_name: Apellidos
         password: Contraseña

--- a/config/locales/models/user/fr.yml
+++ b/config/locales/models/user/fr.yml
@@ -4,8 +4,8 @@ fr:
     attributes:
       user:
         email: Adresse mail
-        family: Famille
-        family_id: Famille
+        family: "%{moniker}"
+        family_id: "%{moniker}"
         first_name: Prénom
         last_name: Nom
         password: Mot de passe

--- a/config/locales/models/user/nb.yml
+++ b/config/locales/models/user/nb.yml
@@ -4,8 +4,8 @@ nb:
     attributes:
       user:
         email: E-post
-        family: Husholdning
-        family_id: Husholdning
+        family: "%{moniker}"
+        family_id: "%{moniker}"
         first_name: Fornavn
         last_name: Etternavn
         password: Passord

--- a/config/locales/models/user/nl.yml
+++ b/config/locales/models/user/nl.yml
@@ -4,8 +4,8 @@ nl:
     attributes:
       user:
         email: Email
-        family: Familie
-        family_id: Familie
+        family: "%{moniker}"
+        family_id: "%{moniker}"
         first_name: Voornaam
         last_name: Achternaam
         password: Wachtwoord

--- a/config/locales/models/user/pt-BR.yml
+++ b/config/locales/models/user/pt-BR.yml
@@ -4,8 +4,8 @@ pt-BR:
     attributes:
       user:
         email: E-mail
-        family: Família
-        family_id: Família
+        family: "%{moniker}"
+        family_id: "%{moniker}"
         first_name: Primeiro Nome
         last_name: Sobrenome
         password: Senha

--- a/config/locales/models/user/ro.yml
+++ b/config/locales/models/user/ro.yml
@@ -3,8 +3,8 @@ ro:
     attributes:
       user:
         email: Email
-        family: Familie
-        family_id: Familie
+        family: "%{moniker}"
+        family_id: "%{moniker}"
         first_name: Prenume
         last_name: Nume de familie
         password: Parolă

--- a/config/locales/models/user/zh-CN.yml
+++ b/config/locales/models/user/zh-CN.yml
@@ -4,8 +4,8 @@ zh-CN:
     attributes:
       user:
         email: 邮箱
-        family: 家庭
-        family_id: 家庭
+        family: "%{moniker}"
+        family_id: "%{moniker}"
         first_name: 名字
         last_name: 姓氏
         password: 密码

--- a/config/locales/views/shared/es.yml
+++ b/config/locales/views/shared/es.yml
@@ -17,5 +17,10 @@ es:
       exchange_rate_help: Elige cómo introducir el importe.
     syncing_notice:
       syncing: Sincronizando datos de cuentas...
+    family_moniker:
+      group_plural: Grupos
+      group_singular: Grupo
+      plural: Familias
+      singular: Familia
     trend_change:
       no_change: "sin cambios"

--- a/config/locales/views/shared/hu.yml
+++ b/config/locales/views/shared/hu.yml
@@ -29,6 +29,8 @@ hu:
       resource_deletion_body: "Biztosan törli a következőt: %{resource}? Ez a művelet nem vonható vissza."
       resource_deletion_btn_text: "%{resource} törlése"
     family_moniker:
+      group_plural: Csoportok
+      group_singular: Csoport
       singular: Háztartás
       plural: Háztartások
     trend_change:

--- a/config/locales/views/shared/nb.yml
+++ b/config/locales/views/shared/nb.yml
@@ -17,5 +17,10 @@ nb:
       exchange_rate_help: Velg hvordan du vil fylle inn beløpet.
     syncing_notice:
       syncing: Synkroniserer kontodata...
+    family_moniker:
+      group_plural: Grupper
+      group_singular: Gruppe
+      plural: Husholdninger
+      singular: Husholdning
     trend_change:
       no_change: "ingen endring"

--- a/config/locales/views/shared/nl.yml
+++ b/config/locales/views/shared/nl.yml
@@ -17,5 +17,10 @@ nl:
       exchange_rate_help: Kies hoe u het bedrag wilt invoeren.
     syncing_notice:
       syncing: Accountsgegevens synchroniseren...
+    family_moniker:
+      group_plural: Groepen
+      group_singular: Groep
+      plural: Families
+      singular: Familie
     trend_change:
       no_change: "geen verandering"

--- a/config/locales/views/shared/pl.yml
+++ b/config/locales/views/shared/pl.yml
@@ -12,5 +12,10 @@ pl:
     syncing_notice:
       syncing: Synchronizowanie danych kont...
     require_admin: "Tę akcję mogą wykonać tylko administratorzy"
+    family_moniker:
+      group_plural: Grupy
+      group_singular: Grupa
+      plural: Rodziny
+      singular: Rodzina
     trend_change:
       no_change: "bez zmian"

--- a/config/locales/views/shared/pt-BR.yml
+++ b/config/locales/views/shared/pt-BR.yml
@@ -17,5 +17,10 @@ pt-BR:
       exchange_rate_help: Escolha como inserir o valor.
     syncing_notice:
       syncing: Sincronizando dados das contas...
+    family_moniker:
+      group_plural: Grupos
+      group_singular: Grupo
+      plural: Famílias
+      singular: Família
     trend_change:
       no_change: "sem alteração"

--- a/config/locales/views/shared/ro.yml
+++ b/config/locales/views/shared/ro.yml
@@ -17,5 +17,10 @@ ro:
       exchange_rate_help: Alege cum dorești să introduci suma.
     syncing_notice:
       syncing: Se sincronizează datele conturilor...
+    family_moniker:
+      group_plural: Grupuri
+      group_singular: Grup
+      plural: Familii
+      singular: Familie
     trend_change:
       no_change: "fără schimbare"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -68,6 +68,60 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "D", user.initial
   end
 
+  test "family validation label uses localized default moniker" do
+    I18n.with_locale(:es) do
+      Current.stubs(:family).returns(nil)
+      user = User.new(email: "missing-family@example.com", password: user_password_test)
+
+      assert_not user.valid?
+      assert_includes user.errors.full_messages, "Familia debe existir"
+    end
+  end
+
+  test "family validation label uses current family moniker" do
+    family = families(:dylan_family)
+    family.update!(moniker: "Group")
+
+    I18n.with_locale(:es) do
+      Current.stubs(:family).returns(family)
+      user = User.new(email: "missing-group@example.com", password: user_password_test)
+
+      assert_not user.valid?
+      assert_includes user.errors.full_messages, "Grupo debe existir"
+    end
+  end
+
+  test "family attribute labels use requested locale for current family moniker" do
+    family = families(:dylan_family)
+    family.update!(moniker: "Group")
+    Current.stubs(:family).returns(family)
+
+    I18n.with_locale(:en) do
+      assert_equal "Grupo", User.human_attribute_name(:family, locale: :es)
+      assert_equal "Grupo", User.human_attribute_name(:family_id, locale: :es)
+    end
+  end
+
+  test "family validation label renders in every supported locale" do
+    family = families(:dylan_family)
+    family.update!(moniker: "Group")
+    Current.stubs(:family).returns(family)
+
+    LanguagesHelper::SUPPORTED_LOCALES.each do |locale|
+      I18n.with_locale(locale) do
+        user = User.new(email: "missing-family-#{locale.parameterize}@example.com", password: user_password_test)
+        family_label = User.human_attribute_name(:family, locale: locale)
+        family_id_label = User.human_attribute_name(:family_id, locale: locale)
+
+        assert_not user.valid?
+        assert_includes user.errors.full_messages_for(:family).to_sentence,
+                        family_label,
+                        "expected family error to include moniker label for #{locale}"
+        assert_equal family_label, family_id_label
+      end
+    end
+  end
+
   test "names are normalized" do
     @user.update!(first_name: "", last_name: "")
     assert_nil @user.first_name


### PR DESCRIPTION
## Summary
- add User.human_attribute_name moniker interpolation for family labels
- update `user.family` / `user.family_id` labels to `%{moniker}` across all supported app locales
- add missing shared family/group moniker labels for supported locales
- cover missing-family validation messages for Spanish default and Group monikers, plus a regression that renders the family label in every supported locale

Closes #3059

## Tests
- bin/rails test test/models/user_test.rb
- bin/rails test test/i18n_test.rb
- bin/rubocop app/models/user.rb test/models/user_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Family-related form labels and validation messages now reflect configured terminology, defaulting to “Family” when no custom term is provided.
  * Added localized singular and plural terminology for families, groups, and households across supported languages, including Spanish, French, Norwegian, Dutch, Portuguese, Romanian, Chinese, Hungarian, and Polish.

* **Bug Fixes**
  * Corrected localized family and family ID labels to display the appropriate configured terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->