### PR TITLE
fix(l10n): localize OpenAI timeout settings

### DIFF
--- a/config/locales/views/settings/hostings/de.yml
+++ b/config/locales/views/settings/hostings/de.yml
@@ -81,6 +81,8 @@ de:
         uri_base_placeholder: "https://api.openai.com/v1 (Standard)"
         model_label: Modell (optional)
         model_placeholder: "gpt-4.1 (Standard)"
+        model_function_calling_help: Der KI-Assistent liest deine Daten mithilfe von Funktionsaufrufen. Wähl daher ein Modell, das laut Dokumentation deines Anbieters Tools beziehungsweise Function Calling unterstützt. Ohne diese Unterstützung schlägt der Chat mit einer wenig aussagekräftigen Fehlermeldung des Anbieters fehl.
+        model_function_calling_link: Konfiguriertes Modell prüfen
         json_mode_label: JSON-Modus
         json_mode_auto: Auto (empfohlen)
         json_mode_strict: Streng (am besten für Denk-Modelle)
@@ -96,6 +98,12 @@ de:
         max_items_per_call_label: Maximale Einträge pro Stapel (optional)
         max_response_tokens_help: 'Tokens, die für die Antwort des Modells reserviert sind. Standard: 512. Niedriger ansetzen, um Platz für längere Verläufe zu schaffen.'
         max_response_tokens_label: Maximale Antwort-Tokens (optional)
+        timeout_heading: Zeitlimits
+        timeout_description: Legt fest, wie lange Aufrufe OpenAI-kompatibler Modelle laufen dürfen, bevor Sure sie abbricht. Erhöhe diese Werte, wenn du ein lokales Modell auf langsamer Hardware betreibst.
+        openai_request_timeout_label: Anfragezeitlimit in Sekunden (optional)
+        openai_request_timeout_help: 'Standard: 60. Gilt für jede OpenAI-kompatible HTTP-Anfrage, einschließlich automatischer Kategorisierung, Händlererkennung, Chat, PDF-Verarbeitung und Vektorspeicher-Aufrufen. OPENAI_REQUEST_TIMEOUT überschreibt dieses Feld.'
+        ai_response_timeout_label: Antwortzeitlimit in Sekunden (optional)
+        ai_response_timeout_help: 'Standard: 90. Gilt nur für das Zeitlimit der gesamten Chat-Runde. Setz den Wert daher als Summe an: (1 + ASSISTANT_MAX_TOOL_CALL_ITERATIONS) × Anfragezeitlimit, plus Ausführungszeit der Tools und Wartezeit in der Warteschlange. AI_RESPONSE_TIMEOUT überschreibt dieses Feld.'
       yahoo_finance_settings:
         title: Yahoo Finance
         description: Yahoo Finance bietet kostenlosen Zugriff auf Aktienkurse, Wechselkurse und Finanzdaten – ganz ohne API-Schlüssel.

--- a/test/controllers/settings/hostings_controller_test.rb
+++ b/test/controllers/settings/hostings_controller_test.rb
@@ -52,6 +52,38 @@ class Settings::HostingsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "renders OpenAI model and timeout guidance in German" do
+    sign_in users(:sure_support_staff)
+
+    with_self_hosting do
+      get settings_hosting_url(locale: :de)
+
+      assert_response :success
+      assert_includes response.body, "Konfiguriertes Modell prüfen"
+      assert_includes response.body, "Tools beziehungsweise Function Calling unterstützt"
+      assert_includes response.body, "Zeitlimits"
+      assert_includes response.body, "Anfragezeitlimit in Sekunden (optional)"
+      assert_includes response.body, "OPENAI_REQUEST_TIMEOUT"
+      assert_includes response.body, "Antwortzeitlimit in Sekunden (optional)"
+      assert_includes response.body, "(1 + ASSISTANT_MAX_TOOL_CALL_ITERATIONS) × Anfragezeitlimit"
+      assert_includes response.body, "AI_RESPONSE_TIMEOUT"
+      refute_includes response.body, "Request Timeout in Seconds"
+    end
+
+    %w[
+      model_function_calling_help
+      model_function_calling_link
+      timeout_heading
+      timeout_description
+      openai_request_timeout_label
+      openai_request_timeout_help
+      ai_response_timeout_label
+      ai_response_timeout_help
+    ].each do |key|
+      assert I18n.exists?("settings.hostings.openai_settings.#{key}", :de, fallback: false)
+    end
+  end
+
   test "can update rentcast api key when self hosting is enabled" do
     with_self_hosting do
       patch settings_hosting_url, params: { setting: { rentcast_api_key: "rentcast-token" } }


### PR DESCRIPTION
## Summary

German self-hosting settings now explain which OpenAI-compatible models support the assistant and how to tune request and whole-chat timeouts. The guidance keeps the documented environment-variable overrides and timeout formula visible, so local-model operators can adjust slow setups without switching to English.

This is an independent slice of the ongoing German localization work.

## Testing

- `bin/rails test test/controllers/settings/hostings_controller_test.rb`
- `bin/rails test test/i18n_test.rb`
- `TZ=UTC bin/rails test`
- `bin/rubocop`

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This changes German locale copy and test coverage only; the existing settings behavior is unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added German-language guidance to hosting settings explaining that the AI assistant requires a model supporting tools or function calling.
  - Added German explanations for configurable request and response timeouts, including default values and environment-variable overrides.
  - German users can now view OpenAI model and timeout configuration guidance without falling back to English text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->