### PR TITLE
Surface reconciliation state on transactions in the ledger

### DIFF
--- a/app/controllers/concerns/entryable_resource.rb
+++ b/app/controllers/concerns/entryable_resource.rb
@@ -48,6 +48,7 @@ module EntryableResource
       @entry = Current.family.entries
                  .joins(:account)
                  .merge(Account.accessible_by(Current.user))
+                 .includes(:reconciled_by_statement)
                  .find(params[:id])
     end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -25,7 +25,7 @@ class TransactionsController < ApplicationController
     base_scope = @search.transactions_scope
                        .reverse_chronological
                        .includes(
-                         { entry: :account },
+                         { entry: [ :account, :reconciled_by_statement ] },
                          :category, :merchant, :tags,
                          # Union of #2643 counterpart UI + Skylight category-menu N+1:
                          # - outflow rows need inflow_transaction (to_account) for both

--- a/app/helpers/entries_helper.rb
+++ b/app/helpers/entries_helper.rb
@@ -61,4 +61,39 @@ module EntriesHelper
       entry.name
     ].join(" • ")
   end
+
+  def entry_reconciliation_icon(state)
+    case state.to_sym
+    when :reconciled then "circle-check"
+    when :cleared then "check"
+    else "circle"
+    end
+  end
+
+  def entry_reconciliation_icon_color(state)
+    case state.to_sym
+    when :reconciled then "success"
+    when :cleared then "info"
+    else "default"
+    end
+  end
+
+  def entry_reconciliation_pill_tone(state)
+    case state.to_sym
+    when :reconciled then :success
+    when :cleared then :info
+    else :neutral
+    end
+  end
+
+  # Prefer a human period when the statement has dates; otherwise the filename.
+  def entry_reconciliation_statement_label(statement)
+    return nil if statement.blank?
+
+    if statement.period_start_on.present? && statement.period_end_on.present?
+      "#{l(statement.period_start_on)} – #{l(statement.period_end_on)}"
+    else
+      statement.filename
+    end
+  end
 end

--- a/app/views/entries/_reconciliation_status.html.erb
+++ b/app/views/entries/_reconciliation_status.html.erb
@@ -1,0 +1,53 @@
+<%# locals: (entry:) %>
+<%# Surfaces Entry#reconciliation_state in the transaction drawer.
+    Cleared is shown here (detail only) — not on ledger rows — to avoid
+    badge noise on provider-synced accounts. See #3119. %>
+<%= turbo_frame_tag dom_id(entry, :reconciliation) do %>
+  <% state = entry.reconciliation_state %>
+  <% statement = entry.reconciled_by_statement %>
+  <div class="shadow-border-xs bg-container rounded-xl mb-3 text-xs text-secondary">
+    <div class="flex items-center justify-between gap-2 px-3 py-2">
+      <div class="flex items-center gap-2 min-w-0">
+        <%= icon entry_reconciliation_icon(state), size: "sm", color: entry_reconciliation_icon_color(state) %>
+        <span class="font-medium uppercase text-primary"><%= t("entries.reconciliation.title") %></span>
+      </div>
+      <%= render DS::Pill.new(
+            label: t("entries.reconciliation.states.#{state}"),
+            tone: entry_reconciliation_pill_tone(state),
+            marker: false,
+            icon: entry_reconciliation_icon(state),
+            title: t("entries.reconciliation.tooltips.#{state}")
+          ) %>
+    </div>
+    <div class="px-3 pb-3 space-y-2">
+      <p class="text-sm text-secondary">
+        <%= t("entries.reconciliation.descriptions.#{state}") %>
+      </p>
+
+      <% if entry.reconciled? %>
+        <dl class="space-y-2 bg-surface-inset rounded-lg px-3 py-2">
+          <div class="flex items-center justify-between gap-2 text-sm">
+            <dt class="text-secondary shrink-0"><%= t("entries.reconciliation.statement_label") %></dt>
+            <dd class="text-primary text-right min-w-0">
+              <% if statement.present? %>
+                <%= link_to entry_reconciliation_statement_label(statement),
+                      account_statement_path(statement),
+                      class: "text-primary hover:text-primary-hover underline underline-offset-2 truncate inline-block max-w-full",
+                      data: { turbo_frame: "_top" },
+                      title: statement.filename %>
+              <% else %>
+                <span class="text-secondary"><%= t("entries.reconciliation.no_statement") %></span>
+              <% end %>
+            </dd>
+          </div>
+          <% if entry.reconciled_at.present? %>
+            <div class="flex items-center justify-between gap-2 text-sm">
+              <dt class="text-secondary shrink-0"><%= t("entries.reconciliation.reconciled_on_label") %></dt>
+              <dd class="text-primary"><%= l(entry.reconciled_at.to_date, format: :long) %></dd>
+            </div>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/entries/_reconciliation_status.html.erb
+++ b/app/views/entries/_reconciliation_status.html.erb
@@ -30,11 +30,18 @@
             <dt class="text-secondary shrink-0"><%= t("entries.reconciliation.statement_label") %></dt>
             <dd class="text-primary text-right min-w-0">
               <% if statement.present? %>
-                <%= link_to entry_reconciliation_statement_label(statement),
-                      account_statement_path(statement),
-                      class: "text-primary hover:text-primary-hover underline underline-offset-2 truncate inline-block max-w-full",
-                      data: { turbo_frame: "_top" },
-                      title: statement.filename %>
+                <%# The visible label is the period range when the statement has
+                    one, so the filename is additive context. It goes through
+                    DS::Tooltip rather than a raw title= attribute (DS rule 1).
+                    Default as: :button keeps it keyboard-reachable — the
+                    tooltip is a sibling of the link, not inside it. %>
+                <span class="inline-flex items-center gap-1 max-w-full">
+                  <%= link_to entry_reconciliation_statement_label(statement),
+                        account_statement_path(statement),
+                        class: "text-primary hover:text-primary-hover underline underline-offset-2 truncate",
+                        data: { turbo_frame: "_top" } %>
+                  <%= render DS::Tooltip.new(text: statement.filename, html_class: "shrink-0") %>
+                </span>
               <% else %>
                 <span class="text-secondary"><%= t("entries.reconciliation.no_statement") %></span>
               <% end %>

--- a/app/views/transactions/_header.html.erb
+++ b/app/views/transactions/_header.html.erb
@@ -30,6 +30,15 @@
           title: t("transactions.transaction.pending_tooltip")
         ) %>
       <% end %>
+      <% if entry.reconciled? %>
+        <%= render DS::Pill.new(
+          label: t("transactions.transaction.reconciled"),
+          tone: :success,
+          marker: false,
+          icon: "circle-check",
+          title: t("transactions.transaction.reconciled_tooltip")
+        ) %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -107,6 +107,17 @@
                       ) %>
                     <% end %>
 
+                    <%# Reconciled only — cleared would badge nearly every synced row (#3119) %>
+                    <% if entry.reconciled? %>
+                      <%= render DS::Pill.new(
+                        label: t("transactions.transaction.reconciled"),
+                        tone: :success,
+                        marker: false,
+                        icon: "circle-check",
+                        title: t("transactions.transaction.reconciled_tooltip")
+                      ) %>
+                    <% end %>
+
                     <%# Potential duplicate indicator - different styling for low vs medium confidence %>
                     <% if transaction.has_potential_duplicate? %>
                       <% if transaction.low_confidence_duplicate? %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -49,6 +49,7 @@
       <% end %>
     <% end %>
     <%= render "entries/protection_indicator", entry: @entry, unlock_path: unlock_transaction_path(@entry.transaction) %>
+    <%= render "entries/reconciliation_status", entry: @entry %>
     <% dialog.with_section(title: t(".overview"), open: true) do %>
       <div>
         <% split_locked = @entry.split_child? || @entry.split_parent? %>

--- a/config/locales/views/entries/en.yml
+++ b/config/locales/views/entries/en.yml
@@ -21,3 +21,20 @@ en:
       locked_fields_label: "Locked fields:"
       unlock_button: Allow sync to update
       unlock_confirm: Allow sync to update this entry? Your changes may be overwritten on the next sync.
+    reconciliation:
+      title: Reconciliation
+      statement_label: Statement
+      reconciled_on_label: Reconciled on
+      no_statement: No statement on file
+      states:
+        uncleared: Uncleared
+        cleared: Cleared
+        reconciled: Reconciled
+      descriptions:
+        uncleared: Entered by hand — nothing has confirmed this transaction yet.
+        cleared: The institution has acknowledged this transaction (via sync or import).
+        reconciled: A statement was matched against this transaction.
+      tooltips:
+        uncleared: Not confirmed by an institution or statement
+        cleared: Confirmed by the institution
+        reconciled: Matched to a bank statement

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -140,6 +140,8 @@ en:
     transaction:
       pending: Pending
       pending_tooltip: Pending transaction — may change when posted
+      reconciled: Reconciled
+      reconciled_tooltip: Matched to a bank statement
       linked_with_provider: Linked with %{provider}
       activity_type_tooltip: Investment activity type
       possible_duplicate: Duplicate?

--- a/test/helpers/entries_helper_reconciliation_test.rb
+++ b/test/helpers/entries_helper_reconciliation_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class EntriesHelperReconciliationTest < ActionView::TestCase
+  include EntriesHelper
+
+  test "statement label prefers period dates when present" do
+    statement = AccountStatement.new(
+      filename: "jan.pdf",
+      period_start_on: Date.new(2026, 1, 1),
+      period_end_on: Date.new(2026, 1, 31)
+    )
+
+    assert_equal "#{I18n.l(statement.period_start_on)} – #{I18n.l(statement.period_end_on)}",
+                 entry_reconciliation_statement_label(statement)
+  end
+
+  test "statement label falls back to filename without period" do
+    statement = AccountStatement.new(filename: "orphan.pdf")
+
+    assert_equal "orphan.pdf", entry_reconciliation_statement_label(statement)
+  end
+
+  test "pill tone and icon map by state" do
+    assert_equal :success, entry_reconciliation_pill_tone(:reconciled)
+    assert_equal :info, entry_reconciliation_pill_tone(:cleared)
+    assert_equal :neutral, entry_reconciliation_pill_tone(:uncleared)
+
+    assert_equal "circle-check", entry_reconciliation_icon(:reconciled)
+    assert_equal "check", entry_reconciliation_icon(:cleared)
+    assert_equal "circle", entry_reconciliation_icon(:uncleared)
+  end
+end

--- a/test/views/entries/reconciliation_status_view_test.rb
+++ b/test/views/entries/reconciliation_status_view_test.rb
@@ -47,10 +47,22 @@ module Entries
 
       html = render(partial: "entries/reconciliation_status", locals: { entry: entry.reload })
 
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+
       assert_includes html, "march-statement.pdf"
       assert_includes html, 'role="tooltip"'
       assert_includes html, "DS--tooltip"
-      assert_no_match(/title="march-statement\.pdf"/, html)
+
+      # Parsed rather than regexed: a raw title= would still be a raw title=
+      # single-quoted, unquoted, or with the filename HTML-escaped.
+      link = doc.at_css("a[href='#{account_statement_path(statement)}']")
+      assert link, "expected the statement link"
+      assert_nil link["title"], "filename must go through DS::Tooltip, not a title attribute on the link"
+
+      # Scoped to the filename, because DS::Pill renders its own title= for the
+      # state tooltip — a blanket "no title anywhere" would fail on that.
+      assert_empty doc.css("[title]").select { |el| el["title"] == statement.filename },
+        "no element may carry the filename as a raw title attribute"
     end
 
     # Pins the a11y contract behind `as:`. The tooltip is a SIBLING of the

--- a/test/views/entries/reconciliation_status_view_test.rb
+++ b/test/views/entries/reconciliation_status_view_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class Entries::ReconciliationStatusViewTest < ActionView::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @account = accounts(:depository)
+  end
+
+  test "shows uncleared state for a manual entry" do
+    entry = create_transaction(account: @account)
+
+    html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
+
+    assert_includes html, I18n.t("entries.reconciliation.states.uncleared")
+    assert_includes html, I18n.t("entries.reconciliation.descriptions.uncleared")
+    assert_not_includes html, I18n.t("entries.reconciliation.statement_label")
+  end
+
+  test "shows cleared state for a provider-sourced entry" do
+    entry = create_transaction(account: @account, source: "plaid")
+
+    html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
+
+    assert_includes html, I18n.t("entries.reconciliation.states.cleared")
+    assert_includes html, I18n.t("entries.reconciliation.descriptions.cleared")
+  end
+
+  test "shows reconciled state with statement link" do
+    statement = create_statement
+    entry = create_transaction(account: @account, source: "plaid")
+    entry.mark_reconciled!(statement: statement)
+
+    html = render(partial: "entries/reconciliation_status", locals: { entry: entry.reload })
+
+    assert_includes html, I18n.t("entries.reconciliation.states.reconciled")
+    assert_includes html, account_statement_path(statement)
+    assert_includes html, entry_reconciliation_statement_label(statement)
+  end
+
+  test "shows reconciled without statement when evidence was removed" do
+    statement = create_statement
+    entry = create_transaction(account: @account)
+    entry.mark_reconciled!(statement: statement)
+    statement.destroy!
+    entry.reload
+
+    html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
+
+    assert_includes html, I18n.t("entries.reconciliation.states.reconciled")
+    assert_includes html, I18n.t("entries.reconciliation.no_statement")
+  end
+
+  test "ledger row shows reconciled pill only when reconciled" do
+    entry = create_transaction(account: @account, source: "plaid")
+    entry.mark_reconciled!
+
+    html = render(partial: "transactions/transaction", locals: { entry: entry, balance_trend: nil, view_ctx: "global" })
+
+    assert_includes html, I18n.t("transactions.transaction.reconciled")
+  end
+
+  test "ledger row does not show a cleared badge" do
+    entry = create_transaction(account: @account, source: "plaid")
+
+    html = render(partial: "transactions/transaction", locals: { entry: entry, balance_trend: nil, view_ctx: "global" })
+
+    assert_not_includes html, I18n.t("entries.reconciliation.states.cleared")
+    assert_not_includes html, I18n.t("transactions.transaction.reconciled")
+  end
+
+  private
+    def create_statement(account: @account, filename: "statement.pdf")
+      AccountStatement.create_from_upload!(
+        family: account.family,
+        account: account,
+        file: uploaded_file(
+          filename: filename,
+          content_type: "application/pdf",
+          content: file_fixture("imports/sample_bank_statement.pdf").binread
+        )
+      )
+    end
+end

--- a/test/views/entries/reconciliation_status_view_test.rb
+++ b/test/views/entries/reconciliation_status_view_test.rb
@@ -53,6 +53,28 @@ module Entries
       assert_no_match(/title="march-statement\.pdf"/, html)
     end
 
+    # Pins the a11y contract behind `as:`. The tooltip is a SIBLING of the
+    # statement link, so DS--tooltip's closest("summary, a") lookup finds no
+    # focusable ancestor to borrow focus from. `as: :span` would render a
+    # tabindex-less <span> and strand the tooltip for keyboard users; the
+    # default `as: :button` keeps a real focusable trigger.
+    test "statement filename tooltip keeps a keyboard-reachable trigger" do
+      statement = create_statement(filename: "march-statement.pdf")
+      entry = create_transaction(account: @account, source: "plaid")
+      entry.mark_reconciled!(statement: statement)
+
+      html = render(partial: "entries/reconciliation_status", locals: { entry: entry.reload })
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+
+      trigger = doc.at_css('[data-controller="DS--tooltip"]')
+      assert trigger, "expected a DS::Tooltip wrapper in the reconciled panel"
+
+      assert trigger.at_css("button[type='button']"),
+        "tooltip trigger must stay focusable (as: :button) — it has no <a>/<summary> ancestor to borrow focus from"
+      assert_empty trigger.ancestors("a"),
+        "tooltip must remain a sibling of the statement link, not a descendant of it"
+    end
+
     test "shows reconciled without statement when evidence was removed" do
       statement = create_statement
       entry = create_transaction(account: @account)

--- a/test/views/entries/reconciliation_status_view_test.rb
+++ b/test/views/entries/reconciliation_status_view_test.rb
@@ -1,84 +1,86 @@
 require "test_helper"
 
-class Entries::ReconciliationStatusViewTest < ActionView::TestCase
-  include EntriesTestHelper
+module Entries
+  class ReconciliationStatusViewTest < ActionView::TestCase
+    include EntriesTestHelper
 
-  setup do
-    @account = accounts(:depository)
-  end
-
-  test "shows uncleared state for a manual entry" do
-    entry = create_transaction(account: @account)
-
-    html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
-
-    assert_includes html, I18n.t("entries.reconciliation.states.uncleared")
-    assert_includes html, I18n.t("entries.reconciliation.descriptions.uncleared")
-    assert_not_includes html, I18n.t("entries.reconciliation.statement_label")
-  end
-
-  test "shows cleared state for a provider-sourced entry" do
-    entry = create_transaction(account: @account, source: "plaid")
-
-    html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
-
-    assert_includes html, I18n.t("entries.reconciliation.states.cleared")
-    assert_includes html, I18n.t("entries.reconciliation.descriptions.cleared")
-  end
-
-  test "shows reconciled state with statement link" do
-    statement = create_statement
-    entry = create_transaction(account: @account, source: "plaid")
-    entry.mark_reconciled!(statement: statement)
-
-    html = render(partial: "entries/reconciliation_status", locals: { entry: entry.reload })
-
-    assert_includes html, I18n.t("entries.reconciliation.states.reconciled")
-    assert_includes html, account_statement_path(statement)
-    assert_includes html, entry_reconciliation_statement_label(statement)
-  end
-
-  test "shows reconciled without statement when evidence was removed" do
-    statement = create_statement
-    entry = create_transaction(account: @account)
-    entry.mark_reconciled!(statement: statement)
-    statement.destroy!
-    entry.reload
-
-    html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
-
-    assert_includes html, I18n.t("entries.reconciliation.states.reconciled")
-    assert_includes html, I18n.t("entries.reconciliation.no_statement")
-  end
-
-  test "ledger row shows reconciled pill only when reconciled" do
-    entry = create_transaction(account: @account, source: "plaid")
-    entry.mark_reconciled!
-
-    html = render(partial: "transactions/transaction", locals: { entry: entry, balance_trend: nil, view_ctx: "global" })
-
-    assert_includes html, I18n.t("transactions.transaction.reconciled")
-  end
-
-  test "ledger row does not show a cleared badge" do
-    entry = create_transaction(account: @account, source: "plaid")
-
-    html = render(partial: "transactions/transaction", locals: { entry: entry, balance_trend: nil, view_ctx: "global" })
-
-    assert_not_includes html, I18n.t("entries.reconciliation.states.cleared")
-    assert_not_includes html, I18n.t("transactions.transaction.reconciled")
-  end
-
-  private
-    def create_statement(account: @account, filename: "statement.pdf")
-      AccountStatement.create_from_upload!(
-        family: account.family,
-        account: account,
-        file: uploaded_file(
-          filename: filename,
-          content_type: "application/pdf",
-          content: file_fixture("imports/sample_bank_statement.pdf").binread
-        )
-      )
+    setup do
+      @account = accounts(:depository)
     end
+
+    test "shows uncleared state for a manual entry" do
+      entry = create_transaction(account: @account)
+
+      html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
+
+      assert_includes html, I18n.t("entries.reconciliation.states.uncleared")
+      assert_includes html, I18n.t("entries.reconciliation.descriptions.uncleared")
+      assert_not_includes html, I18n.t("entries.reconciliation.statement_label")
+    end
+
+    test "shows cleared state for a provider-sourced entry" do
+      entry = create_transaction(account: @account, source: "plaid")
+
+      html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
+
+      assert_includes html, I18n.t("entries.reconciliation.states.cleared")
+      assert_includes html, I18n.t("entries.reconciliation.descriptions.cleared")
+    end
+
+    test "shows reconciled state with statement link" do
+      statement = create_statement
+      entry = create_transaction(account: @account, source: "plaid")
+      entry.mark_reconciled!(statement: statement)
+
+      html = render(partial: "entries/reconciliation_status", locals: { entry: entry.reload })
+
+      assert_includes html, I18n.t("entries.reconciliation.states.reconciled")
+      assert_includes html, account_statement_path(statement)
+      assert_includes html, entry_reconciliation_statement_label(statement)
+    end
+
+    test "shows reconciled without statement when evidence was removed" do
+      statement = create_statement
+      entry = create_transaction(account: @account)
+      entry.mark_reconciled!(statement: statement)
+      statement.destroy!
+      entry.reload
+
+      html = render(partial: "entries/reconciliation_status", locals: { entry: entry })
+
+      assert_includes html, I18n.t("entries.reconciliation.states.reconciled")
+      assert_includes html, I18n.t("entries.reconciliation.no_statement")
+    end
+
+    test "ledger row shows reconciled pill only when reconciled" do
+      entry = create_transaction(account: @account, source: "plaid")
+      entry.mark_reconciled!
+
+      html = render(partial: "transactions/transaction", locals: { entry: entry, balance_trend: nil, view_ctx: "global" })
+
+      assert_includes html, I18n.t("transactions.transaction.reconciled")
+    end
+
+    test "ledger row does not show a cleared badge" do
+      entry = create_transaction(account: @account, source: "plaid")
+
+      html = render(partial: "transactions/transaction", locals: { entry: entry, balance_trend: nil, view_ctx: "global" })
+
+      assert_not_includes html, I18n.t("entries.reconciliation.states.cleared")
+      assert_not_includes html, I18n.t("transactions.transaction.reconciled")
+    end
+
+    private
+      def create_statement(account: @account, filename: "statement.pdf")
+        AccountStatement.create_from_upload!(
+          family: account.family,
+          account: account,
+          file: uploaded_file(
+            filename: filename,
+            content_type: "application/pdf",
+            content: file_fixture("imports/sample_bank_statement.pdf").binread
+          )
+        )
+      end
+  end
 end

--- a/test/views/entries/reconciliation_status_view_test.rb
+++ b/test/views/entries/reconciliation_status_view_test.rb
@@ -40,6 +40,19 @@ module Entries
       assert_includes html, entry_reconciliation_statement_label(statement)
     end
 
+    test "surfaces the statement filename through DS::Tooltip, not a raw title attribute" do
+      statement = create_statement(filename: "march-statement.pdf")
+      entry = create_transaction(account: @account, source: "plaid")
+      entry.mark_reconciled!(statement: statement)
+
+      html = render(partial: "entries/reconciliation_status", locals: { entry: entry.reload })
+
+      assert_includes html, "march-statement.pdf"
+      assert_includes html, 'role="tooltip"'
+      assert_includes html, "DS--tooltip"
+      assert_no_match(/title="march-statement\.pdf"/, html)
+    end
+
     test "shows reconciled without statement when evidence was removed" do
       statement = create_statement
       entry = create_transaction(account: @account)

--- a/test/views/entries/reconciliation_status_view_test.rb
+++ b/test/views/entries/reconciliation_status_view_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 module Entries
   class ReconciliationStatusViewTest < ActionView::TestCase
     include EntriesTestHelper
+    include EntriesHelper
 
     setup do
       @account = accounts(:depository)


### PR DESCRIPTION
## Summary
- Implements the suggested minimum from #3119: show `Entry#reconciliation_state` in the transaction detail drawer, with a link to the backing `AccountStatement` when present (and a clear “no statement on file” state when evidence was nullified).
- Adds a **Reconciled** pill on ledger rows and the detail header only when `reconciled?` — deliberately **not** badging `cleared` on every synced row (noise called out in the issue).
- Eager-loads `reconciled_by_statement` on show + index to avoid N+1s.

## Design choices (from #3119)
1. **Cleared on list?** No — detail-only.
2. **User mark/unmark?** Deferred — still read-only UI.
3. **Statement link?** Yes, in detail.
4. **Account rollup / filters?** Deferred.

## Test plan
- [ ] Open a manual (uncleared) transaction → detail shows Uncleared
- [ ] Open a provider-synced (cleared) transaction → detail shows Cleared; list has no Cleared/Reconciled pill
- [ ] Reconcile via PDF statement import → detail shows Reconciled + statement link; list/header show Reconciled pill
- [ ] Delete the statement after reconcile → detail still shows Reconciled with “No statement on file”
- [ ] `bin/rails test test/views/entries/reconciliation_status_view_test.rb test/helpers/entries_helper_reconciliation_test.rb`

Closes #3119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reconciliation status indicators to transaction lists, headers, and details.
  * Reconciled transactions now display a success badge with an icon and tooltip.
  * Reconciliation details include status descriptions, statement links, filenames, and reconciliation dates.
  * Statement labels show localized date ranges when available, with filename fallback.
* **Accessibility**
  * Improved statement filename tooltips with keyboard-accessible controls.
* **Localization**
  * Added English labels, descriptions, and tooltips for reconciliation statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->