### PR TITLE
fix(l10n): localize empty CoinStats wallet result

### DIFF
--- a/app/models/coinstats_item/wallet_linker.rb
+++ b/app/models/coinstats_item/wallet_linker.rb
@@ -22,7 +22,7 @@ class CoinstatsItem::WalletLinker
     balance_data = fetch_balance_data
     tokens = normalize_tokens(balance_data)
 
-    return Result.new(success?: false, created_count: 0, errors: [ "No tokens found for wallet" ]) if tokens.empty?
+    return Result.new(success?: false, created_count: 0, errors: [ I18n.t("models.coinstats_item.wallet_linker.no_tokens_found") ]) if tokens.empty?
 
     created_count = 0
     errors = []

--- a/config/locales/models/coinstats_item/de.yml
+++ b/config/locales/models/coinstats_item/de.yml
@@ -2,6 +2,8 @@
 de:
   models:
     coinstats_item:
+      wallet_linker:
+        no_tokens_found: Für dieses Krypto-Wallet wurden keine Token gefunden.
       syncer:
         importing_wallets: Wallets werden von CoinStats importiert...
         checking_configuration: Wallet-Konfiguration wird geprüft...

--- a/config/locales/models/coinstats_item/en.yml
+++ b/config/locales/models/coinstats_item/en.yml
@@ -2,6 +2,8 @@
 en:
   models:
     coinstats_item:
+      wallet_linker:
+        no_tokens_found: No tokens found for wallet
       syncer:
         importing_wallets: Importing crypto accounts from CoinStats...
         checking_configuration: Checking CoinStats account configuration...

--- a/test/controllers/coinstats_items_controller_test.rb
+++ b/test/controllers/coinstats_items_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CoinstatsItemsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in users(:family_admin)
+    sign_in @user = users(:family_admin)
     @family = families(:dylan_family)
     @coinstats_item = CoinstatsItem.create!(
       family: @family,
@@ -160,7 +160,7 @@ class CoinstatsItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
-  test "link_wallet handles no tokens found" do
+  test "link_wallet preserves no tokens found error in English" do
     Provider::Coinstats.any_instance.expects(:get_wallet_balances)
       .returns(success_response([]))
 
@@ -174,7 +174,28 @@ class CoinstatsItemsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :unprocessable_entity
-    assert_match(/No tokens found/, response.body)
+    assert_includes response.body, "No tokens found for wallet"
+  end
+
+  test "link_wallet localizes no tokens found error in German" do
+    @user.update!(locale: "de")
+    Provider::Coinstats.any_instance.expects(:get_wallet_balances)
+      .returns(success_response([]))
+
+    Provider::Coinstats.any_instance.expects(:extract_wallet_balance)
+      .returns([])
+
+    post link_wallet_coinstats_items_url, params: {
+      coinstats_item_id: @coinstats_item.id,
+      address: "0x123abc",
+      blockchain: "ethereum"
+    }
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, "Für dieses Krypto-Wallet wurden keine Token gefunden."
+    refute_includes response.body, "No tokens found for wallet"
+    assert_equal "Für dieses Krypto-Wallet wurden keine Token gefunden.",
+                 I18n.t("models.coinstats_item.wallet_linker.no_tokens_found", locale: :de, fallback: false)
   end
 
   test "link_exchange filters unexpected connection fields" do


### PR DESCRIPTION
## Summary

German users now see a localized empty-wallet result when CoinStats cannot find any tokens, instead of the hard-coded English message. The English result remains unchanged, and provider/API errors continue to pass through without reinterpretation.

## Validation

- Focused CoinStats model and controller tests: 25 runs, 108 assertions, 0 failures, 0 errors
- Full Rails suite: 8,254 runs, 32,976 assertions, 0 failures, 0 errors
- RuboCop: 2,516 files inspected, no offenses
- YAML parsing and `git diff --check` passed
- A separate AI German product-language review approved the final wording; this does not claim human or native-speaker review

## Post-Deploy Monitoring & Validation

- Exercise the German CoinStats wallet-link flow with an address that returns no tokens.
- Healthy: the dialog displays the German empty-wallet result without a missing-translation marker; the English locale still displays the existing English sentence.
- Failure signal: `translation missing`, `I18n::MissingTranslationData`, or an English fallback in the German dialog. Revert this commit if any appears.
- Owner: deployment maintainer. Validation window: first smoke pass after deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized wallet-linking error messages in English and German.
  * Error messages now reflect the user’s selected language when no tokens are found.

* **Bug Fixes**
  * Improved consistency of the “no tokens found” message across supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->