### PR TITLE
FIX: Refunds or credits incorrectly recorded as cc_payment

### DIFF
--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -224,8 +224,6 @@ class Account::ProviderImportAdapter
         auto_category = account.family.investment_contributions_category
       elsif account.accountable_type == "Loan" && amount.negative?
         auto_kind = "loan_payment"
-      elsif account.accountable_type == "CreditCard" && amount.negative?
-        auto_kind = "cc_payment"
       end
       auto_kind ||= kind.presence
 

--- a/app/models/brex_entry/processor.rb
+++ b/app/models/brex_entry/processor.rb
@@ -26,6 +26,7 @@ class BrexEntry::Processor
       date: date,
       name: name,
       source: "brex",
+      kind: transaction_kind,
       merchant: merchant,
       notes: notes,
       extra: extra
@@ -82,6 +83,10 @@ class BrexEntry::Processor
       note_parts << data[:type] if data[:type].present?
       note_parts << data[:expense_id] if data[:expense_id].present?
       note_parts.any? ? note_parts.join(" - ") : nil
+    end
+
+    def transaction_kind
+      "cc_payment" if brex_account.account_kind == "card" && data[:type] == "COLLECTION" && amount.negative?
     end
 
     def merchant

--- a/test/models/brex_entry/processor_test.rb
+++ b/test/models/brex_entry/processor_test.rb
@@ -43,6 +43,22 @@ class BrexEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal "cc_payment", entry.transaction.kind
   end
 
+  test "does not classify non-negative collection as card payment" do
+    entry = BrexEntry::Processor.new(card_transaction(id: "tx_collection_positive", amount: 50_00, type: "COLLECTION"), brex_account: @brex_account).process
+
+    assert_equal BigDecimal("50.0"), entry.amount
+    assert_equal "standard", entry.transaction.kind
+  end
+
+  test "does not classify non-card collection as card payment" do
+    @brex_account.update!(account_kind: "cash")
+
+    entry = BrexEntry::Processor.new(card_transaction(id: "tx_collection_cash", amount: -50_00, type: "COLLECTION"), brex_account: @brex_account).process
+
+    assert_equal BigDecimal("-50.0"), entry.amount
+    assert_equal "standard", entry.transaction.kind
+  end
+
   test "is idempotent by external id and source" do
     transaction = card_transaction(id: "tx_duplicate", amount: 12_34)
 


### PR DESCRIPTION
Implements @dosu's suggested fix for [#3056](https://github.com/we-promise/sure/issues/3056)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Negative transactions are no longer automatically classified as credit card payments based solely on their amount.
  * Negative loan transactions continue to be classified as loan payments.
  * Brex collection transactions are classified as credit card payments only when they come from card accounts and have a negative amount.
  * Other transactions continue to use their supplied transaction type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->