### PR TITLE
Clear Plaid reconnect status after successful import

### DIFF
--- a/app/models/plaid_item/importer.rb
+++ b/app/models/plaid_item/importer.rb
@@ -7,6 +7,7 @@ class PlaidItem::Importer
   def import
     fetch_and_import_item_data
     fetch_and_import_accounts_data
+    plaid_item.good! if plaid_item.requires_update?
   rescue Plaid::ApiError => e
     handle_plaid_error(e)
   end

--- a/test/models/plaid_item/importer_test.rb
+++ b/test/models/plaid_item/importer_test.rb
@@ -49,4 +49,28 @@ class PlaidItem::ImporterTest < ActiveSupport::TestCase
 
     @importer.import
   end
+
+  test "clears requires update status after a successful import" do
+    @plaid_item.update!(status: :requires_update)
+    @importer.stubs(:fetch_and_import_item_data)
+    @importer.stubs(:fetch_and_import_accounts_data)
+
+    @importer.import
+
+    assert_predicate @plaid_item.reload, :good?
+  end
+
+  test "keeps requires update status when login is still required" do
+    @plaid_item.update!(status: :requires_update)
+    error = Plaid::ApiError.new(
+      code: 400,
+      response_body: { "error_code" => "ITEM_LOGIN_REQUIRED" }.to_json
+    )
+    @importer.stubs(:fetch_and_import_item_data).raises(error)
+    @importer.expects(:fetch_and_import_accounts_data).never
+
+    @importer.import
+
+    assert_predicate @plaid_item.reload, :requires_update?
+  end
 end


### PR DESCRIPTION
## Summary

- restore a Plaid Item from `requires_update` to `good` after its complete import succeeds
- preserve `requires_update` when Plaid still returns `ITEM_LOGIN_REQUIRED`
- add focused regression coverage for both outcomes

Closes #3318

## Validation

- `bin/rails test`: 7,754 runs, 30,569 assertions, 0 failures, 0 errors
- focused Plaid suite: 50 runs, 176 assertions, 0 failures, 0 errors
- `bin/rubocop -f github -a`: clean
- `bin/brakeman --no-pager`: 0 security warnings
- ERB lint reports only existing design-token violations in unrelated templates; this PR changes no ERB
- sanitized self-hosted validation: a previously reconnected Item completed its sync, transitioned from `requires_update` to `good`, retained the same account set, and created no duplicate Item

## Privacy

No institution names, account identifiers, balances, credentials, or production logs are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plaid items now return to good standing after successful item and account data imports.
  * Items requiring user attention remain flagged when login is required, and account importing is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->