### PR TITLE
fix(wise): require encrypted SCA key registration

### DIFF
--- a/app/models/wise_item.rb
+++ b/app/models/wise_item.rb
@@ -3,6 +3,8 @@
 class WiseItem < ApplicationRecord
   include Syncable, Provided, Unlinking, Encryptable
 
+  SCA_PRIVATE_KEY_ATTRIBUTE = "sca_private_key"
+
   # Raised rather than returned so no caller can mistake "not stored" for
   # "stored"; the controller turns it into the same panel error as any other
   # keypair failure.
@@ -156,7 +158,8 @@ class WiseItem < ApplicationRecord
   end
 
   def sca_encryption_available?
-    self.class.encryption_ready?
+    self.class.encryption_ready? &&
+      Array(self.class.encrypted_attributes).map(&:to_s).include?(SCA_PRIVATE_KEY_ATTRIBUTE)
   end
 
   def sca_public_key

--- a/test/controllers/wise_items_controller_test.rb
+++ b/test/controllers/wise_items_controller_test.rb
@@ -121,10 +121,9 @@ class WiseItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to settings_providers_path
   end
 
-  # The key is only ever stored encrypted, and the test environment configures
-  # no encryption keys, so the flow has to be exercised as an install that does.
   test "generate_sca_keypair stores a keypair on the item" do
-    WiseItem.stubs(:encryption_ready?).returns(true)
+    WiseItem.any_instance.stubs(:sca_encryption_available?).returns(true)
+
     assert_nil @wise_item.sca_private_key
 
     post generate_sca_keypair_wise_item_url(@wise_item)
@@ -134,7 +133,8 @@ class WiseItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "generate_sca_keypair replaces a previously generated keypair" do
-    WiseItem.stubs(:encryption_ready?).returns(true)
+    WiseItem.any_instance.stubs(:sca_encryption_available?).returns(true)
+
     @wise_item.generate_sca_keypair!
     previous_key = @wise_item.sca_private_key
 

--- a/test/controllers/wise_sca_localization_test.rb
+++ b/test/controllers/wise_sca_localization_test.rb
@@ -68,10 +68,8 @@ class WiseScaPanelLocalizationTest < ActionDispatch::IntegrationTest
     assert_sca_copy "regenerate_confirm"
   end
 
-  # The key is only ever stored encrypted, and the test environment configures
-  # no encryption keys, so the flow has to be exercised as an install that does.
   test "German Wise SCA keypair generation returns the localized success message" do
-    WiseItem.stubs(:encryption_ready?).returns(true)
+    WiseItem.any_instance.stubs(:generate_sca_keypair!).returns("SYNTHETIC PUBLIC KEY")
 
     post generate_sca_keypair_wise_item_url(wise_items(:one))
 

--- a/test/models/provider/wise_adapter_test.rb
+++ b/test/models/provider/wise_adapter_test.rb
@@ -6,12 +6,9 @@ class Provider::WiseAdapterTest < ActiveSupport::TestCase
     @wise_item = wise_items(:one)
   end
 
-  # The key is only ever stored on an install with Active Record encryption
-  # configured, which the test environment is not.
   test "build_provider threads sca_private_key through to Provider::Wise" do
-    WiseItem.stubs(:encryption_ready?).returns(true)
     key = OpenSSL::PKey::RSA.new(2048).to_pem
-    @wise_item.update!(sca_private_key: key)
+    @wise_item.update_column(:sca_private_key, key)
 
     provider = Provider::WiseAdapter.build_provider(family: @family, wise_item_id: @wise_item.id)
 

--- a/test/models/wise_item_test.rb
+++ b/test/models/wise_item_test.rb
@@ -59,7 +59,8 @@ class WiseItemTest < ActiveSupport::TestCase
   end
 
   test "generate_sca_keypair! stores a private key and returns a matching public key" do
-    WiseItem.stubs(:encryption_ready?).returns(true)
+    stub_sca_encryption_available
+
     public_pem = @wise_item.generate_sca_keypair!
 
     assert @wise_item.sca_configured?
@@ -68,6 +69,24 @@ class WiseItemTest < ActiveSupport::TestCase
 
     private_key = OpenSSL::PKey::RSA.new(@wise_item.sca_private_key)
     assert_equal private_key.public_key.to_pem, public_pem
+  end
+
+  test "refuses to store an SCA private key unless the attribute is registered encrypted" do
+    WiseItem.stubs(:encryption_ready?).returns(true)
+    WiseItem.stubs(:encrypted_attributes).returns([])
+
+    assert_not @wise_item.sca_encryption_available?
+    assert_raises(WiseItem::SCAEncryptionUnavailable) { @wise_item.generate_sca_keypair! }
+    assert_nil @wise_item.reload.sca_private_key
+  end
+
+  test "refuses to store an SCA private key when encrypted attributes are unset" do
+    WiseItem.stubs(:encryption_ready?).returns(true)
+    WiseItem.stubs(:encrypted_attributes).returns(nil)
+
+    assert_not @wise_item.sca_encryption_available?
+    assert_raises(WiseItem::SCAEncryptionUnavailable) { @wise_item.generate_sca_keypair! }
+    assert_nil @wise_item.reload.sca_private_key
   end
 
   # An SCA private key signs requests to Wise. Storing it unencrypted is not a
@@ -110,7 +129,8 @@ class WiseItemTest < ActiveSupport::TestCase
   end
 
   test "generate_sca_keypair! replaces a previously generated key" do
-    WiseItem.stubs(:encryption_ready?).returns(true)
+    stub_sca_encryption_available
+
     first_public_key = @wise_item.generate_sca_keypair!
     second_public_key = @wise_item.generate_sca_keypair!
 
@@ -170,6 +190,11 @@ class WiseItemTest < ActiveSupport::TestCase
   end
 
   private
+
+    def stub_sca_encryption_available
+      WiseItem.stubs(:encryption_ready?).returns(true)
+      WiseItem.stubs(:encrypted_attributes).returns([ "sca_private_key" ])
+    end
 
     def create_interbalance_entry(account, resource_id, side:, amount:)
       external_id = "wise_interbalance_#{resource_id}_#{side}"


### PR DESCRIPTION
## Summary

Follow-up to #3415. `WiseItem#sca_encryption_available?` now requires both the encryption readiness predicate and actual registration of `sca_private_key` in `encrypted_attributes`, so a late/stubbed readiness value cannot allow a plaintext SCA key write when the model did not load with `encrypts :sca_private_key`.

The tests also stop using the Wise SCA storage path for adapter/localization assertions that only need an existing key or a successful controller response.

## Tests

- `bin/rails test test/models/wise_item_test.rb test/controllers/wise_items_controller_test.rb test/controllers/wise_sca_localization_test.rb test/models/provider/wise_adapter_test.rb`
- `bin/rails test $(rg --files test | rg 'wise.*_test\\.rb$|_wise.*_test\\.rb$|wise_' | rg '_test\\.rb$' | tr '\\n' ' ')`\n- `bin/rubocop app/models/wise_item.rb test/models/wise_item_test.rb test/controllers/wise_items_controller_test.rb test/controllers/wise_sca_localization_test.rb test/models/provider/wise_adapter_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security checks for Wise SCA keypair generation.
  - Keypair generation now proceeds only when the private key is configured for encrypted storage.
  - Prevents private keys from being generated or stored when the required encryption protection is unavailable.
  - Ensures SCA keypair availability reflects the actual encryption configuration, reducing the risk of unprotected private-key storage.
  - Added safeguards for cases where encrypted storage configuration is missing or incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->