### PR TITLE
Add support for linking E*TRADE and other investment-only institutions

### DIFF
--- a/app/models/provider/plaid.rb
+++ b/app/models/provider/plaid.rb
@@ -185,6 +185,9 @@ class Provider::Plaid
       [ transactions, securities ]
     end
 
+    # The primary Plaid product to request for a given Sure account type.
+    # Investments map to the `investments` product, liability accounts
+    # (CreditCard/Loan) to `liabilities`, everything else to `transactions`.
     def get_primary_product(accountable_type)
       return "transactions" if eu?
 
@@ -198,13 +201,16 @@ class Provider::Plaid
       end
     end
 
+    # Additional Plaid products to consent to alongside the primary product.
+    #
+    # We only request the `liabilities` product when the account being linked is
+    # itself a liability (CreditCard/Loan). Plaid's Link filters out any
+    # institution that does not support every requested product, so asking for
+    # `liabilities` on e.g. an Investment link silently hides investment-only
+    # brokerages like E*TRADE that don't offer it.
     def get_additional_consented_products(accountable_type)
       return [] if eu?
 
-      # Request liability products only when the account being linked is itself a
-      # liability (CreditCard/Loan). Plaid's Link filters out any institution that
-      # does not support every requested product, so requesting `liabilities` on
-      # e.g. an Investment link hides institutions like E*TRADE that don't offer it.
       case get_primary_product(accountable_type)
       when "liabilities"
         SUPPORTED_PLAID_PRODUCTS - [ "liabilities" ]

--- a/app/models/provider/plaid.rb
+++ b/app/models/provider/plaid.rb
@@ -201,7 +201,16 @@ class Provider::Plaid
     def get_additional_consented_products(accountable_type)
       return [] if eu?
 
-      SUPPORTED_PLAID_PRODUCTS - [ get_primary_product(accountable_type) ]
+      # Request liability products only when the account being linked is itself a
+      # liability (CreditCard/Loan). Plaid's Link filters out any institution that
+      # does not support every requested product, so requesting `liabilities` on
+      # e.g. an Investment link hides institutions like E*TRADE that don't offer it.
+      case get_primary_product(accountable_type)
+      when "liabilities"
+        SUPPORTED_PLAID_PRODUCTS - [ "liabilities" ]
+      else
+        SUPPORTED_PLAID_PRODUCTS - [ get_primary_product(accountable_type), "liabilities" ]
+      end
     end
 
     def eu?

--- a/test/models/provider/plaid_test.rb
+++ b/test/models/provider/plaid_test.rb
@@ -32,6 +32,54 @@ class Provider::PlaidTest < ActiveSupport::TestCase
     end
   end
 
+  test "requests liability products only for liability account types" do
+    request = mock
+    Plaid::LinkTokenCreateRequest.expects(:new).with do |params|
+      params[:products] == [ "investments" ] &&
+        params[:additional_consented_products] == [ "transactions" ]
+    end.returns(request)
+    @plaid.client.expects(:link_token_create).with(request).returns("response")
+
+    @plaid.get_link_token(
+      user_id: "test-user-id",
+      webhooks_url: "https://example.com/webhooks",
+      redirect_url: @redirect_url,
+      accountable_type: "Investment"
+    )
+  end
+
+  test "does not request liabilities for a depository link" do
+    request = mock
+    Plaid::LinkTokenCreateRequest.expects(:new).with do |params|
+      params[:products] == [ "transactions" ] &&
+        params[:additional_consented_products] == [ "investments" ]
+    end.returns(request)
+    @plaid.client.expects(:link_token_create).with(request).returns("response")
+
+    @plaid.get_link_token(
+      user_id: "test-user-id",
+      webhooks_url: "https://example.com/webhooks",
+      redirect_url: @redirect_url,
+      accountable_type: "Depository"
+    )
+  end
+
+  test "requests liabilities as primary for a credit card link" do
+    request = mock
+    Plaid::LinkTokenCreateRequest.expects(:new).with do |params|
+      params[:products] == [ "liabilities" ] &&
+        params[:additional_consented_products] == [ "transactions", "investments" ]
+    end.returns(request)
+    @plaid.client.expects(:link_token_create).with(request).returns("response")
+
+    @plaid.get_link_token(
+      user_id: "test-user-id",
+      webhooks_url: "https://example.com/webhooks",
+      redirect_url: @redirect_url,
+      accountable_type: "CreditCard"
+    )
+  end
+
   test "enables account selection for an update link token" do
     request = mock
     Plaid::LinkTokenCreateRequest.expects(:new).with do |params|


### PR DESCRIPTION
## Summary

This lets you link **E\*TRADE** (and other investment-only brokerages) through Plaid.

The problem: when Sure builds a Plaid link token, it always asks for `liabilities` as an *additional* consented product — even when you're linking an investment account. Plaid's Link flow then quietly hides any institution that doesn't support *every* product in the token. E\*TRADE supports `transactions` and `investments` but **not** `liabilities`, so it never showed up in the search, and there was no way to link it.

## The fix

Only request `liabilities` when the account you're linking is actually a liability (a credit card or loan). Investment and bank-account links no longer force it.

| Account type | What the link token requests (before → after) |
|---|---|
| Depository (checking/savings) | `transactions` + `[investments, liabilities]` → `transactions` + `[investments]` |
| Investment | `investments` + `[transactions, liabilities]` → `investments` + `[transactions]` |
| CreditCard / Loan | `liabilities` + `[transactions, investments]` → unchanged |

Credit-card and loan links behave exactly as before. Non-liability links just stop asking Plaid for a product the institution may not offer.

## Testing

- Added unit tests covering the product list for investment, depository, and credit-card links. They **fail on the old code** (which requested `liabilities` on investment links) and **pass with this change**.
- **Live test**: I applied this patch to a running self-hosted instance and successfully linked a real E\*TRADE brokerage account through Plaid Link. It now appears in the Link search and connects; before the patch it was silently absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account linking for credit cards and loans by requesting the appropriate additional account information.
  * Prevented duplicate liability product requests during account linking.

* **Tests**
  * Added coverage to verify product selections for investment, deposit, and credit card accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->