### PR TITLE
ci: skip Chrome install in unit test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libvips postgresql-client libpq-dev
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y curl libvips postgresql-client libpq-dev
 
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
## Summary

- remove `google-chrome-stable` from the `test_unit` package install step
- keep the Chrome install in `test_system`, where Capybara/Selenium actually needs it

## Why

`test_unit` runs plain `bin/rails test`, which excludes `test/system`. The browser setup only applies to system tests, and `test_system` already installs Chrome independently. Dropping Chrome from `test_unit` should save several minutes on each PR run without changing test coverage.

Refs https://github.com/we-promise/sure/pull/3081#issuecomment-5360453892

## Tests

- Not run locally; workflow-only package list change
- Verified via repo search that Chrome/Selenium references are limited to `test/system`, `test/application_system_test_case.rb`, and the system-test workflow path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the automated testing environment by removing an unnecessary browser installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->