### PR TITLE
Fix Wise sync pagination query and duplicated interbalance transactions

### DIFF
--- a/app/models/provider/wise.rb
+++ b/app/models/provider/wise.rb
@@ -83,7 +83,7 @@ class Provider::Wise
 
   def get_activities(profile_id, cursor: nil, size: 100)
     query = { size: size }
-    query[:cursor] = cursor if cursor
+    query[:nextCursor] = cursor if cursor
     get("/v1/profiles/#{profile_id}/activities", query: query)
   end
 

--- a/app/models/wise_item/importer.rb
+++ b/app/models/wise_item/importer.rb
@@ -299,9 +299,13 @@ class WiseItem::Importer
               t["targetCurrency"] == wise_account.currency
           end
           account_statements = statements[wise_account.id] || []
-          existing_legacy = Array(wise_account.raw_transactions_payload).reject { |transaction| transaction["wise_statement"].present? }
+          existing_legacy = Array(wise_account.raw_transactions_payload)
+                                 .reject { |transaction| transaction["wise_statement"].present? }
+                                 .reject { |transaction| transaction["type"] == "INTERBALANCE" && !activity_for_account?(transaction, wise_account) }
           existing_statements = Array(wise_account.raw_transactions_payload).select { |transaction| transaction["wise_statement"].present? }
-          # Also include INTERBALANCE activities so the standard account shows outflows to the JAR.
+          # Include INTERBALANCE activities only when they are paired with a Wise Jar.
+          # Currency-wallet conversions are already represented by balance statements;
+          # importing their profile activities into every standard wallet duplicates them.
           interbalance = activities.select { |a| activity_for_account?(a, wise_account) }
           payload = merge_transaction_payloads(
             existing_legacy + account_transfers + existing_statements + account_statements + interbalance
@@ -355,23 +359,33 @@ class WiseItem::Importer
     # Routes an activity to the given WiseAccount.
     # JAR: receives INTERBALANCE where the activity title's <strong> tag matches the JAR name,
     #      plus BALANCE_CASHBACK and BALANCE_ASSET_FEE.
-    # STANDARD: receives all INTERBALANCE activities (outflow side of JAR transfers).
+    # STANDARD: receives INTERBALANCE activities only when the other side is a Jar,
+    # so the pair can be linked as a Sure Transfer. Currency-wallet conversions
+    # are intentionally excluded because balance statements already cover them.
     def activity_for_account?(activity, wise_account)
       type = activity["type"]
 
       case type
       when "INTERBALANCE"
+        destination_name = interbalance_destination_name(activity)
+        return false if destination_name.blank?
+
         if wise_account.jar?
-          jar_name_in_title = activity["title"].to_s.scan(/<strong>([^<]+)<\/strong>/).flatten.last.to_s.strip
-          jar_name_in_title.present? && jar_name_in_title.casecmp?(wise_account.name.to_s.strip)
+          destination_name.casecmp?(wise_account.name.to_s.strip)
         else
-          true
+          wise_item.wise_accounts.any? do |candidate|
+            candidate.jar? && destination_name.casecmp?(candidate.name.to_s.strip)
+          end
         end
       when "BALANCE_ASSET_FEE", "BALANCE_CASHBACK"
         wise_account.jar?
       else
         false
       end
+    end
+
+    def interbalance_destination_name(activity)
+      activity["title"].to_s.scan(/<strong>([^<]+)<\/strong>/).flatten.last.to_s.strip
     end
 
     # Called after entries have been created to link interbalance pairs as Sure Transfers.

--- a/test/models/wise_item/importer_test.rb
+++ b/test/models/wise_item/importer_test.rb
@@ -324,6 +324,63 @@ class WiseItem::ImporterTest < ActiveSupport::TestCase
     assert standard.raw_transactions_payload.any? { |a| a["type"] == "INTERBALANCE" }
   end
 
+  test "does not route currency-wallet INTERBALANCE activities to standard accounts" do
+    balances = [
+      {
+        "id" => "10000001",
+        "amount" => { "value" => 100.00, "currency" => "EUR" },
+        "type" => "STANDARD"
+      },
+      {
+        "id" => "10000002",
+        "amount" => { "value" => 108.25, "currency" => "USD" },
+        "type" => "STANDARD"
+      }
+    ]
+    interbalance = build_interbalance(
+      "To <strong>EUR</strong>",
+      resource_id: "4644180289",
+      primary_amount: "100 EUR",
+      secondary_amount: "108.25 USD"
+    )
+    provider = FakeWiseProvider.new(balances: balances, activities: [ interbalance ])
+
+    WiseItem::Importer.new(@wise_item, wise_provider: provider).import
+
+    @wise_item.wise_accounts.each do |wise_account|
+      assert_empty wise_account.raw_transactions_payload.select { |entry| entry["type"] == "INTERBALANCE" }
+    end
+  end
+
+  test "drops previously stored currency-wallet INTERBALANCE activities from standard snapshots" do
+    interbalance = build_interbalance(
+      "To <strong>EUR</strong>",
+      resource_id: "4644180289",
+      primary_amount: "100 EUR",
+      secondary_amount: "108.25 USD"
+    )
+    wise_account = @wise_item.wise_accounts.create!(
+      balance_id: "10000001",
+      name: "Wise EUR",
+      currency: "EUR",
+      raw_payload: { "type" => "STANDARD" },
+      raw_transactions_payload: [ interbalance ]
+    )
+    provider = FakeWiseProvider.new(
+      balances: [
+        {
+          "id" => "10000001",
+          "amount" => { "value" => 100.00, "currency" => "EUR" },
+          "type" => "STANDARD"
+        }
+      ]
+    )
+
+    WiseItem::Importer.new(@wise_item, wise_provider: provider).import
+
+    assert_empty wise_account.reload.raw_transactions_payload.select { |entry| entry["type"] == "INTERBALANCE" }
+  end
+
   test "routes BALANCE_CASHBACK only to JAR account" do
     savings = {
       "id" => "10000002",
@@ -371,13 +428,14 @@ class WiseItem::ImporterTest < ActiveSupport::TestCase
       }
     end
 
-    def build_interbalance(title, resource_id:)
+    def build_interbalance(title, resource_id:, primary_amount: "1,000 EUR", secondary_amount: nil)
       {
         "id" => "interbalance_#{resource_id}",
         "type" => "INTERBALANCE",
         "resource" => { "type" => "BALANCE_TRANSACTION", "id" => resource_id },
         "title" => title,
-        "primaryAmount" => "1,000 EUR",
+        "primaryAmount" => primary_amount,
+        "secondaryAmount" => secondary_amount,
         "status" => "COMPLETED",
         "createdOn" => 7.days.ago.iso8601
       }


### PR DESCRIPTION
Changes:
- Fix Wise’s required `nextCursor` query parameter when fetching subsequent activity pages. This prevents the importer from repeatedly requesting the same page with the same cursor and getting stuck in a sync loop.
[Wise’s Activity API docs](https://docs.wise.com/api-reference/activity)
The query parameter is `nextCursor` instead of `cursor`.
- Prevents currency-wallet conversions (for example, EUR ↔ USD) from being imported as duplicate `INTERBALANCE` activity records across Wise standard accounts.