### PR TITLE
fix(l10n): localize unsupported rule labels

### DIFF
--- a/config/locales/models/rule/de.yml
+++ b/config/locales/models/rule/de.yml
@@ -7,3 +7,6 @@ de:
           duplicate_actions: 'Eine Regel darf keine doppelten Aktionen enthalten: %{types}'
           min_actions: braucht mindestens eine Aktion
           nested_conditions: Zusammengesetzte Bedingungen lassen sich nicht verschachteln
+  rule:
+    conditions:
+      unsupported_label: "Nicht unterstützt (%{type})"

--- a/test/system/rules_test.rb
+++ b/test/system/rules_test.rb
@@ -36,6 +36,7 @@ class RulesTest < ApplicationSystemTestCase
   end
 
   test "rules page renders gracefully when a condition has an unsupported condition_type" do
+    @user.update!(locale: "de")
     rule = @user.family.rules.create!(
       name: "Legacy bad rule",
       resource_type: "transaction",
@@ -53,6 +54,6 @@ class RulesTest < ApplicationSystemTestCase
     visit rules_path
 
     assert_selector "h3", text: "Legacy bad rule"
-    assert_text "Unsupported (name)"
+    assert_text "Nicht unterstützt (name)"
   end
 end


### PR DESCRIPTION
## Summary

German rule pages now keep the legacy unsupported-condition fallback in German instead of falling back to English. This is a focused slice of the rolling German-localization work; the recently merged import-step and Plaid-action slices cover separate surfaces.

Planning decisions carried into this slice: current-main reproduction (user-directed); one root cause per PR and established-vocabulary reuse (user-approved).

## Testing

- `bin/rails test test/system/rules_test.rb` (2 runs, 4 assertions)
- `bin/rails test test/models/rule/condition_test.rb` (34 runs, 63 assertions)
- `bin/rails test test/i18n_test.rb` (6 runs, 132 assertions, 4 skips)
- `bin/rails test` (8,130 runs, 32,234 assertions, 30 skips)
- `bin/rubocop` (2,484 files, no offenses)

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This change only adds a German locale leaf and a rendered regression test; it does not alter runtime control flow or persisted data.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translation support for the unsupported rule condition message.

* **Tests**
  * Updated rule display coverage to verify the German localized message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->