### PR TITLE
Fix manual holding market value recalculation

### DIFF
--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -23,6 +23,8 @@ class Holding < ApplicationRecord
   validates :external_id, uniqueness: { scope: :account_id }, allow_blank: true
   validates :cost_basis_source, inclusion: { in: COST_BASIS_SOURCES }, allow_nil: true
 
+  before_validation :derive_manual_amount_from_price, if: :should_derive_manual_amount_from_price?
+
   scope :chronological, -> { order(:date) }
   scope :for, ->(security) { where(security_id: security).order(:date) }
   scope :with_locked_cost_basis, -> { where(cost_basis_locked: true) }
@@ -262,6 +264,14 @@ class Holding < ApplicationRecord
       Money.new(amount, currency).exchange_to(account.currency, date: date).amount
     rescue Money::ConversionError
       amount
+    end
+
+    def should_derive_manual_amount_from_price?
+      account_provider_id.nil? && external_id.blank? && !will_save_change_to_amount? && (will_save_change_to_qty? || will_save_change_to_price?)
+    end
+
+    def derive_manual_amount_from_price
+      self.amount = qty * price if qty.present? && price.present?
     end
 
     def calculate_trend

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -24,6 +24,7 @@ class Holding < ApplicationRecord
   validates :cost_basis_source, inclusion: { in: COST_BASIS_SOURCES }, allow_nil: true
 
   before_validation :derive_manual_amount_from_price, if: :should_derive_manual_amount_from_price?
+  after_save :clear_amount_assignment_flag
 
   scope :chronological, -> { order(:date) }
   scope :for, ->(security) { where(security_id: security).order(:date) }
@@ -31,6 +32,11 @@ class Holding < ApplicationRecord
   scope :with_unlocked_cost_basis, -> { where(cost_basis_locked: false) }
 
   delegate :ticker, to: :security
+
+  def amount=(value)
+    @amount_assigned = true
+    super
+  end
 
   def name
     security.name || ticker
@@ -267,11 +273,19 @@ class Holding < ApplicationRecord
     end
 
     def should_derive_manual_amount_from_price?
-      account_provider_id.nil? && external_id.blank? && !will_save_change_to_amount? && (will_save_change_to_qty? || will_save_change_to_price?)
+      account_provider_id.nil? && external_id.blank? && !amount_assigned? && (will_save_change_to_qty? || will_save_change_to_price?)
     end
 
     def derive_manual_amount_from_price
       self.amount = qty * price if qty.present? && price.present?
+    end
+
+    def amount_assigned?
+      @amount_assigned == true
+    end
+
+    def clear_amount_assignment_flag
+      @amount_assigned = false
     end
 
     def calculate_trend

--- a/test/models/holding_test.rb
+++ b/test/models/holding_test.rb
@@ -49,6 +49,12 @@ class HoldingTest < ActiveSupport::TestCase
     assert_equal BigDecimal("3240.0"), @amzn.amount
   end
 
+  test "keeps explicit market value when quantity and price change" do
+    @amzn.update!(qty: 20, price: 250, amount: @amzn.amount)
+
+    assert_equal BigDecimal("3240.0"), @amzn.amount
+  end
+
   test "calculates average cost basis" do
     create_trade(@amzn.security, account: @account, qty: 10, price: 212.00, date: 1.day.ago.to_date)
     create_trade(@amzn.security, account: @account, qty: 15, price: 216.00, date: Date.current)

--- a/test/models/holding_test.rb
+++ b/test/models/holding_test.rb
@@ -36,6 +36,19 @@ class HoldingTest < ActiveSupport::TestCase
     assert_in_delta 0.75, foreign_holding.weight, 0.001
   end
 
+  test "recalculates manual market value when price changes" do
+    @amzn.update!(price: 250)
+
+    assert_equal BigDecimal("3750.0"), @amzn.amount
+    assert_equal Money.new(3750, "USD"), @amzn.amount_money
+  end
+
+  test "keeps explicit market value when price changes" do
+    @amzn.update!(price: 250, amount: 4000)
+
+    assert_equal BigDecimal("4000.0"), @amzn.amount
+  end
+
   test "calculates average cost basis" do
     create_trade(@amzn.security, account: @account, qty: 10, price: 212.00, date: 1.day.ago.to_date)
     create_trade(@amzn.security, account: @account, qty: 15, price: 216.00, date: Date.current)

--- a/test/models/holding_test.rb
+++ b/test/models/holding_test.rb
@@ -44,9 +44,9 @@ class HoldingTest < ActiveSupport::TestCase
   end
 
   test "keeps explicit market value when price changes" do
-    @amzn.update!(price: 250, amount: 4000)
+    @amzn.update!(price: 250, amount: @amzn.amount)
 
-    assert_equal BigDecimal("4000.0"), @amzn.amount
+    assert_equal BigDecimal("3240.0"), @amzn.amount
   end
 
   test "calculates average cost basis" do


### PR DESCRIPTION
## Summary
- Recalculate manual holding market value when price or quantity changes without an explicit amount.
- Preserve explicitly supplied holding amounts for imports/provider-style updates.
- Add regression coverage for stale manual holding market value.

## Tests
- bin/rails test test/models/holding_test.rb test/models/holding/materializer_test.rb test/models/balance/materializer_test.rb test/controllers/holdings_controller_test.rb
- bin/rails test test/models/balance/forward_calculator_test.rb test/models/balance/reverse_calculator_test.rb test/models/balance/sync_cache_test.rb
- bin/rubocop app/models/holding.rb test/models/holding_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Manually created or edited holdings now recalculate their value from quantity and price when those details change.
  - Explicitly provided market values remain unchanged during edits, including when the value matches the current calculated amount.
  - Value updates now behave consistently when quantity, price, or both are modified.

- **Tests**
  - Added coverage for recalculated holding values and preservation of manually supplied values across common editing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->