### PR TITLE
Fix flaky sign_out teardown in test suites

### DIFF
--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -8,9 +8,12 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
   end
 
   def sign_out
-    @user.sessions.each do |session|
-      delete session_path(session)
-    end
+    # Deleting sessions through the controller de-authenticates the request the
+    # moment our own session dies, so every later delete in the loop is a
+    # silent no-op and whichever sessions sort after it survive. The order is
+    # unspecified, which made every suite that signs out this way flaky.
+    # Teardown hygiene is not the behavior under test, so destroy directly.
+    @user.sessions.destroy_all
   end
 
   test "redirects to root if MFA already enabled" do

--- a/test/controllers/onboardings_controller_test.rb
+++ b/test/controllers/onboardings_controller_test.rb
@@ -210,8 +210,11 @@ end
     private
 
       def sign_out
-        @user.sessions.each do |session|
-          delete session_path(session)
-        end
+        # Deleting sessions through the controller de-authenticates the request the
+        # moment our own session dies, so every later delete in the loop is a
+        # silent no-op and whichever sessions sort after it survive. The order is
+        # unspecified, which made every suite that signs out this way flaky.
+        # Teardown hygiene is not the behavior under test, so destroy directly.
+        @user.sessions.destroy_all
       end
 end

--- a/test/controllers/passkey_sessions_controller_test.rb
+++ b/test/controllers/passkey_sessions_controller_test.rb
@@ -226,7 +226,12 @@ class PasskeySessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     def sign_out
-      @user.sessions.each { |session| delete session_path(session) }
+      # Deleting sessions through the controller de-authenticates the request the
+      # moment our own session dies, so every later delete in the loop is a
+      # silent no-op and whichever sessions sort after it survive. The order is
+      # unspecified, which made every suite that signs out this way flaky.
+      # Teardown hygiene is not the behavior under test, so destroy directly.
+      @user.sessions.destroy_all
     end
 
     def with_webauthn_config(rp_id:, allowed_origins:)

--- a/test/controllers/snaptrade_items_controller_test.rb
+++ b/test/controllers/snaptrade_items_controller_test.rb
@@ -7,9 +7,12 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def sign_out
-    @user.sessions.each do |session|
-      delete session_path(session)
-    end
+    # Deleting sessions through the controller de-authenticates the request the
+    # moment our own session dies, so every later delete in the loop is a
+    # silent no-op and whichever sessions sort after it survive. The order is
+    # unspecified, which made every suite that signs out this way flaky.
+    # Teardown hygiene is not the behavior under test, so destroy directly.
+    @user.sessions.destroy_all
   end
 
   # A deployment with a confidential OAuth client: both the browser redirect and

--- a/test/controllers/transactions/categorizes_controller_test.rb
+++ b/test/controllers/transactions/categorizes_controller_test.rb
@@ -176,7 +176,12 @@ class Transactions::CategorizesControllerTest < ActionDispatch::IntegrationTest
   private
 
     def sign_out
-      @user.sessions.each { |s| delete session_path(s) }
+      # Deleting sessions through the controller de-authenticates the request the
+      # moment our own session dies, so every later delete in the loop is a
+      # silent no-op and whichever sessions sort after it survive. The order is
+      # unspecified, which made every suite that signs out this way flaky.
+      # Teardown hygiene is not the behavior under test, so destroy directly.
+      @user.sessions.destroy_all
     end
 
     # POST /transactions/categorize

--- a/test/integration/active_storage_authorization_test.rb
+++ b/test/integration/active_storage_authorization_test.rb
@@ -288,7 +288,9 @@ class ActiveStorageAuthorizationTest < ActionDispatch::IntegrationTest
   private
 
     def sign_out(user)
-      user.sessions.each { |session| delete session_path(session) }
+      # Deleting through the controller de-authenticates mid-loop and later
+      # deletes silently no-op; destroy directly, no order to break.
+      user.sessions.destroy_all
     end
 
     def with_protected_record_types(*types)


### PR DESCRIPTION
Six test suites (passkey sessions, MFA, SnapTrade, categorize, onboarding, and the Active Storage authorization integration tests) share a `sign_out` helper that deletes the user's sessions through the controller, one HTTP request per session, iterating in whatever order the database returns rows.

The problem: the moment that loop deletes the session the test itself is signed in with, every later request in the loop is unauthenticated and silently deletes nothing, so whichever sessions happen to sort after it survive. The `sessions` fixture belongs to the same user these suites sign in as, so a surviving fixture row then fails every assertion that expects the user to have no sessions. That is why the failures always show a session with the fixture's `MyString` values.

Row order usually favors the fixture, which is why these suites usually pass. Under parallel CI they fail intermittently, always in this file family, always with the fixture session as the leftover. Forcing newest-first order makes it deterministic on current main: ten of the fifteen passkey tests fail.

Teardown hygiene is not the behavior under test, so the helpers now destroy the sessions directly, which no order can break. Nothing in any of the six suites asserts on cookies or depends on the fixture session existing, and the stale cookie a direct destroy leaves behind resolves to signed-out exactly like the controller path did. All six suites run green three times in a row, 130 tests each pass.

Test-only change, no app code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session cleanup in authentication-related tests.
  - Prevented flaky test results caused by incomplete sign-outs and inconsistent session ordering.

- **Tests**
  - Updated sign-out handling across controller and integration test scenarios to reliably remove all active sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->