### PR TITLE
fix(l10n): localize Lunchflow fallback errors

### DIFF
--- a/app/controllers/lunchflow_items_controller.rb
+++ b/app/controllers/lunchflow_items_controller.rb
@@ -120,7 +120,7 @@ class LunchflowItemsController < ApplicationController
              layout: false
     rescue StandardError => e
       Rails.logger.error("Unexpected error in select_accounts: #{e.class}: #{e.message}")
-      @error_message = "An unexpected error occurred. Please try again later."
+      @error_message = t("lunchflow_items.api_error.unexpected_error")
       @return_path = safe_return_to_path
       render partial: "lunchflow_items/api_error",
              locals: { error_message: @error_message, return_path: @return_path },
@@ -324,7 +324,7 @@ class LunchflowItemsController < ApplicationController
              layout: false
     rescue StandardError => e
       Rails.logger.error("Unexpected error in select_existing_account: #{e.class}: #{e.message}")
-      @error_message = "An unexpected error occurred. Please try again later."
+      @error_message = t("lunchflow_items.api_error.unexpected_error")
       render partial: "lunchflow_items/api_error",
              locals: { error_message: @error_message, return_path: accounts_path },
              layout: false

--- a/config/locales/views/lunchflow_items/de.yml
+++ b/config/locales/views/lunchflow_items/de.yml
@@ -187,6 +187,7 @@ de:
       service_down_label: Dienst nicht erreichbar
       title: Fehler bei der Lunch-Flow-Verbindung
       unable_to_connect: Die Verbindung zu Lunch Flow kam nicht zustande
+      unexpected_error: Ein unerwarteter Fehler ist aufgetreten. Versuch es später noch einmal.
     setup_required:
       api_key_description: Bevor du Lunch-Flow-Konten verknüpfen kannst, musst du deinen Lunch-Flow-API-Key hinterlegen.
       api_key_not_configured: API-Key nicht hinterlegt

--- a/config/locales/views/lunchflow_items/en.yml
+++ b/config/locales/views/lunchflow_items/en.yml
@@ -14,6 +14,7 @@ en:
       service_down_label: Service Down
       service_down_desc: Lunch Flow API may be temporarily unavailable
       check_provider_settings: Check Provider Settings
+      unexpected_error: An unexpected error occurred. Please try again later.
     setup_required:
       title: Lunch Flow Setup Required
       api_key_not_configured: API Key Not Configured

--- a/test/controllers/lunchflow_items_controller_test.rb
+++ b/test/controllers/lunchflow_items_controller_test.rb
@@ -82,6 +82,45 @@ class LunchflowItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Failed to create accounts: An unexpected error occurred", flash[:alert]
   end
 
+  test "account selection localizes an unexpected error in German" do
+    @user.update!(locale: "de")
+    Provider::LunchflowAdapter.stubs(:build_provider).raises(StandardError, "Synthetic failure")
+
+    get select_accounts_lunchflow_items_url
+
+    assert_response :success
+    assert_includes response.body, "Ein unerwarteter Fehler ist aufgetreten. Versuch es später noch einmal."
+    refute_includes response.body, "An unexpected error occurred. Please try again later."
+    assert I18n.exists?("lunchflow_items.api_error.unexpected_error", :de, fallback: false)
+    assert_equal "An unexpected error occurred. Please try again later.",
+                 I18n.t("lunchflow_items.api_error.unexpected_error", locale: :en, fallback: false)
+  end
+
+  test "existing-account selection localizes an unexpected error in German" do
+    @user.update!(locale: "de")
+    Provider::LunchflowAdapter.stubs(:build_provider).raises(StandardError, "Synthetic failure")
+
+    get select_existing_account_lunchflow_items_url(account_id: accounts(:depository).id)
+
+    assert_response :success
+    assert_includes response.body, "Ein unerwarteter Fehler ist aufgetreten. Versuch es später noch einmal."
+    refute_includes response.body, "An unexpected error occurred. Please try again later."
+  end
+
+  test "account selection preserves provider error details" do
+    @user.update!(locale: "de")
+    Provider::LunchflowAdapter.stubs(:build_provider).raises(
+      Provider::Lunchflow::LunchflowError,
+      "Provider-specific failure"
+    )
+
+    get select_accounts_lunchflow_items_url
+
+    assert_response :success
+    assert_includes response.body, "Provider-specific failure"
+    refute_includes response.body, "Ein unerwarteter Fehler ist aufgetreten. Versuch es später noch einmal."
+  end
+
   test "invalid non-Turbo create redirects instead of rendering a missing template" do
     assert_no_difference "LunchflowItem.count" do
       post lunchflow_items_url, params: {


### PR DESCRIPTION
## Summary

German users now see a localized generic fallback in both Lunch Flow account-selection dialogs when an unexpected failure occurs, instead of the hard-coded English sentence. Provider-specific error details remain unchanged, and the English fallback keeps its exact wording.

## Validation

- Focused Lunch Flow and I18n tests: 15 runs, 248 assertions, 0 failures, 0 errors
- Full Rails suite: 8,259 runs, 33,078 assertions, 0 failures, 0 errors
- RuboCop: 2,516 files inspected, no offenses
- YAML parsing and `git diff --check` passed
- The simulated merge tree matches the branch tree exactly
- A separate AI German product-language review approved the final wording; this does not claim human or native-speaker review
- Structured code review completed with no remaining findings or testing gaps

## Post-Deploy Monitoring & Validation

- Exercise both German Lunch Flow account-selection dialogs with an unexpected provider-loading failure, and search application logs for `translation missing` and `I18n::MissingTranslationData`.
- Healthy: both dialogs display the German generic fallback; provider-specific errors still show their original details, and English still displays the existing sentence.
- Failure signal: an English fallback in German, a missing-translation marker, or provider details replaced by the generic message. Revert this commit if any appears.
- Owner: deployment maintainer. Validation window: first smoke pass after deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unexpected errors during Lunch Flow account selection now display localized messages.
  * German users see a German error message instead of an English fallback.
  * Provider-specific error messages continue to be shown unchanged.

* **Tests**
  * Added coverage for localized unexpected errors and provider-specific failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->