### PR TITLE
fix(wise): stub encryption in the SCA localization success test

### DIFF
--- a/test/controllers/wise_sca_localization_test.rb
+++ b/test/controllers/wise_sca_localization_test.rb
@@ -68,7 +68,11 @@ class WiseScaPanelLocalizationTest < ActionDispatch::IntegrationTest
     assert_sca_copy "regenerate_confirm"
   end
 
+  # The key is only ever stored encrypted, and the test environment configures
+  # no encryption keys, so the flow has to be exercised as an install that does.
   test "German Wise SCA keypair generation returns the localized success message" do
+    WiseItem.stubs(:encryption_ready?).returns(true)
+
     post generate_sca_keypair_wise_item_url(wise_items(:one))
 
     assert_redirected_to accounts_path


### PR DESCRIPTION
## What broke

`WiseScaPanelLocalizationTest#test_German_Wise_SCA_keypair_generation_returns_the_localized_success_message` fails on main: it expects a redirect to `/accounts` but gets `/settings/providers`.

## Why

#3415 made `WiseItem#generate_sca_keypair!` raise `SCAEncryptionUnavailable` when Active Record encryption is not configured, so a private key is never stored in the clear. The behavior change is intended. It updated the three keypair tests in `wise_items_controller_test.rb` to stub `encryption_ready?`, but the SCA localization test from #3413 generates a keypair on its success path and was missed. The test env configures no encryption keys, so that test now exercises the refused path: the controller rescues and redirects to `/settings/providers` with the failure flash.

## The fix

One-line setup change mirroring the controller tests: stub `WiseItem.encryption_ready?` to `true` in the success-path test, with the same explanatory comment #3415 used.

## Verification

- `bin/rails test test/controllers/wise_sca_localization_test.rb` - 6 runs, 0 failures (previously 1 failure on this exact test)
- `bin/rails test test/controllers/wise_items_controller_test.rb` - 13 runs, 0 failures
- `bundle exec rubocop test/controllers/wise_sca_localization_test.rb` - clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the Wise SCA keypair-generation integration test to support the encrypted-key flow in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->