### PR TITLE
fix: allow saving a budget without any category allocation

### DIFF
--- a/app/views/budget_categories/_confirm_button.html.erb
+++ b/app/views/budget_categories/_confirm_button.html.erb
@@ -5,6 +5,6 @@
     full_width: true,
     href: budget_path(budget, **budget_owner_query),
     method: :get,
-    disabled: !budget.allocations_valid?
+    disabled: !budget.initialized? || budget.available_to_allocate.negative?
   ) %>
 </div>


### PR DESCRIPTION
Fixes #3100

## Summary
- The budget setup wizard's "Save" button was hard-disabled via `Budget#allocations_valid?`, which requires `allocated_spending > 0`. This blocked finishing a budget that only sets an overall monthly amount without splitting it across categories, even though the `Budget` model itself supports that and the rest of the app already treats an unallocated amount as "Uncategorized" (donut chart, budget show page).
- The wizard's "X" close button confirmed the inconsistency: it navigates to the same budget show page with zero validation, so the unallocated state was already reachable — just not via the intended confirm action.
- Changed `app/views/budget_categories/_confirm_button.html.erb` so the button is disabled only when the budget isn't initialized or is over-allocated (`!budget.initialized? || budget.available_to_allocate.negative?`), dropping the `allocated_spending > 0` requirement. `Budget#allocations_valid?` itself is untouched, since it still correctly drives the "fully allocated" donut/nav state elsewhere.

## Test plan
- [x] `bin/rails test test/models/budget_test.rb` — 24 runs, 0 failures
- [x] `bin/rails test test/controllers/budget_categories_controller_test.rb test/models/budget_category_test.rb` — 28 runs, 0 failures
- [x] Verified via `rails runner`: unallocated budget → old condition `disabled: true`, new condition `disabled: false`; over-allocated budget → still `disabled: true`
- [x] Manually verified live in the browser: created a budget with only an overall amount and no category allocation, confirmed "Save" is now clickable and leads to the budget show page with the full amount shown as unallocated/"Uncategorized"; over-allocation still keeps the button disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented confirmation when a budget has not been initialized or has a negative available allocation.
  * Improved validation behavior for budget confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->