### PR TITLE
fix(mcp): accept native-app redirect URIs during OAuth DCR

### DIFF
--- a/app/controllers/oauth_registration_controller.rb
+++ b/app/controllers/oauth_registration_controller.rb
@@ -18,6 +18,7 @@ class OauthRegistrationController < ApplicationController
     }, status: :bad_request
   end
 
+  # Registers a public OAuth client from MCP dynamic client registration.
   def create
     body = JSON.parse(request.raw_post)
 
@@ -82,8 +83,9 @@ class OauthRegistrationController < ApplicationController
 
   private
 
-    # Allow https, loopback http, and RFC 8252 private-use schemes (cursor://,
-    # vscode://). Still reject javascript/data/file and non-loopback http.
+    # Returns true for https, loopback http, and RFC 8252 private-use schemes
+    # (cursor://, vscode://). Rejects fragments, userinfo, handler schemes, and
+    # non-loopback http.
     def valid_redirect_uri?(raw_uri)
       uri = URI.parse(raw_uri)
       return false unless uri.fragment.nil?
@@ -105,6 +107,7 @@ class OauthRegistrationController < ApplicationController
       false
     end
 
+    # Returns true when +uri+ is http to localhost, 127.0.0.1, or ::1.
     def loopback_http?(uri)
       return false if uri.host.blank?
 
@@ -112,6 +115,7 @@ class OauthRegistrationController < ApplicationController
       LOOPBACK_HOSTS.include?(host)
     end
 
+    # Returns true when a private-use URI has a host or path to redirect to.
     def native_app_redirect?(uri)
       uri.host.present? || uri.path.present?
     end

--- a/app/controllers/oauth_registration_controller.rb
+++ b/app/controllers/oauth_registration_controller.rb
@@ -1,5 +1,8 @@
 class OauthRegistrationController < ApplicationController
   LOOPBACK_HOSTS = [ "localhost", "127.0.0.1", "::1" ].freeze
+  # Schemes that can execute script, read local files, or are not OAuth redirects.
+  FORBIDDEN_SCHEMES = %w[javascript data file about blob ws wss ftp mailto].freeze
+  SCHEME_PATTERN = /\A[a-z][a-z0-9+\-.]*\z/.freeze
 
   skip_authentication
   skip_before_action :verify_authenticity_token
@@ -38,7 +41,7 @@ class OauthRegistrationController < ApplicationController
     unless redirect_uris.all? { |uri| valid_redirect_uri?(uri) }
       render json: {
         error: "invalid_client_metadata",
-        error_description: "redirect_uris must use https or loopback http"
+        error_description: "redirect_uris must use https, loopback http, or a native app URI scheme"
       }, status: :bad_request
       return
     end
@@ -78,17 +81,37 @@ class OauthRegistrationController < ApplicationController
 
   private
 
+    # Allow https, loopback http, and RFC 8252 private-use schemes (cursor://,
+    # vscode://). Still reject javascript/data/file and non-loopback http.
     def valid_redirect_uri?(raw_uri)
       uri = URI.parse(raw_uri)
-      return false if uri.host.blank?
+      return false if uri.fragment.present?
+      return false if uri.userinfo.present?
 
       scheme = uri.scheme.to_s.downcase
-      return true if scheme == "https"
-      return false unless scheme == "http"
+      return false if scheme.blank? || FORBIDDEN_SCHEMES.include?(scheme)
+      return false unless scheme.match?(SCHEME_PATTERN)
+
+      case scheme
+      when "https"
+        uri.host.present?
+      when "http"
+        loopback_http?(uri)
+      else
+        native_app_redirect?(uri)
+      end
+    rescue URI::Error
+      false
+    end
+
+    def loopback_http?(uri)
+      return false if uri.host.blank?
 
       host = uri.host.downcase.delete_prefix("[").delete_suffix("]")
       LOOPBACK_HOSTS.include?(host)
-    rescue URI::InvalidURIError
-      false
+    end
+
+    def native_app_redirect?(uri)
+      uri.host.present? || uri.path.present?
     end
 end

--- a/app/controllers/oauth_registration_controller.rb
+++ b/app/controllers/oauth_registration_controller.rb
@@ -1,7 +1,8 @@
 class OauthRegistrationController < ApplicationController
   LOOPBACK_HOSTS = [ "localhost", "127.0.0.1", "::1" ].freeze
-  # Schemes that can execute script, read local files, or are not OAuth redirects.
-  FORBIDDEN_SCHEMES = %w[javascript data file about blob ws wss ftp mailto].freeze
+  # Schemes that can execute script, read local files, invoke device handlers,
+  # or are not OAuth redirects.
+  FORBIDDEN_SCHEMES = %w[javascript data file about blob ws wss ftp mailto tel sms intent].freeze
   SCHEME_PATTERN = /\A[a-z][a-z0-9+\-.]*\z/.freeze
 
   skip_authentication
@@ -41,7 +42,7 @@ class OauthRegistrationController < ApplicationController
     unless redirect_uris.all? { |uri| valid_redirect_uri?(uri) }
       render json: {
         error: "invalid_client_metadata",
-        error_description: "redirect_uris must use https, loopback http, or a native app URI scheme"
+        error_description: t("oauth.registration.invalid_redirect_uris")
       }, status: :bad_request
       return
     end
@@ -85,7 +86,7 @@ class OauthRegistrationController < ApplicationController
     # vscode://). Still reject javascript/data/file and non-loopback http.
     def valid_redirect_uri?(raw_uri)
       uri = URI.parse(raw_uri)
-      return false if uri.fragment.present?
+      return false unless uri.fragment.nil?
       return false if uri.userinfo.present?
 
       scheme = uri.scheme.to_s.downcase

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -11,6 +11,9 @@ en:
     errors:
       invalid_session_id: "Invalid MCP session id"
       unsupported_protocol_version: "Unsupported MCP protocol version: %{version}"
+  oauth:
+    registration:
+      invalid_redirect_uris: "redirect_uris must use https, loopback http, or a native app URI scheme"
   activerecord:
     errors:
       messages:

--- a/docs/hosting/mcp.md
+++ b/docs/hosting/mcp.md
@@ -393,6 +393,18 @@ If your Claude Desktop build expects a raw MCP endpoint instead of an OAuth inte
 
 Use either the client's OAuth support or a bearer token, depending on what that build supports.
 
+### Cursor and other native MCP clients
+
+Desktop MCP clients such as Cursor and VS Code authenticate with OAuth Dynamic Client Registration (`POST /register`) and then open a browser for consent. Native clients register a private-use redirect URI rather than an `https://` callback, for example:
+
+- Cursor desktop: `cursor://anysphere.cursor-mcp/oauth/callback`
+- Newer Cursor IDE/CLI builds: `http://localhost:8787/callback`
+- VS Code extensions: `vscode://...`
+
+Sure accepts those native-app URI schemes, loopback `http://` callbacks, and `https://` callbacks. After you authorize in the browser, the client exchanges the authorization code (PKCE) for a bearer token and calls `/mcp`.
+
+If OAuth is inconvenient (CI, scripts, or a client that cannot complete the browser flow), use the static `MCP_API_TOKEN` bearer token instead.
+
 ### Custom Agents
 
 Any AI agent that supports JSON-RPC 2.0 can connect to the MCP endpoint. The agent should:

--- a/docs/hosting/mcp.md
+++ b/docs/hosting/mcp.md
@@ -399,6 +399,7 @@ Desktop MCP clients such as Cursor and VS Code authenticate with OAuth Dynamic C
 
 - Cursor desktop: `cursor://anysphere.cursor-mcp/oauth/callback`
 - Newer Cursor IDE/CLI builds: `http://localhost:8787/callback`
+- Cursor web: `https://www.cursor.com/agents/mcp/oauth/callback`
 - VS Code extensions: `vscode://...`
 
 Sure accepts those native-app URI schemes, loopback `http://` callbacks, and `https://` callbacks. After you authorize in the browser, the client exchanges the authorization code (PKCE) for a bearer token and calls `/mcp`.

--- a/test/controllers/oauth_registration_controller_test.rb
+++ b/test/controllers/oauth_registration_controller_test.rb
@@ -109,16 +109,157 @@ class OauthRegistrationControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "http://[::1]:3456/callback" ], json["redirect_uris"]
   end
 
-  test "rejects custom scheme redirect uri" do
+  test "allows native app custom scheme redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Cursor",
+        redirect_uris: [ "cursor://anysphere.cursor-mcp/oauth/callback" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_equal [ "cursor://anysphere.cursor-mcp/oauth/callback" ], json["redirect_uris"]
+  end
+
+  test "allows vscode custom scheme redirect uri" do
+    post "/register",
+      params: {
+        client_name: "VS Code",
+        redirect_uris: [ "vscode://augment.vscode-augment/auth/mcp" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_equal [ "vscode://augment.vscode-augment/auth/mcp" ], json["redirect_uris"]
+  end
+
+  test "allows mixed native and https redirect uris from a desktop client" do
+    post "/register",
+      params: {
+        client_name: "Cursor",
+        redirect_uris: [
+          "cursor://anysphere.cursor-mcp/oauth/callback",
+          "http://localhost:8787/callback",
+          "https://www.cursor.com/agents/mcp/oauth/callback"
+        ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_equal [
+      "cursor://anysphere.cursor-mcp/oauth/callback",
+      "http://localhost:8787/callback",
+      "https://www.cursor.com/agents/mcp/oauth/callback"
+    ], json["redirect_uris"]
+  end
+
+  test "allows reverse-domain native redirect uri without a host" do
+    post "/register",
+      params: {
+        client_name: "Native App",
+        redirect_uris: [ "com.example.app:/oauth2redirect/example-provider" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_equal [ "com.example.app:/oauth2redirect/example-provider" ], json["redirect_uris"]
+  end
+
+  test "rejects javascript redirect uri" do
     post "/register",
       params: {
         client_name: "Claude",
-        redirect_uris: [ "myapp://callback" ]
+        redirect_uris: [ "javascript:alert(1)" ]
       }.to_json,
       headers: { "Content-Type" => "application/json" }
 
     assert_response :bad_request
     json = JSON.parse(response.body)
     assert_equal "invalid_client_metadata", json["error"]
+  end
+
+  test "rejects file redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "file:///etc/passwd" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+    json = JSON.parse(response.body)
+    assert_equal "invalid_client_metadata", json["error"]
+  end
+
+  test "rejects data redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "data:text/html,hello" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+    json = JSON.parse(response.body)
+    assert_equal "invalid_client_metadata", json["error"]
+  end
+
+  test "rejects redirect uri with a fragment" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "https://claude.ai/callback#oops" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+    json = JSON.parse(response.body)
+    assert_equal "invalid_client_metadata", json["error"]
+  end
+
+  test "rejects scheme-only custom redirect uri" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "cursor://" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+    json = JSON.parse(response.body)
+    assert_equal "invalid_client_metadata", json["error"]
+  end
+
+  test "authorization redirects to a dynamically registered native app uri" do
+    post "/register",
+      params: {
+        client_name: "Cursor",
+        redirect_uris: [ "cursor://anysphere.cursor-mcp/oauth/callback" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :created
+    app = Doorkeeper::Application.find_by!(uid: JSON.parse(response.body)["client_id"])
+
+    sign_in(users(:family_admin))
+    verifier = SecureRandom.urlsafe_base64(64)
+    challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), padding: false)
+
+    post "/oauth/authorize", params: {
+      client_id: app.uid,
+      redirect_uri: "cursor://anysphere.cursor-mcp/oauth/callback",
+      response_type: "code",
+      code_challenge: challenge,
+      code_challenge_method: "S256"
+    }
+
+    assert_response :redirect
+    assert response.location.start_with?("cursor://anysphere.cursor-mcp/oauth/callback")
+    code = Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
+    assert code.present?, "Authorization response should contain a code"
   end
 end

--- a/test/controllers/oauth_registration_controller_test.rb
+++ b/test/controllers/oauth_registration_controller_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class OauthRegistrationControllerTest < ActionDispatch::IntegrationTest
+  DOCUMENTED_NATIVE_REDIRECT_URIS = [
+    "cursor://anysphere.cursor-mcp/oauth/callback",
+    "http://localhost:8787/callback",
+    "https://www.cursor.com/agents/mcp/oauth/callback"
+  ].freeze
   test "registers a public client and returns client_id" do
     post "/register",
       params: {
@@ -290,5 +295,45 @@ class OauthRegistrationControllerTest < ActionDispatch::IntegrationTest
     assert response.location.start_with?("cursor://anysphere.cursor-mcp/oauth/callback")
     code = Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
     assert code.present?, "Authorization response should contain a code"
+
+    post "/oauth/token", params: {
+      grant_type: "authorization_code",
+      client_id: app.uid,
+      redirect_uri: "cursor://anysphere.cursor-mcp/oauth/callback",
+      code: code,
+      code_verifier: verifier
+    }
+
+    assert_response :success
+    token_response = JSON.parse(response.body)
+    assert_equal "Bearer", token_response["token_type"]
+    assert token_response["access_token"].present?
+  end
+
+  test "hosting docs document native MCP client redirect URIs" do
+    doc = Rails.root.join("docs/hosting/mcp.md").read
+
+    DOCUMENTED_NATIVE_REDIRECT_URIS.each do |uri|
+      assert_includes doc, uri
+    end
+    assert_includes doc, "vscode://"
+    assert_includes doc, "POST /register"
+    assert_includes doc, "PKCE"
+    assert_includes doc, "MCP_API_TOKEN"
+  end
+
+  test "registers each redirect uri documented for native MCP clients" do
+    DOCUMENTED_NATIVE_REDIRECT_URIS.each do |redirect_uri|
+      post "/register",
+        params: {
+          client_name: "Cursor",
+          redirect_uris: [ redirect_uri ]
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+
+      assert_response :created, "expected #{redirect_uri} to register"
+      json = JSON.parse(response.body)
+      assert_equal [ redirect_uri ], json["redirect_uris"]
+    end
   end
 end

--- a/test/controllers/oauth_registration_controller_test.rb
+++ b/test/controllers/oauth_registration_controller_test.rb
@@ -219,6 +219,35 @@ class OauthRegistrationControllerTest < ActionDispatch::IntegrationTest
     assert_response :bad_request
     json = JSON.parse(response.body)
     assert_equal "invalid_client_metadata", json["error"]
+    assert_equal I18n.t("oauth.registration.invalid_redirect_uris"), json["error_description"]
+  end
+
+  test "rejects redirect uri with an empty trailing fragment" do
+    post "/register",
+      params: {
+        client_name: "Claude",
+        redirect_uris: [ "https://claude.ai/callback#" ]
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+    json = JSON.parse(response.body)
+    assert_equal "invalid_client_metadata", json["error"]
+  end
+
+  test "rejects tel sms and intent redirect uris" do
+    %w[tel:+15551212 sms:+15551212 intent://scan/oauth].each do |redirect_uri|
+      post "/register",
+        params: {
+          client_name: "Claude",
+          redirect_uris: [ redirect_uri ]
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+
+      assert_response :bad_request, "expected #{redirect_uri} to be rejected"
+      json = JSON.parse(response.body)
+      assert_equal "invalid_client_metadata", json["error"]
+    end
   end
 
   test "rejects scheme-only custom redirect uri" do


### PR DESCRIPTION
Dynamic client registration only allowed https and loopback http, so Cursor's cursor:// callback failed POST /register. One custom scheme in a mixed list (cursor:// + localhost + https) rejected the whole client. Accept RFC 8252 private-use schemes while still rejecting javascript/data/file and non-loopback http.

PKCE and the consent screen remain in place. Loopback-only Cursor registrations already worked; this unblocks the default mixed payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth registration supports native app, loopback HTTP, and HTTPS redirect URIs.
  - Native app authorization flows can return to desktop MCP clients such as Cursor and VS Code.
  - Registration errors describe supported redirect URI formats.

- **Bug Fixes**
  - Unsafe or malformed redirect URIs—including unsupported schemes, fragments, userinfo, and device-handler schemes—are rejected.

- **Documentation**
  - Added the Cursor web OAuth callback to the native MCP client examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->