### PR TITLE
fix(l10n): localize recurring allocation feedback

### DIFF
--- a/config/locales/views/recurring_allocations/de.yml
+++ b/config/locales/views/recurring_allocations/de.yml
@@ -1,0 +1,15 @@
+---
+de:
+  recurring_allocations:
+    over_allocation: Damit würdest du mehr als den Transaktionsbetrag zuordnen.
+    missing_rate: Kein Wechselkurs verfügbar. Gib den Betrag manuell ein.
+    already_allocated: Diese Transaktion ist dieser Rechnung bereits zugeordnet
+    invalid: Die Zahlung konnte nicht erfasst werden
+    create:
+      success: Zahlung zugeordnet
+    destroy:
+      success: Zahlungszuordnung entfernt
+    confirm:
+      success: Zahlung der Rechnung zugeordnet
+    reject:
+      success: Vorschlag abgelehnt. Diese Transaktion wird für diese Rechnung nicht mehr vorgeschlagen.

--- a/test/controllers/recurring_allocations_controller_test.rb
+++ b/test/controllers/recurring_allocations_controller_test.rb
@@ -88,4 +88,21 @@ class RecurringAllocationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, @occurrence.reload.allocations.count,
       "a nil-cast date would have silently defaulted the payment to today"
   end
+
+  test "allocation feedback is available in German" do
+    expected_translations = {
+      "recurring_allocations.over_allocation" => "Damit würdest du mehr als den Transaktionsbetrag zuordnen.",
+      "recurring_allocations.missing_rate" => "Kein Wechselkurs verfügbar. Gib den Betrag manuell ein.",
+      "recurring_allocations.already_allocated" => "Diese Transaktion ist dieser Rechnung bereits zugeordnet",
+      "recurring_allocations.invalid" => "Die Zahlung konnte nicht erfasst werden",
+      "recurring_allocations.create.success" => "Zahlung zugeordnet",
+      "recurring_allocations.destroy.success" => "Zahlungszuordnung entfernt",
+      "recurring_allocations.confirm.success" => "Zahlung der Rechnung zugeordnet",
+      "recurring_allocations.reject.success" => "Vorschlag abgelehnt. Diese Transaktion wird für diese Rechnung nicht mehr vorgeschlagen."
+    }
+
+    expected_translations.each do |key, translation|
+      assert_equal translation, I18n.t(key, locale: :de, fallback: false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

German users now see localized feedback when bill payments are linked, unlinked, confirmed, rejected, or cannot be recorded. This keeps the allocation flow in German without changing allocation behavior or English copy.

## Validation

- Added fallback-disabled coverage for all eight messages.
- Focused allocation and i18n tests: 36 runs, 287 assertions.
- Full Rails suite: 8,345 runs, 33,502 assertions.
- RuboCop: 2,521 files, no offenses.
- Brakeman: no security warnings.

## Post-Deploy Monitoring & Validation

- Window/owner: next release smoke test, release reviewer.
- Healthy signal: allocation success and error flashes render in German with no missing translations.
- Watch: application logs for `Translation missing` entries under `recurring_allocations`.
- Failure/mitigation: an English fallback or missing-translation error; revert this locale-only commit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for recurring allocation error and success messages, including allocation validation and action confirmations.

* **Tests**
  * Added coverage to verify that all recurring allocation feedback messages display the expected German translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->