### PR TITLE
fix(l10n): localize import step labels

### DIFF
--- a/app/views/import/confirms/show.html.erb
+++ b/app/views/import/confirms/show.html.erb
@@ -57,7 +57,7 @@
         <% is_active = step_idx == idx %>
 
         <%= link_to url_for(step: idx + 1), class: "w-5 h-[3px] #{is_active ? 'bg-inverse hover:bg-inverse-hover' : 'bg-surface-inset hover:bg-surface-inset-hover'} rounded-xl transition-colors duration-200" do %>
-          <span class="sr-only">Step <%= idx + 1 %></span>
+          <span class="sr-only"><%= t("imports.steps.label", step: idx + 1) %></span>
         <% end %>
       <% end %>
     </div>

--- a/config/locales/views/imports/de.yml
+++ b/config/locales/views/imports/de.yml
@@ -242,6 +242,7 @@ de:
       map: Zuordnen
       confirm: Bestätigen
       select: Auswählen
+      label: Schritt %{step}
       progress: Schritt %{step} von %{total}
     index:
       title: Importe

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -368,6 +368,7 @@ en:
       map: Map
       confirm: Confirm
       select: Select
+      label: "Step %{step}"
       progress: "Step %{step} of %{total}"
     empty:
       message: No imports found.

--- a/test/controllers/import/confirms_controller_test.rb
+++ b/test/controllers/import/confirms_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class Import::ConfirmsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @user = users(:family_admin)
+    ensure_tailwind_build
   end
 
   test "shows if cleaned" do
@@ -12,6 +13,32 @@ class Import::ConfirmsControllerTest < ActionDispatch::IntegrationTest
 
     get import_confirm_path(import)
     assert_response :success
+  end
+
+  test "localizes mapping step labels in German" do
+    import = imports(:transaction)
+    @user.update!(locale: "de")
+    TransactionImport.any_instance.stubs(:cleaned?).returns(true)
+
+    get import_confirm_path(import)
+
+    assert_response :success
+    assert_select "span.sr-only", text: "Schritt 1", count: 1
+    assert_select "span.sr-only", text: "Schritt 2", count: 1
+    assert_select "span.sr-only", text: "Schritt 3", count: 1
+  end
+
+  test "preserves mapping step labels in English" do
+    import = imports(:transaction)
+    @user.update!(locale: "en")
+    TransactionImport.any_instance.stubs(:cleaned?).returns(true)
+
+    get import_confirm_path(import)
+
+    assert_response :success
+    assert_select "span.sr-only", text: "Step 1", count: 1
+    assert_select "span.sr-only", text: "Step 2", count: 1
+    assert_select "span.sr-only", text: "Step 3", count: 1
   end
 
   test "redirects if not cleaned" do


### PR DESCRIPTION
## Summary

German users relying on screen readers now hear localized step labels during import mapping instead of English-only copy.

This is an independent leaf in the German localization cleanup. It reuses the established import-step terminology and does not change navigation or CSV mapping behavior.

## Validation

- `bin/rails test test/controllers/import/confirms_controller_test.rb`: 4 runs, 12 assertions, 0 failures, 0 errors.
- `bin/rails test test/i18n_test.rb`: 6 runs, 132 assertions, 0 failures, 0 errors, 4 skips.
- `bin/rails test`: 8,037 runs, 31,731 assertions, 0 failures, 0 errors, 30 skips.
- `bin/rubocop`: 2,468 files inspected, no offenses.
- Targeted ERB lint and `git diff --check` pass.
- The simulated merge tree matches the tested branch tree on current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Import wizard step indicators now use localized screen-reader labels.

* **Localization**
  * Added English and German translations for import step labels.
  * German users see labels such as “Schritt 1,” while English labels remain “Step 1.”

* **Tests**
  * Added coverage to verify localized step labels on the import confirmation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->