### PR TITLE
feat(ai-health): explain vector store setup failures

### DIFF
--- a/app/models/ai_health.rb
+++ b/app/models/ai_health.rb
@@ -102,6 +102,21 @@ class AiHealth
     :passing
   end
 
+  def vector_store_failure_kind
+    return unless vector_store_adapter == :pgvector
+    return unless vector_store_status == :failing
+
+    failure_codes = [ vector_store_probe.failure_code, embedding_probe.failure_code ].compact
+    return :pgvector_extension_not_enabled if failure_codes.include?(:extension_not_enabled)
+    return :pgvector_table_not_found if failure_codes.include?(:table_not_found)
+    return :embedding_dimensions_mismatch if failure_codes.include?(:dimensions_mismatch)
+    return :embedding_probe_timeout if failure_codes.include?(:timeout) && embedding_probe.failing?
+    return :embedding_probe_failed if embedding_probe.failing?
+    return :pgvector_probe_failed if vector_store_probe.failing?
+
+    :vector_probe_failed
+  end
+
   def openai_vector_store_uses_custom_endpoint?
     vector_store_adapter == :openai && @openai_custom_endpoint
   end

--- a/app/models/ai_health.rb
+++ b/app/models/ai_health.rb
@@ -110,9 +110,9 @@ class AiHealth
     return :pgvector_extension_not_enabled if failure_codes.include?(:extension_not_enabled)
     return :pgvector_table_not_found if failure_codes.include?(:table_not_found)
     return :embedding_dimensions_mismatch if failure_codes.include?(:dimensions_mismatch)
+    return :pgvector_probe_failed if vector_store_probe.failing?
     return :embedding_probe_timeout if failure_codes.include?(:timeout) && embedding_probe.failing?
     return :embedding_probe_failed if embedding_probe.failing?
-    return :pgvector_probe_failed if vector_store_probe.failing?
 
     :vector_probe_failed
   end

--- a/app/views/admin/system_health/_ai_status.html.erb
+++ b/app/views/admin/system_health/_ai_status.html.erb
@@ -4,6 +4,7 @@
    when :unsupported, :failing then "text-destructive"
    else "text-warning"
    end %>
+<% vector_store_failure_kind = ai_health.vector_store_failure_kind %>
 
 <% pdf_checks = [
   {
@@ -39,7 +40,13 @@
     ) %>
   </div>
 
-  <% if ai_health.llm_status == :failing %>
+  <% if ai_health.llm_status == :failing && ai_health.llm_probe.failure_code == :model_not_available %>
+    <%= render DS::Alert.new(
+      title: t("admin.system_health.show.ai.alerts.llm_model_not_available.title"),
+      message: t("admin.system_health.show.ai.alerts.llm_model_not_available.message"),
+      variant: :error
+    ) %>
+  <% elsif ai_health.llm_status == :failing %>
     <%= render DS::Alert.new(
       title: t("admin.system_health.show.ai.alerts.llm_probe_failed.title"),
       message: t("admin.system_health.show.ai.alerts.llm_probe_failed.message"),
@@ -69,6 +76,12 @@
       <%= render DS::Alert.new(title: t("admin.system_health.show.ai.alerts.custom_openai.title"), variant: :error) do %>
         <p><%= t("admin.system_health.show.ai.alerts.custom_openai.message") %></p>
       <% end %>
+    <% elsif vector_store_failure_kind %>
+      <%= render DS::Alert.new(
+        title: t("admin.system_health.show.ai.alerts.#{vector_store_failure_kind}.title"),
+        message: t("admin.system_health.show.ai.alerts.#{vector_store_failure_kind}.message"),
+        variant: :error
+      ) %>
     <% else %>
       <%= render DS::Alert.new(
         title: t("admin.system_health.show.ai.alerts.vector_probe_failed.title"),

--- a/config/locales/views/admin/system_health/en.yml
+++ b/config/locales/views/admin/system_health/en.yml
@@ -51,6 +51,9 @@ en:
             llm_probe_failed:
               title: The LLM live check failed
               message: Sure could not verify both the configured endpoint and model. The failure was recorded in Settings → Debug logs and Rails.logger.
+            llm_model_not_available:
+              title: The configured AI model is not available
+              message: The endpoint answered, but it did not list or serve the configured model. Pick an active model for the selected provider, then run the checks again. For Gemini through an OpenAI-compatible translation layer, use a currently supported model such as gemini-2.5-flash.
             pdf_text_extraction_failed:
               title: The synthetic PDF text-extraction check failed
               message: Sure could not complete the text-first path that extracts embedded PDF text locally and sends it to the configured model. No customer data was sent. The failure was recorded in Settings → Debug logs and Rails.logger.
@@ -60,6 +63,24 @@ en:
             vector_probe_failed:
               title: The document-search live check failed
               message: Sure could not verify the selected vector store and every required embedding service. The failure was recorded in Settings → Debug logs and Rails.logger.
+            pgvector_extension_not_enabled:
+              title: The PostgreSQL vector extension is not enabled
+              message: The pgvector adapter is selected, but PostgreSQL has not enabled the vector extension for this database. Use a PostgreSQL image that includes pgvector, then enable the extension as a database owner or superuser and re-run migrations with VECTOR_STORE_PROVIDER=pgvector.
+            pgvector_table_not_found:
+              title: The vector_store_chunks table is missing
+              message: The pgvector extension is enabled, but the chunks table was not found. Check migration status, then re-run the vector-store migration with VECTOR_STORE_PROVIDER=pgvector so Sure can create vector_store_chunks.
+            pgvector_probe_failed:
+              title: The pgvector storage check failed
+              message: Sure could not query the pgvector chunks table. Check PostgreSQL permissions, the vector extension, and the vector_store_chunks migration. The failure was recorded in Settings → Debug logs and Rails.logger.
+            embedding_dimensions_mismatch:
+              title: The embedding dimensions do not match
+              message: The embedding endpoint returned a vector whose length does not match EMBEDDING_DIMENSIONS. Set EMBEDDING_MODEL and EMBEDDING_DIMENSIONS to the model's documented vector size, restart Sure so the environment persists, then rebuild the pgvector index if existing documents used a different size.
+            embedding_probe_timeout:
+              title: The embedding live check timed out
+              message: The embedding endpoint did not answer before AI_HEALTH_PROBE_TIMEOUT. Increase that health-check timeout if the provider is slow, then restart Sure so the environment persists in every process. If normal AI chat calls also time out, raise OPENAI_REQUEST_TIMEOUT separately.
+            embedding_probe_failed:
+              title: The embedding live check failed
+              message: Sure could not create a short test embedding through the configured endpoint and model. Check EMBEDDING_URI_BASE, EMBEDDING_MODEL, EMBEDDING_ACCESS_TOKEN, and the embedding provider logs. The failure was recorded in Settings → Debug logs and Rails.logger.
             qdrant:
               title: Qdrant support is not implemented yet
               message: The Qdrant adapter is scaffolded, but document upload and search operations currently fail. Select OpenAI or pgvector for document search.

--- a/config/locales/views/admin/system_health/en.yml
+++ b/config/locales/views/admin/system_health/en.yml
@@ -74,7 +74,7 @@ en:
               message: Sure could not query the pgvector chunks table. Check PostgreSQL permissions, the vector extension, and the vector_store_chunks migration. The failure was recorded in Settings → Debug logs and Rails.logger.
             embedding_dimensions_mismatch:
               title: The embedding dimensions do not match
-              message: The embedding endpoint returned a vector whose length does not match EMBEDDING_DIMENSIONS. Set EMBEDDING_MODEL and EMBEDDING_DIMENSIONS to the model's documented vector size, restart Sure so the environment persists, then rebuild the pgvector index if existing documents used a different size.
+              message: The embedding endpoint returned a vector whose length does not match EMBEDDING_DIMENSIONS. Set EMBEDDING_MODEL and EMBEDDING_DIMENSIONS to the model's documented vector size, restart Sure so the environment persists, then alter or recreate the pgvector embedding column/table and re-embed documents if existing data used a different size.
             embedding_probe_timeout:
               title: The embedding live check timed out
               message: The embedding endpoint did not answer before AI_HEALTH_PROBE_TIMEOUT. Increase that health-check timeout if the provider is slow, then restart Sure so the environment persists in every process. If normal AI chat calls also time out, raise OPENAI_REQUEST_TIMEOUT separately.

--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -1455,6 +1455,49 @@ timeout and `AI_HEALTH_PROBE_CACHE_TTL` to change the cache duration. Failed
 checks are written as system-wide entries in **Settings → Debug logs** and to
 `Rails.logger`; endpoints are redacted and credentials are never included.
 
+#### Troubleshooting Pgvector and Embeddings
+
+The AI status page reports separate failures for the PostgreSQL storage check
+and the embedding endpoint check.
+
+If PostgreSQL reports that the `vector` extension is not enabled, make sure the
+database image includes pgvector, then enable the extension as a database owner
+or superuser:
+
+```bash
+sudo -u postgres psql -d sure_production -c "CREATE EXTENSION IF NOT EXISTS vector;"
+```
+
+If `vector_store_chunks` is missing, confirm the migration state and re-run the
+conditional vector-store migration with the pgvector provider selected:
+
+```bash
+RAILS_ENV=production bundle exec rails db:migrate:status
+VECTOR_STORE_PROVIDER=pgvector RAILS_ENV=production bundle exec rails db:migrate:redo VERSION=<migration_version>
+```
+
+If the embedding check reports a dimensions mismatch, align
+`EMBEDDING_MODEL` and `EMBEDDING_DIMENSIONS` with the embedding provider's
+documented vector size. For example, `gemini-embedding-2-preview` returns 3072
+dimensions by default, so a matching configuration is:
+
+```bash
+EMBEDDING_MODEL=gemini-embedding-2-preview
+EMBEDDING_DIMENSIONS=3072
+```
+
+Restart Sure after changing environment values so the new settings are present
+in both web and worker processes. If the embedding live check times out, raise
+the health-check probe timeout in the service environment:
+
+```bash
+AI_HEALTH_PROBE_TIMEOUT=180
+```
+
+If normal AI chat calls also time out, raise `OPENAI_REQUEST_TIMEOUT`
+separately; it controls OpenAI-compatible LLM requests, not the health-check
+probe budget.
+
 You can also check the adapter from the Rails console:
 
 ```ruby

--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -1486,6 +1486,18 @@ EMBEDDING_MODEL=gemini-embedding-2-preview
 EMBEDDING_DIMENSIONS=3072
 ```
 
+Changing only `EMBEDDING_DIMENSIONS` does not reshape an existing pgvector
+column. If `vector_store_chunks` was already created with a different size,
+back up the database and source documents, remove the indexed documents from
+Sure, then alter or recreate the `embedding` column/table before uploading the
+documents again. Dropping the empty chunks table lets Sure recreate it with the
+new vector size:
+
+```bash
+docker compose -f compose.example.ai.yml exec web bin/rails runner \
+  'ActiveRecord::Base.connection_pool.with_connection { |connection| connection.drop_table(VectorStore::Pgvector::TABLE_NAME, if_exists: true) }'
+```
+
 Restart Sure after changing environment values so the new settings are present
 in both web and worker processes. If the embedding live check times out, raise
 the health-check probe timeout in the service environment:

--- a/test/controllers/admin/system_health_controller_test.rb
+++ b/test/controllers/admin/system_health_controller_test.rb
@@ -379,6 +379,7 @@ class Admin::SystemHealthControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match(/The embedding dimensions do not match/, response.body)
     assert_match(/EMBEDDING_MODEL and EMBEDDING_DIMENSIONS/, response.body)
+    assert_match(/alter or recreate the pgvector embedding column\/table/, response.body)
     assert_match(/gemini-embedding-2-preview/, response.body)
     assert_no_match(/anthropic-secret/, response.body)
   end

--- a/test/controllers/admin/system_health_controller_test.rb
+++ b/test/controllers/admin/system_health_controller_test.rb
@@ -181,6 +181,27 @@ class Admin::SystemHealthControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/router-secret/, response.body)
   end
 
+  test "AI status names an unavailable configured LLM model" do
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+    AiHealth::Probe.any_instance.stubs(:llm).returns(
+      probe_result(:failing, failure_code: :model_not_available)
+    )
+
+    with_ai_environment(
+      "OPENAI_ACCESS_TOKEN" => "gemini-secret",
+      "OPENAI_URI_BASE" => "https://generativelanguage.googleapis.com/v1beta/openai",
+      "OPENAI_MODEL" => "retired-gemini-model"
+    ) do
+      get admin_system_health_url(tab: "ai")
+    end
+
+    assert_response :success
+    assert_match(/The configured AI model is not available/, response.body)
+    assert_match(/gemini-2\.5-flash/, response.body)
+    assert_no_match(/gemini-secret/, response.body)
+  end
+
   test "AI status separates a model that ignores tools from one that cannot use them" do
     sign_in users(:sure_support_staff)
     stub_healthy_sidekiq
@@ -297,6 +318,99 @@ class Admin::SystemHealthControllerTest < ActionDispatch::IntegrationTest
     assert_match(/mxbai-embed-large/, response.body)
     assert_match(%r{http://ollama:11434/v1}, response.body)
     assert_match(/Live checks passed/, response.body)
+    assert_no_match(/anthropic-secret/, response.body)
+  end
+
+  test "AI status explains a missing pgvector table" do
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+    Setting.stubs(:llm_provider).returns("anthropic")
+    VectorStore::Pgvector.stubs(:available?).returns(true)
+    AiHealth::Probe.any_instance.stubs(:pgvector).returns(
+      probe_result(:failing, failure_code: :table_not_found)
+    )
+
+    connection = stub("connection")
+    connection.stubs(:table_exists?).with(VectorStore::Pgvector::TABLE_NAME).returns(false)
+    connection.stubs(:extension_enabled?).with("vector").returns(true)
+    ActiveRecord::Base.stubs(:connection).returns(connection)
+
+    with_ai_environment(
+      "ANTHROPIC_ACCESS_TOKEN" => "anthropic-secret",
+      "ANTHROPIC_MODEL" => "claude-sonnet-4-6",
+      "EMBEDDING_URI_BASE" => "http://ollama:11434/v1",
+      "EMBEDDING_MODEL" => "mxbai-embed-large",
+      "EMBEDDING_DIMENSIONS" => "1024"
+    ) do
+      get admin_system_health_url(tab: "ai")
+    end
+
+    assert_response :success
+    assert_match(/The vector_store_chunks table is missing/, response.body)
+    assert_match(/VECTOR_STORE_PROVIDER=pgvector/, response.body)
+    assert_match(/table was not found/, response.body)
+    assert_no_match(/anthropic-secret/, response.body)
+  end
+
+  test "AI status explains an embedding dimensions mismatch" do
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+    Setting.stubs(:llm_provider).returns("anthropic")
+    VectorStore::Pgvector.stubs(:available?).returns(true)
+    AiHealth::Probe.any_instance.stubs(:embedding).returns(
+      probe_result(:failing, failure_code: :dimensions_mismatch)
+    )
+
+    connection = stub("connection")
+    connection.stubs(:table_exists?).with(VectorStore::Pgvector::TABLE_NAME).returns(true)
+    connection.stubs(:extension_enabled?).with("vector").returns(true)
+    ActiveRecord::Base.stubs(:connection).returns(connection)
+
+    with_ai_environment(
+      "ANTHROPIC_ACCESS_TOKEN" => "anthropic-secret",
+      "ANTHROPIC_MODEL" => "claude-sonnet-4-6",
+      "EMBEDDING_URI_BASE" => "https://generativelanguage.googleapis.com/v1beta/openai",
+      "EMBEDDING_MODEL" => "gemini-embedding-2-preview",
+      "EMBEDDING_DIMENSIONS" => "1024"
+    ) do
+      get admin_system_health_url(tab: "ai")
+    end
+
+    assert_response :success
+    assert_match(/The embedding dimensions do not match/, response.body)
+    assert_match(/EMBEDDING_MODEL and EMBEDDING_DIMENSIONS/, response.body)
+    assert_match(/gemini-embedding-2-preview/, response.body)
+    assert_no_match(/anthropic-secret/, response.body)
+  end
+
+  test "AI status explains embedding probe timeouts" do
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+    Setting.stubs(:llm_provider).returns("anthropic")
+    VectorStore::Pgvector.stubs(:available?).returns(true)
+    AiHealth::Probe.any_instance.stubs(:embedding).returns(
+      probe_result(:failing, failure_code: :timeout)
+    )
+
+    connection = stub("connection")
+    connection.stubs(:table_exists?).with(VectorStore::Pgvector::TABLE_NAME).returns(true)
+    connection.stubs(:extension_enabled?).with("vector").returns(true)
+    ActiveRecord::Base.stubs(:connection).returns(connection)
+
+    with_ai_environment(
+      "ANTHROPIC_ACCESS_TOKEN" => "anthropic-secret",
+      "ANTHROPIC_MODEL" => "claude-sonnet-4-6",
+      "EMBEDDING_URI_BASE" => "https://generativelanguage.googleapis.com/v1beta/openai",
+      "EMBEDDING_MODEL" => "gemini-embedding-2-preview",
+      "EMBEDDING_DIMENSIONS" => "3072"
+    ) do
+      get admin_system_health_url(tab: "ai")
+    end
+
+    assert_response :success
+    assert_match(/The embedding live check timed out/, response.body)
+    assert_match(/AI_HEALTH_PROBE_TIMEOUT/, response.body)
+    assert_match(/OPENAI_REQUEST_TIMEOUT/, response.body)
     assert_no_match(/anthropic-secret/, response.body)
   end
 

--- a/test/models/ai_health_test.rb
+++ b/test/models/ai_health_test.rb
@@ -138,6 +138,16 @@ class AiHealthTest < ActiveSupport::TestCase
     end
   end
 
+  test "vector store failure kind does not hide pgvector failure behind generic embedding failure" do
+    health = probed_pgvector_health(
+      vector_store: failing_result(:request_failed),
+      embedding: failing_result(:request_failed)
+    )
+
+    assert_equal :failing, health.vector_store_status
+    assert_equal :pgvector_probe_failed, health.vector_store_failure_kind
+  end
+
   private
     def probed_health(llm:, function_calling:)
       AiHealth::Probe.any_instance.stubs(:llm).returns(result(llm))

--- a/test/models/ai_health_test.rb
+++ b/test/models/ai_health_test.rb
@@ -4,7 +4,8 @@ class AiHealthTest < ActiveSupport::TestCase
   AI_ENVIRONMENT = %w[
     OPENAI_ACCESS_TOKEN OPENAI_URI_BASE OPENAI_MODEL
     ANTHROPIC_ACCESS_TOKEN ANTHROPIC_API_KEY VECTOR_STORE_PROVIDER
-    OPENAI_SUPPORTS_RESPONSES_ENDPOINT
+    OPENAI_SUPPORTS_RESPONSES_ENDPOINT EMBEDDING_URI_BASE EMBEDDING_MODEL
+    EMBEDDING_DIMENSIONS EMBEDDING_ACCESS_TOKEN
   ].index_with(nil).freeze
 
   setup do
@@ -106,6 +107,37 @@ class AiHealthTest < ActiveSupport::TestCase
     end
   end
 
+  test "vector store failure kind explains pgvector storage setup failures" do
+    {
+      extension_not_enabled: :pgvector_extension_not_enabled,
+      table_not_found: :pgvector_table_not_found
+    }.each do |failure_code, failure_kind|
+      health = probed_pgvector_health(
+        vector_store: failing_result(failure_code),
+        embedding: result(:passing)
+      )
+
+      assert_equal :failing, health.vector_store_status
+      assert_equal failure_kind, health.vector_store_failure_kind
+    end
+  end
+
+  test "vector store failure kind explains embedding setup failures" do
+    {
+      dimensions_mismatch: :embedding_dimensions_mismatch,
+      timeout: :embedding_probe_timeout,
+      request_failed: :embedding_probe_failed
+    }.each do |failure_code, failure_kind|
+      health = probed_pgvector_health(
+        vector_store: result(:passing),
+        embedding: failing_result(failure_code)
+      )
+
+      assert_equal :failing, health.vector_store_status
+      assert_equal failure_kind, health.vector_store_failure_kind
+    end
+  end
+
   private
     def probed_health(llm:, function_calling:)
       AiHealth::Probe.any_instance.stubs(:llm).returns(result(llm))
@@ -118,6 +150,29 @@ class AiHealthTest < ActiveSupport::TestCase
           "OPENAI_ACCESS_TOKEN" => "test-token",
           "OPENAI_URI_BASE" => "https://openrouter.ai/api/v1",
           "OPENAI_MODEL" => "test-model"
+        )
+      ) { AiHealth.new }
+    end
+
+    def probed_pgvector_health(vector_store:, embedding:)
+      AiHealth::Probe.any_instance.stubs(:llm).returns(result(:passing))
+      AiHealth::Probe.any_instance.stubs(:function_calling).returns(result(:passing))
+      AiHealth::Probe.any_instance.stubs(:pdf_text_extraction).returns(result(:passing))
+      AiHealth::Probe.any_instance.stubs(:pdf_vision_processing).returns(result(:passing))
+      AiHealth::Probe.any_instance.stubs(:pgvector).returns(vector_store)
+      AiHealth::Probe.any_instance.stubs(:embedding).returns(embedding)
+      ActiveRecord::Base.connection.stubs(:table_exists?).with(VectorStore::Pgvector::TABLE_NAME).returns(true)
+      ActiveRecord::Base.connection.stubs(:extension_enabled?).with("vector").returns(true)
+      VectorStore::Pgvector.stubs(:available?).returns(true)
+
+      ClimateControl.modify(
+        AI_ENVIRONMENT.merge(
+          "OPENAI_ACCESS_TOKEN" => "test-token",
+          "OPENAI_MODEL" => "test-model",
+          "VECTOR_STORE_PROVIDER" => "pgvector",
+          "EMBEDDING_URI_BASE" => "http://ollama:11434/v1",
+          "EMBEDDING_MODEL" => "mxbai-embed-large",
+          "EMBEDDING_DIMENSIONS" => "1024"
         )
       ) { AiHealth.new }
     end


### PR DESCRIPTION
## What Problem This Solves

Fixes #3321.

The AI status page already runs live vector-store probes, but pgvector and embedding failures were still collapsed into a generic document-search error. That left admins without the concrete setup guidance from the Discord investigation: enabling pgvector, re-running the conditional chunks-table migration, matching embedding dimensions, choosing an active LLM model, and persisting timeout settings.

## Why This Change Was Made

This extends the health-check pattern added in #3255: classify the probe's concrete failure code first, then render operator-facing guidance for the specific failure instead of making the admin infer the cause from logs.

## User Impact

Super admins now see targeted System health → AI status alerts for:

- unavailable configured LLM models, including a Gemini OpenAI-compatible example
- disabled PostgreSQL `vector` extension
- missing `vector_store_chunks` table
- pgvector storage query failures
- embedding dimension mismatches
- embedding probe timeouts and generic embedding endpoint failures

The hosting docs now include the matching pgvector and embedding troubleshooting commands.

## Evidence

- `bin/rails test test/models/ai_health_test.rb test/controllers/admin/system_health_controller_test.rb test/models/ai_health/probe_test.rb`
- `bin/rubocop app/models/ai_health.rb test/models/ai_health_test.rb test/controllers/admin/system_health_controller_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added specific AI system-health alerts for unavailable models, pgvector setup issues, embedding dimension mismatches, timeouts, and probe failures.
  * Health diagnostics now provide targeted remediation guidance while retaining generic failure alerts for unclassified issues.

* **Documentation**
  * Added troubleshooting guidance for pgvector, embedding configuration, and related timeout settings.

* **Tests**
  * Expanded coverage for AI health diagnostics, configuration details, failure classification, and credential redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->