### PR TITLE
fix(l10n): localize admin SSO headings

### DIFF
--- a/app/views/admin/sso_providers/edit.html.erb
+++ b/app/views/admin/sso_providers/edit.html.erb
@@ -1,7 +1,7 @@
-<%= content_for :page_title, "Edit #{@sso_provider.label}" %>
+<%= content_for :page_title, t(".title") %>
 
 <div class="space-y-4">
-  <p class="text-secondary">Update configuration for <%= @sso_provider.label %>.</p>
+  <p class="text-secondary"><%= t(".description", label: @sso_provider.label) %></p>
 
   <%= settings_section title: t(".provider_configuration") do %>
     <%= render "form", sso_provider: @sso_provider %>

--- a/app/views/admin/sso_providers/new.html.erb
+++ b/app/views/admin/sso_providers/new.html.erb
@@ -1,7 +1,7 @@
-<%= content_for :page_title, "Add SSO Provider" %>
+<%= content_for :page_title, t(".title") %>
 
 <div class="space-y-4">
-  <p class="text-secondary">Configure a new single sign-on authentication provider.</p>
+  <p class="text-secondary"><%= t(".description") %></p>
 
   <%= settings_section title: t(".provider_configuration") do %>
     <%= render "form", sso_provider: @sso_provider %>

--- a/test/controllers/admin/sso_providers_controller_test.rb
+++ b/test/controllers/admin/sso_providers_controller_test.rb
@@ -27,6 +27,22 @@ class Admin::SsoProvidersControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/name="sso_provider\[client_secret\]"[^>]*required/, response.body)
   end
 
+  test "new page localizes its heading and description" do
+    get new_admin_sso_provider_path(locale: "de")
+
+    assert_response :success
+    assert_select "h1", text: I18n.t("admin.sso_providers.new.title", locale: :de, fallback: false)
+    assert_select "p", text: I18n.t("admin.sso_providers.new.description", locale: :de, fallback: false)
+  end
+
+  test "edit page localizes its heading and description" do
+    get edit_admin_sso_provider_path(@provider, locale: "de")
+
+    assert_response :success
+    assert_select "h1", text: I18n.t("admin.sso_providers.edit.title", locale: :de, fallback: false)
+    assert_select "p", text: I18n.t("admin.sso_providers.edit.description", locale: :de, fallback: false, label: @provider.label)
+  end
+
   test "update persists nested default role setting" do
     patch admin_sso_provider_path(@provider), params: {
       sso_provider: valid_update_params(settings: { default_role: "guest" })


### PR DESCRIPTION
## Summary

German administrators now see localized headings and descriptions when creating or editing an SSO provider instead of English copy.

This is an independent leaf in the German localization cleanup. It reuses the existing SSO locale entries and does not change provider configuration or authentication behavior.

## Validation

- `bin/rails test test/controllers/admin/sso_providers_controller_test.rb`: 5 runs, 24 assertions, 0 failures, 0 errors.
- `bin/rails test`: 7,753 runs, 30,570 assertions, 0 failures, 0 errors, 30 skips.
- `bin/rubocop`: 2,435 files inspected, no offenses.
- Targeted ERB lint, the current I18n test, and `git diff --check` pass.
- The simulated merge tree matches the tested branch tree on current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized titles and descriptions to SSO provider creation and editing pages.
  * Improved support for displaying translated content, including German.

* **Tests**
  * Added coverage to verify localized headings and descriptions render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->