### PR TITLE
fix(l10n): localize invalid Binance sync date

### DIFF
--- a/app/controllers/binance_items_controller.rb
+++ b/app/controllers/binance_items_controller.rb
@@ -223,7 +223,7 @@ class BinanceItemsController < ApplicationController
       if parsed_date.present? && parsed_date <= Date.current
         @binance_item.update!(sync_start_date: parsed_date)
       else
-        flash.now[:alert] = "Sync start date must be a valid date in the past."
+        flash.now[:alert] = t(".invalid_sync_start_date")
       end
     end
 

--- a/config/locales/views/binance_items/de.yml
+++ b/config/locales/views/binance_items/de.yml
@@ -22,6 +22,7 @@ de:
       cancel: Abbrechen
       creating: Importiere...
     complete_account_setup:
+      invalid_sync_start_date: Wähl ein gültiges Startdatum für die Synchronisierung, das nicht in der Zukunft liegt.
       success:
         one: "%{count} Konto importiert"
         other: "%{count} Konten importiert"

--- a/config/locales/views/binance_items/en.yml
+++ b/config/locales/views/binance_items/en.yml
@@ -21,6 +21,7 @@ en:
       cancel: Cancel
       creating: Importing...
     complete_account_setup:
+      invalid_sync_start_date: Sync start date must be a valid date in the past.
       success:
         one: "Imported %{count} account"
         other: "Imported %{count} accounts"

--- a/test/controllers/binance_items_controller_test.rb
+++ b/test/controllers/binance_items_controller_test.rb
@@ -96,6 +96,20 @@ class BinanceItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Sync start date must be a valid date in the past.", flash[:alert]
   end
 
+  test "complete_account_setup localizes an invalid sync_start_date in German" do
+    user = users(:family_admin)
+    user.update!(locale: "de")
+    sign_in user
+
+    post complete_account_setup_binance_item_url(@binance_item), params: {
+      selected_accounts: [],
+      sync_start_date: (Date.current + 2.days).to_s
+    }
+
+    assert_equal "Wähl ein gültiges Startdatum für die Synchronisierung, das nicht in der Zukunft liegt.", flash[:alert]
+    assert I18n.exists?("binance_items.complete_account_setup.invalid_sync_start_date", :de, fallback: false)
+  end
+
   test "complete_account_setup with no selection shows message" do
     @binance_item.binance_accounts.create!(
       name: "Spot Portfolio",


### PR DESCRIPTION
## Summary

- move the invalid Binance sync start-date alert behind an action-scoped I18n key
- preserve the existing English message and add German copy that matches the accepted date range
- cover the localized controller response and direct German key ownership

## Testing

- `bin/rails test test/controllers/binance_items_controller_test.rb` (13 runs, 30 assertions)
- `TZ=UTC bin/rails test` (8,276 runs, 33,143 assertions)
- `bin/rubocop` (2,516 files, no offenses)
- YAML parsing, `git diff --check`, and simulated merge-tree verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The invalid sync start date alert is now localized, including German-language messaging.
  * Users are shown a translated message when they enter a date that is invalid or in the future.

* **Tests**
  * Added coverage to verify the German translation appears correctly for invalid sync start dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->