### PR TITLE
fix(goals): define RELEASED_STATES once

### DIFF
--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -12,7 +12,10 @@ class Goal < ApplicationRecord
   # exclusivity check, and the restore guard below. Keeping them on one constant
   # is what stops the double-counting hole from reopening the day this set
   # grows: adding a state here makes every one of them release together.
-  RELEASED_STATES = %w[archived].freeze
+  #
+  # `completed` belongs here for the same reason `archived` does: completing a
+  # goal hands back the earmark, so its links must stop reserving too.
+  RELEASED_STATES = %w[archived completed].freeze
 
   validates :icon, inclusion: { in: ICONS, allow_nil: true }
   validates :color, format: { with: /\A#[0-9A-Fa-f]{6}\z/ }, allow_nil: true
@@ -116,8 +119,6 @@ class Goal < ApplicationRecord
       super("goal consumption refused: #{reason}")
     end
   end
-
-  RELEASED_STATES = %w[archived completed].freeze
 
   # A one-off goal is reached once and then closed; a maintained one is a
   # floor to hold — an emergency fund is not an achievement to file away, it


### PR DESCRIPTION
## What

`Goal` defines `RELEASED_STATES` twice:

```ruby
app/models/goal.rb:15   RELEASED_STATES = %w[archived].freeze
app/models/goal.rb:120  RELEASED_STATES = %w[archived completed].freeze
```

Ruby warns on every boot:

```
app/models/goal.rb:120: warning: already initialized constant Goal::RELEASED_STATES
app/models/goal.rb:15: warning: previous definition of RELEASED_STATES was here
```

## How it happened

#3160 and #3165 each introduced the constant, in different places and with
different values. Neither touched the other's line, so git merged both in
without a conflict and no review saw them side by side. My doing, both times.

## Why it is not a behaviour change

The later definition wins, so the value in force is already
`%w[archived completed]` — the one #3165 intended, and the correct one for
#3160's restore guard too, since a completed goal has likewise handed back its
earmark. This removes the dead first assignment only.

The documented block at the top of the class is what survives, because that is
where the constant is explained; it gains a line saying why `completed` is in
the set.

## Verification

`goal_test.rb`, `goal_account_test.rb`, `goal_consumption_test.rb` — 141 runs,
349 assertions, 0 failures, and the warning is gone from the test output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTNba5qE5NwzaHzbp27ye

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed goals are now treated like archived goals when calculating shared funds and account conflicts.
  * Restoring goals no longer incorrectly recreates conflicts caused by completed goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->