### PR TITLE
fix(transfers): fall back to nearest cached FX rate for cross-currency transfer matching

### DIFF
--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -1,4 +1,10 @@
 module Family::AutoTransferMatchable
+  # A future-dated rate is only ever a legitimate match for a timezone skew between
+  # a data source and the server (at most a day), not for the provider catching up
+  # on missed days -- unlike the backward direction, it must stay tight so a stale
+  # transaction can't be matched against an unrelated, much-later rate.
+  RATE_LOOKAHEAD_DAYS = 1
+
   def transfer_match_candidates(
     date_window: 4,
     exchange_rate_tolerance: 0.1,
@@ -21,7 +27,8 @@ module Family::AutoTransferMatchable
         include_rejected:,
         lower_exchange_rate_bound: 1 - exchange_rate_tolerance,
         upper_exchange_rate_bound: 1 + exchange_rate_tolerance,
-        rate_lookback_days: ExchangeRate::Provided::NEAREST_RATE_LOOKBACK_DAYS
+        rate_lookback_days: ExchangeRate::Provided::NEAREST_RATE_LOOKBACK_DAYS,
+        rate_lookahead_days: RATE_LOOKAHEAD_DAYS
       }
     ])
   end
@@ -200,7 +207,7 @@ module Family::AutoTransferMatchable
             WHERE
               er.from_currency = outflow_candidates.currency AND
               er.to_currency = inflow_candidates.currency AND
-              er.date BETWEEN outflow_candidates.date - :rate_lookback_days AND outflow_candidates.date + :rate_lookback_days
+              er.date BETWEEN outflow_candidates.date - :rate_lookback_days AND outflow_candidates.date + :rate_lookahead_days
             ORDER BY ABS(er.date - outflow_candidates.date) ASC, er.date DESC
             LIMIT 1
           ) exchange_rates ON TRUE

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -142,6 +142,9 @@ module Family::AutoTransferMatchable
       tolerance
     end
 
+    # On a tie in date-distance between a cached rate before and after the outflow date,
+    # the query below prefers the past-dated rate: the forward window exists only to
+    # cover timezone skew, so it must never outrank real historical data.
     def transfer_match_candidates_sql
       <<~SQL.squish
         SELECT transfer_match_candidates.*
@@ -208,7 +211,7 @@ module Family::AutoTransferMatchable
               er.from_currency = outflow_candidates.currency AND
               er.to_currency = inflow_candidates.currency AND
               er.date BETWEEN outflow_candidates.date - :rate_lookback_days AND outflow_candidates.date + :rate_lookahead_days
-            ORDER BY ABS(er.date - outflow_candidates.date) ASC, er.date DESC
+            ORDER BY ABS(er.date - outflow_candidates.date) ASC, er.date ASC
             LIMIT 1
           ) exchange_rates ON TRUE
           LEFT JOIN transfers existing_transfers ON (

--- a/app/models/family/auto_transfer_matchable.rb
+++ b/app/models/family/auto_transfer_matchable.rb
@@ -20,7 +20,8 @@ module Family::AutoTransferMatchable
         account_id:,
         include_rejected:,
         lower_exchange_rate_bound: 1 - exchange_rate_tolerance,
-        upper_exchange_rate_bound: 1 + exchange_rate_tolerance
+        upper_exchange_rate_bound: 1 + exchange_rate_tolerance,
+        rate_lookback_days: ExchangeRate::Provided::NEAREST_RATE_LOOKBACK_DAYS
       }
     ])
   end
@@ -193,11 +194,16 @@ module Family::AutoTransferMatchable
             outflow_candidates.currency <> inflow_candidates.currency
           )
           JOIN accounts outflow_accounts ON outflow_accounts.id = outflow_candidates.account_id
-          JOIN exchange_rates ON (
-            exchange_rates.date = outflow_candidates.date AND
-            exchange_rates.from_currency = outflow_candidates.currency AND
-            exchange_rates.to_currency = inflow_candidates.currency
-          )
+          LEFT JOIN LATERAL (
+            SELECT er.rate
+            FROM exchange_rates er
+            WHERE
+              er.from_currency = outflow_candidates.currency AND
+              er.to_currency = inflow_candidates.currency AND
+              er.date BETWEEN outflow_candidates.date - :rate_lookback_days AND outflow_candidates.date + :rate_lookback_days
+            ORDER BY ABS(er.date - outflow_candidates.date) ASC, er.date DESC
+            LIMIT 1
+          ) exchange_rates ON TRUE
           LEFT JOIN transfers existing_transfers ON (
             existing_transfers.inflow_transaction_id = inflow_candidates.entryable_id OR
             existing_transfers.outflow_transaction_id = outflow_candidates.entryable_id
@@ -216,6 +222,7 @@ module Family::AutoTransferMatchable
             outflow_accounts.status IN ('draft', 'active') AND
             existing_transfers.id IS NULL AND
             (:account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id) AND
+            exchange_rates.rate IS NOT NULL AND
             ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0))
               BETWEEN :lower_exchange_rate_bound AND :upper_exchange_rate_bound AND
             (:inflow_transaction_id IS NULL OR inflow_candidates.entryable_id = :inflow_transaction_id) AND

--- a/test/controllers/transfer_matches_controller_test.rb
+++ b/test/controllers/transfer_matches_controller_test.rb
@@ -56,6 +56,18 @@ class TransferMatchesControllerTest < ActionDispatch::IntegrationTest
     assert new_entry.user_modified?, "New transfer entry should be marked as user_modified to protect from provider sync"
   end
 
+  test "new lists cross-currency candidate even when exact-date exchange rate is missing" do
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 2.days.ago.to_date, rate: 1.4)
+
+    outflow_entry = create_transaction(date: Date.current, amount: 500, account: accounts(:depository))
+    inflow_entry = create_transaction(date: Date.current, amount: -700, currency: "CAD", account: accounts(:credit_card))
+
+    get new_transaction_transfer_match_path(inflow_entry)
+
+    assert_response :success
+    assert_select "option[value='#{outflow_entry.id}']"
+  end
+
   test "assigns investment_contribution kind and category for investment destination" do
     # Outflow from depository (positive amount), target is investment
     outflow_entry = create_transaction(amount: 100, account: accounts(:depository))

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -345,6 +345,21 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
+  test "on an equal-distance tie between a past and future rate, prefers the past rate" do
+    # Both rates are exactly 1 day from the outflow date, so date-distance alone
+    # can't break the tie. The forward window exists only to cover timezone skew,
+    # so on a tie the past (historical) rate must win over the future one.
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 1.day.ago.to_date, rate: 1.4)
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 1.day.from_now.to_date, rate: 5.0)
+
+    create_transaction(date: Date.current, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
+
+    assert_difference -> { Transfer.count } => 1 do
+      @family.auto_match_transfers!
+    end
+  end
+
   test "same-currency matching ignores amount-mismatched busy-window entries" do
     noise_transaction_ids = []
 

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -283,6 +283,53 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
+  test "matches multi-currency transfer when exact-date rate is missing but an earlier in-window rate exists" do
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 2.days.ago.to_date, rate: 1.4)
+
+    create_transaction(date: Date.current, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
+
+    assert_difference -> { Transfer.count } => 1 do
+      @family.auto_match_transfers!
+    end
+  end
+
+  test "matches multi-currency transfer when exact-date rate is missing but a later in-window rate exists (timezone offset case)" do
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 2.days.from_now.to_date, rate: 1.4)
+
+    create_transaction(date: Date.current, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
+
+    assert_difference -> { Transfer.count } => 1 do
+      @family.auto_match_transfers!
+    end
+  end
+
+  test "does not match multi-currency transfer when the only cached rate is outside the lookback window" do
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 10.days.ago.to_date, rate: 1.4)
+
+    create_transaction(date: Date.current, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
+
+    assert_no_difference -> { Transfer.count } do
+      @family.auto_match_transfers!
+    end
+  end
+
+  test "picks the nearest in-window rate by date distance, not the first one that happens to match" do
+    # Farther rate (distance 4) would satisfy the tolerance if chosen; nearer rate
+    # (distance 1) would not. Asserting no match proves the nearer rate wins.
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 4.days.ago.to_date, rate: 1.4)
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 1.day.ago.to_date, rate: 2.0)
+
+    create_transaction(date: Date.current, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
+
+    assert_no_difference -> { Transfer.count } do
+      @family.auto_match_transfers!
+    end
+  end
+
   test "same-currency matching ignores amount-mismatched busy-window entries" do
     noise_transaction_ids = []
 
@@ -329,7 +376,11 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     assert_includes sql, "outflow_candidates.excluded = FALSE"
     assert_includes sql, ":account_id IS NULL OR inflow_candidates.account_id = :account_id OR outflow_candidates.account_id = :account_id"
     assert_includes sql, "outflow_candidates.amount = -inflow_candidates.amount"
-    assert_includes sql, "JOIN exchange_rates"
+    assert_includes sql, "LEFT JOIN LATERAL"
+    assert_includes sql, "exchange_rates ON TRUE"
+    assert_includes sql, "exchange_rates.rate IS NOT NULL"
+    assert_includes sql, "outflow_candidates.date - :rate_lookback_days AND outflow_candidates.date + :rate_lookback_days"
+    assert_includes sql, "ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0))"
   end
 
   # Regression tests for loan transfer kind assignment bug

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -294,8 +294,8 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
-  test "matches multi-currency transfer when exact-date rate is missing but a later in-window rate exists (timezone offset case)" do
-    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 2.days.from_now.to_date, rate: 1.4)
+  test "matches multi-currency transfer when exact-date rate is missing but a next-day rate exists (timezone offset case)" do
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 1.day.from_now.to_date, rate: 1.4)
 
     create_transaction(date: Date.current, account: @depository, amount: 500)
     create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
@@ -305,8 +305,23 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     end
   end
 
-  test "does not match multi-currency transfer when the only cached rate is outside the lookback window" do
+  test "does not match multi-currency transfer when the only cached rate is outside the backward lookback window" do
     ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 10.days.ago.to_date, rate: 1.4)
+
+    create_transaction(date: Date.current, account: @depository, amount: 500)
+    create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
+
+    assert_no_difference -> { Transfer.count } do
+      @family.auto_match_transfers!
+    end
+  end
+
+  test "does not match multi-currency transfer when the only cached rate is more than one day in the future" do
+    # The forward window only exists to cover a timezone skew between a data source
+    # and the server (at most a day) -- unlike the 5-day backward lookback, it must
+    # not reach further, or a stale transaction could be matched against an
+    # unrelated, much-later rate.
+    ExchangeRate.create!(from_currency: "USD", to_currency: "CAD", date: 2.days.from_now.to_date, rate: 1.4)
 
     create_transaction(date: Date.current, account: @depository, amount: 500)
     create_transaction(date: Date.current, account: @credit_card, amount: -700, currency: "CAD")
@@ -379,7 +394,7 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
     assert_includes sql, "LEFT JOIN LATERAL"
     assert_includes sql, "exchange_rates ON TRUE"
     assert_includes sql, "exchange_rates.rate IS NOT NULL"
-    assert_includes sql, "outflow_candidates.date - :rate_lookback_days AND outflow_candidates.date + :rate_lookback_days"
+    assert_includes sql, "outflow_candidates.date - :rate_lookback_days AND outflow_candidates.date + :rate_lookahead_days"
     assert_includes sql, "ABS(inflow_candidates.amount / NULLIF(outflow_candidates.amount * exchange_rates.rate, 0))"
   end
 


### PR DESCRIPTION
## Summary

Closes #3273.

`Family::AutoTransferMatchable#transfer_match_candidates_sql`'s cross-currency branch joined `exchange_rates` with an `INNER JOIN` requiring an **exact date match**. Because it's an inner join, a missing rate for that specific date silently dropped an otherwise-valid transfer-match candidate from the result set entirely — not just for `auto_match_transfers!`, but also for the manual "match as transfer" dialog (`TransferMatchesController#new` calls the same `Transaction#transfer_match_candidates` → same SQL). Most commonly hit for transactions dated "today" (or "tomorrow", from a timezone offset between a data source and the server) before the daily FX-rate sync has caught up.

This mirrors an established fallback pattern already used elsewhere in the codebase (`ExchangeRate::Provided#find_or_fetch_rate`, `Balance::ChartSeriesBuilder`), which fall back to the nearest cached rate instead of requiring an exact-date hit.

## Change

In the cross-currency branch of `transfer_match_candidates_sql`, replaced the exact-date `INNER JOIN exchange_rates` with a `LEFT JOIN LATERAL` that picks the nearest available rate for the currency pair within `outflow_candidates.date ± ExchangeRate::Provided::NEAREST_RATE_LOOKBACK_DAYS` (5 days), searching **both directions** (the timezone-offset "tomorrow" case needs forward-looking too, not just backward like `find_or_fetch_rate`'s single-direction lookback), ordered by absolute date distance. An explicit `exchange_rates.rate IS NOT NULL` guard was added since the join is now a `LEFT JOIN` — a currency pair with no rate history anywhere still correctly produces no candidate.

The lookback is deliberately **bounded**, not unbounded — this same branch has a known, separately-tracked false-positive problem (#3308, filed against the ±10% tolerance on manual accounts), so this fix avoids widening that exposure by falling back to arbitrarily old rates.

The same-currency exact-amount branch is untouched.

## Test plan

- [x] `test/models/family/auto_transfer_matchable_test.rb`:
  - New: exact-date rate missing, matches on an earlier in-window rate
  - New: exact-date rate missing, matches on a later in-window rate (timezone-offset case)
  - New: no rate within the lookback window → still no match (bounded, not unbounded fallback)
  - New: nearest in-window rate is chosen over a farther one that would have passed the tolerance check, proving the `ORDER BY` distance actually drives selection
  - Existing test asserting "no rate exists at all, ever → no match" left unmodified, still passes
  - Updated the structural SQL assertion test to match the new `LEFT JOIN LATERAL` shape
- [x] `test/controllers/transfer_matches_controller_test.rb`: new test proving the manual "match as transfer" dialog now lists the cross-currency candidate when the exact-date rate is missing
- [x] `bin/rails test test/models/family/auto_transfer_matchable_test.rb test/controllers/transfer_matches_controller_test.rb` — 31 runs, 0 failures/errors
- [x] `bin/rails test` (full suite) — pre-existing, unrelated failures only (self-hosted feature-flag config, an FX-provider mock mismatch in an unrelated test); none touch transfer matching or exchange-rate logic; confirmed by reproducing them in isolation off this branch
- [x] `bin/rubocop` on changed files — 0 offenses
- [x] `bin/brakeman --no-pager` — 0 warnings/errors

## Related

- #3308 — separate, opposite-direction bug in the same cross-currency branch (FX tolerance too loose on manual accounts). Not addressed here; this fix keeps the lookback bounded specifically so it doesn't make that problem worse.
- #3306 — separate axis (pending→booked provider dedup), different file, not touched.
- #3034 (open) — touches a different, non-overlapping part of the same file (`auto_match_transfers!`'s kind/category assignment, moved to `Transfer#confirm!`). Verified via `git merge-tree` in both directions that this PR merges cleanly against it regardless of merge order.

---

*Disclosure: this PR was written with the help of an AI assistant (Claude Code).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cross-currency transfer matching now works when no exchange rate is available on the exact transaction date.
  - The system selects the nearest available exchange rate within the supported lookback period or up to one day afterward.
  - Earlier rates are preferred when past and future rates are equally close.
  - Rates outside the supported date window are not used for matching.
  - Transfer-match forms now correctly show eligible cross-currency transactions when a nearby exchange rate is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->