### PR TITLE
feat(transfers): Allow categorizing transfers on creation and for all…

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -31,10 +31,10 @@ class TransactionsController < ApplicationController
                          :category, :merchant, :tags,
                          # Union of #2643 counterpart UI + Skylight category-menu N+1:
                          # - outflow rows need inflow_transaction (to_account) for both
-                         #   counterpart display and Transfer#categorizable?/#payment?
+                         #   counterpart display and Transfer#payment?
                          # - inflow rows need outflow_transaction (from_account) for
                          #   counterpart display, and inflow_transaction (to_account)
-                         #   for the category menu on the same row
+                         #   for Transfer#payment? on the same row
                          {
                            transfer_as_outflow: {
                              inflow_transaction: { entry: :account }

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -254,7 +254,8 @@ class TransfersController < ApplicationController
     end
 
     def update_transfer_details
-      @transfer.outflow_transaction.update!(category_id: transfer_update_params[:category_id])
+      category_id = Current.family.categories.find_by(id: transfer_update_params[:category_id].presence)&.id
+      @transfer.outflow_transaction.update!(category_id: category_id)
       @transfer.update!(notes: transfer_update_params[:notes])
     end
 

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -34,7 +34,7 @@ class TransfersController < ApplicationController
     return unless require_account_permission!(source_account, redirect_path: transactions_path)
     return unless require_account_permission!(destination_account, redirect_path: transactions_path)
 
-    @transfer = Transfer::Creator.new(
+    creator_params = {
       family: Current.family,
       source_account_id: source_account.id,
       destination_account_id: destination_account.id,
@@ -44,9 +44,11 @@ class TransfersController < ApplicationController
       source_fee_amount: transfer_params[:source_fee_amount],
       destination_fee_amount: transfer_params[:destination_fee_amount],
       tag_ids: transfer_params[:tag_ids],
-      category_id: transfer_params[:category_id],
       idempotency_key: submitted_idempotency_key
-    ).create
+    }
+    creator_params[:category_id] = transfer_params[:category_id] if transfer_params.key?(:category_id)
+
+    @transfer = Transfer::Creator.new(**creator_params).create
 
     if @transfer.persisted?
       success_message = "Transfer created"
@@ -253,8 +255,10 @@ class TransfersController < ApplicationController
     end
 
     def update_transfer_details
-      category_id = Current.family.categories.find_by(id: transfer_update_params[:category_id].presence)&.id
-      @transfer.outflow_transaction.update!(category_id: category_id)
+      if transfer_update_params.key?(:category_id)
+        category_id = Current.family.categories.find_by(id: transfer_update_params[:category_id].presence)&.id
+        @transfer.outflow_transaction.update!(category_id: category_id)
+      end
       @transfer.update!(notes: transfer_update_params[:notes])
     end
 

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -3,20 +3,17 @@ class TransfersController < ApplicationController
 
   before_action :set_transfer, only: %i[show destroy update update_tags mark_as_recurring]
   before_action :set_accounts, only: %i[new create]
+  before_action :set_categories, only: %i[new show create]
+  before_action :set_tags, only: %i[new show create]
 
   helper_method :new_transfer_idempotency_key
 
   def new
     @transfer = Transfer.new
     @from_account_id = params[:from_account_id]
-    @tags = Current.family.tags.alphabetically
-    @categories = Current.family.categories.alphabetically_by_hierarchy
   end
 
   def show
-    @categories = Current.family.categories.alphabetically_by_hierarchy
-    @tags = Current.family.tags.alphabetically
-
     # Whether the current user can hit `mark_as_recurring`: feature flag on,
     # AND they have write access to BOTH transfer endpoints. Gating the
     # view button on this avoids showing a CTA that the controller would
@@ -60,8 +57,6 @@ class TransfersController < ApplicationController
     else
       @from_account_id = transfer_params[:from_account_id]
       @selected_category_id = transfer_params[:category_id]
-      @tags = Current.family.tags.alphabetically
-      @categories = Current.family.categories.alphabetically_by_hierarchy
       render :new, status: :unprocessable_entity
     end
   rescue Money::ConversionError
@@ -71,8 +66,6 @@ class TransfersController < ApplicationController
     @from_account_id = transfer_params[:from_account_id]
     set_accounts
     @selected_category_id = transfer_params[:category_id]
-    @tags = Current.family.tags.alphabetically
-    @categories = Current.family.categories.alphabetically_by_hierarchy
     render :new, status: :unprocessable_entity
   rescue ArgumentError
     @transfer ||= Transfer.new
@@ -89,8 +82,6 @@ class TransfersController < ApplicationController
     @from_account_id = transfer_params[:from_account_id]
     set_accounts
     @selected_category_id = transfer_params[:category_id]
-    @tags = Current.family.tags.alphabetically
-    @categories = Current.family.categories.alphabetically_by_hierarchy
     render :new, status: :unprocessable_entity
   end
 
@@ -239,6 +230,14 @@ class TransfersController < ApplicationController
           :account_providers,
           logo_attachment: :blob
         )
+    end
+
+    def set_categories
+      @categories = Current.family.categories.alphabetically_by_hierarchy
+    end
+
+    def set_tags
+      @tags = Current.family.tags.alphabetically
     end
 
     def transfer_update_params

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -10,6 +10,7 @@ class TransfersController < ApplicationController
     @transfer = Transfer.new
     @from_account_id = params[:from_account_id]
     @tags = Current.family.tags.alphabetically
+    @categories = Current.family.categories.alphabetically_by_hierarchy
   end
 
   def show
@@ -46,6 +47,7 @@ class TransfersController < ApplicationController
       source_fee_amount: transfer_params[:source_fee_amount],
       destination_fee_amount: transfer_params[:destination_fee_amount],
       tag_ids: transfer_params[:tag_ids],
+      category_id: transfer_params[:category_id],
       idempotency_key: submitted_idempotency_key
     ).create
 
@@ -57,7 +59,9 @@ class TransfersController < ApplicationController
       end
     else
       @from_account_id = transfer_params[:from_account_id]
+      @selected_category_id = transfer_params[:category_id]
       @tags = Current.family.tags.alphabetically
+      @categories = Current.family.categories.alphabetically_by_hierarchy
       render :new, status: :unprocessable_entity
     end
   rescue Money::ConversionError
@@ -66,7 +70,9 @@ class TransfersController < ApplicationController
     @transfer.errors.add(:base, t(".exchange_rate_unavailable"))
     @from_account_id = transfer_params[:from_account_id]
     set_accounts
+    @selected_category_id = transfer_params[:category_id]
     @tags = Current.family.tags.alphabetically
+    @categories = Current.family.categories.alphabetically_by_hierarchy
     render :new, status: :unprocessable_entity
   rescue ArgumentError
     @transfer ||= Transfer.new
@@ -82,7 +88,9 @@ class TransfersController < ApplicationController
     @transfer.errors.add(:base, t(".stale_form"))
     @from_account_id = transfer_params[:from_account_id]
     set_accounts
+    @selected_category_id = transfer_params[:category_id]
     @tags = Current.family.tags.alphabetically
+    @categories = Current.family.categories.alphabetically_by_hierarchy
     render :new, status: :unprocessable_entity
   end
 
@@ -203,7 +211,7 @@ class TransfersController < ApplicationController
     end
 
     def transfer_params
-      params.require(:transfer).permit(:from_account_id, :to_account_id, :amount, :date, :name, :excluded, :exchange_rate, :source_fee_amount, :destination_fee_amount, tag_ids: [])
+      params.require(:transfer).permit(:from_account_id, :to_account_id, :amount, :date, :name, :excluded, :exchange_rate, :source_fee_amount, :destination_fee_amount, :category_id, tag_ids: [])
     end
 
     # Anti-double-submit token: a random UUID rendered fresh on every "new

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -259,7 +259,7 @@ class TransfersController < ApplicationController
         category_id = Current.family.categories.find_by(id: transfer_update_params[:category_id].presence)&.id
         @transfer.outflow_transaction.update!(category_id: category_id)
       end
-      @transfer.update!(notes: transfer_update_params[:notes])
+      @transfer.update!(notes: transfer_update_params[:notes]) if transfer_update_params.key?(:notes)
     end
 
     def update_transfer_fees_and_amount

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,4 +1,18 @@
 module CategoriesHelper
+  def transfer_category
+    Category.new \
+      name: I18n.t("categories.virtual.transfer"),
+      color: Category::TRANSFER_COLOR,
+      lucide_icon: "arrow-right-left"
+  end
+
+  def payment_category
+    Category.new \
+      name: I18n.t("categories.virtual.payment"),
+      color: Category::PAYMENT_COLOR,
+      lucide_icon: "arrow-right"
+  end
+
   def trade_category
     Category.new \
       name: I18n.t("categories.virtual.trade"),
@@ -7,5 +21,16 @@ module CategoriesHelper
 
   def family_categories
     [ Category.uncategorized ].concat(Current.family.categories.alphabetically_by_hierarchy)
+  end
+
+  # Transactions keep a real, editable category (nil when none is chosen).
+  # For transfers with no category picked, show the Transfer/Payment badge
+  # instead of the generic Uncategorized one, so the row still visually
+  # reads as a transfer rather than "needs categorizing."
+  def display_category_for(transaction)
+    return transaction.category if transaction.category
+    return transaction.transfer.payment? ? payment_category : transfer_category if transaction.transfer
+
+    Category.uncategorized
   end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,18 +1,4 @@
 module CategoriesHelper
-  def transfer_category
-    Category.new \
-      name: I18n.t("categories.virtual.transfer"),
-      color: Category::TRANSFER_COLOR,
-      lucide_icon: "arrow-right-left"
-  end
-
-  def payment_category
-    Category.new \
-      name: I18n.t("categories.virtual.payment"),
-      color: Category::PAYMENT_COLOR,
-      lucide_icon: "arrow-right"
-  end
-
   def trade_category
     Category.new \
       name: I18n.t("categories.virtual.trade"),

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -91,10 +91,6 @@ class Transfer < ApplicationRecord
     "transfer"
   end
 
-  def categorizable?
-    to_account&.accountable_type == "Loan"
-  end
-
   def reject!
     Transfer.transaction do
       RejectedTransfer.find_or_create_by!(inflow_transaction_id: inflow_transaction_id, outflow_transaction_id: outflow_transaction_id)

--- a/app/models/transfer/creator.rb
+++ b/app/models/transfer/creator.rb
@@ -5,7 +5,7 @@ class Transfer::Creator
   # than a genuine double-submit. See #find_existing_transfer.
   StaleIdempotencyKeyError = Class.new(StandardError)
 
-  def initialize(family:, source_account_id:, destination_account_id:, date:, amount:, exchange_rate: nil, source_fee_amount: nil, destination_fee_amount: nil, tag_ids: nil, idempotency_key: nil)
+  def initialize(family:, source_account_id:, destination_account_id:, date:, amount:, exchange_rate: nil, source_fee_amount: nil, destination_fee_amount: nil, tag_ids: nil, category_id: nil, idempotency_key: nil)
     @family = family
     @source_account = family.accounts.find(source_account_id) # early throw if not found
     @destination_account = family.accounts.find(destination_account_id) # early throw if not found
@@ -14,6 +14,7 @@ class Transfer::Creator
     @source_fee_amount = source_fee_amount.to_d
     @destination_fee_amount = destination_fee_amount.to_d
     @tag_ids = Array(tag_ids).reject(&:blank?)
+    @category_id = category_id.presence
     @idempotency_key = idempotency_key
 
     if exchange_rate.present?
@@ -89,7 +90,7 @@ class Transfer::Creator
   end
 
   private
-    attr_reader :family, :source_account, :destination_account, :date, :amount, :exchange_rate, :source_fee_amount, :destination_fee_amount, :tag_ids, :idempotency_key
+    attr_reader :family, :source_account, :destination_account, :date, :amount, :exchange_rate, :source_fee_amount, :destination_fee_amount, :tag_ids, :category_id, :idempotency_key
 
     # Scoped to source_account + idempotency_key so it only ever finds a
     # transfer this same key could plausibly refer to, but the key alone
@@ -166,7 +167,7 @@ class Transfer::Creator
 
       Transaction.new(
         kind: kind,
-        category: (investment_contributions_category if kind == "investment_contribution"),
+        category_id: outflow_category_id(kind),
         entry: source_account.entries.build(
           amount: amount,
           currency: source_account.currency,
@@ -176,6 +177,12 @@ class Transfer::Creator
           **entry_idempotency_attrs(leg: :outflow)
         )
       )
+    end
+
+    def outflow_category_id(kind)
+      return category_id if category_id.present?
+
+      investment_contributions_category.id if kind == "investment_contribution"
     end
 
     def investment_contributions_category

--- a/app/models/transfer/creator.rb
+++ b/app/models/transfer/creator.rb
@@ -14,7 +14,7 @@ class Transfer::Creator
     @source_fee_amount = source_fee_amount.to_d
     @destination_fee_amount = destination_fee_amount.to_d
     @tag_ids = Array(tag_ids).reject(&:blank?)
-    @category_id = category_id.presence
+    @category_id = family.categories.find_by(id: category_id.presence)&.id
     @idempotency_key = idempotency_key
 
     if exchange_rate.present?

--- a/app/models/transfer/creator.rb
+++ b/app/models/transfer/creator.rb
@@ -5,7 +5,13 @@ class Transfer::Creator
   # than a genuine double-submit. See #find_existing_transfer.
   StaleIdempotencyKeyError = Class.new(StandardError)
 
-  def initialize(family:, source_account_id:, destination_account_id:, date:, amount:, exchange_rate: nil, source_fee_amount: nil, destination_fee_amount: nil, tag_ids: nil, category_id: nil, idempotency_key: nil)
+  # Sentinel default so we can tell "caller didn't pass category_id" (keep the
+  # investment-contribution fallback) apart from "caller explicitly passed a
+  # blank category_id" (user picked Uncategorized; honor it).
+  CATEGORY_ID_NOT_PROVIDED = Object.new
+  private_constant :CATEGORY_ID_NOT_PROVIDED
+
+  def initialize(family:, source_account_id:, destination_account_id:, date:, amount:, exchange_rate: nil, source_fee_amount: nil, destination_fee_amount: nil, tag_ids: nil, category_id: CATEGORY_ID_NOT_PROVIDED, idempotency_key: nil)
     @family = family
     @source_account = family.accounts.find(source_account_id) # early throw if not found
     @destination_account = family.accounts.find(destination_account_id) # early throw if not found
@@ -14,7 +20,8 @@ class Transfer::Creator
     @source_fee_amount = source_fee_amount.to_d
     @destination_fee_amount = destination_fee_amount.to_d
     @tag_ids = Array(tag_ids).reject(&:blank?)
-    @category_id = family.categories.find_by(id: category_id.presence)&.id
+    @category_provided = category_id != CATEGORY_ID_NOT_PROVIDED
+    @category_id = @category_provided ? family.categories.find_by(id: category_id.presence)&.id : nil
     @idempotency_key = idempotency_key
 
     if exchange_rate.present?
@@ -152,6 +159,10 @@ class Transfer::Creator
       { idempotency_key: key }
     end
 
+    def category_provided?
+      @category_provided
+    end
+
     def apply_tags!(transfer)
       resolved_ids = family.tags.where(id: tag_ids).pluck(:id)
       return if resolved_ids.empty?
@@ -180,7 +191,7 @@ class Transfer::Creator
     end
 
     def outflow_category_id(kind)
-      return category_id if category_id.present?
+      return category_id if category_provided?
 
       investment_contributions_category.id if kind == "investment_contribution"
     end

--- a/app/views/categories/_category_name_mobile.html.erb
+++ b/app/views/categories/_category_name_mobile.html.erb
@@ -1,3 +1,3 @@
 <span id="category_name_mobile_<%= transaction.id %>" class="text-secondary lg:hidden min-w-0 truncate">
-  <%= transaction.category&.display_name || Category.uncategorized.display_name %>
+  <%= display_category_for(transaction).display_name %>
 </span>

--- a/app/views/categories/_category_name_mobile.html.erb
+++ b/app/views/categories/_category_name_mobile.html.erb
@@ -1,7 +1,3 @@
 <span id="category_name_mobile_<%= transaction.id %>" class="text-secondary lg:hidden min-w-0 truncate">
-  <% if transaction.transfer&.categorizable? || transaction.transfer.nil? %>
-    <%= transaction.category&.display_name || Category.uncategorized.display_name %>
-  <% else %>
-    <%= transaction.transfer&.payment? ? payment_category.display_name :  transfer_category.display_name %>
-  <% end %>
+  <%= transaction.category&.display_name || Category.uncategorized.display_name %>
 </span>

--- a/app/views/categories/_menu.html.erb
+++ b/app/views/categories/_menu.html.erb
@@ -3,10 +3,10 @@
 <%= render DS::Popover.new(variant: "button") do |popover| %>
   <% popover.with_button(class: "block w-full overflow-hidden") do %>
     <div class="hidden min-w-0 w-full lg:flex">
-      <%= render partial: "categories/badge", locals: { category: transaction.category } %>
+      <%= render partial: "categories/badge", locals: { category: display_category_for(transaction) } %>
     </div>
     <div class="flex lg:hidden">
-      <%= render partial: "categories/badge_mobile", locals: { category: transaction.category } %>
+      <%= render partial: "categories/badge_mobile", locals: { category: display_category_for(transaction) } %>
     </div>
   <% end %>
 

--- a/app/views/transactions/_transaction_category.html.erb
+++ b/app/views/transactions/_transaction_category.html.erb
@@ -1,14 +1,5 @@
 <%# locals: (transaction:, variant:, in_split_group: false) %>
 
 <div id="<%= dom_id(transaction, "category_menu_#{variant}") %>" class="min-w-0 overflow-hidden">
-  <% if transaction.transfer&.categorizable? || transaction.transfer.nil? %>
-    <%= render "categories/menu", transaction: transaction, in_split_group: in_split_group %>
-  <% else %>
-    <div class="hidden lg:flex">
-      <%= render "categories/badge", category: transaction.transfer&.payment? ? payment_category :  transfer_category %>
-    </div>
-    <div class="flex lg:hidden">
-      <%= render "categories/badge_mobile", category: transaction.transfer&.payment? ? payment_category :  transfer_category %>
-    </div>
-  <% end %>
+  <%= render "categories/menu", transaction: transaction, in_split_group: in_split_group %>
 </div>

--- a/app/views/transfers/_form.html.erb
+++ b/app/views/transfers/_form.html.erb
@@ -41,6 +41,8 @@
 
     <%= f.number_field :amount, label: t(".source_amount"), required: true, min: 0, placeholder: "100", step: 0.00000001, data: { transfer_form_target: "amount", action: "input->transfer-form#onSourceAmountChange" } %>
 
+    <%= f.collection_select :category_id, @categories, :id, :name, { label: t(".category"), include_blank: t(".uncategorized"), selected: @selected_category_id, variant: :badge, searchable: true } %>
+
     <%= render DS::TagSelect.new(
           form: f,
           tags: @tags,

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -83,9 +83,7 @@
     <% dialog.with_section(title: t(".details")) do %>
       <%= styled_form_with model: @transfer,
               data: { controller: "auto-submit-form" }, class: "space-y-2" do |f| %>
-        <% if @transfer.categorizable? %>
-          <%= f.collection_select :category_id, @categories, :id, :name, { label: t(".category"), include_blank: t(".uncategorized"), selected: @transfer.outflow_transaction.category&.id, variant: :badge, searchable: true }, "data-auto-submit-form-target": "auto" %>
-        <% end %>
+        <%= f.collection_select :category_id, @categories, :id, :name, { label: t(".category"), include_blank: t(".uncategorized"), selected: @transfer.outflow_transaction.category&.id, variant: :badge, searchable: true }, "data-auto-submit-form-target": "auto" %>
         <%= render DS::TagSelect.new(
               form: f,
               tags: @tags,

--- a/config/locales/views/transfers/en.yml
+++ b/config/locales/views/transfers/en.yml
@@ -11,6 +11,7 @@ en:
     form:
       amount: Amount
       bank_charges: Bank Charges
+      category: Category
       outgoing_fee: Outgoing transfer fee
       incoming_fee: Incoming transfer fee
       date: Date
@@ -25,6 +26,7 @@ en:
       submit: Create transfer
       to: To
       transfer: Transfer
+      uncategorized: Uncategorized
     new:
       title: New transfer
     show:

--- a/config/locales/views/transfers/fr.yml
+++ b/config/locales/views/transfers/fr.yml
@@ -10,6 +10,7 @@ fr:
       success: Transfert supprimé
     form:
       amount: Montant
+      category: Catégorie
       date: Date
       destination_amount: Montant de destination
       destination_amount_display: "Montant de destination : %{amount}"
@@ -25,6 +26,7 @@ fr:
       submit: Créer le transfert
       to: Vers
       transfer: Transfert
+      uncategorized: Non classé
     new:
       title: Nouveau transfert
     show:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,7 +97,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
   end
 
   create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "account_providers_count", default: 0, null: false
     t.uuid "accountable_id"
     t.string "accountable_type"
     t.decimal "balance", precision: 19, scale: 4
@@ -307,10 +306,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.string "institution_name"
     t.string "institution_url"
     t.string "name"
-    t.boolean "pending_account_setup", default: false, null: false
+    t.boolean "pending_account_setup", default: false
     t.jsonb "raw_payload"
-    t.boolean "scheduled_for_deletion", default: false, null: false
-    t.string "status", default: "good", null: false
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
     t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_binance_items_on_family_id"
@@ -680,6 +679,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.check_constraint "reconciled_by_statement_id IS NULL OR reconciled_at IS NOT NULL", name: "chk_entries_reconciled_at_present_when_statement_set"
   end
 
+  create_table "envelopes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "category_id"
+    t.string "color"
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.uuid "family_id", null: false
+    t.string "icon"
+    t.decimal "monthly_contribution", precision: 19, scale: 4, default: "0.0", null: false
+    t.string "name", null: false
+    t.text "notes"
+    t.date "starts_on", null: false
+    t.decimal "target_amount", precision: 19, scale: 4
+    t.date "target_date"
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_envelopes_on_category_unique", unique: true, where: "(category_id IS NOT NULL)"
+    t.index ["family_id"], name: "index_envelopes_on_family_id"
+    t.check_constraint "char_length(name::text) <= 255", name: "chk_envelopes_name_length"
+    t.check_constraint "monthly_contribution >= 0::numeric", name: "chk_envelopes_monthly_contribution_non_negative"
+    t.check_constraint "target_amount IS NULL OR target_amount > 0::numeric", name: "chk_envelopes_target_amount_positive"
+    t.check_constraint "target_date IS NULL OR target_amount IS NOT NULL", name: "chk_envelopes_target_date_requires_target_amount"
+  end
+
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "active", default: true
     t.datetime "created_at", null: false
@@ -896,11 +917,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index ["family_id"], name: "index_goals_on_family_id"
     t.check_constraint "char_length(name::text) <= 255", name: "chk_savings_goals_name_length"
     t.check_constraint "consumed_amount >= 0::numeric", name: "chk_goals_consumed_amount_non_negative"
-    t.check_constraint "kind::text = ANY (ARRAY['one_off'::character varying::text, 'maintained'::character varying::text])", name: "chk_goals_kind_enum"
+    t.check_constraint "kind::text = ANY (ARRAY['one_off'::character varying, 'maintained'::character varying]::text[])", name: "chk_goals_kind_enum"
     t.check_constraint "progress_basis::text = ANY (ARRAY['balance'::character varying::text, 'contributions'::character varying::text])", name: "chk_goals_progress_basis_enum"
     t.check_constraint "state::text = ANY (ARRAY['active'::character varying::text, 'paused'::character varying::text, 'completed'::character varying::text, 'archived'::character varying::text])", name: "chk_savings_goals_state_enum"
     t.check_constraint "target_amount > 0::numeric", name: "chk_savings_goals_target_amount_positive"
-    t.check_constraint "target_mode::text = ANY (ARRAY['fixed'::character varying::text, 'months_of_expenses'::character varying::text])", name: "chk_goals_target_mode_enum"
+    t.check_constraint "target_mode::text = ANY (ARRAY['fixed'::character varying, 'months_of_expenses'::character varying]::text[])", name: "chk_goals_target_mode_enum"
   end
 
   create_table "holdings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -939,10 +960,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.datetime "last_activities_sync"
     t.datetime "last_holdings_sync"
     t.string "name"
-    t.jsonb "raw_activities_payload", default: {}
-    t.jsonb "raw_cash_report_payload", default: []
+    t.jsonb "raw_activities_payload", default: {}, null: false
+    t.jsonb "raw_cash_report_payload", default: [], null: false
     t.jsonb "raw_equity_summary_payload", default: [], null: false
-    t.jsonb "raw_holdings_payload", default: []
+    t.jsonb "raw_holdings_payload", default: [], null: false
     t.date "report_date"
     t.datetime "updated_at", null: false
     t.index ["ibkr_item_id", "ibkr_account_id"], name: "index_ibkr_accounts_on_item_and_ibkr_account_id", unique: true, where: "(ibkr_account_id IS NOT NULL)"
@@ -956,8 +977,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.boolean "pending_account_setup", default: false, null: false
     t.string "query_id"
     t.jsonb "raw_payload"
-    t.boolean "scheduled_for_deletion", default: false
-    t.string "status", default: "good"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
     t.string "token"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_ibkr_items_on_family_id"
@@ -1591,7 +1612,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index ["onchain_wallet_item_id", "chain", "wallet_address"], name: "index_onchain_wallet_accounts_unique_native", unique: true, where: "((asset_kind)::text = 'native'::text)"
     t.index ["onchain_wallet_item_id"], name: "index_onchain_wallet_accounts_on_onchain_wallet_item_id"
     t.check_constraint "asset_kind::text = 'native'::text OR contract_address IS NOT NULL", name: "chk_onchain_wallet_accounts_token_has_contract"
-    t.check_constraint "asset_kind::text = ANY (ARRAY['native'::character varying::text, 'erc20'::character varying::text, 'spl'::character varying::text])", name: "chk_onchain_wallet_accounts_known_asset_kind"
+    t.check_constraint "asset_kind::text = ANY (ARRAY['native'::character varying, 'erc20'::character varying, 'spl'::character varying]::text[])", name: "chk_onchain_wallet_accounts_known_asset_kind"
   end
 
   create_table "onchain_wallet_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1667,6 +1688,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index ["plaid_id"], name: "index_plaid_items_on_plaid_id", unique: true
   end
 
+  create_table "pockets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.decimal "allocated_amount", precision: 19, scale: 4, default: "0.0", null: false
+    t.string "color"
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.string "description"
+    t.string "fill_direction", default: "inflows", null: false
+    t.string "icon"
+    t.string "name", null: false
+    t.uuid "tag_id"
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "tag_id"], name: "index_pockets_on_account_and_tag_unique", unique: true, where: "(tag_id IS NOT NULL)"
+    t.index ["account_id"], name: "index_pockets_on_account_id"
+    t.index ["tag_id"], name: "index_pockets_on_tag_id"
+    t.check_constraint "allocated_amount >= 0::numeric", name: "chk_pockets_allocated_amount_non_negative"
+    t.check_constraint "btrim(currency::text) <> ''::text", name: "chk_pockets_currency_present"
+    t.check_constraint "btrim(name::text) <> ''::text", name: "chk_pockets_name_present"
+    t.check_constraint "fill_direction::text = ANY (ARRAY['inflows'::character varying::text, 'outflows'::character varying::text, 'both'::character varying::text])", name: "chk_pockets_fill_direction"
+  end
+
   create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "area_unit"
     t.integer "area_value"
@@ -1701,7 +1743,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index "lower((token)::text)", name: "index_push_subscriptions_on_lower_token", unique: true
     t.index ["last_registered_at"], name: "index_push_subscriptions_on_last_registered_at"
     t.index ["user_id"], name: "index_push_subscriptions_on_user_id"
-    t.check_constraint "environment::text = ANY (ARRAY['sandbox'::character varying::text, 'production'::character varying::text])", name: "chk_push_subscriptions_environment"
+    t.check_constraint "environment::text = ANY (ARRAY['sandbox'::character varying, 'production'::character varying]::text[])", name: "chk_push_subscriptions_environment"
     t.check_constraint "platform::text = 'ios'::text", name: "chk_push_subscriptions_platform"
   end
 
@@ -2321,6 +2363,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.uuid "taggable_id"
     t.string "taggable_type"
     t.datetime "updated_at", null: false
+    t.index ["tag_id", "taggable_type", "taggable_id"], name: "index_taggings_on_tag_and_taggable_unique", unique: true
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
     t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable"
   end
@@ -2673,6 +2716,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
   add_foreign_key "entries", "accounts", on_delete: :cascade
   add_foreign_key "entries", "entries", column: "parent_entry_id", on_delete: :cascade
   add_foreign_key "entries", "imports"
+  add_foreign_key "envelopes", "categories", on_delete: :nullify
+  add_foreign_key "envelopes", "families", on_delete: :cascade
   add_foreign_key "eval_results", "eval_runs"
   add_foreign_key "eval_results", "eval_samples"
   add_foreign_key "eval_runs", "eval_datasets"
@@ -2729,6 +2774,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
   add_foreign_key "onchain_wallet_items", "families"
   add_foreign_key "plaid_accounts", "plaid_items"
   add_foreign_key "plaid_items", "families"
+  add_foreign_key "pockets", "accounts"
+  add_foreign_key "pockets", "tags"
   add_foreign_key "push_subscriptions", "users"
   add_foreign_key "questrade_accounts", "questrade_items"
   add_foreign_key "questrade_items", "families"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,6 +97,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
   end
 
   create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "account_providers_count", default: 0, null: false
     t.uuid "accountable_id"
     t.string "accountable_type"
     t.decimal "balance", precision: 19, scale: 4
@@ -306,10 +307,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.string "institution_name"
     t.string "institution_url"
     t.string "name"
-    t.boolean "pending_account_setup", default: false
+    t.boolean "pending_account_setup", default: false, null: false
     t.jsonb "raw_payload"
-    t.boolean "scheduled_for_deletion", default: false
-    t.string "status", default: "good"
+    t.boolean "scheduled_for_deletion", default: false, null: false
+    t.string "status", default: "good", null: false
     t.datetime "sync_start_date"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_binance_items_on_family_id"
@@ -679,28 +680,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.check_constraint "reconciled_by_statement_id IS NULL OR reconciled_at IS NOT NULL", name: "chk_entries_reconciled_at_present_when_statement_set"
   end
 
-  create_table "envelopes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "category_id"
-    t.string "color"
-    t.datetime "created_at", null: false
-    t.string "currency", null: false
-    t.uuid "family_id", null: false
-    t.string "icon"
-    t.decimal "monthly_contribution", precision: 19, scale: 4, default: "0.0", null: false
-    t.string "name", null: false
-    t.text "notes"
-    t.date "starts_on", null: false
-    t.decimal "target_amount", precision: 19, scale: 4
-    t.date "target_date"
-    t.datetime "updated_at", null: false
-    t.index ["category_id"], name: "index_envelopes_on_category_unique", unique: true, where: "(category_id IS NOT NULL)"
-    t.index ["family_id"], name: "index_envelopes_on_family_id"
-    t.check_constraint "char_length(name::text) <= 255", name: "chk_envelopes_name_length"
-    t.check_constraint "monthly_contribution >= 0::numeric", name: "chk_envelopes_monthly_contribution_non_negative"
-    t.check_constraint "target_amount IS NULL OR target_amount > 0::numeric", name: "chk_envelopes_target_amount_positive"
-    t.check_constraint "target_date IS NULL OR target_amount IS NOT NULL", name: "chk_envelopes_target_date_requires_target_amount"
-  end
-
   create_table "eval_datasets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "active", default: true
     t.datetime "created_at", null: false
@@ -917,11 +896,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index ["family_id"], name: "index_goals_on_family_id"
     t.check_constraint "char_length(name::text) <= 255", name: "chk_savings_goals_name_length"
     t.check_constraint "consumed_amount >= 0::numeric", name: "chk_goals_consumed_amount_non_negative"
-    t.check_constraint "kind::text = ANY (ARRAY['one_off'::character varying, 'maintained'::character varying]::text[])", name: "chk_goals_kind_enum"
+    t.check_constraint "kind::text = ANY (ARRAY['one_off'::character varying::text, 'maintained'::character varying::text])", name: "chk_goals_kind_enum"
     t.check_constraint "progress_basis::text = ANY (ARRAY['balance'::character varying::text, 'contributions'::character varying::text])", name: "chk_goals_progress_basis_enum"
     t.check_constraint "state::text = ANY (ARRAY['active'::character varying::text, 'paused'::character varying::text, 'completed'::character varying::text, 'archived'::character varying::text])", name: "chk_savings_goals_state_enum"
     t.check_constraint "target_amount > 0::numeric", name: "chk_savings_goals_target_amount_positive"
-    t.check_constraint "target_mode::text = ANY (ARRAY['fixed'::character varying, 'months_of_expenses'::character varying]::text[])", name: "chk_goals_target_mode_enum"
+    t.check_constraint "target_mode::text = ANY (ARRAY['fixed'::character varying::text, 'months_of_expenses'::character varying::text])", name: "chk_goals_target_mode_enum"
   end
 
   create_table "holdings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -960,10 +939,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.datetime "last_activities_sync"
     t.datetime "last_holdings_sync"
     t.string "name"
-    t.jsonb "raw_activities_payload", default: {}, null: false
-    t.jsonb "raw_cash_report_payload", default: [], null: false
+    t.jsonb "raw_activities_payload", default: {}
+    t.jsonb "raw_cash_report_payload", default: []
     t.jsonb "raw_equity_summary_payload", default: [], null: false
-    t.jsonb "raw_holdings_payload", default: [], null: false
+    t.jsonb "raw_holdings_payload", default: []
     t.date "report_date"
     t.datetime "updated_at", null: false
     t.index ["ibkr_item_id", "ibkr_account_id"], name: "index_ibkr_accounts_on_item_and_ibkr_account_id", unique: true, where: "(ibkr_account_id IS NOT NULL)"
@@ -977,8 +956,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.boolean "pending_account_setup", default: false, null: false
     t.string "query_id"
     t.jsonb "raw_payload"
-    t.boolean "scheduled_for_deletion", default: false, null: false
-    t.string "status", default: "good", null: false
+    t.boolean "scheduled_for_deletion", default: false
+    t.string "status", default: "good"
     t.string "token"
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_ibkr_items_on_family_id"
@@ -1612,7 +1591,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index ["onchain_wallet_item_id", "chain", "wallet_address"], name: "index_onchain_wallet_accounts_unique_native", unique: true, where: "((asset_kind)::text = 'native'::text)"
     t.index ["onchain_wallet_item_id"], name: "index_onchain_wallet_accounts_on_onchain_wallet_item_id"
     t.check_constraint "asset_kind::text = 'native'::text OR contract_address IS NOT NULL", name: "chk_onchain_wallet_accounts_token_has_contract"
-    t.check_constraint "asset_kind::text = ANY (ARRAY['native'::character varying, 'erc20'::character varying, 'spl'::character varying]::text[])", name: "chk_onchain_wallet_accounts_known_asset_kind"
+    t.check_constraint "asset_kind::text = ANY (ARRAY['native'::character varying::text, 'erc20'::character varying::text, 'spl'::character varying::text])", name: "chk_onchain_wallet_accounts_known_asset_kind"
   end
 
   create_table "onchain_wallet_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1688,27 +1667,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index ["plaid_id"], name: "index_plaid_items_on_plaid_id", unique: true
   end
 
-  create_table "pockets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "account_id", null: false
-    t.decimal "allocated_amount", precision: 19, scale: 4, default: "0.0", null: false
-    t.string "color"
-    t.datetime "created_at", null: false
-    t.string "currency", null: false
-    t.string "description"
-    t.string "fill_direction", default: "inflows", null: false
-    t.string "icon"
-    t.string "name", null: false
-    t.uuid "tag_id"
-    t.datetime "updated_at", null: false
-    t.index ["account_id", "tag_id"], name: "index_pockets_on_account_and_tag_unique", unique: true, where: "(tag_id IS NOT NULL)"
-    t.index ["account_id"], name: "index_pockets_on_account_id"
-    t.index ["tag_id"], name: "index_pockets_on_tag_id"
-    t.check_constraint "allocated_amount >= 0::numeric", name: "chk_pockets_allocated_amount_non_negative"
-    t.check_constraint "btrim(currency::text) <> ''::text", name: "chk_pockets_currency_present"
-    t.check_constraint "btrim(name::text) <> ''::text", name: "chk_pockets_name_present"
-    t.check_constraint "fill_direction::text = ANY (ARRAY['inflows'::character varying::text, 'outflows'::character varying::text, 'both'::character varying::text])", name: "chk_pockets_fill_direction"
-  end
-
   create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "area_unit"
     t.integer "area_value"
@@ -1743,7 +1701,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.index "lower((token)::text)", name: "index_push_subscriptions_on_lower_token", unique: true
     t.index ["last_registered_at"], name: "index_push_subscriptions_on_last_registered_at"
     t.index ["user_id"], name: "index_push_subscriptions_on_user_id"
-    t.check_constraint "environment::text = ANY (ARRAY['sandbox'::character varying, 'production'::character varying]::text[])", name: "chk_push_subscriptions_environment"
+    t.check_constraint "environment::text = ANY (ARRAY['sandbox'::character varying::text, 'production'::character varying::text])", name: "chk_push_subscriptions_environment"
     t.check_constraint "platform::text = 'ios'::text", name: "chk_push_subscriptions_platform"
   end
 
@@ -2363,7 +2321,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
     t.uuid "taggable_id"
     t.string "taggable_type"
     t.datetime "updated_at", null: false
-    t.index ["tag_id", "taggable_type", "taggable_id"], name: "index_taggings_on_tag_and_taggable_unique", unique: true
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
     t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable"
   end
@@ -2716,8 +2673,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
   add_foreign_key "entries", "accounts", on_delete: :cascade
   add_foreign_key "entries", "entries", column: "parent_entry_id", on_delete: :cascade
   add_foreign_key "entries", "imports"
-  add_foreign_key "envelopes", "categories", on_delete: :nullify
-  add_foreign_key "envelopes", "families", on_delete: :cascade
   add_foreign_key "eval_results", "eval_runs"
   add_foreign_key "eval_results", "eval_samples"
   add_foreign_key "eval_runs", "eval_datasets"
@@ -2774,8 +2729,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
   add_foreign_key "onchain_wallet_items", "families"
   add_foreign_key "plaid_accounts", "plaid_items"
   add_foreign_key "plaid_items", "families"
-  add_foreign_key "pockets", "accounts"
-  add_foreign_key "pockets", "tags"
   add_foreign_key "push_subscriptions", "users"
   add_foreign_key "questrade_accounts", "questrade_items"
   add_foreign_key "questrade_items", "families"

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -35,6 +35,24 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "create defaults to investment contributions category when category_id is omitted" do
+    investment_category = ensure_investment_contributions_category(users(:family_admin).family)
+
+    assert_difference "Transfer.count", 1 do
+      post transfers_url, params: {
+        transfer: {
+          from_account_id: accounts(:depository).id,
+          to_account_id: accounts(:investment).id,
+          date: Date.current,
+          amount: 100
+        }
+      }
+    end
+
+    transfer = Transfer.order(:created_at).last
+    assert_equal investment_category, transfer.outflow_transaction.category
+  end
+
   test "resubmitting the same idempotency key does not create a duplicate transfer" do
     idempotency_key = SecureRandom.uuid
     params = {
@@ -645,6 +663,28 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to transactions_url
     assert_nil transfer.outflow_transaction.reload.category_id, "Should not assign a category belonging to another family"
+  end
+
+  test "omitted category_id on update leaves existing category unchanged" do
+    transfer = transfers(:one)
+    category = users(:family_admin).family.categories.create!(name: "Existing")
+    transfer.outflow_transaction.update!(category_id: category.id)
+
+    patch transfer_url(transfer), params: { transfer: { notes: "Test notes" } }
+
+    assert_redirected_to transactions_url
+    assert_equal category.id, transfer.outflow_transaction.reload.category_id
+  end
+
+  test "explicit blank category_id on update clears the category" do
+    transfer = transfers(:one)
+    category = users(:family_admin).family.categories.create!(name: "Existing")
+    transfer.outflow_transaction.update!(category_id: category.id)
+
+    patch transfer_url(transfer), params: { transfer: { category_id: "" } }
+
+    assert_redirected_to transactions_url
+    assert_nil transfer.outflow_transaction.reload.category_id
   end
 
   test "can add notes to transfer" do

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -687,6 +687,18 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     assert_nil transfer.outflow_transaction.reload.category_id
   end
 
+  test "category-only update leaves existing notes unchanged" do
+    transfer = transfers(:one)
+    transfer.update!(notes: "Existing note")
+    category = users(:family_admin).family.categories.create!(name: "Existing")
+
+    patch transfer_url(transfer), params: { transfer: { category_id: category.id } }
+
+    assert_redirected_to transactions_url
+    assert_equal "Existing note", transfer.reload.notes
+    assert_equal category.id, transfer.outflow_transaction.reload.category_id
+  end
+
   test "can add notes to transfer" do
     transfer = transfers(:one)
     assert_nil transfer.notes

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -636,6 +636,17 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     assert_equal original_inflow_tags, transfer.inflow_transaction.reload.tag_ids
   end
 
+  test "update transfer category ignores category from other family" do
+    transfer = transfers(:one)
+    other_family = Family.create!(name: "Other Family", currency: "USD")
+    other_category = other_family.categories.create!(name: "Foreign")
+
+    patch transfer_url(transfer), params: { transfer: { category_id: other_category.id } }
+
+    assert_redirected_to transactions_url
+    assert_nil transfer.outflow_transaction.reload.category_id, "Should not assign a category belonging to another family"
+  end
+
   test "can add notes to transfer" do
     transfer = transfers(:one)
     assert_nil transfer.notes

--- a/test/models/transfer/creator_test.rb
+++ b/test/models/transfer/creator_test.rb
@@ -43,6 +43,22 @@ class Transfer::CreatorTest < ActiveSupport::TestCase
     assert_equal "Transfer from #{@source_account.name}", inflow.entry.name
   end
 
+  test "preserves explicit blank category_id as uncategorized for investment contribution" do
+    creator = Transfer::Creator.new(
+      family: @family,
+      source_account_id: @source_account.id,
+      destination_account_id: @destination_account.id,
+      date: @date,
+      amount: @amount,
+      category_id: ""
+    )
+
+    transfer = creator.create
+
+    assert transfer.persisted?
+    assert_nil transfer.outflow_transaction.category, "Explicit Uncategorized selection should not fall back to Investment Contributions"
+  end
+
   test "creates basic transfer between depository accounts" do
     other_depository = @family.accounts.create!(name: "Savings", balance: 1000, currency: "USD", accountable: Depository.new)
 

--- a/test/models/transfer/creator_test.rb
+++ b/test/models/transfer/creator_test.rb
@@ -71,6 +71,24 @@ class Transfer::CreatorTest < ActiveSupport::TestCase
     assert_equal "funds_movement", inflow.kind
   end
 
+  test "ignores category_id belonging to another family" do
+    other_family_category = families(:empty).categories.create!(name: "Other family category")
+
+    creator = Transfer::Creator.new(
+      family: @family,
+      source_account_id: @source_account.id,
+      destination_account_id: accounts(:credit_card).id,
+      date: @date,
+      amount: @amount,
+      category_id: other_family_category.id
+    )
+
+    transfer = creator.create
+
+    assert transfer.persisted?
+    assert_nil transfer.outflow_transaction.category, "Should not assign a category belonging to another family"
+  end
+
   test "creates investment contribution when transferring from depository to crypto" do
     crypto_account = accounts(:crypto)
 


### PR DESCRIPTION
feat(transfers): Allow categorizing transfers on creation and for all transfer kinds

  Previously, Transfer#categorizable? only allowed a category on
  loan-payment transfers; regular transfers, credit card payments, and
  investment contributions were locked to a fixed Transfer/Payment
  badge, and the category could only be set after the fact from the
  transfer detail drawer.

  - Remove Transfer#categorizable? and the view-level badge fallback so the real category picker always renders (transactions list, mobile view, transfer detail drawer).
  - Add a category field to Transfer::Creator and the new-transfer form, applied to the outflow transaction; investment contributions still default to the investment-contributions category when none is chosen.
  - Drop the now-dead transfer_category/payment_category badge helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category selection to transfer creation and editing, including searchable dropdowns and an Uncategorized option.
  * Transfer categories can now be assigned, changed, or cleared directly from transaction views.
  * Added localized English and French labels for transfer categories.

* **Bug Fixes**
  * Improved category display for transfers and uncategorized transactions with clear transfer/payment badges.
  * Prevented categories from another family from being assigned to transfers.
  * Preserved explicit Uncategorized selections and existing notes when updating transfers without changing them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->