### PR TITLE
fix(l10n): localize SnapTrade device authorization

### DIFF
--- a/config/locales/views/snaptrade_items/de.yml
+++ b/config/locales/views/snaptrade_items/de.yml
@@ -117,6 +117,25 @@ de:
       failed: Die SnapTrade-Freigabe ließ sich nicht abschließen. Versuch es noch einmal.
       state_mismatch: Die SnapTrade-Freigabe hat eine Sicherheitsprüfung nicht bestanden. Versuch es noch einmal.
       success: SnapTrade-Freigabe abgeschlossen.
+    oauth_device_flow:
+      title: SnapTrade verbinden
+      subtitle: Gib Sure mit einem Gerätecode den Zugriff auf SnapTrade frei.
+      instructions: Öffne SnapTrade, bestätige diesen Gerätecode und komm dann hierher zurück, um die Freigabe abzuschließen.
+      code_label: Gerätecode
+      open_snaptrade: SnapTrade öffnen
+      start_button: Freigabe starten
+      complete_button: Ich habe die Freigabe bei SnapTrade bestätigt
+      cancel_button: Abbrechen
+      missing_client_id: SnapTrade OAuth ist nicht konfiguriert. Füg SNAPTRADE_OAUTH_CLIENT_ID zu .env.local hinzu, starte die App neu und versuch es dann noch einmal.
+    start_oauth_device_flow:
+      failed: Die SnapTrade-Freigabe per Gerätecode ließ sich nicht starten. Versuch es noch einmal.
+    complete_oauth_device_flow:
+      success: SnapTrade-Freigabe abgeschlossen.
+      device_code_required: Für diese Verbindung läuft keine SnapTrade-Freigabe per Gerätecode. Starte sie erneut, um einen neuen Code zu erhalten.
+      authorization_pending: SnapTrade hat deine Bestätigung noch nicht erkannt. Bestätige den Code bei SnapTrade und versuch es dann noch einmal.
+      expired: Dieser Gerätecode ist abgelaufen. Starte die Freigabe erneut.
+      access_denied: Die SnapTrade-Freigabe wurde abgelehnt.
+      failed: Die SnapTrade-Freigabe per Gerätecode ließ sich nicht abschließen. Versuch es noch einmal.
 
   providers:
     snaptrade:
@@ -150,12 +169,14 @@ de:
       delete_connection_confirm: "Verbindung löschen"
       manage_at_snaptrade: Verbindungen bei SnapTrade verwalten
       oauth_connect_button: Mit SnapTrade verbinden
+      oauth_device_button: Gerätecode verwenden
       oauth_reauthorize_button: Erneut freigeben
       oauth_setup_step_1_html: Registrier eine OAuth-App unter <a href="https://dashboard.snaptrade.com" target="_blank" rel="noopener noreferrer" class="underline">dashboard.snaptrade.com</a>
-      oauth_setup_step_2_html: Trag die Callback-URL dieser App (<code>%{callback_url}</code>) als zulässige Redirect-URI ein
-      oauth_setup_step_3: Setz SNAPTRADE_OAUTH_CLIENT_ID und SNAPTRADE_OAUTH_CLIENT_SECRET in deiner Umgebung und starte neu
+      oauth_setup_step_2_html: "Nur für die Browser-Freigabe: Trag die Callback-URL dieser App (<code>%{callback_url}</code>) als zulässige Redirect-URI ein"
+      oauth_setup_step_3: Setz SNAPTRADE_OAUTH_CLIENT_ID in deiner Umgebung und starte neu. Das allein aktiviert die Freigabe per Gerätecode. Füg für die Browser-Freigabe zusätzlich SNAPTRADE_OAUTH_CLIENT_SECRET hinzu.
       oauth_status_authorized: Bei SnapTrade freigegeben.
       oauth_status_ready: Gib Sure den Lesezugriff auf deine SnapTrade-Kontodaten frei.
+      oauth_status_ready_device: Gib Sure mit einem Gerätecode Lesezugriff auf deine SnapTrade-Kontodaten.
       oauth_title: SnapTrade OAuth
 
   snaptrade_item:

--- a/test/controllers/snaptrade_items_controller_test.rb
+++ b/test/controllers/snaptrade_items_controller_test.rb
@@ -55,6 +55,38 @@ class SnaptradeItemsControllerTest < ActionDispatch::IntegrationTest
     post start_oauth_device_flow_snaptrade_items_url, params: { item_id: item.id }.merge(params)
   end
 
+  test "device OAuth copy resolves directly in German" do
+    flatten_keys = lambda do |translations, prefix = nil|
+      translations.flat_map do |key, value|
+        path = [ prefix, key ].compact.join(".")
+        value.is_a?(Hash) ? flatten_keys.call(value, path) : path
+      end
+    end
+
+    scoped_keys = %w[
+      snaptrade_items.oauth_device_flow
+      snaptrade_items.start_oauth_device_flow
+      snaptrade_items.complete_oauth_device_flow
+    ].flat_map do |scope|
+      translations = I18n.t(scope, locale: :en, fallback: false, default: nil)
+      assert_kind_of Hash, translations, "#{scope} must remain a translation subtree"
+
+      flatten_keys.call(translations).map { |key| "#{scope}.#{key}" }
+    end
+
+    scoped_keys.concat %w[
+      providers.snaptrade.oauth_setup_step_1_html
+      providers.snaptrade.oauth_setup_step_2_html
+      providers.snaptrade.oauth_setup_step_3
+      providers.snaptrade.oauth_status_ready_device
+      providers.snaptrade.oauth_device_button
+    ]
+
+    scoped_keys.each do |key|
+      assert I18n.t(key, locale: :de, fallback: false, default: nil).present?, "de is missing #{key}"
+    end
+  end
+
   test "connect redirects to portal when successful" do
     portal_url = "https://app.snaptrade.com/portal/test123"
 


### PR DESCRIPTION
## Summary

German users can complete SnapTrade device-code authorization without falling back to English. The provider setup copy now also explains that a client ID enables device-code authorization, while a client secret is additionally required for browser authorization.

This continues the German localization effort. It stays scoped to SnapTrade authorization so unrelated locale debt cannot block it.

Session-settled decisions carried from planning: one closed device-code localization boundary, a feature-scoped no-fallback guard, and the existing informal German voice (user-approved).

## Validation

- `bin/rails test test/controllers/snaptrade_items_controller_test.rb`
- `bin/rails test test/controllers/settings/providers_controller_test.rb`
- `bin/rails test test/i18n_test.rb`
- `bin/rails test` (7,450 runs, 29,630 assertions, 0 failures, 0 errors)
- `bin/rubocop`

Local browser validation could not start because the integrated browser rejected the local development URL before loading it. The focused controller integration coverage verifies the affected direct translations and existing authorization-flow behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German-language support for SnapTrade device-code authorization.
  * Added labels, status messages, and success/error feedback for starting and completing device authorization.
  * Clarified that browser authorization requires additional credentials, while device-code authorization only needs a client ID.

* **Tests**
  * Added coverage to ensure all device-flow messages have complete German translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->