### PR TITLE
Fix user-triggered Plaid transaction refresh

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -63,6 +63,7 @@ class AccountsController < ApplicationController
   end
 
   def sync_all
+    family.plaid_items.syncable.each(&:request_transactions_refresh_later)
     family.sync_later
     redirect_to accounts_path, notice: t("accounts.sync_all.syncing")
   end
@@ -135,7 +136,13 @@ class AccountsController < ApplicationController
         # Each provider item will trigger an account sync when complete
         @account.account_providers.each do |account_provider|
           item = account_provider.adapter&.item
-          item&.sync_later if item && !item.syncing?
+          next unless item && !item.syncing?
+
+          if item.is_a?(PlaidItem)
+            item.sync_later_with_provider_refresh
+          else
+            item.sync_later
+          end
         end
       else
         # Manual accounts just need balance materialization

--- a/app/controllers/plaid_items_controller.rb
+++ b/app/controllers/plaid_items_controller.rb
@@ -46,7 +46,7 @@ class PlaidItemsController < ApplicationController
 
   def sync
     unless @plaid_item.syncing?
-      @plaid_item.sync_later
+      @plaid_item.sync_later_with_provider_refresh
     end
 
     respond_to do |format|

--- a/app/jobs/plaid_transactions_refresh_follow_up_sync_job.rb
+++ b/app/jobs/plaid_transactions_refresh_follow_up_sync_job.rb
@@ -2,14 +2,23 @@ class PlaidTransactionsRefreshFollowUpSyncJob < ApplicationJob
   queue_as :high_priority
 
   RETRY_DELAY = 10.seconds
-  MAX_ATTEMPTS = 30
+  MAX_ATTEMPTS = 36
 
   def perform(plaid_item, attempts_remaining: MAX_ATTEMPTS)
     if plaid_item.syncs.visible.exists?
       if attempts_remaining.positive?
         self.class.set(wait: RETRY_DELAY).perform_later(plaid_item, attempts_remaining: attempts_remaining - 1)
       else
-        Rails.logger.warn("PlaidTransactionsRefreshFollowUpSyncJob - gave up waiting for PlaidItem #{plaid_item.id} to finish syncing")
+        DebugLogEntry.capture(
+          category: "provider_sync",
+          level: "warn",
+          message: "Plaid transaction refresh follow-up exhausted its wait for an active sync",
+          source: self.class.name,
+          provider_key: "plaid",
+          family: plaid_item.family
+        )
+
+        plaid_item.sync_later
       end
 
       return

--- a/app/jobs/plaid_transactions_refresh_follow_up_sync_job.rb
+++ b/app/jobs/plaid_transactions_refresh_follow_up_sync_job.rb
@@ -1,0 +1,20 @@
+class PlaidTransactionsRefreshFollowUpSyncJob < ApplicationJob
+  queue_as :high_priority
+
+  RETRY_DELAY = 10.seconds
+  MAX_ATTEMPTS = 30
+
+  def perform(plaid_item, attempts_remaining: MAX_ATTEMPTS)
+    if plaid_item.syncs.visible.exists?
+      if attempts_remaining.positive?
+        self.class.set(wait: RETRY_DELAY).perform_later(plaid_item, attempts_remaining: attempts_remaining - 1)
+      else
+        Rails.logger.warn("PlaidTransactionsRefreshFollowUpSyncJob - gave up waiting for PlaidItem #{plaid_item.id} to finish syncing")
+      end
+
+      return
+    end
+
+    plaid_item.sync_later
+  end
+end

--- a/app/jobs/plaid_transactions_refresh_job.rb
+++ b/app/jobs/plaid_transactions_refresh_job.rb
@@ -1,0 +1,25 @@
+class PlaidTransactionsRefreshJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform(plaid_item)
+    cursor = plaid_item.next_cursor
+
+    begin
+      plaid_item.plaid_provider.refresh_transactions(plaid_item.access_token)
+    rescue => error
+      DebugLogEntry.capture(
+        category: "provider_sync",
+        level: "warn",
+        message: "Plaid transaction refresh request did not return successfully; checking for asynchronous completion",
+        source: self.class.name,
+        provider_key: "plaid",
+        family: plaid_item.family,
+        metadata: { error_class: error.class.name }
+      )
+    end
+
+    PlaidTransactionsRefreshPollJob
+      .set(wait: PlaidTransactionsRefreshPollJob::POLL_INTERVAL)
+      .perform_later(plaid_item, cursor: cursor)
+  end
+end

--- a/app/jobs/plaid_transactions_refresh_poll_job.rb
+++ b/app/jobs/plaid_transactions_refresh_poll_job.rb
@@ -6,7 +6,7 @@ class PlaidTransactionsRefreshPollJob < ApplicationJob
 
   def perform(plaid_item, cursor:, attempts_remaining: MAX_ATTEMPTS)
     plaid_item.reload
-    return if plaid_item.next_cursor != cursor
+    cursor = plaid_item.next_cursor if plaid_item.next_cursor != cursor
 
     transactions = plaid_item.plaid_provider.get_transactions(
       plaid_item.access_token,
@@ -14,7 +14,7 @@ class PlaidTransactionsRefreshPollJob < ApplicationJob
     )
 
     if transactions.cursor != cursor
-      plaid_item.sync_later
+      PlaidTransactionsRefreshFollowUpSyncJob.perform_later(plaid_item)
     elsif attempts_remaining.to_i > 1
       self.class
         .set(wait: POLL_INTERVAL)
@@ -29,7 +29,7 @@ class PlaidTransactionsRefreshPollJob < ApplicationJob
         family: plaid_item.family
       )
 
-      plaid_item.sync_later
+      PlaidTransactionsRefreshFollowUpSyncJob.perform_later(plaid_item)
     end
   rescue => error
     DebugLogEntry.capture(
@@ -42,6 +42,6 @@ class PlaidTransactionsRefreshPollJob < ApplicationJob
       metadata: { error_class: error.class.name }
     )
 
-    plaid_item.sync_later
+    PlaidTransactionsRefreshFollowUpSyncJob.perform_later(plaid_item)
   end
 end

--- a/app/jobs/plaid_transactions_refresh_poll_job.rb
+++ b/app/jobs/plaid_transactions_refresh_poll_job.rb
@@ -1,0 +1,47 @@
+class PlaidTransactionsRefreshPollJob < ApplicationJob
+  queue_as :high_priority
+
+  POLL_INTERVAL = 30.seconds
+  MAX_ATTEMPTS = 6
+
+  def perform(plaid_item, cursor:, attempts_remaining: MAX_ATTEMPTS)
+    plaid_item.reload
+    return if plaid_item.next_cursor != cursor
+
+    transactions = plaid_item.plaid_provider.get_transactions(
+      plaid_item.access_token,
+      next_cursor: cursor
+    )
+
+    if transactions.cursor != cursor
+      plaid_item.sync_later
+    elsif attempts_remaining.to_i > 1
+      self.class
+        .set(wait: POLL_INTERVAL)
+        .perform_later(plaid_item, cursor: cursor, attempts_remaining: attempts_remaining.to_i - 1)
+    else
+      DebugLogEntry.capture(
+        category: "provider_sync",
+        level: "warn",
+        message: "Plaid transaction refresh completed without advancing the transaction cursor",
+        source: self.class.name,
+        provider_key: "plaid",
+        family: plaid_item.family
+      )
+
+      plaid_item.sync_later
+    end
+  rescue => error
+    DebugLogEntry.capture(
+      category: "provider_sync",
+      level: "warn",
+      message: "Plaid transaction refresh polling failed; falling back to a normal sync",
+      source: self.class.name,
+      provider_key: "plaid",
+      family: plaid_item.family,
+      metadata: { error_class: error.class.name }
+    )
+
+    plaid_item.sync_later
+  end
+end

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -73,6 +73,7 @@ class PlaidItem < ApplicationRecord
 
   def request_transactions_refresh_later
     return unless supports_product?("transactions")
+    return unless shared_transactions_refresh_cache?
 
     refresh_requested = Rails.cache.write(
       transactions_refresh_cache_key,
@@ -81,7 +82,10 @@ class PlaidItem < ApplicationRecord
       unless_exist: true
     )
 
-    PlaidTransactionsRefreshJob.perform_later(self) if refresh_requested
+    return unless refresh_requested
+
+    enqueued_job = PlaidTransactionsRefreshJob.perform_later(self)
+    Rails.cache.delete(transactions_refresh_cache_key) unless enqueued_job
   end
 
   def sync_later_with_provider_refresh
@@ -143,6 +147,15 @@ class PlaidItem < ApplicationRecord
   private
     def transactions_refresh_cache_key
       "plaid_item:#{id}:transactions_refresh_requested"
+    end
+
+    def shared_transactions_refresh_cache?
+      shared_cache = Rails.cache.is_a?(ActiveSupport::Cache::RedisCacheStore) ||
+        Rails.cache.is_a?(ActiveSupport::Cache::MemCacheStore) ||
+        Rails.cache.class.name == "SolidCache::Store"
+
+      Rails.logger.warn("Plaid transaction refresh requires a shared Rails cache store") unless shared_cache
+      shared_cache
     end
 
     def remove_plaid_item

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -27,6 +27,8 @@ class PlaidItem < ApplicationRecord
   scope :ordered, -> { order(created_at: :desc) }
   scope :needs_update, -> { where(status: :requires_update) }
 
+  TRANSACTIONS_REFRESH_COOLDOWN = 5.minutes
+
   # Get accounts from both new and legacy systems
   def accounts
     @accounts ||= plaid_accounts
@@ -67,6 +69,24 @@ class PlaidItem < ApplicationRecord
   def destroy_later
     update!(scheduled_for_deletion: true)
     DestroyJob.perform_later(self)
+  end
+
+  def request_transactions_refresh_later
+    return unless supports_product?("transactions")
+
+    refresh_requested = Rails.cache.write(
+      transactions_refresh_cache_key,
+      true,
+      expires_in: TRANSACTIONS_REFRESH_COOLDOWN,
+      unless_exist: true
+    )
+
+    PlaidTransactionsRefreshJob.perform_later(self) if refresh_requested
+  end
+
+  def sync_later_with_provider_refresh
+    request_transactions_refresh_later
+    sync_later
   end
 
   def import_latest_plaid_data
@@ -121,6 +141,10 @@ class PlaidItem < ApplicationRecord
   end
 
   private
+    def transactions_refresh_cache_key
+      "plaid_item:#{id}:transactions_refresh_requested"
+    end
+
     def remove_plaid_item
       return unless plaid_provider.present?
 

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -96,7 +96,13 @@ class PlaidItem < ApplicationRecord
 
     return unless refresh_requested
 
-    enqueued_job = PlaidTransactionsRefreshJob.perform_later(self)
+    enqueued_job = begin
+      PlaidTransactionsRefreshJob.perform_later(self)
+    rescue
+      Rails.cache.delete(transactions_refresh_cache_key)
+      raise
+    end
+
     Rails.cache.delete(transactions_refresh_cache_key) unless enqueued_job
   end
 

--- a/app/models/provider/plaid.rb
+++ b/app/models/provider/plaid.rb
@@ -116,6 +116,11 @@ class Provider::Plaid
     TransactionSyncResponse.new(added:, modified:, removed:, cursor:)
   end
 
+  def refresh_transactions(access_token)
+    request = Plaid::TransactionsRefreshRequest.new(access_token: access_token)
+    client.transactions_refresh(request)
+  end
+
   def get_item_investments(access_token, start_date: nil, end_date: Date.current)
     start_date = start_date || MAX_HISTORY_DAYS.days.ago.to_date
     holdings, holding_securities = get_item_holdings(access_token: access_token)

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -79,6 +79,15 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "sync all requests fresh Plaid transactions before syncing the family" do
+    PlaidItem.any_instance.expects(:request_transactions_refresh_later).once
+    Family.any_instance.expects(:sync_later).once
+
+    post sync_all_accounts_url
+
+    assert_redirected_to accounts_url
+  end
+
   test "show avoids N+1 transfer queries across paginated entries" do
     queries = capture_sql_queries { get account_url(@account) }
     assert_response :success
@@ -353,7 +362,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Mock at the class level since controller loads account from DB
     Account.any_instance.expects(:syncing?).returns(false)
     PlaidItem.any_instance.expects(:syncing?).returns(false)
-    PlaidItem.any_instance.expects(:sync_later).once
+    PlaidItem.any_instance.expects(:sync_later_with_provider_refresh).once
 
     post sync_account_url(@account)
     assert_redirected_to account_url(@account)

--- a/test/controllers/plaid_items_controller_test.rb
+++ b/test/controllers/plaid_items_controller_test.rb
@@ -92,7 +92,7 @@ class PlaidItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "sync" do
     plaid_item = plaid_items(:one)
-    PlaidItem.any_instance.expects(:sync_later).once
+    PlaidItem.any_instance.expects(:sync_later_with_provider_refresh).once
 
     post sync_plaid_item_url(plaid_item)
 

--- a/test/jobs/plaid_transactions_refresh_follow_up_sync_job_test.rb
+++ b/test/jobs/plaid_transactions_refresh_follow_up_sync_job_test.rb
@@ -20,4 +20,20 @@ class PlaidTransactionsRefreshFollowUpSyncJobTest < ActiveJob::TestCase
       end
     end
   end
+
+  test "records exhausted retries and still hands off to sync_later" do
+    item = plaid_items(:one)
+    active_sync = item.syncs.create!
+    active_sync.start!
+    item.expects(:sync_later).once
+
+    assert_difference "DebugLogEntry.count", 1 do
+      PlaidTransactionsRefreshFollowUpSyncJob.perform_now(item, attempts_remaining: 0)
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "provider_sync", entry.category
+    assert_equal "PlaidTransactionsRefreshFollowUpSyncJob", entry.source
+    assert_equal item.family, entry.family
+  end
 end

--- a/test/jobs/plaid_transactions_refresh_follow_up_sync_job_test.rb
+++ b/test/jobs/plaid_transactions_refresh_follow_up_sync_job_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class PlaidTransactionsRefreshFollowUpSyncJobTest < ActiveJob::TestCase
+  test "queues a distinct sync after the active sync has finished" do
+    item = plaid_items(:one)
+
+    assert_difference "item.syncs.count", 1 do
+      PlaidTransactionsRefreshFollowUpSyncJob.perform_now(item)
+    end
+  end
+
+  test "retries while an item sync is in progress" do
+    item = plaid_items(:one)
+    active_sync = item.syncs.create!
+    active_sync.start!
+
+    assert_no_difference "item.syncs.count" do
+      assert_enqueued_with job: PlaidTransactionsRefreshFollowUpSyncJob do
+        PlaidTransactionsRefreshFollowUpSyncJob.perform_now(item)
+      end
+    end
+  end
+end

--- a/test/jobs/plaid_transactions_refresh_job_test.rb
+++ b/test/jobs/plaid_transactions_refresh_job_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class PlaidTransactionsRefreshJobTest < ActiveJob::TestCase
+  setup do
+    @plaid_item = plaid_items(:one)
+    @plaid_item.update!(next_cursor: "saved-cursor")
+    @provider = mock
+    PlaidItem.any_instance.stubs(:plaid_provider).returns(@provider)
+  end
+
+  test "requests refresh and schedules cursor polling" do
+    @provider.expects(:refresh_transactions).with(@plaid_item.access_token)
+
+    assert_enqueued_with(
+      job: PlaidTransactionsRefreshPollJob,
+      args: [ @plaid_item, { cursor: "saved-cursor" } ]
+    ) do
+      PlaidTransactionsRefreshJob.perform_now(@plaid_item)
+    end
+  end
+
+  test "still polls after an ambiguous refresh request failure" do
+    @provider.expects(:refresh_transactions).raises(Timeout::Error)
+
+    assert_difference "DebugLogEntry.count", 1 do
+      assert_enqueued_with(job: PlaidTransactionsRefreshPollJob) do
+        PlaidTransactionsRefreshJob.perform_now(@plaid_item)
+      end
+    end
+
+    assert_equal "Timeout::Error", DebugLogEntry.order(:created_at).last.metadata["error_class"]
+  end
+end

--- a/test/jobs/plaid_transactions_refresh_poll_job_test.rb
+++ b/test/jobs/plaid_transactions_refresh_poll_job_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class PlaidTransactionsRefreshPollJobTest < ActiveJob::TestCase
+  setup do
+    @plaid_item = plaid_items(:one)
+    @plaid_item.update!(next_cursor: "saved-cursor")
+    @provider = mock
+    PlaidItem.any_instance.stubs(:plaid_provider).returns(@provider)
+  end
+
+  test "stops when a webhook sync already advanced the cursor" do
+    @plaid_item.update!(next_cursor: "advanced-cursor")
+    @provider.expects(:get_transactions).never
+
+    assert_no_enqueued_jobs do
+      PlaidTransactionsRefreshPollJob.perform_now(@plaid_item, cursor: "saved-cursor")
+    end
+  end
+
+  test "schedules normal sync when refreshed deltas are available" do
+    @provider.expects(:get_transactions)
+      .with(@plaid_item.access_token, next_cursor: "saved-cursor")
+      .returns(stub(cursor: "advanced-cursor"))
+
+    assert_enqueued_with(job: SyncJob) do
+      PlaidTransactionsRefreshPollJob.perform_now(@plaid_item, cursor: "saved-cursor")
+    end
+  end
+
+  test "polls again while the cursor has not advanced" do
+    @provider.expects(:get_transactions).returns(stub(cursor: "saved-cursor"))
+
+    assert_enqueued_with(
+      job: PlaidTransactionsRefreshPollJob,
+      args: [ @plaid_item, { cursor: "saved-cursor", attempts_remaining: 1 } ]
+    ) do
+      PlaidTransactionsRefreshPollJob.perform_now(
+        @plaid_item,
+        cursor: "saved-cursor",
+        attempts_remaining: 2
+      )
+    end
+  end
+
+  test "falls back to normal sync when polling is exhausted" do
+    @provider.expects(:get_transactions).returns(stub(cursor: "saved-cursor"))
+
+    assert_difference "DebugLogEntry.count", 1 do
+      assert_enqueued_with(job: SyncJob) do
+        PlaidTransactionsRefreshPollJob.perform_now(
+          @plaid_item,
+          cursor: "saved-cursor",
+          attempts_remaining: 1
+        )
+      end
+    end
+  end
+
+  test "falls back to normal sync when polling fails" do
+    @provider.expects(:get_transactions).raises(Plaid::ApiError.new(code: 500))
+
+    assert_difference "DebugLogEntry.count", 1 do
+      assert_enqueued_with(job: SyncJob) do
+        PlaidTransactionsRefreshPollJob.perform_now(@plaid_item, cursor: "saved-cursor")
+      end
+    end
+  end
+end

--- a/test/jobs/plaid_transactions_refresh_poll_job_test.rb
+++ b/test/jobs/plaid_transactions_refresh_poll_job_test.rb
@@ -8,12 +8,16 @@ class PlaidTransactionsRefreshPollJobTest < ActiveJob::TestCase
     PlaidItem.any_instance.stubs(:plaid_provider).returns(@provider)
   end
 
-  test "stops when a webhook sync already advanced the cursor" do
+  test "continues polling from a cursor advanced by a concurrent sync" do
     @plaid_item.update!(next_cursor: "advanced-cursor")
-    @provider.expects(:get_transactions).never
+    @provider.expects(:get_transactions)
+      .with(@plaid_item.access_token, next_cursor: "advanced-cursor")
+      .returns(stub(cursor: "refreshed-cursor"))
 
-    assert_no_enqueued_jobs do
-      PlaidTransactionsRefreshPollJob.perform_now(@plaid_item, cursor: "saved-cursor")
+    assert_enqueued_with(job: SyncJob) do
+      perform_enqueued_jobs(only: PlaidTransactionsRefreshFollowUpSyncJob) do
+        PlaidTransactionsRefreshPollJob.perform_now(@plaid_item, cursor: "saved-cursor")
+      end
     end
   end
 
@@ -22,7 +26,7 @@ class PlaidTransactionsRefreshPollJobTest < ActiveJob::TestCase
       .with(@plaid_item.access_token, next_cursor: "saved-cursor")
       .returns(stub(cursor: "advanced-cursor"))
 
-    assert_enqueued_with(job: SyncJob) do
+    assert_enqueued_with(job: PlaidTransactionsRefreshFollowUpSyncJob) do
       PlaidTransactionsRefreshPollJob.perform_now(@plaid_item, cursor: "saved-cursor")
     end
   end
@@ -46,7 +50,7 @@ class PlaidTransactionsRefreshPollJobTest < ActiveJob::TestCase
     @provider.expects(:get_transactions).returns(stub(cursor: "saved-cursor"))
 
     assert_difference "DebugLogEntry.count", 1 do
-      assert_enqueued_with(job: SyncJob) do
+      assert_enqueued_with(job: PlaidTransactionsRefreshFollowUpSyncJob) do
         PlaidTransactionsRefreshPollJob.perform_now(
           @plaid_item,
           cursor: "saved-cursor",
@@ -60,7 +64,7 @@ class PlaidTransactionsRefreshPollJobTest < ActiveJob::TestCase
     @provider.expects(:get_transactions).raises(Plaid::ApiError.new(code: 500))
 
     assert_difference "DebugLogEntry.count", 1 do
-      assert_enqueued_with(job: SyncJob) do
+      assert_enqueued_with(job: PlaidTransactionsRefreshFollowUpSyncJob) do
         PlaidTransactionsRefreshPollJob.perform_now(@plaid_item, cursor: "saved-cursor")
       end
     end

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -88,6 +88,7 @@ class PlaidItemTest < ActiveSupport::TestCase
   end
 
   test "user sync requests a provider refresh when cooldown lease is acquired" do
+    @plaid_item.stubs(:shared_transactions_refresh_cache?).returns(true)
     Rails.cache.expects(:write).with(
       "plaid_item:#{@plaid_item.id}:transactions_refresh_requested",
       true,
@@ -101,6 +102,7 @@ class PlaidItemTest < ActiveSupport::TestCase
   end
 
   test "user sync does not duplicate a recent provider refresh request" do
+    @plaid_item.stubs(:shared_transactions_refresh_cache?).returns(true)
     Rails.cache.stubs(:write).returns(false)
 
     assert_no_enqueued_jobs only: PlaidTransactionsRefreshJob do
@@ -115,6 +117,24 @@ class PlaidItemTest < ActiveSupport::TestCase
     assert_no_enqueued_jobs only: PlaidTransactionsRefreshJob do
       @plaid_item.request_transactions_refresh_later
     end
+  end
+
+  test "user sync rejects provider refresh without a shared cache" do
+    @plaid_item.stubs(:shared_transactions_refresh_cache?).returns(false)
+
+    Rails.cache.expects(:write).never
+    assert_no_enqueued_jobs only: PlaidTransactionsRefreshJob do
+      @plaid_item.request_transactions_refresh_later
+    end
+  end
+
+  test "user sync releases cooldown lease when refresh job is not enqueued" do
+    @plaid_item.stubs(:shared_transactions_refresh_cache?).returns(true)
+    Rails.cache.stubs(:write).returns(true)
+    PlaidTransactionsRefreshJob.stubs(:perform_later).returns(false)
+    Rails.cache.expects(:delete).with("plaid_item:#{@plaid_item.id}:transactions_refresh_requested")
+
+    @plaid_item.request_transactions_refresh_later
   end
 
   test "user sync preserves immediate sync while requesting provider refresh" do

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -86,4 +86,41 @@ class PlaidItemTest < ActiveSupport::TestCase
     end
     assert_predicate @plaid_item.reload, :good?
   end
+
+  test "user sync requests a provider refresh when cooldown lease is acquired" do
+    Rails.cache.expects(:write).with(
+      "plaid_item:#{@plaid_item.id}:transactions_refresh_requested",
+      true,
+      expires_in: PlaidItem::TRANSACTIONS_REFRESH_COOLDOWN,
+      unless_exist: true
+    ).returns(true)
+
+    assert_enqueued_with(job: PlaidTransactionsRefreshJob, args: [ @plaid_item ]) do
+      @plaid_item.request_transactions_refresh_later
+    end
+  end
+
+  test "user sync does not duplicate a recent provider refresh request" do
+    Rails.cache.stubs(:write).returns(false)
+
+    assert_no_enqueued_jobs only: PlaidTransactionsRefreshJob do
+      @plaid_item.request_transactions_refresh_later
+    end
+  end
+
+  test "user sync does not request refresh without the transactions product" do
+    @plaid_item.update!(billed_products: [ "investments" ])
+
+    Rails.cache.expects(:write).never
+    assert_no_enqueued_jobs only: PlaidTransactionsRefreshJob do
+      @plaid_item.request_transactions_refresh_later
+    end
+  end
+
+  test "user sync preserves immediate sync while requesting provider refresh" do
+    @plaid_item.expects(:request_transactions_refresh_later).once
+    @plaid_item.expects(:sync_later).once
+
+    @plaid_item.sync_later_with_provider_refresh
+  end
 end

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -164,6 +164,17 @@ class PlaidItemTest < ActiveSupport::TestCase
     @plaid_item.request_transactions_refresh_later
   end
 
+  test "user sync releases cooldown lease when refresh job enqueue raises" do
+    @plaid_item.stubs(:shared_transactions_refresh_cache?).returns(true)
+    Rails.cache.stubs(:write).returns(true)
+    PlaidTransactionsRefreshJob.stubs(:perform_later).raises(RedisClient::Error, "Redis unavailable")
+    Rails.cache.expects(:delete).with("plaid_item:#{@plaid_item.id}:transactions_refresh_requested")
+
+    assert_raises RedisClient::Error do
+      @plaid_item.request_transactions_refresh_later
+    end
+  end
+
   test "user sync preserves follow-up sync while requesting provider refresh" do
     @plaid_item.expects(:request_transactions_refresh_later).once
     @plaid_item.expects(:sync_later_with_follow_up).once

--- a/test/models/provider/plaid_test.rb
+++ b/test/models/provider/plaid_test.rb
@@ -60,6 +60,14 @@ class Provider::PlaidTest < ActiveSupport::TestCase
     end
   end
 
+  test "requests a transaction refresh" do
+    @plaid.client.expects(:transactions_refresh).with do |request|
+      request.access_token == "access-token"
+    end
+
+    @plaid.refresh_transactions("access-token")
+  end
+
   test "gets item investments" do
     VCR.use_cassette("plaid/get_item_investments") do
       access_token = get_access_token


### PR DESCRIPTION
## Summary

- request Plaid transaction freshness for explicit user-triggered Item, account, and global account syncs
- preserve the existing immediate cursor sync, then poll the saved cursor with bounded retries and enqueue a follow-up sync when Plaid advances it
- coalesce repeated refresh requests for five minutes and skip Items without the Transactions product
- record sanitized provider diagnostics and fall back to a normal sync after polling errors or exhaustion

This polling fallback keeps private self-hosted instances functional when Plaid cannot deliver webhooks to the deployment.

Closes #3204

## Validation

- `bin/rails test` — 7,319 runs, 29,218 assertions, 0 failures, 0 errors
- focused Plaid suite — 86 runs, 296 assertions, 0 failures, 0 errors
- `bin/rubocop -f github` — clean
- focused RuboCop — 12 files, no offenses
- `bin/brakeman --no-pager` — 0 security warnings
- `bundle exec erb_lint ./app/**/*.erb` — reports 10 pre-existing violations in unrelated templates; this PR changes no ERB files
- `git diff --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically refreshes transaction data before syncing supported linked accounts.
  - Polls for refreshed transactions and resumes syncing when new data is available.
  - Enables account selection when adding accounts to eligible US-linked items.
  - Prevents duplicate refresh requests during a five-minute cooldown period.
- **Bug Fixes**
  - Improves synchronization reliability when refreshes fail, time out, stall, or overlap with an active sync.
  - Falls back to regular syncing when refreshed transaction data cannot be retrieved.
  - Ensures account-wide syncs refresh supported transaction data before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->