### PR TITLE
fix(goals): let a months-of-expenses reserve be created at all

### DIFF
--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -46,15 +46,21 @@ class Goal < ApplicationRecord
   # A target_amount edit is in the list because in this mode the amount is
   # derived, not typed: without it the form could persist an arbitrary figure
   # under a "six months of expenses" label until the next monthly refresh.
-  before_save :apply_months_of_expenses_target,
-              if: -> {
-                months_of_expenses_target? && (
-                  new_record? ||
-                  will_save_change_to_target_months? ||
-                  will_save_change_to_target_mode? ||
-                  will_save_change_to_target_amount?
-                )
-              }
+  # before_VALIDATION, not before_save. `target_amount` is required and must be
+  # positive, and those run before any save callback — so a reserve whose
+  # amount is derived arrived at validation empty and was refused before the
+  # callback that fills it ever ran. The form makes the field read-only in this
+  # mode, so there was no way to satisfy the validation by hand either: the
+  # months mode could not be created from the UI at all.
+  before_validation :apply_months_of_expenses_target,
+                    if: -> {
+                      months_of_expenses_target? && (
+                        new_record? ||
+                        target_months_changed? ||
+                        target_mode_changed? ||
+                        target_amount_changed?
+                      )
+                    }
 
   validate :must_have_at_least_one_linked_account
   validate :linked_accounts_must_be_fundable
@@ -1175,7 +1181,7 @@ class Goal < ApplicationRecord
       # the reserve already had. Same reasoning as the refresh job — a stale
       # floor beats a wrong one, and this one would be wearing a label saying
       # it was computed.
-      self.target_amount = target_amount_in_database if will_save_change_to_target_amount? && !new_record?
+      self.target_amount = target_amount_in_database if target_amount_changed? && !new_record?
     end
 
     # target_months only means something for a reserve on the months basis.

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -768,6 +768,42 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       assert_no_match(/already used|déjà utilisés/, label)
     end
 
+    # The months mode could not be created from the UI at all. The form makes the
+    # amount read-only, so it submits empty; `target_amount` is required and
+    # validations run before any save callback, so the derivation that fills it
+    # never ran. Every existing test set the amount explicitly, which is why the
+    # model looked fine.
+    test "a months-of-expenses reserve can be created without typing an amount" do
+      account = unclaimed_account("Reserve Pot")
+      IncomeStatement.any_instance.stubs(:median_expense).returns(500)
+
+      assert_difference -> { Goal.count }, 1 do
+        post goals_url, params: { goal: {
+          name: "Precaution", color: "#4da568", kind: "maintained",
+          target_mode: "months_of_expenses", target_months: "6",
+          target_amount: "", account_ids: [ account.id ]
+        } }
+      end
+
+      goal = Goal.order(created_at: :desc).first
+      assert_equal 3_000, goal.target_amount.to_d, "the floor was not derived from the months"
+      assert goal.maintained?
+    end
+
+    # A fixed reserve still needs one, and still says so.
+    test "a fixed-amount goal still requires the amount" do
+      account = unclaimed_account("Fixed Pot")
+
+      assert_no_difference -> { Goal.count } do
+        post goals_url, params: { goal: {
+          name: "No amount", color: "#4da568",
+          target_amount: "", account_ids: [ account.id ]
+        } }
+      end
+
+      assert_response :unprocessable_entity
+    end
+
   private
 
     # A private account of another member, linked to the goal under test.

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -679,6 +679,42 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t("goals.consume.errors.transaction_not_found"), flash[:alert]
   end
 
+  # The months mode could not be created from the UI at all. The form makes the
+  # amount read-only, so it submits empty; `target_amount` is required and
+  # validations run before any save callback, so the derivation that fills it
+  # never ran. Every existing test set the amount explicitly, which is why the
+  # model looked fine.
+  test "a months-of-expenses reserve can be created without typing an amount" do
+    account = unclaimed_account("Reserve Pot")
+    IncomeStatement.any_instance.stubs(:median_expense).returns(500)
+
+    assert_difference -> { Goal.count }, 1 do
+      post goals_url, params: { goal: {
+        name: "Precaution", color: "#4da568", kind: "maintained",
+        target_mode: "months_of_expenses", target_months: "6",
+        target_amount: "", account_ids: [ account.id ]
+      } }
+    end
+
+    goal = Goal.order(created_at: :desc).first
+    assert_equal 3_000, goal.target_amount.to_d, "the floor was not derived from the months"
+    assert goal.maintained?
+  end
+
+  # A fixed reserve still needs one, and still says so.
+  test "a fixed-amount goal still requires the amount" do
+    account = unclaimed_account("Fixed Pot")
+
+    assert_no_difference -> { Goal.count } do
+      post goals_url, params: { goal: {
+        name: "No amount", color: "#4da568",
+        target_amount: "", account_ids: [ account.id ]
+      } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   private
 
     def spent_goal_for_display
@@ -767,43 +803,6 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       label = css_select("[role=progressbar]").first["aria-label"]
       assert_no_match(/already used|déjà utilisés/, label)
     end
-
-    # The months mode could not be created from the UI at all. The form makes the
-    # amount read-only, so it submits empty; `target_amount` is required and
-    # validations run before any save callback, so the derivation that fills it
-    # never ran. Every existing test set the amount explicitly, which is why the
-    # model looked fine.
-    test "a months-of-expenses reserve can be created without typing an amount" do
-      account = unclaimed_account("Reserve Pot")
-      IncomeStatement.any_instance.stubs(:median_expense).returns(500)
-
-      assert_difference -> { Goal.count }, 1 do
-        post goals_url, params: { goal: {
-          name: "Precaution", color: "#4da568", kind: "maintained",
-          target_mode: "months_of_expenses", target_months: "6",
-          target_amount: "", account_ids: [ account.id ]
-        } }
-      end
-
-      goal = Goal.order(created_at: :desc).first
-      assert_equal 3_000, goal.target_amount.to_d, "the floor was not derived from the months"
-      assert goal.maintained?
-    end
-
-    # A fixed reserve still needs one, and still says so.
-    test "a fixed-amount goal still requires the amount" do
-      account = unclaimed_account("Fixed Pot")
-
-      assert_no_difference -> { Goal.count } do
-        post goals_url, params: { goal: {
-          name: "No amount", color: "#4da568",
-          target_amount: "", account_ids: [ account.id ]
-        } }
-      end
-
-      assert_response :unprocessable_entity
-    end
-
   private
 
     # A private account of another member, linked to the goal under test.

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -701,7 +701,10 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert goal.maintained?
   end
 
-  # A fixed reserve still needs one, and still says so.
+  # A fixed reserve still needs one, and still says so. Asserted on the error the
+  # form puts in front of the user, not on the status alone: a 422 for some
+  # unrelated reason would otherwise keep this green while the guard it names
+  # had quietly gone.
   test "a fixed-amount goal still requires the amount" do
     account = unclaimed_account("Fixed Pot")
 
@@ -713,6 +716,71 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unprocessable_entity
+    # The paragraph is in the markup either way; `hidden` is what decides
+    # whether it is shown, so its absence is the assertion.
+    assert_select "[data-goal-form-target=amountError]:not(.hidden)", 1,
+      "the form did not surface the missing-amount error"
+  end
+
+  # The surface the user actually reads: the figure beside the ring, and the
+  # line saying part of it has been used. Asserted on the rendered page rather
+  # than the model, because the contradiction was a display bug — the model
+  # has always counted both halves.
+  test "the goal page reports the used portion as part of the total" do
+    goal = spent_goal_for_display
+
+    get goal_url(goal)
+
+    assert_response :success
+    assert_includes response.body, I18n.t("goals.show.ring.including_used",
+                                          amount: goal.consumed_amount_money.format(precision: 0))
+
+    # The headline figure specifically, not "somewhere on the page": the
+    # account balance still appears in the funding breakdown below, which is
+    # where that question belongs.
+    headline = css_select("p.text-xl.font-medium.text-primary").map(&:text).map(&:strip)
+    assert_includes headline, goal.progress_amount_money.format(precision: 0)
+    assert_not_includes headline, goal.current_balance_money.format(precision: 0)
+  end
+
+  test "a goal that has spent nothing says nothing about it" do
+    account = unclaimed_account("Quiet Pot")
+    goal = @user.family.goals.create!(name: "Quiet", target_amount: 1_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account, allocated_amount: 1_000)
+    end
+
+    get goal_url(goal)
+
+    assert_response :success
+    assert_no_match(/already used|déjà utilisés/, response.body)
+  end
+
+
+  # The ring announced the account balance while the visible headline beside it
+  # reported the progress total: same ring, two different numbers depending on
+  # whether you could see it.
+  test "the ring announces the same total the headline shows" do
+    goal = spent_goal_for_display
+
+    get goal_url(goal)
+
+    assert_response :success
+    label = css_select("[role=progressbar]").first["aria-label"]
+    assert_includes label, goal.progress_amount_money.format
+    assert_not_includes label, goal.current_balance_money.format
+    assert_includes label, goal.consumed_amount_money.format
+  end
+
+  test "a goal with nothing used keeps the plain wording" do
+    account = unclaimed_account("Plain Pot")
+    goal = @user.family.goals.create!(name: "Plain", target_amount: 1_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account, allocated_amount: 1_000)
+    end
+
+    get goal_url(goal)
+
+    label = css_select("[role=progressbar]").first["aria-label"]
+    assert_no_match(/already used|déjà utilisés/, label)
   end
 
   private
@@ -742,68 +810,6 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       ActiveSupport::Notifications.unsubscribe(sub)
     end
 
-
-    # The surface the user actually reads: the figure beside the ring, and the
-    # line saying part of it has been used. Asserted on the rendered page rather
-    # than the model, because the contradiction was a display bug — the model
-    # has always counted both halves.
-    test "the goal page reports the used portion as part of the total" do
-      goal = spent_goal_for_display
-
-      get goal_url(goal)
-
-      assert_response :success
-      assert_includes response.body, I18n.t("goals.show.ring.including_used",
-                                            amount: goal.consumed_amount_money.format(precision: 0))
-
-      # The headline figure specifically, not "somewhere on the page": the
-      # account balance still appears in the funding breakdown below, which is
-      # where that question belongs.
-      headline = css_select("p.text-xl.font-medium.text-primary").map(&:text).map(&:strip)
-      assert_includes headline, goal.progress_amount_money.format(precision: 0)
-      assert_not_includes headline, goal.current_balance_money.format(precision: 0)
-    end
-
-    test "a goal that has spent nothing says nothing about it" do
-      account = unclaimed_account("Quiet Pot")
-      goal = @user.family.goals.create!(name: "Quiet", target_amount: 1_000, currency: "USD") do |g|
-        g.goal_accounts.build(account: account, allocated_amount: 1_000)
-      end
-
-      get goal_url(goal)
-
-      assert_response :success
-      assert_no_match(/already used|déjà utilisés/, response.body)
-    end
-
-
-    # The ring announced the account balance while the visible headline beside it
-    # reported the progress total: same ring, two different numbers depending on
-    # whether you could see it.
-    test "the ring announces the same total the headline shows" do
-      goal = spent_goal_for_display
-
-      get goal_url(goal)
-
-      assert_response :success
-      label = css_select("[role=progressbar]").first["aria-label"]
-      assert_includes label, goal.progress_amount_money.format
-      assert_not_includes label, goal.current_balance_money.format
-      assert_includes label, goal.consumed_amount_money.format
-    end
-
-    test "a goal with nothing used keeps the plain wording" do
-      account = unclaimed_account("Plain Pot")
-      goal = @user.family.goals.create!(name: "Plain", target_amount: 1_000, currency: "USD") do |g|
-        g.goal_accounts.build(account: account, allocated_amount: 1_000)
-      end
-
-      get goal_url(goal)
-
-      label = css_select("[role=progressbar]").first["aria-label"]
-      assert_no_match(/already used|déjà utilisés/, label)
-    end
-  private
 
     # A private account of another member, linked to the goal under test.
     def private_linked_account


### PR DESCRIPTION
The months-of-expenses reserve mode, added in #3180, cannot be used from the UI.

## What happens

1. Pick **Reserve to maintain**, then **Months of expenses**
2. The amount field becomes read-only — correctly, the figure is derived from the months
3. It is also empty: nothing has computed it yet on a new goal
4. Submit → **422**, *"Target amount can't be blank"*, on a field the user is not allowed to type in

Reproduced through the controller before changing anything:

```
réponse : 422
créé ?  : false
erreurs : blank
```

## Why

`target_amount` is `validates presence: true, numericality: { greater_than: 0 }`. The derivation was a `before_save`. Validations run before every save callback, so the value was refused before the callback that fills it ever ran.

`readonly` inputs are barred from HTML constraint validation, so the browser submits the empty field happily — the block is entirely server-side, and there is no way to satisfy it by hand because the field cannot be typed in.

## Why no test caught it

Every existing test sets `target_amount` explicitly:

```ruby
@family.goals.create!(name: "Precaution", target_amount: 3_000, ...,
                      target_mode: "months_of_expenses", target_months: 6)
```

Which is a reasonable thing for a model test to do, and it means the model looked healthy while the only path a user can take was broken. No controller test exercised the months mode at all.

## What changed

The derivation moves to `before_validation`, which is where a derived value belongs: computed, then validated like anything else.

The dirty-state predicates move with it — `will_save_change_to_*` describes a save that has not been decided on at that point, so they become `*_changed?`.

## What reviewers should look at

Two tests, both through the controller because that is where the gap was: a months reserve created with an empty amount and the floor derived from the months, and a fixed-amount goal still refused without one. The first fails on `main`.

The read-only field is left as it is. It is right that a derived figure cannot be typed over, and #3218's sibling question — whether a derived amount should look like a form field at all — is a presentation question worth its own change rather than a rider here.

## Testing

```
bin/rails test    7,319 runs, 29,214 assertions, 0 failures, 0 errors
rubocop / brakeman    clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creation of reserve goals using months-of-expenses targets by calculating required amounts during validation.
  * Fixed restoration checks to accurately reflect unsaved changes.
  * Preserved validation preventing fixed-amount goals from being saved without an amount.
  * Improved used-progress totals and wording for clearer, more accessible displays.

* **Tests**
  * Added coverage for derived amounts, blank fixed-amount validation, and used-progress displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->