### PR TITLE
Add personal/business account usage type

### DIFF
--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -112,7 +112,7 @@ module AccountableResource
         :name, :balance, :subtype, :currency, :accountable_type, :return_to,
         :opening_balance_date,
         :institution_name, :institution_domain, :notes, :exclude_from_reports,
-        :enable_category_matcher,
+        :enable_category_matcher, :business_usage,
         accountable_attributes: self.class.permitted_accountable_attributes
       )
     end

--- a/app/controllers/wise_items_controller.rb
+++ b/app/controllers/wise_items_controller.rb
@@ -214,8 +214,10 @@ class WiseItemsController < ApplicationController
       redirect_to accounts_path, alert: t("wise_items.link_existing_account.not_found") and return
     end
 
-    account.update!(usage_type: account_usage_type_param(wise_account))
-    AccountProvider.create!(account: account, provider: wise_account)
+    Account.transaction do
+      account.update!(usage_type: account_usage_type_param(wise_account))
+      AccountProvider.create!(account: account, provider: wise_account)
+    end
     wise_account.wise_item.sync_later unless wise_account.wise_item.syncing?
 
     redirect_to safe_return_to_path || accounts_path, notice: t("wise_items.link_existing_account.success", account_name: account.name)

--- a/app/controllers/wise_items_controller.rb
+++ b/app/controllers/wise_items_controller.rb
@@ -144,7 +144,7 @@ class WiseItemsController < ApplicationController
       redirect_to accounts_path, alert: t(".not_found") and return
     end
 
-    account = Account.create_from_wise_account(wise_account)
+    account = Account.create_from_wise_account(wise_account, usage_type: account_usage_type_param(wise_account))
 
     AccountProvider.create!(
       account: account,
@@ -182,7 +182,7 @@ class WiseItemsController < ApplicationController
       redirect_to safe_return_to_path || accounts_path, alert: t("wise_items.link_accounts.not_found") and return
     end
 
-    account = Account.create_from_wise_account(wise_account)
+    account = Account.create_from_wise_account(wise_account, usage_type: account_usage_type_param(wise_account))
     AccountProvider.create!(account: account, provider: wise_account)
     wise_account.wise_item.sync_later unless wise_account.wise_item.syncing?
 
@@ -214,6 +214,7 @@ class WiseItemsController < ApplicationController
       redirect_to accounts_path, alert: t("wise_items.link_existing_account.not_found") and return
     end
 
+    account.update!(usage_type: account_usage_type_param(wise_account))
     AccountProvider.create!(account: account, provider: wise_account)
     wise_account.wise_item.sync_later unless wise_account.wise_item.syncing?
 
@@ -256,6 +257,11 @@ class WiseItemsController < ApplicationController
       WiseAccount.joins(:wise_item)
                  .merge(Current.family.wise_items.active)
                  .find_by(id: wise_account_id)
+    end
+
+    def account_usage_type_param(wise_account)
+      value = params[:usage_type].presence || wise_account.wise_item.profile_type
+      Account.usage_types.key?(value) ? value : "personal"
     end
 
     def profile_display_name(profile)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -40,6 +40,7 @@ class Account < ApplicationRecord
   monetize :balance, :cash_balance
 
   enum :classification, { asset: "asset", liability: "liability" }, validate: { allow_nil: true }
+  enum :usage_type, { personal: "personal", business: "business" }, default: :personal, validate: true
 
   VISIBLE_STATUSES = %w[draft active].freeze
   HISTORICAL_STATUSES = (VISIBLE_STATUSES + %w[disabled]).freeze
@@ -306,7 +307,7 @@ class Account < ApplicationRecord
       )
     end
 
-    def create_from_wise_account(wise_account)
+    def create_from_wise_account(wise_account, usage_type: nil)
       family = wise_account.wise_item.family
 
       create_and_sync(
@@ -316,6 +317,7 @@ class Account < ApplicationRecord
           balance: wise_account.current_balance || 0,
           cash_balance: wise_account.current_balance || 0,
           currency: wise_account.currency,
+          usage_type: usage_type.presence || wise_account.wise_item.profile_type,
           accountable_type: "Depository",
           accountable_attributes: { subtype: wise_account.account_subtype }
         },
@@ -488,6 +490,14 @@ class Account < ApplicationRecord
 
   def institution_domain
     read_attribute(:institution_domain).presence || provider&.institution_domain
+  end
+
+  def business_usage
+    business?
+  end
+
+  def business_usage=(value)
+    self.usage_type = ActiveModel::Type::Boolean.new.cast(value) ? "business" : "personal"
   end
 
   def manual_crypto_exchange?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -40,7 +40,7 @@ class Account < ApplicationRecord
   monetize :balance, :cash_balance
 
   enum :classification, { asset: "asset", liability: "liability" }, validate: { allow_nil: true }
-  enum :usage_type, { personal: "personal", business: "business" }, default: :personal, validate: true
+  enum :usage_type, { personal: "personal", business: "business" }, default: :personal, validate: { allow_nil: true }
 
   VISIBLE_STATUSES = %w[draft active].freeze
   HISTORICAL_STATUSES = (VISIBLE_STATUSES + %w[disabled]).freeze

--- a/app/models/balance_sheet.rb
+++ b/app/models/balance_sheet.rb
@@ -64,6 +64,12 @@ class BalanceSheet
     end
 
     def sorted(accounts)
+      non_business_accounts, business_accounts = accounts.partition { |account| account.usage_type != "business" }
+
+      sort_by_account_order(non_business_accounts) + sort_by_account_order(business_accounts)
+    end
+
+    def sort_by_account_order(accounts)
       account_order = user&.account_order
       order_key = account_order&.key || "name_asc"
 

--- a/app/views/accounts/_account.html.erb
+++ b/app/views/accounts/_account.html.erb
@@ -20,7 +20,7 @@
         <% else %>
           <div class="flex items-center gap-1.5">
             <%= link_to account.name, account, class: [(account.active? ? "text-primary" : "text-subdued"), "text-sm font-medium hover:underline"], data: { turbo_frame: "_top" } %>
-            <%= render "accounts/usage_type_badge", account: account %>
+            <%= render "accounts/usage_type_badge", account: account if account.usage_type.present? %>
 
             <% if account.exclude_from_reports? %>
               <%= render DS::Tooltip.new(text: t("accounts.account.excluded_from_reports_indicator"), as: :span) do %>

--- a/app/views/accounts/_account.html.erb
+++ b/app/views/accounts/_account.html.erb
@@ -20,6 +20,7 @@
         <% else %>
           <div class="flex items-center gap-1.5">
             <%= link_to account.name, account, class: [(account.active? ? "text-primary" : "text-subdued"), "text-sm font-medium hover:underline"], data: { turbo_frame: "_top" } %>
+            <%= render "accounts/usage_type_badge", account: account %>
 
             <% if account.exclude_from_reports? %>
               <%= render DS::Tooltip.new(text: t("accounts.account.excluded_from_reports_indicator"), as: :span) do %>

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -11,6 +11,14 @@
 
     <%= form.text_field :name, placeholder: t(".name_placeholder"), required: "required", label: t(".name_label") %>
 
+    <div class="flex items-center justify-between gap-3 py-2">
+      <div class="space-y-1">
+        <p class="text-sm text-primary"><%= t(".business_usage_label") %></p>
+        <p class="text-secondary text-sm"><%= t(".business_usage_hint") %></p>
+      </div>
+      <%= form.toggle :business_usage %>
+    </div>
+
     <% unless account.linked? %>
       <%= form.money_field :balance, label: t(".balance"), required: true, default_currency: Current.family.currency %>
     <% end %>

--- a/app/views/accounts/_usage_type_badge.html.erb
+++ b/app/views/accounts/_usage_type_badge.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (account:) %>
+
+<%= render DS::Pill.new(
+  label: t("accounts.usage_types.#{account.usage_type}"),
+  tone: account.business? ? :info : :neutral,
+  marker: false
+) %>

--- a/app/views/api/v1/accounts/_account.json.jbuilder
+++ b/app/views/api/v1/accounts/_account.json.jbuilder
@@ -11,6 +11,7 @@ json.cash_balance cash_balance_money.format
 json.cash_balance_cents((cash_balance_money.amount * cash_balance_money.currency.minor_unit_conversion).round(0).to_i)
 json.currency account.currency
 json.classification account.classification
+json.usage_type account.usage_type
 json.account_type account.accountable_type&.underscore
 json.subtype account.subtype
 json.status account.status

--- a/app/views/layouts/shared/_confirm_dialog.html.erb
+++ b/app/views/layouts/shared/_confirm_dialog.html.erb
@@ -20,6 +20,7 @@
           type: :submit,
           autofocus: true,
           full_width: true,
+          class: "min-w-0 truncate",
           value: "confirm",
           data: { variant: variant, confirm_dialog_target: "confirmButton" },
           hidden: true,

--- a/app/views/wise_items/select_accounts.html.erb
+++ b/app/views/wise_items/select_accounts.html.erb
@@ -27,8 +27,6 @@
             <%= hidden_field_tag :wise_item_id, @wise_item.id %>
             <%= hidden_field_tag :accountable_type, @accountable_type %>
             <%= hidden_field_tag :return_to, @return_to %>
-            <%= hidden_field_tag :usage_type, "personal", id: nil %>
-
             <div class="space-y-2">
               <% @available_accounts.each do |wise_account| %>
                 <label class="flex items-start gap-3 p-3 border border-primary rounded-lg hover:bg-subtle cursor-pointer transition-colors">
@@ -45,10 +43,16 @@
               <% end %>
             </div>
 
-            <label class="flex items-center gap-2 text-sm text-primary">
-              <%= check_box_tag :usage_type, "business", @wise_item.business?, class: "rounded border-secondary" %>
+            <div class="flex items-center gap-2 text-sm text-primary">
+              <%= render DS::Toggle.new(
+                id: "wise_usage_type",
+                name: "usage_type",
+                checked: @wise_item.business?,
+                checked_value: "business",
+                unchecked_value: "personal"
+              ) %>
               <span><%= t("accounts.form.business_usage_label") %></span>
-            </label>
+            </div>
 
             <div class="flex gap-2 justify-end pt-4">
               <%= render DS::Link.new(

--- a/app/views/wise_items/select_accounts.html.erb
+++ b/app/views/wise_items/select_accounts.html.erb
@@ -27,6 +27,7 @@
             <%= hidden_field_tag :wise_item_id, @wise_item.id %>
             <%= hidden_field_tag :accountable_type, @accountable_type %>
             <%= hidden_field_tag :return_to, @return_to %>
+            <%= hidden_field_tag :usage_type, "personal", id: nil %>
 
             <div class="space-y-2">
               <% @available_accounts.each do |wise_account| %>
@@ -43,6 +44,11 @@
                 </label>
               <% end %>
             </div>
+
+            <label class="flex items-center gap-2 text-sm text-primary">
+              <%= check_box_tag :usage_type, "business", @wise_item.business?, class: "rounded border-secondary" %>
+              <span><%= t("accounts.form.business_usage_label") %></span>
+            </label>
 
             <div class="flex gap-2 justify-end pt-4">
               <%= render DS::Link.new(

--- a/app/views/wise_items/select_existing_account.html.erb
+++ b/app/views/wise_items/select_existing_account.html.erb
@@ -27,6 +27,7 @@
             <%= hidden_field_tag :wise_item_id, @wise_item&.id %>
             <%= hidden_field_tag :account_id, @account.id %>
             <%= hidden_field_tag :return_to, @return_to %>
+            <%= hidden_field_tag :usage_type, "personal", id: nil %>
 
             <div class="space-y-2">
               <% @available_accounts.each do |wise_account| %>
@@ -43,6 +44,11 @@
                 </label>
               <% end %>
             </div>
+
+            <label class="flex items-center gap-2 text-sm text-primary">
+              <%= check_box_tag :usage_type, "business", @account.business? || @wise_item&.business?, class: "rounded border-secondary" %>
+              <span><%= t("accounts.form.business_usage_label") %></span>
+            </label>
 
             <div class="flex gap-2 justify-end pt-4">
               <%= render DS::Link.new(

--- a/app/views/wise_items/select_existing_account.html.erb
+++ b/app/views/wise_items/select_existing_account.html.erb
@@ -27,8 +27,6 @@
             <%= hidden_field_tag :wise_item_id, @wise_item&.id %>
             <%= hidden_field_tag :account_id, @account.id %>
             <%= hidden_field_tag :return_to, @return_to %>
-            <%= hidden_field_tag :usage_type, "personal", id: nil %>
-
             <div class="space-y-2">
               <% @available_accounts.each do |wise_account| %>
                 <label class="flex items-start gap-3 p-3 border border-primary rounded-lg hover:bg-subtle cursor-pointer transition-colors">
@@ -45,10 +43,16 @@
               <% end %>
             </div>
 
-            <label class="flex items-center gap-2 text-sm text-primary">
-              <%= check_box_tag :usage_type, "business", @account.business? || @wise_item&.business?, class: "rounded border-secondary" %>
+            <div class="flex items-center gap-2 text-sm text-primary">
+              <%= render DS::Toggle.new(
+                id: "wise_existing_usage_type",
+                name: "usage_type",
+                checked: @account.business? || @wise_item&.business?,
+                checked_value: "business",
+                unchecked_value: "personal"
+              ) %>
               <span><%= t("accounts.form.business_usage_label") %></span>
-            </label>
+            </div>
 
             <div class="flex gap-2 justify-end pt-4">
               <%= render DS::Link.new(

--- a/app/views/wise_items/setup_accounts.html.erb
+++ b/app/views/wise_items/setup_accounts.html.erb
@@ -22,7 +22,13 @@
 
         <div class="space-y-3">
           <% @wise_accounts.each do |wise_account| %>
-            <div class="border border-primary rounded-lg p-4 flex items-center justify-between gap-4">
+            <%= form_with url: complete_account_setup_wise_item_path(@wise_item),
+                          method: :post,
+                          data: { turbo_frame: "_top" },
+                          class: "border border-primary rounded-lg p-4 flex items-center justify-between gap-4" do %>
+              <%= hidden_field_tag :wise_account_id, wise_account.id %>
+              <%= hidden_field_tag :usage_type, "personal", id: nil %>
+
               <div>
                 <p class="font-medium text-primary text-sm"><%= wise_account.name %></p>
                 <p class="text-xs text-secondary mt-0.5">
@@ -30,18 +36,19 @@
                   &nbsp;·&nbsp;
                   <%= wise_account.currency %>
                 </p>
+                <label class="mt-3 flex items-center gap-2 text-xs text-secondary">
+                  <%= check_box_tag :usage_type, "business", @wise_item.business?, class: "rounded border-secondary" %>
+                  <span><%= t("accounts.form.business_usage_label") %></span>
+                </label>
               </div>
               <%= render DS::Button.new(
                 text: t(".create_account"),
                 icon: "plus",
                 variant: :outline,
                 size: :sm,
-                href: complete_account_setup_wise_item_path(@wise_item),
-                method: :post,
-                params: { wise_account_id: wise_account.id },
-                frame: "_top"
+                type: :submit
               ) %>
-            </div>
+            <% end %>
           <% end %>
         </div>
 

--- a/app/views/wise_items/setup_accounts.html.erb
+++ b/app/views/wise_items/setup_accounts.html.erb
@@ -27,8 +27,6 @@
                           data: { turbo_frame: "_top" },
                           class: "border border-primary rounded-lg p-4 flex items-center justify-between gap-4" do %>
               <%= hidden_field_tag :wise_account_id, wise_account.id %>
-              <%= hidden_field_tag :usage_type, "personal", id: nil %>
-
               <div>
                 <p class="font-medium text-primary text-sm"><%= wise_account.name %></p>
                 <p class="text-xs text-secondary mt-0.5">
@@ -36,10 +34,16 @@
                   &nbsp;·&nbsp;
                   <%= wise_account.currency %>
                 </p>
-                <label class="mt-3 flex items-center gap-2 text-xs text-secondary">
-                  <%= check_box_tag :usage_type, "business", @wise_item.business?, class: "rounded border-secondary" %>
+                <div class="mt-3 flex items-center gap-2 text-xs text-secondary">
+                  <%= render DS::Toggle.new(
+                    id: "wise_usage_type_#{wise_account.id}",
+                    name: "usage_type",
+                    checked: @wise_item.business?,
+                    checked_value: "business",
+                    unchecked_value: "personal"
+                  ) %>
                   <span><%= t("accounts.form.business_usage_label") %></span>
-                </label>
+                </div>
               </div>
               <%= render DS::Button.new(
                 text: t(".create_account"),

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -53,6 +53,8 @@ en:
       exclude_from_reports: Exclude from all reports
       enable_category_matcher_label: Enable category matcher
       enable_category_matcher_hint: When enabled, the provider's suggested category is applied to imported transactions. Disable to leave new transactions uncategorized.
+      business_usage_label: Business account
+      business_usage_hint: Mark accounts used for business, freelance, or sole proprietor activity.
     index:
       accounts: Accounts
       cancel_sync: Cancel sync
@@ -166,6 +168,9 @@ en:
       tax_deferred: Tax-Deferred
       tax_exempt: Tax-Exempt
       tax_advantaged: Tax-Advantaged
+    usage_types:
+      personal: Personal
+      business: Business
     tax_treatment_descriptions:
       taxable: Gains taxed when realized
       tax_deferred: Contributions deductible, taxed on withdrawal

--- a/db/migrate/20260905120000_add_usage_type_to_accounts.rb
+++ b/db/migrate/20260905120000_add_usage_type_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddUsageTypeToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :usage_type, :string, null: false, default: "personal"
+  end
+end

--- a/db/migrate/20260905120000_add_usage_type_to_accounts.rb
+++ b/db/migrate/20260905120000_add_usage_type_to_accounts.rb
@@ -1,5 +1,8 @@
 class AddUsageTypeToAccounts < ActiveRecord::Migration[7.2]
   def change
-    add_column :accounts, :usage_type, :string, null: false, default: "personal"
+    add_column :accounts, :usage_type, :string
+    add_check_constraint :accounts,
+      "usage_type IS NULL OR usage_type IN ('personal', 'business')",
+      name: "chk_accounts_usage_type"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,7 +121,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_05_120000) do
     t.string "status", default: "active"
     t.string "subtype"
     t.datetime "updated_at", null: false
-    t.string "usage_type", default: "personal", null: false
+    t.string "usage_type"
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_05_120000) do
     t.index ["plaid_account_id"], name: "index_accounts_on_plaid_account_id"
     t.index ["simplefin_account_id"], name: "index_accounts_on_simplefin_account_id"
     t.index ["status"], name: "index_accounts_on_status"
+    t.check_constraint "usage_type IS NULL OR usage_type::text = ANY (ARRAY['personal'::character varying::text, 'business'::character varying::text])", name: "chk_accounts_usage_type"
   end
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_02_180400) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_05_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -121,6 +121,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_180400) do
     t.string "status", default: "active"
     t.string "subtype"
     t.datetime "updated_at", null: false
+    t.string "usage_type", default: "personal", null: false
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -406,6 +406,7 @@ components:
       - cash_balance_cents
       - currency
       - classification
+      - usage_type
       - account_type
       - status
       - created_at
@@ -430,6 +431,12 @@ components:
           type: string
         classification:
           type: string
+        usage_type:
+          type: string
+          enum:
+          - personal
+          - business
+          nullable: true
         account_type:
           type: string
           nullable: true

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -275,7 +275,7 @@ RSpec.configure do |config|
           },
           AccountDetail: {
             type: :object,
-            required: %w[id name balance balance_cents cash_balance cash_balance_cents currency classification account_type status created_at updated_at],
+            required: %w[id name balance balance_cents cash_balance cash_balance_cents currency classification usage_type account_type status created_at updated_at],
             properties: {
               id: { type: :string, format: :uuid },
               name: { type: :string },
@@ -285,6 +285,7 @@ RSpec.configure do |config|
               cash_balance_cents: { type: :integer, description: 'Signed cash balance in minor currency units' },
               currency: { type: :string },
               classification: { type: :string },
+              usage_type: { type: :string, enum: %w[personal business], nullable: true },
               account_type: { type: :string, nullable: true },
               subtype: { type: :string, nullable: true },
               status: { type: :string, enum: %w[active draft disabled pending_deletion] },

--- a/test/controllers/wise_items_controller_test.rb
+++ b/test/controllers/wise_items_controller_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class WiseItemsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    ensure_tailwind_build
     sign_in users(:family_admin)
     SyncJob.stubs(:perform_later)
     @family = families(:dylan_family)
@@ -113,6 +114,34 @@ class WiseItemsControllerTest < ActionDispatch::IntegrationTest
     assert @family.wise_items.find_by!(profile_id: "99999999").import_all_history?
     assert @family.wise_items.find_by!(profile_id: "88888888").import_all_history?
     assert_nil session[:wise_pending_import_all_history]
+  end
+
+  test "complete_account_setup stores explicit account usage type" do
+    wise_account = wise_accounts(:checking)
+
+    assert_difference "Account.count", 1 do
+      post complete_account_setup_wise_item_url(@wise_item), params: {
+        wise_account_id: wise_account.id,
+        usage_type: "personal"
+      }
+    end
+
+    assert_redirected_to accounts_path
+    assert Account.order(:created_at).last.personal?
+  end
+
+  test "link_existing_account updates the account usage type" do
+    account = accounts(:depository)
+    wise_account = wise_accounts(:checking)
+
+    post link_existing_account_wise_items_url, params: {
+      account_id: account.id,
+      wise_account_id: wise_account.id,
+      usage_type: "business"
+    }
+
+    assert_redirected_to accounts_path
+    assert account.reload.business?
   end
 
   test "link_profiles redirects to providers when there is no pending session" do

--- a/test/controllers/wise_items_controller_test.rb
+++ b/test/controllers/wise_items_controller_test.rb
@@ -144,6 +144,23 @@ class WiseItemsControllerTest < ActionDispatch::IntegrationTest
     assert account.reload.business?
   end
 
+  test "link_existing_account rolls back usage type when provider link fails" do
+    account = accounts(:depository)
+    wise_account = wise_accounts(:checking)
+    account.update!(usage_type: "personal")
+    AccountProvider.stubs(:create!).raises(ActiveRecord::RecordNotUnique)
+
+    assert_no_changes -> { account.reload.usage_type } do
+      post link_existing_account_wise_items_url, params: {
+        account_id: account.id,
+        wise_account_id: wise_account.id,
+        usage_type: "business"
+      }
+    end
+
+    assert_redirected_to accounts_path
+  end
+
   test "link_profiles redirects to providers when there is no pending session" do
     post link_profiles_wise_items_url, params: { profile_ids: [ "99999999" ] }
 

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -73,6 +73,39 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal 500, account.balance
   end
 
+  test "usage type defaults to personal and can be set through business usage switch" do
+    account = @family.accounts.build(
+      name: "Usage test",
+      balance: 100,
+      currency: "USD",
+      accountable: Depository.new
+    )
+
+    assert account.personal?
+
+    account.business_usage = "1"
+    assert account.business?
+
+    account.business_usage = "0"
+    assert account.personal?
+  end
+
+  test "create_from_wise_account inherits the Wise profile type" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_from_wise_account(wise_accounts(:checking))
+
+    assert account.business?
+  end
+
+  test "create_from_wise_account accepts an explicit usage type override" do
+    Account.any_instance.stubs(:sync_later)
+
+    account = Account.create_from_wise_account(wise_accounts(:checking), usage_type: "personal")
+
+    assert account.personal?
+  end
+
   test "create_and_sync creates opening anchor with correct currency" do
     Account.any_instance.stubs(:sync_later)
 

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -90,6 +90,19 @@ class AccountTest < ActiveSupport::TestCase
     assert account.personal?
   end
 
+  test "usage type may be unknown for accounts created before classification" do
+    account = @family.accounts.build(
+      name: "Historical usage test",
+      balance: 100,
+      currency: "USD",
+      usage_type: nil,
+      accountable: Depository.new
+    )
+
+    assert account.valid?
+    assert_nil account.usage_type
+  end
+
   test "create_from_wise_account inherits the Wise profile type" do
     Account.any_instance.stubs(:sync_later)
 

--- a/test/models/balance_sheet_test.rb
+++ b/test/models/balance_sheet_test.rb
@@ -156,10 +156,10 @@ class BalanceSheetTest < ActiveSupport::TestCase
     user = users(:empty)
     user.update!(default_account_order: "balance_desc")
 
-    create_account(name: "Business Low", balance: 1000, usage_type: "business", accountable: Depository.new)
-    create_account(name: "Personal Low", balance: 2000, usage_type: "personal", accountable: Depository.new)
-    create_account(name: "Business High", balance: 3000, usage_type: "business", accountable: Depository.new)
-    create_account(name: "Unknown High", balance: 4000, usage_type: nil, accountable: Depository.new)
+    create_account(name: "Business Low", owner: user, balance: 1000, usage_type: "business", accountable: Depository.new)
+    create_account(name: "Personal Low", owner: user, balance: 2000, usage_type: "personal", accountable: Depository.new)
+    create_account(name: "Business High", owner: user, balance: 3000, usage_type: "business", accountable: Depository.new)
+    create_account(name: "Unknown High", owner: user, balance: 4000, usage_type: nil, accountable: Depository.new)
 
     account_names = BalanceSheet.new(@family, user: user).assets.account_groups.first.accounts.map(&:name)
 

--- a/test/models/balance_sheet_test.rb
+++ b/test/models/balance_sheet_test.rb
@@ -142,6 +142,30 @@ class BalanceSheetTest < ActiveSupport::TestCase
     assert_equal 3000 + 5000, liability_groups.find { |ag| ag.name == OtherLiability.display_name }.total
   end
 
+  test "sorts business accounts after nil and personal accounts within each account group" do
+    create_account(name: "A Business", balance: 1000, usage_type: "business", accountable: Depository.new)
+    create_account(name: "B Unknown", balance: 1000, usage_type: nil, accountable: Depository.new)
+    create_account(name: "C Personal", balance: 1000, usage_type: "personal", accountable: Depository.new)
+
+    account_names = BalanceSheet.new(@family).assets.account_groups.first.accounts.map(&:name)
+
+    assert_equal [ "B Unknown", "C Personal", "A Business" ], account_names
+  end
+
+  test "keeps selected account order within usage type buckets" do
+    user = users(:empty)
+    user.update!(default_account_order: "balance_desc")
+
+    create_account(name: "Business Low", balance: 1000, usage_type: "business", accountable: Depository.new)
+    create_account(name: "Personal Low", balance: 2000, usage_type: "personal", accountable: Depository.new)
+    create_account(name: "Business High", balance: 3000, usage_type: "business", accountable: Depository.new)
+    create_account(name: "Unknown High", balance: 4000, usage_type: nil, accountable: Depository.new)
+
+    account_names = BalanceSheet.new(@family, user: user).assets.account_groups.first.accounts.map(&:name)
+
+    assert_equal [ "Unknown High", "Personal Low", "Business High", "Business Low" ], account_names
+  end
+
   private
     def create_account(attributes = {})
       account = @family.accounts.create! name: "Test", currency: "USD", **attributes


### PR DESCRIPTION
## Summary

- add `accounts.usage_type` with personal/business enum values
- show a Personal/Business pill on account rows and a Business account toggle in the shared account form
- let Wise account setup/linking persist or override usage type, defaulting from the Wise profile type
- expose `usage_type` in the accounts API response

## Tests

- `bin/rails test test/models/account_test.rb test/controllers/wise_items_controller_test.rb`
- `bin/rails test test/controllers/accounts_controller_test.rb`
- `bin/rubocop app/models/account.rb app/controllers/concerns/accountable_resource.rb app/controllers/wise_items_controller.rb test/models/account_test.rb test/controllers/wise_items_controller_test.rb db/migrate/20260905120000_add_usage_type_to_accounts.rb`

## Note

- `bin/rails test test/system/accounts_test.rb` currently errors before reaching this change because its helper finds two visible `[data-controller='DS--tabs']` elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Classify accounts as **Personal** or **Business**.
  - Set usage type when creating, editing, or linking accounts, including Wise accounts.
  - View usage-type badges on account lists.
  - Account API responses now include usage type.
- **Improvements**
  - Wise setup suggests a usage type based on the profile, with adjustment options.
  - Existing unclassified accounts remain supported.
  - Account lists group personal and business accounts consistently.
  - Account linking remains consistent if a provider link fails.
  - Added labels and guidance for usage types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->