### PR TITLE
fix(goals): let a months-of-expenses reserve actually be created

### DIFF
--- a/app/javascript/controllers/goal_form_controller.js
+++ b/app/javascript/controllers/goal_form_controller.js
@@ -89,9 +89,19 @@ export default class extends Controller {
   // button only enables when a submit would actually succeed.
   isValid() {
     const name = this.hasNameInputTarget ? this.nameInputTarget.value.trim() : "";
-    const amount = this.hasAmountInputTarget ? Number.parseFloat(this.amountInputTarget.value) : Number.NaN;
     const accountOk = !this.requireAccountValue || this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
-    return name.length > 0 && Number.isFinite(amount) && amount > 0 && accountOk;
+    return name.length > 0 && this.#amountValid() && accountOk;
+  }
+
+  // goal-kind disables the amount input in months-of-expenses mode: the
+  // figure is derived server-side, not typed, so the field is legitimately
+  // blank. Requiring a positive number there would refuse a submit on a
+  // field the user cannot fill in.
+  #amountValid() {
+    if (!this.hasAmountInputTarget) return false;
+    if (this.amountInputTarget.disabled) return true;
+    const amount = Number.parseFloat(this.amountInputTarget.value);
+    return Number.isFinite(amount) && amount > 0;
   }
 
   // `aria-disabled` instead of the `disabled` attribute: a truly disabled
@@ -116,8 +126,7 @@ export default class extends Controller {
     event.preventDefault();
 
     const nameEmpty = !(this.hasNameInputTarget && this.nameInputTarget.value.trim().length > 0);
-    const amount = this.hasAmountInputTarget ? Number.parseFloat(this.amountInputTarget.value) : Number.NaN;
-    const amountInvalid = !(Number.isFinite(amount) && amount > 0);
+    const amountInvalid = !this.#amountValid();
     const noAccount = this.requireAccountValue && !this.linkedAccountCheckboxTargets.some((cb) => cb.checked);
 
     if (nameEmpty) {

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -30,7 +30,7 @@
         <label class="flex items-start gap-2 rounded-lg border border-primary p-3 cursor-pointer has-[:checked]:border-secondary has-[:checked]:bg-surface-inset">
           <%= f.radio_button :kind, kind,
                              class: "radio mt-0.5 shrink-0",
-                             data: { goal_kind_target: "radio", action: "change->goal-kind#refresh" } %>
+                             data: { goal_kind_target: "radio", action: "change->goal-kind#refresh change->goal-form#amountChanged" } %>
           <span class="min-w-0">
             <span class="block text-sm font-medium text-primary"><%= t("goals.form.kinds.#{kind}.label") %></span>
             <span class="block text-xs text-secondary"><%= t("goals.form.kinds.#{kind}.hint") %></span>
@@ -58,7 +58,7 @@
       <%= f.select :target_mode,
                    Goal::TARGET_MODES.map { |mode| [ t("goals.form.target_modes.#{mode}"), mode ] },
                    { label: t("goals.form.fields.target_mode") },
-                   data: { goal_kind_target: "modeSelect", action: "change->goal-kind#refresh" } %>
+                   data: { goal_kind_target: "modeSelect", action: "change->goal-kind#refresh change->goal-form#amountChanged" } %>
     </div>
 
     <div data-goal-kind-target="monthsField" class="hidden">

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -326,7 +326,7 @@ en:
         target_amount: Target amount
         target_balance: "Target balance"
         target_balance_pending: "Worked out when you save"
-        target_balance_hint: "From your median monthly spending over the months above. Refreshed each month."
+        target_balance_hint: "From your median monthly spending over the months above. Recomputed each month."
         target_date: Target date
         color: Color
         notes: Notes (optional)

--- a/test/system/goals_form_test.rb
+++ b/test/system/goals_form_test.rb
@@ -30,4 +30,38 @@ class GoalsFormTest < ApplicationSystemTestCase
     assert swapped.has_css?("span", text: "*"),
            "the label swap deleted the required marker"
   end
+
+  test "a months-of-expenses reserve can actually be created" do
+    family = @user.family
+    spending = family.accounts.create!(accountable: Depository.new, name: "Checking",
+                                       currency: family.currency, balance: 0)
+    6.times do |i|
+      month = Date.current.prev_month.beginning_of_month - i.months
+      spending.entries.create!(date: month + 5.days, name: "Bills", amount: 1_450,
+                               currency: family.currency, entryable: Transaction.new)
+    end
+    savings = family.accounts.create!(accountable: Depository.new, name: "Savings",
+                                      currency: family.currency, balance: 4_200)
+
+    visit new_goal_path
+    choose I18n.t("goals.form.kinds.maintained.label")
+    select I18n.t("goals.form.target_modes.months_of_expenses"),
+           from: I18n.t("goals.form.fields.target_mode")
+    find("input[name='goal[target_months]']").fill_in(with: "6")
+    fill_in I18n.t("goals.form.fields.name"), with: "Emergency fund E2E"
+    check "goal_account_ids_#{savings.id}"
+
+    # goal-kind disables the amount input in this mode: its figure is derived
+    # server-side, not typed. goal-form's isValid() used to require it to hold
+    # a positive number regardless, so the button stayed refused and the click
+    # never reached the server — a months-of-expenses reserve could not be
+    # created from the UI at all.
+    click_on I18n.t("goals.form.create")
+
+    assert_text I18n.t("goals.create.success")
+    goal = Goal.find_by(name: "Emergency fund E2E")
+    assert goal.present?, "the goal was never created — the submit was refused client-side"
+    assert goal.target_amount.to_d.positive?, "the derived amount never made it in"
+    assert_current_path goal_path(goal)
+  end
 end


### PR DESCRIPTION
`goal-kind` disables the amount input in months-of-expenses mode — its figure is derived server-side, not typed — but `goal-form`'s `isValid()`/`validateOnSubmit()` required it to hold a positive number regardless of disabled state. A brand new months-of-expenses reserve starts with nothing typed in that field, so the submit button stayed refused and a click never reached the server: this mode could not be created from the UI at all.

## Fix

- `isValid()` now treats the amount as satisfied when the field is disabled, matching what `goal-kind` already decided about it.
- Wired the kind radio and mode select to also re-run `goal-form`'s check on change, so switching into this mode updates the button's state immediately instead of waiting on an unrelated field to change first.

## Also fixed while in the area

`target_balance_hint` described the same monthly recompute as `target_months_hint` with a different verb ("Refreshed" vs "Recomputed") — the two hints sit stacked on screen in this mode, so the drift is visible, not just textual. French already used "Recalculé" consistently in both; only English had drifted.

## Test plan

- [x] New system test confirms a months-of-expenses reserve can actually be created end-to-end (fails without the `isValid()` fix — confirmed by temporarily reverting it and re-running)
- [x] Full suite green (7,466 runs, 0 failures)
- [x] `bin/rubocop -a`, `erb_lint -a`, `npm run lint` clean
- [x] `bin/brakeman` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTNba5qE5NwzaHzbp27ye

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating “months of expenses” goals with automatically calculated target amounts.
  * Goal target values now refresh when changing the goal type or target mode.
* **Bug Fixes**
  * Disabled, server-calculated amount fields no longer block goal submission or show validation errors.
  * Updated wording to clarify that target balances are “recomputed each month.”
* **Tests**
  * Added end-to-end coverage for creating months-of-expenses goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->