### PR TITLE
fix(l10n): localize Onchain wallet setup

### DIFF
--- a/config/locales/views/onchain_wallet_items/de.yml
+++ b/config/locales/views/onchain_wallet_items/de.yml
@@ -55,5 +55,5 @@ de:
       cancel: Abbrechen
       explanation: Vermögenswerte mit bekanntem Preis sind vorausgewählt. Alle anderen bleiben abgewählt – Wallets erhalten Spam-Airdrops, und bei deren Verfolgung wird kein Wert angezeigt.
       native: Nativ
-      no_price: Kein Preis verfügbar; wird nur nach Menge verfolgt
+      no_price: Kein Preis verfügbar; wird nur anhand der Menge verfolgt
       nothing_found: Diese Adresse enthält in diesem Netzwerk nichts, was wir erkennen können.

--- a/config/locales/views/onchain_wallet_items/de.yml
+++ b/config/locales/views/onchain_wallet_items/de.yml
@@ -1,0 +1,59 @@
+---
+de:
+  onchain_wallet_items:
+    choose_chain:
+      activity_found: Aktivität gefunden
+      explanation: Dieses Adressformat wird von mehreren Netzwerken verwendet, deren Guthaben sich unterscheiden. Wähl das Netzwerk, das du verfolgen möchtest.
+      no_activity_found: Nichts gefunden
+      subtitle: "%{address}"
+      title: Welches Netzwerk?
+    enable_crypto_prices:
+      not_self_hosted: Marktdatenanbieter werden für diese Bereitstellung vom Betreiber der Instanz konfiguriert.
+      success: Kryptokurse sind aktiviert. Die Wallet-Werte werden nach dem nächsten Sync angezeigt.
+    errors:
+      address_required: Gib eine Wallet-Adresse ein.
+      already_linked: Diese Adresse wird in diesem Netzwerk bereits verfolgt. Welche Vermögenswerte verfolgt werden, kannst du in der Wallet-Verwaltung ändern.
+      chain_unreachable: Der öffentliche Explorer für dieses Netzwerk ist nicht erreichbar. Versuch es gleich noch einmal.
+      rate_limited: Der öffentliche Explorer begrenzt derzeit die Anzahl der Anfragen. Versuch es in ein paar Minuten erneut.
+      unexpected: Beim Lesen dieser Wallet ist etwas schiefgelaufen. Die Details wurden für den Support erfasst.
+      unrecognized_address: Diese Adresse scheint zu keinem unterstützten Netzwerk zu gehören.
+      wallet_not_found: Diese Wallet wird von dieser Verbindung nicht verfolgt.
+    link_wallet:
+      errors:
+        none_tracked: "Nichts wurde verfolgt. Folgende Vermögenswerte konnten nicht hinzugefügt werden: %{assets}. Versuch es gleich noch einmal."
+        nothing_selected: Wähl mindestens einen Vermögenswert zum Verfolgen aus.
+        some_failed: "Folgende Vermögenswerte konnten nicht verfolgt werden und wurden ausgelassen: %{assets}."
+      success:
+        one: 1 Vermögenswert dieser Wallet wird verfolgt.
+        other: "%{count} Vermögenswerte dieser Wallet werden verfolgt."
+    new_wallet:
+      address_label: Wallet-Adresse
+      address_placeholder: bc1..., 0x... oder eine Solana-Adresse
+      bitcoin_single_address_note: Bitcoin wird jeweils über eine einzelne Adresse verfolgt. Erweiterte Schlüssel (xpub/ypub/zpub) werden nicht unterstützt. Eine Wallet, die Guthaben auf abgeleitete Adressen verteilt, zeigt daher nur das Guthaben der eingegebenen Adresse.
+      chain_auto_detect: Automatisch erkennen
+      chain_label: Netzwerk
+      continue: Weiter
+      read_only_note: Es werden nur öffentliche Blockchain-Daten gelesen. Gib niemals eine Seed-Phrase oder einen Private Key ein.
+      subtitle: Verfolge eine Wallet, deren Schlüssel du besitzt, über ihre öffentliche Adresse.
+      title: Selbstverwahrte Wallet hinzufügen
+    price_provider_warning:
+      body: Kein aktivierter Marktdatenanbieter kann Kurse für Krypto-Assets liefern. Diese Wallets verfolgen daher zwar die Mengen, zeigen aber einen Wert von null an.
+      enable: Kryptokurse aktivieren
+      exchange_rate_body: "Krypto wird in USD bewertet, aber es ist kein Wechselkursanbieter eingerichtet, um den Wert in %{currency} umzurechnen. Diese Wallets verfolgen daher zwar die Mengen, zeigen aber einen Wert von null an. Setz EXCHANGE_RATE_PROVIDER – für Frankfurter ist kein API-Schlüssel erforderlich."
+      exchange_rate_title: Kein Wechselkursanbieter eingerichtet
+      link: Marktdateneinstellungen öffnen
+      title: Kryptokurse sind nicht eingerichtet
+    provider_connection:
+      description: Verfolge eine Wallet, deren Schlüssel du besitzt, über ihre öffentliche Adresse.
+      name: Selbstverwahrte Wallet
+    token_review:
+      import_selected: Ausgewählte Vermögenswerte verfolgen
+      subtitle: "%{chain} · %{address}"
+      title: Vermögenswerte zum Verfolgen auswählen
+    token_review_form:
+      assets_truncated: Diese Adresse enthält mehr Token, als mit einer Abfrage geladen werden können. Daher werden nur die %{count} vertrauenswürdigsten angezeigt.
+      cancel: Abbrechen
+      explanation: Vermögenswerte mit bekanntem Preis sind vorausgewählt. Alle anderen bleiben abgewählt – Wallets erhalten Spam-Airdrops, und bei deren Verfolgung wird kein Wert angezeigt.
+      native: Nativ
+      no_price: Kein Preis verfügbar; wird nur nach Menge verfolgt
+      nothing_found: Diese Adresse enthält in diesem Netzwerk nichts, was wir erkennen können.

--- a/config/locales/views/settings/providers/onchain_wallet_panel/de.yml
+++ b/config/locales/views/settings/providers/onchain_wallet_panel/de.yml
@@ -1,0 +1,10 @@
+---
+de:
+  settings:
+    providers:
+      taglines:
+        onchain_wallet: Verfolgt selbstverwahrte Bitcoin-, EVM- und Solana-Wallets über ihre öffentlichen Adressen.
+      onchain_wallet_panel:
+        add_wallet: Wallet hinzufügen
+        keyless_title: Nur Lesezugriff, keine Schlüssel erforderlich
+        keyless_body: Sure liest ausschließlich öffentliche Blockchain-Daten. Dabei werden weder Schlüssel, Seed-Phrases noch Signaturen verwendet. Mit diesen Daten lassen sich keine Vermögenswerte übertragen.

--- a/test/controllers/onchain_wallet_items_localization_test.rb
+++ b/test/controllers/onchain_wallet_items_localization_test.rb
@@ -101,7 +101,7 @@ class OnchainWalletItemsLocalizationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match "Vermögenswerte zum Verfolgen auswählen", response.body
     assert_match "Wallets erhalten Spam-Airdrops", response.body
-    assert_match "Kein Preis verfügbar; wird nur nach Menge verfolgt", response.body
+    assert_match "Kein Preis verfügbar; wird nur anhand der Menge verfolgt", response.body
     assert_match "USDC", response.body
   end
 

--- a/test/controllers/onchain_wallet_items_localization_test.rb
+++ b/test/controllers/onchain_wallet_items_localization_test.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OnchainWalletItemsLocalizationTest < ActionDispatch::IntegrationTest
+  include OnchainTestHelper
+
+  MODAL_HEADERS = { "Turbo-Frame" => "modal" }.freeze
+
+  TRANSLATED_SCOPES = %w[
+    onchain_wallet_items.new_wallet
+    onchain_wallet_items.choose_chain
+    onchain_wallet_items.errors
+    onchain_wallet_items.price_provider_warning
+    onchain_wallet_items.enable_crypto_prices
+    onchain_wallet_items.link_wallet
+    onchain_wallet_items.provider_connection
+    onchain_wallet_items.token_review
+    onchain_wallet_items.token_review_form
+  ].freeze
+
+  TRANSLATED_SETTINGS_KEYS = %w[
+    settings.providers.taglines.onchain_wallet
+    settings.providers.onchain_wallet_panel.add_wallet
+    settings.providers.onchain_wallet_panel.keyless_title
+    settings.providers.onchain_wallet_panel.keyless_body
+  ].freeze
+
+  setup do
+    sign_in users(:family_admin)
+    register_fake_chain!
+  end
+
+  teardown do
+    unregister_fake_chain!
+  end
+
+  test "the Onchain add-wallet slice resolves directly in German" do
+    translated_keys.each do |key|
+      assert I18n.exists?(key, :de, fallback: false), "de is missing #{key}"
+    end
+  end
+
+  test "German translations preserve interpolation and pluralization contracts" do
+    address = OnchainTestHelper::FAKE_ADDRESS
+
+    assert_equal address,
+                 I18n.t("onchain_wallet_items.choose_chain.subtitle", locale: :de, fallback: false, address: address)
+    assert_equal "Fake Chain · #{address}",
+                 I18n.t("onchain_wallet_items.token_review.subtitle", locale: :de, fallback: false,
+                                                                           chain: "Fake Chain", address: address)
+    exchange_rate_body = I18n.t("onchain_wallet_items.price_provider_warning.exchange_rate_body",
+                                locale: :de, fallback: false, currency: "EUR")
+    %w[USD EUR EXCHANGE_RATE_PROVIDER Frankfurter API-Schlüssel].each do |technical_term|
+      assert_match technical_term, exchange_rate_body
+    end
+    tagline = I18n.t("settings.providers.taglines.onchain_wallet", locale: :de, fallback: false)
+    %w[Bitcoin EVM Solana].each { |brand_or_network| assert_match brand_or_network, tagline }
+    assert_match "USDC",
+                 I18n.t("onchain_wallet_items.link_wallet.errors.some_failed", locale: :de,
+                                                                                 fallback: false, assets: "USDC")
+    assert_equal "1 Vermögenswert dieser Wallet wird verfolgt.",
+                 I18n.t("onchain_wallet_items.link_wallet.success", locale: :de, fallback: false, count: 1)
+    assert_equal "2 Vermögenswerte dieser Wallet werden verfolgt.",
+                 I18n.t("onchain_wallet_items.link_wallet.success", locale: :de, fallback: false, count: 2)
+    assert_match "25", I18n.t("onchain_wallet_items.token_review_form.assets_truncated",
+                              locale: :de, fallback: false, count: 25)
+  end
+
+  test "the German add-wallet form renders its security guidance" do
+    get new_wallet_onchain_wallet_items_url(locale: :de), headers: MODAL_HEADERS
+
+    assert_response :success
+    assert_match "Selbstverwahrte Wallet hinzufügen", response.body
+    assert_match "Nur Lesezugriff, keine Schlüssel erforderlich", response.body
+    assert_match "Mit diesen Daten lassen sich keine Vermögenswerte übertragen.", response.body
+    assert_match "Gib niemals eine Seed-Phrase oder einen Private Key ein.", response.body
+    assert_match "Bitcoin wird jeweils über eine einzelne Adresse verfolgt.", response.body
+  end
+
+  test "the German token review renders selection guidance" do
+    stub_fake_snapshot(
+      OnchainTestHelper::FAKE_ADDRESS,
+      Onchain::Snapshot.new(
+        assets: [
+          fake_native_asset(quantity: 2),
+          fake_token_asset(symbol: "USDC", contract: "0xusdc", quantity: 10, notable: false),
+          fake_token_asset(symbol: "Visit site to claim", contract: "0xspam", quantity: 1, notable: false)
+        ],
+        movements: []
+      )
+    )
+
+    post preview_wallet_onchain_wallet_items_url(locale: :de),
+         params: {
+           address: OnchainTestHelper::FAKE_ADDRESS,
+           chain: OnchainTestHelper::FAKE_CHAIN
+         },
+         headers: MODAL_HEADERS
+
+    assert_response :success
+    assert_match "Vermögenswerte zum Verfolgen auswählen", response.body
+    assert_match "Wallets erhalten Spam-Airdrops", response.body
+    assert_match "Kein Preis verfügbar; wird nur nach Menge verfolgt", response.body
+    assert_match "USDC", response.body
+  end
+
+  test "the German account method selector localizes the Onchain entry" do
+    get new_crypto_url(locale: :de, step: "method_select"), headers: MODAL_HEADERS
+
+    assert_response :success
+    assert_match "Selbstverwahrte Wallet", response.body
+    assert_no_match "Self-custody wallet", response.body
+  end
+
+  test "a German recovery state hides the external provider error" do
+    external_error = "external explorer exposed a private diagnostic"
+    OnchainTestHelper::FakeAdapter.error = StandardError.new(external_error)
+
+    assert_difference "DebugLogEntry.count", 1 do
+      post preview_wallet_onchain_wallet_items_url(locale: :de),
+           params: {
+             address: OnchainTestHelper::FAKE_ADDRESS,
+             chain: OnchainTestHelper::FAKE_CHAIN
+           },
+           headers: MODAL_HEADERS
+    end
+
+    assert_response :unprocessable_entity
+    assert_match "Beim Lesen dieser Wallet ist etwas schiefgelaufen.", response.body
+    assert_no_match external_error, response.body
+  end
+
+  test "representative English output remains unchanged" do
+    I18n.with_locale(:en) do
+      assert_equal "Add a self-custody wallet", I18n.t("onchain_wallet_items.new_wallet.title", fallback: false)
+      assert_equal "Read-only, no keys required",
+                   I18n.t("settings.providers.onchain_wallet_panel.keyless_title", fallback: false)
+      assert_equal "Only public chain data is read. Never enter a seed phrase or private key.",
+                   I18n.t("onchain_wallet_items.new_wallet.read_only_note", fallback: false)
+      assert_equal "Self-custody wallet",
+                   I18n.t("onchain_wallet_items.provider_connection.name", fallback: false)
+    end
+
+    get new_wallet_onchain_wallet_items_url(locale: :en), headers: MODAL_HEADERS
+
+    assert_response :success
+    assert_match "Add a self-custody wallet", response.body
+    assert_match "Read-only, no keys required", response.body
+    assert_match "Never enter a seed phrase or private key.", response.body
+  end
+
+  private
+    def translated_keys
+      scoped_keys = TRANSLATED_SCOPES.flat_map do |scope|
+        translations = I18n.t(scope, locale: :en, fallback: false, default: nil)
+        assert_kind_of Hash, translations, "#{scope} must remain a translation subtree"
+
+        flatten_keys(translations).map { |key| "#{scope}.#{key}" }
+      end
+
+      scoped_keys + TRANSLATED_SETTINGS_KEYS
+    end
+
+    def flatten_keys(translations, prefix = nil)
+      translations.flat_map do |key, value|
+        path = [ prefix, key ].compact.join(".")
+        value.is_a?(Hash) ? flatten_keys(value, path) : path
+      end
+    end
+end


### PR DESCRIPTION
## Summary

German users can now complete the Onchain Add-Wallet security and recovery flow without falling back to English. Provider names, networks, addresses, asset symbols, and other external values remain unchanged.

This continues the German UI localization series. Wallet management and disconnect copy remain separate follow-up work.

## Validation

- Focused localization and I18n tests: 13 runs, 259 assertions, 0 failures, 0 errors
- Full Rails suite: 8,150 runs, 32,426 assertions, 0 failures, 0 errors
- RuboCop: 2,485 files inspected, no offenses
- Both locale files load through `YAML.safe_load`, and `git diff --check` is clean
- Real Rails integration renders cover the German Accounts entry, Add-Wallet dialog, token review, and sanitized recovery error

## Language review

An independent Codex German product-language review completed with its two requested wording changes applied. This was an AI review, not a human or native-speaker attestation. The copy follows the established informal `du` register and preserves technical and provider terms.

## Unapplied review findings

- [ ] P2 — `app/controllers/settings/providers_controller.rb:204` — The German Settings entry keeps a hardcoded English title.
  - Suggested fix: resolve only the Onchain `FAMILY_PANELS` title through I18n and assert the German Settings render once the shared controller is overlap-clear.
  - Deferred because several active provider PRs currently touch that shared controller. This PR stays isolated to provider-owned locale files and its focused test.

## Post-deploy validation

- For the first deployment and the following 24 hours, check Rails logs for `translation missing: de.onchain_wallet_items` and `translation missing: de.settings.providers.onchain_wallet`.
- Healthy behavior: German Accounts and Add-Wallet screens render without missing translations or interpolation errors; addresses, chain names, symbols, and provider data remain unchanged.
- Failure signals: missing-key text, raw provider errors, broken interpolation, or clipped dialog copy. Revert this commit if the localized flow cannot render safely.
- Owner: repository maintainers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added German translations for onchain wallet screens, including wallet setup, linking states, token selection, price providers, and error messages.
  * Added German translations for the onchain wallet provider settings panel, including wallet tracking and keyless access guidance.

* **Quality**
  * Added coverage to verify German translations, interpolation, pluralization, formatting, and localized wallet workflows.
  * Added checks for representative English output and recovery error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->