### PR TITLE
fix(accounts): remember transaction page size across account navigation

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -67,9 +67,12 @@ class AccountsController < ApplicationController
       return render_statement_tab_frame if statement_tab_frame_request?
     end
 
+    per_page = safe_per_page(stored_per_page_default)
+    store_per_page!(per_page) if params[:per_page].present?
+
     @pagy, @entries = pagy(
       entries,
-      limit: safe_per_page,
+      limit: per_page,
       params: request.query_parameters.except("tab").merge("tab" => "activity")
     )
 
@@ -273,6 +276,19 @@ class AccountsController < ApplicationController
   private
     def family
       Current.family
+    end
+
+    # Shares the "per page" preference with TransactionsController's
+    # prev_transaction_page_params so the page size the user picks on either
+    # the account activity feed or the global transactions page applies to both.
+    def store_per_page!(value)
+      Current.session.update!(
+        prev_transaction_page_params: Current.session.prev_transaction_page_params.merge("per_page" => value)
+      )
+    end
+
+    def stored_per_page_default
+      Current.session.prev_transaction_page_params["per_page"].presence || 10
     end
 
     def set_account

--- a/app/controllers/concerns/safe_pagination.rb
+++ b/app/controllers/concerns/safe_pagination.rb
@@ -6,6 +6,9 @@ module SafePagination
   private
     def safe_per_page(default = 10)
       allowed_values = [ 10, 20, 30, 50, 100 ]
+      default = default.to_i
+      default = 10 unless allowed_values.include?(default)
+
       per_page = params[:per_page].to_i
 
       return default if per_page <= 0

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -41,7 +41,7 @@ class TransactionsController < ApplicationController
                          }
                        )
 
-    @pagy, @transactions = pagy(base_scope, limit: safe_per_page)
+    @pagy, @transactions = pagy(base_scope, limit: safe_per_page(stored_params["per_page"]))
     Transaction::ActivitySecurityPreloader.new(@transactions).preload
 
     # Preload split parent data

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -577,7 +577,7 @@ class TransactionsController < ApplicationController
           prev_transaction_page_params: {
             q: search_params,
             page: params[:page],
-            per_page: params[:per_page]
+            per_page: params[:per_page].presence || stored_params["per_page"]
           }
         )
       end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -14,6 +14,10 @@ class Session < ApplicationRecord
 
   before_create :capture_session_info
 
+  def prev_transaction_page_params
+    super || {}
+  end
+
   def get_preferred_tab(tab_key)
     data.dig("tab_preferences", tab_key)
   end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -200,6 +200,17 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name='per_page'] option[value='100'][selected]"
   end
 
+  test "shares account per_page preference with the global transactions page" do
+    get account_url(@account, per_page: 50)
+    assert_response :success
+
+    get transactions_url
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+    assert_select "select[name='per_page'] option[value='50'][selected]"
+  end
+
   test "falls back to default per_page when nothing was stored yet" do
     get account_url(@account)
     assert_response :success

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -179,6 +179,33 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: I18n.t("UI.account.chart.title.total_gains")
   end
 
+  test "remembers selected per_page across account navigation" do
+    other_account = accounts(:credit_card)
+
+    get account_url(@account, per_page: 50)
+    assert_response :success
+    assert_select "select[name='per_page'] option[value='50'][selected]"
+
+    get account_url(other_account)
+    assert_response :success
+    assert_select "select[name='per_page'] option[value='50'][selected]"
+  end
+
+  test "shares remembered per_page with the global transactions page" do
+    get transactions_url(per_page: 100)
+    assert_response :success
+
+    get account_url(@account)
+    assert_response :success
+    assert_select "select[name='per_page'] option[value='100'][selected]"
+  end
+
+  test "falls back to default per_page when nothing was stored yet" do
+    get account_url(@account)
+    assert_response :success
+    assert_select "select[name='per_page'] option[value='10'][selected]"
+  end
+
   test "activity pagination keeps activity tab when loaded from holdings tab" do
     investment = accounts(:investment)
 

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -239,6 +239,35 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
   assert_operator overflow_count, :>, 0, "Overflow should show some transactions"
 end
 
+  test "filtered requests without per_page keep the stored page size" do
+    family = families(:empty)
+    sign_in users(:empty)
+
+    family.accounts.each { |account| account.entries.delete_all }
+
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+
+    25.times do |i|
+      create_transaction(
+        account: account,
+        name: "Transaction #{i + 1}",
+        amount: 100 + i,
+        date: Date.current - i.days
+      )
+    end
+
+    get transactions_url(per_page: 20)
+    assert_response :success
+
+    # A filtered request that omits per_page has query params present, so it
+    # is not eligible for the "restore stored params" redirect - it must fall
+    # back to the previously stored per_page instead of the hardcoded default.
+    get transactions_url(q: { search: "Transaction" })
+    assert_response :success
+    assert_select "select[name='per_page'] option[value='20'][selected]"
+    assert_equal 20, css_select("turbo-frame[id^='entry_']").count
+  end
+
   test "pagination does not duplicate or skip transactions with same date and timestamp" do
     family = families(:empty)
     user = users(:empty)


### PR DESCRIPTION
## Summary

- The account detail page's transactions list "per page" selector (10/20/30/50/100) was only ever read from the current request's query string, so navigating to a different account always reset it back to the default of 10.
- Reuses the existing `sessions.prev_transaction_page_params` JSONB column that `TransactionsController` already uses to remember the page size on the global `/transactions` page — no new column/migration needed. The chosen page size now applies consistently to both the account detail activity feed and the global transactions page.

## Changes

- `app/controllers/accounts_controller.rb#show`: compute `per_page` via `safe_per_page(stored_per_page_default)`, and persist the clamped value into `Current.session.prev_transaction_page_params` (merged, so it doesn't clobber the `q`/`page` keys used by the transactions page) whenever the user explicitly picks a page size.
- Added controller tests covering: page size persists across account navigation, page size is shared with the global transactions page, and the default of 10 is used when nothing has been stored yet.

Closes #3082

## Test plan

- [x] `bin/rails test test/controllers/accounts_controller_test.rb test/controllers/transactions_controller_test.rb` — 83 runs, 350 assertions, 0 failures, 0 errors
- [x] `bin/rubocop` on changed files — no offenses
- [x] `bin/brakeman --no-pager` — 0 security warnings
- [ ] Manual verification in browser: set per_page to 50/100 on one account, navigate to another account, confirm it's retained; also confirm the global transactions page reflects the same value


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Account activity pagination now remembers the selected number of items per page during navigation.
  - The preference is shared between account activity and the global transactions page.
  - Explicit page-size selections are retained for future visits.

- **Bug Fixes**
  - Pagination now consistently applies the saved page-size preference.
  - A default of 10 items per page is used when no preference has been selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->