### PR TITLE
fix(enable-banking): discard the merchant-view row of a card purchase (N26)

### DIFF
--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -557,9 +557,20 @@ class EnableBankingItem::Importer
       { success: false, transactions_count: 0, error: handle_sync_error(e) }
     end
 
-    # ISO 20022 bank transaction code families for card payments.
+    # ISO 20022 bank transaction codes for the two halves of a card purchase.
+    # Only the point-of-sale purchase sub-codes take part in pairing: the other
+    # members of these families are separate movements that merely happen to
+    # share a family. CCRD/CWDL is a cash withdrawal, which has no merchant-side
+    # counterpart, and MCRD/DAJT and MCRD/OTHR are adjustments. Any of them can
+    # collide with an unrelated purchase on every field of the grouping key.
+    #
+    # This errs towards leaving a duplicate rather than discarding a real
+    # movement: an ASPSP that pairs some other sub-code keeps its duplicates,
+    # which is visible and recoverable, whereas discarding a genuine row is not.
     CUSTOMER_CARD_CODE = "CCRD".freeze # Customer Card Transactions - the cardholder's view
+    CUSTOMER_CARD_PURCHASE = [ CUSTOMER_CARD_CODE, "POSD" ].freeze # point-of-sale purchase
     MERCHANT_CARD_CODE = "MCRD".freeze # Merchant Card Transactions - the merchant's view
+    MERCHANT_CARD_PURCHASE = [ MERCHANT_CARD_CODE, "UPCT" ].freeze # the merchant's view of one
 
     # Some ASPSPs book a single card purchase twice: once as PMNT-CCRD-* (the
     # cardholder's view) and once as PMNT-MCRD-* (the merchant's view). N26 does
@@ -586,7 +597,8 @@ class EnableBankingItem::Importer
       transactions.each_with_index do |tx, index|
         tx = tx.with_indifferent_access
         code = tx.dig(:bank_transaction_code, :code)
-        next unless [ CUSTOMER_CARD_CODE, MERCHANT_CARD_CODE ].include?(code)
+        sub_code = tx.dig(:bank_transaction_code, :sub_code)
+        next unless [ CUSTOMER_CARD_PURCHASE, MERCHANT_CARD_PURCHASE ].include?([ code, sub_code ])
 
         key = build_card_twin_key(tx)
         next if key.nil?

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -475,7 +475,7 @@ class EnableBankingItem::Importer
 
       # Drop the merchant-side twin of each card purchase before content dedup,
       # so the customer-side row is the one that reaches the snapshot.
-      all_transactions = discard_merchant_card_twins(all_transactions)
+      all_transactions = discard_merchant_card_twins(all_transactions, enable_banking_account)
 
       # Deduplicate API response: Enable Banking sometimes returns the same logical
       # transaction with different entry_reference IDs in the same response.
@@ -580,7 +580,7 @@ class EnableBankingItem::Importer
     # unpaired MCRD rows (adjustments, MCRD/OTHR) are legitimate movements and
     # are kept. Two CCRD rows are never collapsed into each other here, which is
     # what makes this safe for the over-merge reported in #2720.
-    def discard_merchant_card_twins(transactions)
+    def discard_merchant_card_twins(transactions, enable_banking_account)
       groups = Hash.new { |hash, key| hash[key] = [] }
 
       transactions.each_with_index do |tx, index|
@@ -611,9 +611,22 @@ class EnableBankingItem::Importer
 
       return transactions if discarded_indexes.empty?
 
-      Rails.logger.info(
-        "EnableBankingItem::Importer - Discarded #{discarded_indexes.size} merchant-side (MCRD) " \
-        "card twin(s) from API response (#{transactions.count} → #{transactions.count - discarded_indexes.size} transactions)"
+      DebugLogEntry.capture(
+        category: "provider_sync",
+        level: "info",
+        message: "Discarded merchant-side (MCRD) card twin(s) from the API response",
+        source: self.class.name,
+        provider_key: "enable_banking",
+        family: enable_banking_item.family,
+        account_provider: enable_banking_account.account_provider,
+        metadata: {
+          enable_banking_item_id: enable_banking_item.id,
+          enable_banking_account_id: enable_banking_account.id,
+          uid: enable_banking_account.uid,
+          discarded_count: discarded_indexes.size,
+          transactions_before: transactions.count,
+          transactions_after: transactions.count - discarded_indexes.size
+        }
       )
 
       transactions.reject.with_index { |_, index| discarded_indexes.include?(index) }

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -473,6 +473,10 @@ class EnableBankingItem::Importer
 
       all_transactions = all_transactions + tag_as_pending(pending_transactions)
 
+      # Drop the merchant-side twin of each card purchase before content dedup,
+      # so the customer-side row is the one that reaches the snapshot.
+      all_transactions = discard_merchant_card_twins(all_transactions)
+
       # Deduplicate API response: Enable Banking sometimes returns the same logical
       # transaction with different entry_reference IDs in the same response.
       # Remove content-level duplicates before storing. (Issue #954)
@@ -551,6 +555,96 @@ class EnableBankingItem::Importer
     rescue => e
       Rails.logger.error "EnableBankingItem::Importer - Unexpected error fetching transactions for account #{enable_banking_account.uid}: #{e.class} - #{e.message}"
       { success: false, transactions_count: 0, error: handle_sync_error(e) }
+    end
+
+    # ISO 20022 bank transaction code families for card payments.
+    CUSTOMER_CARD_CODE = "CCRD".freeze # Customer Card Transactions - the cardholder's view
+    MERCHANT_CARD_CODE = "MCRD".freeze # Merchant Card Transactions - the merchant's view
+
+    # Some ASPSPs book a single card purchase twice: once as PMNT-CCRD-* (the
+    # cardholder's view) and once as PMNT-MCRD-* (the merchant's view). N26 does
+    # this for point-of-sale card payments. Both rows are booked in the same
+    # instant, both carry status BOOK and each gets its own entry_reference, so
+    # the pending->booked reconciliation never fires and the
+    # content dedup below only catches the pairs whose counterparty name happens
+    # to match on both rows - the rest reach the append-only snapshot and are
+    # never removed again.
+    #
+    # Group by the fields both rows report identically and, wherever CCRD and
+    # MCRD rows coexist, discard MCRD rows down to the number of CCRD rows. The
+    # rule is deliberately an accounting one rather than "one row per group": two
+    # identical purchases on the same day arrive as 2 CCRD + 2 MCRD and must keep
+    # both CCRD rows.
+    #
+    # bank_transaction_code only picks the survivor, it never matches on its own:
+    # unpaired MCRD rows (adjustments, MCRD/OTHR) are legitimate movements and
+    # are kept. Two CCRD rows are never collapsed into each other here, which is
+    # what makes this safe for the over-merge reported in #2720.
+    def discard_merchant_card_twins(transactions)
+      groups = Hash.new { |hash, key| hash[key] = [] }
+
+      transactions.each_with_index do |tx, index|
+        tx = tx.with_indifferent_access
+        code = tx.dig(:bank_transaction_code, :code)
+        next unless [ CUSTOMER_CARD_CODE, MERCHANT_CARD_CODE ].include?(code)
+
+        groups[build_card_twin_key(tx)] << [ index, code ]
+      end
+
+      discarded_indexes = Set.new
+
+      groups.each_value do |members|
+        customer_rows = members.count { |(_, code)| code == CUSTOMER_CARD_CODE }
+        next if customer_rows.zero?
+
+        merchant_indexes = members.filter_map { |(index, code)| index if code == MERCHANT_CARD_CODE }
+
+        # Which MCRD rows are discarded when the group holds more of them than
+        # CCRD rows is response order, i.e. arbitrary: the payload carries no
+        # signal that pairs a particular MCRD row with a particular CCRD one.
+        # It only decides which entry_reference and which spelling of the
+        # counterparty the surviving merchant-side row keeps, and both
+        # candidates are equally valid on those counts. The count is what
+        # matters here, not the identity.
+        discarded_indexes.merge(merchant_indexes.first(customer_rows))
+      end
+
+      return transactions if discarded_indexes.empty?
+
+      Rails.logger.info(
+        "EnableBankingItem::Importer - Discarded #{discarded_indexes.size} merchant-side (MCRD) " \
+        "card twin(s) from API response (#{transactions.count} → #{transactions.count - discarded_indexes.size} transactions)"
+      )
+
+      transactions.reject.with_index { |_, index| discarded_indexes.include?(index) }
+    end
+
+    # Grouping key that brings the cardholder's row (CCRD) and the merchant's row
+    # (MCRD) of one card purchase together. It uses only fields that are always
+    # present and that both rows carry identically.
+    #
+    # Whether the row is pending is part of the key, so a booked row is never
+    # discarded in favour of a pending one. The pending->booked reconciliation
+    # above cannot pair a CCRD row with an MCRD row - they carry different
+    # entry_references and different fingerprints - so a pending CCRD row and a
+    # booked MCRD row can otherwise land in the same group, and discarding the
+    # booked row there would leave the purchase represented by a pending row only.
+    #
+    # creditor.name is deliberately excluded: the two rows spell the counterparty
+    # differently (case-only differences, an extra order reference on the
+    # cardholder's row, character substitutions), so including it would leave
+    # genuine pairs unmatched. remittance_information, merchant_category_code and
+    # transaction_id are excluded because the ASPSPs that exhibit this behaviour
+    # do not populate them.
+    def build_card_twin_key(tx)
+      [
+        tx[:booking_date],
+        tx[:value_date],
+        tx.dig(:transaction_amount, :amount),
+        tx.dig(:transaction_amount, :currency),
+        tx[:credit_debit_indicator],
+        tx[:_pending].present?
+      ].map(&:to_s).join("\x1F")
     end
 
     # Deduplicate transactions from the Enable Banking API response.

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -680,8 +680,10 @@ class EnableBankingItem::Importer
     # differently (case-only differences, an extra order reference on the
     # cardholder's row, character substitutions), so including it would leave
     # genuine pairs unmatched. remittance_information, merchant_category_code and
-    # transaction_id are excluded because the ASPSPs that exhibit this behaviour
-    # do not populate them.
+    # transaction_id are excluded because an ASPSP that double-books need not
+    # populate them (N26 leaves transaction_id and merchant_category_code empty and
+    # fills remittance_information on roughly 1% of rows), so keying on any of them
+    # would break the pairing.
     def build_card_twin_key(tx)
       booking_date = tx[:booking_date]
       value_date = tx[:value_date]

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -588,7 +588,10 @@ class EnableBankingItem::Importer
         code = tx.dig(:bank_transaction_code, :code)
         next unless [ CUSTOMER_CARD_CODE, MERCHANT_CARD_CODE ].include?(code)
 
-        groups[build_card_twin_key(tx)] << [ index, code ]
+        key = build_card_twin_key(tx)
+        next if key.nil?
+
+        groups[key] << [ index, code ]
       end
 
       discarded_indexes = Set.new
@@ -633,8 +636,8 @@ class EnableBankingItem::Importer
     end
 
     # Grouping key that brings the cardholder's row (CCRD) and the merchant's row
-    # (MCRD) of one card purchase together. It uses only fields that are always
-    # present and that both rows carry identically.
+    # (MCRD) of one card purchase together. It uses only fields that both rows
+    # carry identically.
     #
     # Whether the row is pending is part of the key, so a booked row is never
     # discarded in favour of a pending one. The pending->booked reconciliation
@@ -650,9 +653,19 @@ class EnableBankingItem::Importer
     # transaction_id are excluded because the ASPSPs that exhibit this behaviour
     # do not populate them.
     def build_card_twin_key(tx)
+      booking_date = tx[:booking_date]
+      value_date = tx[:value_date]
+      transaction_date = tx[:transaction_date]
+
+      # A booked row always carries booking_date, but pending rows often carry
+      # only transaction_date. With no date at all there is nothing left to tell
+      # two purchases apart, so pairing would be a guess - leave those rows be.
+      return nil if booking_date.blank? && value_date.blank? && transaction_date.blank?
+
       [
-        tx[:booking_date],
-        tx[:value_date],
+        booking_date,
+        value_date,
+        transaction_date,
         tx.dig(:transaction_amount, :amount),
         tx.dig(:transaction_amount, :currency),
         tx[:credit_debit_indicator],

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -490,6 +490,7 @@ class EnableBankingItem::Importer
       existing_transactions = enable_banking_account.raw_transactions_payload.to_a
 
       removed_pending = false
+      new_transactions = []
 
       unless include_pending
         removed_pending = existing_transactions.reject! do |tx|
@@ -538,14 +539,28 @@ class EnableBankingItem::Importer
           ext_id = EnableBankingEntry::Processor.compute_external_id(tx)
           ext_id.present? && !existing_ids.include?(ext_id)
         end
+      end
 
-        if new_transactions.any? || removed_pending
-          enable_banking_account.upsert_enable_banking_transactions_snapshot!(existing_transactions + new_transactions)
-        end
-      elsif removed_pending
-        enable_banking_account.upsert_enable_banking_transactions_snapshot!(
-          existing_transactions
-        )
+      # The stored half of the snapshot has never been filtered. Accounts that
+      # synced before the twin discard landed still hold both rows of every card
+      # purchase, and neither pass above reaches them: new_transactions excludes
+      # what is already stored, and the incremental window never asks for those
+      # dates again. Filtering the merged snapshot is what stops the stored MCRD
+      # row from re-creating its entry on every sync.
+      #
+      # This does not remove the duplicate entries already created - nothing on
+      # the Enable Banking import path deletes transactions, the processor only
+      # upserts. What it buys is that deleting the duplicate by hand finally
+      # sticks instead of coming back with the next sync.
+      merged_transactions = discard_merchant_card_twins(
+        existing_transactions + new_transactions,
+        enable_banking_account,
+        stage: :stored_snapshot
+      )
+      twins_removed = merged_transactions.size != existing_transactions.size + new_transactions.size
+
+      if new_transactions.any? || removed_pending || twins_removed
+        enable_banking_account.upsert_enable_banking_transactions_snapshot!(merged_transactions)
       end
 
       { success: true, transactions_count: transactions_count }
@@ -591,7 +606,7 @@ class EnableBankingItem::Importer
     # unpaired MCRD rows (adjustments, MCRD/OTHR) are legitimate movements and
     # are kept. Two CCRD rows are never collapsed into each other here, which is
     # what makes this safe for the over-merge reported in #2720.
-    def discard_merchant_card_twins(transactions, enable_banking_account)
+    def discard_merchant_card_twins(transactions, enable_banking_account, stage: :api_response)
       groups = Hash.new { |hash, key| hash[key] = [] }
 
       transactions.each_with_index do |tx, index|
@@ -626,10 +641,12 @@ class EnableBankingItem::Importer
 
       return transactions if discarded_indexes.empty?
 
+      origin = stage == :stored_snapshot ? "stored transactions snapshot" : "API response"
+
       DebugLogEntry.capture(
         category: "provider_sync",
         level: "info",
-        message: "Discarded merchant-side (MCRD) card twin(s) from the API response",
+        message: "Discarded merchant-side (MCRD) card twin(s) from the #{origin}",
         source: self.class.name,
         provider_key: "enable_banking",
         family: enable_banking_item.family,
@@ -638,6 +655,7 @@ class EnableBankingItem::Importer
           enable_banking_item_id: enable_banking_item.id,
           enable_banking_account_id: enable_banking_account.id,
           uid: enable_banking_account.uid,
+          stage: stage,
           discarded_count: discarded_indexes.size,
           transactions_before: transactions.count,
           transactions_after: transactions.count - discarded_indexes.size
@@ -681,8 +699,18 @@ class EnableBankingItem::Importer
         tx.dig(:transaction_amount, :amount),
         tx.dig(:transaction_amount, :currency),
         tx[:credit_debit_indicator],
-        tx[:_pending].present?
+        card_row_pending?(tx)
       ].map(&:to_s).join("\x1F")
+    end
+
+    # Freshly fetched rows carry the pending flag in :_pending; rows read back
+    # from the stored snapshot carry it under extra.enable_banking.pending (the
+    # shape EnableBankingEntry::Processor writes). Both spellings have to count,
+    # or merging fresh rows with stored ones groups the two halves of one
+    # purchase inconsistently and a booked row gets discarded in favour of a
+    # pending one.
+    def card_row_pending?(tx)
+      (tx[:_pending] || tx.dig(:extra, :enable_banking, :pending)).present?
     end
 
     # Deduplicate transactions from the Enable Banking API response.

--- a/test/models/enable_banking_item/importer_card_twin_test.rb
+++ b/test/models/enable_banking_item/importer_card_twin_test.rb
@@ -99,13 +99,37 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
     assert_equal "ref_adjustment", @enable_banking_account.raw_transactions_payload.first["entry_reference"]
   end
 
+  test "records the discard in the debug log" do
+    # Per the repo convention, support-relevant sync diagnostics belong in
+    # DebugLogEntry so they show up in /settings/debug, not only in the raw log.
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "BOOK"))
+      .returns([ merchant_card_purchase(entry_reference: "ref_mcrd"), customer_card_purchase(entry_reference: "ref_ccrd") ])
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "PDNG"))
+      .returns([])
+    @importer.stubs(:include_pending?).returns(false)
+    @importer.stubs(:determine_sync_start_date).returns(Date.new(2026, 1, 1))
+
+    assert_difference "DebugLogEntry.count", 1 do
+      @importer.send(:fetch_and_store_transactions, @enable_banking_account)
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "provider_sync", entry.category
+    assert_equal "info", entry.level
+    assert_equal "enable_banking", entry.provider_key
+    assert_equal @account, entry.account
+    assert_equal 1, entry.metadata["discarded_count"]
+  end
+
   test "discards the merchant-side MCRD twin and keeps the customer-side CCRD" do
     transactions = [
       merchant_card_purchase(entry_reference: "ref_mcrd"),
       customer_card_purchase(entry_reference: "ref_ccrd")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 1, result.count
     assert_equal "ref_ccrd", result.first[:entry_reference]
@@ -123,7 +147,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd_2")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
     assert_equal [ "ref_ccrd_1", "ref_ccrd_2" ], result.map { |tx| tx[:entry_reference] }
@@ -138,7 +162,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd_1")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
     assert_equal [ "ref_mcrd_2", "ref_ccrd_1" ], result.map { |tx| tx[:entry_reference] }
@@ -154,7 +178,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       )
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 1, result.count
     assert_equal "ref_adjustment", result.first[:entry_reference]
@@ -168,7 +192,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd_2")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
   end
@@ -186,7 +210,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd", _pending: true)
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
   end
@@ -198,7 +222,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd", _pending: true)
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 1, result.count
     assert_equal "ref_ccrd", result.first[:entry_reference]
@@ -214,7 +238,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd", creditor: { name: "ACME Mktp*K4T9QX2" })
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 1, result.count
     assert_equal "ref_ccrd", result.first[:entry_reference]
@@ -226,7 +250,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
   end
@@ -237,7 +261,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
   end
@@ -248,7 +272,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
   end
@@ -265,7 +289,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       )
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
   end
@@ -276,7 +300,7 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd")
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 2, result.count
   end
@@ -287,14 +311,14 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
       customer_card_purchase(entry_reference: "ref_ccrd").deep_stringify_keys
     ]
 
-    result = @importer.send(:discard_merchant_card_twins, transactions)
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
 
     assert_equal 1, result.count
     assert_equal "ref_ccrd", result.first["entry_reference"]
   end
 
   test "returns empty array for empty input" do
-    assert_equal [], @importer.send(:discard_merchant_card_twins, [])
+    assert_equal [], @importer.send(:discard_merchant_card_twins, [], @enable_banking_account)
   end
 
   private

--- a/test/models/enable_banking_item/importer_card_twin_test.rb
+++ b/test/models/enable_banking_item/importer_card_twin_test.rb
@@ -184,6 +184,39 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
     assert_equal "ref_adjustment", result.first[:entry_reference]
   end
 
+  test "keeps an MCRD adjustment that shares a key with a CCRD purchase" do
+    # MCRD/DAJT is an adjustment, not the merchant's view of a purchase. It can
+    # collide with an unrelated CCRD purchase on every field of the key, and
+    # discarding it would lose a real movement.
+    transactions = [
+      merchant_card_purchase(
+        entry_reference: "ref_adjustment",
+        bank_transaction_code: { code: "MCRD", sub_code: "DAJT", description: "PMNT" }
+      ),
+      customer_card_purchase(entry_reference: "ref_ccrd")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
+
+    assert_equal 2, result.count
+  end
+
+  test "keeps an MCRD purchase row that shares a key with a CCRD cash withdrawal" do
+    # CCRD/CWDL is a cash withdrawal, which has no merchant-side counterpart. It
+    # must not stand in as the CCRD half of a pair and absorb an MCRD row.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd"),
+      customer_card_purchase(
+        entry_reference: "ref_withdrawal",
+        bank_transaction_code: { code: "CCRD", sub_code: "CWDL", description: "PMNT" }
+      )
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
+
+    assert_equal 2, result.count
+  end
+
   test "never merges two identical CCRD rows" do
     # Issue #2720: two legitimately distinct purchases with identical content.
     # This step must not touch them.

--- a/test/models/enable_banking_item/importer_card_twin_test.rb
+++ b/test/models/enable_banking_item/importer_card_twin_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
-# N26 (and other ASPSPs exposing ISO 20022 bank transaction codes through
-# Enable Banking) emit *two* booked entries for a single card purchase:
+# An ASPSP exposing ISO 20022 bank transaction codes through Enable Banking can
+# emit *two* booked entries for a single card purchase (N26 does):
 # one from the cardholder's point of view (PMNT-CCRD-POSD) and one from the
 # merchant's point of view (PMNT-MCRD-UPCT). Both carry status BOOK and their
 # own entry_reference, so neither the pending->booked reconciliation nor the

--- a/test/models/enable_banking_item/importer_card_twin_test.rb
+++ b/test/models/enable_banking_item/importer_card_twin_test.rb
@@ -1,0 +1,326 @@
+require "test_helper"
+
+# N26 (and other ASPSPs exposing ISO 20022 bank transaction codes through
+# Enable Banking) emit *two* booked entries for a single card purchase:
+# one from the cardholder's point of view (PMNT-CCRD-POSD) and one from the
+# merchant's point of view (PMNT-MCRD-UPCT). Both carry status BOOK and their
+# own entry_reference, so neither the pending->booked reconciliation nor the
+# content-level dedup of #988 collapses them.
+#
+# The importer must drop the MCRD row of each pair before content dedup runs.
+class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @enable_banking_item = EnableBankingItem.create!(
+      family: @family,
+      name: "Test Enable Banking",
+      country_code: "DE",
+      application_id: "test_app_id",
+      client_certificate: "test_cert",
+      session_id: "test_session",
+      session_expires_at: 1.day.from_now
+    )
+
+    @account = accounts(:depository)
+    @enable_banking_account = EnableBankingAccount.create!(
+      enable_banking_item: @enable_banking_item,
+      name: "Hauptkonto",
+      uid: "hash_card_twin_test",
+      account_id: "uuid-card-twin-1234",
+      currency: "EUR"
+    )
+    AccountProvider.create!(account: @account, provider: @enable_banking_account)
+
+    mock_provider = mock()
+    @importer = EnableBankingItem::Importer.new(@enable_banking_item, enable_banking_provider: mock_provider)
+  end
+
+  test "stores only the customer-side row of a twin pair" do
+    # The MCRD row is listed first on purpose. The content dedup keeps the first
+    # row of a group and ignores bank_transaction_code, so if the twin discard
+    # ran *after* it the merchant's row would be the survivor. Asserting on
+    # which row reaches the snapshot pins both the wiring and the ordering.
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "BOOK"))
+      .returns([ merchant_card_purchase(entry_reference: "ref_mcrd"), customer_card_purchase(entry_reference: "ref_ccrd") ])
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "PDNG"))
+      .returns([])
+    @importer.stubs(:include_pending?).returns(false)
+    @importer.stubs(:determine_sync_start_date).returns(Date.new(2026, 1, 1))
+
+    @importer.send(:fetch_and_store_transactions, @enable_banking_account)
+
+    @enable_banking_account.reload
+    assert_equal 1, @enable_banking_account.raw_transactions_payload.count
+    assert_equal "ref_ccrd", @enable_banking_account.raw_transactions_payload.first["entry_reference"]
+  end
+
+  test "stores one row for a twin pair whose creditor names differ between the two views" do
+    # This is the pair that survives content dedup today: creditor.name is part
+    # of the content key, and the two rows spell the counterparty differently,
+    # so both reach the append-only snapshot and are never removed again.
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "BOOK"))
+      .returns([
+        merchant_card_purchase(entry_reference: "ref_mcrd", creditor: { name: "ACME Mktp" }),
+        customer_card_purchase(entry_reference: "ref_ccrd", creditor: { name: "ACME Mktp*K4T9QX2" })
+      ])
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "PDNG"))
+      .returns([])
+    @importer.stubs(:include_pending?).returns(false)
+    @importer.stubs(:determine_sync_start_date).returns(Date.new(2026, 1, 1))
+
+    @importer.send(:fetch_and_store_transactions, @enable_banking_account)
+
+    @enable_banking_account.reload
+    assert_equal 1, @enable_banking_account.raw_transactions_payload.count
+    assert_equal "ref_ccrd", @enable_banking_account.raw_transactions_payload.first["entry_reference"]
+  end
+
+  test "stores an unpaired merchant-side row" do
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "BOOK"))
+      .returns([ merchant_card_purchase(
+        entry_reference: "ref_adjustment",
+        bank_transaction_code: { code: "MCRD", sub_code: "DAJT", description: "PMNT" }
+      ) ])
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "PDNG"))
+      .returns([])
+    @importer.stubs(:include_pending?).returns(false)
+    @importer.stubs(:determine_sync_start_date).returns(Date.new(2026, 1, 1))
+
+    @importer.send(:fetch_and_store_transactions, @enable_banking_account)
+
+    @enable_banking_account.reload
+    assert_equal 1, @enable_banking_account.raw_transactions_payload.count
+    assert_equal "ref_adjustment", @enable_banking_account.raw_transactions_payload.first["entry_reference"]
+  end
+
+  test "discards the merchant-side MCRD twin and keeps the customer-side CCRD" do
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd"),
+      customer_card_purchase(entry_reference: "ref_ccrd")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 1, result.count
+    assert_equal "ref_ccrd", result.first[:entry_reference]
+  end
+
+  test "keeps both purchases when two identical card purchases arrive as two twin pairs" do
+    # Two purchases of the same amount at the same merchant on the same day.
+    # The grouping key has no time component, so all four rows land in one
+    # group. The rule is accounting-based: discard MCRD rows only down to the
+    # number of CCRD rows, never "one row per group".
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd_1"),
+      merchant_card_purchase(entry_reference: "ref_mcrd_2"),
+      customer_card_purchase(entry_reference: "ref_ccrd_1"),
+      customer_card_purchase(entry_reference: "ref_ccrd_2")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+    assert_equal [ "ref_ccrd_1", "ref_ccrd_2" ], result.map { |tx| tx[:entry_reference] }
+  end
+
+  test "discards only as many MCRD rows as there are CCRD rows in the group" do
+    # One CCRD is missing (e.g. still pending upstream). Discarding both MCRD
+    # rows would lose a real movement, so only one is dropped.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd_1"),
+      merchant_card_purchase(entry_reference: "ref_mcrd_2"),
+      customer_card_purchase(entry_reference: "ref_ccrd_1")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+    assert_equal [ "ref_mcrd_2", "ref_ccrd_1" ], result.map { |tx| tx[:entry_reference] }
+  end
+
+  test "keeps an MCRD row that has no CCRD twin" do
+    # MCRD/DAJT and MCRD/OTHR rows appear without a CCRD counterpart.
+    # bank_transaction_code picks the survivor, it never matches on its own.
+    transactions = [
+      merchant_card_purchase(
+        entry_reference: "ref_adjustment",
+        bank_transaction_code: { code: "MCRD", sub_code: "DAJT", description: "PMNT" }
+      )
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 1, result.count
+    assert_equal "ref_adjustment", result.first[:entry_reference]
+  end
+
+  test "never merges two identical CCRD rows" do
+    # Issue #2720: two legitimately distinct purchases with identical content.
+    # This step must not touch them.
+    transactions = [
+      customer_card_purchase(entry_reference: "ref_ccrd_1"),
+      customer_card_purchase(entry_reference: "ref_ccrd_2")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+  end
+
+  test "keeps a booked MCRD row whose only CCRD counterpart is still pending" do
+    # The discard runs on the booked and the pending rows together, after the
+    # pending->booked reconciliation has had its say. That reconciliation cannot
+    # pair these two - the twins carry different entry_references and different
+    # fingerprints - so a pending CCRD and a booked MCRD can reach this step in
+    # the same group. Discarding the booked row there would leave the movement
+    # represented by a pending row only, and it disappears from the snapshot
+    # entirely on an account that does not store pendings.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd"),
+      customer_card_purchase(entry_reference: "ref_ccrd", _pending: true)
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+  end
+
+  test "discards the pending MCRD twin of a pending CCRD row" do
+    # Twins that are both still pending pair normally.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", _pending: true),
+      customer_card_purchase(entry_reference: "ref_ccrd", _pending: true)
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 1, result.count
+    assert_equal "ref_ccrd", result.first[:entry_reference]
+  end
+
+  test "pairs twins whose creditor names differ between the merchant and customer views" do
+    # The two rows spell the counterparty differently: case-only changes
+    # (Coffee Bar / COFFEE BAR), an extra order token on the cardholder's row
+    # (ACME Mktp / ACME Mktp*K4T9QX2) or character substitutions
+    # (B&B Store 0334 / B_B Store 0334). creditor.name must stay out of the key.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", creditor: { name: "ACME Mktp" }),
+      customer_card_purchase(entry_reference: "ref_ccrd", creditor: { name: "ACME Mktp*K4T9QX2" })
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 1, result.count
+    assert_equal "ref_ccrd", result.first[:entry_reference]
+  end
+
+  test "keeps an MCRD row whose amount differs from the CCRD row" do
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", transaction_amount: { amount: "12.00", currency: "EUR" }),
+      customer_card_purchase(entry_reference: "ref_ccrd")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+  end
+
+  test "keeps an MCRD row whose booking_date differs from the CCRD row" do
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", booking_date: "2026-02-12"),
+      customer_card_purchase(entry_reference: "ref_ccrd")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+  end
+
+  test "keeps a refund that mirrors a purchase of the same amount on the same day" do
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", credit_debit_indicator: "CRDT"),
+      customer_card_purchase(entry_reference: "ref_ccrd")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+  end
+
+  test "leaves transfers and direct debits untouched" do
+    transactions = [
+      customer_card_purchase(
+        entry_reference: "ref_transfer",
+        bank_transaction_code: { code: "RCDT", sub_code: "ESCT", description: "PMNT" }
+      ),
+      customer_card_purchase(
+        entry_reference: "ref_debit",
+        bank_transaction_code: { code: "IDDT", sub_code: "ESDD", description: "PMNT" }
+      )
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+  end
+
+  test "leaves rows without a bank_transaction_code untouched" do
+    transactions = [
+      customer_card_purchase(entry_reference: "ref_no_code", bank_transaction_code: nil),
+      customer_card_purchase(entry_reference: "ref_ccrd")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 2, result.count
+  end
+
+  test "handles string keys in transaction data" do
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd").deep_stringify_keys,
+      customer_card_purchase(entry_reference: "ref_ccrd").deep_stringify_keys
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions)
+
+    assert_equal 1, result.count
+    assert_equal "ref_ccrd", result.first["entry_reference"]
+  end
+
+  test "returns empty array for empty input" do
+    assert_equal [], @importer.send(:discard_merchant_card_twins, [])
+  end
+
+  private
+    # A single card purchase, as an ASPSP that double-books reports it.
+    def card_purchase(overrides)
+      {
+        entry_reference: "ref",
+        transaction_id: nil,
+        booking_date: "2026-02-11",
+        value_date: "2026-02-11",
+        transaction_amount: { amount: "5.12", currency: "EUR" },
+        credit_debit_indicator: "DBIT",
+        status: "BOOK",
+        creditor: { name: "Corner Store" }
+      }.merge(overrides)
+    end
+
+    def merchant_card_purchase(overrides = {})
+      card_purchase(
+        { bank_transaction_code: { code: "MCRD", sub_code: "UPCT", description: "PMNT" } }.merge(overrides)
+      )
+    end
+
+    def customer_card_purchase(overrides = {})
+      card_purchase(
+        { bank_transaction_code: { code: "CCRD", sub_code: "POSD", description: "PMNT" } }.merge(overrides)
+      )
+    end
+end

--- a/test/models/enable_banking_item/importer_card_twin_test.rb
+++ b/test/models/enable_banking_item/importer_card_twin_test.rb
@@ -123,6 +123,91 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
     assert_equal 1, entry.metadata["discarded_count"]
   end
 
+  test "removes a twin already stored in the snapshot when new transactions arrive" do
+    # Accounts that synced before this change already hold both halves in
+    # raw_transactions_payload. The stored MCRD row keeps re-creating the
+    # duplicate entry, so filtering only the freshly fetched rows fixes nothing
+    # for them.
+    @enable_banking_account.update!(raw_transactions_payload: [
+      merchant_card_purchase(entry_reference: "ref_mcrd").deep_stringify_keys,
+      customer_card_purchase(entry_reference: "ref_ccrd").deep_stringify_keys
+    ])
+
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "BOOK"))
+      .returns([ customer_card_purchase(entry_reference: "ref_new", booking_date: "2026-03-05", value_date: "2026-03-05") ])
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "PDNG"))
+      .returns([])
+    @importer.stubs(:include_pending?).returns(false)
+    @importer.stubs(:determine_sync_start_date).returns(Date.new(2026, 1, 1))
+
+    @importer.send(:fetch_and_store_transactions, @enable_banking_account)
+
+    @enable_banking_account.reload
+    stored = @enable_banking_account.raw_transactions_payload.map { |tx| tx["entry_reference"] }
+    assert_equal [ "ref_ccrd", "ref_new" ], stored.sort
+  end
+
+  test "removes a stored twin even when the sync brings nothing new" do
+    # A quiet account re-fetches the same window and produces no new rows. The
+    # snapshot still has to be rewritten, or the stored twin survives forever.
+    @enable_banking_account.update!(raw_transactions_payload: [
+      merchant_card_purchase(entry_reference: "ref_mcrd").deep_stringify_keys,
+      customer_card_purchase(entry_reference: "ref_ccrd").deep_stringify_keys
+    ])
+
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "BOOK"))
+      .returns([ merchant_card_purchase(entry_reference: "ref_mcrd"), customer_card_purchase(entry_reference: "ref_ccrd") ])
+    @importer.stubs(:fetch_paginated_transactions)
+      .with(@enable_banking_account, has_entry(transaction_status: "PDNG"))
+      .returns([])
+    @importer.stubs(:include_pending?).returns(false)
+    @importer.stubs(:determine_sync_start_date).returns(Date.new(2026, 1, 1))
+
+    @importer.send(:fetch_and_store_transactions, @enable_banking_account)
+
+    @enable_banking_account.reload
+    assert_equal 1, @enable_banking_account.raw_transactions_payload.count
+    assert_equal "ref_ccrd", @enable_banking_account.raw_transactions_payload.first["entry_reference"]
+  end
+
+  test "removes a stored twin when the sync fetches no transactions at all" do
+    # A dormant account whose incremental window comes back empty. The stored
+    # snapshot is re-processed on every sync regardless of what was fetched, so
+    # without rewriting it here the stored MCRD row keeps re-creating its entry.
+    @enable_banking_account.update!(raw_transactions_payload: [
+      merchant_card_purchase(entry_reference: "ref_mcrd").deep_stringify_keys,
+      customer_card_purchase(entry_reference: "ref_ccrd").deep_stringify_keys
+    ])
+
+    @importer.stubs(:fetch_paginated_transactions).returns([])
+    @importer.stubs(:include_pending?).returns(false)
+    @importer.stubs(:determine_sync_start_date).returns(Date.new(2026, 1, 1))
+
+    @importer.send(:fetch_and_store_transactions, @enable_banking_account)
+
+    @enable_banking_account.reload
+    assert_equal 1, @enable_banking_account.raw_transactions_payload.count
+    assert_equal "ref_ccrd", @enable_banking_account.raw_transactions_payload.first["entry_reference"]
+  end
+
+  test "treats a stored row flagged pending in extra as pending when pairing" do
+    # Freshly fetched rows carry _pending; rows already in the snapshot carry
+    # extra.enable_banking.pending. Both have to count, or a booked row gets
+    # discarded in favour of a stored pending one.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd").deep_stringify_keys,
+      customer_card_purchase(entry_reference: "ref_ccrd")
+        .merge(extra: { enable_banking: { pending: true } }).deep_stringify_keys
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
+
+    assert_equal 2, result.count
+  end
+
   test "discards the merchant-side MCRD twin and keeps the customer-side CCRD" do
     transactions = [
       merchant_card_purchase(entry_reference: "ref_mcrd"),

--- a/test/models/enable_banking_item/importer_card_twin_test.rb
+++ b/test/models/enable_banking_item/importer_card_twin_test.rb
@@ -266,6 +266,45 @@ class EnableBankingItem::ImporterCardTwinTest < ActiveSupport::TestCase
     assert_equal 2, result.count
   end
 
+  test "keeps rows whose only date is transaction_date and it differs" do
+    # A booked row always carries booking_date, but pending rows often do not.
+    # If the key ignores transaction_date, every dateless row of the same amount
+    # falls into one group and unrelated rows get paired.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", booking_date: nil, value_date: nil, transaction_date: "2026-02-12"),
+      customer_card_purchase(entry_reference: "ref_ccrd", booking_date: nil, value_date: nil, transaction_date: "2026-02-11")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
+
+    assert_equal 2, result.count
+  end
+
+  test "pairs on transaction_date when booking and value dates are absent" do
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", booking_date: nil, value_date: nil, transaction_date: "2026-02-11"),
+      customer_card_purchase(entry_reference: "ref_ccrd", booking_date: nil, value_date: nil, transaction_date: "2026-02-11")
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
+
+    assert_equal 1, result.count
+    assert_equal "ref_ccrd", result.first[:entry_reference]
+  end
+
+  test "never pairs rows that carry no date at all" do
+    # With no date there is nothing left to tell two purchases apart, so pairing
+    # would be a guess. Leave both rows alone.
+    transactions = [
+      merchant_card_purchase(entry_reference: "ref_mcrd", booking_date: nil, value_date: nil),
+      customer_card_purchase(entry_reference: "ref_ccrd", booking_date: nil, value_date: nil)
+    ]
+
+    result = @importer.send(:discard_merchant_card_twins, transactions, @enable_banking_account)
+
+    assert_equal 2, result.count
+  end
+
   test "keeps a refund that mirrors a purchase of the same amount on the same day" do
     transactions = [
       merchant_card_purchase(entry_reference: "ref_mcrd", credit_debit_indicator: "CRDT"),


### PR DESCRIPTION
N26 books point-of-sale card payments as two ISO 20022 entries, one from the cardholder's side and one from the merchant's. 
Sure imports both, so those purchases are counted twice: two transactions with the same date, amount and merchant, both included in balances and spending totals. Deleting one of them in the UI doesn't help — it's back after the next sync.

## Why the bank sends two rows

Enable Banking passes through the bank's ISO 20022 `bank_transaction_code`. Card payments have two families in the External Bank Transaction Family code set:

- `PMNT-CCRD-POSD` — *Customer Card Transaction*, the cardholder's view of the purchase
- `PMNT-MCRD-UPCT` — *Merchant Card Transaction*, the merchant's view of the same purchase

N26 books both. The two rows agree on date, amount, currency and direction. They differ in the transaction code, in `entry_reference`, and in how the counterparty is spelled:

```jsonc
// cardholder's row
{ "entry_reference": "b3f1…",
  "bank_transaction_code": { "description": "PMNT", "code": "CCRD", "sub_code": "POSD" },
  "booking_date": "2026-02-11", "value_date": "2026-02-11",
  "transaction_amount": { "amount": "5.12", "currency": "EUR" },
  "credit_debit_indicator": "DBIT", "status": "BOOK",
  "creditor": { "name": "ACME Mktp*K4T9QX2" } }

// merchant's row — same purchase
{ "entry_reference": "c7a2…",
  "bank_transaction_code": { "description": "PMNT", "code": "MCRD", "sub_code": "UPCT" },
  "booking_date": "2026-02-11", "value_date": "2026-02-11",
  "transaction_amount": { "amount": "5.12", "currency": "EUR" },
  "credit_debit_indicator": "DBIT", "status": "BOOK",
  "creditor": { "name": "ACME Mktp" } }
```

This is intended behaviour on the bank's side, not a glitch. N26's public PSD2 documentation uses both families in its own examples and documents a field whose stated purpose is to tie together the several entries one purchase produces — [`doc/dedicated-aisp.md`](https://github.com/n26/psd2-tpp-docs/blob/main/doc/dedicated-aisp.md):

> additionalInformation is an ID that links different transactions related to the same purchase

That field would settle this cleanly, but it isn't part of the [Enable Banking transaction schema](https://enablebanking.com/docs/api/reference/), so it never reaches Sure. The match has to be made from the fields we do receive.

## Why this is fixed in Sure and not upstream

Neither side is malfunctioning. N26 books both rows deliberately, and Enable Banking passes them through faithfully — nothing is invented along the way, so there is no provider bug to report.

Nor would an upstream change help retroactively: affected users already have both rows stored, and N26 would still send two of them either way — something on this side has to drop one.

(N26 documents an `additionalInformation` ID linking the entries of one purchase, which the [Enable Banking transaction schema](https://enablebanking.com/docs/api/reference/) doesn't expose. Worth an upstream ask, but not worth keying on: it's one bank's optional metadata, where the ISO codes are shared by any ASPSP that exposes them.)

## Why the existing dedup doesn't catch them

`deduplicate_api_transactions` (added in #988 for #954) builds a content key that includes `creditor.name`. The two rows spell the counterparty differently, so the keys differ and both survive. Three shapes of difference turn up: case-only (`Coffee Bar` / `COFFEE BAR`), an extra order token on the cardholder's row (`ACME Mktp` / `ACME Mktp*K4T9QX2`), and character substitutions (`B&B Store 0334` / `B_B Store 0334`).

The pending→booked reconciliation doesn't catch them either — both rows arrive with `status: BOOK`, so there is no pending row to settle against.

And on the pairs where the names do happen to match, the dedup keeps whichever row came first in the response. That's frequently the merchant's row, which carries the less useful counterparty name.

## Why it doesn't go away on its own

`raw_transactions_payload` is append-only and is reprocessed in full on every sync. Once both rows are in the snapshot, deleting the resulting entries has no lasting effect: the next sync recreates them.

So filtering the incoming rows is not enough by itself. An account that synced before this change already holds both halves, and neither incoming pass reaches them: the new-transactions filter excludes what is already stored, and the incremental window never asks for those dates again. The stored snapshot has to be filtered as well.

## The change

One step in the importer, ahead of content dedup. It runs twice: over the freshly fetched rows, and again over the merged snapshot (stored + new) just before it is written back.

The second pass is what reaches accounts that synced before this change. It does not delete the duplicate transactions they already have — nothing on the Enable Banking import path deletes transactions, the processor only upserts. What it changes is that the stored merchant-side row stops re-creating its entry, so deleting the duplicate by hand finally sticks instead of returning with the next sync.

Group rows by `booking_date`, `value_date`, `transaction_date`, amount, currency, `credit_debit_indicator` and whether the row is pending. In a group holding both codes, discard MCRD rows down to the number of CCRD rows. A row carrying none of the three dates is never paired: with no date there is nothing left to tell two purchases apart.

That last part is deliberate — an accounting rule rather than "one row per group". Two identical purchases on the same day arrive as 2 CCRD + 2 MCRD, and both purchases are real.

`bank_transaction_code` only decides which row survives; it never matches on its own. That is what keeps the change conservative:

- only the point-of-sale sub-codes pair (`CCRD/POSD` ↔ `MCRD/UPCT`); cash withdrawals (`CCRD/CWDL`) and merchant adjustments (`MCRD/DAJT`, `MCRD/OTHR`) never pair and are kept
- two CCRD rows are never collapsed into each other
- a booked row is never discarded in favour of a pending one

`creditor.name` is kept out of the grouping key on purpose, since it is the field that differs between the two rows. `remittance_information`, `merchant_category_code` and `transaction_id` are kept out because an ASPSP that double-books need not populate them — N26 leaves `transaction_id` and `merchant_category_code` empty and fills `remittance_information` on roughly 1% of rows.

When rows are discarded the importer records it with `DebugLogEntry.capture`, so it lands in the super-admin `/settings/debug` UI rather than only in the raw log, attached to the family and the account provider:

```
Discarded merchant-side (MCRD) card twin(s) from the API response
Discarded merchant-side (MCRD) card twin(s) from the stored transactions snapshot
```

The metadata carries `discarded_count`, `transactions_before`/`transactions_after` and which of the two passes did the discarding.

## Checking whether an ASPSP does this

Read-only, in the Rails console — if a connection reports both codes in comparable numbers, it double-books:

```ruby
EnableBankingAccount.find_each do |account|
  codes = account.raw_transactions_payload
    .map { |tx| tx.with_indifferent_access.dig(:bank_transaction_code, :code) }
    .tally

  puts "#{account.name}: CCRD=#{codes["CCRD"].to_i} MCRD=#{codes["MCRD"].to_i}"
end
```

## Tests

`test/models/enable_banking_item/importer_card_twin_test.rb` — 28 tests.

Seven run through `fetch_and_store_transactions` and assert on what actually lands in `raw_transactions_payload` and in the debug log. One of those lists the MCRD row first on purpose, so it fails if the discard is ever moved to after content dedup. Three cover the stored snapshot: a twin already stored when new rows arrive, a sync that brings nothing new, and a sync that fetches nothing at all.

The rest exercise the filter directly: twin pair; two identical purchases the same day; more MCRD rows than CCRD rows; unpaired MCRD; two CCRD rows; differing amount; differing booking date; rows whose only date is `transaction_date`, matching and differing; rows with no date at all; a refund mirroring a purchase of the same amount; transfers and direct debits; rows with no `bank_transaction_code`; a stored row whose pending flag lives under `extra.enable_banking.pending`; string keys; empty input.

## Fyi

Two limitations worth naming. The payload carries no signal tying a particular MCRD row to a particular CCRD row, so a standalone MCRD movement that collides with an unrelated CCRD purchase on the whole grouping key would be discarded; nothing in the data prevents it. And where a retained unpaired MCRD row has content identical to the CCRD row, the existing content dedup still collapses the two, since its key ignores `bank_transaction_code` — pre-existing behaviour that this change neither causes nor fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Removed duplicate merchant-side card transactions from new imports and previously stored account activity.
- Preserved the customer-facing transaction record when duplicates are detected.
- Improved handling of pending and booked transactions, including differing merchant details.
- Limited duplicate matching to point-of-sale purchases, preserving cash withdrawals, adjustments, refunds, and other distinct transactions.
- Improved matching when transaction dates are available while preventing matches without date information.
- Kept legitimate unmatched transactions intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


