### PR TITLE
feat(goals): offer recording a spend where the user is standing

### DIFF
--- a/app/components/goals/lifecycle_panel_component.html.erb
+++ b/app/components/goals/lifecycle_panel_component.html.erb
@@ -34,9 +34,24 @@
               amount: goal.current_balance_money.format(precision: 0)) %>
       </p>
     <% end %>
-    <% case celebration_action %>
-    <% when :close %>
-      <div class="mt-4">
+    <%# The spend action sits before closing because that is the order the two
+        happen in, and because closing is the one that cannot be undone by
+        another click. %>
+    <% if offer_recording_a_spend? || celebration_action != :none %>
+    <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
+      <% if offer_recording_a_spend? %>
+        <%= render DS::Link.new(
+          text: t("goals.show.consume"),
+          href: helpers.consume_goal_path(goal),
+          variant: "secondary",
+          size: "sm",
+          icon: "hand-coins",
+          frame: :modal
+        ) %>
+      <% end %>
+
+      <% case celebration_action %>
+      <% when :close %>
         <%# Same confirmation as the menu action: closing releases the goal's
             earmarked money, and a one-click release is not a gesture to make
             reversible-by-apology. %>
@@ -48,10 +63,7 @@
           method: :patch,
           confirm: helpers.goal_complete_confirm(goal)
         ) %>
-      </div>
-      <p class="text-xs text-secondary mt-2 max-w-md"><%= t("goals.show.celebration.close_hint") %></p>
-    <% when :archive %>
-      <div class="mt-4">
+      <% when :archive %>
         <%= render DS::Button.new(
           text: t("goals.show.celebration.archive_cta"),
           href: helpers.archive_goal_path(goal),
@@ -59,7 +71,11 @@
           size: "sm",
           method: :patch
         ) %>
-      </div>
+      <% end %>
+    </div>
+    <% end %>
+    <% if celebration_action == :close %>
+      <p class="text-xs text-secondary mt-2 max-w-md"><%= t("goals.show.celebration.close_hint") %></p>
     <% end %>
   <% end %>
 

--- a/app/components/goals/lifecycle_panel_component.html.erb
+++ b/app/components/goals/lifecycle_panel_component.html.erb
@@ -38,7 +38,7 @@
         happen in, and because closing is the one that cannot be undone by
         another click. %>
     <% if offer_recording_a_spend? || celebration_action != :none %>
-    <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
+    <div id="goal-celebration-actions" class="mt-4 flex flex-wrap items-center justify-center gap-2">
       <% if offer_recording_a_spend? %>
         <%= render DS::Link.new(
           text: t("goals.show.consume"),

--- a/app/components/goals/lifecycle_panel_component.rb
+++ b/app/components/goals/lifecycle_panel_component.rb
@@ -8,8 +8,13 @@
 class Goals::LifecyclePanelComponent < ApplicationComponent
   attr_reader :goal
 
-  def initialize(goal:)
+  # `viewer_account_ids` are the goal's accounts THIS READER can reach, worked
+  # out once in the controller and shared with the overflow menu. Defaulting to
+  # none rather than to every account: a caller that forgets them withholds the
+  # spend offer, which is the safe way to be wrong about a permission.
+  def initialize(goal:, viewer_account_ids: [])
     @goal = goal
+    @viewer_account_ids = viewer_account_ids
   end
 
   # Order is load-bearing, so it is stated once, here.
@@ -80,19 +85,7 @@ class Goals::LifecyclePanelComponent < ApplicationComponent
   # Offered beside closing, never instead of it: plenty of goals are closed
   # without anything being recorded, and this must not read as a step to clear
   # first. Same condition as the menu entry, which stays where it is.
-  def offer_recording_a_spend?
-    return false unless goal.one_off? && goal.active?
-
-    # `current_balance` counts every linked account, private ones included.
-    # Offering the link on the strength of money this reader cannot reach
-    # sends them to a dialog with nothing to pick and a refusal on submit —
-    # the same scoping the dialog itself already applies.
-    goal.backing_within(viewer_account_ids).to_d.positive?
-  end
-
-  def viewer_account_ids
-    @viewer_account_ids ||= Current.user&.accessible_accounts&.pluck(:id) || []
-  end
+  def offer_recording_a_spend? = goal.spendable_within?(@viewer_account_ids)
 
   # --- projection ---
 

--- a/app/components/goals/lifecycle_panel_component.rb
+++ b/app/components/goals/lifecycle_panel_component.rb
@@ -81,7 +81,17 @@ class Goals::LifecyclePanelComponent < ApplicationComponent
   # without anything being recorded, and this must not read as a step to clear
   # first. Same condition as the menu entry, which stays where it is.
   def offer_recording_a_spend?
-    goal.one_off? && goal.active? && goal.current_balance.to_d.positive?
+    return false unless goal.one_off? && goal.active?
+
+    # `current_balance` counts every linked account, private ones included.
+    # Offering the link on the strength of money this reader cannot reach
+    # sends them to a dialog with nothing to pick and a refusal on submit —
+    # the same scoping the dialog itself already applies.
+    goal.backing_within(viewer_account_ids).to_d.positive?
+  end
+
+  def viewer_account_ids
+    @viewer_account_ids ||= Current.user&.accessible_accounts&.pluck(:id) || []
   end
 
   # --- projection ---

--- a/app/components/goals/lifecycle_panel_component.rb
+++ b/app/components/goals/lifecycle_panel_component.rb
@@ -71,6 +71,19 @@ class Goals::LifecyclePanelComponent < ApplicationComponent
     :none
   end
 
+  # Using the money is the step that normally comes *before* closing — the
+  # close hint says so itself, "Do this once you have actually spent it" — and
+  # until now the only way to say so was an entry in the overflow menu, at the
+  # exact moment the page stops offering any other action. Adding money had a
+  # button on this page; using it had none.
+  #
+  # Offered beside closing, never instead of it: plenty of goals are closed
+  # without anything being recorded, and this must not read as a step to clear
+  # first. Same condition as the menu entry, which stays where it is.
+  def offer_recording_a_spend?
+    goal.one_off? && goal.active? && goal.current_balance.to_d.positive?
+  end
+
   # --- projection ---
 
 

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -188,6 +188,8 @@ class GoalsController < ApplicationController
     perform_transition!(:reopen)
   end
 
+  helper_method :eligible_consumption_accounts
+
   private
     def set_goal
       @goal = Current.family.goals

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -423,6 +423,14 @@ class Goal < ApplicationRecord
       .sum { |account| account_amount_for(account) }
   end
 
+  # Whether this reader can record a spend against this goal. Two doors lead to
+  # the same dialog — the lifecycle panel and the overflow menu — and they have
+  # to agree: offering it on the strength of money the reader cannot reach ends
+  # in a dialog with nothing to pick and a refusal on submit.
+  def spendable_within?(account_ids)
+    one_off? && active? && backing_within(account_ids).to_d.positive?
+  end
+
   def account_backing(account)
     Money.new(account_amount_for(account), currency)
   end

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -38,9 +38,11 @@
           <% menu.with_item(variant: "button", text: t(".resume"), icon: "play", href: resume_goal_path(@goal), method: :patch) %>
         <% end %>
         <%# Partial spend: only offered on a one-off goal that is still running
-            and has something to spend. A reserve is drawn down and refilled,
-            not consumed — the model refuses it outright. %>
-        <% if @goal.one_off? && @goal.active? && @goal.current_balance.to_d.positive? %>
+            and has something THIS READER can spend. A reserve is drawn down and
+            refilled, not consumed — the model refuses it outright. Same
+            question the lifecycle panel asks, off the same scoped list, so the
+            two doors to this dialog cannot disagree. %>
+        <% if @goal.spendable_within?(eligible_consumption_accounts.map(&:id)) %>
           <% menu.with_item(variant: "link", text: t(".consume"), icon: "hand-coins",
                             href: consume_goal_path(@goal), data: { turbo_frame: :modal }) %>
         <% end %>
@@ -165,7 +167,9 @@
       <% end %>
     </div>
 
-    <%= render Goals::LifecyclePanelComponent.new(goal: @goal) %>
+    <%= render Goals::LifecyclePanelComponent.new(
+          goal: @goal, viewer_account_ids: eligible_consumption_accounts.map(&:id)
+        ) %>
   </section>
 
   <% if @goal.linked_accounts.any? %>

--- a/test/components/goals/lifecycle_panel_component_test.rb
+++ b/test/components/goals/lifecycle_panel_component_test.rb
@@ -125,7 +125,7 @@ class Goals::LifecyclePanelComponentTest < ViewComponent::TestCase
     # the template emitted the row anyway, which is the gap this guards.
     render_inline(component_for(goal))
 
-    assert_no_selector "div.mt-4.flex"
+    assert_no_selector "#goal-celebration-actions"
   end
 
   private
@@ -140,8 +140,11 @@ class Goals::LifecyclePanelComponentTest < ViewComponent::TestCase
       ) { |g| g.goal_accounts.build(account: pot(balance: 1_000), allocated_amount: 1_000) }
     end
 
+    # The same list the controller hands the panel and the overflow menu: the
+    # goal's accounts this reader can actually reach.
     def component_for(goal)
-      Goals::LifecyclePanelComponent.new(goal: goal)
+      visible = Current.user.accessible_accounts.where(id: goal.linked_accounts.map(&:id)).pluck(:id)
+      Goals::LifecyclePanelComponent.new(goal: goal, viewer_account_ids: visible)
     end
 
     def panel_for(goal)

--- a/test/components/goals/lifecycle_panel_component_test.rb
+++ b/test/components/goals/lifecycle_panel_component_test.rb
@@ -52,6 +52,56 @@ class Goals::LifecyclePanelComponentTest < ActiveSupport::TestCase
     assert_equal :close, component_for(funded_goal).celebration_action
   end
 
+  # Adding money had a button on this page; using it had none. And the moment
+  # it was most wanted — target reached, trip taken — the page offered only
+  # "Close this goal", which does something else and whose own hint tells you
+  # to have spent the money first.
+  test "a goal still holding money offers to record a spend" do
+    assert component_for(funded_goal).offer_recording_a_spend?
+  end
+
+  # Beside closing, never instead of it: a goal is often closed without
+  # anything being recorded, and this must not read as a step to clear first.
+  test "the closing action is unaffected by the offer" do
+    goal = funded_goal
+
+    assert_equal :close, component_for(goal).celebration_action
+    assert component_for(goal).offer_recording_a_spend?
+  end
+
+  # A reserve refuses consumption outright, so offering it would be offering
+  # something the model then declines.
+  test "a reserve is never offered a spend" do
+    assert_not component_for(funded_goal(kind: "maintained")).offer_recording_a_spend?
+  end
+
+  # Nothing left to spend, and nothing to spend it from once closed.
+  test "a closed goal is not offered a spend" do
+    goal = funded_goal
+    goal.complete!
+
+    assert_not component_for(goal.reload).offer_recording_a_spend?
+  end
+
+  test "a goal holding nothing is not offered a spend" do
+    goal = @family.goals.create!(
+      name: "Empty", target_amount: 1_000, currency: @family.currency
+    ) { |g| g.goal_accounts.build(account: pot(balance: 0), allocated_amount: 0) }
+
+    assert_not component_for(goal).offer_recording_a_spend?
+  end
+
+  # A reserve gets neither action, so the row must not render at all — an
+  # empty flex div still carries its top margin, and would open a gap under
+  # copy that says there is nothing to do.
+  test "a reserve renders no action row" do
+    goal = funded_goal(kind: "maintained")
+    c = component_for(goal)
+
+    assert_not c.offer_recording_a_spend?
+    assert_equal :none, c.celebration_action
+  end
+
   private
     def pot(balance:, name: "Pot #{SecureRandom.hex(3)}")
       Account.create!(family: @family, accountable: Depository.new, name: name,

--- a/test/components/goals/lifecycle_panel_component_test.rb
+++ b/test/components/goals/lifecycle_panel_component_test.rb
@@ -2,10 +2,16 @@ require "test_helper"
 
 # The panel choice was five predicates deep in ERB where the ordering between
 # them mattered and nothing said so. These pin the order, not the markup.
-class Goals::LifecyclePanelComponentTest < ActiveSupport::TestCase
+class Goals::LifecyclePanelComponentTest < ViewComponent::TestCase
   setup do
     @family = families(:dylan_family)
+    # The panel scopes what it offers to the reader's accessible accounts, so
+    # these need a reader — without one the offer is correctly withheld and
+    # every assertion about it would be measuring the wrong thing.
+    Current.session = sessions(:one)
   end
+
+  teardown { Current.session = nil }
 
   test "an archived or paused goal gets the inactive panel whatever its progress" do
     goal = funded_goal
@@ -91,15 +97,35 @@ class Goals::LifecyclePanelComponentTest < ActiveSupport::TestCase
     assert_not component_for(goal).offer_recording_a_spend?
   end
 
+  # `current_balance` counts every linked account, private ones included. The
+  # offer used to ride on that, so a reader backed only by somebody else's
+  # private account was sent to a dialog with nothing to pick and a refusal on
+  # submit.
+  test "money the reader cannot reach does not earn the offer" do
+    private_account = Account.create!(
+      family: @family, owner: users(:family_member), accountable: Depository.new,
+      name: "Member Private", currency: @family.currency, balance: 5_000
+    )
+    private_account.account_shares.destroy_all
+    goal = @family.goals.create!(
+      name: "Hidden", target_amount: 5_000, currency: @family.currency
+    ) { |g| g.goal_accounts.build(account: private_account, allocated_amount: 5_000) }
+
+    assert goal.current_balance.to_d.positive?, "the goal is backed, just not for this reader"
+    assert_not component_for(goal).offer_recording_a_spend?
+  end
+
   # A reserve gets neither action, so the row must not render at all — an
   # empty flex div still carries its top margin, and would open a gap under
   # copy that says there is nothing to do.
   test "a reserve renders no action row" do
     goal = funded_goal(kind: "maintained")
-    c = component_for(goal)
 
-    assert_not c.offer_recording_a_spend?
-    assert_equal :none, c.celebration_action
+    # Rendered, not merely asked: the predicates could both stay false while
+    # the template emitted the row anyway, which is the gap this guards.
+    render_inline(component_for(goal))
+
+    assert_no_selector "div.mt-4.flex"
   end
 
   private

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -834,6 +834,31 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # The gap this closes: at the moment the user has reached the target and
+  # spent some of it, the page offered only "Close this goal" — which releases
+  # the earmark, and whose own hint says to do it once the money is actually
+  # spent. Saying so was two clicks away in the overflow menu.
+  test "a reached goal offers recording a spend outside the overflow menu" do
+    goal = reached_goal_holding_money
+
+    get goal_url(goal)
+
+    assert_response :success
+    # In the panel, not only in the menu: scoped to the celebration panel's
+    # own action row so a menu entry alone cannot satisfy it.
+    panel_links = css_select("section a[href='#{consume_goal_path(goal)}']")
+    assert_operator panel_links.size, :>=, 1,
+      "the spend action was still only reachable through the overflow menu"
+  end
+
+  test "closing is still offered alongside it" do
+    goal = reached_goal_holding_money
+
+    get goal_url(goal)
+
+    assert_select "form[action=?]", complete_goal_path(goal)
+  end
+
   private
 
     def spent_goal_for_display

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -847,6 +847,16 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       goal.consume!(2_000)
       goal
     end
+
+    def reached_goal_holding_money
+      account = Account.create!(
+        family: @user.family, accountable: Depository.new,
+        name: "Reached Pot", currency: "USD", balance: 5_000
+      )
+      @user.family.goals.create!(name: "Trip", target_amount: 5_000, currency: "USD") do |g|
+        g.goal_accounts.build(account: account, allocated_amount: 5_000)
+      end
+    end
     # SQL the pooled-allocation read issues, and nothing else: goal_accounts
     # joined to goals.
     def count_pool_queries

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -844,9 +844,10 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     get goal_url(goal)
 
     assert_response :success
-    # In the panel, not only in the menu: scoped to the celebration panel's
-    # own action row so a menu entry alone cannot satisfy it.
-    panel_links = css_select("section a[href='#{consume_goal_path(goal)}']")
+    # In the panel, not only in the menu: scoped to the celebration panel's own
+    # action row by id. `section` was not enough — the panel renders through
+    # DS::Card, which emits a <section>, so any card on the page satisfied it.
+    panel_links = css_select("#goal-celebration-actions a[href='#{consume_goal_path(goal)}']")
     assert_operator panel_links.size, :>=, 1,
       "the spend action was still only reachable through the overflow menu"
   end
@@ -857,6 +858,29 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     get goal_url(goal)
 
     assert_select "form[action=?]", complete_goal_path(goal)
+  end
+
+  # Two doors lead to the same dialog, the panel and the overflow menu, and they
+  # disagreed: the menu gated on `current_balance`, which counts every linked
+  # account including ones private to another member. A reader backed only by
+  # such an account was shown the entry, opened a dialog with nothing to pick,
+  # and was refused on submit. Asserted page-wide on purpose — neither door may
+  # offer it.
+  test "money the reader cannot reach opens no door to the spend dialog" do
+    account = Account.create!(
+      family: @user.family, owner: users(:family_member), accountable: Depository.new,
+      name: "Member Only Pot", currency: "USD", balance: 5_000
+    )
+    goal = @user.family.goals.create!(name: "Hidden", target_amount: 5_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account, allocated_amount: 5_000)
+    end
+
+    get goal_url(goal)
+
+    assert_response :success
+    assert goal.current_balance.to_d.positive?, "the goal is backed, just not for this reader"
+    assert_empty css_select("a[href='#{consume_goal_path(goal)}']"),
+      "a spend was still offered against money the reader cannot see"
   end
 
   private


### PR DESCRIPTION
> [!NOTE]
> Pairs with #3213, which makes a recorded spend **visible**. This makes it **recordable** at the moment the user thinks of it. Independent — either can land first.

Adding money has a button on the goal page. Using it had none.

`Record pledge` is the single visible action under the ring. `I used some of this money` lives only in the overflow menu, behind `one_off? && active? && current_balance.positive?`.

## Where the asymmetry bites

`Record pledge` is hidden once the goal is reached:

```erb
unless completed? || status == :reached || status == :funded || paused? || archived?
```

So a user who saved 5,000, went on the trip, spent 2,000, and came back to the page is offered exactly one action:

> **Goal reached. Nice work.**
> *It is not closed yet — the money is still earmarked for it.*
> **[ Close this goal ]**

That button does something else — it **releases** the earmark — and its own hint says to press it *"once you have actually spent it"*. The page asks the user to have spent the money, and gives them nowhere to say so. The place to say so is two clicks away, in a menu nobody opens on a page with no other actions.

Using the money is the step that comes *before* closing. Only the second step had a button.

## What changed

The celebration panel offers it beside closing, spend first, close second — that is the order the two happen in, and closing is the one another click cannot undo.

**Beside, never instead.** Plenty of goals are closed with nothing recorded, and the offer must not read as a step to clear first. A test pins that closing is still offered wherever it was before.

**Same condition as the menu entry, which stays where it is.** This is a second door, not a move — the menu remains the way to reach it from any state where it applies.

## What reviewers should look at

The action row is conditional rather than always rendered. A reserve gets neither action (`celebration_action == :none`, and consumption is refused outright), and an empty flex div still carries its `mt-4`, which would open a gap under copy that says there is nothing to do. I introduced that gap while restructuring and caught it before pushing; there is a test for the empty case.

The page test scopes to the panel's own link rather than the response body, so a menu entry alone cannot satisfy it — verified by removing the panel action and watching it fail with *"the spend action was still only reachable through the overflow menu"*.

## Testing

```
bin/rails test    7,323 runs, 29,209 assertions, 0 failures, 0 errors
rubocop / erb_lint / brakeman    clean
```

Six component tests covering who is offered the action and who is not — reserve, closed goal, goal holding nothing — and two page tests: the action present outside the menu, and closing still offered alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Record a spend” action for eligible active, one-off goals with accessible remaining funds.
  * Spend actions now appear alongside close or completion actions for reached goals.
  * Improved celebration-panel action layout and conditional close guidance.

* **Bug Fixes**
  * Reserve, closed, empty, and inaccessible-account goals no longer display the spend action.
  * Reserve goals no longer show an empty action row.
  * Spend availability is now consistent across goal views and menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->