### PR TITLE
fix(l10n): localize SureImport missing-reference messages

### DIFF
--- a/config/locales/models/sure_import/preflight/de.yml
+++ b/config/locales/models/sure_import/preflight/de.yml
@@ -1,0 +1,6 @@
+---
+de:
+  sure_import:
+    preflight:
+      missing_reference: 'Zeile %{line}: %{type} verweist über %{field}=%{value} auf einen nicht vorhandenen Datensatz.'
+      skipped_missing_reference: 'Zeile %{line}: %{type} verweist über %{field}=%{value} auf einen nicht vorhandenen Datensatz. Der Datensatz in dieser Zeile wird beim Import übersprungen.'

--- a/test/models/sure_import_test.rb
+++ b/test/models/sure_import_test.rb
@@ -628,6 +628,33 @@ class SureImportTest < ActiveSupport::TestCase
     assert_includes result.warnings.map { |warning| warning[:code] }, "skipped_missing_reference"
   end
 
+  test "preflight localizes missing reference messages in German" do
+    attach_ndjson(build_ndjson([
+      { type: "Transaction", data: {
+        id: "transaction-1",
+        account_id: "missing-account",
+        date: "2026-01-02",
+        amount: "-5"
+      } },
+      { type: "RejectedTransfer", data: {
+        id: "rejected-transfer-1",
+        inflow_transaction_id: "missing-inflow",
+        outflow_transaction_id: "missing-outflow"
+      } }
+    ]))
+
+    result = I18n.with_locale(:de) { @import.sure_preflight }
+
+    assert_includes result.errors, {
+      code: "missing_reference",
+      message: 'Zeile 1: Transaction verweist über account_id="missing-account" auf einen nicht vorhandenen Datensatz.'
+    }
+    assert_includes result.warnings, {
+      code: "skipped_missing_reference",
+      message: 'Zeile 2: RejectedTransfer verweist über inflow_transaction_id="missing-inflow" auf einen nicht vorhandenen Datensatz. Der Datensatz in dieser Zeile wird beim Import übersprungen.'
+    }
+  end
+
   test "preflight rejects invalid accountable types through explicit allowlist" do
     attach_ndjson(build_ndjson([
       { type: "Account", data: {


### PR DESCRIPTION
## Summary

German SureImport preflight now reports missing references in German instead of falling back to English. Interpolated record types, field names, and values remain unchanged so the diagnostics keep their source identifiers.

This is an independent slice of the ongoing German localization audit. Planning decisions carried forward: verify against current upstream before reporting (user-directed), keep instance evidence private, and ship small thematic PRs (user-approved).

## Validation

- Added focused integration coverage for German error and warning output.
- Full Rails suite: 7,449 runs and 29,606 assertions, with no failures or errors.
- Full RuboCop scan: 2,399 files inspected with no offenses.
- Fresh simulated merge tree matches the fully tested branch tree on current `upstream/main`.
- Current open-PR scan found no matching German locale or translation-key change.
- Dedicated German product-language review was performed by an AI reviewer; this does not claim human or native-speaker review.
- Code review completed with no findings across correctness, testing, and project standards.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This changes only German locale output and does not alter preflight control flow, persistence, or the import schema.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added German translations for missing-reference errors and warnings during Sure Import preflight checks.

- **Bug Fixes**
  - German users now see localized messages when transactions or rejected transfers reference missing records.

- **Tests**
  - Added coverage to verify the localized errors and warnings display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->