### PR TITLE
Plaid: add accounts to an existing connection

### DIFF
--- a/app/controllers/plaid_items_controller.rb
+++ b/app/controllers/plaid_items_controller.rb
@@ -24,6 +24,7 @@ class PlaidItemsController < ApplicationController
     @link_token = @plaid_item.get_update_link_token(
       webhooks_url: webhooks_url,
       redirect_url: accounts_url,
+      account_selection_enabled: params[:add_accounts] == "true",
     )
   rescue Plaid::ApiError => e
     handle_link_token_error(e)

--- a/app/controllers/plaid_items_controller.rb
+++ b/app/controllers/plaid_items_controller.rb
@@ -24,7 +24,7 @@ class PlaidItemsController < ApplicationController
     @link_token = @plaid_item.get_update_link_token(
       webhooks_url: webhooks_url,
       redirect_url: accounts_url,
-      account_selection_enabled: params[:add_accounts] == "true",
+      account_selection_enabled: @plaid_item.us? && params[:add_accounts] == "true",
     )
   rescue Plaid::ApiError => e
     handle_link_token_error(e)
@@ -46,9 +46,7 @@ class PlaidItemsController < ApplicationController
   end
 
   def sync
-    unless @plaid_item.syncing?
-      @plaid_item.sync_later
-    end
+    @plaid_item.sync_later_with_follow_up
 
     respond_to do |format|
       format.html { redirect_back_or_to accounts_path }

--- a/app/jobs/plaid_follow_up_sync_job.rb
+++ b/app/jobs/plaid_follow_up_sync_job.rb
@@ -1,0 +1,24 @@
+class PlaidFollowUpSyncJob < ApplicationJob
+  queue_as :high_priority
+
+  RETRY_DELAY = 10.seconds
+  MAX_ATTEMPTS = 30
+
+  def perform(plaid_item, active_sync_id:, attempts_remaining: MAX_ATTEMPTS)
+    if plaid_item.syncs.visible.exists?(id: active_sync_id)
+      if attempts_remaining.positive?
+        self.class.set(wait: RETRY_DELAY).perform_later(
+          plaid_item,
+          active_sync_id: active_sync_id,
+          attempts_remaining: attempts_remaining - 1
+        )
+      else
+        Rails.logger.warn("PlaidFollowUpSyncJob - gave up waiting for PlaidItem #{plaid_item.id} to finish syncing")
+      end
+
+      return
+    end
+
+    plaid_item.sync_later
+  end
+end

--- a/app/jobs/plaid_follow_up_sync_job.rb
+++ b/app/jobs/plaid_follow_up_sync_job.rb
@@ -5,7 +5,7 @@ class PlaidFollowUpSyncJob < ApplicationJob
   MAX_ATTEMPTS = 30
 
   def perform(plaid_item, active_sync_id:, attempts_remaining: MAX_ATTEMPTS)
-    if plaid_item.syncs.visible.exists?(id: active_sync_id)
+    if plaid_item.syncs.incomplete.exists?(id: active_sync_id)
       if attempts_remaining.positive?
         self.class.set(wait: RETRY_DELAY).perform_later(
           plaid_item,
@@ -13,7 +13,17 @@ class PlaidFollowUpSyncJob < ApplicationJob
           attempts_remaining: attempts_remaining - 1
         )
       else
-        Rails.logger.warn("PlaidFollowUpSyncJob - gave up waiting for PlaidItem #{plaid_item.id} to finish syncing")
+        message = "Gave up waiting for PlaidItem #{plaid_item.id} sync #{active_sync_id} to finish"
+        Rails.logger.warn("PlaidFollowUpSyncJob - #{message}")
+        DebugLogEntry.capture(
+          category: "background_jobs",
+          level: "warn",
+          message: message,
+          source: self.class.name,
+          family: plaid_item.family,
+          provider_key: "plaid",
+          metadata: { plaid_item_id: plaid_item.id, active_sync_id: active_sync_id }
+        )
       end
 
       return

--- a/app/jobs/plaid_follow_up_sync_job.rb
+++ b/app/jobs/plaid_follow_up_sync_job.rb
@@ -14,7 +14,6 @@ class PlaidFollowUpSyncJob < ApplicationJob
         )
       else
         message = "Gave up waiting for PlaidItem #{plaid_item.id} sync #{active_sync_id} to finish"
-        Rails.logger.warn("PlaidFollowUpSyncJob - #{message}")
         DebugLogEntry.capture(
           category: "background_jobs",
           level: "warn",

--- a/app/models/family/plaid_connectable.rb
+++ b/app/models/family/plaid_connectable.rb
@@ -29,7 +29,7 @@ module Family::PlaidConnectable
     plaid_item
   end
 
-  def get_link_token(webhooks_url:, redirect_url:, accountable_type: nil, region: :us, access_token: nil)
+  def get_link_token(webhooks_url:, redirect_url:, accountable_type: nil, region: :us, access_token: nil, account_selection_enabled: false)
     return nil unless plaid(region)
 
     plaid(region).get_link_token(
@@ -37,7 +37,8 @@ module Family::PlaidConnectable
       webhooks_url: webhooks_url,
       redirect_url: redirect_url,
       accountable_type: accountable_type,
-      access_token: access_token
+      access_token: access_token,
+      account_selection_enabled: account_selection_enabled
     ).link_token
   end
 

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -36,12 +36,13 @@ class PlaidItem < ApplicationRecord
       .uniq
   end
 
-  def get_update_link_token(webhooks_url:, redirect_url:)
+  def get_update_link_token(webhooks_url:, redirect_url:, account_selection_enabled: false)
     family.get_link_token(
       webhooks_url: webhooks_url,
       redirect_url: redirect_url,
       region: plaid_region,
-      access_token: access_token
+      access_token: access_token,
+      account_selection_enabled: account_selection_enabled
     )
   rescue Plaid::ApiError => e
     error_body = begin

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -65,6 +65,17 @@ class PlaidItem < ApplicationRecord
     end
   end
 
+  # Queue a fresh import after an in-flight sync. Plaid Link can finish adding
+  # accounts after the active sync already fetched its account list.
+  def sync_later_with_follow_up
+    active_sync = syncs.visible.ordered.first
+    sync_later
+
+    return unless active_sync&.reload&.in_progress?
+
+    PlaidFollowUpSyncJob.set(wait: PlaidFollowUpSyncJob::RETRY_DELAY).perform_later(self, active_sync_id: active_sync.id)
+  end
+
   def destroy_later
     update!(scheduled_for_deletion: true)
     DestroyJob.perform_later(self)

--- a/app/models/provider/plaid.rb
+++ b/app/models/provider/plaid.rb
@@ -42,7 +42,7 @@ class Provider::Plaid
     raise JWT::VerificationError, "Invalid webhook body hash" unless ActiveSupport::SecurityUtils.secure_compare(expected_hash, actual_hash)
   end
 
-  def get_link_token(user_id:, webhooks_url:, redirect_url:, accountable_type: nil, access_token: nil)
+  def get_link_token(user_id:, webhooks_url:, redirect_url:, accountable_type: nil, access_token: nil, account_selection_enabled: false)
     request_params = {
       user: { client_user_id: user_id },
       client_name: "Sure Finances",
@@ -55,6 +55,7 @@ class Provider::Plaid
 
     if access_token.present?
       request_params[:access_token] = access_token
+      request_params[:update] = { account_selection_enabled: true } if account_selection_enabled
     else
       request_params[:products] = [ get_primary_product(accountable_type) ]
       request_params[:additional_consented_products] = get_additional_consented_products(accountable_type)

--- a/app/models/provider/plaid.rb
+++ b/app/models/provider/plaid.rb
@@ -49,14 +49,14 @@ class Provider::Plaid
       country_codes: country_codes,
       language: "en",
       webhook: webhooks_url,
-      redirect_uri: redirect_url,
-      transactions: { days_requested: MAX_HISTORY_DAYS }
+      redirect_uri: redirect_url
     }
 
     if access_token.present?
       request_params[:access_token] = access_token
       request_params[:update] = { account_selection_enabled: true } if account_selection_enabled
     else
+      request_params[:transactions] = { days_requested: MAX_HISTORY_DAYS }
       request_params[:products] = [ get_primary_product(accountable_type) ]
       request_params[:additional_consented_products] = get_additional_consented_products(accountable_type)
     end

--- a/app/views/plaid_items/_plaid_item.html.erb
+++ b/app/views/plaid_items/_plaid_item.html.erb
@@ -57,7 +57,17 @@
                 href: edit_plaid_item_path(plaid_item),
                 frame: "modal"
               ) %>
-            <% elsif Rails.env.development? %>
+            <% else %>
+              <%= render DS::Link.new(
+                text: t(".add_accounts"),
+                icon: "circle-plus",
+                variant: "secondary",
+                href: edit_plaid_item_path(plaid_item, add_accounts: true),
+                frame: "modal"
+              ) %>
+            <% end %>
+
+            <% if Rails.env.development? %>
               <%= icon(
                 "refresh-cw",
                 as_button: true,

--- a/app/views/plaid_items/_plaid_item.html.erb
+++ b/app/views/plaid_items/_plaid_item.html.erb
@@ -57,7 +57,7 @@
                 href: edit_plaid_item_path(plaid_item),
                 frame: "modal"
               ) %>
-            <% else %>
+            <% elsif plaid_item.us? %>
               <%= render DS::Link.new(
                 text: t(".add_accounts"),
                 icon: "circle-plus",
@@ -65,9 +65,7 @@
                 href: edit_plaid_item_path(plaid_item, add_accounts: true),
                 frame: "modal"
               ) %>
-            <% end %>
-
-            <% if Rails.env.development? %>
+            <% elsif Rails.env.development? %>
               <%= icon(
                 "refresh-cw",
                 as_button: true,

--- a/config/locales/views/plaid_items/en.yml
+++ b/config/locales/views/plaid_items/en.yml
@@ -10,6 +10,7 @@ en:
         if the problem persists check the server logs for details.
       link_token_with_message: "Plaid couldn't open the connection: %{message}"
     plaid_item:
+      add_accounts: Add accounts
       add_new: Add new connection
       confirm_accept: Delete institution
       confirm_body: This will permanently delete all the accounts in this group and

--- a/test/controllers/plaid_items_controller_test.rb
+++ b/test/controllers/plaid_items_controller_test.rb
@@ -58,6 +58,19 @@ class PlaidItemsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/not enabled for the following products/, flash[:alert])
   end
 
+  test "edit enables account selection when adding accounts" do
+    plaid_item = plaid_items(:one)
+    PlaidItem.any_instance.expects(:get_update_link_token).with(
+      webhooks_url: webhooks_plaid_url,
+      redirect_url: accounts_url,
+      account_selection_enabled: true
+    ).returns("link-token")
+
+    get edit_plaid_item_url(plaid_item, add_accounts: true)
+
+    assert_response :success
+  end
+
   test "create" do
     @plaid_provider = mock
     Provider::Registry.expects(:plaid_provider_for_region).with("us").returns(@plaid_provider)

--- a/test/controllers/plaid_items_controller_test.rb
+++ b/test/controllers/plaid_items_controller_test.rb
@@ -71,6 +71,20 @@ class PlaidItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "edit does not enable account selection for EU items" do
+    plaid_item = plaid_items(:one)
+    plaid_item.update!(plaid_region: :eu)
+    PlaidItem.any_instance.expects(:get_update_link_token).with(
+      webhooks_url: webhooks_plaid_eu_url,
+      redirect_url: accounts_url,
+      account_selection_enabled: false
+    ).returns("link-token")
+
+    get edit_plaid_item_url(plaid_item, add_accounts: true)
+
+    assert_response :success
+  end
+
   test "create" do
     @plaid_provider = mock
     Provider::Registry.expects(:plaid_provider_for_region).with("us").returns(@plaid_provider)
@@ -105,7 +119,7 @@ class PlaidItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "sync" do
     plaid_item = plaid_items(:one)
-    PlaidItem.any_instance.expects(:sync_later).once
+    PlaidItem.any_instance.expects(:sync_later_with_follow_up).once
 
     post sync_plaid_item_url(plaid_item)
 

--- a/test/jobs/plaid_follow_up_sync_job_test.rb
+++ b/test/jobs/plaid_follow_up_sync_job_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class PlaidFollowUpSyncJobTest < ActiveJob::TestCase
+  test "starts a sync after the active sync finishes" do
+    plaid_item = plaid_items(:one)
+    plaid_item.syncs.destroy_all
+    plaid_item.expects(:sync_later).once
+
+    PlaidFollowUpSyncJob.perform_now(plaid_item, active_sync_id: SecureRandom.uuid)
+  end
+
+  test "reschedules while a sync is active" do
+    plaid_item = plaid_items(:one)
+    plaid_item.syncs.destroy_all
+    active_sync = plaid_item.syncs.create!
+    active_sync.start!
+
+    assert_enqueued_with job: PlaidFollowUpSyncJob do
+      PlaidFollowUpSyncJob.perform_now(plaid_item, active_sync_id: active_sync.id, attempts_remaining: 1)
+    end
+  end
+end

--- a/test/jobs/plaid_follow_up_sync_job_test.rb
+++ b/test/jobs/plaid_follow_up_sync_job_test.rb
@@ -19,4 +19,32 @@ class PlaidFollowUpSyncJobTest < ActiveJob::TestCase
       PlaidFollowUpSyncJob.perform_now(plaid_item, active_sync_id: active_sync.id, attempts_remaining: 1)
     end
   end
+
+  test "does not overlap an incomplete sync hidden from the UI" do
+    plaid_item = plaid_items(:one)
+    plaid_item.syncs.destroy_all
+    active_sync = plaid_item.syncs.create!(created_at: Sync::VISIBLE_FOR.ago - 1.minute)
+    active_sync.start!
+
+    assert_enqueued_with job: PlaidFollowUpSyncJob do
+      PlaidFollowUpSyncJob.perform_now(plaid_item, active_sync_id: active_sync.id, attempts_remaining: 1)
+    end
+  end
+
+  test "captures exhausted retries for support" do
+    plaid_item = plaid_items(:one)
+    plaid_item.syncs.destroy_all
+    active_sync = plaid_item.syncs.create!
+    active_sync.start!
+
+    assert_difference "DebugLogEntry.count", 1 do
+      PlaidFollowUpSyncJob.perform_now(plaid_item, active_sync_id: active_sync.id, attempts_remaining: 0)
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "background_jobs", entry.category
+    assert_equal "PlaidFollowUpSyncJob", entry.source
+    assert_equal plaid_item.family, entry.family
+    assert_equal active_sync.id, entry.metadata["active_sync_id"]
+  end
 end

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -57,6 +57,24 @@ class PlaidItemTest < ActiveSupport::TestCase
     assert_predicate @plaid_item.reload, :requires_update?
   end
 
+  test "get_update_link_token can enable account selection" do
+    Family.any_instance.expects(:get_link_token).with(
+      webhooks_url: "https://example.com/webhooks",
+      redirect_url: "https://example.com/accounts",
+      region: @plaid_item.plaid_region,
+      access_token: @plaid_item.access_token,
+      account_selection_enabled: true
+    ).returns("link-token")
+
+    result = @plaid_item.get_update_link_token(
+      webhooks_url: "https://example.com/webhooks",
+      redirect_url: "https://example.com/accounts",
+      account_selection_enabled: true
+    )
+
+    assert_equal "link-token", result
+  end
+
   test "get_update_link_token re-raises other Plaid errors so the controller can surface them" do
     # Issue #1792: silently swallowing all Plaid errors here is what made the
     # "modal closes with nothing happening" experience so opaque.

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -75,6 +75,15 @@ class PlaidItemTest < ActiveSupport::TestCase
     assert_equal "link-token", result
   end
 
+  test "sync_later_with_follow_up queues a follow-up after an active sync" do
+    active_sync = @plaid_item.syncs.create!
+    active_sync.start!
+
+    assert_enqueued_with job: PlaidFollowUpSyncJob do
+      @plaid_item.sync_later_with_follow_up
+    end
+  end
+
   test "get_update_link_token re-raises other Plaid errors so the controller can surface them" do
     # Issue #1792: silently swallowing all Plaid errors here is what made the
     # "modal closes with nothing happening" experience so opaque.

--- a/test/models/provider/plaid_test.rb
+++ b/test/models/provider/plaid_test.rb
@@ -32,6 +32,26 @@ class Provider::PlaidTest < ActiveSupport::TestCase
     end
   end
 
+  test "enables account selection for an update link token" do
+    request = mock
+    Plaid::LinkTokenCreateRequest.expects(:new).with do |params|
+      params[:access_token] == "access-token" &&
+        params[:update] == { account_selection_enabled: true } &&
+        params[:products].nil?
+    end.returns(request)
+    @plaid.client.expects(:link_token_create).with(request).returns("response")
+
+    result = @plaid.get_link_token(
+      user_id: "test-user-id",
+      webhooks_url: "https://example.com/webhooks",
+      redirect_url: @redirect_url,
+      access_token: "access-token",
+      account_selection_enabled: true
+    )
+
+    assert_equal "response", result
+  end
+
   test "exchanges public token" do
     VCR.use_cassette("plaid/exchange_public_token") do
       public_token = @plaid.create_public_token

--- a/test/models/provider/plaid_test.rb
+++ b/test/models/provider/plaid_test.rb
@@ -37,7 +37,8 @@ class Provider::PlaidTest < ActiveSupport::TestCase
     Plaid::LinkTokenCreateRequest.expects(:new).with do |params|
       params[:access_token] == "access-token" &&
         params[:update] == { account_selection_enabled: true } &&
-        params[:products].nil?
+        params[:products].nil? &&
+        params[:transactions].nil?
     end.returns(request)
     @plaid.client.expects(:link_token_create).with(request).returns("response")
 


### PR DESCRIPTION
Closes #3198.

## Summary

- expose an **Add accounts** action for healthy Plaid connections
- open Plaid Link in update mode with `update.account_selection_enabled`
- preserve the existing reauthentication path for connections requiring an update
- cover request construction, model propagation, and controller behavior

## Why

Using the normal new-connection flow for an institution that is already linked can create duplicate accounts. Update-mode account selection lets newly available accounts join the existing Plaid Item and retain the established mappings.

## Validation

- `git diff --check`
- ERB compilation check
- focused Rails tests added for provider, model, and controller behavior
- local execution is blocked by the workstation system Ruby 2.6; GitHub CI is the authoritative Ruby 3.4.9 run

## Risk and rollback

The new Plaid request option is opt-in and only used by the new action. Existing new-item and reconnect flows retain their prior defaults. Rollback is a revert of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Add accounts”** option for eligible U.S. Plaid connections.
  * Account selection is now available during the update flow.
* **Improvements**
  * Improved synchronization handling with automatic follow-up retries after active syncs complete.
  * Updated development sync controls for eligible non-U.S. connections.
  * Preserved existing account and transaction settings when updating connections.
* **Tests**
  * Added coverage for account selection, adding accounts, and follow-up synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->