### PR TITLE
Add Chancen admin settings

### DIFF
--- a/app/controllers/settings/chancens_controller.rb
+++ b/app/controllers/settings/chancens_controller.rb
@@ -1,0 +1,50 @@
+class Settings::ChancensController < ApplicationController
+  layout "settings"
+
+  before_action :ensure_super_admin
+
+  def show
+    @breadcrumbs = [
+      [ t("breadcrumbs.home"), root_path ],
+      [ t(".title"), nil ]
+    ]
+  end
+
+  def update
+    if chancen_params.key?(:metabase_url)
+      Setting.metabase_url = chancen_params[:metabase_url]
+    end
+
+    update_encrypted_setting(:metabase_api_key)
+
+    if chancen_params.key?(:metabase_student_question_id)
+      Setting.metabase_student_question_id = chancen_params[:metabase_student_question_id]
+    end
+
+    if chancen_params.key?(:metabase_email_param)
+      Setting.metabase_email_param = chancen_params[:metabase_email_param].presence || "email"
+    end
+
+    redirect_to settings_chancen_path, notice: t(".success")
+  end
+
+  private
+    def chancen_params
+      return ActionController::Parameters.new unless params.key?(:setting)
+
+      params.require(:setting).permit(:metabase_url, :metabase_api_key, :metabase_student_question_id, :metabase_email_param)
+    end
+
+    def ensure_super_admin
+      redirect_to root_path, alert: t(".not_authorized") unless Current.user.super_admin?
+    end
+
+    def update_encrypted_setting(param_key)
+      return unless chancen_params.key?(param_key)
+
+      value = chancen_params[param_key].to_s.strip
+      return if value == "********"
+
+      Setting.public_send(:"#{param_key}=", value.presence)
+    end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -32,6 +32,13 @@ class Setting < RailsSettings::Base
   field :external_assistant_url, type: :string
   field :external_assistant_token, type: :string
   field :external_assistant_agent_id, type: :string
+
+  # Metabase student data (Chancen ISA warehouse)
+  field :metabase_url, type: :string, default: ENV["METABASE_URL"]
+  field :metabase_api_key, type: :string, default: ENV["METABASE_API_KEY"]
+  field :metabase_student_question_id, type: :string, default: ENV["METABASE_STUDENT_QUESTION_ID"]
+  field :metabase_email_param, type: :string, default: ENV.fetch("METABASE_EMAIL_PARAM", "email")
+
   field :brand_fetch_client_id, type: :string, default: ENV["BRAND_FETCH_CLIENT_ID"]
   field :brand_fetch_high_res_logos, type: :boolean, default: ENV.fetch("BRAND_FETCH_HIGH_RES_LOGOS", "false") == "true"
 
@@ -91,6 +98,7 @@ class Setting < RailsSettings::Base
       openai_access_token
       anthropic_access_token
       external_assistant_token
+      metabase_api_key
     ].freeze
 
     ENCRYPTED_FIELDS.each do |field_name|

--- a/app/views/settings/_settings_nav.html.erb
+++ b/app/views/settings/_settings_nav.html.erb
@@ -34,6 +34,7 @@ nav_sections = [
         { label: t(".debug_label", default: "Debug"), path: settings_debug_path, icon: "bug", if: Current.user&.super_admin? },
         { label: t(".background_jobs_label"), path: settings_background_jobs_path, icon: "list-checks", if: Current.user&.super_admin? },
         { label: t(".self_hosting_label"), path: settings_hosting_path, icon: "database", if: self_hosted? },
+        { label: t(".chancen_label"), path: settings_chancen_path, icon: "building-2", if: Current.user&.super_admin? },
         { label: t(".imports_label"), path: imports_path, icon: "download" },
         { label: t(".exports_label"), path: family_exports_path, icon: "upload" },
         { label: t(".sso_providers_label"), path: admin_sso_providers_path, icon: "key-round", if: Current.user&.super_admin? },

--- a/app/views/settings/chancens/_metabase_settings.html.erb
+++ b/app/views/settings/chancens/_metabase_settings.html.erb
@@ -1,0 +1,80 @@
+<div class="space-y-4">
+  <div>
+    <h2 class="font-medium mb-1"><%= t(".title") %></h2>
+    <% if ENV["METABASE_URL"].present? && ENV["METABASE_API_KEY"].present? && ENV["METABASE_STUDENT_QUESTION_ID"].present? %>
+      <p class="text-sm text-secondary"><%= t(".env_configured_message") %></p>
+    <% else %>
+      <p class="text-secondary text-sm mb-4"><%= t(".description") %></p>
+    <% end %>
+  </div>
+
+  <%= styled_form_with model: Setting.new,
+                       url: settings_chancen_path,
+                       method: :patch,
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+    <%= form.text_field :metabase_url,
+                        label: t(".url_label"),
+                        placeholder: t(".url_placeholder"),
+                        value: ENV.fetch("METABASE_URL", Setting.metabase_url),
+                        autocomplete: "off",
+                        autocapitalize: "none",
+                        spellcheck: "false",
+                        inputmode: "url",
+                        disabled: ENV["METABASE_URL"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+  <% end %>
+
+  <%= styled_form_with model: Setting.new,
+                       url: settings_chancen_path,
+                       method: :patch,
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+    <%= form.password_field :metabase_api_key,
+                            label: t(".api_key_label"),
+                            placeholder: t(".api_key_placeholder"),
+                            value: (Setting.metabase_api_key.present? ? "********" : nil),
+                            autocomplete: "off",
+                            autocapitalize: "none",
+                            spellcheck: "false",
+                            disabled: ENV["METABASE_API_KEY"].present?,
+                            data: { "auto-submit-form-target": "auto" } %>
+  <% end %>
+
+  <%= styled_form_with model: Setting.new,
+                       url: settings_chancen_path,
+                       method: :patch,
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+    <%= form.text_field :metabase_student_question_id,
+                        label: t(".question_id_label"),
+                        placeholder: t(".question_id_placeholder"),
+                        value: ENV.fetch("METABASE_STUDENT_QUESTION_ID", Setting.metabase_student_question_id),
+                        autocomplete: "off",
+                        disabled: ENV["METABASE_STUDENT_QUESTION_ID"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+  <% end %>
+
+  <%= styled_form_with model: Setting.new,
+                       url: settings_chancen_path,
+                       method: :patch,
+                       data: {
+                         controller: "auto-submit-form",
+                         "auto-submit-form-trigger-event-value": "blur"
+                       } do |form| %>
+    <%= form.text_field :metabase_email_param,
+                        label: t(".email_param_label"),
+                        placeholder: t(".email_param_placeholder"),
+                        value: ENV.fetch("METABASE_EMAIL_PARAM", Setting.metabase_email_param),
+                        autocomplete: "off",
+                        autocapitalize: "none",
+                        disabled: ENV["METABASE_EMAIL_PARAM"].present?,
+                        data: { "auto-submit-form-target": "auto" } %>
+  <% end %>
+</div>

--- a/app/views/settings/chancens/show.html.erb
+++ b/app/views/settings/chancens/show.html.erb
@@ -1,0 +1,5 @@
+<%= content_for :page_title, t(".title") %>
+
+<%= settings_section title: t(".metabase") do %>
+  <%= render "settings/chancens/metabase_settings" %>
+<% end %>

--- a/config/locales/views/settings/chancens/en.yml
+++ b/config/locales/views/settings/chancens/en.yml
@@ -1,0 +1,23 @@
+---
+en:
+  settings:
+    chancens:
+      show:
+        title: Chancen
+        metabase: Metabase
+      update:
+        success: Chancen settings updated
+      ensure_super_admin:
+        not_authorized: You are not authorized to view Chancen settings
+      metabase_settings:
+        title: Metabase Student Data
+        description: Connect to the Chancen ISA warehouse via Metabase to power the My Account screen.
+        env_configured_message: Configured via environment variable.
+        url_label: Metabase URL
+        url_placeholder: "https://metabase.example.com"
+        api_key_label: API Key
+        api_key_placeholder: Enter API key
+        question_id_label: Student Question ID
+        question_id_placeholder: "1329"
+        email_param_label: Email Template Tag
+        email_param_placeholder: email

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -328,6 +328,7 @@ en:
       ai_prompts_label: AI Prompts
       background_jobs_label: Background jobs
       api_key_label: API Keys
+      chancen_label: Chancen
       payment_label: Payment
       categories_label: Categories
       feedback_label: Feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -352,6 +352,7 @@ Rails.application.routes.draw do
       delete :clear_cache, on: :collection
       delete :disconnect_external_assistant, on: :collection
     end
+    resource :chancen, only: %i[show update]
     resource :payment, only: :show
     resource :security, only: :show
     resources :webauthn_credentials, only: %i[create destroy] do


### PR DESCRIPTION
## Summary
- add a dedicated super-admin Chancen settings page at /settings/chancen
- move the Metabase student-data configuration UI out of self-hosting
- store the Metabase API key through the existing encrypted Setting path

## Verification
- bin/rails routes -g settings/chancen
- bin/rails zeitwerk:check
- ruby YAML parse for touched locale files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Chancen section under Advanced Settings for configuring student-data integration.
  * Super-admins can manage the integration URL, API key, student question ID, and email parameter.
  * Environment-provided values are clearly indicated and protected from editing; stored API keys are masked.
  * Settings are saved automatically when fields are completed, with confirmation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->