### PR TITLE
fix: localize German transaction selectors

### DIFF
--- a/config/locales/views/transactions/de.yml
+++ b/config/locales/views/transactions/de.yml
@@ -7,7 +7,10 @@ de:
       account_prompt: Konto auswählen
       amount: Betrag
       category: Kategorie
+      category_search_placeholder: Kategorien suchen
       category_prompt: Kategorie auswählen
+      create_category: '„%{name}“ erstellen'
+      create_category_error: Kategorie konnte nicht erstellt werden
       date: Datum
       description: Beschreibung
       description_placeholder: Transaktion beschreiben
@@ -17,6 +20,9 @@ de:
       note_label: Notizen
       note_placeholder: Notiz eingeben
       create_tag: Erstellen
+      create_merchant: Erstellen
+      create_merchant_error: Händler konnte nicht erstellt werden
+      merchant_search_placeholder: Händler suchen oder erstellen
       submit: Transaktion hinzufügen
       tag_search_placeholder: Tag suchen oder erstellen
       tags_label: Tags

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -713,6 +713,24 @@ end
     assert_not entry.protected_from_sync?
   end
 
+  test "new renders category and merchant selectors in German" do
+    get new_transaction_url(locale: "de")
+
+    assert_response :success
+
+    assert_select "[data-controller='category-select']" do
+      assert_select "input[type='search'][placeholder=?]", "Kategorien suchen"
+      assert_select "[data-category-select-create-label-value=?]", "„__CATEGORY_NAME__“ erstellen"
+      assert_select "[data-category-select-create-error-message-value=?]", "Kategorie konnte nicht erstellt werden"
+    end
+
+    assert_select "[data-controller='merchant-select']" do
+      assert_select "input[type='search'][placeholder=?]", "Händler suchen oder erstellen"
+      assert_select "[data-merchant-select-error-message-value=?]", "Händler konnte nicht erstellt werden"
+      assert_select "[data-merchant-select-target='createForm']", text: /Erstellen/
+    end
+  end
+
   test "new groups subcategories immediately after their parent in the category select" do
     get new_transaction_url
     assert_response :success


### PR DESCRIPTION
## Summary

German transaction forms now show German search and create text in the category and merchant selectors instead of falling back to English.

This is an independent follow-up to #3250 in the broader German localization cleanup. Other product areas remain separate follow-up slices.

## Validation

- `bin/rails test test/controllers/transactions_controller_test.rb:716` — 1 run, 9 assertions, passed
- `bin/rails test test/controllers/transactions_controller_test.rb test/i18n_test.rb` — 66 runs, 408 assertions, passed with 4 skips
- `bin/rails test test/system/transaction_category_select_test.rb` — 2 runs, 8 assertions, passed
- `bin/rubocop` — 2,391 files inspected, no offenses
- `bin/rails test` — 7,449 runs and 29,613 assertions; one unrelated failure in `Account::ProviderImportAdapterTest#test_imports_holding_with_all_parameters`, which reproduces in isolation

## Post-deploy monitoring and validation

No additional operational monitoring is required for this locale-only change. During the first German transaction-form smoke check after deployment, maintainers should see German placeholders and create actions in both selectors. An English fallback indicates a regression; mitigation is to revert this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for transaction category and merchant search, creation, and error messages.

* **Bug Fixes**
  * Ensured the new transaction form displays the correct German labels and placeholders for category and merchant selectors.

* **Tests**
  * Added coverage verifying German localization on the new transaction form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->