### PR TITLE
fix(rules): batch category/merchant/tag operand resolution in exports

### DIFF
--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -835,7 +835,10 @@ class Family::DataExporter
 
     def operand_records(relation_key)
       @operand_records ||= {}
-      @operand_records[relation_key] ||= @family.public_send(relation_key).to_a
+      # `.reload` bypasses any pre-existing in-memory association cache on
+      # `@family` (e.g. a prior `create!` through the same association) so
+      # destroyed records aren't served stale from that cache.
+      @operand_records[relation_key] ||= @family.public_send(relation_key).reload.to_a
     end
 
     def operand_records_by_id(relation_key)

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -833,14 +833,19 @@ class Family::DataExporter
       operand_records_by_name(relation_key)[value] if fallback_to_name
     end
 
+    def operand_records(relation_key)
+      @operand_records ||= {}
+      @operand_records[relation_key] ||= @family.public_send(relation_key).to_a
+    end
+
     def operand_records_by_id(relation_key)
       @operand_records_by_id ||= {}
-      @operand_records_by_id[relation_key] ||= @family.public_send(relation_key).index_by(&:id)
+      @operand_records_by_id[relation_key] ||= operand_records(relation_key).index_by(&:id)
     end
 
     def operand_records_by_name(relation_key)
       @operand_records_by_name ||= {}
-      @operand_records_by_name[relation_key] ||= @family.public_send(relation_key).index_by(&:name)
+      @operand_records_by_name[relation_key] ||= operand_records(relation_key).index_by(&:name)
     end
 
     def rule_value_ref(type, record)

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -828,7 +828,7 @@ class Family::DataExporter
     end
 
     def resolve_rule_operand_record(relation_key, value, fallback_to_name:)
-      return operand_records_by_id(relation_key)[value] if uuid_like?(value)
+      return operand_records_by_id(relation_key)[value.to_s.downcase] if uuid_like?(value)
 
       operand_records_by_name(relation_key)[value] if fallback_to_name
     end

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -761,17 +761,17 @@ class Family::DataExporter
 
       # Map category UUIDs to names for portability
       if condition.condition_type == "transaction_category"
-        return rule_operand(condition.value, type: "Category", relation: @family.categories)
+        return rule_operand(condition.value, type: "Category", relation: :categories)
       end
 
       # Map merchant UUIDs to names for portability
       if condition.condition_type == "transaction_merchant"
-        return rule_operand(condition.value, type: "Merchant", relation: @family.merchants)
+        return rule_operand(condition.value, type: "Merchant", relation: :merchants)
       end
 
       # Map tag UUIDs to names for portability
       if condition.condition_type == "transaction_tag"
-        return rule_operand(condition.value, type: "Tag", relation: @family.tags)
+        return rule_operand(condition.value, type: "Tag", relation: :tags)
       end
 
       rule_operand(condition.value)
@@ -782,12 +782,12 @@ class Family::DataExporter
 
       # Map category UUIDs to names for portability
       if action.action_type == "set_transaction_category"
-        return rule_operand(action.value, type: "Category", relation: @family.categories, fallback_to_name: true)
+        return rule_operand(action.value, type: "Category", relation: :categories, fallback_to_name: true)
       end
 
       # Map merchant UUIDs to names for portability
       if action.action_type == "set_transaction_merchant"
-        return rule_operand(action.value, type: "Merchant", relation: @family.merchants, fallback_to_name: true)
+        return rule_operand(action.value, type: "Merchant", relation: :merchants, fallback_to_name: true)
       end
 
       # Map tag UUIDs to names for portability. Stored as a comma-separated
@@ -802,7 +802,7 @@ class Family::DataExporter
 
     def resolve_multi_tag_operand(value)
       ids = value.to_s.split(",")
-      records = ids.map { |id| resolve_rule_operand_record(@family.tags, id, fallback_to_name: true) }
+      records = ids.map { |id| resolve_rule_operand_record(:tags, id, fallback_to_name: true) }
       names = records.each_with_index.map { |record, i| record&.name || ids[i] }
       refs = records.compact.map { |record| rule_value_ref("Tag", record) }
 
@@ -827,10 +827,20 @@ class Family::DataExporter
       }
     end
 
-    def resolve_rule_operand_record(relation, value, fallback_to_name:)
-      return relation.find_by(id: value) if uuid_like?(value)
+    def resolve_rule_operand_record(relation_key, value, fallback_to_name:)
+      return operand_records_by_id(relation_key)[value] if uuid_like?(value)
 
-      relation.find_by(name: value) if fallback_to_name
+      operand_records_by_name(relation_key)[value] if fallback_to_name
+    end
+
+    def operand_records_by_id(relation_key)
+      @operand_records_by_id ||= {}
+      @operand_records_by_id[relation_key] ||= @family.public_send(relation_key).index_by(&:id)
+    end
+
+    def operand_records_by_name(relation_key)
+      @operand_records_by_name ||= {}
+      @operand_records_by_name[relation_key] ||= @family.public_send(relation_key).index_by(&:name)
     end
 
     def rule_value_ref(type, record)

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -524,15 +524,13 @@ class Family::DataExporterTest < ActiveSupport::TestCase
 
   test "rule operand lookup skips name fallback for stale UUID values" do
     stale_uuid = SecureRandom.uuid
-    relation = mock
-    relation.expects(:find_by).with(id: stale_uuid).once.returns(nil)
-    relation.expects(:find_by).with(name: stale_uuid).never
+    @exporter.expects(:operand_records_by_name).never
 
     operand = @exporter.send(
       :rule_operand,
       stale_uuid,
       type: "Category",
-      relation: relation,
+      relation: :categories,
       fallback_to_name: true
     )
 

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -522,6 +522,19 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     end
   end
 
+  test "rule operand lookup matches uppercase UUID values" do
+    operand = @exporter.send(
+      :rule_operand,
+      @category.id.upcase,
+      type: "Category",
+      relation: :categories,
+      fallback_to_name: true
+    )
+
+    assert_equal "Test Category", operand[:value]
+    assert_equal({ type: "Category", id: @category.id, name: "Test Category" }, operand[:value_ref])
+  end
+
   test "rule operand lookup skips name fallback for stale UUID values" do
     stale_uuid = SecureRandom.uuid
     @exporter.expects(:operand_records_by_name).never

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -551,6 +551,13 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     assert_nil operand[:value_ref]
   end
 
+  test "operand id and name lookups for the same relation share a single query" do
+    assert_queries_count(1) do
+      @exporter.send(:operand_records_by_id, :categories)
+      @exporter.send(:operand_records_by_name, :categories)
+    end
+  end
+
   test "exports rule actions and maps tag UUIDs to names" do
     # Create a rule with a tag action
     tag_rule = @family.rules.build(


### PR DESCRIPTION
## Problem

`Family::DataExporter#resolve_rule_operand_record` ran one `find_by` query per rule condition/action operand value (category, merchant, or tag). Since `generate_export` serializes rules for both `rules.csv` and `all.ndjson`, every one of these queries ran twice per export.

Flagged by CodeRabbit while reviewing #3397 (multi-tag `set_transaction_tags` support), which made the pre-existing per-record pattern more visible. Out of scope for that PR since it's a pre-existing pattern across all three operand types, not something introduced there — tracked as #3414 for a holistic fix.

## Fix

Preload all category/merchant/tag records for the family once per export into id- and name-indexed hashes, then have `resolve_rule_operand_record` look up from those in-memory maps instead of issuing a query per call. Covers all three operand types (category, merchant, tag) across both rule conditions and actions.

Category, merchant, and tag names are all uniquely scoped per family at the model level, so the name-indexed hash lookup is behaviorally equivalent to the previous `find_by(name:)`.

## Validation

No local Ruby/Docker available in the environment this was authored in; relying on CI (rubocop, Minitest, Brakeman) for this PR. Manually traced all call sites (`resolve_condition_operand`, `resolve_action_operand`) to confirm output (`value`/`value_ref`) is unchanged, just computed from preloaded data instead of per-call queries.

Fixes #3414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Family rule exports now correctly resolve uppercase UUID values to associated category, merchant, or tag names.
  - Multi-tag assignment actions now resolve each tag independently during export.
  - Stale or unrecognized identifiers continue to use the appropriate fallback behavior.

- **Tests**
  - Added coverage for case-insensitive UUID matching and multi-tag operand resolution.
  - Updated tests for stale identifier handling and fallback results.
  - Added coverage ensuring repeated lookups remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->