### PR TITLE
fix(insights): project month-to-date spend over the whole month

### DIFF
--- a/app/models/insight/generators/spending_anomaly_generator.rb
+++ b/app/models/insight/generators/spending_anomaly_generator.rb
@@ -19,7 +19,12 @@ class Insight::Generators::SpendingAnomalyGenerator < Insight::Generator
     return [] if current.empty?
 
     baseline = baseline_spend(period)
-    pace_factor = period.days.to_f / elapsed_days
+    # The "current month" period ends today rather than at month end, so its own
+    # #days is the elapsed count and dividing by it would make the projection a
+    # no-op. Take the month's true length from its start date, which is also
+    # correct for families on a custom month start.
+    month_days = ((period.start_date + 1.month) - period.start_date).to_i
+    pace_factor = month_days.to_f / elapsed_days
 
     anomalies = current.filter_map do |category_id, data|
       baseline_amount = baseline[category_id]

--- a/test/models/insight/generators/spending_anomaly_generator_test.rb
+++ b/test/models/insight/generators/spending_anomaly_generator_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Insight::Generators::SpendingAnomalyGeneratorTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:dylan_family)
+    @category = @family.categories.create!(name: "Pace Test Cat", color: "#101010", lucide_icon: "circle")
+  end
+
+  # Anchor two months back so the relative-date fixture entries (always in the
+  # real current month) can't leak into the baseline or current periods. Day 10
+  # gives 10 elapsed days, comfortably past MIN_ELAPSED_DAYS.
+  def anchor
+    @anchor ||= (Date.current - 2.months).change(day: 10)
+  end
+
+  def month_start(offset)
+    (anchor.beginning_of_month - offset.months).beginning_of_month
+  end
+
+  def spend(month, total)
+    create_transaction(category: @category, amount: total, date: month.change(day: 3), name: "test #{month}")
+  end
+
+  def generate
+    Insight::Generators::SpendingAnomalyGenerator.new(@family).generate
+  end
+
+  # $1,000 spent by day 10 against a $3,000 monthly baseline is exactly on pace:
+  # projected over a 28-31 day month it lands within 7% of the baseline, well
+  # inside DEVIATION_THRESHOLD_PCT. Without the pace factor the raw $1,000 reads
+  # as 67% below baseline and produces a high-priority false alarm.
+  test "does not flag a category that is on pace for its baseline" do
+    travel_to anchor do
+      3.times { |i| spend(month_start(i + 1), 3_000) }
+      spend(anchor.beginning_of_month, 1_000)
+
+      assert_empty generate
+    end
+  end
+
+  # The same $1,000 by day 10, but against a $1,000 monthly baseline, projects to
+  # roughly triple the usual month and must be flagged. Without the pace factor
+  # the raw total matches the baseline exactly and nothing is reported.
+  test "flags a category running well ahead of its baseline" do
+    travel_to anchor do
+      3.times { |i| spend(month_start(i + 1), 1_000) }
+      spend(anchor.beginning_of_month, 1_000)
+
+      insights = generate
+
+      assert_equal 1, insights.size
+      assert_equal "above", insights.first.metadata[:direction]
+      assert_equal "high", insights.first.priority
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`SpendingAnomalyGenerator` is meant to project month-to-date spending out to a full month before comparing it against the baseline. For any family on the default month start, it never does.

```ruby
period = Period.current_month_for(family)
elapsed_days = (Date.current - period.start_date).to_i + 1
pace_factor = period.days.to_f / elapsed_days
```

`Period.current_month_for` returns the `current_month` key for a family that doesn't use a custom month start, and that key's range is `[Date.current.beginning_of_month, Date.current]` (`app/models/period.rb:32`) — month-to-**date**, not the whole month. `Period#days` is `(end_date - start_date).to_i + 1`, which is the same arithmetic as `elapsed_days` on the line above it. So `pace_factor` is identically `1.0`, and `projected` is just raw spend-so-far.

That spend-so-far is then compared against an average of three **full** months, so for most of every month every category looks like a collapse in spending.

Concretely: a household spending $3,000/month on a category, perfectly on pace, has spent ~$1,000 by day 10. The generator compares $1,000 against the $3,000 baseline, reads −67%, and — being past the 50% high-priority bar — emits a high-priority "trending down" insight. Running the new test on the current code shows exactly that:

```
priority="high", title="Pace Test Cat spending is trending down",
facts={deviation_pct: 67, projected_spend: "$1,000.00", baseline_spend: "$3,000.00"}
```

It does this for every qualifying category, every day from day 7 until raw month-to-date spend catches up with a full month's baseline.

Families that *do* set a custom month start are unaffected: `current_custom_month_period` spans the full custom month, so `period.days` is already the real month length for them.

## The fix

Take the month length from the period's start date instead of its end date:

```ruby
month_days = ((period.start_date + 1.month) - period.start_date).to_i
pace_factor = month_days.to_f / elapsed_days
```

For a default family this is the true length of the calendar month (28–31). For a custom month start it is the length of that custom month, which is what `period.days` already returned — so that path keeps its existing, correct behaviour and both now go through one expression.

## User-visible impact

The spurious "spending is trending down" insights that currently appear for most of the month stop. Genuine anomalies are unaffected, and over-spending is now detected when the *pace* implies it rather than only once raw month-to-date spend has exceeded a full month's baseline.

## Verification

The generator had no test coverage; this adds `test/models/insight/generators/spending_anomaly_generator_test.rb` with two cases, both written to hold for any month length (28–31 days):

- **On pace** — $1,000 by day 10 against a $3,000 monthly baseline produces no insight. Without the fix this fails, emitting the high-priority false alarm quoted above.
- **Genuinely ahead** — $1,000 by day 10 against a $1,000 monthly baseline projects to roughly 3× and is flagged. Without the fix this fails the other way, `Expected: 1, Actual: 0`, because the unprojected total matches the baseline exactly.

Full `bin/rails test` is green (8,401 runs, 33,822 assertions, 0 failures, 0 errors). `bin/rubocop -f github` clean on both files, `erb_lint` and `bin/brakeman --no-pager` clean. No system tests — no view or controller changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected spending anomaly projections for the current month, including families with custom month start dates.
  - Prevented false anomaly insights when spending is tracking normally against the baseline.

- **Tests**
  - Added coverage for spending that is on pace and spending that is significantly above the expected baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->