### PR TITLE
Fix onboarding country and currency defaults

### DIFF
--- a/app/javascript/controllers/onboarding_controller.js
+++ b/app/javascript/controllers/onboarding_controller.js
@@ -2,16 +2,19 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="onboarding"
 export default class extends Controller {
-  static targets = ["nameField", "monikerRadio"]
+  static targets = ["nameField", "monikerRadio", "countryField", "currencyField"]
   static values = {
     householdNameLabel: String,
     householdNamePlaceholder: String,
     groupNameLabel: String,
-    groupNamePlaceholder: String
+    groupNamePlaceholder: String,
+    country: String,
+    currencyOverride: Boolean
   }
 
   connect() {
     this.updateNameFieldForCurrentMoniker();
+    this.applyBrowserLocaleDefaults();
   }
 
   setLocale(event) {
@@ -28,6 +31,49 @@ export default class extends Controller {
 
   setTheme(event) {
     document.documentElement.setAttribute("data-theme", event.target.value);
+  }
+
+  applyBrowserLocaleDefaults() {
+    const browserCountry = this.browserCountry();
+
+    if (this.hasCountryFieldTarget && browserCountry && this.countryFieldTarget.value === "US" && this.hasCountryOption(browserCountry)) {
+      this.countryFieldTarget.value = browserCountry;
+    }
+
+    if (this.hasCurrencyFieldTarget && !this.currencyOverrideValue) {
+      const country = this.countryValue || this.countryFieldTarget?.value || browserCountry;
+      const currency = this.currencyForCountry(country);
+
+      if (currency && this.hasCurrencyOption(currency)) {
+        this.currencyFieldTarget.value = currency;
+      }
+    }
+  }
+
+  browserCountry() {
+    try {
+      return new Intl.Locale(navigator.language).maximize().region;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  currencyForCountry(country) {
+    return {
+      AU: "AUD", CA: "CAD", CH: "CHF", CN: "CNY", CZ: "CZK", DK: "DKK",
+      GB: "GBP", HK: "HKD", HU: "HUF", ID: "IDR", IL: "ILS", IN: "INR",
+      JP: "JPY", KR: "KRW", MX: "MXN", MY: "MYR", NO: "NOK", NZ: "NZD",
+      PH: "PHP", PL: "PLN", SE: "SEK", SG: "SGD", TH: "THB", TR: "TRY",
+      TW: "TWD", US: "USD", ZA: "ZAR"
+    }[country?.toUpperCase()];
+  }
+
+  hasCountryOption(country) {
+    return Array.from(this.countryFieldTarget.options).some((option) => option.value === country);
+  }
+
+  hasCurrencyOption(currency) {
+    return Array.from(this.currencyFieldTarget.options).some((option) => option.value === currency);
   }
 
   updateNameFieldForCurrentMoniker(event = null) {

--- a/app/javascript/controllers/onboarding_controller.js
+++ b/app/javascript/controllers/onboarding_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
     groupNameLabel: String,
     groupNamePlaceholder: String,
     country: String,
+    countryCurrencies: Object,
     currencyOverride: Boolean
   }
 
@@ -41,7 +42,7 @@ export default class extends Controller {
     }
 
     if (this.hasCurrencyFieldTarget && !this.currencyOverrideValue) {
-      const country = this.countryValue || this.countryFieldTarget?.value || browserCountry;
+      const country = this.countryValue || (this.hasCountryFieldTarget ? this.countryFieldTarget.value : null) || browserCountry;
       const currency = this.currencyForCountry(country);
 
       if (currency && this.hasCurrencyOption(currency)) {
@@ -59,13 +60,7 @@ export default class extends Controller {
   }
 
   currencyForCountry(country) {
-    return {
-      AU: "AUD", CA: "CAD", CH: "CHF", CN: "CNY", CZ: "CZK", DK: "DKK",
-      GB: "GBP", HK: "HKD", HU: "HUF", ID: "IDR", IL: "ILS", IN: "INR",
-      JP: "JPY", KR: "KRW", MX: "MXN", MY: "MYR", NO: "NOK", NZ: "NZD",
-      PH: "PHP", PL: "PLN", SE: "SEK", SG: "SGD", TH: "THB", TR: "TRY",
-      TW: "TWD", US: "USD", ZA: "ZAR"
-    }[country?.toUpperCase()];
+    return (this.hasCountryCurrenciesValue ? this.countryCurrenciesValue : {})[country?.toUpperCase()];
   }
 
   hasCountryOption(country) {

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -28,16 +28,6 @@ class Family < ApplicationRecord
   ASSISTANT_TYPES = %w[builtin external].freeze
   SHARING_DEFAULTS = %w[shared private].freeze
 
-  DEFAULT_CURRENCY_BY_COUNTRY = {
-    "AU" => "AUD", "CA" => "CAD", "CH" => "CHF", "CN" => "CNY",
-    "CZ" => "CZK", "DK" => "DKK", "GB" => "GBP", "HK" => "HKD",
-    "HU" => "HUF", "ID" => "IDR", "IL" => "ILS", "IN" => "INR",
-    "JP" => "JPY", "KR" => "KRW", "MX" => "MXN", "MY" => "MYR",
-    "NO" => "NOK", "NZ" => "NZD", "PH" => "PHP", "PL" => "PLN",
-    "SE" => "SEK", "SG" => "SGD", "TH" => "THB", "TR" => "TRY",
-    "TW" => "TWD", "US" => "USD", "ZA" => "ZAR"
-  }.freeze
-
   has_many :users, dependent: :destroy
   has_many :accounts, dependent: :destroy
   has_many :invitations, dependent: :destroy
@@ -161,11 +151,28 @@ class Family < ApplicationRecord
   before_validation :normalize_enabled_currencies!
 
   def primary_currency_code
-    normalize_currency_code(currency) || "USD"
+    self.class.normalize_currency_code(currency) || "USD"
   end
 
   def default_currency_for_country
-    DEFAULT_CURRENCY_BY_COUNTRY.fetch(country.to_s.upcase, "USD")
+    self.class.default_currency_for_country(country)
+  end
+
+  def self.default_currency_for_country(country)
+    country_currency = ISO3166::Country.new(country.to_s.upcase)&.currency_code
+    normalize_currency_code(country_currency) || "USD"
+  end
+
+  def self.default_currency_by_country
+    LanguagesHelper::COUNTRY_MAPPING.keys.index_with { |country| default_currency_for_country(country) }
+  end
+
+  def self.normalize_currency_code(value)
+    return if value.blank?
+
+    Money::Currency.new(value).iso_code
+  rescue Money::Currency::UnknownCurrencyError, ArgumentError
+    nil
   end
 
   def custom_enabled_currencies?
@@ -505,15 +512,7 @@ class Family < ApplicationRecord
     end
 
     def normalize_currency_codes(values)
-      Array(values).filter_map { |value| normalize_currency_code(value) }.uniq
-    end
-
-    def normalize_currency_code(value)
-      return if value.blank?
-
-      Money::Currency.new(value).iso_code
-    rescue Money::Currency::UnknownCurrencyError, ArgumentError
-      nil
+      Array(values).filter_map { |value| self.class.normalize_currency_code(value) }.uniq
     end
 
     # Not a plain `inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }`

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -28,6 +28,16 @@ class Family < ApplicationRecord
   ASSISTANT_TYPES = %w[builtin external].freeze
   SHARING_DEFAULTS = %w[shared private].freeze
 
+  DEFAULT_CURRENCY_BY_COUNTRY = {
+    "AU" => "AUD", "CA" => "CAD", "CH" => "CHF", "CN" => "CNY",
+    "CZ" => "CZK", "DK" => "DKK", "GB" => "GBP", "HK" => "HKD",
+    "HU" => "HUF", "ID" => "IDR", "IL" => "ILS", "IN" => "INR",
+    "JP" => "JPY", "KR" => "KRW", "MX" => "MXN", "MY" => "MYR",
+    "NO" => "NOK", "NZ" => "NZD", "PH" => "PHP", "PL" => "PLN",
+    "SE" => "SEK", "SG" => "SGD", "TH" => "THB", "TR" => "TRY",
+    "TW" => "TWD", "US" => "USD", "ZA" => "ZAR"
+  }.freeze
+
   has_many :users, dependent: :destroy
   has_many :accounts, dependent: :destroy
   has_many :invitations, dependent: :destroy
@@ -152,6 +162,10 @@ class Family < ApplicationRecord
 
   def primary_currency_code
     normalize_currency_code(currency) || "USD"
+  end
+
+  def default_currency_for_country
+    DEFAULT_CURRENCY_BY_COUNTRY.fetch(country.to_s.upcase, "USD")
   end
 
   def custom_enabled_currencies?

--- a/app/views/onboardings/preferences.html.erb
+++ b/app/views/onboardings/preferences.html.erb
@@ -8,7 +8,10 @@
   <%= render "onboardings/logout" %>
 <% end %>
 
-<div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-6 px-4 md:px-0" data-controller="onboarding">
+<div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-6 px-4 md:px-0"
+  data-controller="onboarding"
+  data-onboarding-country-value="<%= @user.family.country %>"
+  data-onboarding-currency-override-value="<%= params[:currency].present? %>">
   <div>
     <div class="space-y-1 mb-6">
       <h1 class="text-2xl font-medium"><%= t(".title") %></h1>
@@ -83,7 +86,7 @@
           <%= family_form.select :currency,
                                  Money::Currency.as_options.map { |currency| [ "#{currency.name} (#{currency.iso_code})", currency.iso_code ] },
                                  { label: t(".currency"), required: true, selected: selected_currency },
-                                 { data: { action: "onboarding#setCurrency" } } %>
+                                 { data: { action: "onboarding#setCurrency", onboarding_target: "currencyField" } } %>
 
           <%= family_form.select :date_format,
                                  Family::DATE_FORMATS,

--- a/app/views/onboardings/preferences.html.erb
+++ b/app/views/onboardings/preferences.html.erb
@@ -9,13 +9,14 @@
 <% end %>
 
 <% currency_override = Family.normalize_currency_code(params[:currency]) %>
-<% selected_currency = currency_override || (@user.set_onboarding_preferences_at? ? @user.family.primary_currency_code : @user.family.default_currency_for_country) %>
+<% saved_currency = @user.family.primary_currency_code if @user.set_onboarding_preferences_at? %>
+<% selected_currency = currency_override || saved_currency || @user.family.default_currency_for_country %>
 
 <div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-6 px-4 md:px-0"
   data-controller="onboarding"
   data-onboarding-country-value="<%= @user.family.country %>"
   data-onboarding-country-currencies-value="<%= Family.default_currency_by_country.to_json %>"
-  data-onboarding-currency-override-value="<%= currency_override.present? %>">
+  data-onboarding-currency-override-value="<%= currency_override.present? || saved_currency.present? %>">
   <div>
     <div class="space-y-1 mb-6">
       <h1 class="text-2xl font-medium"><%= t(".title") %></h1>

--- a/app/views/onboardings/preferences.html.erb
+++ b/app/views/onboardings/preferences.html.erb
@@ -19,10 +19,11 @@
       <div class="bg-container p-4 rounded-lg flex gap-8 shadow-border-xs">
         <div class="space-y-2">
           <%= tag.p t(".example"), class: "text-secondary text-sm" %>
-          <%= tag.p format_money(Money.new(2325.25, params[:currency] || @user.family.currency)), class: "text-primary font-medium text-2xl" %>
+          <% selected_currency = params[:currency].presence || @user.family.default_currency_for_country %>
+          <%= tag.p format_money(Money.new(2325.25, selected_currency)), class: "text-primary font-medium text-2xl" %>
           <p class="text-sm">
-            <span class="text-green-500 font-medium">+<%= format_money(Money.new(78.90, params[:currency] || @user.family.currency)) %></span>
-            <span class="text-green-500 font-medium">(+<%= format_money(Money.new(6.39, params[:currency] || @user.family.currency)) %>)</span>
+            <span class="text-green-500 font-medium">+<%= format_money(Money.new(78.90, selected_currency)) %></span>
+            <span class="text-green-500 font-medium">(+<%= format_money(Money.new(6.39, selected_currency)) %>)</span>
             <span class="text-secondary">as of <%= format_date(Date.parse("2024-10-23"), :default, format_code: params[:date_format] || @user.family.date_format) %></span>
           </p>
         </div>
@@ -81,7 +82,7 @@
 
           <%= family_form.select :currency,
                                  Money::Currency.as_options.map { |currency| [ "#{currency.name} (#{currency.iso_code})", currency.iso_code ] },
-                                 { label: t(".currency"), required: true, selected: params[:currency] || @user.family.currency },
+                                 { label: t(".currency"), required: true, selected: selected_currency },
                                  { data: { action: "onboarding#setCurrency" } } %>
 
           <%= family_form.select :date_format,

--- a/app/views/onboardings/preferences.html.erb
+++ b/app/views/onboardings/preferences.html.erb
@@ -8,10 +8,14 @@
   <%= render "onboardings/logout" %>
 <% end %>
 
+<% currency_override = Family.normalize_currency_code(params[:currency]) %>
+<% selected_currency = currency_override || (@user.set_onboarding_preferences_at? ? @user.family.primary_currency_code : @user.family.default_currency_for_country) %>
+
 <div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-6 px-4 md:px-0"
   data-controller="onboarding"
   data-onboarding-country-value="<%= @user.family.country %>"
-  data-onboarding-currency-override-value="<%= params[:currency].present? %>">
+  data-onboarding-country-currencies-value="<%= Family.default_currency_by_country.to_json %>"
+  data-onboarding-currency-override-value="<%= currency_override.present? %>">
   <div>
     <div class="space-y-1 mb-6">
       <h1 class="text-2xl font-medium"><%= t(".title") %></h1>
@@ -22,7 +26,6 @@
       <div class="bg-container p-4 rounded-lg flex gap-8 shadow-border-xs">
         <div class="space-y-2">
           <%= tag.p t(".example"), class: "text-secondary text-sm" %>
-          <% selected_currency = params[:currency].presence || @user.family.default_currency_for_country %>
           <%= tag.p format_money(Money.new(2325.25, selected_currency)), class: "text-primary font-medium text-2xl" %>
           <p class="text-sm">
             <span class="text-green-500 font-medium">+<%= format_money(Money.new(78.90, selected_currency)) %></span>

--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -10,7 +10,12 @@
   <%= render "onboardings/logout" %>
 <% end %>
 
-<div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-2 px-4 md:px-0">
+<div class="grow max-w-lg w-full mx-auto bg-surface flex flex-col justify-center md:py-0 py-2 px-4 md:px-0"
+  data-controller="onboarding"
+  data-onboarding-household-name-label-value="<%= t(".household_name") %>"
+  data-onboarding-household-name-placeholder-value="<%= t(".household_name_placeholder") %>"
+  data-onboarding-group-name-label-value="<%= t(".group_name") %>"
+  data-onboarding-group-name-placeholder-value="<%= t(".group_name_placeholder") %>">
   <div>
     <div class="space-y-1 mb-6 text-center">
       <h1 class="text-2xl font-medium md:text-2xl"><%= t(".title") %></h1>
@@ -34,12 +39,7 @@
         <div class="space-y-4 mb-4">
           <%= form.fields_for :family do |family_form| %>
             <div class="bg-container rounded-lg shadow-border-xs p-4">
-              <div class="space-y-2"
-                data-controller="onboarding"
-                data-onboarding-household-name-label-value="<%= t(".household_name") %>"
-                data-onboarding-household-name-placeholder-value="<%= t(".household_name_placeholder") %>"
-                data-onboarding-group-name-label-value="<%= t(".group_name") %>"
-                data-onboarding-group-name-placeholder-value="<%= t(".group_name_placeholder") %>">
+              <div class="space-y-2">
                 <p class="text-sm font-medium text-primary"><%= t(".moniker_prompt", product_name: product_name) %></p>
 
                 <label class="flex items-center gap-2 text-sm text-primary">
@@ -67,7 +67,7 @@
             <%= family_form.select :country,
                                    country_options,
                                    { label: t(".country") },
-                                   required: true %>
+                                   { required: true, data: { onboarding_target: "countryField" } } %>
           <% end %>
         </div>
       <% end %>

--- a/test/controllers/onboardings_controller_test.rb
+++ b/test/controllers/onboardings_controller_test.rb
@@ -118,6 +118,16 @@ class OnboardingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name='user[family_attributes][currency]'] option[selected][value='CAD']"
   end
 
+  test "preferences page keeps the saved currency after preferences have been set" do
+    @family.update!(country: "CA", currency: "USD")
+    @user.update!(set_onboarding_preferences_at: Time.current)
+
+    get preferences_onboarding_url
+
+    assert_response :success
+    assert_select "select[name='user[family_attributes][currency]'] option[selected][value='USD']"
+  end
+
   test "preferences page preserves an explicit currency override" do
     @family.update!(country: "CA", currency: "USD")
 
@@ -125,6 +135,16 @@ class OnboardingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "select[name='user[family_attributes][currency]'] option[selected][value='USD']"
+  end
+
+  test "preferences page ignores an unsupported currency override" do
+    @family.update!(country: "CA", currency: "USD")
+
+    get preferences_onboarding_url, params: { currency: "NOPE" }
+
+    assert_response :success
+    assert_select "[data-onboarding-currency-override-value='false']"
+    assert_select "select[name='user[family_attributes][currency]'] option[selected][value='CAD']"
   end
 
   test "preferences page shows date formatting example" do

--- a/test/controllers/onboardings_controller_test.rb
+++ b/test/controllers/onboardings_controller_test.rb
@@ -109,6 +109,24 @@ class OnboardingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "span", text: /\+\$78\.90/
   end
 
+  test "preferences page derives currency from the onboarding country" do
+    @family.update!(country: "CA", currency: "USD")
+
+    get preferences_onboarding_url
+
+    assert_response :success
+    assert_select "select[name='user[family_attributes][currency]'] option[selected][value='CAD']"
+  end
+
+  test "preferences page preserves an explicit currency override" do
+    @family.update!(country: "CA", currency: "USD")
+
+    get preferences_onboarding_url, params: { currency: "USD" }
+
+    assert_response :success
+    assert_select "select[name='user[family_attributes][currency]'] option[selected][value='USD']"
+  end
+
   test "preferences page shows date formatting example" do
   get preferences_onboarding_url
   assert_response :success

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -165,6 +165,13 @@ class FamilyTest < ActiveSupport::TestCase
     assert_equal "Groups", family.moniker_label_plural
   end
 
+  test "default currency comes from country ISO data" do
+    assert_equal "CAD", Family.default_currency_for_country("CA")
+    assert_equal "EUR", Family.default_currency_for_country("DE")
+    assert_equal "BRL", Family.default_currency_for_country("BR")
+    assert_equal "USD", Family.default_currency_for_country("unknown")
+  end
+
   test "available_merchants includes family merchants without transactions" do
     family = families(:dylan_family)
 

--- a/test/system/onboardings_test.rb
+++ b/test/system/onboardings_test.rb
@@ -69,6 +69,17 @@ class OnboardingsTest < ApplicationSystemTestCase
     assert_equal "CAD", @family.currency
   end
 
+  test "saved currency stays authoritative after onboarding controller connects" do
+    @family.update!(country: "CA", currency: "USD")
+    @user.update!(set_onboarding_preferences_at: Time.current)
+    set_browser_language("en-CA")
+
+    visit preferences_onboarding_path
+
+    assert_selector "[data-onboarding-currency-override-value='true']"
+    assert_equal "USD", find("#user_family_attributes_currency").value
+  end
+
   test "preferences page renders chart without errors" do
     visit preferences_onboarding_path
 

--- a/test/system/onboardings_test.rb
+++ b/test/system/onboardings_test.rb
@@ -48,6 +48,27 @@ class OnboardingsTest < ApplicationSystemTestCase
     assert_text I18n.t("onboardings.goals.title")
   end
 
+  test "browser locale defaults onboarding country and currency" do
+    @family.update!(country: "US", currency: "USD")
+    set_browser_language("en-CA")
+
+    visit onboarding_path
+
+    assert_equal "CA", find("#user_family_attributes_country").value
+
+    click_button I18n.t("onboardings.show.submit")
+    assert_current_path preferences_onboarding_path
+
+    assert_equal "CAD", find("#user_family_attributes_currency").value
+
+    click_button I18n.t("onboardings.preferences.submit")
+    assert_current_path goals_onboarding_path
+
+    @family.reload
+    assert_equal "CA", @family.country
+    assert_equal "CAD", @family.currency
+  end
+
   test "preferences page renders chart without errors" do
     visit preferences_onboarding_path
 
@@ -192,6 +213,18 @@ class OnboardingsTest < ApplicationSystemTestCase
       find("#user_theme", visible: :all)
         .find("option[value='#{value}']", visible: :all)
         .select_option
+    end
+
+    def set_browser_language(language)
+      page.driver.browser.execute_cdp(
+        "Page.addScriptToEvaluateOnNewDocument",
+        source: <<~JS
+          Object.defineProperty(navigator, "language", {
+            get: () => "#{language}",
+            configurable: true
+          });
+        JS
+      )
     end
 
     def sign_in(user)


### PR DESCRIPTION
## Summary
- use the browser locale region to preselect onboarding country client-side
- derive the matching currency automatically, including Canada -> CAD
- preserve explicit currency selections
- add onboarding regression coverage

## Testing
- `node --check app/javascript/controllers/onboarding_controller.js`
- `bin/rails test test/controllers/onboardings_controller_test.rb` *(blocked in this environment: Ruby is not installed)*

## Notes
- No merge performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Onboarding detects the browser’s country and suggests a matching country and currency.
  - Families receive country-based default currencies, with USD used when no mapping is available.
  - Users can override the suggested currency during onboarding.
  - Preview amounts update using the selected currency.

- **Bug Fixes**
  - Explicit currency selections remain preserved after preferences are saved.
  - Unsupported currency overrides fall back safely to the appropriate default.
  - Locale detection handles unsupported or unavailable browser data.
  - Currency suggestions now support a broader range of countries and ISO currency codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->