### PR TITLE
feat(budgets): show what is actually free, beside the plan

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -229,8 +229,13 @@ class Budget < ApplicationRecord
       if ids.empty?
         0.to_d
       else
+        # Converted per goal. `available_cash` converts each account balance
+        # into the budget currency, so summing backings in their own would
+        # subtract euros from dollars: a fully earmarked EUR 1,000 account in
+        # a USD budget would read 1,200 available, 1,000 earmarked and 200
+        # free, when none of it is free.
         Goal.prepared_for(family, scope: family.goals.where.not(state: Goal::RELEASED_STATES))
-            .sum { |goal| goal.backing_within(ids) }
+            .sum { |goal| convert_to_budget_currency(goal.backing_within(ids), goal.currency) }
       end
     end
   end
@@ -493,12 +498,17 @@ class Budget < ApplicationRecord
   end
 
   private
+    # `find_or_fetch_rate`, not `find_rate` — the latter does not exist, and
+    # every multi-currency family opening this page hit a NoMethodError.
+    #
+    # No rate for the day leaves the amount as it stands. A cash panel that
+    # renders with one figure unconverted is wrong by the spread; one that
+    # raises takes the whole budget page down with it.
     def convert_to_budget_currency(amount, from_currency)
       return amount.to_d if from_currency == currency
 
-      ExchangeRate.find_rate(from: from_currency, to: currency, date: Date.current)&.rate.then do |rate|
-        rate ? amount.to_d * rate : amount.to_d
-      end
+      rate = ExchangeRate.find_or_fetch_rate(from: from_currency, to: currency, date: Date.current)&.rate
+      rate ? amount.to_d * rate : amount.to_d
     end
     def income_statement
       @income_statement ||= family.income_statement(user: current_user, accounts: income_statement_accounts)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -19,6 +19,7 @@ class Budget < ApplicationRecord
   validates :start_date, :end_date, presence: true
   validates :start_date, :end_date, uniqueness: { scope: [ :family_id, :user_id ] }
 
+  monetize :available_cash, :earmarked_for_goals, :free_cash
   monetize :budgeted_spending, :expected_income, :allocated_spending,
            :actual_spending, :available_to_spend, :available_to_allocate,
            :estimated_spending, :estimated_income, :actual_income, :remaining_expected_income,
@@ -175,6 +176,67 @@ class Budget < ApplicationRecord
     end
 
     scope
+  end
+
+  # --- Cash on hand, next to the plan ---
+  #
+  # DELIBERATELY OUTSIDE the allocation arithmetic. `budgeted_spending`,
+  # `allocated_spending` and `available_to_allocate` keep their exact meaning:
+  # they answer "what did I plan to spend, and how much of it have I
+  # distributed". These three answer a different question — "what do I actually
+  # have" — and mixing the two is how a budget stops being readable. A page
+  # showing "expected income 3,000" beside "really free 1,600" leaves the user
+  # unsure which number drives the split.
+  #
+  # This is the whole of the compromise: the plan stays a forecast, and the
+  # cash is shown beside it rather than folded into it.
+
+  # Liquidity only. Cash held inside investment accounts (Account#cash_balance)
+  # is deliberately out: it is not money available to this month's budget.
+  #
+  # Scoped like #transactions — a personal budget sees only its owner's
+  # accounts, the household one what the viewer can see — because a figure
+  # labelled "available" must mean available to the person reading it.
+  def cash_accounts
+    scope = family.accounts.visible.included_in_reports.where(accountable_type: "Depository")
+
+    if user_id.present?
+      scope.where(owner_id: user_id)
+    elsif current_user
+      scope.accessible_by(current_user)
+    else
+      scope
+    end
+  end
+
+  def available_cash
+    @available_cash ||= cash_accounts.sum { |account| convert_to_budget_currency(account.balance, account.currency) }
+  end
+
+  # What goals have already spoken for, out of THE SAME accounts. Restricting
+  # to `cash_accounts` is the point: Goal::FUNDABLE_ACCOUNT_TYPES also includes
+  # Investment, and subtracting an earmark held on a brokerage account from a
+  # cash figure that never counted it would show a "really free" amount that is
+  # too low — or negative — with nothing on the page to explain why.
+  #
+  # Built from the shared pool rather than summing allocated_amount, because a
+  # whole-account link reserves no fixed slice and would otherwise count as
+  # zero while actually claiming the remainder.
+  def earmarked_for_goals
+    @earmarked_for_goals ||= begin
+      ids = cash_accounts.map(&:id)
+
+      if ids.empty?
+        0.to_d
+      else
+        Goal.prepared_for(family, scope: family.goals.where.not(state: Goal::RELEASED_STATES))
+            .sum { |goal| goal.backing_within(ids) }
+      end
+    end
+  end
+
+  def free_cash
+    [ available_cash - earmarked_for_goals, 0 ].max
   end
 
   def name
@@ -431,6 +493,13 @@ class Budget < ApplicationRecord
   end
 
   private
+    def convert_to_budget_currency(amount, from_currency)
+      return amount.to_d if from_currency == currency
+
+      ExchangeRate.find_rate(from: from_currency, to: currency, date: Date.current)&.rate.then do |rate|
+        rate ? amount.to_d * rate : amount.to_d
+      end
+    end
     def income_statement
       @income_statement ||= family.income_statement(user: current_user, accounts: income_statement_accounts)
     end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -358,6 +358,20 @@ class Goal < ApplicationRecord
   # This goal's backing from a single linked account — the earmarked slice, or
   # the whole-balance remainder when the link is unallocated — as Money. Used
   # by the funding breakdown so the per-account rows reconcile with the ring.
+  # This goal's backing drawn from a specific set of accounts, in its own
+  # currency. Used by the budget to ask "how much of THESE accounts is already
+  # spoken for" without counting a link held on an account outside the set.
+  #
+  # Goes through the same `backing_share_for` as everything else, so a
+  # whole-account link is counted for the remainder it actually claims rather
+  # than the zero its nil allocation would suggest.
+  def backing_within(account_ids)
+    ids = Array(account_ids).to_set
+    linked_accounts
+      .select { |account| account.currency == currency && ids.include?(account.id) }
+      .sum { |account| account_amount_for(account) }
+  end
+
   def account_backing(account)
     Money.new(account_amount_for(account), currency)
   end

--- a/app/views/budgets/_available_cash.html.erb
+++ b/app/views/budgets/_available_cash.html.erb
@@ -1,0 +1,43 @@
+<%# locals: (budget:) %>
+
+<%# Beside the plan, never inside it. The figures above answer "what did I plan
+    to spend"; these answer "what do I actually have". Folding one into the
+    other leaves the reader unsure which number drives the split, so the panel
+    keeps its own frame and its own heading. %>
+<div class="w-full bg-container rounded-xl shadow-border-xs p-4">
+  <div class="flex items-start justify-between gap-3 mb-3">
+    <div class="min-w-0">
+      <h2 class="text-sm font-medium text-primary"><%= t(".heading") %></h2>
+      <p class="text-xs text-secondary mt-0.5"><%= t(".subtitle") %></p>
+    </div>
+    <%= render DS::Link.new(
+          text: t(".goals_link"),
+          href: goals_path,
+          variant: "outline",
+          size: "sm"
+        ) %>
+  </div>
+
+  <dl class="space-y-2">
+    <div class="flex items-baseline justify-between gap-3">
+      <dt class="text-sm text-secondary"><%= t(".available") %></dt>
+      <dd class="text-lg font-medium text-primary tabular-nums privacy-sensitive">
+        <%= format_money budget.available_cash_money %>
+      </dd>
+    </div>
+
+    <div class="flex items-baseline justify-between gap-3">
+      <dt class="text-sm text-secondary"><%= t(".earmarked") %></dt>
+      <dd class="text-sm text-secondary tabular-nums privacy-sensitive">
+        −<%= format_money budget.earmarked_for_goals_money %>
+      </dd>
+    </div>
+
+    <div class="flex items-baseline justify-between gap-3 border-t border-subdued pt-2">
+      <dt class="text-sm font-medium text-primary"><%= t(".free") %></dt>
+      <dd class="text-lg font-medium text-primary tabular-nums privacy-sensitive">
+        <%= format_money budget.free_cash_money %>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -46,6 +46,13 @@
       <% end %>
     </div>
 
+    <%# Goals live behind the preview flag, so a panel that subtracts what they
+        claim — and links to them — must too, or it points at a page the reader
+        cannot reach and explains a subtraction they have no way to inspect. %>
+    <% if preview_features_enabled? %>
+      <%= render "budgets/available_cash", budget: @budget %>
+    <% end %>
+
     <%# Bottom Section: Categories full width %>
     <% has_over_budget = budget_has_over_budget?(@budget) %>
     <%= content_tag :div,

--- a/config/locales/views/budgets/en.yml
+++ b/config/locales/views/budgets/en.yml
@@ -38,6 +38,13 @@ en:
     name:
       custom_range: "%{start} - %{end_date}"
       month_year: "%{month}"
+    available_cash:
+      heading: Cash on hand
+      subtitle: Beside the plan above, not part of it.
+      available: Available in cash
+      earmarked: Already earmarked for goals
+      free: Really free
+      goals_link: View goals
     show:
       categories:
         amount: Amount

--- a/config/locales/views/budgets/fr.yml
+++ b/config/locales/views/budgets/fr.yml
@@ -42,13 +42,6 @@ fr:
       no_categories_message: Vous n'avez pas encore créé ou attribué de catégories de dépenses à vos transactions.
       oops: Oups !
       use_defaults: Utiliser les valeurs par défaut (recommandé)
-    available_cash:
-      heading: Trésorerie disponible
-      subtitle: À côté du plan ci-dessus, pas dedans.
-      available: Disponible en cash
-      earmarked: Déjà fléché vers des objectifs
-      free: Réellement libre
-      goals_link: Voir les objectifs
     show:
       budgeted: Budgétisé
       category: Catégorie
@@ -64,6 +57,13 @@ fr:
       status: Statut
       view_all_transactions: Voir toutes les transactions de catégorie
   budgets:
+    available_cash:
+      heading: Trésorerie disponible
+      subtitle: À côté du plan ci-dessus, pas dedans.
+      available: Disponible en cash
+      earmarked: Déjà fléché vers des objectifs
+      free: Réellement libre
+      goals_link: Voir les objectifs
     switcher:
       aria_label: "Changer de budget"
       household: "Commun"

--- a/config/locales/views/budgets/fr.yml
+++ b/config/locales/views/budgets/fr.yml
@@ -42,6 +42,13 @@ fr:
       no_categories_message: Vous n'avez pas encore créé ou attribué de catégories de dépenses à vos transactions.
       oops: Oups !
       use_defaults: Utiliser les valeurs par défaut (recommandé)
+    available_cash:
+      heading: Trésorerie disponible
+      subtitle: À côté du plan ci-dessus, pas dedans.
+      available: Disponible en cash
+      earmarked: Déjà fléché vers des objectifs
+      free: Réellement libre
+      goals_link: Voir les objectifs
     show:
       budgeted: Budgétisé
       category: Catégorie

--- a/test/controllers/budgets_controller_test.rb
+++ b/test/controllers/budgets_controller_test.rb
@@ -35,6 +35,26 @@ class BudgetsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", plan_path, count: 0
     assert_select "a[href=?]", budgets_path, minimum: 1
   end
+  # --- Lot A3: cash on hand ---
+
+  test "the cash panel is hidden without preview access" do
+    @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => false))
+
+    get budget_url(Budget.date_to_param(Date.current.beginning_of_month))
+
+    assert_response :success
+    assert_no_match I18n.t("budgets.available_cash.heading"), response.body
+  end
+
+  test "the cash panel shows what goals have already claimed" do
+    @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => true))
+
+    get budget_url(Budget.date_to_param(Date.current.beginning_of_month))
+
+    assert_response :success
+    assert_match I18n.t("budgets.available_cash.heading"), response.body
+    assert_match I18n.t("budgets.available_cash.free"), response.body
+  end
 end
 
 class BudgetsControllerSharingTest < ActionDispatch::IntegrationTest

--- a/test/models/budget_available_cash_test.rb
+++ b/test/models/budget_available_cash_test.rb
@@ -83,6 +83,54 @@ class BudgetAvailableCashTest < ActiveSupport::TestCase
     assert_equal 3_000, reloaded.budgeted_spending
   end
 
+
+  # --- Review follow-ups (#3179) ---
+
+  # `available_cash` converts each balance into the budget currency, so an
+  # earmark summed in the goal's own would be subtracted from a figure it does
+  # not match: a fully earmarked EUR account reading as partly free.
+  test "a foreign-currency earmark is converted before it is subtracted" do
+    account = Account.create!(
+      family: @family, accountable: Depository.new,
+      name: "EUR pot", currency: "EUR", balance: 1_000
+    )
+    @family.goals.create!(
+      name: "Trip", target_amount: 1_000, currency: "EUR"
+    ) { |g| g.goal_accounts.build(account: account, allocated_amount: 1_000) }
+
+    ExchangeRate.stubs(:find_or_fetch_rate).returns(OpenStruct.new(rate: 1.2))
+
+    assert_equal 1_200, @budget.available_cash
+    assert_equal 1_200, @budget.earmarked_for_goals
+    assert_equal 0, @budget.free_cash, "none of a fully earmarked account is free"
+  end
+
+  # `ExchangeRate.find_rate` does not exist; every multi-currency family
+  # opening the budget page hit a NoMethodError before the cash panel rendered.
+  test "a foreign-currency account does not take the page down" do
+    Account.create!(
+      family: @family, accountable: Depository.new,
+      name: "EUR pot", currency: "EUR", balance: 1_000
+    )
+
+    ExchangeRate.stubs(:find_or_fetch_rate).returns(OpenStruct.new(rate: 1.2))
+
+    assert_equal 1_200, @budget.available_cash
+  end
+
+  # A missing rate leaves the amount as it stands rather than raising: a panel
+  # wrong by the spread beats the whole budget page failing to render.
+  test "a missing rate leaves the figure standing rather than raising" do
+    Account.create!(
+      family: @family, accountable: Depository.new,
+      name: "EUR pot", currency: "EUR", balance: 1_000
+    )
+
+    ExchangeRate.stubs(:find_or_fetch_rate).returns(nil)
+
+    assert_equal 1_000, @budget.available_cash
+  end
+
   private
     def depository(balance)
       Account.create!(

--- a/test/models/budget_available_cash_test.rb
+++ b/test/models/budget_available_cash_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+# Lot A3: cash on hand shown beside the plan, never folded into it.
+class BudgetAvailableCashTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:empty)
+    @budget = Budget.find_or_bootstrap(@family, start_date: Date.current, user: nil)
+    @budget.update!(budgeted_spending: 3_000, expected_income: 5_000)
+  end
+
+  test "counts only liquidity" do
+    cash = depository(2_000)
+    investment(9_000)
+
+    assert_equal cash.balance.to_d, @budget.available_cash
+  end
+
+  test "leaves out accounts excluded from reports" do
+    depository(2_000)
+    depository(500).update!(exclude_from_reports: true)
+
+    assert_equal 2_000, @budget.available_cash
+  end
+
+  test "subtracts what a goal has earmarked on those accounts" do
+    account = depository(6_000)
+    goal_on(account, earmark: 2_000)
+
+    assert_equal 6_000, @budget.available_cash
+    assert_equal 2_000, @budget.earmarked_for_goals
+    assert_equal 4_000, @budget.free_cash
+  end
+
+  # A whole-account link reserves no fixed slice, so summing `allocated_amount`
+  # would read it as zero while it actually claims the remainder.
+  test "a whole-account link counts for what it really claims" do
+    account = depository(6_000)
+    goal_on(account, earmark: nil)
+
+    assert_equal 6_000, @budget.earmarked_for_goals
+    assert_equal 0, @budget.free_cash
+  end
+
+  # Goal::FUNDABLE_ACCOUNT_TYPES includes Investment. Subtracting an earmark
+  # held on a brokerage account from a cash figure that never counted it would
+  # show a "really free" amount too low, with nothing on the page to explain it.
+  test "ignores an earmark held on an account the cash figure never counted" do
+    depository(4_000)
+    goal_on(investment(9_000), earmark: 5_000)
+
+    assert_equal 4_000, @budget.available_cash
+    assert_equal 0, @budget.earmarked_for_goals
+    assert_equal 4_000, @budget.free_cash
+  end
+
+  test "a released goal has handed its money back" do
+    account = depository(6_000)
+    goal = goal_on(account, earmark: 2_000)
+
+    goal.archive!
+
+    assert_equal 0, Budget.find(@budget.id).earmarked_for_goals
+  end
+
+  test "free cash never reads as negative" do
+    account = depository(1_000)
+    goal_on(account, earmark: nil)
+    goal_on(depository(500), earmark: nil)
+
+    assert_operator Budget.find(@budget.id).free_cash, :>=, 0
+  end
+
+  # The whole point of the compromise: the plan is a forecast and stays one.
+  test "none of this touches the allocation arithmetic" do
+    before_allocated = @budget.allocated_spending
+    before_available = @budget.available_to_allocate
+    goal_on(depository(6_000), earmark: 2_000)
+
+    reloaded = Budget.find(@budget.id)
+
+    assert_equal before_allocated, reloaded.allocated_spending
+    assert_equal before_available, reloaded.available_to_allocate
+    assert_equal 3_000, reloaded.budgeted_spending
+  end
+
+  private
+    def depository(balance)
+      Account.create!(
+        family: @family, accountable: Depository.new,
+        name: "Cash #{SecureRandom.hex(4)}", currency: @family.currency, balance: balance
+      )
+    end
+
+    def investment(balance)
+      Account.create!(
+        family: @family, accountable: Investment.new,
+        name: "Brokerage #{SecureRandom.hex(4)}", currency: @family.currency, balance: balance
+      )
+    end
+
+    def goal_on(account, earmark:)
+      @family.goals.create!(
+        name: "Goal #{SecureRandom.hex(4)}", target_amount: 10_000, currency: @family.currency
+      ) { |g| g.goal_accounts.build(account: account, allocated_amount: earmark) }
+    end
+end


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #3160, #3165 and #3167 — do not merge before them.** The commit list carries all three. One commit belongs to this PR, `feat(budgets): show what is actually free, beside the plan`, and it rebases down to that single commit once they land. The dependency is on the goal side, not the budget one: the earmark figure is only correct once completed goals release their claim (#3165) and two goals can no longer both claim an account in full (#3160).
>
> It will conflict with #3143 and #3164 in `app/models/budget.rb` when they land — additive, in a different part of the file. Happy to rebase whenever the order is decided.

## A design decision worth disagreeing with before reviewing the code

The budget has never consulted an account balance. `budgeted_spending` and `expected_income` are numbers the user typed, and every figure on the page derives from them. It is a *forecast*, checked against reality after the fact, and it cannot answer "what do I actually have right now".

There are two ways to close that gap:

1. **Fold cash into the allocation arithmetic.** The budget becomes YNAB's: you distribute money you hold, not money you expect. `available_to_allocate` stops meaning "what is left of my plan" and starts meaning "what is left of my balance".
2. **Show the cash beside the plan.** The forecast stays a forecast, and the answer to the second question sits next to it.

This PR does (2), deliberately. Folding the two together is a different product, and a page showing *"expected income 3,000"* beside *"really free 1,600"* leaves the reader unsure which number drives the split. A test asserts `allocated_spending`, `available_to_allocate` and `budgeted_spending` are all untouched.

If the project wants (1), this is the wrong shape and I would rather rework it than bolt the other behaviour on. Say so and I will.

## What changed

`Budget#available_cash`, `#earmarked_for_goals`, `#free_cash`, and a panel below the plan showing the three.

## What reviewers should look at

**The subtraction must be over the same accounts as the sum.** `Goal::FUNDABLE_ACCOUNT_TYPES` includes Investment, so a goal can be backed by a brokerage account that `available_cash` never counted. Subtracting that earmark would show a "really free" figure too low — or negative — with nothing on the page to explain why. `earmarked_for_goals` is restricted to `cash_accounts`, and `Goal#backing_within` exists to ask exactly that.

**It reads through the shared pool, not `allocated_amount`.** A whole-account link reserves no fixed slice, so summing the column naively counts it as zero while it actually claims the remainder. Going through `backing_share_for` is what makes a 6,000 account fully claimed by one whole-account goal come out as 6,000 earmarked and 0 free.

**Scoping.** Like `#transactions`: a personal budget sees its owner's accounts, the household one what the viewer can see. A figure labelled "available" has to mean available to the person reading it.

**The preview flag.** Goals are behind it, so a panel that subtracts what they claim and links to them must be too — otherwise it points at a page the reader cannot open and explains a subtraction they have no way to inspect.

## Testing

`bin/rails test` — 7083 runs, 28500 assertions, 0 failures, 0 errors. RuboCop, erb_lint and Brakeman clean.

Eight model tests: liquidity only, excluded accounts left out, a fixed earmark subtracted, a whole-account link counted for what it really claims, an investment-backed earmark ignored, a released goal handing its money back, free cash never negative, and the allocation arithmetic untouched. Two controller tests cover the flag in both positions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added maintained reserve goals with funded and depleted statuses.
  * Added reserve-specific forms, indicators, messaging, and shortfall details.
  * Added lifecycle panels for projections, celebrations, empty states, and inactive goals.
  * Added an available-cash panel showing cash, earmarked funds, and free cash.
  * Added goal-kind selection with automatic target-date handling.
* **Bug Fixes**
  * Prevented conflicting full-account allocations.
  * Preserved selected accounts after validation errors.
  * Improved completed-goal balances, cash calculations, KPI treatment, and restore validation.
* **Localization**
  * Added English and French translations for reserve goals, cash summaries, and validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->