### PR TITLE
fix(l10n): localize bills page shell

### DIFF
--- a/config/locales/views/bills/de.yml
+++ b/config/locales/views/bills/de.yml
@@ -1,0 +1,14 @@
+---
+de:
+  bills:
+    views:
+      aria_label: Rechnungsansichten
+      overview: Übersicht
+      calendar: Kalender
+      paycheck: Einkommensplan
+      all: Alle Rechnungen
+    index:
+      title: Rechnungen
+      add_bill: Rechnung hinzufügen
+      add_income: Einkommen hinzufügen
+      review_with_ai: Mit KI prüfen

--- a/test/controllers/bills_controller_test.rb
+++ b/test/controllers/bills_controller_test.rb
@@ -36,6 +36,57 @@ class BillsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "bills page shell is localized in German" do
+    @user.update!(locale: "de")
+    Provider::Registry.stubs(:preferred_llm_provider).returns(Object.new)
+
+    get bills_url
+
+    assert_response :success
+
+    translations = {
+      "bills.views.aria_label" => "Rechnungsansichten",
+      "bills.views.overview" => "Übersicht",
+      "bills.views.calendar" => "Kalender",
+      "bills.views.paycheck" => "Einkommensplan",
+      "bills.views.all" => "Alle Rechnungen",
+      "bills.index.title" => "Rechnungen",
+      "bills.index.add_bill" => "Rechnung hinzufügen",
+      "bills.index.add_income" => "Einkommen hinzufügen",
+      "bills.index.review_with_ai" => "Mit KI prüfen"
+    }
+
+    translations.each do |key, text|
+      assert_equal text, I18n.t(key, locale: :de, fallback: false)
+    end
+
+    assert_select "main h1", text: translations.fetch("bills.index.title")
+    assert_select "div.segmented-control[aria-label=?]", translations.fetch("bills.views.aria_label") do
+      translations.slice(
+        "bills.views.overview",
+        "bills.views.calendar",
+        "bills.views.paycheck",
+        "bills.views.all"
+      ).each_value do |text|
+        assert_select "a.segmented-control__segment", text: text
+      end
+    end
+    assert_select "header" do
+      assert_select "a:not([role=menuitem])", text: translations.fetch("bills.index.add_bill")
+      assert_select "a[role=menuitem]", text: translations.fetch("bills.index.add_income")
+      assert_select "button", text: translations.fetch("bills.index.review_with_ai")
+    end
+
+    get bills_url(view: "paycheck")
+
+    assert_response :success
+    assert_select "header" do
+      assert_select "a:not([role=menuitem])", text: translations.fetch("bills.index.add_income")
+      assert_select "a[role=menuitem]", text: translations.fetch("bills.index.add_bill")
+      assert_select "button", text: translations.fetch("bills.index.review_with_ai")
+    end
+  end
+
   test "index lists a bill" do
     bill = create_bill(name: "Rent", amount: 1200)
 


### PR DESCRIPTION
## Summary

German users can now navigate the Bills page header and view switcher without English fallbacks. The overview, calendar, income-plan, and all-bills views share the same German title and actions.

This is an independent slice of the ongoing German localization work. Detailed bill content remains unchanged.

## Validation

- `bin/rails test test/controllers/bills_controller_test.rb` (87 runs, 554 assertions)
- `bin/rails test test/i18n_test.rb` (7 runs, 191 assertions, 4 skips)
- `TZ=UTC bin/rails test` (8,297 runs, 33,280 assertions, 30 skips)
- `bin/rubocop` (2,517 files, no offenses)
- Independent German wording review found no issues.
- Structured code review found no actionable findings.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this changes static locale text only. During the first deployment, verify one German Bills overview and Income plan request renders the translated page title, view labels, and actions. Roll back if those requests fall back to English or the longer labels break the header or segmented control. Owner: maintainers; validation window: first deploy containing this change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for the bills overview, calendar, paycheck, and all-bills views.
  * Localized bills page labels and actions, including adding bills, adding income, and reviewing with AI.

* **Tests**
  * Added coverage verifying that the bills page displays the expected German text across supported views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->