### PR TITLE
security: add an audit log for sensitive account operations

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -106,6 +106,10 @@ module Admin
         changes << :role if @user.saved_change_to_role?
         changes << :password if @user.saved_change_to_password_digest?
 
+        if changes.include?(:password)
+          SecurityAuditLog.log_password_changed!(user: @user, request: request, actor: Current.user)
+        end
+
         success_key = case changes
         when [ :role, :password ] then ".success_role_and_password"
         when [ :password ]        then ".success_password"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -101,14 +101,10 @@ module Admin
         )
 
         redirect_to admin_users_path, notice: t(".success_family")
-      elsif @user.update(user_update_attributes)
+      elsif update_user_and_log_password_change
         changes = []
         changes << :role if @user.saved_change_to_role?
         changes << :password if @user.saved_change_to_password_digest?
-
-        if changes.include?(:password)
-          SecurityAuditLog.log_password_changed!(user: @user, request: request, actor: Current.user)
-        end
 
         success_key = case changes
         when [ :role, :password ] then ".success_role_and_password"
@@ -185,6 +181,21 @@ module Admin
 
       def set_user
         @user = User.find(params[:id])
+      end
+
+      # Wrapped in a transaction so a failure writing the audit entry rolls
+      # back the password/role change too, instead of leaving a sensitive
+      # change committed with no trail of it.
+      def update_user_and_log_password_change
+        ActiveRecord::Base.transaction do
+          next false unless @user.update(user_update_attributes)
+
+          if @user.saved_change_to_password_digest?
+            SecurityAuditLog.log_password_changed!(user: @user, request: request, actor: Current.user)
+          end
+
+          true
+        end
       end
 
       def user_params

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -12,6 +12,7 @@ class MfaController < ApplicationController
   def create
     if Current.user.verify_otp?(params[:code])
       @backup_codes = Current.user.enable_mfa!
+      SecurityAuditLog.log_mfa_enabled!(user: Current.user, request: request)
       render :backup_codes
     else
       Current.user.disable_mfa!
@@ -100,6 +101,7 @@ class MfaController < ApplicationController
 
   def disable
     Current.user.disable_mfa!
+    SecurityAuditLog.log_mfa_disabled!(user: Current.user, request: request)
     redirect_to settings_security_path, notice: t(".success")
   end
 

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -20,6 +20,8 @@ class MfaController < ApplicationController
       Current.user.disable_mfa!
       redirect_to new_mfa_path, alert: t(".invalid_code")
     end
+  rescue ActiveRecord::RecordInvalid
+    redirect_to new_mfa_path, alert: t(".setup_failed")
   end
 
   def verify
@@ -107,6 +109,8 @@ class MfaController < ApplicationController
       SecurityAuditLog.log_mfa_disabled!(user: Current.user, request: request)
     end
     redirect_to settings_security_path, notice: t(".success")
+  rescue ActiveRecord::RecordInvalid
+    redirect_to settings_security_path, alert: t(".failure")
   end
 
   private

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -11,8 +11,10 @@ class MfaController < ApplicationController
 
   def create
     if Current.user.verify_otp?(params[:code])
-      @backup_codes = Current.user.enable_mfa!
-      SecurityAuditLog.log_mfa_enabled!(user: Current.user, request: request)
+      ActiveRecord::Base.transaction do
+        @backup_codes = Current.user.enable_mfa!
+        SecurityAuditLog.log_mfa_enabled!(user: Current.user, request: request)
+      end
       render :backup_codes
     else
       Current.user.disable_mfa!
@@ -100,8 +102,10 @@ class MfaController < ApplicationController
   end
 
   def disable
-    Current.user.disable_mfa!
-    SecurityAuditLog.log_mfa_disabled!(user: Current.user, request: request)
+    ActiveRecord::Base.transaction do
+      Current.user.disable_mfa!
+      SecurityAuditLog.log_mfa_disabled!(user: Current.user, request: request)
+    end
     redirect_to settings_security_path, notice: t(".success")
   end
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -37,8 +37,7 @@ class PasswordResetsController < ApplicationController
       return
     end
 
-    if @user.update(password_params)
-      SecurityAuditLog.log_password_changed!(user: @user, request: request)
+    if update_password_and_log_change
       redirect_to new_session_path, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity
@@ -46,6 +45,16 @@ class PasswordResetsController < ApplicationController
   end
 
   private
+
+    def update_password_and_log_change
+      ActiveRecord::Base.transaction do
+        next false unless @user.update(password_params)
+
+        SecurityAuditLog.log_password_changed!(user: @user, request: request)
+
+        true
+      end
+    end
 
     def ensure_password_resets_enabled
       return if AuthConfig.password_features_enabled?

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -38,6 +38,7 @@ class PasswordResetsController < ApplicationController
     end
 
     if @user.update(password_params)
+      SecurityAuditLog.log_password_changed!(user: @user, request: request)
       redirect_to new_session_path, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -3,8 +3,7 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if Current.user.update(password_params)
-      SecurityAuditLog.log_password_changed!(user: Current.user, request: request)
+    if update_password_and_log_change
       redirect_to root_path, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity
@@ -12,6 +11,16 @@ class PasswordsController < ApplicationController
   end
 
   private
+
+    def update_password_and_log_change
+      ActiveRecord::Base.transaction do
+        next false unless Current.user.update(password_params)
+
+        SecurityAuditLog.log_password_changed!(user: Current.user, request: request)
+
+        true
+      end
+    end
 
     def password_params
       params.require(:user).permit(:password, :password_confirmation, :password_challenge).with_defaults(password_challenge: "")

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -4,6 +4,7 @@ class PasswordsController < ApplicationController
 
   def update
     if Current.user.update(password_params)
+      SecurityAuditLog.log_password_changed!(user: Current.user, request: request)
       redirect_to root_path, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/settings/api_keys_controller.rb
+++ b/app/controllers/settings/api_keys_controller.rb
@@ -41,12 +41,20 @@ class Settings::ApiKeysController < ApplicationController
   end
 
   def destroy
-    @api_key.revoke!
-    SecurityAuditLog.log_api_key_revoked!(user: Current.user, api_key: @api_key, request: request)
+    begin
+      @api_key.revoke!
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotDestroyed
+      flash[:alert] = t(".revoke_failed")
+      return redirect_to settings_api_keys_path
+    end
+
+    begin
+      SecurityAuditLog.log_api_key_revoked!(user: Current.user, api_key: @api_key, request: request)
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error("[Settings::ApiKeys] Failed to write audit log for revoked key #{@api_key.id}: #{e.message}")
+    end
+
     flash[:notice] = t(".revoked_successfully")
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotDestroyed
-    flash[:alert] = t(".revoke_failed")
-  ensure
     redirect_to settings_api_keys_path
   end
 

--- a/app/controllers/settings/api_keys_controller.rb
+++ b/app/controllers/settings/api_keys_controller.rb
@@ -31,13 +31,15 @@ class Settings::ApiKeysController < ApplicationController
     @api_key = Current.user.api_keys.build(api_key_params)
     @api_key.key = @plain_key
 
-    if @api_key.save
+    ActiveRecord::Base.transaction do
+      @api_key.save!
       SecurityAuditLog.log_api_key_created!(user: Current.user, api_key: @api_key, request: request)
-      flash[:notice] = t(".success")
-      redirect_to settings_api_key_path(@api_key, newly_created: true)
-    else
-      render :new, status: :unprocessable_entity
     end
+
+    flash[:notice] = t(".success")
+    redirect_to settings_api_key_path(@api_key, newly_created: true)
+  rescue ActiveRecord::RecordInvalid
+    render :new, status: :unprocessable_entity
   end
 
   def destroy

--- a/app/controllers/settings/api_keys_controller.rb
+++ b/app/controllers/settings/api_keys_controller.rb
@@ -32,6 +32,7 @@ class Settings::ApiKeysController < ApplicationController
     @api_key.key = @plain_key
 
     if @api_key.save
+      SecurityAuditLog.log_api_key_created!(user: Current.user, api_key: @api_key, request: request)
       flash[:notice] = t(".success")
       redirect_to settings_api_key_path(@api_key, newly_created: true)
     else
@@ -41,6 +42,7 @@ class Settings::ApiKeysController < ApplicationController
 
   def destroy
     @api_key.revoke!
+    SecurityAuditLog.log_api_key_revoked!(user: Current.user, api_key: @api_key, request: request)
     flash[:notice] = t(".revoked_successfully")
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotDestroyed
     flash[:alert] = t(".revoke_failed")

--- a/app/controllers/settings/api_keys_controller.rb
+++ b/app/controllers/settings/api_keys_controller.rb
@@ -52,7 +52,7 @@ class Settings::ApiKeysController < ApplicationController
 
     begin
       SecurityAuditLog.log_api_key_revoked!(user: Current.user, api_key: @api_key, request: request)
-    rescue ActiveRecord::RecordInvalid => e
+    rescue ActiveRecord::ActiveRecordError => e
       Rails.logger.error("[Settings::ApiKeys] Failed to write audit log for revoked key #{@api_key.id}: #{e.message}")
     end
 

--- a/app/controllers/settings/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/webauthn_credentials_controller.rb
@@ -43,7 +43,7 @@ class Settings::WebauthnCredentialsController < ApplicationController
       user_presence: true
     )
 
-    Current.user.webauthn_credentials.create!(
+    stored_credential = Current.user.webauthn_credentials.create!(
       nickname: webauthn_credential_name,
       credential_id: credential.id,
       public_key: credential.public_key,
@@ -51,13 +51,17 @@ class Settings::WebauthnCredentialsController < ApplicationController
       transports: webauthn_credential_transports
     )
 
+    SecurityAuditLog.log_webauthn_credential_added!(user: Current.user, credential: stored_credential, request: request)
+
     render json: { redirect_url: settings_security_path }
   rescue WebAuthn::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique, ActionController::BadRequest, ActionController::ParameterMissing
     render json: { error: t("webauthn_credentials.failure") }, status: :unprocessable_entity
   end
 
   def destroy
-    Current.user.webauthn_credentials.find(params[:id]).destroy!
+    credential = Current.user.webauthn_credentials.find(params[:id])
+    credential.destroy!
+    SecurityAuditLog.log_webauthn_credential_removed!(user: Current.user, credential: credential, request: request)
     redirect_to settings_security_path, notice: t("webauthn_credentials.success")
   end
 

--- a/app/controllers/settings/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/webauthn_credentials_controller.rb
@@ -43,15 +43,17 @@ class Settings::WebauthnCredentialsController < ApplicationController
       user_presence: true
     )
 
-    stored_credential = Current.user.webauthn_credentials.create!(
-      nickname: webauthn_credential_name,
-      credential_id: credential.id,
-      public_key: credential.public_key,
-      sign_count: credential.sign_count,
-      transports: webauthn_credential_transports
-    )
+    ActiveRecord::Base.transaction do
+      stored_credential = Current.user.webauthn_credentials.create!(
+        nickname: webauthn_credential_name,
+        credential_id: credential.id,
+        public_key: credential.public_key,
+        sign_count: credential.sign_count,
+        transports: webauthn_credential_transports
+      )
 
-    SecurityAuditLog.log_webauthn_credential_added!(user: Current.user, credential: stored_credential, request: request)
+      SecurityAuditLog.log_webauthn_credential_added!(user: Current.user, credential: stored_credential, request: request)
+    end
 
     render json: { redirect_url: settings_security_path }
   rescue WebAuthn::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique, ActionController::BadRequest, ActionController::ParameterMissing
@@ -60,9 +62,15 @@ class Settings::WebauthnCredentialsController < ApplicationController
 
   def destroy
     credential = Current.user.webauthn_credentials.find(params[:id])
-    credential.destroy!
-    SecurityAuditLog.log_webauthn_credential_removed!(user: Current.user, credential: credential, request: request)
+
+    ActiveRecord::Base.transaction do
+      credential.destroy!
+      SecurityAuditLog.log_webauthn_credential_removed!(user: Current.user, credential: credential, request: request)
+    end
+
     redirect_to settings_security_path, notice: t("webauthn_credentials.success")
+  rescue ActiveRecord::RecordInvalid
+    redirect_to settings_security_path, alert: t("webauthn_credentials.failure")
   end
 
   private

--- a/app/models/security_audit_log.rb
+++ b/app/models/security_audit_log.rb
@@ -28,7 +28,7 @@ class SecurityAuditLog < ApplicationRecord
         event_type: "api_key_created",
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
-        metadata: { api_key_id: api_key.id, name: api_key.name, scopes: api_key.scopes }
+        metadata: identity_snapshot(user).merge(api_key_id: api_key.id, name: api_key.name, scopes: api_key.scopes)
       )
     end
 
@@ -38,7 +38,7 @@ class SecurityAuditLog < ApplicationRecord
         event_type: "api_key_revoked",
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
-        metadata: { api_key_id: api_key.id, name: api_key.name }
+        metadata: identity_snapshot(user).merge(api_key_id: api_key.id, name: api_key.name)
       )
     end
 
@@ -47,7 +47,8 @@ class SecurityAuditLog < ApplicationRecord
         user: user,
         event_type: "mfa_enabled",
         ip_address: request.remote_ip,
-        user_agent: request.user_agent&.truncate(500)
+        user_agent: request.user_agent&.truncate(500),
+        metadata: identity_snapshot(user)
       )
     end
 
@@ -56,17 +57,36 @@ class SecurityAuditLog < ApplicationRecord
         user: user,
         event_type: "mfa_disabled",
         ip_address: request.remote_ip,
-        user_agent: request.user_agent&.truncate(500)
+        user_agent: request.user_agent&.truncate(500),
+        metadata: identity_snapshot(user)
       )
     end
 
-    def log_password_changed!(user:, request:)
+    # actor is the user who performed the change when it wasn't the account
+    # owner themselves (e.g. a super admin resetting another user's password
+    # from Admin::UsersController). Self-service changes (PasswordsController,
+    # PasswordResetsController) leave it nil.
+    def log_password_changed!(user:, request:, actor: nil)
+      metadata = identity_snapshot(user)
+      metadata[:actor_user_id] = actor.id if actor && actor.id != user.id
+
       create!(
         user: user,
         event_type: "password_changed",
         ip_address: request.remote_ip,
-        user_agent: request.user_agent&.truncate(500)
+        user_agent: request.user_agent&.truncate(500),
+        metadata: metadata
       )
     end
+
+    private
+
+      # The user_id column is nullified (not cascaded) when the user is
+      # deleted, so it alone can't identify who a row was about afterward.
+      # Snapshotting the email into metadata keeps that identity legible to
+      # an investigator even after the account is gone.
+      def identity_snapshot(user)
+        { user_email: user.email }
+      end
   end
 end

--- a/app/models/security_audit_log.rb
+++ b/app/models/security_audit_log.rb
@@ -13,6 +13,8 @@ class SecurityAuditLog < ApplicationRecord
     mfa_enabled
     mfa_disabled
     password_changed
+    webauthn_credential_added
+    webauthn_credential_removed
   ].freeze
 
   validates :event_type, presence: true, inclusion: { in: EVENT_TYPES }
@@ -59,6 +61,26 @@ class SecurityAuditLog < ApplicationRecord
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
         metadata: identity_snapshot(user)
+      )
+    end
+
+    def log_webauthn_credential_added!(user:, credential:, request:)
+      create!(
+        user: user,
+        event_type: "webauthn_credential_added",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500),
+        metadata: identity_snapshot(user).merge(credential_id: credential.id, nickname: credential.nickname)
+      )
+    end
+
+    def log_webauthn_credential_removed!(user:, credential:, request:)
+      create!(
+        user: user,
+        event_type: "webauthn_credential_removed",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500),
+        metadata: identity_snapshot(user).merge(credential_id: credential.id, nickname: credential.nickname)
       )
     end
 

--- a/app/models/security_audit_log.rb
+++ b/app/models/security_audit_log.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Audit trail for security-sensitive account operations. Separate from
+# SsoAuditLog (app/models/sso_audit_log.rb), which is specifically about SSO
+# login/link/unlink events and has a `provider` column these events have no
+# use for.
+class SecurityAuditLog < ApplicationRecord
+  belongs_to :user, optional: true
+
+  EVENT_TYPES = %w[
+    api_key_created
+    api_key_revoked
+    mfa_enabled
+    mfa_disabled
+    password_changed
+  ].freeze
+
+  validates :event_type, presence: true, inclusion: { in: EVENT_TYPES }
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :for_user, ->(user) { where(user: user) }
+  scope :by_event, ->(event) { where(event_type: event) }
+
+  class << self
+    def log_api_key_created!(user:, api_key:, request:)
+      create!(
+        user: user,
+        event_type: "api_key_created",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500),
+        metadata: { api_key_id: api_key.id, name: api_key.name, scopes: api_key.scopes }
+      )
+    end
+
+    def log_api_key_revoked!(user:, api_key:, request:)
+      create!(
+        user: user,
+        event_type: "api_key_revoked",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500),
+        metadata: { api_key_id: api_key.id, name: api_key.name }
+      )
+    end
+
+    def log_mfa_enabled!(user:, request:)
+      create!(
+        user: user,
+        event_type: "mfa_enabled",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500)
+      )
+    end
+
+    def log_mfa_disabled!(user:, request:)
+      create!(
+        user: user,
+        event_type: "mfa_disabled",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500)
+      )
+    end
+
+    def log_password_changed!(user:, request:)
+      create!(
+        user: user,
+        event_type: "password_changed",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500)
+      )
+    end
+  end
+end

--- a/app/models/security_audit_log.rb
+++ b/app/models/security_audit_log.rb
@@ -7,6 +7,15 @@
 class SecurityAuditLog < ApplicationRecord
   belongs_to :user, optional: true
 
+  # Non-deterministic: this column is never queried by value, only ever
+  # displayed to an investigator, so there's no reason to give up the
+  # stronger (non-deterministic) ciphertext for lookup capability we don't
+  # need. Keeping the email out of `metadata` (plain jsonb) matters because
+  # these rows deliberately survive the user's deletion (see the FK comment
+  # in the migration) — a plaintext copy would otherwise outlive and bypass
+  # the encryption boundary `User#email` is under.
+  encrypts :user_email
+
   EVENT_TYPES = %w[
     api_key_created
     api_key_revoked
@@ -27,60 +36,64 @@ class SecurityAuditLog < ApplicationRecord
     def log_api_key_created!(user:, api_key:, request:)
       create!(
         user: user,
+        user_email: user.email,
         event_type: "api_key_created",
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
-        metadata: identity_snapshot(user).merge(api_key_id: api_key.id, name: api_key.name, scopes: api_key.scopes)
+        metadata: { api_key_id: api_key.id, name: api_key.name, scopes: api_key.scopes }
       )
     end
 
     def log_api_key_revoked!(user:, api_key:, request:)
       create!(
         user: user,
+        user_email: user.email,
         event_type: "api_key_revoked",
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
-        metadata: identity_snapshot(user).merge(api_key_id: api_key.id, name: api_key.name)
+        metadata: { api_key_id: api_key.id, name: api_key.name }
       )
     end
 
     def log_mfa_enabled!(user:, request:)
       create!(
         user: user,
+        user_email: user.email,
         event_type: "mfa_enabled",
         ip_address: request.remote_ip,
-        user_agent: request.user_agent&.truncate(500),
-        metadata: identity_snapshot(user)
+        user_agent: request.user_agent&.truncate(500)
       )
     end
 
     def log_mfa_disabled!(user:, request:)
       create!(
         user: user,
+        user_email: user.email,
         event_type: "mfa_disabled",
         ip_address: request.remote_ip,
-        user_agent: request.user_agent&.truncate(500),
-        metadata: identity_snapshot(user)
+        user_agent: request.user_agent&.truncate(500)
       )
     end
 
     def log_webauthn_credential_added!(user:, credential:, request:)
       create!(
         user: user,
+        user_email: user.email,
         event_type: "webauthn_credential_added",
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
-        metadata: identity_snapshot(user).merge(credential_id: credential.id, nickname: credential.nickname)
+        metadata: { credential_id: credential.id, nickname: credential.nickname }
       )
     end
 
     def log_webauthn_credential_removed!(user:, credential:, request:)
       create!(
         user: user,
+        user_email: user.email,
         event_type: "webauthn_credential_removed",
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
-        metadata: identity_snapshot(user).merge(credential_id: credential.id, nickname: credential.nickname)
+        metadata: { credential_id: credential.id, nickname: credential.nickname }
       )
     end
 
@@ -89,26 +102,17 @@ class SecurityAuditLog < ApplicationRecord
     # from Admin::UsersController). Self-service changes (PasswordsController,
     # PasswordResetsController) leave it nil.
     def log_password_changed!(user:, request:, actor: nil)
-      metadata = identity_snapshot(user)
+      metadata = {}
       metadata[:actor_user_id] = actor.id if actor && actor.id != user.id
 
       create!(
         user: user,
+        user_email: user.email,
         event_type: "password_changed",
         ip_address: request.remote_ip,
         user_agent: request.user_agent&.truncate(500),
         metadata: metadata
       )
     end
-
-    private
-
-      # The user_id column is nullified (not cascaded) when the user is
-      # deleted, so it alone can't identify who a row was about afterward.
-      # Snapshotting the email into metadata keeps that identity legible to
-      # an investigator even after the account is gone.
-      def identity_snapshot(user)
-        { user_email: user.email }
-      end
   end
 end

--- a/config/locales/views/mfa/en.yml
+++ b/config/locales/views/mfa/en.yml
@@ -12,7 +12,9 @@ en:
       title: Save Your Backup Codes
     create:
       invalid_code: Invalid verification code. Please try again.
+      setup_failed: Something went wrong enabling two-factor authentication. Please try again.
     disable:
+      failure: Something went wrong disabling two-factor authentication. Please try again.
       success: Two-factor authentication has been disabled
     new:
       code_label: Verification Code

--- a/db/migrate/20260829180000_create_security_audit_logs.rb
+++ b/db/migrate/20260829180000_create_security_audit_logs.rb
@@ -1,0 +1,31 @@
+# Audit trail for security-sensitive account operations that had no record
+# at all before this: API key creation/revocation, MFA enable/disable,
+# password changes. Deliberately a separate table from sso_audit_logs
+# (app/models/sso_audit_log.rb) rather than repurposing it — that model's
+# name, its `provider` column, and its existing 12 call sites are all
+# SSO-specific; folding unrelated event types into it would make "Sso" a
+# misnomer and risk touching working code for no benefit.
+class CreateSecurityAuditLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :security_audit_logs, id: :uuid do |t|
+      # Nullable, not the FK's on_delete: :nullify, matching
+      # debug_log_entries: an audit trail should outlive the account it's
+      # about (an admin investigating a deleted account still needs to see
+      # what it did beforehand), not disappear or block the deletion.
+      t.uuid :user_id
+      t.string :event_type, null: false
+      t.string :ip_address
+      t.string :user_agent
+      t.jsonb :metadata, default: {}, null: false
+
+      t.timestamps
+    end
+
+    add_index :security_audit_logs, :user_id
+    add_index :security_audit_logs, [ :user_id, :created_at ]
+    add_index :security_audit_logs, :event_type
+    add_index :security_audit_logs, :created_at
+
+    add_foreign_key :security_audit_logs, :users, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260829180000_create_security_audit_logs.rb
+++ b/db/migrate/20260829180000_create_security_audit_logs.rb
@@ -16,6 +16,12 @@ class CreateSecurityAuditLogs < ActiveRecord::Migration[7.2]
       t.string :event_type, null: false
       t.string :ip_address
       t.string :user_agent
+      # AR-encrypted (see SecurityAuditLog) rather than folded into `metadata`
+      # (plain jsonb): these rows deliberately outlive the user (see the FK
+      # below), so this is the only copy of the user's email left once the
+      # account is gone, and it needs the same encryption boundary that
+      # `User#email` has.
+      t.text :user_email
       t.jsonb :metadata, default: {}, null: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1985,6 +1985,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_180400) do
     t.check_constraint "kind::text = ANY (ARRAY['standard'::character varying::text, 'cash'::character varying::text])", name: "chk_securities_kind"
   end
 
+  create_table "security_audit_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "event_type", null: false
+    t.string "ip_address"
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.uuid "user_id"
+    t.index ["created_at"], name: "index_security_audit_logs_on_created_at"
+    t.index ["event_type"], name: "index_security_audit_logs_on_event_type"
+    t.index ["user_id", "created_at"], name: "index_security_audit_logs_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_security_audit_logs_on_user_id"
+  end
+
   create_table "security_prices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "currency", default: "USD", null: false
@@ -2705,6 +2719,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_180400) do
   add_foreign_key "rule_conditions", "rules"
   add_foreign_key "rule_runs", "rules"
   add_foreign_key "rules", "families"
+  add_foreign_key "security_audit_logs", "users", on_delete: :nullify
   add_foreign_key "security_prices", "securities"
   add_foreign_key "sessions", "impersonation_sessions", column: "active_impersonator_session_id"
   add_foreign_key "sessions", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1992,6 +1992,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_180400) do
     t.jsonb "metadata", default: {}, null: false
     t.datetime "updated_at", null: false
     t.string "user_agent"
+    t.text "user_email"
     t.uuid "user_id"
     t.index ["created_at"], name: "index_security_audit_logs_on_created_at"
     t.index ["event_type"], name: "index_security_audit_logs_on_event_type"

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -299,7 +299,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal "password_changed", log.event_type
     assert_equal target.id, log.user_id
     assert_equal users(:sure_support_staff).id, log.metadata["actor_user_id"]
-    assert_equal target.email, log.metadata["user_email"]
+    assert_equal target.email, log.user_email
   end
 
   test "update does not log an audit entry when the password is unchanged" do

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -283,6 +283,35 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert target.authenticate(new_password), "User should authenticate with the new password"
   end
 
+  test "update logs an audit entry with the admin as actor when setting a new password" do
+    target = users(:family_member)
+
+    assert_difference "SecurityAuditLog.count", 1 do
+      patch admin_user_url(target), params: {
+        user: {
+          role: target.role,
+          password: "Secure1!pass"
+        }
+      }
+    end
+
+    log = SecurityAuditLog.last
+    assert_equal "password_changed", log.event_type
+    assert_equal target.id, log.user_id
+    assert_equal users(:sure_support_staff).id, log.metadata["actor_user_id"]
+    assert_equal target.email, log.metadata["user_email"]
+  end
+
+  test "update does not log an audit entry when the password is unchanged" do
+    target = users(:family_member)
+
+    assert_no_difference "SecurityAuditLog.count" do
+      patch admin_user_url(target), params: {
+        user: { role: "admin", password: "" }
+      }
+    end
+  end
+
   test "update shows descriptive notification for role change only" do
     target = users(:family_member)
 

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -48,12 +48,16 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     assert_equal 8, rendered_codes.length
     assert rendered_codes.all? { |code| code.match?(/\A[0-9a-f]{16}\z/) }
     assert_empty rendered_codes & @user.otp_backup_codes
+
+    assert SecurityAuditLog.exists?(user: @user, event_type: "mfa_enabled")
   end
 
   test "does not enable MFA with invalid code" do
     @user.setup_mfa!
 
-    post mfa_path, params: { code: "invalid" }
+    assert_no_difference "SecurityAuditLog.count" do
+      post mfa_path, params: { code: "invalid" }
+    end
 
     assert_redirected_to new_mfa_path
     assert_not @user.reload.otp_required?
@@ -292,6 +296,8 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     assert_nil @user.otp_secret
     assert_empty @user.otp_backup_codes
     assert_empty @user.webauthn_credentials
+
+    assert SecurityAuditLog.exists?(user: @user, event_type: "mfa_disabled")
   end
 
   private

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -52,6 +52,19 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     assert SecurityAuditLog.exists?(user: @user, event_type: "mfa_enabled")
   end
 
+  test "does not enable MFA when the audit log write fails" do
+    @user.setup_mfa!
+    totp = ROTP::TOTP.new(@user.otp_secret, issuer: "Sure Finances")
+    SecurityAuditLog.stubs(:log_mfa_enabled!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+
+    assert_raises ActiveRecord::RecordInvalid do
+      post mfa_path, params: { code: totp.now }
+    end
+
+    assert_not @user.reload.otp_required?
+    assert_empty @user.otp_backup_codes
+  end
+
   test "does not enable MFA with invalid code" do
     @user.setup_mfa!
 
@@ -298,6 +311,25 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     assert_empty @user.webauthn_credentials
 
     assert SecurityAuditLog.exists?(user: @user, event_type: "mfa_disabled")
+  end
+
+  test "does not disable MFA when the audit log write fails" do
+    @user.setup_mfa!
+    @user.enable_mfa!
+    @user.webauthn_credentials.create!(
+      nickname: "YubiKey",
+      credential_id: "disable-mfa-audit-fail-credential",
+      public_key: "public-key"
+    )
+    SecurityAuditLog.stubs(:log_mfa_disabled!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+
+    assert_raises ActiveRecord::RecordInvalid do
+      delete disable_mfa_path
+    end
+
+    assert @user.reload.otp_required?
+    assert @user.otp_secret.present?
+    assert_not_empty @user.webauthn_credentials
   end
 
   private

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -57,10 +57,9 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     totp = ROTP::TOTP.new(@user.otp_secret, issuer: "Sure Finances")
     SecurityAuditLog.stubs(:log_mfa_enabled!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
 
-    assert_raises ActiveRecord::RecordInvalid do
-      post mfa_path, params: { code: totp.now }
-    end
+    post mfa_path, params: { code: totp.now }
 
+    assert_redirected_to new_mfa_path
     assert_not @user.reload.otp_required?
     assert_empty @user.otp_backup_codes
   end
@@ -323,10 +322,9 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     )
     SecurityAuditLog.stubs(:log_mfa_disabled!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
 
-    assert_raises ActiveRecord::RecordInvalid do
-      delete disable_mfa_path
-    end
+    delete disable_mfa_path
 
+    assert_redirected_to settings_security_path
     assert @user.reload.otp_required?
     assert @user.otp_secret.present?
     assert_not_empty @user.webauthn_credentials

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -26,6 +26,19 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     patch password_reset_path(token: @user.generate_token_for(:password_reset)),
       params: { user: { password: "password", password_confirmation: "password" } }
     assert_redirected_to new_session_url
+
+    assert SecurityAuditLog.exists?(user: @user, event_type: "password_changed")
+  end
+
+  test "update with an invalid password does not write an audit log" do
+    # has_secure_password validations: false (see app/models/user.rb) means
+    # password_confirmation mismatches aren't actually validated — only the
+    # minimum-length rule is, so that's the real failure mode to exercise.
+    assert_no_difference "SecurityAuditLog.count" do
+      patch password_reset_path(token: @user.generate_token_for(:password_reset)),
+        params: { user: { password: "short", password_confirmation: "short" } }
+    end
+    assert_response :unprocessable_entity
   end
 
   test "all actions redirect when password features are disabled" do

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -41,6 +41,17 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "rolls back the password change when the audit log write fails" do
+    SecurityAuditLog.stubs(:log_password_changed!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+    original_digest = @user.password_digest
+
+    patch password_reset_path(token: @user.generate_token_for(:password_reset)),
+      params: { user: { password: "password", password_confirmation: "password" } }
+
+    assert_response :unprocessable_entity
+    assert_equal original_digest, @user.reload.password_digest
+  end
+
   test "all actions redirect when password features are disabled" do
     AuthConfig.stubs(:password_features_enabled?).returns(false)
 

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -27,4 +27,14 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :unprocessable_entity
   end
+
+  test "rolls back the password change when the audit log write fails" do
+    SecurityAuditLog.stubs(:log_password_changed!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+    original_digest = @user.password_digest
+
+    patch password_path, params: { user: { password: "newtestpassword817983172", password_confirmation: "newtestpassword817983172" } }
+
+    assert_response :unprocessable_entity
+    assert_equal original_digest, @user.reload.password_digest
+  end
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    sign_in @user
+  end
+
+  test "edit" do
+    get edit_password_path
+    assert_response :ok
+  end
+
+  test "update changes the password and writes an audit log" do
+    patch password_path, params: { user: { password: "newtestpassword817983172", password_confirmation: "newtestpassword817983172" } }
+
+    assert_redirected_to root_path
+    assert SecurityAuditLog.exists?(user: @user, event_type: "password_changed")
+  end
+
+  test "update with an invalid password does not write an audit log" do
+    # has_secure_password validations: false (see app/models/user.rb) means
+    # password_confirmation mismatches aren't actually validated — only the
+    # minimum-length rule is, so that's the real failure mode to exercise.
+    assert_no_difference "SecurityAuditLog.count" do
+      patch password_path, params: { user: { password: "short", password_confirmation: "short" } }
+    end
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/controllers/settings/api_keys_controller_test.rb
+++ b/test/controllers/settings/api_keys_controller_test.rb
@@ -61,6 +61,22 @@ class Settings::ApiKeysControllerTest < ActionDispatch::IntegrationTest
     assert_equal new_key.id, log.metadata["api_key_id"]
   end
 
+  test "create does not persist the key when the audit log write fails" do
+    SecurityAuditLog.stubs(:log_api_key_created!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+
+    assert_no_difference "ApiKey.count" do
+      post settings_api_keys_path, params: {
+        api_key: {
+          name: "Never Persisted Key",
+          scopes: "read"
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_nil @user.api_keys.find_by(name: "Never Persisted Key")
+  end
+
   test "create rejects blank name" do
     assert_no_difference "ApiKey.count" do
       post settings_api_keys_path, params: {
@@ -182,6 +198,22 @@ class Settings::ApiKeysControllerTest < ActionDispatch::IntegrationTest
       scopes: [ "read" ]
     )
     SecurityAuditLog.stubs(:log_api_key_revoked!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+
+    delete settings_api_key_path(key)
+
+    assert_redirected_to settings_api_keys_path
+    assert_equal I18n.t("settings.api_keys.destroy.revoked_successfully"), flash[:notice]
+    assert key.reload.revoked?
+  end
+
+  test "destroy still revokes and reports success when the audit log write raises a database error" do
+    key = ApiKey.create!(
+      user: @user,
+      name: "Key One",
+      display_key: "key_one_db_error_123",
+      scopes: [ "read" ]
+    )
+    SecurityAuditLog.stubs(:log_api_key_revoked!).raises(ActiveRecord::StatementInvalid.new("connection lost"))
 
     delete settings_api_key_path(key)
 

--- a/test/controllers/settings/api_keys_controller_test.rb
+++ b/test/controllers/settings/api_keys_controller_test.rb
@@ -174,6 +174,22 @@ class Settings::ApiKeysControllerTest < ActionDispatch::IntegrationTest
     assert_equal key1.id, log.metadata["api_key_id"]
   end
 
+  test "destroy still revokes and reports success when the audit log write fails" do
+    key = ApiKey.create!(
+      user: @user,
+      name: "Key One",
+      display_key: "key_one_audit_fail_123",
+      scopes: [ "read" ]
+    )
+    SecurityAuditLog.stubs(:log_api_key_revoked!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+
+    delete settings_api_key_path(key)
+
+    assert_redirected_to settings_api_keys_path
+    assert_equal I18n.t("settings.api_keys.destroy.revoked_successfully"), flash[:notice]
+    assert key.reload.revoked?
+  end
+
   test "destroy of a nonexistent key does not write an audit log" do
     other_user = users(:family_member)
     other_user.api_keys.destroy_all

--- a/test/controllers/settings/api_keys_controller_test.rb
+++ b/test/controllers/settings/api_keys_controller_test.rb
@@ -56,6 +56,9 @@ class Settings::ApiKeysControllerTest < ActionDispatch::IntegrationTest
     existing.reload
     refute existing.revoked?
     assert_includes new_key.scopes, "read_write"
+
+    log = SecurityAuditLog.where(user: @user, event_type: "api_key_created").last
+    assert_equal new_key.id, log.metadata["api_key_id"]
   end
 
   test "create rejects blank name" do
@@ -166,6 +169,25 @@ class Settings::ApiKeysControllerTest < ActionDispatch::IntegrationTest
     key2.reload
     assert key1.revoked?
     refute key2.revoked?
+
+    log = SecurityAuditLog.where(user: @user, event_type: "api_key_revoked").last
+    assert_equal key1.id, log.metadata["api_key_id"]
+  end
+
+  test "destroy of a nonexistent key does not write an audit log" do
+    other_user = users(:family_member)
+    other_user.api_keys.destroy_all
+    other_key = ApiKey.create!(
+      user: other_user,
+      name: "Other User Key",
+      display_key: "other_user_key_456",
+      scopes: [ "read" ]
+    )
+
+    assert_no_difference "SecurityAuditLog.count" do
+      delete settings_api_key_path(other_key)
+    end
+    assert_response :not_found
   end
 
   test "destroy cannot revoke demo monitoring key" do

--- a/test/controllers/settings/api_keys_controller_test.rb
+++ b/test/controllers/settings/api_keys_controller_test.rb
@@ -180,7 +180,7 @@ class Settings::ApiKeysControllerTest < ActionDispatch::IntegrationTest
     other_key = ApiKey.create!(
       user: other_user,
       name: "Other User Key",
-      display_key: "other_user_key_456",
+      display_key: "other_user_key_#{SecureRandom.hex(8)}",
       scopes: [ "read" ]
     )
 

--- a/test/controllers/settings/webauthn_credentials_controller_test.rb
+++ b/test/controllers/settings/webauthn_credentials_controller_test.rb
@@ -48,6 +48,35 @@ class Settings::WebauthnCredentialsControllerTest < ActionDispatch::IntegrationT
     assert @user.reload.webauthn_id.present?
   end
 
+  test "creating a credential writes an audit log entry" do
+    options = registration_options
+    credential = @client.create(challenge: options.fetch("challenge"), rp_id: "www.example.com")
+
+    assert_difference "SecurityAuditLog.count", 1 do
+      post settings_webauthn_credentials_path, params: {
+        webauthn_credential: { nickname: "MacBook Touch ID" },
+        credential: credential
+      }, as: :json
+    end
+
+    log = SecurityAuditLog.last
+    stored_credential = @user.webauthn_credentials.reload.last
+    assert_equal "webauthn_credential_added", log.event_type
+    assert_equal stored_credential.id, log.metadata["credential_id"]
+    assert_equal "MacBook Touch ID", log.metadata["nickname"]
+  end
+
+  test "a rejected registration does not write an audit log" do
+    registration_options
+
+    assert_no_difference "SecurityAuditLog.count" do
+      post settings_webauthn_credentials_path, params: {
+        webauthn_credential: { nickname: "Malformed" },
+        credential: []
+      }, as: :json
+    end
+  end
+
   test "uses configured relying party id and allowed origin" do
     with_webauthn_config(rp_id: "example.test", allowed_origins: [ "https://app.example.test" ]) do
       client = WebAuthn::FakeClient.new("https://app.example.test")
@@ -151,6 +180,10 @@ class Settings::WebauthnCredentialsControllerTest < ActionDispatch::IntegrationT
     end
 
     assert_redirected_to settings_security_path
+
+    log = SecurityAuditLog.where(user: @user, event_type: "webauthn_credential_removed").last
+    assert_equal credential.id, log.metadata["credential_id"]
+    assert_equal "YubiKey", log.metadata["nickname"]
   end
 
   private

--- a/test/controllers/settings/webauthn_credentials_controller_test.rb
+++ b/test/controllers/settings/webauthn_credentials_controller_test.rb
@@ -66,6 +66,36 @@ class Settings::WebauthnCredentialsControllerTest < ActionDispatch::IntegrationT
     assert_equal "MacBook Touch ID", log.metadata["nickname"]
   end
 
+  test "does not persist the credential when the audit log write fails" do
+    options = registration_options
+    credential = @client.create(challenge: options.fetch("challenge"), rp_id: "www.example.com")
+    SecurityAuditLog.stubs(:log_webauthn_credential_added!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+
+    assert_no_difference -> { @user.webauthn_credentials.count } do
+      post settings_webauthn_credentials_path, params: {
+        webauthn_credential: { nickname: "MacBook Touch ID" },
+        credential: credential
+      }, as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "does not destroy the credential when the audit log write fails" do
+    credential = @user.webauthn_credentials.create!(
+      nickname: "YubiKey",
+      credential_id: "credential-audit-fail",
+      public_key: "public-key"
+    )
+    SecurityAuditLog.stubs(:log_webauthn_credential_removed!).raises(ActiveRecord::RecordInvalid.new(SecurityAuditLog.new))
+
+    assert_no_difference -> { @user.webauthn_credentials.count } do
+      delete settings_webauthn_credential_path(credential)
+    end
+
+    assert_redirected_to settings_security_path
+  end
+
   test "a rejected registration does not write an audit log" do
     registration_options
 

--- a/test/models/security_audit_log_test.rb
+++ b/test/models/security_audit_log_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class SecurityAuditLogTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:family_admin)
+    @request = ActionDispatch::TestRequest.create
+    @request.remote_addr = "203.0.113.5"
+    @request.user_agent = "TestAgent/1.0"
+  end
+
+  test "rejects an event_type outside the allowlist" do
+    log = SecurityAuditLog.new(user: @user, event_type: "not_a_real_event")
+    assert_not log.valid?
+    assert_includes log.errors[:event_type], "is not included in the list"
+  end
+
+  test "log_api_key_created! records the api key id, name, and scopes" do
+    api_key = ApiKey.create!(user: @user, name: "Test Key", display_key: "test_key_abc", scopes: [ "read" ])
+
+    log = SecurityAuditLog.log_api_key_created!(user: @user, api_key: api_key, request: @request)
+
+    assert_equal "api_key_created", log.event_type
+    assert_equal api_key.id, log.metadata["api_key_id"]
+    assert_equal "Test Key", log.metadata["name"]
+    assert_equal "203.0.113.5", log.ip_address
+  end
+
+  test "log_password_changed! does not include the password anywhere" do
+    log = SecurityAuditLog.log_password_changed!(user: @user, request: @request)
+
+    assert_equal "password_changed", log.event_type
+    assert_empty log.metadata
+  end
+
+  test "survives its user being deleted" do
+    disposable_user = User.create!(
+      email: "disposable-audit-test@example.com",
+      password: "somesecurepassword12345",
+      first_name: "Disposable",
+      last_name: "User",
+      family: families(:dylan_family)
+    )
+    log = SecurityAuditLog.log_mfa_enabled!(user: disposable_user, request: @request)
+
+    disposable_user.destroy!
+
+    assert_nil log.reload.user_id
+  end
+end

--- a/test/models/security_audit_log_test.rb
+++ b/test/models/security_audit_log_test.rb
@@ -78,6 +78,13 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
     assert_equal "YubiKey", log.metadata["nickname"]
   end
 
+  test "stores the user_email column encrypted at rest" do
+    log = SecurityAuditLog.log_mfa_enabled!(user: @user, request: @request)
+
+    raw_value = log.read_attribute_before_type_cast(:user_email).to_s
+    assert_not_includes raw_value, @user.email
+  end
+
   test "survives its user being deleted, preserving the user's email" do
     disposable_user = User.create!(
       email: "disposable-audit-test@example.com",

--- a/test/models/security_audit_log_test.rb
+++ b/test/models/security_audit_log_test.rb
@@ -15,7 +15,7 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
   end
 
   test "log_api_key_created! records the api key id, name, and scopes" do
-    api_key = ApiKey.create!(user: @user, name: "Test Key", display_key: "test_key_#{SecureRandom.hex(8)}", scopes: [ "read" ])
+    api_key = ApiKey.create!(user: @user, name: "Test Key", display_key: "test_key_#{SecureRandom.hex(8)}", scopes: [ "read" ]) # pipelock:ignore
 
     log = SecurityAuditLog.log_api_key_created!(user: @user, api_key: api_key, request: @request)
 

--- a/test/models/security_audit_log_test.rb
+++ b/test/models/security_audit_log_test.rb
@@ -15,13 +15,14 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
   end
 
   test "log_api_key_created! records the api key id, name, and scopes" do
-    api_key = ApiKey.create!(user: @user, name: "Test Key", display_key: "test_key_abc", scopes: [ "read" ])
+    api_key = ApiKey.create!(user: @user, name: "Test Key", display_key: "test_key_#{SecureRandom.hex(8)}", scopes: [ "read" ])
 
     log = SecurityAuditLog.log_api_key_created!(user: @user, api_key: api_key, request: @request)
 
     assert_equal "api_key_created", log.event_type
     assert_equal api_key.id, log.metadata["api_key_id"]
     assert_equal "Test Key", log.metadata["name"]
+    assert_equal @user.email, log.metadata["user_email"]
     assert_equal "203.0.113.5", log.ip_address
   end
 
@@ -29,10 +30,26 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
     log = SecurityAuditLog.log_password_changed!(user: @user, request: @request)
 
     assert_equal "password_changed", log.event_type
-    assert_empty log.metadata
+    assert_equal @user.email, log.metadata["user_email"]
+    assert_not_includes log.metadata.to_s, "password"
   end
 
-  test "survives its user being deleted" do
+  test "log_password_changed! records the actor when someone else changed the password" do
+    admin = users(:family_admin)
+    other_user = users(:family_member)
+
+    log = SecurityAuditLog.log_password_changed!(user: other_user, request: @request, actor: admin)
+
+    assert_equal admin.id, log.metadata["actor_user_id"]
+  end
+
+  test "log_password_changed! does not record an actor for self-service changes" do
+    log = SecurityAuditLog.log_password_changed!(user: @user, request: @request, actor: @user)
+
+    assert_nil log.metadata["actor_user_id"]
+  end
+
+  test "survives its user being deleted, preserving the user's email in metadata" do
     disposable_user = User.create!(
       email: "disposable-audit-test@example.com",
       password: "somesecurepassword12345",
@@ -44,6 +61,8 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
 
     disposable_user.destroy!
 
-    assert_nil log.reload.user_id
+    log.reload
+    assert_nil log.user_id
+    assert_equal "disposable-audit-test@example.com", log.metadata["user_email"]
   end
 end

--- a/test/models/security_audit_log_test.rb
+++ b/test/models/security_audit_log_test.rb
@@ -49,6 +49,35 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
     assert_nil log.metadata["actor_user_id"]
   end
 
+  test "log_webauthn_credential_added! records the credential id and nickname" do
+    credential = @user.webauthn_credentials.create!(
+      nickname: "YubiKey",
+      credential_id: "credential-added-test",
+      public_key: "public-key"
+    )
+
+    log = SecurityAuditLog.log_webauthn_credential_added!(user: @user, credential: credential, request: @request)
+
+    assert_equal "webauthn_credential_added", log.event_type
+    assert_equal credential.id, log.metadata["credential_id"]
+    assert_equal "YubiKey", log.metadata["nickname"]
+    assert_equal @user.email, log.metadata["user_email"]
+  end
+
+  test "log_webauthn_credential_removed! records the credential id and nickname" do
+    credential = @user.webauthn_credentials.create!(
+      nickname: "YubiKey",
+      credential_id: "credential-removed-test",
+      public_key: "public-key"
+    )
+
+    log = SecurityAuditLog.log_webauthn_credential_removed!(user: @user, credential: credential, request: @request)
+
+    assert_equal "webauthn_credential_removed", log.event_type
+    assert_equal credential.id, log.metadata["credential_id"]
+    assert_equal "YubiKey", log.metadata["nickname"]
+  end
+
   test "survives its user being deleted, preserving the user's email in metadata" do
     disposable_user = User.create!(
       email: "disposable-audit-test@example.com",

--- a/test/models/security_audit_log_test.rb
+++ b/test/models/security_audit_log_test.rb
@@ -22,7 +22,7 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
     assert_equal "api_key_created", log.event_type
     assert_equal api_key.id, log.metadata["api_key_id"]
     assert_equal "Test Key", log.metadata["name"]
-    assert_equal @user.email, log.metadata["user_email"]
+    assert_equal @user.email, log.user_email
     assert_equal "203.0.113.5", log.ip_address
   end
 
@@ -30,7 +30,7 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
     log = SecurityAuditLog.log_password_changed!(user: @user, request: @request)
 
     assert_equal "password_changed", log.event_type
-    assert_equal @user.email, log.metadata["user_email"]
+    assert_equal @user.email, log.user_email
     assert_not_includes log.metadata.to_s, "password"
   end
 
@@ -61,7 +61,7 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
     assert_equal "webauthn_credential_added", log.event_type
     assert_equal credential.id, log.metadata["credential_id"]
     assert_equal "YubiKey", log.metadata["nickname"]
-    assert_equal @user.email, log.metadata["user_email"]
+    assert_equal @user.email, log.user_email
   end
 
   test "log_webauthn_credential_removed! records the credential id and nickname" do
@@ -78,7 +78,7 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
     assert_equal "YubiKey", log.metadata["nickname"]
   end
 
-  test "survives its user being deleted, preserving the user's email in metadata" do
+  test "survives its user being deleted, preserving the user's email" do
     disposable_user = User.create!(
       email: "disposable-audit-test@example.com",
       password: "somesecurepassword12345",
@@ -92,6 +92,6 @@ class SecurityAuditLogTest < ActiveSupport::TestCase
 
     log.reload
     assert_nil log.user_id
-    assert_equal "disposable-audit-test@example.com", log.metadata["user_email"]
+    assert_equal "disposable-audit-test@example.com", log.user_email
   end
 end


### PR DESCRIPTION
## Summary

Follow-up on [#1087](https://github.com/we-promise/sure/issues/1087) (Finding L5). PR 6 of the 6-PR series (last one — #5, encryption boot-fail-fast, is on hold pending the encryption PR series merging first, since it touches the exact same files).

`SsoAuditLog` covers SSO login/link/unlink events, but API key creation/revocation, MFA enable/disable, and password changes had no audit trail at all — confirmed by grepping every call site of those operations before writing anything.

### Design: new model, not a repurposed `SsoAuditLog`

`SsoAuditLog`'s name, its `provider` column, and its 12 existing call sites are all SSO-specific — folding unrelated event types into it would make "Sso" a misnomer for no real benefit. `SecurityAuditLog` mirrors its shape and per-event-type `log_x!` class-method convention for consistency, but is its own table. `user_id` is nullable with `on_delete: :nullify` — matching `debug_log_entries`, not `sso_audit_logs` — since an audit trail should outlive the account it's about (an admin investigating a deleted account still needs to see what it did beforehand), not disappear or block the deletion.

### Five entry points, logged only on actual success

Enumerated by grepping for `ApiKey.build`/`#revoke!`, `#enable_mfa!`/`#disable_mfa!`, and every controller that permits `:password`:

- `Settings::ApiKeysController#create` / `#destroy`
- `MfaController#create` (success branch only) / `#disable` — the same action's OTP-verification-failure branch also calls `disable_mfa!`, but that's an internal rollback of a setup that was never actually completed, not a real "MFA disabled" event, so it's deliberately not logged
- `PasswordsController#update` (in-session change)
- `PasswordResetsController#update` (token-based reset) — logs `@user`, not `Current.user`, since this controller runs unauthenticated

Every log call sits right after the bang/truthy save succeeds, never in a rescue or the failure branch, so a failed attempt can't log a false "changed" event.

### Race-condition check

Logging happens synchronously right after the state-changing call in the same request, not via a background job, so there's no window for the log to observe stale state. The only accepted gap is a process crash between the state change and the log write — closing that fully would need outbox-pattern complexity, not justified for a best-effort audit trail at this scope.

### A wrong assumption caught by testing

A planned test for "mismatched password confirmation should reject and not log" failed — because it actually *succeeded*. `User` has `has_secure_password validations: false`, so `password_confirmation` mismatches were never validated in this app to begin with. Switched both password-change tests to a real failure mode (too-short password) instead of asserting behavior around a validation that doesn't exist.

## Test plan
- [x] `bin/rails db:migrate` + `db:schema:dump` run against the NAS `sure_test_web` container (with explicit user go-ahead, since running migrations isn't otherwise something to do unprompted) to get the exact `schema.rb` block Rails generates — hand-spliced into the current `db/schema.rb` rather than copying the container's full dump wholesale, since the container's own schema was already a few migrations behind current `main` (confirmed by comparing versions) and copying the whole file back would have silently reverted unrelated tables
- [x] `bin/rails test` — 31/31 green across the new model test and 4 controller test files; the adjacent 5 WebAuthn failures in `mfa_controller_test.rb` reproduce identically with this branch's changes fully reverted, confirmed pre-existing/environmental (RP-ID mismatch), not a regression
- [x] `bin/rubocop` — clean
- [x] `bin/brakeman --no-pager` — 0 security warnings, 0 errors
- [x] Migration rolled back (`db:migrate:down`) and all files restored to their original state on the container afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added security audit logging for MFA changes, password updates, API key creation or revocation, and WebAuthn credential changes.
  - Audit records include event details, timestamps, IP addresses, browser information, and relevant account context.
  - Security activity remains available after an associated account is deleted.
  - Administrator-initiated password changes identify the administrator.

- **Bug Fixes**
  - Invalid operations do not create audit records.
  - Password changes roll back if audit logging fails.
  - API key revocation still completes if audit logging encounters an error.

- **Tests**
  - Added coverage for successful, unsuccessful, and administrator-initiated security actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->