### PR TITLE
fix(goals): stop the first goal being told about earmarks it has none of

### DIFF
--- a/app/helpers/goals_helper.rb
+++ b/app/helpers/goals_helper.rb
@@ -35,8 +35,21 @@ module GoalsHelper
   # they reserve no fixed slice. That is the right reading here — what they
   # do claim is guarded separately, at write time, by GoalAccount.
   def earmarked_by_other_goals(account, pooled:, current_goal: nil)
-    (pooled[account.id] || [])
-      .reject { |row| current_goal&.persisted? && row[:goal_id] == current_goal.id }
-      .sum { |row| row[:allocated_amount].to_d }
+    other_goal_rows(account, pooled, current_goal).sum { |row| row[:allocated_amount].to_d }
   end
+
+  # A whole-account link carries a nil allocation, so it contributes zero to
+  # the sum above — "nothing else claims this account" and "another goal
+  # claims all of it" look identical from that figure alone. They are not:
+  # the second refuses a blank allocation at the door
+  # (`GoalAccount#whole_account_link_must_be_exclusive`).
+  def whole_account_claimed_by_other_goals?(account, pooled:, current_goal: nil)
+    other_goal_rows(account, pooled, current_goal).any? { |row| row[:allocated_amount].nil? }
+  end
+
+  private
+    def other_goal_rows(account, pooled, current_goal)
+      (pooled[account.id] || [])
+        .reject { |row| current_goal&.persisted? && row[:goal_id] == current_goal.id }
+    end
 end

--- a/app/javascript/controllers/goal_earmark_controller.js
+++ b/app/javascript/controllers/goal_earmark_controller.js
@@ -19,6 +19,7 @@ export default class extends Controller {
     wholeBalance: String,
     prorata: String,
     headroom: String,
+    wholeBalanceAlone: String,
   }
 
   // A complete number, optionally with one decimal separator and digits after
@@ -51,8 +52,14 @@ export default class extends Controller {
     const others = Number.parseFloat(row.dataset.earmarkedByOthers || "0")
     const raw = input.value.trim()
 
+    // "whatever is left after the other earmarks" describes nothing when there
+    // are none — and this is where a first-time user meets the word, pointed
+    // at something absent. With the account to itself, say that instead.
     if (raw === "") {
-      return this.#show(warning, this.wholeBalanceValue)
+      return this.#show(
+        warning,
+        others > 0 ? this.wholeBalanceValue : this.wholeBalanceAloneValue,
+      )
     }
 
     if (!this.constructor.ALLOCATION_PATTERN.test(raw)) return this.#hide(warning)

--- a/app/javascript/controllers/goal_earmark_controller.js
+++ b/app/javascript/controllers/goal_earmark_controller.js
@@ -50,6 +50,9 @@ export default class extends Controller {
 
     const balance = Number.parseFloat(row.dataset.balance || "0")
     const others = Number.parseFloat(row.dataset.earmarkedByOthers || "0")
+    // A whole-account link elsewhere sums to zero above, so the amount alone
+    // cannot tell "nobody else claims this" from "somebody claims all of it".
+    const claimedWhole = row.dataset.wholeAccountClaimed === "true"
     const raw = input.value.trim()
 
     // "whatever is left after the other earmarks" describes nothing when there
@@ -58,7 +61,7 @@ export default class extends Controller {
     if (raw === "") {
       return this.#show(
         warning,
-        others > 0 ? this.wholeBalanceValue : this.wholeBalanceAloneValue,
+        others > 0 || claimedWhole ? this.wholeBalanceValue : this.wholeBalanceAloneValue,
       )
     }
 

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -137,7 +137,8 @@
               <% linked_ga = linked_allocation_by_account[account.id] %>
               <div class="px-3 py-2.5 hover:bg-surface-hover <%= "border-t border-subdued" if idx > 0 %>"
                    data-balance="<%= account.balance.to_d %>"
-                   data-earmarked-by-others="<%= earmarked_by_other_goals(account, pooled: pooled_allocations, current_goal: goal) %>">
+                   data-earmarked-by-others="<%= earmarked_by_other_goals(account, pooled: pooled_allocations, current_goal: goal) %>"
+                   data-whole-account-claimed="<%= whole_account_claimed_by_other_goals?(account, pooled: pooled_allocations, current_goal: goal) %>">
               <div class="flex items-center gap-3">
                 <label class="flex items-center gap-3 flex-1 min-w-0 cursor-pointer">
                   <%= check_box_tag "goal[account_ids][]",

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -125,6 +125,7 @@
                the server decides the locale and the client applies it. %>
            data-goal-earmark-locale-value="<%= I18n.locale %>"
            data-goal-earmark-whole-balance-value="<%= t("goals.form.earmark.whole_balance") %>"
+           data-goal-earmark-whole-balance-alone-value="<%= t("goals.form.earmark.whole_balance_alone") %>"
            data-goal-earmark-prorata-value="<%= t("goals.form.earmark.prorata") %>"
            data-goal-earmark-headroom-value="<%= t("goals.form.earmark.headroom") %>">
         <% linked_allocation_by_account = goal.goal_accounts.index_by(&:account_id) %>

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -316,6 +316,7 @@ en:
         headroom: "{left} left to earmark on this account."
         prorata: "Your goals on this account come to {total} for a balance of {balance} — they will progress pro rata."
         whole_balance: This account will fund whatever is left after the other earmarks.
+        whole_balance_alone: "This goal will use this account's whole balance."
       fields:
         target_mode: How the target balance is set
         target_months: Months of expenses

--- a/config/locales/views/goals/fr.yml
+++ b/config/locales/views/goals/fr.yml
@@ -49,6 +49,7 @@ fr:
         headroom: "Il reste {left} affectables sur ce compte."
         prorata: "Vos objectifs sur ce compte totalisent {total} pour un solde de {balance} : ils progresseront au prorata."
         whole_balance: Ce compte financera le solde restant après les autres affectations.
+        whole_balance_alone: "Cet objectif utilisera tout le solde de ce compte."
       fields:
         target_mode: Comment le solde cible est fixé
         target_months: Mois de dépenses

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -862,6 +862,22 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     end
 
 
+    # The row must carry both readings, since one of them is invisible to the
+    # other: a whole-account claim elsewhere sums to zero, and without the flag
+    # the form would tell the user the account is theirs alone and then refuse
+    # the blank allocation on submit.
+    test "each account row carries the whole-account claim as well as the sum" do
+      account = unclaimed_account("Claimed Pot")
+      @user.family.goals.create!(name: "Neighbour", target_amount: 5_000, currency: "USD") do |g|
+        g.goal_accounts.build(account: account)
+      end
+
+      get new_goal_url
+
+      assert_response :success
+      assert_match(/data-earmarked-by-others="0(\.0)?"[^>]*data-whole-account-claimed="true"/m, response.body)
+    end
+
     # The hint for a blank amount is chosen client-side from two strings the
     # form hands over. A missing one does not raise — the value reads as
     # undefined and the line renders empty — so the wiring is what needs

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -862,6 +862,34 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     end
 
 
+    # The hint for a blank amount is chosen client-side from two strings the
+    # form hands over. A missing one does not raise — the value reads as
+    # undefined and the line renders empty — so the wiring is what needs
+    # pinning, not the ternary that picks between them.
+    test "the form carries both blank-amount hints" do
+      unclaimed_account("Hint Pot")
+
+      get new_goal_url
+
+      assert_response :success
+      # Escaped: the copy carries an apostrophe, and the attribute value in the
+      # response is HTML-escaped.
+      assert_includes response.body, ERB::Util.html_escape(I18n.t("goals.form.earmark.whole_balance_alone"))
+      assert_includes response.body, ERB::Util.html_escape(I18n.t("goals.form.earmark.whole_balance"))
+    end
+
+    # The two must stay distinguishable: if they ever say the same thing, the
+    # branch is doing nothing and a first-time user is back to being told about
+    # earmarks that do not exist.
+    test "the two blank-amount hints say different things" do
+      assert_not_equal I18n.t("goals.form.earmark.whole_balance"),
+                       I18n.t("goals.form.earmark.whole_balance_alone")
+      assert_no_match(/earmark/i, I18n.t("goals.form.earmark.whole_balance_alone"),
+        "the hint shown with no other claims should not mention earmarks")
+    end
+
+  private
+
     # A private account of another member, linked to the goal under test.
     def private_linked_account
       account = Account.create!(

--- a/test/helpers/goals_helper_test.rb
+++ b/test/helpers/goals_helper_test.rb
@@ -61,6 +61,31 @@ class GoalsHelperTest < ActionView::TestCase
     assert_equal BigDecimal("750"), earmarked_by_other_goals(@account, pooled: pooled)
   end
 
+
+  # A whole-account link carries a nil allocation, so it sums to zero — the
+  # figure alone cannot tell "nobody else claims this account" from "another
+  # goal claims all of it". The second refuses a blank allocation at the door,
+  # so a form that reads them the same way promises something it cannot keep.
+  test "a whole-account claim is invisible to the sum but not to the predicate" do
+    build_goal("Whole", nil)
+
+    assert_equal BigDecimal("0"), earmarked_by_other_goals(@account, pooled: pooled)
+    assert whole_account_claimed_by_other_goals?(@account, pooled: pooled)
+  end
+
+  test "fixed earmarks alone leave the account unclaimed as a whole" do
+    build_goal("A", 2_000)
+
+    assert_not whole_account_claimed_by_other_goals?(@account, pooled: pooled)
+  end
+
+  # The goal being edited never counts against itself, on either reading.
+  test "the goal being edited is excluded from the whole-account check" do
+    mine = build_goal("Mine", nil)
+
+    assert_not whole_account_claimed_by_other_goals?(@account, pooled: pooled, current_goal: mine)
+  end
+
   private
     def build_goal(name, allocated)
       @family.goals.create!(name: name, target_amount: 10_000, currency: "USD") do |g|


### PR DESCRIPTION
Link an account to a new goal, leave the amount blank, and the form says:

> *This account will fund whatever is left after **the other earmarks**.*

On a first goal there are no other earmarks. The sentence points at something absent — and it is exactly where a user meets the word for the first time.

## The form already knows

Each row carries `data-earmarked-by-others`, and it is `0` in that case. The blank-amount hint now picks between two strings:

| | |
|---|---|
| Nothing else claims the account | *This goal will use this account's whole balance.* |
| Something else does | *This account will fund whatever is left after the other earmarks.* (unchanged) |

So "earmark" only ever appears where earmarks actually exist. That is the point: the context does the explaining, rather than the vocabulary needing an explanation of its own.

## Why not a glossary, or a rename

Two alternatives were on the table and I would rather record why they were not taken.

Defining the word in a note above the account list adds copy every user reads to fix a problem only some users have. This change makes the confusing case disappear instead of annotating it.

Renaming `earmark` to something self-explanatory would be the strongest fix, but the natural candidate — *reserve* — is already taken by maintained goals, which are a different concept in this domain. Colliding those two words would trade one confusion for a worse one.

## What reviewers should look at

**The test is server-side, deliberately.** The branch itself is a ternary; the failure that actually bites is the form not handing over the second string, which does not raise — the value reads as `undefined` and the line renders empty. So the test pins the wiring, and a second one pins that the two hints stay *different*, since identical copy would leave the branch doing nothing and the first-time reader exactly where they started.

**Nothing runs `test/javascript`** — no npm script, no CI step. A test there would have documented the intent and guarded nothing, so I did not add one. Worth knowing more generally: those four `.mjs` files are currently dead weight from CI's point of view.

The expected strings are `html_escape`d in the assertion. The English copy carries an apostrophe, and the attribute value in the response is escaped; my first version compared the raw string and failed for that reason alone.

## Testing

```
bin/rails test    7,317 runs, 29,206 assertions, 0 failures, 0 errors
rubocop / erb_lint / biome / brakeman    clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer allocation guidance when a goal will use an account’s entire balance without sharing it with other goals.
  * Added English and French translations for the new guidance.
  * Added indicators showing when an account is fully claimed by another goal.

* **Bug Fixes**
  * Improved whole-balance messages based on account-sharing status.

* **Tests**
  * Added coverage for allocation guidance and full-account claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->