### PR TITLE
fix(securities): give prefixed crypto tickers their logo back

### DIFF
--- a/app/models/provider/binance_public.rb
+++ b/app/models/provider/binance_public.rb
@@ -255,7 +255,58 @@ class Provider::BinancePublic < Provider
     end
   end
 
+  # Maps a user-visible ticker to the Binance pair symbol, base asset, and
+  # display currency. Accepts:
+  #   - "BTCUSD"/"ETHEUR" — fiat suffix from search_securities output
+  #   - "CRYPTO:BTCUSD" — prefixed form stored by holdings processors
+  #   - "CRYPTO:SOL"/"SOL" — bare base asset; defaults to the USDT pair (USD)
+  #   - "CRYPTO:USDT"/"USDT" — USD-pegged stablecoin; binance_pair is nil and
+  #     callers short-circuit to a synthetic 1.0 USD price
+  # Returns nil only when the input is empty after stripping the prefix.
+  def self.parse_ticker(ticker)
+    raw = ticker.to_s.upcase
+    prefixed = raw.start_with?(CRYPTO_PREFIX)
+    ticker_up = raw.delete_prefix(CRYPTO_PREFIX)
+    return nil if ticker_up.empty?
+
+    if USD_STABLECOINS.include?(ticker_up)
+      return { binance_pair: nil, base: ticker_up, display_currency: "USD", stablecoin: true }
+    end
+
+    SUPPORTED_QUOTES.each do |quote|
+      display_currency = QUOTE_TO_CURRENCY[quote]
+      next unless ticker_up.end_with?(display_currency)
+
+      # Strip the quote plus any separator so the canonical "BTC-USD" form
+      # yields "BTC" (not "BTC-") and builds a valid "BTCUSDT" pair.
+      base = ticker_up.delete_suffix(display_currency).sub(QUOTE_SEPARATOR, "")
+      next if base.empty?
+
+      # "{stablecoin}USD" form (e.g. "USDTUSD" produced by search_securities)
+      # routes to synthetic 1.0 USD pricing — there is no Binance self-pair.
+      if display_currency == "USD" && USD_STABLECOINS.include?(base)
+        return { binance_pair: nil, base: base, display_currency: "USD", stablecoin: true }
+      end
+
+      return { binance_pair: "#{base}#{quote}", base: base, display_currency: display_currency }
+    end
+
+    # No fiat suffix matched. Only treat the input as a bare base asset when
+    # it arrived with the CRYPTO: prefix from a holdings processor — that
+    # tells us it really is a single coin symbol (SOL, TRUMP, KAITO), not a
+    # malformed pair like "BTCBNB" or "BTCGBP" that we want to reject.
+    return nil unless prefixed
+
+    { binance_pair: "#{ticker_up}USDT", base: ticker_up, display_currency: "USD" }
+  end
+
   private
+
+    # The instance form its own methods and tests use; the parsing itself is
+    # a class method so callers outside this provider can reach it.
+    def parse_ticker(ticker)
+      self.class.parse_ticker(ticker)
+    end
     # Synthetic search hit for a USD-pegged stablecoin. Binance has no self-pair
     # (USDTUSDT etc. don't exist), so we manufacture a result instead of letting
     # the resolver fall back to an offline CRYPTO:* row. The downstream price
@@ -313,50 +364,6 @@ class Provider::BinancePublic < Provider
       end
     end
 
-    # Maps a user-visible ticker to the Binance pair symbol, base asset, and
-    # display currency. Accepts:
-    #   - "BTCUSD"/"ETHEUR" — fiat suffix from search_securities output
-    #   - "CRYPTO:BTCUSD" — prefixed form stored by holdings processors
-    #   - "CRYPTO:SOL"/"SOL" — bare base asset; defaults to the USDT pair (USD)
-    #   - "CRYPTO:USDT"/"USDT" — USD-pegged stablecoin; binance_pair is nil and
-    #     callers short-circuit to a synthetic 1.0 USD price
-    # Returns nil only when the input is empty after stripping the prefix.
-    def parse_ticker(ticker)
-      raw = ticker.to_s.upcase
-      prefixed = raw.start_with?(CRYPTO_PREFIX)
-      ticker_up = raw.delete_prefix(CRYPTO_PREFIX)
-      return nil if ticker_up.empty?
-
-      if USD_STABLECOINS.include?(ticker_up)
-        return { binance_pair: nil, base: ticker_up, display_currency: "USD", stablecoin: true }
-      end
-
-      SUPPORTED_QUOTES.each do |quote|
-        display_currency = QUOTE_TO_CURRENCY[quote]
-        next unless ticker_up.end_with?(display_currency)
-
-        # Strip the quote plus any separator so the canonical "BTC-USD" form
-        # yields "BTC" (not "BTC-") and builds a valid "BTCUSDT" pair.
-        base = ticker_up.delete_suffix(display_currency).sub(QUOTE_SEPARATOR, "")
-        next if base.empty?
-
-        # "{stablecoin}USD" form (e.g. "USDTUSD" produced by search_securities)
-        # routes to synthetic 1.0 USD pricing — there is no Binance self-pair.
-        if display_currency == "USD" && USD_STABLECOINS.include?(base)
-          return { binance_pair: nil, base: base, display_currency: "USD", stablecoin: true }
-        end
-
-        return { binance_pair: "#{base}#{quote}", base: base, display_currency: display_currency }
-      end
-
-      # No fiat suffix matched. Only treat the input as a bare base asset when
-      # it arrived with the CRYPTO: prefix from a holdings processor — that
-      # tells us it really is a single coin symbol (SOL, TRUMP, KAITO), not a
-      # malformed pair like "BTCBNB" or "BTCGBP" that we want to reject.
-      return nil unless prefixed
-
-      { binance_pair: "#{ticker_up}USDT", base: ticker_up, display_currency: "USD" }
-    end
 
     # Cached for 24h — exchangeInfo returns the full symbol universe (thousands
     # of rows, weight 10) and rarely changes.

--- a/app/models/security.rb
+++ b/app/models/security.rb
@@ -79,12 +79,12 @@ class Security < ApplicationRecord
   # doesn't end in a supported quote.
   def crypto_base_asset
     return nil unless crypto?
-    Provider::BinancePublic::QUOTE_TO_CURRENCY.each_value do |suffix|
-      next unless ticker.end_with?(suffix)
-      base = ticker.delete_suffix(suffix)
-      return base unless base.empty?
-    end
-    nil
+
+    # Delegated rather than parsed here: this stripped a fiat suffix only, so it
+    # answered nil for the "CRYPTO:BTC" form the holdings processors store — the
+    # form every crypto integration writes — and those securities carried no
+    # logo at all. The provider already parses every shape it accepts.
+    Provider::BinancePublic.parse_ticker(ticker)&.dig(:base)
   end
 
   # Single source of truth for which logo URL the UI should render.

--- a/test/models/security_test.rb
+++ b/test/models/security_test.rb
@@ -187,4 +187,25 @@ class SecurityTest < ActiveSupport::TestCase
       sec.logo_url
     )
   end
+
+  # Every crypto integration stores the prefixed form — the on-chain wallets,
+  # Kraken, CoinStats and Binance all write "CRYPTO:BTC" — and this answered nil
+  # for all of them, so none of their securities carried a logo.
+  test "resolves the base asset from a prefixed crypto ticker" do
+    security = Security.new(ticker: "CRYPTO:BTC", exchange_operating_mic: Provider::BinancePublic::BINANCE_MIC)
+
+    assert_equal "BTC", security.crypto_base_asset
+  end
+
+  test "still resolves the pair form the search results produce" do
+    security = Security.new(ticker: "BTCUSD", exchange_operating_mic: Provider::BinancePublic::BINANCE_MIC)
+
+    assert_equal "BTC", security.crypto_base_asset
+  end
+
+  test "a non-crypto security has no base asset" do
+    security = Security.new(ticker: "AAPL", exchange_operating_mic: "XNAS")
+
+    assert_nil security.crypto_base_asset
+  end
 end


### PR DESCRIPTION
`Security#crypto_base_asset` only stripped a fiat suffix — `BTCUSD` gives `BTC` — so it answered nil for the `CRYPTO:BTC` form. That is the form **every** crypto integration writes: Kraken, CoinStats, Binance holdings and the self-custody wallets all store the prefix.

`display_logo_url` feeds that nil to its crypto branch, so none of those securities carried a logo at all.

`Provider::BinancePublic` already parses every shape it accepts — the pair form, the prefixed pair, the bare base asset, the USD stablecoins — so this delegates rather than growing a second parser beside it. The parsing moves to a class method for that; the private instance method stays as a delegator, so its own callers and their tests are untouched.

Verified across the four documented forms:

```
CRYPTO:BTC → BTC     BTCUSD → BTC
CRYPTO:ETH → ETH     CRYPTO:USDT → USDT
```

A logo still needs `BRAND_FETCH_CLIENT_ID` configured — this fixes the parsing, not the hosting requirement.

```
bin/rails test        6922 runs, 27880 assertions, 0 failures
rubocop               clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crypto asset recognition for prefixed and pair-form ticker symbols.
  * Ensured ticker parsing consistently handles supported quote currencies and separators.

* **Tests**
  * Added coverage for prefixed crypto tickers, combined crypto/fiat symbols, and non-crypto securities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->