### PR TITLE
fix(rules): batch category/merchant/tag operand lookups in Family::DataImporter

### DIFF
--- a/app/models/family/data_importer.rb
+++ b/app/models/family/data_importer.rb
@@ -1388,28 +1388,17 @@ class Family::DataImporter
 
       # Map category names to IDs
       if condition_type == "transaction_category"
-        category = @family.categories.find_by(name: value)
-        category ||= @family.categories.create!(
-          name: value,
-          color: Category::UNCATEGORIZED_COLOR,
-          classification_unused: "expense",
-          lucide_icon: "shapes"
-        )
-        return category.id
+        return find_or_create_rule_category(value).id
       end
 
       # Map merchant names to IDs
       if condition_type == "transaction_merchant"
-        merchant = @family.merchants.find_by(name: value)
-        merchant ||= @family.merchants.create!(name: value)
-        return merchant.id
+        return find_or_create_rule_merchant(value).id
       end
 
       # Map tag names to IDs
       if condition_type == "transaction_tag"
-        tag = @family.tags.find_by(name: value)
-        tag ||= @family.tags.create!(name: value)
-        return tag.id
+        return find_or_create_rule_tag(value).id
       end
 
       value
@@ -1430,21 +1419,12 @@ class Family::DataImporter
 
       # Map category names to IDs
       if action_type == "set_transaction_category"
-        category = @family.categories.find_by(name: value)
-        category ||= @family.categories.create!(
-          name: value,
-          color: Category::UNCATEGORIZED_COLOR,
-          classification_unused: "expense",
-          lucide_icon: "shapes"
-        )
-        return category.id
+        return find_or_create_rule_category(value).id
       end
 
       # Map merchant names to IDs
       if action_type == "set_transaction_merchant"
-        merchant = @family.merchants.find_by(name: value)
-        merchant ||= @family.merchants.create!(name: value)
-        return merchant.id
+        return find_or_create_rule_merchant(value).id
       end
 
       value
@@ -1459,16 +1439,47 @@ class Family::DataImporter
       end
 
       names = refs.any? ? refs.map { |ref| ref["name"] } : Rule::Action.decode_multi_value_names(action_data["value"])
-      tags_by_name = @family.tags.where(name: names).index_by(&:name)
 
       tag_ids = names.filter_map do |name|
         next if name.blank?
 
-        tag = tags_by_name[name] ||= @family.tags.create!(name: name)
-        tag.id
+        find_or_create_rule_tag(name).id
       end
 
       tag_ids.join(",")
+    end
+
+    # Preloaded once per import and extended in place on cache-miss, so a
+    # category/merchant/tag created for an earlier record is immediately
+    # visible to a later record referencing the same name, instead of one
+    # query per condition/action across every imported rule.
+    def rule_categories_by_name
+      @rule_categories_by_name ||= @family.categories.index_by(&:name)
+    end
+
+    def rule_merchants_by_name
+      @rule_merchants_by_name ||= @family.merchants.index_by(&:name)
+    end
+
+    def rule_tags_by_name
+      @rule_tags_by_name ||= @family.tags.index_by(&:name)
+    end
+
+    def find_or_create_rule_category(name)
+      rule_categories_by_name[name] ||= @family.categories.create!(
+        name: name,
+        color: Category::UNCATEGORIZED_COLOR,
+        classification_unused: "expense",
+        lucide_icon: "shapes"
+      )
+    end
+
+    def find_or_create_rule_merchant(name)
+      rule_merchants_by_name[name] ||= @family.merchants.create!(name: name)
+    end
+
+    def find_or_create_rule_tag(name)
+      rule_tags_by_name[name] ||= @family.tags.create!(name: name)
     end
 
     def rule_operand_value(data)

--- a/test/models/family/data_importer_test.rb
+++ b/test/models/family/data_importer_test.rb
@@ -1924,6 +1924,147 @@ class Family::DataImporterTest < ActiveSupport::TestCase
     assert_equal tag.id, condition.value
   end
 
+  test "reuses a category created for an earlier rule within the same import" do
+    ndjson = build_ndjson([
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "First coffee rule",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            { condition_type: "transaction_name", operator: "like", value: "coffee" }
+          ],
+          actions: [
+            { action_type: "set_transaction_category", value: "Coffee Shops" }
+          ]
+        }
+      },
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "Second coffee rule",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            { condition_type: "transaction_name", operator: "like", value: "latte" }
+          ],
+          actions: [
+            { action_type: "set_transaction_category", value: "Coffee Shops" }
+          ]
+        }
+      }
+    ])
+
+    importer = Family::DataImporter.new(@family, ndjson)
+
+    assert_difference -> { @family.categories.where(name: "Coffee Shops").count }, 1 do
+      importer.import!
+    end
+
+    category = @family.categories.find_by!(name: "Coffee Shops")
+    first_rule = @family.rules.find_by!(name: "First coffee rule")
+    second_rule = @family.rules.find_by!(name: "Second coffee rule")
+    assert_equal category.id, first_rule.actions.first.value
+    assert_equal category.id, second_rule.actions.first.value
+  end
+
+  test "reuses a merchant created for an earlier rule within the same import" do
+    ndjson = build_ndjson([
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "First coffee merchant rule",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            { condition_type: "transaction_name", operator: "like", value: "coffee" }
+          ],
+          actions: [
+            { action_type: "set_transaction_merchant", value: "Blue Bottle" }
+          ]
+        }
+      },
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "Second coffee merchant rule",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            { condition_type: "transaction_name", operator: "like", value: "latte" }
+          ],
+          actions: [
+            { action_type: "set_transaction_merchant", value: "Blue Bottle" }
+          ]
+        }
+      }
+    ])
+
+    importer = Family::DataImporter.new(@family, ndjson)
+
+    assert_difference -> { @family.merchants.where(name: "Blue Bottle").count }, 1 do
+      importer.import!
+    end
+
+    merchant = @family.merchants.find_by!(name: "Blue Bottle")
+    first_rule = @family.rules.find_by!(name: "First coffee merchant rule")
+    second_rule = @family.rules.find_by!(name: "Second coffee merchant rule")
+    assert_equal merchant.id, first_rule.actions.first.value
+    assert_equal merchant.id, second_rule.actions.first.value
+  end
+
+  test "reuses a tag created for an earlier rule within the same import" do
+    ndjson = build_ndjson([
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "First coffee tag rule",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            { condition_type: "transaction_name", operator: "like", value: "coffee" }
+          ],
+          actions: [
+            { action_type: "set_transaction_tags", value: "Recurring" }
+          ]
+        }
+      },
+      {
+        type: "Rule",
+        version: 1,
+        data: {
+          name: "Second coffee tag rule",
+          resource_type: "transaction",
+          active: true,
+          conditions: [
+            { condition_type: "transaction_name", operator: "like", value: "latte" }
+          ],
+          actions: [
+            { action_type: "set_transaction_tags", value: "Recurring" }
+          ]
+        }
+      }
+    ])
+
+    importer = Family::DataImporter.new(@family, ndjson)
+
+    assert_difference -> { @family.tags.where(name: "Recurring").count }, 1 do
+      importer.import!
+    end
+
+    tag = @family.tags.find_by!(name: "Recurring")
+    first_rule = @family.rules.find_by!(name: "First coffee tag rule")
+    second_rule = @family.rules.find_by!(name: "Second coffee tag rule")
+    assert_equal [ tag.id ], first_rule.actions.first.value.split(",")
+    assert_equal [ tag.id ], second_rule.actions.first.value.split(",")
+  end
+
   test "session rule reimport only replaces current family conditions and actions" do
     rule = @family.rules.build(name: "Original Rule", resource_type: "transaction", active: true)
     rule.conditions.build(condition_type: "transaction_name", operator: "like", value: "old")


### PR DESCRIPTION
## Problem

`Family::DataImporter` (the full backup/ZIP restore path) has the same N+1 pattern as `Family::DataExporter` (fixed in #3414/#3416) and `RuleImport` (fixed in #3417/#3419): `resolve_rule_condition_value`/`resolve_rule_action_value` ran one `find_by(name:)` query per category/merchant/tag condition/action, across all rule records in `import_rules`, unbatched.

Unlike the exporter (read-only), this importer creates missing categories/merchants/tags on cache-miss, so the fix keeps newly created records visible to later records referencing the same name within the same import.

## Fix

Preload `rule_categories_by_name`/`rule_merchants_by_name`/`rule_tags_by_name` hashes once per import, extended in place on cache-miss (`hash[name] ||= @family.categories.create!(...)`), and have `resolve_rule_condition_value`/`resolve_rule_action_value` look up from those maps instead of querying per call.

`transaction_tag` condition mapping was already handled correctly here (unlike the bug found and fixed in `RuleImport`, #3417) — this is a pure performance fix, no correctness bug bundled.

Added a regression test confirming a category created for an earlier rule in the same import is reused by a later rule referencing the same name (rather than re-queried or duplicated).

## Validation

No local Ruby/Docker available in the environment this was authored in; relying on CI (rubocop, Minitest, Brakeman).

Fixes #3418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rule imports involving categories, merchants, and tags to consistently resolve names to the correct records.
  - Prevented duplicate category, merchant, and tag records when multiple rules reference the same item during an import.
  - Improved multi-tag rule imports, including comma-containing tag names and legacy tag references.

- **Tests**
  - Added coverage for shared category, merchant, and tag references across multiple rule actions.
  - Added tests for multi-tag resolution and legacy single-tag imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->