### PR TITLE
feat(enable-banking): review and remove duplicate merchant-side card transactions

### DIFF
--- a/app/components/UI/account_page.html.erb
+++ b/app/components/UI/account_page.html.erb
@@ -15,6 +15,22 @@
       </div>
     <% end %>
 
+    <% if card_twin_candidate_count.positive? %>
+      <div class="px-3">
+        <%= render DS::Alert.new(
+          message: t("accounts.show.card_twin_notice", count: card_twin_candidate_count),
+          variant: :warning
+        ) %>
+        <%= render DS::Link.new(
+          text: t("accounts.show.card_twin_notice_action"),
+          href: account_card_twin_cleanup_path(account),
+          variant: :secondary,
+          size: "sm",
+          class: "mt-2"
+        ) %>
+      </div>
+    <% end %>
+
     <div data-testid="account-details">
       <% if tabs.count > 1 %>
         <%= render DS::Tabs.new(active_tab: active_tab, url_param_key: "tab") do |tabs_container| %>

--- a/app/components/UI/account_page.rb
+++ b/app/components/UI/account_page.rb
@@ -78,6 +78,10 @@ class UI::AccountPage < ApplicationComponent
   def card_twin_candidate_count
     return @card_twin_candidate_count if defined?(@card_twin_candidate_count)
 
+    # The cleanup screen only accepts accounts the user can write to, so a
+    # read-only viewer would follow the notice's link into a 404.
+    return @card_twin_candidate_count = 0 unless account.permission_for(Current.user).in?(%i[owner full_control])
+
     @card_twin_candidate_count = EnableBankingAccount
       .joins(:account_provider)
       .where(account_providers: { account_id: account.id })

--- a/app/components/UI/account_page.rb
+++ b/app/components/UI/account_page.rb
@@ -72,6 +72,18 @@ class UI::AccountPage < ApplicationComponent
     @fx_coverage_start_date = result
   end
 
+  # Duplicate merchant-side card rows left in the database from before the twin
+  # filter landed. Memoized because the check parses the account's stored
+  # snapshot, which is not free on a long history.
+  def card_twin_candidate_count
+    return @card_twin_candidate_count if defined?(@card_twin_candidate_count)
+
+    @card_twin_candidate_count = EnableBankingAccount
+      .joins(:account_provider)
+      .where(account_providers: { account_id: account.id })
+      .sum { |enable_banking_account| enable_banking_account.card_twin_candidates.size }
+  end
+
   def tab_content_for(tab)
     case tab
     when :activity

--- a/app/controllers/accounts/card_twin_cleanups_controller.rb
+++ b/app/controllers/accounts/card_twin_cleanups_controller.rb
@@ -1,0 +1,36 @@
+# Review and removal of the duplicate merchant-side card transactions that were
+# imported before the twin filter landed.
+class Accounts::CardTwinCleanupsController < ApplicationController
+  before_action :set_account
+
+  def show
+    @candidates = candidates
+  end
+
+  def create
+    # The form is not trusted: the candidate set is re-derived here and the
+    # submitted ids are only ever used to narrow it.
+    selected_ids = Array(params.dig(:card_twin_cleanup, :entry_ids)).map(&:to_s).to_set
+    removable = candidates.select { |candidate| selected_ids.include?(candidate.entry.id) }
+
+    ApplicationRecord.transaction do
+      removable.each(&:remove!)
+    end
+
+    @account.sync_later if removable.any?
+
+    redirect_to account_path(@account), notice: t(".success", count: removable.size)
+  end
+
+  private
+    def set_account
+      @account = Current.family.accounts.writable_by(Current.user).find(params[:account_id])
+    end
+
+    def candidates
+      @candidates ||= EnableBankingAccount
+        .joins(:account_provider)
+        .where(account_providers: { account_id: @account.id })
+        .flat_map { |enable_banking_account| enable_banking_account.card_twin_candidates.to_a }
+    end
+end

--- a/app/controllers/accounts/card_twin_cleanups_controller.rb
+++ b/app/controllers/accounts/card_twin_cleanups_controller.rb
@@ -10,7 +10,7 @@ class Accounts::CardTwinCleanupsController < ApplicationController
   def create
     # The form is not trusted: the candidate set is re-derived here and the
     # submitted ids are only ever used to narrow it.
-    selected_ids = Array(params.dig(:card_twin_cleanup, :entry_ids)).map(&:to_s).to_set
+    selected_ids = Array(card_twin_cleanup_params[:entry_ids]).map(&:to_s).to_set
     removable = candidates.select { |candidate| selected_ids.include?(candidate.entry.id) }
 
     ApplicationRecord.transaction do
@@ -23,6 +23,10 @@ class Accounts::CardTwinCleanupsController < ApplicationController
   end
 
   private
+    def card_twin_cleanup_params
+      params.fetch(:card_twin_cleanup, {}).permit(entry_ids: [])
+    end
+
     def set_account
       @account = Current.family.accounts.writable_by(Current.user).find(params[:account_id])
     end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -4,6 +4,16 @@ module AccountsHelper
     render "accounts/summary_card", title: title, content: content
   end
 
+  # Human list of what a card twin removal would carry onto the surviving row.
+  # Lives here rather than in the template so the view holds no domain logic.
+  def candidate_carried_fields(candidate)
+    fields = []
+    fields << t("accounts.card_twin_cleanups.show.carried_category", name: candidate.category.name) if candidate.category.present?
+    fields << t("accounts.card_twin_cleanups.show.carried_tags", count: candidate.tag_ids.size) if candidate.tag_ids.any?
+    fields << t("accounts.card_twin_cleanups.show.carried_notes") if candidate.notes.present?
+    fields
+  end
+
   def sync_path_for(account)
     # Always use the account sync path, which handles syncing all providers
     sync_account_path(account)

--- a/app/javascript/controllers/select_all_controller.js
+++ b/app/javascript/controllers/select_all_controller.js
@@ -23,10 +23,18 @@ export default class extends Controller {
   }
 
   refresh() {
-    if (!this.hasCountTarget) return
-
     const selected = this.checkboxTargets.filter((checkbox) => checkbox.checked).length
     const kept = this.checkboxTargets.length - selected
+
+    // Keep the master checkbox honest once individual boxes are unticked. Pages
+    // that drive this controller with a plain checkbox (no selectAll target) are
+    // unaffected.
+    if (this.hasSelectAllTarget) {
+      this.selectAllTarget.checked = selected > 0 && kept === 0
+      this.selectAllTarget.indeterminate = selected > 0 && kept > 0
+    }
+
+    if (!this.hasCountTarget) return
 
     this.countTarget.textContent = `${selected} ${this.selectedLabelValue} · ${kept} ${this.keptLabelValue}`
   }

--- a/app/javascript/controllers/select_all_controller.js
+++ b/app/javascript/controllers/select_all_controller.js
@@ -2,13 +2,32 @@ import { Controller } from "@hotwired/stimulus"
 
 // Simple "select all" checkbox controller
 // Connect to a container, specify which checkboxes to control via target
+//
+// The optional "count" target receives a live tally. Both it and the
+// selectedLabel/keptLabel values are optional, so existing users of this
+// controller that only declare checkbox/selectAll keep working unchanged.
 export default class extends Controller {
-  static targets = ["checkbox", "selectAll"]
+  static targets = ["checkbox", "selectAll", "count"]
+  static values = { selectedLabel: String, keptLabel: String }
+
+  connect() {
+    this.refresh()
+  }
 
   toggle(event) {
     const checked = event.target.checked
     this.checkboxTargets.forEach((checkbox) => {
       checkbox.checked = checked
     })
+    this.refresh()
+  }
+
+  refresh() {
+    if (!this.hasCountTarget) return
+
+    const selected = this.checkboxTargets.filter((checkbox) => checkbox.checked).length
+    const kept = this.checkboxTargets.length - selected
+
+    this.countTarget.textContent = `${selected} ${this.selectedLabelValue} · ${kept} ${this.keptLabelValue}`
   }
 }

--- a/app/models/enable_banking_account.rb
+++ b/app/models/enable_banking_account.rb
@@ -23,6 +23,12 @@ class EnableBankingAccount < ApplicationRecord
     account
   end
 
+  # Duplicate merchant-side card transactions still in the database from before
+  # the twin filter landed. See EnableBankingAccount::CardTwinCandidates.
+  def card_twin_candidates
+    @card_twin_candidates ||= CardTwinCandidates.new(self)
+  end
+
   # Returns the API account ID (UUID) for Enable Banking API calls
   # The Enable Banking API requires a valid UUID for balance/transaction endpoints
   # Falls back to raw_payload["uid"] for existing accounts that have the wrong account_id stored

--- a/app/models/enable_banking_account/card_twin_candidates.rb
+++ b/app/models/enable_banking_account/card_twin_candidates.rb
@@ -12,7 +12,20 @@
 class EnableBankingAccount::CardTwinCandidates
   include Enumerable
 
-  Candidate = Struct.new(:entry, :survivor, keyword_init: true)
+  # category, tag_ids and notes are what would move to the surviving row rather
+  # than what the duplicate holds: they are already narrowed to fields the
+  # survivor lacks and is willing to accept.
+  #
+  # blockers are the things that cannot be carried across at all, so the UI
+  # unticks them. A transfer-linked transaction cascades
+  # (add_foreign_key "transfers", "transactions", on_delete: :cascade), which
+  # destroys the transfer and strips the link from the counterpart transaction on
+  # the other account.
+  Candidate = Struct.new(:entry, :survivor, :category, :tag_ids, :notes, :blockers, keyword_init: true) do
+    def blocked? = blockers.any?
+
+    def transfers_anything? = category.present? || tag_ids.any? || notes.present?
+  end
 
   def initialize(enable_banking_account)
     @enable_banking_account = enable_banking_account
@@ -48,7 +61,8 @@ class EnableBankingAccount::CardTwinCandidates
       entries = account.entries
         .where(source: "enable_banking", entryable_type: "Transaction", parent_entry_id: nil)
         .where.not(external_id: nil)
-        .includes(entryable: [ :category, :taggings ])
+        .includes(entryable: [ :category, :taggings, :transfer_as_inflow, :transfer_as_outflow,
+                              { attachments_attachments: :blob } ])
         .to_a
 
       stored, orphaned = entries.partition { |entry| snapshot_external_ids.include?(entry.external_id) }
@@ -60,8 +74,32 @@ class EnableBankingAccount::CardTwinCandidates
         survivor = survivors_by_key[sibling_key(entry)]&.min_by { |candidate| [ candidate.created_at, candidate.id ] }
         next if survivor.nil?
 
-        Candidate.new(entry: entry, survivor: survivor)
+        build_candidate(entry, survivor)
       end
+    end
+
+    def build_candidate(entry, survivor)
+      transaction = entry.transaction
+      blockers = []
+      # Transaction::Transferable#transfer, not the transfer_id column: the link
+      # lives on transfers.inflow_transaction_id / outflow_transaction_id, which
+      # is also what the cascading foreign key is declared on.
+      blockers << :transfer if transaction.transfer.present?
+      blockers << :attachment if transaction.attachments.attached?
+
+      # Mirrors Transaction#merge_with_duplicate! (transaction.rb:304): a
+      # survivor the user has already protected is never written to.
+      inheritable = !survivor.protected_from_sync?
+      survivor_transaction = survivor.transaction
+
+      Candidate.new(
+        entry: entry,
+        survivor: survivor,
+        category: (transaction.category if inheritable && survivor_transaction.category_id.blank?),
+        tag_ids: (inheritable && survivor_transaction.tag_ids.empty? ? transaction.tag_ids : []),
+        notes: (entry.notes.presence if inheritable && survivor.notes.blank?),
+        blockers: blockers
+      )
     end
 
     # date, amount and currency derive only from fields both halves of a twin

--- a/app/models/enable_banking_account/card_twin_candidates.rb
+++ b/app/models/enable_banking_account/card_twin_candidates.rb
@@ -25,6 +25,23 @@ class EnableBankingAccount::CardTwinCandidates
     def blocked? = blockers.any?
 
     def transfers_anything? = category.present? || tag_ids.any? || notes.present?
+
+    # Carries whatever the survivor can accept across, then destroys the
+    # duplicate. Marking the survivor user_modified mirrors
+    # Transaction#merge_with_duplicate!, so a later sync does not revert what was
+    # just moved onto it.
+    def remove!
+      ApplicationRecord.transaction do
+        survivor_transaction = survivor.transaction
+
+        survivor_transaction.update!(category: category) if category.present?
+        survivor_transaction.update!(tag_ids: tag_ids) if tag_ids.any?
+        survivor.update!(notes: notes) if notes.present?
+        survivor.mark_user_modified! if transfers_anything?
+
+        entry.destroy!
+      end
+    end
   end
 
   def initialize(enable_banking_account)

--- a/app/models/enable_banking_account/card_twin_candidates.rb
+++ b/app/models/enable_banking_account/card_twin_candidates.rb
@@ -1,0 +1,73 @@
+# Finds the duplicate merchant-side (MCRD) card transactions that were imported
+# before PR #3274 landed and are still in the database.
+#
+# Identification is exact, not heuristic. bank_transaction_code is never read --
+# it is not persisted on the transaction (EnableBankingEntry::Processor#extra
+# writes only fx_*, merchant_category_code and pending). Instead this relies on
+# what #3274 leaves behind: when its filter drops the stored merchant-side rows
+# from raw_transactions_payload, the entries they created are left pointing at
+# external_ids that are no longer in the snapshot.
+#
+# Orphanhood alone is not enough -- see the two pending scenarios in the tests.
+class EnableBankingAccount::CardTwinCandidates
+  include Enumerable
+
+  Candidate = Struct.new(:entry, :survivor, keyword_init: true)
+
+  def initialize(enable_banking_account)
+    @enable_banking_account = enable_banking_account
+  end
+
+  def to_a
+    @to_a ||= build
+  end
+
+  def each(&block) = to_a.each(&block)
+
+  delegate :size, :any?, :empty?, to: :to_a
+
+  private
+    attr_reader :enable_banking_account
+
+    def account
+      @account ||= enable_banking_account.current_account
+    end
+
+    def snapshot_external_ids
+      @snapshot_external_ids ||= Array(enable_banking_account.raw_transactions_payload)
+        .filter_map { |row| EnableBankingEntry::Processor.compute_external_id(row) }
+        .to_set
+    end
+
+    def build
+      return [] if account.blank?
+      # An empty snapshot cannot distinguish an orphan from an account that has
+      # simply never synced, so it yields nothing rather than everything.
+      return [] if snapshot_external_ids.empty?
+
+      entries = account.entries
+        .where(source: "enable_banking", entryable_type: "Transaction", parent_entry_id: nil)
+        .where.not(external_id: nil)
+        .includes(entryable: [ :category, :taggings ])
+        .to_a
+
+      stored, orphaned = entries.partition { |entry| snapshot_external_ids.include?(entry.external_id) }
+      survivors_by_key = stored.group_by { |entry| sibling_key(entry) }
+
+      orphaned.filter_map do |entry|
+        next if entry.transaction.pending?
+
+        survivor = survivors_by_key[sibling_key(entry)]&.min_by { |candidate| [ candidate.created_at, candidate.id ] }
+        next if survivor.nil?
+
+        Candidate.new(entry: entry, survivor: survivor)
+      end
+    end
+
+    # date, amount and currency derive only from fields both halves of a twin
+    # report identically, so the surviving row is findable without re-parsing
+    # the raw payload.
+    def sibling_key(entry)
+      [ entry.date, entry.amount, entry.currency ]
+    end
+end

--- a/app/models/enable_banking_account/card_twin_candidates.rb
+++ b/app/models/enable_banking_account/card_twin_candidates.rb
@@ -83,12 +83,20 @@ class EnableBankingAccount::CardTwinCandidates
         .to_a
 
       stored, orphaned = entries.partition { |entry| snapshot_external_ids.include?(entry.external_id) }
-      survivors_by_key = stored.group_by { |entry| sibling_key(entry) }
 
-      orphaned.filter_map do |entry|
+      # Claimed one-to-one: a twin pair is one merchant-side row per cardholder
+      # row, so each survivor absorbs at most one duplicate. Sharing a survivor
+      # would let the second removal overwrite the category, tags and notes the
+      # first one moved onto it, and would leave the other survivor with nothing.
+      # More duplicates than survivors is not a twin pattern, so the surplus is
+      # left alone rather than guessed at.
+      survivors_by_key = stored.group_by { |entry| sibling_key(entry) }
+      survivors_by_key.each_value { |survivors| survivors.sort_by! { |entry| [ entry.created_at, entry.id ] } }
+
+      orphaned.sort_by { |entry| [ entry.created_at, entry.id ] }.filter_map do |entry|
         next if entry.transaction.pending?
 
-        survivor = survivors_by_key[sibling_key(entry)]&.min_by { |candidate| [ candidate.created_at, candidate.id ] }
+        survivor = survivors_by_key[sibling_key(entry)]&.shift
         next if survivor.nil?
 
         build_candidate(entry, survivor)

--- a/app/views/accounts/card_twin_cleanups/show.html.erb
+++ b/app/views/accounts/card_twin_cleanups/show.html.erb
@@ -1,0 +1,92 @@
+<% blocked_count = @candidates.count(&:blocked?) %>
+<% selected_count = @candidates.size - blocked_count %>
+
+<div class="space-y-6 p-4 max-w-3xl mx-auto">
+  <header class="space-y-1">
+    <h1 class="text-primary text-xl font-medium"><%= t(".title") %></h1>
+    <p class="text-secondary text-sm"><%= @account.name %></p>
+  </header>
+
+  <% if @candidates.empty? %>
+    <%= render DS::Alert.new(message: t(".empty"), variant: :info) %>
+  <% else %>
+    <%= render DS::Alert.new(message: t(".explanation"), variant: :info) %>
+
+    <%= styled_form_with url: account_card_twin_cleanup_path(@account),
+                         scope: :card_twin_cleanup,
+                         class: "space-y-4",
+                         data: {
+                           controller: "select-all",
+                           select_all_selected_label_value: t(".selected_label"),
+                           select_all_kept_label_value: t(".kept_label")
+                         } do |f| %>
+      <div class="flex items-center gap-2 px-2">
+        <%= check_box_tag "card_twin_cleanup_select_all", "1", blocked_count.zero?,
+                          class: "checkbox checkbox--light",
+                          data: { select_all_target: "selectAll", action: "change->select-all#toggle" } %>
+        <p class="text-secondary text-sm" data-select-all-target="count">
+          <%= t(".selected_count", selected: selected_count, kept: blocked_count) %>
+        </p>
+      </div>
+
+      <ul class="divide-y divide-primary border border-primary rounded-lg bg-container">
+        <% @candidates.each do |candidate| %>
+          <li class="p-4">
+            <label class="flex items-start gap-3 cursor-pointer">
+              <%= check_box_tag "card_twin_cleanup[entry_ids][]", candidate.entry.id, !candidate.blocked?,
+                                id: "candidate_#{candidate.entry.id}",
+                                class: "checkbox checkbox--light mt-1",
+                                data: { select_all_target: "checkbox", action: "change->select-all#refresh" } %>
+
+              <div class="flex-1 text-sm space-y-1">
+                <div class="flex items-center justify-between gap-3">
+                  <span class="text-primary font-medium"><%= candidate.entry.name %></span>
+                  <span class="text-primary tabular-nums privacy-sensitive">
+                    <%= format_money(candidate.entry.amount_money.abs) %>
+                  </span>
+                </div>
+
+                <p class="text-secondary text-xs">
+                  <%= l(candidate.entry.date, format: :short) %> •
+                  <%= t(".keeps", name: candidate.survivor.name) %>
+                </p>
+
+                <% if candidate.blockers.include?(:transfer) %>
+                  <p class="text-warning text-xs inline-flex items-start gap-1">
+                    <%= icon "alert-triangle", size: "sm", class: "text-warning shrink-0" %>
+                    <%= t(".blocker_transfer") %>
+                  </p>
+                <% end %>
+
+                <% if candidate.blockers.include?(:attachment) %>
+                  <p class="text-warning text-xs inline-flex items-start gap-1">
+                    <%= icon "alert-triangle", size: "sm", class: "text-warning shrink-0" %>
+                    <%= t(".blocker_attachment",
+                          count: candidate.entry.entryable.attachments.count) %>
+                  </p>
+                <% end %>
+
+                <% if candidate.transfers_anything? %>
+                  <p class="text-secondary text-xs">
+                    <%= t(".carried_over",
+                          fields: candidate_carried_fields(candidate).to_sentence) %>
+                  </p>
+                <% end %>
+              </div>
+            </label>
+          </li>
+        <% end %>
+      </ul>
+
+      <% if blocked_count.positive? %>
+        <%= render DS::Alert.new(message: t(".unticked_explanation", count: blocked_count),
+                                 variant: :warning) %>
+      <% end %>
+
+      <div class="flex justify-end items-center gap-2">
+        <%= render DS::Link.new(text: t(".cancel"), variant: :secondary, href: account_path(@account)) %>
+        <%= f.submit t(".submit"), data: { turbo_confirm: t(".confirm") } %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -106,6 +106,10 @@ en:
         title: How would you like to add it?
       title: What would you like to add?
     show:
+      card_twin_notice:
+        one: "1 card purchase was imported twice by your bank and is still duplicated here."
+        other: "%{count} card purchases were imported twice by your bank and are still duplicated here."
+      card_twin_notice_action: "Review duplicates"
       limited_fx_history_warning: "Exchange rate history is only available from %{date} onwards. Transactions before this date use approximate currency conversions — this can happen when the FX provider only offers a limited historical window."
       tabs:
         activity: Activity

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -29,6 +29,30 @@ en:
         success:
           one: "1 duplicate removed."
           other: "%{count} duplicates removed."
+      show:
+        title: "Review duplicate card transactions"
+        empty: "No duplicates found on this account."
+        explanation: "Your bank recorded these card purchases twice, once from your side and once from the shop's. Sure now imports only one copy, so these are leftovers from before. Removing them doesn't change anything your bank sends in future."
+        keeps: "keeps %{name}"
+        selected_count: "%{selected} selected · %{kept} kept"
+        selected_label: "selected"
+        kept_label: "kept"
+        blocker_transfer: "Part of a transfer. Removing this deletes the transfer on both accounts."
+        blocker_attachment:
+          one: "Has 1 attachment. The file is deleted with the row."
+          other: "Has %{count} attachments. The files are deleted with the row."
+        carried_over: "%{fields} move to the row that stays."
+        carried_category: "Category %{name}"
+        carried_tags:
+          one: "1 tag"
+          other: "%{count} tags"
+        carried_notes: "the notes"
+        unticked_explanation:
+          one: "1 row is unticked because removing it would destroy something that can't be moved to the row that stays. Tick it only if you're sure."
+          other: "%{count} rows are unticked because removing them would destroy something that can't be moved to the row that stays. Tick them only if you're sure."
+        cancel: "Cancel"
+        submit: "Remove selected"
+        confirm: "Remove the selected duplicates? This can't be undone."
     chart:
       data_not_available: Data not available for the selected period
     create:

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -24,6 +24,11 @@ en:
       default_label: Default
       delete: Delete account
       sharing: Sharing
+    card_twin_cleanups:
+      create:
+        success:
+          one: "1 duplicate removed."
+          other: "%{count} duplicates removed."
     chart:
       data_not_available: Data not available for the selected period
     create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -591,6 +591,7 @@ Rails.application.routes.draw do
     end
 
     resource :sharing, only: [ :show, :update ], controller: "account_sharings"
+    resource :card_twin_cleanup, only: %i[show create], controller: "accounts/card_twin_cleanups"
   end
 
   resources :account_statements, only: %i[index show create update destroy] do

--- a/test/controllers/accounts/card_twin_cleanups_controller_test.rb
+++ b/test/controllers/accounts/card_twin_cleanups_controller_test.rb
@@ -60,6 +60,31 @@ class Accounts::CardTwinCleanupsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "blocked rows arrive unticked" do
+    # A Transfer is only valid across two accounts of the same family.
+    inflow = accounts(:credit_card).entries.create!(
+      name: "Inflow", date: orphan_entry.date, amount: -orphan_entry.amount,
+      currency: orphan_entry.currency, entryable: Transaction.new
+    )
+    Transfer.create!(
+      inflow_transaction: inflow.entryable,
+      outflow_transaction: orphan_entry.entryable,
+      amount: orphan_entry.amount.abs
+    )
+
+    get account_card_twin_cleanup_url(@account)
+
+    assert_response :success
+    assert_select "input[type=checkbox][value=?]:not([checked])", orphan_entry.id
+  end
+
+  test "unblocked rows arrive ticked" do
+    get account_card_twin_cleanup_url(@account)
+
+    assert_response :success
+    assert_select "input[type=checkbox][value=?][checked]", orphan_entry.id
+  end
+
   private
     def setup_pair!
       customer = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")

--- a/test/controllers/accounts/card_twin_cleanups_controller_test.rb
+++ b/test/controllers/accounts/card_twin_cleanups_controller_test.rb
@@ -85,6 +85,19 @@ class Accounts::CardTwinCleanupsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type=checkbox][value=?][checked]", orphan_entry.id
   end
 
+  test "create tolerates a malformed selection" do
+    Account.any_instance.stubs(:sync_later)
+
+    assert_no_difference "Entry.count" do
+      post account_card_twin_cleanup_url(@account),
+           params: { card_twin_cleanup: { entry_ids: { "0" => orphan_entry.id } } }
+      assert_redirected_to account_url(@account)
+
+      post account_card_twin_cleanup_url(@account)
+      assert_redirected_to account_url(@account)
+    end
+  end
+
   private
     def setup_pair!
       customer = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")

--- a/test/controllers/accounts/card_twin_cleanups_controller_test.rb
+++ b/test/controllers/accounts/card_twin_cleanups_controller_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Accounts::CardTwinCleanupsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in @user = users(:family_admin)
+    @family = @user.family
+    @account = accounts(:depository)
+    @item = EnableBankingItem.create!(
+      family: @family, name: "Test Bank", country_code: "DE", application_id: "app",
+      client_certificate: "cert", session_id: "sess", session_expires_at: 1.day.from_now
+    )
+    @eba = EnableBankingAccount.create!(
+      enable_banking_item: @item, name: "Test Account",
+      uid: "hash_twin_controller", account_id: "uuid-twin-controller", currency: "EUR"
+    )
+    AccountProvider.create!(account: @account, provider: @eba)
+    setup_pair!
+  end
+
+  test "show renders the candidate list" do
+    get account_card_twin_cleanup_url(@account)
+
+    assert_response :success
+    assert_select "input[type=checkbox][value=?]", orphan_entry.id
+  end
+
+  test "create removes the selected candidate and resyncs" do
+    Account.any_instance.expects(:sync_later).once
+
+    assert_difference "Entry.count", -1 do
+      post account_card_twin_cleanup_url(@account),
+           params: { card_twin_cleanup: { entry_ids: [ orphan_entry.id ] } }
+    end
+
+    assert_redirected_to account_url(@account)
+  end
+
+  test "create ignores ids that are not candidates" do
+    Account.any_instance.stubs(:sync_later)
+    survivor_id = survivor_entry.id
+
+    assert_no_difference "Entry.count" do
+      post account_card_twin_cleanup_url(@account),
+           params: { card_twin_cleanup: { entry_ids: [ survivor_id ] } }
+    end
+
+    assert Entry.exists?(survivor_id)
+  end
+
+  test "create rejects an account the user cannot write to" do
+    other_family = families(:empty)
+    other_account = Account.create!(
+      family: other_family, name: "Someone else's", balance: 0, currency: "USD",
+      accountable: Depository.new, status: "active"
+    )
+
+    post account_card_twin_cleanup_url(other_account),
+         params: { card_twin_cleanup: { entry_ids: [] } }
+
+    assert_response :not_found
+  end
+
+  private
+    def setup_pair!
+      customer = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+      merchant = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+
+      @eba.update!(raw_transactions_payload: [ customer, merchant ])
+      EnableBankingAccount::Transactions::Processor.new(@eba).process
+      @eba.update!(raw_transactions_payload: [ customer ])
+      @eba.reload
+    end
+
+    def row(code:, sub_code:, ref:, creditor:, amount: "5.12")
+      {
+        "entry_reference" => ref,
+        "transaction_id" => nil,
+        "booking_date" => "2026-02-11",
+        "value_date" => "2026-02-11",
+        "transaction_amount" => { "amount" => amount, "currency" => "EUR" },
+        "credit_debit_indicator" => "DBIT",
+        "status" => "BOOK",
+        "creditor" => { "name" => creditor },
+        "bank_transaction_code" => { "code" => code, "sub_code" => sub_code, "description" => "PMNT" }
+      }
+    end
+
+    def orphan_entry = @account.entries.find_by!(external_id: "enable_banking_mcrd_1")
+    def survivor_entry = @account.entries.find_by!(external_id: "enable_banking_ccrd_1")
+end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -642,6 +642,35 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", account_card_twin_cleanup_path(account)
   end
 
+
+  test "hides the card twin notice from a read-only viewer" do
+    account = accounts(:depository)
+    item = EnableBankingItem.create!(
+      family: @user.family, name: "Test Bank", country_code: "DE", application_id: "app",
+      client_certificate: "cert", session_id: "sess", session_expires_at: 1.day.from_now
+    )
+    enable_banking_account = EnableBankingAccount.create!(
+      enable_banking_item: item, name: "Test Account",
+      uid: "hash_twin_read_only", account_id: "uuid-twin-read-only", currency: "EUR"
+    )
+    AccountProvider.create!(account: account, provider: enable_banking_account)
+
+    customer = card_row(ref: "ccrd_1", code: "CCRD", sub_code: "POSD", creditor: "ACME Mktp*K4T9QX2")
+    merchant = card_row(ref: "mcrd_1", code: "MCRD", sub_code: "UPCT", creditor: "ACME Mktp")
+    enable_banking_account.update!(raw_transactions_payload: [ customer, merchant ])
+    EnableBankingAccount::Transactions::Processor.new(enable_banking_account).process
+    enable_banking_account.update!(raw_transactions_payload: [ customer ])
+
+    viewer = users(:family_member)
+    account_shares(:depository_shared_with_member).update!(permission: "read_only")
+    sign_in viewer
+
+    get account_url(account)
+
+    assert_response :success
+    assert_select "a[href=?]", account_card_twin_cleanup_path(account), count: 0
+  end
+
   private
     def card_row(ref:, code:, sub_code:, creditor:)
       {

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -617,6 +617,45 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     ActionView::Base.logger = original_view_logger
     Rails.logger = original_rails_logger
   end
+
+  test "shows a notice when the account has card twin duplicates" do
+    account = accounts(:depository)
+    item = EnableBankingItem.create!(
+      family: @user.family, name: "Test Bank", country_code: "DE", application_id: "app",
+      client_certificate: "cert", session_id: "sess", session_expires_at: 1.day.from_now
+    )
+    enable_banking_account = EnableBankingAccount.create!(
+      enable_banking_item: item, name: "Test Account",
+      uid: "hash_twin_notice", account_id: "uuid-twin-notice", currency: "EUR"
+    )
+    AccountProvider.create!(account: account, provider: enable_banking_account)
+
+    customer = card_row(ref: "ccrd_1", code: "CCRD", sub_code: "POSD", creditor: "ACME Mktp*K4T9QX2")
+    merchant = card_row(ref: "mcrd_1", code: "MCRD", sub_code: "UPCT", creditor: "ACME Mktp")
+    enable_banking_account.update!(raw_transactions_payload: [ customer, merchant ])
+    EnableBankingAccount::Transactions::Processor.new(enable_banking_account).process
+    enable_banking_account.update!(raw_transactions_payload: [ customer ])
+
+    get account_url(account)
+
+    assert_response :success
+    assert_select "a[href=?]", account_card_twin_cleanup_path(account)
+  end
+
+  private
+    def card_row(ref:, code:, sub_code:, creditor:)
+      {
+        "entry_reference" => ref,
+        "transaction_id" => nil,
+        "booking_date" => "2026-02-11",
+        "value_date" => "2026-02-11",
+        "transaction_amount" => { "amount" => "5.12", "currency" => "EUR" },
+        "credit_debit_indicator" => "DBIT",
+        "status" => "BOOK",
+        "creditor" => { "name" => creditor },
+        "bank_transaction_code" => { "code" => code, "sub_code" => sub_code, "description" => "PMNT" }
+      }
+    end
 end
 
 class AccountsControllerSimplefinCtaTest < ActionDispatch::IntegrationTest

--- a/test/models/enable_banking_account/card_twin_candidates_test.rb
+++ b/test/models/enable_banking_account/card_twin_candidates_test.rb
@@ -1,0 +1,148 @@
+require "test_helper"
+
+class EnableBankingAccount::CardTwinCandidatesTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @item = EnableBankingItem.create!(
+      family: @family, name: "Test Bank", country_code: "DE", application_id: "app",
+      client_certificate: "cert", session_id: "sess", session_expires_at: 1.day.from_now
+    )
+    @account = accounts(:depository)
+    @eba = EnableBankingAccount.create!(
+      enable_banking_item: @item, name: "Test Account",
+      uid: "hash_twin_candidates", account_id: "uuid-twin-candidates", currency: "EUR"
+    )
+    AccountProvider.create!(account: @account, provider: @eba)
+  end
+
+  test "finds the merchant-side entry the snapshot filter left behind" do
+    customer = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+    merchant = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+
+    import!([ customer, merchant ])
+    apply_fix!([ customer ])
+
+    candidates = @eba.card_twin_candidates.to_a
+
+    assert_equal 1, candidates.size
+    assert_equal "enable_banking_mcrd_1", candidates.first.entry.external_id
+    assert_equal "enable_banking_ccrd_1", candidates.first.survivor.external_id
+  end
+
+  test "keeps both cardholder rows when two identical purchases were double-booked" do
+    customer_1 = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+    merchant_1 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+    customer_2 = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_2", creditor: "ACME Mktp*P8W1ZR5")
+    merchant_2 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_2", creditor: "ACME Mktp")
+
+    import!([ customer_1, merchant_1, customer_2, merchant_2 ])
+    apply_fix!([ customer_1, customer_2 ])
+
+    removable = @eba.card_twin_candidates.map { |c| c.entry.external_id }.sort
+
+    assert_equal [ "enable_banking_mcrd_1", "enable_banking_mcrd_2" ], removable
+  end
+
+  test "handles rows carrying neither transaction_id nor entry_reference" do
+    customer = row(code: "CCRD", sub_code: "POSD", ref: nil, creditor: "ACME Mktp*K4T9QX2")
+    merchant = row(code: "MCRD", sub_code: "UPCT", ref: nil, creditor: "ACME Mktp")
+    merchant_id = EnableBankingEntry::Processor.compute_external_id(merchant)
+
+    import!([ customer, merchant ])
+    apply_fix!([ customer ])
+
+    assert_equal [ merchant_id ], @eba.card_twin_candidates.map { |c| c.entry.external_id }
+  end
+
+  # Predicate 2. Turning off Setting.syncs_include_pending makes importer.rb:495
+  # reject every stored pending row without checking whether it settled, and
+  # nothing deletes the entries those rows created.
+  test "ignores a pending entry orphaned by turning the pending setting off" do
+    booked = row(code: "CCRD", sub_code: "POSD", ref: "book_1", creditor: "Corner Store")
+    pending = row(code: "CCRD", sub_code: "POSD", ref: "pdng_1", creditor: "Corner Store",
+                  amount: "9.99", pending: true)
+
+    import!([ booked, pending ])
+    apply_fix!([ booked ])
+
+    assert_empty @eba.card_twin_candidates.to_a
+  end
+
+  # Predicate 2. A settlement at a different amount (tip, FX, fuel hold) is
+  # matched by entry_reference at importer.rb:522 so the stored pending row is
+  # stripped, but the auto-claim at provider_import_adapter.rb:118 needs an exact
+  # amount, so the stale pending entry survives, orphaned.
+  test "ignores a pending entry orphaned by a settlement at a different amount" do
+    pending = row(code: "CCRD", sub_code: "POSD", ref: "ref_x", creditor: "Corner Store",
+                  amount: "5.12", pending: true)
+    settled = row(code: "CCRD", sub_code: "POSD", ref: "ref_x", creditor: "Corner Store",
+                  amount: "5.47").merge("transaction_id" => "txn_settled")
+
+    import!([ pending ])
+    import!([ pending, settled ])
+    apply_fix!([ settled ])
+
+    assert_empty @eba.card_twin_candidates.to_a
+  end
+
+  # Predicate 3. Deleting and re-adding a connection creates a new
+  # EnableBankingAccount whose snapshot starts empty, which would otherwise make
+  # every older booked entry look orphaned.
+  test "ignores an orphan with no surviving sibling" do
+    lonely = row(code: "CCRD", sub_code: "POSD", ref: "lonely_1", creditor: "Bakery")
+    other = row(code: "CCRD", sub_code: "POSD", ref: "other_1", creditor: "Corner Store",
+                amount: "31.00")
+
+    import!([ lonely, other ])
+    apply_fix!([ other ])
+
+    assert_empty @eba.card_twin_candidates.to_a
+  end
+
+  test "never lists a split child" do
+    customer = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+    merchant = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+
+    import!([ customer, merchant ])
+    apply_fix!([ customer ])
+
+    orphan = @account.entries.find_by(external_id: "enable_banking_mcrd_1")
+    parent = @account.entries.create!(
+      name: "Parent", date: orphan.date, amount: orphan.amount, currency: orphan.currency,
+      entryable: Transaction.new
+    )
+    orphan.update!(parent_entry_id: parent.id)
+
+    assert_empty @eba.card_twin_candidates.to_a
+  end
+
+  private
+    def row(code:, sub_code:, ref:, creditor:, amount: "5.12", pending: false)
+      base = {
+        "entry_reference" => ref,
+        "transaction_id" => nil,
+        "booking_date" => "2026-02-11",
+        "value_date" => "2026-02-11",
+        "transaction_amount" => { "amount" => amount, "currency" => "EUR" },
+        "credit_debit_indicator" => "DBIT",
+        "status" => "BOOK",
+        "creditor" => { "name" => creditor },
+        "bank_transaction_code" => { "code" => code, "sub_code" => sub_code, "description" => "PMNT" }
+      }
+      pending ? base.merge("_pending" => true) : base
+    end
+
+    # Pre-fix state: the snapshot holds every row and the entries exist.
+    def import!(rows)
+      @eba.update!(raw_transactions_payload: rows)
+      EnableBankingAccount::Transactions::Processor.new(@eba).process
+      @eba.reload
+    end
+
+    # What #3274's snapshot filter leaves behind: the merchant-side rows are gone
+    # from raw_transactions_payload, their entries are not.
+    def apply_fix!(surviving_rows)
+      @eba.update!(raw_transactions_payload: surviving_rows)
+      @eba.reload
+    end
+end

--- a/test/models/enable_banking_account/card_twin_candidates_test.rb
+++ b/test/models/enable_banking_account/card_twin_candidates_test.rb
@@ -187,6 +187,47 @@ class EnableBankingAccount::CardTwinCandidatesTest < ActiveSupport::TestCase
     refute candidate.transfers_anything?
   end
 
+  test "copies category, tags and notes to the survivor then destroys the duplicate" do
+    setup_pair!
+    tag = @family.tags.create!(name: "Reimbursable")
+    category = @family.categories.create!(name: "Groceries")
+    orphan_transaction.update!(category: category, tag_ids: [ tag.id ])
+    orphan_entry.update!(notes: "split with a friend")
+    orphan_id = orphan_entry.id
+
+    assert_difference "Entry.count", -1 do
+      @eba.card_twin_candidates.to_a.sole.remove!
+    end
+
+    assert_nil Entry.find_by(id: orphan_id)
+    survivor_entry.reload
+    assert_equal category, survivor_transaction.category
+    assert_equal [ tag.id ], survivor_transaction.tag_ids
+    assert_equal "split with a friend", survivor_entry.notes
+    assert survivor_entry.user_modified?
+  end
+
+  test "does not mark the survivor user_modified when nothing was copied" do
+    setup_pair!
+
+    @eba.card_twin_candidates.to_a.sole.remove!
+
+    refute survivor_entry.reload.user_modified?
+  end
+
+  test "leaves a protected survivor untouched" do
+    setup_pair!
+    category = @family.categories.create!(name: "Groceries")
+    orphan_transaction.update!(category: category)
+    survivor_entry.update!(user_modified: true)
+
+    assert_difference "Entry.count", -1 do
+      @eba.card_twin_candidates.to_a.sole.remove!
+    end
+
+    assert_nil survivor_transaction.reload.category_id
+  end
+
   private
     def row(code:, sub_code:, ref:, creditor:, amount: "5.12", pending: false)
       base = {

--- a/test/models/enable_banking_account/card_twin_candidates_test.rb
+++ b/test/models/enable_banking_account/card_twin_candidates_test.rb
@@ -228,6 +228,61 @@ class EnableBankingAccount::CardTwinCandidatesTest < ActiveSupport::TestCase
     assert_nil survivor_transaction.reload.category_id
   end
 
+  # Each surviving row absorbs at most one duplicate. Sharing a survivor would let
+  # the second removal overwrite the category/tags/notes the first moved onto it.
+  test "pairs each duplicate with its own surviving row" do
+    customer_1 = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+    merchant_1 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+    customer_2 = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_2", creditor: "ACME Mktp*P8W1ZR5")
+    merchant_2 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_2", creditor: "ACME Mktp")
+
+    import!([ customer_1, merchant_1, customer_2, merchant_2 ])
+    apply_fix!([ customer_1, customer_2 ])
+
+    survivors = @eba.card_twin_candidates.map { |c| c.survivor.external_id }
+
+    assert_equal 2, survivors.size
+    assert_equal survivors.uniq, survivors
+    assert_equal [ "enable_banking_ccrd_1", "enable_banking_ccrd_2" ], survivors.sort
+  end
+
+  test "leaves an unpaired duplicate alone when the survivors run out" do
+    customer = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+    merchant_1 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+    merchant_2 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_2", creditor: "ACME Mktp Ltd")
+
+    import!([ customer, merchant_1, merchant_2 ])
+    apply_fix!([ customer ])
+
+    candidates = @eba.card_twin_candidates.to_a
+
+    assert_equal 1, candidates.size
+    assert_equal "enable_banking_ccrd_1", candidates.sole.survivor.external_id
+  end
+
+  test "does not carry a second duplicate's category onto an already-updated survivor" do
+    customer_1 = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+    merchant_1 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+    customer_2 = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_2", creditor: "ACME Mktp*P8W1ZR5")
+    merchant_2 = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_2", creditor: "ACME Mktp")
+
+    import!([ customer_1, merchant_1, customer_2, merchant_2 ])
+    apply_fix!([ customer_1, customer_2 ])
+
+    groceries = @family.categories.create!(name: "Groceries")
+    shopping = @family.categories.create!(name: "Shopping")
+    @account.entries.find_by!(external_id: "enable_banking_mcrd_1").entryable.update!(category: groceries)
+    @account.entries.find_by!(external_id: "enable_banking_mcrd_2").entryable.update!(category: shopping)
+
+    @eba.card_twin_candidates.each(&:remove!)
+
+    categories = [ "enable_banking_ccrd_1", "enable_banking_ccrd_2" ].map do |external_id|
+      @account.entries.find_by!(external_id: external_id).entryable.category
+    end
+
+    assert_equal [ groceries, shopping ].map(&:name).sort, categories.map(&:name).sort
+  end
+
   private
     def row(code:, sub_code:, ref:, creditor:, amount: "5.12", pending: false)
       base = {

--- a/test/models/enable_banking_account/card_twin_candidates_test.rb
+++ b/test/models/enable_banking_account/card_twin_candidates_test.rb
@@ -116,6 +116,77 @@ class EnableBankingAccount::CardTwinCandidatesTest < ActiveSupport::TestCase
     assert_empty @eba.card_twin_candidates.to_a
   end
 
+  test "offers category, tags and notes when the survivor has none" do
+    setup_pair!
+    tag = @family.tags.create!(name: "Reimbursable")
+    category = @family.categories.create!(name: "Groceries")
+    orphan_transaction.update!(category: category, tag_ids: [ tag.id ])
+    orphan_entry.update!(notes: "split with a friend")
+
+    candidate = @eba.card_twin_candidates.to_a.sole
+
+    assert_equal category, candidate.category
+    assert_equal [ tag.id ], candidate.tag_ids
+    assert_equal "split with a friend", candidate.notes
+    assert candidate.transfers_anything?
+  end
+
+  test "offers nothing for a field the survivor already has" do
+    setup_pair!
+    kept = @family.categories.create!(name: "Groceries")
+    other = @family.categories.create!(name: "Shopping")
+    survivor_transaction.update!(category: kept)
+    orphan_transaction.update!(category: other)
+
+    assert_nil @eba.card_twin_candidates.to_a.sole.category
+  end
+
+  test "offers nothing when the survivor is protected from sync" do
+    setup_pair!
+    category = @family.categories.create!(name: "Groceries")
+    orphan_transaction.update!(category: category)
+    survivor_entry.update!(user_modified: true)
+
+    candidate = @eba.card_twin_candidates.to_a.sole
+
+    assert_nil candidate.category
+    assert_empty candidate.tag_ids
+    refute candidate.transfers_anything?
+  end
+
+  test "flags a transfer as a blocker" do
+    setup_pair!
+    Transfer.create!(
+      inflow_transaction: counterpart_inflow.entryable,
+      outflow_transaction: orphan_transaction,
+      amount: orphan_entry.amount.abs
+    )
+
+    candidate = @eba.card_twin_candidates.to_a.sole
+
+    assert_includes candidate.blockers, :transfer
+    assert candidate.blocked?
+  end
+
+  test "flags an attachment as a blocker" do
+    setup_pair!
+    orphan_transaction.attachments.attach(
+      io: StringIO.new("receipt"), filename: "receipt.png", content_type: "image/png"
+    )
+
+    assert_includes @eba.card_twin_candidates.to_a.sole.blockers, :attachment
+  end
+
+  test "an untouched candidate is not blocked" do
+    setup_pair!
+
+    candidate = @eba.card_twin_candidates.to_a.sole
+
+    assert_empty candidate.blockers
+    refute candidate.blocked?
+    refute candidate.transfers_anything?
+  end
+
   private
     def row(code:, sub_code:, ref:, creditor:, amount: "5.12", pending: false)
       base = {
@@ -141,6 +212,29 @@ class EnableBankingAccount::CardTwinCandidatesTest < ActiveSupport::TestCase
 
     # What #3274's snapshot filter leaves behind: the merchant-side rows are gone
     # from raw_transactions_payload, their entries are not.
+    # One twin pair, post-fix: enable_banking_mcrd_1 is the orphan,
+    # enable_banking_ccrd_1 is the survivor.
+    def setup_pair!
+      customer = row(code: "CCRD", sub_code: "POSD", ref: "ccrd_1", creditor: "ACME Mktp*K4T9QX2")
+      merchant = row(code: "MCRD", sub_code: "UPCT", ref: "mcrd_1", creditor: "ACME Mktp")
+      import!([ customer, merchant ])
+      apply_fix!([ customer ])
+    end
+
+    def orphan_entry = @account.entries.find_by!(external_id: "enable_banking_mcrd_1")
+    def survivor_entry = @account.entries.find_by!(external_id: "enable_banking_ccrd_1")
+    def orphan_transaction = orphan_entry.entryable
+    def survivor_transaction = survivor_entry.entryable
+
+    # A Transfer is only valid across two accounts of the same family, so the
+    # matching inflow lives on the family's other account.
+    def counterpart_inflow
+      accounts(:credit_card).entries.create!(
+        name: "Inflow", date: orphan_entry.date, amount: -orphan_entry.amount,
+        currency: orphan_entry.currency, entryable: Transaction.new
+      )
+    end
+
     def apply_fix!(surviving_rows)
       @eba.update!(raw_transactions_payload: surviving_rows)
       @eba.reload


### PR DESCRIPTION
## What

Adds a reviewable screen that removes the duplicate merchant-side card transactions left in users' databases from before the card-twin filter landed.

Some ASPSPs (N26 and others exposing ISO 20022 bank transaction codes through Enable Banking) emit two booked entries for a single card purchase: the cardholder's view (`PMNT-CCRD-POSD`) and the merchant's view (`PMNT-MCRD-UPCT`). #3274 stops storing the merchant-side row going forward, but it does not touch the duplicates already imported. This PR gives users a way to clear those out.

## How it identifies duplicates

Identification is exact, not heuristic. `bank_transaction_code` is never read — it isn't persisted on the transaction. Instead it relies on what the snapshot filter leaves behind: once the merchant-side rows are dropped from `raw_transactions_payload`, the entries they created point at `external_id`s that are no longer in the snapshot.

Orphanhood alone isn't enough, so a candidate must also be:

- **not pending** — a pending entry can be orphaned for unrelated reasons (the pending setting being turned off, or a settlement at a different amount that the exact-amount auto-claim misses)
- **paired with a surviving sibling** on the same date, amount and currency — a re-added connection starts with an empty snapshot, which would otherwise make every older booked entry look orphaned
- **not a split child**

An empty snapshot yields nothing rather than everything.

## The screen

One pre-ticked list at `/accounts/:id/card_twin_cleanup`, reachable from a notice on the account page. Each row says what will be kept and what moves across. Rows that would destroy something unrecoverable arrive **unticked**:

- part of a transfer (the cascading FK would delete the transfer on both accounts)
- carrying attachments

Category, tags and notes move onto the surviving row before the duplicate is destroyed — but only for fields the survivor lacks, and never onto a survivor the user has already protected (`protected_from_sync?`), mirroring `Transaction#merge_with_duplicate!`. The survivor is marked `user_modified` only when something was actually carried over, so a later sync doesn't revert it.

The form is not trusted: the controller re-derives the candidate set server-side and uses the submitted ids only to narrow it.

## Relationship to #3274

Independent of it, and based on `main`. The code shares no files with #3274 and calls nothing it adds — it reads the stored snapshot, which #3274 only changes the *contents* of. Until #3274 lands, this screen simply finds nothing, because the merchant-side rows are still in the snapshot. No migrations, no new columns.

## Testing

- `test/models/enable_banking_account/card_twin_candidates_test.rb` — 16 tests: identification across the three predicates, id-less rows, the transferable metadata, blockers, and removal semantics
- `test/controllers/accounts/card_twin_cleanups_controller_test.rb` — 6 tests: rendering, tick state, selection filtering, authorization, resync
- `test/controllers/accounts_controller_test.rb` — the account-page notice

Full suite: 7471 runs, 0 new failures (the 13 failures / 3 errors present are pre-existing on `main` — `hostings_controller`, `market_data_importer`, `simplefin_entry/processor`). Rubocop, erb_lint, biome and Brakeman all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fxCmw8rDMySpQq1He2GuD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a review and cleanup workflow for duplicate card transactions.
  - Account pages now show an alert when duplicate card transactions require attention.
  - Users can review duplicates, see warnings and carried-over details, select entries for removal, and confirm cleanup.
  - Cleanup automatically synchronizes account data after removals.

- **Bug Fixes**
  - Prevents duplicate card transactions from remaining after historical imports.

- **Tests**
  - Added coverage for duplicate detection, cleanup behavior, permissions, warnings, and account-page alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->