### PR TITLE
feat(budgets): name what the cash panel is, instead of what it is not

### DIFF
--- a/app/views/budgets/_available_cash.html.erb
+++ b/app/views/budgets/_available_cash.html.erb
@@ -3,7 +3,12 @@
 <%# Beside the plan, never inside it. The figures above answer "what did I plan
     to spend"; these answer "what do I actually have". Folding one into the
     other leaves the reader unsure which number drives the split, so the panel
-    keeps its own frame and its own heading. %>
+    keeps its own frame and its own heading.
+
+    The subtitle names the relationship rather than denying one. "Beside the
+    plan above, not part of it" told the reader what this is not, and left
+    them holding two figures that both look like an answer to "how much have
+    I got left" with nothing to choose between them. See #3218. %>
 <div class="w-full bg-container rounded-xl shadow-border-xs p-4">
   <div class="flex items-start justify-between gap-3 mb-3">
     <div class="min-w-0">

--- a/config/locales/views/budgets/en.yml
+++ b/config/locales/views/budgets/en.yml
@@ -40,7 +40,7 @@ en:
       month_year: "%{month}"
     available_cash:
       heading: Cash on hand
-      subtitle: Beside the plan above, not part of it.
+      subtitle: "The plan above is what you mean to spend. This is what you have to spend it from."
       available: Available in cash
       earmarked: Already earmarked for goals
       free: Really free

--- a/config/locales/views/budgets/fr.yml
+++ b/config/locales/views/budgets/fr.yml
@@ -59,7 +59,7 @@ fr:
   budgets:
     available_cash:
       heading: Trésorerie disponible
-      subtitle: À côté du plan ci-dessus, pas dedans.
+      subtitle: "Le plan ci-dessus est ce que vous comptez dépenser. Ceci est ce avec quoi vous pouvez le faire."
       available: Disponible en cash
       earmarked: Déjà fléché vers des objectifs
       free: Réellement libre


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft, and one of three options in #3218.** Not a recommendation. Opened so the cheapest option can be looked at rather than only described — the decision there is yours, and options 1 and 3 are incompatible with this one. Close it without ceremony if either is chosen.

The budget page shows two numbers that both answer *"how much have I got left"*, computed from different things:

- **"600 left to allocate"** — `budgeted_spending − allocated_spending`. Plan minus plan; never consults a balance.
- **"Really free 6,000"** — `available_cash − earmarked_for_goals`. Real balances, minus what goals claim.

Both correct. Neither a bug. Nothing relates them, and the one governing the decision the reader is about to make — setting a category budget — is the smaller, less prominent one.

## What this changes

The panel's subtitle. It read:

> *Beside the plan above, not part of it.*

True, and it defines the number by negation. Now:

> *The plan above is what you mean to spend. This is what you have to spend it from.*

The plan is the intention; this is the means. One sentence, no new figure, no arithmetic for the reader.

## Why it stops there

Option 2's whole appeal is that it is cheap and reversible. Padding it with a computed line — *"your plan assigns 1,800 more than you currently hold"* — would start answering the question option 1 answers properly, while keeping the forecast model that makes the two numbers different in the first place. Half of one option and half of another is worse than either.

No test: this is a copy change, and a test asserting a specific sentence is brittle without guarding anything.

## The comparison this is meant to support

**Option 1 — fold cash into the allocation arithmetic.** The confusion disappears rather than being explained. Costs: a different product, reaching rollover (#3143), envelope moves (#3164) and the category bars; and anyone budgeting before payday can no longer allocate.

**Option 2 — this PR.** Cheap, contained, nobody's workflow changes. Leaves the oddity in place: a plan can still exceed the cash behind it, and the page shows both facts.

**Option 3 — remove the panel.** Restores one unambiguous number. Costs: the question it answers has no other home.

## Testing

```
bin/rails test    7,317 runs, 29,207 assertions, 0 failures, 0 errors
rubocop / erb_lint    clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
