### PR TITLE
Refresh provider account setup mappings

### DIFF
--- a/app/controllers/lunchflow_items_controller.rb
+++ b/app/controllers/lunchflow_items_controller.rb
@@ -699,9 +699,6 @@ class LunchflowItemsController < ApplicationController
     # Fetch Lunchflow accounts from the API and store them locally
     # Returns nil on success, or an error message string on failure
     def fetch_lunchflow_accounts_from_api
-      # Skip if we already have accounts cached
-      return nil unless @lunchflow_item.lunchflow_accounts.empty?
-
       # Validate API key is configured
       unless @lunchflow_item.credentials_configured?
         return t("lunchflow_items.setup_accounts.no_api_key")

--- a/app/controllers/mercury_items_controller.rb
+++ b/app/controllers/mercury_items_controller.rb
@@ -695,9 +695,6 @@ class MercuryItemsController < ApplicationController
     # Fetch Mercury accounts from the API and store them locally
     # Returns nil on success, or an error message string on failure
     def fetch_mercury_accounts_from_api
-      # Skip if we already have accounts cached
-      return nil unless @mercury_item.mercury_accounts.empty?
-
       # Validate API token is configured
       unless @mercury_item.credentials_configured?
         return t("mercury_items.setup_accounts.no_api_token")

--- a/app/views/brex_items/_brex_item.html.erb
+++ b/app/views/brex_items/_brex_item.html.erb
@@ -78,6 +78,13 @@
 
             <%= render DS::Menu.new do |menu| %>
               <% menu.with_item(
+                variant: "link",
+                text: t(".setup_action"),
+                icon: "settings",
+                href: setup_accounts_brex_item_path(brex_item),
+                frame: :modal
+              ) %>
+              <% menu.with_item(
                 variant: "button",
                 text: t(".delete"),
                 icon: "trash-2",

--- a/app/views/lunchflow_items/_lunchflow_item.html.erb
+++ b/app/views/lunchflow_items/_lunchflow_item.html.erb
@@ -67,6 +67,13 @@
 
             <%= render DS::Menu.new do |menu| %>
               <% menu.with_item(
+                variant: "link",
+                text: t(".setup_action"),
+                icon: "settings",
+                href: setup_accounts_lunchflow_item_path(lunchflow_item),
+                frame: :modal
+              ) %>
+              <% menu.with_item(
                 variant: "button",
                 text: t(".delete"),
                 icon: "trash-2",

--- a/app/views/mercury_items/_mercury_item.html.erb
+++ b/app/views/mercury_items/_mercury_item.html.erb
@@ -67,6 +67,13 @@
 
             <%= render DS::Menu.new do |menu| %>
               <% menu.with_item(
+                variant: "link",
+                text: t(".setup_action"),
+                icon: "settings",
+                href: setup_accounts_mercury_item_path(mercury_item),
+                frame: :modal
+              ) %>
+              <% menu.with_item(
                 variant: "button",
                 text: t(".delete"),
                 icon: "trash-2",

--- a/test/controllers/lunchflow_items_controller_test.rb
+++ b/test/controllers/lunchflow_items_controller_test.rb
@@ -8,6 +8,7 @@ class LunchflowItemsControllerTest < ActionDispatch::IntegrationTest
   test "setup accounts renders German subtype options without English fallbacks" do
     ensure_tailwind_build
     @user.update!(locale: "de")
+    stub_lunchflow_accounts
 
     get setup_accounts_lunchflow_item_url(lunchflow_items(:one))
 
@@ -45,6 +46,7 @@ class LunchflowItemsControllerTest < ActionDispatch::IntegrationTest
   test "setup accounts preserves the English title and placeholders" do
     ensure_tailwind_build
     @user.update!(locale: "en")
+    stub_lunchflow_accounts
 
     get setup_accounts_lunchflow_item_url(lunchflow_items(:one))
 
@@ -52,6 +54,32 @@ class LunchflowItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "title", text: "Set Up Lunch Flow Accounts"
     assert_select "option", text: "Select subtype"
     assert_select "option", text: "Select type"
+  end
+
+  test "setup accounts refreshes provider accounts when local accounts already exist" do
+    lunchflow_item = lunchflow_items(:one)
+    existing_account = lunchflow_accounts(:investment_account)
+    stub_lunchflow_accounts([
+      {
+        id: "lf_acc_investment_1",
+        name: "Test Investment Account",
+        currency: "USD"
+      },
+      {
+        id: "lf_acc_new_1",
+        name: "New Lunch Flow Account",
+        currency: "USD"
+      }
+    ])
+
+    assert_difference -> { LunchflowAccount.where(lunchflow_item: lunchflow_item).count }, 1 do
+      get setup_accounts_lunchflow_item_url(lunchflow_item)
+    end
+
+    assert_response :success
+    assert existing_account.reload
+    assert lunchflow_item.lunchflow_accounts.exists?(account_id: "lf_acc_new_1")
+    assert_includes response.body, "New Lunch Flow Account"
   end
 
   test "account setup localizes an unexpected error in German" do
@@ -134,4 +162,20 @@ class LunchflowItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to accounts_path
     assert_match "Api key can't be blank", flash[:alert]
   end
+
+  private
+
+    def stub_lunchflow_accounts(accounts = nil)
+      accounts ||= [
+        {
+          id: "lf_acc_investment_1",
+          name: "Test Investment Account",
+          currency: "USD"
+        }
+      ]
+
+      provider = mock("lunchflow_provider")
+      provider.expects(:get_accounts).returns(accounts: accounts)
+      LunchflowItem.any_instance.expects(:lunchflow_provider).returns(provider)
+    end
 end

--- a/test/controllers/mercury_items_controller_test.rb
+++ b/test/controllers/mercury_items_controller_test.rb
@@ -174,6 +174,39 @@ class MercuryItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, %(value="#{@second_item.id}")
   end
 
+  test "setup accounts refreshes provider accounts when local accounts already exist" do
+    existing_account = mercury_accounts(:checking_account)
+    provider = mock("mercury_provider")
+    provider.expects(:get_accounts).returns(accounts: [
+      {
+        id: "merc_acc_checking_1",
+        nickname: "Mercury Checking",
+        name: "Mercury Checking",
+        status: "active",
+        type: "checking",
+        currentBalance: 1000
+      },
+      {
+        id: "merc_acc_new_1",
+        nickname: "New Mercury Account",
+        name: "New Mercury Account",
+        status: "active",
+        type: "checking",
+        currentBalance: 2500
+      }
+    ])
+    MercuryItem.any_instance.expects(:mercury_provider).returns(provider)
+
+    assert_difference -> { MercuryAccount.where(mercury_item: @existing_item).count }, 1 do
+      get setup_accounts_mercury_item_url(@existing_item)
+    end
+
+    assert_response :success
+    assert existing_account.reload
+    assert @existing_item.mercury_accounts.exists?(account_id: "merc_acc_new_1")
+    assert_includes response.body, "New Mercury Account"
+  end
+
   test "link accounts uses selected mercury item and allows duplicate upstream ids across items" do
     @existing_item.mercury_accounts.create!(
       account_id: "shared_mercury_account",


### PR DESCRIPTION
## Summary
- add provider-card setup actions for Brex, Lunch Flow, and Mercury so admins can reopen account mapping even when all known provider accounts are linked
- refresh Lunch Flow and Mercury provider account snapshots whenever the setup modal opens, instead of only when there are no local provider-account rows
- leave transaction sync button behavior unchanged

## Tests
- git diff --check
- bin/rails test test/controllers/lunchflow_items_controller_test.rb test/controllers/mercury_items_controller_test.rb test/controllers/brex_items_controller_test.rb test/controllers/sophtron_items_controller_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only **Setup** option for Brex, Lunchflow, and Mercury items.
  * Setup opens the account configuration in a modal.

* **Bug Fixes**
  * Account setup now refreshes provider account data even when local accounts already exist.
  * Existing local accounts are retained while newly available provider accounts are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->