### PR TITLE
EXPERIMENT / DO NOT MERGE: parallel system tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
           bin/rails db:seed
 
       - name: System tests
-        run: DISABLE_PARALLELIZATION=true bin/rails test:system
+        run: bin/rails test:system
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION
Throwaway experiment: runs system tests with Minitest process parallelization enabled (DISABLE_PARALLELIZATION removed from the system test step) to measure timing and flakiness.

Will be closed without merging after data collection. Not a real change proposal.
