### PR TITLE
fix(accounts): keep the entered current balance when it differs from the opening one

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -175,7 +175,10 @@ class Account < ApplicationRecord
       attrs = attributes.dup
       attrs[:cash_balance] = attrs[:balance] unless attrs.key?(:cash_balance)
       account = new(attrs)
-      initial_balance = attributes.dig(:accountable_attributes, :initial_balance)&.to_d
+      # Presence is read from the raw value: a blank form field arrives as ""
+      # and would convert to a very present-looking 0.
+      raw_initial_balance = attributes.dig(:accountable_attributes, :initial_balance)
+      initial_balance = raw_initial_balance.to_d if raw_initial_balance.present?
 
       transaction do
         account.save!
@@ -186,6 +189,29 @@ class Account < ApplicationRecord
           date: opening_balance_date
         )
         raise result.error if result.error
+
+        # When the opening balance differs from the entered current balance
+        # (a loan created with its original principal), the opening anchor is
+        # the account's only entry — the initial sync would recalculate
+        # today's balance back to it, silently discarding what the user just
+        # typed. Anchor today's balance too so both survive.
+        #
+        # Only when the opening anchor is on an earlier day: the opening date
+        # is user-supplied and may be today, and a same-day reconciliation
+        # would be matched to the opening anchor by date and overwrite it.
+        # On its own date the opening balance wins.
+        if initial_balance && initial_balance != account.balance && manager.opening_date < Date.current
+          # An explicit reconciliation, not CurrentBalanceManager: for cash
+          # accounts its transaction-adjustment strategy computes a zero delta
+          # here (account.balance already holds the entered value) and would
+          # only rewrite the opening anchor, leaving today's balance unanchored
+          # for the first sync.
+          reconciliation = Account::ReconciliationManager.new(account).reconcile_balance(
+            balance: account.balance,
+            date: Date.current
+          )
+          raise reconciliation.error_message unless reconciliation.success?
+        end
 
         account.auto_share_with_family! if account.family.share_all_by_default?
       end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -95,6 +95,95 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal 1000, opening_anchor.entry.amount
   end
 
+  test "create_and_sync keeps the entered current balance when it differs from the opening balance" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: 20_000, rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true
+    )
+
+    assert_equal 20_000, account.valuations.opening_anchor.first.entry.amount
+    # Without a today anchor, the initial sync would walk forward from the
+    # opening valuation and overwrite the entered 8,000 with 20,000.
+    today_valuation = account.entries.valuations.find_by(date: Date.current)
+    assert_not_nil today_valuation
+    assert_equal 8_000, today_valuation.amount
+  end
+
+  test "create_and_sync leaves the opening anchor alone when the opening balance date is today" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: 20_000, rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true,
+      opening_balance_date: Date.current
+    )
+
+    # Both balances land on the same day, so today's balance cannot be
+    # anchored without reusing (and overwriting) the opening anchor.
+    valuations = account.entries.valuations.where(date: Date.current)
+    assert_equal 1, valuations.count
+    assert_equal 20_000, valuations.first.amount
+    assert_equal "opening_anchor", valuations.first.entryable.kind
+  end
+
+  test "create_and_sync treats a blank initial balance as absent" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: "", rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true
+    )
+
+    assert_equal 8_000, account.valuations.opening_anchor.first.entry.amount
+    assert_nil account.entries.valuations.find_by(date: Date.current)
+  end
+
+  test "create_and_sync treats a zero initial balance as a real opening balance" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_and_sync(
+      {
+        family: @family,
+        owner: @admin,
+        name: "Student Loan",
+        balance: 8_000,
+        currency: "USD",
+        accountable_type: "Loan",
+        accountable_attributes: { initial_balance: 0, rate_type: "fixed", interest_rate: 4.5, term_months: 120 }
+      },
+      skip_initial_sync: true
+    )
+
+    assert_equal 0, account.valuations.opening_anchor.first.entry.amount
+    assert_equal 8_000, account.entries.valuations.find_by(date: Date.current)&.amount
+  end
+
   test "create_and_sync uses provided opening balance date" do
     Account.any_instance.stubs(:sync_later)
     opening_date = Time.zone.today


### PR DESCRIPTION
Cleaner resubmit of #3281, as requested — same fix, one commit.

### The problem

Create a loan with an opening balance that differs from its current balance —
original principal 250,000, remaining 180,000 — and the 180,000 is gone as soon
as the account syncs. The account shows 250,000.

`Account.create_and_sync` anchors only the opening balance, so that anchor is
the account's only entry and the initial sync walks forward from it, overwriting
the current balance the user just typed.

### The change

Anchor today's balance too, as an explicit same-day reconciliation, whenever the
two differ **and** the opening anchor sits on an earlier day.

The date guard is load-bearing. `opening_balance_date` is user-editable and can
be today, and `ReconciliationManager` matches an existing valuation by date
alone — `kind` is not part of the lookup. Without the guard it reuses the opening
anchor and reassigns its amount, which discards the opening balance and leaves a
`kind: "opening_anchor"` row holding the current balance. On its own date the
opening balance wins.

A direct reconciliation rather than `CurrentBalanceManager`: the manager's
cash-account strategy computes a zero delta at creation, because `account.balance`
already holds the entered value, so it would only rewrite the opening anchor and
leave today's balance unanchored for the first sync.

`initial_balance`'s presence is read from the raw value, since `"".to_d` is `0`.
A blank field would otherwise record an opening balance of 0 and, because 0
differs from the entered balance, write a reconciliation on top of it. An
explicit 0 is still a real opening balance.

`initial_balance` is a `Loan` attribute today, so the loan regression tests cover
the reachable path.

### Verification

`bin/rails test`, `bin/rubocop -f github`, `bin/brakeman --no-pager`, all green.
Four regression tests in `account_test.rb` cover the differing-balance case, the
opening date falling on today, and an explicit zero opening balance; they fail
against `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account setup when entering an opening balance.
  - Blank opening balances are now treated as unspecified rather than zero.
  - Preserves both the opening balance and the entered current balance when they differ and the opening date is earlier than today.
  - Correctly handles zero opening balances and opening balances dated today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->