### PR TITLE
fix(onchain-wallets): show linked wallets on the accounts page, and drop the tracking row on unlink

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -28,10 +28,22 @@ class AccountsController < ApplicationController
     @ibkr_items = visible_provider_items(family.ibkr_items.ordered.with_attached_logo.includes(:ibkr_accounts))
     @indexa_capital_items = visible_provider_items(family.indexa_capital_items.ordered.with_attached_logo.includes(:indexa_capital_accounts))
     @sophtron_items = visible_provider_items(family.sophtron_items.ordered.with_attached_logo.includes(:sophtron_accounts))
+    @onchain_wallet_items = visible_provider_items(
+      family.onchain_wallet_items.ordered.includes(:accounts, onchain_wallet_accounts: { account_provider: :account })
+    )
     @binance_items = visible_provider_items(family.binance_items.ordered.with_attached_logo.includes(:binance_accounts, :accounts))
     @kraken_items = visible_provider_items(family.kraken_items.ordered.with_attached_logo.includes(:kraken_accounts, :accounts))
     @questrade_items = visible_provider_items(family.questrade_items.ordered.with_attached_logo.includes(:accounts, questrade_accounts: :account_provider))
     @wise_items = visible_provider_items(family.wise_items.ordered.includes(:wise_accounts, :accounts))
+
+    # An on-chain item is admitted as soon as ONE of its accounts is accessible,
+    # so the card is told which of them this viewer may actually see. nil is the
+    # admin case, which visible_provider_items already lets through whole.
+    allowed_ids = Current.user&.admin? ? nil : @accessible_account_ids
+    @onchain_wallet_cards = @onchain_wallet_items.to_h do |item|
+      visible = item.accounts_visible_to(allowed_ids)
+      [ item.id, { accounts: visible, address_count: item.address_count_for(visible) } ]
+    end
 
     preload_latest_sync_metadata_for_index!
 
@@ -333,7 +345,8 @@ class AccountsController < ApplicationController
         @binance_items,
         @kraken_items,
         @questrade_items,
-        @wise_items
+        @wise_items,
+        @onchain_wallet_items
       ].flatten.compact
 
       accounts = @manual_accounts.to_a

--- a/app/models/account_provider.rb
+++ b/app/models/account_provider.rb
@@ -12,6 +12,14 @@ class AccountProvider < ApplicationRecord
   # Other providers may legitimately enter a "needs setup" state.
   after_destroy :destroy_coinstats_provider_account, if: :coinstats_provider?
 
+  # An on-chain tracking row IS the link: unlike a bank connection there is
+  # nothing to reconnect to and nothing worth keeping. Left behind by a generic
+  # unlink it stops syncing, because the syncer only reads linked rows, while
+  # its partial unique index still holds the (item, chain, address, asset) slot
+  # — so linking that same asset again would collide with a row nothing shows.
+  # The Sure account and its holdings are untouched and carry on as manual.
+  after_destroy :destroy_onchain_provider_account, if: :onchain_provider?
+
   # Returns the provider adapter for this connection
   def adapter
     Provider::Factory.create_adapter(provider, account: account)
@@ -30,6 +38,18 @@ class AccountProvider < ApplicationRecord
     end
 
     def destroy_coinstats_provider_account
+      provider&.destroy
+    end
+
+    def onchain_provider?
+      provider_type == "OnchainWalletAccount"
+    end
+
+    def destroy_onchain_provider_account
+      # The row destroys this link itself through dependent: :destroy, so
+      # answering that by destroying the row again would go round in circles.
+      return if destroyed_by_association
+
       provider&.destroy
     end
 end

--- a/app/models/onchain_wallet_item.rb
+++ b/app/models/onchain_wallet_item.rb
@@ -129,6 +129,32 @@ class OnchainWalletItem < ApplicationRecord
     onchain_wallet_accounts.for_wallet(chain, address).exists?
   end
 
+  # The accounts a viewer may see on this item, and how many addresses those
+  # cover. An item is surfaced on the accounts page as soon as ONE of its
+  # accounts is accessible, so a card rendering them all would show a
+  # partially-authorised member the names and balances of accounts nobody
+  # shared with them. Passing nil means "no restriction", which is what an
+  # admin gets.
+  #
+  # Both read the preloaded associations rather than opening new relations: the
+  # accounts page renders one card per item, and a scope here would cost a
+  # query per row.
+  def accounts_visible_to(allowed_account_ids)
+    return accounts.to_a if allowed_account_ids.nil?
+
+    accounts.select { |account| allowed_account_ids.include?(account.id) }
+  end
+
+  def address_count_for(visible_accounts)
+    visible_ids = visible_accounts.map(&:id).to_set
+
+    onchain_wallet_accounts
+      .select { |row| visible_ids.include?(row.account_provider&.account_id) }
+      .map { |row| [ row.chain, row.wallet_address ] }
+      .uniq
+      .size
+  end
+
   def institution_display_name
     institution_name.presence || name
   end

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -10,7 +10,7 @@
   ) %>
 <% end %>
 
-<% if @manual_accounts.empty? && @plaid_items.empty? && @simplefin_items.empty? && @lunchflow_items.empty? && @redbark_items.empty? && @akahu_items.empty? && @up_items.empty? && @enable_banking_items.empty? && @coinstats_items.empty? && @coinbase_items.empty? && @mercury_items.empty? && @brex_items.empty? && @ibkr_items.empty? && @snaptrade_items.empty? && @indexa_capital_items.empty? && @sophtron_items.empty? && @binance_items.empty? && @kraken_items.empty? && @questrade_items.empty? && @wise_items.empty? %>
+<% if @manual_accounts.empty? && @plaid_items.empty? && @simplefin_items.empty? && @lunchflow_items.empty? && @redbark_items.empty? && @akahu_items.empty? && @up_items.empty? && @enable_banking_items.empty? && @coinstats_items.empty? && @coinbase_items.empty? && @mercury_items.empty? && @brex_items.empty? && @ibkr_items.empty? && @snaptrade_items.empty? && @indexa_capital_items.empty? && @sophtron_items.empty? && @binance_items.empty? && @kraken_items.empty? && @questrade_items.empty? && @wise_items.empty? && @onchain_wallet_items.empty? %>
   <%= render "empty" %>
 <% else %>
   <div class="space-y-2">
@@ -44,6 +44,16 @@
 
     <% if @coinstats_items.any? %>
       <%= render @coinstats_items.sort_by(&:created_at) %>
+    <% end %>
+
+    <% if @onchain_wallet_items.any? %>
+      <%# Rendered by name rather than as a collection: the model's default
+          partial is the provider settings row, and this is the accounts card. %>
+      <% @onchain_wallet_items.sort_by(&:created_at).each do |onchain_wallet_item| %>
+        <%= render "onchain_wallet_items/wallet_card",
+                   onchain_wallet_item: onchain_wallet_item,
+                   card: @onchain_wallet_cards.fetch(onchain_wallet_item.id) %>
+      <% end %>
     <% end %>
 
     <% if @sophtron_items.any? %>

--- a/app/views/onchain_wallet_items/_wallet_card.html.erb
+++ b/app/views/onchain_wallet_items/_wallet_card.html.erb
@@ -1,0 +1,76 @@
+<%# locals: (onchain_wallet_item:, card:) %>
+
+<%= tag.div id: dom_id(onchain_wallet_item, :accounts_index) do %>
+  <%= render DS::Disclosure.new(variant: :card, open: true) do |disclosure| %>
+    <% disclosure.with_summary_content do %>
+      <div class="flex items-center justify-between gap-2 focus-visible:outline-hidden">
+        <div class="flex items-center gap-2">
+          <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
+
+          <div class="flex items-center justify-center h-8 w-8 rounded-full bg-surface-inset shrink-0">
+            <%= icon "wallet", size: "sm", class: "text-primary" %>
+          </div>
+
+          <div class="pl-1 text-sm">
+            <div class="flex items-center gap-2">
+              <%= tag.p onchain_wallet_item.institution_display_name, class: "font-medium text-primary" %>
+              <% if onchain_wallet_item.scheduled_for_deletion? %>
+                <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
+              <% end %>
+            </div>
+
+            <p class="text-xs text-secondary">
+              <%= t(".addresses_tracked", count: card[:address_count]) %>
+            </p>
+
+            <% if onchain_wallet_item.syncing? %>
+              <div class="text-secondary flex items-center gap-1">
+                <%= icon "loader", size: "sm", class: "animate-spin" %>
+                <%= tag.span t(".syncing") %>
+              </div>
+            <% elsif onchain_wallet_item.requires_update? %>
+              <div class="text-warning flex items-center gap-1">
+                <%= icon "alert-triangle", size: "sm", color: "warning" %>
+                <%= tag.span t(".needs_attention") %>
+              </div>
+            <% else %>
+              <p class="text-secondary">
+                <% if onchain_wallet_item.last_synced_at %>
+                  <%= t(".status", timestamp: time_ago_in_words(onchain_wallet_item.last_synced_at)) %>
+                <% else %>
+                  <%= t(".status_never") %>
+                <% end %>
+              </p>
+            <% end %>
+          </div>
+        </div>
+
+        <%# Management lives in the provider settings panel, where linking,
+            token review and disconnection already are — this card links to it
+            rather than growing a second, partial copy of those controls. %>
+        <% if Current.user&.admin? %>
+          <%= render DS::Link.new(
+                text: t(".manage"),
+                icon: "settings",
+                variant: "secondary",
+                href: settings_providers_path,
+                frame: "_top"
+              ) %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% unless onchain_wallet_item.scheduled_for_deletion? %>
+      <div class="space-y-4 mt-4">
+        <% if card[:accounts].any? %>
+          <%= render "accounts/index/account_groups", accounts: card[:accounts] %>
+        <% else %>
+          <div class="p-4 flex flex-col gap-3 items-center justify-center">
+            <p class="text-primary font-medium text-sm"><%= t(".no_wallets_title") %></p>
+            <p class="text-secondary text-sm"><%= t(".no_wallets_message") %></p>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/views/onchain_wallet_items/en.yml
+++ b/config/locales/views/onchain_wallet_items/en.yml
@@ -79,6 +79,18 @@ en:
         other: "%{count} assets tracked"
       sync: Sync now
       syncing: Syncing...
+    wallet_card:
+      addresses_tracked:
+        one: 1 address tracked
+        other: "%{count} addresses tracked"
+      deletion_in_progress: Removing...
+      manage: Manage
+      needs_attention: Needs attention
+      no_wallets_message: Link an address from the provider settings to see it here.
+      no_wallets_title: No wallets linked yet
+      status: Synced %{timestamp} ago
+      status_never: Not synced yet
+      syncing: Syncing...
     price_provider_warning:
       body: No enabled market data provider can price crypto, so these wallets track quantities but show a value of zero.
       enable: Enable crypto prices

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class AccountsControllerTest < ActionDispatch::IntegrationTest
   include ActionView::RecordIdentifier
+  include OnchainTestHelper
 
   setup do
     sign_in @user = users(:family_admin)
@@ -19,6 +20,55 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     get accounts_url
     assert_response :success
     assert_select "##{dom_id(kraken_item)}"
+  end
+
+  test "index renders on-chain wallet items" do
+    register_fake_chain!
+    item = create_onchain_wallet_item(family: @user.family)
+    onchain_account = create_onchain_wallet_account(item: item)
+    onchain_account.ensure_account_provider!(accounts(:investment))
+
+    get accounts_url
+
+    assert_response :success
+    # Without this the wallet is invisible here: its accounts carry a provider
+    # link, so Account.manual excludes them, and no provider section claimed them.
+    assert_select "##{dom_id(item, :accounts_index)}"
+  ensure
+    unregister_fake_chain!
+  end
+
+  test "index does not leak wallet accounts a member was never given" do
+    register_fake_chain!
+    admin = users(:family_admin)
+    member = users(:family_member)
+    item = create_onchain_wallet_item(family: admin.family)
+
+    shared = accounts(:investment)
+    unshared = accounts(:credit_card)
+    [ shared, unshared ].each_with_index do |account, index|
+      account.update!(owner: admin)
+      account.account_shares.destroy_all
+      row = create_onchain_wallet_account(
+        item: item,
+        address: "#{OnchainTestHelper::FAKE_ADDRESS}#{index}"
+      )
+      row.ensure_account_provider!(account)
+    end
+    shared.account_shares.create!(user: member, permission: "read_only")
+
+    sign_in member
+    get accounts_url
+
+    assert_response :success
+    assert_select "##{dom_id(item, :accounts_index)}"
+    # The item is surfaced as soon as ONE of its accounts is accessible, so
+    # rendering them all would hand a partially-authorised member the names and
+    # balances of accounts nobody shared with them.
+    assert_includes response.body, shared.name
+    assert_not_includes response.body, unshared.name
+  ensure
+    unregister_fake_chain!
   end
 
   test "should get show" do

--- a/test/models/onchain_wallet_account_test.rb
+++ b/test/models/onchain_wallet_account_test.rb
@@ -93,6 +93,27 @@ class OnchainWalletAccountTest < ActiveSupport::TestCase
     end
   end
 
+  test "unlinking the account drops the tracking row and leaves the account manual" do
+    onchain_account = create_onchain_wallet_account(item: @item)
+    account = accounts(:investment)
+    provider_link = onchain_account.ensure_account_provider!(account)
+    holding = holdings(:one)
+    holding.update!(account_provider: provider_link)
+
+    assert_difference "OnchainWalletAccount.count", -1 do
+      account.account_providers.destroy_all
+    end
+
+    # What the user asked for is to stop tracking the address, not to lose the
+    # account: the Sure account and its holdings stay, as manual ones.
+    assert Account.exists?(account.id)
+    assert Holding.exists?(holding.id)
+    assert_nil holding.reload.account_provider_id
+    # Left behind, the row would stop syncing while its partial unique index
+    # still held the slot, so linking the same asset again would collide.
+    assert_not OnchainWalletAccount.exists?(onchain_account.id)
+  end
+
   test "a native row and token rows coexist for one address" do
     create_onchain_wallet_account(item: @item)
     create_onchain_wallet_account(item: @item, asset: fake_token_asset(contract: "0xaaa"))


### PR DESCRIPTION
Two gaps in #3081, both identified by @jjmata's review of #2191 on that PR — credit to #2191 for finding them.

## Linked wallets were invisible on `/accounts`

The feature creates real Sure accounts and they count towards net worth, but the accounts page never showed them. `Account.manual` excludes anything carrying a provider link, and unlike the twenty other providers there was no on-chain section to claim them — so a family whose only connection was a wallet saw the empty state on the one page meant to list their accounts.

The controller now loads the items, the view renders them, and the empty-state condition counts them.

One deliberate deviation: the card is rendered by name rather than as a collection, because the model's default partial slot is already taken by the provider settings row. Renaming it would be the tidier convention, but its locale keys are spelled after it and that is eight locale files of churn for a follow-up fix.

## A generic unlink left the tracking row behind

The dedicated disconnect flow is careful, but `AccountsController#unlink` destroys the `AccountProvider` directly — and an `OnchainWalletAccount` *holds* that link rather than being held by it. Orphaned, it stops syncing (the syncer only reads linked rows) while its partial unique index still holds the `(item, chain, address, asset)` slot, so linking that same asset again would collide with a row nothing displays.

It is now destroyed with its link, following the CoinStats precedent in the same model, plus a guard against the recursion that precedent lacks.

The regression test is the one @jjmata asked for explicitly: it states that the Sure account and its holdings survive as manual while the tracking row and the provider link go. Without the callback it fails with `didn't change by -1, but by 0`.

## Verification

```
bin/rails test                                      6859 runs, 27620 assertions, 0 failures
DISABLE_PARALLELIZATION=true bin/rails test:system    98 runs,   403 assertions, 0 failures
bin/rubocop -f github                               no offenses
bundle exec erb_lint                                no errors
bin/brakeman --no-pager                             0 security warnings
```

Both regression tests were checked against the pre-fix code.

Beyond the suite, a real Bitcoin address was linked and both flows driven over real HTTP requests:

- `GET /accounts` → 200, rendering `<div id="accounts_index_onchain_wallet_item_…">` with the provider name, the account, and the address count.
- `DELETE /accounts/:id/unlink` → 302, and the state moves from `rows=1 providers=1` to `rows=0 providers=0` with the account surviving and reporting `manual: true`.

Integration parity with the other providers was checked rather than assumed: on-chain now appears in every place CoinStats does, it is picked up automatically by the nightly family sync (which reflects over `*_items` associations including `Syncable`), and it is already exposed to the mobile client through `/api/v1/accounts` and to `/api/v1/provider_connections` as `onchain_wallet: good`.

## Not included

@jjmata's third suggestion was to cherry-pick some lower-level provider tests from #2191 around rate limits, pagination and address validation. I checked our coverage first: those areas already have tests across the on-chain suite, so there is nothing to port. The modal JS, importer shape, security resolver and admin-only carveout are left alone, as he recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-chain wallets now appear on the Accounts page with wallet identity, tracked address counts, synchronization status, and account details.
  * Administrators can access wallet provider settings directly from wallet cards.
  * Wallet cards display deletion progress and helpful empty or attention states.
  * Shared wallet accounts are shown only to members with access, while administrators retain full visibility.

* **Bug Fixes**
  * Removing an account’s provider connection now cleans up associated on-chain tracking data while preserving manually managed account records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->