### PR TITLE
Reconcile PDF statement imports against transactions that already exist

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,7 +1,7 @@
 class ImportsController < ApplicationController
   include SettingsHelper
 
-  before_action :set_import, only: %i[show update publish destroy revert apply_template cancel]
+  before_action :set_import, only: %i[show update publish destroy revert apply_template cancel summary]
   before_action :require_statement_import_permission!, only: %i[update publish destroy revert apply_template cancel]
 
   def update
@@ -38,6 +38,14 @@ class ImportsController < ApplicationController
     redirect_to import_path(@import), notice: t(".started")
   rescue Import::MaxRowCountExceededError
     redirect_back_or_to import_path(@import), alert: t(".max_rows_exceeded", max: @import.max_row_count)
+  end
+
+  # Statement imports only: what became of each extracted transaction. Without it
+  # a statement whose lines all matched finishes on the generic complete screen,
+  # which cannot distinguish "everything was already recorded" from "nothing was
+  # found".
+  def summary
+    raise ActiveRecord::RecordNotFound unless @import.is_a?(PdfImport)
   end
 
   def cancel

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -16,7 +16,17 @@ class ImportsController < ApplicationController
       end
       return if @import.account_statement.present? && !require_account_permission!(account)
 
-      @import.is_a?(PdfImport) ? @import.assign_account!(account) : @import.update!(account: account)
+      if @import.is_a?(PdfImport)
+        # Refused for an import whose data already landed -- see
+        # PdfImport#reassignable?. A replayed or back-button PATCH gets the
+        # explanation rather than a silent unwind.
+        unless @import.assign_account!(account)
+          redirect_back_or_to import_path(@import), alert: t("imports.update.account_locked")
+          return
+        end
+      else
+        @import.update!(account: account)
+      end
     end
 
     redirect_to import_path(@import), notice: t("imports.update.account_saved", default: "Account saved.")

--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -717,24 +717,40 @@ class Account::ProviderImportAdapter
   # @param name [String, nil] Optional transaction name for more accurate matching
   # @param exclude_entry_ids [Set, Array, nil] Entry IDs to exclude from the search (e.g., already claimed entries)
   # @return [Entry, nil] The duplicate entry or nil if not found
-  def find_duplicate_transaction(date:, amount:, currency:, name: nil, exclude_entry_ids: nil)
+  # @param date_window [Integer] days either side of `date` to consider. Defaults
+  #   to 0 (exact date), which is what provider sync wants. Statement imports
+  #   pass a small window, because a statement's posting date routinely differs
+  #   from the date a provider recorded for the same transaction.
+  # @param include_provider_entries [Boolean] when false (the default) only
+  #   manual and CSV-imported entries are considered, which is correct for
+  #   provider sync: a provider must not claim another provider's entry. A
+  #   statement import passes true, because the whole question it is asking is
+  #   whether this transaction already arrived via sync.
+  def find_duplicate_transaction(date:, amount:, currency:, name: nil, exclude_entry_ids: nil, date_window: 0, include_provider_entries: false)
     # Convert date to Date object if it's a string
     date = Date.parse(date.to_s) unless date.is_a?(Date)
 
     # Look for entries on the same account with:
-    # 1. Same date
+    # 1. Same date (or within date_window of it)
     # 2. Same amount (exact match)
     # 3. Same currency
-    # 4. No external_id (manual/CSV imported transactions)
+    # 4. No external_id (manual/CSV imported transactions), unless the caller
+    #    opted into provider-sourced entries too
     # 5. Entry type is Transaction (not Trade or Valuation)
     # 6. Optionally same name (if name parameter is provided)
     # 7. Not in the excluded IDs list (if provided)
     query = account.entries
                    .where(entryable_type: "Transaction")
-                   .where(date: date)
                    .where(amount: amount)
                    .where(currency: currency)
-                   .where(external_id: nil)
+
+    query = if date_window.to_i.zero?
+      query.where(date: date)
+    else
+      query.where(date: (date - date_window.days)..(date + date_window.days))
+    end
+
+    query = query.where(external_id: nil) unless include_provider_entries
 
     # Add name filter if provided
     query = query.where(name: name) if name.present?
@@ -742,7 +758,15 @@ class Account::ProviderImportAdapter
     # Exclude already claimed entries if provided
     query = query.where.not(id: exclude_entry_ids) if exclude_entry_ids.present?
 
-    query.order(created_at: :asc).first
+    candidates = query.order(created_at: :asc)
+
+    # Exact-date search keeps the original oldest-first behaviour.
+    return candidates.first if date_window.to_i.zero?
+
+    # A windowed search prefers the closest date, falling back to oldest-created
+    # on a tie. Done in Ruby because the candidate set is already narrowed to one
+    # account, one amount and one currency within a few days -- a handful of rows.
+    candidates.to_a.min_by { |entry| [ (entry.date - date).abs, entry.created_at ] }
   end
 
   # Finds a pending transaction that likely matches a newly posted transaction

--- a/app/models/account_statement/account_matcher.rb
+++ b/app/models/account_statement/account_matcher.rb
@@ -3,6 +3,8 @@
 class AccountStatement::AccountMatcher
   Match = Struct.new(:account, :confidence, keyword_init: true)
 
+  MINIMUM_CONFIDENCE = "0.35".to_d
+
   attr_reader :statement
 
   def initialize(statement)
@@ -10,64 +12,104 @@ class AccountStatement::AccountMatcher
   end
 
   def best_match
-    candidates = statement.family.accounts.visible.to_a.filter_map do |account|
-      confidence = confidence_for(account)
-      next if confidence < 0.35
-
-      Match.new(account: account, confidence: confidence.round(4))
-    end
-
-    candidates.max_by(&:confidence)
+    self.class.best_match(
+      family: statement.family,
+      institution_hint: statement.institution_name_hint,
+      account_name_hint: statement.account_name_hint,
+      account_last4_hint: statement.account_last4_hint,
+      currency: statement.statement_currency
+    )
   end
 
-  private
+  class << self
+    # Hint-based entry point so callers that hold statement metadata without an
+    # AccountStatement row (e.g. per-account reconciliation entries extracted
+    # from a multi-account PDF) score against the same rules.
+    #
+    # `exclude_account_ids` lets a caller resolving several accounts out of one
+    # document avoid handing the same account to two different entries.
+    def best_match(family:, institution_hint: nil, account_name_hint: nil, account_last4_hint: nil, currency: nil, exclude_account_ids: [])
+      return nil if family.blank?
 
-    def confidence_for(account)
-      score = 0.to_d
+      institution_hint = normalize_hint(institution_hint)
+      account_name_hint = normalize_hint(account_name_hint)
+      account_last4_hint = normalize_hint(account_last4_hint)
 
-      if institution_hint.present?
-        score += 0.45.to_d if account_text(account).include?(institution_hint)
+      return nil if institution_hint.blank? && account_name_hint.blank? && account_last4_hint.blank?
+
+      excluded = Array.wrap(exclude_account_ids).compact
+
+      candidates = family.accounts.visible.to_a.filter_map do |account|
+        next if excluded.include?(account.id)
+
+        confidence = confidence_for(
+          account,
+          institution_hint: institution_hint,
+          account_name_hint: account_name_hint,
+          account_last4_hint: account_last4_hint,
+          currency: currency
+        )
+        next if confidence < MINIMUM_CONFIDENCE
+
+        Match.new(account: account, confidence: confidence.round(4))
       end
 
-      if account_name_hint.present?
-        score += 0.25.to_d if account.name.to_s.downcase.include?(account_name_hint)
+      ranked = candidates.sort_by { |match| -match.confidence }
+      best = ranked.first
+      return nil if best.nil?
+
+      # Two accounts the hints cannot tell apart (identical names at the same
+      # institution) would otherwise resolve to whichever the scan reached
+      # first. Refuse to guess instead.
+      if ranked.length > 1 && ranked[1].confidence == best.confidence
+        Rails.logger.warn("AccountStatement::AccountMatcher found equally confident candidates; refusing to guess")
+        return nil
       end
 
-      if account_last4_hint.present?
-        score += 0.25.to_d if account_sensitive_match_text(account).include?(account_last4_hint)
+      best
+    end
+
+    private
+
+      def confidence_for(account, institution_hint:, account_name_hint:, account_last4_hint:, currency:)
+        score = 0.to_d
+
+        if institution_hint.present?
+          score += 0.45.to_d if account_text(account).include?(institution_hint)
+        end
+
+        if account_name_hint.present?
+          score += 0.25.to_d if account.name.to_s.downcase.include?(account_name_hint)
+        end
+
+        if account_last4_hint.present?
+          score += 0.25.to_d if account_sensitive_match_text(account).include?(account_last4_hint)
+        end
+
+        score += 0.05.to_d if currency.present? && currency == account.currency
+        [ score, 1.to_d ].min
       end
 
-      score += 0.05.to_d if statement.statement_currency == account.currency
-      [ score, 1.to_d ].min
-    end
+      def normalize_hint(value)
+        value.to_s.downcase.squish.presence
+      end
 
-    def institution_hint
-      @institution_hint ||= statement.institution_name_hint.to_s.downcase.squish.presence
-    end
+      def account_text(account)
+        [
+          account.name,
+          account.institution_name,
+          account.institution_domain
+        ].compact.join(" ").downcase
+      end
 
-    def account_name_hint
-      @account_name_hint ||= statement.account_name_hint.to_s.downcase.squish.presence
-    end
-
-    def account_last4_hint
-      @account_last4_hint ||= statement.account_last4_hint.to_s.downcase.squish.presence
-    end
-
-    def account_text(account)
-      [
-        account.name,
-        account.institution_name,
-        account.institution_domain
-      ].compact.join(" ").downcase
-    end
-
-    def account_sensitive_match_text(account)
-      # Exclude user-controlled account notes from matching hints. Statement
-      # matching should use conservative account metadata, not free-form prose
-      # that can accidentally manufacture a last-four match.
-      [
-        account.name,
-        account.institution_name
-      ].compact.join(" ").downcase
-    end
+      def account_sensitive_match_text(account)
+        # Exclude user-controlled account notes from matching hints. Statement
+        # matching should use conservative account metadata, not free-form prose
+        # that can accidentally manufacture a last-four match.
+        [
+          account.name,
+          account.institution_name
+        ].compact.join(" ").downcase
+      end
+  end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -12,6 +12,7 @@ class Entry < ApplicationRecord
   belongs_to :transfer, optional: true
   belongs_to :import, optional: true
   belongs_to :parent_entry, class_name: "Entry", optional: true
+  belongs_to :reconciled_by_statement, class_name: "AccountStatement", optional: true
 
   has_many :child_entries, class_name: "Entry", foreign_key: :parent_entry_id, dependent: :destroy
 
@@ -51,6 +52,10 @@ class Entry < ApplicationRecord
   }
 
   # Pending transaction scopes - check Transaction.extra for provider pending flags
+  scope :reconciled, -> { where.not(reconciled_at: nil) }
+  scope :unreconciled, -> { where(reconciled_at: nil) }
+  scope :reconciled_by, ->(statement) { where(reconciled_by_statement_id: statement) }
+
   # Works with any provider that stores pending status in extra["provider_name"]["pending"]
   scope :pending, -> {
     conditions = Transaction::PENDING_PROVIDERS.map { |p| "(transactions.extra -> '#{p}' ->> 'pending')::boolean = true" }
@@ -293,6 +298,42 @@ class Entry < ApplicationRecord
 
   def linked?
     external_id.present?
+  end
+
+  # Reconciliation state, following the Quicken uncleared / cleared / reconciled
+  # model. Only the last state is stored -- see AddReconciliationToEntries.
+  #
+  # @return [Symbol] :uncleared, :cleared or :reconciled
+  def reconciliation_state
+    return :reconciled if reconciled?
+    return :cleared if cleared?
+
+    :uncleared
+  end
+
+  # The institution has acknowledged this transaction: it either arrived from a
+  # provider, or was entered by hand and later claimed by one (which stamps
+  # external_id and source -- see Account::ProviderImportAdapter). Derived rather
+  # than stored so it cannot drift, and deliberately not user-settable: this is a
+  # fact about where the entry came from, not an opinion about it.
+  def cleared?
+    external_id.present? || source.present?
+  end
+
+  # A statement has been matched against this transaction. Unlike cleared?, this
+  # is a judgement -- made by a statement import, or by the user directly -- so
+  # it is stored and can be undone.
+  def reconciled?
+    reconciled_at.present?
+  end
+
+  # @param statement [AccountStatement, nil] the statement providing the evidence
+  def mark_reconciled!(statement: nil, at: Time.current)
+    update!(reconciled_at: at, reconciled_by_statement: statement)
+  end
+
+  def unmark_reconciled!
+    update!(reconciled_at: nil, reconciled_by_statement: nil)
   end
 
   # Checks if entry should be protected from provider sync overwrites.

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -14,6 +14,10 @@ class Entry < ApplicationRecord
   belongs_to :parent_entry, class_name: "Entry", optional: true
   belongs_to :reconciled_by_statement, class_name: "AccountStatement", optional: true
 
+  # Mirrors chk_entries_reconciled_at_present_when_statement_set so a direct
+  # assignment surfaces a validation error rather than a StatementInvalid.
+  validates :reconciled_at, presence: true, if: -> { reconciled_by_statement_id.present? }
+
   has_many :child_entries, class_name: "Entry", foreign_key: :parent_entry_id, dependent: :destroy
 
   delegated_type :entryable, types: Entryable::TYPES, dependent: :destroy
@@ -51,11 +55,12 @@ class Entry < ApplicationRecord
     )
   }
 
-  # Pending transaction scopes - check Transaction.extra for provider pending flags
+  # Reconciliation scopes - see AddReconciliationToEntries
   scope :reconciled, -> { where.not(reconciled_at: nil) }
   scope :unreconciled, -> { where(reconciled_at: nil) }
   scope :reconciled_by, ->(statement) { where(reconciled_by_statement_id: statement) }
 
+  # Pending transaction scopes - check Transaction.extra for provider pending flags
   # Works with any provider that stores pending status in extra["provider_name"]["pending"]
   scope :pending, -> {
     conditions = Transaction::PENDING_PROVIDERS.map { |p| "(transactions.extra -> '#{p}' ->> 'pending')::boolean = true" }

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -319,11 +319,12 @@ class Import < ApplicationRecord
     Import.transaction do
       accounts.destroy_all
       entries.destroy_all
+      revert_derived_state!
     end
 
     family.sync_later
 
-    update! status: :pending
+    update! status: status_after_revert
   rescue => error
     update! status: :revert_failed, error: error.message
   end
@@ -531,6 +532,19 @@ class Import < ApplicationRecord
   end
 
   private
+    # Hook for import types that also maintain state outside their own rows and
+    # entries -- PdfImport records statement reconciliation on entries it did
+    # not create, and destroying its own entries does not unwind that. Runs
+    # inside revert's transaction, so a failure here rolls the whole revert back.
+    def revert_derived_state!
+    end
+
+    # Where the record lands once its data is gone. Most imports return to
+    # pending with their rows intact, ready to be published again.
+    def status_after_revert
+      :pending
+    end
+
     # Commit signal for import types whose records hang off the family rather
     # than the import itself (Category/Merchant/Rule imports create no entries
     # or accounts, so the base data_committed? can't see them). import! runs as

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -166,7 +166,7 @@ class PdfImport < Import
 
       # Matching is per-account, so anything reconciled against the old account
       # is no longer evidence-backed, and the rows have to be judged again.
-      release_reconciliations!
+      release_reconciliations!(previous_account_id)
       if has_extracted_transactions?
         generate_rows_from_extracted_data
         sync_mappings
@@ -267,7 +267,12 @@ class PdfImport < Import
 
   def generate_rows_from_extracted_data
     transaction do
-      rows.destroy_all
+      # insert_all! below bypasses ActiveRecord, so the `rows` association is
+      # never populated with what it wrote. Reload before destroying, or a second
+      # call on the same in-memory record (assign_account! regenerating after
+      # ProcessPdfJob already generated) clears a stale empty collection, deletes
+      # nothing, and collides on (import_id, source_row_number).
+      rows.reload.destroy_all
 
       unless has_extracted_transactions?
         update_column(:rows_count, 0)
@@ -306,6 +311,9 @@ class PdfImport < Import
       end
 
       Import::Row.insert_all!(mapped_rows) if mapped_rows.any?
+      # Drop the now-stale association cache so later reads (sync_mappings, the
+      # view) see what was actually written.
+      rows.reset
       update_column(:rows_count, mapped_rows.size)
     end
   end
@@ -475,10 +483,15 @@ class PdfImport < Import
       update!(status: target) unless status.to_s == target
     end
 
-    def release_reconciliations!
-      return if account_statement.blank?
+    # Scoped to the account being moved away from. A statement is evidence for
+    # exactly one account at a time, but it can back more than one import, so an
+    # unscoped release would clear reconciliations another account still relies
+    # on. Nothing is reconciled while no account is assigned, so a blank scope
+    # has nothing to release.
+    def release_reconciliations!(account_scope_id)
+      return if account_statement.blank? || account_scope_id.blank?
 
-      Entry.reconciled_by(account_statement).update_all(
+      Entry.reconciled_by(account_statement).where(account_id: account_scope_id).update_all(
         reconciled_at: nil,
         reconciled_by_statement_id: nil,
         updated_at: Time.current

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -110,7 +110,13 @@ class PdfImport < Import
       # generated, but a provider sync can land in between, so check again here
       # the way TransactionImport#import! does.
       adapter = Account::ProviderImportAdapter.new(account)
-      claimed = []
+      # Entries this statement already consumed during row generation are spoken
+      # for. Without excluding them, a statement carrying two same-amount
+      # transactions where the account held only one would re-match the surviving
+      # row against that same entry and silently drop a genuinely new
+      # transaction. Newly synced entries are still caught, because only the
+      # already-reconciled ones are excluded.
+      claimed = reconciled_entries.pluck(:id)
       reconciled_now = []
       reconciled_at = Time.current
 
@@ -164,6 +170,7 @@ class PdfImport < Import
       if has_extracted_transactions?
         generate_rows_from_extracted_data
         sync_mappings
+        refresh_status_after_regeneration!
       end
     end
   end
@@ -426,7 +433,22 @@ class PdfImport < Import
     rescue ArgumentError, TypeError => e # Date::Error subclasses ArgumentError
       # A row whose date or amount will not parse cannot be judged. Offer it for
       # import rather than dropping it silently -- the review step surfaces it.
-      Rails.logger.warn("PDF import #{id}: could not evaluate row for reconciliation (#{e.class})")
+      DebugLogEntry.capture(
+        category: "import",
+        level: "warn",
+        message: "PdfImport: could not evaluate statement row for reconciliation (#{e.class})",
+        source: "pdf_import",
+        family: family,
+        account: account,
+        metadata: {
+          import_id: id,
+          account_statement_id: account_statement_id,
+          source_row_number: row.source_row_number,
+          raw_date: row.date,
+          raw_amount: row.amount,
+          error_class: e.class.name
+        }
+      )
       nil
     end
 
@@ -438,6 +460,19 @@ class PdfImport < Import
         reconciled_by_statement_id: account_statement&.id,
         updated_at: at
       )
+    end
+
+    # Regeneration can empty the row set (everything now matches) or refill it
+    # (the new account matches nothing). Status has to follow, using the same
+    # rule ProcessPdfJob applies after initial processing -- otherwise a
+    # fully-matched import sits at pending with no rows, which renders as the
+    # processing screen forever and cannot be restarted.
+    def refresh_status_after_regeneration!
+      return if data_committed?
+      return unless pending? || complete?
+
+      target = statement_with_transactions? && rows_count > 0 ? "pending" : "complete"
+      update!(status: target) unless status.to_s == target
     end
 
     def release_reconciliations!

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -152,8 +152,14 @@ class PdfImport < Import
     end
   end
 
+  # Re-targeting is destructive: it releases the statement's evidence on the
+  # account being left and rebuilds the rows from scratch. Returns false rather
+  # than doing any of that when the import is no longer re-targetable, so a
+  # back-button or replayed PATCH cannot unwind a published import.
   def assign_account!(account)
-    transaction do
+    with_lock do
+      return false unless reassignable?
+
       previous_account_id = account_id
       update!(account: account)
 
@@ -162,7 +168,7 @@ class PdfImport < Import
         statement.link_to_account!(account) if statement.account_id != account.id
       end
 
-      next if previous_account_id == account.id
+      next true if previous_account_id == account.id
 
       # Matching is per-account, so anything reconciled against the old account
       # is no longer evidence-backed, and the rows have to be judged again.
@@ -172,7 +178,18 @@ class PdfImport < Import
         sync_mappings
         refresh_status_after_regeneration!
       end
+
+      true
     end
+  end
+
+  # A published import's entries already live in the account it was published
+  # to, and a running job owns the record while it is importing or reverting.
+  # An import that reconciled every line is still re-targetable: it is complete
+  # but committed nothing of its own, and the user may well have picked the
+  # wrong account.
+  def reassignable?
+    !data_committed? && !importing? && !reverting?
   end
 
   def pdf_uploaded?
@@ -498,6 +515,29 @@ class PdfImport < Import
       )
     end
 
+    # Reverting a statement import unwinds its evidence as well as its rows. The
+    # entries it created are already destroyed by the time this runs; the ones it
+    # only matched keep marks this statement no longer backs. Releasing and then
+    # regenerating re-judges every statement line against what the account
+    # actually holds now, so the review screen offers exactly what is missing.
+    def revert_derived_state!
+      release_reconciliations!(account_id)
+      return unless has_extracted_transactions?
+
+      generate_rows_from_extracted_data
+      # A line that matched at publish time carried no row and so no mapping.
+      # If it no longer matches it is a row again, and needs one.
+      sync_mappings
+    end
+
+    # A statement whose every line still matches something -- a provider-synced
+    # account, say -- reverts to zero rows. Returning that to pending renders the
+    # processing screen with no way out, so an import with nothing left to offer
+    # finishes as complete, the same way refresh_status_after_regeneration! ends
+    # a fully reconciled import.
+    def status_after_revert
+      statement_with_transactions? && rows_count > 0 ? :pending : :complete
+    end
 
     def format_date_for_import(date_str)
       return "" if date_str.blank?

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -351,23 +351,31 @@ class PdfImport < Import
     reconciled_entries.where.not(id: entries.select(:id))
   end
 
+  # The next three are memoized because the summary dialog and the review screen
+  # each read them more than once, and every read is its own COUNT -- rendering
+  # the dialog issued roughly fifteen queries for a static summary. They report
+  # a finished outcome for display, so a value cached for the life of the
+  # request is what callers want; anything re-judging the import recomputes from
+  # the entries directly. (`||=` is safe here: 0 is truthy in Ruby.)
   def already_recorded_count
-    already_recorded_entries.count
+    @already_recorded_count ||= already_recorded_entries.count
   end
 
   def imported_count
-    entries.count
-  end
-
-  def extracted_count
-    extracted_transactions.size
+    @imported_count ||= entries.count
   end
 
   # Rows still on offer. import! creates an entry per row and leaves the rows in
   # place as the record of what was published, so past that point rows_count is
-  # a history, not a queue.
+  # a history, not a queue. Memoized mostly for data_committed?, which is two
+  # more EXISTS queries every time it is asked.
   def awaiting_review_count
-    data_committed? ? 0 : rows_count
+    @awaiting_review_count ||= data_committed? ? 0 : rows_count
+  end
+
+  # No query: extracted_data is already in memory.
+  def extracted_count
+    extracted_transactions.size
   end
 
   # Whether the statement described transactions the account already had. The

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -343,6 +343,39 @@ class PdfImport < Import
     Entry.reconciled_by(account_statement)
   end
 
+  # The half of reconciled_entries this import did not create -- transactions the
+  # account already held when the statement arrived. Everything this import
+  # creates is born reconciled too, so the two have to be told apart before
+  # either count means anything.
+  def already_recorded_entries
+    reconciled_entries.where.not(id: entries.select(:id))
+  end
+
+  def already_recorded_count
+    already_recorded_entries.count
+  end
+
+  def imported_count
+    entries.count
+  end
+
+  def extracted_count
+    extracted_transactions.size
+  end
+
+  # Rows still on offer. import! creates an entry per row and leaves the rows in
+  # place as the record of what was published, so past that point rows_count is
+  # a history, not a queue.
+  def awaiting_review_count
+    data_committed? ? 0 : rows_count
+  end
+
+  # Whether the statement described transactions the account already had. The
+  # difference between "nothing to import" and "nothing was found".
+  def reconciled_anything?
+    already_recorded_count.positive?
+  end
+
   def send_next_steps_email(user)
     PdfImportMailer.with(
       user: user,

--- a/app/models/pdf_import.rb
+++ b/app/models/pdf_import.rb
@@ -106,11 +106,23 @@ class PdfImport < Import
     transaction do
       mappings.each(&:create_mappable!)
 
-      new_transactions = rows.map do |row|
-        category = mappings.categories.mappable_for(row.category)
+      # Rows were already filtered against existing records when they were
+      # generated, but a provider sync can land in between, so check again here
+      # the way TransactionImport#import! does.
+      adapter = Account::ProviderImportAdapter.new(account)
+      claimed = []
+      reconciled_now = []
+      reconciled_at = Time.current
+
+      new_transactions = rows.filter_map do |row|
+        if (existing = already_recorded_entry(adapter, row, claimed))
+          claimed << existing.id
+          reconciled_now << existing
+          next
+        end
 
         Transaction.new(
-          category: category,
+          category: mappings.categories.mappable_for(row.category),
           entry: Entry.new(
             account: account,
             date: row.date_iso,
@@ -119,21 +131,39 @@ class PdfImport < Import
             currency: row.currency,
             notes: row.notes,
             import: self,
-            import_locked: true
+            import_locked: true,
+            # Born reconciled: the statement being imported is the evidence.
+            # Set by id rather than association so activerecord-import writes the
+            # column directly on the recursive insert.
+            reconciled_at: reconciled_at,
+            reconciled_by_statement_id: account_statement&.id
           )
         )
       end
 
       Transaction.import!(new_transactions, recursive: true) if new_transactions.any?
+      reconcile_entries!(reconciled_now, at: reconciled_at)
     end
   end
 
   def assign_account!(account)
     transaction do
+      previous_account_id = account_id
       update!(account: account)
+
       if (statement = account_statement)
         statement.lock!
         statement.link_to_account!(account) if statement.account_id != account.id
+      end
+
+      next if previous_account_id == account.id
+
+      # Matching is per-account, so anything reconciled against the old account
+      # is no longer evidence-backed, and the rows have to be judged again.
+      release_reconciliations!
+      if has_extracted_transactions?
+        generate_rows_from_extracted_data
+        sync_mappings
       end
     end
   end
@@ -203,8 +233,13 @@ class PdfImport < Import
       raise error_message
     end
 
-    update!(extracted_data: response.data)
-    response.data
+    # BankStatementExtractor returns symbol keys, but every reader here (and in
+    # generate_rows_from_extracted_data) digs with strings. jsonb keeps the hash
+    # exactly as assigned until the record is reloaded, so without this the
+    # in-memory read comes back empty and the import produces no rows at all.
+    data = response.data.deep_stringify_keys
+    update!(extracted_data: data)
+    data
   end
 
   def bank_statement?
@@ -233,10 +268,9 @@ class PdfImport < Import
       end
 
       currency = account&.currency || family.currency
-
-      mapped_rows = extracted_transactions.map.with_index(1) do |txn, index|
-        {
-          import_id: id,
+      candidates = extracted_transactions.map.with_index(1) do |txn, index|
+        Import::Row.new(
+          import: self,
           source_row_number: index,
           date: format_date_for_import(txn["date"]),
           amount: txn["amount"].to_s,
@@ -244,12 +278,37 @@ class PdfImport < Import
           category: txn["category"].to_s,
           notes: txn["notes"].to_s,
           currency: currency
+        )
+      end
+
+      unmatched, matched_entries = partition_already_recorded(candidates)
+
+      reconcile_entries!(matched_entries)
+
+      mapped_rows = unmatched.map.with_index(1) do |row, index|
+        {
+          import_id: id,
+          source_row_number: index,
+          date: row.date,
+          amount: row.amount,
+          name: row.name,
+          category: row.category,
+          notes: row.notes,
+          currency: row.currency
         }
       end
 
       Import::Row.insert_all!(mapped_rows) if mapped_rows.any?
       update_column(:rows_count, mapped_rows.size)
     end
+  end
+
+  # Transactions this statement reconciled against records that already existed.
+  # Derived from the statement link rather than stored, so it cannot go stale.
+  def reconciled_entries
+    return Entry.none if account_statement.blank?
+
+    Entry.reconciled_by(account_statement)
   end
 
   def send_next_steps_email(user)
@@ -322,6 +381,75 @@ class PdfImport < Import
   end
 
   private
+
+    # A statement's posting date routinely differs by a day or two from the date
+    # a provider recorded for the same transaction, so matching allows a small
+    # window rather than demanding an exact date.
+    RECONCILIATION_DATE_WINDOW = 3
+
+    # Splits candidate rows into those that are genuinely new and the existing
+    # entries the rest already correspond to. Matching is per-account, so with no
+    # account assigned yet every row is treated as new and judged again once the
+    # user picks one (see assign_account!).
+    def partition_already_recorded(candidates)
+      return [ candidates, [] ] if account.blank?
+
+      adapter = Account::ProviderImportAdapter.new(account)
+      claimed = []
+      unmatched = []
+      matched = []
+
+      candidates.each do |row|
+        if (existing = already_recorded_entry(adapter, row, claimed))
+          claimed << existing.id
+          matched << existing
+        else
+          unmatched << row
+        end
+      end
+
+      [ unmatched, matched ]
+    end
+
+    # Name is deliberately not part of the match: statement descriptions and
+    # provider names for the same transaction rarely agree, and the adapter makes
+    # the same choice for provider sync.
+    def already_recorded_entry(adapter, row, claimed)
+      adapter.find_duplicate_transaction(
+        date: row.date_iso,
+        amount: row.signed_amount,
+        currency: row.currency,
+        exclude_entry_ids: claimed,
+        date_window: RECONCILIATION_DATE_WINDOW,
+        include_provider_entries: true
+      )
+    rescue ArgumentError, TypeError => e # Date::Error subclasses ArgumentError
+      # A row whose date or amount will not parse cannot be judged. Offer it for
+      # import rather than dropping it silently -- the review step surfaces it.
+      Rails.logger.warn("PDF import #{id}: could not evaluate row for reconciliation (#{e.class})")
+      nil
+    end
+
+    def reconcile_entries!(entries, at: Time.current)
+      return if entries.blank?
+
+      Entry.where(id: entries.map(&:id)).update_all(
+        reconciled_at: at,
+        reconciled_by_statement_id: account_statement&.id,
+        updated_at: at
+      )
+    end
+
+    def release_reconciliations!
+      return if account_statement.blank?
+
+      Entry.reconciled_by(account_statement).update_all(
+        reconciled_at: nil,
+        reconciled_by_statement_id: nil,
+        updated_at: Time.current
+      )
+    end
+
 
     def format_date_for_import(date_str)
       return "" if date_str.blank?

--- a/app/views/imports/_pdf_import.html.erb
+++ b/app/views/imports/_pdf_import.html.erb
@@ -43,7 +43,11 @@
         <div class="space-y-2">
           <h2 id="pdf-import-select-account" class="font-medium text-primary"><%= t("imports.pdf_import.select_account") %></h2>
           <%= styled_form_with model: import, scope: :import, url: import_path(import), method: :patch, class: "space-y-2" do |f| %>
-            <% accounts = Current.user.accessible_accounts.manual.alphabetically.pluck(:name, :id) %>
+            <%# Provider-backed accounts are offered too: rows are matched against
+                existing transactions before they are ever shown, so importing a
+                statement for a synced account can no longer duplicate what sync
+                already brought in. %>
+            <% accounts = Current.user.accessible_accounts.alphabetically.pluck(:name, :id) %>
             <% if accounts.any? %>
               <%= f.select :account_id, accounts,
                            { include_blank: t("imports.pdf_import.select_account_placeholder"), selected: import.account_id, label: false },

--- a/app/views/imports/_pdf_import.html.erb
+++ b/app/views/imports/_pdf_import.html.erb
@@ -36,7 +36,15 @@
         <div class="space-y-2">
           <h2 class="font-medium text-primary"><%= t("imports.pdf_import.transactions_extracted") %></h2>
           <p class="text-sm text-secondary px-3 py-2 bg-container-inset rounded-lg">
-            <%= t("imports.pdf_import.transactions_extracted_count", count: import.rows_count) %>
+            <%# rows_count is what is left to import, not what the statement held:
+                anything the account already had was matched and withheld. Calling
+                that number "extracted" under-reports the statement. %>
+            <%= t("imports.pdf_import.transactions_extracted_count", count: import.extracted_count) %>
+            <% if import.reconciled_anything? %>
+              <span class="block mt-1 text-xs text-subdued">
+                <%= t("imports.pdf_import.already_recorded_note", count: import.already_recorded_count) %>
+              </span>
+            <% end %>
           </p>
         </div>
 
@@ -83,6 +91,7 @@
         <% else %>
           <p class="text-center text-sm text-secondary"><%= t("imports.pdf_import.select_account_to_continue") %></p>
         <% end %>
+        <%= render DS::Link.new(text: t("imports.pdf_import.view_summary"), href: summary_import_path(import), variant: "secondary", full_width: true, frame: :modal) %>
         <%= render DS::Link.new(text: t("imports.pdf_import.back_to_imports"), href: imports_path, variant: "secondary", full_width: true) %>
       </div>
 
@@ -132,7 +141,13 @@
 
       <div class="text-center space-y-2">
         <h1 class="font-medium text-primary text-center text-3xl"><%= t("imports.pdf_import.complete_title") %></h1>
-        <p class="text-sm text-secondary"><%= t("imports.pdf_import.complete_description") %></p>
+        <%# A statement whose every line was already on file creates nothing, and
+            the generic description reads as though the import did nothing at all. %>
+        <% if import.imported_count.zero? && import.reconciled_anything? %>
+          <p class="text-sm text-secondary"><%= t("imports.pdf_import.complete_fully_reconciled", count: import.already_recorded_count) %></p>
+        <% else %>
+          <p class="text-sm text-secondary"><%= t("imports.pdf_import.complete_description") %></p>
+        <% end %>
       </div>
 
       <div class="bg-container border border-primary rounded-xl p-4 space-y-4">
@@ -165,7 +180,8 @@
       </div>
 
       <div class="space-y-2 flex flex-col">
-        <%= render DS::Link.new(text: t("imports.pdf_import.back_to_imports"), href: imports_path, variant: "primary", full_width: true) %>
+        <%= render DS::Link.new(text: t("imports.pdf_import.view_summary"), href: summary_import_path(import), variant: "primary", full_width: true, frame: :modal) %>
+        <%= render DS::Link.new(text: t("imports.pdf_import.back_to_imports"), href: imports_path, variant: "secondary", full_width: true) %>
         <%= render DS::Button.new(
               text: t("imports.pdf_import.delete_import"),
               href: import_path(import),

--- a/app/views/imports/summary.html.erb
+++ b/app/views/imports/summary.html.erb
@@ -1,0 +1,61 @@
+<%# Where every transaction the statement listed ended up. Counts are derived
+    from the entries themselves rather than stored on the import, so they stay
+    true if a later sync or edit changes the picture. %>
+<%= render DS::Dialog.new(width: "md") do |dialog| %>
+  <% dialog.with_header(
+       title: t(".title"),
+       subtitle: @import.account.present? ? t(".subtitle", account: @import.account.name) : t(".subtitle_no_account")
+     ) %>
+
+  <% dialog.with_body do %>
+    <div class="space-y-4">
+      <dl class="divide-y divide-alpha-black-200 theme-dark:divide-alpha-white-200 border border-primary rounded-xl overflow-hidden">
+        <div class="flex items-center justify-between gap-4 px-4 py-3">
+          <dt class="text-sm text-secondary"><%= t(".extracted") %></dt>
+          <dd class="text-sm font-medium text-primary tabular-nums"><%= @import.extracted_count %></dd>
+        </div>
+
+        <div class="flex items-center justify-between gap-4 px-4 py-3">
+          <dt class="text-sm text-secondary">
+            <%= t(".already_recorded") %>
+            <span class="block text-xs text-subdued"><%= t(".already_recorded_hint") %></span>
+          </dt>
+          <dd class="text-sm font-medium text-primary tabular-nums"><%= @import.already_recorded_count %></dd>
+        </div>
+
+        <% if @import.imported_count.positive? %>
+          <div class="flex items-center justify-between gap-4 px-4 py-3">
+            <dt class="text-sm text-secondary"><%= t(".imported") %></dt>
+            <dd class="text-sm font-medium text-primary tabular-nums"><%= @import.imported_count %></dd>
+          </div>
+        <% end %>
+
+        <% if @import.awaiting_review_count.positive? %>
+          <div class="flex items-center justify-between gap-4 px-4 py-3">
+            <dt class="text-sm text-secondary"><%= t(".awaiting_review") %></dt>
+            <dd class="text-sm font-medium text-primary tabular-nums"><%= @import.awaiting_review_count %></dd>
+          </div>
+        <% end %>
+      </dl>
+
+      <%# The case this dialog exists for: an import that finished having created
+          nothing looks identical to one that found nothing. %>
+      <% if @import.reconciled_anything? && @import.awaiting_review_count.zero? && @import.imported_count.zero? %>
+        <p class="text-sm text-secondary px-3 py-2 bg-container-inset rounded-lg">
+          <%= t(".fully_reconciled", count: @import.already_recorded_count) %>
+        </p>
+      <% end %>
+
+      <% if @import.account_statement.present? %>
+        <p class="text-xs text-subdued">
+          <%= t(".statement_evidence_html",
+                statement: link_to(@import.account_statement.filename,
+                                   account_statement_path(@import.account_statement),
+                                   class: "text-primary hover:text-primary-hover underline")) %>
+        </p>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% dialog.with_action(cancel_action: true, text: t(".close"), variant: "secondary", full_width: true) %>
+<% end %>

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -283,6 +283,20 @@ en:
       category_icon: "Lucide icon"
       merchant_color: "Color"
       merchant_website: "Website URL"
+    summary:
+      title: "Import summary"
+      subtitle: "What became of each transaction on this statement in %{account}."
+      subtitle_no_account: "What became of each transaction on this statement."
+      extracted: "Found on the statement"
+      already_recorded: "Already recorded"
+      already_recorded_hint: "Matched to a transaction this account already had, and marked reconciled."
+      imported: "Imported as new"
+      awaiting_review: "Waiting to be imported"
+      fully_reconciled:
+        one: "Nothing needed importing — the statement's only transaction was already on file."
+        other: "Nothing needed importing — all %{count} transactions were already on file."
+      statement_evidence_html: "Reconciled against %{statement}."
+      close: "Close"
     update:
       account_saved: "Account saved."
       account_locked: "This import has already been published, so its account can't be changed. Revert it first if you need to import it somewhere else."
@@ -480,7 +494,9 @@ en:
       processing_failed_with_message: "%{message}"
       processing_failed_generic: "Processing failed: %{error}"
       ready_for_review_title: Ready for Review
-      ready_for_review_description: "We extracted %{count} transactions from your statement. Review and publish them to add to your account."
+      ready_for_review_description:
+        one: "%{count} transaction from your statement isn't in this account yet. Review and publish it to add it."
+        other: "%{count} transactions from your statement aren't in this account yet. Review and publish them to add them."
       transactions_extracted: Transactions Extracted
       transactions_extracted_count:
         one: "%{count} transaction"
@@ -495,5 +511,12 @@ en:
         one: "Publish %{count} Transaction"
         other: "Publish %{count} Transactions"
       review_transactions: Review Transactions
+      view_summary: View import summary
+      already_recorded_note:
+        one: "%{count} was already in this account and was matched to the statement."
+        other: "%{count} were already in this account and were matched to the statement."
+      complete_fully_reconciled:
+        one: "Every transaction on this statement was already in your account. %{count} was matched and marked reconciled — nothing needed importing."
+        other: "Every transaction on this statement was already in your account. All %{count} were matched and marked reconciled — nothing needed importing."
       select_account_to_continue: Please select an account above to continue.
       unknown_document_type: Unknown

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -285,6 +285,7 @@ en:
       merchant_website: "Website URL"
     update:
       account_saved: "Account saved."
+      account_locked: "This import has already been published, so its account can't be changed. Revert it first if you need to import it somewhere else."
       invalid_account: "Account not found."
     publish:
       started: "Your import has started in the background."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,6 +434,7 @@ Rails.application.routes.draw do
       put :revert
       put :apply_template
       post :cancel
+      get :summary
     end
 
     resource :upload, only: %i[show update], module: :import

--- a/db/migrate/20260820120000_add_reconciliation_to_entries.rb
+++ b/db/migrate/20260820120000_add_reconciliation_to_entries.rb
@@ -1,4 +1,10 @@
 class AddReconciliationToEntries < ActiveRecord::Migration[7.2]
+  # entries is the largest table in the app, so the indexes are built
+  # concurrently and the check constraint is added unvalidated then validated
+  # separately -- VALIDATE takes only SHARE UPDATE EXCLUSIVE, so neither step
+  # blocks writes for the length of a full scan.
+  disable_ddl_transaction!
+
   # Reconciliation follows the Quicken model of uncleared / cleared / reconciled,
   # but only the last state is stored.
   #
@@ -25,27 +31,31 @@ class AddReconciliationToEntries < ActiveRecord::Migration[7.2]
     add_index :entries,
               :reconciled_by_statement_id,
               where: "reconciled_by_statement_id IS NOT NULL",
-              name: "index_entries_on_reconciled_by_statement"
+              name: "index_entries_on_reconciled_by_statement",
+              algorithm: :concurrently
 
     # Supports the per-account reconciled/unreconciled split the import review
     # screen and the account ledger both need.
     add_index :entries,
               [ :account_id, :reconciled_at ],
               where: "reconciled_at IS NOT NULL",
-              name: "index_entries_on_account_and_reconciled_at"
+              name: "index_entries_on_account_and_reconciled_at",
+              algorithm: :concurrently
 
     # An entry can be reconciled without a statement on file (marked by hand, or
     # the statement was later deleted and the FK nulled), but it can never point
     # at a statement without being reconciled.
     add_check_constraint :entries,
                          "reconciled_by_statement_id IS NULL OR reconciled_at IS NOT NULL",
-                         name: "chk_entries_reconciled_at_present_when_statement_set"
+                         name: "chk_entries_reconciled_at_present_when_statement_set",
+                         validate: false
+    validate_check_constraint :entries, name: "chk_entries_reconciled_at_present_when_statement_set"
   end
 
   def down
     remove_check_constraint :entries, name: "chk_entries_reconciled_at_present_when_statement_set"
-    remove_index :entries, name: "index_entries_on_account_and_reconciled_at"
-    remove_index :entries, name: "index_entries_on_reconciled_by_statement"
+    remove_index :entries, name: "index_entries_on_account_and_reconciled_at", algorithm: :concurrently
+    remove_index :entries, name: "index_entries_on_reconciled_by_statement", algorithm: :concurrently
     remove_reference :entries, :reconciled_by_statement, type: :uuid, foreign_key: { to_table: :account_statements }
     remove_column :entries, :reconciled_at
   end

--- a/db/migrate/20260820120000_add_reconciliation_to_entries.rb
+++ b/db/migrate/20260820120000_add_reconciliation_to_entries.rb
@@ -1,0 +1,52 @@
+class AddReconciliationToEntries < ActiveRecord::Migration[7.2]
+  # Reconciliation follows the Quicken model of uncleared / cleared / reconciled,
+  # but only the last state is stored.
+  #
+  # "Cleared" means the institution acknowledged the transaction, which is
+  # exactly what entries.source and entries.external_id already record — and it
+  # stays accurate on its own, because Account::ProviderImportAdapter stamps both
+  # onto a manually-entered entry when a provider transaction claims it. Storing
+  # a separate flag would duplicate that truth and let it drift.
+  #
+  # "Reconciled" means a specific statement was matched against the transaction.
+  # Nothing in the schema can derive that, so it is recorded here.
+  def up
+    add_column :entries, :reconciled_at, :datetime, null: true
+
+    add_reference :entries,
+                  :reconciled_by_statement,
+                  type: :uuid,
+                  null: true,
+                  index: false,
+                  foreign_key: { to_table: :account_statements, on_delete: :nullify }
+
+    # Supports "what has this statement reconciled?" when unwinding a statement,
+    # and is narrow because the reconciled rows are a small slice of entries.
+    add_index :entries,
+              :reconciled_by_statement_id,
+              where: "reconciled_by_statement_id IS NOT NULL",
+              name: "index_entries_on_reconciled_by_statement"
+
+    # Supports the per-account reconciled/unreconciled split the import review
+    # screen and the account ledger both need.
+    add_index :entries,
+              [ :account_id, :reconciled_at ],
+              where: "reconciled_at IS NOT NULL",
+              name: "index_entries_on_account_and_reconciled_at"
+
+    # An entry can be reconciled without a statement on file (marked by hand, or
+    # the statement was later deleted and the FK nulled), but it can never point
+    # at a statement without being reconciled.
+    add_check_constraint :entries,
+                         "reconciled_by_statement_id IS NULL OR reconciled_at IS NOT NULL",
+                         name: "chk_entries_reconciled_at_present_when_statement_set"
+  end
+
+  def down
+    remove_check_constraint :entries, name: "chk_entries_reconciled_at_present_when_statement_set"
+    remove_index :entries, name: "index_entries_on_account_and_reconciled_at"
+    remove_index :entries, name: "index_entries_on_reconciled_by_statement"
+    remove_reference :entries, :reconciled_by_statement, type: :uuid, foreign_key: { to_table: :account_statements }
+    remove_column :entries, :reconciled_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_18_060353) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -656,6 +656,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_18_060353) do
     t.boolean "user_modified", default: false, null: false
     t.boolean "import_locked", default: false, null: false
     t.uuid "parent_entry_id"
+    t.datetime "reconciled_at"
+    t.uuid "reconciled_by_statement_id"
     t.index "lower((name)::text)", name: "index_entries_on_lower_name"
     t.index ["account_id", "date", "entryable_id"], name: "index_entries_on_investment_totals_lookup", where: "(((entryable_type)::text = 'Trade'::text) AND (excluded = false))"
     t.index ["account_id", "date"], name: "index_entries_on_account_id_and_date"
@@ -668,6 +670,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_18_060353) do
     t.index ["import_locked"], name: "index_entries_on_import_locked_true", where: "(import_locked = true)"
     t.index ["parent_entry_id"], name: "index_entries_on_parent_entry_id"
     t.index ["user_modified"], name: "index_entries_on_user_modified_true", where: "(user_modified = true)"
+    t.index ["account_id", "reconciled_at"], name: "index_entries_on_account_and_reconciled_at", where: "(reconciled_at IS NOT NULL)"
+    t.index ["reconciled_by_statement_id"], name: "index_entries_on_reconciled_by_statement", where: "(reconciled_by_statement_id IS NOT NULL)"
+    t.check_constraint "reconciled_by_statement_id IS NULL OR reconciled_at IS NOT NULL", name: "chk_entries_reconciled_at_present_when_statement_set"
   end
 
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -2376,6 +2381,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_18_060353) do
   add_foreign_key "debug_log_entries", "users", on_delete: :nullify
   add_foreign_key "enable_banking_accounts", "enable_banking_items"
   add_foreign_key "enable_banking_items", "families"
+  add_foreign_key "entries", "account_statements", column: "reconciled_by_statement_id", on_delete: :nullify
   add_foreign_key "entries", "accounts", on_delete: :cascade
   add_foreign_key "entries", "entries", column: "parent_entry_id", on_delete: :cascade
   add_foreign_key "entries", "imports"

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -113,6 +113,19 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t("imports.create.document_uploaded"), flash[:notice]
   end
 
+  test "summary renders the import outcome for a pdf import" do
+    get summary_import_url(imports(:pdf_with_rows))
+
+    assert_response :success
+    assert_select "dialog"
+  end
+
+  test "summary is not available for non-pdf imports" do
+    get summary_import_url(imports(:transaction))
+
+    assert_response :not_found
+  end
+
   test "uploads pdf document as PdfImport when using DocumentImport option" do
     adapter = mock("vector_store_adapter")
     adapter.stubs(:supported_extensions).returns(%w[.pdf .txt])

--- a/test/models/account/provider_import_adapter_statement_test.rb
+++ b/test/models/account/provider_import_adapter_statement_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+# Covers the two options find_duplicate_transaction grew for statement imports:
+# seeing provider-sourced entries, and tolerating a small date difference.
+class Account::ProviderImportAdapterStatementTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @account = accounts(:depository)
+    @adapter = Account::ProviderImportAdapter.new(@account)
+    @date = Date.current
+  end
+
+  test "provider-synced entries stay invisible by default" do
+    create_transaction(account: @account, date: @date, amount: 50, external_id: "plaid-1", source: "plaid")
+
+    assert_nil @adapter.find_duplicate_transaction(date: @date, amount: 50, currency: "USD")
+  end
+
+  test "provider-synced entries are found when the caller opts in" do
+    synced = create_transaction(account: @account, date: @date, amount: 50, external_id: "plaid-1", source: "plaid")
+
+    found = @adapter.find_duplicate_transaction(
+      date: @date, amount: 50, currency: "USD", include_provider_entries: true
+    )
+
+    assert_equal synced, found
+  end
+
+  test "manual entries are still found when opting in" do
+    manual = create_transaction(account: @account, date: @date, amount: 50)
+
+    found = @adapter.find_duplicate_transaction(
+      date: @date, amount: 50, currency: "USD", include_provider_entries: true
+    )
+
+    assert_equal manual, found
+  end
+
+  test "an exact-date search ignores neighbouring dates" do
+    create_transaction(account: @account, date: @date - 2, amount: 50)
+
+    assert_nil @adapter.find_duplicate_transaction(date: @date, amount: 50, currency: "USD")
+  end
+
+  test "a windowed search finds a nearby date" do
+    nearby = create_transaction(account: @account, date: @date - 2, amount: 50)
+
+    found = @adapter.find_duplicate_transaction(date: @date, amount: 50, currency: "USD", date_window: 3)
+
+    assert_equal nearby, found
+  end
+
+  test "a windowed search prefers the closest date" do
+    create_transaction(account: @account, date: @date - 3, amount: 50, name: "Far")
+    closest = create_transaction(account: @account, date: @date + 1, amount: 50, name: "Near")
+
+    found = @adapter.find_duplicate_transaction(date: @date, amount: 50, currency: "USD", date_window: 3)
+
+    assert_equal closest, found
+  end
+
+  test "a windowed search still respects the window edge" do
+    create_transaction(account: @account, date: @date - 5, amount: 50)
+
+    assert_nil @adapter.find_duplicate_transaction(date: @date, amount: 50, currency: "USD", date_window: 3)
+  end
+
+  test "amount and currency still have to match exactly" do
+    create_transaction(account: @account, date: @date, amount: 50)
+
+    assert_nil @adapter.find_duplicate_transaction(date: @date, amount: 51, currency: "USD", date_window: 3)
+    assert_nil @adapter.find_duplicate_transaction(date: @date, amount: 50, currency: "EUR", date_window: 3)
+  end
+
+  test "already-claimed entries are excluded" do
+    first = create_transaction(account: @account, date: @date, amount: 50)
+    second = create_transaction(account: @account, date: @date, amount: 50)
+
+    found = @adapter.find_duplicate_transaction(
+      date: @date, amount: 50, currency: "USD", date_window: 3, exclude_entry_ids: [ first.id ]
+    )
+
+    assert_equal second, found
+  end
+end

--- a/test/models/entry_reconciliation_test.rb
+++ b/test/models/entry_reconciliation_test.rb
@@ -50,6 +50,16 @@ class EntryReconciliationTest < ActiveSupport::TestCase
     assert_nil entry.reconciled_by_statement_id
   end
 
+  test "an entry cannot cite a statement without being reconciled" do
+    entry = create_transaction(account: @account)
+    entry.reconciled_by_statement = @statement
+
+    # Mirrors chk_entries_reconciled_at_present_when_statement_set: the model
+    # rejects it before the database constraint is reached.
+    assert_not entry.valid?
+    assert_predicate entry.errors[:reconciled_at], :any?
+  end
+
   test "scopes partition reconciled from unreconciled" do
     reconciled = create_transaction(account: @account)
     unreconciled = create_transaction(account: @account)

--- a/test/models/entry_reconciliation_test.rb
+++ b/test/models/entry_reconciliation_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class EntryReconciliationTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @account = accounts(:depository)
+    @statement = create_statement
+  end
+
+  test "an entry with no provenance is uncleared" do
+    entry = create_transaction(account: @account)
+
+    assert_equal :uncleared, entry.reconciliation_state
+    assert_not entry.cleared?
+    assert_not entry.reconciled?
+  end
+
+  test "an entry carrying provider provenance is cleared without storing a flag" do
+    from_external_id = create_transaction(account: @account, external_id: "plaid-1")
+    from_source = create_transaction(account: @account, source: "simplefin")
+
+    assert_equal :cleared, from_external_id.reconciliation_state
+    assert_equal :cleared, from_source.reconciliation_state
+  end
+
+  test "reconciled outranks cleared" do
+    entry = create_transaction(account: @account, source: "plaid")
+    entry.mark_reconciled!(statement: @statement)
+
+    assert_equal :reconciled, entry.reload.reconciliation_state
+    assert_equal @statement, entry.reconciled_by_statement
+  end
+
+  test "reconciling is reversible but clearing is not affected by it" do
+    entry = create_transaction(account: @account, source: "plaid")
+    entry.mark_reconciled!(statement: @statement)
+    entry.unmark_reconciled!
+
+    assert_equal :cleared, entry.reload.reconciliation_state
+    assert_nil entry.reconciled_at
+    assert_nil entry.reconciled_by_statement_id
+  end
+
+  test "an entry can be reconciled by hand with no statement on file" do
+    entry = create_transaction(account: @account)
+    entry.mark_reconciled!
+
+    assert entry.reload.reconciled?
+    assert_nil entry.reconciled_by_statement_id
+  end
+
+  test "scopes partition reconciled from unreconciled" do
+    reconciled = create_transaction(account: @account)
+    unreconciled = create_transaction(account: @account)
+    reconciled.mark_reconciled!(statement: @statement)
+
+    assert_includes Entry.reconciled, reconciled
+    assert_not_includes Entry.reconciled, unreconciled
+    assert_includes Entry.unreconciled, unreconciled
+    assert_includes Entry.reconciled_by(@statement), reconciled
+  end
+
+  test "deleting the statement leaves the entry reconciled but unevidenced" do
+    entry = create_transaction(account: @account)
+    entry.mark_reconciled!(statement: @statement)
+
+    @statement.destroy!
+
+    entry.reload
+    assert entry.reconciled?, "reconciliation should survive losing the evidence"
+    assert_nil entry.reconciled_by_statement_id
+  end
+
+  private
+
+    def create_statement(account: @account, filename: "statement.pdf")
+      AccountStatement.create_from_upload!(
+        family: account.family,
+        account: account,
+        file: uploaded_file(
+          filename: filename,
+          content_type: "application/pdf",
+          content: file_fixture("imports/sample_bank_statement.pdf").binread
+        )
+      )
+    end
+end

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -193,6 +193,37 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
     assert_equal @import.id, logged.metadata["import_id"]
   end
 
+  test "regenerating rows twice does not collide on source row numbers" do
+    # insert_all! leaves the rows association stale, so a second generation on
+    # the same in-memory record used to re-insert source_row_number 1.
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -12, name: "Bookstore") ] })
+
+    @import.generate_rows_from_extracted_data
+    @import.generate_rows_from_extracted_data
+
+    assert_equal 1, @import.reload.rows_count
+    assert_equal 1, @import.rows.count
+  end
+
+  test "releasing reconciliations leaves another account's evidence intact" do
+    other = @family.accounts.create!(
+      name: "Sibling Checking", balance: 0, currency: "USD", accountable: Depository.new
+    )
+    # Same statement, evidence recorded against a second account by another import.
+    on_other = create_transaction(account: other, date: @date, amount: 99, name: "Elsewhere")
+    on_other.mark_reconciled!(statement: @statement)
+
+    on_first = create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    assert on_first.reload.reconciled?
+
+    @import.assign_account!(other)
+
+    assert_not on_first.reload.reconciled?, "the account being left is released"
+    assert on_other.reload.reconciled?, "another account's evidence must survive"
+  end
+
   private
 
     def create_statement

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -131,6 +131,68 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
     assert_equal "Coffee", @import.extracted_transactions.first["name"]
   end
 
+  test "publishing does not re-match a row against an entry row generation already consumed" do
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+
+    # Two identical statement lines, one existing transaction: the first line
+    # reconciles against it, the second is genuinely new and must be created.
+    @import.update!(extracted_data: { "transactions" => [
+      extracted(date: @date, amount: -50, name: "Coffee"),
+      extracted(date: @date, amount: -50, name: "Coffee")
+    ] })
+    @import.generate_rows_from_extracted_data
+    assert_equal 1, @import.reload.rows_count
+
+    assert_difference -> { @account.entries.count }, 1 do
+      @import.import!
+    end
+  end
+
+  test "assigning an account that reconciles every row completes the import" do
+    @import.update!(account: nil, status: :pending)
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    assert_equal 1, @import.reload.rows_count, "nothing matches while no account is assigned"
+
+    @import.assign_account!(@account)
+
+    @import.reload
+    assert_equal 0, @import.rows_count
+    assert @import.complete?, "a fully reconciled import must finish rather than sit at pending with no rows"
+  end
+
+  test "assigning an account that matches nothing returns the import to pending" do
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    @import.update!(status: :complete)
+
+    other = @family.accounts.create!(
+      name: "Untouched Checking", balance: 0, currency: "USD", accountable: Depository.new
+    )
+    @import.assign_account!(other)
+
+    @import.reload
+    assert_equal 1, @import.rows_count
+    assert @import.pending?
+  end
+
+  test "a row that cannot be evaluated is recorded in the debug log" do
+    @import.update!(extracted_data: { "transactions" => [
+      { "date" => "not-a-date", "amount" => "-50", "name" => "Mystery" }
+    ] })
+
+    assert_difference "DebugLogEntry.count", 1 do
+      @import.generate_rows_from_extracted_data
+    end
+
+    logged = DebugLogEntry.last
+    assert_equal "import", logged.category
+    assert_equal @family, logged.family
+    assert_equal @import.id, logged.metadata["import_id"]
+  end
+
   private
 
     def create_statement

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -120,7 +120,7 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
     provider = mock("llm_provider")
     Provider::Registry.stubs(:preferred_llm_provider).returns(provider)
     provider.stubs(:extract_bank_statement).returns(
-      stub(success?: true, data: { transactions: [ { date: @date.to_s, amount: "-5.0", name: "Coffee" } ] })
+      OpenStruct.new(success?: true, data: { transactions: [ { date: @date.to_s, amount: "-5.0", name: "Coffee" } ] })
     )
     @import.stubs(:pdf_file_content).returns("fake-pdf")
 

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -331,6 +331,62 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
     assert_equal @account, @import.reload.account
   end
 
+  test "the outcome counts separate what was already recorded from what is new" do
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+    @import.update!(extracted_data: { "transactions" => [
+      extracted(date: @date, amount: -50, name: "Coffee"),
+      extracted(date: @date, amount: -12, name: "Bookstore")
+    ] })
+    @import.generate_rows_from_extracted_data
+    @import.reload
+
+    assert_equal 2, @import.extracted_count
+    assert_equal 1, @import.already_recorded_count
+    assert_equal 0, @import.imported_count
+    assert_equal 1, @import.awaiting_review_count
+    assert @import.reconciled_anything?
+  end
+
+  test "publishing moves the offered rows into the imported count" do
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+    @import.update!(extracted_data: { "transactions" => [
+      extracted(date: @date, amount: -50, name: "Coffee"),
+      extracted(date: @date, amount: -12, name: "Bookstore")
+    ] })
+    @import.generate_rows_from_extracted_data
+    @import.import!
+    @import.reload
+
+    # Entries this import created are born reconciled too, so they must not be
+    # counted as transactions the account already had.
+    assert_equal 1, @import.already_recorded_count
+    assert_equal 1, @import.imported_count
+    # Rows survive publishing as the record of what was written, so the count
+    # has to stop describing them as a queue.
+    assert_equal 0, @import.awaiting_review_count
+  end
+
+  test "a fully reconciled statement reports everything as already recorded" do
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    @import.reload
+
+    assert_equal 1, @import.extracted_count
+    assert_equal 1, @import.already_recorded_count
+    assert_equal 0, @import.imported_count
+    assert_equal 0, @import.awaiting_review_count
+  end
+
+  test "an import that matched nothing reports nothing as already recorded" do
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -12, name: "Bookstore") ] })
+    @import.generate_rows_from_extracted_data
+    @import.reload
+
+    assert_equal 0, @import.already_recorded_count
+    assert_not @import.reconciled_anything?
+  end
+
   private
 
     def create_statement

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -234,8 +234,15 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
 
     @import.assign_account!(other)
 
-    assert_not on_first.reload.reconciled?, "the account being left is released"
-    assert on_other.reload.reconciled?, "another account's evidence must survive"
+    # Both fields matter: reconciled_at is the state, reconciled_by_statement_id
+    # is the evidence, and Entry#unmark_reconciled! clears the pair.
+    on_first.reload
+    assert_not on_first.reconciled?, "the account being left is released"
+    assert_nil on_first.reconciled_by_statement_id, "its statement evidence is cleared too"
+
+    on_other.reload
+    assert on_other.reconciled?, "another account's evidence must survive"
+    assert_equal @statement.id, on_other.reconciled_by_statement_id
   end
 
   private

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -100,6 +100,20 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
     assert_equal 1, @import.reload.rows_count
   end
 
+  test "a row whose amount cannot be parsed is offered with its raw value intact" do
+    @import.update!(extracted_data: { "transactions" => [
+      { "date" => @date.to_s, "amount" => "not-a-number", "name" => "Mystery" }
+    ] })
+
+    @import.generate_rows_from_extracted_data
+
+    row = @import.reload.rows.sole
+    assert_equal 1, @import.rows_count
+    # Stored verbatim rather than coerced to 0, so the review step shows the user
+    # what the statement actually said.
+    assert_equal "not-a-number", row.amount
+  end
+
   test "reassigning the account re-judges the rows and releases the old reconciliation" do
     other = @family.accounts.create!(
       name: "Second Checking", balance: 0, currency: "USD", accountable: Depository.new

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -1,0 +1,147 @@
+require "test_helper"
+
+# The behaviour issue #1379 actually asked for: a statement should only offer
+# transactions that are not already recorded, and should mark the rest reconciled.
+class PdfImportReconciliationTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @account = accounts(:depository)
+    @family = @account.family
+    @statement = create_statement
+    @import = PdfImport.create_from_statement!(statement: @statement)
+    @import.update!(document_type: "bank_statement")
+    @date = Date.current
+  end
+
+  # Extractor convention: negative for debits, positive for credits. Import
+  # signage ("inflows_positive") flips that into Entry convention, where an
+  # expense is positive.
+  def extracted(date:, amount:, name:)
+    { "date" => date.to_s, "amount" => amount.to_s, "name" => name }
+  end
+
+  test "rows are only generated for transactions that are not already recorded" do
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+
+    @import.update!(extracted_data: { "transactions" => [
+      extracted(date: @date, amount: -50, name: "COFFEE SHOP"),
+      extracted(date: @date, amount: -12, name: "BOOKSTORE")
+    ] })
+
+    @import.generate_rows_from_extracted_data
+
+    assert_equal 1, @import.reload.rows_count
+    assert_equal "BOOKSTORE", @import.rows.sole.name
+  end
+
+  test "the already-recorded transaction is marked reconciled against the statement" do
+    existing = create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "COFFEE SHOP") ] })
+    @import.generate_rows_from_extracted_data
+
+    existing.reload
+    assert_equal :reconciled, existing.reconciliation_state
+    assert_equal @statement, existing.reconciled_by_statement
+    assert_equal [ existing ], @import.reconciled_entries.to_a
+  end
+
+  test "a provider-synced transaction counts as already recorded" do
+    synced = create_transaction(
+      account: @account, date: @date, amount: 50, name: "COFFEE", external_id: "plaid-1", source: "plaid"
+    )
+
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee Shop") ] })
+    @import.generate_rows_from_extracted_data
+
+    assert_equal 0, @import.reload.rows_count
+    assert_equal :reconciled, synced.reload.reconciliation_state
+  end
+
+  test "a statement date a day or two off the recorded date still matches" do
+    create_transaction(account: @account, date: @date - 2, amount: 50, name: "Coffee")
+
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+
+    assert_equal 0, @import.reload.rows_count
+  end
+
+  test "two identical statement lines do not both match one recorded transaction" do
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+
+    @import.update!(extracted_data: { "transactions" => [
+      extracted(date: @date, amount: -50, name: "Coffee"),
+      extracted(date: @date, amount: -50, name: "Coffee")
+    ] })
+    @import.generate_rows_from_extracted_data
+
+    assert_equal 1, @import.reload.rows_count, "the second identical line is genuinely new"
+  end
+
+  test "with no account assigned every transaction is offered" do
+    @import.update!(account: nil)
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+
+    assert_equal 1, @import.reload.rows_count
+  end
+
+  test "a row whose date cannot be parsed is offered rather than dropped" do
+    @import.update!(extracted_data: { "transactions" => [
+      { "date" => "not-a-date", "amount" => "-50", "name" => "Mystery" }
+    ] })
+
+    @import.generate_rows_from_extracted_data
+
+    assert_equal 1, @import.reload.rows_count
+  end
+
+  test "reassigning the account re-judges the rows and releases the old reconciliation" do
+    other = @family.accounts.create!(
+      name: "Second Checking", balance: 0, currency: "USD", accountable: Depository.new
+    )
+    on_first = create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    assert_equal 0, @import.reload.rows_count
+
+    @import.assign_account!(other)
+
+    assert_not on_first.reload.reconciled?, "the old account's entry is no longer evidence-backed"
+    assert_equal 1, @import.reload.rows_count, "nothing on the new account matches, so it is offered"
+  end
+
+  test "extract_transactions stores string keys so rows can actually be generated" do
+    provider = mock("llm_provider")
+    Provider::Registry.stubs(:preferred_llm_provider).returns(provider)
+    provider.stubs(:extract_bank_statement).returns(
+      stub(success?: true, data: { transactions: [ { date: @date.to_s, amount: "-5.0", name: "Coffee" } ] })
+    )
+    @import.stubs(:pdf_file_content).returns("fake-pdf")
+
+    @import.extract_transactions
+
+    # Without deep_stringify_keys this reads back empty and no rows are built.
+    assert_equal 1, @import.extracted_transactions.size
+    assert_equal "Coffee", @import.extracted_transactions.first["name"]
+  end
+
+  private
+
+    def create_statement
+      AccountStatement.create_from_upload!(
+        family: @family,
+        account: @account,
+        file: uploaded_file(
+          filename: "statement.pdf",
+          content_type: "application/pdf",
+          content: file_fixture("imports/sample_bank_statement.pdf").binread
+        )
+      )
+    end
+end

--- a/test/models/pdf_import_reconciliation_test.rb
+++ b/test/models/pdf_import_reconciliation_test.rb
@@ -185,7 +185,8 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
     other = @family.accounts.create!(
       name: "Untouched Checking", balance: 0, currency: "USD", accountable: Depository.new
     )
-    @import.assign_account!(other)
+    # complete but nothing of its own committed: still the user's to re-target.
+    assert @import.assign_account!(other)
 
     @import.reload
     assert_equal 1, @import.rows_count
@@ -243,6 +244,91 @@ class PdfImportReconciliationTest < ActiveSupport::TestCase
     on_other.reload
     assert on_other.reconciled?, "another account's evidence must survive"
     assert_equal @statement.id, on_other.reconciled_by_statement_id
+  end
+
+  test "reverting a fully reconciled import completes it rather than stranding it at pending" do
+    create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    @import.update!(status: :complete)
+    assert_equal 0, @import.reload.rows_count
+
+    @import.revert
+
+    @import.reload
+    assert_nil @import.error
+    # pending with no rows renders the processing screen with no way back out.
+    assert @import.complete?, "expected complete, got #{@import.status}"
+    assert_equal 0, @import.rows_count
+  end
+
+  test "reverting an import puts the transactions it created back on offer" do
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    assert_equal 1, @import.reload.rows_count
+
+    assert_difference -> { @account.entries.count }, 1 do
+      @import.import!
+    end
+    @import.update!(status: :complete)
+
+    assert_difference -> { @account.entries.count }, -1 do
+      @import.revert
+    end
+
+    @import.reload
+    assert @import.pending?, "expected pending, got #{@import.status}"
+    assert_equal 1, @import.rows_count, "the created entry is gone, so its statement line is new again"
+  end
+
+  test "reverting releases evidence from an entry the statement no longer matches" do
+    drifted = create_transaction(account: @account, date: @date, amount: 50, name: "Coffee")
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    assert drifted.reload.reconciled?
+    @import.update!(status: :complete)
+
+    # Corrected after the fact, so the statement line no longer describes it.
+    drifted.update!(amount: 75)
+
+    @import.revert
+
+    drifted.reload
+    assert_not drifted.reconciled?, "a statement that no longer matches must stop claiming the entry"
+    assert_nil drifted.reconciled_by_statement_id
+    assert_equal 1, @import.reload.rows_count
+    assert @import.pending?, "expected pending, got #{@import.status}"
+  end
+
+  test "reassigning a published import is refused rather than half-unwinding it" do
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    @import.import!
+    @import.update!(status: :complete)
+
+    other = @family.accounts.create!(
+      name: "Wrong Turn Checking", balance: 0, currency: "USD", accountable: Depository.new
+    )
+
+    assert_not @import.assign_account!(other), "a replayed PATCH must not unwind a published import"
+
+    @import.reload
+    assert_equal @account, @import.account
+    assert_equal 1, @import.rows_count, "the rows recording what was published survive"
+    assert_equal 1, @import.entries.count
+  end
+
+  test "reassigning is refused while a job still owns the record" do
+    @import.update!(extracted_data: { "transactions" => [ extracted(date: @date, amount: -50, name: "Coffee") ] })
+    @import.generate_rows_from_extracted_data
+    @import.update!(status: :importing)
+
+    other = @family.accounts.create!(
+      name: "Mid Flight Checking", balance: 0, currency: "USD", accountable: Depository.new
+    )
+
+    assert_not @import.assign_account!(other)
+    assert_equal @account, @import.reload.account
   end
 
   private


### PR DESCRIPTION
Supersedes #1382 (closed, with the reasoning [there](https://github.com/we-promise/sure/pull/1382#issuecomment-5363340580)). Refs #1379.

## The problem

When a statement is uploaded for an account whose transactions have already arrived — by sync or by hand — the import has no idea. `TransactionImport#import!` deduplicates CSV rows via `Account::ProviderImportAdapter`; `PdfImport#import!` overrode `import!` and called it **zero** times, building one `Transaction` per row unconditionally. It was the only import path in the repo without duplicate protection.

#1382 approached this by having the LLM compare whole-statement totals. That is all-or-nothing: with 18 of 20 transactions already synced the totals disagree, the import proceeds, and 18 duplicates are created. The only case it helps is the one where nothing needed importing. Partial overlap is the normal case.

## What this does

Matches each extracted transaction against what the account already holds, at row-generation time. **Only genuinely new transactions are ever offered for import**; the rest are marked reconciled against the statement.

### Reconciliation state

Follows Quicken&#39;s uncleared / cleared / reconciled, but only the last state is stored.

**Cleared** — the institution acknowledged it. That is already exactly what `entries.source` / `entries.external_id` record, so it is derived, not stored. It stays accurate on its own: the adapter stamps both onto a manual entry when a provider transaction claims it (`provider_import_adapter.rb:98-99`), so a hand-entered transaction that later shows up in a download becomes cleared with no extra bookkeeping. Deriving it also keeps it non-editable, which is right — it is a fact about provenance, not an opinion.

**Reconciled** — a statement was matched against it. Nothing can derive that, so `entries` gains `reconciled_at` and `reconciled_by_statement_id`. It is a judgement, so it can be set and unset, and it survives the statement being deleted (FK nullifies, timestamp stays).

`Entry#reconciliation_state` returns `:uncleared | :cleared | :reconciled` — which maps straight back to blank / `c` / `R` if a QIF export ever wants it.

### Matching

- `find_duplicate_transaction` grows `include_provider_entries`. **This is what makes it work for `Provider`-backed accounts** — the existing `where(external_id: nil)` filter hid synced transactions from every import path, so this gap affected CSV imports equally. Default stays `false`: provider sync must not claim another provider&#39;s entry.
- It also grows `date_window`, because a statement&#39;s posting date routinely differs by a day or two from what a provider recorded. Nearest date wins.
- Name is deliberately **not** matched on — statement descriptions and provider names for the same transaction rarely agree. The adapter makes the same choice for sync.
- Candidates are built as real `Import::Row` objects so matching uses the same `signed_amount` / `date_iso` the import itself would write, rather than a second interpretation of signage that could drift.
- Matching is per-account: with no account assigned every row is offered and re-judged on assignment. Reassigning also releases the previous account&#39;s reconciliations.
- A row whose date or amount will not parse is **offered for import rather than dropped**, so nothing disappears silently.
- `import!` re-checks at publish, since a sync can land between review and publish. New transactions are born reconciled — the statement is their evidence.

### Provider-backed accounts

Now offered in the import target picker. The `.manual`-only restriction existed because importing into a synced account would duplicate what sync brought in, which is precisely what this removes.

### Showing the outcome

Matching silently withholds rows, which made the import's result unreadable: a statement whose lines were all already on file finishes with `rows_count: 0` on the generic "Document analyzed" screen, indistinguishable from a statement nothing could be extracted from. Two counts were also actively wrong — the ready-for-review screen labelled `rows_count` as "Transactions Extracted", so a 20-line statement against an account already holding 18 of them read *"2 transactions extracted"*.

`GET /imports/:id/summary` now renders a dialog breaking the statement into what was found, what was already recorded, what was imported, and what is still waiting, linked from both the ready-for-review and complete screens. The complete screen explains a fully-reconciled import rather than claiming to have found something, and the extracted count reports the statement's real size with the matched count beside it.

The counts are derived from the entries, not stored, so they stay true if a later sync or edit changes the picture. Two need care: entries this import creates are *born* reconciled, so `already_recorded_count` excludes them or it double-counts what the account genuinely already had; and publishing does not destroy rows — they remain as the record of what was written — so `awaiting_review_count` reports zero once the data is committed rather than repeating `rows_count`.

### Revert and reassignment

Reconciliation is state this import owns, so both paths have to unwind it.

`Import#revert` gained two subclass hooks — `revert_derived_state!` and `status_after_revert`, base behavior unchanged. `PdfImport` releases the statement&#39;s reconciliations, re-judges every extracted line against what the account holds *now*, and ends as `complete` when nothing is left to offer: `pending` with zero rows renders the processing screen with no way back out. Without this, reverting left pre-existing entries permanently flagged against a statement whose import had gone back to `pending`.

`assign_account!` now takes the row lock and refuses — returning `false`, with the controller explaining rather than reporting a save that did not happen — when the import has committed data or a job owns the record. A back-button or replayed PATCH could otherwise release the old account&#39;s reconciliations and rebuild the row set of an already-published import. An import that merely reconciled every line is still re-targetable: it is `complete`, but committed nothing of its own.

## Separate bug fixed

`extract_transactions` stored the extractor&#39;s **symbol**-keyed hash while every reader digs with **strings**. jsonb keeps the hash as assigned until reload and `ProcessPdfJob` never reloads, so `has_extracted_transactions?` was false and **PDF imports generated zero rows**. Existing tests missed it — one uses a YAML fixture (string keys), the other stubs the extractor with string keys. Present on `main` today, independent of reconciliation.

## Also included

`AccountStatement::AccountMatcher` gains a hint-based class-level entry point so callers without an `AccountStatement` row score against the same rules, and it now refuses to guess between equally-confident candidates instead of letting `max_by` take whichever the scan reached first. Account names are not unique within a family, so that tie was reachable. The instance path used by `assign_account_match` is unchanged.

## Testing

Three new test files: `entry_reconciliation_test.rb`, `account/provider_import_adapter_statement_test.rb`, `pdf_import_reconciliation_test.rb`.

**CI is green on `14796ea`** — full unit suite, system tests, rubocop, erb_lint, brakeman and the JS checks.

### The migration has now been run

The earlier warning here — that `db:migrate` had never been executed — is resolved. CI prepares its database with `db:schema:load` (`ci.yml:128,179`), so green CI alone would only prove `schema.rb` loads, not that `AddReconciliationToEntries` reproduces it. That was verified separately, against a real Postgres:

1. Database **A**: the PR base `schema.rb` loaded, then `db:migrate` run — all six DDL steps executed, including both `algorithm: :concurrently` indexes and the `add_check_constraint(validate: false)` + `validate_check_constraint` pair.
2. Database **B**: the checked-in `schema.rb` loaded directly.
3. `pg_dump --schema-only` of both compared.

**The full-database catalogs are byte-identical**, the only differences being pg_dump's per-invocation `\restrict` / `\unrestrict` nonce tokens. `db:rollback` also reverts cleanly.

⚠️ **One thing to expect if you run `db:migrate` yourself**, unrelated to this PR: the checked-in `db/schema.rb` declares `ActiveRecord::Schema[7.2]` while `Gemfile.lock` pins Rails 8.1.3.1. It is stale from an upgrade, so a fresh dump reformats ~1,600 lines across the whole file (column reordering, `plpgsql` → `pg_catalog.plpgsql`). None of that is caused by this migration — it is pre-existing drift that the first person to regenerate the schema will surface.

## Known follow-ups

- **Ledger indicator** — `reconciliation_state` still has no per-transaction UI; a transaction gives no sign of whether anything has confirmed it. Filed as #3119 for design, since whether `cleared` deserves a marker at all (it is near-universal in a synced account) and whether users may reconcile by hand are product questions, not mechanical ones.
- Multi-account statements (a combined checking + credit card PDF) remain unhandled: `Import` has one `account_id` and writes every row to it.
- `AccountMatcher` scores `account_last4_hint` against `account.name` / `institution_name` only; `Account` has no mask field, so last-4 matching needs `plaid_accounts.mask` surfaced to be genuinely useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvWSJotDiqP6qSR7qEiC8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvWSJotDiqP6qSR7qEiC8Q)_


## Summary by CodeRabbit

* **New Features**
  * PDF imports now match extracted transactions with existing records, including provider-sourced transactions and nearby dates.
  * Matched transactions retain statement reconciliation details and can be reviewed through reconciliation status.
  * PDF imports can be reassigned across accessible accounts when eligible.
  * Account matching now uses confidence-based hints and avoids ambiguous matches.
  * An import summary dialog reports what was found, already recorded, imported, and still waiting.

* **Bug Fixes**
  * Reverting or changing imports correctly releases outdated reconciliation links.
  * Published or in-progress imports cannot be reassigned; clear guidance is provided.
  * Import screens no longer report the unmatched row count as the number of transactions extracted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PDF imports now reconcile extracted transactions with existing account activity, including provider-synced entries and nearby transaction dates.
  - Added import summaries showing extracted, imported, already recorded, reconciled, and review-required counts.
  - Added links to summaries and associated account statements.
- **Bug Fixes**
  - Improved duplicate detection, reconciliation tracking, and reversal behavior.
  - Invalid dates or amounts remain importable with warnings for review.
  - Account reassignment is protected when imports cannot safely be changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->