### PR TITLE
Migrate SnapTrade to device-flow OAuth with API credentials

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,9 +12,10 @@ SIMPLEFIN_DEBUG_RAW=false
 # SIMPLEFIN_INCLUDE_PENDING: when truthy, forces `pending=1` on SimpleFIN fetches when caller doesn't specify `pending:`
 SIMPLEFIN_INCLUDE_PENDING=false
 
-# SnapTrade OAuth app credentials (register an OAuth app at https://dashboard.snaptrade.com,
-# add https://<your-host>/snaptrade_items/oauth_callback as a redirect URI)
+# SnapTrade OAuth device flow client ID (public OAuth client identifier, configured by Sure deployments)
 SNAPTRADE_OAUTH_CLIENT_ID=
+# DEPRECATED, only needed to keep connections made through a SnapTrade OAuth app
+# (authorization-code + PKCE) working until they move to the device flow.
 SNAPTRADE_OAUTH_CLIENT_SECRET=
 
 # Lunchflow runtime flags (default-off)

--- a/.env.test.example
+++ b/.env.test.example
@@ -11,9 +11,10 @@ SIMPLEFIN_DEBUG_RAW=false
 # SIMPLEFIN_INCLUDE_PENDING: when truthy, forces `pending=1` on SimpleFIN fetches when caller doesn't specify `pending:`
 SIMPLEFIN_INCLUDE_PENDING=false
 
-# SnapTrade OAuth app credentials (register an OAuth app at https://dashboard.snaptrade.com,
-# add https://<your-host>/snaptrade_items/oauth_callback as a redirect URI)
+# SnapTrade OAuth device flow client ID (public OAuth client identifier, configured by Sure deployments)
 SNAPTRADE_OAUTH_CLIENT_ID=
+# DEPRECATED, only needed to keep connections made through a SnapTrade OAuth app
+# (authorization-code + PKCE) working until they move to the device flow.
 SNAPTRADE_OAUTH_CLIENT_SECRET=
 
 # Lunchflow runtime flags (default-off)

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ gem "rchardet" # Character encoding detection
 gem "redcarpet"
 gem "stripe"
 gem "plaid"
+gem "snaptrade", "~> 2.0"
 gem "httparty"
 gem "rotp", "~> 6.3"
 gem "rqrcode", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -765,6 +765,9 @@ GEM
     snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
       version_gem (~> 1.1, >= 1.1.14)
+    snaptrade (2.0.156)
+      faraday (>= 1.0.1, < 3.0)
+      faraday-multipart (~> 1.0, >= 1.0.4)
     ssrf_filter (1.5.0)
     stackprof (0.2.27)
     standardwebhooks (1.1.0)
@@ -949,6 +952,7 @@ DEPENDENCIES
   sidekiq-unique-jobs
   simplecov
   skylight
+  snaptrade (~> 2.0)
   stackprof
   stimulus-rails
   stripe

--- a/app/controllers/snaptrade_items_controller.rb
+++ b/app/controllers/snaptrade_items_controller.rb
@@ -1,12 +1,42 @@
 class SnaptradeItemsController < ApplicationController
-  before_action :set_snaptrade_item, only: [ :show, :destroy, :sync, :connect, :setup_accounts, :complete_account_setup, :connections, :delete_connection ]
-  before_action :require_admin!, only: [ :destroy, :sync, :connect, :callback, :setup_accounts, :complete_account_setup, :connections, :delete_connection, :oauth_authorize, :oauth_callback, :preload_accounts, :select_accounts, :select_existing_account, :link_existing_account ]
+  PERMITTED_OAUTH_SCOPES = %w[read].freeze
+
+  before_action :set_snaptrade_item, only: [ :show, :edit, :update, :destroy, :sync, :connect, :setup_accounts, :complete_account_setup, :connections, :start_oauth_device_flow, :complete_oauth_device_flow, :delete_connection, :delete_orphaned_user ]
+  before_action :require_admin!, only: [ :new, :create, :edit, :update, :destroy, :sync, :connect, :callback, :setup_accounts, :complete_account_setup, :connections, :delete_connection, :delete_orphaned_user, :oauth_connect, :start_oauth_connect, :start_oauth_device_flow, :complete_oauth_device_flow, :oauth_authorize, :oauth_callback, :preload_accounts, :select_accounts, :select_existing_account, :link_existing_account ]
 
   def index
     @snaptrade_items = Current.family.snaptrade_items.ordered
   end
 
   def show
+  end
+
+  def new
+    @snaptrade_item = Current.family.snaptrade_items.build
+  end
+
+  def edit
+  end
+
+  def create
+    @snaptrade_item = Current.family.snaptrade_items.build(snaptrade_item_params)
+    @snaptrade_item.name ||= t("snaptrade_items.default_name")
+
+    if @snaptrade_item.save
+      register_snaptrade_user(@snaptrade_item)
+      render_panel_success(t(".success", default: "Successfully configured SnapTrade."))
+    else
+      render_panel_error(@snaptrade_item.errors.full_messages.join(", "))
+    end
+  end
+
+  def update
+    if @snaptrade_item.update(snaptrade_item_params)
+      register_snaptrade_user(@snaptrade_item)
+      render_panel_success(t(".success", default: "Successfully updated SnapTrade configuration."))
+    else
+      render_panel_error(@snaptrade_item.errors.full_messages.join(", "))
+    end
   end
 
   def destroy
@@ -27,6 +57,8 @@ class SnaptradeItemsController < ApplicationController
 
   # Redirect user to SnapTrade connection portal
   def connect
+    @snaptrade_item.ensure_user_registered! if @snaptrade_item.device_flow? && !@snaptrade_item.user_registered?
+
     redirect_url = callback_snaptrade_items_url(
       item_id: @snaptrade_item.id,
       return_to: params[:return_to].presence,
@@ -47,6 +79,7 @@ class SnaptradeItemsController < ApplicationController
     # SnapTrade redirects back after user connects their brokerage
     # The connection is already established - we just need to sync to get the accounts
     unless params[:item_id].present?
+      clear_snaptrade_resume_context
       redirect_to settings_providers_path, alert: t(".no_item")
       return
     end
@@ -56,12 +89,17 @@ class SnaptradeItemsController < ApplicationController
     if snaptrade_item
       snaptrade_item.sync_later_with_follow_up
 
-      if params[:return_to].presence == "setup_accounts"
-        redirect_to setup_accounts_snaptrade_item_path(snaptrade_item, accountable_type: params[:accountable_type].presence), notice: t(".success")
+      stored_return_to, stored_accountable_type = clear_snaptrade_resume_context
+      return_to = params[:return_to].presence || stored_return_to
+      accountable_type = params[:accountable_type].presence || stored_accountable_type
+
+      if return_to == "setup_accounts"
+        redirect_to setup_accounts_snaptrade_item_path(snaptrade_item, accountable_type: accountable_type.presence), notice: t(".success")
       else
         redirect_to accounts_path, notice: t(".success")
       end
     else
+      clear_snaptrade_resume_context
       redirect_to settings_providers_path, alert: t(".no_item")
     end
   end
@@ -79,7 +117,7 @@ class SnaptradeItemsController < ApplicationController
     latest_sync = @snaptrade_item.syncs.ordered.first
     should_sync = latest_sync.nil? || !latest_sync.completed?
 
-    if @snaptrade_item.oauth_configured? && no_accounts && !@snaptrade_item.syncing? && should_sync
+    if @snaptrade_item.fully_configured? && no_accounts && !@snaptrade_item.syncing? && should_sync
       @snaptrade_item.sync_later
     end
 
@@ -178,25 +216,170 @@ class SnaptradeItemsController < ApplicationController
     data = build_connections_list
     render partial: "snaptrade_items/connections_list", layout: false, locals: {
       connections: data[:connections],
+      orphaned_users: data[:orphaned_users],
       snaptrade_item: @snaptrade_item,
       error: @error
     }
   end
 
-  # Start the SnapTrade OAuth authorization-code + PKCE flow
+  # --- OAuth device flow (the supported way to connect) ---
+
+  def oauth_connect
+    assign_oauth_connect_context
+
+    unless Provider::Snaptrade.oauth_client_id_configured?
+      @error_message = snaptrade_oauth_client_id_missing_message
+      render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+      return
+    end
+
+    @snaptrade_item = if params[:item_id].present?
+      Current.family.snaptrade_items.find(params[:item_id])
+    else
+      current_snaptrade_item
+    end
+
+    return unless require_api_credentials_for_device_flow!
+
+    render :oauth_device_flow
+  rescue ActiveRecord::Encryption::Errors::Decryption => e
+    Rails.logger.error "SnapTrade decryption error for item #{@snaptrade_item&.id}: #{e.class} - #{e.message}"
+    @error_message = t("snaptrade_items.connect.decryption_failed")
+    render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+  rescue ActiveRecord::ActiveRecordError, ActiveRecord::Encryption::Errors::Base => e
+    Rails.logger.error "SnapTrade OAuth connect error: #{e.class} - #{e.message}"
+    @error_message = start_oauth_device_flow_error_message
+    render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+  end
+
+  def start_oauth_connect
+    assign_oauth_connect_context
+
+    unless Provider::Snaptrade.oauth_client_id_configured?
+      @error_message = snaptrade_oauth_client_id_missing_message
+      render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+      return
+    end
+
+    @snaptrade_item = if params[:item_id].present?
+      Current.family.snaptrade_items.find(params[:item_id])
+    else
+      current_snaptrade_item
+    end
+
+    return unless require_api_credentials_for_device_flow!
+
+    @device_authorization = @snaptrade_item.start_oauth_device_flow(scope: @oauth_scope)
+
+    render :oauth_device_flow
+  rescue ActiveRecord::Encryption::Errors::Decryption => e
+    Rails.logger.error "SnapTrade decryption error for item #{@snaptrade_item&.id}: #{e.class} - #{e.message}"
+    @error_message = t("snaptrade_items.connect.decryption_failed")
+    render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+  rescue Provider::Snaptrade::Error, ActiveRecord::ActiveRecordError, ActiveRecord::Encryption::Errors::Base => e
+    Rails.logger.error "SnapTrade OAuth connect error: #{e.class} - #{e.message}"
+    @error_message = oauth_connect_error_message(e)
+    render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+  end
+
+  def start_oauth_device_flow
+    unless @snaptrade_item.api_credentials_configured?
+      render json: { error: snaptrade_api_credentials_required_message }, status: :unprocessable_entity
+      return
+    end
+
+    render json: @snaptrade_item.start_oauth_device_flow(scope: permitted_oauth_scope)
+  rescue ActiveRecord::Encryption::Errors::Decryption => e
+    Rails.logger.error "SnapTrade decryption error for item #{@snaptrade_item.id}: #{e.class} - #{e.message}"
+    render json: { error: t("snaptrade_items.connect.decryption_failed") }, status: :unprocessable_entity
+  rescue Provider::Snaptrade::Error => e
+    Rails.logger.error "SnapTrade OAuth device authorization error: #{e.class} - #{e.message}"
+    render json: { error: start_oauth_device_flow_error_message }, status: :unprocessable_entity
+  end
+
+  def complete_oauth_device_flow
+    # Applying device-flow tokens overwrites whatever is in the oauth_* columns.
+    # On a connection still running on #2747's PKCE tokens that would destroy a
+    # working connection, so the device flow only runs once the item has the
+    # API credentials that make it a device-flow connection in the first place.
+    unless @snaptrade_item.api_credentials_configured?
+      if request.format.json?
+        render json: { error: snaptrade_api_credentials_required_message }, status: :unprocessable_entity
+      else
+        @error_message = snaptrade_api_credentials_required_message
+        restore_device_authorization_from_params
+        render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+      end
+      return
+    end
+
+    if params[:device_code].blank?
+      render json: { error: t("snaptrade_items.complete_oauth_device_flow.device_code_required") }, status: :unprocessable_entity
+      return
+    end
+
+    token_response = @snaptrade_item.complete_oauth_device_flow!(device_code: params[:device_code])
+    if request.format.json?
+      render json: {
+        token_type: token_response["token_type"],
+        scope: token_response["scope"],
+        expires_in: token_response["expires_in"],
+        expires_at: @snaptrade_item.oauth_token_expires_at&.iso8601
+      }
+    else
+      if prepare_snaptrade_item_for_setup_after_oauth
+        redirect_after_oauth_completion setup_accounts_snaptrade_item_path(
+          @snaptrade_item,
+          accountable_type: params[:accountable_type].presence,
+          return_to: params[:return_to].presence
+        ), notice: t(".success", default: "SnapTrade authorization complete.")
+      else
+        redirect_after_oauth_completion settings_providers_path, alert: snaptrade_oauth_setup_incomplete_message
+      end
+    end
+  rescue Provider::Snaptrade::ApiError => e
+    if request.format.json?
+      render json: oauth_error_payload(e), status: e.status_code || :unprocessable_entity
+    else
+      payload = oauth_error_payload(e)
+      @error_message = payload["error_description"].presence || payload["error"]
+      restore_device_authorization_from_params
+      render :oauth_device_flow, status: e.status_code || :unprocessable_entity, formats: :html
+    end
+  rescue Provider::Snaptrade::Error, ActiveRecord::ActiveRecordError, ActiveRecord::Encryption::Errors::Base => e
+    Rails.logger.error "SnapTrade OAuth device token error: #{e.class} - #{e.message}"
+    if request.format.json?
+      render json: { error: complete_oauth_device_flow_error_message }, status: :unprocessable_entity
+    else
+      @error_message = complete_oauth_device_flow_error_message
+      restore_device_authorization_from_params
+      render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+    end
+  end
+
+  # --- DEPRECATED authorization-code + PKCE flow (#2747) ---
+  #
+  # Closed to new connections. It stays reachable only so a connection already
+  # authorized under PKCE can re-consent when its refresh token dies, rather
+  # than being stranded before its owner has migrated to the device flow.
+
   def oauth_authorize
-    unless Provider::Snaptrade.oauth_configured?
+    snaptrade_item = params[:item_id].present? ? Current.family.snaptrade_items.find_by(id: params[:item_id]) : nil
+
+    unless snaptrade_item&.legacy_oauth?
+      redirect_to oauth_connect_snaptrade_items_path(
+        return_to: params[:return_to].presence,
+        accountable_type: params[:accountable_type].presence
+      ), notice: t(".deprecated")
+      return
+    end
+
+    unless Provider::SnaptradeOauth.oauth_configured?
       redirect_to settings_providers_path, alert: t(".not_configured")
       return
     end
 
-    snaptrade_item = if params[:item_id].present?
-      Current.family.snaptrade_items.find(params[:item_id])
-    else
-      current_snaptrade_item || Current.family.snaptrade_items.create!(name: t("snaptrade_items.default_name"))
-    end
-
-    pkce = Provider::Snaptrade.generate_pkce
+    pkce = Provider::SnaptradeOauth.generate_pkce
     state = SecureRandom.hex(32)
 
     session[:snaptrade_oauth] = {
@@ -207,7 +390,7 @@ class SnaptradeItemsController < ApplicationController
       "accountable_type" => params[:accountable_type].presence
     }
 
-    redirect_to Provider::Snaptrade.authorize_url(
+    redirect_to Provider::SnaptradeOauth.authorize_url(
       redirect_uri: oauth_callback_snaptrade_items_url,
       state: state,
       code_challenge: pkce[:challenge]
@@ -282,7 +465,7 @@ class SnaptradeItemsController < ApplicationController
     api_deletion_failed = false
     if accounts_deleted == 0
       provider = @snaptrade_item.snaptrade_provider
-      if provider
+      if provider && @snaptrade_item.fully_configured?
         provider.delete_connection(authorization_id: authorization_id)
       else
         Rails.logger.warn "SnapTrade: Cannot delete orphaned connection #{authorization_id} - item not authorized"
@@ -312,6 +495,38 @@ class SnaptradeItemsController < ApplicationController
     end
   end
 
+  # Delete an orphaned SnapTrade user (and all their connections)
+  def delete_orphaned_user
+    user_id = params[:user_id]
+
+    # Security: verify this is actually an orphaned user
+    unless @snaptrade_item.orphaned_users.include?(user_id)
+      respond_to do |format|
+        format.html { redirect_to settings_providers_path, alert: t(".failed") }
+        format.turbo_stream do
+          flash.now[:alert] = t(".failed")
+          render turbo_stream: flash_notification_stream_items
+        end
+      end
+      return
+    end
+
+    if @snaptrade_item.delete_orphaned_user(user_id)
+      respond_to do |format|
+        format.html { redirect_to settings_providers_path, notice: t(".success") }
+        format.turbo_stream { render turbo_stream: turbo_stream.remove("orphaned_user_#{user_id.parameterize}") }
+      end
+    else
+      respond_to do |format|
+        format.html { redirect_to settings_providers_path, alert: t(".failed") }
+        format.turbo_stream do
+          flash.now[:alert] = t(".failed")
+          render turbo_stream: flash_notification_stream_items
+        end
+      end
+    end
+  end
+
   # Collection actions for account linking flow
 
   def preload_accounts
@@ -321,11 +536,11 @@ class SnaptradeItemsController < ApplicationController
       return
     end
 
-    if snaptrade_item.oauth_configured?
+    if snaptrade_item.fully_configured?
       snaptrade_item.sync_later_with_follow_up
       redirect_to setup_accounts_snaptrade_item_path(snaptrade_item)
     else
-      redirect_to oauth_authorize_snaptrade_items_path(item_id: snaptrade_item.id)
+      redirect_to oauth_connect_snaptrade_items_path(item_id: snaptrade_item.id)
     end
   end
 
@@ -339,10 +554,11 @@ class SnaptradeItemsController < ApplicationController
       return
     end
 
-    if snaptrade_item.oauth_configured?
+    if snaptrade_item.fully_configured?
       redirect_to setup_accounts_snaptrade_item_path(snaptrade_item, accountable_type: @accountable_type, return_to: @return_to)
     else
-      redirect_to oauth_authorize_snaptrade_items_path(item_id: snaptrade_item.id, accountable_type: @accountable_type, return_to: @return_to)
+      store_snaptrade_resume_context(return_to: @return_to, accountable_type: @accountable_type)
+      redirect_to oauth_connect_snaptrade_items_path(item_id: snaptrade_item.id, accountable_type: @accountable_type, return_to: @return_to)
     end
   end
 
@@ -402,7 +618,120 @@ class SnaptradeItemsController < ApplicationController
       active_items = Current.family.snaptrade_items.active
 
       active_items.syncable.ordered.first ||
+        active_items.api_credentials_configured.ordered.first ||
         active_items.ordered.first
+    end
+
+    # Registration failures shouldn't fail the credential save - the panel
+    # surfaces the "registration needed" state and the user can retry.
+    def register_snaptrade_user(snaptrade_item)
+      return unless snaptrade_item.api_credentials_configured?
+
+      snaptrade_item.ensure_user_registered!
+    rescue => e
+      Rails.logger.error "SnapTrade user registration failed: #{e.message}"
+    end
+
+    def render_panel_success(message)
+      if turbo_frame_request?
+        flash.now[:notice] = message
+        @snaptrade_items = Current.family.snaptrade_items.ordered
+        render turbo_stream: [
+          turbo_stream.replace(
+            "snaptrade-providers-panel",
+            partial: "settings/providers/snaptrade_panel",
+            locals: { snaptrade_items: @snaptrade_items }
+          ),
+          *flash_notification_stream_items
+        ]
+      else
+        redirect_to settings_providers_path, notice: message, status: :see_other
+      end
+    end
+
+    def render_panel_error(message)
+      @error_message = message
+
+      if turbo_frame_request?
+        render turbo_stream: turbo_stream.replace(
+          "snaptrade-providers-panel",
+          partial: "settings/providers/snaptrade_panel",
+          locals: { error_message: @error_message }
+        ), status: :unprocessable_entity
+      else
+        redirect_to settings_providers_path, alert: @error_message, status: :see_other
+      end
+    end
+
+    def store_snaptrade_resume_context(return_to:, accountable_type:)
+      session[:snaptrade_resume] = {
+        return_to: return_to,
+        accountable_type: accountable_type
+      }
+    end
+
+    def clear_snaptrade_resume_context
+      resume = (session.delete(:snaptrade_resume) || {}).with_indifferent_access
+      [ resume[:return_to], resume[:accountable_type] ]
+    end
+
+    def restore_device_authorization_from_params
+      @device_authorization = params.permit(
+        :device_code,
+        :user_code,
+        :verification_uri,
+        :verification_uri_complete,
+        :expires_in,
+        :interval
+      ).to_h
+      @return_to = params[:return_to]
+      @accountable_type = params[:accountable_type]
+    end
+
+    def assign_oauth_connect_context
+      @return_to = params[:return_to]
+      @accountable_type = params[:accountable_type]
+      @oauth_scope = permitted_oauth_scope
+    end
+
+    def permitted_oauth_scope
+      requested_scope = params[:scope].to_s
+      return requested_scope if PERMITTED_OAUTH_SCOPES.include?(requested_scope)
+
+      "read"
+    end
+
+    def prepare_snaptrade_item_for_setup_after_oauth
+      if !@snaptrade_item.user_registered? && @snaptrade_item.api_credentials_configured?
+        @snaptrade_item.ensure_user_registered!
+      end
+
+      return false unless @snaptrade_item.fully_configured?
+
+      @snaptrade_item.sync_later_with_follow_up
+      true
+    rescue Provider::Snaptrade::Error => e
+      Rails.logger.error "SnapTrade user registration after authorization failed: #{e.class} - #{e.message}"
+      false
+    end
+
+    def redirect_after_oauth_completion(path, notice: nil, alert: nil)
+      if turbo_frame_request?
+        flash[:notice] = notice if notice.present?
+        flash[:alert] = alert if alert.present?
+        render turbo_stream: turbo_stream.action(:redirect, path)
+      else
+        redirect_to path, notice: notice, alert: alert
+      end
+    end
+
+    def snaptrade_item_params
+      params.require(:snaptrade_item).permit(
+        :name,
+        :sync_start_date,
+        :client_id,
+        :consumer_key
+      )
     end
 
     def build_connections_list
@@ -412,7 +741,7 @@ class SnaptradeItemsController < ApplicationController
         .includes(:account_provider)
         .group_by(&:snaptrade_authorization_id)
 
-      result = { connections: [] }
+      result = { connections: [], orphaned_users: [] }
 
       api_connections.each do |api_conn|
         auth_id = api_conn["id"]
@@ -429,10 +758,90 @@ class SnaptradeItemsController < ApplicationController
         }
       end
 
+      # Users left over from earlier registrations still hold connection slots.
+      # Only the device flow registers SnapTrade users, so legacy items have none.
+      @snaptrade_item.orphaned_users.each do |user_id|
+        result[:orphaned_users] << {
+          user_id: user_id,
+          display_name: user_id.truncate(30)
+        }
+      end
+
       result
     rescue Provider::Snaptrade::ApiError => e
       @error = e.message
-      { connections: [] }
+      { connections: [], orphaned_users: [] }
+    end
+
+    def oauth_error_payload(error)
+      parsed_body = parse_oauth_error_body(error.response_body)
+      payload = parsed_body.slice("error", "error_description", "error_uri", "interval")
+      payload["error"] ||= error.message
+      payload
+    end
+
+    def start_oauth_device_flow_error_message
+      t(
+        "snaptrade_items.start_oauth_device_flow.failed",
+        default: "Unable to start SnapTrade OAuth device authorization. Please try again."
+      )
+    end
+
+    def oauth_connect_error_message(error)
+      if error.is_a?(Provider::Snaptrade::ConfigurationError) && error.message.include?("OAuth client ID")
+        snaptrade_oauth_client_id_missing_message
+      else
+        start_oauth_device_flow_error_message
+      end
+    end
+
+    # The device flow needs the family's API credentials before it runs: they
+    # are what makes the resulting connection a device-flow one, and what its
+    # data calls are scoped by. Renders the drawer explaining that rather than
+    # starting a ceremony whose tokens we could not use.
+    def require_api_credentials_for_device_flow!
+      return true if @snaptrade_item&.api_credentials_configured?
+
+      @error_message = snaptrade_api_credentials_required_message
+      render :oauth_device_flow, status: :unprocessable_entity, formats: :html
+      false
+    end
+
+    def snaptrade_api_credentials_required_message
+      t(
+        "snaptrade_items.oauth_device_flow.credentials_required",
+        default: "Add your SnapTrade Client ID and Consumer Key first, then authorize with a device code."
+      )
+    end
+
+    def snaptrade_oauth_client_id_missing_message
+      t(
+        "snaptrade_items.oauth_device_flow.missing_client_id",
+        default: "SnapTrade OAuth client ID is not configured. Add SNAPTRADE_OAUTH_CLIENT_ID to .env.local, restart the app, then try again."
+      )
+    end
+
+    def snaptrade_oauth_setup_incomplete_message
+      t(
+        "snaptrade_items.complete_oauth_device_flow.setup_incomplete",
+        default: "SnapTrade authorization is complete, but API credentials are required before accounts can sync."
+      )
+    end
+
+    def complete_oauth_device_flow_error_message
+      t(
+        "snaptrade_items.complete_oauth_device_flow.failed",
+        default: "Unable to complete SnapTrade OAuth device authorization. Please try again."
+      )
+    end
+
+    def parse_oauth_error_body(response_body)
+      return {} if response_body.blank?
+
+      parsed_body = JSON.parse(response_body)
+      parsed_body.is_a?(Hash) ? parsed_body : {}
+    rescue JSON::ParserError
+      {}
     end
 
     def link_snaptrade_account(snaptrade_account, selected_type)

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -94,8 +94,12 @@ module SettingsHelper
       return { status: :off } unless @kraken_items&.any?
       sync_based_summary(key)
     when "snaptrade"
-      configured_item = @snaptrade_items&.find(&:oauth_configured?)
+      configured_item = @snaptrade_items&.find(&:credentials_configured?)
       return { status: :off } unless configured_item
+
+      unless configured_item.fully_configured?
+        return { status: :warn, meta: t("settings.providers.meta.registration_needed") }
+      end
 
       sync_based_summary(key)
     when "ibkr"

--- a/app/models/provider/snaptrade.rb
+++ b/app/models/provider/snaptrade.rb
@@ -1,12 +1,18 @@
-# SnapTrade API client using SnapTrade OAuth apps (pre-release feature).
+# SnapTrade API client for the device-flow auth model.
 #
 # Auth model:
-#   - Instance admin registers an OAuth app on dashboard.snaptrade.com and sets
-#     SNAPTRADE_OAUTH_CLIENT_ID / SNAPTRADE_OAUTH_CLIENT_SECRET.
-#   - Users authorize via authorization-code + PKCE; per-item access/refresh
-#     tokens are stored (encrypted) on SnaptradeItem.
-#   - Data calls send Authorization: Bearer <access_token>. The SnapTrade user
-#     is implicit in the token; there is no userId/userSecret.
+#   - The family stores its own SnapTrade API credentials (client_id /
+#     consumer_key) on SnaptradeItem, and a SnapTrade user is registered
+#     against them (snaptrade_user_id / snaptrade_user_secret).
+#   - The user authorizes Sure through the OAuth device flow, using the
+#     deployment-wide public client id in SNAPTRADE_OAUTH_CLIENT_ID.
+#   - Data calls go through the SnapTrade SDK and are scoped by the registered
+#     user's id/secret, which are bound at construction.
+#
+# The authorization-code + PKCE model added in #2747 is deprecated but still
+# supported for connections made under it; see Provider::SnaptradeOauth. Both
+# clients expose the same data-method signatures and return plain hashes, so
+# everything downstream of SnaptradeItem#snaptrade_provider is auth-agnostic.
 class Provider::Snaptrade
   class Error < StandardError; end
   class AuthenticationError < Error; end
@@ -21,388 +27,312 @@ class Provider::Snaptrade
     end
   end
 
+  # Retry configuration for transient network failures
   MAX_RETRIES = 3
   INITIAL_RETRY_DELAY = 2 # seconds
   MAX_RETRY_DELAY = 30 # seconds
 
-  API_BASE_URL = "https://api.snaptrade.com".freeze
-  AUTHORIZE_URL = "https://dashboard.snaptrade.com/oauth/authorize".freeze
-  TOKEN_URL = "https://api.snaptrade.com/oauth/token/".freeze
-  REVOKE_URL = "https://api.snaptrade.com/oauth/revoke_token/".freeze
   DASHBOARD_URL = "https://dashboard.snaptrade.com".freeze
-  TOKEN_EXPIRY_LEEWAY = 60 # seconds; refresh this long before actual expiry
+  OAUTH_DISCOVERY_URL = "https://api.snaptrade.com/.well-known/oauth-authorization-server".freeze
+  DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code".freeze
 
-  # Filtered out of get_positions so they never reach raw_holdings_payload:
-  # units are per-contract and symbols OCC-style, which neither
-  # SnaptradeAccount::HoldingsProcessor nor the units * price sum in
-  # SnaptradeAccount::Processor#calculate_holdings_value models. A denylist, so
-  # equity-like kinds added later still import rather than being dropped.
-  UNSUPPORTED_INSTRUMENT_KINDS = %w[option future cfd].freeze
+  attr_reader :client_id, :consumer_key, :user_id, :user_secret
 
-  class << self
-    def oauth_configured?
-      oauth_client_id.present? && oauth_client_secret.present?
+  def initialize(client_id: nil, consumer_key: nil, user_id: nil, user_secret: nil)
+    @client_id = client_id
+    @consumer_key = consumer_key
+    @user_id = user_id
+    @user_secret = user_secret
+
+    return if client_id.blank? && consumer_key.blank?
+    raise ConfigurationError, "client_id is required" if client_id.blank?
+    raise ConfigurationError, "consumer_key is required" if consumer_key.blank?
+
+    configuration = SnapTrade::Configuration.new
+    configuration.client_id = client_id
+    configuration.consumer_key = consumer_key
+    @client = SnapTrade::Client.new(configuration)
+  end
+
+  def self.oauth_client_id_configured?
+    Rails.configuration.x.snaptrade&.oauth_client_id.present?
+  end
+
+  # --- OAuth device flow. Only needs the deployment's public client id. ---
+
+  def oauth_authorization_server_metadata
+    @oauth_authorization_server_metadata ||= with_retries("oauth_authorization_server_metadata") do
+      response = oauth_connection.get(OAUTH_DISCOVERY_URL)
+      parse_oauth_response(response, "oauth_authorization_server_metadata")
+    end
+  end
+
+  def start_device_authorization(scope: "read")
+    client_id = oauth_client_id
+    metadata = oauth_authorization_server_metadata
+    endpoint = metadata.fetch("device_authorization_endpoint") do
+      raise ApiError.new("SnapTrade OAuth metadata missing device_authorization_endpoint")
     end
 
-    def oauth_client_id
-      Rails.configuration.x.snaptrade&.oauth_client_id
-    end
-
-    def oauth_client_secret
-      Rails.configuration.x.snaptrade&.oauth_client_secret
-    end
-
-    # PKCE pair per RFC 7636 (S256)
-    def generate_pkce
-      verifier = SecureRandom.urlsafe_base64(64).delete("=")[0, 128]
-      challenge = Base64.urlsafe_encode64(OpenSSL::Digest::SHA256.digest(verifier), padding: false)
-      { verifier: verifier, challenge: challenge }
-    end
-
-    def authorize_url(redirect_uri:, state:, code_challenge:, scope: "read")
-      raise ConfigurationError, "SnapTrade OAuth is not configured" unless oauth_configured?
-
-      params = {
-        response_type: "code",
-        client_id: oauth_client_id,
-        redirect_uri: redirect_uri,
-        scope: scope,
-        state: state,
-        code_challenge: code_challenge,
-        code_challenge_method: "S256"
-      }
-      "#{AUTHORIZE_URL}?#{params.to_query}"
-    end
-
-    def exchange_code(code:, redirect_uri:, code_verifier:)
-      token_request(
-        grant_type: "authorization_code",
-        code: code,
-        redirect_uri: redirect_uri,
-        code_verifier: code_verifier
-      )
-    end
-
-    def refresh_tokens(refresh_token:)
-      token_request(grant_type: "refresh_token", refresh_token: refresh_token)
-    end
-
-    # Best-effort revocation (RFC 7009). Returns true on success.
-    def revoke_token(token:)
-      return false if token.blank?
-      raise ConfigurationError, "SnapTrade OAuth is not configured" unless oauth_configured?
-
-      response = oauth_connection.post(REVOKE_URL) do |request|
-        request.headers["Authorization"] = basic_auth_header
+    with_retries("start_device_authorization") do
+      response = oauth_connection.post(endpoint) do |request|
         request.headers["Content-Type"] = "application/x-www-form-urlencoded"
-        request.body = URI.encode_www_form(token: token)
-      end
-      response.success?
-    rescue Faraday::Error => e
-      Rails.logger.warn("SnapTrade token revocation failed: #{e.class} - #{e.message}")
-      false
-    end
-
-    private
-
-      def token_request(params)
-        raise ConfigurationError, "SnapTrade OAuth is not configured" unless oauth_configured?
-
-        # Not retried: a token request consumes a single-use authorization code
-        # or rotates the refresh token. If the response is lost after SnapTrade
-        # processed it, replaying the same params would fail with invalid_grant
-        # even though the original request actually succeeded.
-        response = without_retry("POST #{TOKEN_URL}") do
-          oauth_connection.post(TOKEN_URL) do |request|
-            request.headers["Authorization"] = basic_auth_header
-            request.headers["Content-Type"] = "application/x-www-form-urlencoded"
-            request.body = URI.encode_www_form(params)
-          end
-        end
-
-        payload = parse_json(response.body)
-        return payload if response.success?
-
-        error = payload["error_description"].presence || payload["error"].presence || "HTTP #{response.status}"
-        if (400..499).cover?(response.status)
-          raise AuthenticationError, "SnapTrade OAuth token request failed: #{error}"
-        end
-
-        raise ApiError.new(
-          "SnapTrade OAuth token request failed: #{error}",
-          status_code: response.status, response_body: response.body
+        request.body = URI.encode_www_form(
+          client_id: client_id,
+          scope: scope
         )
       end
 
-      def basic_auth_header
-        "Basic #{Base64.strict_encode64("#{oauth_client_id}:#{oauth_client_secret}")}"
-      end
-
-      def oauth_connection
-        Faraday.new do |faraday|
-          faraday.options.timeout = 30
-          faraday.options.open_timeout = 10
-        end
-      end
-
-      def parse_json(body)
-        body.present? ? JSON.parse(body) : {}
-      rescue JSON::ParserError
-        {}
-      end
-
-      def with_retries(operation_name, max_retries: MAX_RETRIES)
-        retries = 0
-
-        begin
-          yield
-        rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
-          retries += 1
-
-          if retries <= max_retries
-            delay = calculate_retry_delay(retries)
-            Rails.logger.warn(
-              "SnapTrade OAuth: #{operation_name} failed (attempt #{retries}/#{max_retries}): " \
-              "#{e.class}: #{e.message}. Retrying in #{delay}s..."
-            )
-            sleep(delay)
-            retry
-          else
-            Rails.logger.error(
-              "SnapTrade OAuth: #{operation_name} failed after #{max_retries} retries: " \
-              "#{e.class}: #{e.message}"
-            )
-            raise ApiError.new("Network error after #{max_retries} retries: #{e.message}")
-          end
-        end
-      end
-
-      # For requests that must not be replayed (single-use codes, token rotation):
-      # translate a network failure into an ApiError without retrying.
-      def without_retry(operation_name)
-        yield
-      rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
-        Rails.logger.error("SnapTrade OAuth: #{operation_name} failed (not retried, non-idempotent): #{e.class}: #{e.message}")
-        raise ApiError.new("Network error (not retried, non-idempotent request): #{e.message}")
-      end
-
-      def calculate_retry_delay(retry_count)
-        base_delay = INITIAL_RETRY_DELAY * (2 ** (retry_count - 1))
-        jitter = base_delay * rand * 0.25
-        [ base_delay + jitter, MAX_RETRY_DELAY ].min
-      end
+      parse_oauth_response(response, "start_device_authorization")
+    end
   end
 
-  attr_reader :snaptrade_item
+  def poll_device_token(device_code:)
+    raise ConfigurationError, "device_code is required" if device_code.blank?
 
-  def initialize(snaptrade_item)
-    raise ConfigurationError, "snaptrade_item is required" if snaptrade_item.nil?
-    @snaptrade_item = snaptrade_item
+    client_id = oauth_client_id
+    metadata = oauth_authorization_server_metadata
+    endpoint = metadata.fetch("token_endpoint") do
+      raise ApiError.new("SnapTrade OAuth metadata missing token_endpoint")
+    end
+
+    with_retries("poll_device_token") do
+      response = oauth_connection.post(endpoint) do |request|
+        request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request.body = URI.encode_www_form(
+          grant_type: DEVICE_CODE_GRANT,
+          device_code: device_code,
+          client_id: client_id
+        )
+      end
+
+      parse_oauth_response(response, "poll_device_token")
+    end
   end
 
-  # --- Data methods. The SnapTrade user is implicit in the Bearer token. ---
+  # --- User registration. Needs the API credentials, not a registered user. ---
+
+  # Register a new SnapTrade user. Returns { user_id: String, user_secret: String }.
+  #
+  # Deliberately not retried: registration is a non-idempotent create whose
+  # user_secret is returned exactly once, so replaying a request whose response
+  # was lost would strand an upstream user and burn a connection slot.
+  def register_user(new_user_id)
+    response = client.authentication.register_snap_trade_user(
+      user_id: new_user_id
+    )
+    {
+      user_id: response.user_id,
+      user_secret: response.user_secret
+    }
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "register_user")
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+    Rails.logger.error("SnapTrade API: register_user failed (not retried, non-idempotent): #{e.class}: #{e.message}")
+    raise ApiError.new("Network error (not retried, non-idempotent request): #{e.message}")
+  end
+
+  # Delete a SnapTrade user (resets all their connections)
+  def delete_user(user_id:)
+    with_retries("delete_user") do
+      client.authentication.delete_snap_trade_user(
+        user_id: user_id
+      )
+    end
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "delete_user")
+  end
+
+  # List all users registered under these API credentials
+  def list_users
+    with_retries("list_users") do
+      normalize(client.authentication.list_snap_trade_users)
+    end
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "list_users")
+  end
+
+  # --- Data methods. Scoped by the registered user bound at construction. ---
 
   # Returns Array<Hash> of brokerage accounts
   def list_accounts
-    get_json("/api/v1/accounts")
+    with_retries("list_accounts") do
+      normalize(client.account_information.list_user_accounts(**user_credentials))
+    end
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "list_accounts")
   end
 
   # Returns Array<Hash> of balance entries
   def get_balances(account_id:)
-    get_json("/api/v1/accounts/#{account_id}/balances")
+    with_retries("get_balances") do
+      normalize(client.account_information.get_user_account_balance(
+        **user_credentials,
+        account_id: account_id
+      ))
+    end
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "get_balances")
   end
 
   # Returns Array<Hash> of positions
   def get_positions(account_id:)
-    response = get_json("/api/v1/accounts/#{account_id}/positions/all")
-    results = response["results"] if response.is_a?(Hash)
-
-    # An empty `results` is a legitimately empty account, but a missing one is
-    # a partial or schema-changed response. Raising leaves the previous
-    # snapshot in place rather than overwriting it with nothing.
-    unless results.is_a?(Array)
-      raise ApiError.new(
-        "SnapTrade positions response has no results array " \
-        "(keys: #{response.is_a?(Hash) ? response.keys.inspect : response.class})"
-      )
+    with_retries("get_positions") do
+      normalize(client.account_information.get_user_account_positions(
+        **user_credentials,
+        account_id: account_id
+      ))
     end
-
-    results.reject { |position| unsupported_instrument?(position) }
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "get_positions")
   end
 
   # Returns raw JSON: paginated form is {"data" => [...]}, may also be a plain Array
   def get_account_activities(account_id:, start_date: nil, end_date: nil)
-    params = {}
-    params[:startDate] = start_date.to_date.to_s if start_date
-    params[:endDate] = end_date.to_date.to_s if end_date
-    get_json("/api/v1/accounts/#{account_id}/activities", params)
+    with_retries("get_account_activities") do
+      params = user_credentials.merge(account_id: account_id)
+      params[:start_date] = start_date.to_date.to_s if start_date
+      params[:end_date] = end_date.to_date.to_s if end_date
+
+      normalize(client.account_information.get_account_activities(**params))
+    end
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "get_account_activities")
   end
 
   # Cross-account activities endpoint. Returns Array<Hash>.
   def get_activities(start_date: nil, end_date: nil, accounts: nil, brokerage_authorizations: nil, type: nil)
-    params = {}
-    params[:startDate] = start_date.to_date.to_s if start_date
-    params[:endDate] = end_date.to_date.to_s if end_date
-    params[:accounts] = accounts if accounts
-    params[:brokerageAuthorizations] = brokerage_authorizations if brokerage_authorizations
-    params[:type] = type if type
-    get_json("/api/v1/activities", params)
+    with_retries("get_activities") do
+      params = user_credentials
+      params[:start_date] = start_date.to_date.to_s if start_date
+      params[:end_date] = end_date.to_date.to_s if end_date
+      params[:accounts] = accounts if accounts
+      params[:brokerage_authorizations] = brokerage_authorizations if brokerage_authorizations
+      params[:type] = type if type
+
+      normalize(client.transactions_and_reporting.get_activities(**params))
+    end
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "get_activities")
   end
 
   # Returns Array<Hash> of brokerage authorizations (connections)
   def list_connections
-    get_json("/api/v1/authorizations")
+    with_retries("list_connections") do
+      normalize(client.connections.list_brokerage_authorizations(**user_credentials))
+    end
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "list_connections")
   end
 
+  # Delete a brokerage connection, freeing up one connection slot
   def delete_connection(authorization_id:)
-    request_json(:delete, "/api/v1/authorizations/#{authorization_id}")
+    client.connections.remove_brokerage_authorization(
+      **user_credentials,
+      authorization_id: authorization_id
+    )
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "delete_connection")
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+    Rails.logger.error("SnapTrade API: delete_connection failed (not retried, non-idempotent): #{e.class}: #{e.message}")
+    raise ApiError.new("Network error (not retried, non-idempotent request): #{e.message}")
   end
 
   # Connection portal URL (loginUser). Returns the redirect URL string.
   def get_connection_url(redirect_url:, broker: nil)
-    body = { customRedirect: redirect_url, connectionType: "read" }
-    body[:broker] = broker if broker
-    response = request_json(:post, "/api/v1/snapTrade/login", body: body)
-    response["redirectURI"] || response["redirectUri"]
+    response = client.authentication.login_snap_trade_user(
+      **user_credentials,
+      custom_redirect: redirect_url,
+      connection_type: "read",
+      broker: broker
+    )
+    response.redirect_uri
+  rescue SnapTrade::ApiError => e
+    handle_api_error(e, "get_connection_url")
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+    Rails.logger.error("SnapTrade API: get_connection_url failed (not retried, non-idempotent): #{e.class}: #{e.message}")
+    raise ApiError.new("Network error (not retried, non-idempotent request): #{e.message}")
   end
 
   private
 
-    def unsupported_instrument?(position)
-      return false unless position.is_a?(Hash)
-
-      instrument = position["instrument"]
-      return false unless instrument.is_a?(Hash)
-
-      UNSUPPORTED_INSTRUMENT_KINDS.include?(instrument["kind"].to_s.downcase)
+    def client
+      @client || raise(ConfigurationError, "SnapTrade API credentials are required")
     end
 
-    def get_json(path, params = {})
-      request_json(:get, path, params: params)
-    end
-
-    def request_json(method, path, params: {}, body: nil, retry_on_auth_failure: true)
-      ensure_fresh_token!
-      operation = "#{method.to_s.upcase} #{path}"
-      used_access_token = snaptrade_item.oauth_access_token
-
-      # Only GET is safe to retry: a lost response to a POST/DELETE (e.g.
-      # get_connection_url, delete_connection) may already have been applied by
-      # SnapTrade, so replaying it risks duplicate side effects.
-      retrier = method == :get ? method(:with_retries) : method(:without_retry)
-      response = retrier.call(operation) do
-        api_connection.public_send(method, "#{API_BASE_URL}#{path}") do |request|
-          request.headers["Authorization"] = "Bearer #{used_access_token}"
-          request.headers["Accept"] = "application/json"
-          request.params.update(params) if params.present?
-          if body
-            request.headers["Content-Type"] = "application/json"
-            request.body = body.to_json
-          end
-        end
+    def user_credentials
+      if user_id.blank? || user_secret.blank?
+        raise ConfigurationError, "SnapTrade user is not registered"
       end
 
-      if response.status == 401 && retry_on_auth_failure
-        refresh_access_token!(previous_access_token: used_access_token)
-        return request_json(method, path, params: params, body: body, retry_on_auth_failure: false)
-      end
-
-      handle_response(response, operation)
+      { user_id: user_id, user_secret: user_secret }
     end
 
-    def ensure_fresh_token!
-      raise AuthenticationError, "SnapTrade item has no access token" if snaptrade_item.oauth_access_token.blank?
-
-      expires_at = snaptrade_item.oauth_token_expires_at
-      return if expires_at.blank? || expires_at > TOKEN_EXPIRY_LEEWAY.seconds.from_now
-
-      refresh_access_token!
-    end
-
-    # Guards against a concurrent refresh-token rotation race: multiple threads/processes
-    # (e.g. per-account jobs sharing one SnapTrade item) may all observe an expiring/rejected
-    # token and attempt to refresh at once. If SnapTrade rotates refresh tokens as single-use,
-    # every refresh after the first would fail with invalid_grant and needlessly brick the
-    # item. Taking a DB row lock and re-checking freshness after reload ensures only one
-    # caller actually performs the HTTP refresh; the rest observe the winner's fresh token.
-    #
-    # `previous_access_token`, when present, means we're refreshing reactively after a 401 on
-    # that specific token (called from request_json). In that case we skip the HTTP refresh
-    # only if the DB row's access token has already changed since we made the failed request
-    # (i.e. another caller already won the race) -- an expiry-based freshness check would be
-    # wrong here since the server rejected a token we believed was still time-valid.
-    # When `previous_access_token` is absent, we're refreshing proactively (from
-    # ensure_fresh_token!) and skip only if the reloaded row is still time-fresh.
-    def refresh_access_token!(previous_access_token: nil)
-      snaptrade_item.with_lock do
-        snaptrade_item.reload
-
-        if previous_access_token.present?
-          next if snaptrade_item.oauth_access_token != previous_access_token
-        else
-          expires_at = snaptrade_item.oauth_token_expires_at
-          next if expires_at.present? && expires_at > TOKEN_EXPIRY_LEEWAY.seconds.from_now
-        end
-
-        refresh_token = snaptrade_item.oauth_refresh_token
-        raise AuthenticationError, "SnapTrade item has no refresh token" if refresh_token.blank?
-
-        payload = self.class.refresh_tokens(refresh_token: refresh_token)
-        snaptrade_item.apply_oauth_tokens!(payload)
-      end
-    rescue AuthenticationError => e
-      mark_requires_update!
-      DebugLogEntry.capture(
-        category: "provider_sync",
-        level: :error,
-        message: "SnapTrade token refresh failed: #{e.message}",
-        source: "Provider::Snaptrade",
-        provider_key: "snaptrade",
-        family: snaptrade_item.try(:family),
-        metadata: { snaptrade_item_id: snaptrade_item.try(:id) }
-      )
-      raise
-    end
-
-    def mark_requires_update!
-      snaptrade_item.update!(status: :requires_update)
-    rescue StandardError => e
-      Rails.logger.warn("SnapTrade: could not mark item requires_update: #{e.message}")
-    end
-
-    def handle_response(response, operation)
-      if response.success?
-        return {} if response.body.blank?
-        begin
-          JSON.parse(response.body)
-        rescue JSON::ParserError
-          raise ApiError.new("SnapTrade API error (#{operation}): invalid JSON response",
-                             status_code: response.status, response_body: response.body)
-        end
+    # SDK responses are model objects; downstream code (importer, jobs, the
+    # SnaptradeAccount upserts) works in plain hashes so that it does not have
+    # to care which auth model produced the payload. SnapTrade's models expose
+    # their wire shape -- API-cased keys, nested models resolved -- through
+    # to_hash, which is what those hashes are keyed by everywhere else.
+    def normalize(value)
+      case value
+      when Array
+        value.map { |element| normalize(element) }
+      when Hash
+        value.to_h { |key, element| [ key, normalize(element) ] }
+      when String, Symbol, Numeric, TrueClass, FalseClass, NilClass, Date, Time
+        value
+      when ->(object) { object.respond_to?(:to_hash) }
+        normalize(value.to_hash)
       else
-        Rails.logger.error("SnapTrade API error (#{operation}): #{response.status}")
-        case response.status
-        when 401, 403
-          mark_requires_update!
-          raise AuthenticationError, "Authentication failed (#{operation}): HTTP #{response.status}"
-        when 429
-          raise ApiError.new("Rate limit exceeded. Please try again later.",
-                             status_code: response.status, response_body: response.body)
-        when 500..599
-          raise ApiError.new("SnapTrade server error (#{response.status}). Please try again later.",
-                             status_code: response.status, response_body: response.body)
-        else
-          raise ApiError.new("SnapTrade API error (#{operation}): HTTP #{response.status}",
-                             status_code: response.status, response_body: response.body)
-        end
+        JSON.parse(value.to_json)
+      end
+    rescue JSON::ParserError, TypeError
+      value
+    end
+
+    def handle_api_error(error, operation)
+      status = error.code
+      body = error.response_body
+
+      Rails.logger.error("SnapTrade API error (#{operation}): #{status} - #{error.message}")
+
+      case status
+      when 401, 403
+        raise AuthenticationError, "Authentication failed: #{error.message}"
+      when 429
+        raise ApiError.new("Rate limit exceeded. Please try again later.", status_code: status, response_body: body)
+      when 500..599
+        raise ApiError.new("SnapTrade server error (#{status}). Please try again later.", status_code: status, response_body: body)
+      else
+        raise ApiError.new("SnapTrade API error: #{error.message}", status_code: status, response_body: body)
       end
     end
 
-    def api_connection
-      @api_connection ||= Faraday.new do |faraday|
+    def oauth_connection
+      @oauth_connection ||= Faraday.new do |faraday|
         faraday.options.timeout = 30
         faraday.options.open_timeout = 10
       end
+    end
+
+    def oauth_client_id
+      configured_client_id = Rails.configuration.x.snaptrade&.oauth_client_id
+      return configured_client_id if configured_client_id.present?
+
+      raise ConfigurationError, "SnapTrade OAuth client ID is not configured"
+    end
+
+    def parse_oauth_response(response, operation)
+      payload = response.body.present? ? JSON.parse(response.body) : {}
+
+      if response.success?
+        payload
+      else
+        error = payload["error_description"].presence || payload["error"].presence || response.reason_phrase
+        raise ApiError.new("SnapTrade OAuth error (#{operation}): #{error}", status_code: response.status, response_body: response.body)
+      end
+    rescue JSON::ParserError
+      raise ApiError.new("SnapTrade OAuth error (#{operation}): invalid JSON response", status_code: response.status, response_body: response.body)
     end
 
     def with_retries(operation_name, max_retries: MAX_RETRIES)
@@ -429,13 +359,6 @@ class Provider::Snaptrade
           raise ApiError.new("Network error after #{max_retries} retries: #{e.message}")
         end
       end
-    end
-
-    def without_retry(operation_name)
-      yield
-    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
-      Rails.logger.error("SnapTrade API: #{operation_name} failed (not retried, non-idempotent): #{e.class}: #{e.message}")
-      raise ApiError.new("Network error (not retried, non-idempotent request): #{e.message}")
     end
 
     def calculate_retry_delay(retry_count)

--- a/app/models/provider/snaptrade_adapter.rb
+++ b/app/models/provider/snaptrade_adapter.rb
@@ -38,17 +38,14 @@ class Provider::SnaptradeAdapter < Provider::Base
     "snaptrade"
   end
 
-  # Build a SnapTrade provider instance for a family's authorized item
-  # @param family [Family] The family to get an authorized item for (required)
-  # @return [Provider::Snaptrade, nil] Returns nil if OAuth is not configured/authorized
+  # Build a SnapTrade client for a family's connected item, under whichever
+  # auth model that item uses.
+  # @param family [Family] The family to get a connected item for (required)
+  # @return [Provider::Snaptrade, Provider::SnaptradeOauth, nil] nil if the family has no usable connection
   def self.build_provider(family: nil)
     return nil unless family.present?
-    return nil unless Provider::Snaptrade.oauth_configured?
 
-    snaptrade_item = family.snaptrade_items.syncable.first
-    return nil unless snaptrade_item
-
-    Provider::Snaptrade.new(snaptrade_item)
+    family.snaptrade_items.syncable.ordered.filter_map(&:snaptrade_provider).first
   end
 
   def sync_path

--- a/app/models/provider/snaptrade_oauth.rb
+++ b/app/models/provider/snaptrade_oauth.rb
@@ -1,0 +1,450 @@
+# DEPRECATED SnapTrade API client for the authorization-code + PKCE auth model
+# introduced in #2747.
+#
+# Auth model:
+#   - Instance admin registers an OAuth app on dashboard.snaptrade.com and sets
+#     SNAPTRADE_OAUTH_CLIENT_ID / SNAPTRADE_OAUTH_CLIENT_SECRET.
+#   - Users authorize via authorization-code + PKCE; per-item access/refresh
+#     tokens are stored (encrypted) on SnaptradeItem.
+#   - Data calls send Authorization: Bearer <access_token>. The SnapTrade user
+#     is implicit in the token; there is no userId/userSecret.
+#
+# SnapTrade OAuth apps are a pre-release feature that has not worked out for
+# self-hosted deployments, so new connections go through the device flow in
+# Provider::Snaptrade instead. This client stays in place, fully functional, so
+# that connections already authorized under PKCE keep syncing until their owner
+# migrates -- see SnaptradeItem#legacy_oauth? and the deprecation notice in the
+# SnapTrade settings panel. Nothing here should gain new features; when the
+# deprecation window closes, this file and the oauth_authorize/oauth_callback
+# routes go away together.
+#
+# Raises Provider::Snaptrade's error classes so that callers can rescue one
+# hierarchy regardless of which auth model an item uses.
+class Provider::SnaptradeOauth
+  Error = Provider::Snaptrade::Error
+  AuthenticationError = Provider::Snaptrade::AuthenticationError
+  ConfigurationError = Provider::Snaptrade::ConfigurationError
+  ApiError = Provider::Snaptrade::ApiError
+
+  MAX_RETRIES = 3
+  INITIAL_RETRY_DELAY = 2 # seconds
+  MAX_RETRY_DELAY = 30 # seconds
+
+  API_BASE_URL = "https://api.snaptrade.com".freeze
+  AUTHORIZE_URL = "https://dashboard.snaptrade.com/oauth/authorize".freeze
+  TOKEN_URL = "https://api.snaptrade.com/oauth/token/".freeze
+  REVOKE_URL = "https://api.snaptrade.com/oauth/revoke_token/".freeze
+  TOKEN_EXPIRY_LEEWAY = 60 # seconds; refresh this long before actual expiry
+
+  # Filtered out of get_positions so they never reach raw_holdings_payload:
+  # units are per-contract and symbols OCC-style, which neither
+  # SnaptradeAccount::HoldingsProcessor nor the units * price sum in
+  # SnaptradeAccount::Processor#calculate_holdings_value models. A denylist, so
+  # equity-like kinds added later still import rather than being dropped.
+  UNSUPPORTED_INSTRUMENT_KINDS = %w[option future cfd].freeze
+
+  class << self
+    def oauth_configured?
+      oauth_client_id.present? && oauth_client_secret.present?
+    end
+
+    def oauth_client_id
+      Rails.configuration.x.snaptrade&.oauth_client_id
+    end
+
+    def oauth_client_secret
+      Rails.configuration.x.snaptrade&.oauth_client_secret
+    end
+
+    # PKCE pair per RFC 7636 (S256)
+    def generate_pkce
+      verifier = SecureRandom.urlsafe_base64(64).delete("=")[0, 128]
+      challenge = Base64.urlsafe_encode64(OpenSSL::Digest::SHA256.digest(verifier), padding: false)
+      { verifier: verifier, challenge: challenge }
+    end
+
+    def authorize_url(redirect_uri:, state:, code_challenge:, scope: "read")
+      raise ConfigurationError, "SnapTrade OAuth is not configured" unless oauth_configured?
+
+      params = {
+        response_type: "code",
+        client_id: oauth_client_id,
+        redirect_uri: redirect_uri,
+        scope: scope,
+        state: state,
+        code_challenge: code_challenge,
+        code_challenge_method: "S256"
+      }
+      "#{AUTHORIZE_URL}?#{params.to_query}"
+    end
+
+    def exchange_code(code:, redirect_uri:, code_verifier:)
+      token_request(
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: redirect_uri,
+        code_verifier: code_verifier
+      )
+    end
+
+    def refresh_tokens(refresh_token:)
+      token_request(grant_type: "refresh_token", refresh_token: refresh_token)
+    end
+
+    # Best-effort revocation (RFC 7009). Returns true on success.
+    def revoke_token(token:)
+      return false if token.blank?
+      raise ConfigurationError, "SnapTrade OAuth is not configured" unless oauth_configured?
+
+      response = oauth_connection.post(REVOKE_URL) do |request|
+        request.headers["Authorization"] = basic_auth_header
+        request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request.body = URI.encode_www_form(token: token)
+      end
+      response.success?
+    rescue Faraday::Error => e
+      Rails.logger.warn("SnapTrade token revocation failed: #{e.class} - #{e.message}")
+      false
+    end
+
+    private
+
+      def token_request(params)
+        raise ConfigurationError, "SnapTrade OAuth is not configured" unless oauth_configured?
+
+        # Not retried: a token request consumes a single-use authorization code
+        # or rotates the refresh token. If the response is lost after SnapTrade
+        # processed it, replaying the same params would fail with invalid_grant
+        # even though the original request actually succeeded.
+        response = without_retry("POST #{TOKEN_URL}") do
+          oauth_connection.post(TOKEN_URL) do |request|
+            request.headers["Authorization"] = basic_auth_header
+            request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+            request.body = URI.encode_www_form(params)
+          end
+        end
+
+        payload = parse_json(response.body)
+        return payload if response.success?
+
+        error = payload["error_description"].presence || payload["error"].presence || "HTTP #{response.status}"
+        if (400..499).cover?(response.status)
+          raise AuthenticationError, "SnapTrade OAuth token request failed: #{error}"
+        end
+
+        raise ApiError.new(
+          "SnapTrade OAuth token request failed: #{error}",
+          status_code: response.status, response_body: response.body
+        )
+      end
+
+      def basic_auth_header
+        "Basic #{Base64.strict_encode64("#{oauth_client_id}:#{oauth_client_secret}")}"
+      end
+
+      def oauth_connection
+        Faraday.new do |faraday|
+          faraday.options.timeout = 30
+          faraday.options.open_timeout = 10
+        end
+      end
+
+      def parse_json(body)
+        body.present? ? JSON.parse(body) : {}
+      rescue JSON::ParserError
+        {}
+      end
+
+      def with_retries(operation_name, max_retries: MAX_RETRIES)
+        retries = 0
+
+        begin
+          yield
+        rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+          retries += 1
+
+          if retries <= max_retries
+            delay = calculate_retry_delay(retries)
+            Rails.logger.warn(
+              "SnapTrade OAuth: #{operation_name} failed (attempt #{retries}/#{max_retries}): " \
+              "#{e.class}: #{e.message}. Retrying in #{delay}s..."
+            )
+            sleep(delay)
+            retry
+          else
+            Rails.logger.error(
+              "SnapTrade OAuth: #{operation_name} failed after #{max_retries} retries: " \
+              "#{e.class}: #{e.message}"
+            )
+            raise ApiError.new("Network error after #{max_retries} retries: #{e.message}")
+          end
+        end
+      end
+
+      # For requests that must not be replayed (single-use codes, token rotation):
+      # translate a network failure into an ApiError without retrying.
+      def without_retry(operation_name)
+        yield
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        Rails.logger.error("SnapTrade OAuth: #{operation_name} failed (not retried, non-idempotent): #{e.class}: #{e.message}")
+        raise ApiError.new("Network error (not retried, non-idempotent request): #{e.message}")
+      end
+
+      def calculate_retry_delay(retry_count)
+        base_delay = INITIAL_RETRY_DELAY * (2 ** (retry_count - 1))
+        jitter = base_delay * rand * 0.25
+        [ base_delay + jitter, MAX_RETRY_DELAY ].min
+      end
+  end
+
+  attr_reader :snaptrade_item
+
+  def initialize(snaptrade_item)
+    raise ConfigurationError, "snaptrade_item is required" if snaptrade_item.nil?
+    @snaptrade_item = snaptrade_item
+  end
+
+  # --- Data methods. The SnapTrade user is implicit in the Bearer token. ---
+
+  # Returns Array<Hash> of brokerage accounts
+  def list_accounts
+    get_json("/api/v1/accounts")
+  end
+
+  # Returns Array<Hash> of balance entries
+  def get_balances(account_id:)
+    get_json("/api/v1/accounts/#{account_id}/balances")
+  end
+
+  # Returns Array<Hash> of positions
+  def get_positions(account_id:)
+    response = get_json("/api/v1/accounts/#{account_id}/positions/all")
+    results = response["results"] if response.is_a?(Hash)
+
+    # An empty `results` is a legitimately empty account, but a missing one is
+    # a partial or schema-changed response. Raising leaves the previous
+    # snapshot in place rather than overwriting it with nothing.
+    unless results.is_a?(Array)
+      raise ApiError.new(
+        "SnapTrade positions response has no results array " \
+        "(keys: #{response.is_a?(Hash) ? response.keys.inspect : response.class})"
+      )
+    end
+
+    results.reject { |position| unsupported_instrument?(position) }
+  end
+
+  # Returns raw JSON: paginated form is {"data" => [...]}, may also be a plain Array
+  def get_account_activities(account_id:, start_date: nil, end_date: nil)
+    params = {}
+    params[:startDate] = start_date.to_date.to_s if start_date
+    params[:endDate] = end_date.to_date.to_s if end_date
+    get_json("/api/v1/accounts/#{account_id}/activities", params)
+  end
+
+  # Cross-account activities endpoint. Returns Array<Hash>.
+  def get_activities(start_date: nil, end_date: nil, accounts: nil, brokerage_authorizations: nil, type: nil)
+    params = {}
+    params[:startDate] = start_date.to_date.to_s if start_date
+    params[:endDate] = end_date.to_date.to_s if end_date
+    params[:accounts] = accounts if accounts
+    params[:brokerageAuthorizations] = brokerage_authorizations if brokerage_authorizations
+    params[:type] = type if type
+    get_json("/api/v1/activities", params)
+  end
+
+  # Returns Array<Hash> of brokerage authorizations (connections)
+  def list_connections
+    get_json("/api/v1/authorizations")
+  end
+
+  def delete_connection(authorization_id:)
+    request_json(:delete, "/api/v1/authorizations/#{authorization_id}")
+  end
+
+  # Connection portal URL (loginUser). Returns the redirect URL string.
+  def get_connection_url(redirect_url:, broker: nil)
+    body = { customRedirect: redirect_url, connectionType: "read" }
+    body[:broker] = broker if broker
+    response = request_json(:post, "/api/v1/snapTrade/login", body: body)
+    response["redirectURI"] || response["redirectUri"]
+  end
+
+  private
+
+    def unsupported_instrument?(position)
+      return false unless position.is_a?(Hash)
+
+      instrument = position["instrument"]
+      return false unless instrument.is_a?(Hash)
+
+      UNSUPPORTED_INSTRUMENT_KINDS.include?(instrument["kind"].to_s.downcase)
+    end
+
+    def get_json(path, params = {})
+      request_json(:get, path, params: params)
+    end
+
+    def request_json(method, path, params: {}, body: nil, retry_on_auth_failure: true)
+      ensure_fresh_token!
+      operation = "#{method.to_s.upcase} #{path}"
+      used_access_token = snaptrade_item.oauth_access_token
+
+      # Only GET is safe to retry: a lost response to a POST/DELETE (e.g.
+      # get_connection_url, delete_connection) may already have been applied by
+      # SnapTrade, so replaying it risks duplicate side effects.
+      retrier = method == :get ? method(:with_retries) : method(:without_retry)
+      response = retrier.call(operation) do
+        api_connection.public_send(method, "#{API_BASE_URL}#{path}") do |request|
+          request.headers["Authorization"] = "Bearer #{used_access_token}"
+          request.headers["Accept"] = "application/json"
+          request.params.update(params) if params.present?
+          if body
+            request.headers["Content-Type"] = "application/json"
+            request.body = body.to_json
+          end
+        end
+      end
+
+      if response.status == 401 && retry_on_auth_failure
+        refresh_access_token!(previous_access_token: used_access_token)
+        return request_json(method, path, params: params, body: body, retry_on_auth_failure: false)
+      end
+
+      handle_response(response, operation)
+    end
+
+    def ensure_fresh_token!
+      raise AuthenticationError, "SnapTrade item has no access token" if snaptrade_item.oauth_access_token.blank?
+
+      expires_at = snaptrade_item.oauth_token_expires_at
+      return if expires_at.blank? || expires_at > TOKEN_EXPIRY_LEEWAY.seconds.from_now
+
+      refresh_access_token!
+    end
+
+    # Guards against a concurrent refresh-token rotation race: multiple threads/processes
+    # (e.g. per-account jobs sharing one SnapTrade item) may all observe an expiring/rejected
+    # token and attempt to refresh at once. If SnapTrade rotates refresh tokens as single-use,
+    # every refresh after the first would fail with invalid_grant and needlessly brick the
+    # item. Taking a DB row lock and re-checking freshness after reload ensures only one
+    # caller actually performs the HTTP refresh; the rest observe the winner's fresh token.
+    #
+    # `previous_access_token`, when present, means we're refreshing reactively after a 401 on
+    # that specific token (called from request_json). In that case we skip the HTTP refresh
+    # only if the DB row's access token has already changed since we made the failed request
+    # (i.e. another caller already won the race) -- an expiry-based freshness check would be
+    # wrong here since the server rejected a token we believed was still time-valid.
+    # When `previous_access_token` is absent, we're refreshing proactively (from
+    # ensure_fresh_token!) and skip only if the reloaded row is still time-fresh.
+    def refresh_access_token!(previous_access_token: nil)
+      snaptrade_item.with_lock do
+        snaptrade_item.reload
+
+        if previous_access_token.present?
+          next if snaptrade_item.oauth_access_token != previous_access_token
+        else
+          expires_at = snaptrade_item.oauth_token_expires_at
+          next if expires_at.present? && expires_at > TOKEN_EXPIRY_LEEWAY.seconds.from_now
+        end
+
+        refresh_token = snaptrade_item.oauth_refresh_token
+        raise AuthenticationError, "SnapTrade item has no refresh token" if refresh_token.blank?
+
+        payload = self.class.refresh_tokens(refresh_token: refresh_token)
+        snaptrade_item.apply_oauth_tokens!(payload)
+      end
+    rescue AuthenticationError => e
+      mark_requires_update!
+      DebugLogEntry.capture(
+        category: "provider_sync",
+        level: :error,
+        message: "SnapTrade token refresh failed: #{e.message}",
+        source: "Provider::SnaptradeOauth",
+        provider_key: "snaptrade",
+        family: snaptrade_item.try(:family),
+        metadata: { snaptrade_item_id: snaptrade_item.try(:id) }
+      )
+      raise
+    end
+
+    def mark_requires_update!
+      snaptrade_item.update!(status: :requires_update)
+    rescue StandardError => e
+      Rails.logger.warn("SnapTrade: could not mark item requires_update: #{e.message}")
+    end
+
+    def handle_response(response, operation)
+      if response.success?
+        return {} if response.body.blank?
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError
+          raise ApiError.new("SnapTrade API error (#{operation}): invalid JSON response",
+                             status_code: response.status, response_body: response.body)
+        end
+      else
+        Rails.logger.error("SnapTrade API error (#{operation}): #{response.status}")
+        case response.status
+        when 401, 403
+          mark_requires_update!
+          raise AuthenticationError, "Authentication failed (#{operation}): HTTP #{response.status}"
+        when 429
+          raise ApiError.new("Rate limit exceeded. Please try again later.",
+                             status_code: response.status, response_body: response.body)
+        when 500..599
+          raise ApiError.new("SnapTrade server error (#{response.status}). Please try again later.",
+                             status_code: response.status, response_body: response.body)
+        else
+          raise ApiError.new("SnapTrade API error (#{operation}): HTTP #{response.status}",
+                             status_code: response.status, response_body: response.body)
+        end
+      end
+    end
+
+    def api_connection
+      @api_connection ||= Faraday.new do |faraday|
+        faraday.options.timeout = 30
+        faraday.options.open_timeout = 10
+      end
+    end
+
+    def with_retries(operation_name, max_retries: MAX_RETRIES)
+      retries = 0
+
+      begin
+        yield
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        retries += 1
+
+        if retries <= max_retries
+          delay = calculate_retry_delay(retries)
+          Rails.logger.warn(
+            "SnapTrade API: #{operation_name} failed (attempt #{retries}/#{max_retries}): " \
+            "#{e.class}: #{e.message}. Retrying in #{delay}s..."
+          )
+          sleep(delay)
+          retry
+        else
+          Rails.logger.error(
+            "SnapTrade API: #{operation_name} failed after #{max_retries} retries: " \
+            "#{e.class}: #{e.message}"
+          )
+          raise ApiError.new("Network error after #{max_retries} retries: #{e.message}")
+        end
+      end
+    end
+
+    def without_retry(operation_name)
+      yield
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+      Rails.logger.error("SnapTrade API: #{operation_name} failed (not retried, non-idempotent): #{e.class}: #{e.message}")
+      raise ApiError.new("Network error (not retried, non-idempotent request): #{e.message}")
+    end
+
+    def calculate_retry_delay(retry_count)
+      base_delay = INITIAL_RETRY_DELAY * (2 ** (retry_count - 1))
+      jitter = base_delay * rand * 0.25
+      [ base_delay + jitter, MAX_RETRY_DELAY ].min
+    end
+end

--- a/app/models/snaptrade_item.rb
+++ b/app/models/snaptrade_item.rb
@@ -25,6 +25,10 @@ class SnaptradeItem < ApplicationRecord
   end
 
   validates :name, presence: true
+  validates :client_id, presence: true, if: -> { consumer_key.present? }
+  validates :consumer_key, presence: true, if: -> { client_id.present? }
+  # Note: snaptrade_user_id and snaptrade_user_secret are populated after user
+  # registration via ensure_user_registered!, so they aren't validated on create
 
   belongs_to :family
   has_one_attached :logo, dependent: :purge_later
@@ -33,10 +37,16 @@ class SnaptradeItem < ApplicationRecord
   has_many :linked_accounts, through: :snaptrade_accounts
 
   scope :active, -> { where(scheduled_for_deletion: false) }
-  # Syncable = active + authorized via OAuth (has an access token).
-  # oauth_access_token is non-deterministically encrypted, so it can only be
-  # queried with an IS NULL check (never persisted as "" -- see apply_oauth_tokens!).
-  scope :syncable, -> { active.where.not(oauth_access_token: nil) }
+  scope :api_credentials_configured, -> { where.not(client_id: [ nil, "" ]).where.not(consumer_key: [ nil, "" ]) }
+  # Device flow: the family's API credentials plus a registered SnapTrade user.
+  scope :registered, -> { api_credentials_configured.where.not(snaptrade_user_id: [ nil, "" ]).where.not(snaptrade_user_secret: nil) }
+  # DEPRECATED authorization-code + PKCE (#2747): a bearer token and no API
+  # credentials. oauth_access_token is non-deterministically encrypted, so it
+  # can only be queried with an IS NULL check (never persisted as "" -- see
+  # apply_oauth_tokens!); client_id is deterministic, so it can be compared.
+  scope :legacy_oauth, -> { where(client_id: [ nil, "" ]).where.not(oauth_access_token: nil) }
+  # Syncable = active + usable under either auth model.
+  scope :syncable, -> { registered.or(legacy_oauth).where(scheduled_for_deletion: false) }
   scope :ordered, -> { order(created_at: :desc) }
   scope :needs_update, -> { where(status: :requires_update) }
 
@@ -48,7 +58,7 @@ class SnaptradeItem < ApplicationRecord
   def import_latest_snaptrade_data(sync: nil)
     provider = snaptrade_provider
     unless provider
-      Rails.logger.error "SnaptradeItem #{id} - Cannot import: OAuth not authorized"
+      Rails.logger.error "SnaptradeItem #{id} - Cannot import: no usable SnapTrade authorization"
       raise StandardError, "SnapTrade is not authorized"
     end
 
@@ -185,10 +195,42 @@ class SnaptradeItem < ApplicationRecord
   def oauth_configured?
     oauth_access_token.present?
   end
-  alias_method :credentials_configured?, :oauth_configured?
+
+  # The family's own SnapTrade API credentials, used by the device flow.
+  def api_credentials_configured?
+    client_id.present? && consumer_key.present?
+  end
+
+  # Cross-provider convention: does this connection hold credentials we can
+  # use at all? True under either auth model.
+  def credentials_configured?
+    api_credentials_configured? || oauth_configured?
+  end
+
+  # Which auth model this item talks to SnapTrade under.
+  #   :device_flow  - the family's API credentials + a registered SnapTrade user
+  #   :legacy_oauth - DEPRECATED authorization-code + PKCE bearer tokens (#2747)
+  #   nil           - not connected yet
+  def auth_method
+    return :device_flow if api_credentials_configured?
+    return :legacy_oauth if oauth_configured?
+
+    nil
+  end
+
+  def device_flow?
+    auth_method == :device_flow
+  end
+
+  # Connections made under #2747's authorization-code + PKCE flow. They keep
+  # syncing on their bearer tokens, but the flow is closed to new connections
+  # and these items are prompted to migrate; see Provider::SnaptradeOauth.
+  def legacy_oauth?
+    auth_method == :legacy_oauth
+  end
 
   def fully_configured?
-    oauth_configured?
+    device_flow? ? user_registered? : oauth_configured?
   end
 
   # Override Syncable#syncing? to also show syncing state when activities are being

--- a/app/models/snaptrade_item/provided.rb
+++ b/app/models/snaptrade_item/provided.rb
@@ -2,18 +2,150 @@ module SnaptradeItem::Provided
   extend ActiveSupport::Concern
 
   included do
-    before_destroy :revoke_oauth_tokens
+    before_destroy :cleanup_snaptrade_authorization
   end
 
+  # The API client for whichever auth model this item is connected under, or
+  # nil when it is not connected. Both clients expose the same data methods and
+  # return plain hashes, so callers do not have to care which one they got.
   def snaptrade_provider
-    return nil unless oauth_configured?
-
-    Provider::Snaptrade.new(self)
+    case auth_method
+    when :device_flow then snaptrade_api_client
+    when :legacy_oauth then Provider::SnaptradeOauth.new(self)
+    end
   end
 
-  # Exchange an authorization code for tokens and mark the item usable.
+  # Device-flow client, bound to this family's API credentials and -- once
+  # registration has run -- to its SnapTrade user.
+  def snaptrade_api_client
+    return nil unless api_credentials_configured?
+
+    Provider::Snaptrade.new(
+      client_id: client_id,
+      consumer_key: consumer_key,
+      user_id: snaptrade_user_id,
+      user_secret: snaptrade_user_secret
+    )
+  end
+
+  # The device flow authorizes against the deployment's public OAuth client id
+  # alone, so it works before the family has entered any API credentials.
+  def oauth_device_client
+    snaptrade_api_client || Provider::Snaptrade.new
+  end
+
+  # User ID and secret for SnapTrade API calls
+  def snaptrade_credentials
+    return nil unless user_registered?
+
+    {
+      user_id: snaptrade_user_id,
+      user_secret: snaptrade_user_secret
+    }
+  end
+
+  # Check if a SnapTrade user has been registered against our API credentials
+  def user_registered?
+    snaptrade_user_id.present? && snaptrade_user_secret.present?
+  end
+
+  # Register a SnapTrade user if we don't have a working one already.
+  # Returns true once the item has a usable user_id/user_secret pair.
+  def ensure_user_registered!
+    if user_registered?
+      case verify_user_exists?
+      when :ok
+        return true
+      when :missing
+        # The user was deleted upstream, so the stored secret is dead weight:
+        # clear it and register a replacement.
+        Rails.logger.warn "SnapTrade: User #{snaptrade_user_id} no longer exists, clearing credentials and re-registering"
+        update!(snaptrade_user_id: nil, snaptrade_user_secret: nil)
+      else
+        # Transient failure. user_secret is returned exactly once and cannot be
+        # recovered, so never discard it on anything short of proof the user is
+        # gone -- one rate-limit blip would otherwise orphan a working
+        # connection permanently.
+        raise Provider::Snaptrade::ApiError.new(
+          "Could not verify the SnapTrade user right now. Please try again shortly."
+        )
+      end
+    end
+
+    provider = snaptrade_api_client
+    raise StandardError, "SnapTrade provider not configured" unless provider
+
+    # Family ID plus the current timestamp, so a re-registration after a
+    # deletion never collides with the previous user id.
+    unique_user_id = "family_#{family_id}_#{Time.current.to_i}"
+
+    Rails.logger.info "SnapTrade: Registering user #{unique_user_id} for family #{family_id}"
+
+    result = provider.register_user(unique_user_id)
+
+    Rails.logger.info "SnapTrade: Successfully registered user #{result[:user_id]}"
+
+    update!(
+      snaptrade_user_id: result[:user_id],
+      snaptrade_user_secret: result[:user_secret]
+    )
+
+    true
+  rescue Provider::Snaptrade::ApiError => e
+    Rails.logger.error "SnapTrade user registration failed: #{e.class} - #{e.message}"
+    # Log status code but not response_body to avoid credential exposure
+    Rails.logger.error "SnapTrade error details: status=#{e.status_code}" if e.respond_to?(:status_code)
+    Rails.logger.debug { "SnapTrade response body: #{e.response_body&.truncate(500)}" } if e.respond_to?(:response_body)
+
+    # Shouldn't happen with the timestamp suffix, but handle it gracefully
+    if e.message.include?("already registered") || e.message.include?("already exists")
+      Rails.logger.warn "SnapTrade: User already exists. Generating new unique ID."
+      raise StandardError, "User registration conflict. Please try again."
+    end
+
+    raise
+  end
+
+  # Does the stored SnapTrade user still exist upstream?
+  #   :ok      - the user answered a request
+  #   :missing - SnapTrade rejected our credentials, so the user is gone
+  #   :unknown - we could not tell (network, rate limit, 5xx)
+  def verify_user_exists?
+    return :missing unless user_registered?
+
+    provider = snaptrade_api_client
+    return :unknown unless provider
+
+    provider.list_connections
+    :ok
+  rescue Provider::Snaptrade::AuthenticationError => e
+    Rails.logger.warn "SnapTrade: User verification failed - #{e.message}"
+    :missing
+  rescue Provider::Snaptrade::ApiError => e
+    Rails.logger.warn "SnapTrade: User verification error - #{e.message}"
+    :unknown
+  end
+
+  # --- Device flow (current) ---
+
+  def start_oauth_device_flow(scope: "read")
+    oauth_device_client.start_device_authorization(scope: scope)
+  end
+
+  def complete_oauth_device_flow!(device_code:)
+    token_response = oauth_device_client.poll_device_token(device_code: device_code)
+    apply_oauth_tokens!(token_response)
+    update!(status: :good)
+    token_response
+  end
+
+  # --- DEPRECATED authorization-code + PKCE (#2747) ---
+
+  # Exchange an authorization code for tokens. Only reachable when
+  # re-authorizing a connection that was already made under the PKCE flow;
+  # new connections go through the device flow above.
   def complete_oauth_exchange!(code:, redirect_uri:, code_verifier:)
-    payload = Provider::Snaptrade.exchange_code(
+    payload = Provider::SnaptradeOauth.exchange_code(
       code: code,
       redirect_uri: redirect_uri,
       code_verifier: code_verifier
@@ -23,10 +155,13 @@ module SnaptradeItem::Provided
     payload
   end
 
+  # --- Shared ---
+
   # Get the connection portal URL for linking brokerages
   def connection_portal_url(redirect_url:, broker: nil)
     provider = snaptrade_provider
     raise StandardError, "SnapTrade is not authorized" unless provider
+    raise StandardError, "User not registered with SnapTrade" if device_flow? && !user_registered?
 
     provider.get_connection_url(redirect_url: redirect_url, broker: broker)
   end
@@ -35,6 +170,7 @@ module SnaptradeItem::Provided
   def fetch_connections
     provider = snaptrade_provider
     return [] unless provider
+    return [] if device_flow? && !user_registered?
 
     provider.list_connections
   rescue Provider::Snaptrade::ApiError => e
@@ -42,16 +178,71 @@ module SnaptradeItem::Provided
     raise
   end
 
+  # List all SnapTrade users registered under this family's client id
+  def list_all_users
+    return [] unless api_credentials_configured?
+
+    snaptrade_api_client.list_users
+  rescue Provider::Snaptrade::ApiError => e
+    Rails.logger.error "SnaptradeItem #{id} - Failed to list users: #{e.message}"
+    []
+  end
+
+  # SnapTrade users left behind by this family's earlier registrations. Each
+  # one holds connection slots, so the settings panel offers to delete them.
+  def orphaned_users
+    return [] unless api_credentials_configured? && user_registered?
+
+    list_all_users.select { |uid| uid != snaptrade_user_id && uid.start_with?("family_#{family_id}_") }
+  end
+
+  # Delete an orphaned SnapTrade user and all their connections
+  def delete_orphaned_user(user_id)
+    return false unless api_credentials_configured?
+    return false if user_id == snaptrade_user_id # Don't delete current user
+    return false unless user_id.start_with?("family_#{family_id}_")
+
+    snaptrade_api_client.delete_user(user_id: user_id)
+    true
+  rescue Provider::Snaptrade::ApiError => e
+    Rails.logger.error "SnaptradeItem #{id} - Failed to delete orphaned user #{user_id}: #{e.message}"
+    false
+  end
+
   private
 
-    # Best-effort token revocation when the item is destroyed.
+    # Release whatever this item holds upstream when it is destroyed. Never
+    # blocks deletion: the local record goes either way.
+    def cleanup_snaptrade_authorization
+      if legacy_oauth?
+        revoke_oauth_tokens
+      else
+        delete_snaptrade_user
+      end
+    end
+
+    def delete_snaptrade_user
+      return unless user_registered?
+
+      provider = snaptrade_api_client
+      return unless provider
+
+      Rails.logger.info "SnapTrade: Deleting user #{snaptrade_user_id} for family #{family_id}"
+
+      provider.delete_user(user_id: snaptrade_user_id)
+
+      Rails.logger.info "SnapTrade: Successfully deleted user #{snaptrade_user_id}"
+    rescue => e
+      # User may not exist or credentials may be invalid; log and move on
+      Rails.logger.warn "SnapTrade: Failed to delete user #{snaptrade_user_id}: #{e.class} - #{e.message}"
+    end
+
     def revoke_oauth_tokens
       token = oauth_refresh_token.presence || oauth_access_token # pipelock:ignore Credential in URL
       return if token.blank?
 
-      Provider::Snaptrade.revoke_token(token: token)
+      Provider::SnaptradeOauth.revoke_token(token: token)
     rescue => e
-      # Never block deletion on revocation failures
       Rails.logger.warn "SnapTrade: Failed to revoke tokens for item #{id}: #{e.class} - #{e.message}"
     end
 end

--- a/app/models/snaptrade_item/syncer.rb
+++ b/app/models/snaptrade_item/syncer.rb
@@ -10,9 +10,10 @@ class SnaptradeItem::Syncer
   def perform_sync(sync)
     Rails.logger.info "SnaptradeItem::Syncer - Starting sync for item #{snaptrade_item.id}"
 
-    # Verify the item is authorized
-    unless snaptrade_item.oauth_configured?
-      raise StandardError, "SnapTrade is not authorized"
+    # Verify the item can talk to SnapTrade under whichever auth model it uses
+    unless snaptrade_item.fully_configured?
+      reason = snaptrade_item.device_flow? ? "SnapTrade user not registered" : "SnapTrade is not authorized"
+      raise StandardError, reason
     end
 
     # Phase 1: Import data from SnapTrade API

--- a/app/views/settings/providers/_snaptrade_panel.html.erb
+++ b/app/views/settings/providers/_snaptrade_panel.html.erb
@@ -8,86 +8,171 @@
 
   <%
     items = local_assigns[:snaptrade_items] || @snaptrade_items || Current.family.snaptrade_items.active.ordered
-    snaptrade_item = items.reject(&:scheduled_for_deletion?).first
-    oauth_env_configured = Provider::Snaptrade.oauth_configured?
-    oauth_active = snaptrade_item&.oauth_token_active?
+    active_items = items.reject(&:scheduled_for_deletion?)
+    snaptrade_item =
+      active_items.first ||
+      Current.family.snaptrade_items.build(name: t("snaptrade_items.default_name"))
+    is_new_record = snaptrade_item.new_record?
+    legacy_item = active_items.find(&:legacy_oauth?)
+    credentials_configured = snaptrade_item.api_credentials_configured?
+    oauth_href =
+      if snaptrade_item.persisted?
+        oauth_connect_snaptrade_items_path(item_id: snaptrade_item.id)
+      else
+        oauth_connect_snaptrade_items_path
+      end
+    oauth_active = snaptrade_item.persisted? && snaptrade_item.oauth_token_active? && !snaptrade_item.legacy_oauth?
   %>
 
-  <% if !oauth_env_configured %>
-    <%= render "settings/providers/setup_steps",
-               steps: [
-                 t("providers.snaptrade.oauth_setup_step_1_html").html_safe,
-                 t("providers.snaptrade.oauth_setup_step_2_html", callback_url: oauth_callback_snaptrade_items_url).html_safe,
-                 t("providers.snaptrade.oauth_setup_step_3")
-               ] %>
-  <% else %>
-    <div class="bg-surface-inset rounded-xl p-4 space-y-3">
-      <div class="flex items-start gap-3">
-        <span class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
-          <%= icon "key-round", class: "w-4 h-4 text-success" %>
-        </span>
-        <div class="min-w-0">
-          <p class="text-sm font-medium text-primary"><%= t("providers.snaptrade.oauth_title") %></p>
-          <p class="text-sm text-secondary">
-            <% if oauth_active %>
-              <%= t("providers.snaptrade.oauth_status_authorized") %>
+  <% if legacy_item %>
+    <%= render DS::Alert.new(
+      title: t("providers.snaptrade.deprecated_oauth_title"),
+      message: t("providers.snaptrade.deprecated_oauth_description"),
+      variant: :warning
+    ) %>
+
+    <%= render DS::Link.new(
+      text: t("providers.snaptrade.deprecated_oauth_reauthorize_button"),
+      icon: "rotate-ccw",
+      variant: :ghost,
+      full_width: true,
+      href: oauth_authorize_snaptrade_items_path(item_id: legacy_item.id),
+      frame: "_top"
+    ) %>
+  <% end %>
+
+  <%= render DS::Disclosure.new(variant: :card_inset, open: !credentials_configured) do |disclosure| %>
+    <% disclosure.with_summary_content do %>
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <p class="text-sm font-medium text-primary">
+            <%= t("providers.snaptrade.api_credentials_title") %>
+          </p>
+          <p class="text-xs text-secondary mt-1">
+            <% if credentials_configured %>
+              <%= t("providers.snaptrade.api_credentials_configured") %>
             <% else %>
-              <%= t("providers.snaptrade.oauth_status_ready") %>
+              <%= t("providers.snaptrade.api_credentials_description") %>
             <% end %>
           </p>
         </div>
-      </div>
-
-      <%= render DS::Link.new(
-        text: oauth_active ? t("providers.snaptrade.oauth_reauthorize_button") : t("providers.snaptrade.oauth_connect_button"),
-        icon: "external-link",
-        variant: :primary,
-        full_width: true,
-        href: snaptrade_item&.persisted? ?
-          oauth_authorize_snaptrade_items_path(item_id: snaptrade_item.id) :
-          oauth_authorize_snaptrade_items_path
-      ) %>
-    </div>
-
-    <% if snaptrade_item&.persisted? && snaptrade_item.oauth_configured? %>
-      <div class="border-t border-primary pt-4 mt-4">
-        <%= render DS::Disclosure.new(
-          variant: :inline,
-          data: {
-            controller: "lazy-load",
-            action: "toggle->lazy-load#toggled",
-            lazy_load_url_value: connections_snaptrade_item_path(snaptrade_item),
-            lazy_load_auto_open_param_value: "manage"
-          }
-        ) do |disclosure| %>
-          <% disclosure.with_summary_content do %>
-            <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <p class="text-sm text-secondary">
-                  <%= t("providers.snaptrade.status_connected", count: snaptrade_item.snaptrade_accounts.count) %>
-                  <% if snaptrade_item.unlinked_accounts_count > 0 %>
-                    <span class="text-warning">(<%= t("providers.snaptrade.needs_setup", count: snaptrade_item.unlinked_accounts_count) %>)</span>
-                  <% end %>
-                </p>
-              </div>
-              <span class="flex items-center gap-1 text-sm text-secondary hover:text-primary">
-                <%= t("providers.snaptrade.manage_connections") %>
-                <%= icon "chevron-right", class: "w-3 h-3 group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
-              </span>
-            </div>
-          <% end %>
-
-          <div class="mt-3 space-y-3" data-lazy-load-target="content">
-            <div data-lazy-load-target="loading" class="flex items-center gap-2 text-sm text-secondary py-2">
-              <%= icon "loader-2", class: "w-4 h-4 animate-spin" %>
-              <%= t("providers.snaptrade.loading_connections") %>
-            </div>
-
-            <div data-lazy-load-target="frame">
-            </div>
-          </div>
-        <% end %>
+        <%= icon(
+          "chevron-down",
+          class: "mt-0.5 text-secondary group-open:rotate-180 motion-safe:transition-transform motion-safe:duration-150"
+        ) %>
       </div>
     <% end %>
+
+    <div class="mt-4 space-y-3">
+      <%= render "settings/providers/setup_steps",
+                 steps: [
+                   t("providers.snaptrade.step_1_html").html_safe,
+                   t("providers.snaptrade.step_2"),
+                   t("providers.snaptrade.step_3"),
+                   t("providers.snaptrade.step_4")
+                 ] %>
+
+      <%= styled_form_with model: snaptrade_item,
+                           url: is_new_record ? snaptrade_items_path : snaptrade_item_path(snaptrade_item),
+                           scope: :snaptrade_item,
+                           method: is_new_record ? :post : :patch,
+                           data: { turbo: true },
+                           class: "space-y-3" do |form| %>
+        <%= form.text_field :client_id,
+                            label: t("providers.snaptrade.client_id_label"),
+                            placeholder: is_new_record ?
+                              t("providers.snaptrade.client_id_placeholder") :
+                              t("providers.snaptrade.client_id_update_placeholder"),
+                            type: :password %>
+
+        <%= form.text_field :consumer_key,
+                            label: t("providers.snaptrade.consumer_key_label"),
+                            placeholder: is_new_record ?
+                              t("providers.snaptrade.consumer_key_placeholder") :
+                              t("providers.snaptrade.consumer_key_update_placeholder"),
+                            type: :password %>
+
+        <div class="flex justify-end">
+          <%= form.submit is_new_record ? t("providers.snaptrade.save_button") : t("providers.snaptrade.update_button") %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="bg-surface-inset rounded-xl p-4 space-y-3">
+    <div class="flex items-start gap-3">
+      <span class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
+        <%= icon "key-round", class: "w-4 h-4 text-success" %>
+      </span>
+      <div class="min-w-0">
+        <p class="text-sm font-medium text-primary"><%= t("providers.snaptrade.oauth_title") %></p>
+        <p class="text-sm text-secondary">
+          <% if oauth_active %>
+            <%= t("providers.snaptrade.oauth_status_authorized") %>
+          <% elsif credentials_configured %>
+            <%= t("providers.snaptrade.oauth_status_ready") %>
+          <% else %>
+            <%= t("providers.snaptrade.oauth_status_needs_credentials") %>
+          <% end %>
+        </p>
+      </div>
+    </div>
+
+    <%= render DS::Link.new(
+      text: oauth_active ? t("providers.snaptrade.oauth_reauthorize_button") : t("providers.snaptrade.oauth_connect_button"),
+      icon: "external-link",
+      variant: :primary,
+      full_width: true,
+      href: oauth_href,
+      data: { turbo_frame: "drawer" }
+    ) %>
+  </div>
+
+  <% if snaptrade_item.persisted? && credentials_configured && !snaptrade_item.user_registered? %>
+    <div class="flex items-center gap-2 border-t border-primary pt-4 mt-4">
+      <span class="w-2 h-2 bg-warning rounded-full"></span>
+      <p class="text-sm text-secondary"><%= t("providers.snaptrade.status_needs_registration") %></p>
+    </div>
+  <% end %>
+
+  <% if snaptrade_item.persisted? && snaptrade_item.fully_configured? %>
+    <div class="border-t border-primary pt-4 mt-4">
+      <%= render DS::Disclosure.new(
+        variant: :inline,
+        data: {
+          controller: "lazy-load",
+          action: "toggle->lazy-load#toggled",
+          lazy_load_url_value: connections_snaptrade_item_path(snaptrade_item),
+          lazy_load_auto_open_param_value: "manage"
+        }
+      ) do |disclosure| %>
+        <% disclosure.with_summary_content do %>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <p class="text-sm text-secondary">
+                <%= t("providers.snaptrade.status_connected", count: snaptrade_item.snaptrade_accounts.count) %>
+                <% if snaptrade_item.unlinked_accounts_count > 0 %>
+                  <span class="text-warning">(<%= t("providers.snaptrade.needs_setup", count: snaptrade_item.unlinked_accounts_count) %>)</span>
+                <% end %>
+              </p>
+            </div>
+            <span class="flex items-center gap-1 text-sm text-secondary hover:text-primary">
+              <%= t("providers.snaptrade.manage_connections") %>
+              <%= icon "chevron-right", class: "w-3 h-3 group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
+            </span>
+          </div>
+        <% end %>
+
+        <div class="mt-3 space-y-3" data-lazy-load-target="content">
+          <div data-lazy-load-target="loading" class="flex items-center gap-2 text-sm text-secondary py-2">
+            <%= icon "loader-2", class: "w-4 h-4 animate-spin" %>
+            <%= t("providers.snaptrade.loading_connections") %>
+          </div>
+
+          <div data-lazy-load-target="frame">
+          </div>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/app/views/snaptrade_items/_connections_list.html.erb
+++ b/app/views/snaptrade_items/_connections_list.html.erb
@@ -1,10 +1,10 @@
-<%# locals: (connections:, snaptrade_item:, error: nil) %>
+<%# locals: (connections:, snaptrade_item:, orphaned_users: [], error: nil) %>
 
 <% if error.present? %>
   <div class="p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
     <%= t("providers.snaptrade.connections_error", message: error) %>
   </div>
-<% elsif connections.empty? %>
+<% elsif connections.empty? && orphaned_users.empty? %>
   <p class="text-sm text-secondary py-2">
     <%= t("providers.snaptrade.no_connections") %>
   </p>
@@ -61,6 +61,53 @@
               </li>
             <% end %>
           </ul>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%# SnapTrade users left over from earlier registrations still hold
+        connection slots, so offer to release them. %>
+    <% if orphaned_users.any? %>
+      <div class="border-t border-secondary pt-3 mt-3">
+        <p class="text-xs text-warning font-medium mb-2">
+          <%= icon "alert-triangle", size: "xs", class: "inline-block mr-1" %>
+          <%= t("providers.snaptrade.orphaned_users_title", count: orphaned_users.size) %>
+        </p>
+        <p class="text-xs text-secondary mb-3">
+          <%= t("providers.snaptrade.orphaned_users_description") %>
+        </p>
+
+        <% orphaned_users.each do |orphan| %>
+          <div id="orphaned_user_<%= orphan[:user_id].parameterize %>"
+               class="border rounded-lg p-3 border-warning/50 bg-warning/5 mb-2">
+            <div class="flex items-center justify-between gap-3">
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-medium text-warning">
+                  <%= t("providers.snaptrade.orphaned_user") %>
+                </p>
+                <p class="text-xs text-secondary font-mono truncate" title="<%= orphan[:user_id] %>">
+                  <%= orphan[:display_name] %>
+                </p>
+              </div>
+
+              <%= render DS::Menu.new do |menu| %>
+                <% menu.with_item(
+                  variant: "button",
+                  text: t("providers.snaptrade.delete_orphaned_user"),
+                  icon: "trash-2",
+                  href: delete_orphaned_user_snaptrade_item_path(snaptrade_item, user_id: orphan[:user_id]),
+                  method: :delete,
+                  confirm: CustomConfirm.new(
+                    title: t("providers.snaptrade.delete_orphaned_user_title"),
+                    body: t("providers.snaptrade.delete_orphaned_user_body"),
+                    btn_text: t("providers.snaptrade.delete_orphaned_user_confirm"),
+                    destructive: true,
+                    high_severity: true
+                  )
+                ) %>
+              <% end %>
+            </div>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/snaptrade_items/_snaptrade_item.html.erb
+++ b/app/views/snaptrade_items/_snaptrade_item.html.erb
@@ -2,10 +2,14 @@
 
 <%= tag.div id: dom_id(snaptrade_item) do %>
   <% unlinked_count = snaptrade_item.unlinked_accounts_count %>
-  <% snaptrade_registered = snaptrade_item.oauth_configured? %>
-  <% brokerage_connect_href = snaptrade_registered ? connect_snaptrade_item_path(snaptrade_item) : oauth_authorize_snaptrade_items_path(item_id: snaptrade_item.id) %>
-  <% brokerage_connect_frame = snaptrade_registered ? "_top" : :drawer %>
-  <% reconnect_href = oauth_authorize_snaptrade_items_path(item_id: snaptrade_item.id) %>
+  <%# Ready to talk to SnapTrade under whichever auth model this item uses.
+      Items that aren't are sent to the device flow, the supported way to
+      connect; a deprecated PKCE item can still re-consent from the settings
+      panel while its owner migrates. %>
+  <% snaptrade_ready = snaptrade_item.fully_configured? %>
+  <% brokerage_connect_href = snaptrade_ready ? connect_snaptrade_item_path(snaptrade_item) : oauth_connect_snaptrade_items_path(item_id: snaptrade_item.id) %>
+  <% brokerage_connect_frame = snaptrade_ready ? "_top" : :drawer %>
+  <% reconnect_href = oauth_connect_snaptrade_items_path(item_id: snaptrade_item.id) %>
 
   <%= render DS::Disclosure.new(variant: :card, open: true) do |disclosure| %>
     <% disclosure.with_summary_content do %>
@@ -64,7 +68,7 @@
 
         <% if Current.user&.admin? %>
           <div class="flex items-center gap-2">
-            <% if snaptrade_item.requires_update? || !snaptrade_registered %>
+            <% if snaptrade_item.requires_update? || !snaptrade_ready %>
               <%= render DS::Link.new(
                 text: t(".reconnect"),
                 icon: "link",

--- a/app/views/snaptrade_items/oauth_device_flow.html.erb
+++ b/app/views/snaptrade_items/oauth_device_flow.html.erb
@@ -1,0 +1,112 @@
+<%= render DS::Dialog.new(frame: "drawer", responsive: true, auto_open: true) do |dialog| %>
+  <% dialog.with_header(custom_header: true) do %>
+    <%= render "settings/providers/drawer_header",
+               provider_key: "snaptrade",
+               title: t("snaptrade_items.oauth_device_flow.title", default: "Connect SnapTrade") %>
+  <% end %>
+
+  <% dialog.with_body do %>
+    <div class="space-y-4">
+      <p class="text-sm text-secondary">
+        <%= t("snaptrade_items.oauth_device_flow.subtitle", default: "Authorize Sure from SnapTrade") %>
+      </p>
+
+      <% if @error_message.present? %>
+        <%= render DS::Alert.new(message: @error_message, variant: :error) %>
+      <% end %>
+
+      <% if @device_authorization.present? %>
+        <div class="bg-surface-inset rounded-xl p-4 space-y-4">
+          <p class="text-sm text-secondary">
+            <%= t(
+              "snaptrade_items.oauth_device_flow.instructions",
+              default: "Open SnapTrade and confirm this device code, then return here to complete authorization."
+            ) %>
+          </p>
+
+          <div class="space-y-1">
+            <p class="text-xs uppercase text-secondary">
+              <%= t("snaptrade_items.oauth_device_flow.code_label", default: "Device code") %>
+            </p>
+            <p class="text-2xl font-semibold text-primary font-mono"><%= @device_authorization["user_code"] %></p>
+          </div>
+
+          <%= render DS::Link.new(
+            text: t("snaptrade_items.oauth_device_flow.open_snaptrade", default: "Open SnapTrade"),
+            href: @device_authorization["verification_uri_complete"].presence || @device_authorization["verification_uri"],
+            variant: :primary,
+            icon: "external-link",
+            target: "_blank",
+            rel: "noopener noreferrer",
+            full_width: true
+          ) %>
+        </div>
+
+        <%= form_with url: complete_oauth_device_flow_snaptrade_item_path(@snaptrade_item),
+                      method: :post,
+                      data: { turbo_frame: "drawer" },
+                      class: "space-y-3" do %>
+          <%= hidden_field_tag :device_code, @device_authorization["device_code"] %>
+          <%= hidden_field_tag :user_code, @device_authorization["user_code"] %>
+          <%= hidden_field_tag :verification_uri, @device_authorization["verification_uri"] %>
+          <%= hidden_field_tag :verification_uri_complete, @device_authorization["verification_uri_complete"] %>
+          <%= hidden_field_tag :expires_in, @device_authorization["expires_in"] %>
+          <%= hidden_field_tag :interval, @device_authorization["interval"] %>
+          <%= hidden_field_tag :return_to, @return_to if @return_to.present? %>
+          <%= hidden_field_tag :accountable_type, @accountable_type if @accountable_type.present? %>
+
+          <div class="flex justify-end gap-2">
+            <%= render DS::Link.new(
+              text: t("snaptrade_items.oauth_device_flow.cancel_button", default: "Cancel"),
+              variant: :secondary,
+              href: connect_form_settings_providers_path(provider_key: "snaptrade"),
+              data: { turbo_frame: "drawer" }
+            ) %>
+            <%= render DS::Button.new(
+              text: t("snaptrade_items.oauth_device_flow.complete_button", default: "I've authorized SnapTrade"),
+              variant: :primary,
+              icon: "check",
+              type: :submit
+            ) %>
+          </div>
+        <% end %>
+      <% else %>
+        <% if @error_message.blank? %>
+          <%= form_with url: start_oauth_connect_snaptrade_items_path,
+                        method: :post,
+                        data: { turbo_frame: "drawer" },
+                        class: "space-y-3" do %>
+            <%= hidden_field_tag :item_id, @snaptrade_item.id if @snaptrade_item&.persisted? %>
+            <%= hidden_field_tag :scope, @oauth_scope if @oauth_scope.present? %>
+            <%= hidden_field_tag :return_to, @return_to if @return_to.present? %>
+            <%= hidden_field_tag :accountable_type, @accountable_type if @accountable_type.present? %>
+
+            <div class="flex justify-end gap-2">
+              <%= render DS::Link.new(
+                text: t("snaptrade_items.oauth_device_flow.cancel_button", default: "Cancel"),
+                variant: :secondary,
+                href: connect_form_settings_providers_path(provider_key: "snaptrade"),
+                data: { turbo_frame: "drawer" }
+              ) %>
+              <%= render DS::Button.new(
+                text: t("snaptrade_items.oauth_device_flow.start_button", default: "Start authorization"),
+                variant: :primary,
+                icon: "external-link",
+                type: :submit
+              ) %>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="flex justify-end">
+            <%= render DS::Link.new(
+              text: t("snaptrade_items.oauth_device_flow.cancel_button", default: "Cancel"),
+              variant: :secondary,
+              href: connect_form_settings_providers_path(provider_key: "snaptrade"),
+              data: { turbo_frame: "drawer" }
+            ) %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/snaptrade_items/setup_accounts.html.erb
+++ b/app/views/snaptrade_items/setup_accounts.html.erb
@@ -71,20 +71,20 @@
         </div>
         <div class="flex gap-3 justify-center">
           <%
-            brokerage_connect_href = if @snaptrade_item.oauth_configured?
+            brokerage_connect_href = if @snaptrade_item.fully_configured?
               connect_snaptrade_item_path(
                 @snaptrade_item,
                 return_to: "setup_accounts",
                 accountable_type: params[:accountable_type]
               )
             else
-              oauth_authorize_snaptrade_items_path(
+              oauth_connect_snaptrade_items_path(
                 item_id: @snaptrade_item.id,
                 accountable_type: params[:accountable_type],
                 return_to: params[:return_to]
               )
             end
-            brokerage_connect_frame = @snaptrade_item.oauth_configured? ? "_top" : "drawer"
+            brokerage_connect_frame = @snaptrade_item.fully_configured? ? "_top" : "drawer"
           %>
           <%= render DS::Link.new(
             text: t("snaptrade_items.setup_accounts.try_again", default: "Connect Brokerage"),

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -26,25 +26,25 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "fc14dec97ce908f7483a8eb1f3aa6ea38f4369b8f9fe656e089c91a91c01a125",
+      "fingerprint": "f55341ce70d2b712e566b5eae5eff821932bb7da7102f89ea323975d72811512",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/snaptrade_items_controller.rb",
-      "line": 201,
+      "line": 369,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Provider::Snaptrade.authorize_url(:redirect_uri => oauth_callback_snaptrade_items_url, :state => SecureRandom.hex(32), :code_challenge => Provider::Snaptrade.generate_pkce[:challenge]), :allow_other_host => true)",
+      "code": "redirect_to(Provider::SnaptradeOauth.authorize_url(:redirect_uri => oauth_callback_snaptrade_items_url, :state => SecureRandom.hex(32), :code_challenge => Provider::SnaptradeOauth.generate_pkce[:challenge]), :allow_other_host => true)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "SnaptradeItemsController",
         "method": "oauth_authorize"
       },
-      "user_input": "Provider::Snaptrade.authorize_url(:redirect_uri => oauth_callback_snaptrade_items_url, :state => SecureRandom.hex(32), :code_challenge => Provider::Snaptrade.generate_pkce[:challenge])",
+      "user_input": "Provider::SnaptradeOauth.authorize_url(:redirect_uri => oauth_callback_snaptrade_items_url, :state => SecureRandom.hex(32), :code_challenge => Provider::SnaptradeOauth.generate_pkce[:challenge])",
       "confidence": "Weak",
       "cwe_id": [
         601
       ],
-      "note": "Intentional redirect to SnapTrade's external OAuth authorize endpoint. URL is built entirely from Provider::Snaptrade::AUTHORIZE_URL (hardcoded constant), server-side oauth_client_id config, the internal oauth_callback_snaptrade_items_url named route, and locally generated SecureRandom state/PKCE values -- no request params are interpolated into the redirect target."
+      "note": "Intentional redirect to SnapTrade's external OAuth authorize endpoint. URL is built entirely from Provider::SnaptradeOauth::AUTHORIZE_URL (hardcoded constant), server-side oauth_client_id config, the internal oauth_callback_snaptrade_items_url named route, and locally generated SecureRandom state/PKCE values -- no request params are interpolated into the redirect target."
     },
     {
       "warning_type": "Redirect",

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -398,6 +398,7 @@ en:
       meta:
         sync_error: Sync error
         no_recent_sync: Sync overdue
+        registration_needed: Registration needed
         reconsent_required: Re-consent required
         reconsent_needed:
           one: Re-consent needed in 1 day

--- a/config/locales/views/snaptrade_items/en.yml
+++ b/config/locales/views/snaptrade_items/en.yml
@@ -1,6 +1,10 @@
 en:
   snaptrade_items:
     default_name: "SnapTrade Connection"
+    create:
+      success: "Successfully configured SnapTrade."
+    update:
+      success: "Successfully updated SnapTrade configuration."
     destroy:
       success: "Scheduled SnapTrade connection for deletion."
     connect:
@@ -22,7 +26,26 @@ en:
       not_configured: "SnapTrade is not configured."
     select_accounts:
       not_configured: "SnapTrade is not configured."
+    oauth_device_flow:
+      title: "Connect SnapTrade"
+      subtitle: "Authorize Sure for SnapTrade"
+      instructions: "Open SnapTrade and confirm this device code, then return here to complete authorization."
+      code_label: "Device code"
+      open_snaptrade: "Open SnapTrade"
+      start_button: "Start authorization"
+      complete_button: "I've authorized SnapTrade"
+      cancel_button: "Cancel"
+      missing_client_id: "SnapTrade OAuth client ID is not configured. Add SNAPTRADE_OAUTH_CLIENT_ID to .env.local, restart the app, then try again."
+      credentials_required: "Add your SnapTrade Client ID and Consumer Key first, then authorize with a device code."
+    start_oauth_device_flow:
+      failed: "Unable to start SnapTrade OAuth device authorization. Please try again."
+    complete_oauth_device_flow:
+      success: "SnapTrade authorization complete."
+      setup_incomplete: "SnapTrade authorization is complete, but API credentials are required before accounts can sync."
+      device_code_required: "A device code is required to complete authorization."
+      failed: "Unable to complete SnapTrade OAuth device authorization. Please try again."
     oauth_authorize:
+      deprecated: "SnapTrade OAuth apps are no longer used for new connections. Authorize with a device code instead."
       not_configured: "SnapTrade OAuth is not configured. Set SNAPTRADE_OAUTH_CLIENT_ID and SNAPTRADE_OAUTH_CLIENT_SECRET, restart the app, then try again."
     oauth_callback:
       success: "SnapTrade authorization complete."
@@ -52,6 +75,9 @@ en:
       failed: "Failed to delete connection: %{message}"
       missing_authorization_id: "Missing authorization ID"
       api_deletion_failed: "Could not delete connection from SnapTrade - this item is not authorized. The connection may still exist in your SnapTrade account."
+    delete_orphaned_user:
+      success: "Orphaned registration deleted successfully."
+      failed: "Failed to delete orphaned registration."
     setup_accounts:
       title: "Set Up SnapTrade Accounts"
       header: "Set Up Your SnapTrade Accounts"
@@ -122,15 +148,33 @@ en:
       name: "SnapTrade"
       connection_description: "Connect to your brokerage via SnapTrade (25+ brokers supported)"
       description: "SnapTrade connects to 25+ major brokerages (Fidelity, Vanguard, Schwab, Robinhood, etc.) and provides full trade history with activity labels and cost basis."
-      oauth_setup_step_1_html: "Register an OAuth app at <a href=\"https://dashboard.snaptrade.com\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"underline\">dashboard.snaptrade.com</a>"
-      oauth_setup_step_2_html: "Add this app's callback URL (<code>%{callback_url}</code>) as a registered redirect URI"
-      oauth_setup_step_3: "Set SNAPTRADE_OAUTH_CLIENT_ID and SNAPTRADE_OAUTH_CLIENT_SECRET in your environment and restart"
+      setup_title: "Setup instructions:"
+      step_1_html: "Create an account at <a href=\"https://dashboard.snaptrade.com\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-primary underline\">dashboard.snaptrade.com</a>"
+      step_2: "Copy your Client ID and Consumer Key from the dashboard"
+      step_3: "Enter your credentials below and click Save"
+      step_4: "Authorize Sure with a device code, then connect your brokerage"
       free_tier_warning: "SnapTrade's free tier covers 20 brokerage connections."
+      api_credentials_title: "SnapTrade API credentials"
+      api_credentials_description: "Sure needs your SnapTrade Client ID and Consumer Key before it can connect a brokerage."
+      api_credentials_configured: "Saved. Enter new values to replace them."
+      deprecated_oauth_title: "This connection uses a deprecated sign-in"
+      deprecated_oauth_description: "It was authorized through a SnapTrade OAuth app, which is no longer used for new connections. It keeps syncing for now. To move it over, add your SnapTrade API credentials below and authorize Sure with a device code."
+      deprecated_oauth_reauthorize_button: "Re-authorize the old way"
       oauth_title: "SnapTrade OAuth"
-      oauth_status_ready: "Authorize Sure to read your SnapTrade account data."
+      oauth_status_ready: "Use a device code to authorize Sure for SnapTrade."
+      oauth_status_needs_credentials: "Save your API credentials above, then authorize with a device code."
       oauth_status_authorized: "Authorized with SnapTrade."
       oauth_connect_button: "Connect with SnapTrade"
       oauth_reauthorize_button: "Reauthorize"
+      client_id_label: "Client ID"
+      client_id_placeholder: "Enter your SnapTrade Client ID"
+      client_id_update_placeholder: "Enter new Client ID to update"
+      consumer_key_label: "Consumer Key"
+      consumer_key_placeholder: "Enter your SnapTrade Consumer Key"
+      consumer_key_update_placeholder: "Enter new Consumer Key to update"
+      save_button: "Save Configuration"
+      update_button: "Update Configuration"
+      status_needs_registration: "Credentials saved. Finish setup to connect a brokerage."
       status_connected:
         one: "%{count} account from SnapTrade"
         other: "%{count} accounts from SnapTrade"
@@ -155,6 +199,15 @@ en:
       delete_connection_body: "This will permanently remove the %{brokerage} connection from SnapTrade. All accounts from this brokerage will be unlinked. You'll need to reconnect to sync these accounts again."
       delete_connection_confirm: "Delete Connection"
       manage_at_snaptrade: "Manage connections at SnapTrade"
+      orphaned_users_title:
+        one: "%{count} orphaned registration"
+        other: "%{count} orphaned registrations"
+      orphaned_users_description: "These are previous SnapTrade user registrations that are using your connection slots. Delete them to free up slots."
+      orphaned_user: "Orphaned Registration"
+      delete_orphaned_user: "Delete"
+      delete_orphaned_user_title: "Delete Orphaned Registration?"
+      delete_orphaned_user_body: "This will permanently delete this orphaned SnapTrade user and all their brokerage connections, freeing up connection slots."
+      delete_orphaned_user_confirm: "Delete Registration"
 
   snaptrade_item:
     sync_status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,13 +127,17 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :snaptrade_items, only: [ :index, :show, :destroy ] do
+  resources :snaptrade_items, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     collection do
       get :preload_accounts
       get :select_accounts
       get :select_existing_account
       post :link_existing_account
       get :callback
+      get :oauth_connect
+      post :start_oauth_connect
+      # DEPRECATED (#2747 authorization-code + PKCE): reachable only to
+      # re-authorize a connection already made under that flow.
       get :oauth_authorize
       get :oauth_callback
     end
@@ -144,7 +148,10 @@ Rails.application.routes.draw do
       get :setup_accounts
       post :complete_account_setup
       get :connections
+      post :start_oauth_device_flow
+      post :complete_oauth_device_flow
       delete :delete_connection
+      delete :delete_orphaned_user
     end
   end
 

--- a/test/controllers/settings/providers_controller_test.rb
+++ b/test/controllers/settings/providers_controller_test.rb
@@ -422,42 +422,43 @@ class Settings::ProvidersControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Query ID/i, response.body)
   end
 
-  test "GET connect_form for snaptrade shows OAuth setup instructions when instance is not configured" do
-    Provider::Snaptrade.stubs(:oauth_configured?).returns(false)
-
-    get connect_form_settings_providers_path(provider_key: "snaptrade")
-
-    assert_response :success
-    assert_includes response.body, I18n.t("providers.snaptrade.oauth_setup_step_3")
-    refute_includes response.body, I18n.t("providers.snaptrade.oauth_connect_button")
-    refute_includes response.body, I18n.t("providers.snaptrade.oauth_status_ready")
-  end
-
-  test "GET connect_form for snaptrade shows connect CTA when configured but item is not authorized" do
+  test "GET connect_form for snaptrade asks for API credentials before anything else" do
     sign_in users(:empty)
-    Provider::Snaptrade.stubs(:oauth_configured?).returns(true)
+    snaptrade_items(:legacy_oauth_item).destroy!
 
     get connect_form_settings_providers_path(provider_key: "snaptrade")
 
     assert_response :success
-    assert_includes response.body, I18n.t("providers.snaptrade.oauth_connect_button")
-    assert_includes response.body, I18n.t("providers.snaptrade.oauth_status_ready")
+    assert_includes response.body, I18n.t("providers.snaptrade.api_credentials_description")
+    assert_includes response.body, I18n.t("providers.snaptrade.step_3")
+    assert_includes response.body, I18n.t("providers.snaptrade.oauth_status_needs_credentials")
     refute_includes response.body, I18n.t("providers.snaptrade.oauth_status_authorized")
-    refute_includes response.body, I18n.t("providers.snaptrade.oauth_reauthorize_button")
   end
 
-  test "GET connect_form for snaptrade shows authorized status and reauthorize CTA when item is connected" do
+  test "GET connect_form for snaptrade shows the device-flow CTA once credentials are saved" do
     # Default signed-in user (family_admin) belongs to dylan_family, which owns
-    # the oauth-authorized `configured_item` fixture.
-    Provider::Snaptrade.stubs(:oauth_configured?).returns(true)
+    # the device-flow `configured_item` fixture.
+    get connect_form_settings_providers_path(provider_key: "snaptrade")
+
+    assert_response :success
+    assert_includes response.body, I18n.t("providers.snaptrade.api_credentials_configured")
+    assert_includes response.body, I18n.t("providers.snaptrade.oauth_connect_button")
+    assert_includes response.body, I18n.t("providers.snaptrade.manage_connections")
+    refute_includes response.body, I18n.t("providers.snaptrade.deprecated_oauth_title")
+  end
+
+  test "GET connect_form for snaptrade flags a deprecated PKCE connection and offers re-consent" do
+    sign_in users(:empty)
+    legacy_item = snaptrade_items(:legacy_oauth_item)
 
     get connect_form_settings_providers_path(provider_key: "snaptrade")
 
     assert_response :success
-    assert_includes response.body, I18n.t("providers.snaptrade.oauth_status_authorized")
-    assert_includes response.body, I18n.t("providers.snaptrade.oauth_reauthorize_button")
-    assert_includes response.body, I18n.t("providers.snaptrade.manage_connections")
-    refute_includes response.body, I18n.t("providers.snaptrade.oauth_connect_button")
+    assert_includes response.body, I18n.t("providers.snaptrade.deprecated_oauth_title")
+    assert_includes response.body, I18n.t("providers.snaptrade.deprecated_oauth_reauthorize_button")
+    assert_includes response.body, oauth_authorize_snaptrade_items_path(item_id: legacy_item.id)
+    # It still needs API credentials to move over to the device flow
+    assert_includes response.body, I18n.t("providers.snaptrade.api_credentials_description")
   end
 
   test "POST sync for ibkr without an active Ibkr sync enqueues SyncJob" do

--- a/test/controllers/snaptrade_items_controller_test.rb
+++ b/test/controllers/snaptrade_items_controller_test.rb
@@ -12,6 +12,76 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def sign_in_legacy_family
+    sign_out
+    sign_in @user = users(:empty)
+    snaptrade_items(:legacy_oauth_item)
+  end
+
+  def with_oauth_app_configured
+    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
+    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
+    yield
+  ensure
+    Rails.configuration.x.snaptrade.oauth_client_id = nil
+    Rails.configuration.x.snaptrade.oauth_client_secret = nil
+  end
+
+  # --- Credentials ---
+
+  test "create saves api credentials and registers a SnapTrade user" do
+    sign_in_legacy_family
+    SnaptradeItem.any_instance.expects(:ensure_user_registered!).once.returns(true)
+
+    assert_difference "SnaptradeItem.count", 1 do
+      post snaptrade_items_url, params: {
+        snaptrade_item: { client_id: "cid", consumer_key: "ck" }
+      }
+    end
+
+    item = SnaptradeItem.order(:created_at).last
+    assert_equal "cid", item.client_id
+    assert item.device_flow?
+  end
+
+  test "create surfaces validation errors without registering" do
+    sign_in_legacy_family
+    SnaptradeItem.any_instance.expects(:ensure_user_registered!).never
+
+    assert_no_difference "SnaptradeItem.count" do
+      post snaptrade_items_url, params: { snaptrade_item: { client_id: "cid" } }
+    end
+
+    assert_response :redirect
+    assert flash[:alert].present?
+  end
+
+  test "create still saves credentials when registration fails" do
+    sign_in_legacy_family
+    SnaptradeItem.any_instance.expects(:ensure_user_registered!)
+      .raises(Provider::Snaptrade::ApiError.new("rate limited", status_code: 429))
+
+    assert_difference "SnaptradeItem.count", 1 do
+      post snaptrade_items_url, params: {
+        snaptrade_item: { client_id: "cid", consumer_key: "ck" }
+      }
+    end
+
+    assert_equal "cid", SnaptradeItem.order(:created_at).last.client_id
+  end
+
+  test "update replaces api credentials on an existing item" do
+    SnaptradeItem.any_instance.stubs(:ensure_user_registered!).returns(true)
+
+    patch snaptrade_item_url(@snaptrade_item), params: {
+      snaptrade_item: { client_id: "new-cid", consumer_key: "new-ck" }
+    }
+
+    assert_equal "new-cid", @snaptrade_item.reload.client_id
+  end
+
+  # --- Connection portal ---
+
   test "connect redirects to portal when successful" do
     portal_url = "https://app.snaptrade.com/portal/test123"
 
@@ -44,48 +114,221 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Failed to connect/, flash[:alert])
   end
 
-  test "oauth_authorize stores state and verifier in session and redirects to SnapTrade" do
-    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
+  test "connect registers the SnapTrade user first when the device flow has not yet" do
+    @snaptrade_item.update!(snaptrade_user_id: nil, snaptrade_user_secret: nil)
+    SnaptradeItem.any_instance.expects(:ensure_user_registered!).once.returns(true)
+    SnaptradeItem.any_instance.stubs(:connection_portal_url).returns("https://app.snaptrade.com/portal/x")
 
-    get oauth_authorize_snaptrade_items_url
+    get connect_snaptrade_item_url(@snaptrade_item)
 
     assert_response :redirect
-    redirect = URI.parse(response.location)
-    assert_equal "dashboard.snaptrade.com", redirect.host
-    params = Rack::Utils.parse_query(redirect.query)
-    oauth_session = session[:snaptrade_oauth]
-    assert_equal oauth_session["state"], params["state"]
-    assert_equal "S256", params["code_challenge_method"]
-    assert oauth_session["code_verifier"].present?
-    assert oauth_session["item_id"].present?
+  end
+
+  test "connect does not try to register a deprecated PKCE connection" do
+    legacy_item = sign_in_legacy_family
+    SnaptradeItem.any_instance.expects(:ensure_user_registered!).never
+    SnaptradeItem.any_instance.stubs(:connection_portal_url).returns("https://app.snaptrade.com/portal/x")
+
+    get connect_snaptrade_item_url(legacy_item)
+
+    assert_response :redirect
+  end
+
+  # --- OAuth device flow ---
+
+  test "oauth_connect renders the device flow drawer" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+
+    get oauth_connect_snaptrade_items_url(item_id: @snaptrade_item.id)
+
+    assert_response :success
+    assert_match(/Start authorization/, response.body)
   ensure
     Rails.configuration.x.snaptrade.oauth_client_id = nil
-    Rails.configuration.x.snaptrade.oauth_client_secret = nil
   end
 
-  test "oauth_authorize redirects to settings when OAuth is not configured" do
+  test "oauth_connect explains a missing public client id" do
+    Rails.configuration.x.snaptrade.oauth_client_id = nil
+
+    get oauth_connect_snaptrade_items_url
+
+    assert_response :unprocessable_entity
+    assert_match(/SNAPTRADE_OAUTH_CLIENT_ID/, response.body)
+  end
+
+  test "oauth_connect asks for API credentials before starting the ceremony" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    item = @user.family.snaptrade_items.create!(name: "No credentials yet")
+
+    get oauth_connect_snaptrade_items_url(item_id: item.id)
+
+    assert_response :unprocessable_entity
+    assert_match(/Client ID and Consumer Key/, response.body)
+  ensure
+    Rails.configuration.x.snaptrade.oauth_client_id = nil
+  end
+
+  # Device-flow tokens land in the same oauth_* columns a PKCE connection runs
+  # on, so starting the ceremony against one would destroy a working connection.
+  test "the device flow refuses to run against a deprecated PKCE connection" do
+    legacy_item = sign_in_legacy_family
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    original_token = legacy_item.oauth_access_token
+    SnaptradeItem.any_instance.expects(:start_oauth_device_flow).never
+
+    post start_oauth_connect_snaptrade_items_url, params: { item_id: legacy_item.id }
+
+    assert_response :unprocessable_entity
+    assert_match(/Client ID and Consumer Key/, response.body)
+    assert_equal original_token, legacy_item.reload.oauth_access_token
+  ensure
+    Rails.configuration.x.snaptrade.oauth_client_id = nil
+  end
+
+  test "complete_oauth_device_flow will not overwrite a deprecated PKCE connection's tokens" do
+    legacy_item = sign_in_legacy_family
+    original_token = legacy_item.oauth_access_token
+    SnaptradeItem.any_instance.expects(:complete_oauth_device_flow!).never
+
+    post complete_oauth_device_flow_snaptrade_item_url(legacy_item), params: { device_code: "dc" }
+
+    assert_response :unprocessable_entity
+    assert_equal original_token, legacy_item.reload.oauth_access_token
+  end
+
+  test "start_oauth_connect shows the device code" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    SnaptradeItem.any_instance.expects(:start_oauth_device_flow).with(scope: "read").returns(
+      "device_code" => "dc", "user_code" => "WXYZ", "verification_uri" => "https://snaptrade.test/device"
+    )
+
+    post start_oauth_connect_snaptrade_items_url, params: { item_id: @snaptrade_item.id }
+
+    assert_response :success
+    assert_match(/WXYZ/, response.body)
+  ensure
+    Rails.configuration.x.snaptrade.oauth_client_id = nil
+  end
+
+  test "start_oauth_connect rejects an unsupported scope" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    SnaptradeItem.any_instance.expects(:start_oauth_device_flow).with(scope: "read").returns({})
+
+    post start_oauth_connect_snaptrade_items_url, params: { item_id: @snaptrade_item.id, scope: "trade" }
+
+    assert_response :success
+  ensure
+    Rails.configuration.x.snaptrade.oauth_client_id = nil
+  end
+
+  test "complete_oauth_device_flow stores tokens and queues a sync" do
+    SnaptradeItem.any_instance.expects(:complete_oauth_device_flow!)
+      .with(device_code: "dc")
+      .returns({ "access_token" => "at", "token_type" => "Bearer" })
+
+    assert_difference "Sync.count", 1 do
+      post complete_oauth_device_flow_snaptrade_item_url(@snaptrade_item), params: { device_code: "dc" }
+    end
+
+    assert_redirected_to setup_accounts_snaptrade_item_path(@snaptrade_item, accountable_type: nil, return_to: nil)
+  end
+
+  test "complete_oauth_device_flow requires a device code" do
+    SnaptradeItem.any_instance.expects(:complete_oauth_device_flow!).never
+
+    post complete_oauth_device_flow_snaptrade_item_url(@snaptrade_item), params: {}, as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "complete_oauth_device_flow re-renders the drawer when authorization is still pending" do
+    SnaptradeItem.any_instance.expects(:complete_oauth_device_flow!).raises(
+      Provider::Snaptrade::ApiError.new(
+        "pending", status_code: 400,
+        response_body: { error: "authorization_pending", error_description: "Not yet approved" }.to_json
+      )
+    )
+
+    post complete_oauth_device_flow_snaptrade_item_url(@snaptrade_item), params: { device_code: "dc" }
+
+    assert_response :bad_request
+    assert_match(/Not yet approved/, response.body)
+  end
+
+  test "complete_oauth_device_flow reports when credentials are still missing" do
+    item = @user.family.snaptrade_items.create!(name: "No credentials yet")
+    SnaptradeItem.any_instance.expects(:complete_oauth_device_flow!).never
+
+    post complete_oauth_device_flow_snaptrade_item_url(item), params: { device_code: "dc" }
+
+    assert_response :unprocessable_entity
+    assert_match(/Client ID and Consumer Key/, response.body)
+  end
+
+  # --- DEPRECATED authorization-code + PKCE flow ---
+
+  test "oauth_authorize sends a device-flow item to the device flow instead" do
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: @snaptrade_item.id)
+
+      assert_redirected_to oauth_connect_snaptrade_items_path(return_to: nil, accountable_type: nil)
+      assert_match(/no longer used for new connections/, flash[:notice])
+      assert_nil session[:snaptrade_oauth]
+    end
+  end
+
+  test "oauth_authorize refuses to start a brand new PKCE authorization" do
+    with_oauth_app_configured do
+      assert_no_difference "SnaptradeItem.count" do
+        get oauth_authorize_snaptrade_items_url
+      end
+
+      assert_redirected_to oauth_connect_snaptrade_items_path(return_to: nil, accountable_type: nil)
+      assert_nil session[:snaptrade_oauth]
+    end
+  end
+
+  test "oauth_authorize lets an existing PKCE connection re-consent" do
+    legacy_item = sign_in_legacy_family
+
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id)
+
+      assert_response :redirect
+      redirect = URI.parse(response.location)
+      assert_equal "dashboard.snaptrade.com", redirect.host
+      params = Rack::Utils.parse_query(redirect.query)
+      oauth_session = session[:snaptrade_oauth]
+      assert_equal oauth_session["state"], params["state"]
+      assert_equal "S256", params["code_challenge_method"]
+      assert oauth_session["code_verifier"].present?
+      assert_equal legacy_item.id, oauth_session["item_id"]
+    end
+  end
+
+  test "oauth_authorize redirects to settings when the OAuth app is not configured" do
+    legacy_item = sign_in_legacy_family
     Rails.configuration.x.snaptrade.oauth_client_id = nil
     Rails.configuration.x.snaptrade.oauth_client_secret = nil
 
-    get oauth_authorize_snaptrade_items_url
-    assert_redirected_to settings_providers_path
-  end
-
-  test "oauth_callback rejects state mismatch without exchanging the code" do
-    Provider::Snaptrade.expects(:exchange_code).never
-
-    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
-    get oauth_authorize_snaptrade_items_url
-
-    get oauth_callback_snaptrade_items_url(code: "c0de", state: "wrong-state")
+    get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id)
 
     assert_redirected_to settings_providers_path
     assert flash[:alert].present?
-  ensure
-    Rails.configuration.x.snaptrade.oauth_client_id = nil
-    Rails.configuration.x.snaptrade.oauth_client_secret = nil
+  end
+
+  test "oauth_callback rejects state mismatch without exchanging the code" do
+    legacy_item = sign_in_legacy_family
+    Provider::SnaptradeOauth.expects(:exchange_code).never
+
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id)
+
+      get oauth_callback_snaptrade_items_url(code: "c0de", state: "wrong-state")
+
+      assert_redirected_to settings_providers_path
+      assert flash[:alert].present?
+    end
   end
 
   test "oauth_callback handles access_denied" do
@@ -95,122 +338,124 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "oauth_callback fails when code param is missing" do
-    Provider::Snaptrade.expects(:exchange_code).never
+    legacy_item = sign_in_legacy_family
+    Provider::SnaptradeOauth.expects(:exchange_code).never
 
-    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
-    get oauth_authorize_snaptrade_items_url
-    oauth_session = session[:snaptrade_oauth]
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id)
+      oauth_session = session[:snaptrade_oauth]
 
-    get oauth_callback_snaptrade_items_url(state: oauth_session["state"])
+      get oauth_callback_snaptrade_items_url(state: oauth_session["state"])
 
-    assert_redirected_to settings_providers_path
-    assert_equal "Unable to complete SnapTrade authorization. Please try again.", flash[:alert]
-    assert_nil session[:snaptrade_oauth]
-  ensure
-    Rails.configuration.x.snaptrade.oauth_client_id = nil
-    Rails.configuration.x.snaptrade.oauth_client_secret = nil
+      assert_redirected_to settings_providers_path
+      assert_equal "Unable to complete SnapTrade authorization. Please try again.", flash[:alert]
+      assert_nil session[:snaptrade_oauth]
+    end
   end
 
   test "oauth_callback handles exchange failures without applying tokens" do
-    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
-    get oauth_authorize_snaptrade_items_url
-    oauth_session = session[:snaptrade_oauth]
-    item = SnaptradeItem.find(oauth_session["item_id"])
-    original_token = item.oauth_access_token
+    legacy_item = sign_in_legacy_family
+    original_token = legacy_item.oauth_access_token
 
-    Provider::Snaptrade.expects(:exchange_code)
-      .with(code: "c0de", redirect_uri: oauth_callback_snaptrade_items_url, code_verifier: oauth_session["code_verifier"])
-      .raises(Provider::Snaptrade::Error.new("upstream exchange failed"))
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id)
+      oauth_session = session[:snaptrade_oauth]
 
-    get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
+      Provider::SnaptradeOauth.expects(:exchange_code)
+        .with(code: "c0de", redirect_uri: oauth_callback_snaptrade_items_url, code_verifier: oauth_session["code_verifier"])
+        .raises(Provider::Snaptrade::Error.new("upstream exchange failed"))
 
-    assert_redirected_to settings_providers_path
-    assert_equal "Unable to complete SnapTrade authorization. Please try again.", flash[:alert]
-    assert_nil session[:snaptrade_oauth]
-    assert_equal original_token, item.reload.oauth_access_token
-  ensure
-    Rails.configuration.x.snaptrade.oauth_client_id = nil
-    Rails.configuration.x.snaptrade.oauth_client_secret = nil
+      get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
+
+      assert_redirected_to settings_providers_path
+      assert_equal "Unable to complete SnapTrade authorization. Please try again.", flash[:alert]
+      assert_nil session[:snaptrade_oauth]
+      assert_equal original_token, legacy_item.reload.oauth_access_token
+    end
   end
 
   test "oauth_callback exchanges code, stores tokens, queues sync, and resumes setup" do
-    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
-    get oauth_authorize_snaptrade_items_url(return_to: "setup_accounts")
-    oauth_session = session[:snaptrade_oauth]
-    item = SnaptradeItem.find(oauth_session["item_id"])
+    legacy_item = sign_in_legacy_family
 
-    Provider::Snaptrade.expects(:exchange_code)
-      .with(code: "c0de", redirect_uri: oauth_callback_snaptrade_items_url, code_verifier: oauth_session["code_verifier"])
-      .returns({ "access_token" => "at", "refresh_token" => "rt", "expires_in" => 900 })
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id, return_to: "setup_accounts")
+      oauth_session = session[:snaptrade_oauth]
 
-    get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
+      Provider::SnaptradeOauth.expects(:exchange_code)
+        .with(code: "c0de", redirect_uri: oauth_callback_snaptrade_items_url, code_verifier: oauth_session["code_verifier"])
+        .returns({ "access_token" => "at", "refresh_token" => "rt", "expires_in" => 900 })
 
-    assert_redirected_to setup_accounts_snaptrade_item_path(item, accountable_type: nil)
-    assert_equal "at", item.reload.oauth_access_token
-    assert_nil session[:snaptrade_oauth]
-  ensure
-    Rails.configuration.x.snaptrade.oauth_client_id = nil
-    Rails.configuration.x.snaptrade.oauth_client_secret = nil
+      get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
+
+      assert_redirected_to setup_accounts_snaptrade_item_path(legacy_item, accountable_type: nil)
+      assert_equal "at", legacy_item.reload.oauth_access_token
+      assert_nil session[:snaptrade_oauth]
+    end
   end
 
   test "oauth_callback clears a reconnect warning after successful authorization" do
-    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
-    @snaptrade_item.update!(status: :requires_update)
+    legacy_item = sign_in_legacy_family
+    legacy_item.update!(status: :requires_update)
 
-    get oauth_authorize_snaptrade_items_url(item_id: @snaptrade_item.id)
-    oauth_session = session[:snaptrade_oauth]
-    Provider::Snaptrade.expects(:exchange_code).returns({ "access_token" => "at", "refresh_token" => "rt" })
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id)
+      oauth_session = session[:snaptrade_oauth]
+      Provider::SnaptradeOauth.expects(:exchange_code).returns({ "access_token" => "at", "refresh_token" => "rt" })
 
-    get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
+      get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
 
-    assert @snaptrade_item.reload.good?
-  ensure
-    Rails.configuration.x.snaptrade.oauth_client_id = nil
-    Rails.configuration.x.snaptrade.oauth_client_secret = nil
+      assert legacy_item.reload.good?
+    end
   end
 
   test "oauth_callback queues a sync even while activities are fetching" do
-    Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
-    get oauth_authorize_snaptrade_items_url(item_id: @snaptrade_item.id)
-    oauth_session = session[:snaptrade_oauth]
-    Provider::Snaptrade.expects(:exchange_code).returns({ "access_token" => "at", "refresh_token" => "rt" })
-    active_sync = @snaptrade_item.syncs.create!
-    active_sync.start!
+    legacy_item = sign_in_legacy_family
 
-    assert_enqueued_with job: SnaptradeFollowUpSyncJob do
-      get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
+    with_oauth_app_configured do
+      get oauth_authorize_snaptrade_items_url(item_id: legacy_item.id)
+      oauth_session = session[:snaptrade_oauth]
+      Provider::SnaptradeOauth.expects(:exchange_code).returns({ "access_token" => "at", "refresh_token" => "rt" })
+      active_sync = legacy_item.syncs.create!
+      active_sync.start!
+
+      assert_enqueued_with job: SnaptradeFollowUpSyncJob do
+        get oauth_callback_snaptrade_items_url(code: "c0de", state: oauth_session["state"])
+      end
     end
-  ensure
-    Rails.configuration.x.snaptrade.oauth_client_id = nil
-    Rails.configuration.x.snaptrade.oauth_client_secret = nil
   end
 
-  test "Reconnect starts OAuth authorization instead of adding a brokerage" do
+  # --- Entry points ---
+
+  test "Reconnect starts the device flow instead of adding a brokerage" do
     @snaptrade_item.update!(status: :requires_update)
 
     get accounts_url
 
-    assert_select "a[href='#{oauth_authorize_snaptrade_items_path(item_id: @snaptrade_item.id)}'][data-turbo-frame='_top']", text: /Reconnect/
+    assert_select "a[href='#{oauth_connect_snaptrade_items_path(item_id: @snaptrade_item.id)}'][data-turbo-frame='_top']", text: /Reconnect/
     assert_select "a[href='#{connect_snaptrade_item_path(@snaptrade_item)}']", text: /Reconnect/, count: 0
   end
 
-  test "select_accounts redirects unregistered users into connect flow" do
+  test "select_accounts redirects unconnected users into the device flow" do
     sign_out
     sign_in @user = users(:empty)
+    snaptrade_items(:legacy_oauth_item).destroy!
     snaptrade_item = snaptrade_items(:unauthorized_item)
 
     get select_accounts_snaptrade_items_url, params: { accountable_type: "Investment", return_to: "setup_accounts" }
 
-    assert_redirected_to oauth_authorize_snaptrade_items_path(
+    assert_redirected_to oauth_connect_snaptrade_items_path(
       item_id: snaptrade_item.id,
       accountable_type: "Investment",
       return_to: "setup_accounts"
     )
+  end
+
+  test "select_accounts sends a deprecated PKCE connection straight to setup" do
+    legacy_item = sign_in_legacy_family
+
+    get select_accounts_snaptrade_items_url, params: { accountable_type: "Investment", return_to: "/accounts" }
+
+    assert_redirected_to setup_accounts_snaptrade_item_path(legacy_item, accountable_type: "Investment", return_to: "/accounts")
   end
 
   test "select_accounts redirects registered users to setup flow" do
@@ -219,14 +464,16 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to setup_accounts_snaptrade_item_path(@snaptrade_item, accountable_type: "Investment", return_to: "/accounts")
   end
 
-  test "preload_accounts redirects unregistered users into connect flow" do
+  test "preload_accounts redirects unconnected users into the device flow" do
     sign_out
     sign_in @user = users(:empty)
+    snaptrade_items(:legacy_oauth_item).destroy!
+
     assert_no_difference "Sync.count" do
       get preload_accounts_snaptrade_items_url
     end
 
-    assert_redirected_to oauth_authorize_snaptrade_items_path(item_id: snaptrade_items(:unauthorized_item).id)
+    assert_redirected_to oauth_connect_snaptrade_items_path(item_id: snaptrade_items(:unauthorized_item).id)
   end
 
   test "preload_accounts redirects registered users to setup flow and queues sync" do
@@ -237,9 +484,11 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to setup_accounts_snaptrade_item_path(@snaptrade_item)
   end
 
-  test "entry routing prefers a registered active item over a pending one" do
+  test "entry routing prefers a connected active item over a pending one" do
     pending_item = @user.family.snaptrade_items.create!(
       name: "Pending Registration",
+      client_id: "pending-cid",
+      consumer_key: "pending-ck",
       status: :good,
       scheduled_for_deletion: false,
       pending_account_setup: true
@@ -253,8 +502,10 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to setup_accounts_snaptrade_item_path(@snaptrade_item)
 
-    assert_not pending_item.oauth_configured?
+    assert_not pending_item.fully_configured?
   end
+
+  # --- Account setup ---
 
   test "setup_accounts shows linkable investment and crypto accounts in dropdown" do
     get setup_accounts_snaptrade_item_url(@snaptrade_item)
@@ -310,7 +561,7 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Depository", account.reload.current_account.accountable_type
   end
 
-  test "select_existing_account prefers registered active item over pending one" do
+  test "select_existing_account prefers a connected active item over a pending one" do
     pending_item = @user.family.snaptrade_items.create!(
       name: "Pending Registration",
       status: :good,
@@ -366,6 +617,28 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/not found/i, flash[:alert])
   end
 
+  # --- Connection management ---
+
+  test "delete_orphaned_user refuses a user id that is not orphaned" do
+    SnaptradeItem.any_instance.stubs(:orphaned_users).returns([])
+    SnaptradeItem.any_instance.expects(:delete_orphaned_user).never
+
+    delete delete_orphaned_user_snaptrade_item_url(@snaptrade_item, user_id: "family_other_1")
+
+    assert_redirected_to settings_providers_path
+    assert flash[:alert].present?
+  end
+
+  test "delete_orphaned_user releases an orphaned registration" do
+    SnaptradeItem.any_instance.stubs(:orphaned_users).returns([ "family_other_1" ])
+    SnaptradeItem.any_instance.expects(:delete_orphaned_user).with("family_other_1").returns(true)
+
+    delete delete_orphaned_user_snaptrade_item_url(@snaptrade_item, user_id: "family_other_1")
+
+    assert_redirected_to settings_providers_path
+    assert flash[:notice].present?
+  end
+
   # --- setup_accounts throttle-sync fix ---
   #
   # The fix on setup_accounts ensures sync_later is only called when there are no
@@ -409,7 +682,7 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".no-accounts-found", count: 1, message: "Expected the no-accounts UI to be shown after a completed sync with zero accounts"
     assert_select "#snaptrade-sync-spinner", count: 0, message: "Expected the spinner to be hidden when there is no active sync"
     assert_select "a[href=?]", connect_snaptrade_item_path(@snaptrade_item, return_to: "setup_accounts", accountable_type: nil), text: /Connect Brokerage/
-    assert_no_match oauth_authorize_snaptrade_items_path(item_id: @snaptrade_item.id), response.body
+    assert_no_match oauth_connect_snaptrade_items_path(item_id: @snaptrade_item.id), response.body
   end
 
   test "setup_accounts does not re-queue a sync when a sync is already in progress" do

--- a/test/fixtures/snaptrade_items.yml
+++ b/test/fixtures/snaptrade_items.yml
@@ -1,9 +1,22 @@
 # Minimal fixtures for SnapTrade items
 # Per CLAUDE.md: Keep fixtures minimal (2-3 per model for base cases)
 
+# Device flow: the family's API credentials plus a registered SnapTrade user
 configured_item:
   family: dylan_family
   name: "SnapTrade Connection"
+  client_id: "test_client_id"
+  consumer_key: "test_consumer_key"
+  snaptrade_user_id: "user_123"
+  snaptrade_user_secret: "secret_abc"
+  status: good
+  scheduled_for_deletion: false
+  pending_account_setup: false
+
+# DEPRECATED authorization-code + PKCE (#2747): bearer tokens, no API credentials
+legacy_oauth_item:
+  family: empty
+  name: "Legacy SnapTrade OAuth"
   oauth_access_token: "test-access-token"
   oauth_refresh_token: "test-refresh-token"
   oauth_token_type: "Bearer"
@@ -13,7 +26,7 @@ configured_item:
   scheduled_for_deletion: false
   pending_account_setup: false
 
-# Item that has never completed the OAuth flow (no tokens)
+# Never connected under either auth model
 unauthorized_item:
   family: empty
   name: "Unauthorized SnapTrade"

--- a/test/helpers/settings_helper_test.rb
+++ b/test/helpers/settings_helper_test.rb
@@ -9,15 +9,25 @@ class SettingsHelperTest < ActionView::TestCase
     assert_equal({ status: :off }, provider_summary("snaptrade"))
   end
 
-  test "provider_summary for snaptrade is off when no item has completed OAuth" do
-    item = OpenStruct.new(oauth_configured?: false)
+  test "provider_summary for snaptrade is off when no item holds credentials" do
+    item = OpenStruct.new(credentials_configured?: false, fully_configured?: false)
     @snaptrade_items = [ item ]
 
     assert_equal({ status: :off }, provider_summary("snaptrade"))
   end
 
-  test "provider_summary for snaptrade reports sync-based status once an item is oauth configured" do
-    item = OpenStruct.new(oauth_configured?: true)
+  test "provider_summary for snaptrade warns while a device-flow item awaits registration" do
+    item = OpenStruct.new(credentials_configured?: true, fully_configured?: false)
+    @snaptrade_items = [ item ]
+
+    assert_equal(
+      { status: :warn, meta: I18n.t("settings.providers.meta.registration_needed") },
+      provider_summary("snaptrade")
+    )
+  end
+
+  test "provider_summary for snaptrade reports sync-based status once an item is connected" do
+    item = OpenStruct.new(credentials_configured?: true, fully_configured?: true)
     @snaptrade_items = [ item ]
     @provider_sync_health = {}
 

--- a/test/models/provider/snaptrade_adapter_test.rb
+++ b/test/models/provider/snaptrade_adapter_test.rb
@@ -10,26 +10,25 @@ class Provider::SnaptradeAdapterTest < ActiveSupport::TestCase
     assert_nil Provider::SnaptradeAdapter.build_provider(family: nil)
   end
 
-  test "build_provider returns nil when OAuth app is not configured" do
-    Provider::Snaptrade.stubs(:oauth_configured?).returns(false)
-
-    assert_nil Provider::SnaptradeAdapter.build_provider(family: families(:dylan_family))
-  end
-
-  test "build_provider returns nil when family has no authorized snaptrade item" do
-    Provider::Snaptrade.stubs(:oauth_configured?).returns(true)
+  test "build_provider returns nil when the family has no connected snaptrade item" do
+    snaptrade_items(:legacy_oauth_item).destroy!
 
     assert_nil Provider::SnaptradeAdapter.build_provider(family: families(:empty))
   end
 
-  test "build_provider returns a Provider::Snaptrade wrapping the authorized item" do
-    Provider::Snaptrade.stubs(:oauth_configured?).returns(true)
-    family = families(:dylan_family)
-    item = snaptrade_items(:configured_item)
-
-    provider = Provider::SnaptradeAdapter.build_provider(family: family)
+  test "build_provider returns the device-flow client for a registered item" do
+    provider = Provider::SnaptradeAdapter.build_provider(family: families(:dylan_family))
 
     assert_instance_of Provider::Snaptrade, provider
+    assert_equal "user_123", provider.user_id
+  end
+
+  test "build_provider returns the deprecated client for a PKCE item" do
+    item = snaptrade_items(:legacy_oauth_item)
+
+    provider = Provider::SnaptradeAdapter.build_provider(family: families(:empty))
+
+    assert_instance_of Provider::SnaptradeOauth, provider
     assert_equal item, provider.snaptrade_item
   end
 end

--- a/test/models/provider/snaptrade_device_flow_test.rb
+++ b/test/models/provider/snaptrade_device_flow_test.rb
@@ -1,0 +1,239 @@
+require "test_helper"
+require "ostruct"
+
+# The device-flow SnapTrade client: the OAuth ceremony it drives, and the
+# credential binding and hash normalization that let it stand in for the
+# deprecated PKCE client behind one interface.
+class Provider::SnaptradeDeviceFlowTest < ActiveSupport::TestCase
+  setup do
+    @original = Rails.configuration.x.snaptrade
+    Rails.configuration.x.snaptrade = ActiveSupport::OrderedOptions.new
+  end
+
+  teardown do
+    Rails.configuration.x.snaptrade = @original
+  end
+
+  def faraday_response(status:, body:)
+    OpenStruct.new(status: status, body: body, success?: (200..299).cover?(status), reason_phrase: "Bad Request")
+  end
+
+  def client(user_id: "u-1", user_secret: "s-1")
+    Provider::Snaptrade.new(
+      client_id: "cid", consumer_key: "ck", user_id: user_id, user_secret: user_secret
+    )
+  end
+
+  # Stands in for a SnapTrade SDK model, which exposes its wire shape through
+  # to_hash rather than being a Hash itself.
+  class SdkModel
+    def initialize(attributes) = @attributes = attributes
+    def to_hash = @attributes
+  end
+
+  # --- Configuration ---
+
+  test "oauth_client_id_configured? follows the deployment's public client id" do
+    assert_not Provider::Snaptrade.oauth_client_id_configured?
+
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    assert Provider::Snaptrade.oauth_client_id_configured?
+  end
+
+  test "api credentials must be given as a pair" do
+    assert_nothing_raised { Provider::Snaptrade.new }
+    assert_raises(Provider::Snaptrade::ConfigurationError) { Provider::Snaptrade.new(client_id: "cid") }
+    assert_raises(Provider::Snaptrade::ConfigurationError) { Provider::Snaptrade.new(consumer_key: "ck") }
+  end
+
+  test "data calls refuse to run without a registered user" do
+    provider = Provider::Snaptrade.new(client_id: "cid", consumer_key: "ck")
+
+    assert_raises(Provider::Snaptrade::ConfigurationError) { provider.list_accounts }
+  end
+
+  # --- Device flow ---
+
+  # Records what the provider builds into a Faraday request
+  class RequestRecorder
+    attr_reader :headers, :body
+
+    def initialize
+      @headers = {}
+    end
+
+    def body=(value)
+      @body = value
+    end
+  end
+
+  test "start_device_authorization posts the public client id to the discovered endpoint" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    provider = Provider::Snaptrade.new
+    request = RequestRecorder.new
+
+    connection = mock("faraday")
+    connection.expects(:get)
+      .with(Provider::Snaptrade::OAUTH_DISCOVERY_URL)
+      .returns(faraday_response(status: 200, body: {
+        "device_authorization_endpoint" => "https://api.snaptrade.com/oauth/device/",
+        "token_endpoint" => "https://api.snaptrade.com/oauth/token/"
+      }.to_json))
+    connection.expects(:post)
+      .with("https://api.snaptrade.com/oauth/device/")
+      .yields(request)
+      .returns(faraday_response(status: 200, body: { "device_code" => "dc", "user_code" => "ABCD" }.to_json))
+    provider.stubs(:oauth_connection).returns(connection)
+
+    result = provider.start_device_authorization
+
+    assert_equal "dc", result["device_code"]
+    assert_equal "ABCD", result["user_code"]
+    assert_equal(
+      { "client_id" => "public-client-id", "scope" => "read" },
+      Rack::Utils.parse_query(request.body)
+    )
+  end
+
+  test "poll_device_token sends the device-code grant" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    provider = Provider::Snaptrade.new
+    request = RequestRecorder.new
+
+    connection = mock("faraday")
+    connection.stubs(:get).returns(faraday_response(status: 200, body: {
+      "token_endpoint" => "https://api.snaptrade.com/oauth/token/"
+    }.to_json))
+    connection.expects(:post)
+      .with("https://api.snaptrade.com/oauth/token/")
+      .yields(request)
+      .returns(faraday_response(status: 200, body: { "access_token" => "at" }.to_json))
+    provider.stubs(:oauth_connection).returns(connection)
+
+    assert_equal "at", provider.poll_device_token(device_code: "dc")["access_token"]
+    assert_equal(
+      {
+        "grant_type" => Provider::Snaptrade::DEVICE_CODE_GRANT,
+        "device_code" => "dc",
+        "client_id" => "public-client-id"
+      },
+      Rack::Utils.parse_query(request.body)
+    )
+  end
+
+  test "the discovery document is fetched once per client" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    provider = Provider::Snaptrade.new
+
+    connection = mock("faraday")
+    connection.expects(:get).once.returns(faraday_response(status: 200, body: {
+      "device_authorization_endpoint" => "https://api.snaptrade.com/oauth/device/",
+      "token_endpoint" => "https://api.snaptrade.com/oauth/token/"
+    }.to_json))
+    provider.stubs(:oauth_connection).returns(connection)
+
+    2.times { provider.oauth_authorization_server_metadata }
+  end
+
+  test "device flow raises before any request when the public client id is missing" do
+    provider = Provider::Snaptrade.new
+    connection = mock("faraday")
+    connection.expects(:get).never
+    connection.expects(:post).never
+    provider.stubs(:oauth_connection).returns(connection)
+
+    assert_raises(Provider::Snaptrade::ConfigurationError) { provider.start_device_authorization }
+    assert_raises(Provider::Snaptrade::ConfigurationError) { provider.poll_device_token(device_code: "dc") }
+  end
+
+  test "poll_device_token requires a device code" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+
+    assert_raises(Provider::Snaptrade::ConfigurationError) do
+      Provider::Snaptrade.new.poll_device_token(device_code: "")
+    end
+  end
+
+  test "an OAuth error response surfaces the error description" do
+    Rails.configuration.x.snaptrade.oauth_client_id = "public-client-id"
+    provider = Provider::Snaptrade.new
+
+    connection = mock("faraday")
+    connection.stubs(:get).returns(faraday_response(status: 200, body: {
+      "device_authorization_endpoint" => "https://api.snaptrade.com/oauth/device/"
+    }.to_json))
+    connection.stubs(:post).returns(faraday_response(
+      status: 400, body: { "error" => "authorization_pending", "error_description" => "Not yet approved" }.to_json
+    ))
+    provider.stubs(:oauth_connection).returns(connection)
+
+    error = assert_raises(Provider::Snaptrade::ApiError) { provider.start_device_authorization }
+    assert_match "Not yet approved", error.message
+    assert_equal 400, error.status_code
+  end
+
+  # --- Data methods ---
+
+  test "data calls bind the registered user and return plain hashes" do
+    provider = client
+    account_information = mock("account_information")
+    account_information.expects(:list_user_accounts)
+      .with(user_id: "u-1", user_secret: "s-1")
+      .returns([ SdkModel.new("id" => "acct-1", "name" => "Brokerage") ])
+    provider.stubs(:client).returns(OpenStruct.new(account_information: account_information))
+
+    accounts = provider.list_accounts
+
+    assert_equal 1, accounts.size
+    assert_instance_of Hash, accounts.first
+    assert_equal "acct-1", accounts.first["id"]
+  end
+
+  test "get_account_activities passes through the date window" do
+    provider = client
+    account_information = mock("account_information")
+    account_information.expects(:get_account_activities)
+      .with(
+        user_id: "u-1", user_secret: "s-1", account_id: "acct-1",
+        start_date: "2026-01-01", end_date: "2026-02-01"
+      )
+      .returns(SdkModel.new("data" => [ SdkModel.new("id" => "act-1") ]))
+    provider.stubs(:client).returns(OpenStruct.new(account_information: account_information))
+
+    response = provider.get_account_activities(
+      account_id: "acct-1", start_date: Date.new(2026, 1, 1), end_date: Date.new(2026, 2, 1)
+    )
+
+    assert_equal [ { "id" => "act-1" } ], response["data"]
+  end
+
+  test "SDK errors are mapped onto the shared error hierarchy" do
+    provider = client
+    account_information = mock("account_information")
+    account_information.stubs(:list_user_accounts).raises(SnapTrade::ApiError.new(code: 401, response_body: "{}"))
+    provider.stubs(:client).returns(OpenStruct.new(account_information: account_information))
+
+    assert_raises(Provider::Snaptrade::AuthenticationError) { provider.list_accounts }
+  end
+
+  test "rate limits keep their status code" do
+    provider = client
+    account_information = mock("account_information")
+    account_information.stubs(:list_user_accounts).raises(SnapTrade::ApiError.new(code: 429, response_body: "{}"))
+    provider.stubs(:client).returns(OpenStruct.new(account_information: account_information))
+
+    error = assert_raises(Provider::Snaptrade::ApiError) { provider.list_accounts }
+    assert_equal 429, error.status_code
+  end
+
+  # register_user is a non-idempotent create whose user_secret comes back once,
+  # so a timed-out request must never be replayed.
+  test "register_user is not retried on a network timeout" do
+    provider = client
+    authentication = mock("authentication")
+    authentication.expects(:register_snap_trade_user).once.raises(Faraday::TimeoutError.new("timeout"))
+    provider.stubs(:client).returns(OpenStruct.new(authentication: authentication))
+
+    assert_raises(Provider::Snaptrade::ApiError) { provider.register_user("family_1_2") }
+  end
+end

--- a/test/models/provider/snaptrade_oauth_test.rb
+++ b/test/models/provider/snaptrade_oauth_test.rb
@@ -12,13 +12,13 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
   end
 
   test "oauth_configured? requires both client id and secret" do
-    assert_not Provider::Snaptrade.oauth_configured?
+    assert_not Provider::SnaptradeOauth.oauth_configured?
 
     Rails.configuration.x.snaptrade.oauth_client_id = "client-id"
-    assert_not Provider::Snaptrade.oauth_configured?
+    assert_not Provider::SnaptradeOauth.oauth_configured?
 
     Rails.configuration.x.snaptrade.oauth_client_secret = "client-secret"
-    assert Provider::Snaptrade.oauth_configured?
+    assert Provider::SnaptradeOauth.oauth_configured?
   end
 
   # --- helpers ---
@@ -45,7 +45,7 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
     def item.applied = @applied || []
     def item.update!(attrs) = (@updates ||= []) << attrs
     def item.updates = @updates || []
-    # Stand in for ActiveRecord's row-locking API used by Provider::Snaptrade#refresh_access_token!.
+    # Stand in for ActiveRecord's row-locking API used by Provider::SnaptradeOauth#refresh_access_token!.
     # By default there's nothing concurrent to guard against in these tests, so locking is a no-op
     # and reload leaves attributes untouched (they're already "current" in memory).
     def item.with_lock
@@ -58,7 +58,7 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
   end
 
   test "generate_pkce returns S256 challenge of the verifier" do
-    pkce = Provider::Snaptrade.generate_pkce
+    pkce = Provider::SnaptradeOauth.generate_pkce
     expected = Base64.urlsafe_encode64(OpenSSL::Digest::SHA256.digest(pkce[:verifier]), padding: false)
     assert_equal expected, pkce[:challenge]
     assert pkce[:verifier].length.between?(43, 128)
@@ -66,7 +66,7 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
 
   test "authorize_url contains all required OAuth params" do
     configure_oauth!
-    url = Provider::Snaptrade.authorize_url(
+    url = Provider::SnaptradeOauth.authorize_url(
       redirect_uri: "https://sure.test/callback", state: "st4te", code_challenge: "ch4llenge"
     )
     uri = URI.parse(url)
@@ -85,11 +85,11 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
     configure_oauth!
     connection = mock("faraday")
     request = OpenStruct.new(headers: {})
-    connection.expects(:post).with(Provider::Snaptrade::TOKEN_URL).yields(request)
+    connection.expects(:post).with(Provider::SnaptradeOauth::TOKEN_URL).yields(request)
       .returns(faraday_response(status: 200, body: { access_token: "at", refresh_token: "rt", expires_in: 900, token_type: "Bearer", scope: "read" }.to_json))
-    Provider::Snaptrade.stubs(:oauth_connection).returns(connection)
+    Provider::SnaptradeOauth.stubs(:oauth_connection).returns(connection)
 
-    payload = Provider::Snaptrade.exchange_code(code: "c0de", redirect_uri: "https://sure.test/cb", code_verifier: "v3rifier")
+    payload = Provider::SnaptradeOauth.exchange_code(code: "c0de", redirect_uri: "https://sure.test/cb", code_verifier: "v3rifier")
 
     assert_equal "at", payload["access_token"]
     assert_equal "Basic #{Base64.strict_encode64('client-id:client-secret')}", request.headers["Authorization"]
@@ -104,10 +104,10 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
     configure_oauth!
     connection = mock("faraday")
     connection.expects(:post).returns(faraday_response(status: 400, body: { error: "invalid_grant", error_description: "expired" }.to_json))
-    Provider::Snaptrade.stubs(:oauth_connection).returns(connection)
+    Provider::SnaptradeOauth.stubs(:oauth_connection).returns(connection)
 
-    error = assert_raises(Provider::Snaptrade::AuthenticationError) do
-      Provider::Snaptrade.refresh_tokens(refresh_token: "dead-rt")
+    error = assert_raises(Provider::SnaptradeOauth::AuthenticationError) do
+      Provider::SnaptradeOauth.refresh_tokens(refresh_token: "dead-rt")
     end
     assert_match "expired", error.message
   end
@@ -115,11 +115,11 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
   test "data calls send Bearer token on API base URL" do
     configure_oauth!
     item = fake_item
-    provider = Provider::Snaptrade.new(item)
+    provider = Provider::SnaptradeOauth.new(item)
 
     request = OpenStruct.new(headers: {}, params: {})
     connection = mock("faraday")
-    connection.expects(:get).with("#{Provider::Snaptrade::API_BASE_URL}/api/v1/accounts").yields(request)
+    connection.expects(:get).with("#{Provider::SnaptradeOauth::API_BASE_URL}/api/v1/accounts").yields(request)
       .returns(faraday_response(status: 200, body: [ { id: "acct-1" } ].to_json))
     provider.stubs(:api_connection).returns(connection)
 
@@ -130,7 +130,7 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
 
   test "get_positions calls /positions/all and unwraps results" do
     configure_oauth!
-    provider = Provider::Snaptrade.new(fake_item)
+    provider = Provider::SnaptradeOauth.new(fake_item)
 
     request = OpenStruct.new(headers: {}, params: {})
     body = {
@@ -140,7 +140,7 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
 
     connection = mock("faraday")
     connection.expects(:get)
-      .with("#{Provider::Snaptrade::API_BASE_URL}/api/v1/accounts/acct-1/positions/all")
+      .with("#{Provider::SnaptradeOauth::API_BASE_URL}/api/v1/accounts/acct-1/positions/all")
       .yields(request).returns(faraday_response(status: 200, body: body))
     provider.stubs(:api_connection).returns(connection)
 
@@ -152,7 +152,7 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
 
   test "get_positions returns an empty array for an account holding nothing" do
     configure_oauth!
-    provider = Provider::Snaptrade.new(fake_item)
+    provider = Provider::SnaptradeOauth.new(fake_item)
 
     connection = mock("faraday")
     connection.expects(:get).yields(OpenStruct.new(headers: {}, params: {}))
@@ -164,14 +164,14 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
 
   test "get_positions raises rather than reporting no positions when results are absent" do
     configure_oauth!
-    provider = Provider::Snaptrade.new(fake_item)
+    provider = Provider::SnaptradeOauth.new(fake_item)
 
     connection = mock("faraday")
     connection.expects(:get).yields(OpenStruct.new(headers: {}, params: {}))
       .returns(faraday_response(status: 200, body: { data_freshness: {} }.to_json))
     provider.stubs(:api_connection).returns(connection)
 
-    error = assert_raises(Provider::Snaptrade::ApiError) do
+    error = assert_raises(Provider::SnaptradeOauth::ApiError) do
       provider.get_positions(account_id: "acct-1")
     end
     assert_match "no results array", error.message
@@ -179,7 +179,7 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
 
   test "get_positions filters out instrument kinds the holdings pipeline cannot model" do
     configure_oauth!
-    provider = Provider::Snaptrade.new(fake_item)
+    provider = Provider::SnaptradeOauth.new(fake_item)
 
     body = {
       results: [
@@ -204,9 +204,9 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
   test "expired token is refreshed before the data call and rotation persisted" do
     configure_oauth!
     item = fake_item(expires_at: 1.minute.ago)
-    provider = Provider::Snaptrade.new(item)
+    provider = Provider::SnaptradeOauth.new(item)
 
-    Provider::Snaptrade.expects(:refresh_tokens).with(refresh_token: "rt-1")
+    Provider::SnaptradeOauth.expects(:refresh_tokens).with(refresh_token: "rt-1")
       .returns({ "access_token" => "at-2", "refresh_token" => "rt-2", "expires_in" => 900 })
 
     request = OpenStruct.new(headers: {}, params: {})
@@ -222,9 +222,9 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
   test "401 triggers one refresh and retry" do
     configure_oauth!
     item = fake_item
-    provider = Provider::Snaptrade.new(item)
+    provider = Provider::SnaptradeOauth.new(item)
 
-    Provider::Snaptrade.expects(:refresh_tokens).with(refresh_token: "rt-1")
+    Provider::SnaptradeOauth.expects(:refresh_tokens).with(refresh_token: "rt-1")
       .returns({ "access_token" => "at-2", "expires_in" => 900 })
 
     connection = mock("faraday")
@@ -238,22 +238,22 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
   test "failed refresh marks item requires_update and raises AuthenticationError" do
     configure_oauth!
     item = fake_item(expires_at: 1.minute.ago)
-    provider = Provider::Snaptrade.new(item)
+    provider = Provider::SnaptradeOauth.new(item)
     DebugLogEntry.stubs(:capture)
 
-    Provider::Snaptrade.expects(:refresh_tokens).raises(Provider::Snaptrade::AuthenticationError, "invalid_grant")
+    Provider::SnaptradeOauth.expects(:refresh_tokens).raises(Provider::SnaptradeOauth::AuthenticationError, "invalid_grant")
 
-    assert_raises(Provider::Snaptrade::AuthenticationError) { provider.list_accounts }
+    assert_raises(Provider::SnaptradeOauth::AuthenticationError) { provider.list_accounts }
     assert_includes item.updates, { status: :requires_update }
   end
 
   test "blank refresh token raises AuthenticationError and marks requires_update exactly once" do
     configure_oauth!
     item = fake_item(refresh_token: nil, expires_at: 1.minute.ago)
-    provider = Provider::Snaptrade.new(item)
+    provider = Provider::SnaptradeOauth.new(item)
     DebugLogEntry.stubs(:capture)
 
-    assert_raises(Provider::Snaptrade::AuthenticationError) { provider.list_accounts }
+    assert_raises(Provider::SnaptradeOauth::AuthenticationError) { provider.list_accounts }
     assert_equal [ { status: :requires_update } ], item.updates
   end
 
@@ -268,9 +268,9 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
       self.oauth_token_expires_at = 1.hour.from_now
       self
     end
-    provider = Provider::Snaptrade.new(item)
+    provider = Provider::SnaptradeOauth.new(item)
 
-    Provider::Snaptrade.expects(:refresh_tokens).never
+    Provider::SnaptradeOauth.expects(:refresh_tokens).never
 
     request = OpenStruct.new(headers: {}, params: {})
     connection = mock("faraday")
@@ -283,11 +283,11 @@ class Provider::SnaptradeOauthTest < ActiveSupport::TestCase
 
   test "get_connection_url posts login and returns redirect URI" do
     configure_oauth!
-    provider = Provider::Snaptrade.new(fake_item)
+    provider = Provider::SnaptradeOauth.new(fake_item)
 
     request = OpenStruct.new(headers: {}, params: {})
     connection = mock("faraday")
-    connection.expects(:post).with("#{Provider::Snaptrade::API_BASE_URL}/api/v1/snapTrade/login").yields(request)
+    connection.expects(:post).with("#{Provider::SnaptradeOauth::API_BASE_URL}/api/v1/snapTrade/login").yields(request)
       .returns(faraday_response(status: 200, body: { redirectURI: "https://app.snaptrade.com/connect/xyz" }.to_json))
     provider.stubs(:api_connection).returns(connection)
 

--- a/test/models/snaptrade_item_oauth_test.rb
+++ b/test/models/snaptrade_item_oauth_test.rb
@@ -1,62 +1,82 @@
 require "test_helper"
 require "ostruct"
 
+# Authorization ceremonies on SnaptradeItem: the device flow that new
+# connections use, and the deprecated authorization-code + PKCE exchange that
+# connections made under #2747 still rely on.
 class SnaptradeItemOauthTest < ActiveSupport::TestCase
   setup do
     @item = snaptrade_items(:configured_item)
-  end
-
-  test "syncable scope includes only active items with an access token" do
-    assert_includes SnaptradeItem.syncable, snaptrade_items(:configured_item)
-    assert_not_includes SnaptradeItem.syncable, snaptrade_items(:unauthorized_item)
-  end
-
-  test "oauth_configured? and fully_configured? reflect token presence" do
-    assert @item.oauth_configured?
-    assert @item.fully_configured?
-    assert_not snaptrade_items(:unauthorized_item).oauth_configured?
+    @legacy_item = snaptrade_items(:legacy_oauth_item)
   end
 
   test "apply_oauth_tokens! persists rotated tokens and keeps old refresh token when omitted" do
-    @item.apply_oauth_tokens!(
+    @legacy_item.apply_oauth_tokens!(
       "access_token" => "new-at", "refresh_token" => "new-rt",
       "token_type" => "Bearer", "scope" => "read", "expires_in" => 900
     )
-    assert_equal "new-at", @item.oauth_access_token
-    assert_equal "new-rt", @item.oauth_refresh_token
-    assert_in_delta 900, @item.oauth_token_expires_at - Time.current, 10
+    assert_equal "new-at", @legacy_item.oauth_access_token
+    assert_equal "new-rt", @legacy_item.oauth_refresh_token
+    assert_in_delta 900, @legacy_item.oauth_token_expires_at - Time.current, 10
 
-    @item.apply_oauth_tokens!("access_token" => "newer-at", "expires_in" => 900)
-    assert_equal "newer-at", @item.oauth_access_token
-    assert_equal "new-rt", @item.oauth_refresh_token, "refresh token must survive rotation that omits it"
+    @legacy_item.apply_oauth_tokens!("access_token" => "newer-at", "expires_in" => 900)
+    assert_equal "newer-at", @legacy_item.oauth_access_token
+    assert_equal "new-rt", @legacy_item.oauth_refresh_token, "refresh token must survive rotation that omits it"
   end
 
-  test "complete_oauth_exchange! stores tokens and marks item good" do
+  # --- Device flow ---
+
+  test "start_oauth_device_flow works before api credentials are entered" do
+    item = snaptrade_items(:unauthorized_item)
+    Provider::Snaptrade.any_instance.expects(:start_device_authorization)
+      .with(scope: "read")
+      .returns({ "device_code" => "dc", "user_code" => "ABCD" })
+
+    assert_equal "ABCD", item.start_oauth_device_flow["user_code"]
+  end
+
+  test "complete_oauth_device_flow! stores tokens and marks the item good" do
     @item.update!(status: :requires_update)
-    Provider::Snaptrade.expects(:exchange_code)
-      .with(code: "c0de", redirect_uri: "https://sure.test/cb", code_verifier: "v")
+    Provider::Snaptrade.any_instance.expects(:poll_device_token)
+      .with(device_code: "dc")
       .returns({ "access_token" => "at", "refresh_token" => "rt", "expires_in" => 900 })
 
-    @item.complete_oauth_exchange!(code: "c0de", redirect_uri: "https://sure.test/cb", code_verifier: "v")
+    @item.complete_oauth_device_flow!(device_code: "dc")
 
     assert_equal "at", @item.oauth_access_token
     assert @item.good?
   end
 
-  test "snaptrade_provider returns provider only when token present" do
-    assert_instance_of Provider::Snaptrade, @item.snaptrade_provider
-    assert_nil snaptrade_items(:unauthorized_item).snaptrade_provider
+  # --- DEPRECATED authorization-code + PKCE (#2747) ---
+
+  test "complete_oauth_exchange! stores tokens and marks item good" do
+    @legacy_item.update!(status: :requires_update)
+    Provider::SnaptradeOauth.expects(:exchange_code)
+      .with(code: "c0de", redirect_uri: "https://sure.test/cb", code_verifier: "v")
+      .returns({ "access_token" => "at", "refresh_token" => "rt", "expires_in" => 900 })
+
+    @legacy_item.complete_oauth_exchange!(code: "c0de", redirect_uri: "https://sure.test/cb", code_verifier: "v")
+
+    assert_equal "at", @legacy_item.oauth_access_token
+    assert @legacy_item.good?
   end
 
-  test "destroy revokes tokens best-effort" do
-    Provider::Snaptrade.expects(:revoke_token).with(token: @item.oauth_refresh_token).returns(true)
-    @item.destroy!
+  test "destroying a deprecated PKCE connection revokes its tokens best-effort" do
+    Provider::SnaptradeOauth.expects(:revoke_token).with(token: @legacy_item.oauth_refresh_token).returns(true)
+    @legacy_item.destroy!
   end
 
   test "destroy proceeds even when revocation raises" do
-    Provider::Snaptrade.expects(:revoke_token).raises(Provider::Snaptrade::ApiError.new("boom"))
+    Provider::SnaptradeOauth.expects(:revoke_token).raises(Provider::Snaptrade::ApiError.new("boom"))
     assert_difference "SnaptradeItem.count", -1 do
-      @item.destroy!
+      @legacy_item.destroy!
     end
+  end
+
+  test "destroying a device-flow connection deletes its SnapTrade user instead" do
+    Provider::SnaptradeOauth.expects(:revoke_token).never
+    Provider::Snaptrade.any_instance.expects(:delete_user).with(user_id: @item.snaptrade_user_id).returns(true)
+
+    @item.destroy!
   end
 end

--- a/test/models/snaptrade_item_registration_test.rb
+++ b/test/models/snaptrade_item_registration_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+# SnapTrade user registration, which the device flow needs before any data call.
+class SnaptradeItemRegistrationTest < ActiveSupport::TestCase
+  setup do
+    @item = snaptrade_items(:configured_item)
+  end
+
+  test "ensure_user_registered! is a no-op when the stored user still exists" do
+    Provider::Snaptrade.any_instance.expects(:list_connections).returns([])
+    Provider::Snaptrade.any_instance.expects(:register_user).never
+
+    assert @item.ensure_user_registered!
+    assert_equal "user_123", @item.reload.snaptrade_user_id
+  end
+
+  test "ensure_user_registered! registers and stores a user when there is none" do
+    @item.update!(snaptrade_user_id: nil, snaptrade_user_secret: nil)
+    Provider::Snaptrade.any_instance.expects(:register_user)
+      .returns({ user_id: "family_x_1", user_secret: "s3cret" })
+
+    assert @item.ensure_user_registered!
+
+    @item.reload
+    assert_equal "family_x_1", @item.snaptrade_user_id
+    assert_equal "s3cret", @item.snaptrade_user_secret
+  end
+
+  test "ensure_user_registered! re-registers when SnapTrade says the user is gone" do
+    Provider::Snaptrade.any_instance.expects(:list_connections)
+      .raises(Provider::Snaptrade::AuthenticationError.new("no such user"))
+    Provider::Snaptrade.any_instance.expects(:register_user)
+      .returns({ user_id: "family_x_2", user_secret: "fresh" })
+
+    assert @item.ensure_user_registered!
+    assert_equal "family_x_2", @item.reload.snaptrade_user_id
+  end
+
+  # user_secret is returned exactly once and cannot be recovered, so a
+  # transient failure must never be taken as proof the user is gone.
+  test "ensure_user_registered! keeps credentials when verification fails transiently" do
+    Provider::Snaptrade.any_instance.expects(:list_connections)
+      .raises(Provider::Snaptrade::ApiError.new("Rate limit exceeded", status_code: 429))
+    Provider::Snaptrade.any_instance.expects(:register_user).never
+
+    assert_raises(Provider::Snaptrade::ApiError) { @item.ensure_user_registered! }
+
+    @item.reload
+    assert_equal "user_123", @item.snaptrade_user_id
+    assert_equal "secret_abc", @item.snaptrade_user_secret
+  end
+
+  test "verify_user_exists? distinguishes a missing user from an unknown outcome" do
+    Provider::Snaptrade.any_instance.expects(:list_connections).returns([])
+    assert_equal :ok, @item.verify_user_exists?
+
+    Provider::Snaptrade.any_instance.expects(:list_connections)
+      .raises(Provider::Snaptrade::AuthenticationError.new("gone"))
+    assert_equal :missing, @item.verify_user_exists?
+
+    Provider::Snaptrade.any_instance.expects(:list_connections)
+      .raises(Provider::Snaptrade::ApiError.new("boom", status_code: 500))
+    assert_equal :unknown, @item.verify_user_exists?
+  end
+
+  test "orphaned_users lists this family's earlier registrations only" do
+    family_id = @item.family_id
+    Provider::Snaptrade.any_instance.expects(:list_users).returns(
+      [ "user_123", "family_#{family_id}_111", "family_someone_else_222" ]
+    )
+
+    assert_equal [ "family_#{family_id}_111" ], @item.orphaned_users
+  end
+
+  test "delete_orphaned_user refuses ids outside this family" do
+    Provider::Snaptrade.any_instance.expects(:delete_user).never
+
+    assert_not @item.delete_orphaned_user("family_someone_else_222")
+    assert_not @item.delete_orphaned_user(@item.snaptrade_user_id)
+  end
+
+  test "a deprecated PKCE connection has no SnapTrade user to register" do
+    legacy_item = snaptrade_items(:legacy_oauth_item)
+
+    assert_not legacy_item.user_registered?
+    assert_empty legacy_item.orphaned_users
+    assert_empty legacy_item.list_all_users
+  end
+end

--- a/test/models/snaptrade_item_test.rb
+++ b/test/models/snaptrade_item_test.rb
@@ -13,34 +13,78 @@ class SnaptradeItemTest < ActiveSupport::TestCase
     assert_includes item.errors[:name], "can't be blank"
   end
 
-  test "allows oauth-only items without api credentials" do
-    item = SnaptradeItem.new(family: @family, name: "Test")
-    assert item.valid?
+  test "requires client_id and consumer_key together" do
+    assert SnaptradeItem.new(family: @family, name: "Test").valid?
+    assert_not SnaptradeItem.new(family: @family, name: "Test", client_id: "cid").valid?
+    assert_not SnaptradeItem.new(family: @family, name: "Test", consumer_key: "ck").valid?
+    assert SnaptradeItem.new(family: @family, name: "Test", client_id: "cid", consumer_key: "ck").valid?
   end
 
-  test "snaptrade_provider returns nil when oauth token not present" do
+  test "auth_method is nil until the item is connected" do
     item = SnaptradeItem.new(family: @family, name: "Test")
+
+    assert_nil item.auth_method
     assert_nil item.snaptrade_provider
+    assert_not item.credentials_configured?
   end
 
-  test "snaptrade_provider returns provider instance when oauth token present" do
+  test "api credentials select the device flow" do
+    item = SnaptradeItem.new(family: @family, name: "Test", client_id: "cid", consumer_key: "ck")
+
+    assert_equal :device_flow, item.auth_method
+    assert item.device_flow?
+    assert_not item.legacy_oauth?
+    assert item.credentials_configured?
+    assert_instance_of Provider::Snaptrade, item.snaptrade_provider
+  end
+
+  test "a bearer token without api credentials is a deprecated PKCE connection" do
+    item = SnaptradeItem.new(family: @family, name: "Test", oauth_access_token: "test-access-token")
+
+    assert_equal :legacy_oauth, item.auth_method
+    assert item.legacy_oauth?
+    assert_not item.device_flow?
+    assert item.credentials_configured?
+    assert_instance_of Provider::SnaptradeOauth, item.snaptrade_provider
+  end
+
+  test "api credentials win over a leftover PKCE token when a connection migrates" do
     item = SnaptradeItem.new(
       family: @family,
       name: "Test",
-      oauth_access_token: "test-access-token"
+      client_id: "cid",
+      consumer_key: "ck",
+      oauth_access_token: "stale-pkce-token"
     )
-    provider = item.snaptrade_provider
-    assert_instance_of Provider::Snaptrade, provider
+
+    assert_equal :device_flow, item.auth_method
+    assert_instance_of Provider::Snaptrade, item.snaptrade_provider
   end
 
-  test "credentials_configured? mirrors oauth_configured?" do
-    item = SnaptradeItem.new(family: @family, name: "Test")
-    assert_equal item.oauth_configured?, item.credentials_configured?
-    assert_not item.credentials_configured?
+  test "fully_configured? needs a registered user under the device flow" do
+    item = SnaptradeItem.new(family: @family, name: "Test", client_id: "cid", consumer_key: "ck")
+    assert_not item.fully_configured?
 
-    item.oauth_access_token = "test-access-token"
-    assert_equal item.oauth_configured?, item.credentials_configured?
-    assert item.credentials_configured?
+    item.assign_attributes(snaptrade_user_id: "u", snaptrade_user_secret: "s")
+    assert item.fully_configured?
+  end
+
+  test "fully_configured? needs only a token on a deprecated PKCE connection" do
+    assert snaptrade_items(:legacy_oauth_item).fully_configured?
+    assert_not snaptrade_items(:unauthorized_item).fully_configured?
+  end
+
+  test "syncable scope covers both auth models but not unconnected items" do
+    assert_includes SnaptradeItem.syncable, snaptrade_items(:configured_item)
+    assert_includes SnaptradeItem.syncable, snaptrade_items(:legacy_oauth_item)
+    assert_not_includes SnaptradeItem.syncable, snaptrade_items(:unauthorized_item)
+  end
+
+  test "syncable scope excludes items scheduled for deletion" do
+    item = snaptrade_items(:configured_item)
+    item.update!(scheduled_for_deletion: true)
+
+    assert_not_includes SnaptradeItem.syncable, item
   end
 
   test "an unlinked account awaiting activities does not keep the item syncing" do


### PR DESCRIPTION
## Summary
Replaces the deprecated authorization-code + PKCE OAuth flow with a new device-flow model that requires families to provide their own SnapTrade API credentials (client_id and consumer_key). The device flow is simpler for self-hosted deployments and doesn't require instance-wide OAuth app registration.

## Key Changes

### New Device-Flow Authentication Model
- **Provider::Snaptrade** now implements the device-flow OAuth ceremony, bound to per-family API credentials
- Families must register their own SnapTrade API credentials (client_id/consumer_key) before authorizing
- Device-flow tokens are stored in the same oauth_* columns as the deprecated PKCE flow, allowing both to coexist during migration
- Added `SnaptradeItem#ensure_user_registered!` to register a SnapTrade user against the family's credentials before data calls

### Deprecated PKCE Support
- Moved all authorization-code + PKCE logic to new **Provider::SnaptradeOauth** class
- Existing PKCE connections continue to work via `SnaptradeItem#legacy_oauth?` detection
- Both auth models expose identical data-method signatures through `snaptrade_provider`, making downstream code auth-agnostic
- Added deprecation notice in settings UI with migration path for legacy connections

### SnaptradeItem Model Updates
- Added `client_id` and `consumer_key` encrypted fields for storing family API credentials
- Added `snaptrade_user_id` and `snaptrade_user_secret` for device-flow user registration
- Added `auth_method` to distinguish between `:device_flow` and `:legacy_oauth` connections
- Validation ensures client_id and consumer_key are provided together
- New methods: `api_credentials_configured?`, `user_registered?`, `snaptrade_api_client`, `oauth_device_client`

### Controller & UI Changes
- Added `new`, `create`, `edit`, `update` actions to allow families to enter API credentials
- New `oauth_connect` view renders device-flow authorization drawer
- New `start_oauth_device_flow` and `complete_oauth_device_flow` actions handle the ceremony
- Device-flow refuses to run against legacy PKCE connections to avoid overwriting working tokens
- Connection portal now registers the SnapTrade user first if needed (device-flow only)
- Added orphaned user cleanup UI for users left over from earlier registrations

### Configuration
- Changed from requiring instance-wide `SNAPTRADE_OAUTH_CLIENT_ID` + `SNAPTRADE_OAUTH_CLIENT_SECRET` to only needing the public `SNAPTRADE_OAUTH_CLIENT_ID`
- Added `snaptrade` gem (~> 2.0) dependency for SDK-based API calls

### Testing
- New test files: `provider/snaptrade_device_flow_test.rb`, `snaptrade_item_registration_test.rb`
- Updated existing tests to cover both auth models
- Test fixtures include both device-flow and legacy PKCE items

## Notable Implementation Details
- Device-flow metadata is discovered from SnapTrade's OAuth server at runtime
- User registration is best-effort: credentials are saved even if registration fails, allowing retry later
- Stored SnapTrade user secrets are never discarded on transient failures (only on proof the user is gone)
- Both auth models use the same retry logic and error handling hierarchy
- Connections list now shows orphaned SnapTrade users with cleanup options

https://claude.ai/code/session_018kiEqKRgwX3GRKC3vhTR2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SnapTrade device-flow authorization for new connections.
  * Added API credential setup and registration management.
  * Added detection and deletion of orphaned SnapTrade connections.
  * Added clearer setup, authorization, registration, and error guidance.

* **Improvements**
  * Existing legacy OAuth connections remain supported while transitioning to device flow.
  * Connection readiness and provider status now distinguish missing credentials, pending registration, and active connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->