### PR TITLE
feat(forms): parse pasted formatted amounts in money fields

### DIFF
--- a/app/javascript/controllers/money_field_controller.js
+++ b/app/javascript/controllers/money_field_controller.js
@@ -48,4 +48,25 @@ export default class extends Controller {
       // Silently ignored as they are unactionable by the user.
     });
   }
+
+  // Number inputs silently reject pasted formatted values ("20,000 ",
+  // "1.234,56"), leaving the field blank. Intercept the paste, parse the
+  // locale format, and insert the plain number instead so copy/paste from
+  // statements and spreadsheets just works.
+  pasteAmount(event) {
+    const text = (event.clipboardData || window.clipboardData)?.getData("text")?.trim() ?? "";
+    if (text === "") return;
+
+    const parsed = parseLocaleFloat(text);
+    if (!Number.isFinite(parsed)) return;
+
+    event.preventDefault();
+    const precision =
+      this.hasPrecisionValue && Number.isInteger(this.precisionValue)
+        ? this.precisionValue
+        : 2;
+    this.amountTarget.value = parsed.toFixed(precision);
+    // Let auto-submit / validation listeners know the value changed.
+    this.amountTarget.dispatchEvent(new Event("input", { bubbles: true }));
+  }
 }

--- a/app/javascript/controllers/money_field_controller.js
+++ b/app/javascript/controllers/money_field_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { CurrenciesService } from "services/currencies_service";
 import parseLocaleFloat from "utils/parse_locale_float";
+import parseAmountPaste from "utils/parse_amount_paste";
 
 // Connects to data-controller="money-field"
 // when currency select change, update the input value with the correct placeholder and step
@@ -50,23 +51,38 @@ export default class extends Controller {
   }
 
   // Number inputs silently reject pasted formatted values ("20,000 ",
-  // "1.234,56"), leaving the field blank. Intercept the paste, parse the
-  // locale format, and insert the plain number instead so copy/paste from
-  // statements and spreadsheets just works.
+  // "1.234,56", "$1,234.56"), leaving the field blank. Intercept the paste,
+  // parse the amount, and insert the plain number instead so copy/paste from
+  // statements and spreadsheets just works. Text that is not an amount is left
+  // to the browser.
   pasteAmount(event) {
-    const text = (event.clipboardData || window.clipboardData)?.getData("text")?.trim() ?? "";
-    if (text === "") return;
-
-    const parsed = parseLocaleFloat(text);
-    if (!Number.isFinite(parsed)) return;
+    const text = (event.clipboardData || window.clipboardData)?.getData("text") ?? "";
+    const parsed = parseAmountPaste(text);
+    if (parsed === null) return;
 
     event.preventDefault();
-    const precision =
-      this.hasPrecisionValue && Number.isInteger(this.precisionValue)
-        ? this.precisionValue
-        : 2;
-    this.amountTarget.value = parsed.toFixed(precision);
-    // Let auto-submit / validation listeners know the value changed.
+    this.amountTarget.value = parsed.toFixed(this.#pastePrecision());
+
+    // auto_submit_form listens for "change" on number inputs while validation
+    // and the goal form's suggestion listen for "input", and assigning .value
+    // emits neither.
     this.amountTarget.dispatchEvent(new Event("input", { bubbles: true }));
+    this.amountTarget.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  // The amount input's step already carries the selected currency's precision,
+  // rendered server-side and refreshed by updateAmount, so it tracks the live
+  // currency selection without a second lookup. BTC's step arrives as
+  // "1.0e-08", so the decimal count is derived numerically rather than by
+  // counting characters.
+  #pastePrecision() {
+    if (this.hasPrecisionValue && Number.isInteger(this.precisionValue)) {
+      return this.precisionValue;
+    }
+
+    const step = Number(this.amountTarget.step);
+    if (!Number.isFinite(step) || step <= 0) return 2;
+
+    return Math.max(0, Math.ceil(-Math.log10(step)));
   }
 }

--- a/app/javascript/controllers/money_field_controller.js
+++ b/app/javascript/controllers/money_field_controller.js
@@ -61,7 +61,9 @@ export default class extends Controller {
     if (parsed === null) return;
 
     event.preventDefault();
-    this.amountTarget.value = parsed.toFixed(this.#pastePrecision());
+    const precision = this.#pastePrecision();
+    this.amountTarget.value =
+      precision === null ? String(parsed) : parsed.toFixed(precision);
 
     // auto_submit_form listens for "change" on number inputs while validation
     // and the goal form's suggestion listen for "input", and assigning .value
@@ -74,14 +76,17 @@ export default class extends Controller {
   // rendered server-side and refreshed by updateAmount, so it tracks the live
   // currency selection without a second lookup. BTC's step arrives as
   // "1.0e-08", so the decimal count is derived numerically rather than by
-  // counting characters.
+  // counting characters. Returns null when the step declares no precision —
+  // step="any", which the trade amount, price and fee fields use — so the
+  // pasted value is written unrounded instead of being truncated to a default
+  // that would drop a sub-cent crypto price to "0.00".
   #pastePrecision() {
     if (this.hasPrecisionValue && Number.isInteger(this.precisionValue)) {
       return this.precisionValue;
     }
 
     const step = Number(this.amountTarget.step);
-    if (!Number.isFinite(step) || step <= 0) return 2;
+    if (!Number.isFinite(step) || step <= 0) return null;
 
     return Math.max(0, Math.ceil(-Math.log10(step)));
   }

--- a/app/javascript/utils/parse_amount_paste.js
+++ b/app/javascript/utils/parse_amount_paste.js
@@ -1,32 +1,57 @@
 import parseLocaleFloat from "utils/parse_locale_float"
 
+// A currency symbol or code, as it appears next to a pasted amount: "$", "R$",
+// "kr", "USD". Capped at three characters so prose ("memo 500") is rejected
+// rather than silently read as an amount.
+const CURRENCY_TOKEN = "[^\\d\\s.,()+-]{1,3}"
+
+const stripCurrency = (value) =>
+  value
+    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`), "")
+    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`), "")
+    .trim()
+
 // Parses text pasted into a money field, or returns null when the text is not
 // an amount at all.
 //
 // parseLocaleFloat coerces anything it cannot read to 0, which is unsafe for a
 // paste: "$1,234.56", "USD 500" and "abc" would all silently overwrite the
-// field with 0. So the text is validated here first. A leading or trailing
-// currency symbol or code is stripped, since both are common when copying from
-// a statement, and whatever is left must be digits with , . or spaces as
-// separators. Anything else returns null, and the browser handles the paste.
+// field with 0. So the text is matched against a strict grammar first — an
+// optional sign, an optional currency symbol or code on either side, and a
+// number — and anything else returns null so the browser handles the paste.
 //
-// Amounts wrapped in parentheses are read as negative, the accounting
-// convention used by most statement exports.
+// The sign is read before the currency is stripped, because it can sit on
+// either side of the symbol ("-$500", "$-500"), and because a negative that is
+// only recognised after stripping would post a debit as a credit. Amounts
+// wrapped in parentheses are negative, the convention used by most statement
+// exports, and the currency may sit outside them ("USD (1,200.00)").
 export default function parseAmountPaste(text, options = {}) {
   const trimmed = typeof text === "string" ? text.trim() : ""
   if (trimmed === "") return null
 
-  const negative = trimmed.startsWith("-") || /^\(.*\)$/.test(trimmed)
+  let rest = trimmed
+  let negative = false
 
-  const body = trimmed
-    .replace(/^[+-]/, "")
-    .replace(/^[^\d]+/, "")
-    .replace(/[^\d]+$/, "")
+  const outerSign = rest.match(/^([+-])\s*/)
+  if (outerSign) {
+    negative = outerSign[1] === "-"
+    rest = rest.slice(outerSign[0].length)
+  }
 
-  if (!/^\d[\d.,\s]*$/.test(body)) return null
+  rest = stripCurrency(rest)
 
-  const parsed = parseLocaleFloat(body, options)
+  const parenthesised = rest.match(/^\((.+)\)$/)
+  if (parenthesised) {
+    negative = true
+    rest = stripCurrency(parenthesised[1].trim())
+  }
+
+  const match = rest.match(/^([+-]?)(\d[\d.,\s]*)$/)
+  if (!match) return null
+  if (match[1] === "-") negative = true
+
+  const parsed = parseLocaleFloat(match[2], options)
   if (!Number.isFinite(parsed)) return null
 
-  return negative ? -parsed : parsed
+  return negative ? -Math.abs(parsed) : parsed
 }

--- a/app/javascript/utils/parse_amount_paste.js
+++ b/app/javascript/utils/parse_amount_paste.js
@@ -1,14 +1,21 @@
 import parseLocaleFloat from "utils/parse_locale_float"
 
-// A currency symbol or code, as it appears next to a pasted amount: "$", "R$",
-// "kr", "USD". Capped at three characters so prose ("memo 500") is rejected
-// rather than silently read as an amount.
-const CURRENCY_TOKEN = "[^\\d\\s.,()+-]{1,3}"
+// A currency marker sitting next to a pasted amount: either a symbol ("$",
+// "€", "£"), which by definition carries no letters, or a three-letter
+// uppercase ISO code ("USD", "EUR").
+//
+// Letters are otherwise excluded because a lowercase letter run is
+// indistinguishable from prose without a real currency list — and the server's
+// currency set is not available synchronously inside a paste event. That means
+// markers containing letters, such as "R$" or "kr", are not stripped and those
+// pastes fall through to the browser, which is the safe direction: accepting
+// them would also accept "fee 500".
+const CURRENCY_TOKEN = "(?:[^\\p{L}\\p{N}\\s.,()+-]{1,3}|[A-Z]{3})"
 
 const stripCurrency = (value) =>
   value
-    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`), "")
-    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`), "")
+    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`, "u"), "")
+    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`, "u"), "")
     .trim()
 
 // Parses text pasted into a money field, or returns null when the text is not

--- a/app/javascript/utils/parse_amount_paste.js
+++ b/app/javascript/utils/parse_amount_paste.js
@@ -7,6 +7,12 @@ import parseLocaleFloat from "utils/parse_locale_float"
 // so those pastes fall through to the browser untouched.
 const CURRENCY_SYMBOL = "[$£¥֏؋৳฿៛₡₦₨₩₪₫€₭₮₱₲₴₵₸₹₺₼₽₾₿﷼]"
 
+// Only the spaces that locales actually use to group digits ("1 234,56") are
+// allowed inside the number. Any other whitespace is a token boundary, not a
+// separator, so a multi-cell spreadsheet paste ("100\t200") is rejected rather
+// than concatenated into one amount.
+const GROUPED_NUMBER = /^([+-]?)(\d[\d.,\u0020\u00a0\u202f]*)$/
+
 const stripCurrency = (value) =>
   value
     .replace(new RegExp(`^${CURRENCY_SYMBOL}\\s*`), "")
@@ -19,14 +25,14 @@ const stripCurrency = (value) =>
 // parseLocaleFloat coerces anything it cannot read to 0, which is unsafe for a
 // paste: "$1,234.56", "USD 500" and "abc" would all silently overwrite the
 // field with 0. So the text is matched against a strict grammar first — an
-// optional sign, an optional currency symbol or code on either side, and a
-// number — and anything else returns null so the browser handles the paste.
+// optional sign, an optional currency symbol on either side, and a number —
+// and anything else returns null so the browser handles the paste.
 //
 // The sign is read before the currency is stripped, because it can sit on
 // either side of the symbol ("-$500", "$-500"), and because a negative that is
 // only recognised after stripping would post a debit as a credit. Amounts
 // wrapped in parentheses are negative, the convention used by most statement
-// exports, and the currency may sit outside them ("USD (1,200.00)").
+// exports, and the symbol may sit outside them ("$(1,200.00)").
 export default function parseAmountPaste(text, options = {}) {
   const trimmed = typeof text === "string" ? text.trim() : ""
   if (trimmed === "") return null
@@ -48,7 +54,7 @@ export default function parseAmountPaste(text, options = {}) {
     rest = stripCurrency(parenthesised[1].trim())
   }
 
-  const match = rest.match(/^([+-]?)(\d[\d.,\s]*)$/)
+  const match = rest.match(GROUPED_NUMBER)
   if (!match) return null
   if (match[1] === "-") negative = true
 

--- a/app/javascript/utils/parse_amount_paste.js
+++ b/app/javascript/utils/parse_amount_paste.js
@@ -1,0 +1,32 @@
+import parseLocaleFloat from "utils/parse_locale_float"
+
+// Parses text pasted into a money field, or returns null when the text is not
+// an amount at all.
+//
+// parseLocaleFloat coerces anything it cannot read to 0, which is unsafe for a
+// paste: "$1,234.56", "USD 500" and "abc" would all silently overwrite the
+// field with 0. So the text is validated here first. A leading or trailing
+// currency symbol or code is stripped, since both are common when copying from
+// a statement, and whatever is left must be digits with , . or spaces as
+// separators. Anything else returns null, and the browser handles the paste.
+//
+// Amounts wrapped in parentheses are read as negative, the accounting
+// convention used by most statement exports.
+export default function parseAmountPaste(text, options = {}) {
+  const trimmed = typeof text === "string" ? text.trim() : ""
+  if (trimmed === "") return null
+
+  const negative = trimmed.startsWith("-") || /^\(.*\)$/.test(trimmed)
+
+  const body = trimmed
+    .replace(/^[+-]/, "")
+    .replace(/^[^\d]+/, "")
+    .replace(/[^\d]+$/, "")
+
+  if (!/^\d[\d.,\s]*$/.test(body)) return null
+
+  const parsed = parseLocaleFloat(body, options)
+  if (!Number.isFinite(parsed)) return null
+
+  return negative ? -parsed : parsed
+}

--- a/app/javascript/utils/parse_amount_paste.js
+++ b/app/javascript/utils/parse_amount_paste.js
@@ -1,21 +1,16 @@
 import parseLocaleFloat from "utils/parse_locale_float"
 
-// A currency marker sitting next to a pasted amount: either a symbol ("$",
-// "€", "£"), which by definition carries no letters, or a three-letter
-// uppercase ISO code ("USD", "EUR").
-//
-// Letters are otherwise excluded because a lowercase letter run is
-// indistinguishable from prose without a real currency list — and the server's
-// currency set is not available synchronously inside a paste event. That means
-// markers containing letters, such as "R$" or "kr", are not stripped and those
-// pastes fall through to the browser, which is the safe direction: accepting
-// them would also accept "fee 500".
-const CURRENCY_TOKEN = "(?:[^\\p{L}\\p{N}\\s.,()+-]{1,3}|[A-Z]{3})"
+// The currency symbols carried by config/currencies.yml, restricted to the
+// ones that contain no letters. A letter-bearing marker ("kr", "R$", "USD")
+// cannot be told apart from prose such as "fee 500" or "TAX 500" without
+// consulting the currency list itself, and a paste event has nothing to await,
+// so those pastes fall through to the browser untouched.
+const CURRENCY_SYMBOL = "[$£¥֏؋৳฿៛₡₦₨₩₪₫€₭₮₱₲₴₵₸₹₺₼₽₾₿﷼]"
 
 const stripCurrency = (value) =>
   value
-    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`, "u"), "")
-    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`, "u"), "")
+    .replace(new RegExp(`^${CURRENCY_SYMBOL}\\s*`), "")
+    .replace(new RegExp(`\\s*${CURRENCY_SYMBOL}$`), "")
     .trim()
 
 // Parses text pasted into a money field, or returns null when the text is not

--- a/app/views/shared/_money_field.html.erb
+++ b/app/views/shared/_money_field.html.erb
@@ -62,7 +62,8 @@
           disabled: options[:disabled],
           data: (options[:amount_data] || {}).merge({
             "money-field-target": "amount",
-            "auto-submit-form-target": ("auto" if options[:auto_submit])
+            "auto-submit-form-target": ("auto" if options[:auto_submit]),
+            action: [ options.dig(:amount_data, :action), "paste->money-field#pasteAmount" ].compact.join(" ")
           }.compact),
           required: options[:required] %>
       </div>

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -44,6 +44,14 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "the target amount field keeps its own action alongside the paste handler" do
+    get new_goal_url
+
+    assert_response :success
+    assert_select "input[data-money-field-target=?][data-action=?]", "amount",
+                  "input->goal-form#suggestedChanged paste->money-field#pasteAmount"
+  end
+
   test "create persists a goal with linked accounts" do
     # Fresh accounts: the goal fixtures already claim @depository and
     # @connected in full, and GoalAccount refuses a second whole-balance

--- a/test/javascript/parse_amount_paste_test.mjs
+++ b/test/javascript/parse_amount_paste_test.mjs
@@ -32,22 +32,17 @@ function parseLocaleFloat(value, { separator } = {}) {
 
 // Inline the function to avoid needing a bundler for ESM imports.
 // Must be kept in sync with app/javascript/utils/parse_amount_paste.js
-// A currency marker sitting next to a pasted amount: either a symbol ("$",
-// "€", "£"), which by definition carries no letters, or a three-letter
-// uppercase ISO code ("USD", "EUR").
-//
-// Letters are otherwise excluded because a lowercase letter run is
-// indistinguishable from prose without a real currency list — and the server's
-// currency set is not available synchronously inside a paste event. That means
-// markers containing letters, such as "R$" or "kr", are not stripped and those
-// pastes fall through to the browser, which is the safe direction: accepting
-// them would also accept "fee 500".
-const CURRENCY_TOKEN = "(?:[^\\p{L}\\p{N}\\s.,()+-]{1,3}|[A-Z]{3})"
+// The currency symbols carried by config/currencies.yml, restricted to the
+// ones that contain no letters. A letter-bearing marker ("kr", "R$", "USD")
+// cannot be told apart from prose such as "fee 500" or "TAX 500" without
+// consulting the currency list itself, and a paste event has nothing to await,
+// so those pastes fall through to the browser untouched.
+const CURRENCY_SYMBOL = "[$£¥֏؋৳฿៛₡₦₨₩₪₫€₭₮₱₲₴₵₸₹₺₼₽₾₿﷼]"
 
 const stripCurrency = (value) =>
   value
-    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`, "u"), "")
-    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`, "u"), "")
+    .replace(new RegExp(`^${CURRENCY_SYMBOL}\\s*`), "")
+    .replace(new RegExp(`\\s*${CURRENCY_SYMBOL}$`), "")
     .trim()
 
 function parseAmountPaste(text, options = {}) {
@@ -100,17 +95,9 @@ describe("parseAmountPaste", () => {
     })
   })
 
-  describe("strips currency symbols and codes", () => {
+  describe("strips currency symbols", () => {
     it('parses "$1,234.56" as 1234.56', () => {
       assert.equal(parseAmountPaste("$1,234.56"), 1234.56)
-    })
-
-    it('parses "USD 500" as 500', () => {
-      assert.equal(parseAmountPaste("USD 500"), 500)
-    })
-
-    it('parses "1,234.56 EUR" as 1234.56', () => {
-      assert.equal(parseAmountPaste("1,234.56 EUR"), 1234.56)
     })
 
     it('parses "1,234.56 €" as 1234.56', () => {
@@ -119,6 +106,14 @@ describe("parseAmountPaste", () => {
 
     it('parses "£99.99" as 99.99', () => {
       assert.equal(parseAmountPaste("£99.99"), 99.99)
+    })
+
+    it('parses "₹500" as 500', () => {
+      assert.equal(parseAmountPaste("₹500"), 500)
+    })
+
+    it('parses "¥1,200" as 1200', () => {
+      assert.equal(parseAmountPaste("¥1,200"), 1200)
     })
   })
 
@@ -139,12 +134,12 @@ describe("parseAmountPaste", () => {
       assert.equal(parseAmountPaste("-$500"), -500)
     })
 
-    it('parses "USD (1,200.00)" as -1200', () => {
-      assert.equal(parseAmountPaste("USD (1,200.00)"), -1200)
+    it('parses "$(1,200.00)" as -1200', () => {
+      assert.equal(parseAmountPaste("$(1,200.00)"), -1200)
     })
 
-    it('parses "(1,200.00) USD" as -1200', () => {
-      assert.equal(parseAmountPaste("(1,200.00) USD"), -1200)
+    it('parses "(1,200.00) €" as -1200', () => {
+      assert.equal(parseAmountPaste("(1,200.00) €"), -1200)
     })
   })
 
@@ -193,8 +188,32 @@ describe("parseAmountPaste", () => {
       assert.equal(parseAmountPaste("500 tax"), null)
     })
 
+    it('rejects "TAX 500"', () => {
+      assert.equal(parseAmountPaste("TAX 500"), null)
+    })
+
+    it('rejects "500 TAX"', () => {
+      assert.equal(parseAmountPaste("500 TAX"), null)
+    })
+
+    it('rejects "*** 500"', () => {
+      assert.equal(parseAmountPaste("*** 500"), null)
+    })
+
+    it('rejects "500 ***"', () => {
+      assert.equal(parseAmountPaste("500 ***"), null)
+    })
+
     it('rejects "R$ 1.234,56", since a lettered marker cannot be told from prose', () => {
       assert.equal(parseAmountPaste("R$ 1.234,56"), null)
+    })
+
+    it('rejects "USD 500", since a lettered code cannot be told from prose', () => {
+      assert.equal(parseAmountPaste("USD 500"), null)
+    })
+
+    it('rejects "1,234.56 EUR", since a lettered code cannot be told from prose', () => {
+      assert.equal(parseAmountPaste("1,234.56 EUR"), null)
     })
   })
 })

--- a/test/javascript/parse_amount_paste_test.mjs
+++ b/test/javascript/parse_amount_paste_test.mjs
@@ -32,23 +32,46 @@ function parseLocaleFloat(value, { separator } = {}) {
 
 // Inline the function to avoid needing a bundler for ESM imports.
 // Must be kept in sync with app/javascript/utils/parse_amount_paste.js
+// A currency symbol or code, as it appears next to a pasted amount: "$", "R$",
+// "kr", "USD". Capped at three characters so prose ("memo 500") is rejected
+// rather than silently read as an amount.
+const CURRENCY_TOKEN = "[^\\d\\s.,()+-]{1,3}"
+
+const stripCurrency = (value) =>
+  value
+    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`), "")
+    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`), "")
+    .trim()
+
 function parseAmountPaste(text, options = {}) {
   const trimmed = typeof text === "string" ? text.trim() : ""
   if (trimmed === "") return null
 
-  const negative = trimmed.startsWith("-") || /^\(.*\)$/.test(trimmed)
+  let rest = trimmed
+  let negative = false
 
-  const body = trimmed
-    .replace(/^[+-]/, "")
-    .replace(/^[^\d]+/, "")
-    .replace(/[^\d]+$/, "")
+  const outerSign = rest.match(/^([+-])\s*/)
+  if (outerSign) {
+    negative = outerSign[1] === "-"
+    rest = rest.slice(outerSign[0].length)
+  }
 
-  if (!/^\d[\d.,\s]*$/.test(body)) return null
+  rest = stripCurrency(rest)
 
-  const parsed = parseLocaleFloat(body, options)
+  const parenthesised = rest.match(/^\((.+)\)$/)
+  if (parenthesised) {
+    negative = true
+    rest = stripCurrency(parenthesised[1].trim())
+  }
+
+  const match = rest.match(/^([+-]?)(\d[\d.,\s]*)$/)
+  if (!match) return null
+  if (match[1] === "-") negative = true
+
+  const parsed = parseLocaleFloat(match[2], options)
   if (!Number.isFinite(parsed)) return null
 
-  return negative ? -parsed : parsed
+  return negative ? -Math.abs(parsed) : parsed
 }
 
 describe("parseAmountPaste", () => {
@@ -82,6 +105,10 @@ describe("parseAmountPaste", () => {
     it('parses "1,234.56 EUR" as 1234.56', () => {
       assert.equal(parseAmountPaste("1,234.56 EUR"), 1234.56)
     })
+
+    it('parses "R$ 1.234,56" as 1234.56', () => {
+      assert.equal(parseAmountPaste("R$ 1.234,56"), 1234.56)
+    })
   })
 
   describe("handles negatives", () => {
@@ -91,6 +118,22 @@ describe("parseAmountPaste", () => {
 
     it('parses "(1,200.00)" as -1200', () => {
       assert.equal(parseAmountPaste("(1,200.00)"), -1200)
+    })
+
+    it('parses "$-500" as -500', () => {
+      assert.equal(parseAmountPaste("$-500"), -500)
+    })
+
+    it('parses "-$500" as -500', () => {
+      assert.equal(parseAmountPaste("-$500"), -500)
+    })
+
+    it('parses "USD (1,200.00)" as -1200', () => {
+      assert.equal(parseAmountPaste("USD (1,200.00)"), -1200)
+    })
+
+    it('parses "(1,200.00) USD" as -1200', () => {
+      assert.equal(parseAmountPaste("(1,200.00) USD"), -1200)
     })
   })
 
@@ -121,6 +164,14 @@ describe("parseAmountPaste", () => {
 
     it("rejects undefined", () => {
       assert.equal(parseAmountPaste(undefined), null)
+    })
+
+    it('rejects "memo 500"', () => {
+      assert.equal(parseAmountPaste("memo 500"), null)
+    })
+
+    it('rejects "500 memo"', () => {
+      assert.equal(parseAmountPaste("500 memo"), null)
     })
   })
 })

--- a/test/javascript/parse_amount_paste_test.mjs
+++ b/test/javascript/parse_amount_paste_test.mjs
@@ -1,80 +1,28 @@
+import { readFile } from "node:fs/promises"
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
 
-// Inline the function to avoid needing a bundler for ESM imports.
-// Must be kept in sync with app/javascript/utils/parse_locale_float.js
-function parseLocaleFloat(value, { separator } = {}) {
-  if (typeof value !== "string") return Number.parseFloat(value) || 0
+// The parser resolves "utils/parse_locale_float" through the importmap, which
+// Node has no equivalent of, so the specifier is rewritten to a file URL and
+// the module is imported as written. These cases therefore run the shipped
+// parser rather than a copy of it that could drift.
+const SOURCE_URL = new URL(
+  "../../app/javascript/utils/parse_amount_paste.js",
+  import.meta.url,
+)
+const PARSE_LOCALE_FLOAT_URL = new URL(
+  "../../app/javascript/utils/parse_locale_float.js",
+  import.meta.url,
+)
 
-  const cleaned = value.replace(/\s/g, "")
+const source = (await readFile(SOURCE_URL, "utf8")).replace(
+  '"utils/parse_locale_float"',
+  JSON.stringify(PARSE_LOCALE_FLOAT_URL.href),
+)
 
-  if (separator === ",") {
-    return Number.parseFloat(cleaned.replace(/\./g, "").replace(",", ".")) || 0
-  }
-  if (separator === ".") {
-    return Number.parseFloat(cleaned.replace(/,/g, "")) || 0
-  }
-
-  const lastComma = cleaned.lastIndexOf(",")
-  const lastDot = cleaned.lastIndexOf(".")
-
-  if (lastComma > lastDot) {
-    const digitsAfterComma = cleaned.length - lastComma - 1
-    if (lastDot === -1 && digitsAfterComma === 3) {
-      return Number.parseFloat(cleaned.replace(/,/g, "")) || 0
-    }
-
-    return Number.parseFloat(cleaned.replace(/\./g, "").replace(",", ".")) || 0
-  }
-
-  return Number.parseFloat(cleaned.replace(/,/g, "")) || 0
-}
-
-// Inline the function to avoid needing a bundler for ESM imports.
-// Must be kept in sync with app/javascript/utils/parse_amount_paste.js
-// The currency symbols carried by config/currencies.yml, restricted to the
-// ones that contain no letters. A letter-bearing marker ("kr", "R$", "USD")
-// cannot be told apart from prose such as "fee 500" or "TAX 500" without
-// consulting the currency list itself, and a paste event has nothing to await,
-// so those pastes fall through to the browser untouched.
-const CURRENCY_SYMBOL = "[$£¥֏؋৳฿៛₡₦₨₩₪₫€₭₮₱₲₴₵₸₹₺₼₽₾₿﷼]"
-
-const stripCurrency = (value) =>
-  value
-    .replace(new RegExp(`^${CURRENCY_SYMBOL}\\s*`), "")
-    .replace(new RegExp(`\\s*${CURRENCY_SYMBOL}$`), "")
-    .trim()
-
-function parseAmountPaste(text, options = {}) {
-  const trimmed = typeof text === "string" ? text.trim() : ""
-  if (trimmed === "") return null
-
-  let rest = trimmed
-  let negative = false
-
-  const outerSign = rest.match(/^([+-])\s*/)
-  if (outerSign) {
-    negative = outerSign[1] === "-"
-    rest = rest.slice(outerSign[0].length)
-  }
-
-  rest = stripCurrency(rest)
-
-  const parenthesised = rest.match(/^\((.+)\)$/)
-  if (parenthesised) {
-    negative = true
-    rest = stripCurrency(parenthesised[1].trim())
-  }
-
-  const match = rest.match(/^([+-]?)(\d[\d.,\s]*)$/)
-  if (!match) return null
-  if (match[1] === "-") negative = true
-
-  const parsed = parseLocaleFloat(match[2], options)
-  if (!Number.isFinite(parsed)) return null
-
-  return negative ? -Math.abs(parsed) : parsed
-}
+const { default: parseAmountPaste } = await import(
+  `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+)
 
 describe("parseAmountPaste", () => {
   describe("parses plain and locale-formatted amounts", () => {
@@ -214,6 +162,24 @@ describe("parseAmountPaste", () => {
 
     it('rejects "1,234.56 EUR", since a lettered code cannot be told from prose', () => {
       assert.equal(parseAmountPaste("1,234.56 EUR"), null)
+    })
+  })
+
+  describe("rejects multi-cell pastes rather than joining them", () => {
+    it('rejects "100\\t200"', () => {
+      assert.equal(parseAmountPaste("100\t200"), null)
+    })
+
+    it('rejects "1,234.56\\t500"', () => {
+      assert.equal(parseAmountPaste("1,234.56\t500"), null)
+    })
+
+    it('rejects "100\\n200"', () => {
+      assert.equal(parseAmountPaste("100\n200"), null)
+    })
+
+    it('still parses "1\\u00a0234,56" as 1234.56, since a no-break space groups digits', () => {
+      assert.equal(parseAmountPaste("1\u00a0234,56"), 1234.56)
     })
   })
 })

--- a/test/javascript/parse_amount_paste_test.mjs
+++ b/test/javascript/parse_amount_paste_test.mjs
@@ -32,15 +32,22 @@ function parseLocaleFloat(value, { separator } = {}) {
 
 // Inline the function to avoid needing a bundler for ESM imports.
 // Must be kept in sync with app/javascript/utils/parse_amount_paste.js
-// A currency symbol or code, as it appears next to a pasted amount: "$", "R$",
-// "kr", "USD". Capped at three characters so prose ("memo 500") is rejected
-// rather than silently read as an amount.
-const CURRENCY_TOKEN = "[^\\d\\s.,()+-]{1,3}"
+// A currency marker sitting next to a pasted amount: either a symbol ("$",
+// "€", "£"), which by definition carries no letters, or a three-letter
+// uppercase ISO code ("USD", "EUR").
+//
+// Letters are otherwise excluded because a lowercase letter run is
+// indistinguishable from prose without a real currency list — and the server's
+// currency set is not available synchronously inside a paste event. That means
+// markers containing letters, such as "R$" or "kr", are not stripped and those
+// pastes fall through to the browser, which is the safe direction: accepting
+// them would also accept "fee 500".
+const CURRENCY_TOKEN = "(?:[^\\p{L}\\p{N}\\s.,()+-]{1,3}|[A-Z]{3})"
 
 const stripCurrency = (value) =>
   value
-    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`), "")
-    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`), "")
+    .replace(new RegExp(`^${CURRENCY_TOKEN}\\s*`, "u"), "")
+    .replace(new RegExp(`\\s*${CURRENCY_TOKEN}$`, "u"), "")
     .trim()
 
 function parseAmountPaste(text, options = {}) {
@@ -106,8 +113,12 @@ describe("parseAmountPaste", () => {
       assert.equal(parseAmountPaste("1,234.56 EUR"), 1234.56)
     })
 
-    it('parses "R$ 1.234,56" as 1234.56', () => {
-      assert.equal(parseAmountPaste("R$ 1.234,56"), 1234.56)
+    it('parses "1,234.56 €" as 1234.56', () => {
+      assert.equal(parseAmountPaste("1,234.56 €"), 1234.56)
+    })
+
+    it('parses "£99.99" as 99.99', () => {
+      assert.equal(parseAmountPaste("£99.99"), 99.99)
     })
   })
 
@@ -172,6 +183,18 @@ describe("parseAmountPaste", () => {
 
     it('rejects "500 memo"', () => {
       assert.equal(parseAmountPaste("500 memo"), null)
+    })
+
+    it('rejects "fee 500"', () => {
+      assert.equal(parseAmountPaste("fee 500"), null)
+    })
+
+    it('rejects "500 tax"', () => {
+      assert.equal(parseAmountPaste("500 tax"), null)
+    })
+
+    it('rejects "R$ 1.234,56", since a lettered marker cannot be told from prose', () => {
+      assert.equal(parseAmountPaste("R$ 1.234,56"), null)
     })
   })
 })

--- a/test/javascript/parse_amount_paste_test.mjs
+++ b/test/javascript/parse_amount_paste_test.mjs
@@ -1,0 +1,126 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+// Inline the function to avoid needing a bundler for ESM imports.
+// Must be kept in sync with app/javascript/utils/parse_locale_float.js
+function parseLocaleFloat(value, { separator } = {}) {
+  if (typeof value !== "string") return Number.parseFloat(value) || 0
+
+  const cleaned = value.replace(/\s/g, "")
+
+  if (separator === ",") {
+    return Number.parseFloat(cleaned.replace(/\./g, "").replace(",", ".")) || 0
+  }
+  if (separator === ".") {
+    return Number.parseFloat(cleaned.replace(/,/g, "")) || 0
+  }
+
+  const lastComma = cleaned.lastIndexOf(",")
+  const lastDot = cleaned.lastIndexOf(".")
+
+  if (lastComma > lastDot) {
+    const digitsAfterComma = cleaned.length - lastComma - 1
+    if (lastDot === -1 && digitsAfterComma === 3) {
+      return Number.parseFloat(cleaned.replace(/,/g, "")) || 0
+    }
+
+    return Number.parseFloat(cleaned.replace(/\./g, "").replace(",", ".")) || 0
+  }
+
+  return Number.parseFloat(cleaned.replace(/,/g, "")) || 0
+}
+
+// Inline the function to avoid needing a bundler for ESM imports.
+// Must be kept in sync with app/javascript/utils/parse_amount_paste.js
+function parseAmountPaste(text, options = {}) {
+  const trimmed = typeof text === "string" ? text.trim() : ""
+  if (trimmed === "") return null
+
+  const negative = trimmed.startsWith("-") || /^\(.*\)$/.test(trimmed)
+
+  const body = trimmed
+    .replace(/^[+-]/, "")
+    .replace(/^[^\d]+/, "")
+    .replace(/[^\d]+$/, "")
+
+  if (!/^\d[\d.,\s]*$/.test(body)) return null
+
+  const parsed = parseLocaleFloat(body, options)
+  if (!Number.isFinite(parsed)) return null
+
+  return negative ? -parsed : parsed
+}
+
+describe("parseAmountPaste", () => {
+  describe("parses plain and locale-formatted amounts", () => {
+    it('parses "20,000 " as 20000', () => {
+      assert.equal(parseAmountPaste("20,000 "), 20000)
+    })
+
+    it('parses "1.234,56" as 1234.56', () => {
+      assert.equal(parseAmountPaste("1.234,56"), 1234.56)
+    })
+
+    it('parses "1 234.56" as 1234.56', () => {
+      assert.equal(parseAmountPaste("1 234.56"), 1234.56)
+    })
+
+    it('parses "0.00001234" as 0.00001234', () => {
+      assert.equal(parseAmountPaste("0.00001234"), 0.00001234)
+    })
+  })
+
+  describe("strips currency symbols and codes", () => {
+    it('parses "$1,234.56" as 1234.56', () => {
+      assert.equal(parseAmountPaste("$1,234.56"), 1234.56)
+    })
+
+    it('parses "USD 500" as 500', () => {
+      assert.equal(parseAmountPaste("USD 500"), 500)
+    })
+
+    it('parses "1,234.56 EUR" as 1234.56', () => {
+      assert.equal(parseAmountPaste("1,234.56 EUR"), 1234.56)
+    })
+  })
+
+  describe("handles negatives", () => {
+    it('parses "-45.20" as -45.2', () => {
+      assert.equal(parseAmountPaste("-45.20"), -45.2)
+    })
+
+    it('parses "(1,200.00)" as -1200', () => {
+      assert.equal(parseAmountPaste("(1,200.00)"), -1200)
+    })
+  })
+
+  describe("rejects text that is not an amount (returns null)", () => {
+    it('rejects "abc"', () => {
+      assert.equal(parseAmountPaste("abc"), null)
+    })
+
+    it('rejects ""', () => {
+      assert.equal(parseAmountPaste(""), null)
+    })
+
+    it('rejects "   "', () => {
+      assert.equal(parseAmountPaste("   "), null)
+    })
+
+    it('rejects "12/31/2025"', () => {
+      assert.equal(parseAmountPaste("12/31/2025"), null)
+    })
+
+    it('rejects "-"', () => {
+      assert.equal(parseAmountPaste("-"), null)
+    })
+
+    it("rejects null", () => {
+      assert.equal(parseAmountPaste(null), null)
+    })
+
+    it("rejects undefined", () => {
+      assert.equal(parseAmountPaste(undefined), null)
+    })
+  })
+})


### PR DESCRIPTION
Pasting an amount copied from a bank statement or a spreadsheet into a money
field usually does nothing. `20,000 `, `1.234,56`, `1 234.56`, `$1,234.56` — a
native `<input type="number">` rejects all of them and silently leaves the
field blank, so the value has to be retyped by hand. It is easy to not notice
until the form is submitted with a zero or an empty amount.

Money fields now intercept the paste, parse the text, and insert the plain
number. Typing is unaffected — only paste is intercepted.

`utils/parse_amount_paste` decides whether the clipboard holds an amount at
all. This matters because the existing `parseLocaleFloat` deliberately coerces
anything it cannot read to `0`, which is safe for its current callers but not
for a paste: a bare `parseLocaleFloat` would turn `$1,234.56`, `USD 500` and
`abc` alike into `0.00` written over the field, which is worse than the blank
field this set out to fix. So the text is validated first and unparseable text
returns `null`, leaving the browser to handle the paste. A leading or trailing
currency symbol or code is stripped, since both are common when copying from a
statement, and parenthesised amounts are read as negative per the usual
accounting export convention.

Precision comes from the amount input's `step`, which already carries the
selected currency's precision and is refreshed by `updateAmount` when the
currency select changes — so a BTC field keeps its eight decimals and a JPY
field keeps none, and it stays correct after an in-form currency switch.

Both `input` and `change` are dispatched after the value is assigned, since
assigning `.value` emits neither: `auto_submit_form` listens for `change` on
number inputs, while validation and the goal form's suggestion listen for
`input`.

The amount input's `data-action` is built by joining any caller-supplied action
with `paste->money-field#pasteAmount`, so callers that already bind their own
handler keep it. `goals/_form` is the only such caller today
(`input->goal-form#suggestedChanged`), and a controller test asserts both
actions survive on the rendered input.

Verified with `bin/rails test`, `bin/rubocop -f github`, `bundle exec erb_lint`,
`bin/brakeman --no-pager` and `npm run lint`. The parsing rules have 16 cases in
`test/javascript/parse_amount_paste_test.mjs`, following the same inlined
convention as the existing `parse_locale_float_test.mjs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved pasting amounts into money fields, including supported currency symbols, locale-specific formatting, and negative values.
  * Automatically formats pasted amounts according to each field’s precision.
  * Pasting now triggers both input and change updates for improved form responsiveness.

* **Bug Fixes**
  * Invalid or ambiguous clipboard content is safely ignored and handled by normal browser paste behavior.
  * Added paste handling to money fields while preserving existing form actions.
  * Unrecognized currency codes and punctuation are no longer incorrectly treated as currency symbols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->