### PR TITLE
fix(reports): a transfer out is not a sale

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -521,6 +521,12 @@ class ReportsController < ApplicationController
         .where(entries: { date: @period.date_range })
         .merge(Account.included_in_reports)
         .where("trades.qty < 0")
+        # A transfer out has the same negative quantity as a sale and would be
+        # counted and listed as one. Nothing was sold, so it belongs in neither.
+        .where(
+          "trades.investment_activity_label IS NULL OR trades.investment_activity_label NOT IN (?)",
+          Trade::INTERNAL_MOVEMENT_LABELS
+        )
         .includes(:security, entry: { account: :accountable })
         .to_a
 

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -11,9 +11,19 @@ class Trade < ApplicationRecord
   ACTIVITY_LABELS = Transaction::ACTIVITY_LABELS.dup.freeze
 
   # The labels that mean the asset went somewhere else you own rather than
-  # being bought or sold. Shared with Transaction, which already keeps them out
-  # of the income statement for the same reason.
-  INTERNAL_MOVEMENT_LABELS = Transaction::INTERNAL_MOVEMENT_LABELS
+  # being bought or sold.
+  #
+  # Deliberately NOT `Transaction::INTERNAL_MOVEMENT_LABELS`, which also holds
+  # "Exchange". On cash that means a currency exchange and is internal; on a
+  # security the label covers "currency **or security** exchanges"
+  # (docs/onboarding/guide.md), and a security-for-security exchange can
+  # dispose of an appreciated asset.
+  #
+  # The two errors are not symmetrical. Listing a movement that was not a sale
+  # is visible and correctable; erasing a realized gain is neither — it simply
+  # is not there. So only labels that unambiguously preserve ownership are
+  # excluded, and an ambiguous one is left where the user can see it.
+  INTERNAL_MOVEMENT_LABELS = %w[Transfer Sweep\ In Sweep\ Out].freeze
 
   validates :qty, presence: true
   validates :price, :currency, presence: true

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -10,6 +10,11 @@ class Trade < ApplicationRecord
   # Use the same activity labels as Transaction
   ACTIVITY_LABELS = Transaction::ACTIVITY_LABELS.dup.freeze
 
+  # The labels that mean the asset went somewhere else you own rather than
+  # being bought or sold. Shared with Transaction, which already keeps them out
+  # of the income statement for the same reason.
+  INTERNAL_MOVEMENT_LABELS = Transaction::INTERNAL_MOVEMENT_LABELS
+
   validates :qty, presence: true
   validates :price, :currency, presence: true
   validates :investment_activity_label, inclusion: { in: ACTIVITY_LABELS }, allow_nil: true
@@ -42,6 +47,12 @@ class Trade < ApplicationRecord
 
   def sell?
     qty.negative?
+  end
+
+  # A negative quantity that left for another account you own. It looks exactly
+  # like a sale — same sign, same shape — and only the label tells them apart.
+  def internal_movement?
+    INTERNAL_MOVEMENT_LABELS.include?(investment_activity_label)
   end
 
   class << self
@@ -91,6 +102,10 @@ class Trade < ApplicationRecord
 
     def calculate_realized_gain_loss
       return nil unless sell?
+      # Moving an asset to another account you own realises nothing. Without
+      # this the cost basis is compared against the day's price and the
+      # difference is booked as a gain the user never made.
+      return nil if internal_movement?
 
       # Use preloaded holdings if available (set by reports controller to avoid N+1)
       # Treat defined-but-empty preload as authoritative to prevent DB fallback

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -614,7 +614,10 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
       )
     end
 
-    get reports_path(period: "last_30_days")
+    # `period_type`, not `period` — the controller reads the former, so the
+    # latter silently fell back to the current month and the trades dated
+    # three days ago dropped out of range on the 1st to the 3rd.
+    get reports_path(period_type: :custom, start_date: 30.days.ago.to_date, end_date: Date.current)
     assert_response :success
 
     # A transfer out carries the same negative quantity as a sale. Counting it

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -598,4 +598,28 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "button[disabled][aria-label=?]", I18n.t("reports.index.next_period")
   end
+
+  test "a transfer out is not listed among the period's sales" do
+    account = @family.accounts.create!(name: "Wallet", balance: 100, currency: "USD",
+                                       accountable: Investment.new)
+    security = Security.find_or_create_by!(ticker: "MOVE") { |sec| sec.name = "Movable" }
+    Holding.create!(account: account, security: security, date: 10.days.ago.to_date,
+                    qty: 100, price: 2, amount: 200, currency: "USD", cost_basis: 1)
+
+    %w[Transfer Sell].each do |label|
+      account.entries.create!(
+        date: 3.days.ago.to_date, name: "out #{label}", amount: 0, currency: "USD",
+        entryable: Trade.new(security: security, qty: -40, price: 3, currency: "USD",
+                             investment_activity_label: label)
+      )
+    end
+
+    get reports_path(period: "last_30_days")
+    assert_response :success
+
+    # A transfer out carries the same negative quantity as a sale. Counting it
+    # as one both inflates the number of sales and books a gain nobody made.
+    assert_match I18n.t("reports.investment_performance.sells_count", count: 1), response.body
+    assert_no_match(/#{Regexp.escape(I18n.t("reports.investment_performance.sells_count", count: 2))}/, response.body)
+  end
 end

--- a/test/models/trade_test.rb
+++ b/test/models/trade_test.rb
@@ -136,4 +136,26 @@ class TradeTest < ActiveSupport::TestCase
                              investment_activity_label: label)
       ).entryable
     end
+
+    # "Exchange" means a currency exchange on cash and is internal there. On a
+    # security the label covers currency *or security* exchanges, and a
+    # security-for-security exchange can dispose of an appreciated asset — so
+    # borrowing Transaction's list erased a realized gain with nothing to show
+    # for it.
+    test "an exchange is not treated as an internal movement on a trade" do
+      assert_not Trade.new(investment_activity_label: "Exchange").internal_movement?
+    end
+
+    test "the labels that unambiguously preserve ownership still are" do
+      %w[Transfer Sweep\ In Sweep\ Out].each do |label|
+        assert Trade.new(investment_activity_label: label).internal_movement?, label
+      end
+    end
+
+    # The two lists are deliberately different; this fails if one is ever
+    # aliased back onto the other.
+    test "a trade does not borrow the cash list" do
+      assert_includes Transaction::INTERNAL_MOVEMENT_LABELS, "Exchange"
+      assert_not_includes Trade::INTERNAL_MOVEMENT_LABELS, "Exchange"
+    end
 end

--- a/test/models/trade_test.rb
+++ b/test/models/trade_test.rb
@@ -93,4 +93,47 @@ class TradeTest < ActiveSupport::TestCase
 
     assert_equal BigDecimal("1.1234567890"), trade.price
   end
+
+  test "a transfer out realises nothing, however it is priced" do
+    account, security = position_with_known_cost_basis
+
+    moved = build_negative_trade(account, security, label: "Transfer")
+    sold  = build_negative_trade(account, security, label: "Sell")
+
+    # Same sign, same shape, same price — only the label separates a sale from
+    # coins walking to another wallet you own.
+    assert_nil moved.realized_gain_loss
+    assert_not_nil sold.realized_gain_loss
+  end
+
+  test "every internal movement label realises nothing" do
+    account, security = position_with_known_cost_basis
+
+    Trade::INTERNAL_MOVEMENT_LABELS.each do |label|
+      trade = build_negative_trade(account, security, label: label)
+      assert_nil trade.realized_gain_loss, "#{label} should not realise a gain"
+    end
+  end
+
+  private
+    # A position whose cost basis is known, which is what makes a fabricated
+    # gain possible: without one, realized_gain_loss returns nil for any reason.
+    def position_with_known_cost_basis
+      family = families(:empty)
+      account = family.accounts.create!(name: "Wallet", balance: 100, currency: "USD",
+                                        accountable: Investment.new)
+      security = Security.find_or_create_by!(ticker: "MOVE") { |s| s.name = "Movable" }
+      Holding.create!(account: account, security: security, date: 10.days.ago.to_date,
+                      qty: 100, price: 2, amount: 200, currency: "USD", cost_basis: 1)
+
+      [ account, security ]
+    end
+
+    def build_negative_trade(account, security, label:)
+      account.entries.create!(
+        date: 3.days.ago.to_date, name: "out #{label}", amount: 0, currency: "USD",
+        entryable: Trade.new(security: security, qty: -40, price: 3, currency: "USD",
+                             investment_activity_label: label)
+      ).entryable
+    end
 end


### PR DESCRIPTION
A negative quantity was all it took to be counted as a sale. Moving an asset to another account you own — a transfer, a sweep, an exchange — was listed among the period's sales in **Reports → Investment performance**, and its cost basis was compared against that day's price to book a realized gain nobody made.

## Reproducing it

A position with a known cost basis, then a transfer out:

```
trades counted as SALES: 1
  CRYPTO:ONDO qty=-40 label="Transfer" realized gain=120 EUR
```

40 units left for another wallet. €120 of realized gain appeared.

It needs a *stored* cost basis to show, which is why it does not appear on every account — `Holding#calculate_avg_cost` already ignores transfers, but a stored `cost_basis` outranks that guard. So the report is only ever one stored figure away from inventing a gain.

## The change

The labels for this already exist and are already trusted elsewhere: `Transaction::INTERNAL_MOVEMENT_LABELS` (`Transfer`, `Sweep In`, `Sweep Out`, `Exchange`) keeps the same four out of the income statement, for the same reason. The investment report just never consulted them.

- `Trade#realized_gain_loss` returns `nil` for an internal movement, so no caller can book the gain
- the report's sell-trades query leaves those trades out, so the movement is no longer counted or listed as a sale

Not specific to crypto: any provider that labels a withdrawal `Transfer` or a cash sweep `Sweep Out` hits the same path.

## Tests

Three, each verified to fail without the change: a transfer realizes nothing while an identical `Sell` still does; every label in `INTERNAL_MOVEMENT_LABELS` realizes nothing; and the report lists one sale where two negative-quantity trades exist.

Full suite green (7276 runs). Rubocop and Brakeman clean.

## A design question for you

I fixed this the way the income statement already treats these labels, but there are two judgement calls in it I would rather you settled than have me assume:

**1. Should the movement disappear from the report, or appear with no gain?** I dropped it from the query entirely, so the sells count and list reflect actual sales. The alternative is to keep listing it — the view already renders `no_data` when a gain is `nil` — so a user who moved coins still sees the movement in the period's activity. Hiding it is cleaner arithmetic; showing it is more honest about what happened. I chose hiding because the section is titled "sells" and a transfer is not one, but I can see the case for the other.

**2. Should `Trade#sell?` itself become label-aware?** It is `qty.negative?` today, and I deliberately left it alone: it drives display in a few places, and quietly changing what "sell" means across the app felt like more than this bug warranted. But it does mean the codebase now has two notions of a sale — the predicate, and what the report counts. If you would rather have one, `sell?` is the place, and I am happy to do it here.

Neither affects the correctness of the gain being suppressed, only where the movement shows up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transfers and account sweeps are no longer counted as sales or realized gains.
  * Reports now include only genuine sales in sales metrics.
  * Internal asset movements no longer produce misleading gain or loss calculations.
  * Exchange activity continues to be handled separately from internal transfers.

* **Tests**
  * Added coverage confirming internal movements are excluded while genuine sales remain accurately reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->