### PR TITLE
fix(l10n): localize Plaid add accounts action

### DIFF
--- a/config/locales/views/plaid_items/de.yml
+++ b/config/locales/views/plaid_items/de.yml
@@ -6,6 +6,7 @@ de:
     destroy:
       success: Konten zur Löschung vorgemerkt
     plaid_item:
+      add_accounts: Konten hinzufügen
       add_new: Neue Verbindung hinzufügen
       confirm_accept: Institut löschen
       confirm_body: Dadurch werden alle Konten dieser Gruppe und alle zugehörigen Daten dauerhaft gelöscht

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -15,6 +15,19 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p.ml-auto.privacy-sensitive"
   end
 
+  test "index localizes the Plaid add accounts action" do
+    ensure_tailwind_build
+    @user.update!(locale: "de")
+
+    get accounts_url
+
+    assert_response :success
+    assert_select "a[href=?]",
+                  edit_plaid_item_path(plaid_items(:one), add_accounts: true),
+                  text: "Konten hinzufügen",
+                  count: 1
+  end
+
   test "index renders kraken items" do
     kraken_item = kraken_items(:one)
     get accounts_url


### PR DESCRIPTION
## Summary

- translate Plaid's **Add accounts** action for German users
- add rendered regression coverage for the localized action link

## Testing

- `bin/rails test test/controllers/accounts_controller_test.rb -n '/index localizes the Plaid add accounts action/'`
- `bin/rails test test/i18n_test.rb`
- `bin/rails test` (8,036 runs, 31,725 assertions)
- `bin/rubocop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added the German translation for the “Add accounts” action in the Plaid account interface.

- **Bug Fixes**
  - German-localized account pages now display the correct translated action text, link, and result count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->