### PR TITLE
Book investment transfers as funds movement

### DIFF
--- a/app/controllers/transfer_matches_controller.rb
+++ b/app/controllers/transfer_matches_controller.rb
@@ -16,9 +16,9 @@ class TransferMatchesController < ApplicationController
     Transfer.transaction do
       @transfer.save!
 
-      # Use DESTINATION (inflow) account for kind, matching Transfer::Creator logic
       destination_account = @transfer.inflow_transaction.entry.account
-      outflow_kind = Transfer.kind_for_account(destination_account)
+      source_account = @transfer.outflow_transaction.entry.account
+      outflow_kind = Transfer.kind_for_account(destination_account, source_account: source_account)
       outflow_attrs = { kind: outflow_kind }
 
       if outflow_kind == "investment_contribution"

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -51,9 +51,9 @@ module Family::AutoTransferMatchable
         inflow_transaction = transactions_by_id.fetch(match.inflow_transaction_id)
         outflow_transaction = transactions_by_id.fetch(match.outflow_transaction_id)
         destination_account = inflow_transaction.entry.account
-        transfer_kind = Transfer.kind_for_account(destination_account)
+        source_account = outflow_transaction.entry.account
+        transfer_kind = Transfer.kind_for_account(destination_account, source_account: source_account)
 
-        # The kind is determined by the DESTINATION account (inflow), matching Transfer::Creator logic
         inflow_transaction.update!(kind: "funds_movement")
         outflow_transaction.update!(kind: transfer_kind)
 

--- a/app/models/rule/action_executor/set_as_transfer_or_payment.rb
+++ b/app/models/rule/action_executor/set_as_transfer_or_payment.rb
@@ -19,9 +19,9 @@ class Rule::ActionExecutor::SetAsTransferOrPayment < Rule::ActionExecutor
         Transfer.transaction do
           transfer.save!
 
-          # Use DESTINATION (inflow) account for kind, matching Transfer::Creator logic
           destination_account = transfer.inflow_transaction.entry.account
-          outflow_kind = Transfer.kind_for_account(destination_account)
+          source_account = transfer.outflow_transaction.entry.account
+          outflow_kind = Transfer.kind_for_account(destination_account, source_account: source_account)
           outflow_attrs = { kind: outflow_kind }
 
           if outflow_kind == "investment_contribution"

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -17,13 +17,14 @@ class Transfer < ApplicationRecord
   validate :transfer_has_same_family
 
   class << self
-    def kind_for_account(account)
+    def kind_for_account(account, source_account: nil)
       if account.loan?
         "loan_payment"
       elsif account.credit_card?
         "cc_payment"
       elsif account.investment? || account.crypto?
-        "investment_contribution"
+        source_is_investment = source_account.present? && (source_account.investment? || source_account.crypto?)
+        source_is_investment ? "funds_movement" : "investment_contribution"
       elsif account.liability?
         "cc_payment"
       else

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -258,6 +258,22 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     assert_equal category, outflow_entry.entryable.category
   end
 
+  test "auto-matched investment to investment is funds_movement without contribution category" do
+    investment = accounts(:investment)
+    crypto = accounts(:crypto)
+    outflow_entry = create_transaction(date: Date.current, account: crypto, amount: 500)
+    inflow_entry = create_transaction(date: Date.current, account: investment, amount: -500)
+
+    @family.auto_match_transfers!
+
+    outflow_entry.reload
+    inflow_entry.reload
+
+    assert_equal "funds_movement", outflow_entry.entryable.kind
+    assert_equal "funds_movement", inflow_entry.entryable.kind
+    refute_equal @family.investment_contributions_category, outflow_entry.entryable.category
+  end
+
   test "auto-matched investment transfers reuse contribution category lookup" do
     investment = accounts(:investment)
     category = @family.investment_contributions_category

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -125,6 +125,18 @@ class TransferTest < ActiveSupport::TestCase
     assert_equal "funds_movement", Transfer.kind_for_account(accounts(:depository))
   end
 
+  test "kind_for_account returns funds_movement for investment to investment" do
+    assert_equal "funds_movement", Transfer.kind_for_account(accounts(:investment), source_account: accounts(:investment))
+  end
+
+  test "kind_for_account returns funds_movement for crypto to investment" do
+    assert_equal "funds_movement", Transfer.kind_for_account(accounts(:investment), source_account: accounts(:crypto))
+  end
+
+  test "kind_for_account returns investment_contribution for depository to investment" do
+    assert_equal "investment_contribution", Transfer.kind_for_account(accounts(:investment), source_account: accounts(:depository))
+  end
+
   test "has_source_fee? returns true when source fee present" do
     transfer = transfers(:one)
     entry = accounts(:depository).entries.create!(name: "Fee", date: Date.current, amount: 5, currency: "USD", entryable: Transaction.new(kind: "standard"))


### PR DESCRIPTION
## Summary

- make `Transfer.kind_for_account` source-aware for investment/crypto destinations
- pass the outflow account at auto-match, manual transfer match, and rule-action call sites
- keep bank-to-investment transfers as `investment_contribution`, while investment/crypto-to-investment transfers become `funds_movement`

## Notes

Cherry-picks the focused behavior and tests from shebetov/sure#3, without the fork-only `FORK-CHANGELOG.md` change.

## Tests

- `bin/rails test test/models/transfer_test.rb test/models/family/auto_transfer_matchable_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transfer categorization for investment and crypto account movements.
  - Transfers between investment or crypto accounts are now classified as fund movements instead of investment contributions.
  - Investment contributions remain correctly identified when funds originate from a depository account.
  - Automatic transfer matching and transfer rules now apply the same classification consistently.

- **Tests**
  - Added coverage for investment-to-investment, crypto-to-investment, and depository-to-investment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->