### PR TITLE
fix(demo): stop the goal-seeding matrix crashing rake demo_data:default

### DIFF
--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -1322,6 +1322,18 @@ class Demo::Generator
       #                   :reached, :on_track, :behind, :no_target_date
       #   Edge surfaces:  past-due target_date ("was due"), open pledge
       #                   banner, matched pledge ("last pledge matched")
+      # A whole-account link (no `allocations:` entry for that account) claims
+      # 100% of the balance and is exclusive per account — only one active/
+      # paused goal may hold one on a given account at a time
+      # (GoalAccount#whole_account_link_must_be_exclusive). Every goal below
+      # used to link `primary`/`secondary` wholly, which only ever worked
+      # because they saved one at a time with nothing to conflict with yet;
+      # the moment more than one wanted the same account, `save!` started
+      # raising — crashing `rake demo_data:default` on a clean checkout, every
+      # time. Only "Long-term portfolio" keeps a whole claim on `primary`
+      # (its on_track pace needs most of that balance) — everyone else on
+      # `primary`/`secondary` gets an explicit partial earmark instead, sized
+      # to preserve the status each goal is here to demonstrate.
       goals = [
         # active · behind — secondary account only, target above its balance
         {
@@ -1329,23 +1341,26 @@ class Demo::Generator
           target: 20_000,
           target_date: 4.months.from_now.to_date,
           accounts: [ secondary ],
+          allocations: { secondary => 3_000 },
           pledges: [
             { account: secondary, amount: 250, kind: "transfer", status: "open", expires_at: 5.days.from_now }
           ]
         },
-        # active · reached — primary balance comfortably above target
+        # active · reached — earmark comfortably above target
         {
           name: "Wedding fund",
           target: 2_400,
           target_date: 12.months.from_now.to_date,
-          accounts: [ primary ]
+          accounts: [ primary ],
+          allocations: { primary => 2_500 }
         },
         # active · no_target_date — secondary so progress doesn't auto-cap at 100%
         {
           name: "Emergency fund",
           target: 30_000,
           target_date: nil,
-          accounts: [ secondary ]
+          accounts: [ secondary ],
+          allocations: { secondary => 3_000 }
         },
         # active · behind big — combined pools still well short of the target
         {
@@ -1353,12 +1368,14 @@ class Demo::Generator
           target: 500_000,
           target_date: 24.months.from_now.to_date,
           accounts: eligible.first(2),
+          allocations: { primary => 1_000, secondary => 2_000 },
           pledges: [
             { account: primary, amount: 2_000, kind: "transfer", status: "open", expires_at: 4.days.from_now }
           ]
         },
-        # active · on_track — primary balance close to target, long horizon makes
-        # the required monthly rate small enough for the demo's pace to cover
+        # active · on_track — the one goal left holding all of `primary`, so
+        # its balance stays close enough to the target for a 60-month pace to
+        # read as on track
         {
           name: "Long-term portfolio",
           target: 200_000,
@@ -1371,7 +1388,8 @@ class Demo::Generator
           name: "Tax prep buffer",
           target: 1_200,
           target_date: 2.months.ago.to_date,
-          accounts: [ secondary ]
+          accounts: [ secondary ],
+          allocations: { secondary => 1_000 }
         },
         # AASM paused
         {
@@ -1379,7 +1397,8 @@ class Demo::Generator
           target: 15_000,
           target_date: 18.months.from_now.to_date,
           state: "paused",
-          accounts: [ primary ]
+          accounts: [ primary ],
+          allocations: { primary => 1_000 }
         },
         # AASM archived
         {
@@ -1387,7 +1406,8 @@ class Demo::Generator
           target: 1_500,
           target_date: 12.months.ago.to_date,
           state: "archived",
-          accounts: [ primary ]
+          accounts: [ primary ],
+          allocations: { primary => 500 }
         },
         # AASM completed
         {
@@ -1395,7 +1415,8 @@ class Demo::Generator
           target: 8_000,
           target_date: 6.months.ago.to_date,
           state: "completed",
-          accounts: [ primary ]
+          accounts: [ primary ],
+          allocations: { primary => 8_000 }
         }
       ]
 
@@ -1409,7 +1430,9 @@ class Demo::Generator
           color: Goal::COLORS.sample,
           state: goal_spec[:state] || "active"
         )
-        goal_spec[:accounts].uniq.each { |a| goal.goal_accounts.build(account: a) }
+        goal_spec[:accounts].uniq.each do |a|
+          goal.goal_accounts.build(account: a, allocated_amount: goal_spec.dig(:allocations, a))
+        end
         goal.save!
         wedding_goal = goal if goal_spec[:name] == "Wedding fund"
 

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -1322,18 +1322,6 @@ class Demo::Generator
       #                   :reached, :on_track, :behind, :no_target_date
       #   Edge surfaces:  past-due target_date ("was due"), open pledge
       #                   banner, matched pledge ("last pledge matched")
-      # A whole-account link (no `allocations:` entry for that account) claims
-      # 100% of the balance and is exclusive per account — only one active/
-      # paused goal may hold one on a given account at a time
-      # (GoalAccount#whole_account_link_must_be_exclusive). Every goal below
-      # used to link `primary`/`secondary` wholly, which only ever worked
-      # because they saved one at a time with nothing to conflict with yet;
-      # the moment more than one wanted the same account, `save!` started
-      # raising — crashing `rake demo_data:default` on a clean checkout, every
-      # time. Only "Long-term portfolio" keeps a whole claim on `primary`
-      # (its on_track pace needs most of that balance) — everyone else on
-      # `primary`/`secondary` gets an explicit partial earmark instead, sized
-      # to preserve the status each goal is here to demonstrate.
       goals = [
         # active · behind — secondary account only, target above its balance
         {

--- a/test/models/demo/generator_test.rb
+++ b/test/models/demo/generator_test.rb
@@ -39,6 +39,22 @@ class Demo::GeneratorTest < ActiveSupport::TestCase
     assert_equal 1, ApiKey.where(display_key: ApiKey::DEMO_MONITORING_KEY).count
   end
 
+  # Regression for a `rake demo_data:default` crash: the goal-seeding matrix
+  # linked several active goals to the same account as a 100%-whole-account
+  # claim each, which violates GoalAccount#whole_account_link_must_be_exclusive
+  # the moment the second one tries to save.
+  test "generate_goals! seeds the full matrix without raising" do
+    @family.update!(currency: "USD")
+    @family.accounts.create!(accountable: Depository.new, name: "Primary Checking",
+                              currency: @family.currency, balance: 150_000)
+    @family.accounts.create!(accountable: Depository.new, name: "Secondary Savings",
+                              currency: @family.currency, balance: 10_000)
+
+    assert_difference "@family.goals.count", 9 do
+      Demo::Generator.new.send(:generate_goals!, @family)
+    end
+  end
+
   private
     def create_user!(family, email)
       family.users.create!(


### PR DESCRIPTION
## Summary

Found while trying to seed sample data to compare goal/pocket approaches for #2892 — `rake demo_data:default` currently crashes on a clean `main` checkout.

Several goals in `Demo::Generator#generate_goals!`'s coverage matrix claimed the same account as a 100%-whole-account link (`GoalAccount#whole_account_link_must_be_exclusive`). This only ever worked because they saved one at a time with nothing to conflict with yet — the moment a second active goal wanted the same account, `save!` raised and the whole task aborted.

Fix: give every goal but one per account an explicit partial earmark instead of a whole-account claim. `Long-term portfolio` keeps the whole of `primary` (its on_track pace needs most of that balance); everyone else gets a small allocation sized to preserve the status each goal is there to demonstrate.

Independent of the Goal/Pocket architecture discussion on #2892 — this is a straight bug, reproducible on `main` as-is.

## Test plan

- [x] `rake demo_data:default` runs to completion on a clean checkout (previously crashed on the 3rd goal)
- [x] New regression test (`Demo::GeneratorTest#test_generate_goals!_seeds_the_full_matrix_without_raising`) fails on the pre-fix code, passes after
- [x] `bin/rails test test/models/demo/generator_test.rb test/models/goal_account_test.rb test/models/goal_test.rb` — 124 runs, 0 failures
- [x] `bundle exec rubocop app/models/demo/generator.rb test/models/demo/generator_test.rb` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTNba5qE5NwzaHzbp27ye

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed demo data generation so multiple goals can safely share accounts through partial allocations.
  * Prevented clean-checkout demo setup from failing when creating several account-linked goals.
  * Preserved intended goal scenarios, including whole-account and partial-allocation examples.

* **Tests**
  * Added coverage confirming the complete set of demo goals is generated successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->