### PR TITLE
fix: respect SURE_IMPORT_MAX_NDJSON_SIZE_MB in Sure import GUI upload

### DIFF
--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -41,8 +41,8 @@ class Import::UploadsController < ApplicationController
         return
       end
 
-      if uploaded.size > SureImport::MAX_NDJSON_SIZE
-        flash.now[:alert] = t("imports.create.file_too_large", max_size: SureImport::MAX_NDJSON_SIZE / 1.megabyte)
+      if uploaded.size > SureImport.max_ndjson_size
+        flash.now[:alert] = t("imports.create.file_too_large", max_size: SureImport.max_ndjson_size / 1.megabyte)
         render :show, status: :unprocessable_entity
         return
       end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -233,8 +233,8 @@ class ImportsController < ApplicationController
     end
 
     def create_sure_import(file)
-      if file.size > SureImport::MAX_NDJSON_SIZE
-        redirect_to new_import_path, alert: t("imports.create.file_too_large", max_size: SureImport::MAX_NDJSON_SIZE / 1.megabyte)
+      if file.size > SureImport.max_ndjson_size
+        redirect_to new_import_path, alert: t("imports.create.file_too_large", max_size: SureImport.max_ndjson_size / 1.megabyte)
         return
       end
 

--- a/app/models/sure_import.rb
+++ b/app/models/sure_import.rb
@@ -4,7 +4,6 @@ class SureImport < Import
 
   DEFAULT_MAX_NDJSON_SIZE_MB = 10
   DEFAULT_MAX_ROW_COUNT = 100_000
-  MAX_NDJSON_SIZE = DEFAULT_MAX_NDJSON_SIZE_MB.megabytes
   IMPORTABLE_NDJSON_TYPES = {
     "Account" => :accounts,
     "Balance" => :balances,

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -47,6 +47,25 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'select[name="import[account_id]"] option', text: "Plaid Depository Account", count: 0
   end
 
+  test "respects SURE_IMPORT_MAX_NDJSON_SIZE_MB when uploading Sure import file (#3010)" do
+    configured_limit = 2.megabytes
+    SureImport.stubs(:max_ndjson_size).returns(configured_limit)
+
+    sure_import = imports(:sure)
+    oversized_file = Rack::Test::UploadedFile.new(
+      StringIO.new("x" * (configured_limit + 1)),
+      "application/x-ndjson",
+      original_filename: "all.ndjson"
+    )
+
+    patch import_upload_url(sure_import), params: {
+      import: { ndjson_file: oversized_file }
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t("imports.create.file_too_large", max_size: configured_limit / 1.megabyte), flash[:alert]
+  end
+
   test "invalid csv cannot be uploaded" do
     patch import_upload_url(@import), params: {
       import: {

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -398,6 +398,29 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to imports_path
   end
 
+  test "respects SURE_IMPORT_MAX_NDJSON_SIZE_MB when creating Sure import (#3010)" do
+    configured_limit = 2.megabytes
+    SureImport.stubs(:max_ndjson_size).returns(configured_limit)
+
+    oversized_file = Rack::Test::UploadedFile.new(
+      StringIO.new("x" * (configured_limit + 1)),
+      "application/x-ndjson",
+      original_filename: "all.ndjson"
+    )
+
+    assert_no_difference "Import.count" do
+      post imports_url, params: {
+        import: {
+          type: "SureImport",
+          import_file: oversized_file
+        }
+      }
+    end
+
+    assert_redirected_to new_import_url
+    assert_equal I18n.t("imports.create.file_too_large", max_size: configured_limit / 1.megabyte), flash[:alert]
+  end
+
   test "PDF import account select does not leak unshared family accounts (#1803)" do
     sign_in users(:family_member)
     pdf_import = imports(:pdf_with_rows)


### PR DESCRIPTION
## Summary
- Fixes #3010 (\"Can't import files larger than 10MB\"). The root cause is not the 10MB default itself (that's configurable) — it's that the GUI upload paths never read the config. `Import::UploadsController#update_sure_import_upload` and `ImportsController#create_sure_import` compared the uploaded file's size against the hardcoded `SureImport::MAX_NDJSON_SIZE` constant, while the API upload paths (`api/v1/import_sessions_controller.rb`, `api/v1/imports_controller.rb`, `import/preflight.rb`) all correctly use `SureImport.max_ndjson_size`, which reads `SURE_IMPORT_MAX_NDJSON_SIZE_MB`. So a self-hosted admin who raised that env var still hit a hard 10MB wall in the GUI, with no way to know why.
- Switches both GUI call sites to `SureImport.max_ndjson_size` and removes the now-unused, misleading `MAX_NDJSON_SIZE` constant.

## Test plan
- [x] Added a regression test in `test/controllers/imports_controller_test.rb` that stubs `SureImport.max_ndjson_size` to a smaller configured limit and confirms the create flow honors it.
- [x] Added the equivalent regression test in `test/controllers/import/uploads_controller_test.rb` for the upload flow.
- [x] `bin/rails test test/controllers/imports_controller_test.rb test/controllers/import/uploads_controller_test.rb test/models/sure_import_test.rb` — 73 runs, 318 assertions, 0 failures, 0 errors.
- [x] `bin/rubocop` on changed files — no offenses.
- [x] `bin/brakeman --no-pager` — 0 errors, 0 security warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NDJSON uploads now consistently use the configured maximum file size.
  * Oversized uploads are rejected with the appropriate error message and configured limit.
* **Tests**
  * Added coverage confirming oversized uploads are rejected and do not create an import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->