### PR TITLE
test: stabilize property subtype system test

### DIFF
--- a/test/system/property_test.rb
+++ b/test/system/property_test.rb
@@ -12,49 +12,12 @@ class PropertiesEditTest < ApplicationSystemTestCase
   end
 
   test "can persist property subtype" do
-    click_link "[system test] Property Account"
-    open_account_edit_dialog
+    visit edit_property_path(@property_account)
+
     assert_field "account_accountable_attributes_subtype", with: "single_family_home"
   end
 
   private
-
-    # The account page issues a Turbo morph refresh shortly after it loads
-    # (`turbo_refreshes_with method: :morph` reacting to a family-stream
-    # broadcast). If the edit modal is opened while that refresh is in flight,
-    # the morph re-renders the page and wipes the just-loaded `#modal`
-    # turbo-frame before the dialog is interactive — and can detach the menu
-    # node mid-click ("Node with given id does not belong to the document"),
-    # which Capybara does not auto-retry. Open via the account menu and retry
-    # until the edit form is present so the test is deterministic instead of
-    # racing the broadcast.
-    def open_account_edit_dialog
-      3.times do
-        # A prior (slow) attempt may have already opened the edit form.
-        return if has_selector?("#account_accountable_attributes_subtype", wait: 0)
-
-        begin
-          within_testid("account-menu") do
-            # Open the menu only when it's closed. DS::Menu's trigger toggles
-            # (menu_controller#toggle), so blindly re-clicking an already-open
-            # menu would close it and hide "Edit", turning a slow-but-successful
-            # modal load into a fresh flake.
-            unless has_selector?("[role='menu']", visible: true, wait: 0)
-              find("button").click
-            end
-            click_on "Edit"
-          end
-        rescue Selenium::WebDriver::Error::WebDriverError => e
-          raise unless e.message.match?(
-            /does not belong to the document|stale element reference/i,
-          )
-          next
-        end
-        return if has_selector?("#account_accountable_attributes_subtype", wait: 2)
-      end
-      assert_selector "#account_accountable_attributes_subtype"
-    end
-
     def open_new_account_modal
       within "[data-controller='DS--tabs']" do
         click_button "All"
@@ -91,10 +54,13 @@ class PropertiesEditTest < ApplicationSystemTestCase
       # Verify account was created and is now active
       assert_text account_name
 
-      created_account = Account.order(:created_at).last
-      assert_equal "active", created_account.status
-      assert_equal 500000, created_account.balance
-      assert_equal "123 Main St", created_account.property.address.line1
-      assert_equal "San Francisco", created_account.property.address.locality
+      @property_account = @user.family.accounts.find_by!(
+        name: account_name,
+        accountable_type: "Property"
+      )
+      assert_equal "active", @property_account.status
+      assert_equal 500000, @property_account.balance
+      assert_equal "123 Main St", @property_account.property.address.line1
+      assert_equal "San Francisco", @property_account.property.address.locality
     end
 end


### PR DESCRIPTION
## Summary
- open the property edit route directly when checking persisted subtype state
- remove the flaky account-header menu/modal helper from the property system test

## Validation
- DISABLE_PARALLELIZATION=true bin/rails test test/system/property_test.rb test/system/accounts_test.rb
- bin/rubocop test/system/property_test.rb

Note: a full local system run still hits the self-hosted Redis setup gate in SettingsTest on this host, which is separate from the GitHub failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved property account test reliability by using direct navigation to the edit page.
  - Made test setup more deterministic when identifying the relevant property account.
  - Continued validating account status, balance, address, and subtype fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->