### PR TITLE
fix(l10n): localize import template guidance

### DIFF
--- a/app/views/import/configurations/show.html.erb
+++ b/app/views/import/configurations/show.html.erb
@@ -12,14 +12,14 @@
           <%= icon "sparkles" %>
         </span>
 
-        Template configuration found
+        <%= t(".template_found") %>
       </h3>
 
-      <p class="text-sm text-secondary">We found a configuration from a previous import for this account.  Would you like to apply it to this import?</p>
+      <p class="text-sm text-secondary"><%= t(".template_description") %></p>
 
       <div class="mt-4 flex gap-2 items-center">
-        <%= render DS::Link.new(text: "Manually configure", href: import_configuration_path(@import), variant: "outline") %>
-        <%= render DS::Button.new(text: "Apply template", href: apply_template_import_path(@import), method: :put, data: { turbo_frame: :_top }) %>
+        <%= render DS::Link.new(text: t(".manually_configure"), href: import_configuration_path(@import), variant: "outline") %>
+        <%= render DS::Button.new(text: t(".apply_template"), href: apply_template_import_path(@import), method: :put, data: { turbo_frame: :_top }) %>
       </div>
     </div>
   </div>
@@ -32,7 +32,7 @@
 
     <div class="mx-auto max-w-lg space-y-4">
       <%= render partial: permitted_import_configuration_path(@import), locals: { import: @import } %>
-      <%= render "imports/table", headers: @import.csv_headers, rows: @import.csv_sample, caption: "Sample data from your uploaded CSV" %>
+      <%= render "imports/table", headers: @import.csv_headers, rows: @import.csv_sample, caption: t(".sample_caption") %>
     </div>
   </div>
 <% end %>

--- a/config/locales/views/imports/de.yml
+++ b/config/locales/views/imports/de.yml
@@ -68,6 +68,11 @@ de:
       show:
         description: Wähle die Spalten aus, die den jeweiligen Feldern in deiner CSV entsprechen.
         title: Import konfigurieren
+        template_found: Importvorlage gefunden
+        template_description: Wir haben eine Konfiguration aus einem früheren Import für dieses Konto gefunden. Möchtest du sie für diesen Import übernehmen?
+        manually_configure: Manuell konfigurieren
+        apply_template: Vorlage übernehmen
+        sample_caption: Beispieldaten aus deiner hochgeladenen CSV-Datei
       trade_import:
         date_format_label: Datumsformat
         account_label: Konto

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -163,6 +163,11 @@ en:
       show:
         description: Select the columns that correspond to each field in your CSV.
         title: Configure your import
+        template_found: Template configuration found
+        template_description: We found a configuration from a previous import for this account.  Would you like to apply it to this import?
+        manually_configure: Manually configure
+        apply_template: Apply template
+        sample_caption: Sample data from your uploaded CSV
     confirms:
       sure_import:
         title: Confirm your import

--- a/test/controllers/import/configurations_controller_test.rb
+++ b/test/controllers/import/configurations_controller_test.rb
@@ -11,6 +11,55 @@ class Import::ConfigurationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "template suggestion renders German copy and preserves action destinations" do
+    ensure_tailwind_build
+    @user.update!(locale: "de")
+    %w[template_found template_description manually_configure apply_template sample_caption].each do |key|
+      assert I18n.exists?("import.configurations.show.#{key}", :de, fallback: false)
+    end
+    @user.family.imports.create!(type: "TransactionImport", status: "complete")
+
+    get import_configuration_url(@import, template_hint: true)
+
+    assert_response :success
+    assert_select "h3", text: "Importvorlage gefunden"
+    assert_select "p", text: "Wir haben eine Konfiguration aus einem früheren Import für dieses Konto gefunden. Möchtest du sie für diesen Import übernehmen?"
+    assert_select "a[href=?]", import_configuration_path(@import), text: "Manuell konfigurieren"
+    assert_select "form[action=?][method=post]", apply_template_import_path(@import) do
+      assert_select "input[name=_method][value=put]"
+      assert_select "button", text: "Vorlage übernehmen"
+    end
+  end
+
+  test "template suggestion preserves English copy" do
+    ensure_tailwind_build
+    @user.update!(locale: "en")
+    @user.family.imports.create!(type: "TransactionImport", status: "complete")
+
+    get import_configuration_url(@import, template_hint: true)
+
+    assert_response :success
+    assert_select "h3", text: "Template configuration found"
+    assert_select "p", text: "We found a configuration from a previous import for this account. Would you like to apply it to this import?"
+    assert_select "a", text: "Manually configure"
+    assert_select "button", text: "Apply template"
+    get import_configuration_url(@import)
+    assert_select "h2", text: "Sample data from your uploaded CSV"
+  end
+
+  test "manual configuration localizes the sample caption without translating CSV data" do
+    ensure_tailwind_build
+    @user.update!(locale: "de")
+    @import.update!(raw_file_str: "Date,Name,Amount\n2026-01-02,Synthetic Sample,12.34\n", col_sep: ",")
+
+    get import_configuration_url(@import, template_hint: true)
+
+    assert_response :success
+    assert_select "h2", text: "Beispieldaten aus deiner hochgeladenen CSV-Datei"
+    assert_includes response.body, "Synthetic Sample"
+    assert_select "h3", text: "Importvorlage gefunden", count: 0
+  end
+
   test "show renders the YNAB configuration partial" do
     ynab = @user.family.imports.create!(
       type: "YnabImport",


### PR DESCRIPTION
## Summary

German users now see translated guidance when a previous import configuration is available, instead of English instructions and action labels. The CSV sample heading is translated too.

This is an independent continuation of the German localization work. Template selection, applying a template, and uploaded CSV content remain unchanged; English output is preserved. German wording received an independent AI language review.

## Validation

- Full Rails suite: 8,461 runs, 34,073 assertions, no failures or errors; 31 skips.
- Focused controller and locale checks: 13 runs, 231 assertions, no failures or errors; four existing locale-test skips.
- Existing import system tests: six runs, 24 assertions, all green.
- German suggestion and sample-heading rendering inspected at narrow and wide desktop widths; controls remain visible without clipping.
- RuboCop, ERB lint, Biome and Brakeman pass.
- Code review completed; the missing English description and sample-heading assertions were added and verified.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes presentation text only. On the next deployment, verify the German template suggestion and manual configuration sample heading with synthetic CSV data. Existing import behavior should remain unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localized German and English text for CSV import template suggestions, including descriptions, action labels, and sample-data captions.
  - The import configuration screen now displays translated content based on the selected language.

- **Bug Fixes**
  - Preserved action destinations and ensured uploaded CSV sample data remains unchanged while surrounding labels are translated.

- **Tests**
  - Added coverage for English and German template suggestions, action links, captions, and scenarios without a detected template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->