### PR TITLE
chore(goals): drop copy-pasted duplicates and an unused lock-key helper

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -491,26 +491,6 @@ class Account < ApplicationRecord
     balance.to_d - goal_earmarked_total
   end
 
-  # Total fixed earmark this account currently has reserved across every
-  # non-archived goal (unallocated/whole-balance links reserve no fixed
-  # slice). Mirrors Budget#allocated_spending.
-  def goal_earmarked_total
-    GoalAccount.joins(:goal)
-               .where(account_id: id)
-               .where.not(allocated_amount: nil)
-               .where.not(goals: { state: "archived" })
-               .sum(:allocated_amount)
-               .to_d
-  end
-
-  # Headroom left to earmark toward goals before fixed allocations exceed the
-  # balance. Negative means the account is over-earmarked. Intended to back a
-  # non-blocking over-allocation warning (UI is a follow-up). Mirrors
-  # Budget#available_to_allocate.
-  def free_to_earmark
-    balance.to_d - goal_earmarked_total
-  end
-
   def logo_url
     if institution_domain.present? && Setting.brand_fetch_client_id.present?
       logo_size = Setting.brand_fetch_logo_size

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -45,10 +45,6 @@ class Goal < ApplicationRecord
     order(Arel.sql("CASE state WHEN 'active' THEN 0 WHEN 'paused' THEN 1 WHEN 'completed' THEN 2 ELSE 3 END"))
   }
 
-  def self.advisory_lock_key_for(family_id)
-    Digest::SHA1.hexdigest("goals:family:#{family_id}").to_i(16) % (2**63)
-  end
-
   # Family-wide map of non-archived goal earmarks, grouped by account_id:
   # { account_id => [{ goal_id:, allocated_amount: }, ...] }. The controller
   # assigns this to each goal on index (goal.pooled_allocations = ...) so the

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -339,13 +339,6 @@ class GoalTest < ActiveSupport::TestCase
     assert_equal :reached, @goal.display_status
   end
 
-  test "advisory_lock_key_for is stable per family" do
-    k1 = Goal.advisory_lock_key_for(@family.id)
-    k2 = Goal.advisory_lock_key_for(@family.id)
-    assert_equal k1, k2
-    assert_kind_of Integer, k1
-  end
-
   test "any_connected_account? reflects plaid_account presence" do
     assert @goal.any_connected_account?
     only_manual = goals(:emergency_fund)


### PR DESCRIPTION
Two no-behavior-change cleanups in the goal earmarking code.

### 1. `Account#goal_earmarked_total` / `#free_to_earmark` were defined twice

Both methods appeared twice in `app/models/account.rb`, byte for byte identical, with no `private` boundary or singleton class between the blocks — a copy-paste artifact where the second definition silently overwrote the first. Ruby accepts this quietly, so nothing broke, but the file carried two live definitions of the same two methods and a reader had no way to tell which one was in effect. One copy of each is kept.

### 2. `Goal.advisory_lock_key_for` had no callers

`grep` over `app/` finds no reference to it. The only mention anywhere in the repo was a test asserting the dead helper returned a deterministic integer. Both the method and that test are removed.

31 lines deleted, no production behavior touched.

### Verification

- `bin/rails test` — 6918 runs, 27875 assertions, 0 failures, 0 errors
- `bin/rubocop -f github -a` — clean, no autocorrections
- `bin/brakeman --no-pager` — 0 security warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJ1npaGEHr6t2HW1rYZdt4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed obsolete goal earmarking calculations from account handling.
  * Removed unused goal locking functionality.

* **Tests**
  * Removed the test covering the retired goal locking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->