### PR TITLE
fix(enable_banking): recognize N26's PERIOD_INVALID error shape as retryable

### DIFF
--- a/app/models/provider/enable_banking.rb
+++ b/app/models/provider/enable_banking.rb
@@ -328,12 +328,22 @@ class Provider::EnableBanking
         @response_data = response_data
       end
 
+      # Different ASPSPs signal the same "requested date range exceeds the
+      # allowed lookback" condition with different payload shapes. Most use
+      # `{"error": "WRONG_TRANSACTIONS_PERIOD"}` (422), but some (e.g. N26)
+      # instead return `{"code": "PERIOD_INVALID", "detail": "dateFrom=...,dateTo=..."}`
+      # with a plain string `detail`, not a hash. (Issue #1262)
       def wrong_transactions_period?
-        error_type == :validation_error && response_data.is_a?(Hash) && response_data[:error] == "WRONG_TRANSACTIONS_PERIOD"
+        return false unless response_data.is_a?(Hash)
+
+        response_data[:error] == "WRONG_TRANSACTIONS_PERIOD" || response_data[:code] == "PERIOD_INVALID"
       end
 
       def corrected_date_from
-        value = response_data&.dig(:detail, :date_from)
+        detail = response_data.is_a?(Hash) ? response_data[:detail] : nil
+        return nil unless detail.is_a?(Hash)
+
+        value = detail[:date_from]
 
         if value.is_a?(Date)
           value

--- a/test/models/provider/enable_banking_test.rb
+++ b/test/models/provider/enable_banking_test.rb
@@ -118,6 +118,57 @@ class Provider::EnableBankingTest < ActiveSupport::TestCase
     assert error.wrong_transactions_period?
   end
 
+  test "get_account_transactions retries a PERIOD_INVALID error with a string detail (N26 shape)" do
+    requested_queries = []
+
+    # N26 (via Enable Banking) rejects the period with a different payload
+    # shape than WRONG_TRANSACTIONS_PERIOD: no "error" key, and "detail" is a
+    # plain string instead of a hash, so no corrected date_from is available.
+    period_invalid_response = OpenStruct.new(
+      code: 400,
+      body: {
+        title: "Range is out of the last 90-day period",
+        code: "PERIOD_INVALID",
+        detail: "dateFrom=2025-12-11, dateTo=2026-03-23"
+      }.to_json
+    )
+    success_response = OpenStruct.new(code: 200, body: { transactions: [] }.to_json)
+
+    Provider::EnableBanking.expects(:get).twice.with do |_url, options|
+      requested_queries << options[:query].dup
+      true
+    end.returns(period_invalid_response, success_response)
+
+    result = @provider.get_account_transactions(
+      account_id: "acct_123",
+      date_from: 6.months.ago.to_date,
+      transaction_status: "BOOK"
+    )
+
+    assert_equal [], result[:transactions]
+    assert_equal 6.months.ago.to_date.iso8601, requested_queries.first[:date_from]
+    assert_equal 89.days.ago.to_date.iso8601, requested_queries.second[:date_from]
+  end
+
+  test "PERIOD_INVALID errors with a string detail expose a nil corrected_date_from instead of raising" do
+    response = OpenStruct.new(
+      code: 400,
+      body: {
+        title: "Range is out of the last 90-day period",
+        code: "PERIOD_INVALID",
+        detail: "dateFrom=2025-12-11, dateTo=2026-03-23"
+      }.to_json
+    )
+
+    error = assert_raises Provider::EnableBanking::EnableBankingError do
+      @provider.send(:handle_response, response)
+    end
+
+    assert_equal :bad_request, error.error_type
+    assert error.wrong_transactions_period?
+    assert_nil error.corrected_date_from
+  end
+
   test "start_authorization includes auth_method in the request body when provided" do
     captured_body = nil
     response = OpenStruct.new(


### PR DESCRIPTION
## Summary
- N26 (via Enable Banking) rejects an out-of-range transaction period with `{"code": "PERIOD_INVALID", "detail": "dateFrom=...,dateTo=..."}` — a different shape than `{"error": "WRONG_TRANSACTIONS_PERIOD"}`, which is the only shape the progressive fallback retry ladder introduced in #2992/#3038 recognized.
- `EnableBankingError#wrong_transactions_period?` now also matches on `response_data[:code] == "PERIOD_INVALID"`, so this ASPSP's rejection triggers the same shorter-window retry instead of failing the sync outright.
- `EnableBankingError#corrected_date_from` now guards against a non-hash `detail` payload (N26 sends a plain string, not a hash), which previously would have raised `NoMethodError` the first time this shape reached that code path.

Fixes #1262.

## Test plan
- [x] `bin/rails test test/models/provider/enable_banking_test.rb test/models/enable_banking_item/importer_error_handling_test.rb` — 21 runs, 0 failures/errors (including 2 new tests covering the N26 shape)
- [x] `bin/rubocop` on both changed files — no offenses
- [x] `bin/brakeman --no-pager -q` — 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bank transaction period errors, including additional error responses.
  * Prevented failures when error details are provided in an unexpected format.
  * Transaction retrieval now retries with a shorter fallback period when appropriate.
  * Corrected error reporting when no replacement start date is available.

* **Tests**
  * Added coverage for the new error responses and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->