### PR TITLE
End spending comparison axis at selected month end

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -555,12 +555,19 @@ class PagesController < ApplicationController
 
     # A longer previous month's curve is clipped to the axis, with the extra
     # days' spend folded into the final visible point, so the curve still
-    # ends at the full-month total shown in the header.
+    # ends at the full-month total shown in the header. The folded point
+    # keeps its axis slot (day) for positioning but carries the true
+    # endpoint's date metadata, so the tooltip says what the value actually
+    # contains (e.g. "Jan 31" and the total through Jan 31).
     def fold_extra_days(series, axis_days)
       return series if series.size <= axis_days
 
       series.first(axis_days).tap do |folded|
-        folded[-1] = folded[-1].merge(value: series.last[:value])
+        folded[-1] = folded[-1].merge(
+          value: series.last[:value],
+          date: series.last[:date],
+          date_formatted: series.last[:date_formatted]
+        )
       end
     end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -493,15 +493,23 @@ class PagesController < ApplicationController
       current_daily = income_statement.daily_expense_series(period: current_period).index_by(&:date)
       previous_daily = income_statement.daily_expense_series(period: previous_period).index_by(&:date)
 
+      # The selected month always owns the axis: when the previous month is
+      # longer, its extra days fold into the final visible point so the curve
+      # still ends at the full-month total without the axis rolling into
+      # previous-month dates (e.g. a September view ends at "Sep 30", not
+      # "Aug 31").
+      axis_days = month_end.day
+
       current_series = cumulative_spending_series(current_period, current_daily)
-      previous_series = cumulative_spending_series(previous_period, previous_daily)
+      previous_series = fold_extra_days(
+        cumulative_spending_series(previous_period, previous_daily),
+        axis_days
+      )
 
       current_total = current_series.last&.fetch(:value) || 0
       previous_total = previous_series.last&.fetch(:value) || 0
       currency = income_statement.family.currency
 
-      # The axis spans the longer of the two months so both curves share it.
-      axis_days = [ month_end.day, previous_period.end_date.day ].max
 
       {
         month: month_start,
@@ -509,7 +517,7 @@ class PagesController < ApplicationController
         previous_period: previous_period,
         days: axis_days,
         current_days: month_end.day,
-        axis_labels: spending_trend_axis_labels(month_start, previous_month_start, axis_days),
+        axis_labels: spending_trend_axis_labels(month_start, axis_days),
         current: current_series,
         previous: previous_series,
         current_total: Money.new(current_total, currency),
@@ -537,16 +545,22 @@ class PagesController < ApplicationController
       end
     end
 
-    # Localized tick labels, one per axis day. The selected month owns the
-    # axis up to its length; when the previous month is longer, its dates
-    # label the tail so a tick never rolls past month-end into the next month
-    # (e.g. day 31 of a February view is "Jan 31", not "Mar 3").
-    def spending_trend_axis_labels(month_start, previous_month_start, days)
-      month_length = month_start.end_of_month.day
-
+    # Localized tick labels, one per axis day. The axis always spans exactly
+    # the selected month, so labels never roll into the previous month.
+    def spending_trend_axis_labels(month_start, days)
       (1..days).map do |day|
-        date = day <= month_length ? month_start + (day - 1) : previous_month_start + (day - 1)
-        I18n.l(date, format: :short)
+        I18n.l(month_start + (day - 1), format: :short)
+      end
+    end
+
+    # A longer previous month's curve is clipped to the axis, with the extra
+    # days' spend folded into the final visible point, so the curve still
+    # ends at the full-month total shown in the header.
+    def fold_extra_days(series, axis_days)
+      return series if series.size <= axis_days
+
+      series.first(axis_days).tap do |folded|
+        folded[-1] = folded[-1].merge(value: series.last[:value])
       end
     end
 

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -378,10 +378,13 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal selected_month.end_of_month.day, current.size
     assert_equal previous_month.end_of_month.day, previous.size
 
-    # Cumulative: each month's final point carries the month's total.
+    # Cumulative: each month's final point carries the month's total. When the
+    # previous month is longer its curve is folded, but the final visible
+    # point still carries the full-month total.
     assert_equal 75.0, current.last.fetch("value")
     assert_equal 200.0, previous.last.fetch("value")
-    assert_equal [ selected_month.end_of_month.day, previous_month.end_of_month.day ].max, chart.fetch("days")
+    assert_equal selected_month.end_of_month.day, chart.fetch("days")
+    assert_equal [ previous_month.end_of_month.day, selected_month.end_of_month.day ].min, previous.size
     # The chart needs the selected month's own length to label only its days
     # on narrow (mobile) widths.
     assert_equal selected_month.end_of_month.day, chart.fetch("current_days")
@@ -400,11 +403,11 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert chart.fetch("days") >= Date.current.day
   end
 
-  test "dashboard spending trend axis labels follow the month that owns each day" do
+  test "dashboard spending trend axis labels stay inside the selected month when the previous month is longer" do
     account = @family.accounts.create!(name: "Spending Trend Axis Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
 
     # Find a recent past month whose previous month is longer (e.g. February
-    # after January), so the axis has tail days owned by the previous month.
+    # after January), so the previous curve has days beyond the axis.
     selected_month = (1..11).map { |i| i.months.ago.beginning_of_month.to_date }
       .find { |m| (m - 1.month).end_of_month.day > m.end_of_month.day }
     previous_month = (selected_month - 1.month).beginning_of_month
@@ -419,12 +422,70 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     chart = spending_trend_chart_data
     labels = chart.fetch("axis_labels")
 
-    assert_equal previous_month.end_of_month.day, chart.fetch("days")
+    # The selected month always owns the axis, so no tick can roll into the
+    # previous month's dates (e.g. a September view ends at "Sep 30", not
+    # "Aug 31").
+    assert_equal selected_month.end_of_month.day, chart.fetch("days")
     assert_equal chart.fetch("days"), labels.size
     assert_equal I18n.l(selected_month, format: :short), labels.first
-    # The tail day belongs to the previous, longer month - not a date rolled
-    # past the selected month's end (e.g. "Jan 31", not "Mar 3").
-    assert_equal I18n.l(previous_month.end_of_month, format: :short), labels.last
+    assert_equal I18n.l(selected_month.end_of_month, format: :short), labels.last
+    expected_labels = (1..selected_month.end_of_month.day).map { |d| I18n.l(selected_month + (d - 1), format: :short) }
+    assert_equal expected_labels, labels
+  end
+
+  test "dashboard spending trend folds a longer previous month into the final axis point (February)" do
+    account = @family.accounts.create!(name: "Spending Trend Fold Feb Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
+
+    selected_month = Date.new(2026, 2, 1)  # 28 days, previous January has 31
+    create_transaction(account: account, name: "Jan mid", amount: 100, date: Date.new(2026, 1, 15))
+    create_transaction(account: account, name: "Jan extra day", amount: 40, date: Date.new(2026, 1, 31))
+    create_transaction(account: account, name: "Feb spend", amount: 25, date: Date.new(2026, 2, 10))
+
+    get root_path, params: { spending_month: selected_month.iso8601 }
+
+    assert_response :ok
+    chart = spending_trend_chart_data
+    previous = chart.fetch("previous")
+
+    # The January curve is clipped to February's 28-day axis, with day 31's
+    # spend folded into the final visible point so it still lands on the
+    # full-month total.
+    assert_equal 28, chart.fetch("days")
+    assert_equal 28, previous.size
+    expected_total = IncomeStatement.new(@family)
+      .daily_expense_series(period: Period.custom(start_date: Date.new(2026, 1, 1), end_date: Date.new(2026, 1, 31)))
+      .sum { |row| row.total.to_d }.to_f.round(2)
+    assert_equal 140.0, expected_total # sanity: no fixture transactions leaked into January
+    assert_equal expected_total, previous.last.fetch("value")
+    assert_equal 25.0, chart.fetch("current").last.fetch("value")
+
+    labels = chart.fetch("axis_labels")
+    assert_equal 28, labels.size
+    assert_equal I18n.l(Date.new(2026, 2, 28), format: :short), labels.last
+    assert_equal (1..28).map { |d| I18n.l(Date.new(2026, 2, d), format: :short) }, labels
+  end
+
+  test "dashboard spending trend folds a longer previous month into the final axis point (30-day month)" do
+    account = @family.accounts.create!(name: "Spending Trend Fold Jun Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
+
+    selected_month = Date.new(2026, 6, 1)  # 30 days, previous May has 31
+    create_transaction(account: account, name: "May mid", amount: 90, date: Date.new(2026, 5, 10))
+    create_transaction(account: account, name: "May extra day", amount: 60, date: Date.new(2026, 5, 31))
+    create_transaction(account: account, name: "Jun spend", amount: 15, date: Date.new(2026, 6, 5))
+
+    get root_path, params: { spending_month: selected_month.iso8601 }
+
+    assert_response :ok
+    chart = spending_trend_chart_data
+    previous = chart.fetch("previous")
+
+    assert_equal 30, chart.fetch("days")
+    assert_equal 30, previous.size
+    assert_equal 150.0, previous.last.fetch("value")
+
+    labels = chart.fetch("axis_labels")
+    assert_equal I18n.l(Date.new(2026, 6, 30), format: :short), labels.last
+    assert_equal (1..30).map { |d| I18n.l(Date.new(2026, 6, d), format: :short) }, labels
   end
 
   test "dashboard spending trend names the compared month in the comparison header" do

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -374,9 +374,10 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     current = chart.fetch("current")
     previous = chart.fetch("previous")
 
-    # Both months are past, so both curves run their full length.
+    # Both months are past, so the selected month's curve runs its full
+    # length; the previous curve runs its own length unless folded to the
+    # shorter axis.
     assert_equal selected_month.end_of_month.day, current.size
-    assert_equal previous_month.end_of_month.day, previous.size
 
     # Cumulative: each month's final point carries the month's total. When the
     # previous month is longer its curve is folded, but the final visible
@@ -457,6 +458,8 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
       .sum { |row| row.total.to_d }.to_f.round(2)
     assert_equal 140.0, expected_total # sanity: no fixture transactions leaked into January
     assert_equal expected_total, previous.last.fetch("value")
+    assert_equal "2026-01-31", previous.last.fetch("date")
+    assert_equal I18n.l(Date.new(2026, 1, 31), format: :short), previous.last.fetch("date_formatted")
     assert_equal 25.0, chart.fetch("current").last.fetch("value")
 
     labels = chart.fetch("axis_labels")


### PR DESCRIPTION
## Problem

On the dashboard spending comparison widget, the x axis spanned the **longer** of the two compared months. When the previous month had more days (e.g. Aug 31 vs Sep 30), the right-edge tick labels fell through to the previous month's dates - a September view ended at "Aug 31" instead of "Sep 30".

## Fix

The selected month now always owns the axis (`axis_days = month_end.day`). When the previous month is longer, its curve is clipped to the axis with the extra days' spend **folded into the final visible point**, so the curve still ends at the full-month total shown in the comparison header.

- `fold_extra_days(series, axis_days)` clips and folds the previous-month curve.
- `spending_trend_axis_labels` simplified: labels are always dates inside the selected month (no more previous-month tail labels).

## Tests

- Updated the two existing spending-trend specs that asserted the old shared-axis contract.
- New 30-day-month case (June view, previous May with 31 days) and February case (Feb 2026 view, previous January with 31 days): assert the axis labels stay inside the selected month, the previous curve is clipped to the axis length, and its folded final point equals the full-month total recomputed through `IncomeStatement.daily_expense_series`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spending trend charts now consistently match the number of days in the selected month.
  * Data from longer previous months is consolidated into the final visible chart point.
  * Consolidated points retain their actual dates for accurate tooltip details.
  * Chart labels now correspond exclusively to dates within the selected month.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->