### PR TITLE
fix: disable Mark as Recurring button when a manual recurring transaction already exists

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -354,17 +354,9 @@ class TransactionsController < ApplicationController
     return unless require_account_permission!(transaction.entry.account)
 
     # Check if a recurring transaction already exists for this pattern.
-    # Amount is included so two distinct recurring payments with the same
-    # payee but different amounts aren't treated as duplicates (matches the
-    # DB uniqueness scope and RecurringTransaction::Identifier's grouping key).
-    existing = Current.family.recurring_transactions.find_by(
-      account_id: transaction.entry.account_id,
-      merchant_id: transaction.merchant_id,
-      name: transaction.merchant_id.present? ? nil : transaction.entry.name,
-      amount: transaction.entry.amount,
-      currency: transaction.entry.currency,
-      manual: true
-    )
+    # The UI disables the button ahead of time using the same lookup, but this
+    # guard remains as the authoritative check (e.g. stale page, direct POST).
+    existing = transaction.existing_manual_recurring_transaction
 
     if existing
       flash[:alert] = t("recurring_transactions.already_exists")

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,6 +5,11 @@ class TransactionsController < ApplicationController
   before_action :set_entry_for_tags, only: :update_tags
   before_action :store_params!, only: :index
 
+  def show
+    super
+    @existing_manual_recurring = @entry.transaction.existing_manual_recurring_transaction
+  end
+
   def new
     prefill_params_from_duplicate!
     super

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -7,7 +7,7 @@ class TransactionsController < ApplicationController
 
   def show
     super
-    @existing_manual_recurring = @entry.transaction.existing_manual_recurring_transaction
+    assign_mark_recurring_state
   end
 
   def new
@@ -194,6 +194,7 @@ class TransactionsController < ApplicationController
         end
       end
     else
+      assign_mark_recurring_state
       render :show, status: :unprocessable_entity
     end
   end
@@ -430,6 +431,17 @@ class TransactionsController < ApplicationController
   end
 
   private
+    def assign_mark_recurring_state
+      existing = @entry.transaction.existing_manual_recurring_transaction
+
+      @mark_recurring_subtitle_class = existing ? "text-subdued" : "text-secondary"
+      @mark_recurring_subtitle = existing ? t("recurring_transactions.already_exists") : t("transactions.show.mark_recurring_subtitle")
+      @mark_recurring_href = existing ? nil : mark_as_recurring_transaction_path(@entry.transaction)
+      @mark_recurring_disabled = existing.present?
+      @mark_recurring_title = existing ? t("recurring_transactions.already_exists") : nil
+      @mark_recurring_button_class = existing ? "disabled:opacity-50" : nil
+    end
+
     def accessible_transactions
       Current.family.transactions
         .joins(entry: :account)

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -164,6 +164,8 @@ class TransactionsController < ApplicationController
       # Reload to ensure fresh state for turbo stream rendering
       @entry.reload
 
+      assign_mark_recurring_state
+
       respond_to do |format|
         format.html { redirect_back_or_to account_path(@entry.account), notice: t(".updated") }
         format.turbo_stream do
@@ -184,6 +186,11 @@ class TransactionsController < ApplicationController
               partial: "transactions/notes",
               locals: { entry: @entry, can_annotate: can_annotate_entry? }
             ) if params[:entry]&.key?(:notes) && notes_changed),
+            (turbo_stream.replace(
+              dom_id(@entry, :mark_recurring),
+              partial: "transactions/mark_recurring",
+              locals: { entry: @entry }
+            ) if can_edit_entry? && !@entry.split_child?),
             turbo_stream.replace(
               dom_id(@entry),
               partial: "entries/entry",
@@ -431,12 +438,18 @@ class TransactionsController < ApplicationController
   end
 
   private
+    # The "Mark as Recurring" block is only ever rendered under these same
+    # conditions (see transactions/show.html.erb), so skip the extra query
+    # entirely when it won't be used — this runs on every show/failed-update
+    # render, including read-only viewers and split-child transactions.
     def assign_mark_recurring_state
+      return unless can_edit_entry? && !@entry.split_child?
+
       existing = @entry.transaction.existing_manual_recurring_transaction
 
+      @mark_recurring_href = mark_as_recurring_transaction_path(@entry.transaction)
       @mark_recurring_subtitle_class = existing ? "text-subdued" : "text-secondary"
       @mark_recurring_subtitle = existing ? t("recurring_transactions.already_exists") : t("transactions.show.mark_recurring_subtitle")
-      @mark_recurring_href = existing ? nil : mark_as_recurring_transaction_path(@entry.transaction)
       @mark_recurring_disabled = existing.present?
       @mark_recurring_title = existing ? t("recurring_transactions.already_exists") : nil
       @mark_recurring_button_class = existing ? "disabled:opacity-50" : nil

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -188,6 +188,20 @@ class Transaction < ApplicationRecord
     potential_posted_match_data.present? && !potential_duplicate_dismissed?
   end
 
+  # Manual recurring transactions are unique per (family, account, merchant/name, amount, currency)
+  # — see the partial unique indexes on recurring_transactions. Used to guard "mark as recurring"
+  # so the UI can disable the action ahead of time instead of failing after a POST.
+  def existing_manual_recurring_transaction
+    entry.account.family.recurring_transactions.find_by(
+      account_id: entry.account_id,
+      merchant_id: merchant_id,
+      name: merchant_id.present? ? nil : entry.name,
+      amount: entry.amount,
+      currency: entry.currency,
+      manual: true
+    )
+  end
+
   def potential_duplicate_entry
     return nil unless has_potential_duplicate?
     Entry.find_by(id: potential_posted_match_data["entry_id"])

--- a/app/views/transactions/_mark_recurring.html.erb
+++ b/app/views/transactions/_mark_recurring.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (entry:) %>
+<div class="flex items-center justify-between gap-2 p-3" id="<%= dom_id(entry, :mark_recurring) %>">
+  <div class="text-sm space-y-1">
+    <h4 class="text-primary"><%= t("transactions.show.mark_recurring_title") %></h4>
+    <p class="<%= @mark_recurring_subtitle_class %>">
+      <%= @mark_recurring_subtitle %>
+    </p>
+  </div>
+  <%= render DS::Button.new(
+    text: t("transactions.show.mark_recurring"),
+    variant: "outline",
+    icon: "repeat",
+    href: @mark_recurring_href,
+    method: :post,
+    frame: "_top",
+    disabled: @mark_recurring_disabled,
+    title: @mark_recurring_title,
+    class: @mark_recurring_button_class
+  ) %>
+</div>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -398,18 +398,24 @@
             </div>
           <% end %>
           <!-- Mark as Recurring Form -->
+          <% existing_manual_recurring = @entry.transaction.existing_manual_recurring_transaction %>
           <div class="flex items-center justify-between gap-2 p-3">
             <div class="text-sm space-y-1">
               <h4 class="text-primary"><%= t(".mark_recurring_title") %></h4>
-              <p class="text-secondary"><%= t(".mark_recurring_subtitle") %></p>
+              <p class="<%= existing_manual_recurring ? "text-subdued" : "text-secondary" %>">
+                <%= existing_manual_recurring ? t("recurring_transactions.already_exists") : t(".mark_recurring_subtitle") %>
+              </p>
             </div>
             <%= render DS::Button.new(
               text: t(".mark_recurring"),
               variant: "outline",
               icon: "repeat",
-              href: mark_as_recurring_transaction_path(@entry.transaction),
+              href: existing_manual_recurring ? nil : mark_as_recurring_transaction_path(@entry.transaction),
               method: :post,
-              frame: "_top"
+              frame: "_top",
+              disabled: existing_manual_recurring.present?,
+              title: existing_manual_recurring ? t("recurring_transactions.already_exists") : nil,
+              class: existing_manual_recurring ? "disabled:opacity-50" : nil
             ) %>
           </div>
         <% end %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -398,24 +398,23 @@
             </div>
           <% end %>
           <!-- Mark as Recurring Form -->
-          <% existing_manual_recurring = @entry.transaction.existing_manual_recurring_transaction %>
           <div class="flex items-center justify-between gap-2 p-3">
             <div class="text-sm space-y-1">
               <h4 class="text-primary"><%= t(".mark_recurring_title") %></h4>
-              <p class="<%= existing_manual_recurring ? "text-subdued" : "text-secondary" %>">
-                <%= existing_manual_recurring ? t("recurring_transactions.already_exists") : t(".mark_recurring_subtitle") %>
+              <p class="<%= @existing_manual_recurring ? "text-subdued" : "text-secondary" %>">
+                <%= @existing_manual_recurring ? t("recurring_transactions.already_exists") : t(".mark_recurring_subtitle") %>
               </p>
             </div>
             <%= render DS::Button.new(
               text: t(".mark_recurring"),
               variant: "outline",
               icon: "repeat",
-              href: existing_manual_recurring ? nil : mark_as_recurring_transaction_path(@entry.transaction),
+              href: @existing_manual_recurring ? nil : mark_as_recurring_transaction_path(@entry.transaction),
               method: :post,
               frame: "_top",
-              disabled: existing_manual_recurring.present?,
-              title: existing_manual_recurring ? t("recurring_transactions.already_exists") : nil,
-              class: existing_manual_recurring ? "disabled:opacity-50" : nil
+              disabled: @existing_manual_recurring.present?,
+              title: @existing_manual_recurring ? t("recurring_transactions.already_exists") : nil,
+              class: @existing_manual_recurring ? "disabled:opacity-50" : nil
             ) %>
           </div>
         <% end %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -401,20 +401,20 @@
           <div class="flex items-center justify-between gap-2 p-3">
             <div class="text-sm space-y-1">
               <h4 class="text-primary"><%= t(".mark_recurring_title") %></h4>
-              <p class="<%= @existing_manual_recurring ? "text-subdued" : "text-secondary" %>">
-                <%= @existing_manual_recurring ? t("recurring_transactions.already_exists") : t(".mark_recurring_subtitle") %>
+              <p class="<%= @mark_recurring_subtitle_class %>">
+                <%= @mark_recurring_subtitle %>
               </p>
             </div>
             <%= render DS::Button.new(
               text: t(".mark_recurring"),
               variant: "outline",
               icon: "repeat",
-              href: @existing_manual_recurring ? nil : mark_as_recurring_transaction_path(@entry.transaction),
+              href: @mark_recurring_href,
               method: :post,
               frame: "_top",
-              disabled: @existing_manual_recurring.present?,
-              title: @existing_manual_recurring ? t("recurring_transactions.already_exists") : nil,
-              class: @existing_manual_recurring ? "disabled:opacity-50" : nil
+              disabled: @mark_recurring_disabled,
+              title: @mark_recurring_title,
+              class: @mark_recurring_button_class
             ) %>
           </div>
         <% end %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -398,25 +398,7 @@
             </div>
           <% end %>
           <!-- Mark as Recurring Form -->
-          <div class="flex items-center justify-between gap-2 p-3">
-            <div class="text-sm space-y-1">
-              <h4 class="text-primary"><%= t(".mark_recurring_title") %></h4>
-              <p class="<%= @mark_recurring_subtitle_class %>">
-                <%= @mark_recurring_subtitle %>
-              </p>
-            </div>
-            <%= render DS::Button.new(
-              text: t(".mark_recurring"),
-              variant: "outline",
-              icon: "repeat",
-              href: @mark_recurring_href,
-              method: :post,
-              frame: "_top",
-              disabled: @mark_recurring_disabled,
-              title: @mark_recurring_title,
-              class: @mark_recurring_button_class
-            ) %>
-          </div>
+          <%= render "transactions/mark_recurring", entry: @entry %>
         <% end %>
         <%# Delete Transaction Form - hidden for split children %>
         <% unless @entry.split_child? %>

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -96,8 +96,8 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
 
     patch transaction_url(entry), params: {
       entry: {
-        name: entry.name,
-        date: "",
+        name: "",
+        date: entry.date,
         currency: entry.currency,
         amount: entry.amount.abs,
         nature: "outflow",
@@ -108,6 +108,8 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     assert_includes response.body, "A manual recurring transaction already exists for this pattern"
+    assert_select "button[disabled]", text: /Mark as Recurring/
+    assert_no_match(/#{Regexp.escape(mark_as_recurring_transaction_path(entry))}/, response.body)
   end
 
   test "transaction count represents filtered total" do

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -74,6 +74,42 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_enqueued_with(job: SyncJob)
   end
 
+  test "re-renders show with mark-recurring state when update fails validation" do
+    family = families(:empty)
+    sign_in users(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+    merchant = family.merchants.create! name: "Test Merchant"
+    entry = create_transaction(account: account, amount: 100, merchant: merchant)
+
+    family.recurring_transactions.create!(
+      account: account,
+      merchant: merchant,
+      amount: entry.amount,
+      currency: entry.currency,
+      expected_day_of_month: entry.date.day,
+      last_occurrence_date: entry.date,
+      next_expected_date: 1.month.from_now,
+      status: "active",
+      manual: true,
+      occurrence_count: 1
+    )
+
+    patch transaction_url(entry), params: {
+      entry: {
+        name: entry.name,
+        date: "",
+        currency: entry.currency,
+        amount: entry.amount.abs,
+        nature: "outflow",
+        entryable_type: entry.entryable_type,
+        entryable_attributes: { id: entry.entryable_id }
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, "A manual recurring transaction already exists for this pattern"
+  end
+
   test "transaction count represents filtered total" do
     family = families(:empty)
     sign_in users(:empty)

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -109,7 +109,7 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     assert_includes response.body, "A manual recurring transaction already exists for this pattern"
     assert_select "button[disabled]", text: /Mark as Recurring/
-    assert_no_match(/#{Regexp.escape(mark_as_recurring_transaction_path(entry))}/, response.body)
+    assert_no_match(/#{Regexp.escape(mark_as_recurring_transaction_path(entry.entryable))}/, response.body)
   end
 
   test "transaction count represents filtered total" do

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -109,7 +109,41 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     assert_includes response.body, "A manual recurring transaction already exists for this pattern"
     assert_select "button[disabled]", text: /Mark as Recurring/
-    assert_no_match(/#{Regexp.escape(mark_as_recurring_transaction_path(entry.entryable))}/, response.body)
+  end
+
+  test "turbo_stream update refreshes mark-recurring state when it newly matches" do
+    family = families(:empty)
+    sign_in users(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+    merchant = family.merchants.create! name: "Test Merchant"
+    entry = create_transaction(account: account, amount: 100, name: "Other Name")
+
+    family.recurring_transactions.create!(
+      account: account,
+      merchant: merchant,
+      amount: entry.amount,
+      currency: entry.currency,
+      expected_day_of_month: entry.date.day,
+      last_occurrence_date: entry.date,
+      next_expected_date: 1.month.from_now,
+      status: "active",
+      manual: true,
+      occurrence_count: 1
+    )
+
+    patch transaction_url(entry), params: {
+      entry: {
+        date: entry.date,
+        currency: entry.currency,
+        amount: entry.amount.abs,
+        nature: "outflow",
+        entryable_type: entry.entryable_type,
+        entryable_attributes: { id: entry.entryable_id, merchant_id: merchant.id }
+      }
+    }, as: :turbo_stream
+
+    assert_response :success
+    assert_select "turbo-stream[target='#{dom_id(entry, :mark_recurring)}'] button[disabled]", text: /Mark as Recurring/
   end
 
   test "transaction count represents filtered total" do

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -51,9 +51,40 @@ class TransactionTest < ActiveSupport::TestCase
   test "existing_manual_recurring_transaction returns nil when no manual recurring transaction matches" do
     family = families(:empty)
     account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+    other_account = family.accounts.create! name: "Other", balance: 0, currency: "USD", accountable: Depository.new
     merchant = family.merchants.create! name: "Test Merchant"
+    other_merchant = family.merchants.create! name: "Other Merchant"
     entry = create_transaction(account: account, amount: 100, merchant: merchant)
     transaction = entry.entryable
+
+    base_attrs = {
+      expected_day_of_month: entry.date.day,
+      last_occurrence_date: entry.date,
+      next_expected_date: 1.month.from_now,
+      status: "active",
+      occurrence_count: 1
+    }
+
+    # Differs by account
+    family.recurring_transactions.create!(base_attrs.merge(
+      account: other_account, merchant: merchant, amount: entry.amount, currency: entry.currency, manual: true
+    ))
+    # Differs by merchant
+    family.recurring_transactions.create!(base_attrs.merge(
+      account: account, merchant: other_merchant, amount: entry.amount, currency: entry.currency, manual: true
+    ))
+    # Differs by amount
+    family.recurring_transactions.create!(base_attrs.merge(
+      account: account, merchant: merchant, amount: entry.amount + 1, currency: entry.currency, manual: true
+    ))
+    # Differs by currency
+    family.recurring_transactions.create!(base_attrs.merge(
+      account: account, merchant: merchant, amount: entry.amount, currency: "EUR", manual: true
+    ))
+    # Differs by manual flag
+    family.recurring_transactions.create!(base_attrs.merge(
+      account: account, merchant: merchant, amount: entry.amount, currency: entry.currency, manual: false
+    ))
 
     assert_nil transaction.existing_manual_recurring_transaction
   end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -1,6 +1,63 @@
 require "test_helper"
 
 class TransactionTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  test "existing_manual_recurring_transaction finds a match by merchant" do
+    family = families(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+    merchant = family.merchants.create! name: "Test Merchant"
+    entry = create_transaction(account: account, amount: 100, merchant: merchant)
+    transaction = entry.entryable
+
+    recurring = family.recurring_transactions.create!(
+      account: account,
+      merchant: merchant,
+      amount: entry.amount,
+      currency: entry.currency,
+      expected_day_of_month: entry.date.day,
+      last_occurrence_date: entry.date,
+      next_expected_date: 1.month.from_now,
+      status: "active",
+      manual: true,
+      occurrence_count: 1
+    )
+
+    assert_equal recurring, transaction.existing_manual_recurring_transaction
+  end
+
+  test "existing_manual_recurring_transaction finds a match by name when no merchant" do
+    family = families(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+    entry = create_transaction(account: account, amount: 50, name: "Netflix")
+    transaction = entry.entryable
+
+    recurring = family.recurring_transactions.create!(
+      account: account,
+      name: "Netflix",
+      amount: entry.amount,
+      currency: entry.currency,
+      expected_day_of_month: entry.date.day,
+      last_occurrence_date: entry.date,
+      next_expected_date: 1.month.from_now,
+      status: "active",
+      manual: true,
+      occurrence_count: 1
+    )
+
+    assert_equal recurring, transaction.existing_manual_recurring_transaction
+  end
+
+  test "existing_manual_recurring_transaction returns nil when no manual recurring transaction matches" do
+    family = families(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+    merchant = family.merchants.create! name: "Test Merchant"
+    entry = create_transaction(account: account, amount: 100, merchant: merchant)
+    transaction = entry.entryable
+
+    assert_nil transaction.existing_manual_recurring_transaction
+  end
+
   test "pending? is true when extra.simplefin.pending is truthy" do
     transaction = Transaction.new(extra: { "simplefin" => { "pending" => true } })
 


### PR DESCRIPTION
## Summary

Fixes #3102.

The "Mark as Recurring" button on the transaction detail view was always clickable, even when a manual recurring transaction already exists for that pattern (account + merchant/name + amount + currency). Clicking it only surfaced the error after a POST ("A manual recurring transaction already exists for this pattern").

- Extracted the existing lookup from `TransactionsController#mark_as_recurring` into `Transaction#existing_manual_recurring_transaction`, reused by both the controller guard (kept as the authoritative backstop for races/stale pages) and the view.
- The view now disables the button and shows the same "already exists" message inline (instead of only a hover tooltip) when a match is found, so the disabled state is clearly visible and explained.
- The lookup is a single indexed point query backed by the existing partial unique indexes on `recurring_transactions`, so checking it at render time has no meaningful performance impact.

## Test plan

- [x] Manually verified on a live instance: button is disabled with an inline explanation when a matching manual recurring transaction exists, and behaves as before (clickable, works) otherwise.
- [x] `bin/rubocop` clean on changed files.
- [x] `bin/brakeman` clean (0 warnings).
- [x] Added model tests for `Transaction#existing_manual_recurring_transaction` (merchant match, name match, no match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added duplicate detection for manual recurring transactions based on account, merchant or transaction name, amount, and currency.
  - Recurring transaction controls now identify matching entries and prevent duplicate creation.

- **Bug Fixes**
  - Preserved duplicate warnings and disabled controls when transaction updates fail validation because a matching recurring transaction already exists.

- **Tests**
  - Expanded coverage for matching and non-matching recurring transactions across relevant attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->