### PR TITLE
fix(l10n): localize recurrence rule validation errors

### DIFF
--- a/config/locales/models/recurrence_rule/de.yml
+++ b/config/locales/models/recurrence_rule/de.yml
@@ -1,0 +1,35 @@
+---
+de:
+  activerecord:
+    attributes:
+      recurrence_rule:
+        frequency: Häufigkeit
+        interval: Intervall
+        day_of_month: Tag des Monats
+        weekday: Wochentag
+        weekday_ordinal: Woche des Monats
+        month_of_year: Monat
+      recurring_transaction/recurrence_rules:
+        base: "Wiederholungsregel:"
+        frequency: Häufigkeit
+        interval: Intervall
+        day_of_month: Tag des Monats
+        weekday: Wochentag
+        weekday_ordinal: Woche des Monats
+        month_of_year: Monat
+    errors:
+      models:
+        recurrence_rule:
+          day_spec_required: Wähle entweder einen Tag des Monats oder einen Wochentag aus
+          attributes:
+            weekday:
+              required_for_weekly: muss für eine wöchentliche Regel angegeben werden
+            weekday_ordinal:
+              not_allowed_for_weekly: gilt nicht für eine wöchentliche Regel
+              required_with_weekday: muss angegeben werden, wenn ein Wochentag festgelegt ist
+              not_allowed_without_weekday: gilt nur, wenn ein Wochentag festgelegt ist
+            day_of_month:
+              not_allowed_for_weekly: gilt nicht für eine wöchentliche Regel
+            month_of_year:
+              required_for_yearly: muss für eine jährliche Regel angegeben werden
+              not_allowed: gilt nur für eine jährliche Regel

--- a/config/locales/models/recurrence_rule/en.yml
+++ b/config/locales/models/recurrence_rule/en.yml
@@ -9,6 +9,14 @@ en:
         weekday: "Weekday"
         weekday_ordinal: "Week of month"
         month_of_year: "Month"
+      recurring_transaction/recurrence_rules:
+        base: "Recurrence rule:"
+        frequency: "Frequency"
+        interval: "Interval"
+        day_of_month: "Day of month"
+        weekday: "Weekday"
+        weekday_ordinal: "Week of month"
+        month_of_year: "Month"
     errors:
       models:
         recurrence_rule:

--- a/test/controllers/recurring_transactions_localization_test.rb
+++ b/test/controllers/recurring_transactions_localization_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class RecurringTransactionsLocalizationTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in @user = users(:family_admin)
+    @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => true))
+    @recurring_transaction = recurring_transactions(:netflix_subscription)
+    ensure_tailwind_build
+  end
+
+  test "German edit form renders localized recurrence rule errors" do
+    patch recurring_transaction_url(@recurring_transaction, locale: :de),
+          params: { recurring_transaction: { frequency_preset: "weekly" } },
+          headers: { "Turbo-Frame" => "modal" }
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, "Wochentag muss für eine wöchentliche Regel angegeben werden"
+    assert_no_match(/Recurrence rules/, response.body)
+    assert_no_match(/Weekday is required for a weekly rule/, response.body)
+  end
+end

--- a/test/models/recurrence_rule_test.rb
+++ b/test/models/recurrence_rule_test.rb
@@ -175,12 +175,47 @@ class RecurrenceRuleTest < ActiveSupport::TestCase
     end
   end
 
+  test "nested validation errors use English recurrence rule names" do
+    attribute_names = {
+      frequency: "Frequency",
+      interval: "Interval",
+      day_of_month: "Day of month",
+      weekday: "Weekday",
+      weekday_ordinal: "Week of month",
+      month_of_year: "Month"
+    }
+
+    I18n.with_locale(:en) do
+      attribute_names.each do |attribute, expected|
+        assert_equal expected, RecurringTransaction.human_attribute_name("recurrence_rules.#{attribute}")
+      end
+
+      assert_nested_rule_error(
+        { frequency: "monthly" },
+        "Recurrence rule: Choose exactly one of a day of the month or a weekday"
+      )
+      assert_nested_rule_error(
+        { frequency: "weekly" },
+        "Weekday is required for a weekly rule"
+      )
+    end
+  end
+
   private
     def assert_rule_errors(attributes, expected)
       rule = @recurring.recurrence_rules.build(**attributes)
 
       assert_not rule.valid?
       assert_equal expected, rule.errors.full_messages
+    ensure
+      @recurring.recurrence_rules.reset
+    end
+
+    def assert_nested_rule_error(attributes, expected)
+      @recurring.recurrence_rules.build(**attributes)
+
+      assert_not @recurring.valid?
+      assert_equal [ expected ], @recurring.errors.full_messages
     ensure
       @recurring.recurrence_rules.reset
     end

--- a/test/models/recurrence_rule_test.rb
+++ b/test/models/recurrence_rule_test.rb
@@ -119,4 +119,69 @@ class RecurrenceRuleTest < ActiveSupport::TestCase
     assert rule.errors[:weekday_ordinal].any?,
       "an ordinal with no weekday persists an incoherent day anchor"
   end
+
+  test "validation errors are localized in German" do
+    attribute_names = {
+      frequency: "Häufigkeit",
+      interval: "Intervall",
+      day_of_month: "Tag des Monats",
+      weekday: "Wochentag",
+      weekday_ordinal: "Woche des Monats",
+      month_of_year: "Monat"
+    }
+
+    I18n.with_locale(:de) do
+      attribute_names.each do |attribute, expected|
+        assert_equal expected, RecurrenceRule.human_attribute_name(attribute)
+      end
+
+      assert_rule_errors(
+        { frequency: "monthly" },
+        [ "Wähle entweder einen Tag des Monats oder einen Wochentag aus" ]
+      )
+      assert_rule_errors(
+        { frequency: "weekly" },
+        [ "Wochentag muss für eine wöchentliche Regel angegeben werden" ]
+      )
+      assert_rule_errors(
+        { frequency: "weekly", weekday: 4, weekday_ordinal: 2, day_of_month: 10, month_of_year: 3 },
+        [
+          "Woche des Monats gilt nicht für eine wöchentliche Regel",
+          "Tag des Monats gilt nicht für eine wöchentliche Regel",
+          "Monat gilt nur für eine jährliche Regel"
+        ]
+      )
+      assert_rule_errors(
+        { frequency: "monthly", weekday: 5 },
+        [ "Woche des Monats muss angegeben werden, wenn ein Wochentag festgelegt ist" ]
+      )
+      assert_rule_errors(
+        { frequency: "monthly", day_of_month: 10, weekday_ordinal: 2 },
+        [ "Woche des Monats gilt nur, wenn ein Wochentag festgelegt ist" ]
+      )
+      assert_rule_errors(
+        { frequency: "yearly", day_of_month: 1 },
+        [ "Monat muss für eine jährliche Regel angegeben werden" ]
+      )
+      assert_rule_errors(
+        { frequency: "monthly", day_of_month: 5, month_of_year: 3 },
+        [ "Monat gilt nur für eine jährliche Regel" ]
+      )
+
+      @recurring.recurrence_rules.build(frequency: "monthly")
+      assert_not @recurring.valid?
+      assert_includes @recurring.errors.full_messages,
+                      "Wiederholungsregel: Wähle entweder einen Tag des Monats oder einen Wochentag aus"
+    end
+  end
+
+  private
+    def assert_rule_errors(attributes, expected)
+      rule = @recurring.recurrence_rules.build(**attributes)
+
+      assert_not rule.valid?
+      assert_equal expected, rule.errors.full_messages
+    ensure
+      @recurring.recurrence_rules.reset
+    end
 end


### PR DESCRIPTION
## Summary

German families now see fully localized recurrence-rule validation errors in recurring bill forms. This includes nested Active Record prefixes that previously leaked English into otherwise German messages.

This is another focused slice of the ongoing German localization effort.

## Validation

- Focused localization and model tests: 23 runs, 252 assertions, 0 failures
- Full Rails suite: 8,349 runs, 33,597 assertions, 0 failures
- RuboCop: 2,522 files inspected, no offenses
- Simulated merge tree matches the tested branch exactly
- ERB-Lint reports 10 pre-existing findings in unchanged views; this PR changes no ERB files
- Structured code review completed; both findings were fixed and re-tested

## Post-Deploy Monitoring & Validation

- Search application logs for missing-translation errors containing `recurrence_rule` or `recurring_transaction/recurrence_rules`.
- Healthy signal: invalid German recurring-bill submissions render a German validation message with no `Recurrence rules` or `Weekday` prefix.
- Failure signal: a missing-translation exception or an English prefix in the German validation banner. Revert this PR if either appears.
- Validation window and owner: first release cycle after deployment, owned by the maintainer validating German recurring-bill edits.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added German labels for recurring transaction recurrence rule fields.
  * Added German validation messages for weekly and yearly recurrence rules.
  * German recurring transaction forms now display localized recurrence rule errors.
  * Added English labels for nested recurring transaction recurrence rule fields.

* **Tests**
  * Added coverage confirming German and English labels and validation messages render correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->