### PR TITLE
fix(l10n): localize Wise SCA guidance

### DIFF
--- a/config/locales/views/wise_items/de.yml
+++ b/config/locales/views/wise_items/de.yml
@@ -63,6 +63,16 @@ de:
         create_token: Leg einen neuen persönlichen API-Token mit reinem Lesezugriff an
         open_tokens: Gehe zu Settings → Connect and manage apps → Developer tools → API tokens
         sign_in_html: Öffne %{link} und melde dich in deinem Konto an
+      sca:
+        title: Starke Kundenauthentifizierung (SCA)
+        description: Wise benötigt eine signierte Einmal-Token-Challenge, um vollständige Kontoauszüge einschließlich eingehender Zahlungen abzurufen. Erzeuge hier ein Schlüsselpaar und registriere den öffentlichen Schlüssel bei Wise, um den vollständigen Abruf zu ermöglichen.
+        public_key_label: Öffentlicher Schlüssel (PEM)
+        registered_help_html: "Registriere diesen Schlüssel bei Wise: Settings → Connect and manage apps → Developer tools → Public keys → Add public key."
+        copy: Kopieren
+        copied: Kopiert!
+        generate: Schlüsselpaar erzeugen
+        regenerate: Neues Schlüsselpaar erzeugen
+        regenerate_confirm: "Dadurch wird ein neues Schlüsselpaar erzeugt. Wise akzeptiert den bisherigen öffentlichen Schlüssel weiterhin, bis du ihn selbst in deinem Wise-Konto entfernst – Sure kann ihn nicht aus der Ferne widerrufen. Du musst den neuen öffentlichen Schlüssel bei Wise registrieren, bevor Kontoauszüge wieder synchronisiert werden können. Fortfahren?"
       import_all_history_help: Holt alle historischen Wise-Kontoauszüge statt nur das letzte Jahr.
       import_all_history_label: Vollständige Transaktionshistorie importieren
       keep_token_placeholder: Leer lassen, um den bisherigen Token zu behalten

--- a/test/controllers/wise_sca_localization_test.rb
+++ b/test/controllers/wise_sca_localization_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class WiseScaLocalizationTest < ActiveSupport::TestCase
+  TRANSLATIONS = {
+    "title" => "Starke Kundenauthentifizierung (SCA)",
+    "description" => "Wise benötigt eine signierte Einmal-Token-Challenge, um vollständige Kontoauszüge einschließlich eingehender Zahlungen abzurufen. Erzeuge hier ein Schlüsselpaar und registriere den öffentlichen Schlüssel bei Wise, um den vollständigen Abruf zu ermöglichen.",
+    "public_key_label" => "Öffentlicher Schlüssel (PEM)",
+    "registered_help_html" => "Registriere diesen Schlüssel bei Wise: Settings → Connect and manage apps → Developer tools → Public keys → Add public key.",
+    "copy" => "Kopieren",
+    "copied" => "Kopiert!",
+    "generate" => "Schlüsselpaar erzeugen",
+    "regenerate" => "Neues Schlüsselpaar erzeugen",
+    "regenerate_confirm" => "Dadurch wird ein neues Schlüsselpaar erzeugt. Wise akzeptiert den bisherigen öffentlichen Schlüssel weiterhin, bis du ihn selbst in deinem Wise-Konto entfernst – Sure kann ihn nicht aus der Ferne widerrufen. Du musst den neuen öffentlichen Schlüssel bei Wise registrieren, bevor Kontoauszüge wieder synchronisiert werden können. Fortfahren?"
+  }.freeze
+
+  test "German Wise SCA copy matches the expected translations" do
+    TRANSLATIONS.each do |key, expected|
+      full_key = "wise_items.provider_panel.sca.#{key}"
+
+      assert I18n.exists?(full_key, :de, fallback: false), "de is missing #{full_key}"
+      assert_equal expected, I18n.t(full_key, locale: :de, resolve: false)
+    end
+  end
+end
+
+class WiseScaPanelLocalizationTest < ActionDispatch::IntegrationTest
+  setup do
+    ensure_tailwind_build
+    sign_in @user = users(:family_admin)
+    @user.update!(locale: "de")
+  end
+
+  test "German Wise panel renders the SCA setup state" do
+    get connect_form_settings_providers_path(provider_key: "wise")
+
+    assert_response :success
+    assert_sca_copy "title"
+    assert_sca_copy "description"
+    assert_sca_copy "generate"
+  end
+
+  test "German Wise panel renders configured SCA guidance and regeneration warning" do
+    WiseItem.any_instance.stubs(:sca_public_key).returns("SYNTHETIC PUBLIC KEY")
+
+    get connect_form_settings_providers_path(provider_key: "wise")
+
+    assert_response :success
+    assert_includes response.body, "SYNTHETIC PUBLIC KEY"
+    assert_sca_copy "public_key_label"
+    assert_sca_copy "registered_help_html"
+    assert_sca_copy "copy"
+    assert_sca_copy "copied"
+    assert_sca_copy "regenerate"
+    assert_sca_copy "regenerate_confirm"
+  end
+
+  private
+
+    def assert_sca_copy(key)
+      expected = WiseScaLocalizationTest::TRANSLATIONS.fetch(key)
+      assert_includes response.body, ERB::Util.html_escape(expected)
+    end
+end


### PR DESCRIPTION
## Summary

German users no longer fall back to English for Wise Strong Customer Authentication setup, key registration, copy feedback, or key regeneration warnings. Wise product labels, SCA/PEM identifiers, and the exact navigation labels from the Wise interface remain unchanged.

## Validation

- Focused localization and panel tests: 10 runs, 234 assertions, no failures, 4 existing skips
- Full Rails suite: 8,399 runs, 33,818 assertions, no failures, 30 skips
- `bin/rubocop`: 2,526 files, no offenses
- German fallback-disabled lookup reports no missing Wise SCA keys
- Simulated merge tree matches the branch tree
- Structured code review completed with no findings
- Independent AI language review approved all nine German strings

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this changes locale data and localization coverage only. After deployment, verify both the initial and configured Wise SCA panels in German; an English fallback or clipped guidance is the rollback trigger.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added German translations for the Wise Strong Customer Authentication (SCA) setup panel.
  - Included labels and guidance for public keys, registration, copying keys, and confirming copied values.
  - Added German text for generating or regenerating key pairs, including a warning that the previous public key remains accepted until manually removed.

- **Tests**
  - Added coverage to verify the German SCA setup content and user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->