### PR TITLE
Make importmap audit best-effort for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      require_js_dependency_audit:
+        description: "Fail the workflow when the importmap JavaScript dependency audit cannot complete"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   scan_ruby:
@@ -38,12 +44,20 @@ jobs:
           bundler-cache: true
 
       - name: Scan for security vulnerabilities in JavaScript dependencies
+        continue-on-error: ${{ !inputs.require_js_dependency_audit }}
+        env:
+          REQUIRE_JS_DEPENDENCY_AUDIT: ${{ inputs.require_js_dependency_audit }}
         run: |
-          for attempt in 1 2 3; do
-            echo "Running importmap audit, attempt ${attempt}/3"
+          attempts=3
+          if [ "$REQUIRE_JS_DEPENDENCY_AUDIT" != "true" ]; then
+            attempts=1
+          fi
+
+          for attempt in $(seq 1 "$attempts"); do
+            echo "Running importmap audit, attempt ${attempt}/${attempts}"
             bin/importmap audit && exit 0
 
-            if [ "$attempt" = 3 ]; then
+            if [ "$attempt" = "$attempts" ]; then
               exit 1
             fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ permissions:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
+    with:
+      require_js_dependency_audit: false
 
   build:
     name: Build Docker image


### PR DESCRIPTION
## Summary
- make the importmap JavaScript dependency audit advisory by default so npm advisory endpoint timeouts do not block PRs or Docker publishing
- keep the reusable workflow input so a caller can opt into requiring the audit later
- run one best-effort audit attempt by default, while required callers would still get three attempts

## Validation
- ruby -rpsych -e 'Psych.load_file(".github/workflows/ci.yml"); Psych.load_file(".github/workflows/publish.yml")'
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added configuration to control whether JavaScript dependency audits are required during continuous integration checks.
  * Audits run once by default when configured as non-blocking, reducing repeated checks and workflow delays.
  * Publishing workflows now use non-blocking JavaScript dependency audits, allowing releases to proceed when an audit cannot be completed successfully.
  * Strict auditing remains available for workflows that require audit success before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->