### PR TITLE
fix(l10n): localize onchain wallet movement names

### DIFF
--- a/app/models/onchain_wallet_account/processor.rb
+++ b/app/models/onchain_wallet_account/processor.rb
@@ -357,8 +357,11 @@ class OnchainWalletAccount::Processor
     end
 
     def translated_name(key, quantity)
+      # Entry names persist across request- and scheduler-triggered syncs, so
+      # they must not depend on whichever locale happened to enqueue the job.
       I18n.t(
         key,
+        locale: onchain_wallet_account.onchain_wallet_item.family.locale,
         quantity: quantity.abs.round(8).to_s("F"),
         symbol: onchain_wallet_account.symbol
       )

--- a/config/locales/models/onchain_wallet_item/de.yml
+++ b/config/locales/models/onchain_wallet_item/de.yml
@@ -1,0 +1,6 @@
+---
+de:
+  onchain_wallet_item:
+    movement:
+      received: "Eingang: %{quantity} %{symbol}"
+      sent: "Ausgang: %{quantity} %{symbol}"

--- a/test/models/onchain_wallet_account/processor_test.rb
+++ b/test/models/onchain_wallet_account/processor_test.rb
@@ -122,6 +122,38 @@ class OnchainWalletAccount::ProcessorTest < ActiveSupport::TestCase
     assert_equal "Sent 1.0 FAKE", entry.name
   end
 
+  test "localizes wallet movement names in German" do
+    date = 3.days.ago.to_date
+    @family.update!(locale: "de")
+    price_asset_at(date, 50)
+    store_movements(
+      fake_movement(external_id: "received", amount: "1.5", timestamp: date),
+      fake_movement(external_id: "sent", amount: "-1", timestamp: date)
+    )
+
+    I18n.with_locale(:en) do
+      OnchainWalletAccount::Processor.new(@onchain_account).process
+    end
+
+    received = @account.entries.find_by!(external_id: "onchain_#{@onchain_account.id}_received")
+    sent = @account.entries.find_by!(external_id: "onchain_#{@onchain_account.id}_sent")
+
+    assert_equal "Eingang: 1.5 FAKE", received.name
+    assert_equal "Ausgang: 1.0 FAKE", sent.name
+
+    received.update!(name: "Received 1.5 FAKE")
+    received.entryable.update!(investment_activity_label: "Buy")
+
+    I18n.with_locale(:en) do
+      assert_equal 1, OnchainWalletAccount::Processor.new(@onchain_account).repair_display_only_movements
+    end
+
+    assert_equal "Eingang: 1.5 FAKE", received.reload.name
+    assert_equal "Ausgang: 1.0 FAKE", sent.reload.name
+    assert I18n.exists?("onchain_wallet_item.movement.received", :de, fallback: false)
+    assert I18n.exists?("onchain_wallet_item.movement.sent", :de, fallback: false)
+  end
+
   test "materializes a display-only excluded entry when that day's price is unknown" do
     date = 3.days.ago.to_date
     store_movements(fake_movement(external_id: "tx3", amount: "1.5", timestamp: date))


### PR DESCRIPTION
## Summary

- Show self-custody wallet movements as `Eingang` and `Ausgang` for German families.
- Generate persisted movement names from the owning family's locale so scheduler and request locales cannot overwrite them inconsistently.
- Cover both new movement imports and the repair path for legacy trade labels.

## Validation

- Focused onchain processor, syncer, and localization tests: 43 runs, 329 assertions, 0 failures
- Full Rails suite: 8,349 runs, 33,580 assertions, 0 failures, 0 errors, 30 skips
- RuboCop: 2,522 files inspected, no offenses
- German locale YAML and `git diff --check` pass
- Simulated merge tree matches the tested branch exactly
- Independent German language review approved `Eingang` / `Ausgang`
- Structured correctness, testing, and project-standards review completed with no remaining findings

## Post-Deploy Monitoring & Validation

- Verify that a German family's newly imported inbound and outbound wallet movements appear as `Eingang: …` and `Ausgang: …` in account activity.
- Healthy signal: later scheduled syncs and legacy movement repairs retain the family's language.
- Failure signal: German families receive new English `Received` / `Sent` names or a later sync changes an existing German name back to English. Revert this PR if either appears.
- Validation window and owner: first release cycle after deployment, owned by the maintainer validating German onchain wallet activity.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for on-chain wallet movement descriptions, including received and sent amounts.

* **Bug Fixes**
  * Wallet movement names now consistently use the wallet’s configured language, regardless of the language active when synchronization was initiated.
  * Repairing display-only movement details now restores localized German names correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->