### PR TITLE
Show exact share count in the holding drawer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -226,19 +226,21 @@ module ApplicationHelper
     ENV.fetch("DEV_WEBHOOKS_URL", root_url).chomp("/") + "/enable_banking_items/callback"
   end
 
-  # Formats quantity with adaptive precision based on the value size.
+  # Formats a holding quantity with adaptive precision based on the value size.
   # Shows more decimal places for small quantities (common with crypto).
   #
   # @param qty [Numeric] The quantity to format
-  # @param max_precision [Integer] Maximum precision for very small numbers
+  # @param exact [Boolean] Show the full stored precision, without rounding
   # @return [String] Formatted quantity with appropriate precision
-  def format_quantity(qty)
+  def format_quantity(qty, exact: false)
     return "0" if qty.nil? || qty.zero?
 
     abs_qty = qty.abs
 
-    precision = if abs_qty >= 1
-      1     # "10.5"
+    precision = if exact
+      8     # "10.374"
+    elsif abs_qty >= 1
+      1     # "10.4"
     elsif abs_qty >= 0.01
       2     # "0.52"
     elsif abs_qty >= 0.0001

--- a/app/views/holdings/show.html.erb
+++ b/app/views/holdings/show.html.erb
@@ -96,7 +96,7 @@
           </div>
           <div class="flex items-center justify-between text-sm">
             <dt class="text-secondary"><%= t(".shares_label") %></dt>
-            <dd class="text-primary"><%= format_quantity(@holding.qty, exact: true) %></dd>
+            <dd id="<%= dom_id(@holding, :shares) %>" class="text-primary"><%= format_quantity(@holding.qty, exact: true) %></dd>
           </div>
           <div class="flex items-center justify-between text-sm">
             <dt class="text-secondary"><%= t(".portfolio_weight_label") %></dt>

--- a/app/views/holdings/show.html.erb
+++ b/app/views/holdings/show.html.erb
@@ -96,7 +96,7 @@
           </div>
           <div class="flex items-center justify-between text-sm">
             <dt class="text-secondary"><%= t(".shares_label") %></dt>
-            <dd class="text-primary"><%= format_quantity(@holding.qty) %></dd>
+            <dd class="text-primary"><%= format_quantity(@holding.qty, exact: true) %></dd>
           </div>
           <div class="flex items-center justify-between text-sm">
             <dt class="text-secondary"><%= t(".portfolio_weight_label") %></dt>
@@ -141,7 +141,7 @@
                     class: "space-y-3",
                     data: drawer_form_data do |f| %>
                 <p class="text-xs text-secondary mb-2">
-                  <%= t("holdings.cost_basis_cell.set_cost_basis_header", ticker: @holding.ticker, qty: format_quantity(@holding.qty)) %>
+                  <%= t("holdings.cost_basis_cell.set_cost_basis_header", ticker: @holding.ticker, qty: format_quantity(@holding.qty, exact: true)) %>
                 </p>
                 <!-- Total cost basis input -->
                 <div class="form-field">

--- a/test/controllers/holdings_controller_test.rb
+++ b/test/controllers/holdings_controller_test.rb
@@ -18,6 +18,14 @@ class HoldingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "shows exact share count without rounding" do
+    @holding.update!(qty: 10.374)
+
+    get holding_path(@holding)
+
+    assert_select "##{dom_id(@holding, :shares)}", text: "10.374"
+  end
+
   test "destroys holding and associated entries" do
     assert_difference -> { Holding.count } => -1,
                       -> { Entry.count } => -1 do


### PR DESCRIPTION
## Problem

I noticed that my holding showed 10.4 shares when my brokerage account said 10.374. The stored value was correct - the API returned 10.374 - but the drawer rounded it for display, so it appeared as a discrepancy.

It's important for the share count to be accurate for reconciliation and cost basis calculation. 

## Cause

In #737, a `format_quantity` helper was added to format share counts. It applies adaptive precision to constrain length.

This makes sense for the holdings table, where there is limited space. However, in the holdings drawer there is much more space, and users have a reasonable expectation to see greater detail + more accurate values there.

## Solution

Added an `exact` flag to `format_quantity` to disable adaptive precision when it is not wanted.

For consistency, `format_quantity` will remain the source of truth for formatting holding quantities.

## Testing

Added a new `HoldingsControllerTest` case, asserting the drawer renders `10.374` unrounded. The test needed an `id` on the shares field to target it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Holding details now display share quantities with up to eight decimal places when exact values are needed.
  * Cost-basis editing displays the full share quantity without rounding.

* **Bug Fixes**
  * Fractional share quantities, such as 10.374, are now shown accurately in holding details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->