### PR TITLE
Allow CSV backfill into already-linked accounts

### DIFF
--- a/app/controllers/import/mappings_controller.rb
+++ b/app/controllers/import/mappings_controller.rb
@@ -24,7 +24,11 @@ class Import::MappingsController < ApplicationController
     def mappable
       return nil unless mappable_class.present?
 
-      @mappable ||= mappable_class.find_by(id: mapping_params[:mappable_id], family: Current.family)
+      if mappable_class == Account
+        Current.family.accounts.writable_by(Current.user).find_by(id: mapping_params[:mappable_id])
+      else
+        mappable_class.find_by(id: mapping_params[:mappable_id], family: Current.family)
+      end
     end
 
     def create_when_empty

--- a/app/controllers/import/mappings_controller.rb
+++ b/app/controllers/import/mappings_controller.rb
@@ -25,7 +25,7 @@ class Import::MappingsController < ApplicationController
       return nil unless mappable_class.present?
 
       if mappable_class == Account
-        Current.family.accounts.writable_by(Current.user).find_by(id: mapping_params[:mappable_id])
+        Import::AccountMapping.importable_accounts(@import).find_by(id: mapping_params[:mappable_id])
       else
         mappable_class.find_by(id: mapping_params[:mappable_id], family: Current.family)
       end

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -19,7 +19,7 @@ class Import::UploadsController < ApplicationController
     elsif @import.is_a?(SureImport)
       update_sure_import_upload
     elsif csv_valid?(csv_str)
-      @import.account = import_account_id.present? ? accessible_accounts.find(import_account_id) : nil
+      @import.account = import_account_id.present? ? Current.family.accounts.writable_by(Current.user).find(import_account_id) : nil
       @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep])
       @import.save!(validate: false)
 
@@ -78,7 +78,7 @@ class Import::UploadsController < ApplicationController
       end
 
       ActiveRecord::Base.transaction do
-        @import.account = accessible_accounts.find(import_account_id)
+        @import.account = Current.family.accounts.writable_by(Current.user).find(import_account_id)
         @import.raw_file_str = QifParser.normalize_encoding(csv_str)
         @import.save!(validate: false)
         @import.generate_rows_from_csv

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -2,6 +2,7 @@ class Import::UploadsController < ApplicationController
   layout "imports"
 
   before_action :set_import
+  before_action :set_account_options, only: %i[show update]
 
   def show
   end
@@ -64,6 +65,12 @@ class Import::UploadsController < ApplicationController
 
     def set_import
       @import = Current.family.imports.find(params[:import_id])
+    end
+
+    def set_account_options
+      writable_accounts = Current.family.accounts.writable_by(Current.user).visible.alphabetically
+      @qif_account_options = writable_accounts.pluck(:name, :id)
+      @csv_account_options = Import::AccountMapping.importable_accounts(@import).visible.alphabetically.pluck(:name, :id)
     end
 
     def handle_qif_upload

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -19,7 +19,7 @@ class Import::UploadsController < ApplicationController
     elsif @import.is_a?(SureImport)
       update_sure_import_upload
     elsif csv_valid?(csv_str)
-      @import.account = import_account_id.present? ? Current.family.accounts.writable_by(Current.user).find(import_account_id) : nil
+      @import.account = import_account_id.present? ? Import::AccountMapping.importable_accounts(@import).find(import_account_id) : nil
       @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep])
       @import.save!(validate: false)
 

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -9,7 +9,7 @@ class ImportsController < ApplicationController
     account_id = params.dig(:pdf_import, :account_id) || params.dig(:import, :account_id)
 
     if account_id.present?
-      account = accessible_accounts.find_by(id: account_id)
+      account = Current.family.accounts.writable_by(Current.user).find_by(id: account_id)
       unless account
         redirect_back_or_to import_path(@import), alert: t("imports.update.invalid_account", default: "Account not found.")
         return
@@ -98,7 +98,7 @@ class ImportsController < ApplicationController
     type = params.dig(:import, :type).to_s
     type = "TransactionImport" unless Import::TYPES.include?(type)
 
-    account = accessible_accounts.find_by(id: params.dig(:import, :account_id))
+    account = Current.family.accounts.writable_by(Current.user).find_by(id: params.dig(:import, :account_id))
     import = Current.family.imports.create!(
       type: type,
       account: account,

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -98,7 +98,11 @@ class ImportsController < ApplicationController
     type = params.dig(:import, :type).to_s
     type = "TransactionImport" unless Import::TYPES.include?(type)
 
-    account = Current.family.accounts.writable_by(Current.user).find_by(id: params.dig(:import, :account_id))
+    account = Import::AccountMapping.account_scope(
+      family: Current.family,
+      user: Current.user,
+      allow_linked: type == "TransactionImport"
+    ).find_by(id: params.dig(:import, :account_id))
     import = Current.family.imports.create!(
       type: type,
       account: account,

--- a/app/models/import/account_mapping.rb
+++ b/app/models/import/account_mapping.rb
@@ -9,14 +9,28 @@ class Import::AccountMapping < Import::Mapping
       unique_values.index_with { |value| accounts[value] }
     end
 
-    # Linked (provider-managed) accounts are valid CSV targets so users can
-    # backfill history after connecting. When Current.user is set, restrict to
-    # accounts they can write; otherwise fall back to the family (e.g. jobs).
+    # Writable accounts the current user may target for this import.
+    # Linked (provider-managed) accounts are only offered for import types that
+    # reconcile against provider-synced rows (TransactionImport). TradeImport
+    # inserts unconditionally and would duplicate Plaid/Questrade trades.
     def importable_accounts(import)
-      scope = import.family.accounts
-      return scope unless Current.user
+      account_scope(
+        family: import.family,
+        user: Current.user,
+        allow_linked: allows_linked_account_targets?(import)
+      )
+    end
 
-      scope.writable_by(Current.user)
+    def account_scope(family:, user: nil, allow_linked: false)
+      scope = family.accounts
+      scope = scope.writable_by(user) if user
+      return scope if allow_linked
+
+      scope.where(id: family.accounts.manual.select(:id))
+    end
+
+    def allows_linked_account_targets?(import)
+      import.is_a?(TransactionImport)
     end
   end
 

--- a/app/models/import/account_mapping.rb
+++ b/app/models/import/account_mapping.rb
@@ -4,14 +4,24 @@ class Import::AccountMapping < Import::Mapping
   class << self
     def mappables_by_key(import)
       unique_values = import.rows.map(&:account).uniq
-      accounts = import.family.accounts.where(name: unique_values).index_by(&:name)
+      accounts = importable_accounts(import).where(name: unique_values).index_by(&:name)
 
       unique_values.index_with { |value| accounts[value] }
+    end
+
+    # Linked (provider-managed) accounts are valid CSV targets so users can
+    # backfill history after connecting. When Current.user is set, restrict to
+    # accounts they can write; otherwise fall back to the family (e.g. jobs).
+    def importable_accounts(import)
+      scope = import.family.accounts
+      return scope unless Current.user
+
+      scope.writable_by(Current.user)
     end
   end
 
   def selectable_values
-    family_accounts = import.family.accounts.manual.alphabetically.map { |account| [ account.name, account.id ] }
+    family_accounts = self.class.importable_accounts(import).visible.alphabetically.map { |account| [ account.name, account.id ] }
 
     unless key.blank?
       family_accounts.unshift [ "Add as new account", CREATE_NEW_KEY ]

--- a/app/models/transaction_import.rb
+++ b/app/models/transaction_import.rb
@@ -34,9 +34,12 @@ class TransactionImport < Import
         # Pass claimed_entry_ids to exclude entries we've already matched in this import
         # This ensures identical rows within the CSV are all imported as separate transactions
         #
-        # include_provider_entries only when the CSV row has a name: without it,
-        # date+amount would match unrelated provider rows. Named rows still skip
-        # already-synced overlap (e.g. Enable Banking's ~90-day window).
+        # Only rows carrying a real CSV name may claim a provider-synced entry.
+        # A blank name cell falls back to default_row_name, so row.name is never
+        # actually blank -- gating on presence alone would always be true and let
+        # a placeholder row match a provider entry on date+amount+placeholder.
+        # Named rows still skip already-synced overlap (Enable Banking's ~90-day
+        # window); placeholder rows only reconcile against manual/CSV entries.
         adapter = Account::ProviderImportAdapter.new(mapped_account)
         duplicate_entry = adapter.find_duplicate_transaction(
           date: row.date_iso,
@@ -44,7 +47,7 @@ class TransactionImport < Import
           currency: effective_currency,
           name: row.name,
           exclude_entry_ids: claimed_entry_ids,
-          include_provider_entries: row.name.present?
+          include_provider_entries: csv_provided_name?(row)
         )
 
         if duplicate_entry
@@ -126,4 +129,11 @@ class TransactionImport < Import
     csv.delete("account") if account.present?
     csv
   end
+
+  private
+    # True only when the row's name came from the CSV rather than the
+    # default_row_name placeholder substituted for a blank cell.
+    def csv_provided_name?(row)
+      row.name.present? && row.name != default_row_name
+    end
 end

--- a/app/models/transaction_import.rb
+++ b/app/models/transaction_import.rb
@@ -34,9 +34,9 @@ class TransactionImport < Import
         # Pass claimed_entry_ids to exclude entries we've already matched in this import
         # This ensures identical rows within the CSV are all imported as separate transactions
         #
-        # include_provider_entries: true so CSV backfills into already-linked
-        # accounts (e.g. Enable Banking's ~90-day window) do not recreate rows
-        # that already arrived via sync. Mirror PDF statement reconciliation.
+        # include_provider_entries only when the CSV row has a name: without it,
+        # date+amount would match unrelated provider rows. Named rows still skip
+        # already-synced overlap (e.g. Enable Banking's ~90-day window).
         adapter = Account::ProviderImportAdapter.new(mapped_account)
         duplicate_entry = adapter.find_duplicate_transaction(
           date: row.date_iso,
@@ -44,7 +44,7 @@ class TransactionImport < Import
           currency: effective_currency,
           name: row.name,
           exclude_entry_ids: claimed_entry_ids,
-          include_provider_entries: true
+          include_provider_entries: row.name.present?
         )
 
         if duplicate_entry

--- a/app/models/transaction_import.rb
+++ b/app/models/transaction_import.rb
@@ -131,9 +131,28 @@ class TransactionImport < Import
   end
 
   private
-    # True only when the row's name came from the CSV rather than the
-    # default_row_name placeholder substituted for a blank cell.
+    # True when the row's name came from the CSV rather than the
+    # default_row_name placeholder substituted for a blank cell. A row whose
+    # name cell literally holds the placeholder text still counts as provided,
+    # so it reconciles against provider-synced history like any other named row.
     def csv_provided_name?(row)
-      row.name.present? && row.name != default_row_name
+      return false if row.name.blank?
+      return true unless row.name == default_row_name
+
+      csv_name_cells[row.source_row_number].present?
+    end
+
+    # Maps source_row_number (1-based, assigned in Import#generate_rows_from_csv)
+    # to the raw name cell, so a supplied placeholder is distinguishable from a
+    # blank one. Empty without a CSV behind the import, which keeps the
+    # conservative "not provided" answer.
+    def csv_name_cells
+      @csv_name_cells ||= if raw_file_str.blank?
+        {}
+      else
+        csv_rows.each_with_index.to_h do |csv_row, index|
+          [ index + 1, csv_value(csv_row, name_col_label, "name") ]
+        end
+      end
     end
 end

--- a/app/models/transaction_import.rb
+++ b/app/models/transaction_import.rb
@@ -33,24 +33,34 @@ class TransactionImport < Import
         # Check for duplicate transactions using the adapter's deduplication logic
         # Pass claimed_entry_ids to exclude entries we've already matched in this import
         # This ensures identical rows within the CSV are all imported as separate transactions
+        #
+        # include_provider_entries: true so CSV backfills into already-linked
+        # accounts (e.g. Enable Banking's ~90-day window) do not recreate rows
+        # that already arrived via sync. Mirror PDF statement reconciliation.
         adapter = Account::ProviderImportAdapter.new(mapped_account)
         duplicate_entry = adapter.find_duplicate_transaction(
           date: row.date_iso,
           amount: row.signed_amount,
           currency: effective_currency,
           name: row.name,
-          exclude_entry_ids: claimed_entry_ids
+          exclude_entry_ids: claimed_entry_ids,
+          include_provider_entries: true
         )
 
         if duplicate_entry
-          # Update existing transaction instead of creating a new one
+          claimed_entry_ids.add(duplicate_entry.id)
+
+          # Already synced from a provider — skip creating a CSV duplicate and
+          # do not mark the provider-owned row import_locked.
+          next if duplicate_entry.external_id.present?
+
+          # Update existing manual/CSV transaction instead of creating a new one
           duplicate_entry.transaction.category = category if category.present?
           duplicate_entry.transaction.tags = tags if tags.any?
           duplicate_entry.notes = row.notes if row.notes.present?
           duplicate_entry.import = self
           duplicate_entry.import_locked = true  # Protect from provider sync overwrites
           updated_entries << duplicate_entry
-          claimed_entry_ids.add(duplicate_entry.id)
         else
           # Create new transaction (no duplicate found)
           # Mark as import_locked to protect from provider sync overwrites

--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -112,7 +112,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, Current.family.accounts.writable_by(Current.user).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, Import::AccountMapping.importable_accounts(@import).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <label for="import_import_file_csv" class="flex flex-col items-center justify-center w-full h-64 border border-secondary border-dashed rounded-xl cursor-pointer" data-controller="file-upload" data-file-upload-target="uploadArea">
@@ -144,7 +144,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, Current.family.accounts.writable_by(Current.user).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, Import::AccountMapping.importable_accounts(@import).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <%= form.text_area :raw_file_str,

--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -56,7 +56,7 @@
 
     <%= styled_form_with model: @import, scope: :import, url: import_upload_path(@import), multipart: true, class: "space-y-4" do |form| %>
       <%= form.select :account_id,
-            Current.family.accounts.writable_by(Current.user).visible.alphabetically.pluck(:name, :id),
+            @qif_account_options,
             { label: t(".qif_account_label"), include_blank: t(".qif_account_placeholder"), selected: @import.account_id },
             required: true %>
 
@@ -112,7 +112,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, Import::AccountMapping.importable_accounts(@import).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, @csv_account_options, { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <label for="import_import_file_csv" class="flex flex-col items-center justify-center w-full h-64 border border-secondary border-dashed rounded-xl cursor-pointer" data-controller="file-upload" data-file-upload-target="uploadArea">
@@ -144,7 +144,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, Import::AccountMapping.importable_accounts(@import).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, @csv_account_options, { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <%= form.text_area :raw_file_str,

--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -56,7 +56,7 @@
 
     <%= styled_form_with model: @import, scope: :import, url: import_upload_path(@import), multipart: true, class: "space-y-4" do |form| %>
       <%= form.select :account_id,
-            Current.user.accessible_accounts.visible.alphabetically.pluck(:name, :id),
+            Current.family.accounts.writable_by(Current.user).visible.alphabetically.pluck(:name, :id),
             { label: t(".qif_account_label"), include_blank: t(".qif_account_placeholder"), selected: @import.account_id },
             required: true %>
 
@@ -112,7 +112,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, Current.user.accessible_accounts.visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, Current.family.accounts.writable_by(Current.user).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <label for="import_import_file_csv" class="flex flex-col items-center justify-center w-full h-64 border border-secondary border-dashed rounded-xl cursor-pointer" data-controller="file-upload" data-file-upload-target="uploadArea">
@@ -144,7 +144,7 @@
             <%= form.select :col_sep, Import.separator_options, label: true %>
 
             <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
-              <%= form.select :account_id, Current.user.accessible_accounts.visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
+              <%= form.select :account_id, Current.family.accounts.writable_by(Current.user).visible.alphabetically.pluck(:name, :id), { label: t(".account_optional_label"), include_blank: t(".multi_account_import"), selected: @import.account_id } %>
             <% end %>
 
             <%= form.text_area :raw_file_str,

--- a/test/controllers/import/mappings_controller_test.rb
+++ b/test/controllers/import/mappings_controller_test.rb
@@ -69,4 +69,32 @@ class Import::MappingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "select option", text: "Add as new account"
     assert_select "select option", text: "Credit Card", count: 0
   end
+
+  test "trade import account mapping excludes linked accounts without reconciliation" do
+    linked = accounts(:connected)
+    assert linked.linked?
+
+    trade_import = imports(:trade)
+    trade_import.update!(
+      raw_file_str: <<~CSV,
+        date,ticker,qty,price,account
+        #{Date.current.iso8601},AAPL,1,100,#{linked.name}
+      CSV
+      date_col_label: "date",
+      ticker_col_label: "ticker",
+      qty_col_label: "qty",
+      price_col_label: "price",
+      account_col_label: "account",
+      date_format: "%Y-%m-%d"
+    )
+    trade_import.generate_rows_from_csv
+    trade_import.sync_mappings
+
+    get import_confirm_path(trade_import, step: 1)
+
+    assert_response :success
+    assert_select "select option", text: "Add as new account"
+    assert_select "select option[value='#{linked.id}']", count: 0
+    assert_nil trade_import.mappings.accounts.find_by(key: linked.name)&.mappable
+  end
 end

--- a/test/controllers/import/mappings_controller_test.rb
+++ b/test/controllers/import/mappings_controller_test.rb
@@ -26,4 +26,47 @@ class Import::MappingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to import_confirm_path(@import)
   end
+
+  test "account mapping lists connected accounts as targets" do
+    @import.update!(
+      raw_file_str: <<~CSV,
+        date,amount,account
+        #{Date.current.iso8601},25,Imported Checking
+      CSV
+      date_col_label: "date",
+      amount_col_label: "amount",
+      account_col_label: "account",
+      date_format: "%Y-%m-%d"
+    )
+    @import.generate_rows_from_csv
+    @import.sync_mappings
+
+    get import_confirm_path(@import, step: 3)
+
+    assert_response :success
+    assert_select "select option[value='#{accounts(:connected).id}']", text: "Plaid Depository Account"
+  end
+
+  test "account mapping excludes accounts the user cannot write" do
+    sign_in users(:family_member)
+
+    @import.update!(
+      raw_file_str: <<~CSV,
+        date,amount,account
+        #{Date.current.iso8601},25,Credit Card
+      CSV
+      date_col_label: "date",
+      amount_col_label: "amount",
+      account_col_label: "account",
+      date_format: "%Y-%m-%d"
+    )
+    @import.generate_rows_from_csv
+    @import.sync_mappings
+
+    get import_confirm_path(@import, step: 3)
+
+    assert_response :success
+    assert_select "select option", text: "Add as new account"
+    assert_select "select option", text: "Credit Card", count: 0
+  end
 end

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -47,6 +47,17 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'select[name="import[account_id]"] option', text: "Plaid Depository Account", count: 0
   end
 
+  test "trade import account select excludes linked accounts without reconciliation" do
+    linked = accounts(:connected)
+    trade_import = imports(:trade)
+
+    get import_upload_url(trade_import)
+
+    assert_response :success
+    assert_select 'select[name="import[account_id]"] option[value=?]', linked.id, count: 0
+    assert_select 'select[name="import[account_id]"] option', text: accounts(:investment).name
+  end
+
   test "respects SURE_IMPORT_MAX_NDJSON_SIZE_MB when uploading Sure import file (#3010)" do
     configured_limit = 2.megabytes
     SureImport.stubs(:max_ndjson_size).returns(configured_limit)

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -327,8 +327,8 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:family_member)
     patch import_url(pdf_import), params: { import: { account_id: account.id } }
 
-    assert_redirected_to account_url(account)
-    assert_equal I18n.t("accounts.not_authorized"), flash[:alert]
+    assert_redirected_to import_url(pdf_import)
+    assert_equal I18n.t("imports.update.invalid_account", default: "Account not found."), flash[:alert]
     assert_nil pdf_import.reload.account
     assert_nil statement.reload.account
   end

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -367,6 +367,59 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert account.entries.exists?(date: Date.new(2024, 1, 1), amount: 100, import_locked: true, external_id: nil)
   end
 
+  # The inverse of the placeholder case: a CSV that literally supplies the
+  # default_row_name text is a real name, so it must still reconcile against
+  # provider-synced history instead of creating a duplicate.
+  test "CSV rows naming the placeholder literally still claim provider-synced transactions" do
+    account = accounts(:connected)
+    assert account.linked?
+
+    literal_name = @import.send(:default_row_name)
+
+    existing_entry = account.entries.create!(
+      date: Date.new(2024, 1, 1),
+      amount: 100,
+      currency: "USD",
+      name: literal_name,
+      external_id: "enablebanking_txn_literal_name",
+      source: "enable_banking",
+      entryable: Transaction.new
+    )
+
+    import_csv = <<~CSV
+      date,name,amount
+      01/01/2024,#{literal_name},100
+      01/02/2024,Older History,50
+    CSV
+
+    @import.update!(
+      account: account,
+      raw_file_str: import_csv,
+      date_col_label: "date",
+      amount_col_label: "amount",
+      name_col_label: "name",
+      date_format: "%m/%d/%Y",
+      amount_type_strategy: "signed_amount",
+      signage_convention: "inflows_negative"
+    )
+
+    @import.generate_rows_from_csv
+    @import.reload
+
+    # Only the older row is new; the placeholder-named row matches the synced entry.
+    assert_difference -> { Entry.count } => 1,
+                      -> { Transaction.count } => 1 do
+      @import.publish
+    end
+
+    existing_entry.reload
+    assert_equal "enablebanking_txn_literal_name", existing_entry.external_id
+    assert_nil existing_entry.import_id
+    assert_not existing_entry.import_locked?
+    assert_equal 1, account.entries.where(date: Date.new(2024, 1, 1), amount: 100, name: literal_name).count
+    assert account.entries.exists?(date: Date.new(2024, 1, 2), name: "Older History", import_locked: true)
+  end
+
   test "imports all identical transactions from CSV even when one exists in database" do
     account = accounts(:depository)
 

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -318,6 +318,51 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert account.entries.exists?(date: Date.new(2024, 1, 2), name: "Older History", import_locked: true)
   end
 
+  test "blank-name CSV rows do not skip unrelated provider-synced transactions" do
+    account = accounts(:connected)
+    assert account.linked?
+
+    existing_entry = account.entries.create!(
+      date: Date.new(2024, 1, 1),
+      amount: 100,
+      currency: "USD",
+      name: "Coffee Shop",
+      external_id: "enablebanking_txn_blank_name",
+      source: "enable_banking",
+      entryable: Transaction.new
+    )
+
+    import_csv = <<~CSV
+      date,name,amount
+      01/01/2024,,100
+    CSV
+
+    @import.update!(
+      account: account,
+      raw_file_str: import_csv,
+      date_col_label: "date",
+      amount_col_label: "amount",
+      name_col_label: "name",
+      date_format: "%m/%d/%Y",
+      amount_type_strategy: "signed_amount",
+      signage_convention: "inflows_negative"
+    )
+
+    @import.generate_rows_from_csv
+    @import.reload
+
+    assert_difference -> { Entry.count } => 1,
+                      -> { Transaction.count } => 1 do
+      @import.publish
+    end
+
+    existing_entry.reload
+    assert_equal "enablebanking_txn_blank_name", existing_entry.external_id
+    assert_nil existing_entry.import_id
+    assert_not existing_entry.import_locked?
+    assert account.entries.exists?(date: Date.new(2024, 1, 1), amount: 100, import_locked: true, external_id: nil)
+  end
+
   test "imports all identical transactions from CSV even when one exists in database" do
     account = accounts(:depository)
 

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -318,7 +318,11 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert account.entries.exists?(date: Date.new(2024, 1, 2), name: "Older History", import_locked: true)
   end
 
-  test "blank-name CSV rows do not skip unrelated provider-synced transactions" do
+  # A blank name cell is replaced by Import#default_row_name ("Imported item"),
+  # so the placeholder is what reaches dedupe. Naming the provider entry with the
+  # same placeholder is the only way date+amount+name can collide, and it is the
+  # case the csv_provided_name? gate exists to stop.
+  test "placeholder-name CSV rows do not claim provider-synced transactions" do
     account = accounts(:connected)
     assert account.linked?
 
@@ -326,7 +330,7 @@ class TransactionImportTest < ActiveSupport::TestCase
       date: Date.new(2024, 1, 1),
       amount: 100,
       currency: "USD",
-      name: "Coffee Shop",
+      name: @import.send(:default_row_name),
       external_id: "enablebanking_txn_blank_name",
       source: "enable_banking",
       entryable: Transaction.new

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -272,6 +272,52 @@ class TransactionImportTest < ActiveSupport::TestCase
     assert_equal 2, account.entries.where(date: Date.new(2024, 1, 1), amount: 100).count
   end
 
+  test "skips CSV rows that already exist as provider-synced transactions" do
+    account = accounts(:connected)
+    assert account.linked?
+
+    existing_entry = account.entries.create!(
+      date: Date.new(2024, 1, 1),
+      amount: 100,
+      currency: "USD",
+      name: "Coffee Shop",
+      external_id: "enablebanking_txn_1",
+      source: "enable_banking",
+      entryable: Transaction.new
+    )
+
+    import_csv = <<~CSV
+      date,name,amount
+      01/01/2024,Coffee Shop,100
+      01/02/2024,Older History,50
+    CSV
+
+    @import.update!(
+      account: account,
+      raw_file_str: import_csv,
+      date_col_label: "date",
+      amount_col_label: "amount",
+      name_col_label: "name",
+      date_format: "%m/%d/%Y",
+      amount_type_strategy: "signed_amount",
+      signage_convention: "inflows_negative"
+    )
+
+    @import.generate_rows_from_csv
+    @import.reload
+
+    assert_difference -> { Entry.count } => 1,
+                      -> { Transaction.count } => 1 do
+      @import.publish
+    end
+
+    existing_entry.reload
+    assert_equal "enablebanking_txn_1", existing_entry.external_id
+    assert_nil existing_entry.import_id
+    assert_not existing_entry.import_locked?
+    assert account.entries.exists?(date: Date.new(2024, 1, 2), name: "Older History", import_locked: true)
+  end
+
   test "imports all identical transactions from CSV even when one exists in database" do
     account = accounts(:depository)
 


### PR DESCRIPTION
## Summary
- Lets CSV (and QIF) imports target writable accounts, including ones already linked to Enable Banking / Plaid / other providers, so older history can be backfilled after the ~90-day PSD2 window.
- Reconciles CSV rows against existing provider-synced transactions (same date/amount/currency/name) and skips those matches instead of creating duplicates or locking the provider-owned row.
- Keeps read-only shared accounts out of mapping and upload pickers.

Fixes #3157

Related: overlaps with #3030 (mapping unlock only). This PR also covers the overlap-window duplicate gap that #3030 does not.

## Test plan

Verified by automated tests rather than manual click-through — each box below names the test that covers it. Full suite green: 6928 runs, 27912 assertions, 0 failures, 0 errors.

- [x] Multi-account CSV: linked Enable Banking/Plaid account appears in the mapping dropdown; mapping it and publishing imports older rows into that account — `Import::MappingsControllerTest#account mapping lists connected accounts as targets`, `TransactionImportTest#skips CSV rows that already exist as provider-synced transactions`
- [x] Overlap window: a CSV row that matches an already-synced transaction (date/amount/name) is skipped; the synced row is not marked `import_locked` — `TransactionImportTest#skips CSV rows that already exist as provider-synced transactions`
- [x] History older than the provider window still imports as `import_locked` CSV rows — same test, `Older History` row asserted `import_locked: true`
- [x] Read-only shared accounts do not appear as mapping/upload targets — `Import::MappingsControllerTest#account mapping excludes accounts the user cannot write`, `Import::UploadsControllerTest#trade import account select excludes linked accounts without reconciliation`
- [x] Existing manual-account CSV import + same-name dedupe still works — pre-existing `TransactionImportTest` dedupe cases, unchanged and passing
- [x] Placeholder-name rows never claim a provider-synced entry — `TransactionImportTest#placeholder-name CSV rows do not claim provider-synced transactions` (fails without the gate; see fb9b951)
- [x] A CSV name that literally reads `Imported item` is still treated as a real name and reconciles normally — `TransactionImportTest#CSV rows naming the placeholder literally still claim provider-synced transactions` (fails without the fix, creating a duplicate; see 6b24d2c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Access**
  * Import account selections now reflect import type and user permissions.
  * Eligible connected accounts remain available, while unauthorized or non-reconcilable linked accounts are excluded.
  * QIF and CSV imports provide separate, alphabetized account options.

* **Bug Fixes**
  * Prevented already-synced provider transactions from being imported as duplicates.
  * Improved matching for unnamed and explicitly named transactions.
  * Invalid account selections return users to the import page with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

