### PR TITLE
fix(l10n): localize Trade Republic account setup

### DIFF
--- a/config/locales/views/trade_republic_items/de.yml
+++ b/config/locales/views/trade_republic_items/de.yml
@@ -52,15 +52,38 @@ de:
           stale: Veraltet
     setup_accounts:
       page_title: "Trade-Republic-Konto einrichten"
+      dialog_title: "Dein Trade-Republic-Konto einrichten"
       subtitle: "Verknüpfe dein Trade-Republic-Investmentkonto."
+      info_box:
+        title: "Trade-Republic-Import"
+        items:
+          item_1: "Aktuelle Positionen mit Kursen und Stückzahlen"
+          item_2: "Ausgeführte Käufe und Verkäufe"
+          item_3: "Ein- und Auszahlungen sowie Zinsgutschriften"
+      status:
+        fetching_accounts: "Konto wird von Trade Republic abgerufen …"
+        no_accounts_found_title: "Kein Konto gefunden."
+        no_accounts_found_description: "Sure hat kein Trade-Republic-Konto gefunden. Prüf, ob deine Trade-Republic-Sitzung noch gültig ist."
       available_accounts:
+        title: "Verfügbares Konto"
+        account_summary: "%{account_type} • Saldo: %{balance}"
+        account_id: "Konto-ID: %{account_id}"
         account_type_investment: "Investment-Portfolio"
         account_type_cash: "Cash-Konto"
+      link_existing:
+        description: "Alternativ kannst du das gefundene Trade-Republic-Konto mit einem bestehenden manuellen Investmentkonto verknüpfen."
+        manual_account_option: "%{name} (%{balance})"
+        select_prompt: "Konto auswählen …"
+      linked_accounts:
+        title: "Bereits verknüpft"
+        linked_to_html: "Verknüpft mit: %{account}"
       buttons:
         refresh: "Aktualisieren"
         cancel: "Abbrechen"
         link: "Verknüpfen"
         done: "Fertig"
+        back_to_settings: "Zurück zu den Einstellungen"
+        create_selected_accounts: "Ausgewählte Konten anlegen"
     sync:
       errors:
         phone_number_missing: "Die Telefonnummer für Trade Republic fehlt."

--- a/test/controllers/trade_republic_items_localization_test.rb
+++ b/test/controllers/trade_republic_items_localization_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+class TradeRepublicItemsLocalizationTest < ActiveSupport::TestCase
+  SETUP_ACCOUNT_TRANSLATIONS = {
+    "dialog_title" => "Dein Trade-Republic-Konto einrichten",
+    "info_box.title" => "Trade-Republic-Import",
+    "info_box.items.item_1" => "Aktuelle Positionen mit Kursen und Stückzahlen",
+    "info_box.items.item_2" => "Ausgeführte Käufe und Verkäufe",
+    "info_box.items.item_3" => "Ein- und Auszahlungen sowie Zinsgutschriften",
+    "status.fetching_accounts" => "Konto wird von Trade Republic abgerufen …",
+    "status.no_accounts_found_title" => "Kein Konto gefunden.",
+    "status.no_accounts_found_description" => "Sure hat kein Trade-Republic-Konto gefunden. Prüf, ob deine Trade-Republic-Sitzung noch gültig ist.",
+    "available_accounts.title" => "Verfügbares Konto",
+    "available_accounts.account_summary" => "%{account_type} • Saldo: %{balance}",
+    "available_accounts.account_id" => "Konto-ID: %{account_id}",
+    "link_existing.description" => "Alternativ kannst du das gefundene Trade-Republic-Konto mit einem bestehenden manuellen Investmentkonto verknüpfen.",
+    "link_existing.manual_account_option" => "%{name} (%{balance})",
+    "link_existing.select_prompt" => "Konto auswählen …",
+    "linked_accounts.title" => "Bereits verknüpft",
+    "linked_accounts.linked_to_html" => "Verknüpft mit: %{account}",
+    "buttons.back_to_settings" => "Zurück zu den Einstellungen",
+    "buttons.create_selected_accounts" => "Ausgewählte Konten anlegen"
+  }.freeze
+
+  test "German account setup copy matches the expected translations" do
+    SETUP_ACCOUNT_TRANSLATIONS.each do |key, expected|
+      full_key = "trade_republic_items.setup_accounts.#{key}"
+
+      assert I18n.exists?(full_key, :de, fallback: false), "de is missing #{full_key}"
+      assert_equal expected, I18n.t(full_key, locale: :de, resolve: false)
+    end
+  end
+end
+
+class TradeRepublicItemsSetupAccountsLocalizationTest < ActionDispatch::IntegrationTest
+  setup do
+    ensure_tailwind_build
+    sign_in @user = users(:family_admin)
+    @user.update!(locale: "de")
+    @item = trade_republic_items(:configured_item)
+  end
+
+  test "German account setup renders available, linkable, and linked accounts" do
+    trade_republic_accounts(:main_account).ensure_account_provider!(accounts(:investment))
+
+    get setup_accounts_trade_republic_item_url(@item)
+
+    assert_response :success
+    assert_setup_copy "dialog_title"
+    assert_setup_copy "info_box.title"
+    assert_setup_copy "available_accounts.title"
+    assert_setup_copy "buttons.create_selected_accounts"
+    assert_setup_copy "link_existing.select_prompt"
+    assert_setup_copy "linked_accounts.title"
+    assert_setup_copy "linked_accounts.linked_to_html", account: ""
+  end
+
+  test "German account setup renders the waiting state" do
+    @item.trade_republic_accounts.destroy_all
+    TradeRepublicItem.any_instance.stubs(:syncing?).returns(true)
+
+    get setup_accounts_trade_republic_item_url(@item)
+
+    assert_response :success
+    assert_setup_copy "status.fetching_accounts"
+  end
+
+  test "German account setup renders the empty state" do
+    @item.trade_republic_accounts.destroy_all
+    @item.syncs.create!(status: "completed", completed_at: Time.current)
+    TradeRepublicItem.any_instance.stubs(:syncing?).returns(false)
+    TradeRepublicItem.any_instance.stubs(:sync_later)
+
+    get setup_accounts_trade_republic_item_url(@item)
+
+    assert_response :success
+    assert_setup_copy "status.no_accounts_found_title"
+    assert_setup_copy "status.no_accounts_found_description"
+    assert_setup_copy "buttons.back_to_settings"
+  end
+
+  private
+
+    def assert_page_includes(text)
+      assert_includes response.body, ERB::Util.html_escape(text)
+    end
+
+    def assert_setup_copy(key, **interpolations)
+      template = TradeRepublicItemsLocalizationTest::SETUP_ACCOUNT_TRANSLATIONS.fetch(key)
+      assert_page_includes(template % interpolations)
+    end
+end


### PR DESCRIPTION
## Summary

German users now see the complete Trade Republic account setup dialog in German across account discovery, linking, waiting, and empty states. Provider names and interpolation values remain unchanged.

This is a focused part of the ongoing German localization work. Other provider-specific copy remains separate.

## Validation

- `bin/rails test test/controllers/trade_republic_items_localization_test.rb` (4 runs, 61 assertions)
- `bin/rails test test/i18n_test.rb` (7 runs, 194 assertions, 4 skips)
- `bin/rails test` (8,378 runs, 33,716 assertions, 30 skips)
- `bin/rubocop` (2,525 files, no offenses)
- Simulated merge tree matches the branch tree against current `upstream/main`
- Structured code review found no actionable issues

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This change only supplies localized copy to existing I18n keys, and focused rendering tests cover the available, linked, waiting, and empty states.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded German translations for the Trade Republic account setup flow, including import information, account-fetch statuses, available and existing account details, linked-account labels, and navigation and account-creation buttons.

- **Bug Fixes**
  - Improved German-language coverage across available, linkable, linked, waiting, and empty account states to provide clearer and more consistent setup messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->