### PR TITLE
chore(security): update Pipelock integration to 3.4.0

### DIFF
--- a/.github/workflows/pipelock.yml
+++ b/.github/workflows/pipelock.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.21.4
 
       - name: Build chart dependencies
         shell: bash
@@ -48,15 +50,25 @@ jobs:
             config/locales/views/reports/ro.yml
             config/locales/views/reports/ru.yml
             config/locales/views/reports/tr.yml
+            config/locales/views/reports/uk.yml
             config/locales/views/reports/vi.yml
             config/locales/views/reports/zh-CN.yml
+            config/locales/views/reports/zh-TW.yml
 
       - name: Validate Pipelock deployment contracts
         shell: bash
         run: |
           set -euo pipefail
 
+          assert_no_blocklist() {
+            ruby -ryaml -e '
+              config = YAML.safe_load_file(ARGV.fetch(0), aliases: true)
+              abort "blocklist is configured but its vectors are not enabled" if config.key?("blocklist")
+            ' "$1"
+          }
+
           pipelock check --config pipelock.example.yaml
+          assert_no_blocklist pipelock.example.yaml
           vector_categories="dlp,entropy,scheme,response_injection,mcp_response,mcp_input,mcp_tools,clean"
           pipelock test --fail-on-gap --category "${vector_categories}" --config pipelock.example.yaml
           docker compose -f compose.example.ai.yml config --quiet
@@ -77,18 +89,33 @@ jobs:
             > "${rendered_config}"
           test -s "${rendered_config}"
           pipelock check --config "${rendered_config}"
+          assert_no_blocklist "${rendered_config}"
           pipelock test --fail-on-gap --category "${vector_categories}" --config "${rendered_config}"
 
-          if helm template sure charts/sure \
+          helm template sure charts/sure \
             --set rails.externalAssistant.enabled=true \
             --set rails.externalAssistant.url=https://agent.vendor.example/v1/chat \
-            >/dev/null 2>&1; then
+            --set pipelock.enabled=true \
+            >/dev/null
+
+          if rejection_output="$(helm template sure charts/sure \
+            --set rails.externalAssistant.enabled=true \
+            --set rails.externalAssistant.url=https://agent.vendor.example/v1/chat \
+            --set pipelock.enabled=false \
+            2>&1)"; then
             echo "::error::External assistant rendered without Pipelock"
+            exit 1
+          fi
+          expected_rejection="pipelock.requireForExternalAssistant is true but pipelock.enabled is false"
+          if ! grep -Fq "${expected_rejection}" <<<"${rejection_output}"; then
+            echo "::error::External assistant failed for an unexpected reason"
+            printf '%s\n' "${rejection_output}"
             exit 1
           fi
 
           helm template sure charts/sure \
             --set rails.externalAssistant.enabled=true \
             --set rails.externalAssistant.url=https://agent.vendor.example/v1/chat \
+            --set pipelock.enabled=false \
             --set pipelock.requireForExternalAssistant=false \
             >/dev/null

--- a/.github/workflows/pipelock.yml
+++ b/.github/workflows/pipelock.yml
@@ -53,6 +53,13 @@ jobs:
           pipelock test --fail-on-gap --category "${vector_categories}" --config pipelock.example.yaml
           docker compose -f compose.example.ai.yml config --quiet
 
+          external_services="$(docker compose -f compose.example.ai.yml --profile external-assistant config --services)"
+          grep -qx 'openclaw' <<<"${external_services}"
+          if grep -Eqx 'ollama|ollama-webui' <<<"${external_services}"; then
+            echo "::error::External assistant profile exposes local AI services"
+            exit 1
+          fi
+
           rendered_config="${RUNNER_TEMP}/sure-pipelock.yaml"
           helm template sure charts/sure \
             --kube-version 1.25.0 \

--- a/.github/workflows/pipelock.yml
+++ b/.github/workflows/pipelock.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
+      - name: Build chart dependencies
+        shell: bash
+        run: |
+          helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
+          helm repo add ot-helm https://ot-container-kit.github.io/helm-charts
+          helm repo update
+          helm dependency build charts/sure
+
       - name: Pipelock Scan
         uses: luckyPipewrench/pipelock@4c748ab986d611138ce202ab800b16eca6fb589f # v3.4.0
         with:

--- a/.github/workflows/pipelock.yml
+++ b/.github/workflows/pipelock.yml
@@ -25,7 +25,7 @@ jobs:
           version: '3.4.0'
           scan-diff: 'true'
           fail-on-findings: 'true'
-          test-vectors: 'true'
+          test-vectors: 'false'
           exclude-paths: |
             config/locales/views/reports/ca.yml
             config/locales/views/reports/de.yml

--- a/.github/workflows/pipelock.yml
+++ b/.github/workflows/pipelock.yml
@@ -16,17 +16,64 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
       - name: Pipelock Scan
-        uses: luckyPipewrench/pipelock@818ca0a7af4dbcd56ada7fa57e2dc32f9e799e34 # v2.8.0
+        uses: luckyPipewrench/pipelock@4c748ab986d611138ce202ab800b16eca6fb589f # v3.4.0
         with:
-          version: '2.8.0'
+          version: '3.4.0'
           scan-diff: 'true'
           fail-on-findings: 'true'
-          test-vectors: 'false'
+          test-vectors: 'true'
           exclude-paths: |
-            .env.example
-            compose.example.yml
-            compose.example.ai.yml
-            config/locales/views/reports/
-            docs/hosting/ai.md
-            app/models/provider/binance.rb
+            config/locales/views/reports/ca.yml
+            config/locales/views/reports/de.yml
+            config/locales/views/reports/en.yml
+            config/locales/views/reports/es.yml
+            config/locales/views/reports/fr.yml
+            config/locales/views/reports/hu.yml
+            config/locales/views/reports/it.yml
+            config/locales/views/reports/nl.yml
+            config/locales/views/reports/pl.yml
+            config/locales/views/reports/pt-BR.yml
+            config/locales/views/reports/ro.yml
+            config/locales/views/reports/ru.yml
+            config/locales/views/reports/tr.yml
+            config/locales/views/reports/vi.yml
+            config/locales/views/reports/zh-CN.yml
+
+      - name: Validate Pipelock deployment contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pipelock check --config pipelock.example.yaml
+          vector_categories="dlp,entropy,scheme,response_injection,mcp_response,mcp_input,mcp_tools,clean"
+          pipelock test --fail-on-gap --category "${vector_categories}" --config pipelock.example.yaml
+          docker compose -f compose.example.ai.yml config --quiet
+
+          rendered_config="${RUNNER_TEMP}/sure-pipelock.yaml"
+          helm template sure charts/sure \
+            --kube-version 1.25.0 \
+            --set pipelock.enabled=true \
+            --show-only templates/pipelock-configmap.yaml \
+            | awk '/pipelock.yaml: \|/{copy=1; next} copy{sub(/^    /, ""); print}' \
+            > "${rendered_config}"
+          test -s "${rendered_config}"
+          pipelock check --config "${rendered_config}"
+          pipelock test --fail-on-gap --category "${vector_categories}" --config "${rendered_config}"
+
+          if helm template sure charts/sure \
+            --set rails.externalAssistant.enabled=true \
+            --set rails.externalAssistant.url=https://agent.vendor.example/v1/chat \
+            >/dev/null 2>&1; then
+            echo "::error::External assistant rendered without Pipelock"
+            exit 1
+          fi
+
+          helm template sure charts/sure \
+            --set rails.externalAssistant.enabled=true \
+            --set rails.externalAssistant.url=https://agent.vendor.example/v1/chat \
+            --set pipelock.requireForExternalAssistant=false \
+            >/dev/null

--- a/charts/sure/CHANGELOG.md
+++ b/charts/sure/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Updated the Pipelock CI action and deployment image from 2.8.0 to 3.4.0. The image uses the release's multi-architecture manifest digest.
+- CI now runs Pipelock's built-in test vectors and validates the Compose config plus the Helm-rendered `pipelock.yaml` with the pinned binary.
+- Corrected the HTTPS coverage docs. The default examples apply tunnel-level controls but can't inspect encrypted request or response bodies without TLS interception.
+- Helm now rejects external-assistant deployments without Pipelock by default. Operators can set `pipelock.requireForExternalAssistant=false` to accept direct traffic.
 - Bumped `pipelock.image.tag` from `2.5.0` to `2.8.0`, picking up default-on flight recorder receipts, safe-by-default receipt verification, MCP `defer` authorization, `pipelock explain`, `pipelock keys status`, `pipelock support bundle`, verified self-update, and inert-exemption diagnostics.
 - Refreshed Pipelock docs across Docker, MCP, AI, and chart setup to distinguish scanning from verifiable receipt evidence.
 - Enabled `pipelock.requestBodyScanning` by default with `action: warn`, matching Pipelock's current balanced preset so outbound prompt bodies and sensitive headers are scanned.

--- a/charts/sure/README.md
+++ b/charts/sure/README.md
@@ -642,10 +642,10 @@ hpa:
 
 [Pipelock](https://github.com/luckyPipewrench/pipelock) is an optional security proxy that scans AI agent traffic for secret exfiltration, prompt injection, tool poisoning, and SSRF. It runs as a separate Deployment with two listeners:
 
-- **Forward proxy** (port 8888): Scans outbound HTTPS from Faraday-based AI clients. Auto-injected via `HTTPS_PROXY` env vars when enabled.
+- **Forward proxy** (port 8888): Applies destination, SSRF, rate, budget, CONNECT-header DLP, and receipt controls to HTTPS tunnels from clients that honor the proxy variables. The chart doesn't configure TLS interception, so encrypted bodies stay opaque.
 - **MCP reverse proxy** (port 8889): Scans inbound MCP traffic from external AI assistants.
 
-Recent Pipelock releases add default-on flight recorder receipts, safe-by-default receipt verification, MCP `defer` authorization, request-policy scoring, request-body prompt-injection blocking, SPIFFE-strict inbound mediation envelopes, scanner attribution on MCP block receipts, trusted domain allowlisting, MCP tool redirect profiles, learn-and-lock behavioural contracts, the wedge-detection health watchdog, `pipelock explain`, `pipelock keys status`, `pipelock support bundle`, verified `pipelock update`, and `pipelock doctor` checks for inert exemptions. Browser Shield, process sandboxing, request policy, redaction, and attack assessment are available via `extraConfig` and CLI. See the [Pipelock changelog](https://github.com/luckyPipewrench/pipelock/releases) for details.
+The chart pins Pipelock 3.4.0 by tag and multi-architecture image digest. Read the [Pipelock release notes](https://github.com/luckyPipewrench/pipelock/releases/tag/v3.4.0) before overriding that pin.
 
 ### Enabling Pipelock
 
@@ -653,7 +653,7 @@ Recent Pipelock releases add default-on flight recorder receipts, safe-by-defaul
 pipelock:
   enabled: true
   image:
-    tag: "2.8.0"
+    tag: "3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c"
   mode: balanced   # strict, balanced, or audit
 ```
 
@@ -688,9 +688,9 @@ pipelock:
         reason: "Route fetch calls through audited proxy"
 ```
 
-### Request body scanning (pipelock 2.5+)
+### Request body scanning
 
-Pipelock 2.5 added prompt-injection detection on outbound request bodies (JSON, form-encoded, raw text, WebSocket frames). When enabled, findings hard-block non-provider destinations even when `action: warn`; trusted provider hosts (OpenAI, Anthropic, etc.) remain exempt through the response-scanning exemption list.
+Request body scanning covers cleartext HTTP, reverse-proxy, and WebSocket bodies. It can't inspect encrypted HTTPS tunnel bodies unless you configure TLS interception and install Pipelock's CA in the client container.
 
 ```yaml
 pipelock:
@@ -730,7 +730,7 @@ kubectl create secret generic sure-pipelock-receipts \
   --from-file=flight-recorder-signing.key=./flight-recorder-signing.key
 ```
 
-If you do not have the `pipelock` binary installed, generate the key with the image instead: `docker run --rm -v "$PWD:/out" ghcr.io/luckypipewrench/pipelock:2.8.0 signing key generate --purpose receipt-signing --out /out/flight-recorder-signing.key --id sure-k8s`.
+If you don't have the `pipelock` binary installed, generate the key with the pinned image instead: `docker run --rm -v "$PWD:/out" ghcr.io/luckypipewrench/pipelock:3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c signing key generate --purpose receipt-signing --out /out/flight-recorder-signing.key --id sure-k8s`.
 
 Then mount persistent evidence storage and the key:
 
@@ -866,16 +866,16 @@ pipelock:
 
 These are appended verbatim to `pipelock.yaml`. Do not duplicate keys already rendered by the chart.
 
-### Requiring Pipelock for external assistants
+### Pipelock requirement for external assistants
 
-To enforce that Pipelock is enabled whenever the external AI assistant feature is active:
+The chart rejects an external AI assistant deployment without Pipelock by default:
 
 ```yaml
 pipelock:
   requireForExternalAssistant: true
 ```
 
-This causes `helm template` / `helm install` to fail if `rails.externalAssistant.enabled=true` and `pipelock.enabled=false`. Note: this only guards the `externalAssistant` path. Direct MCP access via `MCP_API_TOKEN` is configured through env vars and not detectable from Helm values.
+`helm template` and `helm install` fail when `rails.externalAssistant.enabled=true` and `pipelock.enabled=false`. Set `requireForExternalAssistant: false` only when you accept direct external-assistant traffic. This guard can't detect direct MCP access configured through `MCP_API_TOKEN`.
 
 ## Security Notes
 

--- a/charts/sure/values.yaml
+++ b/charts/sure/values.yaml
@@ -490,14 +490,15 @@ hpa:
     targetCPUUtilizationPercentage: 70
 
 # Pipelock: AI agent security proxy (optional)
-# Provides forward proxy (outbound HTTPS scanning) and MCP reverse proxy
+# Provides forward proxy (outbound HTTPS tunnel controls) and MCP reverse proxy
 # (inbound MCP traffic scanning for prompt injection, DLP, tool poisoning).
 # More info: https://github.com/luckyPipewrench/pipelock
 pipelock:
   enabled: false
   image:
     repository: ghcr.io/luckypipewrench/pipelock
-    tag: "2.8.0"
+    # Stable release pinned to its multi-architecture manifest digest.
+    tag: "3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c"
     pullPolicy: IfNotPresent
     imagePullSecrets: []
   replicas: 1
@@ -559,8 +560,9 @@ pipelock:
     action: warn
     windowSize: 20
     maxGap: 3
-  # Request body scanning (pipelock 2.5+): detect prompt-injection payloads
-  # in outbound request bodies (JSON, form-encoded, raw text, WebSocket frames).
+  # Request body scanning: detects prompt-injection payloads in cleartext HTTP,
+  # reverse-proxy, and WebSocket bodies. It cannot inspect encrypted HTTPS tunnel
+  # bodies unless TLS interception is separately configured and its CA trusted.
   # In enforce mode, prompt-injection findings hard-block non-provider
   # destinations even when action is "warn"; trusted provider hosts (OpenAI,
   # Anthropic, etc.) remain exempt via the response_scanning exemption list.
@@ -651,4 +653,5 @@ pipelock:
   # NOTE: This only guards the rails.externalAssistant path. Direct MCP access
   # (/mcp endpoint with MCP_API_TOKEN) is not detectable from Helm values.
   # For full coverage, also ensure pipelock is enabled whenever MCP_API_TOKEN is set.
-  requireForExternalAssistant: false
+  # Set false only when you deliberately accept direct external-assistant traffic.
+  requireForExternalAssistant: true

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -10,10 +10,11 @@
 #
 #   Pipelock — agent security proxy
 #   (always runs)
-#     - Forward proxy (port 8888): scans outbound HTTPS from Faraday-based
-#       clients (e.g. ruby-openai). NOT covered: SimpleFin, Coinbase, or
-#       anything using Net::HTTP/HTTParty directly. HTTPS_PROXY is
-#       cooperative; Docker Compose has no egress network policy.
+#     - Forward proxy (port 8888): applies destination, SSRF, rate, budget,
+#       CONNECT-header DLP, and receipt controls to HTTPS tunnels from clients
+#       that honor HTTPS_PROXY. HTTPS bodies remain encrypted because this
+#       example does not configure TLS interception. HTTPS_PROXY is cooperative;
+#       Docker Compose has no egress network policy.
 #     - MCP reverse proxy (port 8889): scans inbound AI traffic (DLP,
 #       prompt injection, tool poisoning, tool call policy). External AI
 #       clients should connect to Pipelock on port 8889 rather than
@@ -83,7 +84,8 @@ x-rails-env: &rails_env
   MCP_API_TOKEN: ${MCP_API_TOKEN:-}
   MCP_USER_EMAIL: ${MCP_USER_EMAIL:-}
   # Route outbound HTTPS through Pipelock for clients that respect HTTPS_PROXY.
-  # Covered: OpenAI API (ruby-openai/Faraday). NOT covered: SimpleFin, Coinbase (Net::HTTP).
+  # This applies tunnel-level controls; encrypted HTTPS bodies are not inspected
+  # unless you separately configure TLS interception and trust its CA.
   HTTPS_PROXY: "http://pipelock:8888"
   HTTP_PROXY: "http://pipelock:8888"
   # Skip proxy for internal Docker network services (including ollama for local LLM calls)
@@ -130,7 +132,7 @@ x-rails-env: &rails_env
 
 services:
   pipelock:
-    image: ghcr.io/luckypipewrench/pipelock:2.8.0
+    image: ghcr.io/luckypipewrench/pipelock:3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c
     user: "${PIPELOCK_UID:-1000}:${PIPELOCK_GID:-1000}"
     container_name: pipelock
     hostname: pipelock
@@ -146,12 +148,12 @@ services:
       #   mkdir -p ./pipelock-evidence ./pipelock-keys
       # Generate the receipt-signing key via the image (no host binary needed;
       # --out must be an absolute path inside the container):
-      #   docker run --rm -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:2.8.0 \
+      #   docker run --rm -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c \
       #     signing key generate --purpose receipt-signing --out /keys/flight-recorder-signing.key --id sure-compose
       # The key is written 0600 owned by uid 1000 (Pipelock's default user). If
       # your host user is not uid 1000, use this variant instead:
       #   export PIPELOCK_UID="$(id -u)" PIPELOCK_GID="$(id -g)"
-      #   docker run --rm --user "$PIPELOCK_UID:$PIPELOCK_GID" -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:2.8.0 \
+      #   docker run --rm --user "$PIPELOCK_UID:$PIPELOCK_GID" -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c \
       #     signing key generate --purpose receipt-signing --out /keys/flight-recorder-signing.key --id sure-compose
       # That makes the key and evidence directory readable/writable by the same
       # uid/gid the compose service uses.

--- a/compose.example.ai.yml
+++ b/compose.example.ai.yml
@@ -26,9 +26,8 @@
 #   (optional, --profile local-ai)
 #     - Only starts when you run: docker compose --profile local-ai up
 #
-#   Ollama + Open WebUI + OpenClaw — external AI assistant
+#   OpenClaw — external AI assistant
 #   (optional, --profile external-assistant)
-#     - Local LLM inference available via Ollama + Open WebUI
 #     - Starts an OpenClaw locally for Sure's external assistant mode.
 #     - Set EXTERNAL_ASSISTANT_URL to http://openclaw:18789/v1/chat/completions
 #       for internal routing.
@@ -187,7 +186,6 @@ services:
   ollama:
     profiles:
       - local-ai
-      - external-assistant
     volumes:
       - ollama:/root/.ollama
     container_name: ollama
@@ -213,7 +211,6 @@ services:
   ollama-webui:
     profiles:
       - local-ai
-      - external-assistant
     image: ghcr.io/open-webui/open-webui
     container_name: ollama-webui
     volumes:

--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -483,14 +483,14 @@ it implements.
 
 ### Security with Pipelock
 
-When [Pipelock](https://github.com/luckyPipewrench/pipelock) is enabled (`pipelock.enabled=true` in Helm, or the `pipelock` service in Docker Compose), all traffic between Sure and the external agent is scanned:
+When [Pipelock](https://github.com/luckyPipewrench/pipelock) is enabled (`pipelock.enabled=true` in Helm, or the `pipelock` service in Docker Compose), Sure configures two mediated routes:
 
 - **Outbound** (Sure -> agent): routed through Pipelock's forward proxy via `HTTPS_PROXY`
 - **Inbound** (agent -> Sure /mcp): routed through Pipelock's MCP reverse proxy (port 8889)
 
-Pipelock scans for prompt injection, DLP violations, and tool poisoning. The external agent does not need Pipelock installed. Sure's Pipelock handles both directions.
+The MCP reverse proxy scans readable MCP traffic for prompt injection, DLP violations, and tool poisoning. The forward proxy applies tunnel-level controls to HTTPS, but the default examples don't enable TLS interception and can't scan encrypted bodies. The external agent doesn't need Pipelock installed.
 
-If you need audit evidence, configure Pipelock's flight recorder as described in [Pipelock signed action receipts](pipelock.md#signed-action-receipts). `pipelock.enabled=true` gives scanning; receipts require mounted evidence storage plus a receipt-signing key.
+If you need audit evidence, configure Pipelock's flight recorder as described in [Pipelock signed action receipts](pipelock.md#signed-action-receipts). Enabling Pipelock adds the mediated routes, while receipts require mounted evidence storage plus a receipt-signing key.
 
 **`NO_PROXY` behavior (Helm/Kubernetes only):** The Helm chart's env template sets `NO_PROXY` to include `.svc.cluster.local` and other internal domains. This means in-cluster agent URLs (like `http://agent.namespace.svc.cluster.local:18789`) bypass the forward proxy and go directly. If your agent is in-cluster, its traffic won't be forward-proxy scanned (but MCP callbacks from the agent are still scanned by the reverse proxy). Docker Compose deployments use a different `NO_PROXY` set; check your compose file for the exact values.
 

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -252,7 +252,7 @@ The external assistant delegates chat to a remote AI agent instead of calling LL
    - **Per-family (UI):** Go to Settings > Self-Hosting > AI Assistant, select "External"
    - **Global (env):** Set `ASSISTANT_TYPE=external` to force all families to use external
 
-To use the bundled OpenClaw service instead of a separately hosted agent, start the `external-assistant` profile:
+To use the bundled OpenClaw service instead of a separately hosted agent, start the `external-assistant` profile. This profile starts OpenClaw without the local Ollama or Open WebUI services:
 
 ```bash
 docker compose -f compose.ai.yml --profile external-assistant up -d

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -214,8 +214,8 @@ If you find bugs or have a feature request, be sure to read through our [contrib
 
 Sure ships with a separate compose file for AI-related features: `compose.example.ai.yml`. It adds:
 
-- **Pipelock** (always on): AI agent security proxy that scans outbound LLM calls and inbound MCP traffic
-- **Ollama + Open WebUI** (optional `--profile ai`): local LLM inference
+- **Pipelock** (always on): AI agent security proxy for outbound tunnel controls and inbound MCP scanning
+- **Ollama + Open WebUI** (optional `--profile local-ai`): local LLM inference
 
 ### Using the AI compose file
 
@@ -229,7 +229,7 @@ curl -o pipelock.example.yaml https://raw.githubusercontent.com/we-promise/sure/
 docker compose -f compose.ai.yml up -d
 
 # Run with Pipelock + Ollama
-docker compose -f compose.ai.yml --profile ai up -d
+docker compose -f compose.ai.yml --profile local-ai up -d
 ```
 
 ### Setting up the external AI assistant
@@ -252,16 +252,22 @@ The external assistant delegates chat to a remote AI agent instead of calling LL
    - **Per-family (UI):** Go to Settings > Self-Hosting > AI Assistant, select "External"
    - **Global (env):** Set `ASSISTANT_TYPE=external` to force all families to use external
 
+To use the bundled OpenClaw service instead of a separately hosted agent, start the `external-assistant` profile:
+
+```bash
+docker compose -f compose.ai.yml --profile external-assistant up -d
+```
+
 See [docs/hosting/ai.md](ai.md) for full configuration details including agent ID, session keys, and email allowlisting.
 
 ### Pipelock security proxy
 
-Pipelock sits between Sure and external services, scanning AI traffic for:
+Pipelock sits between Sure and external services. The default Compose file provides:
 
-- **Secret exfiltration** (DLP): catches API keys, tokens, or personal data leaking in prompts
-- **Prompt injection**: detects attempts to override system instructions
-- **Tool poisoning**: validates MCP tool calls against known-safe patterns
-- **Signed receipts**: optional hash-chained evidence of mediated decisions when `flight_recorder.dir` and `signing_key_path` are configured
+- MCP request and response scanning for DLP, prompt injection, and tool poisoning
+- HTTPS tunnel controls for destination, SSRF, rate, budget, CONNECT headers, and optional signed receipts
+
+The example doesn't enable TLS interception, so Pipelock can't read encrypted HTTPS request or response bodies. Docker Compose also doesn't prevent a client from bypassing the proxy.
 
 When using `compose.example.ai.yml`, Pipelock is always running. External AI agents should connect to port 8889 (MCP reverse proxy) instead of directly to Sure's `/mcp` on port 3000.
 

--- a/docs/hosting/pipelock.md
+++ b/docs/hosting/pipelock.md
@@ -8,15 +8,14 @@ Pipelock runs as a separate proxy service alongside Sure with two listeners:
 
 | Listener | Port | Direction | What it scans |
 |----------|------|-----------|---------------|
-| Forward proxy | 8888 | Outbound (Sure to LLM) | DLP (secrets in prompts), response injection |
+| Forward proxy | 8888 | Outbound (Sure to LLM) | Destination, SSRF, rate, budget, CONNECT-header DLP, and receipt controls for HTTPS tunnels |
 | MCP reverse proxy | 8889 | Inbound (agent to Sure /mcp) | Prompt injection, tool poisoning, DLP |
 
 ### Forward proxy (outbound)
 
-When `HTTPS_PROXY=http://pipelock:8888` is set, outbound HTTPS requests from Faraday-based clients (like `ruby-openai`) are routed through Pipelock. It scans request bodies for leaked secrets and response bodies for prompt injection.
+When `HTTPS_PROXY=http://pipelock:8888` is set, outbound HTTPS requests from clients that honor the variable are routed through Pipelock. The default Sure examples don't configure TLS interception, so Pipelock can control the tunnel destination and connection but can't read encrypted request or response bodies. Body scanning requires TLS interception plus installing Pipelock's CA in the client container.
 
-**Covered:** OpenAI API calls via ruby-openai (uses Faraday).
-**Not covered:** SimpleFIN, Coinbase, Plaid, or anything using Net::HTTP/HTTParty directly. These bypass `HTTPS_PROXY`.
+Faraday-based OpenAI calls honor the proxy variables. Some provider clients may open direct connections, and Docker Compose doesn't enforce a network route that prevents bypass.
 
 ### MCP reverse proxy (inbound)
 
@@ -56,7 +55,7 @@ The `compose.example.ai.yml` file includes Pipelock. To use it:
    mkdir -p pipelock-evidence pipelock-keys
    # --out must be an absolute path inside the container. The key is written
    # 0600 owned by uid 1000, which is the user the Pipelock proxy runs as.
-   docker run --rm -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:2.8.0 \
+   docker run --rm -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c \
      signing key generate --purpose receipt-signing --out /keys/flight-recorder-signing.key --id sure-compose
    ```
 
@@ -64,7 +63,7 @@ The `compose.example.ai.yml` file includes Pipelock. To use it:
 
    ```bash
    export PIPELOCK_UID="$(id -u)" PIPELOCK_GID="$(id -g)"
-   docker run --rm --user "$PIPELOCK_UID:$PIPELOCK_GID" -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:2.8.0 \
+   docker run --rm --user "$PIPELOCK_UID:$PIPELOCK_GID" -v "$PWD/pipelock-keys:/keys" ghcr.io/luckypipewrench/pipelock:3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c \
      signing key generate --purpose receipt-signing --out /keys/flight-recorder-signing.key --id sure-compose
    ```
 
@@ -109,13 +108,13 @@ Enable Pipelock in your Helm values:
 pipelock:
   enabled: true
   image:
-    tag: "2.8.0"
+    tag: "3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c"
   mode: balanced
 ```
 
 This creates a separate Deployment, Service, and ConfigMap. The chart auto-injects `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` into web and worker pods.
 
-Recent Pipelock releases add default-on flight recorder receipts, safe-by-default receipt verification, MCP `defer` authorization, request-policy scoring, request-body prompt-injection blocking, SPIFFE-strict inbound mediation envelopes, scanner attribution on MCP block receipts, trusted domain allowlisting, MCP tool redirect profiles, learn-and-lock behavioural contracts, the wedge-detection health watchdog, `pipelock explain`, `pipelock keys status`, `pipelock support bundle`, verified `pipelock update`, and `pipelock doctor` checks for inert exemptions. See the [Pipelock changelog](https://github.com/luckyPipewrench/pipelock/releases) for details.
+Sure pins Pipelock 3.4.0 by tag and multi-architecture image digest. Read the [Pipelock release notes](https://github.com/luckyPipewrench/pipelock/releases/tag/v3.4.0) before overriding that pin.
 
 ### Signed action receipts
 
@@ -132,7 +131,7 @@ kubectl create secret generic sure-pipelock-receipts \
   --from-file=flight-recorder-signing.key=./flight-recorder-signing.key
 ```
 
-If you do not have the `pipelock` binary installed, generate the key with the image instead: `docker run --rm -v "$PWD:/out" ghcr.io/luckypipewrench/pipelock:2.8.0 signing key generate --purpose receipt-signing --out /out/flight-recorder-signing.key --id sure-k8s`.
+If you don't have the `pipelock` binary installed, generate the key with the pinned image instead: `docker run --rm -v "$PWD:/out" ghcr.io/luckypipewrench/pipelock:3.4.0@sha256:2e6caa43967a5ef19cacbce00188d829c1b5de1eb0ad304a51d2085f32c5694c signing key generate --purpose receipt-signing --out /out/flight-recorder-signing.key --id sure-k8s`.
 
 Example Helm values using an existing PVC named `sure-pipelock-evidence`:
 
@@ -231,10 +230,10 @@ The `pipelock.example.yaml` file (Docker Compose) or ConfigMap (Helm) controls s
 |---------|-----------------|
 | `mode` | `strict` (block threats), `balanced` (warn + block critical), `audit` (log only) |
 | `trusted_domains` | Allow internal services whose public DNS resolves to private IPs |
-| `forward_proxy` | Outbound HTTPS scanning (tunnel timeouts, idle timeouts) |
+| `forward_proxy` | Outbound HTTPS tunnel controls and connection timeouts |
 | `dlp` | Data loss prevention (scan env vars, built-in patterns) |
-| `request_body_scanning` | Scan outbound request bodies for prompt-injection and bodies/sensitive headers for DLP (pipelock 2.5+) |
-| `response_scanning` | Scan LLM responses for prompt injection |
+| `request_body_scanning` | Scan cleartext HTTP, reverse-proxy, and WebSocket request bodies; HTTPS bodies require TLS interception |
+| `response_scanning` | Scan readable responses for prompt injection; HTTPS tunnel responses require TLS interception |
 | `mcp_input_scanning` | Scan inbound MCP requests |
 | `mcp_tool_scanning` | Validate tool calls, detect drift |
 | `mcp_tool_policy` | Pre-execution rules, shell obfuscation, redirect profiles |
@@ -267,9 +266,10 @@ Start with `audit` mode to see what Pipelock detects without blocking anything. 
 
 ## Limitations
 
-- Forward proxy only covers Faraday-based HTTP clients. Net::HTTP, HTTParty, and other libraries ignore `HTTPS_PROXY`.
+- Proxy variables are cooperative. Clients that don't honor them can connect directly unless the deployment enforces egress routing.
+- The default examples don't configure TLS interception, so Pipelock can't scan encrypted HTTPS request or response bodies.
 - Docker Compose has no egress network policies. The `/mcp` endpoint on port 3000 is still reachable directly (auth token required). For enforcement, use Kubernetes NetworkPolicies.
-- Pipelock scans text content. Binary payloads (images, file uploads) are passed through by default.
+- Pipelock 3.4 scans reverse-proxy bodies that declare media types, but it doesn't inspect secrets embedded inside a valid image.
 - Signed receipts prove traffic that traversed Pipelock. They do not prove traffic could not bypass Pipelock; pair them with NetworkPolicies, containment, or firewall rules for non-bypass claims.
 
 ## Troubleshooting

--- a/pipelock.example.yaml
+++ b/pipelock.example.yaml
@@ -1,14 +1,8 @@
 # Pipelock configuration for Docker Compose
 # See https://github.com/luckyPipewrench/pipelock for full options.
 #
-# Recent additions through 2.8: default-on flight recorder receipts, safe-by-
-# default receipt verification, request-policy scoring, request-body prompt-
-# injection blocking, SPIFFE-strict inbound mediation envelopes, scanner
-# attribution on MCP block receipts, wedge-detection health watchdog,
-# learn-and-lock behavioural contracts, trusted domains, redirect profiles,
-# MCP `defer` authorization, `pipelock explain`, `pipelock keys status`,
-# `pipelock support bundle`, verified `pipelock update`, and `pipelock doctor`
-# checks for inert exemptions.
+# This file is validated in CI with Pipelock 3.4.0. See the release changelog
+# for the full control surface and upgrade notes.
 # Run `pipelock assess init --config <file>` to create an assessment workspace.
 # Run `pipelock audit score --config <file>` for a security posture score (0-100).
 # Run `pipelock doctor` to verify configured protections are actually enforceable.
@@ -78,8 +72,9 @@ tool_chain_detection:
   window_size: 20
   max_gap: 3
 
-# Request body scanning (pipelock 2.5+): detect prompt-injection payloads in
-# outbound request bodies (JSON, form-encoded, raw text, WebSocket frames).
+# Request body scanning covers cleartext HTTP, reverse-proxy, and WebSocket
+# bodies. It cannot inspect encrypted HTTPS tunnel bodies unless TLS
+# interception is separately configured and its CA trusted by the client.
 # In enforce mode, prompt-injection findings hard-block non-provider
 # destinations even when action is "warn". Trusted provider hosts (OpenAI,
 # Anthropic, etc.) remain exempt via the response_scanning exemption list.


### PR DESCRIPTION
## What changed

- Pin Pipelock 3.4.0 across CI, Docker Compose, and Helm, then validate the shipped Compose config and Helm-rendered config with the applicable attack vectors.
- Require Pipelock for Helm external-assistant deployments by default, narrow scan exclusions, and correct the HTTPS coverage and Compose profile documentation.

Configuration or coverage drift now fails CI, and Helm refuses an external assistant without Pipelock unless the operator explicitly opts out. Reviewers should distrust any claim that the default examples scan encrypted HTTPS bodies because they don't enable TLS interception.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded Pipelock to version 3.4.0 with a pinned multi-architecture image.
  - Pipelock is now required by default for external-assistant deployments unless explicitly disabled.
  - Clarified HTTPS tunnel controls, MCP traffic inspection, receipts, and request-body scanning limitations.

- **Documentation**
  - Updated Docker Compose, Helm, and hosting guidance with current configuration and setup instructions.
  - Clarified service profiles and external-assistant deployment behavior.

- **Tests**
  - Expanded validation for configuration, Docker Compose rendering, Helm output, coverage, and proxy enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->