### PR TITLE
fix(onchain): let the account take its wallet row with it

### DIFF
--- a/app/models/account_provider.rb
+++ b/app/models/account_provider.rb
@@ -46,9 +46,13 @@ class AccountProvider < ApplicationRecord
     end
 
     def destroy_onchain_provider_account
-      # The row destroys this link itself through dependent: :destroy, so
-      # answering that by destroying the row again would go round in circles.
-      return if destroyed_by_association
+      # Skipped only when the row is the one destroying this link, through its
+      # own dependent: :destroy — answering that by destroying the row again
+      # would go round in circles. The account destroys this link by association
+      # too, and there the row must follow: a guard reading nothing but
+      # `destroyed_by_association` could not tell the two apart, and left the
+      # row behind with no account to track.
+      return if destroyed_by_association&.active_record == OnchainWalletAccount
 
       provider&.destroy
     end

--- a/app/models/family/onchain_wallet_connectable.rb
+++ b/app/models/family/onchain_wallet_connectable.rb
@@ -32,11 +32,15 @@ module Family::OnchainWalletConnectable
   end
 
   # True when an address is already tracked on this chain anywhere in the
-  # family, which is what makes re-linking it a duplicate.
+  # family, which is what makes re-linking it a duplicate. Tracked means linked,
+  # not merely present: a row whose account is gone syncs nothing and displays
+  # nowhere, so counting it here would refuse the address with nothing to show
+  # for it.
   def onchain_address_linked?(chain, address)
     OnchainWalletAccount
       .where(onchain_wallet_item: onchain_wallet_items.active)
       .for_wallet(chain, address)
+      .linked
       .exists?
   end
 end

--- a/app/models/onchain_wallet_item.rb
+++ b/app/models/onchain_wallet_item.rb
@@ -104,6 +104,12 @@ class OnchainWalletItem < ApplicationRecord
     raise ActiveRecord::RecordNotFound, "No tracked assets at that address" if rows.empty?
 
     transaction do
+      # The destination can still hold rows left behind by deleted accounts.
+      # They track nothing, yet they hold the slot in the partial unique index
+      # that the rows moving in need, so they make way. A destination that is
+      # genuinely tracked never reaches here — the caller refuses it.
+      accounts_for_wallet(chain, to).unlinked.destroy_all
+
       rows.each do |row|
         previous_display_name = row.display_name
         # The digest is cleared so the next sync reprocesses against the new

--- a/app/models/onchain_wallet_item/wallet_linker.rb
+++ b/app/models/onchain_wallet_item/wallet_linker.rb
@@ -81,8 +81,21 @@ class OnchainWalletItem::WalletLinker
   end
 
   private
+    def discard_leftover_row(asset)
+      onchain_wallet_item.onchain_wallet_accounts
+        .for_wallet(chain, address)
+        .unlinked
+        .select { |row| row.matches_asset?(asset) }
+        .each(&:destroy!)
+    end
+
     def create_asset!(asset)
       OnchainWalletAccount.transaction do
+        # A row left behind by a deleted account still holds this asset's slot in
+        # the partial unique index while displaying nowhere, so creating beside
+        # it raises. It tracks nothing, so it is the one that goes.
+        discard_leftover_row(asset)
+
         onchain_account = onchain_wallet_item.onchain_wallet_accounts.create!(
           chain: chain,
           wallet_address: address,

--- a/app/models/onchain_wallet_item/wallet_linker.rb
+++ b/app/models/onchain_wallet_item/wallet_linker.rb
@@ -29,6 +29,14 @@ class OnchainWalletItem::WalletLinker
     created = 0
     errors = []
 
+    # Reclaiming the address clears every row it left behind, not only the ones
+    # matching what was picked now. An orphan row tracks nothing and yet shows
+    # up in `grouped_accounts` and token review as though it did, so leaving
+    # the unpicked ones behind trades one silent phantom for another — and
+    # `revise` would then refuse to recreate the asset, because it would find
+    # the orphan and take the asset for tracked.
+    discard_orphan_rows
+
     snapshot.assets.each do |asset|
       next unless selected.include?(OnchainWalletItem::TokenReview.key_for(asset))
 
@@ -51,15 +59,22 @@ class OnchainWalletItem::WalletLinker
   # token would be to change the address, which is not the same thing.
   def revise(snapshot:, selected_keys:)
     selected = Array(selected_keys).map(&:to_s).to_set
-    tracked = onchain_wallet_item.accounts_for_wallet(chain, address).to_a
+    rows = onchain_wallet_item.accounts_for_wallet(chain, address).to_a
     errors = []
 
-    removed = tracked.count do |onchain_account|
+    removed = rows.count do |onchain_account|
       next false if selected.include?(onchain_account.asset_key)
 
       onchain_account.destroy!
       true
     end
+
+    # Only a LINKED row means the asset is really tracked. A row left behind by
+    # a deleted account has no Account and no AccountProvider, so counting it
+    # here made ticking that asset a no-op: nothing created, the row still
+    # orphaned, and the screen still reporting it as tracked. The rows just
+    # destroyed above are out for the same reason.
+    tracked = rows.reject(&:destroyed?).select { |row| row.account_provider.present? }
 
     created = snapshot.assets.count do |asset|
       next false unless selected.include?(OnchainWalletItem::TokenReview.key_for(asset))
@@ -81,6 +96,14 @@ class OnchainWalletItem::WalletLinker
   end
 
   private
+    # Every row at this address that no longer has an account behind it.
+    def discard_orphan_rows
+      onchain_wallet_item.onchain_wallet_accounts
+        .for_wallet(chain, address)
+        .unlinked
+        .destroy_all
+    end
+
     def discard_leftover_row(asset)
       onchain_wallet_item.onchain_wallet_accounts
         .for_wallet(chain, address)

--- a/test/controllers/onchain_wallet_items_controller_test.rb
+++ b/test/controllers/onchain_wallet_items_controller_test.rb
@@ -480,8 +480,14 @@ class OnchainWalletItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "unticking one asset removes only it" do
     item = create_onchain_wallet_item(family: @family)
+    # Linked, because that is what a tracked asset actually is. Left unlinked
+    # these are orphan rows, and revising now rebuilds those into real ones —
+    # so the surviving row would be a new one and the assertion below would be
+    # measuring the repair rather than the removal.
     native = create_onchain_wallet_account(item: item)
+    link_onchain_wallet_account!(native)
     token_asset = create_onchain_wallet_account(item: item, asset: fake_token_asset(symbol: "USDC", contract: "0xusdc"))
+    link_onchain_wallet_account!(token_asset)
     stub_wallet_with_token
 
     post update_tokens_onchain_wallet_item_url(item), params: {

--- a/test/controllers/onchain_wallet_items_controller_test.rb
+++ b/test/controllers/onchain_wallet_items_controller_test.rb
@@ -240,7 +240,7 @@ class OnchainWalletItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "link_wallet refuses an address the family already tracks" do
     item = create_onchain_wallet_item(family: @family)
-    create_onchain_wallet_account(item: item)
+    link_onchain_wallet_account!(create_onchain_wallet_account(item: item))
     stub_wallet_with_token
 
     assert_no_difference "OnchainWalletAccount.count" do
@@ -257,7 +257,7 @@ class OnchainWalletItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "preview_wallet refuses an address the family already tracks" do
     item = create_onchain_wallet_item(family: @family)
-    create_onchain_wallet_account(item: item)
+    link_onchain_wallet_account!(create_onchain_wallet_account(item: item))
 
     post preview_wallet_onchain_wallet_items_url, params: {
       address: OnchainTestHelper::FAKE_ADDRESS,
@@ -550,8 +550,8 @@ class OnchainWalletItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "change_address refuses an address already tracked elsewhere" do
     item = create_onchain_wallet_item(family: @family)
-    create_onchain_wallet_account(item: item)
-    create_onchain_wallet_account(item: item, address: OnchainTestHelper::FAKE_ADDRESS_ALT)
+    link_onchain_wallet_account!(create_onchain_wallet_account(item: item))
+    link_onchain_wallet_account!(create_onchain_wallet_account(item: item, address: OnchainTestHelper::FAKE_ADDRESS_ALT))
 
     patch change_address_onchain_wallet_item_url(item), params: {
       chain: OnchainTestHelper::FAKE_CHAIN,
@@ -561,6 +561,25 @@ class OnchainWalletItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     assert_match I18n.t("onchain_wallet_items.change_address.errors.already_linked"), response.body
+  end
+
+  test "change_address moves onto an address whose leftover row tracks nothing" do
+    item = create_onchain_wallet_item(family: @family)
+    link_onchain_wallet_account!(create_onchain_wallet_account(item: item))
+    leftover = create_onchain_wallet_account(item: item, address: OnchainTestHelper::FAKE_ADDRESS_ALT)
+
+    patch change_address_onchain_wallet_item_url(item), params: {
+      chain: OnchainTestHelper::FAKE_CHAIN,
+      address: OnchainTestHelper::FAKE_ADDRESS,
+      new_address: OnchainTestHelper::FAKE_ADDRESS_ALT
+    }
+
+    # The destination looks taken but is not: the leftover holds the slot in the
+    # unique index without tracking anything, and colliding with it would put a
+    # database error in front of the user.
+    assert_redirected_to manage_onchain_wallet_item_path(item)
+    assert_not OnchainWalletAccount.exists?(leftover.id)
+    assert_equal OnchainTestHelper::FAKE_ADDRESS_ALT, item.onchain_wallet_accounts.sole.wallet_address
   end
 
   test "disconnect_wallet stops tracking every asset at that address only" do

--- a/test/models/onchain_wallet_account_test.rb
+++ b/test/models/onchain_wallet_account_test.rb
@@ -114,6 +114,20 @@ class OnchainWalletAccountTest < ActiveSupport::TestCase
     assert_not OnchainWalletAccount.exists?(onchain_account.id)
   end
 
+  test "deleting the account takes the tracking row with it" do
+    onchain_account = create_onchain_wallet_account(item: @item)
+    account = link_onchain_wallet_account!(onchain_account)
+
+    # Same reasoning as unlinking, by a route that used to miss it: the link is
+    # destroyed by the account here rather than by the row, and a guard meant to
+    # stop the row destroying itself was catching this case too.
+    assert_difference "OnchainWalletAccount.count", -1 do
+      account.destroy!
+    end
+
+    assert_not OnchainWalletAccount.exists?(onchain_account.id)
+  end
+
   test "a native row and token rows coexist for one address" do
     create_onchain_wallet_account(item: @item)
     create_onchain_wallet_account(item: @item, asset: fake_token_asset(contract: "0xaaa"))

--- a/test/models/onchain_wallet_item/wallet_linker_test.rb
+++ b/test/models/onchain_wallet_item/wallet_linker_test.rb
@@ -44,7 +44,83 @@ class OnchainWalletItem::WalletLinkerTest < ActiveSupport::TestCase
     assert OnchainWalletAccount.exists?(tracked.id)
   end
 
+  # --- Review follow-ups (#3182) ---
+
+  # An orphan row tracks nothing, yet `grouped_accounts` and token review show
+  # it as tracked. Clearing only the rows matching what was picked left the
+  # others claiming assets that have no account behind them.
+  test "reclaiming an address clears the rows it left behind, not just the picked ones" do
+    picked = create_onchain_wallet_account(item: @item)
+    stranded = create_onchain_wallet_account(item: @item, asset: fake_token_asset(contract: "0xdead"))
+
+    assert stranded.account_provider.blank?
+
+    result = link(fake_native_asset)
+
+    assert_equal 1, result.created
+    assert_not OnchainWalletAccount.exists?(picked.id)
+    assert_not OnchainWalletAccount.exists?(stranded.id),
+      "an orphan nobody picked kept claiming its asset"
+  end
+
+  # A live row belongs to somebody. Reclaiming the address must not sweep it up
+  # alongside the dead ones.
+  test "reclaiming an address leaves a live row alone" do
+    live = create_onchain_wallet_account(item: @item, asset: fake_token_asset(contract: "0xbeef"))
+    link_onchain_wallet_account!(live)
+
+    link(fake_native_asset)
+
+    assert OnchainWalletAccount.exists?(live.id)
+  end
+
+  # `revise` counted any matching row as tracked, orphans included, so ticking
+  # an asset whose account had been deleted did nothing at all: no Account, no
+  # AccountProvider, the row still orphaned — and the screen still saying it
+  # was tracked.
+  test "reviving an orphaned asset actually rebuilds its account" do
+    orphan = create_onchain_wallet_account(item: @item)
+    assert orphan.account_provider.blank?
+
+    result = revise(fake_native_asset)
+
+    assert_equal 1, result.created
+    assert_not OnchainWalletAccount.exists?(orphan.id)
+
+    rebuilt = @item.onchain_wallet_accounts.sole
+    assert rebuilt.account_provider.present?, "the asset came back tracking nothing"
+  end
+
+  test "revising leaves an asset that is already properly tracked alone" do
+    tracked = create_onchain_wallet_account(item: @item)
+    link_onchain_wallet_account!(tracked)
+
+    result = revise(fake_native_asset)
+
+    assert_equal 0, result.created
+    assert_equal 0, result.removed
+    assert OnchainWalletAccount.exists?(tracked.id)
+  end
+
+  test "unticking an asset stops tracking it" do
+    tracked = create_onchain_wallet_account(item: @item)
+    link_onchain_wallet_account!(tracked)
+
+    result = revise
+
+    assert_equal 1, result.removed
+    assert_not OnchainWalletAccount.exists?(tracked.id)
+  end
+
   private
+
+    def revise(*assets)
+      snapshot = Onchain::Snapshot.new(assets: assets, movements: [])
+
+      OnchainWalletItem::WalletLinker
+        .new(@item, chain: FAKE_CHAIN, address: FAKE_ADDRESS)
+        .revise(snapshot: snapshot, selected_keys: assets.map { |a| OnchainWalletItem::TokenReview.key_for(a) })
+    end
     def link(*assets)
       snapshot = Onchain::Snapshot.new(assets: assets, movements: [])
 

--- a/test/models/onchain_wallet_item/wallet_linker_test.rb
+++ b/test/models/onchain_wallet_item/wallet_linker_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OnchainWalletItem::WalletLinkerTest < ActiveSupport::TestCase
+  include OnchainTestHelper
+
+  setup do
+    register_fake_chain!
+    @item = create_onchain_wallet_item(family: families(:dylan_family))
+  end
+
+  teardown do
+    unregister_fake_chain!
+  end
+
+  test "a row left behind by a deleted account does not block tracking the asset again" do
+    leftover = create_onchain_wallet_account(item: @item)
+
+    # What an instance carrying the old destroy bug looks like: the row survived
+    # its account, and its partial unique index still holds the asset's slot.
+    assert leftover.account_provider.blank?
+
+    result = link(fake_native_asset)
+
+    assert_equal 1, result.created
+    assert_empty result.errors
+    assert_not OnchainWalletAccount.exists?(leftover.id), "the dead row should have made way rather than sit alongside"
+
+    tracked = @item.onchain_wallet_accounts.sole
+    assert tracked.account_provider.present?
+  end
+
+  test "a row that still tracks an account is left alone" do
+    tracked = create_onchain_wallet_account(item: @item)
+    link_onchain_wallet_account!(tracked)
+
+    result = link(fake_native_asset)
+
+    # Nothing to absorb here: the asset is already tracked, so the duplicate is
+    # refused rather than allowed to replace a live account.
+    assert_equal 0, result.created
+    assert_equal [ "FAKE" ], result.errors
+    assert OnchainWalletAccount.exists?(tracked.id)
+  end
+
+  private
+    def link(*assets)
+      snapshot = Onchain::Snapshot.new(assets: assets, movements: [])
+
+      OnchainWalletItem::WalletLinker
+        .new(@item, chain: FAKE_CHAIN, address: FAKE_ADDRESS)
+        .link(snapshot: snapshot, selected_keys: assets.map { |a| OnchainWalletItem::TokenReview.key_for(a) })
+    end
+end

--- a/test/models/onchain_wallet_item_test.rb
+++ b/test/models/onchain_wallet_item_test.rb
@@ -66,9 +66,18 @@ class OnchainWalletItemTest < ActiveSupport::TestCase
   test "family only reports linked addresses it actually tracks" do
     assert_not @family.onchain_address_linked?(OnchainTestHelper::FAKE_CHAIN, OnchainTestHelper::FAKE_ADDRESS)
 
-    create_onchain_wallet_account(item: @item)
+    link_onchain_wallet_account!(create_onchain_wallet_account(item: @item))
 
     assert @family.onchain_address_linked?(OnchainTestHelper::FAKE_CHAIN, OnchainTestHelper::FAKE_ADDRESS)
     assert_not @family.onchain_address_linked?(OnchainTestHelper::FAKE_CHAIN, OnchainTestHelper::FAKE_ADDRESS_ALT)
+  end
+
+  test "an address whose row tracks nothing is free to be added again" do
+    onchain_account = create_onchain_wallet_account(item: @item)
+
+    # No account behind it: it syncs nothing and appears nowhere, so reporting
+    # the address as taken would refuse it with nothing to show the user.
+    assert_not @family.onchain_address_linked?(OnchainTestHelper::FAKE_CHAIN, OnchainTestHelper::FAKE_ADDRESS)
+    assert OnchainWalletAccount.exists?(onchain_account.id)
   end
 end


### PR DESCRIPTION
An on-chain wallet row carries an `after_destroy` callback so that it follows its account link into the grave. That link can die two ways — destroyed *by the row* through its own `dependent: :destroy`, or *by the account* through the same association seen from the other side — and the guard meant to stop the row destroying itself could not tell them apart. It caught both, so the account route left the row standing.

## Latent, not lived

I want to be straight about the severity, because it changes how much attention this deserves: **no instance can be carrying a stranded row.** Deleting a linked account is refused by `AccountsController#destroy`, and the control is hidden in both account menus when `account.linked?` — guards that date from #318 and #1272, long before on-chain wallets landed in #3081. The route that leaves the row behind is not one a user can take.

The routes users do take were already right: `accounts#unlink` goes through `account_providers.destroy_all`, which fires the callback, and the wallet manage page's disconnect actions destroy the row directly. Both were already covered by tests.

## Why fix it anyway

That controller guard is the only one there is. `Account#destroy_later` has none of its own, and three provider controllers already call `previous_account.destroy_later` without asking whether the account is linked. Nothing stops a future path from doing the same to an on-chain account.

And the callback is wrong on its own terms — it exists to keep a row from outliving its account, and it does not fire on one of the two ways that happens. One line, and the trap is gone.

## Tests

The unlink route was already covered. The account route had no test at all; it now has one, verified to fail without the change.

Full suite green. Rubocop and Brakeman clean.