### PR TITLE
fix(l10n): localize removed SSO identity recovery

### DIFF
--- a/config/locales/views/admin/sso_identity_blocks/de.yml
+++ b/config/locales/views/admin/sso_identity_blocks/de.yml
@@ -1,0 +1,5 @@
+de:
+  admin:
+    sso_identity_blocks:
+      destroy:
+        success: "Die SSO-Identität kann wieder für die Anmeldung oder Kontoerstellung verwendet werden."

--- a/config/locales/views/admin/users/de.yml
+++ b/config/locales/views/admin/users/de.yml
@@ -30,6 +30,11 @@ de:
           never: "Nie"
           role: "Rolle"
         role_descriptions_title: "Rollenbeschreibungen"
+        removed_sso_identities:
+          title: "Entfernte SSO-Identitäten"
+          description: "Mit diesen Identitäten kann kein Konto erstellt oder erneut verknüpft werden. Lass eine Identität nur dann wieder zu, wenn sie versehentlich entfernt wurde."
+          allow_again: "Wieder zulassen"
+          confirm: "Möchtest du die SSO-Identität %{email} wieder für die Anmeldung oder Kontoerstellung zulassen?"
         roles:
           guest: "Gast"
           member: "Mitglied"

--- a/test/controllers/admin/sso_identity_blocks_controller_test.rb
+++ b/test/controllers/admin/sso_identity_blocks_controller_test.rb
@@ -19,11 +19,45 @@ class Admin::SsoIdentityBlocksControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to admin_users_path
+    assert_equal "The SSO identity can sign in or create an account again.", flash[:notice]
 
     audit_log = SsoAuditLog.by_event("identity_unblocked").last
     assert_equal users(:sure_support_staff).id, audit_log.metadata["actor_user_id"]
     assert_equal @block.id, audit_log.metadata["identity_block_id"]
     assert_equal @block.provider, audit_log.provider
+  end
+
+  test "super admin sees the identity unblocked notice in German" do
+    user = users(:sure_support_staff)
+    user.update!(locale: "de")
+    sign_in user
+
+    delete admin_sso_identity_block_url(@block)
+
+    assert_redirected_to admin_users_path
+    assert_equal "Die SSO-Identität kann wieder für die Anmeldung oder Kontoerstellung verwendet werden.", flash[:notice]
+    assert_equal "Die SSO-Identität kann wieder für die Anmeldung oder Kontoerstellung verwendet werden.",
+                 I18n.t("admin.sso_identity_blocks.destroy.success", locale: :de, fallback: false)
+  end
+
+  test "super admin sees the removed identity recovery section in German" do
+    user = users(:sure_support_staff)
+    user.update!(locale: "de")
+    sign_in user
+
+    get admin_users_url
+
+    assert_response :success
+    assert_includes response.body, "Entfernte SSO-Identitäten"
+    assert_includes response.body, "Mit diesen Identitäten kann kein Konto erstellt oder erneut verknüpft werden. Lass eine Identität nur dann wieder zu, wenn sie versehentlich entfernt wurde."
+    assert_includes response.body, "Wieder zulassen"
+    assert_includes response.body,
+                    "Möchtest du die SSO-Identität #{@block.identity_label} wieder für die Anmeldung oder Kontoerstellung zulassen?"
+    refute_includes response.body, "Removed SSO identities"
+
+    %w[title description allow_again confirm].each do |key|
+      assert I18n.exists?("admin.users.index.removed_sso_identities.#{key}", :de, fallback: false)
+    end
   end
 
   test "regular user cannot allow a removed SSO identity again" do


### PR DESCRIPTION
## Summary

German super admins now see the complete removed-SSO-identity recovery flow in German, including the recovery guidance, confirmation, and success notice. The English flow and its authorization and audit behavior remain unchanged.

## Validation

- Focused SSO identity and I18n tests: 11 runs, 225 assertions, 0 failures, 0 errors
- Full Rails suite: 8,258 runs, 33,082 assertions, 0 failures, 0 errors
- RuboCop: 2,516 files inspected, no offenses
- YAML parsing and `git diff --check` passed
- The simulated merge tree matches the branch tree exactly
- A separate AI German product-language review approved the final wording; this does not claim human or native-speaker review
- Structured code review completed with no remaining findings

## Post-Deploy Monitoring & Validation

- Open the removed SSO identities section as a German super admin, restore one blocked identity, and search application logs for `translation missing` and `I18n::MissingTranslationData`.
- Healthy: the section, confirmation, and success notice render in German while provider identifiers and the identity label remain intact.
- Failure signal: an English fallback, missing-translation marker, broken interpolation, or changed unblock behavior. Revert this commit if any appears.
- Owner: deployment maintainer. Validation window: first smoke pass after deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added German translations for the admin SSO identity recovery section.
  - Added German labels, descriptions, confirmation prompts, and success messages for allowing removed SSO identities to log in or create accounts again.

- **Bug Fixes**
  - Improved German-language messaging after restoring an SSO identity, providing clear confirmation that the identity is available again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->