### PR TITLE
fix(rules): keep dynamically added nested-attribute keys numeric

### DIFF
--- a/app/javascript/controllers/rule/conditions_controller.js
+++ b/app/javascript/controllers/rule/conditions_controller.js
@@ -123,13 +123,6 @@ export default class extends Controller {
   }
 
   #uniqueKey() {
-    // Must stay numeric: strong params only recognize integer-keyed hashes
-    // as nested attributes (ActionController::Parameters.nested_attribute?
-    // matches /\A-?\d+\z/), so a "new_1"-style key is silently dropped and
-    // the submit fails validation. Date.now() alone can repeat when rows are
-    // added in the same millisecond, and a small counter alone can collide
-    // with the numeric indexes Rails assigns persisted rows on edit forms,
-    // so combine them.
     this.keySequence = (this.keySequence ?? 0) + 1;
     return Date.now() * 1000 + this.keySequence;
   }

--- a/app/javascript/controllers/rule/conditions_controller.js
+++ b/app/javascript/controllers/rule/conditions_controller.js
@@ -123,7 +123,15 @@ export default class extends Controller {
   }
 
   #uniqueKey() {
-    return Date.now();
+    // Must stay numeric: strong params only recognize integer-keyed hashes
+    // as nested attributes (ActionController::Parameters.nested_attribute?
+    // matches /\A-?\d+\z/), so a "new_1"-style key is silently dropped and
+    // the submit fails validation. Date.now() alone can repeat when rows are
+    // added in the same millisecond, and a small counter alone can collide
+    // with the numeric indexes Rails assigns persisted rows on edit forms,
+    // so combine them.
+    this.keySequence = (this.keySequence ?? 0) + 1;
+    return Date.now() * 1000 + this.keySequence;
   }
 
   #toggleValueFieldVisibility() {

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -50,12 +50,15 @@ export default class extends Controller {
   }
 
   #uniqueKey() {
-    // Prefixed so it can never collide with the numeric indexes Rails
-    // assigns to already-persisted conditions/actions when rendering an
-    // edit form (0, 1, 2, ...). A plain monotonic counter starting at 1
-    // would otherwise reuse index 1 and clobber an existing nested record.
+    // Must stay numeric: strong params only recognize integer-keyed hashes
+    // as nested attributes (ActionController::Parameters.nested_attribute?
+    // matches /\A-?\d+\z/), so a "new_1"-style key is silently dropped and
+    // the submit fails validation. Date.now() alone can repeat when rows are
+    // added in the same millisecond, and a small counter alone can collide
+    // with the numeric indexes Rails assigns persisted rows on edit forms,
+    // so combine them.
     this.keySequence = (this.keySequence ?? 0) + 1;
-    return `new_${this.keySequence}`;
+    return Date.now() * 1000 + this.keySequence;
   }
 
   // Updates the prefix visibility of all conditions and condition groups

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -50,13 +50,6 @@ export default class extends Controller {
   }
 
   #uniqueKey() {
-    // Must stay numeric: strong params only recognize integer-keyed hashes
-    // as nested attributes (ActionController::Parameters.nested_attribute?
-    // matches /\A-?\d+\z/), so a "new_1"-style key is silently dropped and
-    // the submit fails validation. Date.now() alone can repeat when rows are
-    // added in the same millisecond, and a small counter alone can collide
-    // with the numeric indexes Rails assigns persisted rows on edit forms,
-    // so combine them.
     this.keySequence = (this.keySequence ?? 0) + 1;
     return Date.now() * 1000 + this.keySequence;
   }

--- a/test/system/rules_test.rb
+++ b/test/system/rules_test.rb
@@ -56,4 +56,26 @@ class RulesTest < ApplicationSystemTestCase
     assert_selector "h3", text: "Legacy bad rule"
     assert_text "Nicht unterstützt (name)"
   end
+
+  test "creates a transaction rule through the modal with dynamically added condition and action" do
+    visit new_rule_path(resource_type: "transaction")
+
+    within "dialog" do
+      click_on "Add condition"
+      find("[data-rules-target='conditionsList'] input[name$='[value]']").fill_in(with: "Coffee")
+      click_on "Add action"
+      click_on "Create Rule"
+    end
+
+    # A successful create lands on the confirmation dialog; before the
+    # nested-attribute keys were numeric, the submit failed validation with
+    # "must have at least one action" because strong params dropped the rows.
+    assert_text "Confirm changes"
+
+    rule = Rule.order(:created_at).last
+    assert_equal "transaction_name", rule.conditions.first.condition_type
+    assert_equal "Coffee", rule.conditions.first.value
+    assert_equal "set_transaction_category", rule.actions.first.action_type
+    assert rule.actions.first.value.present?
+  end
 end


### PR DESCRIPTION
## Problem

Creating a rule from the modal (New transaction rule → Add condition → Add action → Create Rule) fails with a 422 and the error **"must have at least one action"** even though the THEN section visibly has an action. The re-rendered form also drops the rows the user entered.

Reproducible on demo.sure.am (v0.7.5-alpha.5); v0.7.5-alpha.4 is not affected.

## Root cause

#3397 changed the key generator for dynamically added condition/action rows in `rules_controller.js` from `Date.now()` to `` `new_${counter}` `` (to avoid colliding with the numeric indexes Rails assigns to persisted rows on edit forms).

Rails strong parameters only recognize **integer-keyed** hash entries as nested attributes:

```ruby
# actionpack/lib/action_controller/metal/strong_parameters.rb
def nested_attribute?(key, value)
  /\A-?\d+\z/.match?(key) && (value.is_a?(Hash) || value.is_a?(Parameters))
end
```

The browser submits the payload correctly (`rule[actions_attributes][new_2][action_type]=...`), but with `new_1`/`new_2` keys `permit(actions_attributes: [...])` silently returns an empty hash, `rules.build(rule_params)` gets zero actions, and the `min_actions` validation fails.

Verified live on demo.sure.am: renaming the same form's nested keys from `new_1`/`new_2` to `0`/`1` in the DOM and resubmitting makes the submit pass `min_actions`.

Existing controller tests post numeric keys (`"0"`, `"1"`) and the system specs only covered read paths, which is why CI stayed green.

## Fix

`#uniqueKey` in both `rules_controller.js` and `rule/conditions_controller.js` now returns `Date.now() * 1000 + sequence`:

- numeric, so strong params accepts the keys;
- unique even when two rows are added within the same millisecond (the reason #3397 moved away from bare `Date.now()`);
- far from the small `0..n` indexes Rails assigns persisted rows on edit forms, preserving #3397's anti-collision intent.

## Test

Adds a system test that creates a rule through the modal with dynamically added rows and asserts the persisted condition and action. It fails on the broken code (422, no rule created) and passes with this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when adding multiple rule conditions or actions rapidly, preventing duplicate field identifiers created within the same millisecond.
  - Rule creation through the modal now preserves dynamically added conditions and actions more consistently.

- **Tests**
  - Added coverage for creating transaction rules with dynamically added fields, reviewing the confirmation, and verifying saved rule details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->