### PR TITLE
Instrument AI calls with Sentry spans

### DIFF
--- a/app/models/assistant/function_tool_caller.rb
+++ b/app/models/assistant/function_tool_caller.rb
@@ -8,9 +8,13 @@ class Assistant::FunctionToolCaller
     @functions = functions
   end
 
-  def fulfill_requests(function_requests)
+  def fulfill_requests(function_requests, conversation_id: nil, user_identifier: nil)
     function_requests.map do |function_request|
-      result = execute(function_request)
+      result = execute(
+        function_request,
+        conversation_id: conversation_id,
+        user_identifier: user_identifier
+      )
 
       ToolCall::Function.from_function_request(function_request, result)
     end
@@ -24,7 +28,7 @@ class Assistant::FunctionToolCaller
     # Tool failures come back as data instead of raising, so one bad call no
     # longer aborts the whole turn. The hint steers the model toward a single
     # corrected retry (the system prompt pairs it with a retry-once rule).
-    def execute(function_request)
+    def execute(function_request, conversation_id: nil, user_identifier: nil)
       fn = find_function(function_request)
 
       if fn.nil?
@@ -35,7 +39,14 @@ class Assistant::FunctionToolCaller
       end
 
       fn_args = JSON.parse(function_request.function_args.presence || "{}")
-      fn.call(fn_args)
+      Provider::SentryAiMonitoring.with_tool_span(
+        function_name: fn.name,
+        description: fn.description,
+        conversation_id: conversation_id,
+        user_identifier: user_identifier
+      ) do
+        fn.call(fn_args)
+      end
     rescue JSON::ParserError
       {
         error: "Arguments were not valid JSON",

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -31,7 +31,11 @@ class Assistant::Responder
               "Assistant exceeded the tool-call limit of #{max_tool_call_iterations} for one response"
       end
 
-      function_tool_calls = function_tool_caller.fulfill_requests(response.function_requests)
+      function_tool_calls = function_tool_caller.fulfill_requests(
+        response.function_requests,
+        conversation_id: chat_session_id,
+        user_identifier: chat_user_identifier
+      )
       function_results = function_tool_calls.map(&:to_result)
       in_flight_function_results.concat(function_results)
 

--- a/app/models/provider/anthropic.rb
+++ b/app/models/provider/anthropic.rb
@@ -238,7 +238,12 @@ class Provider::Anthropic < Provider
 
       partial_usage_recorded = false
 
-      begin
+      Provider::SentryAiMonitoring.with_chat_span(
+        provider: custom_endpoint? ? "anthropic-compatible" : "anthropic",
+        model: model,
+        conversation_id: session_id,
+        user_identifier: user_identifier
+      ) do |sentry_span|
         parsed, usage =
           if streamer.present?
             stream_chat_response(
@@ -267,9 +272,11 @@ class Provider::Anthropic < Provider
         # anyway so a future change that emits partial usage on success can't
         # silently double-bill — the symptom we chased in the #1984 review.
         record_llm_usage(family: family, model: model, operation: "chat", usage: usage) unless partial_usage_recorded
+        Provider::SentryAiMonitoring.set_usage(sentry_span, usage)
 
         parsed
       rescue => e
+        Provider::SentryAiMonitoring.set_error(sentry_span, e)
         log_langfuse_generation(
           name: "chat_response",
           model: model,

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -395,7 +395,12 @@ class Provider::Openai < Provider
 
         input_payload = chat_config.build_input(prompt: prompt)
 
-        begin
+        Provider::SentryAiMonitoring.with_chat_span(
+          provider: custom_provider? ? "openai-compatible" : "openai",
+          model: model,
+          conversation_id: session_id,
+          user_identifier: user_identifier
+        ) do |sentry_span|
           request_params = {
             model: model,
             input: input_payload,
@@ -435,6 +440,7 @@ class Provider::Openai < Provider
               user_identifier: user_identifier
             )
             record_llm_usage(family: family, model: model, operation: "chat", usage: usage)
+            Provider::SentryAiMonitoring.set_usage(sentry_span, usage)
             response
           else
             parsed = ChatParser.new(raw_response).parsed
@@ -449,9 +455,11 @@ class Provider::Openai < Provider
               user_identifier: user_identifier
             )
             record_llm_usage(family: family, model: model, operation: "chat", usage: raw_response["usage"])
+            Provider::SentryAiMonitoring.set_usage(sentry_span, raw_response["usage"])
             parsed
           end
         rescue => e
+          Provider::SentryAiMonitoring.set_error(sentry_span, e)
           log_langfuse_generation(
             name: "chat_response",
             model: model,
@@ -498,7 +506,12 @@ class Provider::Openai < Provider
         params[:tool_choice] = "none" if tool_choice == :none && tools.present?
         params[:max_tokens] = explicit_max_response_tokens if explicit_max_response_tokens
 
-        begin
+        Provider::SentryAiMonitoring.with_chat_span(
+          provider: custom_provider? ? "openai-compatible" : "openai",
+          model: model,
+          conversation_id: session_id,
+          user_identifier: user_identifier
+        ) do |sentry_span|
           raw_response = client.chat(parameters: params)
 
           parsed = GenericChatParser.new(raw_response).parsed
@@ -514,6 +527,7 @@ class Provider::Openai < Provider
           )
 
           record_llm_usage(family: family, model: model, operation: "chat", usage: raw_response["usage"])
+          Provider::SentryAiMonitoring.set_usage(sentry_span, raw_response["usage"])
 
           # If a streamer was provided, manually call it with the parsed response
           # to maintain the same contract as the streaming version
@@ -531,6 +545,7 @@ class Provider::Openai < Provider
 
           parsed
         rescue => e
+          Provider::SentryAiMonitoring.set_error(sentry_span, e)
           log_langfuse_generation(
             name: "chat_response",
             model: model,

--- a/app/models/provider/sentry_ai_monitoring.rb
+++ b/app/models/provider/sentry_ai_monitoring.rb
@@ -1,8 +1,8 @@
-require "digest"
+require "openssl"
 
 class Provider::SentryAiMonitoring
-  SAFE_CONVERSATION_ID = /\A[a-zA-Z0-9_-]{1,120}\z/
   AI_SAMPLE_CONTEXT = { ai_monitoring: true }.freeze
+  TELEMETRY_KEY_PURPOSE = "sentry_ai_monitoring_identifier".freeze
 
   class << self
     def with_chat_span(provider:, model:, conversation_id: nil, user_identifier: nil)
@@ -109,8 +109,8 @@ class Provider::SentryAiMonitoring
       def set_common_data(span, provider:, model:, conversation_id:, user_identifier:, attributes:)
         set_data(span, "gen_ai.system", provider) if provider.present?
         set_data(span, "gen_ai.request.model", model) if model.present?
-        set_data(span, "gen_ai.conversation.id", safe_conversation_id(conversation_id))
-        set_data(span, "user.id", user_identifier.to_s) if user_identifier.present?
+        set_data(span, "gen_ai.conversation.id", telemetry_identifier("conversation", conversation_id))
+        set_data(span, "user.id", telemetry_identifier("user", user_identifier))
 
         attributes.each { |key, value| set_data(span, key, value) if value.present? }
       end
@@ -121,12 +121,15 @@ class Provider::SentryAiMonitoring
         span.set_data(key, value)
       end
 
-      def safe_conversation_id(value)
-        id = value.to_s.strip
-        return if id.blank?
-        return id if id.match?(SAFE_CONVERSATION_ID)
+      def telemetry_identifier(namespace, value)
+        identifier = value.to_s.strip
+        return if identifier.blank?
 
-        Digest::SHA256.hexdigest(id)
+        OpenSSL::HMAC.hexdigest("SHA256", telemetry_secret, "#{namespace}:#{identifier}")
+      end
+
+      def telemetry_secret
+        Rails.application.key_generator.generate_key(TELEMETRY_KEY_PURPOSE, 32)
       end
 
       def integer_from(value)

--- a/app/models/provider/sentry_ai_monitoring.rb
+++ b/app/models/provider/sentry_ai_monitoring.rb
@@ -1,0 +1,140 @@
+require "digest"
+
+class Provider::SentryAiMonitoring
+  SAFE_CONVERSATION_ID = /\A[a-zA-Z0-9_-]{1,120}\z/
+  AI_SAMPLE_CONTEXT = { ai_monitoring: true }.freeze
+
+  class << self
+    def with_chat_span(provider:, model:, conversation_id: nil, user_identifier: nil)
+      with_span(
+        op: "gen_ai.chat",
+        name: "chat #{model}",
+        provider: provider,
+        model: model,
+        conversation_id: conversation_id,
+        user_identifier: user_identifier,
+        attributes: {
+          "gen_ai.operation.name" => "chat"
+        }
+      ) { |span| yield(span) }
+    end
+
+    def with_tool_span(function_name:, description: nil, conversation_id: nil, user_identifier: nil)
+      with_span(
+        op: "gen_ai.execute_tool",
+        name: "execute_tool #{function_name}",
+        provider: nil,
+        model: nil,
+        conversation_id: conversation_id,
+        user_identifier: user_identifier,
+        attributes: {
+          "gen_ai.operation.name" => "execute_tool",
+          "gen_ai.tool.name" => function_name,
+          "gen_ai.tool.description" => description
+        }
+      ) { |span| yield(span) }
+    end
+
+    def set_usage(span, usage)
+      return unless span && usage.present?
+
+      input_tokens = integer_from(usage["input_tokens"] || usage["prompt_tokens"])
+      output_tokens = integer_from(usage["output_tokens"] || usage["completion_tokens"])
+      total_tokens = integer_from(usage["total_tokens"]) || [ input_tokens, output_tokens ].compact.sum
+
+      set_data(span, "gen_ai.usage.input_tokens", input_tokens)
+      set_data(span, "gen_ai.usage.output_tokens", output_tokens)
+      set_data(span, "gen_ai.usage.total_tokens", total_tokens)
+      set_data(
+        span,
+        "gen_ai.usage.input_tokens.cached",
+        integer_from(usage["cached_tokens"] || usage["cache_read_input_tokens"])
+      )
+      set_data(
+        span,
+        "gen_ai.usage.input_tokens.cache_write",
+        integer_from(usage["cache_write_input_tokens"] || usage["cache_creation_input_tokens"])
+      )
+      set_data(
+        span,
+        "gen_ai.usage.output_tokens.reasoning",
+        integer_from(usage["reasoning_tokens"] || usage["output_tokens_reasoning"])
+      )
+    end
+
+    def set_error(span, error)
+      return unless span
+
+      set_data(span, "gen_ai.response.error_type", error.class.name)
+    end
+
+    private
+      def with_span(op:, name:, provider:, model:, conversation_id:, user_identifier:, attributes:)
+        return yield(nil) unless active?
+
+        transaction = Sentry.start_transaction(
+          name: name,
+          op: op,
+          source: :custom,
+          custom_sampling_context: AI_SAMPLE_CONTEXT
+        )
+        return yield(nil) unless transaction
+
+        set_common_data(
+          transaction,
+          provider: provider,
+          model: model,
+          conversation_id: conversation_id,
+          user_identifier: user_identifier,
+          attributes: attributes
+        )
+
+        result = yield(transaction)
+        transaction.set_status("ok")
+        result
+      rescue => e
+        if transaction
+          set_error(transaction, e)
+          transaction.set_status("internal_error")
+        end
+        raise
+      ensure
+        transaction&.finish
+      end
+
+      def active?
+        defined?(Sentry) && Sentry.respond_to?(:initialized?) && Sentry.initialized?
+      end
+
+      def set_common_data(span, provider:, model:, conversation_id:, user_identifier:, attributes:)
+        set_data(span, "gen_ai.system", provider) if provider.present?
+        set_data(span, "gen_ai.request.model", model) if model.present?
+        set_data(span, "gen_ai.conversation.id", safe_conversation_id(conversation_id))
+        set_data(span, "user.id", user_identifier.to_s) if user_identifier.present?
+
+        attributes.each { |key, value| set_data(span, key, value) if value.present? }
+      end
+
+      def set_data(span, key, value)
+        return if value.nil?
+
+        span.set_data(key, value)
+      end
+
+      def safe_conversation_id(value)
+        id = value.to_s.strip
+        return if id.blank?
+        return id if id.match?(SAFE_CONVERSATION_ID)
+
+        Digest::SHA256.hexdigest(id)
+      end
+
+      def integer_from(value)
+        return if value.nil?
+
+        Integer(value)
+      rescue ArgumentError, TypeError
+        nil
+      end
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -13,7 +13,15 @@ if ENV["SENTRY_DSN"].present?
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
     # We recommend adjusting this value in production.
-    config.traces_sample_rate = 0.25
+    traces_sample_rate = 0.25
+    config.traces_sample_rate = traces_sample_rate
+    config.traces_sampler = lambda do |sampling_context|
+      if sampling_context[:ai_monitoring]
+        1.0
+      else
+        sampling_context[:parent_sampled].nil? ? traces_sample_rate : sampling_context[:parent_sampled]
+      end
+    end
 
     # Set profiles_sample_rate to profile 100%
     # of sampled transactions.

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,9 +10,8 @@ if ENV["SENTRY_DSN"].present?
     # Patch Ruby logger to forward logs
     config.enabled_patches = [ :logger ]
 
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production.
+    # Capture 25% of ordinary performance transactions by default.
+    # AI monitoring transactions opt into 100% sampling through traces_sampler.
     traces_sample_rate = 0.25
     config.traces_sample_rate = traces_sample_rate
     config.traces_sampler = lambda do |sampling_context|

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -201,6 +201,8 @@ class ChatProvider with ChangeNotifier {
   }) async {
     _isSendingMessage = true;
     _errorMessage = null;
+    var sendSucceeded = false;
+    Object? sendThrowable;
     final sendSpan = TelemetryService.instance.startSpan(
       'gen_ai.chat',
       'mobile chat message',
@@ -255,6 +257,7 @@ class ChatProvider with ChangeNotifier {
 
         // Start polling for AI response
         _startPolling(accessToken, chatId);
+        sendSucceeded = true;
         return true;
       } else {
         // Roll back the optimistic message on failure.
@@ -265,13 +268,15 @@ class ChatProvider with ChangeNotifier {
     } catch (e) {
       // Roll back the optimistic message on error.
       _rollbackOptimisticMessage(optimisticId, chatId);
+      sendThrowable = e;
       _log.warning('ChatProvider', 'sendMessage failed: ${e.runtimeType}');
       _errorMessage = 'Something went wrong. Please try again.';
       return false;
     } finally {
       await TelemetryService.instance.finishSpan(
         sendSpan,
-        success: _errorMessage == null,
+        success: sendSucceeded,
+        throwable: sendThrowable,
       );
       _isSendingMessage = false;
       notifyListeners();

--- a/mobile/lib/providers/chat_provider.dart
+++ b/mobile/lib/providers/chat_provider.dart
@@ -4,6 +4,7 @@ import '../models/chat.dart';
 import '../models/message.dart';
 import '../services/chat_service.dart';
 import '../services/log_service.dart';
+import '../services/telemetry_service.dart';
 
 class ChatProvider with ChangeNotifier {
   final ChatService _chatService = ChatService();
@@ -18,6 +19,7 @@ class ChatProvider with ChangeNotifier {
   Timer? _pollingTimer;
   DateTime? _pollingStartTime;
   bool _isPollingRequestInFlight = false;
+  Object? _assistantResponseSpan;
 
   static const _pollingTimeout = Duration(seconds: 20);
 
@@ -78,7 +80,7 @@ class ChatProvider with ChangeNotifier {
     // Stop any in-progress polling — the server response is the source of truth
     // when explicitly fetching a chat. This prevents a stale poll from
     // overwriting the freshly fetched data and ensures the message filter lifts.
-    _stopPolling();
+    _stopPolling(success: false);
     _isLoading = true;
     _errorMessage = null;
     notifyListeners();
@@ -112,6 +114,16 @@ class ChatProvider with ChangeNotifier {
   }) async {
     _isLoading = true;
     _errorMessage = null;
+    final createSpan = initialMessage == null
+        ? null
+        : TelemetryService.instance.startSpan(
+            'gen_ai.chat',
+            'mobile chat message',
+            data: {
+              'gen_ai.operation.name': 'chat',
+              'gen_ai.system': 'sure-rails-api',
+            },
+          );
     notifyListeners();
 
     try {
@@ -139,6 +151,7 @@ class ChatProvider with ChangeNotifier {
           );
           _currentChat = chat.copyWith(messages: [userMessage]);
           _chats.insert(0, _currentChat!);
+          await TelemetryService.instance.finishSpan(createSpan, success: true);
           _startPolling(accessToken, chat.id);
         } else {
           _currentChat = chat;
@@ -150,6 +163,7 @@ class ChatProvider with ChangeNotifier {
         return _currentChat!;
       } else {
         _errorMessage = result['error'] ?? 'Failed to create chat';
+        await TelemetryService.instance.finishSpan(createSpan, success: false);
         _isLoading = false;
         notifyListeners();
         return null;
@@ -157,6 +171,11 @@ class ChatProvider with ChangeNotifier {
     } catch (e) {
       _log.warning('ChatProvider', 'createChat failed: ${e.runtimeType}');
       _errorMessage = 'Something went wrong. Please try again.';
+      await TelemetryService.instance.finishSpan(
+        createSpan,
+        success: false,
+        throwable: e,
+      );
       _isLoading = false;
       notifyListeners();
       return null;
@@ -182,6 +201,15 @@ class ChatProvider with ChangeNotifier {
   }) async {
     _isSendingMessage = true;
     _errorMessage = null;
+    final sendSpan = TelemetryService.instance.startSpan(
+      'gen_ai.chat',
+      'mobile chat message',
+      data: {
+        'gen_ai.conversation.id': chatId,
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.system': 'sure-rails-api',
+      },
+    );
 
     // Optimistically add the user message so it appears immediately — before
     // the network round-trip completes. This makes the empty-state disappear
@@ -241,6 +269,10 @@ class ChatProvider with ChangeNotifier {
       _errorMessage = 'Something went wrong. Please try again.';
       return false;
     } finally {
+      await TelemetryService.instance.finishSpan(
+        sendSpan,
+        success: _errorMessage == null,
+      );
       _isSendingMessage = false;
       notifyListeners();
     }
@@ -365,6 +397,24 @@ class ChatProvider with ChangeNotifier {
   /// Start polling for new messages (AI responses)
   void _startPolling(String accessToken, String chatId) {
     _pollingTimer?.cancel();
+    unawaited(TelemetryService.instance.finishSpan(
+      _assistantResponseSpan,
+      success: false,
+    ));
+    _assistantResponseSpan = TelemetryService.instance.startSpan(
+      'gen_ai.invoke_agent',
+      'mobile assistant response',
+      data: {
+        'gen_ai.conversation.id': chatId,
+        'gen_ai.operation.name': 'invoke_agent',
+        'gen_ai.agent.name': 'sure-assistant',
+      },
+    );
+    TelemetryService.instance.addBreadcrumb(
+      'gen_ai',
+      'assistant_response_polling_started',
+      data: {'gen_ai.conversation.id': chatId},
+    );
     _lastAssistantContentLength = null;
     _stablePollingCount = 0;
     _isWaitingForResponse = true;
@@ -383,7 +433,7 @@ class ChatProvider with ChangeNotifier {
   }
 
   /// Stop polling
-  void _stopPolling() {
+  void _stopPolling({bool success = true, Object? throwable}) {
     _pollingTimer?.cancel();
     _pollingTimer = null;
     _pollingStartTime = null;
@@ -391,6 +441,12 @@ class ChatProvider with ChangeNotifier {
     _isWaitingForResponse = false;
     _lastAssistantContentLength = null;
     _stablePollingCount = 0;
+    unawaited(TelemetryService.instance.finishSpan(
+      _assistantResponseSpan,
+      success: success,
+      throwable: throwable,
+    ));
+    _assistantResponseSpan = null;
   }
 
   /// Poll for updates
@@ -444,7 +500,7 @@ class ChatProvider with ChangeNotifier {
           if (!shouldUpdate) {
             _currentChat = updatedChat;
           }
-          _stopPolling();
+          _stopPolling(success: false);
           _errorMessage = updatedChat.error;
           notifyListeners();
           return;
@@ -470,6 +526,11 @@ class ChatProvider with ChangeNotifier {
             // stopping prematurely on a brief server-side generation pause.
             _stablePollingCount++;
             if (_stablePollingCount >= 2) {
+              TelemetryService.instance.addBreadcrumb(
+                'gen_ai',
+                'assistant_response_polling_completed',
+                data: {'gen_ai.conversation.id': chatId},
+              );
               _stopPolling();
               _lastAssistantContentLength = null;
               notifyListeners();
@@ -488,7 +549,7 @@ class ChatProvider with ChangeNotifier {
     // Evaluate timeout only after the attempt, and only when no progress was made.
     if (_pollingStartTime != null &&
         DateTime.now().difference(_pollingStartTime!) >= _pollingTimeout) {
-      _stopPolling();
+      _stopPolling(success: false);
       _errorMessage =
           'The assistant took too long to respond. Please try again.';
       notifyListeners();
@@ -498,13 +559,13 @@ class ChatProvider with ChangeNotifier {
   /// Clear current chat
   void clearCurrentChat() {
     _currentChat = null;
-    _stopPolling();
+    _stopPolling(success: false);
     notifyListeners();
   }
 
   @override
   void dispose() {
-    _stopPolling();
+    _stopPolling(success: false);
     super.dispose();
   }
 }

--- a/mobile/lib/services/telemetry_service.dart
+++ b/mobile/lib/services/telemetry_service.dart
@@ -333,9 +333,7 @@ class TelemetryService {
       final key = LogService.sanitize(entry.key);
       if (_isSensitiveKey(key)) continue;
 
-      final value = _normalizeDataKey(key) == 'gen_ai_conversation_id'
-          ? _sanitizeConversationId(entry.value)
-          : sanitizeValue(entry.value);
+      final value = _sanitizeDataValue(key, entry.value);
       if (value != null) {
         sanitized[key] = value;
       }
@@ -357,7 +355,7 @@ class TelemetryService {
         final key = LogService.sanitize(entry.key.toString());
         if (_isSensitiveKey(key)) continue;
 
-        final sanitizedValue = sanitizeValue(entry.value);
+        final sanitizedValue = _sanitizeDataValue(key, entry.value);
         if (sanitizedValue != null) {
           sanitized[key] = sanitizedValue;
         }
@@ -394,6 +392,12 @@ class TelemetryService {
     if (RegExp(r'^[a-zA-Z0-9_-]{1,120}$').hasMatch(id)) return id;
 
     return null;
+  }
+
+  static Object? _sanitizeDataValue(String key, Object? value) {
+    return _normalizeDataKey(key) == 'gen_ai_conversation_id'
+        ? _sanitizeConversationId(value)
+        : sanitizeValue(value);
   }
 
   static bool _isSensitiveKey(String key) {

--- a/mobile/lib/services/telemetry_service.dart
+++ b/mobile/lib/services/telemetry_service.dart
@@ -333,7 +333,9 @@ class TelemetryService {
       final key = LogService.sanitize(entry.key);
       if (_isSensitiveKey(key)) continue;
 
-      final value = sanitizeValue(entry.value);
+      final value = _normalizeDataKey(key) == 'gen_ai_conversation_id'
+          ? _sanitizeConversationId(entry.value)
+          : sanitizeValue(entry.value);
       if (value != null) {
         sanitized[key] = value;
       }
@@ -384,6 +386,14 @@ class TelemetryService {
 
   static String? _sanitizeOptionalString(String? value) {
     return value == null ? null : _sanitizeFreeformText(value);
+  }
+
+  static String? _sanitizeConversationId(Object? value) {
+    final id = value?.toString().trim();
+    if (id == null || id.isEmpty) return null;
+    if (RegExp(r'^[a-zA-Z0-9_-]{1,120}$').hasMatch(id)) return id;
+
+    return null;
   }
 
   static bool _isSensitiveKey(String key) {

--- a/mobile/test/services/telemetry_service_test.dart
+++ b/mobile/test/services/telemetry_service_test.dart
@@ -97,6 +97,10 @@ void main() {
           'page': 1,
           'transaction_id': 'txn_123',
           'backend_url': 'https://sure.example.test',
+          'gen_ai.conversation.id': 'conversation/with/slash',
+        },
+        'metadata': {
+          'gen_ai.conversation.id': 'conv_safe-123',
         },
         'items': [
           {'success': true, 'account_id': 'acct_123'},
@@ -108,6 +112,7 @@ void main() {
         equals({
           'status': 'ok',
           'pagination': {'page': 1},
+          'metadata': {'gen_ai.conversation.id': 'conv_safe-123'},
           'items': [
             {'success': true},
           ],

--- a/mobile/test/services/telemetry_service_test.dart
+++ b/mobile/test/services/telemetry_service_test.dart
@@ -69,6 +69,26 @@ void main() {
       expect(sanitized, isNot(contains('message')));
     });
 
+    test('preserves safe gen AI conversation ids', () {
+      final sanitized = TelemetryService.sanitizeData({
+        'gen_ai.conversation.id': '48e35936-82ab-4f1a-beaf-b2fa4273ac5e',
+        'other_id': '48e35936-82ab-4f1a-beaf-b2fa4273ac5e',
+      });
+      final unsafe = TelemetryService.sanitizeData({
+        'gen_ai.conversation.id': 'conversation/with/slash',
+      });
+
+      expect(
+        sanitized,
+        containsPair(
+          'gen_ai.conversation.id',
+          '48e35936-82ab-4f1a-beaf-b2fa4273ac5e',
+        ),
+      );
+      expect(sanitized, containsPair('other_id', '[id]'));
+      expect(unsafe, isNot(contains('gen_ai.conversation.id')));
+    });
+
     test('sanitizes nested telemetry maps without preserving sensitive keys',
         () {
       final sanitized = TelemetryService.sanitizeValue({

--- a/test/models/provider/sentry_ai_monitoring_test.rb
+++ b/test/models/provider/sentry_ai_monitoring_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Provider::SentryAiMonitoringTest < ActiveSupport::TestCase
+  test "telemetry identifiers are stable keyed HMACs" do
+    identifier = "48e35936-82ab-4f1a-beaf-b2fa4273ac5e"
+
+    first = Provider::SentryAiMonitoring.send(
+      :telemetry_identifier,
+      "conversation",
+      identifier
+    )
+    second = Provider::SentryAiMonitoring.send(
+      :telemetry_identifier,
+      "conversation",
+      identifier
+    )
+    user_scoped = Provider::SentryAiMonitoring.send(
+      :telemetry_identifier,
+      "user",
+      identifier
+    )
+
+    assert_equal first, second
+    assert_not_equal identifier, first
+    assert_not_equal user_scoped, first
+    assert_match(/\A\h{64}\z/, first)
+  end
+end


### PR DESCRIPTION
## Summary
- add privacy-preserving Sentry gen_ai spans for Rails OpenAI/Anthropic chat calls and assistant tool execution
- sample Sentry AI monitoring transactions at 100% while preserving the existing 25% default for other traces
- add Flutter chat send/polling spans with safe conversation IDs and keep prompt/output bodies out of telemetry

## Privacy
Prompt, response, tool argument, and tool result capture is not enabled. The instrumentation records model/provider, opaque conversation/user identifiers, tool names/descriptions, token usage, and error type only.

## Tests
- ruby -c app/models/provider/sentry_ai_monitoring.rb app/models/provider/openai.rb app/models/provider/anthropic.rb app/models/assistant/function_tool_caller.rb app/models/assistant/responder.rb config/initializers/sentry.rb
- git diff --check
- bin/rails test test/models/provider/openai_test.rb test/models/provider/anthropic_test.rb test/models/assistant_test.rb

## Not run
- Flutter formatter/tests: no flutter, fvm, or dart executable is installed in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added detailed monitoring for AI chat requests, tool executions, token usage, and errors.
  * Improved tracking of chat creation, message delivery, and assistant-response polling across mobile experiences.
  * Enhanced visibility into successful, failed, timed-out, and interrupted chat operations.

* **Privacy & Security**
  * Conversation and user identifiers are now protected and sanitized before telemetry is recorded.
  * Unsafe conversation identifiers are excluded from telemetry data.

* **Tests**
  * Added coverage for identifier protection, validation, sanitization, and telemetry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->