### PR TITLE
fix(l10n): localize trade activity labels

### DIFF
--- a/config/locales/views/trades/de.yml
+++ b/config/locales/views/trades/de.yml
@@ -26,6 +26,15 @@ de:
       sell: Verkaufen
       dividend: Dividende
       interest: Zinsen
+      contribution: Einlage
+      exchange: Umtausch
+      fee: Gebühr
+      other: Sonstige
+      reinvestment: Reinvestition
+      sweep_in: Sweep In
+      sweep_out: Sweep Out
+      transfer: Überweisung
+      withdrawal: Entnahme
       current_market_price_label: Aktueller Marktpreis
       overview: Übersicht
       purchase_price_label: Kaufpreis

--- a/test/controllers/trades_controller_test.rb
+++ b/test/controllers/trades_controller_test.rb
@@ -23,6 +23,42 @@ class TradesControllerTest < ActionDispatch::IntegrationTest
     assert_select "span.text-secondary.text-sm", text: I18n.t("trades.header.buy"), count: 0
   end
 
+  test "the German header localizes supported provider activity labels" do
+    @user.update!(locale: "de")
+
+    translations = {
+      "Buy" => "Kaufen",
+      "Contribution" => "Einlage",
+      "Dividend" => "Dividende",
+      "Exchange" => "Umtausch",
+      "Fee" => "Gebühr",
+      "Interest" => "Zinsen",
+      "Other" => "Sonstige",
+      "Reinvestment" => "Reinvestition",
+      "Sell" => "Verkaufen",
+      "Sweep In" => "Sweep In",
+      "Sweep Out" => "Sweep Out",
+      "Transfer" => "Überweisung",
+      "Withdrawal" => "Entnahme"
+    }
+
+    assert_equal Trade::ACTIVITY_LABELS.sort, translations.keys.sort
+
+    translations.each do |activity_label, translation|
+      key = activity_label.parameterize(separator: "_")
+
+      assert_equal translation,
+                   I18n.t("trades.header.#{key}", locale: :de, fallback: false, default: nil)
+
+      @entry.trade.update!(investment_activity_label: activity_label)
+
+      get trade_url(@entry)
+
+      assert_response :success
+      assert_select "span.text-secondary.text-sm", text: translation
+    end
+  end
+
   test "an unlabelled trade still reads from the amount" do
     @entry.trade.update!(investment_activity_label: nil)
 


### PR DESCRIPTION
## Summary

German trade headers now show canonical German labels for every supported imported investment activity instead of falling back to English. This is an independent slice of the broader German localization cleanup and reuses the terminology already established for transaction activity labels.

Session-settled decisions carried from planning: use source-only public evidence, ship independent thematic PRs, and prefer focused regression coverage over a global locale-completeness gate (user-approved).

## Validation

- `bin/rails test test/controllers/trades_controller_test.rb` (26 runs, 186 assertions)
- `bin/rails test test/i18n_test.rb` (6 runs, 132 assertions, 4 skips)
- Fresh simulated merge with current `upstream/main`: `bin/rails test` (7,450 runs, 29,646 assertions)
- Fresh simulated merge with current `upstream/main`: `bin/rubocop` (2,391 files, no offenses)
- Independent correctness, project-standards, and testing review; the one coverage finding was fixed and re-tested

## Post-Deploy Monitoring & Validation

- Logs and metrics: no dedicated query is needed because this changes presentation-only locale data and test coverage.
- Healthy signal: supported investment activity labels render in German on trade detail pages for German-locale users.
- Failure signal: a supported label falls back to English or raises a missing-translation error.
- Mitigation trigger: revert this PR if either failure appears after deployment.
- Window and owner: the release owner checks the first normal German-locale trade-detail smoke test after deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for supported trade activity labels, including contributions, exchanges, fees, transfers, withdrawals, and reinvestments.

* **Bug Fixes**
  * Trade headers now display the appropriate German labels when German is selected as the language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->