### PR TITLE
fix(transfers): hide disabled accounts from new transfer modal

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -225,6 +225,7 @@ class TransfersController < ApplicationController
 
     def set_accounts
       @accounts = accessible_accounts
+        .active
         .alphabetically
         .includes(
           :account_providers,

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -10,6 +10,16 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "excludes disabled accounts from the new transfer form" do
+    disabled_account = accounts(:depository)
+    disabled_account.update!(status: "disabled")
+
+    get new_transfer_url
+
+    assert_response :success
+    assert_no_match disabled_account.name, response.body
+  end
+
   test "can create transfers" do
     assert_difference "Transfer.count", 1 do
       post transfers_url, params: {


### PR DESCRIPTION
## Summary
- Disabled accounts are already hidden from the dashboard accounts list and the new transaction modal's account picker, but the new transfer modal's "From"/"To" account selects still listed them.
- `TransfersController#set_accounts` now chains `.active` (same filter already used by `TransactionsController#set_new_transaction_form_options`), so disabled accounts no longer appear as transfer endpoints.

## Test plan
- [x] `bin/rails test test/controllers/transfers_controller_test.rb` — 34 runs, 0 failures (added a regression test: "excludes disabled accounts from the new transfer form")

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled accounts are now excluded from the new-transfer form.
  * Only active accounts are shown when selecting an account for a transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->