### PR TITLE
fix(investments): report real dividend and interest totals

### DIFF
--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -321,7 +321,7 @@ class InvestmentStatement
       account_ids_hash = Digest::MD5.hexdigest(account_ids.sort.join(","))
 
       Rails.cache.fetch([
-        "investment_statement", "totals_query", family.id, user&.id,
+        "investment_statement", "totals_query/v2", family.id, user&.id,
         account_ids_hash, date_range.begin, date_range.end, family.entries_cache_version
       ]) { Totals.new(family, account_ids: account_ids, date_range: date_range).call }
     end

--- a/app/models/investment_statement/totals.rb
+++ b/app/models/investment_statement/totals.rb
@@ -13,8 +13,8 @@ class InvestmentStatement::Totals
     {
       contributions: result["contributions"]&.to_d || 0,
       withdrawals: result["withdrawals"]&.to_d || 0,
-      dividends: 0, # Dividends come through as transactions, not trades
-      interest: 0,  # Interest comes through as transactions, not trades
+      dividends: result["dividends"]&.to_d || 0,
+      interest: result["interest"]&.to_d || 0,
       trades_count: result["trades_count"]&.to_i || 0
     }
   end
@@ -40,6 +40,13 @@ class InvestmentStatement::Totals
     # Aggregate trades by direction (buy vs sell)
     # Buys (qty > 0) = contributions (cash going out to buy securities)
     # Sells (qty < 0) = withdrawals (cash coming in from selling securities)
+    #
+    # Investment income (dividends, interest) is aggregated by activity label
+    # rather than by direction. Since #1311 these are recorded as Trades with
+    # qty: 0 and price: 0 (Trade::CreateForm#create_income_trade), so they fall
+    # outside both the qty > 0 and qty < 0 branches above and cannot be
+    # double-counted as contributions or withdrawals.
+    #
     # Missing FX rates preserve InvestmentStatement's existing 1:1 fallback.
     #
     # account_ids is already scoped to the family's visible (draft/active)
@@ -50,6 +57,8 @@ class InvestmentStatement::Totals
         SELECT
           COALESCE(SUM(CASE WHEN trades.qty > 0 THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as contributions,
           COALESCE(SUM(CASE WHEN trades.qty < 0 THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as withdrawals,
+          COALESCE(SUM(CASE WHEN trades.investment_activity_label = 'Dividend' THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as dividends,
+          COALESCE(SUM(CASE WHEN trades.investment_activity_label = 'Interest' THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as interest,
           COUNT(trades.id) as trades_count
         FROM entries
         JOIN trades ON trades.id = entries.entryable_id AND entries.entryable_type = 'Trade'

--- a/app/models/investment_statement/totals.rb
+++ b/app/models/investment_statement/totals.rb
@@ -43,20 +43,27 @@ class InvestmentStatement::Totals
     #
     # Investment income (dividends, interest) is aggregated by activity label
     # rather than by direction. Since #1311 these are recorded as Trades with
-    # qty: 0 and price: 0 (Trade::CreateForm#create_income_trade), so they fall
-    # outside both the qty > 0 and qty < 0 branches above and cannot be
-    # double-counted as contributions or withdrawals.
+    # qty: 0 and price: 0 (Trade::CreateForm#create_income_trade).
+    #
+    # The direction branches additionally exclude income labels rather than
+    # relying on qty: 0 to keep the buckets disjoint. Without this guard such
+    # a row would be counted twice: once by direction and once as income.
     #
     # Missing FX rates preserve InvestmentStatement's existing 1:1 fallback.
     #
     # account_ids is already scoped to the family's visible (draft/active)
     # investment accounts, so the query trusts that input and skips a join back
     # to accounts for family/status filtering.
+    # COALESCE keeps an unlabeled trade (NULL) out of the set.
+    def income_label_sql
+      "COALESCE(trades.investment_activity_label, '') IN ('Dividend', 'Interest')"
+    end
+
     def aggregation_sql
       <<~SQL
         SELECT
-          COALESCE(SUM(CASE WHEN trades.qty > 0 THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as contributions,
-          COALESCE(SUM(CASE WHEN trades.qty < 0 THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as withdrawals,
+          COALESCE(SUM(CASE WHEN trades.qty > 0 AND NOT #{income_label_sql} THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as contributions,
+          COALESCE(SUM(CASE WHEN trades.qty < 0 AND NOT #{income_label_sql} THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as withdrawals,
           COALESCE(SUM(CASE WHEN trades.investment_activity_label = 'Dividend' THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as dividends,
           COALESCE(SUM(CASE WHEN trades.investment_activity_label = 'Interest' THEN ABS(entries.amount * COALESCE(er.rate, 1)) ELSE 0 END), 0) as interest,
           COUNT(trades.id) as trades_count

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -300,6 +300,55 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_equal Money.new(50, "USD"), totals.dividends
   end
 
+  test "a buy relabeled to Dividend is counted as income only, not also as a contribution" do
+    # The activity-label quick editor permits changing the label on its own and
+    # leaves qty untouched, so an income-labeled trade can carry qty > 0. It must
+    # not land in both the direction bucket and the income bucket.
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
+    account = create_investment_account(balance: 500)
+
+    trade_entry = create_trade(account: account, qty: 2, amount: 120, date: period.start_date)
+    trade_entry.trade.update!(investment_activity_label: "Dividend")
+
+    totals = @statement.totals(period: period)
+
+    assert_equal Money.new(0, "USD"), totals.contributions
+    assert_equal Money.new(120, "USD"), totals.dividends
+    assert_equal Money.new(120, "USD"), totals.total_income
+  end
+
+  test "a sell relabeled to Interest is counted as income only, not also as a withdrawal" do
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
+    account = create_investment_account(balance: 500)
+
+    trade_entry = create_trade(account: account, qty: -1, amount: -40, date: period.start_date)
+    trade_entry.trade.update!(investment_activity_label: "Interest")
+
+    totals = @statement.totals(period: period)
+
+    assert_equal Money.new(0, "USD"), totals.withdrawals
+    assert_equal Money.new(40, "USD"), totals.interest
+  end
+
+  test "labeled non-income trades still count by direction" do
+    # Only Dividend/Interest are excluded from the direction buckets; Buy, Sell
+    # and Reinvestment keep their existing contribution/withdrawal treatment.
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
+    account = create_investment_account(balance: 500)
+
+    buy = create_trade(account: account, qty: 2, amount: 120, date: period.start_date)
+    buy.trade.update!(investment_activity_label: "Buy")
+    reinvest = create_trade(account: account, qty: 1, amount: 30, date: period.start_date)
+    reinvest.trade.update!(investment_activity_label: "Reinvestment")
+
+    totals = @statement.totals(period: period)
+
+    assert_equal Money.new(150, "USD"), totals.contributions
+    # Reinvestment is deliberately not folded into dividend income; doing so
+    # would require removing it from contributions too.
+    assert_equal Money.new(0, "USD"), totals.dividends
+  end
+
   test "totals convert foreign-currency dividends into family currency" do
     period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
     account = create_investment_account(balance: 500, currency: "EUR")

--- a/test/models/investment_statement_test.rb
+++ b/test/models/investment_statement_test.rb
@@ -268,6 +268,66 @@ class InvestmentStatementTest < ActiveSupport::TestCase
     assert_no_match(/JOIN accounts/, aggregate_queries.first)
   end
 
+  test "totals aggregate dividend and interest income from income trades" do
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
+    account = create_investment_account(balance: 500)
+
+    create_income_trade(account: account, label: "Dividend", amount: 50, date: period.start_date)
+    create_income_trade(account: account, label: "Dividend", amount: 25, date: period.start_date + 1.day)
+    create_income_trade(account: account, label: "Interest", amount: 10, date: period.start_date)
+    # Outside the period, must not be counted
+    create_income_trade(account: account, label: "Dividend", amount: 999, date: period.start_date - 1.day)
+
+    totals = @statement.totals(period: period)
+
+    assert_equal Money.new(75, "USD"), totals.dividends
+    assert_equal Money.new(10, "USD"), totals.interest
+    assert_equal Money.new(85, "USD"), totals.total_income
+  end
+
+  test "income trades are not counted as contributions or withdrawals" do
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
+    account = create_investment_account(balance: 500)
+
+    create_trade(account: account, qty: 2, amount: 120, date: period.start_date)
+    create_income_trade(account: account, label: "Dividend", amount: 50, date: period.start_date)
+
+    totals = @statement.totals(period: period)
+
+    # qty: 0 keeps income out of both direction branches
+    assert_equal Money.new(120, "USD"), totals.contributions
+    assert_equal Money.new(0, "USD"), totals.withdrawals
+    assert_equal Money.new(50, "USD"), totals.dividends
+  end
+
+  test "totals convert foreign-currency dividends into family currency" do
+    period = Period.custom(start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month)
+    account = create_investment_account(balance: 500, currency: "EUR")
+
+    ExchangeRate.create!(
+      from_currency: "EUR",
+      to_currency: "USD",
+      date: period.start_date,
+      rate: 1.1
+    )
+
+    create_income_trade(account: account, label: "Dividend", amount: 100, date: period.start_date)
+
+    totals = @statement.totals(period: period)
+
+    assert_equal Money.new(110, "USD"), totals.dividends
+  end
+
+  test "total_dividends and total_interest expose all-time income" do
+    account = create_investment_account(balance: 500)
+
+    create_income_trade(account: account, label: "Dividend", amount: 40, date: 2.years.ago.to_date)
+    create_income_trade(account: account, label: "Interest", amount: 5, date: Date.current)
+
+    assert_equal 40, @statement.total_dividends
+    assert_equal 5, @statement.total_interest
+  end
+
   test "current_holdings memoizes so repeated dashboard-style calls issue a single query" do
     account = create_investment_account(balance: 2100, currency: "USD")
     security = Security.create!(ticker: "AAPL", name: "Apple")
@@ -308,6 +368,25 @@ class InvestmentStatementTest < ActiveSupport::TestCase
         cash_balance: cash_balance,
         currency: currency,
         accountable: Investment.new
+      )
+    end
+
+    # Investment income (dividends, interest) is recorded as a Trade with
+    # qty: 0 and price: 0, matching Trade::CreateForm#create_income_trade.
+    # A negative amount means cash coming in.
+    def create_income_trade(account:, label:, amount:, date:)
+      account.entries.create!(
+        name: "#{label} #{SecureRandom.hex(3)}",
+        amount: -amount.to_d.abs,
+        date: date,
+        currency: account.currency,
+        entryable: Trade.new(
+          security: Security.create!(ticker: "T#{SecureRandom.hex(8)}", name: "Test Security"),
+          qty: 0,
+          price: 0,
+          currency: account.currency,
+          investment_activity_label: label
+        )
       )
     end
 


### PR DESCRIPTION
## Problem

`InvestmentStatement::Totals` returns hardcoded zeros for dividends and interest:

```ruby
dividends: 0, # Dividends come through as transactions, not trades
interest: 0,  # Interest comes through as transactions, not trades
```

That comment was accurate until #1311, which moved investment income to `Trade` records with `qty: 0` and `price: 0` via `Trade::CreateForm#create_income_trade`.

Since #1311, `InvestmentStatement#total_dividends`, `#total_interest` and `PeriodTotals#total_income` have returned zero for every family, regardless of data. A user who records dividends through the trade form has no aggregate anywhere that reflects them.

## Fix

Aggregate dividends and interest by `trades.investment_activity_label` in the existing single-query aggregation, and return the real values.

Property worth noting:

- **No double-counting.** Income trades carry `qty: 0`, so they fall outside both the `qty > 0` (contributions) and `qty < 0` (withdrawals) branches already in the query. _Covered by a dedicated test._

The totals cache key is bumped to `v2` so warm caches stop serving the old zeros before `entries_cache_version` happens to change on its own.

## Deliberately out of scope

These are known gaps, listed so they aren't mistaken for oversights. Each is a separate concern with its own trade-offs:

- **Trading212 and SimpleFIN dividends still report 0.** They are stored as `Transaction` records carrying `extra["security_id"]` (see `Trading212Account::ActivitiesProcessor#process_dividend`), not as Trades. Reading both shapes is a product decision — see questions below.

- **Plaid dividends also report 0**, for an unrelated pre-existing reason: `PlaidAccount::Investments::TransactionsProcessor#find_or_create_trade_entry` computes `amount: derived_qty(transaction) * transaction["price"]`, and a cash dividend has `quantity == 0`, so the entry is written with amount 0. Fixing that touches a provider write path and needs its own sign-convention review; happy to open it as a follow-up.

## Questions for maintainers

1. **How should pre-#1311 dividend transactions be treated?** Instances that upgraded across #1311 have dividend history split in two: `Transaction` rows before the upgrade, `Trade` rows after. #1311 deliberately left the transactions table untouched, so no backfill exists. Options as I see them:
 - leave them as-is and accept that investment income aggregates cover only post-upgrade data;
 - have the aggregate also read dividend-labelled Transactions (via `investment_activity_label` plus `extra["security_id"]`), which makes history complete but entrenches two storage shapes;
 - offer a migration path.

I've kept this PR to trades-only rather than pick one. Which direction do you prefer?

2. **Should provider-delivered dividends be normalized to Trades?** Trading212 has a ticker and could resolve a security; SimpleFIN structurally cannot (which is why `SimplefinAccount::Investments::TransactionsProcessor` is a no-op). So full normalization isn't reachable for every provider — is forward-only normalization where a security is resolvable worth doing, or should the readers handle both shapes instead?

3. **Should dividends appear in `IncomeStatement` too?**
All three `IncomeStatement` stat classes hard-join `entryable_type = 'Transaction'`, so dividend income is currently absent from reports, budgets and category breakdowns.
Is investment income intended to be reported separately from ordinary income, or should it flow into both?

4. **Should `Reinvestment` count as dividend income, and if so what happens to `contributions`?** Per the reasoning above, the two are coupled: counting reinvested distributions as income requires deciding whether `contributions` means all buys or only external inflows. If contributions are meant to be external only, then `Reinvestment` (and arguably the internal-movement labels) should leave that bucket regardless of this PR, I can do that as a follow-up. If contributions are meant to be all buys, then reinvested distributions can only be surfaced as a separate figure rather than added to `total_dividends`. Which is intended?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Investment totals now include dividends and interest from eligible transactions.
  * Income received in foreign currencies is converted correctly.
  * Dividends and interest are excluded from contribution and withdrawal totals.
  * All-time income totals now reflect recorded investment income accurately.
  * Previously cached totals are refreshed to ensure updated results are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->