### PR TITLE
fix: normalize Fidelity SimpleFIN transaction signs

### DIFF
--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -24,9 +24,10 @@ class Account::ProviderImportAdapter
   # @param notes [String, nil] Optional transaction notes/memo
   # @param pending_transaction_id [String, nil] Plaid's linking ID for pending→posted reconciliation
   # @param extra [Hash, nil] Optional provider-specific metadata to merge into transaction.extra
+  # @param extra_keys_to_remove [Array<Array<String>>] Nested metadata paths to remove after merging
   # @param investment_activity_label [String, nil] Optional activity type label (e.g., "Buy", "Dividend")
   # @return [Entry] The created or updated entry
-  def import_transaction(external_id:, amount:, currency:, date:, name:, source:, category_id: nil, kind: nil, merchant: nil, notes: nil, pending_transaction_id: nil, extra: nil, investment_activity_label: nil)
+  def import_transaction(external_id:, amount:, currency:, date:, name:, source:, category_id: nil, kind: nil, merchant: nil, notes: nil, pending_transaction_id: nil, extra: nil, extra_keys_to_remove: [], investment_activity_label: nil)
     raise ArgumentError, "external_id is required" if external_id.blank?
     raise ArgumentError, "source is required" if source.blank?
 
@@ -195,10 +196,15 @@ class Account::ProviderImportAdapter
       end
 
       # Persist extra provider metadata on the transaction (non-enriched; always merged)
-      if extra.present? && entry.entryable.is_a?(Transaction)
+      if (extra.present? || extra_keys_to_remove.present?) && entry.entryable.is_a?(Transaction)
         existing = entry.transaction.extra || {}
         incoming = extra.is_a?(Hash) ? extra.deep_stringify_keys : {}
-        entry.transaction.extra = existing.deep_merge(incoming)
+        merged = existing.deep_merge(incoming)
+        extra_keys_to_remove.each do |path|
+          parent = merged.dig(*path[0...-1])
+          parent.delete(path.last) if parent.is_a?(Hash)
+        end
+        entry.transaction.extra = merged
         entry.transaction.save!
       end
 

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -59,7 +59,8 @@ class SimplefinEntry::Processor
       source: "simplefin",
       merchant: merchant,
       notes: notes,
-      extra: extra_metadata
+      extra: extra_metadata,
+      extra_keys_to_remove: amount_normalization_keys_to_remove
     )
   end
 
@@ -180,6 +181,12 @@ class SimplefinEntry::Processor
 
     def amount_normalization
       amount_normalization_rule&.first&.to_s
+    end
+
+    # Remove a marker from a prior Fidelity sync when current institution metadata no
+    # longer selects Fidelity's rules. New unsupported-institution imports remain keyless.
+    def amount_normalization_keys_to_remove
+      institution_amount_normalization_rules ? [] : [ %w[simplefin amount_normalization] ]
     end
 
     def amount_normalization_direction

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -8,8 +8,9 @@ class SimplefinEntry::Processor
     eft_paid: { direction: :expense, pattern: /\AEFT\s+PAID\b/i },
     direct_deposit: { direction: :income, pattern: /\ADIRECT\s+DEPOSIT\b/i },
     check_received: { direction: :income, pattern: /\ACHECK\s+RECEIVED\b/i },
-    dividend: { direction: :income, pattern: /\ADIVIDEND\b/i }
+    dividend: { direction: :income, pattern: /\ADIVIDEND(?:\s+(?:PAYMENT|RECEIVED|INCOME|CREDIT))?\z/i }
   }.freeze
+  FIDELITY_ORGANIZATION = /\AFidelity Investments\b/i
   AMBIGUOUS_AMOUNT_TERMS = /\b(?:REVERS|RETURN|REFUND|REINVEST)/i
   # simplefin_transaction is the raw hash fetched from SimpleFin API and converted to JSONB
   # @param import_adapter [Account::ProviderImportAdapter, nil] Optional shared adapter for accumulating skipped entries
@@ -176,6 +177,7 @@ class SimplefinEntry::Processor
     end
 
     def amount_normalization_rule
+      return unless fidelity_account?
       return if amount_descriptor_fields.any? { |value| value.match?(AMBIGUOUS_AMOUNT_TERMS) }
 
       @amount_normalization_rule ||= AMOUNT_NORMALIZATION_RULES.find do |_name, rule|
@@ -184,7 +186,12 @@ class SimplefinEntry::Processor
     end
 
     def amount_descriptor_fields
-      [ data[:payee], data[:description], data[:memo] ].filter_map { |value| value.to_s.strip.presence }
+      [ data[:description] ].filter_map { |value| value.to_s.strip.presence }
+    end
+
+    def fidelity_account?
+      institution_name = simplefin_account.org_data.to_h.with_indifferent_access[:name]
+      institution_name.to_s.match?(FIDELITY_ORGANIZATION)
     end
 
     def currency

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -2,6 +2,15 @@ require "digest/md5"
 
 class SimplefinEntry::Processor
   include CurrencyNormalizable
+
+  AMOUNT_NORMALIZATION_RULES = {
+    direct_debit: { direction: :expense, pattern: /\ADIRECT\s+DEBIT\b/i },
+    eft_paid: { direction: :expense, pattern: /\AEFT\s+PAID\b/i },
+    direct_deposit: { direction: :income, pattern: /\ADIRECT\s+DEPOSIT\b/i },
+    check_received: { direction: :income, pattern: /\ACHECK\s+RECEIVED\b/i },
+    dividend: { direction: :income, pattern: /\ADIVIDEND\b/i }
+  }.freeze
+  AMBIGUOUS_AMOUNT_TERMS = /\b(?:REVERS|RETURN|REFUND|REINVEST)/i
   # simplefin_transaction is the raw hash fetched from SimpleFin API and converted to JSONB
   # @param import_adapter [Account::ProviderImportAdapter, nil] Optional shared adapter for accumulating skipped entries
   def initialize(simplefin_transaction, simplefin_account:, import_adapter: nil)
@@ -94,6 +103,8 @@ class SimplefinEntry::Processor
         sf["fx_date"] = fx_d&.to_s
       end
 
+      sf["amount_normalization"] = amount_normalization
+
       return nil if sf.empty?
       { "simplefin" => sf }
     end
@@ -144,6 +155,9 @@ class SimplefinEntry::Processor
         BigDecimal("0")
       end
 
+      return parsed_amount.abs if amount_normalization_direction == :expense
+      return -parsed_amount.abs if amount_normalization_direction == :income
+
       # SimpleFin uses banking convention (expenses negative, income positive)
       # Maybe expects opposite convention (expenses positive, income negative)
       # So we negate the amount to convert from SimpleFin to Maybe format
@@ -151,6 +165,26 @@ class SimplefinEntry::Processor
     rescue ArgumentError => e
       Rails.logger.error "Failed to parse SimpleFin transaction amount: #{data[:amount].inspect} - #{e.message}"
       raise
+    end
+
+    def amount_normalization
+      amount_normalization_rule&.first&.to_s
+    end
+
+    def amount_normalization_direction
+      amount_normalization_rule&.last&.fetch(:direction)
+    end
+
+    def amount_normalization_rule
+      return if amount_descriptor_fields.any? { |value| value.match?(AMBIGUOUS_AMOUNT_TERMS) }
+
+      @amount_normalization_rule ||= AMOUNT_NORMALIZATION_RULES.find do |_name, rule|
+        amount_descriptor_fields.any? { |value| value.match?(rule.fetch(:pattern)) }
+      end
+    end
+
+    def amount_descriptor_fields
+      [ data[:payee], data[:description], data[:memo] ].filter_map { |value| value.to_s.strip.presence }
     end
 
     def currency

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -3,14 +3,21 @@ require "digest/md5"
 class SimplefinEntry::Processor
   include CurrencyNormalizable
 
-  AMOUNT_NORMALIZATION_RULES = {
+  # Institution-specific sign normalization. SimpleFIN reports some Fidelity transaction
+  # signs inconsistently, so descriptors with an unambiguous direction are normalized.
+  # Keyed by an org_data name pattern so another institution can add its own rules
+  # without changing how existing ones match.
+  FIDELITY_ORGANIZATION = /\AFidelity Investments\b/i
+  FIDELITY_AMOUNT_NORMALIZATION_RULES = {
     direct_debit: { direction: :expense, pattern: /\ADIRECT\s+DEBIT\b/i },
     eft_paid: { direction: :expense, pattern: /\AEFT\s+PAID\b/i },
     direct_deposit: { direction: :income, pattern: /\ADIRECT\s+DEPOSIT\b/i },
     check_received: { direction: :income, pattern: /\ACHECK\s+RECEIVED\b/i },
     dividend: { direction: :income, pattern: /\ADIVIDEND(?:\s+(?:PAYMENT|RECEIVED|INCOME|CREDIT))?\z/i }
   }.freeze
-  FIDELITY_ORGANIZATION = /\AFidelity Investments\b/i
+  INSTITUTION_AMOUNT_NORMALIZATION_RULES = {
+    FIDELITY_ORGANIZATION => FIDELITY_AMOUNT_NORMALIZATION_RULES
+  }.freeze
   AMBIGUOUS_AMOUNT_TERMS = /\b(?:REVERS|RETURN|REFUND|REINVEST)/i
   # simplefin_transaction is the raw hash fetched from SimpleFin API and converted to JSONB
   # @param import_adapter [Account::ProviderImportAdapter, nil] Optional shared adapter for accumulating skipped entries
@@ -104,7 +111,10 @@ class SimplefinEntry::Processor
         sf["fx_date"] = fx_d&.to_s
       end
 
-      sf["amount_normalization"] = amount_normalization
+      # Only institutions with normalization rules carry this key. For them it is always
+      # set (rule name or nil) so a resync whose descriptor becomes unmapped or ambiguous
+      # overwrites a stale value via deep_merge. Other institutions' metadata is unchanged.
+      sf["amount_normalization"] = amount_normalization if institution_amount_normalization_rules
 
       return nil if sf.empty?
       { "simplefin" => sf }
@@ -177,21 +187,34 @@ class SimplefinEntry::Processor
     end
 
     def amount_normalization_rule
-      return unless fidelity_account?
+      return @amount_normalization_rule if defined?(@amount_normalization_rule)
+
+      @amount_normalization_rule = find_amount_normalization_rule
+    end
+
+    def find_amount_normalization_rule
+      rules = institution_amount_normalization_rules
+      return if rules.nil?
       return if amount_descriptor_fields.any? { |value| value.match?(AMBIGUOUS_AMOUNT_TERMS) }
 
-      @amount_normalization_rule ||= AMOUNT_NORMALIZATION_RULES.find do |_name, rule|
+      rules.find do |_name, rule|
         amount_descriptor_fields.any? { |value| value.match?(rule.fetch(:pattern)) }
       end
     end
 
     def amount_descriptor_fields
-      [ data[:description] ].filter_map { |value| value.to_s.strip.presence }
+      @amount_descriptor_fields ||= [ data[:description] ].filter_map { |value| value.to_s.strip.presence }
     end
 
-    def fidelity_account?
-      institution_name = simplefin_account.org_data.to_h.with_indifferent_access[:name]
-      institution_name.to_s.match?(FIDELITY_ORGANIZATION)
+    # Rules for the account's institution, or nil when it has no sign normalization.
+    # org_data is raw provider JSON, so it may be nil, a non-Hash value, or lack a name.
+    def institution_amount_normalization_rules
+      return @institution_amount_normalization_rules if defined?(@institution_amount_normalization_rules)
+
+      org = simplefin_account.org_data
+      institution_name = org.is_a?(Hash) ? (org["name"] || org[:name]).to_s : ""
+      _organization, rules = INSTITUTION_AMOUNT_NORMALIZATION_RULES.find { |organization, _rules| institution_name.match?(organization) }
+      @institution_amount_normalization_rules = rules
     end
 
     def currency

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -13,6 +13,7 @@ class SimplefinEntry::Processor
     eft_paid: { direction: :expense, pattern: /\AEFT\s+PAID\b/i },
     direct_deposit: { direction: :income, pattern: /\ADIRECT\s+DEPOSIT\b/i },
     check_received: { direction: :income, pattern: /\ACHECK\s+RECEIVED\b/i },
+    card_payment: { direction: :income, pattern: /\APAYMENT MADE BY ACCOUNT ENDING IN:\s*\d+\z/i },
     dividend: { direction: :income, pattern: /\ADIVIDEND(?:\s+(?:PAYMENT|RECEIVED|INCOME|CREDIT))?\z/i }
   }.freeze
   INSTITUTION_AMOUNT_NORMALIZATION_RULES = {

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -10,16 +10,29 @@ class SimplefinEntry::Processor
   FIDELITY_ORGANIZATION = /\AFidelity Investments\b/i
   FIDELITY_AMOUNT_NORMALIZATION_RULES = {
     direct_debit: { direction: :expense, pattern: /\ADIRECT\s+DEBIT\b/i },
-    eft_paid: { direction: :expense, pattern: /\AEFT\s+PAID\b/i },
+    eft_paid: { direction: :expense, pattern: /\A(?:EFT\s+PAID|ELECTRONIC\s+FUNDS\s+TRANSFER\s+PAID)\b/i },
     direct_deposit: { direction: :income, pattern: /\ADIRECT\s+DEPOSIT\b/i },
+    rollover_check: { direction: :income, pattern: /\AROLLOVER\s+CASH\s+CHECK\s+RECEIVED\b/i },
     check_received: { direction: :income, pattern: /\ACHECK\s+RECEIVED\b/i },
+    check_paid: { direction: :expense, pattern: /\ACHECK\s+PAID\b/i },
+    wire_out: { direction: :expense, pattern: /\AWIRE\s+TRANSFER\s+TO\s+BANK\b/i },
+    cash_advance: { direction: :expense, pattern: /\ACASH\s+ADVANCE\b/i },
+    fee: { direction: :expense, pattern: /\A(?:ADJUST\s+)?FEE\s+CHARGED\b/i },
+    core_purchase: { direction: :expense, pattern: /\APURCHASE\s+INTO\s+CORE\s+ACCOUNT\b/i },
+    core_redemption: { direction: :income, pattern: /\AREDEMPTION\s+FROM\s+CORE\s+ACCOUNT\b/i },
     card_payment: { direction: :income, pattern: /\APAYMENT MADE BY ACCOUNT ENDING IN:\s*\d+\z/i },
-    dividend: { direction: :income, pattern: /\ADIVIDEND(?:\s+(?:PAYMENT|RECEIVED|INCOME|CREDIT))?\z/i }
+    interest: { direction: :income, pattern: /\AINTEREST\s+FULLY\s+PAID\b/i },
+    reinvestment: { direction: :expense, pattern: /\AREINVESTMENT\b/i },
+    cash_in_lieu: { direction: :income, pattern: /\AIN\s+LIEU\s+OF\s+FRX\s+SHARE\s+LEU\s+PAYOUT\b/i },
+    dividend: {
+      direction: :income,
+      pattern: /\A(?:DIVIDEND\s+RECEIVED\b(?!.*\b(?:TAX|WITHHOLDING)\b)|DIVIDEND(?:\s+(?:PAYMENT|INCOME|CREDIT))?\z)/i
+    }
   }.freeze
   INSTITUTION_AMOUNT_NORMALIZATION_RULES = {
     FIDELITY_ORGANIZATION => FIDELITY_AMOUNT_NORMALIZATION_RULES
   }.freeze
-  AMBIGUOUS_AMOUNT_TERMS = /\b(?:REVERS|RETURN|REFUND|REINVEST)/i
+  AMBIGUOUS_AMOUNT_TERMS = /\b(?:REVERS|RETURN|REFUND)/i
   # simplefin_transaction is the raw hash fetched from SimpleFin API and converted to JSONB
   # @param import_adapter [Account::ProviderImportAdapter, nil] Optional shared adapter for accumulating skipped entries
   def initialize(simplefin_transaction, simplefin_account:, import_adapter: nil)

--- a/app/models/simplefin_entry/processor.rb
+++ b/app/models/simplefin_entry/processor.rb
@@ -17,6 +17,7 @@ class SimplefinEntry::Processor
     check_paid: { direction: :expense, pattern: /\ACHECK\s+PAID\b/i },
     wire_out: { direction: :expense, pattern: /\AWIRE\s+TRANSFER\s+TO\s+BANK\b/i },
     cash_advance: { direction: :expense, pattern: /\ACASH\s+ADVANCE\b/i },
+    fee_rebate: { direction: :income, pattern: /\A(?:ADJUST\s+)?FEE\s+CHARGED\s+ATM\s+FEE\s+REBATE\b/i },
     fee: { direction: :expense, pattern: /\A(?:ADJUST\s+)?FEE\s+CHARGED\b/i },
     core_purchase: { direction: :expense, pattern: /\APURCHASE\s+INTO\s+CORE\s+ACCOUNT\b/i },
     core_redemption: { direction: :income, pattern: /\AREDEMPTION\s+FROM\s+CORE\s+ACCOUNT\b/i },

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -1483,6 +1483,33 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
   # entry is found by find_or_initialize_by (persisted), bypassing auto-claim.
   # =========================================================================
 
+  test "removes only explicitly requested extra metadata keys" do
+    entry = @adapter.import_transaction(
+      external_id: "simplefin_metadata_cleanup",
+      amount: 10.0,
+      currency: "USD",
+      date: Date.today,
+      name: "DIRECT DEBIT",
+      source: "simplefin",
+      extra: { "simplefin" => { "pending" => false, "amount_normalization" => "direct_debit" } }
+    )
+
+    entry = @adapter.import_transaction(
+      external_id: "simplefin_metadata_cleanup",
+      amount: -10.0,
+      currency: "USD",
+      date: Date.today,
+      name: "DIRECT DEBIT",
+      source: "simplefin",
+      extra: { "simplefin" => { "pending" => false } },
+      extra_keys_to_remove: [ %w[simplefin amount_normalization] ]
+    )
+
+    sf = entry.transaction.extra.fetch("simplefin")
+    assert_equal false, sf.fetch("pending")
+    assert_not sf.key?("amount_normalization")
+  end
+
   test "clears pending flag when same external_id is reused for booked version (not user-modified)" do
     pending_entry = @adapter.import_transaction(
       external_id: "eb_same_id_123",

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -1501,7 +1501,7 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
       date: Date.today,
       name: "DIRECT DEBIT",
       source: "simplefin",
-      extra: { "simplefin" => { "pending" => false } },
+      extra: nil,
       extra_keys_to_remove: [ %w[simplefin amount_normalization] ]
     )
 

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -388,7 +388,39 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
 
     entry = @account.entries.find_by!(external_id: "simplefin_tx_other_institution_direct_debit", source: "simplefin")
     assert_equal BigDecimal("-25.00"), entry.amount
-    assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
+    sf = entry.transaction.extra.fetch("simplefin")
+    assert_not sf.key?("amount_normalization"), "expected non-Fidelity transactions to carry no amount_normalization key"
+  end
+
+  test "does not raise or normalize when org_data is missing or malformed" do
+    cases = {
+      "nil" => nil,
+      "empty" => {},
+      "no_name" => { "domain" => "fidelity.com" },
+      "non_string_name" => { "name" => 123 },
+      "json_string" => "Fidelity Investments",
+      "json_array" => [ "Fidelity Investments" ]
+    }
+
+    cases.each do |label, org_data|
+      @simplefin_account.update!(org_data: org_data)
+      tx = {
+        id: "tx_org_data_#{label}",
+        amount: "25.00",
+        currency: "USD",
+        description: "DIRECT DEBIT",
+        posted: Date.current.to_s
+      }
+
+      assert_nothing_raised do
+        SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+      end
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_org_data_#{label}", source: "simplefin")
+      assert_equal BigDecimal("-25.00"), entry.amount, "expected org_data #{label} to fall back to upstream sign behavior"
+      sf = entry.transaction.extra.fetch("simplefin")
+      assert_not sf.key?("amount_normalization"), "expected org_data #{label} to carry no amount_normalization key"
+    end
   end
 
   test "leaves ambiguous and unmapped descriptions on upstream sign behavior" do
@@ -437,5 +469,28 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
     entry.reload
     assert_equal BigDecimal("-10.00"), entry.amount
     assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
+  test "clears stale normalization metadata when a resynced descriptor becomes unmapped" do
+    tx = {
+      id: "tx_normalization_resync_2",
+      amount: "-40.00",
+      currency: "USD",
+      description: "DIRECT DEPOSIT",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_normalization_resync_2", source: "simplefin")
+    assert_equal "direct_deposit", entry.transaction.extra.dig("simplefin", "amount_normalization")
+
+    tx[:description] = "PURCHASE"
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry.reload
+    assert_equal BigDecimal("40.00"), entry.amount
+    sf = entry.transaction.extra.fetch("simplefin")
+    assert sf.key?("amount_normalization"), "expected Fidelity transactions to keep the key so stale values are overwritten"
+    assert_nil sf["amount_normalization"]
   end
 end

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -17,6 +17,7 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
       currency: "USD",
       current_balance: 1000,
       available_balance: 1000,
+      org_data: { name: "Fidelity Investments" },
       account: @account
     )
   end
@@ -301,7 +302,7 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
       id: "tx_direct_deposit_1",
       amount: "-80.00",
       currency: "USD",
-      payee: "  direct   deposit payroll ",
+      description: "  direct   deposit payroll ",
       posted: Date.current.to_s
     }
 
@@ -324,7 +325,7 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
         id: "tx_semantic_class_#{index}",
         amount: raw_amount,
         currency: "USD",
-        memo: description,
+        description: description,
         posted: Date.current.to_s
       }
 
@@ -334,6 +335,60 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
       assert_equal expected_amount, entry.amount
       assert_equal normalization, entry.transaction.extra.dig("simplefin", "amount_normalization")
     end
+  end
+
+  test "leaves dividend expenses on upstream sign behavior" do
+    [ "DIVIDEND TAX", "DIVIDEND WITHHOLDING" ].each_with_index do |description, index|
+      tx = {
+        id: "tx_dividend_expense_#{index}",
+        amount: "-7.00",
+        currency: "USD",
+        description: description,
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_dividend_expense_#{index}", source: "simplefin")
+      assert_equal BigDecimal("7.00"), entry.amount
+      assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
+    end
+  end
+
+  test "does not derive Fidelity transaction direction from merchant text" do
+    [ "Dividend Finance", "Direct Deposit Cafe" ].each_with_index do |payee, index|
+      tx = {
+        id: "tx_fidelity_merchant_#{index}",
+        amount: "-100.00",
+        currency: "USD",
+        payee: payee,
+        description: "PURCHASE",
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_fidelity_merchant_#{index}", source: "simplefin")
+      assert_equal BigDecimal("100.00"), entry.amount
+      assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
+    end
+  end
+
+  test "does not normalize transaction signs for non-Fidelity institutions" do
+    @simplefin_account.update!(org_data: { name: "Example Credit Union" })
+    tx = {
+      id: "tx_other_institution_direct_debit",
+      amount: "25.00",
+      currency: "USD",
+      description: "DIRECT DEBIT",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_other_institution_direct_debit", source: "simplefin")
+    assert_equal BigDecimal("-25.00"), entry.amount
+    assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
   end
 
   test "leaves ambiguous and unmapped descriptions on upstream sign behavior" do

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -279,4 +279,108 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
     sf = entry.transaction.extra.fetch("simplefin")
     assert_equal false, sf["pending"], "expected a non-numeric posted value to not be inferred as pending"
   end
+
+  test "normalizes a direct debit to a positive Sure expense" do
+    tx = {
+      id: "tx_direct_debit_1",
+      amount: "25.00",
+      currency: "USD",
+      description: "DIRECT DEBIT",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_direct_debit_1", source: "simplefin")
+    assert_equal BigDecimal("25.00"), entry.amount
+    assert_equal "direct_debit", entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
+  test "normalizes a direct deposit to negative Sure income" do
+    tx = {
+      id: "tx_direct_deposit_1",
+      amount: "-80.00",
+      currency: "USD",
+      payee: "  direct   deposit payroll ",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_direct_deposit_1", source: "simplefin")
+    assert_equal BigDecimal("-80.00"), entry.amount
+    assert_equal "direct_deposit", entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
+  test "normalizes mapped transaction classes by semantic direction" do
+    cases = [
+      [ "eft_paid", "EFT PAID UTILITY", "35.00", BigDecimal("35.00") ],
+      [ "check_received", "CHECK RECEIVED", "-120.00", BigDecimal("-120.00") ],
+      [ "dividend", "DIVIDEND PAYMENT", "-9.50", BigDecimal("-9.50") ]
+    ]
+
+    cases.each_with_index do |(normalization, description, raw_amount, expected_amount), index|
+      tx = {
+        id: "tx_semantic_class_#{index}",
+        amount: raw_amount,
+        currency: "USD",
+        memo: description,
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_semantic_class_#{index}", source: "simplefin")
+      assert_equal expected_amount, entry.amount
+      assert_equal normalization, entry.transaction.extra.dig("simplefin", "amount_normalization")
+    end
+  end
+
+  test "leaves ambiguous and unmapped descriptions on upstream sign behavior" do
+    cases = [
+      [ "DIRECT DEBIT REVERSAL", "10.00" ],
+      [ "DIRECT DEBIT RETURNED", "11.00" ],
+      [ "DIRECT DEBIT REVERSED", "12.00" ],
+      [ "DIRECT DEPOSIT REFUNDED", "13.00" ],
+      [ "DIVIDEND REINVESTMENT", "14.00" ],
+      [ "REINVESTMENT", "15.00" ]
+    ]
+
+    cases.each_with_index do |(description, raw_amount), index|
+      tx = {
+        id: "tx_unmapped_class_#{index}",
+        amount: raw_amount,
+        currency: "USD",
+        description: description,
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_unmapped_class_#{index}", source: "simplefin")
+      assert_equal BigDecimal("-#{raw_amount}"), entry.amount
+      assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
+    end
+  end
+
+  test "clears stale normalization metadata when a resynced descriptor becomes ambiguous" do
+    tx = {
+      id: "tx_normalization_resync_1",
+      amount: "10.00",
+      currency: "USD",
+      description: "DIRECT DEBIT",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_normalization_resync_1", source: "simplefin")
+    assert_equal "direct_debit", entry.transaction.extra.dig("simplefin", "amount_normalization")
+
+    tx[:description] = "DIRECT DEBIT REVERSAL"
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry.reload
+    assert_equal BigDecimal("-10.00"), entry.amount
+    assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
 end

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -471,6 +471,35 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
     assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
   end
 
+  test "clears stale normalization metadata when account changes from Fidelity" do
+    {
+      "unsupported" => { name: "Example Credit Union" },
+      "malformed" => "Fidelity Investments"
+    }.each do |label, org_data|
+      @simplefin_account.update!(org_data: { name: "Fidelity Investments" })
+      tx = {
+        id: "tx_normalization_institution_transition_#{label}",
+        amount: "10.00",
+        currency: "USD",
+        description: "DIRECT DEBIT",
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+      entry = @account.entries.find_by!(external_id: "simplefin_#{tx[:id]}", source: "simplefin")
+      assert_equal BigDecimal("10.00"), entry.amount
+      assert_equal "direct_debit", entry.transaction.extra.dig("simplefin", "amount_normalization")
+
+      @simplefin_account.update!(org_data: org_data)
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry.reload
+      assert_equal BigDecimal("-10.00"), entry.amount
+      sf = entry.transaction.extra.fetch("simplefin")
+      assert_not sf.key?("amount_normalization"), "expected #{label} transition to remove stale normalization metadata"
+    end
+  end
+
   test "clears stale normalization metadata when a resynced descriptor becomes unmapped" do
     tx = {
       id: "tx_normalization_resync_2",

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -316,6 +316,7 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
   test "normalizes mapped transaction classes by semantic direction" do
     cases = [
       [ "eft_paid", "EFT PAID UTILITY", "35.00", BigDecimal("35.00") ],
+      [ "eft_paid", "ELECTRONIC FUNDS TRANSFER PAID (CASH)", "35.00", BigDecimal("35.00") ],
       [ "check_received", "CHECK RECEIVED", "-120.00", BigDecimal("-120.00") ],
       [ "dividend", "DIVIDEND PAYMENT", "-9.50", BigDecimal("-9.50") ]
     ]
@@ -337,6 +338,54 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "normalizes Fidelity rollover checks to negative Sure inflows" do
+    tx = {
+      id: "tx_rollover_check_1",
+      amount: "-171645.83",
+      currency: "USD",
+      description: "ROLLOVER CASH CHECK RECEIVED IRA DIR ROLOVR MOBILE DEPOSIT (CASH)",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_rollover_check_1", source: "simplefin")
+    assert_equal BigDecimal("-171645.83"), entry.amount
+    assert_equal "rollover_check", entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
+  test "normalizes Fidelity core-account purchases to positive Sure outflows" do
+    tx = {
+      id: "tx_core_purchase_1",
+      amount: "216.21",
+      currency: "USD",
+      description: "PURCHASE INTO CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (CASH)",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_core_purchase_1", source: "simplefin")
+    assert_equal BigDecimal("216.21"), entry.amount
+    assert_equal "core_purchase", entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
+  test "marks Fidelity core-account redemptions as negative Sure inflows" do
+    tx = {
+      id: "tx_core_redemption_1",
+      amount: "3533.18",
+      currency: "USD",
+      description: "REDEMPTION FROM CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (CASH)",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_core_redemption_1", source: "simplefin")
+    assert_equal BigDecimal("-3533.18"), entry.amount
+    assert_equal "core_redemption", entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
   test "normalizes Fidelity card payments to negative Sure inflows" do
     [ "2303.00", "-2303.00" ].each_with_index do |raw_amount, index|
       tx = {
@@ -352,6 +401,50 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
       entry = @account.entries.find_by!(external_id: "simplefin_tx_card_payment_#{index}", source: "simplefin")
       assert_equal BigDecimal("-2303.00"), entry.amount
       assert_equal "card_payment", entry.transaction.extra.dig("simplefin", "amount_normalization")
+    end
+  end
+
+  test "marks Fidelity security dividends as negative Sure income" do
+    tx = {
+      id: "tx_security_dividend_1",
+      amount: "204.70",
+      currency: "USD",
+      description: "DIVIDEND RECEIVED PROSHARES BITCOIN ETF (BITO) (MARGIN)",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_security_dividend_1", source: "simplefin")
+    assert_equal BigDecimal("-204.70"), entry.amount
+    assert_equal "dividend", entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
+  test "normalizes the observed Fidelity cash-action matrix" do
+    cases = [
+      [ "check_paid", "CHECK PAID # 1234 (CASH)", "44.63", BigDecimal("44.63") ],
+      [ "wire_out", "WIRE TRANSFER TO BANK (CASH)", "500.00", BigDecimal("500.00") ],
+      [ "cash_advance", "CASH ADVANCE ATM (CASH)", "202.95", BigDecimal("202.95") ],
+      [ "fee", "ADJUST FEE CHARGED ATM FEE REBATE (CASH)", "2.95", BigDecimal("2.95") ],
+      [ "interest", "INTEREST FULLY PAID (CASH)", "-18.16", BigDecimal("-18.16") ],
+      [ "reinvestment", "REINVESTMENT PROSHARES BITCOIN ETF (BITO) (MARGIN)", "4.30", BigDecimal("4.30") ],
+      [ "cash_in_lieu", "IN LIEU OF FRX SHARE LEU PAYOUT SECURITY (CASH)", "-3.11", BigDecimal("-3.11") ]
+    ]
+
+    cases.each_with_index do |(normalization, description, raw_amount, expected_amount), index|
+      tx = {
+        id: "tx_fidelity_cash_action_#{index}",
+        amount: raw_amount,
+        currency: "USD",
+        description: description,
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_fidelity_cash_action_#{index}", source: "simplefin")
+      assert_equal expected_amount, entry.amount
+      assert_equal normalization, entry.transaction.extra.dig("simplefin", "amount_normalization")
     end
   end
 
@@ -454,8 +547,7 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
       [ "DIRECT DEBIT RETURNED", "11.00" ],
       [ "DIRECT DEBIT REVERSED", "12.00" ],
       [ "DIRECT DEPOSIT REFUNDED", "13.00" ],
-      [ "DIVIDEND REINVESTMENT", "14.00" ],
-      [ "REINVESTMENT", "15.00" ]
+      [ "DIVIDEND REINVESTMENT", "14.00" ]
     ]
 
     cases.each_with_index do |(description, raw_amount), index|
@@ -471,6 +563,32 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
 
       entry = @account.entries.find_by!(external_id: "simplefin_tx_unmapped_class_#{index}", source: "simplefin")
       assert_equal BigDecimal("-#{raw_amount}"), entry.amount
+      assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
+    end
+  end
+
+  test "preserves Fidelity nonfinancial and mixed-leg action signs" do
+    cases = [
+      [ "INCREASE COLLATERAL MARK TO MARKET ADJ COLLATERAL DELV TO US BANK NA SECURI... (L0C990063) (FINANCING)", "0", BigDecimal("0") ],
+      [ "DECREASE COLLATERAL MARK TO MARKET ADJ COLLATERAL DELV TO US BANK NA SECURI... (L0C990063) (FINANCING)", "0", BigDecimal("0") ],
+      [ "YOU LOANED VS X20-123-2 PROSHARES BITCOIN ETF (BITO) (FINANCING)", "-1217.58", BigDecimal("1217.58") ],
+      [ "LOAN RETURNED YOU RETURNED VS X20-123-2 PROSHARES BITCOIN ETF (BITO) (FINANCING)", "1217.58", BigDecimal("-1217.58") ],
+      [ "REVERSE SPLIT R/S FROM 92891H606#REOR M0051756140001 VS TRUST 2X LONG VIX FUT (UVIX) (FINANCING)", "335.00", BigDecimal("-335.00") ]
+    ]
+
+    cases.each_with_index do |(description, raw_amount, expected_amount), index|
+      tx = {
+        id: "tx_fidelity_passthrough_#{index}",
+        amount: raw_amount,
+        currency: "USD",
+        description: description,
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_fidelity_passthrough_#{index}", source: "simplefin")
+      assert_equal expected_amount, entry.amount
       assert_nil entry.transaction.extra.dig("simplefin", "amount_normalization")
     end
   end

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -404,6 +404,22 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "normalizes Fidelity ATM fee rebates to negative Sure inflows" do
+    tx = {
+      id: "tx_atm_fee_rebate_1",
+      amount: "-2.95",
+      currency: "USD",
+      description: "ADJUST FEE CHARGED ATM FEE REBATE (CASH)",
+      posted: Date.current.to_s
+    }
+
+    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+    entry = @account.entries.find_by!(external_id: "simplefin_tx_atm_fee_rebate_1", source: "simplefin")
+    assert_equal BigDecimal("-2.95"), entry.amount
+    assert_equal "fee_rebate", entry.transaction.extra.dig("simplefin", "amount_normalization")
+  end
+
   test "marks Fidelity security dividends as negative Sure income" do
     tx = {
       id: "tx_security_dividend_1",
@@ -425,7 +441,7 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
       [ "check_paid", "CHECK PAID # 1234 (CASH)", "44.63", BigDecimal("44.63") ],
       [ "wire_out", "WIRE TRANSFER TO BANK (CASH)", "500.00", BigDecimal("500.00") ],
       [ "cash_advance", "CASH ADVANCE ATM (CASH)", "202.95", BigDecimal("202.95") ],
-      [ "fee", "ADJUST FEE CHARGED ATM FEE REBATE (CASH)", "2.95", BigDecimal("2.95") ],
+      [ "fee", "ADJUST FEE CHARGED ATM SURCHARGE (CASH)", "-2.95", BigDecimal("2.95") ],
       [ "interest", "INTEREST FULLY PAID (CASH)", "-18.16", BigDecimal("-18.16") ],
       [ "reinvestment", "REINVESTMENT PROSHARES BITCOIN ETF (BITO) (MARGIN)", "4.30", BigDecimal("4.30") ],
       [ "cash_in_lieu", "IN LIEU OF FRX SHARE LEU PAYOUT SECURITY (CASH)", "-3.11", BigDecimal("-3.11") ]

--- a/test/models/simplefin_entry/processor_test.rb
+++ b/test/models/simplefin_entry/processor_test.rb
@@ -337,6 +337,24 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "normalizes Fidelity card payments to negative Sure inflows" do
+    [ "2303.00", "-2303.00" ].each_with_index do |raw_amount, index|
+      tx = {
+        id: "tx_card_payment_#{index}",
+        amount: raw_amount,
+        currency: "USD",
+        description: "PAYMENT MADE BY ACCOUNT ENDING IN:9923",
+        posted: Date.current.to_s
+      }
+
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_card_payment_#{index}", source: "simplefin")
+      assert_equal BigDecimal("-2303.00"), entry.amount
+      assert_equal "card_payment", entry.transaction.extra.dig("simplefin", "amount_normalization")
+    end
+  end
+
   test "leaves dividend expenses on upstream sign behavior" do
     [ "DIVIDEND TAX", "DIVIDEND WITHHOLDING" ].each_with_index do |description, index|
       tx = {
@@ -376,20 +394,27 @@ class SimplefinEntry::ProcessorTest < ActiveSupport::TestCase
 
   test "does not normalize transaction signs for non-Fidelity institutions" do
     @simplefin_account.update!(org_data: { name: "Example Credit Union" })
-    tx = {
-      id: "tx_other_institution_direct_debit",
-      amount: "25.00",
-      currency: "USD",
-      description: "DIRECT DEBIT",
-      posted: Date.current.to_s
-    }
+    cases = [
+      [ "direct_debit", "25.00", "DIRECT DEBIT", BigDecimal("-25.00") ],
+      [ "card_payment", "-25.00", "PAYMENT MADE BY ACCOUNT ENDING IN:9923", BigDecimal("25.00") ]
+    ]
 
-    SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+    cases.each do |label, raw_amount, description, expected_amount|
+      tx = {
+        id: "tx_other_institution_#{label}",
+        amount: raw_amount,
+        currency: "USD",
+        description: description,
+        posted: Date.current.to_s
+      }
 
-    entry = @account.entries.find_by!(external_id: "simplefin_tx_other_institution_direct_debit", source: "simplefin")
-    assert_equal BigDecimal("-25.00"), entry.amount
-    sf = entry.transaction.extra.fetch("simplefin")
-    assert_not sf.key?("amount_normalization"), "expected non-Fidelity transactions to carry no amount_normalization key"
+      SimplefinEntry::Processor.new(tx, simplefin_account: @simplefin_account).process
+
+      entry = @account.entries.find_by!(external_id: "simplefin_tx_other_institution_#{label}", source: "simplefin")
+      assert_equal expected_amount, entry.amount
+      sf = entry.transaction.extra.fetch("simplefin")
+      assert_not sf.key?("amount_normalization"), "expected non-Fidelity transactions to carry no amount_normalization key"
+    end
   end
 
   test "does not raise or normalize when org_data is missing or malformed" do


### PR DESCRIPTION
## Summary

- correct transaction-direction mismatches observed in Fidelity Investments data delivered through SimpleFIN
- scope normalization to accounts whose SimpleFIN organization is Fidelity Investments
- classify only the provider `description` field, never merchant `payee` or free-text `memo`
- keep upstream sign behavior for non-Fidelity institutions and ambiguous or expense-qualified descriptors
- persist the applied normalization rule in namespaced SimpleFIN metadata for traceability

## Problem

SimpleFIN uses banking signs while Sure stores expenses as positive amounts and income as negative amounts. Sure normally handles this by negating the provider amount.

Fidelity Investments payloads delivered through SimpleFIN can contain a raw amount sign that conflicts with an unambiguous transaction-class description such as `DIRECT DEBIT`, `DIRECT DEPOSIT`, or `DIVIDEND PAYMENT`. Blind negation then places the transaction in the wrong direction.

This change is intentionally institution-specific. It activates only when the account-level SimpleFIN organization name identifies Fidelity Investments. It uses only the provider `description` field and applies a small allowlist of known transaction classes.

Dividend normalization is limited to exact income descriptors (`DIVIDEND`, `DIVIDEND PAYMENT`, `DIVIDEND RECEIVED`, `DIVIDEND INCOME`, and `DIVIDEND CREDIT`). Descriptions such as `DIVIDEND TAX` and `DIVIDEND WITHHOLDING` retain upstream behavior. Reversals, returns, refunds, reinvestments, unknown descriptions, and all non-Fidelity accounts also retain upstream behavior.

## Review feedback addressed

- Added regressions proving `DIVIDEND TAX` and `DIVIDEND WITHHOLDING` remain expenses.
- Removed transaction-direction inference from merchant/free-text fields; `Dividend Finance` and `Direct Deposit Cafe` payees no longer trigger normalization.
- Added a non-Fidelity institution regression proving the workaround does not alter other SimpleFIN accounts.

## Test plan

Validated from current upstream `main` in a freshly built Linux/amd64 image:

- `bin/rails test test/models/simplefin_entry/processor_test.rb`
  - 19 runs, 61 assertions, 0 failures
- `DISABLE_PARALLELIZATION=true bin/rails test test/models/simplefin_account test/models/provider/simplefin_adapter_test.rb`
  - 64 runs, 148 assertions, 0 failures
- `bundle exec rubocop app/models/simplefin_entry/processor.rb test/models/simplefin_entry/processor_test.rb`
  - 2 files inspected, no offenses
- Rails runner smoke test passed

## Risk and compatibility

- no database migration
- no configuration change
- no behavior change for non-Fidelity institutions
- no behavior change for unmapped or ambiguous descriptions
- normalization metadata remains scoped under `transaction.extra["simplefin"]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction amount handling based on the financial institution, correctly distinguishing expenses from income.
  * Direct debits, deposits, electronic transfers, checks, and dividends now use transaction descriptions to determine the appropriate sign.
  * Ambiguous transactions, including reversals, returns, refunds, and reinvestments, retain their original amounts.
  * Dividend taxes and withholdings are treated as expenses, while unrelated merchant names no longer affect transaction direction.
  * Accounts without supported institution data continue using their original amount behavior without errors.
  * Removed outdated amount-normalization metadata when institution-specific rules no longer apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->