### PR TITLE
Fix repository-wide ERB lint failures

### DIFF
--- a/app/views/DS/category_select/_option.html.erb
+++ b/app/views/DS/category_select/_option.html.erb
@@ -25,7 +25,7 @@
 
   <span data-category-select-badge>
     <%= view_helpers.render partial: "categories/badge",
-                       	    formats: [ :html ],
+                            formats: [ :html ],
                             locals: { category: category } %>
 
   </span>

--- a/app/views/impersonation_sessions/_approval_bar.html.erb
+++ b/app/views/impersonation_sessions/_approval_bar.html.erb
@@ -1,7 +1,7 @@
 <% pending_session = Current.true_user.impersonated_support_sessions.pending.first %>
 <% in_progress_session = Current.true_user.impersonated_support_sessions.in_progress.first %>
 
-<div class="sticky top-0 left-0 w-full bg-black flex items-center justify-between font-mono">
+<div class="sticky top-0 left-0 w-full bg-inverse flex items-center justify-between font-mono">
   <div class="flex items-center bg-red-600 text-inverse px-6 py-4">
     <%= icon "alert-triangle", size: "lg", color: "current", class: "mr-2" %>
     <span class="text-inverse font-semibold uppercase">Access <%= in_progress_session.present? ? "Session" : "Request" %></span>

--- a/app/views/impersonation_sessions/_approval_bar.html.erb
+++ b/app/views/impersonation_sessions/_approval_bar.html.erb
@@ -6,7 +6,7 @@
     <%= icon "alert-triangle", size: "lg", color: "current", class: "mr-2" %>
     <span class="text-inverse font-semibold uppercase">Access <%= in_progress_session.present? ? "Session" : "Request" %></span>
   </div>
-  <div class="flex items-center space-x-2 px-2 py-2 text-white gap-4">
+  <div class="flex items-center space-x-2 px-2 py-2 text-inverse gap-4">
     <% if pending_session.present? %>
       <p class="text-xs max-w-3xl text-right">Sure support staff has requested access to your account (likely to help you with a support request). If you approve the request, all activity they take will be logged for security and audit purposes.</p>
       <%= button_to "Approve", approve_impersonation_session_path(pending_session), method: :put, class: "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-green-500" %>

--- a/app/views/impersonation_sessions/_super_admin_bar.html.erb
+++ b/app/views/impersonation_sessions/_super_admin_bar.html.erb
@@ -9,9 +9,9 @@
     </div>
   <% end %>
 
-  <div class="flex items-center space-x-2 px-2 py-2 text-white">
+  <div class="flex items-center space-x-2 px-2 py-2 text-inverse">
     <% if Current.session.active_impersonator_session.present? %>
-      <div class="flex items-center space-x-3 bg-gray-800 border border-gray-700 rounded-md pl-3">
+      <div class="flex items-center space-x-3 bg-inverse border border-inverse rounded-md pl-3">
         <div class="text-sm">
           <%= t(".impersonating") %>: <span class="font-semibold text-red-400"><%= Current.impersonated_user.email %></span>
         </div>

--- a/app/views/impersonation_sessions/_super_admin_bar.html.erb
+++ b/app/views/impersonation_sessions/_super_admin_bar.html.erb
@@ -1,4 +1,4 @@
-<div class="sticky top-0 left-0 w-full bg-black flex items-center justify-between font-mono">
+<div class="sticky top-0 left-0 w-full bg-inverse flex items-center justify-between font-mono">
   <div class="flex items-center bg-red-600 px-6 py-4">
     <%= icon "alert-triangle", size: "lg", color: "current", class: "mr-2" %>
     <span class="text-inverse font-semibold uppercase"><%= t(".super_admin") %></span>

--- a/app/views/impersonation_sessions/_super_admin_bar.html.erb
+++ b/app/views/impersonation_sessions/_super_admin_bar.html.erb
@@ -11,7 +11,7 @@
 
   <div class="flex items-center space-x-2 px-2 py-2 text-inverse">
     <% if Current.session.active_impersonator_session.present? %>
-      <div class="flex items-center space-x-3 bg-inverse border border-inverse rounded-md pl-3">
+      <div class="flex items-center space-x-3 bg-inverse-hover border border-inverse rounded-md pl-3">
         <div class="text-sm">
           <%= t(".impersonating") %>: <span class="font-semibold text-red-400"><%= Current.impersonated_user.email %></span>
         </div>

--- a/app/views/layouts/print.html.erb
+++ b/app/views/layouts/print.html.erb
@@ -10,7 +10,7 @@
     <meta name="robots" content="noindex, nofollow">
   </head>
 
-  <body class="bg-white text-gray-900 antialiased print-body">
+  <body class="bg-container text-primary antialiased print-body">
     <div class="print-container">
       <%= yield %>
     </div>

--- a/app/views/pages/changelog.html.erb
+++ b/app/views/pages/changelog.html.erb
@@ -9,7 +9,7 @@
             <%= image_tag @release_notes[:avatar], class: "rounded-full w-full h-full object-cover" %>
           </div>
         <% else %>
-          <div class="bg-gray-300 text-gray-600 shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
+          <div class="bg-gray-300 text-secondary shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
             <%= @release_notes[:username]&.first&.upcase || "?" %>
           </div>
         <% end %>

--- a/app/views/pages/changelog.html.erb
+++ b/app/views/pages/changelog.html.erb
@@ -9,7 +9,7 @@
             <%= image_tag @release_notes[:avatar], class: "rounded-full w-full h-full object-cover" %>
           </div>
         <% else %>
-          <div class="bg-gray-300 text-secondary shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
+          <div class="bg-surface-inset text-secondary shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-sm font-medium">
             <%= @release_notes[:username]&.first&.upcase || "?" %>
           </div>
         <% end %>

--- a/app/views/settings/_user_avatar_field.html.erb
+++ b/app/views/settings/_user_avatar_field.html.erb
@@ -5,7 +5,7 @@
     <button type="button"
             data-profile-image-preview-target="clearBtn"
             data-action="click->profile-image-preview#clearFileInput"
-      class="<%= user.profile_image.attached? ? "" : "hidden" %> z-50 cursor-pointer absolute bottom-0 right-0 w-8 h-8 bg-surface-inset rounded-full flex justify-center items-center border border-white border-2">
+      class="<%= user.profile_image.attached? ? "" : "hidden" %> z-50 cursor-pointer absolute bottom-0 right-0 w-8 h-8 bg-surface-inset rounded-full flex justify-center items-center border border-inverse border-2">
       <%= icon "x", size: "sm" %>
     </button>
 

--- a/app/views/trading212_items/setup_accounts.html.erb
+++ b/app/views/trading212_items/setup_accounts.html.erb
@@ -136,7 +136,7 @@
         <% end %>
 
         <% if @linked_accounts.any? %>
-          <div class="<%= 'border-t border-primary pt-6 mt-4' if @unlinked_accounts.any? %>">
+          <div class="<%= "border-t border-primary pt-6 mt-4" if @unlinked_accounts.any? %>">
             <h3 class="font-medium text-primary mb-4"><%= t(".linked_accounts.title") %></h3>
             <% @linked_accounts.each do |t212_account| %>
               <div class="border border-success/20 bg-success/5 rounded-lg p-4 mb-2">


### PR DESCRIPTION
Closes #3447

## Summary

- replace deprecated raw color utilities with matching semantic design tokens
- normalize one tab-indented ERB argument and one single-quoted Ruby string
- clear the full repository ERB-lint baseline (11 violations across 7 templates)

## Validation

- `bundle exec erb_lint --lint-all` (692 files, no errors)
- `bin/rails test` (8,443 runs, 33,975 assertions, 0 failures, 0 errors)
- focused controller/rendering tests (95 runs, 346 assertions)
- `bin/rubocop -f github -a`
- `npm run lint` (123 files)
- `bin/brakeman --no-pager` (0 warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated impersonation controls and status bars to use theme-aware text, background, and border colors.
  - Improved print layout colors so backgrounds and text follow the active theme.
  - Updated changelog avatar placeholders and the clear-avatar control to use theme-aware styling.
  - Refined visual consistency across supported interfaces while preserving existing behavior and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->