### PR TITLE
fix(transactions): dedupe tag filter for correct summary totals (#3174)

### DIFF
--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -187,6 +187,8 @@ class Transaction::Search
       query.joins(:merchant).where(merchants: { name: merchants })
     end
 
+    # Filter transactions by tag name, matching any transaction that carries
+    # at least one of the given tags.
     def apply_tag_filter(query, tags)
       return query unless tags.present?
 

--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -189,7 +189,14 @@ class Transaction::Search
 
     def apply_tag_filter(query, tags)
       return query unless tags.present?
-      query.joins(:tags).where(tags: { name: tags })
+
+      # Use a subquery instead of an INNER JOIN: `.joins(:tags)` fans out to
+      # one row per matching tag, so a transaction tagged with two of the
+      # filtered tags produces two rows and double-counts in the summary
+      # box (COUNT / SUM) even though the list renders it once.
+      # See https://github.com/we-promise/sure/issues/3174
+      matching_ids = query.joins(:tags).where(tags: { name: tags }).distinct.select(:id)
+      query.where(id: matching_ids)
     end
 
     def apply_status_filter(query, statuses)

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -684,16 +684,16 @@ class Transaction::SearchTest < ActiveSupport::TestCase
 
     # One transaction carrying two of the filtered tags.
     double_tagged = create_transaction(account: @checking_account, amount: 100, kind: "standard")
-    double_tagged.entryable << tag_a
-    double_tagged.entryable << tag_b
+    double_tagged.entryable.tags << tag_a
+    double_tagged.entryable.tags << tag_b
 
     # One transaction carrying one of the filtered tags.
     single_tagged = create_transaction(account: @checking_account, amount: 50, kind: "standard")
-    single_tagged.entryable << tag_a
+    single_tagged.entryable.tags << tag_a
 
     # One transaction carrying only a tag NOT in the filter set.
     unrelated = create_transaction(account: @checking_account, amount: 75, kind: "standard")
-    unrelated.entryable << tag_c
+    unrelated.entryable.tags << tag_c
 
     search = Transaction::Search.new(@family, filters: { tags: [ "TagA", "TagB" ] })
     result_ids = search.transactions_scope.distinct.pluck(:id)
@@ -710,11 +710,11 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     tag_b = @family.tags.create!(name: "FanB")
 
     double_tagged = create_transaction(account: @checking_account, amount: 100, kind: "standard")
-    double_tagged.entryable << tag_a
-    double_tagged.entryable << tag_b
+    double_tagged.entryable.tags << tag_a
+    double_tagged.entryable.tags << tag_b
 
     single_tagged = create_transaction(account: @checking_account, amount: 50, kind: "standard")
-    single_tagged.entryable << tag_a
+    single_tagged.entryable.tags << tag_a
 
     # Sanity: the list deduplicates — exactly 2 rows.
     list_count = Transaction::Search.new(@family, filters: { tags: [ "FanA", "FanB" ] })
@@ -738,9 +738,9 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     t3 = @family.tags.create!(name: "Triple3")
 
     triple_tagged = create_transaction(account: @checking_account, amount: 42, kind: "standard")
-    triple_tagged.entryable << t1
-    triple_tagged.entryable << t2
-    triple_tagged.entryable << t3
+    triple_tagged.entryable.tags << t1
+    triple_tagged.entryable.tags << t2
+    triple_tagged.entryable.tags << t3
 
     totals = Transaction::Search.new(@family, filters: { tags: [ "Triple1", "Triple2", "Triple3" ] }).totals
 

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -703,6 +703,8 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     assert_not_includes result_ids, unrelated.entryable.id
   end
 
+  # Pins the exact bug from #3174: the list count and the summary count must
+  # match even when a transaction is tagged with more than one filtered tag.
   test "totals.count is not inflated when a transaction has multiple matching tags" do
     tag_a = @family.tags.create!(name: "FanA")
     tag_b = @family.tags.create!(name: "FanB")
@@ -728,6 +730,8 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     assert_equal Money.new(150, "USD"), totals.expense_money, "SUM must not double-count tagged rows"
   end
 
+  # Extends the invariant to a three-way tag fan-out, so a future INNER JOIN
+  # regression can't hide behind the two-tag case above.
   test "totals.count is stable when a transaction has three matching tags" do
     t1 = @family.tags.create!(name: "Triple1")
     t2 = @family.tags.create!(name: "Triple2")

--- a/test/models/transaction/search_test.rb
+++ b/test/models/transaction/search_test.rb
@@ -670,4 +670,77 @@ class Transaction::SearchTest < ActiveSupport::TestCase
     assert_includes confirmed_ids, confirmed.entryable.id
     assert_not_includes pending_ids, confirmed.entryable.id
   end
+
+  # Regression for https://github.com/we-promise/sure/issues/3174
+  # The summary box (COUNT / SUM) on the Transactions page inflated when a
+  # transaction was tagged with multiple of the filtered tags, because the
+  # previous INNER JOIN produced one row per matching tag while the list
+  # deduplicated. These tests pin the invariant: totals.count must equal
+  # the deduplicated transaction count.
+  test "tag filter matches transactions with any of the filtered tags, once each" do
+    tag_a = @family.tags.create!(name: "TagA")
+    tag_b = @family.tags.create!(name: "TagB")
+    tag_c = @family.tags.create!(name: "TagC")
+
+    # One transaction carrying two of the filtered tags.
+    double_tagged = create_transaction(account: @checking_account, amount: 100, kind: "standard")
+    double_tagged.entryable << tag_a
+    double_tagged.entryable << tag_b
+
+    # One transaction carrying one of the filtered tags.
+    single_tagged = create_transaction(account: @checking_account, amount: 50, kind: "standard")
+    single_tagged.entryable << tag_a
+
+    # One transaction carrying only a tag NOT in the filter set.
+    unrelated = create_transaction(account: @checking_account, amount: 75, kind: "standard")
+    unrelated.entryable << tag_c
+
+    search = Transaction::Search.new(@family, filters: { tags: [ "TagA", "TagB" ] })
+    result_ids = search.transactions_scope.distinct.pluck(:id)
+
+    assert_includes result_ids, double_tagged.entryable.id
+    assert_includes result_ids, single_tagged.entryable.id
+    assert_not_includes result_ids, unrelated.entryable.id
+  end
+
+  test "totals.count is not inflated when a transaction has multiple matching tags" do
+    tag_a = @family.tags.create!(name: "FanA")
+    tag_b = @family.tags.create!(name: "FanB")
+
+    double_tagged = create_transaction(account: @checking_account, amount: 100, kind: "standard")
+    double_tagged.entryable << tag_a
+    double_tagged.entryable << tag_b
+
+    single_tagged = create_transaction(account: @checking_account, amount: 50, kind: "standard")
+    single_tagged.entryable << tag_a
+
+    # Sanity: the list deduplicates — exactly 2 rows.
+    list_count = Transaction::Search.new(@family, filters: { tags: [ "FanA", "FanB" ] })
+                                    .transactions_scope.count
+
+    # The summary box must return the same number — without the EXISTS-style
+    # subquery fix, `.joins(:tags)` produced 3 rows (2 for double_tagged + 1
+    # for single_tagged), so `tot.count` returned 3.
+    totals = Transaction::Search.new(@family, filters: { tags: [ "FanA", "FanB" ] }).totals
+
+    assert_equal 2, list_count
+    assert_equal 2, totals.count, "summary count must equal the deduplicated list count (see #3174)"
+    assert_equal Money.new(150, "USD"), totals.expense_money, "SUM must not double-count tagged rows"
+  end
+
+  test "totals.count is stable when a transaction has three matching tags" do
+    t1 = @family.tags.create!(name: "Triple1")
+    t2 = @family.tags.create!(name: "Triple2")
+    t3 = @family.tags.create!(name: "Triple3")
+
+    triple_tagged = create_transaction(account: @checking_account, amount: 42, kind: "standard")
+    triple_tagged.entryable << t1
+    triple_tagged.entryable << t2
+    triple_tagged.entryable << t3
+
+    totals = Transaction::Search.new(@family, filters: { tags: [ "Triple1", "Triple2", "Triple3" ] }).totals
+
+    assert_equal 1, totals.count, "a single transaction tagged with all three must be counted once"
+    assert_equal Money.new(42, "USD"), totals.expense_money
+  end
 end


### PR DESCRIPTION
## Summary

The Transactions page summary box (Totale transazioni / Entrate / Spese) inflates when a tag filter is active and a transaction has more than one of the filtered tags. The list renders the transaction once (Postgres dedupes), but the summary box showed **173 while 171 rows were visible** on the reporter's account.

## Root cause

`Transaction::Search#apply_tag_filter` used:

```ruby
query.joins(:tags).where(tags: { name: tags })
```

`.joins(:tags)` is an INNER JOIN across `taggings`. A transaction carrying **two** of the filtered tags therefore produces **two rows** in the join. The summary box aggregates `COUNT(entries.id)` and four `SUM(...)` expressions over that fan-out, so each matching row contributes again — `COUNT` and `SUM` all over-report.

## Fix

Switch to the same `IN (subquery)` idiom already used in `Api::V1::TransactionsController#index` for the equivalent tag filter:

```ruby
matching_ids = query.joins(:tags).where(tags: { name: tags }).distinct.select(:id)
query.where(id: matching_ids)
```

The subquery selects the deduplicated `transactions.id`s; the outer query filters via `WHERE transactions.id IN (SELECT ...)`. No INNER JOIN on the outer query, so `COUNT`/`SUM` in `#totals` see exactly one row per matching transaction.

## Verification — new regression tests

Added three tests to `test/models/transaction/search_test.rb`:

1. **Filter match is correct and deduped** — a transaction with two matching tags appears once in `transactions_scope`; a transaction with only an unfiltered tag is excluded.
2. **`totals.count` equals the deduplicated list count** — two transactions (one double-tagged, one single-tagged); pre-fix, `.joins(:tags)` produced 3 rows so `totals.count == 3`; post-fix it is `2`. Also asserts `SUM` is not double-counted (`150 = 100 + 50`).
3. **Three-of-three tag fan-out** — a single transaction tagged with all three filter values is counted exactly once.

Test 2 is the one that *bites*: with the old code `list_count == 2` but `totals.count == 3`, so `assert_equal 2, totals.count` fails until the fix is applied. Test 3 is an invariant that would also have failed under the old code.

## Scope

Single method, single file. No schema change, no API change, no cache-key change (`cache_key_base` already hashes the full filter set which includes the tag names). The sibling filter `apply_merchant_filter` (line 187) uses the same INNER JOIN pattern for `:merchant`, but `Merchant` has a `belongs_to` 1:1 relationship (each transaction can have at most one merchant), so there is no fan-out there — no change required.

Closes #3174.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filtered transaction summaries to prevent duplicate transactions when a transaction has multiple matching tags.
  * Corrected summary counts and expense totals so they are no longer overstated by matching tags.

* **Tests**
  * Added coverage for tag filtering and accurate totals across transactions with multiple matching tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->