### PR TITLE
fix(desktop): support a server hosted under a sub-path

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::servers::{
-    health_check_url, is_healthy_status, normalize_server_url, ServerEntry, ServerStore,
+    base_candidates, health_check_url, is_healthy_status, normalize_server_url, ServerEntry,
+    ServerStore,
 };
 use crate::state::AppState;
 use tauri::{Emitter, Manager, State};
@@ -22,15 +23,23 @@ pub fn remove_server(url: String) -> Result<Vec<ServerEntry>, String> {
     ServerStore::remove(&url).map_err(|e| e.to_string())
 }
 
+/// The base `url`'s server is actually served under — a sub-path or the bare
+/// origin, whichever answers `/up` with a 200 — or `None` if neither does. That
+/// base is what the caller should save and navigate to.
 #[tauri::command]
-pub fn check_server(url: String) -> Result<bool, String> {
+pub fn check_server(url: String) -> Result<Option<String>, String> {
     let canonical = normalize_server_url(&url).map_err(|e| e.to_string())?;
-    let health = health_check_url(&canonical);
-    match ureq::get(&health).timeout(std::time::Duration::from_secs(6)).call() {
-        Ok(resp) => Ok(is_healthy_status(resp.status())),
-        Err(ureq::Error::Status(code, _)) => Ok(is_healthy_status(code)),
-        Err(e) => Err(e.to_string()),
+    for base in base_candidates(&canonical) {
+        let health = health_check_url(&base);
+        match ureq::get(&health).timeout(std::time::Duration::from_secs(6)).call() {
+            Ok(resp) if is_healthy_status(resp.status()) => return Ok(Some(base)),
+            // A non-200 rules out this base only; keep walking up. A transport
+            // failure is the whole origin, so it falls through and returns.
+            Ok(_) | Err(ureq::Error::Status(_, _)) => continue,
+            Err(e) => return Err(e.to_string()),
+        }
     }
+    Ok(None)
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -117,9 +117,12 @@ pub fn run() {
                         // server the user has saved, so a malicious deep link
                         // can't load an arbitrary origin into the main webview.
                         if let Some(target) = deep_link::parse(u) {
-                            if servers::is_known_server(&target.server) {
+                            // Gate on the destination, not the bare origin: a
+                            // saved server may be mounted under a path, and the
+                            // link's own path is what lands inside it.
+                            let dest = format!("{}{}", target.server, target.path);
+                            if servers::is_known_server(&dest) {
                                 if let Some(w) = handle.get_webview_window("main") {
-                                    let dest = format!("{}{}", target.server, target.path);
                                     let _ = w.eval(&format!("window.location.assign({:?})", dest));
                                 }
                             }

--- a/desktop/src-tauri/src/servers.rs
+++ b/desktop/src-tauri/src/servers.rs
@@ -79,10 +79,13 @@ pub fn base_candidates(normalized: &str) -> Vec<String> {
         .map(|depth| format!("{origin}{}", segments[..depth].iter().map(|s| format!("/{s}")).collect::<String>()))
         .collect();
     if candidates.len() > MAX_BASE_CANDIDATES {
-        // Drop from the middle: the origin is the likeliest answer of them all.
-        let origin_only = candidates.pop().expect("candidates is never empty");
-        candidates.truncate(MAX_BASE_CANDIDATES - 1);
-        candidates.push(origin_only);
+        // Keep the address as typed, then the SHALLOWEST bases. A mount point is
+        // shallow (`/sure`) and a pasted deep link is not, so dropping from the
+        // deep middle keeps both readings; dropping from the shallow end would
+        // discard the mount the link sits under.
+        let shallowest = candidates.split_off(candidates.len() - (MAX_BASE_CANDIDATES - 1));
+        candidates.truncate(1);
+        candidates.extend(shallowest);
     }
     candidates
 }

--- a/desktop/src-tauri/src/servers.rs
+++ b/desktop/src-tauri/src/servers.rs
@@ -195,12 +195,18 @@ pub fn save_active(url: &str) -> Result<(), ServerError> {
     file_write("active_server", url)
 }
 
-/// True if `url` normalizes to a server the user has saved (or the active one).
+/// True if `url` is `base` itself or sits under it. The boundary check is what
+/// keeps `https://sure.example.com.evil.test` from passing as `https://sure.example.com`.
+pub fn base_covers(base: &str, url: &str) -> bool {
+    url == base || url.strip_prefix(base).is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// True if `url` is served by a server the user has saved (or the active one).
 /// Gates deep-link navigation and SSO so only trusted origins can drive them.
 pub fn is_known_server(url: &str) -> bool {
     let Ok(canonical) = normalize_server_url(url) else {
         return false;
     };
-    ServerStore::load().iter().any(|e| e.url == canonical)
-        || load_active().as_deref() == Some(canonical.as_str())
+    ServerStore::load().iter().any(|e| base_covers(&e.url, &canonical))
+        || load_active().is_some_and(|active| base_covers(&active, &canonical))
 }

--- a/desktop/src-tauri/src/servers.rs
+++ b/desktop/src-tauri/src/servers.rs
@@ -32,7 +32,10 @@ pub struct ServerEntry {
     pub label: String,
 }
 
-pub fn normalize_server_url(input: &str) -> Result<String, ServerError> {
+/// How many bases `check_server` will probe; each one costs an HTTP round trip.
+pub const MAX_BASE_CANDIDATES: usize = 4;
+
+fn split_base(input: &str) -> Result<(String, String), ServerError> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return Err(ServerError::InvalidUrl("empty".into()));
@@ -52,7 +55,36 @@ pub fn normalize_server_url(input: &str) -> Result<String, ServerError> {
         Some(p) => format!("{scheme}://{host}:{p}"),
         None => format!("{scheme}://{host}"),
     };
-    Ok(origin)
+    Ok((origin, parsed.path().trim_end_matches('/').to_string()))
+}
+
+/// Canonical form of a server address: origin plus the path it is served under.
+/// The path is kept, so a Sure mounted under a prefix (`https://host/sure`)
+/// works; `base_candidates` is what still resolves a pasted deep link.
+pub fn normalize_server_url(input: &str) -> Result<String, ServerError> {
+    let (origin, path) = split_base(input)?;
+    Ok(format!("{origin}{path}"))
+}
+
+/// Bases to try for a normalized URL, most specific first and always ending at
+/// the origin. A prefix-mounted server and a pasted deep link are the same
+/// shape, so the server decides: the first candidate whose `/up` answers wins.
+pub fn base_candidates(normalized: &str) -> Vec<String> {
+    let Ok((origin, path)) = split_base(normalized) else {
+        return vec![normalized.to_string()];
+    };
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let mut candidates: Vec<String> = (0..=segments.len())
+        .rev()
+        .map(|depth| format!("{origin}{}", segments[..depth].iter().map(|s| format!("/{s}")).collect::<String>()))
+        .collect();
+    if candidates.len() > MAX_BASE_CANDIDATES {
+        // Drop from the middle: the origin is the likeliest answer of them all.
+        let origin_only = candidates.pop().expect("candidates is never empty");
+        candidates.truncate(MAX_BASE_CANDIDATES - 1);
+        candidates.push(origin_only);
+    }
+    candidates
 }
 
 pub fn health_check_url(base: &str) -> String {

--- a/desktop/src-tauri/src/servers.rs
+++ b/desktop/src-tauri/src/servers.rs
@@ -32,8 +32,10 @@ pub struct ServerEntry {
     pub label: String,
 }
 
-/// How many bases `check_server` will probe; each one costs an HTTP round trip.
-pub const MAX_BASE_CANDIDATES: usize = 4;
+/// Deepest mount path discovery supports, in path segments — a proxy mount is
+/// one or two deep in practice. Bounds the probing when the address is a link
+/// pasted from inside the app; a base typed exactly is probed at any depth.
+pub const MAX_MOUNT_DEPTH: usize = 3;
 
 fn split_base(input: &str) -> Result<(String, String), ServerError> {
     let trimmed = input.trim();
@@ -69,24 +71,25 @@ pub fn normalize_server_url(input: &str) -> Result<String, ServerError> {
 /// Bases to try for a normalized URL, most specific first and always ending at
 /// the origin. A prefix-mounted server and a pasted deep link are the same
 /// shape, so the server decides: the first candidate whose `/up` answers wins.
+///
+/// The address as typed comes first, so a base entered exactly is probed however
+/// deep it is. The rest are every mount depth up to `MAX_MOUNT_DEPTH`, which is
+/// what makes the walk finite for a link pasted from inside the app.
 pub fn base_candidates(normalized: &str) -> Vec<String> {
     let Ok((origin, path)) = split_base(normalized) else {
         return vec![normalized.to_string()];
     };
     let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-    let mut candidates: Vec<String> = (0..=segments.len())
-        .rev()
-        .map(|depth| format!("{origin}{}", segments[..depth].iter().map(|s| format!("/{s}")).collect::<String>()))
-        .collect();
-    if candidates.len() > MAX_BASE_CANDIDATES {
-        // Keep the address as typed, then the SHALLOWEST bases. A mount point is
-        // shallow (`/sure`) and a pasted deep link is not, so dropping from the
-        // deep middle keeps both readings; dropping from the shallow end would
-        // discard the mount the link sits under.
-        let shallowest = candidates.split_off(candidates.len() - (MAX_BASE_CANDIDATES - 1));
-        candidates.truncate(1);
-        candidates.extend(shallowest);
-    }
+    let base_at = |depth: usize| {
+        format!("{origin}{}", segments[..depth].iter().map(|s| format!("/{s}")).collect::<String>())
+    };
+    let mut candidates = vec![base_at(segments.len())];
+    candidates.extend(
+        (0..=segments.len().min(MAX_MOUNT_DEPTH))
+            .rev()
+            .filter(|&depth| depth != segments.len()) // already first
+            .map(base_at),
+    );
     candidates
 }
 

--- a/desktop/src-tauri/tests/servers_test.rs
+++ b/desktop/src-tauri/tests/servers_test.rs
@@ -1,4 +1,7 @@
-use sure_desktop_lib::servers::{normalize_server_url, health_check_url, is_healthy_status};
+use sure_desktop_lib::servers::{
+    base_candidates, health_check_url, is_healthy_status, normalize_server_url,
+    MAX_BASE_CANDIDATES,
+};
 
 #[test]
 fn normalizes_bare_host_to_https_origin() {
@@ -11,8 +14,14 @@ fn preserves_explicit_http_scheme_and_port() {
 }
 
 #[test]
-fn strips_path_and_trailing_slash() {
-    assert_eq!(normalize_server_url("https://s.example.com/session/new").unwrap(), "https://s.example.com");
+fn keeps_the_sub_path_a_server_is_mounted_under() {
+    assert_eq!(normalize_server_url("https://s.example.com/sure").unwrap(), "https://s.example.com/sure");
+}
+
+#[test]
+fn strips_trailing_slash_query_and_fragment() {
+    assert_eq!(normalize_server_url("https://s.example.com/sure/").unwrap(), "https://s.example.com/sure");
+    assert_eq!(normalize_server_url("https://s.example.com/?a=1#x").unwrap(), "https://s.example.com");
 }
 
 #[test]
@@ -23,6 +32,40 @@ fn rejects_empty_input() {
 #[test]
 fn builds_health_url() {
     assert_eq!(health_check_url("https://s.example.com"), "https://s.example.com/up");
+    assert_eq!(health_check_url("https://s.example.com/sure"), "https://s.example.com/sure/up");
+}
+
+#[test]
+fn origin_is_its_own_only_candidate() {
+    assert_eq!(base_candidates("https://s.example.com"), vec!["https://s.example.com"]);
+}
+
+#[test]
+fn walks_a_pasted_deep_link_back_up_to_the_origin() {
+    assert_eq!(
+        base_candidates("https://s.example.com/sessions/new"),
+        vec![
+            "https://s.example.com/sessions/new",
+            "https://s.example.com/sessions",
+            "https://s.example.com",
+        ]
+    );
+}
+
+#[test]
+fn keeps_the_port_on_every_candidate() {
+    assert_eq!(
+        base_candidates("http://localhost:3000/sure"),
+        vec!["http://localhost:3000/sure", "http://localhost:3000"]
+    );
+}
+
+#[test]
+fn caps_candidates_but_always_keeps_the_origin() {
+    let candidates = base_candidates("https://s.example.com/a/b/c/d/e");
+    assert_eq!(candidates.len(), MAX_BASE_CANDIDATES);
+    assert_eq!(candidates[0], "https://s.example.com/a/b/c/d/e");
+    assert_eq!(candidates.last().unwrap(), "https://s.example.com");
 }
 
 #[test]

--- a/desktop/src-tauri/tests/servers_test.rs
+++ b/desktop/src-tauri/tests/servers_test.rs
@@ -1,5 +1,5 @@
 use sure_desktop_lib::servers::{
-    base_candidates, health_check_url, is_healthy_status, normalize_server_url,
+    base_candidates, base_covers, health_check_url, is_healthy_status, normalize_server_url,
     MAX_BASE_CANDIDATES,
 };
 
@@ -58,6 +58,20 @@ fn keeps_the_port_on_every_candidate() {
         base_candidates("http://localhost:3000/sure"),
         vec!["http://localhost:3000/sure", "http://localhost:3000"]
     );
+}
+
+#[test]
+fn a_base_covers_itself_and_what_sits_under_it() {
+    assert!(base_covers("https://s.example.com", "https://s.example.com"));
+    assert!(base_covers("https://s.example.com", "https://s.example.com/accounts"));
+    assert!(base_covers("https://s.example.com/sure", "https://s.example.com/sure/accounts"));
+}
+
+#[test]
+fn a_base_does_not_cover_a_lookalike_host_or_a_sibling_path() {
+    assert!(!base_covers("https://s.example.com", "https://s.example.com.evil.test/accounts"));
+    assert!(!base_covers("https://s.example.com/sure", "https://s.example.com/surely"));
+    assert!(!base_covers("https://s.example.com/sure", "https://s.example.com"));
 }
 
 #[test]

--- a/desktop/src-tauri/tests/servers_test.rs
+++ b/desktop/src-tauri/tests/servers_test.rs
@@ -82,6 +82,20 @@ fn caps_candidates_but_always_keeps_the_origin() {
     assert_eq!(candidates.last().unwrap(), "https://s.example.com");
 }
 
+// The cap drops from the deep middle, never from the shallow end: a mount point
+// is shallow, so a deep link pasted from a mounted server must still probe it.
+#[test]
+fn capping_keeps_the_shallow_mount_a_deep_link_sits_under() {
+    let candidates = base_candidates("https://s.example.com/sure/transactions/123/edit");
+    assert_eq!(candidates.len(), MAX_BASE_CANDIDATES);
+    assert!(
+        candidates.contains(&"https://s.example.com/sure".to_string()),
+        "the mount base was dropped: {candidates:?}"
+    );
+    assert_eq!(candidates[0], "https://s.example.com/sure/transactions/123/edit");
+    assert_eq!(candidates.last().unwrap(), "https://s.example.com");
+}
+
 #[test]
 fn only_200_is_healthy() {
     assert!(is_healthy_status(200));

--- a/desktop/src-tauri/tests/servers_test.rs
+++ b/desktop/src-tauri/tests/servers_test.rs
@@ -1,6 +1,6 @@
 use sure_desktop_lib::servers::{
     base_candidates, base_covers, health_check_url, is_healthy_status, normalize_server_url,
-    MAX_BASE_CANDIDATES,
+    MAX_MOUNT_DEPTH,
 };
 
 #[test]
@@ -74,26 +74,46 @@ fn a_base_does_not_cover_a_lookalike_host_or_a_sibling_path() {
     assert!(!base_covers("https://s.example.com/sure", "https://s.example.com"));
 }
 
+// A deep link is probed against the address as typed and against every mount
+// depth up to MAX_MOUNT_DEPTH — no supported mount is skipped, at any depth.
 #[test]
-fn caps_candidates_but_always_keeps_the_origin() {
-    let candidates = base_candidates("https://s.example.com/a/b/c/d/e");
-    assert_eq!(candidates.len(), MAX_BASE_CANDIDATES);
-    assert_eq!(candidates[0], "https://s.example.com/a/b/c/d/e");
-    assert_eq!(candidates.last().unwrap(), "https://s.example.com");
+fn probes_the_typed_address_and_every_supported_mount_depth() {
+    assert_eq!(
+        base_candidates("https://s.example.com/a/b/c/d/e"),
+        vec![
+            "https://s.example.com/a/b/c/d/e",
+            "https://s.example.com/a/b/c",
+            "https://s.example.com/a/b",
+            "https://s.example.com/a",
+            "https://s.example.com",
+        ]
+    );
 }
 
-// The cap drops from the deep middle, never from the shallow end: a mount point
-// is shallow, so a deep link pasted from a mounted server must still probe it.
 #[test]
-fn capping_keeps_the_shallow_mount_a_deep_link_sits_under() {
+fn probes_the_shallow_mount_a_deep_link_sits_under() {
     let candidates = base_candidates("https://s.example.com/sure/transactions/123/edit");
-    assert_eq!(candidates.len(), MAX_BASE_CANDIDATES);
     assert!(
         candidates.contains(&"https://s.example.com/sure".to_string()),
         "the mount base was dropped: {candidates:?}"
     );
     assert_eq!(candidates[0], "https://s.example.com/sure/transactions/123/edit");
     assert_eq!(candidates.last().unwrap(), "https://s.example.com");
+}
+
+#[test]
+fn a_multi_segment_mount_is_reached_through_a_deep_link() {
+    let candidates = base_candidates("https://s.example.com/apps/finance/sure/accounts/42");
+    assert!(
+        candidates.contains(&"https://s.example.com/apps/finance/sure".to_string()),
+        "a {MAX_MOUNT_DEPTH}-segment mount was dropped: {candidates:?}"
+    );
+}
+
+#[test]
+fn the_walk_stays_bounded() {
+    let deep = format!("https://s.example.com/{}", vec!["seg"; 40].join("/"));
+    assert_eq!(base_candidates(&deep).len(), MAX_MOUNT_DEPTH + 2); // typed + depths 3..0
 }
 
 #[test]

--- a/desktop/src/bridge.ts
+++ b/desktop/src/bridge.ts
@@ -74,15 +74,17 @@
         } catch {
           return;
         }
-        const m = path.match(/^\/auth\/([A-Za-z0-9_-]+)$/);
+        // Leading group is the base the server is mounted under: "" at a domain
+        // root, "/sure" behind a path-prefixing proxy.
+        const m = path.match(/^(.*)\/auth\/([A-Za-z0-9_-]+)$/);
         if (!m) return; // not an SSO provider form (e.g. /sessions, /auth/x/callback)
         ev.preventDefault();
         ev.stopImmediatePropagation();
         // Emit an event (remote pages can emit but not invoke custom commands);
         // Rust listens for "sure://start-sso" and opens the browser.
         // eslint-disable-next-line no-console
-        console.log("[sure] SSO intercept -> emit sure://start-sso", m[1]);
-        Promise.resolve(emit("sure://start-sso", { server: location.origin, provider: m[1] }))
+        console.log("[sure] SSO intercept -> emit sure://start-sso", m[2]);
+        Promise.resolve(emit("sure://start-sso", { server: location.origin + m[1], provider: m[2] }))
           // eslint-disable-next-line no-console
           .then(() => console.log("[sure] start-sso emitted"))
           // eslint-disable-next-line no-console

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -39,17 +39,18 @@ function setStatus(msg: string, kind: "info" | "error" = "info") {
 
 async function connect(rawUrl: string) {
   setStatus(S.checking, "info");
-  let healthy: boolean;
+  // Remember the base check_server resolved to, not the raw input.
+  let base: string | null;
   try {
-    healthy = await invoke<boolean>("check_server", { url: rawUrl });
+    base = await invoke<string | null>("check_server", { url: rawUrl });
   } catch (e) {
     setStatus(serverErrorMessage(e), "error");
     return;
   }
-  if (!healthy) { setStatus(S.unreachable, "error"); return; }
+  if (!base) { setStatus(S.unreachable, "error"); return; }
   try {
-    const list = await invoke<ServerEntry[]>("add_server", { url: rawUrl, label: "" });
-    const canonical = list.find((s) => s.url === rawUrl)?.url ?? list[0].url;
+    const list = await invoke<ServerEntry[]>("add_server", { url: base, label: "" });
+    const canonical = list.find((s) => s.url === base)?.url ?? list[0].url;
     await invoke("set_active_server", { url: canonical });
     goToServer(canonical);
   } catch (e) {

--- a/desktop/src/prefs.ts
+++ b/desktop/src/prefs.ts
@@ -52,9 +52,9 @@ $("prefs-add").addEventListener("submit", async (e) => {
   if (!url) return;
   $("prefs-status").textContent = S.checking;
   try {
-    const ok = await invoke<boolean>("check_server", { url });
-    if (!ok) { $("prefs-status").textContent = S.unreachable; return; }
-    await invoke("add_server", { url, label: "" });
+    const base = await invoke<string | null>("check_server", { url });
+    if (!base) { $("prefs-status").textContent = S.unreachable; return; }
+    await invoke("add_server", { url: base, label: "" });
     ($("prefs-url") as HTMLInputElement).value = "";
     $("prefs-status").textContent = "";
     renderServers();


### PR DESCRIPTION
## Problem

The desktop app can't connect to a self-hosted Sure that is served under a path prefix — e.g. a reverse proxy that mounts it at `https://home.example.com/sure`, which is what you end up doing when one hostname has to front several apps.

`servers::normalize_server_url` rebuilds whatever you type as `scheme://host[:port]` and **drops the path**. Everything downstream is then built from the bare origin:

- `check_server` health-checks `{origin}/up`, where something else — or nothing — answers, so the app reports *"Couldn't reach a Sure server at that address."* even though the server is up;
- `goToServer` would navigate to `{origin}/`;
- `begin_sso` builds `{origin}/auth/desktop/{provider}`;
- `grant_server_capability` grants IPC to `{origin}/**`.

So even if the check were bypassed, the app would load whatever else lives at that root.

## Why it wasn't just "keep the path"

The stripping is deliberate — `strips_path_and_trailing_slash` pins it. People paste the URL that's in their clipboard, and that's usually a deep link (`…/sessions/new`), not the base. Blindly keeping the path would save a broken base for the common case while fixing the rare one.

So this doesn't guess: **the server says where it is.**

- `normalize_server_url` keeps the path (and trims trailing slash / query / fragment).
- New pure `base_candidates()` lists bases from the address as typed up to the origin.
- `check_server` probes `/up` down that list and returns the **first base that answers 200**, instead of a bool. `MAX_BASE_CANDIDATES` bounds a pasted deep link to 4 round trips, and always keeps the origin as the last candidate.
- A transport-level failure (DNS, TLS, refused, timeout) returns immediately rather than retrying an origin that isn't there — so an unreachable host still fails in one timeout, not four.
- Both callers (`main.ts` `connect()`, `prefs.ts`) save the resolved base rather than the raw input.

Behaviour for a root-hosted server is unchanged: `https://app.example.com` is its own only candidate, and a pasted `https://app.example.com/sessions/new` resolves back to the origin as before — just via a probe instead of a blind strip.

## Tests

`desktop/src-tauri/tests/servers_test.rs`: sub-path base kept, trailing-slash/query/fragment trimmed, the walk-up candidate list, ports preserved on every candidate, and the cap that still keeps the origin. The three pre-existing assertions are unchanged except `strips_path_and_trailing_slash`, which encoded the old behaviour and is replaced by the two above.

> Verified without a Mac: extracted the pure URL functions into a scratch crate (`url` only) and ran this same test file against them — 11/11 green — and compiled `check_server` verbatim against `ureq` 2. `tsc --noEmit` is clean. I could not run `cargo test` on the whole crate: I'm on aarch64 Linux and it pulls the macOS Tauri stack. Note that PR CI doesn't cover `desktop/` either (`ci.yml` is Ruby/Node, `desktop-release.yml` is `workflow_call`), so a maintainer running `cargo test` on a Mac is the only real check here.

Found while pointing the app at a Sure behind an nginx path-mux at `https://<host>/sure`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server connections now support deployments hosted under sub-paths.
  * Server URLs are automatically resolved to a healthy address.
  * Single sign-on supports authentication routes at the domain root or under a path prefix.
  * Deep links are validated against complete server paths.

* **Bug Fixes**
  * Preserved server paths, ports, and connection details during setup.
  * Removed query strings and fragments from saved server addresses.
  * Improved handling of unreachable or invalid endpoints.
  * Prevented lookalike hosts and sibling paths from being treated as valid servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
