### PR TITLE
feat(ai): support OPENAI_EXTRA_HEADERS on the OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ OPENAI_URI_BASE=
 
 # Optional: OpenAI-compatible capability flags
 # OPENAI_REQUEST_TIMEOUT=60                  # HTTP timeout in seconds; raise for slow local models
-# OPENAI_EXTRA_HEADERS='{"x-session":"<value>"}'  # Extra JSON headers attached to OpenAI-compatible provider requests
+# OPENAI_EXTRA_HEADERS='{"x-opencode-session":"{session_id}"}'  # Extra JSON headers for chat requests; value containing {session_id} becomes the chat UUID
 # OPENAI_SUPPORTS_PDF_PROCESSING=true        # Set to false for endpoints without vision support
 # OPENAI_SUPPORTS_RESPONSES_ENDPOINT=        # Override Responses-API vs chat.completions routing
 # LLM_JSON_MODE=                             # auto | strict | json_object | none

--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,7 @@ OPENAI_URI_BASE=
 
 # Optional: OpenAI-compatible capability flags
 # OPENAI_REQUEST_TIMEOUT=60                  # HTTP timeout in seconds; raise for slow local models
+# OPENAI_EXTRA_HEADERS='{"x-session":"<value>"}'  # Extra JSON headers attached to OpenAI-compatible provider requests
 # OPENAI_SUPPORTS_PDF_PROCESSING=true        # Set to false for endpoints without vision support
 # OPENAI_SUPPORTS_RESPONSES_ENDPOINT=        # Override Responses-API vs chat.completions routing
 # LLM_JSON_MODE=                             # auto | strict | json_object | none

--- a/.env.local.example
+++ b/.env.local.example
@@ -50,7 +50,7 @@ OPENAI_MODEL =
 
 # OpenAI-compatible capability flags (custom/self-hosted providers)
 # OPENAI_REQUEST_TIMEOUT = 60                # HTTP timeout in seconds; raise for slow local models
-# OPENAI_EXTRA_HEADERS = '{"x-session":"<value>"}'  # Extra JSON headers attached to OpenAI-compatible provider requests
+# OPENAI_EXTRA_HEADERS = '{"x-opencode-session":"{session_id}"}'  # Extra JSON headers for chat requests; value containing {session_id} becomes the chat UUID
 # AI_RESPONSE_TIMEOUT = 90                   # Whole-turn budget: (1 + iterations) * OPENAI_REQUEST_TIMEOUT + tool time + queue wait
 # ASSISTANT_MAX_TOOL_CALL_ITERATIONS = 5     # Chained tool calls per turn; a turn costs up to (1 + this) model calls
 # OPENAI_SUPPORTS_PDF_PROCESSING = true      # Set to false for endpoints without vision support

--- a/.env.local.example
+++ b/.env.local.example
@@ -50,6 +50,7 @@ OPENAI_MODEL =
 
 # OpenAI-compatible capability flags (custom/self-hosted providers)
 # OPENAI_REQUEST_TIMEOUT = 60                # HTTP timeout in seconds; raise for slow local models
+# OPENAI_EXTRA_HEADERS = '{"x-session":"<value>"}'  # Extra JSON headers attached to OpenAI-compatible provider requests
 # AI_RESPONSE_TIMEOUT = 90                   # Whole-turn budget: (1 + iterations) * OPENAI_REQUEST_TIMEOUT + tool time + queue wait
 # ASSISTANT_MAX_TOOL_CALL_ITERATIONS = 5     # Chained tool calls per turn; a turn costs up to (1 + this) model calls
 # OPENAI_SUPPORTS_PDF_PROCESSING = true      # Set to false for endpoints without vision support

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -59,7 +59,9 @@ class Provider::Openai < Provider
     client_options[:uri_base] = llm_uri_base if llm_uri_base.present?
     client_options[:request_timeout] = self.class.request_timeout
     parsed_headers = self.class.extra_headers
-    client_options[:extra_headers] = parsed_headers if parsed_headers.present?
+    @session_extra_headers = parsed_headers.select { |_, value| value.include?("{session_id}") }
+    static_headers = parsed_headers.except(*@session_extra_headers.keys)
+    client_options[:extra_headers] = static_headers if static_headers.present?
 
     @client = ::OpenAI::Client.new(**client_options)
     @uri_base = llm_uri_base
@@ -396,6 +398,18 @@ class Provider::Openai < Provider
   private
     attr_reader :client
 
+    # Substitutes {session_id} into session-valued extra headers and merges
+    # them onto the client for this chat request. Static headers were already
+    # set at construction; a session header without a session_id is simply
+    # never merged (a merge can only add/overwrite, never delete).
+    def apply_session_headers(session_id:)
+      return if @session_extra_headers.blank? || session_id.blank?
+
+      client.add_headers(
+        @session_extra_headers.transform_values { |value| value.gsub("{session_id}") { session_id } }
+      )
+    end
+
     # Returns the first positive integer among env, setting, default. Treats
     # zero or negative values as "unset" and falls through — a 0-token budget
     # is never what the user meant.
@@ -433,6 +447,8 @@ class Provider::Openai < Provider
       family: nil
     )
       with_provider_response do
+        apply_session_headers(session_id: session_id)
+
         chat_config = ChatConfig.new(
           functions: functions,
           function_results: function_results
@@ -541,6 +557,8 @@ class Provider::Openai < Provider
       family: nil
     )
       with_provider_response do
+        apply_session_headers(session_id: session_id)
+
         messages = build_generic_messages(
           prompt: prompt,
           instructions: instructions,

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -30,6 +30,27 @@ class Provider::Openai < Provider
     [ configured, MIN_REQUEST_TIMEOUT ].max
   end
 
+  # Extra HTTP headers for OpenAI-compatible requests, parsed from the
+  # OPENAI_EXTRA_HEADERS env var (a JSON object). ENV-only: no Setting
+  # fallback. Keys and values are stringified for Faraday; blank values are
+  # dropped. Nested JSON values are Ruby-inspect-stringified, not
+  # JSON-serialized. Fail-closed: any parse problem yields {} plus an error
+  # log (raw value never logged) so chat never breaks from bad config.
+  def self.extra_headers
+    raw = ENV["OPENAI_EXTRA_HEADERS"].presence
+    return {} unless raw
+
+    parsed = JSON.parse(raw)
+    unless parsed.is_a?(Hash)
+      Rails.logger.error("OPENAI_EXTRA_HEADERS must be a JSON object; ignoring")
+      return {}
+    end
+    parsed.transform_keys(&:to_s).transform_values(&:to_s).compact_blank
+  rescue JSON::ParserError, TypeError
+    Rails.logger.error("OPENAI_EXTRA_HEADERS is not valid JSON; ignoring")
+    {}
+  end
+
   # Builds a client that uses the effective request timeout for every OpenAI call.
   def initialize(access_token, uri_base: nil, model: nil)
     client_options = { access_token: access_token }
@@ -37,6 +58,8 @@ class Provider::Openai < Provider
     llm_model = model.presence
     client_options[:uri_base] = llm_uri_base if llm_uri_base.present?
     client_options[:request_timeout] = self.class.request_timeout
+    parsed_headers = self.class.extra_headers
+    client_options[:extra_headers] = parsed_headers if parsed_headers.present?
 
     @client = ::OpenAI::Client.new(**client_options)
     @uri_base = llm_uri_base

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -22,6 +22,8 @@ class Provider::Openai < Provider
 
   # Effective per-request HTTP timeout for OpenAI-compatible calls.
   # Precedence matches other self-hosting settings: ENV > Setting > default.
+  #
+  # @return [Integer] timeout in seconds, at least MIN_REQUEST_TIMEOUT
   def self.request_timeout
     configured = ENV["OPENAI_REQUEST_TIMEOUT"].to_s.strip.to_i
     configured = Setting.openai_request_timeout.to_i unless configured.positive?
@@ -36,6 +38,8 @@ class Provider::Openai < Provider
   # dropped. Nested JSON values are Ruby-inspect-stringified, not
   # JSON-serialized. Fail-closed: any parse problem yields {} plus an error
   # log (raw value never logged) so chat never breaks from bad config.
+  #
+  # @return [Hash<String, String>] parsed headers, {} when unset or invalid
   def self.extra_headers
     raw = ENV["OPENAI_EXTRA_HEADERS"].presence
     return {} unless raw
@@ -52,6 +56,13 @@ class Provider::Openai < Provider
   end
 
   # Builds a client that uses the effective request timeout for every OpenAI call.
+  # Static extra headers from OPENAI_EXTRA_HEADERS are attached at construction;
+  # session-valued headers are withheld for per-request resolution.
+  #
+  # @param access_token [String] API token for the OpenAI-compatible endpoint
+  # @param uri_base [String, nil] custom endpoint base URL (OpenAI when nil)
+  # @param model [String, nil] default model; required when uri_base is set
+  # @return [void]
   def initialize(access_token, uri_base: nil, model: nil)
     client_options = { access_token: access_token }
     llm_uri_base = uri_base.presence
@@ -404,6 +415,10 @@ class Provider::Openai < Provider
     # request-scoped client copy carrying the resolved headers — session
     # headers must not persist on the shared client, so later batch requests
     # (which reuse this provider instance's client) never see them.
+    #
+    # @param session_id [String, nil] chat session UUID to substitute
+    # @return [OpenAI::Client] scoped copy when session headers apply, otherwise
+    #   the shared client
     def with_session_headers(session_id:)
       return client if @session_extra_headers.blank? || session_id.blank?
 

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -398,16 +398,20 @@ class Provider::Openai < Provider
   private
     attr_reader :client
 
-    # Substitutes {session_id} into session-valued extra headers and merges
-    # them onto the client for this chat request. Static headers were already
-    # set at construction; a session header without a session_id is simply
-    # never merged (a merge can only add/overwrite, never delete).
-    def apply_session_headers(session_id:)
-      return if @session_extra_headers.blank? || session_id.blank?
+    # Substitutes {session_id} into session-valued extra headers for this chat
+    # request. Static headers were already set at construction; a session
+    # header without a session_id is simply never applied. Returns a
+    # request-scoped client copy carrying the resolved headers — session
+    # headers must not persist on the shared client, so later batch requests
+    # (which reuse this provider instance's client) never see them.
+    def with_session_headers(session_id:)
+      return client if @session_extra_headers.blank? || session_id.blank?
 
-      client.add_headers(
+      session_client = client.dup
+      session_client.add_headers(
         @session_extra_headers.transform_values { |value| value.gsub("{session_id}") { session_id } }
       )
+      session_client
     end
 
     # Returns the first positive integer among env, setting, default. Treats
@@ -447,7 +451,7 @@ class Provider::Openai < Provider
       family: nil
     )
       with_provider_response do
-        apply_session_headers(session_id: session_id)
+        session_client = with_session_headers(session_id: session_id)
 
         chat_config = ChatConfig.new(
           functions: functions,
@@ -484,7 +488,7 @@ class Provider::Openai < Provider
           request_params[:tool_choice] = "none" if tool_choice == :none && chat_config.tools.present?
           request_params[:max_output_tokens] = explicit_max_response_tokens if explicit_max_response_tokens
 
-          raw_response = client.responses.create(parameters: request_params)
+          raw_response = session_client.responses.create(parameters: request_params)
 
           # If streaming, Ruby OpenAI does not return anything, so to normalize this method's API, we search
           # for the "response chunk" in the stream and return it (it is already parsed)
@@ -557,7 +561,7 @@ class Provider::Openai < Provider
       family: nil
     )
       with_provider_response do
-        apply_session_headers(session_id: session_id)
+        session_client = with_session_headers(session_id: session_id)
 
         messages = build_generic_messages(
           prompt: prompt,
@@ -578,7 +582,7 @@ class Provider::Openai < Provider
         params[:max_tokens] = explicit_max_response_tokens if explicit_max_response_tokens
 
         begin
-          raw_response = client.chat(parameters: params)
+          raw_response = session_client.chat(parameters: params)
 
           parsed = GenericChatParser.new(raw_response).parsed
 

--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -118,6 +118,9 @@ OPENAI_ACCESS_TOKEN=sk-proj-...
 
 # Optional: Request timeout in seconds (default: 60)
 # OPENAI_REQUEST_TIMEOUT=60
+
+# Optional: extra HTTP headers as a JSON object (see "Extra HTTP Headers" below)
+# OPENAI_EXTRA_HEADERS='{"x-session":"<value>"}'
 ```
 
 **Recommended models:**
@@ -166,6 +169,26 @@ Any service offering an OpenAI-compatible API should work:
 - [Together AI](https://together.ai/) - Various open models
 - [Anyscale](https://www.anyscale.com/) - Llama models
 - [Replicate](https://replicate.com/) - Various models
+
+### Extra HTTP Headers
+
+Some gateways require custom headers on requests to OpenAI-compatible
+endpoints (e.g. OpenRouter's `HTTP-Referer`). Set `OPENAI_EXTRA_HEADERS`
+to a JSON object mapping header names to values:
+
+```bash
+# Single-quoted so the shell does not interpret braces or quotes.
+OPENAI_EXTRA_HEADERS='{"x-session":"b3f1c2d4-0000-0000-0000-000000000000"}'
+```
+
+Behavior:
+
+- Extra headers are attached to **all requests** made by the OpenAI-compatible provider's client — chat and batch flows (auto-categorize, merchant detection, PDF processing) alike.
+- Values are stringified: nested JSON objects/arrays become Ruby inspect-style strings, not valid JSON. Header values must be plain strings.
+- User headers merge over the client's managed headers — setting `Authorization` here would override the access token.
+- Unset, blank, malformed, or non-object JSON is ignored with an error in the logs; chat keeps working. The raw value is never logged.
+- These headers are NOT sent to embedding, vector-store, or AI-health-probe calls — those build separate clients. A gateway requiring the header on those endpoints is not supported.
+- ENV-only: there is no settings-page equivalent. The value is re-read every time a provider client is built (nothing is cached), but updating the environment requires restarting the app.
 
 ## Local LLM Setup (Ollama)
 

--- a/docs/hosting/ai.md
+++ b/docs/hosting/ai.md
@@ -120,7 +120,7 @@ OPENAI_ACCESS_TOKEN=sk-proj-...
 # OPENAI_REQUEST_TIMEOUT=60
 
 # Optional: extra HTTP headers as a JSON object (see "Extra HTTP Headers" below)
-# OPENAI_EXTRA_HEADERS='{"x-session":"<value>"}'
+# OPENAI_EXTRA_HEADERS='{"x-opencode-session":"{session_id}"}'
 ```
 
 **Recommended models:**
@@ -178,12 +178,19 @@ to a JSON object mapping header names to values:
 
 ```bash
 # Single-quoted so the shell does not interpret braces or quotes.
-OPENAI_EXTRA_HEADERS='{"x-session":"b3f1c2d4-0000-0000-0000-000000000000"}'
+# A value containing the literal {session_id} is replaced with the chat's UUID
+# on each chat request, identifying the conversation rather than the install.
+OPENAI_EXTRA_HEADERS='{"x-opencode-session":"{session_id}"}'
+
+# Static value instead — sent on every OpenAI-provider request, including
+# batch jobs (auto-categorize, merchant detection, PDF processing):
+OPENAI_EXTRA_HEADERS='{"x-opencode-session":"b3f1c2d4-0000-0000-0000-000000000000"}'
 ```
 
 Behavior:
 
-- Extra headers are attached to **all requests** made by the OpenAI-compatible provider's client — chat and batch flows (auto-categorize, merchant detection, PDF processing) alike.
+- A value containing the literal `{session_id}` is substituted with the chat's UUID on each chat request, so requests are attributable per conversation. Batch flows only receive static (non-`{session_id}`) headers, because a session only exists for a chat. If your gateway requires the header on every endpoint, use a static value.
+- Extra headers are attached to **chat requests** made by the OpenAI-compatible provider. Batch flows (auto-categorize, merchant detection, PDF processing) only receive static headers.
 - Values are stringified: nested JSON objects/arrays become Ruby inspect-style strings, not valid JSON. Header values must be plain strings.
 - User headers merge over the client's managed headers — setting `Authorization` here would override the access token.
 - Unset, blank, malformed, or non-object JSON is ignored with an error in the logs; chat keeps working. The raw value is never logged.

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -107,14 +107,16 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     end
   end
 
-  test "session headers substitute the chat id and merge onto the client" do
+  test "session headers substitute the chat id onto a request-scoped client copy" do
     with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}","X-Static":"1"}') do
       subject = Provider::Openai.new("test-token")
       fake_client = mock
-      fake_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
+      scoped_client = mock
+      fake_client.expects(:dup).returns(scoped_client)
+      scoped_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
       subject.stubs(:client).returns(fake_client)
 
-      subject.send(:apply_session_headers, session_id: "chat-42")
+      assert_same scoped_client, subject.send(:with_session_headers, session_id: "chat-42")
     end
   end
 
@@ -122,20 +124,40 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}"}') do
       subject = Provider::Openai.new("test-token")
       fake_client = mock
+      fake_client.expects(:dup).never
       fake_client.expects(:add_headers).never
       subject.stubs(:client).returns(fake_client)
 
-      subject.send(:apply_session_headers, session_id: nil)
+      assert_same subject.send(:client), subject.send(:with_session_headers, session_id: nil)
     end
   end
 
-  test "native chat path resolves session headers onto the client" do
+  test "session headers never persist onto the shared client after a chat request" do
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}"}') do
+      subject = Provider::Openai.new("test-token")
+      scoped_client = mock
+      fake_client = mock
+      fake_client.expects(:dup).returns(scoped_client)
+      scoped_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
+      fake_client.expects(:responses).never
+      subject.stubs(:client).returns(fake_client)
+
+      scoped = subject.send(:with_session_headers, session_id: "chat-42")
+
+      assert_same scoped_client, scoped
+      assert_same fake_client, subject.send(:client)
+    end
+  end
+
+  test "native chat path resolves session headers onto a request-scoped client" do
     with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}"}') do
       subject = Provider::Openai.new("test-token")
       fake_responses = mock
+      scoped_client = mock
+      scoped_client.stubs(:responses).returns(fake_responses)
       fake_client = mock
-      fake_client.stubs(:responses).returns(fake_responses)
-      fake_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
+      fake_client.stubs(:dup).returns(scoped_client)
+      scoped_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
       fake_responses.stubs(:create).returns(
         { "id" => "resp_1", "model" => "gpt-4.1", "output" => [], "usage" => { "total_tokens" => 1 } }
       )
@@ -147,15 +169,17 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
     end
   end
 
-  test "generic chat path resolves session headers onto the client" do
+  test "generic chat path resolves session headers onto a request-scoped client" do
     with_env_overrides(
       "OPENAI_SUPPORTS_RESPONSES_ENDPOINT" => "false",
       "OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}"}'
     ) do
       subject = Provider::Openai.new("test-token")
+      scoped_client = mock
       fake_client = mock
-      fake_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
-      fake_client.stubs(:chat).returns(
+      fake_client.stubs(:dup).returns(scoped_client)
+      scoped_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
+      scoped_client.stubs(:chat).returns(
         { "id" => "resp_1", "model" => "gpt-4.1", "choices" => [ { "message" => { "content" => "Yes" } } ],
           "usage" => { "total_tokens" => 1 } }
       )

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -85,9 +85,87 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
   test "extra headers knob is documented in hosting docs and env examples" do
     doc = Rails.root.join("docs/hosting/ai.md").read
     assert_includes doc, "OPENAI_EXTRA_HEADERS"
+    assert_includes doc, "{session_id}"
 
     assert_includes Rails.root.join(".env.example").read, "OPENAI_EXTRA_HEADERS"
     assert_includes Rails.root.join(".env.local.example").read, "OPENAI_EXTRA_HEADERS"
+  end
+
+  test "client construction receives static extra_headers only; session values withheld" do
+    with_env_overrides(
+      "OPENAI_REQUEST_TIMEOUT" => nil,
+      "OPENAI_EXTRA_HEADERS" => '{"X-Static":"1","x-opencode-session":"sess-{session_id}"}'
+    ) do
+      Setting.stubs(:openai_request_timeout).returns(nil)
+      ::OpenAI::Client.expects(:new).with(
+        access_token: "test-token",
+        request_timeout: 60,
+        extra_headers: { "X-Static" => "1" }
+      ).returns(mock)
+
+      Provider::Openai.new("test-token")
+    end
+  end
+
+  test "session headers substitute the chat id and merge onto the client" do
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}","X-Static":"1"}') do
+      subject = Provider::Openai.new("test-token")
+      fake_client = mock
+      fake_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
+      subject.stubs(:client).returns(fake_client)
+
+      subject.send(:apply_session_headers, session_id: "chat-42")
+    end
+  end
+
+  test "session headers are absent from the request when no session_id is given" do
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}"}') do
+      subject = Provider::Openai.new("test-token")
+      fake_client = mock
+      fake_client.expects(:add_headers).never
+      subject.stubs(:client).returns(fake_client)
+
+      subject.send(:apply_session_headers, session_id: nil)
+    end
+  end
+
+  test "native chat path resolves session headers onto the client" do
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}"}') do
+      subject = Provider::Openai.new("test-token")
+      fake_responses = mock
+      fake_client = mock
+      fake_client.stubs(:responses).returns(fake_responses)
+      fake_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
+      fake_responses.stubs(:create).returns(
+        { "id" => "resp_1", "model" => "gpt-4.1", "output" => [], "usage" => { "total_tokens" => 1 } }
+      )
+      subject.stubs(:client).returns(fake_client)
+
+      response = subject.chat_response("hi", model: "gpt-4.1", session_id: "chat-42")
+
+      assert response.success?
+    end
+  end
+
+  test "generic chat path resolves session headers onto the client" do
+    with_env_overrides(
+      "OPENAI_SUPPORTS_RESPONSES_ENDPOINT" => "false",
+      "OPENAI_EXTRA_HEADERS" => '{"x-opencode-session":"sess-{session_id}"}'
+    ) do
+      subject = Provider::Openai.new("test-token")
+      fake_client = mock
+      fake_client.expects(:add_headers).with({ "x-opencode-session" => "sess-chat-42" })
+      fake_client.stubs(:chat).returns(
+        { "id" => "resp_1", "model" => "gpt-4.1", "choices" => [ { "message" => { "content" => "Yes" } } ],
+          "usage" => { "total_tokens" => 1 } }
+      )
+      subject.stubs(:client).returns(fake_client)
+
+      response = subject.chat_response("hi", model: "gpt-4.1", session_id: "chat-42")
+
+      assert response.success?
+      assert_equal "Yes", response.data.messages.first.output_text
+    end
   end
 
   test "openai errors are automatically raised" do

--- a/test/models/provider/openai_test.rb
+++ b/test/models/provider/openai_test.rb
@@ -26,12 +26,68 @@ class Provider::OpenaiTest < ActiveSupport::TestCase
   end
 
   test "request_timeout is passed to OpenAI client" do
-    with_env_overrides("OPENAI_REQUEST_TIMEOUT" => nil) do
+    with_env_overrides("OPENAI_REQUEST_TIMEOUT" => nil, "OPENAI_EXTRA_HEADERS" => nil) do
       Setting.stubs(:openai_request_timeout).returns(180)
       ::OpenAI::Client.expects(:new).with(access_token: "test-token", request_timeout: 180).returns(mock)
 
       Provider::Openai.new("test-token")
     end
+  end
+
+  test "extra_headers parses valid JSON, stringifies keys and values, drops blanks" do
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-session": "abc", "Retry": 3, "empty": "", "drop": null}') do
+      assert_equal({ "x-session" => "abc", "Retry" => "3" }, Provider::Openai.extra_headers)
+    end
+  end
+
+  test "extra_headers stringifies nested values Ruby-style" do
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => '{"x-meta":{"a":1}}') do
+      assert_equal({ "x-meta" => '{"a" => 1}' }, Provider::Openai.extra_headers)
+    end
+  end
+
+  test "extra_headers returns empty hash for unset, blank, malformed, and non-object JSON" do
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => nil) do
+      assert_equal({}, Provider::Openai.extra_headers)
+    end
+
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => "  ") do
+      assert_equal({}, Provider::Openai.extra_headers)
+    end
+
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => "{not json") do
+      Rails.logger.expects(:error).with(regexp_matches(/OPENAI_EXTRA_HEADERS is not valid JSON/))
+      assert_equal({}, Provider::Openai.extra_headers)
+    end
+
+    with_env_overrides("OPENAI_EXTRA_HEADERS" => "[1,2]") do
+      Rails.logger.expects(:error).with(regexp_matches(/must be a JSON object/))
+      assert_equal({}, Provider::Openai.extra_headers)
+    end
+  end
+
+  test "client construction receives parsed extra_headers" do
+    with_env_overrides(
+      "OPENAI_REQUEST_TIMEOUT" => nil,
+      "OPENAI_EXTRA_HEADERS" => '{"X-Static":"1"}'
+    ) do
+      Setting.stubs(:openai_request_timeout).returns(nil)
+      ::OpenAI::Client.expects(:new).with(
+        access_token: "test-token",
+        request_timeout: 60,
+        extra_headers: { "X-Static" => "1" }
+      ).returns(mock)
+
+      Provider::Openai.new("test-token")
+    end
+  end
+
+  test "extra headers knob is documented in hosting docs and env examples" do
+    doc = Rails.root.join("docs/hosting/ai.md").read
+    assert_includes doc, "OPENAI_EXTRA_HEADERS"
+
+    assert_includes Rails.root.join(".env.example").read, "OPENAI_EXTRA_HEADERS"
+    assert_includes Rails.root.join(".env.local.example").read, "OPENAI_EXTRA_HEADERS"
   end
 
   test "openai errors are automatically raised" do


### PR DESCRIPTION
Closes #3363

## Summary
- Add `OPENAI_EXTRA_HEADERS` (a JSON object of header name → value), parsed in `Provider::Openai` and passed as per-client `extra_headers:` to `OpenAI::Client.new`
- Values containing a `{session_id}` placeholder are resolved per conversation from the existing chat session id and merged per chat request; batch flows (auto-categorize, merchant detection, PDF processing, bill setup, bank-statement extraction) send static headers only
- Fail-closed parsing: malformed/non-object/blank JSON is logged and ignored (raw value never logged); keys and values are coerced to strings
- Document the knob in `docs/hosting/ai.md` and the env example files

## Motivation

Some OpenAI-compatible gateways require custom HTTP headers on every LLM request. The concrete one that prompted this: OpenCode Zen (usable as an `OPENAI_URI_BASE`) will start rejecting requests from unrecognized clients that lack an `x-opencode-session` header (announced via email, enforcement beginning 2026-09-06). OpenRouter and LiteLLM deployments commonly need custom headers as well (e.g. `HTTP-Referer`, `X-Title` for OpenRouter attribution).

`ruby-openai` already supports per-client `extra_headers`, so this is a small diff — Sure just never exposes it.

## Testing
- `bin/rails test test/models/provider/openai_test.rb` — new tests for parsing (valid/blank/malformed/non-object JSON), client construction receiving static `extra_headers:` only (session-valued headers withheld), session substitution (resolved / dropped-without-session / static untouched), and a docs-consistency test binding the knob to its docs
- `bin/rails test` full suite, `bin/rubocop`, `bin/brakeman` all green

## Notes for reviewers
- Scoped to the chat LLM provider by design; vector-store and AI-health probe clients are intentionally untouched (documented in `docs/hosting/ai.md`)
- User-supplied headers merge over the gem's managed ones — setting `Authorization` here would override the access token; called out in the docs
- ENV-only by design: no Setting fallback or settings-UI entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional custom HTTP headers for OpenAI-compatible chat requests through `OPENAI_EXTRA_HEADERS`.
  * Supports JSON-formatted headers, dynamic `{session_id}` substitution, and static values for batch requests.
  * Invalid or blank header configurations are safely ignored.

* **Bug Fixes**
  * Prevented session-specific headers from carrying over to subsequent requests.

* **Documentation**
  * Added configuration examples and guidance covering header behavior, supported requests, substitutions, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->