### PR TITLE
fix(rules): batch operand lookups and map transaction_tag conditions in RuleImport

### DIFF
--- a/app/models/rule_import.rb
+++ b/app/models/rule_import.rb
@@ -215,24 +215,17 @@ class RuleImport < Import
 
       # Map category names to UUIDs
       if condition_type == "transaction_category"
-        category = family.categories.find_by(name: value)
-        unless category
-          category = family.categories.create!(
-            name: value,
-            color: Category::UNCATEGORIZED_COLOR,
-            lucide_icon: "shapes"
-          )
-        end
-        return category.id
+        return find_or_create_category(value).id
       end
 
       # Map merchant names to UUIDs
       if condition_type == "transaction_merchant"
-        merchant = family.merchants.find_by(name: value)
-        unless merchant
-          merchant = family.merchants.create!(name: value)
-        end
-        return merchant.id
+        return find_or_create_merchant(value).id
+      end
+
+      # Map tag names to UUIDs
+      if condition_type == "transaction_tag"
+        return find_or_create_tag(value).id
       end
 
       value
@@ -246,26 +239,12 @@ class RuleImport < Import
 
       # Map category names to UUIDs
       if action_type == "set_transaction_category"
-        category = family.categories.find_by(name: value)
-        # Create category if it doesn't exist
-        unless category
-          category = family.categories.create!(
-            name: value,
-            color: Category::UNCATEGORIZED_COLOR,
-            lucide_icon: "shapes"
-          )
-        end
-        return category.id
+        return find_or_create_category(value).id
       end
 
       # Map merchant names to UUIDs
       if action_type == "set_transaction_merchant"
-        merchant = family.merchants.find_by(name: value)
-        # Create merchant if it doesn't exist
-        unless merchant
-          merchant = family.merchants.create!(name: value)
-        end
-        return merchant.id
+        return find_or_create_merchant(value).id
       end
 
       # Map tag names to UUIDs. `value` may be a comma-separated list of tag
@@ -283,14 +262,39 @@ class RuleImport < Import
       names = Rule::Action.decode_multi_value_names(value).map(&:strip).reject(&:blank?)
       return value if names.empty?
 
-      tags_by_name = family.tags.where(name: names).index_by(&:name)
+      names.map { |name| find_or_create_tag(name).id }.join(",")
+    end
 
-      tag_ids = names.map do |name|
-        tag = tags_by_name[name] ||= family.tags.create!(name: name)
-        tag.id
-      end
+    # Preloaded once per import and extended in place on cache-miss, so a
+    # category/merchant/tag created for an earlier row is immediately visible
+    # to a later row referencing the same name, instead of one query per
+    # condition/action across every row in the file.
+    def categories_by_name
+      @categories_by_name ||= family.categories.index_by(&:name)
+    end
 
-      tag_ids.join(",")
+    def merchants_by_name
+      @merchants_by_name ||= family.merchants.index_by(&:name)
+    end
+
+    def tags_by_name
+      @tags_by_name ||= family.tags.index_by(&:name)
+    end
+
+    def find_or_create_category(name)
+      categories_by_name[name] ||= family.categories.create!(
+        name: name,
+        color: Category::UNCATEGORIZED_COLOR,
+        lucide_icon: "shapes"
+      )
+    end
+
+    def find_or_create_merchant(name)
+      merchants_by_name[name] ||= family.merchants.create!(name: name)
+    end
+
+    def find_or_create_tag(name)
+      tags_by_name[name] ||= family.tags.create!(name: name)
     end
 
     def parse_boolean(value)

--- a/test/models/rule_import_test.rb
+++ b/test/models/rule_import_test.rb
@@ -213,6 +213,66 @@ class RuleImportTest < ActiveSupport::TestCase
     assert_equal [ existing_tag.id, comma_tag.id ], action.value.split(",")
   end
 
+  test "imports transaction_tag condition and maps tag name to id" do
+    existing_tag = @family.tags.create!(name: "Existing Tag")
+
+    csv = <<~CSV
+      name,resource_type,active,effective_date,conditions,actions
+      "Tag condition rule","transaction",true,,"[{\"condition_type\":\"transaction_tag\",\"operator\":\"=\",\"value\":\"Existing Tag\"}]","[{\"action_type\":\"auto_categorize\"}]"
+    CSV
+
+    import = @family.imports.create!(type: "RuleImport", raw_file_str: csv, col_sep: ",")
+    import.generate_rows_from_csv
+
+    assert_no_difference -> { Tag.where(family: @family).count } do
+      import.send(:import!)
+    end
+
+    rule = Rule.find_by!(family: @family, name: "Tag condition rule")
+    condition = rule.conditions.first
+    assert_equal "transaction_tag", condition.condition_type
+    assert_equal existing_tag.id, condition.value
+  end
+
+  test "creates a missing tag referenced by a transaction_tag condition" do
+    csv = <<~CSV
+      name,resource_type,active,effective_date,conditions,actions
+      "New tag condition rule","transaction",true,,"[{\"condition_type\":\"transaction_tag\",\"operator\":\"=\",\"value\":\"Brand New Tag\"}]","[{\"action_type\":\"auto_categorize\"}]"
+    CSV
+
+    import = @family.imports.create!(type: "RuleImport", raw_file_str: csv, col_sep: ",")
+    import.generate_rows_from_csv
+
+    assert_difference -> { Tag.where(family: @family).count }, 1 do
+      import.send(:import!)
+    end
+
+    new_tag = Tag.find_by!(family: @family, name: "Brand New Tag")
+    rule = Rule.find_by!(family: @family, name: "New tag condition rule")
+    assert_equal new_tag.id, rule.conditions.first.value
+  end
+
+  test "reuses a category created for an earlier row within the same import" do
+    csv = <<~CSV
+      name,resource_type,active,effective_date,conditions,actions
+      "First coffee rule","transaction",true,,"[{\"condition_type\":\"transaction_name\",\"operator\":\"like\",\"value\":\"coffee\"}]","[{\"action_type\":\"set_transaction_category\",\"value\":\"Coffee Shops\"}]"
+      "Second coffee rule","transaction",true,,"[{\"condition_type\":\"transaction_name\",\"operator\":\"like\",\"value\":\"latte\"}]","[{\"action_type\":\"set_transaction_category\",\"value\":\"Coffee Shops\"}]"
+    CSV
+
+    import = @family.imports.create!(type: "RuleImport", raw_file_str: csv, col_sep: ",")
+    import.generate_rows_from_csv
+
+    assert_difference -> { Category.where(family: @family).count }, 1 do
+      import.send(:import!)
+    end
+
+    category = Category.find_by!(family: @family, name: "Coffee Shops")
+    first_rule = Rule.find_by!(family: @family, name: "First coffee rule")
+    second_rule = Rule.find_by!(family: @family, name: "Second coffee rule")
+    assert_equal category.id, first_rule.actions.first.value
+    assert_equal category.id, second_rule.actions.first.value
+  end
+
   test "updates existing rule when re-importing with same name" do
     # First import
     import1 = @family.imports.create!(type: "RuleImport", raw_file_str: @csv, col_sep: ",")


### PR DESCRIPTION
## Problem

`RuleImport` (the standalone `rules.csv` template importer) resolved category/merchant/tag names to ids with one `find_by(name:)` query per condition/action, across all rows in an import file — unbatched, unlike the export-side fix in #3416.

## Bug found while investigating

`resolve_import_condition_value` never handled `condition_type == "transaction_tag"` at all — the value fell through unmapped, so the tag's *name* string (not its UUID) was stored as the condition's value. `Rule::ConditionFilter::TransactionTag#apply` expects a tag UUID (`tagging_exists(tag_id: value)`), so a rule exported by `Family::DataExporter` (which correctly exports tag conditions as names for portability) and re-imported via `rules.csv` would silently break: the condition matches nothing, or errors with an invalid UUID at query time. `Family::DataImporter` already handles this correctly at the equivalent spot — `RuleImport` was the outlier.

## Fix

- Added `categories_by_name`/`merchants_by_name`/`tags_by_name` hashes, preloaded once per import and extended in place on cache-miss (`hash[name] ||= family.categories.create!(...)`), so a record created for an earlier row is reused by a later row referencing the same name instead of one query per condition/action.
- Added the missing `transaction_tag` condition-type branch, mirroring `Family::DataImporter`'s handling.
- Added regression tests: `transaction_tag` condition mapping (existing + newly-created tag), and reuse of a category created for an earlier row within the same import.

## Validation

No local Ruby/Docker available in the environment this was authored in; relying on CI (rubocop, Minitest, Brakeman).

Fixes #3417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rule imports now correctly resolve category, merchant, and tag names across imported rows.
  - Missing categories, merchants, and tags are created automatically when referenced.
  - Repeated references within the same import reuse the same records, preventing duplicates.
  - Transaction tag conditions correctly map existing or newly created tags.
  - Multi-tag actions now preserve tag names that contain commas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->