### PR TITLE
fix(holdings): stop listing settlement-fund cash twice

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -537,6 +537,19 @@ class Account < ApplicationRecord
     end
   end
 
+  # Cash that isn't already represented by one of this account's holdings.
+  #
+  # Investment syncs treat money market / settlement funds as cash when
+  # deriving cash_balance (see SimplefinAccount::Investments::BalanceCalculator),
+  # but the provider also sends those funds as holdings. Rendering both a
+  # "Brokerage cash" row and the fund itself lists the same dollars twice and
+  # pushes the weight column past 100%.
+  def cash_balance_outside_holdings
+    held_cash = current_holdings.sum { |h| h.security.cash_equivalent? ? h.amount.to_d : 0 }
+
+    [ cash_balance.to_d - held_cash, 0 ].max
+  end
+
   def latest_provider_holdings_snapshot_date
     holdings.where.not(account_provider_id: nil).maximum(:date)
   end

--- a/app/models/security.rb
+++ b/app/models/security.rb
@@ -67,6 +67,26 @@ class Security < ApplicationRecord
     kind == "cash"
   end
 
+  # True when this security functions as cash rather than an investment —
+  # synthetic cash securities plus the brokerage settlement / money market
+  # funds enumerated in the simplefin initializer. Investment syncs already
+  # fold these into an account's cash_balance, so callers use this to avoid
+  # presenting the same dollars as both a cash balance and a holding.
+  #
+  # The ticker list and description patterns live under the simplefin config
+  # namespace because that's where the detection was first needed; they aren't
+  # provider-specific.
+  def cash_equivalent?
+    return true if cash?
+
+    simplefin = Rails.configuration.x.simplefin
+    return false if simplefin.blank?
+
+    return true if Array(simplefin.money_market_tickers).include?(ticker.to_s.upcase.strip)
+
+    Array(simplefin.money_market_patterns).any? { |pattern| name.to_s.match?(pattern) }
+  end
+
   # True when this security represents a crypto asset. Today the only signal
   # is the Binance ISO MIC — when we add a second crypto provider, extend
   # this check rather than duplicating the test at every call site.

--- a/app/views/holdings/_cash.html.erb
+++ b/app/views/holdings/_cash.html.erb
@@ -1,5 +1,8 @@
-<%# locals: (account:) %>
+<%# locals: (account:, amount: nil) %>
 
+<%# `amount` is the cash not already shown as a holding row; see
+    Account#cash_balance_outside_holdings. Falls back to the full cash balance. %>
+<% cash = (amount || account.cash_balance).to_d %>
 <% currency = Money::Currency.new(account.currency) %>
 
 <div class="grid grid-cols-12 items-center text-primary text-sm font-medium p-4">
@@ -18,7 +21,7 @@
   </div>
 
   <div class="col-span-2 flex justify-end items-center gap-2">
-    <% cash_weight = account.balance.zero? ? 0 : account.cash_balance / account.balance * 100 %>
+    <% cash_weight = account.balance.zero? ? 0 : cash / account.balance * 100 %>
 
     <%= render "shared/progress_circle", progress: cash_weight %>
     <%= tag.p number_to_percentage(cash_weight, precision: 1) %>
@@ -29,7 +32,7 @@
   </div>
 
   <div class="col-span-2 text-right">
-    <%= tag.p format_money(account.cash_balance_money), class: "privacy-sensitive" %>
+    <%= tag.p format_money(Money.new(cash, account.currency)), class: "privacy-sensitive" %>
   </div>
 
   <div class="col-span-2 text-right">

--- a/app/views/holdings/index.html.erb
+++ b/app/views/holdings/index.html.erb
@@ -24,8 +24,9 @@
         </div>
 
         <div class="bg-container rounded-lg shadow-border-xs">
-          <% if @account.cash_balance.to_d > 0 %>
-            <%= render "holdings/cash", account: @account %>
+          <% unlisted_cash = @account.cash_balance_outside_holdings %>
+          <% if unlisted_cash > 0 %>
+            <%= render "holdings/cash", account: @account, amount: unlisted_cash %>
             <%= render "shared/ruler" %>
           <% end %>
 

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -550,4 +550,49 @@ class AccountTest < ActiveSupport::TestCase
     outflow_transaction.reload
     assert_equal "standard", outflow_transaction.kind
   end
+
+  # Investment syncs fold money market / settlement funds into cash_balance, but
+  # providers also send those funds as holdings. Without this the holdings table
+  # renders both a "Brokerage cash" row and the fund itself.
+  test "cash_balance_outside_holdings excludes cash already listed as a money market holding" do
+    account = accounts(:investment)
+    sweep = Security.create!(ticker: "SPAXX", name: "Some Sweep Fund")
+
+    Holding.create!(
+      account: account, security: sweep, date: Date.current,
+      qty: 5000, price: 1, amount: account.cash_balance, currency: account.currency
+    )
+
+    assert_equal 0, account.cash_balance_outside_holdings
+  end
+
+  test "cash_balance_outside_holdings keeps cash with no matching holding" do
+    account = accounts(:investment)
+
+    assert_equal account.cash_balance, account.cash_balance_outside_holdings
+  end
+
+  test "cash_balance_outside_holdings returns only the uncovered remainder" do
+    account = accounts(:investment)
+    sweep = Security.create!(ticker: "SPAXX", name: "Some Sweep Fund")
+
+    Holding.create!(
+      account: account, security: sweep, date: Date.current,
+      qty: 2000, price: 1, amount: 2000, currency: account.currency
+    )
+
+    assert_equal account.cash_balance - 2000, account.cash_balance_outside_holdings
+  end
+
+  test "cash_balance_outside_holdings never goes negative" do
+    account = accounts(:investment)
+    sweep = Security.create!(ticker: "SPAXX", name: "Some Sweep Fund")
+
+    Holding.create!(
+      account: account, security: sweep, date: Date.current,
+      qty: 9999, price: 1, amount: account.cash_balance + 1000, currency: account.currency
+    )
+
+    assert_equal 0, account.cash_balance_outside_holdings
+  end
 end

--- a/test/models/security_test.rb
+++ b/test/models/security_test.rb
@@ -187,4 +187,28 @@ class SecurityTest < ActiveSupport::TestCase
       sec.logo_url
     )
   end
+
+  test "cash_equivalent? is true for synthetic cash securities" do
+    account = accounts(:investment)
+
+    assert Security.cash_for(account).cash_equivalent?
+  end
+
+  test "cash_equivalent? is true for known money market tickers" do
+    sec = Security.create!(ticker: "SPAXX", name: "Some Sweep Fund")
+
+    assert sec.cash_equivalent?
+  end
+
+  test "cash_equivalent? is true when the name matches a money market pattern" do
+    sec = Security.create!(ticker: "ZZTEST", name: "Example Federal Money Market Fund")
+
+    assert sec.cash_equivalent?
+  end
+
+  test "cash_equivalent? is false for ordinary securities" do
+    sec = Security.create!(ticker: "ZZEQTY", name: "Example Total Stock Market ETF")
+
+    assert_not sec.cash_equivalent?
+  end
 end


### PR DESCRIPTION
## Summary

The holdings table lists a settlement fund's value twice — once as the
"Brokerage cash" row and again as the fund's own holding row — so the weight
column sums past 100%.

`SimplefinAccount::Investments::BalanceCalculator` derives `cash_balance` by
subtracting *non-cash* holdings from the account's total balance, deliberately
treating money market / settlement funds as cash. That classification is
correct, but `holdings#index` then renders a cash row **and** every holding,
sweep funds included. The same dollars are presented twice.

For an account whose cash is entirely a settlement fund, the cash row exactly
duplicates a row already in the list, and the two weights double-count.

## Steps to reproduce

1. Link an investment account whose provider reports a settlement / money
   market fund (e.g. one of the tickers in `config/initializers/simplefin.rb`)
   as a holding.
2. Open the account's holdings page.
3. The fund appears as its own row, and its value appears again as
   "Brokerage cash".
4. The WEIGHT column sums to more than 100%.

## Expected

Each dollar appears once, and the weight column sums to 100%.

## Approach

Render the cash row only for cash not already represented by a holding.

- `Security#cash_equivalent?` — identifies synthetic cash securities plus the
  money market tickers and description patterns **already enumerated** in
  `config/initializers/simplefin.rb`. No new list is introduced; this reuses
  the same source of truth the balance calculator uses.
- `Account#cash_balance_outside_holdings` — `cash_balance` minus the value of
  those holdings, floored at zero.
- `holdings#index` renders the cash row only when that remainder is positive,
  and `_cash` displays the remainder rather than the full cash balance.

Behaviour by case:

| Account | Before | After |
| --- | --- | --- |
| Cash is entirely a settlement fund | cash row + fund row (double-counted) | fund row only |
| Ordinary uninvested cash, no sweep fund | cash row | unchanged |
| Both a sweep fund and idle cash | cash row shows the full balance | cash row shows the uncovered remainder |

Holding rows are never hidden, so the fund stays visible with its shares,
price and cost basis.

## Tests

Added to `test/models/security_test.rb` and `test/models/account_test.rb`,
covering synthetic cash securities, ticker matches, description-pattern
matches, ordinary securities, and the full / none / partial / over-covered
cases for `cash_balance_outside_holdings`.

## Validation

`ruby -c` on all changed Ruby files, plus a manual walkthrough of the three
account shapes above.

I was not able to run `bin/rails test`, RuboCop, or `erb_lint` locally — no
Ruby 3.4, Bundler, or Docker available in the environment this was written in.
CI should be treated as the authoritative check, and I'm happy to follow up on
anything it flags.
