### PR TITLE
fix(holdings): an outbound transfer must not clear a cost basis

### DIFF
--- a/db/migrate/20260826090000_clear_transferred_position_cost_bases.rb
+++ b/db/migrate/20260826090000_clear_transferred_position_cost_bases.rb
@@ -11,6 +11,13 @@
 # Only figures this app worked out are cleared. A `manual` or `provider` basis
 # is somebody asserting what the position cost, which is exactly the thing the
 # app cannot derive for a transfer, and stays.
+#
+# And only an INBOUND transfer, matching what the runtime does: both
+# `Holding#calculate_avg_cost` and the calculators drop `qty <= 0` rows before
+# they ever look at the label. Shares sent elsewhere say nothing about what the
+# remaining ones cost — that figure was worked out from real purchases and is
+# correct. Clearing it here would destroy a good number, irreversibly, on a
+# position the app still stands behind.
 class ClearTransferredPositionCostBases < ActiveRecord::Migration[7.2]
   def up
     execute <<~SQL
@@ -27,6 +34,7 @@ class ClearTransferredPositionCostBases < ActiveRecord::Migration[7.2]
           WHERE trades.security_id = holdings.security_id
             AND entries.account_id = holdings.account_id
             AND trades.investment_activity_label = 'Transfer'
+            AND trades.qty > 0
             AND entries.date <= holdings.date
         )
     SQL

--- a/test/migrations/clear_transferred_position_cost_bases_migration_test.rb
+++ b/test/migrations/clear_transferred_position_cost_bases_migration_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require Rails.root.join("db/migrate/20260826090000_clear_transferred_position_cost_bases")
+
+# The migration exists to clear figures the app fabricated for positions it
+# could not know the cost of. Which positions those are is decided at runtime by
+# `Holding#calculate_avg_cost` and the calculators, and the migration has to
+# agree with them — it destroys data and cannot be undone.
+class ClearTransferredPositionCostBasesMigrationTest < ActiveSupport::TestCase
+  setup do
+    @holding = holdings(:one)
+    @account = @holding.account
+    # Everything already there is an ordinary purchase; the transfer under test
+    # is the only one.
+    @account.trades.update_all(investment_activity_label: "Buy")
+    @holding.update_columns(
+      cost_basis: 100, cost_basis_source: "calculated", cost_basis_locked: false
+    )
+  end
+
+  test "a position transferred in loses the figure the app worked out" do
+    transfer(qty: 5)
+
+    assert_nil computed_basis, "the runtime already treats this position as unknowable"
+
+    run_migration
+
+    assert_nil @holding.reload.cost_basis
+    assert_nil @holding.reload.cost_basis_source
+  end
+
+  # The runtime only invalidates on a transfer IN: both `calculate_avg_cost` and
+  # the calculators drop `qty <= 0` rows before they ever look at the label.
+  # Shares sent elsewhere leave the remaining ones with the cost they were
+  # actually bought at, and that figure is correct.
+  test "a position transferred out keeps it" do
+    transfer(qty: -5)
+
+    assert_not_nil computed_basis, "the runtime keeps the basis after an outbound transfer"
+
+    run_migration
+
+    assert_equal 100, @holding.reload.cost_basis.to_d,
+                 "an outbound transfer destroyed a basis the app still stands behind"
+  end
+
+  test "a figure the user asserted is not the app's to discard" do
+    transfer(qty: 5)
+    @holding.update_columns(cost_basis_source: "manual")
+
+    run_migration
+
+    assert_equal 100, @holding.reload.cost_basis.to_d
+  end
+
+  private
+    # The computed path, not `avg_cost`: that one returns the stored figure
+    # first, which is exactly the figure this migration exists to remove.
+    def computed_basis
+      @holding.send(:calculate_avg_cost)
+    end
+
+    def transfer(qty:)
+      @account.entries.create!(
+        date: @holding.date - 1,
+        name: "Moved #{qty} units",
+        amount: -100,
+        currency: @holding.currency,
+        entryable: Trade.new(
+          security: @holding.security,
+          qty: qty,
+          price: 100,
+          currency: @holding.currency,
+          investment_activity_label: Trade::TRANSFER_LABEL
+        )
+      )
+    end
+
+    def run_migration
+      ActiveRecord::Migration.suppress_messages do
+        ClearTransferredPositionCostBases.new.up
+      end
+    end
+end

--- a/test/migrations/clear_transferred_position_cost_bases_migration_test.rb
+++ b/test/migrations/clear_transferred_position_cost_bases_migration_test.rb
@@ -14,15 +14,16 @@ class ClearTransferredPositionCostBasesMigrationTest < ActiveSupport::TestCase
     # Everything already there is an ordinary purchase; the transfer under test
     # is the only one.
     @account.trades.update_all(investment_activity_label: "Buy")
-    @holding.update_columns(
-      cost_basis: 100, cost_basis_source: "calculated", cost_basis_locked: false
-    )
+    # Left empty so `avg_cost` reports the computed figure rather than a stored
+    # one; each test stores what the migration is then asked to judge.
+    @holding.update_columns(cost_basis: nil, cost_basis_source: nil, cost_basis_locked: false)
   end
 
   test "a position transferred in loses the figure the app worked out" do
     transfer(qty: 5)
 
-    assert_nil computed_basis, "the runtime already treats this position as unknowable"
+    assert_nil @holding.reload.avg_cost, "the runtime already treats this position as unknowable"
+    store_calculated_basis
 
     run_migration
 
@@ -37,7 +38,8 @@ class ClearTransferredPositionCostBasesMigrationTest < ActiveSupport::TestCase
   test "a position transferred out keeps it" do
     transfer(qty: -5)
 
-    assert_not_nil computed_basis, "the runtime keeps the basis after an outbound transfer"
+    assert_not_nil @holding.reload.avg_cost, "the runtime keeps the basis after an outbound transfer"
+    store_calculated_basis
 
     run_migration
 
@@ -47,7 +49,7 @@ class ClearTransferredPositionCostBasesMigrationTest < ActiveSupport::TestCase
 
   test "a figure the user asserted is not the app's to discard" do
     transfer(qty: 5)
-    @holding.update_columns(cost_basis_source: "manual")
+    @holding.update_columns(cost_basis: 100, cost_basis_source: "manual")
 
     run_migration
 
@@ -55,10 +57,8 @@ class ClearTransferredPositionCostBasesMigrationTest < ActiveSupport::TestCase
   end
 
   private
-    # The computed path, not `avg_cost`: that one returns the stored figure
-    # first, which is exactly the figure this migration exists to remove.
-    def computed_basis
-      @holding.send(:calculate_avg_cost)
+    def store_calculated_basis
+      @holding.update_columns(cost_basis: 100, cost_basis_source: "calculated")
     end
 
     def transfer(qty:)


### PR DESCRIPTION
Follow-up to #3154. @jjmata reported this from Codex six minutes after that PR merged, so the bug is on `main`.

## The finding

The migration cleared any calculated cost basis on a position that had ever been part of a `Transfer`, **in either direction**:

```sql
AND trades.investment_activity_label = 'Transfer'
AND entries.date <= holdings.date
```

The runtime does not agree. Both paths drop `qty <= 0` rows **before** they look at the label:

- `Holding#calculate_avg_cost` — `.where("trades.qty > 0 AND entries.date <= ?", date)`, then the transfer check.
- `Holding::ForwardCalculator` / `ReverseCalculator` — `next unless trade.qty > 0 # Only track buys`, then the transfer check.

So only a transfer **in** makes a position unknowable. Shares sent elsewhere say nothing about what the remaining ones cost — that figure came from real purchases and is correct. The migration destroyed it, irreversibly, on a position the app still stands behind.

## The fix

The `EXISTS` clause gains the `qty > 0` the runtime applies, and the comment says why, so it does not get tidied away later.

## Verification

`test/migrations/clear_transferred_position_cost_bases_migration_test.rb` runs the migration against real records and holds both directions down:

- `a position transferred in loses the figure the app worked out`
- `a position transferred out keeps it` — **fails on the old SQL** with "an outbound transfer destroyed a basis the app still stands behind"
- `a figure the user asserted is not the app's to discard`

Each asserts what the computed path returns *before* running the migration, so the migration and the runtime cannot drift apart again without a test noticing.

Full model suite plus migrations: 4846 runs, 18709 assertions, 0 failures. Rubocop clean.

## What this cannot do

The migration is irreversible, and installs that already ran the previous version cannot have those figures restored. A connected account recomputes its basis when it next materializes; a manual or disconnected account will not — which is precisely the case #3154 was written for. Amending the file in place stops it happening to anyone who has not migrated yet, and #3154 is on the unreleased v0.7.4 milestone, so that should be nearly everyone. Happy to take a different approach if you would rather it be a separate migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTNba5qE5NwzaHzbp27ye

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cost-basis cleanup for transferred positions.
  * Transferred-in positions with unknown cost basis are cleared as expected.
  * Transferred-out positions now retain their valid cost basis.
  * Previously cleared cost bases for eligible outbound transfers are restored.
  * Manually confirmed cost bases are preserved.
  * Cost bases remain cleared when both inbound and outbound transfers are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->