### PR TITLE
Allow API transaction create to opt into sync protection (user_modified)

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -102,6 +102,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
       @entry.sync_account_later
       @entry.lock_saved_attributes!
       @entry.transaction.lock_attr!(:tag_ids) if @entry.transaction.tags.any?
+      @entry.mark_user_modified! if user_modified_requested?
 
       @transaction = @entry.transaction
       render :show, status: :created
@@ -310,8 +311,18 @@ class Api::V1::TransactionsController < Api::V1::BaseController
     def transaction_params
       params.require(:transaction).permit(
         :date, :amount, :name, :description, :notes, :currency,
-        :category_id, :merchant_id, :nature, tag_ids: []
+        :category_id, :merchant_id, :nature, :user_modified, tag_ids: []
       )
+    end
+
+    # An API client can opt a transaction it creates into the same
+    # sync-protection a manual edit gets (Entry#protected_from_sync?) -
+    # useful for a client that owns its own writes into an account also
+    # linked to a bank-sync provider (Plaid/SimpleFin/etc.), so the next
+    # sync only links its external_id to the entry instead of overwriting
+    # the category/name the client already set.
+    def user_modified_requested?
+      ActiveModel::Type::Boolean.new.cast(transaction_params[:user_modified])
     end
 
     def account_id_param

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -99,10 +99,10 @@ class Api::V1::TransactionsController < Api::V1::BaseController
     @entry = account.entries.new(entry_params_for_create)
 
     if @entry.save
-      @entry.sync_account_later
       @entry.lock_saved_attributes!
       @entry.transaction.lock_attr!(:tag_ids) if @entry.transaction.tags.any?
       @entry.mark_user_modified! if user_modified_requested?
+      @entry.sync_account_later
 
       @transaction = @entry.transaction
       render :show, status: :created

--- a/app/views/api/v1/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v1/transactions/_transaction.json.jbuilder
@@ -19,6 +19,7 @@ json.name transaction.entry.name
 json.notes transaction.entry.notes
 json.external_id transaction.entry.external_id
 json.source transaction.entry.source
+json.user_modified transaction.entry.user_modified
 json.classification transaction.entry.classification
 
 # Account information

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -356,6 +356,53 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal response_data["id"], entry.transaction.id
   end
 
+  test "should create transaction protected from provider sync when user_modified is true" do
+    transaction_params = {
+      transaction: {
+        account_id: @account.id,
+        name: "Imported Transaction",
+        amount: 25.00,
+        date: Date.current,
+        currency: "USD",
+        nature: "expense",
+        user_modified: true
+      }
+    }
+
+    assert_difference("@account.entries.count", 1) do
+      post api_v1_transactions_url,
+           params: transaction_params,
+           headers: api_headers(@api_key)
+    end
+
+    assert_response :created
+    response_data = JSON.parse(response.body)
+    assert_equal true, response_data["user_modified"]
+
+    entry = Transaction.find(response_data["id"]).entry
+    assert entry.user_modified?
+    assert entry.protected_from_sync?
+  end
+
+  test "should not mark transaction user_modified by default" do
+    transaction_params = {
+      transaction: {
+        account_id: @account.id,
+        name: "Imported Transaction",
+        amount: 25.00,
+        date: Date.current,
+        currency: "USD",
+        nature: "expense"
+      }
+    }
+
+    post api_v1_transactions_url, params: transaction_params, headers: api_headers(@api_key)
+
+    assert_response :created
+    response_data = JSON.parse(response.body)
+    assert_equal false, response_data["user_modified"]
+  end
+
   test "should use default source when external_id provided without source" do
     transaction_params = {
       transaction: {


### PR DESCRIPTION
## Summary
- `POST /api/v1/transactions` has no way to mark a newly-created transaction `user_modified`, which is the only thing that protects an entry from a later provider sync (Plaid/SimpleFin/etc.) silently overwriting its category or name - `Account::ProviderImportAdapter#import_transaction` claims any entry matching on date/amount/currency with no `external_id` yet, then enriches unlocked fields from the sync payload.
- This matters for any API client that writes its own transactions into an account that's *also* linked to a bank-sync provider: without a way to protect its own entries, that data can get silently overwritten the first time the linked provider happens to sync a matching transaction.
- Adds an optional `user_modified` param to transaction create, reusing the existing `Entry#mark_user_modified!` (added for #1977, currently only wired into the merchant merge/convert/unlink flows) rather than mass-assigning the column directly.
- Exposes `user_modified` in the transaction JSON response, matching how `external_id`/`source` already are.

Scoped to `create` only, matching my concrete need (a document-processing pipeline that reconciles scanned statements into Sure via the API, alongside SimpleFin covering the same accounts directly) - happy to extend to `update` in a follow-up if that's wanted too.

## Test plan
- [x] `ruby -c` syntax check on all three changed files
- [x] Added two request tests matching the existing idempotency-key test style: one asserting `user_modified: true` protects the entry (`user_modified?` and `protected_from_sync?` both true, plus the response echoes it back), one asserting the default (no param) leaves it `false`
- [ ] Couldn't run the full suite locally (no Rails-compatible Ruby toolchain in this environment) - relying on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transactions can now be marked as user-modified when created.
  - User-modified transactions are protected from provider synchronization.
  - Transaction responses now include the user-modified status.
  - The setting is applied before synchronization is scheduled, ensuring the protection takes effect immediately.

- **Bug Fixes**
  - Ensured transactions default to not user-modified when no value is provided.
  - Boolean input values are interpreted consistently when creating transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->