### PR TITLE
Fix: keep the entered current balance when it differs from the opening balance

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -175,7 +175,10 @@ class Account < ApplicationRecord
       attrs = attributes.dup
       attrs[:cash_balance] = attrs[:balance] unless attrs.key?(:cash_balance)
       account = new(attrs)
-      initial_balance = attributes.dig(:accountable_attributes, :initial_balance)&.to_d
+      # Presence is read from the raw value: a blank form field arrives as ""
+      # and would convert to a very present-looking 0.
+      raw_initial_balance = attributes.dig(:accountable_attributes, :initial_balance)
+      initial_balance = raw_initial_balance.to_d if raw_initial_balance.present?
 
       transaction do
         account.save!
@@ -192,16 +195,20 @@ class Account < ApplicationRecord
         # the account's only entry — the initial sync would recalculate
         # today's balance back to it, silently discarding what the user just
         # typed. Anchor today's balance too so both survive.
-        if initial_balance.present? && initial_balance != account.balance
-          # An explicit same-day reconciliation, not CurrentBalanceManager:
-          # for cash accounts its transaction-adjustment strategy computes a
-          # zero delta here (account.balance already holds the entered value)
-          # and would only rewrite the opening anchor, leaving today's balance
-          # unanchored for the first sync.
+        #
+        # Only when the opening anchor is on an earlier day: the opening date
+        # is user-supplied and may be today, and a same-day reconciliation
+        # would be matched to the opening anchor by date and overwrite it.
+        # On its own date the opening balance wins.
+        if initial_balance && initial_balance != account.balance && manager.opening_date < Date.current
+          # An explicit reconciliation, not CurrentBalanceManager: for cash
+          # accounts its transaction-adjustment strategy computes a zero delta
+          # here (account.balance already holds the entered value) and would
+          # only rewrite the opening anchor, leaving today's balance unanchored
+          # for the first sync.
           reconciliation = Account::ReconciliationManager.new(account).reconcile_balance(
             balance: account.balance,
-            date: Date.current,
-            existing_valuation_entry: account.entries.valuations.find_by(date: Date.current)
+            date: Date.current
           )
           raise reconciliation.error_message unless reconciliation.success?
         end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -187,6 +187,25 @@ class Account < ApplicationRecord
         )
         raise result.error if result.error
 
+        # When the opening balance differs from the entered current balance
+        # (a loan created with its original principal), the opening anchor is
+        # the account's only entry — the initial sync would recalculate
+        # today's balance back to it, silently discarding what the user just
+        # typed. Anchor today's balance too so both survive.
+        if initial_balance.present? && initial_balance != account.balance
+          # An explicit same-day reconciliation, not CurrentBalanceManager:
+          # for cash accounts its transaction-adjustment strategy computes a
+          # zero delta here (account.balance already holds the entered value)
+          # and would only rewrite the opening anchor, leaving today's balance
+          # unanchored for the first sync.
+          reconciliation = Account::ReconciliationManager.new(account).reconcile_balance(
+            balance: account.balance,
+            date: Date.current,
+            existing_valuation_entry: account.entries.valuations.find_by(date: Date.current)
+          )
+          raise reconciliation.error_message unless reconciliation.success?
+        end
+
         account.auto_share_with_family! if account.family.share_all_by_default?
       end
 

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -95,6 +95,30 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal 1000, opening_anchor.entry.amount
   end
 
+  test "create_and_sync keeps the entered current balance when it differs from the opening balance" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: 20_000, rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true
+    )
+
+    assert_equal 20_000, account.valuations.opening_anchor.first.entry.amount
+    # Without a today anchor, the initial sync would walk forward from the
+    # opening valuation and overwrite the entered 8,000 with 20,000.
+    today_valuation = account.entries.valuations.find_by(date: Date.current)
+    assert_not_nil today_valuation
+    assert_equal 8_000, today_valuation.amount
+  end
+
   test "create_and_sync uses provided opening balance date" do
     Account.any_instance.stubs(:sync_later)
     opening_date = Time.zone.today

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -119,6 +119,71 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal 8_000, today_valuation.amount
   end
 
+  test "create_and_sync leaves the opening anchor alone when the opening balance date is today" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: 20_000, rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true,
+      opening_balance_date: Date.current
+    )
+
+    # Both balances land on the same day, so today's balance cannot be
+    # anchored without reusing (and overwriting) the opening anchor.
+    valuations = account.entries.valuations.where(date: Date.current)
+    assert_equal 1, valuations.count
+    assert_equal 20_000, valuations.first.amount
+    assert_equal "opening_anchor", valuations.first.entryable.kind
+  end
+
+  test "create_and_sync treats a blank initial balance as absent" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: "", rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true
+    )
+
+    assert_equal 8_000, account.valuations.opening_anchor.first.entry.amount
+    assert_nil account.entries.valuations.find_by(date: Date.current)
+  end
+
+  test "create_and_sync treats a zero initial balance as a real opening balance" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: 0, rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true
+    )
+
+    assert_equal 0, account.valuations.opening_anchor.first.entry.amount
+    assert_equal 8_000, account.entries.valuations.find_by(date: Date.current)&.amount
+  end
+
   test "create_and_sync uses provided opening balance date" do
     Account.any_instance.stubs(:sync_later)
     opening_date = Time.zone.today


### PR DESCRIPTION
## Problem

Creating a manual account whose opening balance differs from its current balance — the common case for a loan entered with its original principal and today's remaining balance — silently discards the current balance.

`Account.create_and_sync` anchors only the opening balance. For a brand-new manual account that opening anchor is the only entry, so the initial sync walks forward from it and recalculates today's balance back to the opening amount, overwriting what the user just typed.

## Reproduce

1. New manual Loan account
2. Original loan balance: 20,000 — current balance: 8,000
3. Save; after the initial sync the account shows 20,000

## Fix

When `initial_balance` is present and differs from the entered balance, anchor today's balance too as an explicit reconciliation, so both values survive the first sync. `Account::ReconciliationManager` directly rather than `Account::CurrentBalanceManager`: for cash accounts the latter's transaction-adjustment strategy computes a zero delta at creation (`account.balance` already holds the entered value) and would only rewrite the opening anchor.

No behavior change when the two match or no `initial_balance` is given.

### Edge cases (from review)

* **`opening_balance_date` is today.** The field is user-editable, and the date-ordering guard in `OpeningBalanceManager#set_opening_balance` is a no-op at creation. `ReconciliationManager` matches an existing valuation by date alone, so it reused the opening anchor and reassigned its amount — the same overwrite this PR fixes, one field over. Today is now anchored only when the opening anchor is on an earlier day; on its own date the opening balance wins.
* **Blank `initial_balance`.** `"".to_d` is `0`, and `BigDecimal(0)` is present, so an empty field set the opening balance to 0 and then wrote a reconciliation over it. Presence is read from the raw value now; an explicit `0` is still a real opening balance.

Regression tests for all three cases in `test/models/account_test.rb`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account synchronization when opening and current balances differ, preserving the entered current balance.
  * Prevented same-day opening balances from being overwritten during reconciliation.
  * Blank initial balances are now treated as absent, while zero balances remain valid.
  * Improved default account ownership selection by prioritizing the earliest-created administrator and keeping ownership within the correct family.

* **Tests**
  * Added coverage for ownership selection, balance preservation, same-day openings, and blank or zero initial balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

