### PR TITLE
fix: Show category hierarchy in transaction picker/editor

### DIFF
--- a/app/components/DS/category_select.html.erb
+++ b/app/components/DS/category_select.html.erb
@@ -80,13 +80,22 @@
           </button>
         <% end %>
 
-        <% categories.each do |category| %>
+        <% Category::Group.for(categories).each do |group| %>
           <%= render partial: "DS/category_select/option",
                      locals: {
-                       category: category,
-                       selected: category.id.to_s == selected_id,
+                       category: group.category,
+                       selected: group.category.id.to_s == selected_id,
                        view_helpers: helpers
                      } %>
+
+          <% group.subcategories.each do |category| %>
+            <%= render partial: "DS/category_select/option",
+                       locals: {
+                         category: category,
+                         selected: category.id.to_s == selected_id,
+                         view_helpers: helpers
+                       } %>
+          <% end %>
         <% end %>
 
         <button type="button"

--- a/app/views/DS/category_select/_option.html.erb
+++ b/app/views/DS/category_select/_option.html.erb
@@ -15,6 +15,14 @@
     <%= view_helpers.icon("check") %>
   </span>
 
+  <% if category.parent_id.present? %>
+    <span class="ml-2 shrink-0"
+          data-testid="category-select-subcategory-indicator"
+          style="color: <%= category.color %>">
+      <%= view_helpers.icon("corner-down-right", size: "sm", color: "current") %>
+    </span>
+  <% end %>
+
   <span data-category-select-badge>
     <%= view_helpers.render partial: "categories/badge",
                        	    formats: [ :html ],

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -748,6 +748,11 @@ end
     assert_not_nil parent_index
     assert_not_nil child_index
     assert_equal parent_index + 1, child_index
+
+    child_option = wrapper.at_css("[data-category-id='#{categories(:subcategory).id}']")
+    assert_not_nil child_option, "expected the subcategory option to render"
+    assert child_option.at_css("[data-testid='category-select-subcategory-indicator']"),
+           "expected the subcategory option to show the hierarchy indicator used in Settings"
   end
 
   test "new renders a search box for account selection" do


### PR DESCRIPTION
This is a follow-up to the previous PR #[2845](https://github.com/we-promise/sure/pull/2845)

This fix is required because transaction category selection did not clearly preserve the parent–child hierarchy in create/edit transaction flow

  Previously, categories in the add/edit transaction picker were rendered as a flat list. Even when their database order happened to place children after parents, there was no visual relationship between them, making categories harder to scan and increasing the chance of  assigning a transaction to the wrong category.

  The update uses the same parent-with-children grouping as Settings → Categories and adds the established hierarchy indicator to child entries. This gives users a consistent category structure across configuration and transaction workflows, while preserving existing search, selection, and auto-save behaviour.


<img width="557" height="585" alt="create_transaction_scrren" src="https://github.com/user-attachments/assets/8a05afb7-97d2-4165-b18e-d43d9212a7ce" />


<img width="551" height="739" alt="edit_transaction_screen" src="https://github.com/user-attachments/assets/21de4a63-8d70-4de0-99ed-c64607cd4181" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Category selection lists now display categories in a clear hierarchy, with subcategories grouped beneath their parent categories.
  * Subcategories include a visual indicator to make their relationship to the parent category easier to recognize.

* **Tests**
  * Added coverage confirming subcategory ordering and hierarchy indicators in category selection lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->