### PR TITLE
fix(l10n): localize transaction bill links

### DIFF
--- a/config/locales/views/transactions/de.yml
+++ b/config/locales/views/transactions/de.yml
@@ -69,8 +69,12 @@ de:
       keep_both: Nein, beide behalten
       loan_payment: Kreditrate
       mark_recurring: Als wiederkehrend markieren
+      create_bill: Rechnung hinzufügen
       mark_recurring_subtitle: Erfasse das als wiederkehrende Transaktion. Die Schwankungsbreite des Betrags wird automatisch aus ähnlichen Transaktionen der letzten 6 Monate berechnet.
       mark_recurring_title: Wiederkehrende Transaktion
+      applied_to_title: Damit bezahlte Rechnungen
+      applied_to_detail: "%{amount} für die am %{date} fällige Rechnung"
+      applied_to_unreviewed: Prüfung erforderlich
       memo: Memo
       merge_duplicate: Ja, zusammenführen
       open_matcher: Zuordnung öffnen

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -11,7 +11,8 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
   # Bills has always linked out to transactions. Until now nothing linked back,
   # so a transaction that settled a bill was a dead end. The link-back is part
   # of the preview-gated bills surface, so the viewer needs the flag.
-  test "a transaction shows the bill it paid, and links to it" do
+  test "a German transaction shows the bill it paid with localized copy" do
+    @user.update!(locale: "de")
     @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => true))
     series = @user.family.recurring_transactions.create!(
       account: accounts(:depository), name: "Watson Property", amount: 2000,
@@ -32,6 +33,20 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match "Watson Property", response.body
     assert_match bill_path(series), response.body, "the bill must be reachable from the transaction"
+
+    translations = {
+      "transactions.show.create_bill" => "Rechnung hinzufügen",
+      "transactions.show.applied_to_title" => "Damit bezahlte Rechnungen",
+      "transactions.show.applied_to_detail" => "%{amount} für die am %{date} fällige Rechnung",
+      "transactions.show.applied_to_unreviewed" => "Prüfung erforderlich"
+    }
+    translations.each do |key, text|
+      assert_equal text, I18n.t(key, locale: :de, fallback: false)
+    end
+
+    assert_match translations.fetch("transactions.show.create_bill"), response.body
+    assert_match translations.fetch("transactions.show.applied_to_title"), response.body
+    assert_match(/für die am .* fällige Rechnung/, response.body)
   end
 
   test "the bill link-back stays hidden without preview access" do


### PR DESCRIPTION
## Summary

German transaction details no longer fall back to English when users create a bill or inspect which bills a transaction paid. Suggested bill allocations also show a German review status.

## Validation

- `bin/rails test test/controllers/transactions_controller_test.rb` — 69 runs, 326 assertions, no failures
- `bin/rails test test/i18n_test.rb` — 7 runs, 194 assertions, no failures, 4 existing skips
- `bin/rubocop` — 2,525 files, no offenses
- Full Rails suite — 8,378 runs and 33,728 assertions; one unrelated `Account::ProviderImportAdapterTest` failure reproduced on untouched `upstream/main`
- Simulated merge tree matches the branch tree
- Structured code review completed with no findings

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; this is a locale-only UI change with no data, API, or background-job behavior. After deployment, a maintainer can verify that the German transaction drawer shows no English fallback around bill links; any English regression is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for transaction bill details, including bill creation, payment information, amount, due date, and review status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->