### PR TITLE
fix(l10n): localize SimpleFIN status summaries

### DIFF
--- a/app/models/simplefin_item.rb
+++ b/app/models/simplefin_item.rb
@@ -318,27 +318,19 @@ class SimplefinItem < ApplicationRecord
       total = stats["total_accounts"] || 0
       linked = stats["linked_accounts"] || 0
       unlinked = stats["unlinked_accounts"] || 0
-
-      if total == 0
-        "No accounts found"
-      elsif unlinked == 0
-        "#{linked} #{'account'.pluralize(linked)} synced"
-      else
-        "#{linked} synced, #{unlinked} need setup"
-      end
     else
       # Fallback to current account counts
-      total_accounts = simplefin_accounts.count
-      linked_count = accounts.count
-      unlinked_count = total_accounts - linked_count
+      total = simplefin_accounts.count
+      linked = accounts.count
+      unlinked = total - linked
+    end
 
-      if total_accounts == 0
-        "No accounts found"
-      elsif unlinked_count == 0
-        "#{linked_count} #{'account'.pluralize(linked_count)} synced"
-      else
-        "#{linked_count} synced, #{unlinked_count} need setup"
-      end
+    if total == 0
+      I18n.t("simplefin_items.sync_status.no_accounts")
+    elsif unlinked == 0
+      I18n.t("simplefin_items.sync_status.synced", count: linked)
+    else
+      I18n.t("simplefin_items.sync_status.partial_setup", count: unlinked, linked: linked, unlinked: unlinked)
     end
   end
 
@@ -359,11 +351,11 @@ class SimplefinItem < ApplicationRecord
     institutions = connected_institutions
     case institutions.count
     when 0
-      "No institutions connected"
+      I18n.t("simplefin_items.institution_summary.none")
     when 1
-      institutions.first["name"] || institutions.first["domain"] || "1 institution"
+      institutions.first["name"] || institutions.first["domain"] || I18n.t("simplefin_items.institution_summary.count", count: 1)
     else
-      "#{institutions.count} institutions"
+      I18n.t("simplefin_items.institution_summary.count", count: institutions.count)
     end
   end
 
@@ -383,7 +375,7 @@ class SimplefinItem < ApplicationRecord
 
     down = msg.downcase
     if down.include?("make fewer requests") || down.include?("only refreshed once every 24 hours") || down.include?("rate limit")
-      "You've hit SimpleFin's daily refresh limit. Please try again after the bridge refreshes (up to 24 hours)."
+      I18n.t("simplefin_items.rate_limited.daily_refresh")
     else
       nil
     end
@@ -400,7 +392,7 @@ class SimplefinItem < ApplicationRecord
       return {
         stale: true,
         days_since_sync: days_since_sync,
-        message: "Last successful sync was #{days_since_sync} days ago. Your SimpleFin connection may need attention."
+        message: I18n.t("simplefin_items.stale_sync.last_successful", count: days_since_sync)
       }
     end
 
@@ -419,7 +411,7 @@ class SimplefinItem < ApplicationRecord
         return {
           stale: true,
           days_since_transaction: days_since_transaction,
-          message: "No new transactions in #{days_since_transaction} days. Check your SimpleFin dashboard to ensure your bank connections are active."
+          message: I18n.t("simplefin_items.stale_sync.no_transactions", count: days_since_transaction)
         }
       end
     end

--- a/config/locales/views/simplefin_items/de.yml
+++ b/config/locales/views/simplefin_items/de.yml
@@ -92,6 +92,24 @@ de:
       stale_accounts_errors:
         one: "%{count} Aktion für veraltetes Konto fehlgeschlagen. Details in den Logs prüfen."
         other: "%{count} Aktionen für veraltete Konten fehlgeschlagen. Details in den Logs prüfen."
+    sync_status:
+      no_accounts: Keine Konten gefunden
+      synced:
+        one: "%{count} Konto synchronisiert"
+        other: "%{count} Konten synchronisiert"
+      partial_setup:
+        one: "%{linked} synchronisiert, %{unlinked} muss eingerichtet werden"
+        other: "%{linked} synchronisiert, %{unlinked} müssen eingerichtet werden"
+    institution_summary:
+      none: Keine Institute verbunden
+      count:
+        one: "%{count} Institut"
+        other: "%{count} Institute"
+    rate_limited:
+      daily_refresh: "Du hast das tägliche Aktualisierungslimit von SimpleFIN erreicht. Versuch es erneut, sobald die SimpleFIN Bridge die Daten aktualisiert hat (das kann bis zu 24 Stunden dauern)."
+    stale_sync:
+      last_successful: "Die letzte erfolgreiche Synchronisierung war vor %{count} Tagen. Deine SimpleFIN-Verbindung braucht möglicherweise Aufmerksamkeit."
+      no_transactions: "Seit %{count} Tagen gibt es keine neuen Transaktionen. Prüfe in deinem SimpleFIN-Dashboard, ob deine Bankverbindungen aktiv sind."
     simplefin_item:
       add_new: Neue Verbindung hinzufügen
       confirm_accept: Verbindung löschen

--- a/config/locales/views/simplefin_items/en.yml
+++ b/config/locales/views/simplefin_items/en.yml
@@ -106,10 +106,10 @@ en:
         one: "%{count} institution"
         other: "%{count} institutions"
     rate_limited:
-      daily_refresh: "You've hit SimpleFin's daily refresh limit. Please try again after the bridge refreshes (up to 24 hours)."
+      daily_refresh: "You've hit SimpleFIN's daily refresh limit. Please try again after the bridge refreshes (up to 24 hours)."
     stale_sync:
-      last_successful: "Last successful sync was %{count} days ago. Your SimpleFin connection may need attention."
-      no_transactions: "No new transactions in %{count} days. Check your SimpleFin dashboard to ensure your bank connections are active."
+      last_successful: "Last successful sync was %{count} days ago. Your SimpleFIN connection may need attention."
+      no_transactions: "No new transactions in %{count} days. Check your SimpleFIN dashboard to ensure your bank connections are active."
     simplefin_item:
       add_new: Add new connection
       confirm_accept: Delete connection

--- a/config/locales/views/simplefin_items/en.yml
+++ b/config/locales/views/simplefin_items/en.yml
@@ -92,6 +92,24 @@ en:
       stale_accounts_errors:
         one: "%{count} stale account action failed. Check logs for details."
         other: "%{count} stale account actions failed. Check logs for details."
+    sync_status:
+      no_accounts: No accounts found
+      synced:
+        one: "%{count} account synced"
+        other: "%{count} accounts synced"
+      partial_setup:
+        one: "%{linked} synced, %{unlinked} need setup"
+        other: "%{linked} synced, %{unlinked} need setup"
+    institution_summary:
+      none: No institutions connected
+      count:
+        one: "%{count} institution"
+        other: "%{count} institutions"
+    rate_limited:
+      daily_refresh: "You've hit SimpleFin's daily refresh limit. Please try again after the bridge refreshes (up to 24 hours)."
+    stale_sync:
+      last_successful: "Last successful sync was %{count} days ago. Your SimpleFin connection may need attention."
+      no_transactions: "No new transactions in %{count} days. Check your SimpleFin dashboard to ensure your bank connections are active."
     simplefin_item:
       add_new: Add new connection
       confirm_accept: Delete connection

--- a/test/models/simplefin_item_localization_test.rb
+++ b/test/models/simplefin_item_localization_test.rb
@@ -75,7 +75,7 @@ class SimplefinItemLocalizationTest < ActiveSupport::TestCase
 
     assert_equal "Du hast das tägliche Aktualisierungslimit von SimpleFIN erreicht. Versuch es erneut, sobald die SimpleFIN Bridge die Daten aktualisiert hat (das kann bis zu 24 Stunden dauern).",
                  I18n.with_locale(:de) { @simplefin_item.rate_limited_message }
-    assert_equal "You've hit SimpleFin's daily refresh limit. Please try again after the bridge refreshes (up to 24 hours).",
+    assert_equal "You've hit SimpleFIN's daily refresh limit. Please try again after the bridge refreshes (up to 24 hours).",
                  I18n.with_locale(:en) { @simplefin_item.rate_limited_message }
     assert_equal provider_error, sync.reload.error
   end
@@ -90,7 +90,7 @@ class SimplefinItemLocalizationTest < ActiveSupport::TestCase
 
       assert_equal "Die letzte erfolgreiche Synchronisierung war vor 5 Tagen. Deine SimpleFIN-Verbindung braucht möglicherweise Aufmerksamkeit.",
                    I18n.with_locale(:de) { @simplefin_item.stale_sync_status[:message] }
-      assert_equal "Last successful sync was 5 days ago. Your SimpleFin connection may need attention.",
+      assert_equal "Last successful sync was 5 days ago. Your SimpleFIN connection may need attention.",
                    I18n.with_locale(:en) { @simplefin_item.stale_sync_status[:message] }
     end
   end
@@ -115,7 +115,7 @@ class SimplefinItemLocalizationTest < ActiveSupport::TestCase
 
       assert_equal "Seit 20 Tagen gibt es keine neuen Transaktionen. Prüfe in deinem SimpleFIN-Dashboard, ob deine Bankverbindungen aktiv sind.",
                    I18n.with_locale(:de) { @simplefin_item.reload.stale_sync_status[:message] }
-      assert_equal "No new transactions in 20 days. Check your SimpleFin dashboard to ensure your bank connections are active.",
+      assert_equal "No new transactions in 20 days. Check your SimpleFIN dashboard to ensure your bank connections are active.",
                    I18n.with_locale(:en) { @simplefin_item.reload.stale_sync_status[:message] }
     end
   end

--- a/test/models/simplefin_item_localization_test.rb
+++ b/test/models/simplefin_item_localization_test.rb
@@ -1,0 +1,201 @@
+require "test_helper"
+
+class SimplefinItemLocalizationTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:dylan_family)
+    @simplefin_item = create_simplefin_item
+  end
+
+  test "sync summaries are localized with account-aware pluralization" do
+    sync = create_sync(total: 0, linked: 0, unlinked: 0)
+
+    assert_localized_summary sync, de: "Keine Konten gefunden", en: "No accounts found"
+
+    sync.update!(sync_stats: sync_stats(total: 1, linked: 1, unlinked: 0))
+    assert_localized_summary sync, de: "1 Konto synchronisiert", en: "1 account synced"
+
+    sync.update!(sync_stats: sync_stats(total: 2, linked: 2, unlinked: 0))
+    assert_localized_summary sync, de: "2 Konten synchronisiert", en: "2 accounts synced"
+
+    sync.update!(sync_stats: sync_stats(total: 2, linked: 1, unlinked: 1))
+    assert_localized_summary sync, de: "1 synchronisiert, 1 muss eingerichtet werden", en: "1 synced, 1 need setup"
+
+    sync.update!(sync_stats: sync_stats(total: 3, linked: 1, unlinked: 2))
+    assert_localized_summary sync, de: "1 synchronisiert, 2 müssen eingerichtet werden", en: "1 synced, 2 need setup"
+  end
+
+  test "sync summaries fall back to linked and unlinked account counts" do
+    all_synced_item = create_simplefin_item
+    Sync.create!(syncable: all_synced_item, status: "completed", completed_at: Time.current)
+    all_synced_provider_account = create_simplefin_account(all_synced_item, account_id: "all-synced", org_data: {})
+    create_linked_account(all_synced_provider_account, name: "All-synced account")
+
+    assert_localized_item_summary all_synced_item, de: "1 Konto synchronisiert", en: "1 account synced"
+
+    partial_item = create_simplefin_item
+    Sync.create!(syncable: partial_item, status: "completed", completed_at: Time.current)
+    linked_provider_account = create_simplefin_account(partial_item, account_id: "linked-fallback", org_data: {})
+    create_linked_account(linked_provider_account, name: "Linked fallback account")
+    create_simplefin_account(partial_item, account_id: "unlinked-fallback", org_data: {})
+
+    assert_localized_item_summary partial_item,
+                                  de: "1 synchronisiert, 1 muss eingerichtet werden",
+                                  en: "1 synced, 1 need setup"
+  end
+
+  test "institution summaries localize fallbacks and preserve provider names" do
+    assert_localized_institution_summary @simplefin_item,
+                                         de: "Keine Institute verbunden",
+                                         en: "No institutions connected"
+
+    named_item = create_simplefin_item
+    create_simplefin_account(named_item, account_id: "named", org_data: { "name" => "Fjord Bank" })
+    assert_localized_institution_summary named_item, de: "Fjord Bank", en: "Fjord Bank"
+
+    unnamed_item = create_simplefin_item
+    create_simplefin_account(unnamed_item, account_id: "unnamed", org_data: { "id" => "provider-1" })
+    assert_localized_institution_summary unnamed_item, de: "1 Institut", en: "1 institution"
+
+    multiple_item = create_simplefin_item
+    create_simplefin_account(multiple_item, account_id: "first", org_data: { "name" => "Fjord Bank" })
+    create_simplefin_account(multiple_item, account_id: "second", org_data: { "name" => "Harbor Credit" })
+    assert_localized_institution_summary multiple_item, de: "2 Institute", en: "2 institutions"
+  end
+
+  test "daily refresh limit message is localized without changing the provider error" do
+    provider_error = "SimpleFin rate limit: data refreshes at most once every 24 hours."
+    sync = Sync.create!(
+      syncable: @simplefin_item,
+      status: "failed",
+      failed_at: Time.current,
+      error: provider_error
+    )
+
+    assert_equal "Du hast das tägliche Aktualisierungslimit von SimpleFIN erreicht. Versuch es erneut, sobald die SimpleFIN Bridge die Daten aktualisiert hat (das kann bis zu 24 Stunden dauern).",
+                 I18n.with_locale(:de) { @simplefin_item.rate_limited_message }
+    assert_equal "You've hit SimpleFin's daily refresh limit. Please try again after the bridge refreshes (up to 24 hours).",
+                 I18n.with_locale(:en) { @simplefin_item.rate_limited_message }
+    assert_equal provider_error, sync.reload.error
+  end
+
+  test "stale successful sync message is localized" do
+    travel_to Time.zone.local(2026, 9, 2, 12) do
+      Sync.create!(
+        syncable: @simplefin_item,
+        status: "completed",
+        completed_at: 5.days.ago
+      )
+
+      assert_equal "Die letzte erfolgreiche Synchronisierung war vor 5 Tagen. Deine SimpleFIN-Verbindung braucht möglicherweise Aufmerksamkeit.",
+                   I18n.with_locale(:de) { @simplefin_item.stale_sync_status[:message] }
+      assert_equal "Last successful sync was 5 days ago. Your SimpleFin connection may need attention.",
+                   I18n.with_locale(:en) { @simplefin_item.stale_sync_status[:message] }
+    end
+  end
+
+  test "stale transaction message is localized" do
+    travel_to Time.zone.local(2026, 9, 2, 12) do
+      Sync.create!(
+        syncable: @simplefin_item,
+        status: "completed",
+        completed_at: 1.day.ago
+      )
+      account = Account.create!(
+        family: @family,
+        name: "Everyday account",
+        accountable: Depository.new(subtype: "checking"),
+        balance: 100,
+        currency: "USD"
+      )
+      simplefin_account = create_simplefin_account(@simplefin_item, account_id: "linked", org_data: { "name" => "Fjord Bank" })
+      account.update!(simplefin_account: simplefin_account)
+      create_transaction(account: account, name: "Invented purchase", date: 20.days.ago.to_date)
+
+      assert_equal "Seit 20 Tagen gibt es keine neuen Transaktionen. Prüfe in deinem SimpleFIN-Dashboard, ob deine Bankverbindungen aktiv sind.",
+                   I18n.with_locale(:de) { @simplefin_item.reload.stale_sync_status[:message] }
+      assert_equal "No new transactions in 20 days. Check your SimpleFin dashboard to ensure your bank connections are active.",
+                   I18n.with_locale(:en) { @simplefin_item.reload.stale_sync_status[:message] }
+    end
+  end
+
+  test "German summary translations exist without fallback" do
+    assert_equal "Keine Konten gefunden",
+                 I18n.t("simplefin_items.sync_status.no_accounts", locale: :de, fallback: false, default: nil)
+    assert_equal "2 Konten synchronisiert",
+                 I18n.t("simplefin_items.sync_status.synced", locale: :de, fallback: false, default: nil, count: 2)
+    assert_equal "1 synchronisiert, 2 müssen eingerichtet werden",
+                 I18n.t("simplefin_items.sync_status.partial_setup", locale: :de, fallback: false, default: nil,
+                        count: 2, linked: 1, unlinked: 2)
+    assert_equal "2 Institute",
+                 I18n.t("simplefin_items.institution_summary.count", locale: :de, fallback: false, default: nil, count: 2)
+    assert I18n.t("simplefin_items.rate_limited.daily_refresh", locale: :de, fallback: false, default: nil).present?
+    assert I18n.t("simplefin_items.stale_sync.last_successful", locale: :de, fallback: false, default: nil, count: 5).present?
+    assert I18n.t("simplefin_items.stale_sync.no_transactions", locale: :de, fallback: false, default: nil, count: 20).present?
+  end
+
+  private
+    def create_simplefin_item
+      SimplefinItem.create!(
+        family: @family,
+        name: "Invented SimpleFIN connection",
+        access_url: "synthetic-simplefin-access"
+      )
+    end
+
+    def create_simplefin_account(item, account_id:, org_data:)
+      item.simplefin_accounts.create!(
+        name: "Invented provider account",
+        account_id: account_id,
+        currency: "USD",
+        account_type: "checking",
+        current_balance: 100,
+        org_data: org_data
+      )
+    end
+
+    def create_sync(total:, linked:, unlinked:)
+      Sync.create!(
+        syncable: @simplefin_item,
+        status: "completed",
+        completed_at: Time.current,
+        sync_stats: sync_stats(total: total, linked: linked, unlinked: unlinked)
+      )
+    end
+
+    def create_linked_account(simplefin_account, name:)
+      Account.create!(
+        family: @family,
+        name: name,
+        accountable: Depository.new(subtype: "checking"),
+        balance: 100,
+        currency: "USD",
+        simplefin_account: simplefin_account
+      )
+    end
+
+    def sync_stats(total:, linked:, unlinked:)
+      {
+        "total_accounts" => total,
+        "linked_accounts" => linked,
+        "unlinked_accounts" => unlinked
+      }
+    end
+
+    def assert_localized_summary(sync, de:, en:)
+      sync.reload
+      assert_equal de, I18n.with_locale(:de) { @simplefin_item.sync_status_summary }
+      assert_equal en, I18n.with_locale(:en) { @simplefin_item.sync_status_summary }
+    end
+
+    def assert_localized_item_summary(item, de:, en:)
+      assert_equal de, I18n.with_locale(:de) { item.sync_status_summary }
+      assert_equal en, I18n.with_locale(:en) { item.sync_status_summary }
+    end
+
+    def assert_localized_institution_summary(item, de:, en:)
+      assert_equal de, I18n.with_locale(:de) { item.institution_summary }
+      assert_equal en, I18n.with_locale(:en) { item.institution_summary }
+    end
+end


### PR DESCRIPTION
## Summary

German SimpleFIN status cards now localize account sync counts, institution fallbacks, daily refresh-limit guidance, and stale-connection messages. Existing English text stays unchanged, including its legacy singular wording.

Provider-supplied institution names and raw sync errors remain untouched. The shared summaries use provider-owned locale keys, with fallback-disabled German coverage and real-record coverage for stored statistics and fallback account counts.

The German wording received an independent Codex language review; this is not a claim of human or native-speaker review.

Planning decisions carried into this slice: current-main reproduction (user-directed); one provider flow per PR and established-vocabulary reuse (user-approved).

## Testing

- `bin/rails test test/models/simplefin_item_localization_test.rb test/models/simplefin_item_test.rb test/i18n_test.rb` (29 runs, 214 assertions, 4 skips)
- `bin/rails test` (8,150 runs, 32,335 assertions, 30 skips)
- `bin/rubocop` (2,485 files, no offenses)
- Simulated merge against `upstream/main` produced the same tree as the branch

## Post-Deploy Monitoring & Validation

No additional dashboard monitoring is required because this changes display copy only.

- During the first post-deploy smoke check, search logs for `Translation missing` and `I18n::MissingInterpolationArgument` involving `simplefin_items`.
- Healthy behavior shows German SimpleFIN summaries with unchanged provider names and raw provider errors.
- Roll back this commit if missing keys, interpolation errors, or incorrect English regressions appear.
- Owner: release maintainer. Validation window: first post-deploy smoke check.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized SimpleFIN status and summary messages in English and German.
  * Added account and institution count summaries with correct singular and plural wording.
  * Added messages for partial setup, daily refresh limits, stale synchronizations, and missing transactions.
  * Preserved provider names in institution summaries.
  * Added localized fallback messaging when synchronization details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->