### PR TITLE
fix: support DD/MM/YY date format for CSV imports

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -57,6 +57,14 @@ class Import < ApplicationRecord
     "1,234"    => { separator: "",  delimiter: "," }   # Zero-decimal currencies like JPY
   }.freeze
 
+  # 2-digit years are ambiguous (Ruby's %y assumes 1969-2068), so this is kept
+  # out of Family::DATE_FORMATS (the global preference) and only offered when
+  # mapping a CSV file, where the user can see and verify a preview against
+  # their own data (maintainer decision on PR #531).
+  CSV_ONLY_DATE_FORMATS = [
+    [ "DD/MM/YY", "%d/%m/%y" ]
+  ].freeze
+
   def self.reasonable_date_range
     Date.new(1970, 1, 1)..Date.today.next_year(5)
   end

--- a/app/views/import/configurations/_account_import.html.erb
+++ b/app/views/import/configurations/_account_import.html.erb
@@ -9,7 +9,7 @@
   <div class="flex items-center gap-4">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: t(".leave_empty"), label: t(".balance_date") } %>
     <%= form.select :date_format,
-                    Family::DATE_FORMATS,
+                    Family::DATE_FORMATS + Import::CSV_ONLY_DATE_FORMATS,
                     { label: t(".date_format"), prompt: t(".select_format") },
                     required: @import.date_col_label.present? %>
   </div>

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -22,7 +22,7 @@
                     { label: t(".date_label"), prompt: t(".select_column") },
                     required: true %>
     <%= form.select :date_format,
-                    Family::DATE_FORMATS,
+                    Family::DATE_FORMATS + Import::CSV_ONLY_DATE_FORMATS,
                     { label: t(".date_format_label"), prompt: t(".select_format") },
                     required: true %>
   </div>

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -199,4 +199,19 @@ class ImportTest < ActiveSupport::TestCase
 
     assert_equal "failed", stuck.reload.status
   end
+
+  test "CSV-only date formats are not offered as a global family preference" do
+    # 2-digit years are ambiguous (see we-promise/sure#1530 and the rejected
+    # PR #531), so this format must stay out of Family::DATE_FORMATS and only
+    # be offered on the CSV mapping screen, where the user can preview it
+    # against their own data.
+    assert_empty Import::CSV_ONLY_DATE_FORMATS & Family::DATE_FORMATS
+  end
+
+  test "date_format accepts a CSV-only format like DD/MM/YY" do
+    import = imports(:transaction)
+    import.update!(date_format: "%d/%m/%y")
+
+    assert_equal Date.new(2024, 5, 15), Date.strptime("15/05/24", import.date_format)
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `DD/MM/YY` as a selectable date format for CSV imports (transaction and account balance imports), closing #1530.
- Kept **out of `Family::DATE_FORMATS`** (the global date preference used across the app) and added instead as a new `Import::CSV_ONLY_DATE_FORMATS` constant, combined only in the two CSV import config views.

## Why not a global format?
A previous attempt (#531) added `DD/MM/YY` directly to `Family::DATE_FORMATS` and was rejected by @jjmata: 2-digit years are ambiguous (Ruby's `%y` assumes 1969–2068), which can silently misparse historical or future-dated data. The maintainer's suggested resolution in that thread was to support it only for CSV import, where the user maps a real file and can see a parsed preview against their own data — not as a global, unchecked preference. This PR follows that guidance.

## Changes
- `app/models/import.rb`: new `Import::CSV_ONLY_DATE_FORMATS` constant (`DD/MM/YY` → `%d/%m/%y`).
- `app/views/import/configurations/_transaction_import.html.erb` and `_account_import.html.erb`: date format dropdown now offers `Family::DATE_FORMATS + Import::CSV_ONLY_DATE_FORMATS`.
- No changes to `Family::DATE_FORMATS`, the settings/preferences pages, QIF/YNAB/Mint/Actual/Trade imports, or any DB schema/migration.

## Test plan
- [x] `bin/rails test test/models/import_test.rb` — 19 runs, 0 failures (includes 2 new tests: format stays out of `Family::DATE_FORMATS`, and `%d/%m/%y` parses correctly via `Date.strptime`)
- [x] `bin/rails test test/models/transaction_import_test.rb test/models/account_import_test.rb` — 68 runs, 0 failures
- [x] Full suite (`DISABLE_PARALLELIZATION=true bin/rails test`) — only pre-existing, environment-specific failures unrelated to this change (encryption/OAuth config in the test container)
- [x] `bin/rubocop` on changed files — no offenses
- [x] `erb_lint` on changed views — no errors
- [x] `bin/brakeman` — 0 security warnings

Closes #1530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a day/month/two-digit-year date format when configuring CSV account and transaction imports.
  * The format is available during import setup, allowing users to verify interpreted dates in the preview.

* **Bug Fixes**
  * Improved handling of CSV dates using two-digit years without changing global family date preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->