### PR TITLE
fix(l10n): localize new chat default title

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -13,7 +13,9 @@ class ChatsController < ApplicationController
   end
 
   def new
-    @chat = Current.user.chats.new(title: "New chat #{Time.current.strftime("%Y-%m-%d %H:%M")}")
+    @chat = Current.user.chats.new(
+      title: t(".default_title", timestamp: Time.current.strftime("%Y-%m-%d %H:%M"))
+    )
   end
 
   def create

--- a/config/locales/views/chats/de.yml
+++ b/config/locales/views/chats/de.yml
@@ -33,6 +33,8 @@ de:
     index:
       chats: Chats
       new_chat: Neuer Chat
+    new:
+      default_title: "Neuer Chat %{timestamp}"
     update:
       success: Chat aktualisiert
     worker_unhealthy_warning: KI-Antworten kommen gerade womöglich nicht an – der Hintergrundprozess scheint gestoppt oder überlastet. Prüf, ob dein Sidekiq-Worker läuft.

--- a/config/locales/views/chats/en.yml
+++ b/config/locales/views/chats/en.yml
@@ -28,6 +28,8 @@ en:
     index:
       chats: "Chats"
       new_chat: "New chat"
+    new:
+      default_title: "New chat %{timestamp}"
     update:
       success: "Chat updated"
     ai_consent:

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -12,12 +12,38 @@ class ChatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "gets new chat with a localized German default title" do
+    @user.update!(locale: "de")
+
+    travel_to Time.zone.local(2026, 8, 29, 12, 34) do
+      get new_chat_url
+
+      assert_response :success
+      assert_select "turbo-frame#title_chat h3", text: "Neuer Chat 2026-08-29 12:34"
+    end
+  end
+
+  test "gets new chat with the existing English default title" do
+    @user.update!(locale: "en")
+
+    travel_to Time.zone.local(2026, 8, 29, 12, 34) do
+      get new_chat_url
+
+      assert_response :success
+      assert_select "turbo-frame#title_chat h3", text: "New chat 2026-08-29 12:34"
+    end
+  end
+
   test "creates chat" do
     assert_difference("Chat.count") do
       post chats_url, params: { chat: { content: "Hello", ai_model: "gpt-4.1" } }
     end
 
-    assert_redirected_to chat_path(Chat.order(created_at: :desc).first, thinking: true)
+    chat = Chat.order(created_at: :desc).first
+
+    assert_redirected_to chat_path(chat, thinking: true)
+    assert_equal "Hello", chat.title
+    assert_equal "Hello", chat.messages.find_by!(type: "UserMessage").content
   end
 
   test "shows chat" do


### PR DESCRIPTION
## Summary

New chats now show `Neuer Chat` with the existing timestamp when German is active, instead of the hard-coded English title. English and other locales preserve their previous default through the existing fallback, and submitted prompts still determine persisted chat titles.

This localization slice is independent of #3250 and #3254.

## Validation

- `bin/rails test`: 7,450 runs, 29,607 assertions, 0 failures, 0 errors
- `bin/rubocop`: 2,391 files inspected, no offenses
- Focused chat controller and model coverage: 32 runs, 85 assertions, 0 failures
- Structured code review: no actionable findings

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This change only selects server-rendered locale copy and adds no data path, background job, or external request.

- Log queries and metrics: none required
- Healthy signal: a new German chat shows `Neuer Chat YYYY-MM-DD HH:MM`; English keeps `New chat YYYY-MM-DD HH:MM`
- Failure signal: the German new-chat header falls back to English or reports a missing translation
- Mitigation: revert this commit if the locale lookup fails in production
- Validation window and owner: first post-deploy smoke check by the release maintainer

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New chats now use localized default titles in English and German.
  * Default titles include the chat creation date and time.

* **Bug Fixes**
  * Chat creation now preserves the expected chat title and initial message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->