### PR TITLE
Compare the same elapsed days in the spending widget header

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -503,10 +503,8 @@ class PagesController < ApplicationController
       axis_days = month_end.day
 
       current_series = cumulative_spending_series(current_period, current_daily)
-      previous_series = fold_extra_days(
-        cumulative_spending_series(previous_period, previous_daily),
-        axis_days
-      )
+      previous_header_series = cumulative_spending_series(previous_period, previous_daily)
+      previous_series = fold_extra_days(previous_header_series, axis_days)
 
       current_total = current_series.last&.fetch(:value) || 0
 
@@ -524,21 +522,22 @@ class PagesController < ApplicationController
       # day-of-month (Mar 30 has no Feb 30); it has fully elapsed by then, so
       # its complete total is the right comparison.
       #
-      # Once the selected month is over, both months are compared whole. The
-      # clamp must not apply here: a completed month shorter than the one
-      # before it (Feb after Jan) would otherwise truncate the previous month.
-      comparison_days = if current_period.end_date < month_end
-        [ current_series.size, previous_series.size ].min
+      # Once the selected month is over, both months are compared whole. A
+      # current month is still in progress through its final calendar day; the
+      # previous month may have one extra folded chart point (Sep 30 vs Aug 31),
+      # but the header should still compare only days 1-30.
+      comparison_days = if month_start == Date.current.beginning_of_month
+        [ current_series.size, previous_header_series.size ].min
       else
-        previous_series.size
+        previous_header_series.size
       end
 
-      previous_total = comparison_days.positive? ? previous_series[comparison_days - 1][:value] : 0
+      previous_total = comparison_days.positive? ? previous_header_series[comparison_days - 1][:value] : 0
 
       # Set only while the comparison stops short of the previous month's end,
       # so the header can say which days it is comparing instead of implying
       # the whole month.
-      previous_comparison_day = comparison_days if comparison_days.positive? && comparison_days < previous_series.size
+      previous_comparison_day = comparison_days if comparison_days.positive? && comparison_days < previous_header_series.size
 
       currency = income_statement.family.currency
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -510,20 +510,29 @@ class PagesController < ApplicationController
 
       current_total = current_series.last&.fetch(:value) || 0
 
-      # The header answers "how am I tracking against last month at this point
-      # in the month?", so it reads the previous month's curve at the same
-      # day-of-month the current period reached, not at its final day. Taking
-      # the last point of both series compared a month-to-date figure against a
-      # complete month, which made the delta a large, flattering negative on
-      # the 1st that shrank as the month filled in.
+      # How many days of the previous month the header compares against.
+      #
+      # While the selected month is still running, that is the number of days
+      # it has itself reached: the header answers "how am I tracking against
+      # last month at this point in the month?". Reading the last point of both
+      # series instead compared a month-to-date figure against a complete
+      # month, which made the delta a large, flattering negative on the 1st
+      # that shrank as the month filled in.
       # https://github.com/we-promise/sure/issues/3455
       #
-      # Clamped to the shorter series because the previous month can end before
-      # the current day-of-month (Mar 30 has no Feb 30); in that case it has
-      # fully elapsed, so its total is the right comparison. For a month that
-      # is already over, current_series spans the whole month and this is a
-      # no-op.
-      comparison_days = [ current_series.size, previous_series.size ].min
+      # It is clamped because the previous month can end before the current
+      # day-of-month (Mar 30 has no Feb 30); it has fully elapsed by then, so
+      # its complete total is the right comparison.
+      #
+      # Once the selected month is over, both months are compared whole. The
+      # clamp must not apply here: a completed month shorter than the one
+      # before it (Feb after Jan) would otherwise truncate the previous month.
+      comparison_days = if current_period.end_date < month_end
+        [ current_series.size, previous_series.size ].min
+      else
+        previous_series.size
+      end
+
       previous_total = comparison_days.positive? ? previous_series[comparison_days - 1][:value] : 0
 
       # Set only while the comparison stops short of the previous month's end,

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -507,38 +507,13 @@ class PagesController < ApplicationController
       previous_series = fold_extra_days(previous_header_series, axis_days)
 
       current_total = current_series.last&.fetch(:value) || 0
-
-      # How many days of the previous month the header compares against.
-      #
-      # While the selected month is still running, that is the number of days
-      # it has itself reached: the header answers "how am I tracking against
-      # last month at this point in the month?". Reading the last point of both
-      # series instead compared a month-to-date figure against a complete
-      # month, which made the delta a large, flattering negative on the 1st
-      # that shrank as the month filled in.
-      # https://github.com/we-promise/sure/issues/3455
-      #
-      # It is clamped because the previous month can end before the current
-      # day-of-month (Mar 30 has no Feb 30); it has fully elapsed by then, so
-      # its complete total is the right comparison.
-      #
-      # Once the selected month is over, both months are compared whole. A
-      # current month is still in progress through its final calendar day; the
-      # previous month may have one extra folded chart point (Sep 30 vs Aug 31),
-      # but the header should still compare only days 1-30.
       comparison_days = if month_start == Date.current.beginning_of_month
         [ current_series.size, previous_header_series.size ].min
       else
         previous_header_series.size
       end
-
       previous_total = comparison_days.positive? ? previous_header_series[comparison_days - 1][:value] : 0
-
-      # Set only while the comparison stops short of the previous month's end,
-      # so the header can say which days it is comparing instead of implying
-      # the whole month.
       previous_comparison_day = comparison_days if comparison_days.positive? && comparison_days < previous_header_series.size
-
       currency = income_statement.family.currency
 
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -481,7 +481,9 @@ class PagesController < ApplicationController
 
     # Cumulative daily spending for the selected month (capped at today while
     # the month is in progress) against the previous month's full curve, so
-    # the two lines share one day-of-month axis.
+    # the two lines share one day-of-month axis. The header totals compare the
+    # same number of elapsed days; only the chart draws the previous month out
+    # to its final day.
     def build_spending_trend_data(income_statement, selected_month)
       month_start = selected_month.beginning_of_month
       month_end = month_start.end_of_month
@@ -507,7 +509,28 @@ class PagesController < ApplicationController
       )
 
       current_total = current_series.last&.fetch(:value) || 0
-      previous_total = previous_series.last&.fetch(:value) || 0
+
+      # The header answers "how am I tracking against last month at this point
+      # in the month?", so it reads the previous month's curve at the same
+      # day-of-month the current period reached, not at its final day. Taking
+      # the last point of both series compared a month-to-date figure against a
+      # complete month, which made the delta a large, flattering negative on
+      # the 1st that shrank as the month filled in.
+      # https://github.com/we-promise/sure/issues/3455
+      #
+      # Clamped to the shorter series because the previous month can end before
+      # the current day-of-month (Mar 30 has no Feb 30); in that case it has
+      # fully elapsed, so its total is the right comparison. For a month that
+      # is already over, current_series spans the whole month and this is a
+      # no-op.
+      comparison_days = [ current_series.size, previous_series.size ].min
+      previous_total = comparison_days.positive? ? previous_series[comparison_days - 1][:value] : 0
+
+      # Set only while the comparison stops short of the previous month's end,
+      # so the header can say which days it is comparing instead of implying
+      # the whole month.
+      previous_comparison_day = comparison_days if comparison_days.positive? && comparison_days < previous_series.size
+
       currency = income_statement.family.currency
 
 
@@ -524,6 +547,7 @@ class PagesController < ApplicationController
         previous_total: Money.new(previous_total, currency),
         delta: Money.new(current_total - previous_total, currency),
         previous_label: I18n.l(previous_month_start, format: :month_year).capitalize,
+        previous_comparison_day: previous_comparison_day,
         date_range_short: spending_trend_compact_date_range(current_period)
       }
     end

--- a/app/views/pages/dashboard/_spending_trend.html.erb
+++ b/app/views/pages/dashboard/_spending_trend.html.erb
@@ -12,6 +12,7 @@
     previous: data[:previous]
   }
   previous_label = data[:previous_label]
+  previous_comparison_day = data[:previous_comparison_day]
   date_range_short = data[:date_range_short]
 %>
 <div id="spending-trend-section" class="px-4 space-y-4">
@@ -63,7 +64,14 @@
     <div class="flex items-center gap-3 min-w-0">
       <span class="w-1 h-10 rounded-full bg-subdued shrink-0"></span>
       <div class="min-w-0">
-        <p class="text-sm text-secondary capitalize truncate"><%= previous_label %></p>
+        <p class="text-sm text-secondary truncate">
+          <span class="capitalize"><%= previous_label %></span>
+          <%# While the selected month is still running, the figure below covers %>
+          <%# the same elapsed days rather than the whole previous month. %>
+          <% if previous_comparison_day %>
+            <span class="text-xs"><%= t(".previous_comparison_days", end_day: previous_comparison_day) %></span>
+          <% end %>
+        </p>
         <p class="font-medium text-lg tabular-nums text-secondary privacy-sensitive whitespace-nowrap"><%= format_money data[:previous_total] %></p>
       </div>
     </div>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -126,3 +126,4 @@ en:
         month_picker_aria_label: "Select month"
         period_scope_hint: "Shows the month you pick here — independent of the dashboard's time period at the top."
         no_data: "No spending data for this month"
+        previous_comparison_days: "(1-%{end_day})"

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -615,6 +615,33 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
       count: 0
   end
 
+  test "dashboard spending trend header compares complete months when the selected month is the shorter one" do
+    account = @family.accounts.create!(name: "Spending Trend Short Month Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
+    # A past month shorter than the one before it (e.g. February after January),
+    # where clamping to the shorter series would truncate the previous month.
+    selected_month = (1..11).map { |i| i.months.ago.beginning_of_month.to_date }
+      .find { |m| (m - 1.month).end_of_month.day > m.end_of_month.day }
+    previous_month = (selected_month - 1.month).beginning_of_month
+
+    create_transaction(account: account, name: "Selected", amount: 50, date: selected_month)
+    create_transaction(account: account, name: "Previous early", amount: 111, date: previous_month)
+    create_transaction(account: account, name: "Previous last day", amount: 999, date: previous_month.end_of_month)
+
+    get root_path, params: { spending_month: selected_month.iso8601 }
+    assert_response :ok
+
+    previous_series = spending_trend_chart_data.fetch("previous")
+    _current_total, previous_total = spending_trend_header_totals
+
+    # Both months are over, so both are compared whole - the selected month
+    # being shorter must not truncate the previous month's total.
+    assert_operator previous_series.last.fetch("value"), :>, previous_series.fetch(selected_month.end_of_month.day - 1).fetch("value")
+    assert_equal money_text(previous_series.last.fetch("value")), previous_total
+    assert_select "#spending-trend-section span",
+      text: I18n.t("pages.dashboard.spending_trend.previous_comparison_days", end_day: selected_month.end_of_month.day),
+      count: 0
+  end
+
   test "dashboard spending trend header clamps to a previous month shorter than today" do
     # A month longer than the one before it (e.g. March after February), frozen
     # to a day that the previous month never reaches.

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -592,6 +592,32 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "dashboard spending trend header treats current month final day as in progress" do
+    selected_month = (0..24).map { |i| i.months.ago.beginning_of_month.to_date }
+      .find { |m| (m - 1.month).end_of_month.day > m.end_of_month.day }
+    previous_month = (selected_month - 1.month).beginning_of_month
+
+    travel_to selected_month.end_of_month do
+      account = @family.accounts.create!(name: "Spending Trend Final Day Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
+
+      create_transaction(account: account, name: "Prev early", amount: 111, date: previous_month)
+      create_transaction(account: account, name: "Prev extra day", amount: 999, date: previous_month.end_of_month)
+      create_transaction(account: account, name: "Current", amount: 7, date: Date.current)
+
+      get root_path, params: { spending_month: selected_month.iso8601 }
+      assert_response :ok
+
+      previous_series = spending_trend_chart_data.fetch("previous")
+      _current_total, previous_total = spending_trend_header_totals
+
+      assert_equal previous_month.end_of_month.iso8601, previous_series.last.fetch("date")
+      assert_equal money_text(111), previous_total
+      refute_equal money_text(previous_series.last.fetch("value")), previous_total
+      assert_select "#spending-trend-section span",
+        text: I18n.t("pages.dashboard.spending_trend.previous_comparison_days", end_day: Date.current.day)
+    end
+  end
+
   test "dashboard spending trend header compares complete months once the month is over" do
     account = @family.accounts.create!(name: "Spending Trend Past Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
     selected_month = 2.months.ago.beginning_of_month.to_date

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -635,7 +635,8 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
 
     # Both months are over, so both are compared whole - the selected month
     # being shorter must not truncate the previous month's total.
-    assert_operator previous_series.last.fetch("value"), :>, previous_series.fetch(selected_month.end_of_month.day - 1).fetch("value")
+    assert_equal previous_month.end_of_month.iso8601, previous_series.last.fetch("date")
+    assert_equal 1110.0, previous_series.last.fetch("value")
     assert_equal money_text(previous_series.last.fetch("value")), previous_total
     assert_select "#spending-trend-section span",
       text: I18n.t("pages.dashboard.spending_trend.previous_comparison_days", end_day: selected_month.end_of_month.day),

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -546,6 +546,105 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal Date.current.beginning_of_month.iso8601, chart.fetch("current").first.fetch("date")
   end
 
+  test "dashboard spending trend header compares the same elapsed days in both months" do
+    # Mid-month so the previous month always has spending both on or before and
+    # after the current day-of-month, whatever day the suite runs on.
+    travel_to Date.current.beginning_of_month + 14.days do
+      account = @family.accounts.create!(name: "Spending Trend Aligned Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
+      previous_month = (Date.current.beginning_of_month - 1.month).beginning_of_month
+
+      create_transaction(account: account, name: "Prev early", amount: 111, date: previous_month)
+      create_transaction(account: account, name: "Prev late", amount: 999, date: previous_month.end_of_month)
+      create_transaction(account: account, name: "Current", amount: 7, date: Date.current)
+
+      get root_path, params: { spending_month: Date.current.beginning_of_month.iso8601 }
+      assert_response :ok
+
+      chart = spending_trend_chart_data
+      previous_series = chart.fetch("previous")
+      aligned = previous_series.fetch(Date.current.day - 1).fetch("value")
+      full_month = previous_series.last.fetch("value")
+      current_value = chart.fetch("current").last.fetch("value")
+
+      # The late transaction guarantees the two figures differ, so this pins
+      # which one the header reads.
+      assert_operator full_month, :>, aligned
+
+      _current_total, previous_total = spending_trend_header_totals
+      assert_equal money_text(aligned), previous_total
+      refute_equal money_text(full_month), previous_total
+
+      # The delta must be built from the same day-aligned figure.
+      assert_equal money_text(current_value - aligned), spending_trend_header_delta
+    end
+  end
+
+  test "dashboard spending trend header labels the days it compares while the month is in progress" do
+    travel_to Date.current.beginning_of_month + 14.days do
+      account = @family.accounts.create!(name: "Spending Trend Label Days Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
+      create_transaction(account: account, name: "Spend", amount: 10, date: Date.current)
+
+      get root_path, params: { spending_month: Date.current.beginning_of_month.iso8601 }
+      assert_response :ok
+
+      assert_select "#spending-trend-section span",
+        text: I18n.t("pages.dashboard.spending_trend.previous_comparison_days", end_day: Date.current.day)
+    end
+  end
+
+  test "dashboard spending trend header compares complete months once the month is over" do
+    account = @family.accounts.create!(name: "Spending Trend Past Checking", currency: @family.currency, balance: 0, accountable: Depository.new)
+    selected_month = 2.months.ago.beginning_of_month.to_date
+    previous_month = 3.months.ago.beginning_of_month.to_date
+
+    create_transaction(account: account, name: "Selected", amount: 50, date: selected_month)
+    create_transaction(account: account, name: "Previous early", amount: 111, date: previous_month)
+    create_transaction(account: account, name: "Previous late", amount: 999, date: previous_month.end_of_month)
+
+    get root_path, params: { spending_month: selected_month.iso8601 }
+    assert_response :ok
+
+    previous_series = spending_trend_chart_data.fetch("previous")
+    _current_total, previous_total = spending_trend_header_totals
+
+    # A month that has fully elapsed is still compared whole-to-whole.
+    assert_equal money_text(previous_series.last.fetch("value")), previous_total
+    # ...and the header does not claim to be comparing a partial range.
+    assert_select "#spending-trend-section span",
+      text: I18n.t("pages.dashboard.spending_trend.previous_comparison_days", end_day: selected_month.end_of_month.day),
+      count: 0
+  end
+
+  test "dashboard spending trend header clamps to a previous month shorter than today" do
+    # A month longer than the one before it (e.g. March after February), frozen
+    # to a day that the previous month never reaches.
+    selected_month = (1..11).map { |i| i.months.ago.beginning_of_month.to_date }
+      .find { |m| (m - 1.month).end_of_month.day < m.end_of_month.day }
+    previous_month = (selected_month - 1.month).beginning_of_month
+
+    # The day after the previous month's last day, which the selected month
+    # always reaches because it is the longer of the two.
+    travel_to selected_month + previous_month.end_of_month.day.days do
+      account = @family.accounts.create!(name: "Spending Trend Clamp Checking 2", currency: @family.currency, balance: 0, accountable: Depository.new)
+      create_transaction(account: account, name: "Prev", amount: 40, date: previous_month.end_of_month)
+      create_transaction(account: account, name: "Current", amount: 5, date: selected_month)
+
+      assert_operator Date.current.day, :>, previous_month.end_of_month.day
+
+      get root_path, params: { spending_month: selected_month.iso8601 }
+      assert_response :ok
+
+      previous_series = spending_trend_chart_data.fetch("previous")
+      _current_total, previous_total = spending_trend_header_totals
+
+      # There is no day 30 in February: the previous month has fully elapsed, so
+      # its complete total is the comparison. Without the clamp this read past
+      # the end of the series and showed zero.
+      assert_equal money_text(previous_series.last.fetch("value")), previous_total
+      refute_equal money_text(0), previous_total
+    end
+  end
+
   private
     def money_flow_bars
       JSON.parse(css_select("[data-controller='bar-chart']").first["data-bar-chart-data-value"])
@@ -553,5 +652,19 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
 
     def spending_trend_chart_data
       JSON.parse(css_select("[data-controller='spending-chart']").first["data-spending-chart-data-value"])
+    end
+
+    # The two large figures in the widget header: the selected month's
+    # month-to-date total and the previous month's comparison total.
+    def spending_trend_header_totals
+      css_select("#spending-trend-section .text-lg").map { |node| node.text.strip }
+    end
+
+    def spending_trend_header_delta
+      css_select("#spending-trend-section span.text-sm.tabular-nums").first.text.strip
+    end
+
+    def money_text(amount)
+      ApplicationController.helpers.format_money(Money.new(amount, @family.currency))
     end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -646,8 +646,8 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
   test "dashboard spending trend header clamps to a previous month shorter than today" do
     # A month longer than the one before it (e.g. March after February), frozen
     # to a day that the previous month never reaches.
-    selected_month = (1..11).map { |i| i.months.ago.beginning_of_month.to_date }
-      .find { |m| (m - 1.month).end_of_month.day < m.end_of_month.day }
+    selected_month = (1..24).map { |i| i.months.ago.beginning_of_month.to_date }
+      .find { |m| (m - 1.month).end_of_month.day < m.end_of_month.day - 1 }
     previous_month = (selected_month - 1.month).beginning_of_month
 
     # The day after the previous month's last day, which the selected month
@@ -658,6 +658,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
       create_transaction(account: account, name: "Current", amount: 5, date: selected_month)
 
       assert_operator Date.current.day, :>, previous_month.end_of_month.day
+      assert_operator Date.current, :<, selected_month.end_of_month
 
       get root_path, params: { spending_month: selected_month.iso8601 }
       assert_response :ok


### PR DESCRIPTION
## Problem

Fixes #3455.

The dashboard spending widget builds two periods with deliberately different end dates: the selected month is capped at today while it is in progress, the previous month always runs to its final day. That asymmetry is correct for the **chart**, where the grey line is meant to be a full-month reference, but the header totals were read off the last point of each series:

```ruby
current_total  = current_series.last&.fetch(:value) || 0   # cumulative through TODAY
previous_total = previous_series.last&.fetch(:value) || 0  # cumulative through MONTH END
```

So the header compared **month-to-date against a complete previous month**, and `delta` inherited the mismatch.

Reproduced on `main` (`eff81c2da`) with $111 on Aug 1, $999 on Aug 31, $7 on Sep 8 (today):

```
September 2026   $117.00   -$993.00      August 2026   $1,110.00
```

August's cumulative at day 8 is `111.0`. The header showed `1110.0`.

Two points beyond the original report:

- **It is systematically flattering, not just wrong.** Negative deltas render `text-success`, so early each month a near-zero month-to-date against a full previous month produced a large green "saving" that shrank as the month filled in.
- **Only an in-progress month is affected.** Pick a past month and both periods are complete. That is why this slipped through: the existing tests cover the past-month path, and none of them asserted the header totals at all.

## Fix

Read the previous month's curve at the day the current period actually reached:

```ruby
comparison_days = if current_period.end_date < month_end
  [ current_series.size, previous_series.size ].min
else
  previous_series.size
end

previous_total = comparison_days.positive? ? previous_series[comparison_days - 1][:value] : 0
```

The clamp is load-bearing. Indexing naively at `current_series.size - 1` runs off the end of a previous month shorter than today's day-of-month (Mar 30 has no Feb 30) and reports **$0**. Clamping falls back to February's complete total, which is correct because February has fully elapsed.

It is gated on the month still being in progress. Applied unconditionally, a *completed* month shorter than the one before it (February after January) would read January at day 28 instead of its final day. Past-month behaviour is unchanged.

The chart payload is untouched: the previous month still draws in full.

The previous-month label now names the days it compares while the month is in progress (`August 2026 (1-15)`), so the figure no longer implies a whole month. One new `en.yml` key; other locales fall back until translated.

## Alternative considered

Always comparing equal day counts, so a past February (28 days) would compare against only the first 28 days of January, is arguably more principled, but it changes past-month semantics and breaks the existing `"accumulates the selected month against the previous one"` test. I judged that out of scope for a bug fix. Happy to switch if maintainers prefer it.

## Tests

Four new tests in `test/controllers/pages_controller_test.rb`, plus one asserting the partial-range label.

One of them exists because an unconditional clamp shipped in the first draft of this branch and a review bot caught it. The trap is worth flagging: the pre-existing coverage uses `2.months.ago`, which currently resolves to July against June, where the selected month is the *longer* one, so the clamp was a no-op and everything stayed green. The new test searches for a shorter-after-longer month pairing rather than depending on where the calendar happens to fall.

Each test was checked to earn its place by reverting the implementation three ways:

| Implementation | Result |
|---|---|
| Original (`previous_series.last`) | day-alignment test fails, `$1,110.00` vs expected `$111.00` |
| Naive unclamped (`previous_series[current_series.size - 1]`) | clamp test **and** past-month regression test both fail |
| Unconditional clamp | shorter-completed-month test fails, `$111.00` vs expected `$1,110.00` |
| This PR | all pass |

The five pre-existing spending-trend tests pass **unmodified**, which is the check that past-month behaviour did not shift.

## Verification

CI green on a fork PR against this exact base (`jaysbeekay/sure#88`): `scan_ruby`, `scan_js`, `lint`, `lint_js`, `test_unit`, `test_system` and Codacy all passing, including the system tests.

Locally: full suite 8463 runs / 34068 assertions / 0 failures / 0 errors; `bin/rubocop` clean; `erb_lint` clean; `bin/brakeman` 0 warnings.

Opened as a draft. Happy to adjust the labelling or switch to the equal-day-count alternative before it goes up for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spending trend comparisons now align with the same elapsed days in the current and previous months.
  * The final day of the current month is correctly treated as in progress.
  * Partial comparisons are capped when the previous month has fewer available days.

* **Enhancements**
  * In-progress months display the comparable day range for clearer context.
  * Completed months use full-month totals for comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->