### PR TITLE
Refresh Plaid transactions during automatic syncs

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -63,7 +63,7 @@ class AccountsController < ApplicationController
   end
 
   def sync_all
-    family.plaid_items.syncable.each(&:request_transactions_refresh_later)
+    family.request_plaid_transactions_refreshes_later(source: "AccountsController#sync_all")
     family.sync_later
     redirect_to accounts_path, notice: t("accounts.sync_all.syncing")
   end

--- a/app/controllers/concerns/auto_sync.rb
+++ b/app/controllers/concerns/auto_sync.rb
@@ -7,6 +7,7 @@ module AutoSync
 
   private
     def sync_family
+      Current.family.request_plaid_transactions_refreshes_later(source: "AutoSync")
       Current.family.sync_later
     end
 

--- a/app/jobs/plaid_transactions_refresh_all_job.rb
+++ b/app/jobs/plaid_transactions_refresh_all_job.rb
@@ -1,0 +1,30 @@
+class PlaidTransactionsRefreshAllJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform(family, source:)
+    family.plaid_items.syncable.find_each do |plaid_item|
+      plaid_item.request_transactions_refresh_later
+    rescue => error
+      capture_warning(family:, source:, error:)
+    end
+  rescue => error
+    capture_warning(family:, source:, error:)
+  end
+
+  private
+    def capture_warning(family:, source:, error:)
+      DebugLogEntry.capture(
+        category: "provider_sync",
+        level: "warn",
+        message: "Plaid transaction refresh could not be requested; continuing with normal sync",
+        source: source,
+        provider_key: "plaid",
+        family: family,
+        metadata: { error_class: error.class.name }
+      )
+    rescue => logging_error
+      Rails.logger.warn(
+        "Plaid refresh diagnostic failed: #{logging_error.class.name}"
+      )
+    end
+end

--- a/app/jobs/sync_all_job.rb
+++ b/app/jobs/sync_all_job.rb
@@ -5,29 +5,11 @@ class SyncAllJob < ApplicationJob
   def perform
     Rails.logger.info("Starting sync for all families")
     Family.find_each do |family|
-      request_plaid_transactions_refreshes(family)
+      family.request_plaid_transactions_refreshes_later(source: self.class.name)
       family.sync_later
     rescue => e
       Rails.logger.error("Failed to sync family #{family.id}: #{e.message}")
     end
     Rails.logger.info("Completed sync for all families")
   end
-
-  private
-
-    def request_plaid_transactions_refreshes(family)
-      family.plaid_items.syncable.find_each do |plaid_item|
-        plaid_item.request_transactions_refresh_later
-      rescue => error
-        DebugLogEntry.capture(
-          category: "provider_sync",
-          level: "warn",
-          message: "Scheduled Plaid transaction refresh could not be enqueued; continuing with normal sync",
-          source: self.class.name,
-          provider_key: "plaid",
-          family: family,
-          metadata: { error_class: error.class.name }
-        )
-      end
-    end
 end

--- a/app/jobs/sync_all_job.rb
+++ b/app/jobs/sync_all_job.rb
@@ -5,10 +5,29 @@ class SyncAllJob < ApplicationJob
   def perform
     Rails.logger.info("Starting sync for all families")
     Family.find_each do |family|
+      request_plaid_transactions_refreshes(family)
       family.sync_later
     rescue => e
       Rails.logger.error("Failed to sync family #{family.id}: #{e.message}")
     end
     Rails.logger.info("Completed sync for all families")
   end
+
+  private
+
+    def request_plaid_transactions_refreshes(family)
+      family.plaid_items.syncable.find_each do |plaid_item|
+        plaid_item.request_transactions_refresh_later
+      rescue => error
+        DebugLogEntry.capture(
+          category: "provider_sync",
+          level: "warn",
+          message: "Scheduled Plaid transaction refresh could not be enqueued; continuing with normal sync",
+          source: self.class.name,
+          provider_key: "plaid",
+          family: family,
+          metadata: { error_class: error.class.name }
+        )
+      end
+    end
 end

--- a/app/jobs/sync_all_providers_job.rb
+++ b/app/jobs/sync_all_providers_job.rb
@@ -6,25 +6,7 @@ class SyncAllProvidersJob < ApplicationJob
     family = Family.find_by(id: family_id)
     return unless family
 
-    request_plaid_transactions_refreshes(family)
+    family.request_plaid_transactions_refreshes_later(source: self.class.name)
     family.sync_later
   end
-
-  private
-
-    def request_plaid_transactions_refreshes(family)
-      family.plaid_items.syncable.find_each do |plaid_item|
-        plaid_item.request_transactions_refresh_later
-      rescue => error
-        DebugLogEntry.capture(
-          category: "provider_sync",
-          level: "warn",
-          message: "Manual provider-wide Plaid transaction refresh could not be enqueued; continuing with normal sync",
-          source: self.class.name,
-          provider_key: "plaid",
-          family: family,
-          metadata: { error_class: error.class.name }
-        )
-      end
-    end
 end

--- a/app/jobs/sync_all_providers_job.rb
+++ b/app/jobs/sync_all_providers_job.rb
@@ -4,6 +4,27 @@ class SyncAllProvidersJob < ApplicationJob
 
   def perform(family_id)
     family = Family.find_by(id: family_id)
-    family&.sync_later
+    return unless family
+
+    request_plaid_transactions_refreshes(family)
+    family.sync_later
   end
+
+  private
+
+    def request_plaid_transactions_refreshes(family)
+      family.plaid_items.syncable.find_each do |plaid_item|
+        plaid_item.request_transactions_refresh_later
+      rescue => error
+        DebugLogEntry.capture(
+          category: "provider_sync",
+          level: "warn",
+          message: "Manual provider-wide Plaid transaction refresh could not be enqueued; continuing with normal sync",
+          source: self.class.name,
+          provider_key: "plaid",
+          family: family,
+          metadata: { error_class: error.class.name }
+        )
+      end
+    end
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -177,6 +177,10 @@ class Family < ApplicationRecord
     nil
   end
 
+  # Callers should still enqueue the normal family sync immediately. Plaid's
+  # refresh is asynchronous, and its polling chain schedules a distinct item
+  # sync after the cursor advances (or after the bounded polling fallback), so
+  # fresh transactions are imported even if the baseline family sync runs first.
   def request_plaid_transactions_refreshes_later(source:)
     plaid_items.syncable.find_each do |plaid_item|
       plaid_item.request_transactions_refresh_later

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -177,6 +177,22 @@ class Family < ApplicationRecord
     nil
   end
 
+  def request_plaid_transactions_refreshes_later(source:)
+    plaid_items.syncable.find_each do |plaid_item|
+      plaid_item.request_transactions_refresh_later
+    rescue => error
+      DebugLogEntry.capture(
+        category: "provider_sync",
+        level: "warn",
+        message: "Plaid transaction refresh could not be enqueued; continuing with normal sync",
+        source: source,
+        provider_key: "plaid",
+        family: self,
+        metadata: { error_class: error.class.name }
+      )
+    end
+  end
+
   def custom_enabled_currencies?
     enabled_currencies.present?
   end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -182,19 +182,14 @@ class Family < ApplicationRecord
   # sync after the cursor advances (or after the bounded polling fallback), so
   # fresh transactions are imported even if the baseline family sync runs first.
   def request_plaid_transactions_refreshes_later(source:)
-    plaid_items.syncable.find_each do |plaid_item|
-      plaid_item.request_transactions_refresh_later
-    rescue => error
-      DebugLogEntry.capture(
-        category: "provider_sync",
-        level: "warn",
-        message: "Plaid transaction refresh could not be enqueued; continuing with normal sync",
-        source: source,
-        provider_key: "plaid",
-        family: self,
-        metadata: { error_class: error.class.name }
-      )
-    end
+    enqueued_job = PlaidTransactionsRefreshAllJob.perform_later(self, source: source)
+    return enqueued_job if enqueued_job
+
+    capture_plaid_refresh_enqueue_failure(source:, error_class: "ActiveJob::EnqueueError")
+    nil
+  rescue => error
+    capture_plaid_refresh_enqueue_failure(source:, error_class: error.class.name)
+    nil
   end
 
   def custom_enabled_currencies?
@@ -218,6 +213,23 @@ class Family < ApplicationRecord
   def secondary_enabled_currency_objects(extra: [])
     enabled_currency_objects(extra:).reject { |currency| currency.iso_code == primary_currency_code }
   end
+
+  def capture_plaid_refresh_enqueue_failure(source:, error_class:)
+    DebugLogEntry.capture(
+      category: "provider_sync",
+      level: "warn",
+      message: "Plaid transaction refresh could not be enqueued; continuing with normal sync",
+      source: source,
+      provider_key: "plaid",
+      family: self,
+      metadata: { error_class: error_class }
+    )
+  rescue => logging_error
+    Rails.logger.warn(
+      "Plaid refresh enqueue diagnostic failed: #{logging_error.class.name}"
+    )
+  end
+  private :capture_plaid_refresh_enqueue_failure
 
 
   def moniker_label

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -80,7 +80,20 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "sync all requests fresh Plaid transactions before syncing the family" do
-    PlaidItem.any_instance.expects(:request_transactions_refresh_later).once
+    sequence = sequence("manual sync all")
+    Family.any_instance
+      .expects(:request_plaid_transactions_refreshes_later)
+      .with(source: "AccountsController#sync_all")
+      .in_sequence(sequence)
+    Family.any_instance.expects(:sync_later).once.in_sequence(sequence)
+
+    post sync_all_accounts_url
+
+    assert_redirected_to accounts_url
+  end
+
+  test "sync all continues when Plaid refresh orchestration cannot be enqueued" do
+    PlaidTransactionsRefreshAllJob.stubs(:perform_later).raises(RedisClient::Error, "Redis unavailable")
     Family.any_instance.expects(:sync_later).once
 
     post sync_all_accounts_url

--- a/test/controllers/concerns/auto_sync_test.rb
+++ b/test/controllers/concerns/auto_sync_test.rb
@@ -67,4 +67,22 @@ class AutoSyncTest < ActionDispatch::IntegrationTest
 
     controller_class.new.run_sync_family
   end
+
+  test "login-triggered sync continues when Plaid refresh orchestration cannot be enqueued" do
+    controller_class = Class.new do
+      def self.before_action(*) = nil
+
+      include AutoSync
+
+      def run_sync_family
+        sync_family
+      end
+    end
+
+    Current.stubs(:family).returns(@family)
+    PlaidTransactionsRefreshAllJob.stubs(:perform_later).raises(RedisClient::Error, "Redis unavailable")
+    @family.expects(:sync_later).once
+
+    controller_class.new.run_sync_family
+  end
 end

--- a/test/controllers/concerns/auto_sync_test.rb
+++ b/test/controllers/concerns/auto_sync_test.rb
@@ -48,4 +48,23 @@ class AutoSyncTest < ActionDispatch::IntegrationTest
       get root_path
     end
   end
+
+  test "login-triggered sync requests Plaid refresh before syncing family" do
+    controller_class = Class.new do
+      def self.before_action(*) = nil
+
+      include AutoSync
+
+      def run_sync_family
+        sync_family
+      end
+    end
+
+    Current.stubs(:family).returns(@family)
+    sequence = sequence("login-triggered sync")
+    @family.expects(:request_plaid_transactions_refreshes_later).with(source: "AutoSync").in_sequence(sequence)
+    @family.expects(:sync_later).in_sequence(sequence)
+
+    controller_class.new.run_sync_family
+  end
 end

--- a/test/jobs/plaid_transactions_refresh_all_job_test.rb
+++ b/test/jobs/plaid_transactions_refresh_all_job_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class PlaidTransactionsRefreshAllJobTest < ActiveJob::TestCase
+  test "requests transaction refreshes for syncable Plaid items" do
+    family = families(:dylan_family)
+
+    PlaidItem.any_instance.expects(:request_transactions_refresh_later).once
+
+    PlaidTransactionsRefreshAllJob.perform_now(family, source: "TestSync")
+  end
+
+  test "contains per-item refresh failures and records a sanitized diagnostic" do
+    family = families(:dylan_family)
+
+    PlaidItem.any_instance.stubs(:request_transactions_refresh_later).raises(RedisClient::Error, "Redis unavailable")
+
+    assert_difference "DebugLogEntry.count", 1 do
+      PlaidTransactionsRefreshAllJob.perform_now(family, source: "TestSync")
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "provider_sync", entry.category
+    assert_equal "TestSync", entry.source
+    assert_equal family, entry.family
+    assert_equal "RedisClient::Error", entry.metadata["error_class"]
+  end
+
+  test "contains Plaid item query failures" do
+    family = families(:dylan_family)
+    family.stubs(:plaid_items).raises(ActiveRecord::ConnectionNotEstablished, "DB unavailable")
+
+    assert_difference "DebugLogEntry.count", 1 do
+      PlaidTransactionsRefreshAllJob.perform_now(family, source: "TestSync")
+    end
+
+    entry = DebugLogEntry.order(:created_at).last
+    assert_equal "ActiveRecord::ConnectionNotEstablished", entry.metadata["error_class"]
+  end
+end

--- a/test/jobs/sync_all_job_test.rb
+++ b/test/jobs/sync_all_job_test.rb
@@ -5,24 +5,18 @@ class SyncAllJobTest < ActiveJob::TestCase
     family = families(:dylan_family)
     Family.stubs(:find_each).yields(family)
     sequence = sequence("scheduled sync")
-    PlaidItem.any_instance.expects(:request_transactions_refresh_later).in_sequence(sequence)
+    family.expects(:request_plaid_transactions_refreshes_later).with(source: "SyncAllJob").in_sequence(sequence)
     family.expects(:sync_later).in_sequence(sequence)
 
     SyncAllJob.perform_now
   end
 
-  test "scheduled sync continues when a Plaid refresh cannot be enqueued" do
+  test "scheduled sync continues after refresh orchestration" do
     family = families(:dylan_family)
     Family.stubs(:find_each).yields(family)
-    PlaidItem.any_instance.stubs(:request_transactions_refresh_later).raises(RedisClient::Error, "Redis unavailable")
+    family.stubs(:request_plaid_transactions_refreshes_later)
     family.expects(:sync_later)
 
-    assert_difference "DebugLogEntry.count", 1 do
-      SyncAllJob.perform_now
-    end
-
-    debug_entry = DebugLogEntry.order(:created_at).last
-    assert_equal "SyncAllJob", debug_entry.source
-    assert_equal "RedisClient::Error", debug_entry.metadata["error_class"]
+    SyncAllJob.perform_now
   end
 end

--- a/test/jobs/sync_all_job_test.rb
+++ b/test/jobs/sync_all_job_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class SyncAllJobTest < ActiveJob::TestCase
+  test "scheduled sync requests Plaid transaction refreshes before syncing families" do
+    family = families(:dylan_family)
+    Family.stubs(:find_each).yields(family)
+    sequence = sequence("scheduled sync")
+    PlaidItem.any_instance.expects(:request_transactions_refresh_later).in_sequence(sequence)
+    family.expects(:sync_later).in_sequence(sequence)
+
+    SyncAllJob.perform_now
+  end
+
+  test "scheduled sync continues when a Plaid refresh cannot be enqueued" do
+    family = families(:dylan_family)
+    Family.stubs(:find_each).yields(family)
+    PlaidItem.any_instance.stubs(:request_transactions_refresh_later).raises(RedisClient::Error, "Redis unavailable")
+    family.expects(:sync_later)
+
+    assert_difference "DebugLogEntry.count", 1 do
+      SyncAllJob.perform_now
+    end
+
+    debug_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "SyncAllJob", debug_entry.source
+    assert_equal "RedisClient::Error", debug_entry.metadata["error_class"]
+  end
+end

--- a/test/jobs/sync_all_job_test.rb
+++ b/test/jobs/sync_all_job_test.rb
@@ -14,7 +14,7 @@ class SyncAllJobTest < ActiveJob::TestCase
   test "scheduled sync continues after refresh orchestration" do
     family = families(:dylan_family)
     Family.stubs(:find_each).yields(family)
-    family.stubs(:request_plaid_transactions_refreshes_later)
+    PlaidTransactionsRefreshAllJob.stubs(:perform_later).raises(RedisClient::Error, "Redis unavailable")
     family.expects(:sync_later)
 
     SyncAllJob.perform_now

--- a/test/jobs/sync_all_providers_job_test.rb
+++ b/test/jobs/sync_all_providers_job_test.rb
@@ -6,32 +6,26 @@ class SyncAllProvidersJobTest < ActiveJob::TestCase
 
     Family.stubs(:find_by).with(id: family.id).returns(family)
     sequence = sequence("provider-wide sync")
-    PlaidItem.any_instance.expects(:request_transactions_refresh_later).in_sequence(sequence)
+    family.expects(:request_plaid_transactions_refreshes_later).with(source: "SyncAllProvidersJob").in_sequence(sequence)
     family.expects(:sync_later).in_sequence(sequence)
 
     SyncAllProvidersJob.perform_now(family.id)
   end
 
-  test "provider-wide sync continues when a Plaid refresh cannot be enqueued" do
+  test "provider-wide sync continues after refresh orchestration" do
     family = families(:dylan_family)
 
     Family.stubs(:find_by).with(id: family.id).returns(family)
-    PlaidItem.any_instance.stubs(:request_transactions_refresh_later).raises(RedisClient::Error, "Redis unavailable")
+    family.stubs(:request_plaid_transactions_refreshes_later)
     family.expects(:sync_later)
 
-    assert_difference "DebugLogEntry.count", 1 do
-      SyncAllProvidersJob.perform_now(family.id)
-    end
-
-    debug_entry = DebugLogEntry.order(:created_at).last
-    assert_equal "SyncAllProvidersJob", debug_entry.source
-    assert_equal "RedisClient::Error", debug_entry.metadata["error_class"]
+    SyncAllProvidersJob.perform_now(family.id)
   end
 
   test "provider-wide sync ignores a deleted family" do
     Family.expects(:find_by).returns(nil)
 
-    PlaidItem.any_instance.expects(:request_transactions_refresh_later).never
+    Family.any_instance.expects(:request_plaid_transactions_refreshes_later).never
 
     SyncAllProvidersJob.perform_now("missing")
   end

--- a/test/jobs/sync_all_providers_job_test.rb
+++ b/test/jobs/sync_all_providers_job_test.rb
@@ -16,7 +16,7 @@ class SyncAllProvidersJobTest < ActiveJob::TestCase
     family = families(:dylan_family)
 
     Family.stubs(:find_by).with(id: family.id).returns(family)
-    family.stubs(:request_plaid_transactions_refreshes_later)
+    PlaidTransactionsRefreshAllJob.stubs(:perform_later).raises(RedisClient::Error, "Redis unavailable")
     family.expects(:sync_later)
 
     SyncAllProvidersJob.perform_now(family.id)

--- a/test/jobs/sync_all_providers_job_test.rb
+++ b/test/jobs/sync_all_providers_job_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class SyncAllProvidersJobTest < ActiveJob::TestCase
+  test "provider-wide sync requests Plaid transaction refreshes before syncing family" do
+    family = families(:dylan_family)
+
+    Family.stubs(:find_by).with(id: family.id).returns(family)
+    sequence = sequence("provider-wide sync")
+    PlaidItem.any_instance.expects(:request_transactions_refresh_later).in_sequence(sequence)
+    family.expects(:sync_later).in_sequence(sequence)
+
+    SyncAllProvidersJob.perform_now(family.id)
+  end
+
+  test "provider-wide sync continues when a Plaid refresh cannot be enqueued" do
+    family = families(:dylan_family)
+
+    Family.stubs(:find_by).with(id: family.id).returns(family)
+    PlaidItem.any_instance.stubs(:request_transactions_refresh_later).raises(RedisClient::Error, "Redis unavailable")
+    family.expects(:sync_later)
+
+    assert_difference "DebugLogEntry.count", 1 do
+      SyncAllProvidersJob.perform_now(family.id)
+    end
+
+    debug_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "SyncAllProvidersJob", debug_entry.source
+    assert_equal "RedisClient::Error", debug_entry.metadata["error_class"]
+  end
+
+  test "provider-wide sync ignores a deleted family" do
+    Family.expects(:find_by).returns(nil)
+
+    PlaidItem.any_instance.expects(:request_transactions_refresh_later).never
+
+    SyncAllProvidersJob.perform_now("missing")
+  end
+end

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -481,23 +481,32 @@ class FamilyTest < ActiveSupport::TestCase
   test "requests transaction refreshes for syncable Plaid items" do
     family = families(:dylan_family)
 
-    PlaidItem.any_instance.expects(:request_transactions_refresh_later).once
-
-    family.request_plaid_transactions_refreshes_later(source: "TestSync")
+    assert_enqueued_with job: PlaidTransactionsRefreshAllJob, args: [ family, { source: "TestSync" } ] do
+      family.request_plaid_transactions_refreshes_later(source: "TestSync")
+    end
   end
 
-  test "records a sanitized diagnostic when a Plaid refresh cannot be enqueued" do
+  test "records a sanitized diagnostic and returns when Plaid refresh orchestration cannot be enqueued" do
     family = families(:dylan_family)
 
-    PlaidItem.any_instance.stubs(:request_transactions_refresh_later).raises(RedisClient::Error, "Redis unavailable")
+    PlaidTransactionsRefreshAllJob.stubs(:perform_later).raises(RedisClient::Error, "Redis unavailable")
 
     assert_difference "DebugLogEntry.count", 1 do
-      family.request_plaid_transactions_refreshes_later(source: "TestSync")
+      assert_nil family.request_plaid_transactions_refreshes_later(source: "TestSync")
     end
 
     debug_entry = DebugLogEntry.order(:created_at).last
     assert_equal "TestSync", debug_entry.source
     assert_equal "RedisClient::Error", debug_entry.metadata["error_class"]
+  end
+
+  test "does not raise when both Plaid refresh enqueue and diagnostic capture fail" do
+    family = families(:dylan_family)
+
+    PlaidTransactionsRefreshAllJob.stubs(:perform_later).raises(RedisClient::Error, "Redis unavailable")
+    DebugLogEntry.stubs(:capture).raises(ActiveRecord::ConnectionNotEstablished, "DB unavailable")
+
+    assert_nil family.request_plaid_transactions_refreshes_later(source: "TestSync")
   end
 
   private

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -478,6 +478,28 @@ class FamilyTest < ActiveSupport::TestCase
       "different users must not share a memoized InvestmentStatement (family sharing scoping)"
   end
 
+  test "requests transaction refreshes for syncable Plaid items" do
+    family = families(:dylan_family)
+
+    PlaidItem.any_instance.expects(:request_transactions_refresh_later).once
+
+    family.request_plaid_transactions_refreshes_later(source: "TestSync")
+  end
+
+  test "records a sanitized diagnostic when a Plaid refresh cannot be enqueued" do
+    family = families(:dylan_family)
+
+    PlaidItem.any_instance.stubs(:request_transactions_refresh_later).raises(RedisClient::Error, "Redis unavailable")
+
+    assert_difference "DebugLogEntry.count", 1 do
+      family.request_plaid_transactions_refreshes_later(source: "TestSync")
+    end
+
+    debug_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "TestSync", debug_entry.source
+    assert_equal "RedisClient::Error", debug_entry.metadata["error_class"]
+  end
+
   private
     def set_preview_features(user, enabled)
       user.update!(preferences: (user.preferences || {}).merge("preview_features_enabled" => enabled))


### PR DESCRIPTION
## Summary

- request fresh Plaid transaction data before the daily scheduled sync
- request the same refresh for provider-wide syncs and login-triggered auto-syncs
- centralize best-effort refresh enqueueing on the family so a Plaid refresh error does not prevent the normal account sync

This builds on the provider refresh machinery merged in #3206. The normal family sync remains immediate by design; each asynchronous Plaid refresh/poll chain schedules a distinct item follow-up sync after cursor advancement or bounded fallback, so fresh data is imported without making unrelated providers wait.

Closes #3303

## Validation

- Focused tests: 46 runs, 124 assertions, 0 failures, 0 errors
- Full suite: 7,760 runs, 30,581 assertions, 0 failures, 0 errors
- RuboCop: clean
- Brakeman: 0 warnings
- ERB lint: existing unrelated design-token violations only; this change does not modify templates

## Self-hosted validation

Validated on a temporary 0.7.4-compatible overlay:

- the unattended 5:00 AM sync enqueued and ran Plaid transaction refreshes before normal account synchronization
- one updated cursor scheduled its follow-up import; another no-delta response used the bounded fallback
- all Plaid account syncs completed with no incomplete syncs, failed jobs, or retries
- provider-wide and login-triggered paths also enqueued refresh work and completed their normal synchronization

No credentials, institution names, account identifiers, balances, or transaction details are included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatic, scheduled, and account-initiated syncs now refresh connected Plaid transactions before syncing account data.
  * Refresh failures are handled gracefully so synchronization can continue.
  * Refresh activity and failures are recorded for improved diagnostics.
  * Missing or unavailable account connections no longer interrupt scheduled syncs.
  * Bill feeds now support secure token creation, rotation, and member-specific access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->