### PR TITLE
fix(charts): round series values to the currency's display precision

### DIFF
--- a/app/javascript/controllers/time_series_chart_controller.js
+++ b/app/javascript/controllers/time_series_chart_controller.js
@@ -408,11 +408,15 @@ export default class extends Controller {
         </div>
 
         ${
-          datum.trend.value === 0
+          this._extractNumericValue(datum.trend.value) === 0
             ? `<span class="w-20"></span>`
             : `
           <span class="tabular-nums" style="color: ${datum.trend.color};">
-            ${this._extractFormattedValue(datum.trend.value)} (${datum.trend.percent_formatted})
+            ${this._extractFormattedValue(datum.trend.value)}${
+              datum.trend.percent === null
+                ? ""
+                : ` (${datum.trend.percent_formatted})`
+            }
           </span>
         `
         }

--- a/app/models/balance_sheet/net_worth_breakdown_series_builder.rb
+++ b/app/models/balance_sheet/net_worth_breakdown_series_builder.rb
@@ -2,6 +2,7 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilder
   # Monthly interval regardless of period length so the reports chart always
   # shows one point per month in the selected range.
   INTERVAL = "1 month"
+  CACHE_VERSION = "v2"
 
   def initialize(family, user: nil)
     @family = family
@@ -133,6 +134,7 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilder
       shares_version = user ? AccountShare.where(user: user).maximum(:updated_at)&.to_i : nil
       key = [
         "balance_sheet_net_worth_breakdown_series",
+        CACHE_VERSION,
         user&.id,
         shares_version,
         period.start_date,

--- a/app/models/balance_sheet/net_worth_breakdown_series_builder.rb
+++ b/app/models/balance_sheet/net_worth_breakdown_series_builder.rb
@@ -41,18 +41,26 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilder
         }
       end
 
+      # Built by hand rather than through `Series#as_json`, so it needs the same
+      # display rounding: the chart is drawn from the amount, and a sub-unit
+      # residue would plot as a visible move between two points that print the
+      # same value. The classification totals are left alone, since only their
+      # formatted string is rendered.
+      current = value.value.for_display
+      previous_value = (previous&.value || value.value).for_display
+
       {
         date: value.date,
         date_formatted: value.date_formatted,
-        value: value.value,
+        value: current,
         # Month-over-month change between chart points. The trend on the raw
         # series value compares the underlying balance row's own start/end,
         # which at a monthly interval reflects only the last balance update
         # before the sample date. The first point has no prior month, so it
         # gets a flat trend.
         trend: Trend.new(
-          current: value.value,
-          previous: previous&.value || value.value,
+          current: current,
+          previous: previous_value,
           favorable_direction: "up"
         ),
         assets: classification_total(point_groups, "asset"),

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -56,11 +56,14 @@ class Series
     @favorable_direction = favorable_direction
   end
 
+  # Rounded like the serialized values: this trend is only ever rendered next to
+  # them, so a change between two amounts that print identically has to read as
+  # no change here too.
   def trend
     return nil if values.blank?
     @trend ||= Trend.new(
-      current: values.last&.value,
-      previous: values.first&.value,
+      current: display_amount(values.last&.value),
+      previous: display_amount(values.first&.value),
       favorable_direction: favorable_direction
     )
   end
@@ -70,7 +73,7 @@ class Series
       start_date: start_date,
       end_date: end_date,
       interval: interval,
-      trend: display_trend(trend),
+      trend: trend,
       values: values.map do |v|
         { date: v.date, date_formatted: v.date_formatted, value: display_amount(v.value), trend: display_trend(v.trend) }
       end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -70,8 +70,28 @@ class Series
       start_date: start_date,
       end_date: end_date,
       interval: interval,
-      trend: trend,
-      values: values.map { |v| { date: v.date, date_formatted: v.date_formatted, value: v.value, trend: v.trend } }
+      trend: display_trend(trend),
+      values: values.map do |v|
+        { date: v.date, date_formatted: v.date_formatted, value: display_amount(v.value), trend: display_trend(v.trend) }
+      end
     }
   end
+
+  private
+    # A chart is drawn from these amounts, not from the formatted strings, so a
+    # sub-unit residue would plot as a visible move between two points that both
+    # print as the same value, and a change between them would read as non-zero.
+    def display_trend(trend)
+      return trend unless trend.is_a?(Trend)
+
+      Trend.new(
+        current: display_amount(trend.current),
+        previous: display_amount(trend.previous),
+        favorable_direction: trend.favorable_direction
+      )
+    end
+
+    def display_amount(amount)
+      amount.is_a?(Money) ? amount.for_display : amount
+    end
 end

--- a/app/views/accountable_sparklines/show.html.erb
+++ b/app/views/accountable_sparklines/show.html.erb
@@ -4,8 +4,11 @@
       <%= render "shared/sparkline", id: dom_id(@accountable, :sparkline_chart), series: @series %>
     </div>
 
-    <%= tag.p @series.trend.percent_formatted,
-                style: "color: #{@series.trend.color}",
-                class: "font-mono text-right text-xs font-medium text-primary" %>
+    <%# A previous value of zero makes the percentage infinite, with nothing useful to print %>
+    <% if @series.trend.percent.finite? %>
+      <%= tag.p @series.trend.percent_formatted,
+                  style: "color: #{@series.trend.color}",
+                  class: "font-mono text-right text-xs font-medium text-primary" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/accounts/sparkline.html.erb
+++ b/app/views/accounts/sparkline.html.erb
@@ -4,8 +4,11 @@
       <%= render "shared/sparkline", id: dom_id(@account, :sparkline_chart), series: @sparkline_series %>
     </div>
 
-    <%= tag.p @sparkline_series.trend.percent_formatted,
-                style: "color: #{@sparkline_series.trend.color}",
-                class: "font-mono text-right text-xs font-medium text-primary" %>
+    <%# A previous value of zero makes the percentage infinite, with nothing useful to print %>
+    <% if @sparkline_series.trend.percent.finite? %>
+      <%= tag.p @sparkline_series.trend.percent_formatted,
+                  style: "color: #{@sparkline_series.trend.color}",
+                  class: "font-mono text-right text-xs font-medium text-primary" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/reports/_net_worth.html.erb
+++ b/app/views/reports/_net_worth.html.erb
@@ -17,9 +17,11 @@
         <p class="text-2xl font-semibold mb-1 privacy-sensitive" style="color: <%= trend.color %>">
           <%= trend.value.format(signify_positive: true) %>
         </p>
-        <p class="text-xs" style="color: <%= trend.color %>">
-          <%= trend.value >= 0 ? "+" : "" %><%= trend.percent_formatted %>
-        </p>
+        <% if trend.percent.finite? %>
+          <p class="text-xs" style="color: <%= trend.color %>">
+            <%= trend.value >= 0 ? "+" : "" %><%= trend.percent_formatted %>
+          </p>
+        <% end %>
       <% else %>
         <p class="text-2xl font-semibold mb-1 text-subdued">--</p>
       <% end %>

--- a/app/views/reports/print.html.erb
+++ b/app/views/reports/print.html.erb
@@ -82,8 +82,13 @@
             <%= @net_worth_metrics[:current_net_worth].format %>
           </span>
           <% if @net_worth_metrics[:trend] %>
-            <span class="tufte-metric-card-change" style="color: <%= @net_worth_metrics[:trend].color %>">
-              <%= @net_worth_metrics[:trend].value >= 0 ? "+" : "" %><%= @net_worth_metrics[:trend].value.format %> (<%= @net_worth_metrics[:trend].percent_formatted %>) <%= t("reports.print.net_worth.this_period") %>
+            <% trend = @net_worth_metrics[:trend] %>
+            <span class="tufte-metric-card-change" style="color: <%= trend.color %>">
+              <%= trend.value.format(signify_positive: true) %>
+              <% if trend.percent.finite? %>
+                (<%= trend.percent_formatted %>)
+              <% end %>
+              <%= t("reports.print.net_worth.this_period") %>
             </span>
           <% end %>
           <% if has_sparkline_data?(@trends_data) %>

--- a/app/views/reports/print.html.erb
+++ b/app/views/reports/print.html.erb
@@ -83,13 +83,15 @@
           </span>
           <% if @net_worth_metrics[:trend] %>
             <% trend = @net_worth_metrics[:trend] %>
-            <span class="tufte-metric-card-change" style="color: <%= trend.color %>">
-              <%= trend.value.format(signify_positive: true) %>
-              <% if trend.percent.finite? %>
-                (<%= trend.percent_formatted %>)
-              <% end %>
-              <%= t("reports.print.net_worth.this_period") %>
-            </span>
+            <% unless trend.direction.flat? %>
+              <span class="tufte-metric-card-change" style="color: <%= trend.color %>">
+                <%= trend.value.format(signify_positive: true) %>
+                <% if trend.percent.finite? %>
+                  (<%= trend.percent_formatted %>)
+                <% end %>
+                <%= t("reports.print.net_worth.this_period") %>
+              </span>
+            <% end %>
           <% end %>
           <% if has_sparkline_data?(@trends_data) %>
             <svg width="80" height="24" viewBox="0 0 80 24" style="display:block;margin-top:8px;">

--- a/app/views/reports/print.html.erb
+++ b/app/views/reports/print.html.erb
@@ -85,7 +85,7 @@
             <% trend = @net_worth_metrics[:trend] %>
             <% unless trend.direction.flat? %>
               <span class="tufte-metric-card-change" style="color: <%= trend.color %>">
-                <%= trend.value.format(signify_positive: true) %>
+                <%= trend.value >= 0 ? "+" : "" %><%= trend.value.format %>
                 <% if trend.percent.finite? %>
                   (<%= trend.percent_formatted %>)
                 <% end %>

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -68,6 +68,11 @@ class Money
     end
   end
 
+  # Rounded to the precision `format` actually prints.
+  def for_display
+    self.class.new(amount.round(currency.default_precision), currency)
+  end
+
   def as_json
     { amount: amount, currency: currency.iso_code, formatted: format }.as_json
   end

--- a/test/lib/money_test.rb
+++ b/test/lib/money_test.rb
@@ -90,6 +90,11 @@ class MoneyTest < ActiveSupport::TestCase
     assert_equal "€ 1.000,12", Money.new(1000.12, :eur).format(locale: :nl)
   end
 
+  test "rounds for display using currency precision" do
+    assert_equal Money.new(1000.9, :usd).format, Money.new(1000.899, :usd).for_display.format
+    assert_equal Money.new(1001, :jpy).format, Money.new(1000.6, :jpy).for_display.format
+  end
+
   test "formats correctly for French locale" do
     # French uses non-breaking spaces (NBSP = \u00A0) between thousands and before currency symbol
     assert_equal "1\u00A0000,12\u00A0€", Money.new(1000.12, :eur).format(locale: :fr)

--- a/test/lib/money_test.rb
+++ b/test/lib/money_test.rb
@@ -91,8 +91,8 @@ class MoneyTest < ActiveSupport::TestCase
   end
 
   test "rounds for display using currency precision" do
-    assert_equal Money.new(1000.9, :usd).format, Money.new(1000.899, :usd).for_display.format
-    assert_equal Money.new(1001, :jpy).format, Money.new(1000.6, :jpy).for_display.format
+    assert_equal Money.new(1000.9, :usd), Money.new(1000.899, :usd).for_display
+    assert_equal Money.new(1001, :jpy), Money.new(1000.6, :jpy).for_display
   end
 
   test "formats correctly for French locale" do

--- a/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
+++ b/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
@@ -62,6 +62,23 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilderTest < ActiveSupport::TestCase
     assert groups.all? { |g| g[:color].present? }
   end
 
+  test "does not serialize a sub-unit residue the chart would plot as a move" do
+    period = Period.custom(start_date: Date.new(2026, 6, 15), end_date: Date.new(2026, 7, 15))
+
+    # Both amounts print as $0.00, so the chart has to draw a flat line
+    create_balance(account: @asset_account, date: period.start_date, balance: 0.0001)
+    create_balance(account: @asset_account, date: period.end_date, balance: 0.0002)
+
+    series = builder.breakdown_series(period: period)
+
+    assert series[:values].size >= 2
+    series[:values].each do |point|
+      assert_equal 0, point[:value].amount
+      assert point[:trend].direction.flat?, "expected no change between values printing as $0.00"
+      assert point[:trend].percent.finite?, "expected a finite percentage"
+    end
+  end
+
   private
     def builder
       BalanceSheet::NetWorthBreakdownSeriesBuilder.new(@family)

--- a/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
+++ b/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
@@ -79,6 +79,12 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilderTest < ActiveSupport::TestCase
     end
   end
 
+  test "cache key includes payload version" do
+    period = Period.custom(start_date: Date.new(2026, 6, 15), end_date: Date.new(2026, 7, 15))
+
+    assert_includes builder.send(:cache_key, period), BalanceSheet::NetWorthBreakdownSeriesBuilder::CACHE_VERSION
+  end
+
   private
     def builder
       BalanceSheet::NetWorthBreakdownSeriesBuilder.new(@family)

--- a/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
+++ b/test/models/balance_sheet/net_worth_breakdown_series_builder_test.rb
@@ -79,6 +79,20 @@ class BalanceSheet::NetWorthBreakdownSeriesBuilderTest < ActiveSupport::TestCase
     end
   end
 
+  test "serializes a nil trend percentage when displayed value increases from zero" do
+    period = Period.custom(start_date: Date.new(2026, 6, 15), end_date: Date.new(2026, 7, 15))
+
+    create_balance(account: @asset_account, date: period.start_date, balance: 0.0001)
+    create_balance(account: @asset_account, date: period.end_date, balance: 1)
+
+    series = builder.breakdown_series(period: period)
+    parsed = JSON.parse(series.to_json)
+
+    assert_equal 0, series[:values].first[:value].amount
+    assert_equal 1, series[:values].last[:value].amount
+    assert_nil parsed["values"].last["trend"]["percent"]
+  end
+
   test "cache key includes payload version" do
     period = Period.custom(start_date: Date.new(2026, 6, 15), end_date: Date.new(2026, 7, 15))
 

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -4,7 +4,7 @@ class SeriesTest < ActiveSupport::TestCase
   test "a change between two values that print identically reads as no change" do
     series = build_series(previous: 100.001, current: 100.004, currency: "USD")
 
-    trend = series.as_json[:values].first[:trend]
+    trend = series.as_json[:values].last[:trend]
 
     # Both amounts format as $100.00
     assert_equal 0, trend.value.amount
@@ -14,7 +14,7 @@ class SeriesTest < ActiveSupport::TestCase
   test "rounds the trend at the currency's display precision" do
     series = build_series(previous: 1000.4, current: 1000.6, currency: "JPY")
 
-    trend = series.as_json[:values].first[:trend]
+    trend = series.as_json[:values].last[:trend]
 
     # ¥1,000 -> ¥1,001
     assert_equal 1, trend.value.amount
@@ -26,15 +26,24 @@ class SeriesTest < ActiveSupport::TestCase
     # chart is drawn from the amount, so an unrounded 0.0001 fills the y axis
     series = build_series(previous: 0, current: 0.0001, currency: "USD")
 
-    assert_equal 0, series.as_json[:values].first[:value].amount
+    assert_equal 0, series.as_json[:values].last[:value].amount
   end
 
   test "leaves the series values themselves exact" do
     series = build_series(previous: 100.001, current: 100.004, currency: "USD")
 
     # Insights, goals and the assistant read the values directly
-    assert_equal 100.004, series.values.first.value.amount
-    assert_equal 0.003, series.values.first.trend.value.amount
+    assert_equal 100.004, series.values.last.value.amount
+    assert_equal 0.003, series.values.last.trend.value.amount
+  end
+
+  test "the series trend ignores a change that is not visible" do
+    # The account chart renders this trend right above the chart itself
+    series = build_series(previous: 0, current: 0.0001, currency: "USD")
+
+    assert series.trend.direction.flat?
+    assert_equal 0, series.trend.value.amount
+    assert series.trend.percent.finite?
   end
 
   private
@@ -44,6 +53,16 @@ class SeriesTest < ActiveSupport::TestCase
         end_date: Date.new(2026, 6, 2),
         interval: "1 day",
         values: [
+          Series::Value.new(
+            date: Date.new(2026, 6, 1),
+            date_formatted: "June 1, 2026",
+            value: Money.new(previous, currency),
+            trend: Trend.new(
+              current: Money.new(previous, currency),
+              previous: Money.new(previous, currency),
+              favorable_direction: "up"
+            )
+          ),
           Series::Value.new(
             date: Date.new(2026, 6, 2),
             date_formatted: "June 2, 2026",

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class SeriesTest < ActiveSupport::TestCase
+  test "a change between two values that print identically reads as no change" do
+    series = build_series(previous: 100.001, current: 100.004, currency: "USD")
+
+    trend = series.as_json[:values].first[:trend]
+
+    # Both amounts format as $100.00
+    assert_equal 0, trend.value.amount
+    assert trend.direction.flat?
+  end
+
+  test "rounds the trend at the currency's display precision" do
+    series = build_series(previous: 1000.4, current: 1000.6, currency: "JPY")
+
+    trend = series.as_json[:values].first[:trend]
+
+    # ¥1,000 -> ¥1,001
+    assert_equal 1, trend.value.amount
+    assert trend.direction.up?
+  end
+
+  test "does not serialize a sub-unit residue the chart would plot as a move" do
+    # A leftover cent fraction (400 - 199.9999 - 200) prints as $0.00, but the
+    # chart is drawn from the amount, so an unrounded 0.0001 fills the y axis
+    series = build_series(previous: 0, current: 0.0001, currency: "USD")
+
+    assert_equal 0, series.as_json[:values].first[:value].amount
+  end
+
+  test "leaves the series values themselves exact" do
+    series = build_series(previous: 100.001, current: 100.004, currency: "USD")
+
+    # Insights, goals and the assistant read the values directly
+    assert_equal 100.004, series.values.first.value.amount
+    assert_equal 0.003, series.values.first.trend.value.amount
+  end
+
+  private
+    def build_series(previous:, current:, currency:)
+      Series.new(
+        start_date: Date.new(2026, 6, 1),
+        end_date: Date.new(2026, 6, 2),
+        interval: "1 day",
+        values: [
+          Series::Value.new(
+            date: Date.new(2026, 6, 2),
+            date_formatted: "June 2, 2026",
+            value: Money.new(current, currency),
+            trend: Trend.new(
+              current: Money.new(current, currency),
+              previous: Money.new(previous, currency),
+              favorable_direction: "up"
+            )
+          )
+        ]
+      )
+    end
+end


### PR DESCRIPTION
### **Context:**

When you buy shares regularly and the cash balance stays flat, the "Cash value" chart draws a rising staircase, while every label on the card reads €0.00.

The balance really is ~0: a €200 deposit followed by a same-day buy cancels out. But a trade's amount is `signed_qty * price + fee`, so it rarely consumes the deposit to the exact cent — a few hundredths of a cent are left over each week. Balances are stored as `decimal(19,4)`, so that dust is kept, and `Money#format` rounds it away for display while `Money#amount` does not.

The chart plots amount and labels formatted. Since the y-axis auto-scales to the data range with no floor, a domain of
`[0, 0.03]` gets stretched over the full height of the card: three cents of rounding dust rendered as a dramatic upward trend.

The same values also reached Trend, which derives direction, colour and percent from them. That produced a green line and a tooltip reading $0.00 (+∞) — Trend#percent returns Float::INFINITY whenever the previous value is zero.

### **Illustration**

Two deposit and trades:
<img width="2689" height="1591" alt="Screenshot 2026-08-19 at 20-47-40" src="https://github.com/user-attachments/assets/9f55ff7c-0b64-4a1a-92b5-7e62a409b83b" />

The trade details, showing the amount that doesn't land on a round figure:

<img width="1136" height="1833" alt="Screenshot 2026-08-19 at 21-21-34" src="https://github.com/user-attachments/assets/e0d8d17d-f230-4492-a852-04091f0484fa" />

**Before:**
<img width="2707" height="950" alt="Screenshot 2026-08-19 at 21-20-58" src="https://github.com/user-attachments/assets/1d2b929f-d758-43e2-8eb6-9a3cdf9db702" />


**After:**
<img width="2726" height="905" alt="Screenshot 2026-08-19 at 20-48-22" src="https://github.com/user-attachments/assets/a905b327-046f-43ba-8eca-e5789a700bd5" />
<img width="2723" height="919" alt="Screenshot 2026-08-19 at 21-08-36" src="https://github.com/user-attachments/assets/cf29b73c-6370-4fe3-9323-07dda6a0fded" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart tooltips by correctly handling zero values.
  * Percentage details are now hidden when no meaningful percentage is available.
  * Monetary trends and values are rounded to the currency’s standard display precision.
  * Prevented misleading sub-unit chart values while preserving exact underlying data.
  * Applied consistent rounding across net worth breakdowns, sparklines, reports, and serialized chart data.
  * Prevented infinite or misleading percentage changes when the previous value is zero.
  * Improved net worth report trend formatting with clearer currency values and period labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->