### PR TITLE
fix(l10n): localize maintained reserve insights

### DIFF
--- a/config/locales/views/insights/de.yml
+++ b/config/locales/views/insights/de.yml
@@ -8,6 +8,7 @@ de:
       budget: Budget ansehen
       cash_flow_warning: Wiederkehrende Buchungen prüfen
       idle_cash: Zum Konto
+      maintained_goal_depleted: Rücklage ansehen
       net_worth_milestone: Bericht zum Nettovermögen ansehen
       savings_rate_change: Transaktionen dieses Monats ansehen
       spending_anomaly: Transaktionen zu %{category} ansehen
@@ -62,6 +63,7 @@ de:
         low: Nach deinen anstehenden wiederkehrenden Buchungen und deinen üblichen Ausgaben könnte dein Guthaben um den %{projected_low_date} auf %{projected_low} sinken.
         negative: Nach deinen anstehenden wiederkehrenden Buchungen und deinen üblichen Ausgaben könnte dein Guthaben um den %{projected_low_date} auf %{projected_low} fallen.
       idle_cash: Auf %{account} liegen %{balance}, ohne Bewegung in den letzten %{idle_days} Tagen.
+      maintained_goal_depleted: "Für %{goal} sind %{saved} von %{target} zurückgelegt. Bis zum Zielstand fehlen %{missing}."
       net_worth_milestone: Dein Nettovermögen hat %{milestone} überschritten und liegt jetzt bei %{net_worth}.
       savings_rate_change:
         down: Du hast im %{month} %{current_rate} % deiner Einnahmen gespart, %{change_pp} Prozentpunkte weniger als die %{previous_rate} % im Monat davor.
@@ -80,6 +82,7 @@ de:
         low: Dein Guthaben könnte knapp werden
         negative: Dein Guthaben könnte ins Minus rutschen
       idle_cash: Ungenutztes Guthaben in %{account}
+      maintained_goal_depleted: "%{goal} liegt unter dem Zielstand"
       net_worth_milestone: 'Meilenstein beim Nettovermögen: %{milestone}'
       savings_rate_change:
         down: Deine Sparquote ist im %{month} gesunken
@@ -93,6 +96,7 @@ de:
       budget_on_track: Budget
       cash_flow_warning: Liquidität
       idle_cash: Ungenutztes Guthaben
+      maintained_goal_depleted: Rücklage
       net_worth_milestone: Nettovermögen
       savings_rate_change: Sparquote
       spending_anomaly: Ausgaben

--- a/test/helpers/insights_helper_test.rb
+++ b/test/helpers/insights_helper_test.rb
@@ -178,6 +178,21 @@ class InsightsHelperTest < ActionView::TestCase
     assert_nil insight_action(dangling)
   end
 
+  test "maintained reserve metadata and action render in German" do
+    family = families(:dylan_family)
+    goal = family.goals.first
+    insight = build_insight("maintained_goal_depleted", metadata: { "goal_id" => goal.id })
+
+    I18n.with_locale(:de) do
+      assert_equal "Rücklage", insight_meta_line(insight)
+      assert_equal "Rücklage ansehen", insight_action(insight)[:text]
+    end
+
+    %w[types actions titles templates].each do |scope|
+      assert I18n.exists?("insights.#{scope}.maintained_goal_depleted", :de, fallback: false)
+    end
+  end
+
   private
     def build_insight(insight_type, priority: "medium", metadata: {}, facts: {}, period_start: nil, period_end: nil)
       Insight.new(

--- a/test/models/insight/generators/maintained_goal_depleted_generator_test.rb
+++ b/test/models/insight/generators/maintained_goal_depleted_generator_test.rb
@@ -18,6 +18,18 @@ class Insight::Generators::MaintainedGoalDepletedGeneratorTest < ActiveSupport::
     assert_equal 2_000, insight.metadata[:missing]
   end
 
+  test "writes the maintained reserve insight in German" do
+    @family.users.update_all(ai_enabled: false)
+    reserve(name: "Notgroschen", balance: 4_000, target: 6_000)
+
+    generated = I18n.with_locale(:de) { generate.first }
+    body = I18n.with_locale(:de) { Insight::BodyWriter.new(@family).write(generated) }
+
+    assert_equal "Notgroschen liegt unter dem Zielstand", generated.title
+    assert_equal "Für Notgroschen sind #{generated.facts[:saved]} von #{generated.facts[:target]} zurückgelegt. " \
+                 "Bis zum Zielstand fehlen #{generated.facts[:missing]}.", body
+  end
+
   test "says nothing about a reserve sitting at its level" do
     reserve(name: "Whole", balance: 6_000, target: 6_000)
 


### PR DESCRIPTION
## Summary

German families now see the maintained-reserve Insight entirely in German: its type, action, title, and fallback body no longer fall back to English. The wording uses `Rücklage` and `Zielstand` consistently while leaving goal names, amounts, and financial behavior unchanged.

This is another focused slice of the ongoing German localization effort.

## Validation

- Focused generator and helper tests: 27 runs, 62 assertions, 0 failures
- I18n parsing and duplicate-key tests: 7 runs, 194 assertions, 0 failures
- Full Rails suite: 8,352 runs, 33,587 assertions, 0 failures, 0 errors, 30 skips
- RuboCop: 2,522 files inspected, no offenses
- Simulated merge tree matches the tested branch exactly
- Independent German language review approved all four strings and interpolation names
- Structured correctness, testing, and project-standards review completed with no findings

## Post-Deploy Monitoring & Validation

- Open a maintained reserve that is below its target and verify its generated Insight on the dashboard and Insights page.
- Healthy signal: the type and action read `Rücklage` and `Rücklage ansehen`; the title and body are German and retain the goal name and all formatted amounts.
- Failure signal: any English `Reserve`, `View reserve`, title, or fallback body appears for a German family. Revert this PR if the localized keys do not resolve correctly.
- Validation window and owner: first release cycle after deployment, owned by the maintainer validating German Insight rendering.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added German-language content for the “maintained goal depleted” insight, including its title, description, action label, and type label.
  - German users can now view this insight with localized messaging when a reserve falls below its target.

- **Tests**
  - Added coverage confirming the insight’s German labels, title, body text, and action wording render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->