### PR TITLE
fix(goals): make the figure beside the ring agree with the ring

### DIFF
--- a/app/components/goals/card_component.html.erb
+++ b/app/components/goals/card_component.html.erb
@@ -29,10 +29,20 @@
   </div>
 
   <div class="mt-5">
+    <%# The figure the ring is drawn from, not the account balance: money still
+        held plus money already spent on the goal itself. Showing the balance
+        alone put a 100% ring beside "3,000 of 5,000". %>
     <div class="flex items-baseline gap-1.5">
-      <span class="text-xl font-medium text-primary tabular-nums privacy-sensitive"><%= goal.current_balance_money.format(precision: 0) %></span>
+      <span class="text-xl font-medium text-primary tabular-nums privacy-sensitive"><%= goal.progress_amount_money.format(precision: 0) %></span>
       <span class="text-xs text-subdued tabular-nums privacy-sensitive">/ <%= goal.target_amount_money.format(precision: 0) %></span>
     </div>
+    <% if goal.any_consumption? %>
+      <%# "Including", not a second figure beside the first: the amount is part
+          of the total above, and a reader should not have to add anything. %>
+      <p class="text-xs text-subdued tabular-nums mt-1 privacy-sensitive">
+        <%= t("goals.goal_card.including_used", amount: goal.consumed_amount_money.format(precision: 0)) %>
+      </p>
+    <% end %>
     <% if pace_line %>
       <p class="text-xs text-subdued tabular-nums mt-1 privacy-sensitive"><%= pace_line %></p>
     <% end %>

--- a/app/components/goals/progress_ring_component.html.erb
+++ b/app/components/goals/progress_ring_component.html.erb
@@ -5,7 +5,7 @@
      aria-valuenow="<%= percent %>"
      aria-valuemin="0"
      aria-valuemax="100"
-     aria-label="<%= t("goals.show.ring.aria_label", percent: percent, amount: amount_label, target: target_label) %>"
+     aria-label="<%= aria_label %>"
      class="relative mx-auto"
      style="width: <%= size %>px; height: <%= size %>px;">
   <div data-donut-chart-target="chartContainer" class="absolute inset-0 pointer-events-none"></div>

--- a/app/components/goals/progress_ring_component.rb
+++ b/app/components/goals/progress_ring_component.rb
@@ -23,11 +23,11 @@ class Goals::ProgressRingComponent < ApplicationComponent
   # this is the same sentence for someone who cannot see it.
   def aria_label
     if goal.any_consumption?
-      I18n.t("goals.show.ring.aria_label_with_used",
+      t("goals.show.ring.aria_label_with_used",
              percent: percent, amount: amount_label, target: target_label,
              used: goal.consumed_amount_money.format)
     else
-      I18n.t("goals.show.ring.aria_label",
+      t("goals.show.ring.aria_label",
              percent: percent, amount: amount_label, target: target_label)
     end
   end

--- a/app/components/goals/progress_ring_component.rb
+++ b/app/components/goals/progress_ring_component.rb
@@ -10,8 +10,26 @@ class Goals::ProgressRingComponent < ApplicationComponent
     goal.progress_percent
   end
 
+  # The same total the headline beside this ring reports, and the same one the
+  # ring is drawn from. Announcing the account balance while the visible text
+  # said something else left a screen reader and a sighted reader looking at
+  # the same ring and hearing two different numbers.
   def amount_label
-    goal.current_balance_money.format
+    goal.progress_amount_money.format
+  end
+
+  # "saved" stops being the whole truth once part of the total has been spent
+  # on the goal. The sighted reader gets that from the line under the figure;
+  # this is the same sentence for someone who cannot see it.
+  def aria_label
+    if goal.any_consumption?
+      I18n.t("goals.show.ring.aria_label_with_used",
+             percent: percent, amount: amount_label, target: target_label,
+             used: goal.consumed_amount_money.format)
+    else
+      I18n.t("goals.show.ring.aria_label",
+             percent: percent, amount: amount_label, target: target_label)
+    end
   end
 
   def target_label

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -600,6 +600,33 @@ class Goal < ApplicationRecord
     @remaining_amount_money ||= Money.new(remaining_amount, currency)
   end
 
+  # What progress actually counts: money still held for the goal, plus money
+  # already taken out of it and spent on the thing it was for.
+  #
+  # `progress_percent` and `remaining_amount` have always been computed from
+  # both. Only the headline figure showed the first half, so a goal that had
+  # spent part of its savings sat at a 100% ring beside "3,000 of 5,000" — the
+  # ring and the numbers disagreeing on the same card, with nothing to explain
+  # which one to believe.
+  def progress_amount
+    current_balance.to_d + consumed_amount.to_d
+  end
+
+  def progress_amount_money
+    @progress_amount_money ||= Money.new(progress_amount, currency)
+  end
+
+  def consumed_amount_money
+    @consumed_amount_money ||= Money.new(consumed_amount.to_d, currency)
+  end
+
+  # Only a goal that has actually recorded a spend says anything about it: the
+  # overwhelming majority never do, and a permanent "0 used" line would be
+  # noise on every card.
+  def any_consumption?
+    consumed_amount.to_d.positive?
+  end
+
   def progress_percent
     return @progress_percent if defined?(@progress_percent)
 
@@ -1181,6 +1208,7 @@ class Goal < ApplicationRecord
         @current_balance @current_balance_money
         @remaining_amount @remaining_amount_money
         @progress_percent @monthly_target_amount
+        @progress_amount_money @consumed_amount_money
         @pace @pace_money @status @pooled_allocations
       ].each do |ivar|
         remove_instance_variable(ivar) if instance_variable_defined?(ivar)

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -133,7 +133,15 @@
   <section class="grid grid-cols-1 lg:grid-cols-[320px_minmax(0,1fr)] gap-3">
     <div class="rounded-xl p-5 flex flex-col items-center justify-center text-center">
       <%= render Goals::ProgressRingComponent.new(goal: @goal, size: 180) %>
-      <p class="text-xl font-medium text-primary tabular-nums privacy-sensitive mt-4"><%= @goal.current_balance_money.format(precision: 0) %></p>
+      <%# The figure the ring is drawn from — held plus already spent on the
+          goal — so the two agree. What is still sitting in each account is in
+          the funding breakdown below, which is where that question belongs. %>
+      <p class="text-xl font-medium text-primary tabular-nums privacy-sensitive mt-4"><%= @goal.progress_amount_money.format(precision: 0) %></p>
+      <% if @goal.any_consumption? %>
+        <p class="text-xs text-secondary tabular-nums mt-0.5 privacy-sensitive">
+          <%= t(".ring.including_used", amount: @goal.consumed_amount_money.format(precision: 0)) %>
+        </p>
+      <% end %>
       <% if @goal.contributions_basis? %>
         <p class="text-xs text-secondary tabular-nums mt-0.5 privacy-sensitive"><%= t(".ring.market_value", amount: @goal.market_value_money.format(precision: 0)) %></p>
       <% end %>

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -169,6 +169,7 @@ en:
         target_by: "Target %{amount} by %{date}"
         target_by_past: "Target %{amount} · was due %{date}"
       ring:
+        including_used: "Including %{amount} already used"
         saved: Saved
         of: "of %{target}"
         to_go: "%{amount} to go"
@@ -259,6 +260,7 @@ en:
       no_depository_accounts: You need at least one depository account (checking, savings, HSA, CD, money-market) before creating a goal.
       add_account: Add an account
     goal_card:
+      including_used: "Including %{amount} already used"
       no_accounts: No linked accounts
       n_accounts: "%{first} +%{count}"
       left: left

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -176,6 +176,7 @@ en:
         of_target: of target
         market_value: "Market value %{amount}"
         aria_label: "Goal %{percent}% complete. %{amount} of %{target} saved."
+        aria_label_with_used: "Goal %{percent}% complete. %{amount} of %{target}, including %{used} already used."
       projection:
         heading: Projection
         legend_saved: Saved

--- a/config/locales/views/goals/fr.yml
+++ b/config/locales/views/goals/fr.yml
@@ -76,6 +76,7 @@ fr:
       suggested_no_date: Définissez une date cible pour projeter la fin.
       suggested_with_date: Épargnez {monthly}/mois sur {accounts} pour l'atteindre à temps.
     goal_card:
+      including_used: "Dont %{amount} déjà utilisés"
       accounts:
         one: 1 compte
         other: "%{count} comptes"
@@ -302,6 +303,7 @@ fr:
       reopen: Réouvrir l'objectif
       resume: Reprendre
       ring:
+        including_used: "Dont %{amount} déjà utilisés"
         aria_label: Objectif complété à %{percent}%. %{amount} sur %{target} épargnés.
         market_value: Valeur de marché %{amount}
         of: sur %{target}

--- a/config/locales/views/goals/fr.yml
+++ b/config/locales/views/goals/fr.yml
@@ -305,6 +305,7 @@ fr:
       ring:
         including_used: "Dont %{amount} déjà utilisés"
         aria_label: Objectif complété à %{percent}%. %{amount} sur %{target} épargnés.
+        aria_label_with_used: "Objectif à %{percent}%. %{amount} sur %{target}, dont %{used} déjà utilisés."
         market_value: Valeur de marché %{amount}
         of: sur %{target}
         of_target: de l'objectif

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -740,6 +740,34 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       assert_no_match(/already used|déjà utilisés/, response.body)
     end
 
+
+    # The ring announced the account balance while the visible headline beside it
+    # reported the progress total: same ring, two different numbers depending on
+    # whether you could see it.
+    test "the ring announces the same total the headline shows" do
+      goal = spent_goal_for_display
+
+      get goal_url(goal)
+
+      assert_response :success
+      label = css_select("[role=progressbar]").first["aria-label"]
+      assert_includes label, goal.progress_amount_money.format
+      assert_not_includes label, goal.current_balance_money.format
+      assert_includes label, goal.consumed_amount_money.format
+    end
+
+    test "a goal with nothing used keeps the plain wording" do
+      account = unclaimed_account("Plain Pot")
+      goal = @user.family.goals.create!(name: "Plain", target_amount: 1_000, currency: "USD") do |g|
+        g.goal_accounts.build(account: account, allocated_amount: 1_000)
+      end
+
+      get goal_url(goal)
+
+      label = css_select("[role=progressbar]").first["aria-label"]
+      assert_no_match(/already used|déjà utilisés/, label)
+    end
+
   private
 
     # A private account of another member, linked to the goal under test.

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -680,6 +680,18 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+    def spent_goal_for_display
+      account = Account.create!(
+        family: @user.family, accountable: Depository.new,
+        name: "Spent Pot", currency: "USD", balance: 5_000
+      )
+      goal = @user.family.goals.create!(name: "Trip", target_amount: 5_000, currency: "USD") do |g|
+        g.goal_accounts.build(account: account, allocated_amount: 5_000)
+      end
+      goal.consume!(2_000)
+      goal
+    end
     # SQL the pooled-allocation read issues, and nothing else: goal_accounts
     # joined to goals.
     def count_pool_queries
@@ -692,6 +704,40 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       count
     ensure
       ActiveSupport::Notifications.unsubscribe(sub)
+    end
+
+
+    # The surface the user actually reads: the figure beside the ring, and the
+    # line saying part of it has been used. Asserted on the rendered page rather
+    # than the model, because the contradiction was a display bug — the model
+    # has always counted both halves.
+    test "the goal page reports the used portion as part of the total" do
+      goal = spent_goal_for_display
+
+      get goal_url(goal)
+
+      assert_response :success
+      assert_includes response.body, I18n.t("goals.show.ring.including_used",
+                                            amount: goal.consumed_amount_money.format(precision: 0))
+
+      # The headline figure specifically, not "somewhere on the page": the
+      # account balance still appears in the funding breakdown below, which is
+      # where that question belongs.
+      headline = css_select("p.text-xl.font-medium.text-primary").map(&:text).map(&:strip)
+      assert_includes headline, goal.progress_amount_money.format(precision: 0)
+      assert_not_includes headline, goal.current_balance_money.format(precision: 0)
+    end
+
+    test "a goal that has spent nothing says nothing about it" do
+      account = unclaimed_account("Quiet Pot")
+      goal = @user.family.goals.create!(name: "Quiet", target_amount: 1_000, currency: "USD") do |g|
+        g.goal_accounts.build(account: account, allocated_amount: 1_000)
+      end
+
+      get goal_url(goal)
+
+      assert_response :success
+      assert_no_match(/already used|déjà utilisés/, response.body)
     end
 
   private

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -1196,7 +1196,54 @@ class GoalTest < ActiveSupport::TestCase
     assert_equal 3_000, goal.reload.target_amount.to_d
   end
 
+
+  # The ring is drawn from `progress_percent`, which counts money held plus
+  # money already spent on the goal. The headline figure showed only the first
+  # half, so a goal that had spent part of its savings sat at a 100% ring
+  # beside "3,000 of 5,000" — the two disagreeing on the same card, with
+  # nothing to say which one to believe.
+  test "the headline figure agrees with the ring after a spend" do
+    goal = spent_goal
+
+    assert_equal 100, goal.progress_percent
+    assert_equal 5_000, goal.progress_amount_money.amount.to_d,
+      "the figure beside the ring still reported the account balance"
+  end
+
+  # The amount is part of the total above it, never a second figure beside it:
+  # a reader should have nothing to add up.
+  test "what was used is reported as part of the total, and only when there is some" do
+    goal = spent_goal
+
+    assert goal.any_consumption?
+    assert_equal 2_000, goal.consumed_amount_money.amount.to_d
+    assert_equal goal.progress_amount_money.amount.to_d,
+                 goal.current_balance.to_d + goal.consumed_amount_money.amount.to_d
+  end
+
+  test "a goal that has spent nothing says nothing about it" do
+    account = Account.create!(family: @family, accountable: Depository.new,
+                              name: "Quiet pot", currency: @family.currency, balance: 1_000)
+    goal = @family.goals.create!(name: "Quiet", target_amount: 1_000, currency: @family.currency) do |g|
+      g.goal_accounts.build(account: account, allocated_amount: 1_000)
+    end
+
+    assert_not goal.any_consumption?
+  end
+
   private
+
+    # 5,000 saved, 2,000 of it since spent on the thing itself.
+    def spent_goal
+      account = Account.create!(family: @family, accountable: Depository.new,
+                                name: "Spent pot #{SecureRandom.hex(3)}",
+                                currency: @family.currency, balance: 5_000)
+      goal = @family.goals.create!(name: "Trip", target_amount: 5_000, currency: @family.currency) do |g|
+        g.goal_accounts.build(account: account, allocated_amount: 5_000)
+      end
+      goal.consume!(2_000)
+      goal
+    end
 
     # Its own account, so the shared-pool haircut does not make the frozen
     # figure depend on what the fixtures happen to claim.


### PR DESCRIPTION
Recording a spend left the goal page contradicting itself.

The ring is drawn from `progress_percent`, which counts money still held **plus** money already spent on the goal. The figure beside it showed only the first half. Measured on a goal that saved 5,000 and then spent 2,000 of it:

```
BEFORE  ring=100%  figures=$5,000 / $5,000
AFTER   ring=100%  figures=$3,000 / $5,000
        consumed=2000  remaining=0  status=reached
```

A 100% ring next to "3,000 of 5,000". Two answers on one card, and nothing to say which one to believe.

## The model was never wrong

`progress_percent` and `remaining_amount` have counted both halves since the spend feature landed:

```ruby
(((current_balance.to_d + consumed_amount.to_d) / target_amount.to_d) * 100)
```

Only the display took one of them. `progress_amount` names what progress actually counts, and both surfaces read from it now.

## Why "including", and why "used"

The amount already spent is reported **as part of** the total rather than beside it:

> $5,000 / $5,000
> Including $2,000 already used

Two parallel figures — "3,000 saved · 2,000 spent" — would leave the reader adding them up to work out whether the goal is on track. "Including" says the amount is inside the total above, so there is nothing to reconcile.

"Used", not "spent", matching the menu entry the user came through (*I used some of this money*). It is the same gesture, and it should read as the same thing. Spending on the trip you saved for is the goal working, not failing — "spent" carries a loss the model does not intend.

## Where it does not appear

Only when something has actually been recorded. The overwhelming majority of goals never record a spend, and a permanent "0 used" line would be noise on every card. A reserve refuses consumption outright, so it never appears on one either.

What is still sitting in each account keeps its place in the funding breakdown below, with `%{earmarked} earmarked of %{balance}` — that is where the question "how much is actually in this account" belongs, not in the headline figure.

## What reviewers should look at

The view test asserts the **headline element** rather than the page, deliberately. My first version asserted the balance was absent from the whole response and failed — correctly, because the balance still appears in the funding breakdown, which this PR argues is right. `css_select("p.text-xl.font-medium.text-primary")` scopes it to the figure under the ring.

`DS::ProgressRing` documents itself as *"Not a segmented donut"*, so splitting the ring into held-vs-used would mean changing a primitive the budget surfaces also use. Left alone: making the two figures agree removes the contradiction, and the segment is polish on top.

## Testing

```
bin/rails test    7,320 runs, 29,214 assertions, 0 failures, 0 errors
rubocop / erb_lint / brakeman    clean
```

Three model tests and two view tests. The two that matter fail on `main`: the headline figure reporting the balance, and the goal page not saying any of it was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Goal progress now includes both held and already-spent amounts.
  * Goal cards and detail pages show an “including used” amount when applicable.
  * Progress figures now match the visual progress indicator.
  * Accessibility labels describe saved and used amounts.
  * Added English and French translations for spending details.

* **Bug Fixes**
  * Corrected displays that previously showed only the remaining balance instead of total progress.
  * Improved goal spending allocation handling when funds are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->