### PR TITLE
fix(enable-banking): don't let a payment wallet prefix claim the merchant

### DIFF
--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -6,6 +6,18 @@ class EnableBankingEntry::Processor
   # Small-merchant card terminal providers that prefix the payee with "KEYWORD *"
   PAYMENT_PROCESSOR_PREFIX = /\A(SUMUP|SQ|IZETTLE|ZETTLE|PAYPAL)\s*\*\s*/i
 
+  # Payment wallets that some ASPSPs prefix onto the descriptor of a card
+  # purchase, e.g. "Apple pay: <payee and terminal text>". The wallet is how the
+  # card was presented, not who was paid, so it is stripped before anything reads
+  # the remittance text.
+  #
+  # Without this, a family that already knows a merchant named after the wallet
+  # -- which happens after one purchase from that brand's own store, since
+  # Family#known_merchant_names contains every merchant already assigned to a
+  # transaction -- has every wallet-paid transaction named after the wallet and
+  # assigned to it, and the real payee is never read.
+  WALLET_PREFIX = /\A(?:apple|google|samsung)\s+pay\s*:\s*/i
+
   # Guard against spurious matches from very short known merchant names (e.g. a
   # 2-letter FamilyMerchant name matching inside unrelated text, like "IT" would
   # inside "NAME IT" -- a real chain name observed in this issue's own data).
@@ -240,10 +252,20 @@ class EnableBankingEntry::Processor
       matched_known_merchant_name(descriptive) || strip_payment_processor_prefix(descriptive)
     end
 
+    # The remittance lines describing who was paid, one per element, with any
+    # payment-wallet prefix removed and blank lines dropped.
+    #
+    # Stripping WALLET_PREFIX here rather than at each call site keeps every
+    # consumer -- the known-merchant match, the merchant candidate and the entry
+    # name -- looking at the payee instead of the wallet. #notes deliberately
+    # reads data[:remittance_information] directly, so the wallet used to pay is
+    # still recorded on the transaction.
+    #
+    # @return [Array<String>] non-blank remittance lines, wallet prefix removed
     def remittance_information_lines
       remittance = data[:remittance_information]
       Array.wrap(remittance)
-        .map { |value| value.to_s.strip.presence }
+        .map { |value| value.to_s.strip.sub(WALLET_PREFIX, "").strip.presence }
         .compact
     end
 

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -291,6 +291,70 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  # --- payment wallet prefixes ---
+
+  test "a payment wallet prefix does not claim the transaction for the wallet's merchant" do
+    @family.merchants.create!(name: "Apple")
+    @family.merchants.create!(name: "Acme")
+
+    tx = {
+      entry_reference: "ref_wallet_prefix",
+      transaction_id: nil,
+      booking_date: Date.current.to_s,
+      transaction_amount: { amount: "17.95", currency: "EUR" },
+      creditor: { name: "" },
+      bank_transaction_code: nil,
+      credit_debit_indicator: "DBIT",
+      remittance_information: [ "Apple pay: ACME 0001234" ],
+      status: "BOOK"
+    }
+
+    EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+    entry = @account.entries.find_by!(external_id: "enable_banking_ref_wallet_prefix")
+
+    assert_equal "Acme", entry.name
+    assert_equal "Acme", entry.transaction.merchant&.name
+    # The wallet is still recorded: notes read remittance_information directly.
+    assert_includes entry.notes, "Apple pay:"
+  end
+
+  test "a purchase from the wallet brand itself still resolves to that brand" do
+    @family.merchants.create!(name: "Apple")
+
+    tx = {
+      entry_reference: "ref_wallet_own_brand",
+      transaction_id: nil,
+      booking_date: Date.current.to_s,
+      transaction_amount: { amount: "0.99", currency: "EUR" },
+      creditor: { name: "" },
+      bank_transaction_code: nil,
+      credit_debit_indicator: "DBIT",
+      remittance_information: [ "Apple pay: APPLE 0001234" ],
+      status: "BOOK"
+    }
+
+    EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+    entry = @account.entries.find_by!(external_id: "enable_banking_ref_wallet_own_brand")
+
+    assert_equal "Apple", entry.name
+    assert_equal "Apple", entry.transaction.merchant&.name
+  end
+
+  test "strips every supported wallet prefix before matching a known merchant" do
+    %w[Apple Google Samsung Acme].each { |merchant_name| @family.merchants.create!(name: merchant_name) }
+
+    [ "Apple pay: ACME 0001234", "Google pay: ACME 0001234", "Samsung pay: ACME 0001234" ].each do |raw_line|
+      name = build_name_with_family(
+        credit_debit_indicator: "DBIT",
+        creditor: { name: "" },
+        bank_transaction_code: nil,
+        remittance_information: [ raw_line ]
+      )
+
+      assert_equal "Acme", name, "expected #{raw_line.inspect} to resolve to \"Acme\""
+    end
+  end
+
   test "does not match a known merchant name shorter than the minimum match length" do
     @family.merchants.create!(name: "IT")
 


### PR DESCRIPTION
Fixes #3449.

`EnableBankingEntry::Processor#primary_remittance_information` matches known
merchant names against the raw remittance line, before any prefix is stripped:

```ruby
matched_known_merchant_name(descriptive) || strip_payment_processor_prefix(descriptive)
```

Openbank (ES) prefixes card purchases with the wallet used —
`Apple pay: COMPRA EN ZARA, CON LA TARJETA : ...`. Because
`Family#known_merchant_names` contains every merchant already assigned to a
transaction, a single genuine App Store purchase puts `Apple` in that list, and
from then on the matcher hits the wallet prefix rather than the shop. Both the
name and the merchant are set to `Apple`, and the real shop is never read.
`PAYMENT_PROCESSOR_PREFIX` does not cover wallets, and sits on a branch that
never runs once a known name matched.

This strips the wallet prefix in `remittance_information_lines`, at the source,
so the known-merchant match, the merchant candidate and the name all see the
shop. `#notes` reads `data[:remittance_information]` directly and is untouched,
so which wallet was used is still recorded.

### Behaviour

| remittance | before | after |
|---|---|---|
| `Apple pay: COMPRA EN ZARA, …` | `Apple` | `Zara` |
| `Apple pay: COMPRA EN APPLE.COM/BILL, …` | `Apple` | `Apple` |
| `Apple pay: COMPRA EN <unknown shop>, …` | `Apple` | the descriptor, no merchant |

### Tests

Three added to `test/models/enable_banking_entry/processor_test.rb`, following
the conventions already there (`@family.merchants.create!`,
`build_name_with_family`): a wallet prefix must not claim the transaction and
the wallet must still appear in `notes`; a genuine purchase from the wallet's
own brand still resolves to it; all three supported prefixes strip.

```
processor_test.rb      42 runs, 83 assertions, 0 failures   (39 before)
all enable_banking     136 runs, 291 assertions, 0 failures
```

### Notes for review

- The change is wider than the reported symptom: it shortens the *name* of every
  Enable Banking transaction whose remittance begins with a wallet prefix, not
  only the ones a known merchant was wrongly claiming. On an affected instance
  those names update on the next sync. A category rule matching the literal text
  `apple pay` would stop matching — worth a release note.
- A remittance line consisting only of `Apple pay:` now collapses to blank and is
  dropped by the existing `.presence.compact`. That seems right, since it carries
  no payee, but it is a behaviour change rather than a no-op.
- `WALLET_PREFIX` is a fixed list, deliberately mirroring the existing
  `PAYMENT_PROCESSOR_PREFIX` constant directly above it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved merchant identification for wallet payments by ignoring Apple Pay, Google Pay, and Samsung Pay labels when they appear before merchant information.
  - Purchases made directly from a supported wallet brand continue to resolve to the correct merchant.
  - Original payment description details remain available in transaction notes.

- **Tests**
  - Added coverage for wallet-prefixed payment descriptions and merchant matching across supported payment wallets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->