### PR TITLE
fix(l10n): localize Wise SCA keypair results

### DIFF
--- a/config/locales/views/wise_items/de.yml
+++ b/config/locales/views/wise_items/de.yml
@@ -22,6 +22,9 @@ de:
     entries:
       default_name: Wise-Transaktion
       fee_name: Wise-Gebühr
+    generate_sca_keypair:
+      failed: Das neue SCA-Schlüsselpaar ließ sich nicht erzeugen. Versuch es noch einmal.
+      success: Neues SCA-Schlüsselpaar erzeugt. Registriere den öffentlichen Schlüssel bei Wise, um die Einrichtung abzuschließen.
     link_accounts:
       failed: Das Wise-Guthaben ließ sich nicht verknüpfen. Versuch es noch einmal.
       not_found: Wise-Guthaben nicht gefunden.

--- a/test/controllers/wise_sca_localization_test.rb
+++ b/test/controllers/wise_sca_localization_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class WiseScaLocalizationTest < ActiveSupport::TestCase
+  KEYPAIR_RESULTS = {
+    "success" => "Neues SCA-Schlüsselpaar erzeugt. Registriere den öffentlichen Schlüssel bei Wise, um die Einrichtung abzuschließen.",
+    "failed" => "Das neue SCA-Schlüsselpaar ließ sich nicht erzeugen. Versuch es noch einmal."
+  }.freeze
+
   TRANSLATIONS = {
     "title" => "Starke Kundenauthentifizierung (SCA)",
     "description" => "Wise benötigt eine signierte Einmal-Token-Challenge, um vollständige Kontoauszüge einschließlich eingehender Zahlungen abzurufen. Erzeuge hier ein Schlüsselpaar und registriere den öffentlichen Schlüssel bei Wise, um den vollständigen Abruf zu ermöglichen.",
@@ -16,6 +21,15 @@ class WiseScaLocalizationTest < ActiveSupport::TestCase
   test "German Wise SCA copy matches the expected translations" do
     TRANSLATIONS.each do |key, expected|
       full_key = "wise_items.provider_panel.sca.#{key}"
+
+      assert I18n.exists?(full_key, :de, fallback: false), "de is missing #{full_key}"
+      assert_equal expected, I18n.t(full_key, locale: :de, resolve: false)
+    end
+  end
+
+  test "German Wise SCA keypair results match the expected translations" do
+    KEYPAIR_RESULTS.each do |key, expected|
+      full_key = "wise_items.generate_sca_keypair.#{key}"
 
       assert I18n.exists?(full_key, :de, fallback: false), "de is missing #{full_key}"
       assert_equal expected, I18n.t(full_key, locale: :de, resolve: false)
@@ -52,6 +66,22 @@ class WiseScaPanelLocalizationTest < ActionDispatch::IntegrationTest
     assert_sca_copy "copied"
     assert_sca_copy "regenerate"
     assert_sca_copy "regenerate_confirm"
+  end
+
+  test "German Wise SCA keypair generation returns the localized success message" do
+    post generate_sca_keypair_wise_item_url(wise_items(:one))
+
+    assert_redirected_to accounts_path
+    assert_equal WiseScaLocalizationTest::KEYPAIR_RESULTS.fetch("success"), flash[:notice]
+  end
+
+  test "German Wise SCA keypair generation returns the localized failure message" do
+    WiseItem.any_instance.stubs(:generate_sca_keypair!).raises(StandardError, "synthetic failure")
+
+    post generate_sca_keypair_wise_item_url(wise_items(:one))
+
+    assert_redirected_to settings_providers_path
+    assert_equal WiseScaLocalizationTest::KEYPAIR_RESULTS.fetch("failed"), flash[:alert]
   end
 
   private


### PR DESCRIPTION
## Summary

German users now see localized success and failure feedback after generating or regenerating a Wise SCA keypair. This follows up on the remaining English fallback identified during review of #3410.

## Test plan

- `bin/rails test test/controllers/wise_sca_localization_test.rb` (6 runs, 50 assertions)
- `bin/rails test` (8,402 runs, 33,827 assertions, 0 failures, 30 skips)
- `bin/rubocop` (2,526 files, no offenses)
- Parsed the German Wise locale file as YAML
- Structured code review completed with no findings

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. The change only supplies German locale values for existing controller response paths and does not alter control flow.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German localization for SCA keypair generation success and failure messages.
  * Users are instructed to register their public key with Wise to complete setup.

* **Tests**
  * Added coverage for German translations and localized success and failure flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->