### PR TITLE
feat(accounts): group split transactions in account activity feed

### DIFF
--- a/app/components/UI/account/activity_date.html.erb
+++ b/app/components/UI/account/activity_date.html.erb
@@ -38,8 +38,18 @@
   </details>
 
   <div class="bg-container shadow-border-xs rounded-lg">
-    <% entries.each do |entry| %>
-      <%= render entry, view_ctx: "account" %>
+    <% if Current.user.show_split_grouped? %>
+      <% helpers.group_split_entries(entries, split_parents).each do |item| %>
+        <% if item.is_a?(EntriesHelper::SplitGroup) %>
+          <%= render "entries/split_group", split_group: item, view_ctx: "account" %>
+        <% else %>
+          <%= render item, view_ctx: "account" %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <% entries.each do |entry| %>
+        <%= render entry, view_ctx: "account" %>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/components/UI/account/activity_date.rb
+++ b/app/components/UI/account/activity_date.rb
@@ -1,7 +1,7 @@
 class UI::Account::ActivityDate < ApplicationComponent
   attr_reader :account, :data
 
-  delegate :date, :entries, :balance, :transfers, to: :data
+  delegate :date, :entries, :balance, :transfers, :split_parents, to: :data
 
   def initialize(account:, data:)
     @account = account

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -129,7 +129,21 @@ class AccountsController < ApplicationController
       Set.new
     end
 
-    @activity_feed_data = Account::ActivityFeedData.new(@account, @entries)
+    # Load split parent entries for grouped display (only when grouping is enabled)
+    @split_parents = if Current.user.show_split_grouped?
+      split_parent_ids = @entries.filter_map(&:parent_entry_id).uniq
+      if split_parent_ids.any?
+        Entry.where(id: split_parent_ids)
+             .includes(:account, entryable: [ :category, :merchant ])
+             .index_by(&:id)
+      else
+        {}
+      end
+    else
+      {}
+    end
+
+    @activity_feed_data = Account::ActivityFeedData.new(@account, @entries, split_parents: @split_parents)
   end
 
   def sync

--- a/app/models/account/activity_feed_data.rb
+++ b/app/models/account/activity_feed_data.rb
@@ -2,13 +2,14 @@
 # This data object is useful for avoiding N+1 queries and having an easy way to pass around the required data to the
 # activity feed component in controllers and background jobs that refresh it.
 class Account::ActivityFeedData
-  ActivityDateData = Data.define(:date, :entries, :balance, :transfers)
+  ActivityDateData = Data.define(:date, :entries, :balance, :transfers, :split_parents)
 
-  attr_reader :account, :entries
+  attr_reader :account, :entries, :split_parents
 
-  def initialize(account, entries)
+  def initialize(account, entries, split_parents: {})
     @account = account
     @entries = entries.to_a
+    @split_parents = split_parents
   end
 
   def entries_by_date
@@ -18,7 +19,8 @@ class Account::ActivityFeedData
           date: date,
           entries: date_entries,
           balance: balance_for_date(date),
-          transfers: transfers_for_date(date)
+          transfers: transfers_for_date(date),
+          split_parents: split_parents
         )
       end
     end

--- a/app/views/entries/_split_group.html.erb
+++ b/app/views/entries/_split_group.html.erb
@@ -1,10 +1,10 @@
-<%# locals: (split_group:) %>
+<%# locals: (split_group:, view_ctx: "global") %>
 <div class="split-group">
   <%= render "transactions/split_parent_row", entry: split_group.parent %>
   <% split_group.children.each do |child_entry| %>
     <% if child_entry.entryable.present? %>
       <%= render partial: child_entry.entryable.to_partial_path,
-                locals: { entry: child_entry, in_split_group: true } %>
+                locals: { entry: child_entry, in_split_group: true, view_ctx: view_ctx } %>
     <% end %>
   <% end %>
 </div>

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class AccountsControllerTest < ActionDispatch::IntegrationTest
   include ActionView::RecordIdentifier
   include OnchainTestHelper
+  include EntriesTestHelper
 
   setup do
     sign_in @user = users(:family_admin)
@@ -137,6 +138,59 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       q.match?(/FROM "entries".*WHERE.*"parent_entry_id"/) && !q.include?(" IN (")
     }
     assert_equal 0, per_row_split, "N+1 per-row split-parent queries detected (#{per_row_split})"
+  end
+
+  test "show groups split transactions into a single split-group row when grouping is enabled" do
+    @user.update!(preferences: { "show_split_grouped" => true })
+    entry = create_transaction(name: "Grocery Store", amount: 100, account: @account)
+    entry.split!([
+      { name: "Food", amount: 60 },
+      { name: "Household", amount: 40 }
+    ])
+
+    get account_url(@account)
+
+    assert_response :success
+    assert_select ".split-group", count: 1
+    assert_select ".split-group" do
+      assert_select "p", text: "Food", count: 0
+    end
+  end
+
+  test "show renders split children as flat rows when grouping is disabled" do
+    @user.update!(preferences: { "show_split_grouped" => false })
+    entry = create_transaction(name: "Grocery Store", amount: 100, account: @account)
+    entry.split!([
+      { name: "Food", amount: 60 },
+      { name: "Household", amount: 40 }
+    ])
+
+    get account_url(@account)
+
+    assert_response :success
+    assert_select ".split-group", count: 0
+  end
+
+  test "show avoids N+1 queries when loading split parents for grouped display" do
+    @user.update!(preferences: { "show_split_grouped" => true })
+    3.times do |i|
+      entry = create_transaction(name: "Grocery Store #{i}", amount: 100, account: @account)
+      entry.split!([
+        { name: "Food", amount: 60 },
+        { name: "Household", amount: 40 }
+      ])
+    end
+
+    queries = capture_sql_queries { get account_url(@account) }
+    assert_response :success
+
+    # @split_parents loads all referenced split-parent entries in a single
+    # `WHERE "entries"."id" IN (...)` query — a per-row `"id" = $1` lookup
+    # would indicate the batching regressed into N+1.
+    per_row_split_parent = queries.count { |q|
+      q.match?(/FROM "entries".*WHERE.*"entries"\."id" = \$?\d+/) && !q.include?(" IN (")
+    }
+    assert_equal 0, per_row_split_parent, "N+1 per-row split-parent lookups detected (#{per_row_split_parent})"
   end
 
   test "show lazily loads statement tab data unless statements tab is active" do


### PR DESCRIPTION
## Summary
- Fixes we-promise/sure#3227 — split transactions on the account activity tab were rendered as flat, ungrouped rows, unlike `/transactions`, which collapses them into a parent row with indented children when "Group split transactions" (Settings → Appearance) is enabled.
- The original split-grouping feature (#1245, #1661) only wired up `TransactionsController`/`_list.html.erb`. The account activity feed was refactored into a ViewComponent (`UI::Account::ActivityFeed` / `UI::Account::ActivityDate`) after those PRs, and split grouping was never carried over to the new render path.
- `AccountsController#show` now loads `@split_parents` with the same single, batched `Entry.where(id: [...])` query pattern already used by `TransactionsController#index` (no N+1), and passes it through `Account::ActivityFeedData` → `UI::Account::ActivityDate`, which now branches on `Current.user.show_split_grouped?` exactly like `_list.html.erb` does.
- `entries/_split_group` now forwards `view_ctx` to split children instead of silently defaulting to `"global"` — needed so children render correctly on both `/transactions` and the account page (this also fixes a latent gap in the existing transactions-page rendering, e.g. for split children that are transfers).

## Test plan
- [x] `bin/rails test test/controllers/accounts_controller_test.rb` (new + existing split/N+1 tests): 0 failures (11 pre-existing environment-drift errors in unrelated `index`/`sync_all` tests, unaffected by this change)
- [x] `bin/rails test test/models/account/activity_feed_data_test.rb`: all green
- [x] `bin/rubocop -a` on changed Ruby files: 0 offenses
- [x] `bin/brakeman --no-pager`: 0 security warnings, 0 errors
- [x] Manually verified live on a test deployment: split transaction on an account's activity tab now renders as a collapsed parent + indented children, matching `/transactions`; toggling "Group split transactions" off reverts to flat rows on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account activity can now display split transactions grouped under their parent transaction when the split-grouping preference is enabled.
  - Grouped entries preserve the appropriate account activity context when displayed.
- **Bug Fixes**
  - When split grouping is disabled, account activity continues to display individual child entries in the standard flat list format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->