### PR TITLE
fix(ui): keep the account chart view selector in sync on reload

### DIFF
--- a/app/components/UI/account/chart.html.erb
+++ b/app/components/UI/account/chart.html.erb
@@ -21,9 +21,10 @@
       <% if account.supports_trades? %>
         <%= form_with url: account_path(account), method: :get, data: { controller: "auto-submit-form" } do |form| %>
           <%= form.select :chart_view,
-            [[t(".views.total_value"), "balance"], [t(".views.holdings"), "holdings_balance"], [t(".views.cash"), "cash_balance"], [t(".views.gains"), "gains"]],
+            [[t("UI.account.chart.views.total_value"), "balance"], [t("UI.account.chart.views.holdings"), "holdings_balance"], [t("UI.account.chart.views.cash"), "cash_balance"], [t("UI.account.chart.views.gains"), "gains"]],
             { selected: view },
             class: "bg-container border border-secondary rounded-lg text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0",
+            autocomplete: "off",
             data: { "auto-submit-form-target": "auto" } %>
         <% end %>
       <% end %>
@@ -50,7 +51,7 @@
         data-time-series-chart-data-value="<%= series.to_json %>"></div>
       <% else %>
         <div class="w-full h-full flex items-center justify-center">
-          <p class="text-secondary text-sm"><%= t(".no_data_available") %></p>
+          <p class="text-secondary text-sm"><%= t("UI.account.chart.no_data_available") %></p>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
### Problem

On an investment account, picking a chart view (Total value/ Holdings / Cash / Gains) and reloading the page left the selector showing the picked view while the chart and its title showed the default "Total value".

To reproduce: open an investment account -> select "Cash" -> reload -> see "Total value" chart with "Cash" selected.

The selected view only ever lives in the request params, so a reload renders the default view. Browsers restore form control state on reload, so the select kept the value picked before the refresh.

### Illustration
Before:
<img width="1492" height="934" alt="EC18B3A3-EF30-4408-A1BB-2819B85CFB64" src="https://github.com/user-attachments/assets/1d89725a-9c71-4fa5-b58d-3bb73f55e0b6" />


After:
<img width="1492" height="934" alt="B19360D9-8565-4378-8449-E35025623CA0" src="https://github.com/user-attachments/assets/24dec9bd-b982-442e-968a-40327c628a9c" />


### Fix

Opt the select out of autocomplete, so it falls back to the server-rendered default alongside the chart.

### Other issue
The selector labels and the chart empty state used lazy `t(".")` lookups, which resolve against a lowercased scope while the locale files declare the `UI:` namespace.
They rendered `titleized` key names instead of translations (Gains option read "Gains" instead of "Gains / ROI").
I switched to absolute keys.

Others call sites are still affected and I left them untouched: `activity_feed:108`, `activity_date:24` and `:35`, `period_picker:5` (the last one masked by a `default:`). The `activity_date` ones are the most visible — a tooltip renders as "Balance Tooltip" instead of "The end of day balance, after all transactions and adjustments".

Renaming the namespace to `ui:` would make lazy lookups work and match the existing `ds:` / `provider_sync_summary:` namespaces, but it churns 13 locale files plus 13 absolute call sites.
Want me to fix those four with absolute keys in this PR, do the rename in a separate one, or leave it?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chart labels and the no-data message so they display the correct translations consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->