### PR TITLE
Fix demo refresh monitoring key reuse

### DIFF
--- a/app/jobs/demo_family_refresh_job.rb
+++ b/app/jobs/demo_family_refresh_job.rb
@@ -4,34 +4,39 @@ class DemoFamilyRefreshJob < ApplicationJob
   def perform
     return unless Rails.application.config.app_mode.managed?
 
-    period_end = Time.current
-    period_start = period_end - 24.hours
-
-    demo_email = Rails.application.config_for(:demo).with_indifferent_access.fetch(:email)
-    demo_user = User.find_by(email: demo_email)
-    old_family = demo_user&.family
-
-    old_family_session_count = sessions_count_for(old_family, period_start:, period_end:)
-    newly_created_families_count = Family.where(created_at: period_start...period_end).count
-
-    if old_family
-      delete_old_family_monitoring_key!(old_family)
-      anonymize_family_emails!(old_family)
-      DestroyJob.perform_later(old_family)
+    with_advisory_lock do
+      refresh_demo_family
     end
-
-    Demo::Generator.new.generate_default_data!(skip_clear: true, email: demo_email)
-
-    notify_super_admins!(
-      old_family:,
-      old_family_session_count:,
-      newly_created_families_count:,
-      period_start:,
-      period_end:
-    )
   end
 
   private
+    def refresh_demo_family
+      period_end = Time.current
+      period_start = period_end - 24.hours
+
+      demo_email = Rails.application.config_for(:demo).with_indifferent_access.fetch(:email)
+      demo_user = User.find_by(email: demo_email)
+      old_family = demo_user&.family
+
+      old_family_session_count = sessions_count_for(old_family, period_start:, period_end:)
+      newly_created_families_count = Family.where(created_at: period_start...period_end).count
+
+      if old_family
+        anonymize_family_emails!(old_family)
+      end
+
+      Demo::Generator.new.generate_default_data!(skip_clear: true, email: demo_email)
+
+      DestroyJob.perform_later(old_family) if old_family
+
+      notify_super_admins!(
+        old_family:,
+        old_family_session_count:,
+        newly_created_families_count:,
+        period_start:,
+        period_end:
+      )
+    end
 
     def sessions_count_for(family, period_start:, period_end:)
       return 0 unless family
@@ -45,12 +50,6 @@ class DemoFamilyRefreshJob < ApplicationJob
     end
 
 
-    def delete_old_family_monitoring_key!(family)
-      ApiKey
-        .where(user_id: family.users.select(:id), display_key: ApiKey::DEMO_MONITORING_KEY)
-        .delete_all
-    end
-
     def anonymize_family_emails!(family)
       family.users.find_each do |user|
         user.update_columns(
@@ -59,6 +58,30 @@ class DemoFamilyRefreshJob < ApplicationJob
           updated_at: Time.current
         )
       end
+    end
+
+    def with_advisory_lock
+      lock_key = advisory_lock_key
+      acquired = ActiveRecord::Base.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT pg_try_advisory_lock(?)", lock_key ])
+      )
+
+      unless acquired
+        Rails.logger.warn("Skipped demo family refresh: advisory lock unavailable")
+        return
+      end
+
+      begin
+        yield
+      ensure
+        ActiveRecord::Base.connection.execute(
+          ActiveRecord::Base.sanitize_sql_array([ "SELECT pg_advisory_unlock(?)", lock_key ])
+        )
+      end
+    end
+
+    def advisory_lock_key
+      Digest::MD5.hexdigest("demo_family_refresh").to_i(16) % (2**62)
     end
 
     def deleted_email_for(user)

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -96,9 +96,6 @@ class Demo::Generator
       puts "👥 Creating demo family..."
       family = create_family_and_users!("Demo Family", email, onboarded: true, subscribed: true)
 
-      puts "🔑 Creating monitoring API key..."
-      create_monitoring_api_key!(family)
-
       puts "📊 Creating realistic financial data..."
       create_realistic_categories!(family)
       create_realistic_accounts!(family)
@@ -108,6 +105,9 @@ class Demo::Generator
 
       puts "🎯 Seeding goals..."
       generate_goals!(family)
+
+      puts "🔑 Creating monitoring API key..."
+      create_monitoring_api_key!(family)
 
       puts "✅ Realistic demo data loaded successfully!"
     end
@@ -194,17 +194,24 @@ class Demo::Generator
       admin_user = family.users.find_by(role: "admin")
       return unless admin_user
 
-      # Find existing key scoped to this admin user by the deterministic display_key value
-      existing_key = admin_user.api_keys.find_by(display_key: ApiKey::DEMO_MONITORING_KEY)
-
-      if existing_key
-        puts "  → Use existing monitoring API key"
-        return existing_key
-      end
-
       # Revoke any existing user-created web API keys to keep demo access predictable.
       # (the monitoring key uses the dedicated "monitoring" source and cannot be revoked)
       admin_user.api_keys.active.visible.where(source: "web").find_each(&:revoke!)
+
+      existing_key = ApiKey.find_by(display_key: ApiKey::DEMO_MONITORING_KEY)
+
+      if existing_key
+        existing_key.update!(
+          user: admin_user,
+          name: "monitoring",
+          scopes: [ "read" ],
+          source: "monitoring",
+          revoked_at: nil,
+          expires_at: nil
+        )
+        puts "  → Use existing monitoring API key"
+        return existing_key
+      end
 
       api_key = admin_user.api_keys.create!(
         name: "monitoring",

--- a/test/jobs/demo_family_refresh_job_test.rb
+++ b/test/jobs/demo_family_refresh_job_test.rb
@@ -47,7 +47,7 @@ class DemoFamilyRefreshJobTest < ActiveJob::TestCase
 
       generator = mock
       generator.expects(:generate_default_data!).with(skip_clear: true, email: @demo_email) do
-        assert_nil ApiKey.find_by(display_key: ApiKey::DEMO_MONITORING_KEY)
+        assert ApiKey.find_by(display_key: ApiKey::DEMO_MONITORING_KEY)
       end
       Demo::Generator.expects(:new).returns(generator)
 
@@ -70,5 +70,16 @@ class DemoFamilyRefreshJobTest < ActiveJob::TestCase
     Demo::Generator.expects(:new).returns(generator)
 
     DemoFamilyRefreshJob.perform_now
+  end
+
+  test "skips refresh when another worker holds the advisory lock" do
+    connection = ActiveRecord::Base.connection
+    connection.expects(:select_value).with(regexp_matches(/pg_try_advisory_lock/)).returns(false)
+    Rails.logger.expects(:warn).with("Skipped demo family refresh: advisory lock unavailable")
+    Demo::Generator.expects(:new).never
+
+    assert_no_enqueued_jobs do
+      DemoFamilyRefreshJob.perform_now
+    end
   end
 end

--- a/test/models/demo/generator_test.rb
+++ b/test/models/demo/generator_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class Demo::GeneratorTest < ActiveSupport::TestCase
+  setup do
+    @family = Family.create!(name: "Demo Family")
+    @admin_user = create_user!(@family, "demo-admin@example.com")
+  end
+
+  test "monitoring api key creation reassigns stale demo monitoring key owned by another user" do
+    stale_family = Family.create!(name: "Old Demo Family")
+    stale_user = create_user!(stale_family, "old-demo-admin@example.com")
+    stale_key = stale_user.api_keys.create!(
+      name: "monitoring",
+      key: ApiKey::DEMO_MONITORING_KEY,
+      scopes: [ "read" ],
+      source: "monitoring"
+    )
+
+    monitoring_key = Demo::Generator.new.send(:create_monitoring_api_key!, @family)
+
+    assert_equal stale_key.id, monitoring_key.id
+    assert_equal @admin_user, monitoring_key.user
+    assert_equal "monitoring", monitoring_key.source
+    assert_equal [ "read" ], monitoring_key.scopes
+    assert_equal 1, ApiKey.where(display_key: ApiKey::DEMO_MONITORING_KEY).count
+  end
+
+  test "monitoring api key creation reuses the current admin user's key" do
+    existing_key = @admin_user.api_keys.create!(
+      name: "monitoring",
+      key: ApiKey::DEMO_MONITORING_KEY,
+      scopes: [ "read" ],
+      source: "monitoring"
+    )
+
+    monitoring_key = Demo::Generator.new.send(:create_monitoring_api_key!, @family)
+
+    assert_equal existing_key, monitoring_key
+    assert_equal 1, ApiKey.where(display_key: ApiKey::DEMO_MONITORING_KEY).count
+  end
+
+  private
+    def create_user!(family, email)
+      family.users.create!(
+        first_name: "Demo",
+        last_name: "Admin",
+        email: email,
+        password: "password123",
+        role: :admin,
+        onboarded_at: Time.current,
+        ai_enabled: true,
+        show_sidebar: true,
+        show_ai_sidebar: true,
+        ui_layout: :dashboard
+      )
+    end
+end


### PR DESCRIPTION
## Summary
- keep the existing demo monitoring API key alive while the replacement demo family is generated
- reassign the singleton monitoring key to the new demo admin after sample data is ready
- enqueue destruction of the old demo family only after the monitoring-key handoff
- guard the scheduled refresh with a PostgreSQL advisory lock so duplicate executions do not overlap
- add focused coverage for stale-key reassignment, current-key reuse, and advisory-lock skips

## Test plan
- bin/rails test test/models/demo/generator_test.rb test/jobs/demo_family_refresh_job_test.rb test/models/api_key_test.rb
- bundle exec rubocop app/models/demo/generator.rb app/jobs/demo_family_refresh_job.rb test/models/demo/generator_test.rb test/jobs/demo_family_refresh_job_test.rb