### PR TITLE
feat(goals): size a reserve on the months it actually asks for

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -49,6 +49,7 @@ class GoalsController < ApplicationController
     @linkable_accounts = linkable_accounts_for_new
     @currently_linked_account_ids = []
     @pooled_allocations = Goal.pooled_allocations_for(Current.family)
+    @selectable_categories = selectable_categories
     @breadcrumbs = plan_breadcrumb_prefix + [
       [ t("goals.index.title"), goals_path ],
       [ t("goals.new.heading"), nil ]
@@ -63,6 +64,9 @@ class GoalsController < ApplicationController
     allocations = submitted_allocations
     Goal.transaction do
       accounts.each { |a| @goal.goal_accounts.build(account: a, allocated_amount: allocations[a.id.to_s]) }
+      # Built before the save, so the derivation that runs during validation
+      # already knows which spending this reserve covers.
+      submitted_expense_categories.each { |c| @goal.goal_expense_categories.build(category: c) }
       @goal.save!
     end
 
@@ -74,6 +78,7 @@ class GoalsController < ApplicationController
       end
     end
   rescue ActiveRecord::RecordInvalid
+    @selectable_categories = selectable_categories
     @linkable_accounts = linkable_accounts_for_new
     # From the in-memory links, not `pluck`: nothing is persisted on a failed
     # create, so a query would come back empty and every box the user ticked
@@ -89,6 +94,7 @@ class GoalsController < ApplicationController
     @linkable_accounts = linkable_accounts_for_new
     @pooled_allocations = Goal.pooled_allocations_for(Current.family)
     @currently_linked_account_ids = @goal.goal_accounts.pluck(:account_id).map(&:to_s)
+    @selectable_categories = selectable_categories
   end
 
   def update
@@ -98,6 +104,7 @@ class GoalsController < ApplicationController
 
     if accounts_supplied && accounts.empty?
       @goal.errors.add(:base, :at_least_one_linked_account_required)
+      @selectable_categories = selectable_categories
       @linkable_accounts = linkable_accounts_for_new
       @pooled_allocations = Goal.pooled_allocations_for(Current.family)
       @currently_linked_account_ids = @goal.goal_accounts.pluck(:account_id).map(&:to_s)
@@ -114,6 +121,9 @@ class GoalsController < ApplicationController
     # submitted.
     Goal.transaction do
       @goal.assign_attributes(goal_update_params)
+      # Synced before the save so the recompute that follows reads the new
+      # selection rather than the one it is replacing.
+      sync_expense_categories!(@goal, submitted_expense_categories) unless params.dig(:goal, :expense_category_ids).nil?
       if accounts_supplied
         sync_linked_accounts!(@goal, accounts, submitted_allocations)
       else
@@ -129,6 +139,7 @@ class GoalsController < ApplicationController
       end
     end
   rescue ActiveRecord::RecordInvalid
+    @selectable_categories = selectable_categories
     @linkable_accounts = linkable_accounts_for_new
     @pooled_allocations = Goal.pooled_allocations_for(Current.family)
     @currently_linked_account_ids = @goal.goal_accounts.pluck(:account_id).map(&:to_s)
@@ -201,12 +212,50 @@ class GoalsController < ApplicationController
       redirect_to goals_path, alert: t("goals.errors.not_found")
     end
 
+    GOAL_ATTRIBUTES = [
+      :name, :target_amount, :target_date, :color, :icon, :notes,
+      :kind, :target_mode, :target_months, :include_uncategorized_expenses
+    ].freeze
+
     def goal_params
-      params.require(:goal).permit(:name, :target_amount, :target_date, :color, :icon, :notes, :kind, :target_mode, :target_months)
+      params.require(:goal).permit(*GOAL_ATTRIBUTES)
     end
 
     def goal_update_params
-      params.require(:goal).permit(:name, :target_amount, :target_date, :color, :icon, :notes, :kind, :target_mode, :target_months)
+      params.require(:goal).permit(*GOAL_ATTRIBUTES)
+    end
+
+    # Parents first, each followed by its children, so the picker reads as the
+    # tree the user knows rather than a flat alphabetical list.
+    def selectable_categories
+      Current.family.categories.includes(:subcategories).roots.alphabetically.flat_map do |root|
+        [ root ] + root.subcategories.sort_by(&:name)
+      end
+    end
+
+    # Scoped to the family's own categories: the ids arrive from a form and
+    # decide which spending a shared financial figure is derived from.
+    def submitted_expense_categories
+      ids = Array(params.dig(:goal, :expense_category_ids)).reject(&:blank?)
+      return [] if ids.empty?
+
+      Current.family.categories.where(id: ids).to_a
+    end
+
+    def sync_expense_categories!(goal, categories)
+      desired = categories.map(&:id).to_set
+      existing = goal.goal_expense_categories.index_by(&:category_id)
+
+      (existing.keys.to_set - desired).each { |id| existing[id].destroy! }
+      (desired - existing.keys.to_set).each { |id| goal.goal_expense_categories.create!(category_id: id) }
+
+      return if existing.keys.to_set == desired
+
+      # The loaded collection still holds the rows just destroyed, and the
+      # recompute reads it — without this it would derive from the selection it
+      # has just replaced.
+      goal.goal_expense_categories.reset
+      goal.expense_categories_changed_in_place = true
     end
 
     def lookup_accounts(ids)

--- a/app/javascript/controllers/goal_form_controller.js
+++ b/app/javascript/controllers/goal_form_controller.js
@@ -140,6 +140,13 @@ export default class extends Controller {
     firstInvalid?.focus();
   }
 
+  // Read from the DOM rather than held as state: the kind radios belong to the
+  // goal-kind controller, and duplicating the selection here would give the two
+  // a chance to disagree.
+  get #isMaintained() {
+    return this.element.querySelector('input[name="goal[kind]"]:checked')?.value === "maintained";
+  }
+
   // Hook for any input that influences the suggested-pace hint
   // (target_amount, target_date). Also re-evaluates as accounts toggle.
   suggestedChanged() {
@@ -149,6 +156,15 @@ export default class extends Controller {
 
   updateSuggested() {
     if (!this.hasSuggestedTarget) return;
+
+    // A reserve has no finish line to project: its date field is hidden and the
+    // model nils the value. Telling the reader to set a target date was advice
+    // they had no way to follow, on the one screen where it cannot apply.
+    if (this.#isMaintained) {
+      this.suggestedTarget.classList.add("hidden");
+      this.suggestedTarget.textContent = "";
+      return;
+    }
 
     const amount = this.hasAmountInputTarget ? Number.parseFloat(this.amountInputTarget.value) : Number.NaN;
     const dateValue = this.hasDateInputTarget ? this.dateInputTarget.value : null;

--- a/app/javascript/controllers/goal_kind_controller.js
+++ b/app/javascript/controllers/goal_kind_controller.js
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus"
 // something due on a date. Hiding the target-date field keeps a stale value from being
 // submitted and driving a pace the goal does not have.
 export default class extends Controller {
-  static targets = ["radio", "dateField", "modeField", "modeSelect", "monthsField", "amountField", "amountDerived"]
+  static targets = ["radio", "dateField", "modeField", "modeSelect", "monthsField", "categoryField", "amountField", "amountDerived"]
 
   static values = {
     amountLabel: String,
@@ -31,6 +31,15 @@ export default class extends Controller {
     const months = maintained && this.hasModeSelectTarget && this.modeSelectTarget.value === "months_of_expenses"
     this.monthsFieldTargets.forEach((field) => field.classList.toggle("hidden", !months))
     if (!months) this.#clearInputs(this.monthsFieldTargets)
+
+    // Disabled rather than cleared, unlike the months field above. A disabled
+    // control is not submitted, so leaving months mode neither carries hidden
+    // filters into the save nor asks the server to touch a selection the user
+    // can no longer see — and coming back finds the boxes as they were left.
+    this.categoryFieldTargets.forEach((field) => {
+      field.classList.toggle("hidden", !months)
+      field.querySelectorAll("input").forEach((input) => { input.disabled = !months })
+    })
 
     // Three states. A one-off saves toward a target amount; a fixed reserve
     // holds a target balance you type; a months-based reserve holds one worked

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,10 @@ class Category < ApplicationRecord
   belongs_to :family
 
   has_many :budget_categories, dependent: :destroy
+  # A reserve sized on this category simply stops counting it. Without this the
+  # foreign key (NO ACTION) would refuse the delete outright, and taking a
+  # category away would fail on a goal the user may not even remember making.
+  has_many :goal_expense_categories, dependent: :destroy
   has_many :subcategories,
          -> { order(:name) },
          class_name: "Category",

--- a/app/models/category/merger.rb
+++ b/app/models/category/merger.rb
@@ -30,6 +30,7 @@ class Category::Merger
       source_categories.each do |source|
         family.transactions.where(category_id: source.id).update_all(category_id: target_category.id)
         merge_budget_categories(source)
+        merge_goal_expense_categories(source)
         family.categories.where(parent_id: source.id).where.not(id: target_category.id).update_all(parent_id: target_category.id)
         family.categories.find(source.id).destroy!
         @merged_count += 1
@@ -68,6 +69,20 @@ class Category::Merger
       end
 
       ids
+    end
+
+    # A reserve that counted the source now counts the target instead. Where it
+    # already counted both, the surviving row is the one it keeps: the unique
+    # index allows one per goal, and the goal's intent — "count this category" —
+    # is satisfied either way.
+    def merge_goal_expense_categories(source)
+      GoalExpenseCategory.where(category_id: source.id).find_each do |link|
+        if GoalExpenseCategory.exists?(goal_id: link.goal_id, category_id: target_category.id)
+          link.destroy!
+        else
+          link.update!(category_id: target_category.id)
+        end
+      end
     end
 
     def merge_budget_categories(source)

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -473,7 +473,17 @@ class Goal < ApplicationRecord
   # Empty means every expense counts, which is what an unconfigured reserve
   # wants and what every reserve did before this existed.
   def narrowed_to_categories?
-    expense_categories.any?
+    selected_category_ids.any?
+  end
+
+  # Read from the loaded join records rather than through the association, so it
+  # is right for a goal whose selection was built but not yet saved — a create
+  # derives its target during validation, before any child row exists.
+  def selected_category_ids
+    goal_expense_categories
+      .reject { |gec| gec.marked_for_destruction? || gec.destroyed? }
+      .filter_map(&:category_id)
+      .uniq
   end
 
   def months_of_expenses_target?
@@ -557,10 +567,10 @@ class Goal < ApplicationRecord
     # pick each subcategory separately would be a trap, and the two readings
     # cannot both be right.
     def selected_expense_category_ids
-      return nil unless narrowed_to_categories?
+      chosen = selected_category_ids
+      return nil if chosen.empty?
 
-      chosen = expense_categories.to_a
-      (chosen.map(&:id) + Category.where(parent_id: chosen.map(&:id)).pluck(:id)).uniq
+      (chosen + Category.where(parent_id: chosen).pluck(:id)).uniq
     end
 
     # The balance this reserve should hold, or nil when it cannot be computed.

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -34,7 +34,12 @@ class Goal < ApplicationRecord
            class_name: "GoalPledge"
 
   validates :name, presence: true, length: { maximum: 255 }
-  validates :target_amount, presence: true, numericality: { greater_than: 0 }
+  # Not in months mode: the amount is derived there, so "can't be blank" would
+  # name a field the form has hidden and say nothing about why it is empty.
+  # `months_target_must_be_derivable` guards the same ground with the actual
+  # reason, and the column's NOT NULL / > 0 constraint stays covered either way.
+  validates :target_amount, presence: true, numericality: { greater_than: 0 },
+            unless: :months_of_expenses_target?
   validates :currency, presence: true
   # before_save (not before_validation) so it only mutates on persistence, not
   # on every valid? call — a goal can be inspected without its basis flipping.
@@ -71,6 +76,7 @@ class Goal < ApplicationRecord
   # new selection is actually readable.
   after_save :reapply_target_after_category_change, if: :expense_categories_changed_in_place?
 
+  validate :months_target_must_be_derivable, if: :months_of_expenses_target?
   validate :must_have_at_least_one_linked_account
   validate :linked_accounts_must_be_fundable
   validate :linked_accounts_must_match_goal_currency
@@ -1453,6 +1459,16 @@ class Goal < ApplicationRecord
 
       computed = months_of_expenses_amount
       update_column(:target_amount, computed) if computed && computed != target_amount.to_d
+    end
+
+    # Reached when the window holds nothing to read: a family with no history
+    # yet, or — more often — a reserve narrowed to categories nobody has spent
+    # in. The error goes on the months, which the user can see and change,
+    # rather than on the derived amount they cannot type into.
+    def months_target_must_be_derivable
+      return if target_amount.to_d.positive?
+
+      errors.add(:target_months, :no_spending_in_window)
     end
 
     def clear_target_date_for_maintained

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -25,6 +25,8 @@ class Goal < ApplicationRecord
   # persist through goal.save! — without it Rails only saves newly built
   # children, silently dropping changes to existing goal_accounts.
   has_many :goal_accounts, dependent: :destroy, autosave: true
+  has_many :goal_expense_categories, dependent: :destroy
+  has_many :expense_categories, through: :goal_expense_categories, source: :category
   has_many :linked_accounts, through: :goal_accounts, source: :account
   has_many :goal_pledges, dependent: :destroy
   has_many :open_pledges,
@@ -58,9 +60,16 @@ class Goal < ApplicationRecord
                         new_record? ||
                         target_months_changed? ||
                         target_mode_changed? ||
-                        target_amount_changed?
+                        target_amount_changed? ||
+                        include_uncategorized_expenses_changed?
                       )
                     }
+
+  # Narrowing a reserve to a set of categories changes what it should hold, and
+  # the answer has to move with it. The association is saved after this record,
+  # so the recompute cannot ride on the same validation pass — it runs once the
+  # new selection is actually readable.
+  after_save :reapply_target_after_category_change, if: :expense_categories_changed_in_place?
 
   validate :must_have_at_least_one_linked_account
   validate :linked_accounts_must_be_fundable
@@ -140,6 +149,12 @@ class Goal < ApplicationRecord
   # Goal.summary_for, the ring, the card) keeps working untouched, where an
   # effective_target_amount would have to be threaded through all of them.
   TARGET_MODES = %w[fixed months_of_expenses].freeze
+
+  # The window the form probes when deciding whether a months-based target can
+  # be derived at all. It asks before the user has typed a number, so it needs
+  # one to ask with; this is the same figure the months field offers as its
+  # placeholder.
+  DEFAULT_TARGET_MONTHS = 6
 
   validates :kind, inclusion: { in: KINDS }
   validates :target_mode, inclusion: { in: TARGET_MODES }
@@ -447,6 +462,20 @@ class Goal < ApplicationRecord
     kind == "maintained"
   end
 
+  # Set by the controller when it assigns a selection, so the recompute after
+  # save knows the list moved. `expense_categories` is a through association:
+  # its writes land after this record is saved, and nothing on the goal itself
+  # records that they happened.
+  attr_accessor :expense_categories_changed_in_place
+
+  def expense_categories_changed_in_place? = expense_categories_changed_in_place.present?
+
+  # Empty means every expense counts, which is what an unconfigured reserve
+  # wants and what every reserve did before this existed.
+  def narrowed_to_categories?
+    expense_categories.any?
+  end
+
   def months_of_expenses_target?
     target_mode == "months_of_expenses"
   end
@@ -470,17 +499,33 @@ class Goal < ApplicationRecord
   # ignores the goal's own kind, mode and months: it answers "is there spending
   # history to derive from", nothing else. With none, the typed amount is the
   # only way to set a target, so the form must keep offering the field.
+  # The form asks this BEFORE the user has picked anything, so it falls back to
+  # a probe window. It does honour the category selection, because that is what
+  # decides whether the window holds anything — a reserve narrowed to a
+  # category with no spending is exactly the case where the typed amount has to
+  # stay available.
   def months_target_derivable?
     return false if family.nil? || currency.blank?
 
-    median = median_monthly_expense
-    return false unless median.positive?
+    months = target_months.to_i.positive? ? target_months.to_i : DEFAULT_TARGET_MONTHS
+    spent = expenses_over_window(months: months)
+    return false unless spent.positive?
 
-    convert_to_goal_currency(median).to_d.positive?
+    convert_to_goal_currency(spent).to_d.positive?
   end
 
   private
-    # The family's median monthly spend, in FAMILY currency.
+    # What the last `months` complete months actually cost, in FAMILY currency.
+    #
+    # The window ENDS with the last complete month. The current one is still
+    # filling up, and counting it would drag the target down by whatever is
+    # left of the month — most visibly on the 1st, the very day the refresh job
+    # runs.
+    #
+    # A month inside the window with no spending counts as a zero rather than
+    # being skipped. "Six months of expenses" is what six months cost, and a
+    # household that spent nothing in August did not thereby need a bigger
+    # reserve; it also means the figure grows on its own as history fills in.
     #
     # ⚠️ The account scope is passed EXPLICITLY, and that is the whole point
     # of this method. IncomeStatement's constructor does `user || Current.user`
@@ -490,27 +535,47 @@ class Goal < ApplicationRecord
     # whole family: derived from a viewer's slice of the accounts it would
     # change depending on who last triggered it. The rollover chain hit
     # exactly this and had to be pinned the same way.
-    # Deliberately not memoized. The refresh job derives again on an instance
-    # it has already saved through, and a median frozen on first read would
-    # hand it back the figure it started with.
-    def median_monthly_expense
+    # Deliberately not memoized. The refresh job derives again on an instance it
+    # has already saved through, and a total frozen on first read would hand it
+    # back the figure it started with.
+    def expenses_over_window(months: target_months.to_i)
+      return 0.to_d unless months.positive?
+
+      last_complete = Date.current.prev_month.end_of_month
+      first = (last_complete - (months - 1).months).beginning_of_month
+
       IncomeStatement.new(family, accounts: family.accounts.visible.included_in_reports)
-                     .median_expense(interval: "month").to_d
+                     .expense_total(
+                       date_range: first..last_complete,
+                       category_ids: selected_expense_category_ids,
+                       include_uncategorized: include_uncategorized_expenses?
+                     ).to_d
+    end
+
+    # nil when nothing is selected, which the window reads as "every category".
+    # A parent stands for its children: picking "Housing" and then having to
+    # pick each subcategory separately would be a trap, and the two readings
+    # cannot both be right.
+    def selected_expense_category_ids
+      return nil unless narrowed_to_categories?
+
+      chosen = expense_categories.to_a
+      (chosen.map(&:id) + Category.where(parent_id: chosen.map(&:id)).pluck(:id)).uniq
     end
 
     # The balance this reserve should hold, or nil when it cannot be computed.
     def months_of_expenses_amount
       return nil unless maintained? && months_of_expenses_target? && target_months.to_i.positive?
 
-      median = median_monthly_expense
-      return nil unless median.positive?
-
-      computed = (median * target_months).round(2)
+      # The sum over the window IS the target: the window is `target_months`
+      # long, so working out a monthly average and multiplying it back by those
+      # same months returns the figure unchanged.
+      computed = expenses_over_window.round(2)
       return nil unless computed.positive?
 
-      # The median comes back in FAMILY currency; `target_amount` is stored in
+      # The total comes back in FAMILY currency; `target_amount` is stored in
       # the GOAL's. A EUR reserve in a USD family would otherwise read a 3,000
-      # dollar floor as 3,000 euros, and rewrite it that way every month.
+      # dollar target as 3,000 euros, and rewrite it that way every month.
       converted = convert_to_goal_currency(computed)
       converted&.positive? ? converted : nil
     end
@@ -1370,6 +1435,14 @@ class Goal < ApplicationRecord
       return unless state_in_database.in?(RELEASED_STATES)
 
       errors.add(:kind, :locked_while_released)
+    end
+
+    def reapply_target_after_category_change
+      self.expense_categories_changed_in_place = nil
+      return unless months_of_expenses_target?
+
+      computed = months_of_expenses_amount
+      update_column(:target_amount, computed) if computed && computed != target_amount.to_d
     end
 
     def clear_target_date_for_maintained

--- a/app/models/goal_expense_category.rb
+++ b/app/models/goal_expense_category.rb
@@ -9,7 +9,27 @@ class GoalExpenseCategory < ApplicationRecord
 
   validate :category_must_belong_to_family
 
+  # Losing a selection changes what the reserve counts — losing its ONLY one
+  # widens it back to every expense — and the derived target has to follow.
+  # Left alone it would keep a figure worked out from spending the goal no
+  # longer counts, wearing a label saying it was computed from what it counts.
+  #
+  # Only on destroy: rows are created through the controller, which already
+  # recomputes once the whole selection is assembled rather than once per box.
+  after_destroy_commit :refresh_goal_target
+
   private
+    def refresh_goal_target
+      # The goal itself is going away; there is nothing left to recompute, and
+      # reloading it would raise. A category being deleted is the case this
+      # exists for, and reports a different association.
+      return if destroyed_by_association&.active_record == Goal
+
+      goal.reload.refresh_target_from_expenses!
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
     def category_must_belong_to_family
       return if category.nil? || goal&.family_id.nil?
       return if category.family_id == goal.family_id

--- a/app/models/goal_expense_category.rb
+++ b/app/models/goal_expense_category.rb
@@ -1,0 +1,19 @@
+# Which expenses a "N months of expenses" reserve counts. Selecting none keeps
+# the plain meaning — every expense — so this table is empty for a reserve that
+# has never been narrowed.
+class GoalExpenseCategory < ApplicationRecord
+  belongs_to :goal
+  belongs_to :category
+
+  validates :category_id, uniqueness: { scope: :goal_id }
+
+  validate :category_must_belong_to_family
+
+  private
+    def category_must_belong_to_family
+      return if category.nil? || goal&.family_id.nil?
+      return if category.family_id == goal.family_id
+
+      errors.add(:category, :must_belong_to_family)
+    end
+end

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -148,6 +148,20 @@ class IncomeStatement
     end
   end
 
+  # Total spending between two dates, as opposed to the shape of a typical
+  # month. A reserve sized in months of expenses asks this: "six months of
+  # expenses" is what six months actually cost, not six times a median drawn
+  # from every month on record.
+  def expense_total(date_range:, category_ids: nil, include_uncategorized: false)
+    IncomeStatement::ExpenseWindow.new(
+      family,
+      date_range: date_range,
+      account_ids: included_account_ids,
+      category_ids: category_ids,
+      include_uncategorized: include_uncategorized
+    ).total
+  end
+
   def avg_expense(interval: "month", category: nil)
     if category.present?
       category_stats(interval: interval).find { |stat| stat.classification == "expense" && stat.category_id == category.id }&.avg || 0

--- a/app/models/income_statement/expense_predicates.rb
+++ b/app/models/income_statement/expense_predicates.rb
@@ -1,0 +1,35 @@
+# The WHERE fragments that decide what counts as household spending.
+#
+# Extracted so the two readers of that definition cannot drift apart:
+# FamilyStats, which answers "what does a typical month look like", and
+# ExpenseWindow, which answers "what was actually spent between these dates".
+# A reserve sized in months of expenses reads the second and is explained by
+# the first, so a filter added to one and forgotten in the other would show up
+# as a target nobody can reconcile with their own numbers.
+module IncomeStatement::ExpensePredicates
+  private
+    def budget_excluded_kinds_sql
+      @budget_excluded_kinds_sql ||= Transaction::BUDGET_EXCLUDED_KINDS.map { |k| "'#{k}'" }.join(", ")
+    end
+
+    def pending_providers_sql
+      Transaction.pending_providers_sql("t")
+    end
+
+    def exclude_tax_advantaged_sql
+      return "" if @family.tax_advantaged_account_ids.empty?
+
+      "AND a.id NOT IN (:tax_advantaged_account_ids)"
+    end
+
+    def scope_to_account_ids_sql
+      return "" if @account_ids.nil?
+
+      ActiveRecord::Base.sanitize_sql([ "AND a.id IN (?)", @account_ids ])
+    end
+
+    def tax_advantaged_params
+      ids = @family.tax_advantaged_account_ids
+      ids.present? ? { tax_advantaged_account_ids: ids } : {}
+    end
+end

--- a/app/models/income_statement/expense_window.rb
+++ b/app/models/income_statement/expense_window.rb
@@ -1,0 +1,96 @@
+# What was actually spent between two dates, in family currency.
+#
+# FamilyStats answers "what does a typical month look like" by taking a median
+# across every month on record. That is the wrong question for a reserve sized
+# in months of expenses: a household with eight years of partial imports has
+# most of its months near zero, and the median lands on one of them.
+#
+# This answers the literal question instead — the total over a stated window —
+# and shares the same WHERE fragments so the two cannot disagree about what
+# counts as spending.
+class IncomeStatement::ExpenseWindow
+  include IncomeStatement::ExpensePredicates
+
+  # `category_ids` nil means every category, which is what an unconfigured
+  # reserve wants. An empty array would mean "none at all" and is treated the
+  # same as nil, so a goal that has selected nothing still gets a figure rather
+  # than a silent zero.
+  def initialize(family, date_range:, account_ids: nil, category_ids: nil, include_uncategorized: false)
+    @family = family
+    @date_range = date_range
+    @account_ids = account_ids
+    @category_ids = category_ids.presence
+    @include_uncategorized = include_uncategorized
+  end
+
+  # @return [BigDecimal] total expenses over the window, never negative
+  def total
+    return 0.to_d if @account_ids&.empty?
+
+    value = ActiveRecord::Base.connection.select_value(sanitized_query_sql).to_d
+    value.positive? ? value : 0.to_d
+  end
+
+  private
+    def sanitized_query_sql
+      ActiveRecord::Base.sanitize_sql_array([ query_sql, sql_params ])
+    end
+
+    def sql_params
+      {
+        target_currency: @family.currency,
+        family_id: @family.id,
+        start_date: @date_range.begin,
+        end_date: @date_range.end
+      }.merge(tax_advantaged_params)
+    end
+
+    # Only meaningful alongside a category list: with no list every transaction
+    # counts, categorised or not.
+    def category_filter_sql
+      return "" if @category_ids.nil?
+
+      clause = ActiveRecord::Base.sanitize_sql([ "t.category_id IN (?)", @category_ids ])
+      clause += " OR t.category_id IS NULL" if @include_uncategorized
+      "AND (#{clause})"
+    end
+
+    # Same classification as FamilyStats: an inflow carries a negative amount,
+    # and the two kinds below are outflows recorded the other way round.
+    CLASSIFICATION_SQL = <<~SQL.squish
+      CASE WHEN t.kind IN ('investment_contribution', 'loan_payment') THEN 'expense'
+           WHEN ae.amount < 0 THEN 'income'
+           ELSE 'expense' END
+    SQL
+
+    AMOUNT_SQL = <<~SQL.squish
+      CASE WHEN t.kind IN ('investment_contribution', 'loan_payment')
+           THEN ABS(ae.amount * COALESCE(er.rate, 1))
+           ELSE ae.amount * COALESCE(er.rate, 1) END
+    SQL
+
+    def query_sql
+      <<~SQL
+        SELECT COALESCE(SUM(#{AMOUNT_SQL}), 0) AS total
+        FROM transactions t
+        JOIN entries ae ON ae.entryable_id = t.id AND ae.entryable_type = 'Transaction'
+        JOIN accounts a ON a.id = ae.account_id
+        LEFT JOIN exchange_rates er ON (
+          er.date = ae.date AND
+          er.from_currency = ae.currency AND
+          er.to_currency = :target_currency
+        )
+        WHERE a.family_id = :family_id
+          AND ae.date >= :start_date
+          AND ae.date <= :end_date
+          AND t.kind NOT IN (#{budget_excluded_kinds_sql})
+          AND ae.excluded = false
+          AND a.exclude_from_reports = false
+          AND (#{CLASSIFICATION_SQL}) = 'expense'
+          #{pending_providers_sql}
+          #{exclude_tax_advantaged_sql}
+          #{scope_to_account_ids_sql}
+          #{category_filter_sql}
+      SQL
+    end
+end

--- a/app/models/income_statement/family_stats.rb
+++ b/app/models/income_statement/family_stats.rb
@@ -1,4 +1,6 @@
 class IncomeStatement::FamilyStats
+  include IncomeStatement::ExpensePredicates
+
   def initialize(family, interval: "month", account_ids: nil)
     @family = family
     @interval = interval
@@ -28,35 +30,11 @@ class IncomeStatement::FamilyStats
     end
 
     def sql_params
-      params = {
+      {
         target_currency: @family.currency,
         interval: @interval,
         family_id: @family.id
-      }
-
-      ids = @family.tax_advantaged_account_ids
-      params[:tax_advantaged_account_ids] = ids if ids.present?
-
-      params
-    end
-
-    def budget_excluded_kinds_sql
-      @budget_excluded_kinds_sql ||= Transaction::BUDGET_EXCLUDED_KINDS.map { |k| "'#{k}'" }.join(", ")
-    end
-
-    def pending_providers_sql
-      Transaction.pending_providers_sql("t")
-    end
-
-    def exclude_tax_advantaged_sql
-      ids = @family.tax_advantaged_account_ids
-      return "" if ids.empty?
-      "AND a.id NOT IN (:tax_advantaged_account_ids)"
-    end
-
-    def scope_to_account_ids_sql
-      return "" if @account_ids.nil?
-      ActiveRecord::Base.sanitize_sql([ "AND a.id IN (?)", @account_ids ])
+      }.merge(tax_advantaged_params)
     end
 
     def query_sql

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (goal:, linkable_accounts:, currently_linked_account_ids: [], pooled_allocations: {}) %>
+<%# locals: (goal:, linkable_accounts:, currently_linked_account_ids: [], pooled_allocations: {}, selectable_categories: []) %>
 
 <%# goal-kind lives on this wrapper, not on the kind selector: its
      dateField target is a sibling of the radios, and a controller only sees
@@ -30,7 +30,7 @@
         <label class="flex items-start gap-2 rounded-lg border border-primary p-3 cursor-pointer has-[:checked]:border-secondary has-[:checked]:bg-surface-inset">
           <%= f.radio_button :kind, kind,
                              class: "radio mt-0.5 shrink-0",
-                             data: { goal_kind_target: "radio", action: "change->goal-kind#refresh" } %>
+                             data: { goal_kind_target: "radio", action: "change->goal-kind#refresh change->goal-form#suggestedChanged" } %>
           <span class="min-w-0">
             <span class="block text-sm font-medium text-primary"><%= t("goals.form.kinds.#{kind}.label") %></span>
             <span class="block text-xs text-secondary"><%= t("goals.form.kinds.#{kind}.hint") %></span>
@@ -68,6 +68,50 @@
                          step: 1,
                          placeholder: "6" %>
       <p class="mt-1 text-xs text-secondary"><%= t("goals.form.fields.target_months_hint") %></p>
+    </div>
+
+    <%# Which spending the months are counted from. Nothing ticked means every
+        expense, which is what a reserve meant before it could be narrowed — so
+        the section opens closed and costs an untouched form nothing. %>
+    <div data-goal-kind-target="monthsField" class="hidden">
+      <% selected_category_ids = goal.selected_category_ids.map(&:to_s) %>
+      <details class="group rounded-lg border border-primary bg-container" <%= "open" if selected_category_ids.any? || goal.include_uncategorized_expenses? %>>
+        <summary class="flex cursor-pointer items-center justify-between gap-3 px-3 py-2.5">
+          <div class="min-w-0">
+            <span class="block text-sm font-medium text-primary"><%= t("goals.form.fields.expense_categories") %></span>
+            <p class="mt-0.5 text-xs text-secondary"><%= t("goals.form.fields.expense_categories_hint") %></p>
+          </div>
+          <%= icon "chevron-down", size: "sm", color: "secondary", class: "shrink-0 transition-transform group-open:rotate-180" %>
+        </summary>
+
+        <div class="max-h-72 overflow-y-auto border-t border-subdued bg-container-inset p-1">
+          <%# Submitted even when every box is cleared, so "none of them" reaches
+              the server as an empty list rather than as an absent parameter it
+              would read as "leave the selection alone". %>
+          <%= hidden_field_tag "goal[expense_category_ids][]", "", id: nil %>
+
+          <label class="flex cursor-pointer items-center gap-3 rounded-md px-3 py-2.5 hover:bg-surface-hover">
+            <%= hidden_field_tag "goal[include_uncategorized_expenses]", "0", id: nil %>
+            <%= check_box_tag "goal[include_uncategorized_expenses]", "1",
+                              goal.include_uncategorized_expenses?,
+                              id: "goal_include_uncategorized_expenses",
+                              class: "checkbox checkbox--light shrink-0" %>
+            <%= render partial: "categories/badge", locals: { category: Category.uncategorized } %>
+          </label>
+
+          <% selectable_categories.each do |category| %>
+            <label class="flex cursor-pointer items-center gap-3 rounded-md border-t border-subdued px-3 py-2.5 hover:bg-surface-hover">
+              <%= check_box_tag "goal[expense_category_ids][]", category.id,
+                                selected_category_ids.include?(category.id.to_s),
+                                id: "goal_expense_category_#{category.id}",
+                                class: "checkbox checkbox--light shrink-0" %>
+              <span class="min-w-0 <%= "pl-5" if category.parent_id.present? %>">
+                <%= render partial: "categories/badge", locals: { category: category } %>
+              </span>
+            </label>
+          <% end %>
+        </div>
+      </details>
     </div>
 
     <div class="grid grid-cols-2 gap-3 items-start">

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -68,21 +68,33 @@
                          step: 1,
                          placeholder: "6" %>
       <p class="mt-1 text-xs text-secondary"><%= t("goals.form.fields.target_months_hint") %></p>
+      <%# The derived amount has no field of its own to carry an error, so the
+          one explaining that the window is empty is shown here — beside the
+          months and the categories, which are what the user can change. %>
+      <% goal.errors[:target_months].each do |message| %>
+        <p class="mt-1.5 text-xs text-destructive"><%= message %></p>
+      <% end %>
     </div>
 
     <%# Which spending the months are counted from. Nothing ticked means every
         expense, which is what a reserve meant before it could be narrowed — so
         the section opens closed and costs an untouched form nothing. %>
-    <div data-goal-kind-target="monthsField" class="hidden">
+    <div data-goal-kind-target="categoryField" class="hidden">
       <% selected_category_ids = goal.selected_category_ids.map(&:to_s) %>
-      <details class="group rounded-lg border border-primary bg-container" <%= "open" if selected_category_ids.any? || goal.include_uncategorized_expenses? %>>
-        <summary class="flex cursor-pointer items-center justify-between gap-3 px-3 py-2.5">
-          <div class="min-w-0">
-            <span class="block text-sm font-medium text-primary"><%= t("goals.form.fields.expense_categories") %></span>
-            <p class="mt-0.5 text-xs text-secondary"><%= t("goals.form.fields.expense_categories_hint") %></p>
+      <%= render DS::Disclosure.new(
+            variant: :card,
+            open: selected_category_ids.any? || goal.include_uncategorized_expenses?,
+            body_class: nil
+          ) do |disclosure| %>
+        <% disclosure.with_summary_content do %>
+          <div class="flex w-full items-center justify-between gap-3">
+            <div class="min-w-0">
+              <span class="block text-sm font-medium text-primary"><%= t("goals.form.fields.expense_categories") %></span>
+              <p class="mt-0.5 text-xs text-secondary"><%= t("goals.form.fields.expense_categories_hint") %></p>
+            </div>
+            <%= icon "chevron-down", size: "sm", color: "secondary", class: "shrink-0 group-open:rotate-180 motion-safe:transition-transform" %>
           </div>
-          <%= icon "chevron-down", size: "sm", color: "secondary", class: "shrink-0 transition-transform group-open:rotate-180" %>
-        </summary>
+        <% end %>
 
         <div class="max-h-72 overflow-y-auto border-t border-subdued bg-container-inset p-1">
           <%# Submitted even when every box is cleared, so "none of them" reaches
@@ -111,7 +123,7 @@
             </label>
           <% end %>
         </div>
-      </details>
+      <% end %>
     </div>
 
     <div class="grid grid-cols-2 gap-3 items-start">

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -3,7 +3,7 @@
 <%# goal-kind lives on this wrapper, not on the kind selector: its
      dateField target is a sibling of the radios, and a controller only sees
      targets inside its own element. Scoped to the selector, dateFieldTargets
-     came back empty and picking "Reserve to maintain" never hid the date. %>
+     came back empty and picking "Maintained reserve" never hid the date. %>
 <div data-controller="goal-form goal-kind"
      data-goal-form-currency-value="<%= Current.family.primary_currency_code %>"
      data-goal-form-require-account-value="<%= !goal.persisted? %>"

--- a/app/views/goals/edit.html.erb
+++ b/app/views/goals/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render DS::Dialog.new do |dialog| %>
   <% dialog.with_header(title: t(".heading")) %>
   <% dialog.with_body do %>
-    <%= render "form", goal: @goal, linkable_accounts: @linkable_accounts, currently_linked_account_ids: @currently_linked_account_ids, pooled_allocations: @pooled_allocations %>
+    <%= render "form", goal: @goal, linkable_accounts: @linkable_accounts, currently_linked_account_ids: @currently_linked_account_ids, pooled_allocations: @pooled_allocations, selectable_categories: @selectable_categories %>
   <% end %>
 <% end %>

--- a/app/views/goals/new.html.erb
+++ b/app/views/goals/new.html.erb
@@ -13,7 +13,7 @@
       </div>
     <% end %>
     <% dialog.with_body do %>
-      <%= render "form", goal: @goal, linkable_accounts: @linkable_accounts, currently_linked_account_ids: @currently_linked_account_ids, pooled_allocations: @pooled_allocations %>
+      <%= render "form", goal: @goal, linkable_accounts: @linkable_accounts, currently_linked_account_ids: @currently_linked_account_ids, pooled_allocations: @pooled_allocations, selectable_categories: @selectable_categories %>
     <% end %>
   <% end %>
 <% else %>
@@ -25,6 +25,6 @@
         <p class="text-sm text-secondary mt-0.5"><%= t(".subtitle") %></p>
       </div>
     </header>
-    <%= render "form", goal: @goal, linkable_accounts: @linkable_accounts, currently_linked_account_ids: @currently_linked_account_ids, pooled_allocations: @pooled_allocations %>
+    <%= render "form", goal: @goal, linkable_accounts: @linkable_accounts, currently_linked_account_ids: @currently_linked_account_ids, pooled_allocations: @pooled_allocations, selectable_categories: @selectable_categories %>
   </div>
 <% end %>

--- a/config/locales/models/goal/en.yml
+++ b/config/locales/models/goal/en.yml
@@ -20,10 +20,10 @@ en:
               whole_account_conflict_on_restore: "Can't restore this goal: “%{account_name}” is now fully earmarked for “%{goal_name}”. Enter an amount on one of them first."
             target_mode:
               months_requires_maintained: Only a reserve you maintain can have a target set in months of expenses.
-              no_spending_in_window: No spending to work a target out from over these months. Widen the categories, change the months, or set the amount yourself.
             target_months:
               blank: Say how many months of expenses this reserve should cover.
               only_with_months_mode: Months of expenses only apply when the target is set that way.
+              no_spending_in_window: No spending to work a target out from over these months. Widen the categories, change the months, or set the amount yourself.
             linked_accounts:
               must_be_fundable: All linked accounts must be cash or investment accounts.
               currency_mismatch: All linked accounts must share the same currency.

--- a/config/locales/models/goal/en.yml
+++ b/config/locales/models/goal/en.yml
@@ -20,6 +20,7 @@ en:
               whole_account_conflict_on_restore: "Can't restore this goal: “%{account_name}” is now fully earmarked for “%{goal_name}”. Enter an amount on one of them first."
             target_mode:
               months_requires_maintained: Only a reserve you maintain can have a target set in months of expenses.
+              no_spending_in_window: No spending to work a target out from over these months. Widen the categories, change the months, or set the amount yourself.
             target_months:
               blank: Say how many months of expenses this reserve should cover.
               only_with_months_mode: Months of expenses only apply when the target is set that way.

--- a/config/locales/models/goal/fr.yml
+++ b/config/locales/models/goal/fr.yml
@@ -27,6 +27,7 @@ fr:
               locked_after_linked: Impossible de modifier la devise après que l'objectif a été lié à des comptes.
             target_mode:
               months_requires_maintained: Seule une réserve à maintenir peut avoir une cible exprimée en mois de dépenses.
+              no_spending_in_window: Aucune dépense sur ces mois pour en déduire une cible. Élargissez les catégories, changez le nombre de mois, ou fixez le montant vous-même.
             target_months:
               blank: Indiquez combien de mois de dépenses cette réserve doit couvrir.
               only_with_months_mode: Les mois de dépenses ne s'appliquent que si la cible est exprimée ainsi.

--- a/config/locales/models/goal/fr.yml
+++ b/config/locales/models/goal/fr.yml
@@ -27,10 +27,10 @@ fr:
               locked_after_linked: Impossible de modifier la devise après que l'objectif a été lié à des comptes.
             target_mode:
               months_requires_maintained: Seule une réserve à maintenir peut avoir une cible exprimée en mois de dépenses.
-              no_spending_in_window: Aucune dépense sur ces mois pour en déduire une cible. Élargissez les catégories, changez le nombre de mois, ou fixez le montant vous-même.
             target_months:
               blank: Indiquez combien de mois de dépenses cette réserve doit couvrir.
               only_with_months_mode: Les mois de dépenses ne s'appliquent que si la cible est exprimée ainsi.
+              no_spending_in_window: Aucune dépense sur ces mois pour en déduire une cible. Élargissez les catégories, changez le nombre de mois, ou fixez le montant vous-même.
             linked_accounts:
               currency_mismatch: Tous les comptes liés doivent partager la même devise.
               must_be_fundable: Tous les comptes liés doivent être des comptes de trésorerie ou d'investissement.

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -296,14 +296,14 @@ en:
     form:
       target_modes:
         fixed: A fixed amount
-        months_of_expenses: A number of months of expenses
+        months_of_expenses: Months of expenses
       kinds:
         one_off:
           hint: Save toward something, then close it when you spend it.
           label: One-off goal
         maintained:
           hint: A balance to keep, like an emergency fund. Never closed.
-          label: Reserve to maintain
+          label: Maintained reserve
       create: Create goal
       save: Save changes
       suggested_with_date: "Save {monthly}/mo across {accounts} to hit it on time."
@@ -318,17 +318,17 @@ en:
         whole_balance: This account will fund whatever is left after the other earmarks.
         whole_balance_alone: "This goal will use this account's whole balance."
       fields:
-        target_mode: How the target balance is set
+        target_mode: Target basis
         target_months: Months of expenses
-        target_months_hint: What those months actually cost, recomputed on the 1st of each month. The month in progress is not counted.
+        target_months_hint: What those months cost, recomputed on the 1st of each month. The month in progress is not counted.
         name: Name
         name_placeholder: Emergency fund, House down payment…
         target_amount: Target amount
         target_balance: "Target balance"
-        expense_categories: Expenses counted
+        expense_categories: Categories counted
         expense_categories_hint: Tick nothing to count every expense.
         target_balance_pending: "Worked out when you save"
-        target_balance_hint: "What the months above actually cost. Refreshed on the 1st of each month."
+        target_balance_hint: "What the months above cost. Recomputed on the 1st of each month."
         target_date: Target date
         color: Color
         notes: Notes (optional)

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -320,13 +320,15 @@ en:
       fields:
         target_mode: How the target balance is set
         target_months: Months of expenses
-        target_months_hint: Recomputed on the 1st of each month from your median monthly spending.
+        target_months_hint: What those months actually cost, recomputed on the 1st of each month. The month in progress is not counted.
         name: Name
         name_placeholder: Emergency fund, House down payment…
         target_amount: Target amount
         target_balance: "Target balance"
+        expense_categories: Expenses counted
+        expense_categories_hint: Tick nothing to count every expense.
         target_balance_pending: "Worked out when you save"
-        target_balance_hint: "From your median monthly spending over the months above. Refreshed each month."
+        target_balance_hint: "What the months above actually cost. Refreshed on the 1st of each month."
         target_date: Target date
         color: Color
         notes: Notes (optional)

--- a/config/locales/views/goals/fr.yml
+++ b/config/locales/views/goals/fr.yml
@@ -53,7 +53,7 @@ fr:
       fields:
         target_mode: Comment le solde cible est fixé
         target_months: Mois de dépenses
-        target_months_hint: Recalculé le 1er de chaque mois à partir de vos dépenses mensuelles médianes.
+        target_months_hint: Ce que ces mois ont réellement coûté, recalculé le 1er de chaque mois. Le mois en cours n'est pas compté.
         color: Couleur
         earmark_for: Affecter un montant pour %{account}
         earmark_hint: Laissez le montant vide pour dédier la totalité du solde de ce compte.
@@ -65,8 +65,10 @@ fr:
         notes_placeholder: Un rappel pour plus tard…
         target_amount: Montant cible
         target_balance: "Solde cible"
+        expense_categories: Dépenses prises en compte
+        expense_categories_hint: Ne rien cocher revient à compter toutes les dépenses.
         target_balance_pending: "Calculé à l'enregistrement"
-        target_balance_hint: "D'après vos dépenses mensuelles médianes sur le nombre de mois ci-dessus. Recalculé chaque mois."
+        target_balance_hint: "Ce que les mois ci-dessus ont réellement coûté. Recalculé le 1er de chaque mois."
         target_date: Date cible
         whole_balance: Solde total
       save: Enregistrer les modifications

--- a/config/locales/views/goals/fr.yml
+++ b/config/locales/views/goals/fr.yml
@@ -32,11 +32,11 @@ fr:
     form:
       target_modes:
         fixed: Un montant fixe
-        months_of_expenses: Un nombre de mois de dépenses
+        months_of_expenses: Mois de dépenses
       kinds:
         maintained:
           hint: Un solde à maintenir, comme une épargne de précaution. Jamais clôturée.
-          label: Réserve à maintenir
+          label: Réserve maintenue
         one_off:
           hint: Épargner pour quelque chose, puis clôturer une fois la dépense faite.
           label: Objectif ponctuel
@@ -51,9 +51,9 @@ fr:
         whole_balance: Ce compte financera le solde restant après les autres affectations.
         whole_balance_alone: "Cet objectif utilisera tout le solde de ce compte."
       fields:
-        target_mode: Comment le solde cible est fixé
+        target_mode: Base de la cible
         target_months: Mois de dépenses
-        target_months_hint: Ce que ces mois ont réellement coûté, recalculé le 1er de chaque mois. Le mois en cours n'est pas compté.
+        target_months_hint: Ce que ces mois ont coûté, recalculé le 1er de chaque mois. Le mois en cours n'est pas compté.
         color: Couleur
         earmark_for: Affecter un montant pour %{account}
         earmark_hint: Laissez le montant vide pour dédier la totalité du solde de ce compte.
@@ -65,10 +65,10 @@ fr:
         notes_placeholder: Un rappel pour plus tard…
         target_amount: Montant cible
         target_balance: "Solde cible"
-        expense_categories: Dépenses prises en compte
+        expense_categories: Catégories prises en compte
         expense_categories_hint: Ne rien cocher revient à compter toutes les dépenses.
         target_balance_pending: "Calculé à l'enregistrement"
-        target_balance_hint: "Ce que les mois ci-dessus ont réellement coûté. Recalculé le 1er de chaque mois."
+        target_balance_hint: "Ce que les mois ci-dessus ont coûté. Recalculé le 1er de chaque mois."
         target_date: Date cible
         whole_balance: Solde total
       save: Enregistrer les modifications

--- a/db/migrate/20260828090000_add_expense_categories_to_goals.rb
+++ b/db/migrate/20260828090000_add_expense_categories_to_goals.rb
@@ -1,0 +1,18 @@
+# A reserve sized in months of expenses can now be told WHICH expenses count.
+# Selecting none keeps the previous meaning — every expense — so existing
+# reserves need no backfill and nothing changes for them.
+class AddExpenseCategoriesToGoals < ActiveRecord::Migration[7.2]
+  def change
+    create_table :goal_expense_categories, id: :uuid do |t|
+      t.references :goal, null: false, foreign_key: true, type: :uuid
+      t.references :category, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+
+    add_index :goal_expense_categories, [ :goal_id, :category_id ], unique: true
+
+    # Only consulted when a selection exists: with none, everything counts and
+    # uncategorised spending is already in.
+    add_column :goals, :include_uncategorized_expenses, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -849,6 +849,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
     t.check_constraint "allocated_amount IS NULL OR allocated_amount >= 0::numeric", name: "chk_goal_accounts_allocation_non_negative"
   end
 
+  create_table "goal_expense_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "category_id", null: false
+    t.datetime "created_at", null: false
+    t.uuid "goal_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_goal_expense_categories_on_category_id"
+    t.index ["goal_id", "category_id"], name: "index_goal_expense_categories_on_goal_id_and_category_id", unique: true
+    t.index ["goal_id"], name: "index_goal_expense_categories_on_goal_id"
+  end
+
   create_table "goal_pledges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
     t.decimal "amount", precision: 19, scale: 4, null: false
@@ -877,6 +887,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
     t.string "currency", null: false
     t.uuid "family_id", null: false
     t.string "icon"
+    t.boolean "include_uncategorized_expenses", default: false, null: false
     t.string "kind", default: "one_off", null: false
     t.string "name", null: false
     t.text "notes"
@@ -2475,6 +2486,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_090000) do
   add_foreign_key "family_merchant_associations", "merchants"
   add_foreign_key "goal_accounts", "accounts", on_delete: :restrict
   add_foreign_key "goal_accounts", "goals", on_delete: :cascade
+  add_foreign_key "goal_expense_categories", "categories"
+  add_foreign_key "goal_expense_categories", "goals"
   add_foreign_key "goal_pledges", "accounts", on_delete: :restrict
   add_foreign_key "goal_pledges", "goals", on_delete: :cascade
   add_foreign_key "goal_pledges", "transactions", column: "matched_transaction_id", on_delete: :nullify

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -686,7 +686,7 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
   # model looked fine.
   test "a months-of-expenses reserve can be created without typing an amount" do
     account = unclaimed_account("Reserve Pot")
-    IncomeStatement.any_instance.stubs(:median_expense).returns(500)
+    seed_monthly_expenses(500)
 
     assert_difference -> { Goal.count }, 1 do
       post goals_url, params: { goal: {
@@ -697,8 +697,54 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     end
 
     goal = Goal.order(created_at: :desc).first
-    assert_equal 3_000, goal.target_amount.to_d, "the floor was not derived from the months"
+    assert_equal 3_000, goal.target_amount.to_d, "the target was not derived from the months"
     assert goal.maintained?
+  end
+
+  # The categories arrive as their own parameter, so the reserve has to be built
+  # with them in hand: the derivation runs during validation, before any child
+  # row exists to read back.
+  test "a reserve created with categories counts only those" do
+    account = unclaimed_account("Narrowed Pot")
+    essentials = @user.family.categories.create!(name: "Rent", color: "#4da568", lucide_icon: "home")
+    seed_monthly_expenses(500, category: essentials)
+    seed_monthly_expenses(2_000)
+
+    post goals_url, params: { goal: {
+      name: "Precaution", color: "#4da568", kind: "maintained",
+      target_mode: "months_of_expenses", target_months: "6",
+      target_amount: "", account_ids: [ account.id ],
+      expense_category_ids: [ essentials.id ]
+    } }
+
+    goal = Goal.order(created_at: :desc).first
+    assert_equal 3_000, goal.target_amount.to_d,
+                 "spending outside the chosen categories was counted"
+    assert_equal [ essentials.id ], goal.expense_categories.map(&:id)
+  end
+
+  # Clearing every box has to reach the server as an empty list, not as an
+  # absent parameter it would read as "leave the selection alone".
+  test "clearing every category widens the reserve back to all spending" do
+    account = unclaimed_account("Widened Pot")
+    essentials = @user.family.categories.create!(name: "Rent", color: "#4da568", lucide_icon: "home")
+    seed_monthly_expenses(500, category: essentials)
+    seed_monthly_expenses(2_000)
+
+    post goals_url, params: { goal: {
+      name: "Precaution", color: "#4da568", kind: "maintained",
+      target_mode: "months_of_expenses", target_months: "6",
+      target_amount: "", account_ids: [ account.id ],
+      expense_category_ids: [ essentials.id ]
+    } }
+    goal = Goal.order(created_at: :desc).first
+    assert_equal 3_000, goal.target_amount.to_d
+
+    patch goal_url(goal), params: { goal: { expense_category_ids: [ "" ] } }
+
+    assert_empty goal.reload.expense_categories
+    assert_equal 15_000, goal.target_amount.to_d,
+                 "widening the reserve did not move its target"
   end
 
   # A fixed reserve still needs one, and still says so. Asserted on the error the
@@ -1010,6 +1056,22 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     # refuses a second whole-balance link on an account already claimed in
     # full — so any test that wants the default "dedicate the whole balance"
     # link needs an account of its own.
+    # One expense of `amount` in each of the last `months` complete months.
+    def seed_monthly_expenses(amount, months: 6, category: nil)
+      account = @user.family.accounts.create!(
+        accountable: Depository.new, name: "Spending #{SecureRandom.hex(3)}",
+        currency: "USD", balance: 0
+      )
+      months.times do |i|
+        account.entries.create!(
+          date: Date.current.prev_month.beginning_of_month - i.months + 5.days,
+          name: "Living cost", amount: amount, currency: "USD",
+          entryable: Transaction.new(category: category)
+        )
+      end
+      account
+    end
+
     def unclaimed_account(name)
       Account.create!(
         family: @user.family, accountable: Depository.new,

--- a/test/jobs/refresh_maintained_goal_targets_job_test.rb
+++ b/test/jobs/refresh_maintained_goal_targets_job_test.rb
@@ -5,9 +5,9 @@ class RefreshMaintainedGoalTargetsJobTest < ActiveJob::TestCase
     @family = families(:dylan_family)
   end
 
-  test "a reserve's floor follows the median monthly spend" do
+  test "a reserve's target follows what the window actually cost" do
     goal = reserve(months: 6, target: 1_000)
-    stub_median(500)
+    seed_monthly_spend(500)
 
     RefreshMaintainedGoalTargetsJob.perform_now
 
@@ -17,9 +17,9 @@ class RefreshMaintainedGoalTargetsJobTest < ActiveJob::TestCase
   # A family with no spending history yet would compute a floor of zero,
   # which violates the target_amount > 0 constraint and would read as "your
   # reserve is complete". Keep the number the user has been saving against.
-  test "a median of zero leaves the target standing" do
+  test "a window with no spending leaves the target standing" do
     goal = reserve(months: 6, target: 1_000)
-    stub_median(0)
+    seed_monthly_spend(0)
 
     RefreshMaintainedGoalTargetsJob.perform_now
 
@@ -31,7 +31,7 @@ class RefreshMaintainedGoalTargetsJobTest < ActiveJob::TestCase
     one_off = @family.goals.create!(
       name: "Trip", target_amount: 800, currency: "USD"
     ) { |g| g.goal_accounts.build(account: account_for("Trip")) }
-    stub_median(500)
+    seed_monthly_spend(500)
 
     RefreshMaintainedGoalTargetsJob.perform_now
 
@@ -42,7 +42,7 @@ class RefreshMaintainedGoalTargetsJobTest < ActiveJob::TestCase
   test "an archived reserve is not refreshed" do
     goal = reserve(months: 6, target: 1_000)
     goal.archive!
-    stub_median(500)
+    seed_monthly_spend(500)
 
     RefreshMaintainedGoalTargetsJob.perform_now
 
@@ -51,7 +51,7 @@ class RefreshMaintainedGoalTargetsJobTest < ActiveJob::TestCase
 
   test "a target already equal to the computed figure is not rewritten" do
     goal = reserve(months: 6, target: 3_000)
-    stub_median(500)
+    seed_monthly_spend(500)
 
     assert_no_changes -> { goal.reload.updated_at } do
       RefreshMaintainedGoalTargetsJob.perform_now
@@ -62,7 +62,7 @@ class RefreshMaintainedGoalTargetsJobTest < ActiveJob::TestCase
   # the failure belongs in the support UI, not only in the application log.
   test "a write that fails validation is recorded for support" do
     goal = reserve(months: 6, target: 1_000)
-    stub_median(500)
+    seed_monthly_spend(500)
     Goal.any_instance.stubs(:update!).raises(
       ActiveRecord::RecordInvalid.new(goal)
     )
@@ -96,7 +96,25 @@ class RefreshMaintainedGoalTargetsJobTest < ActiveJob::TestCase
       goal.reload
     end
 
-    def stub_median(amount)
-      IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal(amount.to_s))
+    # Real spending rather than a stub of the derivation: what the job exists to
+    # do is re-read the window, and stubbing that out would leave these tests
+    # asserting nothing about it. Twelve months so any window under test is
+    # fully covered; zero means a family that has spent nothing.
+    def seed_monthly_spend(amount)
+      return if amount.to_d.zero?
+
+      account = @family.accounts.create!(
+        accountable: Depository.new, name: "Spending #{SecureRandom.hex(3)}",
+        currency: "USD", balance: 0
+      )
+      12.times do |i|
+        account.entries.create!(
+          date: Date.current.prev_month.beginning_of_month - i.months + 5.days,
+          name: "Living cost",
+          amount: BigDecimal(amount.to_s),
+          currency: "USD",
+          entryable: Transaction.new
+        )
+      end
     end
 end

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -888,6 +888,35 @@ class GoalTest < ActiveSupport::TestCase
     assert goal.persisted?
   end
 
+  # Losing its only selection widens the reserve back to every expense, so the
+  # target has to follow. Left alone it would keep a figure worked out from
+  # spending it no longer counts, under a label saying it was computed.
+  test "losing its only category widens the reserve and its target" do
+    essentials = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    seed_monthly_expenses(500, category: essentials)
+    seed_monthly_expenses(2_000)
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    goal.expense_categories = [ essentials ]
+    goal.refresh_target_from_expenses!
+    assert_equal BigDecimal("3000"), goal.reload.target_amount.to_d
+
+    essentials.destroy!
+
+    assert_equal BigDecimal("15000"), goal.reload.target_amount.to_d,
+                 "the reserve kept a target derived from spending it no longer counts"
+  end
+
+  # Destroying the goal must not send it back through a recompute on its way
+  # out — there is nothing left to recompute, and reloading it would raise.
+  test "destroying a narrowed reserve does not trip over its own selection" do
+    essentials = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    goal = reserve_goal(balance: 100, target: 1_000)
+    goal.expense_categories = [ essentials ]
+
+    assert_nothing_raised { goal.destroy! }
+  end
+
   # Merging moves the reserve onto the surviving category rather than dropping
   # it: the goal said "count this spending", and the spending has moved.
   test "merging a counted category moves the reserve onto the survivor" do
@@ -931,9 +960,12 @@ class GoalTest < ActiveSupport::TestCase
     goal.goal_expense_categories.build(category: empty)
 
     assert_not goal.valid?
-    assert_includes goal.errors.attribute_names, :target_months
     assert_empty goal.errors[:target_amount],
                  "the blank derived amount was reported as if the user had left it out"
+    # The message, not just the attribute: nesting the key under the wrong one
+    # resolves to nothing, and only reading the text catches that.
+    assert_equal [ I18n.t("activerecord.errors.models.goal.attributes.target_months.no_spending_in_window") ],
+                 goal.errors[:target_months]
   end
 
   test "a fixed reserve ignores the refresh entirely" do

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -704,7 +704,7 @@ class GoalTest < ActiveSupport::TestCase
   test "refreshing the floor moves every figure that reads target_amount" do
     goal = reserve_goal(balance: 3_000, target: 1_000)
     goal.update!(target_mode: "months_of_expenses", target_months: 6)
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    seed_monthly_expenses(500)
 
     assert_equal BigDecimal("3000"), goal.refresh_target_from_expenses!
 
@@ -714,16 +714,16 @@ class GoalTest < ActiveSupport::TestCase
     assert_equal 100, refreshed.progress_percent
   end
 
-  # A family with no spending history computes a floor of zero, which would
-  # both break the target_amount > 0 constraint and read as "your reserve is
-  # complete". The figure the user has been saving against stands.
-  test "a zero median leaves the floor untouched" do
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+  # A window with nothing in it computes zero, which would both break the
+  # target_amount > 0 constraint and read as "your reserve is complete". The
+  # figure the user has been saving against stands.
+  test "an empty window leaves the target untouched" do
+    account = seed_monthly_expenses(500)
     goal = reserve_goal(balance: 3_000, target: 1_000)
     goal.update!(target_mode: "months_of_expenses", target_months: 6)
     assert_equal BigDecimal("3000"), goal.reload.target_amount.to_d
 
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("0"))
+    account.entries.destroy_all
 
     assert_nil goal.refresh_target_from_expenses!
     assert_equal BigDecimal("3000"), goal.reload.target_amount.to_d
@@ -732,7 +732,7 @@ class GoalTest < ActiveSupport::TestCase
   # A reserve created in months mode must be right immediately: waiting for
   # the 1st would make the feature's first impression its least convincing.
   test "creating a months-mode reserve computes its floor straight away" do
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    seed_monthly_expenses(500)
     account = Account.create!(
       family: @family, accountable: Depository.new,
       name: "Fresh Reserve Pot", currency: "USD", balance: 100
@@ -747,7 +747,7 @@ class GoalTest < ActiveSupport::TestCase
   end
 
   test "changing the number of months recomputes the floor at once" do
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    seed_monthly_expenses(500)
     goal = reserve_goal(balance: 100, target: 1)
     goal.update!(target_mode: "months_of_expenses", target_months: 6)
     assert_equal BigDecimal("3000"), goal.reload.target_amount.to_d
@@ -759,21 +759,125 @@ class GoalTest < ActiveSupport::TestCase
   # The monthly job owns the cadence: an unrelated edit must not quietly move
   # a financial figure the user has been saving against.
   test "renaming a months-mode reserve leaves its floor alone" do
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    seed_monthly_expenses(500)
     goal = reserve_goal(balance: 100, target: 1)
     goal.update!(target_mode: "months_of_expenses", target_months: 6)
 
-    IncomeStatement.any_instance.unstub(:median_expense)
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("900"))
+    seed_monthly_expenses(400)
     goal.update!(name: "Renamed reserve")
 
     assert_equal BigDecimal("3000"), goal.reload.target_amount.to_d,
                  "only the job, or a change of months, may move the floor"
   end
 
+  # "Six months of expenses" has to mean the six months that just happened. The
+  # old reading took a median across every month on record, so a household with
+  # years of partial imports got a target drawn from its emptiest month.
+  test "the target is what the window actually cost" do
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    seed_monthly_expenses(500)
+
+    assert_equal BigDecimal("3000"), goal.refresh_target_from_expenses!
+  end
+
+  # Spending older than the window says nothing about what the next six months
+  # will cost, and used to drag the figure down for years.
+  test "spending outside the window is not counted" do
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 3)
+    seed_monthly_expenses(500, months: 3)
+    seed_monthly_expenses(9_000, months: 3, offset: 3)
+
+    assert_equal BigDecimal("1500"), goal.refresh_target_from_expenses!,
+                 "the months before the window were counted"
+  end
+
+  # The current month is still filling up. Counting it would make the target sag
+  # by whatever is left of the month — worst on the 1st, the day the job runs.
+  test "the month in progress is not counted" do
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    seed_monthly_expenses(500)
+    spending_account.entries.create!(
+      date: Date.current, name: "Today", amount: 4_000, currency: "USD",
+      entryable: Transaction.new
+    )
+
+    assert_equal BigDecimal("3000"), goal.refresh_target_from_expenses!,
+                 "the month in progress leaked into the window"
+  end
+
+  # A month nobody spent in is a month that cost nothing, not a month to skip.
+  # Skipping it would divide by fewer months and inflate the target.
+  test "a month with no spending counts as a month that cost nothing" do
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    seed_monthly_expenses(600, months: 2)
+
+    assert_equal BigDecimal("1200"), goal.refresh_target_from_expenses!
+  end
+
+  # The reserve covers what you must keep paying, which is rarely everything.
+  test "a reserve narrowed to categories counts only those" do
+    essentials = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    luxuries = @family.categories.create!(name: "Trips #{SecureRandom.hex(2)}", color: "#e5484d", lucide_icon: "plane")
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    seed_monthly_expenses(500, category: essentials)
+    seed_monthly_expenses(2_000, category: luxuries)
+
+    goal.expense_categories = [ essentials ]
+
+    assert_equal BigDecimal("3000"), goal.refresh_target_from_expenses!,
+                 "a category the reserve does not cover was counted"
+  end
+
+  # Selecting a parent has to carry its children, or a reserve on "Housing"
+  # would silently exclude the rent filed under it.
+  test "a selected parent carries its subcategories" do
+    parent = @family.categories.create!(name: "Housing #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    child = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home", parent: parent)
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    seed_monthly_expenses(500, category: child)
+
+    goal.expense_categories = [ parent ]
+
+    assert_equal BigDecimal("3000"), goal.refresh_target_from_expenses!
+  end
+
+  # Uncategorised spending vanishing from a narrowed reserve is the trap this
+  # design has to avoid: it must be a visible choice, not an omission.
+  test "uncategorised spending joins a narrowed reserve only when asked" do
+    essentials = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    seed_monthly_expenses(500, category: essentials)
+    seed_monthly_expenses(100)
+
+    goal.expense_categories = [ essentials ]
+    assert_equal BigDecimal("3000"), goal.refresh_target_from_expenses!
+
+    goal.update!(include_uncategorized_expenses: true)
+    assert_equal BigDecimal("3600"), goal.reload.target_amount.to_d
+  end
+
+  # Empty means every expense, which is what a reserve meant before it could be
+  # narrowed at all — so existing reserves keep their figure.
+  test "selecting no category counts every expense" do
+    essentials = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    goal = reserve_goal(balance: 100, target: 1)
+    goal.update!(target_mode: "months_of_expenses", target_months: 6)
+    seed_monthly_expenses(500, category: essentials)
+    seed_monthly_expenses(100)
+
+    assert_equal BigDecimal("3600"), goal.refresh_target_from_expenses!
+  end
+
   test "a fixed reserve ignores the refresh entirely" do
     goal = reserve_goal(balance: 3_000, target: 1_000)
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    seed_monthly_expenses(500)
 
     assert_nil goal.refresh_target_from_expenses!
     assert_equal BigDecimal("1000"), goal.reload.target_amount.to_d
@@ -783,7 +887,7 @@ class GoalTest < ActiveSupport::TestCase
   # to decide whether to keep offering the amount field. So it must answer for
   # the family alone, not for what this goal happens to be right now.
   test "derivability is answered for the family, whatever the goal is set to" do
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("500"))
+    seed_monthly_expenses(500)
     goal = reserve_goal(balance: 3_000, target: 1_000)
 
     assert goal.months_target_derivable?,
@@ -794,7 +898,6 @@ class GoalTest < ActiveSupport::TestCase
   # reserve a target. The form has to be told, or it hides the only field that
   # would let the user do it.
   test "a family with no spending history can derive nothing" do
-    IncomeStatement.any_instance.stubs(:median_expense).returns(BigDecimal("0"))
     goal = reserve_goal(balance: 3_000, target: 1_000)
 
     assert_not goal.months_target_derivable?
@@ -1198,7 +1301,7 @@ class GoalTest < ActiveSupport::TestCase
     ) { |g| g.goal_accounts.build(account: account, allocated_amount: 1_000) }
 
     # 500/month family currency x 6 months = 3,000, at a rate of 0.9 = 2,700.
-    IncomeStatement.any_instance.stubs(:median_expense).returns(500)
+    seed_monthly_expenses(500)
     Money.any_instance.stubs(:exchange_to).returns(Money.new(2_700, "EUR"))
 
     goal.update!(target_amount: 1)
@@ -1319,6 +1422,34 @@ class GoalTest < ActiveSupport::TestCase
       @family.goals.create!(name: name, target_amount: 5_000, currency: "USD") do |goal|
         goal.goal_accounts.build(account: account)
       end
+    end
+
+    # One expense of `amount` in each of the last `months` COMPLETE months.
+    # Real rows rather than a stub: which months are counted is the whole
+    # behaviour under test, and a stub cannot get that wrong.
+    def spending_account
+      @spending_account ||= @family.accounts.create!(
+        accountable: Depository.new, name: "Spending #{SecureRandom.hex(3)}",
+        currency: "USD", balance: 0
+      )
+    end
+
+    def seed_monthly_expenses(amount, months: 6, category: nil, offset: 0)
+      account = @family.accounts.create!(
+        accountable: Depository.new, name: "Spending #{SecureRandom.hex(3)}",
+        currency: "USD", balance: 0
+      )
+      months.times do |i|
+        month = Date.current.prev_month.beginning_of_month - (i + offset).months
+        account.entries.create!(
+          date: month + 5,
+          name: "Living cost",
+          amount: amount,
+          currency: "USD",
+          entryable: Transaction.new(category: category)
+        )
+      end
+      account
     end
 
     def reserve_goal(balance:, target:, allocated: nil, name: "Emergency reserve")

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -875,6 +875,67 @@ class GoalTest < ActiveSupport::TestCase
     assert_equal BigDecimal("3600"), goal.refresh_target_from_expenses!
   end
 
+  # The join carries a foreign key with no cleanup of its own, so a category a
+  # reserve counts could not be deleted at all — the delete failed, and with it
+  # merging, resetting financial data, and removing the family.
+  test "deleting a counted category leaves the reserve standing" do
+    essentials = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    goal = reserve_goal(balance: 100, target: 1_000)
+    goal.expense_categories = [ essentials ]
+
+    assert_nothing_raised { essentials.destroy! }
+    assert_empty goal.reload.expense_categories
+    assert goal.persisted?
+  end
+
+  # Merging moves the reserve onto the surviving category rather than dropping
+  # it: the goal said "count this spending", and the spending has moved.
+  test "merging a counted category moves the reserve onto the survivor" do
+    source = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    target = @family.categories.create!(name: "Housing #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    goal = reserve_goal(balance: 100, target: 1_000)
+    goal.expense_categories = [ source ]
+
+    Category::Merger.new(family: @family, target_category: target, source_categories: [ source ]).merge!
+
+    assert_equal [ target.id ], goal.reload.expense_categories.map(&:id)
+  end
+
+  # The unique index allows one row per goal, and the intent — "count this
+  # category" — is already satisfied by the row that survives.
+  test "merging into a category the reserve already counts keeps one row" do
+    source = @family.categories.create!(name: "Rent #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    target = @family.categories.create!(name: "Housing #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    goal = reserve_goal(balance: 100, target: 1_000)
+    goal.expense_categories = [ source, target ]
+
+    Category::Merger.new(family: @family, target_category: target, source_categories: [ source ]).merge!
+
+    assert_equal [ target.id ], goal.reload.expense_categories.map(&:id)
+  end
+
+  # Narrowing to a category nobody has spent in leaves nothing to derive. The
+  # amount is not typed in this mode, so "can't be blank" would land on a field
+  # the form hides — the error has to name the cause, on a field the user can
+  # act on.
+  test "a reserve narrowed to spending that does not exist says why" do
+    empty = @family.categories.create!(name: "Unused #{SecureRandom.hex(2)}", color: "#4da568", lucide_icon: "home")
+    account = @family.accounts.create!(accountable: Depository.new, name: "Pot", currency: "USD", balance: 100)
+    seed_monthly_expenses(500)
+
+    goal = @family.goals.new(
+      name: "Precaution", currency: "USD", color: "#4da568", kind: "maintained",
+      target_mode: "months_of_expenses", target_months: 6
+    )
+    goal.goal_accounts.build(account: account)
+    goal.goal_expense_categories.build(category: empty)
+
+    assert_not goal.valid?
+    assert_includes goal.errors.attribute_names, :target_months
+    assert_empty goal.errors[:target_amount],
+                 "the blank derived amount was reported as if the user had left it out"
+  end
+
   test "a fixed reserve ignores the refresh entirely" do
     goal = reserve_goal(balance: 3_000, target: 1_000)
     seed_monthly_expenses(500)

--- a/test/system/goals_form_test.rb
+++ b/test/system/goals_form_test.rb
@@ -30,4 +30,38 @@ class GoalsFormTest < ApplicationSystemTestCase
     assert swapped.has_css?("span", text: "*"),
            "the label swap deleted the required marker"
   end
+
+  # A reserve has no finish line to project: its date field is hidden and the
+  # model nils the value. The hint sat outside that hidden block and told the
+  # reader to set a date the screen does not offer.
+  test "a reserve is not told to set a target date" do
+    visit new_goal_path
+
+    # The hint only appears once there is an amount and an account to pace, so
+    # a one-off has to be brought to that state before the reserve can be shown
+    # not to reach it.
+    find("input[name='goal[target_amount]']").fill_in(with: "1000")
+    find("input[name='goal[account_ids][]']", match: :first).click
+    assert_text I18n.t("goals.form.suggested_no_date")
+
+    choose I18n.t("goals.form.kinds.maintained.label")
+
+    assert_not page.has_text?(I18n.t("goals.form.suggested_no_date")),
+               "the reserve was told to set a date it cannot have"
+  end
+
+  # The categories decide what the months are counted from, so the picker
+  # belongs with the months and nowhere else.
+  test "the categories appear with the months and not before" do
+    visit new_goal_path
+
+    assert_not page.has_text?(I18n.t("goals.form.fields.expense_categories")),
+               "the categories showed before the months they belong to"
+
+    choose I18n.t("goals.form.kinds.maintained.label")
+    select I18n.t("goals.form.target_modes.months_of_expenses"),
+           from: I18n.t("goals.form.fields.target_mode")
+
+    assert_text I18n.t("goals.form.fields.expense_categories")
+  end
 end


### PR DESCRIPTION
Reported from a real instance: a six-month reserve was sized at **€1,610**, which nobody could reconcile with their own spending.

## Why the figure was wrong

`months_of_expenses_amount` took `median_expense(interval: "month")` and multiplied it by the months. That median has **no date window**: `IncomeStatement::FamilyStats` groups by month across the family's entire history and takes `PERCENTILE_CONT(0.5)` over every month on record.

The instance in question had 37 months spanning **eight years**, 15 of them under €200 and 7 under €50 — early months with one to six transactions each, partial imports rather than months of living. They weigh exactly as much as a full month. The median landed on one of them: €268/month, ×6 = €1,610.

Switching to the mean does not fix it either — it gives €19,975 there, dominated by a single €42k month. The median was chosen precisely to resist that. The defect is upstream of the statistic.

## What it does now

**Six months of expenses is what those six months cost.** The window is the last `target_months` **complete** months, summed. The sum is the target: the window is that many months long, so a monthly average multiplied back by the same months returns the figure unchanged.

Three decisions, each a way it could have gone wrong:

- **The month in progress is excluded.** Counting it would drag the target down by whatever is left of the month — worst on the 1st, the day `RefreshMaintainedGoalTargetsJob` runs.
- **A month with no spending counts as a month that cost nothing**, not a month to skip. Skipping divides by fewer months and inflates the target; counting it means the figure rises on its own as history fills in.
- **The predicates are shared, not copied.** `IncomeStatement::ExpensePredicates` is now included by both `FamilyStats` and the new `ExpenseWindow`, so the two readers of "what counts as spending" cannot drift into disagreement — which would surface as a target nobody can reconcile with their own numbers.

## Choosing what counts

A reserve covers what you must keep paying, which is rarely everything. It can now be narrowed to categories, picked with the months because that is what they change.

The two risks of an allowlist are handled rather than accepted:

- **Uncategorised spending is a row in the list**, not an omission. Silently dropping untagged spending understates a reserve, and understating is the failure that hurts — you believe you are covered and you are not.
- **Ticking nothing counts every expense.** The mode keeps working with no configuration, existing reserves are unchanged, and no backfill is needed.

Selecting a parent carries its children.

## Also fixed

Every reserve was told **"Set a target date to project a finish line."** A reserve has no finish line — the date field is hidden and the model nils the value — but the hint sat outside that hidden block, so it applied on the one screen where it cannot. It reads the kind now.

## Verification

- **Model**: the window boundary (spending before it, and the month in progress, are both excluded), empty months counted as zero, category narrowing, parent-carries-children, uncategorised opt-in, and empty-means-everything. The tests that stubbed the median now **seed real months of spending** — which months are counted is the whole behaviour, and a stub cannot get it wrong.
- **Controller**: created-with-categories derives from them during validation, and clearing every box widens the reserve back.
- **Browser**: removing the date-hint guard fails `a reserve is not told to set a target date`; the picker is asserted to appear with the months and not before.

Full suite: 7,421 runs, 29,477 assertions, 0 failures. Rubocop, erb_lint and Brakeman clean.

## For the maintainer

**This changes the target of every existing months-based reserve**, in most cases upwards and sometimes sharply — the instance above would go from €1,610 to €56,167, which is what its last six months actually cost. That is the point of the change, but it is a visible move and worth a release note. Targets are recomputed by the monthly job, or on the next edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTNba5qE5NwzaHzbp27ye

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Months-of-expenses goals can target selected categories, including uncategorized expenses.
  * Targets use actual spending from completed months and refresh monthly.
  * Category selections are preserved and synchronized when editing goals.

* **Bug Fixes**
  * Maintained goals no longer show irrelevant target-date guidance.
  * Category changes, merges, and deletions update goal associations safely.
  * Goals now flag when insufficient spending data prevents target calculation.

* **UI & Documentation**
  * Added category-selection controls and clearer validation messages.
  * Updated English and French guidance text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->