### PR TITLE
fix(goals): let a goal with no color be saved through the form at all

### DIFF
--- a/app/javascript/controllers/color_icon_picker_controller.js
+++ b/app/javascript/controllers/color_icon_picker_controller.js
@@ -44,7 +44,24 @@ export default class extends Controller {
 
     this.selectedIcon = null;
 
-    if (!this.presetColorsValue.includes(this.colorInputTarget.value)) {
+    // A goal created outside the New-goal form (API, import, a fixture) can
+    // have no color at all — `color` has no DB default and the model allows
+    // nil. Left as blank, the custom-color text field still shares
+    // `name="goal[color]"` with the preset radios and is the one whose value
+    // survives to submission regardless of which radio is checked, so ANY
+    // edit to such a goal failed the format validation on save — silently,
+    // since nothing here surfaced it. Falling back to a real preset keeps
+    // what gets submitted always valid.
+    if (!this.colorInputTarget.value) {
+      const fallback = this.presetColorsValue[0];
+      this.colorInputTarget.value = fallback;
+      this.colorPreviewTarget.style.backgroundColor = fallback;
+      this.updateAvatarColors(fallback);
+      this.updateSelectedIconColor(fallback);
+
+      const presetRadio = this.colorsSectionTarget.querySelector(`input[value="${fallback}"]`);
+      if (presetRadio) presetRadio.checked = true;
+    } else if (!this.presetColorsValue.includes(this.colorInputTarget.value)) {
       this.colorPickerRadioBtnTarget.checked = true;
     }
   }

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -17,6 +17,10 @@
                        method: goal.persisted? ? :patch : :post,
                        class: "space-y-5",
                        data: { action: "submit->goal-form#validateOnSubmit" } do |f| %>
+    <% if goal.errors.any? %>
+      <%= render "shared/form_errors", model: goal %>
+    <% end %>
+
     <div class="flex justify-center">
       <%= render "color_picker", form: f, colors: Goal::COLORS, icons: Goal::ICONS %>
     </div>

--- a/test/system/goal_nil_color_edit_test.rb
+++ b/test/system/goal_nil_color_edit_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class GoalNilColorEditTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:family_admin)
+    @user.update!(
+      preferences: (@user.preferences || {}).merge("preview_features_enabled" => true),
+      show_ai_sidebar: false
+    )
+    sign_in @user
+  end
+
+  test "a goal with no color can still be edited and saved" do
+    family = @user.family
+    account = family.accounts.create!(accountable: Depository.new, name: "Livret",
+                                      currency: family.currency, balance: 4_200)
+    goal = family.goals.create!(
+      name: "Précaution", target_amount: 1_000, currency: family.currency, color: nil
+    ) { |g| g.goal_accounts.build(account: account) }
+
+    assert_nil goal.color
+
+    visit edit_goal_path(goal)
+    fill_in I18n.t("goals.form.fields.name"), with: "Renamed"
+    click_on I18n.t("goals.form.save")
+    sleep 0.6
+
+    assert_current_path goal_path(goal)
+    goal.reload
+    assert_equal "Renamed", goal.name
+    assert goal.color.present?, "the goal still has no color after saving through the form"
+  end
+end


### PR DESCRIPTION
Found while testing the months-of-expenses reserve flow: changing "Months of expenses" and saving looked like it did nothing. It wasn't a recalculation bug — the save was failing validation on every submit, silently.

## Root cause

`color` has no DB default and the model allows nil (`validates :color, format: {...}, allow_nil: true`). `GoalsController#new` always assigns a random preset color, so a goal created through the New-goal form never hits this. But a goal created any other way — API, import, a fixture — can have `color: nil`.

The color picker's custom-color text field shares `name="goal[color]"` with the preset radios, and because it comes last in the DOM, its value is the one that actually survives to submission regardless of which radio is checked. With no color to start from, the field rendered blank while `connect()` checked the "custom" radio to match (blank isn't a preset) — an invalid combination that submitted an empty string on every save, failing the format validation (blank isn't nil).

The controller's `rescue ActiveRecord::RecordInvalid` re-rendered the form with no error shown anywhere — `:color` isn't one of the fields `_form.html.erb` gives its own inline message, so the whole thing was silent. Editing the goal's name, its linked accounts, or its months-of-expenses target all looked like no-ops.

## Fix

- `color_icon_picker_controller.js#connect()` falls back to a real preset color when the field is blank, so what gets submitted is always valid.
- Added the shared `shared/form_errors` partial to the goal form (same pattern already used by transactions, categories, rules, trades, etc.), so a future validation failure on a goal is visible instead of failing silently again.

## Test plan

- [x] Confirmed the regression test fails without the JS fix (reverted it locally, re-ran — `current_path` stays on `/edit`, nothing persists) and passes with it
- [x] Full suite green (7,466 runs, 0 failures)
- [x] `bin/rubocop -a`, `erb_lint -a`, `npm run lint` clean
- [x] `bin/brakeman` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTNba5qE5NwzaHzbp27ye

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Goals without a color now automatically receive the first available preset color when edited.
  * Color previews, avatars, icons, and selected color options now stay synchronized.
  * Goal validation errors are now displayed clearly above the form.

* **Tests**
  * Added coverage for editing and saving goals that initially have no color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->