### PR TITLE
Handle duplicate category and tag names before indexing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,7 @@ Purpose: provide short, actionable guidance so Copilot suggestions match project
 - `bin/rails db:migrate` - Run pending migrations
 - `bin/rails db:rollback` - Rollback last migration
 - `bin/rails db:seed` - Load seed data
+- New migrations on `main` should inherit from `ActiveRecord::Migration[8.1]`; backport/release branches may keep the Rails migration version used by that branch.
 
 ### Setup
 - `bin/setup` - Initial project setup (installs dependencies, prepares database)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 
 ## Coding Style & Naming Conventions
 - Ruby: 2-space indent, `snake_case` for methods/vars, `CamelCase` for classes/modules. Follow Rails conventions for folders and file names.
+- Migrations on `main`: inherit from `ActiveRecord::Migration[8.1]`. Backport/release branches may keep the Rails migration version used by that branch.
 - Views: ERB checked by `erb-lint` (see `.erb_lint.yml`). Avoid heavy logic in views; prefer helpers/components.
 - JavaScript: `lowerCamelCase` for vars/functions, `PascalCase` for classes/components. Let Biome format code.
 - Commit small, cohesive changes; keep diffs focused.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ To watch the browser live, open `http://localhost:7900` or `http://localhost:444
 - `bin/rails db:migrate` - Run pending migrations
 - `bin/rails db:rollback` - Rollback last migration
 - `bin/rails db:seed` - Load seed data
+- New migrations on `main` should inherit from `ActiveRecord::Migration[8.1]`; backport/release branches may keep the Rails migration version used by that branch.
 
 ### Setup
 - `bin/setup` - Initial project setup (installs dependencies, prepares database)

--- a/db/migrate/20260727120000_add_family_name_index_to_tags_and_categories.rb
+++ b/db/migrate/20260727120000_add_family_name_index_to_tags_and_categories.rb
@@ -93,6 +93,46 @@ class AddFamilyNameIndexToTagsAndCategories < ActiveRecord::Migration[8.1]
           FROM tags
         ),
         tag_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_tags
+          WHERE id <> keeper_id
+        )
+        UPDATE rule_actions
+        SET value = tag_map.keeper_id::text
+        FROM tag_map
+        WHERE rule_actions.action_type = 'set_transaction_tags'
+          AND rule_actions.value = tag_map.duplicate_id::text
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_tags AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM tags
+        ),
+        tag_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_tags
+          WHERE id <> keeper_id
+        )
+        UPDATE rule_conditions
+        SET value = tag_map.keeper_id::text
+        FROM tag_map
+        WHERE rule_conditions.condition_type = 'transaction_tag'
+          AND rule_conditions.value = tag_map.duplicate_id::text
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_tags AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM tags
+        ),
+        tag_map AS (
           SELECT id AS duplicate_id
           FROM duplicate_tags
           WHERE id <> keeper_id
@@ -299,6 +339,46 @@ class AddFamilyNameIndexToTagsAndCategories < ActiveRecord::Migration[8.1]
         SET category_id = category_map.keeper_id
         FROM category_map
         WHERE budget_categories.category_id = category_map.duplicate_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        UPDATE rule_actions
+        SET value = category_map.keeper_id::text
+        FROM category_map
+        WHERE rule_actions.action_type = 'set_transaction_category'
+          AND rule_actions.value = category_map.duplicate_id::text
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        UPDATE rule_conditions
+        SET value = category_map.keeper_id::text
+        FROM category_map
+        WHERE rule_conditions.condition_type = 'transaction_category'
+          AND rule_conditions.value = category_map.duplicate_id::text
       SQL
 
       execute <<~SQL.squish

--- a/db/migrate/20260727120000_add_family_name_index_to_tags_and_categories.rb
+++ b/db/migrate/20260727120000_add_family_name_index_to_tags_and_categories.rb
@@ -1,6 +1,322 @@
-class AddFamilyNameIndexToTagsAndCategories < ActiveRecord::Migration[7.2]
-  def change
+class AddFamilyNameIndexToTagsAndCategories < ActiveRecord::Migration[8.1]
+  def up
+    merge_duplicate_tags
+    merge_duplicate_categories
+
     add_index :tags, [ :family_id, :name ], unique: true
     add_index :categories, [ :family_id, :name ], unique: true
   end
+
+  def down
+    remove_index :categories, [ :family_id, :name ]
+    remove_index :tags, [ :family_id, :name ]
+  end
+
+  private
+    def merge_duplicate_tags
+      execute <<~SQL.squish
+        WITH duplicate_tags AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM tags
+        ),
+        tag_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_tags
+          WHERE id <> keeper_id
+        )
+        UPDATE import_mappings
+        SET mappable_id = tag_map.keeper_id
+        FROM tag_map
+        WHERE import_mappings.mappable_type = 'Tag'
+          AND import_mappings.mappable_id = tag_map.duplicate_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_tags AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM tags
+        ),
+        tag_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_tags
+          WHERE id <> keeper_id
+        )
+        UPDATE taggings
+        SET tag_id = tag_map.keeper_id
+        FROM tag_map
+        WHERE taggings.tag_id = tag_map.duplicate_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_tags AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM tags
+        ),
+        impacted_tags AS (
+          SELECT DISTINCT keeper_id
+          FROM duplicate_tags
+          WHERE id <> keeper_id
+        ),
+        duplicate_taggings AS (
+          SELECT id
+          FROM (
+            SELECT taggings.id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY taggings.tag_id, taggings.taggable_type, taggings.taggable_id
+                     ORDER BY taggings.created_at, taggings.id
+                   ) AS row_number
+            FROM taggings
+            JOIN impacted_tags ON taggings.tag_id = impacted_tags.keeper_id
+          ) ranked_taggings
+          WHERE row_number > 1
+        )
+        DELETE FROM taggings
+        USING duplicate_taggings
+        WHERE taggings.id = duplicate_taggings.id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_tags AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM tags
+        ),
+        tag_map AS (
+          SELECT id AS duplicate_id
+          FROM duplicate_tags
+          WHERE id <> keeper_id
+        )
+        DELETE FROM tags
+        USING tag_map
+        WHERE tags.id = tag_map.duplicate_id
+      SQL
+    end
+
+    def merge_duplicate_categories
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        UPDATE import_mappings
+        SET mappable_id = category_map.keeper_id
+        FROM category_map
+        WHERE import_mappings.mappable_type = 'Category'
+          AND import_mappings.mappable_id = category_map.duplicate_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        UPDATE transactions
+        SET category_id = category_map.keeper_id
+        FROM category_map
+        WHERE transactions.category_id = category_map.duplicate_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        UPDATE categories
+        SET parent_id = category_map.keeper_id
+        FROM category_map
+        WHERE categories.parent_id = category_map.duplicate_id
+          AND categories.id <> category_map.keeper_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        UPDATE categories
+        SET parent_id = NULL
+        FROM category_map
+        WHERE categories.id = category_map.keeper_id
+          AND categories.parent_id = category_map.duplicate_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        ),
+        canonical_budget_categories AS (
+          SELECT budget_categories.id,
+                 budget_categories.budget_id,
+                 budget_categories.category_id,
+                 COALESCE(category_map.keeper_id, budget_categories.category_id) AS keeper_id,
+                 budget_categories.budgeted_spending
+          FROM budget_categories
+          LEFT JOIN category_map ON budget_categories.category_id = category_map.duplicate_id
+          WHERE category_map.keeper_id IS NOT NULL
+             OR EXISTS (
+               SELECT 1
+               FROM category_map existing_map
+               WHERE existing_map.keeper_id = budget_categories.category_id
+             )
+        ),
+        duplicate_budget_category_totals AS (
+          SELECT budget_id,
+                 keeper_id,
+                 SUM(budgeted_spending) AS budgeted_spending
+          FROM canonical_budget_categories
+          GROUP BY budget_id, keeper_id
+          HAVING COUNT(*) > 1
+        ),
+        budget_category_keepers AS (
+          SELECT id,
+                 budget_id,
+                 keeper_id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY budget_id, keeper_id
+                   ORDER BY (category_id = keeper_id) DESC, id
+                 ) AS row_number
+          FROM canonical_budget_categories
+        )
+        UPDATE budget_categories
+        SET budgeted_spending = duplicate_budget_category_totals.budgeted_spending
+        FROM budget_category_keepers
+        JOIN duplicate_budget_category_totals ON duplicate_budget_category_totals.budget_id = budget_category_keepers.budget_id
+          AND duplicate_budget_category_totals.keeper_id = budget_category_keepers.keeper_id
+        WHERE budget_categories.id = budget_category_keepers.id
+          AND budget_category_keepers.row_number = 1
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        ),
+        canonical_budget_categories AS (
+          SELECT budget_categories.id,
+                 budget_categories.budget_id,
+                 budget_categories.category_id,
+                 COALESCE(category_map.keeper_id, budget_categories.category_id) AS keeper_id
+          FROM budget_categories
+          LEFT JOIN category_map ON budget_categories.category_id = category_map.duplicate_id
+          WHERE category_map.keeper_id IS NOT NULL
+             OR EXISTS (
+               SELECT 1
+               FROM category_map existing_map
+               WHERE existing_map.keeper_id = budget_categories.category_id
+             )
+        ),
+        duplicate_budget_categories AS (
+          SELECT id
+          FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY budget_id, keeper_id
+                     ORDER BY (category_id = keeper_id) DESC, id
+                   ) AS row_number
+            FROM canonical_budget_categories
+          ) ranked_budget_categories
+          WHERE row_number > 1
+        )
+        DELETE FROM budget_categories
+        USING duplicate_budget_categories
+        WHERE budget_categories.id = duplicate_budget_categories.id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id, keeper_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        UPDATE budget_categories
+        SET category_id = category_map.keeper_id
+        FROM category_map
+        WHERE budget_categories.category_id = category_map.duplicate_id
+      SQL
+
+      execute <<~SQL.squish
+        WITH duplicate_categories AS (
+          SELECT id, FIRST_VALUE(id) OVER (
+            PARTITION BY family_id, name
+            ORDER BY created_at, id
+          ) AS keeper_id
+          FROM categories
+        ),
+        category_map AS (
+          SELECT id AS duplicate_id
+          FROM duplicate_categories
+          WHERE id <> keeper_id
+        )
+        DELETE FROM categories
+        USING category_map
+        WHERE categories.id = category_map.duplicate_id
+      SQL
+    end
 end


### PR DESCRIPTION
## Summary
- merge duplicate tags and categories before adding the family/name unique indexes on main
- consolidate budget category rows across the full duplicate category mapping before repointing
- dedupe taggings after applying the complete duplicate tag mapping
- keep this migration on ActiveRecord 8.1 for main

## Validation
- ruby -c db/migrate/20260727120000_add_family_name_index_to_tags_and_categories.rb
- bin/rubocop db/migrate/20260727120000_add_family_name_index_to_tags_and_categories.rb
- targeted Rails runner migration exercise for duplicate category budget rows and duplicate taggings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate tags and categories with the same family and name.
  * Preserved related imports, transactions, taggings, rules, budgets, and category hierarchies when duplicates are consolidated.
  * Combined duplicate budget entries while retaining spending totals and repaired category parent relationships.

* **Data Integrity**
  * Added safeguards to ensure tag and category names remain unique within each family.

* **Documentation**
  * Clarified migration version requirements for main and backport/release branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->