### PR TITLE
fix(imports): preserve accountable and merchant fields on NDJSON import

### DIFF
--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,14 +1,7 @@
 class CreditCardsController < ApplicationController
   include AccountableResource
 
-  permitted_accountable_attributes(
-    :id,
-    :available_credit,
-    :minimum_payment,
-    :apr,
-    :annual_fee,
-    :expiration_date
-  )
+  permitted_accountable_attributes(:id, *CreditCard::IMPORTABLE_ATTRIBUTES)
 
   def update
     super

--- a/app/controllers/cryptos_controller.rb
+++ b/app/controllers/cryptos_controller.rb
@@ -1,5 +1,5 @@
 class CryptosController < ApplicationController
   include AccountableResource
 
-  permitted_accountable_attributes :id, :subtype, :tax_treatment
+  permitted_accountable_attributes(:id, :subtype, *Crypto::IMPORTABLE_ATTRIBUTES)
 end

--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -1,7 +1,5 @@
 class LoansController < ApplicationController
   include AccountableResource
 
-  permitted_accountable_attributes(
-    :id, :subtype, :rate_type, :interest_rate, :term_months, :initial_balance
-  )
+  permitted_accountable_attributes(:id, :subtype, *Loan::IMPORTABLE_ATTRIBUTES)
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -233,7 +233,7 @@ class PropertiesController < ApplicationController
               :institution_name,
               :institution_domain,
               :notes,
-              accountable_attributes: [ :id, :subtype, :year_built, :area_unit, :area_value ]
+              accountable_attributes: [ :id, :subtype, *Property::IMPORTABLE_ATTRIBUTES ]
             )
     end
 

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -1,7 +1,5 @@
 class VehiclesController < ApplicationController
   include AccountableResource
 
-  permitted_accountable_attributes(
-    :id, :make, :model, :year, :mileage_value, :mileage_unit
-  )
+  permitted_accountable_attributes(:id, *Vehicle::IMPORTABLE_ATTRIBUTES)
 end

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -6,6 +6,13 @@ module Accountable
   # Define empty hash to ensure all accountables have this defined
   SUBTYPES = {}.freeze
 
+  # Accountable-specific columns (beyond `subtype`/`locked_attributes`, which
+  # every accountable already supports) that are safe to mass-assign from an
+  # imported NDJSON file. Mirrors each type's controller
+  # `permitted_accountable_attributes` allow-list so import and the web UI
+  # can never persist different sets of fields.
+  IMPORTABLE_ATTRIBUTES = [].freeze
+
   def self.from_type(type)
     return nil unless TYPES.include?(type)
     type.constantize

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -1,6 +1,8 @@
 class CreditCard < ApplicationRecord
   include Accountable
 
+  IMPORTABLE_ATTRIBUTES = %w[available_credit minimum_payment apr annual_fee expiration_date].freeze
+
   DEFAULT_SUBTYPE = "credit_card"
 
   SUBTYPES = {

--- a/app/models/crypto.rb
+++ b/app/models/crypto.rb
@@ -1,6 +1,8 @@
 class Crypto < ApplicationRecord
   include Accountable
 
+  IMPORTABLE_ATTRIBUTES = %w[tax_treatment].freeze
+
   # Subtypes differentiate how crypto is held:
   # - wallet: Self-custody or provider-synced wallets (CoinStats, etc.)
   # - exchange: Centralized exchanges with trade history (Coinbase, Kraken, etc.)

--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -302,32 +302,46 @@ class Family::DataImporter
         if account
           accountable = account.accountable
         else
-          # Build accountable
           accountable = accountable_class.new
-          accountable.subtype = accountable_data["subtype"] if accountable.respond_to?(:subtype=) && accountable_data["subtype"]
-
-          # Copy any other accountable attributes
-          safe_accountable_attrs = %w[subtype locked_attributes]
-          safe_accountable_attrs.each do |attr|
-            if accountable.respond_to?("#{attr}=") && accountable_data[attr].present?
-              accountable.send("#{attr}=", accountable_data[attr])
-            end
-          end
-
           account = @family.accounts.build(accountable: accountable)
         end
 
-        account.assign_attributes(
+        # Copy any other accountable attributes. Allow-listed per accountable
+        # type (see `Accountable::IMPORTABLE_ATTRIBUTES`) so an imported file
+        # can only set the same fields the web UI already permits editing —
+        # never arbitrary columns. Applied on both create and update so a
+        # re-import can correct previously-set accountable fields.
+        safe_accountable_attrs = %w[locked_attributes] + accountable_class::IMPORTABLE_ATTRIBUTES
+        safe_accountable_attrs.each do |attr|
+          if accountable.respond_to?("#{attr}=") && accountable_data.key?(attr) && !accountable_data[attr].nil?
+            accountable.send("#{attr}=", accountable_data[attr])
+          end
+        end
+
+        account_attrs = {
           name: data["name"],
           balance: data["balance"].to_d,
           cash_balance: data["cash_balance"]&.to_d || data["balance"].to_d,
           currency: data["currency"] || @family.currency,
-          subtype: data["subtype"],
           institution_name: data["institution_name"],
           institution_domain: data["institution_domain"],
           notes: data["notes"],
           status: importable_account_status(data["status"])
-        )
+        }
+
+        # `subtype` can be given nested under `accountable` (the shape
+        # `Family::DataExporter#generate_ndjson` emits) or at the top level of
+        # `data`. Nested takes precedence, matching `SureImport::Preflight#validate_accountables`
+        # (`data.dig("accountable", "subtype").presence || data["subtype"].presence`)
+        # so what gets validated pre-import is what actually gets applied.
+        # Only assign it when present: `Account#subtype=` writes straight through
+        # to the accountable, so an unconditional `subtype: data["subtype"]` here
+        # would silently null out a subtype already set from `accountable_data`
+        # (the common case) whenever the top-level field is absent.
+        imported_subtype = accountable_data["subtype"].presence || data["subtype"].presence
+        account_attrs[:subtype] = imported_subtype if imported_subtype.present?
+
+        account.assign_attributes(account_attrs)
 
         account.save!
 
@@ -482,6 +496,9 @@ class Family::DataImporter
         merchant.assign_attributes(
           name: data["name"],
           color: data["color"],
+          website_url: data["website_url"],
+          # If a logo provider (i.e. Brandfetch) is configured, the logo_url may be automatically reset. Otherwise,
+          # keep the imported one.
           logo_url: data["logo_url"]
         )
         merchant.save!

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -1,6 +1,8 @@
 class Loan < ApplicationRecord
   include Accountable
 
+  IMPORTABLE_ATTRIBUTES = %w[rate_type interest_rate term_months initial_balance].freeze
+
   SUBTYPES = {
     "mortgage" => { short: "Mortgage", long: "Mortgage" },
     "student" => { short: "Student Loan", long: "Student Loan" },

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,6 +1,8 @@
 class Property < ApplicationRecord
   include Accountable
 
+  IMPORTABLE_ATTRIBUTES = %w[year_built area_value area_unit].freeze
+
   SUBTYPES = {
     "single_family_home" => { short: "Single Family Home", long: "Single Family Home" },
     "multi_family_home" => { short: "Multi-Family Home", long: "Multi-Family Home" },

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,6 +1,8 @@
 class Vehicle < ApplicationRecord
   include Accountable
 
+  IMPORTABLE_ATTRIBUTES = %w[make model year mileage_value mileage_unit].freeze
+
   attribute :mileage_unit, :string, default: "mi"
 
   def mileage

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -31,6 +31,211 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal "Depository", account.accountable_type
   end
 
+  test "imports loan-specific accountable attributes" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "old-loan-1",
+          name: "Car Loan",
+          balance: "15000",
+          currency: "USD",
+          accountable_type: "Loan",
+          accountable: {
+            subtype: "auto",
+            rate_type: "fixed",
+            interest_rate: "5.25",
+            term_months: 60,
+            initial_balance: "18000"
+          }
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    loan = @family.accounts.find_by!(name: "Car Loan").loan
+    assert_equal "auto", loan.subtype
+    assert_equal "fixed", loan.rate_type
+    assert_equal 5.25, loan.interest_rate.to_f
+    assert_equal 60, loan.term_months
+    assert_equal 18000.0, loan.initial_balance.to_f
+  end
+
+  test "updates accountable attributes on an existing account, not just on creation" do
+    session = @family.import_sessions.create!(expected_chunks: 1)
+    account = @family.accounts.create!(
+      name: "Car Loan",
+      accountable: Loan.new(subtype: "auto", rate_type: "fixed", interest_rate: 5.25, term_months: 60, initial_balance: 18000),
+      balance: 15000,
+      currency: "USD"
+    )
+    session.source_mappings.create!(family: @family, source_type: "Account", source_id: "old-loan-1", target: account)
+
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "old-loan-1",
+          name: "Car Loan",
+          balance: "12000",
+          currency: "USD",
+          accountable_type: "Loan",
+          accountable: {
+            subtype: "auto",
+            rate_type: "variable",
+            interest_rate: "7.5",
+            term_months: 48,
+            initial_balance: "18000"
+          }
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson, import_session: session).import!
+
+    loan = account.reload.loan
+    assert_equal "variable", loan.rate_type
+    assert_equal 7.5, loan.interest_rate.to_f
+    assert_equal 48, loan.term_months
+  end
+
+  test "clears an accountable attribute when re-import supplies it as blank" do
+    session = @family.import_sessions.create!(expected_chunks: 1)
+    account = @family.accounts.create!(
+      name: "Sedan",
+      accountable: Vehicle.new(make: "Toyota", model: "Corolla"),
+      balance: 20000,
+      currency: "USD"
+    )
+    session.source_mappings.create!(family: @family, source_type: "Account", source_id: "old-vehicle-1", target: account)
+
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "old-vehicle-1",
+          name: "Sedan",
+          balance: "20000",
+          currency: "USD",
+          accountable_type: "Vehicle",
+          accountable: { make: "", model: "Corolla" }
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson, import_session: session).import!
+
+    vehicle = account.reload.vehicle
+    assert_equal "", vehicle.make
+    assert_equal "Corolla", vehicle.model
+  end
+
+  test "prefers nested accountable subtype over top-level subtype, matching preflight" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "old-account-precedence",
+          name: "Precedence Checking",
+          balance: "100",
+          currency: "USD",
+          accountable_type: "Depository",
+          subtype: "savings",
+          accountable: { subtype: "checking" }
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    depository = @family.accounts.find_by!(name: "Precedence Checking").depository
+    assert_equal "checking", depository.subtype
+  end
+
+  test "imports credit card, vehicle, crypto, and property accountable attributes" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "cc-1", name: "Card", balance: "500", currency: "USD",
+          accountable_type: "CreditCard",
+          accountable: { available_credit: "5000", minimum_payment: "25", apr: "19.99", annual_fee: "95", expiration_date: "2030-01-01" }
+        }
+      },
+      {
+        type: "Account",
+        data: {
+          id: "vehicle-1", name: "Car", balance: "20000", currency: "USD",
+          accountable_type: "Vehicle",
+          accountable: { make: "Toyota", model: "Corolla", year: 2022, mileage_value: 12000, mileage_unit: "mi" }
+        }
+      },
+      {
+        type: "Account",
+        data: {
+          id: "crypto-1", name: "Wallet", balance: "1000", currency: "USD",
+          accountable_type: "Crypto",
+          accountable: { subtype: "wallet", tax_treatment: "tax_exempt" }
+        }
+      },
+      {
+        type: "Account",
+        data: {
+          id: "property-1", name: "House", balance: "300000", currency: "USD",
+          accountable_type: "Property",
+          accountable: { year_built: 1998, area_value: 1800, area_unit: "sqft" }
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    credit_card = @family.accounts.find_by!(name: "Card").credit_card
+    assert_equal 5000.0, credit_card.available_credit.to_f
+    assert_equal 25.0, credit_card.minimum_payment.to_f
+    assert_equal 19.99, credit_card.apr.to_f
+    assert_equal 95.0, credit_card.annual_fee.to_f
+    assert_equal Date.parse("2030-01-01"), credit_card.expiration_date
+
+    vehicle = @family.accounts.find_by!(name: "Car").vehicle
+    assert_equal "Toyota", vehicle.make
+    assert_equal "Corolla", vehicle.model
+    assert_equal 2022, vehicle.year
+    assert_equal 12000, vehicle.mileage_value
+
+    crypto = @family.accounts.find_by!(name: "Wallet").crypto
+    assert_equal "tax_exempt", crypto.tax_treatment
+
+    property = @family.accounts.find_by!(name: "House").property
+    assert_equal 1998, property.year_built
+    assert_equal 1800, property.area_value
+    assert_equal "sqft", property.area_unit
+  end
+
+  test "does not mass-assign accountable attributes outside the type's import allow-list" do
+    ndjson = build_ndjson([
+      {
+        type: "Account",
+        data: {
+          id: "old-account-2",
+          name: "Test Savings",
+          balance: "1000",
+          currency: "USD",
+          accountable_type: "Depository",
+          accountable: { subtype: "savings", interest_rate: "99", term_months: 60 }
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    depository = @family.accounts.find_by!(name: "Test Savings").depository
+    assert_equal "savings", depository.subtype
+    assert_not_respond_to depository, :interest_rate
+    assert_not_respond_to depository, :term_months
+  end
+
   test "imports non-destructive account status from ndjson" do
     ndjson = build_ndjson([
       {
@@ -495,6 +700,98 @@ class Family::DataImporterTest < ActiveSupport::TestCase
 
     merchant = @family.merchants.find_by(name: "Amazon")
     assert_not_nil merchant
+  end
+
+  test "imports merchant website_url" do
+    ndjson = build_ndjson([
+      {
+        type: "Merchant",
+        data: {
+          id: "merchant-1",
+          name: "Amazon",
+          website_url: "https://amazon.com"
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    merchant = @family.merchants.find_by!(name: "Amazon")
+    assert_equal "https://amazon.com", merchant.website_url
+  end
+
+  test "re-importing a merchant without website_url blanks it (and, via FamilyMerchant's callback, logo_url too)" do
+    session = @family.import_sessions.create!(expected_chunks: 1)
+
+    Family::DataImporter.new(@family, build_ndjson([
+      {
+        type: "Merchant",
+        data: { id: "merchant-1", name: "Amazon", website_url: "https://amazon.com" }
+      }
+    ]), import_session: session).import!
+
+    # website_url is assigned unconditionally, same as color/logo_url in this
+    # method, so a later re-import that omits it blanks it out. That in turn
+    # feeds FamilyMerchant#generate_logo_url_from_website's before_save
+    # callback, which nils logo_url whenever website_url goes blank -- so the
+    # logo_url given in *this same* payload gets wiped right back to nil.
+    Family::DataImporter.new(@family, build_ndjson([
+      {
+        type: "Merchant",
+        data: { id: "merchant-1", name: "Amazon", logo_url: "https://cdn.example.com/amazon.png" }
+      }
+    ]), import_session: session).import!
+
+    merchant = @family.merchants.find_by!(name: "Amazon")
+    assert_nil merchant.website_url
+    assert_nil merchant.logo_url
+  end
+
+  test "keeps the imported logo_url when no logo provider is configured" do
+    Setting.stubs(:brand_fetch_client_id).returns(nil)
+
+    ndjson = build_ndjson([
+      {
+        type: "Merchant",
+        data: {
+          id: "merchant-1",
+          name: "Amazon",
+          website_url: "https://amazon.com",
+          logo_url: "https://cdn.example.com/amazon.png"
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    merchant = @family.merchants.find_by!(name: "Amazon")
+    assert_equal "https://cdn.example.com/amazon.png", merchant.logo_url
+  end
+
+  test "a configured logo provider overwrites the imported logo_url" do
+    Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
+
+    ndjson = build_ndjson([
+      {
+        type: "Merchant",
+        data: {
+          id: "merchant-1",
+          name: "Amazon",
+          website_url: "https://amazon.com",
+          logo_url: "https://cdn.example.com/amazon.png"
+        }
+      }
+    ])
+
+    Family::DataImporter.new(@family, ndjson).import!
+
+    # FamilyMerchant#generate_logo_url_from_website's before_save fires
+    # whenever website_url changes, and when a logo provider is configured it
+    # regenerates logo_url from that provider -- overwriting whatever this
+    # importer just assigned, imported value included.
+    merchant = @family.merchants.find_by!(name: "Amazon")
+    assert_includes merchant.logo_url, "cdn.brandfetch.io"
+    assert_not_equal "https://cdn.example.com/amazon.png", merchant.logo_url
   end
 
   test "imports recurring transactions with remapped account and merchant references" do


### PR DESCRIPTION
## Problem

`Family::DataImporter#import_accounts` only ever copied `subtype` and
`locked_attributes` from an `Account` line's nested `accountable` data.
Every other accountable-specific column was silently dropped on import —
all real, persisted columns already editable through each account type's
own web UI form:

- **Loan**: `rate_type`, `interest_rate`, `term_months`, `initial_balance`
- **CreditCard**: `available_credit`, `minimum_payment`, `apr`, `annual_fee`, `expiration_date`
- **Vehicle**: `make`, `model`, `year`, `mileage_value`, `mileage_unit`
- **Crypto**: `tax_treatment`
- **Property**: `year_built`, `area_value`, `area_unit`

Separately, `Merchant.website_url` was dropped too: it's already exported
(`Merchant#as_json` serializes every column) and already supported by the
legacy CSV `MerchantImport`, but NDJSON import never read it back.

## Cause

`import_accounts` hardcoded a two-field allow-list
(`safe_accountable_attrs = %w[subtype locked_attributes]`) instead of
deferring to each accountable type, even though every controller already
declares its own permitted set via `permitted_accountable_attributes`
(e.g. `LoansController`). The two allow-lists had simply never been
connected.

Writing a subtype regression test surfaced a second, independent bug:
`import_accounts` unconditionally does
`account.assign_attributes(subtype: data["subtype"])` after building the
accountable — which always overwrites the subtype, even when the nested
`accountable.subtype` was the only place a subtype was actually given
(the documented `Account` payload shape) and top-level `data["subtype"]`
is absent. **Every NDJSON import of every account type was silently
losing its subtype on create.**

## Fix

- Added `Accountable::IMPORTABLE_ATTRIBUTES` (empty by default, overridden
  per accountable type) and had the importer union it into its allow-list.
  Pointed each controller's `permitted_accountable_attributes` at the same
  constant, so the web-UI allow-list and the import allow-list can't drift
  apart — one source of truth for "what's safe to mass-assign on this
  accountable type."
- Only assign `subtype` when a value is actually present, preferring the
  nested `accountable.subtype` over top-level `data["subtype"]` to match
  `SureImport::Preflight#validate_accountables`'s own precedence
  (`data.dig("accountable", "subtype").presence || data["subtype"].presence`)
  — so what preflight validates before publish is what import actually
  applies.
- Added `website_url` to `import_merchants`'s `assign_attributes` call,
  alongside the existing `color`/`logo_url` fields.

## Tests

- Regression coverage for each accountable type's new fields (Loan,
  CreditCard, Vehicle, Crypto, Property).
- A guard test confirming fields outside a type's import allow-list are
  never mass-assigned (e.g. a `Depository` payload can't set
  `interest_rate`/`term_months`).
- A precedence test: nested `accountable.subtype` wins over a differing
  top-level `data["subtype"]`, matching preflight.
- Merchant `website_url` import, plus a test documenting the existing
  interaction with `FamilyMerchant#generate_logo_url_from_website`
  (a `before_save` callback that nils `logo_url` whenever `website_url`
  goes blank): since `website_url`/`color`/`logo_url` are all assigned
  unconditionally in this method, a re-import that supplies `logo_url`
  but omits `website_url` blanks both.

## Validation

- `bin/rails test` — 7454 runs, 0 failures, 0 errors (1 pre-existing,
  unrelated failure in `Security::ResolverTest` reproduces identically on
  unmodified `main`, confirmed by stashing this change and re-running).
- `bin/rubocop -f github -a` — no offenses.
- `bin/brakeman --no-pager` — 0 security warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded imports for credit cards, cryptocurrencies, loans, properties, vehicles, and account details.
  * Re-imports can update supported information on existing accounts, including blank values.
  * Merchant imports now include website URLs.

* **Bug Fixes**
  * Improved handling of account subtype information, prioritizing nested values when available.
  * Unsupported attributes are excluded more consistently during imports.
  * Merchant re-imports correctly update website and branding information.
  * Improved reliability for larger imports and resumable import sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->