### PR TITLE
fix(sophtron): preserve balance signs for credit cards and loans

### DIFF
--- a/app/models/sophtron_account/processor.rb
+++ b/app/models/sophtron_account/processor.rb
@@ -64,18 +64,10 @@ class SophtronAccount::Processor
 
       # Update account balance from latest Sophtron data
       account = sophtron_account.current_account
+      # Sophtron account balances should be preserved as returned by the provider.
+      # From testing credit card accounts, the balance is returned as a negative number for owed amounts. But it might depend on the provider or debt type.
+      # To be safe, we will use the balance as-is and not invert it.
       balance = sophtron_account.balance || sophtron_account.available_balance || 0
-
-      # Sophtron balance convention matches our app convention:
-      # - Positive balance = debt (you owe money)
-      # - Negative balance = credit balance (bank owes you, e.g., overpayment)
-      # No sign conversion needed - pass through as-is (same as Plaid)
-      #
-      # Exception: CreditCard and Loan accounts return inverted signs
-      # Provider returns negative for positive balance, so we negate it
-      if account.accountable_type == "CreditCard" || account.accountable_type == "Loan"
-        balance = -balance
-      end
 
       # Normalize currency with fallback chain: parsed sophtron currency -> existing account currency -> USD
       currency = parse_currency(sophtron_account.currency) || account.currency || "USD"

--- a/test/models/sophtron_account_test.rb
+++ b/test/models/sophtron_account_test.rb
@@ -21,4 +21,34 @@ class SophtronAccountTest < ActiveSupport::TestCase
     assert_equal "Apple / Goldman Sachs", account.institution_metadata["name"]
     assert_equal "ui-apple", account.institution_metadata["user_institution_id"]
   end
+
+  test "processor preserves Sophtron balance signs for credit cards and loans" do
+    item = families(:dylan_family).sophtron_items.create!(
+      name: "Sophtron Connection",
+      user_id: "developer-user",
+      access_key: Base64.strict_encode64("secret-key")
+    )
+
+    [ CreditCard, Loan ].each do |accountable_class|
+      sophtron_account = item.sophtron_accounts.create!(
+        name: accountable_class.name,
+        account_id: "#{accountable_class.name.downcase}-1",
+        currency: "USD",
+        balance: -1_947.18
+      )
+      account = families(:dylan_family).accounts.create!(
+        name: accountable_class.name,
+        currency: "USD",
+        balance: 0,
+        cash_balance: 0,
+        accountable: accountable_class.new
+      )
+      AccountProvider.create!(account: account, provider: sophtron_account)
+
+      SophtronAccount::Processor.new(sophtron_account).process
+
+      assert_equal BigDecimal("-1947.18"), account.reload.balance
+      assert_equal BigDecimal("-1947.18"), account.cash_balance
+    end
+  end
 end


### PR DESCRIPTION
Closes #3252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected credit card and loan balances so negative amounts owed are displayed accurately.
  * Ensured both balance and cash balance retain the provider’s reported sign.

* **Tests**
  * Added coverage verifying negative balances are preserved for credit card and loan accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->