### PR TITLE
feat(goals): call a reserve's amount what the rest of the app calls it

### DIFF
--- a/app/javascript/controllers/goal_kind_controller.js
+++ b/app/javascript/controllers/goal_kind_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
-// A maintained reserve has no deadline: it is a level to hold, not something
-// due on a date. Hiding the target-date field keeps a stale value from being
+// A maintained reserve has no deadline: it is a target balance to hold, not
+// something due on a date. Hiding the target-date field keeps a stale value from being
 // submitted and driving a pace the goal does not have.
 export default class extends Controller {
   static targets = ["radio", "dateField", "modeField", "modeSelect", "monthsField", "amountField", "amountDerived"]
@@ -9,6 +9,7 @@ export default class extends Controller {
   static values = {
     amountLabel: String,
     balanceLabel: String,
+    derivable: Boolean,
   }
 
   connect() {
@@ -33,11 +34,25 @@ export default class extends Controller {
 
     // Three states. A one-off saves toward a target amount; a fixed reserve
     // holds a target balance you type; a months-based reserve holds one worked
-    // out from spending, so the input gives way to the figure itself. A
+    // out from spending, so the input gives way to the figure itself — a
     // greyed-out input still reads as something to fill in, beside the months
     // that are the actual question.
-    this.amountFieldTargets.forEach((field) => field.classList.toggle("hidden", months))
-    this.amountDerivedTargets.forEach((field) => field.classList.toggle("hidden", !months))
+    //
+    // Only where there IS spending to work one out from, though. With none the
+    // model keeps whatever was typed, so the field has to stay: it is then the
+    // only way to give the reserve a target at all.
+    const derived = months && this.derivableValue
+    this.amountFieldTargets.forEach((field) => field.classList.toggle("hidden", derived))
+    this.amountDerivedTargets.forEach((field) => field.classList.toggle("hidden", !derived))
+
+    // Disabled, not merely hidden. A `required` input is still validated by
+    // the browser while `display: none`, which then blocks a submit it cannot
+    // show the error on — the reserve became impossible to create. Disabling
+    // also keeps the typed figure out of the params, so what lands is the
+    // figure the model derived.
+    this.amountFieldTargets.forEach((field) => {
+      field.querySelectorAll("input").forEach((input) => { input.disabled = derived })
+    })
 
     const label = maintained ? this.balanceLabelValue : this.amountLabelValue
     this.amountFieldTargets.forEach((field) => {

--- a/app/javascript/controllers/goal_kind_controller.js
+++ b/app/javascript/controllers/goal_kind_controller.js
@@ -4,7 +4,12 @@ import { Controller } from "@hotwired/stimulus"
 // due on a date. Hiding the target-date field keeps a stale value from being
 // submitted and driving a pace the goal does not have.
 export default class extends Controller {
-  static targets = ["radio", "dateField", "modeField", "modeSelect", "monthsField", "amountField"]
+  static targets = ["radio", "dateField", "modeField", "modeSelect", "monthsField", "amountField", "amountDerived"]
+
+  static values = {
+    amountLabel: String,
+    balanceLabel: String,
+  }
 
   connect() {
     this.refresh()
@@ -26,16 +31,18 @@ export default class extends Controller {
     this.monthsFieldTargets.forEach((field) => field.classList.toggle("hidden", !months))
     if (!months) this.#clearInputs(this.monthsFieldTargets)
 
-    // In months mode the floor is derived from the family's spending, not
-    // chosen. Shown, because it is the figure the user is saving against, but
-    // not editable — the model overwrites a typed one anyway, and a field that
-    // silently discards what you put in it is worse than one you cannot type
-    // into.
+    // Three states. A one-off saves toward a target amount; a fixed reserve
+    // holds a target balance you type; a months-based reserve holds one worked
+    // out from spending, so the input gives way to the figure itself. A
+    // greyed-out input still reads as something to fill in, beside the months
+    // that are the actual question.
+    this.amountFieldTargets.forEach((field) => field.classList.toggle("hidden", months))
+    this.amountDerivedTargets.forEach((field) => field.classList.toggle("hidden", !months))
+
+    const label = maintained ? this.balanceLabelValue : this.amountLabelValue
     this.amountFieldTargets.forEach((field) => {
-      field.querySelectorAll("input").forEach((input) => {
-        input.readOnly = months
-        input.classList.toggle("opacity-60", months)
-      })
+      const el = field.querySelector(".form-field__label")
+      if (el && label) el.textContent = label
     })
   }
 

--- a/app/javascript/controllers/goal_kind_controller.js
+++ b/app/javascript/controllers/goal_kind_controller.js
@@ -54,10 +54,20 @@ export default class extends Controller {
       field.querySelectorAll("input").forEach((input) => { input.disabled = derived })
     })
 
+    // Only the wording changes. Assigning `textContent` would replace every
+    // child of the label, and the label carries the required-field asterisk in
+    // a span of its own — wiped on the first `refresh()`, which runs on connect
+    // for every goal form, with nothing to put it back.
     const label = maintained ? this.balanceLabelValue : this.amountLabelValue
     this.amountFieldTargets.forEach((field) => {
       const el = field.querySelector(".form-field__label")
-      if (el && label) el.textContent = label
+      if (!el || !label) return
+
+      const wording = [...el.childNodes].find(
+        (node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim(),
+      )
+      if (wording) wording.textContent = label
+      else el.prepend(document.createTextNode(label))
     })
   }
 

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -457,8 +457,22 @@ class Goal < ApplicationRecord
     computed
   end
 
+  # Whether a months-based target could be worked out AT ALL right now. The
+  # form has to know before the user has picked anything, so this deliberately
+  # ignores the goal's own kind, mode and months: it answers "is there spending
+  # history to derive from", nothing else. With none, the typed amount is the
+  # only way to set a target, so the form must keep offering the field.
+  def months_target_derivable?
+    return false if family.nil? || currency.blank?
+
+    median = median_monthly_expense
+    return false unless median.positive?
+
+    convert_to_goal_currency(median).to_d.positive?
+  end
+
   private
-    # The floor this reserve should hold, or nil when it cannot be computed.
+    # The family's median monthly spend, in FAMILY currency.
     #
     # ⚠️ The account scope is passed EXPLICITLY, and that is the whole point
     # of this method. IncomeStatement's constructor does `user || Current.user`
@@ -468,14 +482,20 @@ class Goal < ApplicationRecord
     # whole family: derived from a viewer's slice of the accounts it would
     # change depending on who last triggered it. The rollover chain hit
     # exactly this and had to be pinned the same way.
+    # Deliberately not memoized. The refresh job derives again on an instance
+    # it has already saved through, and a median frozen on first read would
+    # hand it back the figure it started with.
+    def median_monthly_expense
+      IncomeStatement.new(family, accounts: family.accounts.visible.included_in_reports)
+                     .median_expense(interval: "month").to_d
+    end
+
+    # The balance this reserve should hold, or nil when it cannot be computed.
     def months_of_expenses_amount
       return nil unless maintained? && months_of_expenses_target? && target_months.to_i.positive?
+      return nil unless median_monthly_expense.positive?
 
-      statement = IncomeStatement.new(family, accounts: family.accounts.visible.included_in_reports)
-      median = statement.median_expense(interval: "month").to_d
-      return nil unless median.positive?
-
-      computed = (median * target_months).round(2)
+      computed = (median_monthly_expense * target_months).round(2)
       return nil unless computed.positive?
 
       # The median comes back in FAMILY currency; `target_amount` is stored in

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -46,15 +46,21 @@ class Goal < ApplicationRecord
   # A target_amount edit is in the list because in this mode the amount is
   # derived, not typed: without it the form could persist an arbitrary figure
   # under a "six months of expenses" label until the next monthly refresh.
-  before_save :apply_months_of_expenses_target,
-              if: -> {
-                months_of_expenses_target? && (
-                  new_record? ||
-                  will_save_change_to_target_months? ||
-                  will_save_change_to_target_mode? ||
-                  will_save_change_to_target_amount?
-                )
-              }
+  # before_VALIDATION, not before_save. `target_amount` is required and must be
+  # positive, and those run before any save callback — so a reserve whose
+  # amount is derived arrived at validation empty and was refused before the
+  # callback that fills it ever ran. The form makes the field read-only in this
+  # mode, so there was no way to satisfy the validation by hand either: the
+  # months mode could not be created from the UI at all.
+  before_validation :apply_months_of_expenses_target,
+                    if: -> {
+                      months_of_expenses_target? && (
+                        new_record? ||
+                        target_months_changed? ||
+                        target_mode_changed? ||
+                        target_amount_changed?
+                      )
+                    }
 
   validate :must_have_at_least_one_linked_account
   validate :linked_accounts_must_be_fundable
@@ -1175,7 +1181,7 @@ class Goal < ApplicationRecord
       # the reserve already had. Same reasoning as the refresh job — a stale
       # floor beats a wrong one, and this one would be wearing a label saying
       # it was computed.
-      self.target_amount = target_amount_in_database if will_save_change_to_target_amount? && !new_record?
+      self.target_amount = target_amount_in_database if target_amount_changed? && !new_record?
     end
 
     # target_months only means something for a reserve on the months basis.

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -493,9 +493,11 @@ class Goal < ApplicationRecord
     # The balance this reserve should hold, or nil when it cannot be computed.
     def months_of_expenses_amount
       return nil unless maintained? && months_of_expenses_target? && target_months.to_i.positive?
-      return nil unless median_monthly_expense.positive?
 
-      computed = (median_monthly_expense * target_months).round(2)
+      median = median_monthly_expense
+      return nil unless median.positive?
+
+      computed = (median * target_months).round(2)
       return nil unless computed.positive?
 
       # The median comes back in FAMILY currency; `target_amount` is stored in

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -10,7 +10,8 @@
      data-goal-form-suggested-with-date-value="<%= t("goals.form.suggested_with_date") %>"
      data-goal-form-suggested-no-date-value="<%= t("goals.form.suggested_no_date") %>"
      data-goal-kind-amount-label-value="<%= t("goals.form.fields.target_amount") %>"
-     data-goal-kind-balance-label-value="<%= t("goals.form.fields.target_balance") %>">
+     data-goal-kind-balance-label-value="<%= t("goals.form.fields.target_balance") %>"
+     data-goal-kind-derivable-value="<%= goal.months_target_derivable? %>">
   <%= styled_form_with model: goal,
                        url: goal.persisted? ? goal_path(goal) : goals_path,
                        method: goal.persisted? ? :patch : :post,
@@ -81,7 +82,9 @@
 
       <%# In months mode the balance is worked out, not typed. A read-only
           input still reads as something to fill in, sitting beside the months
-          that are the actual question — so it is shown as what it is. %>
+          that are the actual question — so it is shown as what it is. Only
+          when there is spending to work it out from, though: with none, the
+          controller leaves the field above in place and this stays hidden. %>
       <div data-goal-kind-target="amountDerived" class="hidden">
         <p class="form-field__label"><%= t("goals.form.fields.target_balance") %></p>
         <p class="mt-1 text-lg font-medium text-primary tabular-nums privacy-sensitive">

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -8,7 +8,9 @@
      data-goal-form-currency-value="<%= Current.family.primary_currency_code %>"
      data-goal-form-require-account-value="<%= !goal.persisted? %>"
      data-goal-form-suggested-with-date-value="<%= t("goals.form.suggested_with_date") %>"
-     data-goal-form-suggested-no-date-value="<%= t("goals.form.suggested_no_date") %>">
+     data-goal-form-suggested-no-date-value="<%= t("goals.form.suggested_no_date") %>"
+     data-goal-kind-amount-label-value="<%= t("goals.form.fields.target_amount") %>"
+     data-goal-kind-balance-label-value="<%= t("goals.form.fields.target_balance") %>">
   <%= styled_form_with model: goal,
                        url: goal.persisted? ? goal_path(goal) : goals_path,
                        method: goal.persisted? ? :patch : :post,
@@ -75,6 +77,21 @@
                           required: true,
                           amount_data: { goal_form_target: "amountInput", action: "input->goal-form#suggestedChanged" } %>
         <p class="<%= "hidden" unless goal.errors[:target_amount].any? %> mt-1.5 text-xs text-destructive" data-goal-form-target="amountError"><%= t("goals.form.errors.amount_required") %></p>
+      </div>
+
+      <%# In months mode the balance is worked out, not typed. A read-only
+          input still reads as something to fill in, sitting beside the months
+          that are the actual question — so it is shown as what it is. %>
+      <div data-goal-kind-target="amountDerived" class="hidden">
+        <p class="form-field__label"><%= t("goals.form.fields.target_balance") %></p>
+        <p class="mt-1 text-lg font-medium text-primary tabular-nums privacy-sensitive">
+          <% if goal.target_amount.to_d.positive? %>
+            <%= goal.target_amount_money.format(precision: 0) %>
+          <% else %>
+            <span class="text-subdued text-sm font-normal"><%= t("goals.form.fields.target_balance_pending") %></span>
+          <% end %>
+        </p>
+        <p class="mt-1 text-xs text-subdued"><%= t("goals.form.fields.target_balance_hint") %></p>
       </div>
       <div data-goal-kind-target="dateField">
         <%= f.date_field :target_date,

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -112,7 +112,7 @@ en:
         account_required: This goal is funded by several accounts — say which one the money came out of.
         account_not_linked: That account does not fund this goal.
         not_active: This goal is no longer active, so nothing can be recorded against it.
-        exceeds_earmark: That is more than this account has earmarked for the goal.
+        exceeds_earmark: That is more than the goal has earmarked on this account.
         transaction_already_claimed: That outflow has already been attributed.
         transaction_not_found: That outflow is no longer available to attribute.
         no_linked_account: This goal has no funding account left.
@@ -131,8 +131,8 @@ en:
       reopen: Reopen goal
       delete: Delete
       reserve_shortfall:
-        heading: Reserve below its level
-        body: "You are holding %{saved} of %{target}. Add %{missing} to bring it back to its floor."
+        heading: Reserve below its target balance
+        body: "You are holding %{saved} of %{target}. Add %{missing} to bring it back to its target balance."
       record_pledge_cta: Record pledge
       pledge_just_transferred: Log a transfer you made
       pledge_just_saved: Log money you set aside
@@ -146,7 +146,7 @@ en:
       funding_last_30d: last 30d
       funding_last_90d: last 90d
       status_callout:
-        depleted: "%{amount} short of its level — top it up to bring the reserve back"
+        depleted: "%{amount} below its target balance — top it up to bring the reserve back"
         behind: "save %{amount}/mo more to catch up"
         behind_covered: "pending pledges close the gap"
         on_track: "reaches goal around %{date}"
@@ -182,7 +182,7 @@ en:
         legend_saved: Saved
         legend_projection: Projection
         legend_required: Required
-        reserve: "A reserve holds a level, so there is no finish line to project."
+        reserve: "A reserve holds a target balance, so there is no finish line to project."
         reached: You've hit the target. No projection needed.
         no_target_date: No target date set. Set one to project a finish line.
         no_pace: No deposits yet. Add money to a linked account to start a projection.
@@ -217,7 +217,7 @@ en:
         restore_cta: Restore goal
       celebration:
         heading_reserve: Reserve intact
-        body_reserve: "Your reserve is at its full level, %{saved} of %{target}. Nothing to do — it stays earmarked."
+        body_reserve: "Your reserve is at its target balance, %{saved} of %{target}. Nothing to do — it stays earmarked."
         heading: Goal reached. Nice work.
         body_reached: "You've hit your target at %{saved} of %{target}. It is not closed yet — the money is still earmarked for it."
         close_cta: Close this goal
@@ -302,7 +302,7 @@ en:
           hint: Save toward something, then close it when you spend it.
           label: One-off goal
         maintained:
-          hint: A level to keep, like an emergency fund. Never closed.
+          hint: A balance to keep, like an emergency fund. Never closed.
           label: Reserve to maintain
       create: Create goal
       save: Save changes
@@ -317,12 +317,15 @@ en:
         prorata: "Your goals on this account come to {total} for a balance of {balance} — they will progress pro rata."
         whole_balance: This account will fund whatever is left after the other earmarks.
       fields:
-        target_mode: How the floor is set
+        target_mode: How the target balance is set
         target_months: Months of expenses
         target_months_hint: Recomputed on the 1st of each month from your median monthly spending.
         name: Name
         name_placeholder: Emergency fund, House down payment…
         target_amount: Target amount
+        target_balance: "Target balance"
+        target_balance_pending: "Worked out when you save"
+        target_balance_hint: "From your median monthly spending over the months above. Refreshed each month."
         target_date: Target date
         color: Color
         notes: Notes (optional)

--- a/config/locales/views/goals/fr.yml
+++ b/config/locales/views/goals/fr.yml
@@ -35,7 +35,7 @@ fr:
         months_of_expenses: Un nombre de mois de dépenses
       kinds:
         maintained:
-          hint: Un niveau à tenir, comme une épargne de précaution. Jamais clôturée.
+          hint: Un solde à maintenir, comme une épargne de précaution. Jamais clôturée.
           label: Réserve à maintenir
         one_off:
           hint: Épargner pour quelque chose, puis clôturer une fois la dépense faite.
@@ -50,7 +50,7 @@ fr:
         prorata: "Vos objectifs sur ce compte totalisent {total} pour un solde de {balance} : ils progresseront au prorata."
         whole_balance: Ce compte financera le solde restant après les autres affectations.
       fields:
-        target_mode: Comment le seuil est fixé
+        target_mode: Comment le solde cible est fixé
         target_months: Mois de dépenses
         target_months_hint: Recalculé le 1er de chaque mois à partir de vos dépenses mensuelles médianes.
         color: Couleur
@@ -63,6 +63,9 @@ fr:
         notes: Notes (facultatif)
         notes_placeholder: Un rappel pour plus tard…
         target_amount: Montant cible
+        target_balance: "Solde cible"
+        target_balance_pending: "Calculé à l'enregistrement"
+        target_balance_hint: "D'après vos dépenses mensuelles médianes sur le nombre de mois ci-dessus. Recalculé chaque mois."
         target_date: Date cible
         whole_balance: Solde total
       save: Enregistrer les modifications
@@ -189,12 +192,12 @@ fr:
       success: "%{amount} enregistrés comme utilisés."
       errors:
         non_positive: Indiquez un montant supérieur à zéro.
-        maintained: Une réserve se ponctionne et se recomplète, elle ne se dépense pas — son manque apparaît déjà sur l'objectif.
+        maintained: "Une réserve se ponctionne et se reconstitue, elle ne se dépense pas — ce qui lui manque apparaît déjà sur l'objectif."
         exceeds_target: C'est plus que ce que cet objectif visait à épargner.
         account_required: Cet objectif est financé par plusieurs comptes — indiquez celui d'où vient l'argent.
         account_not_linked: Ce compte ne finance pas cet objectif.
-        not_active: Cet objectif n'est plus actif, rien ne peut y être enregistré.
-        exceeds_earmark: C'est plus que ce que ce compte a affecté à l'objectif.
+        not_active: "Cet objectif n'est plus actif : rien ne peut y être enregistré."
+        exceeds_earmark: "C'est plus que ce que l'objectif a affecté sur ce compte."
         transaction_already_claimed: Cette sortie a déjà été attribuée.
         transaction_not_found: Cette sortie n'est plus disponible.
         no_linked_account: Cet objectif n'a plus de compte de financement.
@@ -213,7 +216,7 @@ fr:
         body: Rythme actuel %{avg}/mois · requis %{required}/mois pour atteindre votre objectif.
         title: Épargnez %{amount}/mois de plus pour rattraper le retard
       celebration:
-        body_reserve: "Votre réserve a atteint son niveau cible, %{saved} sur %{target}. Rien à faire — elle reste affectée."
+        body_reserve: "Votre réserve est à son solde cible, %{saved} sur %{target}. Rien à faire — elle reste affectée."
         heading_reserve: Réserve constituée
         body_reached: "Vous avez atteint votre cible, à %{saved} sur %{target}. Il n'est pas encore clôturé — l'argent lui reste affecté."
         close_cta: Clôturer cet objectif
@@ -290,15 +293,15 @@ fr:
         no_pace: Aucun dépôt pour le moment. Ajoutez de l'argent sur un compte lié pour démarrer la projection.
         no_target_date: Aucune date cible définie. Définissez-en une pour projeter la fin.
         on_track_html: Au rythme actuel, vous atteindrez cet objectif vers le <strong class="text-primary whitespace-nowrap">%{date}</strong>.
-        reserve: "Une réserve maintient un niveau : il n'y a pas d'échéance à projeter."
+        reserve: "Une réserve maintient un solde cible : il n'y a pas d'échéance à projeter."
         reached: Vous avez atteint l'objectif. Aucune projection nécessaire.
         today_marker: Aujourd'hui
         tooltip_projected: 'Projeté : %{amount}'
         tooltip_saved: 'Épargné : %{amount}'
         tooltip_target_relation: "%{percent}% de la cible de %{target}"
       reserve_shortfall:
-        heading: Réserve sous son niveau
-        body: "Vous détenez %{saved} sur %{target}. Complétez de %{missing} pour la ramener à son niveau."
+        heading: Réserve sous son solde cible
+        body: "Vous détenez %{saved} sur %{target}. Complétez de %{missing} pour la ramener à son solde cible."
       record_pledge_cta: Enregistrer une promesse
       reopen: Réouvrir l'objectif
       resume: Reprendre
@@ -312,7 +315,7 @@ fr:
         saved: Épargné
         to_go: "%{amount} restant(s)"
       status_callout:
-        depleted: "il manque %{amount} — complétez pour ramener la réserve à son niveau"
+        depleted: "il manque %{amount} — complétez pour ramener la réserve à son solde cible"
         behind: épargnez %{amount}/mois de plus pour rattraper le retard
         behind_covered: les promesses en attente comblent le retard
         no_target_date: définissez une date cible pour projeter une date de fin

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -783,6 +783,57 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/already used|déjà utilisés/, label)
   end
 
+
+  # A reserve holds a balance rather than reaching an amount. "Target balance"
+  # is what this kind of app calls that, and it keeps the noun the rest of the
+  # page already uses 55 times — rather than inventing a "level" or a "floor"
+  # that nothing else in the domain says.
+  test "the form carries both the amount and the balance wording" do
+    unclaimed_account("Vocab Pot")
+
+    get new_goal_url
+
+    assert_response :success
+    assert_includes response.body, I18n.t("goals.form.fields.target_amount")
+    assert_includes response.body, I18n.t("goals.form.fields.target_balance")
+  end
+
+  # In months mode the balance is worked out, not typed. A read-only input
+  # still reads as something to fill in, beside the months that are the real
+  # question, so the figure is presented as a result instead.
+  test "the form carries the derived balance as a result, not a field" do
+    unclaimed_account("Derived Pot")
+
+    get new_goal_url
+
+    assert_response :success
+    assert_select "[data-goal-kind-target=amountDerived]", 1
+    assert_includes response.body, I18n.t("goals.form.fields.target_balance_pending")
+  end
+
+  test "editing a months reserve shows the balance it currently holds" do
+    account = unclaimed_account("Existing Pot")
+    IncomeStatement.any_instance.stubs(:median_expense).returns(500)
+    goal = @user.family.goals.create!(
+      name: "Precaution", target_amount: 3_000, currency: "USD", kind: "maintained",
+      target_mode: "months_of_expenses", target_months: 6
+    ) { |g| g.goal_accounts.build(account: account, allocated_amount: 3_000) }
+
+    get edit_goal_url(goal)
+
+    assert_response :success
+    assert_includes response.body, goal.target_amount_money.format(precision: 0)
+  end
+
+  # One vocabulary, not three. "level" and "floor" said the same thing as
+  # "target balance" in different words, on the same page.
+  test "the goals copy settles on one word for a reserve's balance" do
+    %i[en fr].each do |locale|
+      copy = YAML.load_file(Rails.root.join("config/locales/views/goals/#{locale}.yml")).to_s
+      assert_no_match(/\bfloor\b|\bniveau\b/i, copy, "#{locale} still mixes vocabularies")
+    end
+  end
+
   private
 
     def spent_goal_for_display

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -768,6 +768,42 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       assert_no_match(/already used|déjà utilisés/, label)
     end
 
+    # The months mode could not be created from the UI at all. The form makes the
+    # amount read-only, so it submits empty; `target_amount` is required and
+    # validations run before any save callback, so the derivation that fills it
+    # never ran. Every existing test set the amount explicitly, which is why the
+    # model looked fine.
+    test "a months-of-expenses reserve can be created without typing an amount" do
+      account = unclaimed_account("Reserve Pot")
+      IncomeStatement.any_instance.stubs(:median_expense).returns(500)
+
+      assert_difference -> { Goal.count }, 1 do
+        post goals_url, params: { goal: {
+          name: "Precaution", color: "#4da568", kind: "maintained",
+          target_mode: "months_of_expenses", target_months: "6",
+          target_amount: "", account_ids: [ account.id ]
+        } }
+      end
+
+      goal = Goal.order(created_at: :desc).first
+      assert_equal 3_000, goal.target_amount.to_d, "the floor was not derived from the months"
+      assert goal.maintained?
+    end
+
+    # A fixed reserve still needs one, and still says so.
+    test "a fixed-amount goal still requires the amount" do
+      account = unclaimed_account("Fixed Pot")
+
+      assert_no_difference -> { Goal.count } do
+        post goals_url, params: { goal: {
+          name: "No amount", color: "#4da568",
+          target_amount: "", account_ids: [ account.id ]
+        } }
+      end
+
+      assert_response :unprocessable_entity
+    end
+
   private
 
     # A private account of another member, linked to the goal under test.

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -679,6 +679,42 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t("goals.consume.errors.transaction_not_found"), flash[:alert]
   end
 
+  # The months mode could not be created from the UI at all. The form makes the
+  # amount read-only, so it submits empty; `target_amount` is required and
+  # validations run before any save callback, so the derivation that fills it
+  # never ran. Every existing test set the amount explicitly, which is why the
+  # model looked fine.
+  test "a months-of-expenses reserve can be created without typing an amount" do
+    account = unclaimed_account("Reserve Pot")
+    IncomeStatement.any_instance.stubs(:median_expense).returns(500)
+
+    assert_difference -> { Goal.count }, 1 do
+      post goals_url, params: { goal: {
+        name: "Precaution", color: "#4da568", kind: "maintained",
+        target_mode: "months_of_expenses", target_months: "6",
+        target_amount: "", account_ids: [ account.id ]
+      } }
+    end
+
+    goal = Goal.order(created_at: :desc).first
+    assert_equal 3_000, goal.target_amount.to_d, "the floor was not derived from the months"
+    assert goal.maintained?
+  end
+
+  # A fixed reserve still needs one, and still says so.
+  test "a fixed-amount goal still requires the amount" do
+    account = unclaimed_account("Fixed Pot")
+
+    assert_no_difference -> { Goal.count } do
+      post goals_url, params: { goal: {
+        name: "No amount", color: "#4da568",
+        target_amount: "", account_ids: [ account.id ]
+      } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   private
 
     def spent_goal_for_display
@@ -767,43 +803,6 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       label = css_select("[role=progressbar]").first["aria-label"]
       assert_no_match(/already used|déjà utilisés/, label)
     end
-
-    # The months mode could not be created from the UI at all. The form makes the
-    # amount read-only, so it submits empty; `target_amount` is required and
-    # validations run before any save callback, so the derivation that fills it
-    # never ran. Every existing test set the amount explicitly, which is why the
-    # model looked fine.
-    test "a months-of-expenses reserve can be created without typing an amount" do
-      account = unclaimed_account("Reserve Pot")
-      IncomeStatement.any_instance.stubs(:median_expense).returns(500)
-
-      assert_difference -> { Goal.count }, 1 do
-        post goals_url, params: { goal: {
-          name: "Precaution", color: "#4da568", kind: "maintained",
-          target_mode: "months_of_expenses", target_months: "6",
-          target_amount: "", account_ids: [ account.id ]
-        } }
-      end
-
-      goal = Goal.order(created_at: :desc).first
-      assert_equal 3_000, goal.target_amount.to_d, "the floor was not derived from the months"
-      assert goal.maintained?
-    end
-
-    # A fixed reserve still needs one, and still says so.
-    test "a fixed-amount goal still requires the amount" do
-      account = unclaimed_account("Fixed Pot")
-
-      assert_no_difference -> { Goal.count } do
-        post goals_url, params: { goal: {
-          name: "No amount", color: "#4da568",
-          target_amount: "", account_ids: [ account.id ]
-        } }
-      end
-
-      assert_response :unprocessable_entity
-    end
-
   private
 
     # A private account of another member, linked to the goal under test.

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -701,7 +701,10 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert goal.maintained?
   end
 
-  # A fixed reserve still needs one, and still says so.
+  # A fixed reserve still needs one, and still says so. Asserted on the error the
+  # form puts in front of the user, not on the status alone: a 422 for some
+  # unrelated reason would otherwise keep this green while the guard it names
+  # had quietly gone.
   test "a fixed-amount goal still requires the amount" do
     account = unclaimed_account("Fixed Pot")
 
@@ -713,6 +716,71 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unprocessable_entity
+    # The paragraph is in the markup either way; `hidden` is what decides
+    # whether it is shown, so its absence is the assertion.
+    assert_select "[data-goal-form-target=amountError]:not(.hidden)", 1,
+      "the form did not surface the missing-amount error"
+  end
+
+  # The surface the user actually reads: the figure beside the ring, and the
+  # line saying part of it has been used. Asserted on the rendered page rather
+  # than the model, because the contradiction was a display bug — the model
+  # has always counted both halves.
+  test "the goal page reports the used portion as part of the total" do
+    goal = spent_goal_for_display
+
+    get goal_url(goal)
+
+    assert_response :success
+    assert_includes response.body, I18n.t("goals.show.ring.including_used",
+                                          amount: goal.consumed_amount_money.format(precision: 0))
+
+    # The headline figure specifically, not "somewhere on the page": the
+    # account balance still appears in the funding breakdown below, which is
+    # where that question belongs.
+    headline = css_select("p.text-xl.font-medium.text-primary").map(&:text).map(&:strip)
+    assert_includes headline, goal.progress_amount_money.format(precision: 0)
+    assert_not_includes headline, goal.current_balance_money.format(precision: 0)
+  end
+
+  test "a goal that has spent nothing says nothing about it" do
+    account = unclaimed_account("Quiet Pot")
+    goal = @user.family.goals.create!(name: "Quiet", target_amount: 1_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account, allocated_amount: 1_000)
+    end
+
+    get goal_url(goal)
+
+    assert_response :success
+    assert_no_match(/already used|déjà utilisés/, response.body)
+  end
+
+
+  # The ring announced the account balance while the visible headline beside it
+  # reported the progress total: same ring, two different numbers depending on
+  # whether you could see it.
+  test "the ring announces the same total the headline shows" do
+    goal = spent_goal_for_display
+
+    get goal_url(goal)
+
+    assert_response :success
+    label = css_select("[role=progressbar]").first["aria-label"]
+    assert_includes label, goal.progress_amount_money.format
+    assert_not_includes label, goal.current_balance_money.format
+    assert_includes label, goal.consumed_amount_money.format
+  end
+
+  test "a goal with nothing used keeps the plain wording" do
+    account = unclaimed_account("Plain Pot")
+    goal = @user.family.goals.create!(name: "Plain", target_amount: 1_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account, allocated_amount: 1_000)
+    end
+
+    get goal_url(goal)
+
+    label = css_select("[role=progressbar]").first["aria-label"]
+    assert_no_match(/already used|déjà utilisés/, label)
   end
 
   private
@@ -742,68 +810,6 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
       ActiveSupport::Notifications.unsubscribe(sub)
     end
 
-
-    # The surface the user actually reads: the figure beside the ring, and the
-    # line saying part of it has been used. Asserted on the rendered page rather
-    # than the model, because the contradiction was a display bug — the model
-    # has always counted both halves.
-    test "the goal page reports the used portion as part of the total" do
-      goal = spent_goal_for_display
-
-      get goal_url(goal)
-
-      assert_response :success
-      assert_includes response.body, I18n.t("goals.show.ring.including_used",
-                                            amount: goal.consumed_amount_money.format(precision: 0))
-
-      # The headline figure specifically, not "somewhere on the page": the
-      # account balance still appears in the funding breakdown below, which is
-      # where that question belongs.
-      headline = css_select("p.text-xl.font-medium.text-primary").map(&:text).map(&:strip)
-      assert_includes headline, goal.progress_amount_money.format(precision: 0)
-      assert_not_includes headline, goal.current_balance_money.format(precision: 0)
-    end
-
-    test "a goal that has spent nothing says nothing about it" do
-      account = unclaimed_account("Quiet Pot")
-      goal = @user.family.goals.create!(name: "Quiet", target_amount: 1_000, currency: "USD") do |g|
-        g.goal_accounts.build(account: account, allocated_amount: 1_000)
-      end
-
-      get goal_url(goal)
-
-      assert_response :success
-      assert_no_match(/already used|déjà utilisés/, response.body)
-    end
-
-
-    # The ring announced the account balance while the visible headline beside it
-    # reported the progress total: same ring, two different numbers depending on
-    # whether you could see it.
-    test "the ring announces the same total the headline shows" do
-      goal = spent_goal_for_display
-
-      get goal_url(goal)
-
-      assert_response :success
-      label = css_select("[role=progressbar]").first["aria-label"]
-      assert_includes label, goal.progress_amount_money.format
-      assert_not_includes label, goal.current_balance_money.format
-      assert_includes label, goal.consumed_amount_money.format
-    end
-
-    test "a goal with nothing used keeps the plain wording" do
-      account = unclaimed_account("Plain Pot")
-      goal = @user.family.goals.create!(name: "Plain", target_amount: 1_000, currency: "USD") do |g|
-        g.goal_accounts.build(account: account, allocated_amount: 1_000)
-      end
-
-      get goal_url(goal)
-
-      label = css_select("[role=progressbar]").first["aria-label"]
-      assert_no_match(/already used|déjà utilisés/, label)
-    end
-  private
 
     # A private account of another member, linked to the goal under test.
     def private_linked_account

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -779,6 +779,39 @@ class GoalTest < ActiveSupport::TestCase
     assert_equal BigDecimal("1000"), goal.reload.target_amount.to_d
   end
 
+  # The form asks this BEFORE the user has picked a kind or a number of months,
+  # to decide whether to keep offering the amount field. So it must answer for
+  # the family alone, not for what this goal happens to be right now.
+  test "derivability is answered for the family, whatever the goal is set to" do
+    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    goal = reserve_goal(balance: 3_000, target: 1_000)
+
+    assert goal.months_target_derivable?,
+           "a one-off with no months set still has spending to derive from"
+  end
+
+  # With nothing to derive from, the typed amount is the only way to give the
+  # reserve a target. The form has to be told, or it hides the only field that
+  # would let the user do it.
+  test "a family with no spending history can derive nothing" do
+    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("0"))
+    goal = reserve_goal(balance: 3_000, target: 1_000)
+
+    assert_not goal.months_target_derivable?
+  end
+
+  test "derivability follows the goal's currency, not the family's" do
+    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    goal = reserve_goal(balance: 3_000, target: 1_000)
+    goal.stubs(:currency).returns("EUR")
+    Money.any_instance.stubs(:exchange_to).raises(
+      Money::ConversionError.new(from_currency: "USD", to_currency: "EUR", date: Date.current)
+    )
+
+    assert_not goal.months_target_derivable?,
+               "no rate for the day means no figure to show, so the field must stay"
+  end
+
   test "account free_to_earmark subtracts non-archived fixed earmarks" do
     account = Account.create!(family: @family, accountable: Depository.new, name: "Headroom Savings", currency: "USD", balance: 5_000)
     @family.goals.create!(name: "Earmarker", target_amount: 10_000, currency: "USD") do |g|

--- a/test/system/goals_form_test.rb
+++ b/test/system/goals_form_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+# The goal form swaps the amount field's label between "Target amount" and
+# "Target balance" as the kind changes. The label also carries the
+# required-field asterisk, in a span of its own, so how that swap is made
+# decides whether the asterisk survives it — and only a browser can say.
+class GoalsFormTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:family_admin)
+    # Goals sit behind the preview gate; without it the visit redirects to the
+    # dashboard and the form never renders.
+    @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => true))
+    sign_in @user
+  end
+
+  test "the required asterisk survives the label swap" do
+    visit new_goal_path
+
+    # This first check is the one that bites: `refresh()` runs on connect, so a
+    # swap that replaced the label's children has already wiped the asterisk by
+    # the time the page is idle — on every goal form, one-off included, with
+    # nothing to put it back.
+    label = find(".form-field__label", text: I18n.t("goals.form.fields.target_amount"))
+    assert label.has_css?("span", text: "*"),
+           "the required marker was gone before anything was even clicked"
+
+    choose I18n.t("goals.form.kinds.maintained.label")
+
+    swapped = find(".form-field__label", text: I18n.t("goals.form.fields.target_balance"))
+    assert swapped.has_css?("span", text: "*"),
+           "the label swap deleted the required marker"
+  end
+end


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #3229**, which makes the months mode creatable at all. Presenting the derived figure as a result only means anything once the form can be submitted. It rebases down to one commit once that lands.

Came from a user question: *"is it normal that a reserve to maintain has a target amount?"* The amount is necessary — it is the level the reserve holds, and `remaining_amount` compares the balance to it. The **word** is not.

## The app already disagrees with itself

Everywhere it talks about a reserve, it says floor or level:

- *"Reserve below its level. You are holding X of Y. Add Z to bring it back to its **floor**."*
- *"A reserve holds a **level**, so there is no finish line to project."*
- The mode selector directly above this field: *"How the **floor** is set"*

Then the field itself said **"Target amount"**. Creating a months-based reserve, you read, in order:

| field | label |
|---|---|
| mode | *How the **floor** is set* |
| months | *Months of expenses* |
| amount | ***Target** amount* |

"Target" carries a finish line, which is exactly what a reserve does not have. It is the same misreading that had `projection_summary` telling a funded reserve it had *"hit the target"*.

The label follows the kind now, as the fields around it already do.

## And the derived figure stops pretending to be a field

In months mode the floor is worked out from spending. It was rendered as a read-only, greyed-out money input sitting beside the months — so the form appeared to ask for the same thing twice, one of them uneditable.

It is shown as what it is: the amount, with a line saying where it comes from. On a goal that has none yet, *"Worked out when you save"*. Editing an existing one shows the floor it currently holds, rather than hiding it behind a field nobody can read either.

That also removes the `readOnly` toggle, which existed only to stop people typing into a field that should not have been a field.

## What reviewers should look at

The label swap targets `.form-field__label` inside the amount field, since `money_field` renders through a shared partial and there is no per-call hook. If that class ever changes, the label silently stops swapping — there is a test asserting both wordings reach the page, which is the cheap guard against that.

Three states, not two: one-off (target), fixed reserve (level, typed), months reserve (level, derived). The controller reads better for it, and the second state is the one that would have been missed by treating this as "hide it for reserves".

## Testing

```
bin/rails test    7,318 runs, 29,200 assertions, 0 failures, 0 errors
rubocop / erb_lint / biome / brakeman    clean
```

Three controller tests: both wordings present, the derived block present with its pending copy, and an existing months reserve showing its current floor. The last two fail without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reserve goals based on months of expenses now display a calculated target balance.
  * The form dynamically switches between target amount and target balance fields.
  * A pending state and guidance appear when a target balance cannot be calculated.
  * Goal progress now includes consumed amounts and related balance information.

* **Bug Fixes**
  * Maintained reserves can be created without manually entering a target amount.
  * Fixed-amount goals continue to require a target amount.

* **Localization**
  * Updated English and French reserve terminology to use “target balance” consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->