### PR TITLE
bugfix: Fix category merge form submission

### DIFF
--- a/app/views/categories/merge.html.erb
+++ b/app/views/categories/merge.html.erb
@@ -23,6 +23,7 @@
 
       <%= render DS::Button.new(
         text: t(".submit"),
+        type: :submit,
         full_width: true
       ) %>
     <% end %>

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -172,6 +172,7 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "#mobile-settings-nav"
+    assert_select "form[action='#{perform_merge_categories_path}'] button[type='submit']"
   end
 
   test "merge renders without the settings layout for modal frame requests" do


### PR DESCRIPTION
## Summary

  Fixes the category merge dialog so clicking “Merge selected categories” submits the form.

  The dialog used DS::Button without an explicit submit type. Since the component defaults to type="button" inside forms, the merge request was never sent.

  ## Changes

  - Set the merge button to type: :submit.
  - Added a rendered-form regression assertion confirming the merge form has a submit button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the category merge dialog’s submit button so it correctly submits the merge form.

* **Tests**
  * Added coverage confirming the merge form and submit button appear in the settings layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->