### PR TITLE
Fix SimpleFIN balances-only liability signs

### DIFF
--- a/app/models/simplefin_item/importer.rb
+++ b/app/models/simplefin_item/importer.rb
@@ -212,8 +212,8 @@ class SimplefinItem::Importer
         end
 
         adapter.update_balance(
-          balance: account_data[:balance],
-          cash_balance: account_data[:"available-balance"],
+          balance: normalized,
+          cash_balance: is_liability ? normalized : account_data[:"available-balance"],
           source: "simplefin"
         )
       end

--- a/app/models/simplefin_item/importer.rb
+++ b/app/models/simplefin_item/importer.rb
@@ -133,7 +133,7 @@ class SimplefinItem::Importer
         # Normalize balances for SimpleFIN liabilities so immediate UI is correct after discovery
         bal   = to_decimal(account_data[:balance])
         avail = to_decimal(account_data[:"available-balance"])
-        observed = bal.nonzero? ? bal : avail
+        observed = account_data[:balance].nil? ? avail : bal
 
         is_linked_liability = [ "CreditCard", "Loan" ].include?(acct.accountable_type)
         inferred = begin
@@ -149,10 +149,17 @@ class SimplefinItem::Importer
           nil
         end
         is_mapper_liability = inferred && [ "CreditCard", "Loan" ].include?(inferred.accountable_type)
-        is_liability = is_linked_liability || is_mapper_liability
+        is_liability =
+          if acct.accountable_type.present?
+            is_linked_liability
+          else
+            is_mapper_liability
+          end
 
         normalized = observed
-        if is_liability
+        if acct.accountable_type == "Loan"
+          normalized = observed.abs
+        elsif is_liability
           # Try the overpayment analyzer first (feature-flagged)
           begin
             result = SimplefinAccount::Liabilities::OverpaymentAnalyzer

--- a/test/models/simplefin_item/importer_test.rb
+++ b/test/models/simplefin_item/importer_test.rb
@@ -87,13 +87,13 @@ class SimplefinItem::ImporterTest < ActiveSupport::TestCase
 
   private
 
-  def create_simplefin_account(account_id, name, account_type, current_balance)
-    @item.simplefin_accounts.create!(
-      name: name,
-      account_id: account_id,
-      account_type: account_type,
-      currency: "USD",
-      current_balance: current_balance
-    )
-  end
+    def create_simplefin_account(account_id, name, account_type, current_balance)
+      @item.simplefin_accounts.create!(
+        name: name,
+        account_id: account_id,
+        account_type: account_type,
+        currency: "USD",
+        current_balance: current_balance
+      )
+    end
 end

--- a/test/models/simplefin_item/importer_test.rb
+++ b/test/models/simplefin_item/importer_test.rb
@@ -21,13 +21,7 @@ class SimplefinItem::ImporterTest < ActiveSupport::TestCase
 
   test "balances-only import persists a negative provider credit-card debt as positive" do
     credit_card = accounts(:credit_card)
-    simplefin_account = @item.simplefin_accounts.create!(
-      name: "Amex",
-      account_id: "sf_amex_1",
-      account_type: "credit",
-      currency: "USD",
-      current_balance: -1911.72
-    )
+    simplefin_account = create_simplefin_account("sf_amex_1", "Amex", "credit", -1911.72)
     credit_card.update!(simplefin_account_id: simplefin_account.id)
 
     @importer.send(:import_account_minimal_and_balance, {
@@ -39,5 +33,67 @@ class SimplefinItem::ImporterTest < ActiveSupport::TestCase
 
     assert_equal 1911.72, credit_card.reload.balance
     assert_equal 1911.72, credit_card.cash_balance
+  end
+
+  test "balances-only import keeps a positive loan principal positive" do
+    loan = accounts(:loan)
+    simplefin_account = create_simplefin_account("sf_loan_1", "Mortgage Loan", "loan", 250_000)
+    loan.update!(simplefin_account_id: simplefin_account.id)
+
+    @importer.send(:import_account_minimal_and_balance, {
+      id: simplefin_account.account_id,
+      name: "Mortgage Loan",
+      balance: 250_000,
+      currency: "USD"
+    })
+
+    assert_equal 250_000, loan.reload.balance
+    assert_equal 250_000, loan.cash_balance
+  end
+
+  test "balances-only import keeps an explicit zero credit-card balance at zero" do
+    credit_card = accounts(:credit_card)
+    simplefin_account = create_simplefin_account("sf_card_zero_1", "Paid Off Card", "credit", 0)
+    credit_card.update!(simplefin_account_id: simplefin_account.id)
+
+    @importer.send(:import_account_minimal_and_balance, {
+      id: simplefin_account.account_id,
+      name: "Paid Off Card",
+      balance: 0,
+      "available-balance": 5_000,
+      currency: "USD"
+    })
+
+    assert_equal 0, credit_card.reload.balance
+    assert_equal 0, credit_card.cash_balance
+  end
+
+  test "balances-only import preserves a linked depository type over a liability inference" do
+    depository = accounts(:depository)
+    simplefin_account = create_simplefin_account("sf_linked_depository_1", "Mortgage Loan", "loan", 1_000)
+    depository.update!(simplefin_account_id: simplefin_account.id)
+
+    @importer.send(:import_account_minimal_and_balance, {
+      id: simplefin_account.account_id,
+      name: "Mortgage Loan",
+      type: "loan",
+      balance: 1_000,
+      currency: "USD"
+    })
+
+    assert_equal 1_000, depository.reload.balance
+    assert_equal 1_000, depository.cash_balance
+  end
+
+  private
+
+  def create_simplefin_account(account_id, name, account_type, current_balance)
+    @item.simplefin_accounts.create!(
+      name: name,
+      account_id: account_id,
+      account_type: account_type,
+      currency: "USD",
+      current_balance: current_balance
+    )
   end
 end

--- a/test/models/simplefin_item/importer_test.rb
+++ b/test/models/simplefin_item/importer_test.rb
@@ -18,4 +18,26 @@ class SimplefinItem::ImporterTest < ActiveSupport::TestCase
 
     assert_equal Time.at(epoch_string.to_i).utc, parsed
   end
+
+  test "balances-only import persists a negative provider credit-card debt as positive" do
+    credit_card = accounts(:credit_card)
+    simplefin_account = @item.simplefin_accounts.create!(
+      name: "Amex",
+      account_id: "sf_amex_1",
+      account_type: "credit",
+      currency: "USD",
+      current_balance: -1911.72
+    )
+    credit_card.update!(simplefin_account_id: simplefin_account.id)
+
+    @importer.send(:import_account_minimal_and_balance, {
+      id: simplefin_account.account_id,
+      name: "Amex",
+      balance: -1911.72,
+      currency: "USD"
+    })
+
+    assert_equal 1911.72, credit_card.reload.balance
+    assert_equal 1911.72, credit_card.cash_balance
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the SimpleFIN balances-only importer so it persists its already-normalized liability balance instead of the raw provider sign.

SimpleFIN institutions can report credit-card debt with either sign. Sure's convention is positive debt and negative issuer credit/overpayment. The normal/full processor applies that convention, but the balances-only path calculated the normalized value and then discarded it while writing `account_data[:balance]`.

## Changes

- Persist `normalized` for linked liabilities during a balances-only import.
- Keep the liability `cash_balance` aligned with the normalized persisted balance.
- Add a regression test for raw `-1911.72` card debt persisting as `+1911.72`.

## Verification

- Fork CI passed for the equivalent fix before this clean upstream-based branch was created: unit, system, lint, and security checks.
- `ruby -c` passes for both changed Ruby files.
- This branch is one commit on top of current upstream `main` (`90203139b`).

No issue link available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balances-only imports by using available balances only when the primary balance is unavailable.
  * Corrected loan and liability balance normalization so debt displays consistently as a positive amount.
  * Preserved explicitly linked account types and applied normalized balances to linked accounts.
  * Ensured non-liability cash accounts continue using the provider’s available balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->