### PR TITLE
fix(reports): stop Safari swallowing every click on the reports page

### DIFF
--- a/app/views/reports/_category_row.html.erb
+++ b/app/views/reports/_category_row.html.erb
@@ -11,9 +11,9 @@
 %>
 
 <tr data-category="category-<%= item[:category_id] %>"
-    class="text-secondary text-sm <%= show_border ? "table-divider" : "" %> <%= clickable ? "relative group/category-row" : "" %>">
+    class="text-secondary text-sm <%= show_border ? "table-divider" : "" %> <%= clickable ? "group/category-row" : "" %>">
   <td colspan="2" class="py-3 px-4 lg:px-6 <%= is_sub ? "pl-7 lg:pl-9" : "" %>">
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2 <%= clickable ? "relative" : "" %>">
       <% if is_sub %>
         <div class="text-subdued">
           <%= icon "corner-down-right" %>
@@ -38,8 +38,12 @@
         ) %>
       <% end %>
       <% if clickable %>
-        <%# Stretched link covers the full row (mirrors dashboard outflows).
-            `before:absolute before:inset-0` is positioned against the relative <tr>. %>
+        <%# Stretched link covers the category cell. The overlay is anchored to the
+            flex wrapper above, NOT to the <tr>: `position: relative` on a table row
+            does not establish a containing block in WebKit (it is left undefined by
+            CSS 2.1 9.3.1, and Safari does not implement it). Anchoring to the row
+            therefore let the overlay escape and blanket the whole page in Safari,
+            swallowing every click on /reports into this drill-down. %>
         <%= link_to item[:category_name],
               transactions_href,
               class: "font-medium text-primary hover:underline before:absolute before:inset-0 before:content-['']",

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -442,8 +442,11 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr[data-category='category-#{income_category.id}'] a[href=?]", income_href, text: income_category.name
     assert_select "tr[data-category='category-uncategorized'] a[href=?]", uncategorized_href, text: Category.uncategorized.name
 
-    # Full-row hit target via stretched ::before (mirrors dashboard outflows)
-    assert_select "tr.relative.group\\/category-row[data-category='category-#{expense_category.id}'] a[class*='before:absolute'][class*='before:inset-0']"
+    # Hit target via stretched ::before, anchored to the category cell's flex
+    # wrapper. Deliberately NOT the <tr>: CSS 2.1 9.3.1 leaves position:relative
+    # undefined on table rows and WebKit does not implement it, so anchoring
+    # there let the overlay escape and swallow every click on the page in Safari.
+    assert_select "tr.group\\/category-row[data-category='category-#{expense_category.id}'] td div.relative a[class*='before:absolute'][class*='before:inset-0']"
   end
 
   test "index uncategorized category link uses localized name that Search accepts" do


### PR DESCRIPTION
## Summary

On Safari, **every click on `/reports` navigates to `/transactions`** filtered by one
category — including clicks on the period-picker popover, so the month cannot be changed.
Chrome and Firefox are unaffected.

## Cause

`app/views/reports/_category_row.html.erb` makes each category row a stretched link:

```erb
<tr class="... relative group/category-row">
  ...
  class: "font-medium text-primary hover:underline before:absolute before:inset-0 before:content-['']"
```

The `::before` overlay is anchored to the parent `<tr class="relative">`. But
`position: relative` on a table row is **left undefined by CSS 2.1 §9.3.1**, and WebKit
does not implement it — the row never becomes a containing block. The overlay therefore
resolves against a much larger positioned ancestor, blankets the reports page, and
intercepts every click, routing it into whichever category's drill-down owns the overlay.

This is invisible in Chrome/Firefox because they *do* establish the containing block, so
the overlay stays inside its row. It arrived with #2923 ("Make report income/expense
categories clickable").

## Reproduction

1. Open `/reports` in Safari with at least one expense category in the breakdown
2. Click the month label to open the period picker, then click any month
3. You land on `/transactions?q[categories][]=<category>&q[start_date]=…&q[end_date]=…`
   instead of changing the period

Diagnosing this from server logs is confusing, because there is **no redirect** — no
`Location` header is ever sent. `/reports` renders `200` and the browser navigates on its
own; the giveaway is the destination's `Referer: /reports` plus a query string that only
`_category_row.html.erb` builds.

## Fix

Anchor the overlay to the flex wrapper already present inside the cell rather than to the
`<tr>`. A `<div>` is an unambiguous containing block in every engine, so no browser-specific
behaviour is relied on.

## Trade-off

The click target narrows from the entire row to the category cell — still the icon, the
category name and the entry count, i.e. the two leftmost of four columns. Preserving
full-row clicking would need a separate overlay anchor in each `<td>`; happy to rework it
that way if you'd prefer to keep the larger target.

## Verification

- Verified on a self-hosted instance running `ghcr.io/we-promise/sure:stable`, in
  **Safari 26.5.2 / macOS**: before the change every click on `/reports` bounced to
  `/transactions`; after it, the period picker works and the category drill-down still
  navigates correctly.
- `bundle exec erb_lint app/views/reports/_category_row.html.erb` → `No errors were found in ERB files`
- Rendering is unchanged in Chrome.

## Related

#3132 also touches Safari behaviour on `/reports`, but covers mobile touch-hold jitter and
iOS scroll freeze — a different mechanism in different files. No overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed report category links in Safari/WebKit so the clickable overlay stays within its intended row.
  * Restored normal click behavior across the Reports page, preventing the drill-down link from covering the entire page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->