### PR TITLE
fix(goals): stop a consumption stamp outliving the state that wrote it

### DIFF
--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -616,7 +616,14 @@ class Goal < ApplicationRecord
         # Same refusal a fixed earmark gives, for the same reason: the link
         # cannot have supplied money it never backed. `still_needed` cannot go
         # negative — the target check above has already refused that.
-        raise ConsumptionRefused.new(:exceeds_earmark) if amount > backed
+        #
+        # Not when a transaction says so, though. `backed` reads the account's
+        # balance NOW, and a recorded outflow has already been taken out of it:
+        # spend 4,000 of a 5,000 account and `backed` is 1,000, so attributing
+        # the very transaction the app itself surfaced was refused — and refused
+        # by an earmark the user never set. The target check above is the real
+        # ceiling, and it still holds.
+        raise ConsumptionRefused.new(:exceeds_earmark) if transaction.nil? && amount > backed
 
         still_needed = target_amount.to_d - consumed_amount.to_d - amount
         link.update!(allocated_amount: [ backed, still_needed ].min)

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -27,6 +27,8 @@ class Goal < ApplicationRecord
   has_many :goal_accounts, dependent: :destroy, autosave: true
   has_many :linked_accounts, through: :goal_accounts, source: :account
   has_many :goal_pledges, dependent: :destroy
+  before_destroy :clear_consumption_stamps
+
   has_many :open_pledges,
            -> { where(status: "open").where("expires_at >= ?", Time.current) },
            class_name: "GoalPledge"
@@ -667,6 +669,27 @@ class Goal < ApplicationRecord
   # Only a goal that has actually recorded a spend says anything about it: the
   # overwhelming majority never do, and a permanent "0 used" line would be
   # noise on every card.
+  private
+    # Mirrors GoalPledge#clear_matched_transaction_extra, but a goal can stamp
+    # many transactions where a pledge stamps at most one, so this sweeps every
+    # match rather than looking up a single id.
+    #
+    # Not scoped to `linked_accounts`: an account can be unlinked from the goal
+    # after a consumption stamped a transaction on it (`sync_linked_accounts!`
+    # destroys the `GoalAccount` join, not the stamp), so a transaction marked
+    # by this goal is not guaranteed to live on an account still linked to it.
+    # `consumed_goal_id` is a UUID, unique enough that a family-wide sweep
+    # cannot cross into another goal's stamps.
+    def clear_consumption_stamps
+      Transaction.where("extra @> ?", { goal: { consumed_goal_id: id } }.to_json).find_each do |txn|
+        new_extra = txn.extra.deep_dup
+        new_extra["goal"]&.delete("consumed_goal_id")
+        new_extra.delete("goal") if new_extra["goal"]&.empty?
+        txn.update!(extra: new_extra)
+      end
+    end
+  public
+
   def any_consumption?
     consumed_amount.to_d.positive?
   end
@@ -1196,7 +1219,14 @@ class Goal < ApplicationRecord
       # is picking the same goal back up rather than restarting it — wiping
       # what it had recorded as spent would delete history nothing replaced,
       # and drop its progress for no reason the user can see.
-      attrs[:consumed_amount] = 0 if completed_amount.present?
+      if completed_amount.present?
+        attrs[:consumed_amount] = 0
+        # The counter resets; the stamps on the transactions that built it do
+        # not, on their own. Left alone, those transactions could never be
+        # attributed again anyway — `stamp_consumption!` refuses the SAME goal
+        # reclaiming one it already holds, not only a different one.
+        clear_consumption_stamps
+      end
 
       update_columns(**attrs)
     end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -627,6 +627,13 @@ class Goal < ApplicationRecord
         # ceiling, and it still holds.
         raise ConsumptionRefused.new(:exceeds_earmark) if transaction.nil? && amount > backed
 
+        # The bypass above only holds if `amount` is what the transaction
+        # actually moved — trusted from callers otherwise, a mismatched pair
+        # would silently over-attribute past what the account backs, with no
+        # defense left once `transaction` is non-nil. Enforced here rather
+        # than trusted, matching this file's fat-model conventions.
+        raise ConsumptionRefused.new(:exceeds_earmark) if transaction && amount != transaction.entry.amount.to_d
+
         still_needed = target_amount.to_d - consumed_amount.to_d - amount
         link.update!(allocated_amount: [ backed, still_needed ].min)
       end

--- a/app/models/goal/withdrawal_detector.rb
+++ b/app/models/goal/withdrawal_detector.rb
@@ -64,6 +64,12 @@ class Goal::WithdrawalDetector
         # positive side. Reading this the other way round would offer to
         # attribute the user's deposits as spending.
         .where("entries.amount >= ?", MIN_AMOUNT)
+        # A transfer out of a goal-backed account — moving the money to
+        # checking before spending it there — is a reallocation, not a spend.
+        # Offering it reads as "was this spent on X?" for money that has not
+        # left the household yet; attributing it and then the real purchase
+        # that follows counts the same money against the goal twice.
+        .where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
         .where("transactions.extra -> 'goal' ->> 'consumed_goal_id' IS NULL")
         # A provisional charge can still be reversed or replaced by its posted
         # form. Attributing one leaves the goal consumed for a transaction that

--- a/test/models/goal/withdrawal_detector_test.rb
+++ b/test/models/goal/withdrawal_detector_test.rb
@@ -32,6 +32,22 @@ class Goal::WithdrawalDetectorTest < ActiveSupport::TestCase
     assert_empty detect
   end
 
+  # Moving money out of a goal-backed account toward checking is a
+  # reallocation, not a spend on the goal — offering it, and then also
+  # offering the real purchase that follows, would count the same money twice.
+  test "ignores a transfer" do
+    create_outflow(@account, 1_200, Date.current).entryable.update!(kind: "funds_movement")
+
+    assert_empty detect
+  end
+
+  test "still surfaces an ordinary spend alongside an ignored transfer" do
+    create_outflow(@account, 1_200, Date.current).entryable.update!(kind: "funds_movement")
+    spend = outflow(300)
+
+    assert_equal [ spend.id ], detect.map(&:id)
+  end
+
   test "ignores an outflow the user excluded" do
     outflow(1_200).update!(excluded: true)
 

--- a/test/models/goal_consumption_earmark_test.rb
+++ b/test/models/goal_consumption_earmark_test.rb
@@ -32,6 +32,21 @@ class GoalConsumptionEarmarkTest < ActiveSupport::TestCase
     assert_raises(Goal::ConsumptionRefused) { goal.consume!(3_800) }
   end
 
+  # The bypass only holds because the caller is trusted to pass the amount the
+  # transaction actually moved. A mismatched pair must not slip past the
+  # ceiling `backed` exists to enforce.
+  test "an amount that does not match the transaction is refused, even with a transaction" do
+    account = fresh_account(5_000)
+    goal = @family.goals.create!(name: "Trip", target_amount: 5_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account) # whole-account link
+    end
+    entry = spend(account, 3_800, 5.days.ago)
+    account.update!(balance: 1_200) # the spend already happened
+
+    assert_raises(Goal::ConsumptionRefused) { goal.consume!(4_500, transaction: entry.entryable) }
+    assert_equal BigDecimal("0"), goal.reload.consumed_amount
+  end
+
   # The target is still the real ceiling either way.
   test "a transaction bigger than the target is still refused" do
     account = fresh_account(5_000)

--- a/test/models/goal_consumption_earmark_test.rb
+++ b/test/models/goal_consumption_earmark_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+# A transaction that attests the spend clears the earmark ceiling; a bare
+# amount does not.
+class GoalConsumptionEarmarkTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "a transaction bigger than what remains is attributable when it attests the spend" do
+    account = fresh_account(5_000)
+    goal = @family.goals.create!(name: "Trip", target_amount: 5_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account) # whole-account link
+    end
+    entry = spend(account, 3_800, 5.days.ago)
+    account.update!(balance: 1_200) # the spend already happened
+
+    goal.consume!(3_800, transaction: entry.entryable)
+
+    assert_equal BigDecimal("3800"), goal.reload.consumed_amount
+  end
+
+  # Without a transaction there is nothing attesting the money is already
+  # gone, so the earmark ceiling still applies.
+  test "a bare amount bigger than what remains is still refused" do
+    account = fresh_account(5_000)
+    goal = @family.goals.create!(name: "Trip", target_amount: 5_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account)
+    end
+    account.update!(balance: 1_200)
+
+    assert_raises(Goal::ConsumptionRefused) { goal.consume!(3_800) }
+  end
+
+  # The target is still the real ceiling either way.
+  test "a transaction bigger than the target is still refused" do
+    account = fresh_account(5_000)
+    goal = @family.goals.create!(name: "Trip", target_amount: 5_000, currency: "USD") do |g|
+      g.goal_accounts.build(account: account)
+    end
+    entry = spend(account, 6_000, 5.days.ago)
+    account.update!(balance: -1_000)
+
+    assert_raises(Goal::ConsumptionRefused) { goal.consume!(6_000, transaction: entry.entryable) }
+  end
+
+  private
+    def fresh_account(balance)
+      Account.create!(
+        family: @family, accountable: Depository.new,
+        name: "Pot #{SecureRandom.hex(4)}", currency: "USD", balance: balance
+      )
+    end
+
+    def spend(account, amount, date)
+      account.entries.create!(
+        name: "Spend #{SecureRandom.hex(3)}", date: date, amount: amount,
+        currency: account.currency, entryable: Transaction.new
+      )
+    end
+end

--- a/test/models/goal_consumption_stamp_lifecycle_test.rb
+++ b/test/models/goal_consumption_stamp_lifecycle_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+# The stamp a consumption leaves on a transaction must not outlive the goal
+# state that wrote it.
+class GoalConsumptionStampLifecycleTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+  end
+
+  test "destroying a goal unstamps every transaction it consumed" do
+    goal, account = goal_with_account(balance: 5_000)
+    entry = spend(account, 800, 1.day.ago)
+    goal.consume!(800, transaction: entry.entryable)
+
+    goal.destroy!
+
+    assert_equal({}, entry.entryable.reload.extra)
+  end
+
+  # An account can be unlinked from the goal after a consumption stamped a
+  # transaction on it, so the sweep cannot rely on `linked_accounts`.
+  test "destroying a goal unstamps even a transaction on an account since unlinked" do
+    goal, account = goal_with_account(balance: 5_000)
+    entry = spend(account, 800, 1.day.ago)
+    goal.consume!(800, transaction: entry.entryable)
+    goal.goal_accounts.destroy_all
+
+    goal.destroy!
+
+    assert_equal({}, entry.entryable.reload.extra)
+  end
+
+  test "reopening a completed goal unstamps what it consumed" do
+    account = fresh_account(5_000)
+    goal = goal_on(account, earmark: 5_000, target: 5_000, name: "Trip")
+    entry = spend(account, 800, 1.day.ago)
+    goal.consume!(800, transaction: entry.entryable)
+    goal.update!(consumed_amount: goal.target_amount)
+    goal.complete!
+
+    goal.reopen!
+
+    assert_equal BigDecimal("0"), goal.reload.consumed_amount
+    assert_nil entry.entryable.reload.extra.dig("goal", "consumed_goal_id")
+  end
+
+  # Without unstamping, this transaction could never be attributed again to
+  # ANY goal: stamp_consumption! refuses the SAME goal reclaiming one it
+  # already holds, not only a different one.
+  test "a spend from a previous cycle can be attributed again after reopening" do
+    account = fresh_account(5_000)
+    goal = goal_on(account, earmark: 5_000, target: 5_000, name: "Trip")
+    entry = spend(account, 800, 1.day.ago)
+    goal.consume!(800, transaction: entry.entryable)
+    goal.update!(consumed_amount: goal.target_amount)
+    goal.complete!
+    goal.reopen!
+
+    assert_nothing_raised { goal.reload.consume!(800, transaction: entry.entryable.reload) }
+  end
+
+  # An archived goal never froze a figure, so unarchiving must NOT wipe
+  # history nothing replaced.
+  test "unarchiving straight from active leaves consumption and stamps alone" do
+    goal, account = goal_with_account(balance: 5_000)
+    entry = spend(account, 800, 1.day.ago)
+    goal.consume!(800, transaction: entry.entryable)
+    goal.archive!
+
+    goal.unarchive!
+
+    assert_equal BigDecimal("800"), goal.reload.consumed_amount
+    assert_equal goal.id, entry.entryable.reload.extra.dig("goal", "consumed_goal_id")
+  end
+
+  private
+    def fresh_account(balance)
+      Account.create!(
+        family: @family, accountable: Depository.new,
+        name: "Pot #{SecureRandom.hex(4)}", currency: "USD", balance: balance
+      )
+    end
+
+    def goal_on(account, earmark:, target:, name:)
+      @family.goals.create!(name: name, target_amount: target, currency: "USD") do |g|
+        g.goal_accounts.build(account: account, allocated_amount: earmark)
+      end
+    end
+
+    def goal_with_account(balance:)
+      account = fresh_account(balance)
+      goal = goal_on(account, earmark: balance, target: balance, name: "Trip #{SecureRandom.hex(4)}")
+      [ goal, account ]
+    end
+
+    def spend(account, amount, date)
+      account.entries.create!(
+        name: "Spend #{SecureRandom.hex(3)}", date: date, amount: amount,
+        currency: account.currency, entryable: Transaction.new
+      )
+    end
+end


### PR DESCRIPTION
Three gaps in the goal-consumption stamping mechanism, found while building on top of it.

## The earmark ceiling refused the very transaction it surfaced

On a whole-account link, `consume!` refused when the amount exceeded `backed` — which reads the account's balance NOW, and a recorded outflow has already been taken out of it. Spend 4,000 of a 5,000 account and `backed` is 1,000, so attributing the very transaction the app itself surfaced was refused, by an earmark the user never set.

The refusal now stands aside when a transaction attests the spend; `:exceeds_target` remains the real ceiling either way.

## Stamps outliving what wrote them

- **Deleting a goal left its stamps behind.** `GoalPledge` unstamps its matched transaction before it goes; `Goal` had no equivalent, so a transaction a deleted goal had consumed stayed marked by an id nothing points to any more.
- **Reopening a goal reset the counter but not the stamps.** `thaw_completed_amount!` zeroes `consumed_amount` on a goal that closed a lifecycle, and the transactions that built that number stayed stamped — meaning they could never be attributed again at all, to this goal or any other: `stamp_consumption!` refuses the SAME goal reclaiming one it already holds, not only a different one.
- Both sweeps are **not scoped to the goal's currently-linked accounts**: an account can be unlinked after a consumption stamped a transaction on it, so a family-wide sweep by id is the only way to be sure.

## The withdrawal detector offered transfers as spends

Moving money out of a goal-backed account toward checking is a reallocation, not a spend on the goal — offering it, and then also offering the real purchase that follows, invites counting the same money twice.

## Test plan

- [x] Full suite green (7,458 runs, 0 failures)
- [x] `bin/rubocop -a`, `erb_lint -a` clean
- [x] `bin/brakeman` clean
- [x] New tests cover both directions of each fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTNba5qE5NwzaHzbp27ye

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transfers between household accounts are no longer incorrectly identified as spending.
  * Deleting or reopening a goal now properly removes transaction consumption markings and resets frozen consumption amounts.
  * Goal spending attribution now validates transaction amounts and handles reclaimed transactions and account changes more accurately.

* **Tests**
  * Added coverage for transfers, spending attribution, goal deletion, reopening, and archived goal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->