### PR TITLE
fix(accounts): hold provider cards to the accounts the viewer may see

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -146,6 +146,37 @@ class AccountsController < ApplicationController
     redirect_to account_path(@account)
   end
 
+  # Fills the frame a background broadcast leaves in a provider card. The
+  # broadcast runs in a job with no `Current.user`, so it cannot decide which of
+  # the card's accounts a given reader may see; this is the reader asking for
+  # them back on their own authenticated request.
+  #
+  # The ids arrive from the frame's own src, so they are a request rather than
+  # an authorisation: everything is resolved through `accessible_accounts`, and
+  # an id for an account the reader may not see simply does not come back.
+  MAX_GROUP_ACCOUNTS = 500
+
+  def groups
+    @requested_account_ids = params[:ids].to_s.split(",").map(&:strip).reject(&:blank?).uniq
+    @groups_accounts =
+      if @requested_account_ids.empty? || @requested_account_ids.size > MAX_GROUP_ACCOUNTS
+        []
+      else
+        Current.user.accessible_accounts
+               .where(id: @requested_account_ids)
+               .with_attached_logo
+               .includes(:accountable, :account_providers)
+               .order(:name)
+               .to_a
+      end
+
+    # The partial scopes to the viewer on its own; this is the list it is
+    # allowed to consider, injected the same way the index injects it.
+    @accessible_account_ids = @groups_accounts.map(&:id)
+
+    render layout: false
+  end
+
   def sparkline
     etag_key = @account.family.build_cache_key("#{@account.id}_sparkline_#{Account::Chartable::SPARKLINE_CACHE_VERSION}", invalidate_on_data_updates: true)
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -37,11 +37,11 @@ class AccountsController < ApplicationController
     @wise_items = visible_provider_items(family.wise_items.ordered.includes(:wise_accounts, :accounts))
 
     # An on-chain item is admitted as soon as ONE of its accounts is accessible,
-    # so the card is told which of them this viewer may actually see. nil is the
-    # admin case, which visible_provider_items already lets through whole.
-    allowed_ids = Current.user&.admin? ? nil : @accessible_account_ids
+    # so the card is told which of them this viewer may actually see. No admin
+    # exemption: the manual list above does not grant one either, and the card's
+    # address count has to agree with what the card actually renders.
     @onchain_wallet_cards = @onchain_wallet_items.to_h do |item|
-      visible = item.accounts_visible_to(allowed_ids)
+      visible = item.accounts_visible_to(@accessible_account_ids)
       [ item.id, { accounts: visible, address_count: item.address_count_for(visible) } ]
     end
 

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -27,7 +27,11 @@ module AccountsHelper
   # "no viewer" are different answers that the empty-set fallback below
   # collapses into one.
   def viewer_present_for_account_scoping?
-    @accessible_account_ids.present? || Current.user.present?
+    # `nil?`, not `present?`: an injected list that is empty is still a viewer
+    # — one who may see nothing, which is a real answer. Treating it as "no
+    # viewer" would hand a member with no shared accounts an "Updating…" card
+    # that never updates into anything.
+    !@accessible_account_ids.nil? || Current.user.present?
   end
 
   # Reuses the list the accounts index already loaded; falls back to a query for

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -4,6 +4,31 @@ module AccountsHelper
     render "accounts/summary_card", title: title, content: content
   end
 
+  # The accounts a viewer may actually see, out of a collection a provider card
+  # was about to render whole.
+  #
+  # A provider item is surfaced on the accounts page as soon as ONE of its
+  # accounts is accessible (AccountsController#visible_provider_items), but the
+  # cards then hand their entire item to accounts/index/_account_groups. A
+  # member shared into one account of a connection would otherwise read the
+  # names, balances and group totals of the ones nobody shared with them.
+  #
+  # The manual list already applies this rule upstream, through
+  # `where(id: @accessible_account_ids)`, and applies it to everyone: an admin
+  # does not see a member's unshared account there either. This keeps the
+  # provider cards to the same rule, in the one place they all render through.
+  def accounts_visible_to_viewer(accounts)
+    ids = viewer_accessible_account_ids
+    accounts.select { |account| ids.include?(account.id) }
+  end
+
+  # Reuses the list the accounts index already loaded; falls back to a query for
+  # any other caller, once per request.
+  def viewer_accessible_account_ids
+    @viewer_accessible_account_ids ||=
+      (@accessible_account_ids || Current.user&.accessible_accounts&.pluck(:id) || []).to_set
+  end
+
   def sync_path_for(account)
     # Always use the account sync path, which handles syncing all providers
     sync_account_path(account)

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -22,6 +22,14 @@ module AccountsHelper
     accounts.select { |account| ids.include?(account.id) }
   end
 
+  # Whether there is a viewer to scope to at all. A background broadcast renders
+  # these partials with `Current.user` nil, and "no accessible accounts" and
+  # "no viewer" are different answers that the empty-set fallback below
+  # collapses into one.
+  def viewer_present_for_account_scoping?
+    @accessible_account_ids.present? || Current.user.present?
+  end
+
   # Reuses the list the accounts index already loaded; falls back to a query for
   # any other caller, once per request.
   def viewer_accessible_account_ids

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -22,6 +22,18 @@ module AccountsHelper
     accounts.select { |account| ids.include?(account.id) }
   end
 
+  # Stable id for the frame a background broadcast leaves in a provider card,
+  # and for the response that fills it. Derived from the accounts the card was
+  # asked to show — sorted, so the two sides agree whatever order they arrive
+  # in, and hashed rather than listed so the id stays a fixed length.
+  #
+  # Built from what was REQUESTED, never from what the viewer turns out to be
+  # allowed: the response is filtered, so keying on the filtered set would give
+  # the reply a different id from the frame waiting for it.
+  def account_groups_frame_id(account_ids)
+    "account_groups_#{Digest::SHA1.hexdigest(Array(account_ids).map(&:to_s).sort.join(","))}"
+  end
+
   # Whether there is a viewer to scope to at all. A background broadcast renders
   # these partials with `Current.user` nil, and "no accessible accounts" and
   # "no viewer" are different answers that the empty-set fallback below

--- a/app/models/onchain_wallet_item.rb
+++ b/app/models/onchain_wallet_item.rb
@@ -139,15 +139,12 @@ class OnchainWalletItem < ApplicationRecord
   # cover. An item is surfaced on the accounts page as soon as ONE of its
   # accounts is accessible, so a card rendering them all would show a
   # partially-authorised member the names and balances of accounts nobody
-  # shared with them. Passing nil means "no restriction", which is what an
-  # admin gets.
+  # shared with them.
   #
   # Both read the preloaded associations rather than opening new relations: the
   # accounts page renders one card per item, and a scope here would cost a
   # query per row.
   def accounts_visible_to(allowed_account_ids)
-    return accounts.to_a if allowed_account_ids.nil?
-
     accounts.select { |account| allowed_account_ids.include?(account.id) }
   end
 

--- a/app/views/accounts/groups.html.erb
+++ b/app/views/accounts/groups.html.erb
@@ -1,0 +1,6 @@
+<%# Fills the frame a background broadcast left in a provider card. Rendered on
+    the reader's own authenticated request, so `_account_groups` scopes to what
+    they may see exactly as it does on the index. %>
+<%= turbo_frame_tag account_groups_frame_id(@requested_account_ids) do %>
+  <%= render "accounts/index/account_groups", accounts: @groups_accounts %>
+<% end %>

--- a/app/views/accounts/index/_account_groups.erb
+++ b/app/views/accounts/index/_account_groups.erb
@@ -1,5 +1,11 @@
 <%# locals: (accounts:) %>
 
+<%# A provider card is surfaced as soon as ONE of its accounts is accessible,
+    and every card hands its whole item to this partial — so this is the single
+    place that can hold all of them to the accounts the viewer may actually
+    see. Filtering here also keeps the group counts and totals honest. %>
+<% accounts = accounts_visible_to_viewer(accounts) %>
+
 <% if accounts.any? %>
   <% ActiveRecord::Associations::Preloader.new(
        records: accounts,

--- a/app/views/accounts/index/_account_groups.erb
+++ b/app/views/accounts/index/_account_groups.erb
@@ -18,9 +18,21 @@
 <% if viewer_present_for_account_scoping? %>
   <% accounts = accounts_visible_to_viewer(accounts) %>
 <% else %>
-  <div class="px-4 py-3 text-sm text-secondary" data-testid="account-groups-awaiting-refresh">
-    <%= t("accounts.index.account_groups.awaiting_refresh") %>
-  </div>
+  <%# Fetched back rather than merely deferred to the sync toast. The toast
+      waits while a modal or a form is open — which is exactly when a card that
+      had gone blank stayed blank — and this frame does not: the reader's own
+      browser asks for the rows on its own authenticated request, so the server
+      answers with `Current.user` in hand and the filtering above applies
+      normally. %>
+  <% requested_ids = accounts.map(&:id) %>
+  <%= turbo_frame_tag account_groups_frame_id(requested_ids),
+                      src: groups_accounts_path(ids: requested_ids.join(",")),
+                      loading: "eager",
+                      data: { controller: "turbo-frame-timeout", turbo_frame_timeout_timeout_value: 10000 } do %>
+    <div class="px-4 py-3 text-sm text-secondary" data-testid="account-groups-awaiting-refresh">
+      <%= t("accounts.index.account_groups.awaiting_refresh") %>
+    </div>
+  <% end %>
   <% accounts = [] %>
 <% end %>
 

--- a/app/views/accounts/index/_account_groups.erb
+++ b/app/views/accounts/index/_account_groups.erb
@@ -4,7 +4,25 @@
     and every card hands its whole item to this partial — so this is the single
     place that can hold all of them to the accounts the viewer may actually
     see. Filtering here also keeps the group counts and totals honest. %>
-<% accounts = accounts_visible_to_viewer(accounts) %>
+<%# A background broadcast has no viewer: `Current.user` is nil in a job, so
+    "the accounts this viewer may see" is not a question with an answer there.
+    Filtering anyway would answer "none" and replace a populated card with an
+    empty one — the accounts looking deleted rather than merely unrendered.
+    Rendering them all instead would hand every family member the private
+    accounts this partial exists to withhold.
+
+    So it says what is true: the card is waiting on a refresh. The sync toast
+    broadcast right after this drives that refresh on each client's own
+    authenticated request, and defers while a modal or form is open — which is
+    exactly the case where a silently empty card would have persisted. %>
+<% if viewer_present_for_account_scoping? %>
+  <% accounts = accounts_visible_to_viewer(accounts) %>
+<% else %>
+  <div class="px-4 py-3 text-sm text-secondary" data-testid="account-groups-awaiting-refresh">
+    <%= t("accounts.index.account_groups.awaiting_refresh") %>
+  </div>
+  <% accounts = [] %>
+<% end %>
 
 <% if accounts.any? %>
   <% ActiveRecord::Associations::Preloader.new(

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -54,6 +54,8 @@ en:
       enable_category_matcher_label: Enable category matcher
       enable_category_matcher_hint: When enabled, the provider's suggested category is applied to imported transactions. Disable to leave new transactions uncategorized.
     index:
+      account_groups:
+        awaiting_refresh: "Updating…"
       accounts: Accounts
       cancel_sync: Cancel sync
       manual_accounts:

--- a/config/locales/views/accounts/fr.yml
+++ b/config/locales/views/accounts/fr.yml
@@ -58,6 +58,8 @@ fr:
       notes_placeholder: Stockez des informations supplémentaires comme les numéros de compte, codes de tri, IBAN, numéros de routage, etc.
       opening_balance_date_label: Date du solde d'ouverture
     index:
+      account_groups:
+        awaiting_refresh: "Mise à jour…"
       accounts: Comptes
       manual_accounts:
         other_accounts: Autres comptes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -584,6 +584,7 @@ Rails.application.routes.draw do
 
     collection do
       post :sync_all
+      get :groups
     end
 
     resource :sharing, only: [ :show, :update ], controller: "account_sharings"

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -9,6 +9,51 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     @account = accounts(:depository)
   end
 
+  # The frame a background broadcast leaves behind, filled on the reader's own
+  # authenticated request. The ids in its src are a request, not an
+  # authorisation: everything resolves through `accessible_accounts`.
+  test "groups renders only the accounts the requester may see" do
+    mine = @account
+    theirs = accounts(:credit_card)
+    theirs.account_shares.destroy_all
+    theirs.update!(owner: users(:family_member))
+
+    get groups_accounts_url(ids: [ mine.id, theirs.id ].join(","))
+
+    assert_response :success
+    assert_includes response.body, mine.name
+    assert_not_includes response.body, theirs.name
+  end
+
+  # Without a matching frame id the reply lands nowhere, so the id is derived
+  # from what was asked for rather than from what came back.
+  test "groups answers in the frame the card is waiting on" do
+    other = accounts(:credit_card)
+    requested = [ @account.id, other.id ]
+
+    get groups_accounts_url(ids: requested.join(","))
+
+    assert_response :success
+    assert_includes response.body,
+                    "account_groups_#{Digest::SHA1.hexdigest(requested.map(&:to_s).sort.join(","))}"
+  end
+
+  test "groups ignores an account from another family" do
+    other_family = Family.create!(name: "Elsewhere", currency: "USD", locale: "en", country: "US", timezone: "UTC")
+    outsider = Account.create!(family: other_family, accountable: Depository.new,
+                               name: "Somebody Else Savings", currency: "USD", balance: 100)
+
+    get groups_accounts_url(ids: outsider.id)
+
+    assert_response :success
+    assert_not_includes response.body, outsider.name
+  end
+
+  test "groups answers an empty request without failing" do
+    get groups_accounts_url(ids: "")
+
+    assert_response :success
+  end
   test "should get index" do
     get accounts_url
     assert_response :success

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -71,6 +71,58 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     unregister_fake_chain!
   end
 
+  test "a provider card renders only the accounts the viewer may see" do
+    admin = users(:family_admin)
+    member = users(:family_member)
+    item = kraken_items(:one)
+
+    shared = accounts(:investment)
+    unshared = accounts(:credit_card)
+    [ shared, unshared ].each_with_index do |account, index|
+      account.update!(owner: admin)
+      account.account_shares.destroy_all
+      item.kraken_accounts.create!(
+        name: "KR#{index}", account_id: "acct#{index}", account_type: "combined", currency: "USD", extra: {}
+      ).ensure_account_provider!(account)
+    end
+    shared.account_shares.create!(user: member, permission: "read_only")
+
+    sign_in member
+    get accounts_url
+
+    assert_response :success
+    # The card is surfaced because one account is accessible; the other one
+    # belongs to somebody who never shared it.
+    assert_includes response.body, shared.name
+    assert_not_includes response.body, unshared.name
+  end
+
+  test "an admin sees no more of a connection than they were given" do
+    admin = users(:family_admin)
+    member = users(:family_member)
+    item = kraken_items(:one)
+
+    theirs = accounts(:investment)
+    not_theirs = accounts(:credit_card)
+    [ theirs, not_theirs ].each_with_index do |account, index|
+      account.account_shares.destroy_all
+      item.kraken_accounts.create!(
+        name: "KR#{index}", account_id: "acct#{index}", account_type: "combined", currency: "USD", extra: {}
+      ).ensure_account_provider!(account)
+    end
+    theirs.update!(owner: admin)
+    not_theirs.update!(owner: member)
+
+    sign_in admin
+    get accounts_url
+
+    assert_response :success
+    # The manual list already refuses this to an admin, through
+    # `where(id: @accessible_account_ids)`. Provider cards now agree with it.
+    assert_includes response.body, theirs.name
+    assert_not_includes response.body, not_theirs.name
+  end
+
   test "should get show" do
     get account_url(@account)
     assert_response :success

--- a/test/controllers/simplefin_items_controller_test.rb
+++ b/test/controllers/simplefin_items_controller_test.rb
@@ -14,6 +14,41 @@ class SimplefinItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
 
+  # This action rebuilds the accounts-page partials for a Turbo Stream, and it
+  # recomputes @manual_accounts as `Current.family.accounts.visible_manual` —
+  # without the `where(id: @accessible_account_ids)` the index applies. It is
+  # admin-only, and the index refuses an admin a member's unshared account, so
+  # the stream should refuse it too. The shared partial is what holds it there.
+  test "the relink stream does not return a member's unshared account" do
+    admin = users(:family_admin)
+
+    theirs = accounts(:investment)
+    theirs.update!(owner: admin)
+    theirs.account_shares.destroy_all
+    theirs.account_providers.destroy_all
+    theirs.update!(plaid_account_id: nil)
+
+    members_own = accounts(:credit_card)
+    members_own.update!(owner: users(:family_member))
+    members_own.account_shares.destroy_all
+
+    simplefin_account = SimplefinAccount.create!(
+      simplefin_item: @simplefin_item,
+      account_id: "sfa-relink",
+      name: "SimpleFIN Checking",
+      account_type: "depository",
+      currency: "USD",
+      current_balance: 100
+    )
+
+    post link_existing_account_simplefin_items_path,
+         params: { account_id: theirs.id, simplefin_account_id: simplefin_account.id },
+         headers: { "Turbo-Frame" => "modal" }
+
+    assert_not_includes response.body, members_own.name,
+      "the stream rebuilt the accounts list and handed back an account nobody shared with this admin"
+  end
+
   test "should destroy simplefin item" do
     assert_difference("SimplefinItem.count", 0) do # doesn't actually delete immediately
       delete simplefin_item_url(@simplefin_item)

--- a/test/controllers/simplefin_items_controller_test.rb
+++ b/test/controllers/simplefin_items_controller_test.rb
@@ -45,6 +45,11 @@ class SimplefinItemsControllerTest < ActionDispatch::IntegrationTest
          params: { account_id: theirs.id, simplefin_account_id: simplefin_account.id },
          headers: { "Turbo-Frame" => "modal" }
 
+    # Asserted first: `assert_not_includes` is satisfied by a redirect or an
+    # empty body, so without this the test would keep passing the day the
+    # action stopped rendering the rebuilt list at all.
+    assert_response :success
+
     assert_not_includes response.body, members_own.name,
       "the stream rebuilt the accounts list and handed back an account nobody shared with this admin"
   end

--- a/test/helpers/accounts_helper_test.rb
+++ b/test/helpers/accounts_helper_test.rb
@@ -97,4 +97,15 @@ class AccountsHelperTest < ActionView::TestCase
     assert_not_includes rendered, @someone_elses.name
     assert_not_includes rendered, @owned.name
   end
+
+  # An empty injected list is still a viewer: one who may see nothing. Read as
+  # "no viewer", a member with no shared accounts would get an "Updating…"
+  # card that never updates into anything.
+  test "an injected empty list is a viewer who sees nothing" do
+    Current.session = nil
+    @accessible_account_ids = []
+
+    assert viewer_present_for_account_scoping?
+    assert_empty accounts_visible_to_viewer([ @owned, @someone_elses ])
+  end
 end

--- a/test/helpers/accounts_helper_test.rb
+++ b/test/helpers/accounts_helper_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class AccountsHelperTest < ActionView::TestCase
+  setup do
+    @user = users(:family_admin)
+    @session = sessions(:one)
+    @owned = accounts(:investment)
+    @someone_elses = accounts(:credit_card)
+
+    @someone_elses.account_shares.destroy_all
+    @someone_elses.update!(owner: users(:family_member))
+    @owned.update!(owner: @user)
+  end
+
+  test "keeps only the accounts the viewer may see" do
+    Current.session = @session
+
+    visible = accounts_visible_to_viewer([ @owned, @someone_elses ])
+
+    assert_equal [ @owned ], visible
+  end
+
+  # The accounts index has already loaded this list, so the helper reuses it
+  # rather than repeating the query for every provider card on the page.
+  test "prefers the list the controller already loaded" do
+    Current.session = @session
+    @accessible_account_ids = [ @someone_elses.id ]
+
+    visible = accounts_visible_to_viewer([ @owned, @someone_elses ])
+
+    assert_equal [ @someone_elses ], visible,
+      "the controller's list should win, and be read rather than recomputed"
+  end
+
+  # SimpleFIN and Kraken re-render these partials from their own controllers,
+  # which never set that ivar, so the fallback is a live path rather than a
+  # defensive one.
+  test "falls back to a query when no controller list is present" do
+    Current.session = @session
+
+    assert_nil @accessible_account_ids
+    assert_equal [ @owned ], accounts_visible_to_viewer([ @owned, @someone_elses ])
+  end
+
+  # Signed out there is no viewer to authorise, and showing everything would be
+  # the wrong way to fail.
+  test "shows nothing when there is no viewer" do
+    Current.session = nil
+
+    assert_empty accounts_visible_to_viewer([ @owned, @someone_elses ])
+  end
+
+  test "an account shared with the viewer is theirs to see" do
+    Current.session = @session
+    @someone_elses.account_shares.create!(user: @user, permission: "read_only")
+
+    visible = accounts_visible_to_viewer([ @owned, @someone_elses ])
+
+    assert_includes visible, @someone_elses
+  end
+end

--- a/test/helpers/accounts_helper_test.rb
+++ b/test/helpers/accounts_helper_test.rb
@@ -88,14 +88,29 @@ class AccountsHelperTest < ActionView::TestCase
   # The whole point: with no viewer the card must not come back empty, because
   # an empty provider card reads as "your accounts are gone" rather than "this
   # is waiting on a refresh".
-  test "the groups partial says it is updating rather than showing nothing" do
+  test "the groups partial asks for the rows back rather than showing nothing" do
     Current.session = nil
 
     render partial: "accounts/index/account_groups", locals: { accounts: [ @owned, @someone_elses ] }
 
     assert_includes rendered, "account-groups-awaiting-refresh"
+    assert_includes rendered, account_groups_frame_id([ @owned.id, @someone_elses.id ])
+    assert_includes rendered, "/accounts/groups"
     assert_not_includes rendered, @someone_elses.name
     assert_not_includes rendered, @owned.name
+  end
+
+  # Both sides derive the id from what was REQUESTED. Keying it on the filtered
+  # result would give the reply a different id from the frame waiting for it,
+  # and the rows would never land.
+  test "the frame id does not depend on the order the accounts arrive in" do
+    assert_equal account_groups_frame_id([ @owned.id, @someone_elses.id ]),
+                 account_groups_frame_id([ @someone_elses.id, @owned.id ])
+  end
+
+  test "the frame id distinguishes different sets of accounts" do
+    assert_not_equal account_groups_frame_id([ @owned.id ]),
+                     account_groups_frame_id([ @owned.id, @someone_elses.id ])
   end
 
   # An empty injected list is still a viewer: one who may see nothing. Read as

--- a/test/helpers/accounts_helper_test.rb
+++ b/test/helpers/accounts_helper_test.rb
@@ -58,4 +58,43 @@ class AccountsHelperTest < ActionView::TestCase
 
     assert_includes visible, @someone_elses
   end
+
+  # A background broadcast renders these partials with no `Current.user`. The
+  # empty-set fallback collapses "no viewer" into "no accessible accounts",
+  # which replaced a populated provider card with an empty one — the accounts
+  # looking deleted rather than merely unrendered.
+  test "knows the difference between no viewer and a viewer who sees nothing" do
+    Current.session = nil
+
+    assert_not viewer_present_for_account_scoping?,
+      "a job with no viewer was treated as a viewer who may see nothing"
+  end
+
+  test "a signed-in viewer is a viewer even with nothing shared" do
+    Current.session = @session
+
+    assert viewer_present_for_account_scoping?
+  end
+
+  # The index injects the list, and the partial must still scope to it even
+  # where `Current.user` has not been reached for.
+  test "an injected list counts as a viewer" do
+    Current.session = nil
+    @accessible_account_ids = [ @owned.id ]
+
+    assert viewer_present_for_account_scoping?
+  end
+
+  # The whole point: with no viewer the card must not come back empty, because
+  # an empty provider card reads as "your accounts are gone" rather than "this
+  # is waiting on a refresh".
+  test "the groups partial says it is updating rather than showing nothing" do
+    Current.session = nil
+
+    render partial: "accounts/index/account_groups", locals: { accounts: [ @owned, @someone_elses ] }
+
+    assert_includes rendered, "account-groups-awaiting-refresh"
+    assert_not_includes rendered, @someone_elses.name
+    assert_not_includes rendered, @owned.name
+  end
 end


### PR DESCRIPTION
Raised on #3136 and asked for there by @jjmata. Fixes the pattern rather than the one card, since it is not specific to on-chain wallets.

## What leaks

A provider item appears on `/accounts` as soon as **one** of its accounts is accessible — that is what `AccountsController#visible_provider_items` decides. But every card then hands its **whole item** to `accounts/index/_account_groups`, which filters nothing and also prints a per-group total. So a member shared into one account of a connection reads the names, balances and totals of the ones nobody shared with them.

Nineteen partials pass `item.accounts` through unfiltered: akahu, binance, brex, coinbase, coinstats, enable_banking, ibkr, indexa_capital, kraken, lunchflow, mercury, plaid, questrade, redbark, snaptrade, sophtron, trading212, up, wise.

It is not only the cards. Nine controllers rebuild the accounts list for a Turbo Stream and recompute it unscoped —

```ruby
@manual_accounts = Account.uncached { Current.family.accounts.visible_manual.order(:name).to_a }
```

— `simplefin` (twice), `sophtron`, `coinbase`, `mercury`, `lunchflow`, `enable_banking`, `brex`, `binance`. Ten call sites. Only `AccountsController` and `TransactionsController` scope that list, and all ten render through the same partial.

## Reproduced, not inferred

Two accounts under one item owned by an admin, a member shared into one of them, signed in as that member:

```
member accessible: ["BTC · 1A1zP1…vfNa"]
GET /accounts as member -> 200
  sees the account shared with them: true
  sees the UNSHARED account:         true
```

Attaching a CoinStats item to the same two accounts made the unshared name appear **twice** on the page — once per card built over them. And on `SimplefinItemsController#link_existing_account`, the Turbo Stream handed back an account the viewer was never given; there is a request test for it that fails without this change.

After, measured on a Kraken connection holding one account owned by an admin (1,000) and one owned by a member (250), neither shared:

```
as admin   sees ADMIN_ONLY only,  group total 1,000   (not 1,250)
as member  sees MEMBER_ONLY only, group total 250
```

The totals filter with the list, so they stop disclosing the balances of hidden accounts.

## The decision that is yours, not mine

**The fix does not exempt admins**, and I want that in front of you rather than buried in a one-line diff.

I checked before choosing: `@manual_accounts` is already scoped `where(id: @accessible_account_ids)` with no admin branch, and an admin genuinely does not see a member's unshared manual account on that page today — verified, not assumed. So the cards were the outlier, not the manual list.

But it *is* a visible behaviour change: an admin who today sees every account of a connection will see only the ones they own or were shared. On a personal-finance app that is your call. It is a one-line change to exempt admins if you would rather.

The `SimplefinItemsController` path argues the same way, incidentally: it is admin-only, so what it leaked was a **member's** unshared accounts back to an **admin** — on a page that refuses them those same accounts.

## Shape

Filtered in the partial rather than in nineteen callers, so the counts and totals are filtered with it and any provider added later inherits the rule instead of having to remember it. The helper is unit tested separately because its fallback is a live path, not a defensive one: those Turbo Streams render through it without the ivar the index provides.

The on-chain card, which shipped its own filter last week, had granted admins an exemption; that is dropped here so its address count agrees with what it renders.

```
bin/rails test                                      6927 runs, 27897 assertions, 0 failures
DISABLE_PARALLELIZATION=true bin/rails test:system    99 runs,   414 assertions, 0 failures
bin/rubocop -f github / erb_lint / brakeman         clean
```

The two accounts-page tests use Kraken rather than the on-chain card, so they exercise the shared partial rather than a card that already filtered itself. All of them fail without the change.

## Not looked at

Whether account data leaks the same way through other surfaces — dashboard, sidebar, the API — and anything rendering outside `_account_groups`. Happy to sweep those too if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account and provider card views now consistently show only accounts the viewer can access.
  * Administrators no longer see unshared accounts belonging to other household members.
  * Account totals, groups, and balances now exclude inaccessible accounts.
  * Account lists no longer briefly display unauthorized or misleading empty cards during refreshes.

* **Improvements**
  * Account groups now refresh securely in the background.
  * Refresh status is shown in English and French.

* **Tests**
  * Added coverage for shared, unshared, owned, read-only, signed-out, and relinked account scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->