### PR TITLE
Fix parent budget overage and shared child status

### DIFF
--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -258,37 +258,22 @@ class BudgetCategory < ApplicationRecord
 
   def available_to_spend
     if inherits_parent_budget?
-      # Subcategories using parent budget share the parent's available_to_spend
+      # A shared subcategory can use its parent's positive balance, but it does
+      # not own the parent's overspending. Copying a negative balance makes an
+      # inactive $0 child appear over budget by the parent's amount.
       parent = parent_budget_category
       return 0 unless parent
-      parent.available_to_spend
+
+      [ parent.available_to_spend, 0 ].max
     elsif subcategory?
       # Subcategory with individual limit
       (self[:budgeted_spending] || 0) + rolled_over_amount - actual_spending
     else
-      # Parent category
-      parent_budget = (self[:budgeted_spending] || 0) + rolled_over_amount
-
-      # Get subcategories with and without individual limits
-      subcategories_with_limits = subcategories.reject(&:inherits_parent_budget?)
-
-      # Ring-fenced budgets for subcategories with individual limits
-      subcategories_individual_budgets = subcategories_with_limits.sum { |sc| sc[:budgeted_spending] || 0 }
-
-      # Shared pool = parent budget - ring-fenced budgets
-      shared_pool = parent_budget - subcategories_individual_budgets
-
-      # Get actual spending from income statement (includes all subcategories)
-      total_spending = actual_spending
-
-      # Subtract spending from subcategories with individual budgets (they use their ring-fenced money)
-      subcategories_with_limits_spending = subcategories_with_limits.sum(&:actual_spending)
-
-      # Spending from shared pool = total spending - ring-fenced spending
-      shared_pool_spending = total_spending - subcategories_with_limits_spending
-
-      # Available in shared pool
-      shared_pool - shared_pool_spending
+      # A parent card displays its full allocation and total spending (including
+      # all children), so the available amount must reconcile with those same
+      # figures. Child allocations are already included in the parent's stored
+      # budget and must not be subtracted a second time here.
+      (self[:budgeted_spending] || 0) + rolled_over_amount - actual_spending
     end
   end
 

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -230,7 +230,7 @@ class BudgetCategory < ApplicationRecord
   end
 
   def rolled_over?
-    rolled_over_amount.positive?
+    display_rolled_over_amount.positive?
   end
 
   # Returns true if this subcategory has no individual budget limit and should use parent's budget
@@ -332,12 +332,14 @@ class BudgetCategory < ApplicationRecord
     (display_budgeted_spending.to_d + display_rolled_over_amount.to_d).positive?
   end
 
-  # Sibling of `display_budgeted_spending`: a subcategory sharing its
-  # parent's budget shares its parent's carry as well.
+  # Sibling of `display_budgeted_spending`: shared children show the parent's
+  # shared carry, while parents aggregate carry held by ring-fenced children so
+  # their displayed budget, rollover, spending, and availability reconcile.
   def display_rolled_over_amount
-    return rolled_over_amount unless inherits_parent_budget?
+    return parent_budget_category&.rolled_over_amount || 0 if inherits_parent_budget?
+    return rolled_over_amount if subcategory?
 
-    parent_budget_category&.rolled_over_amount || 0
+    rolled_over_amount + subcategories.reject(&:inherits_parent_budget?).sum(&:rolled_over_amount)
   end
 
   def unbudgeted_with_spending?

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -258,13 +258,18 @@ class BudgetCategory < ApplicationRecord
 
   def available_to_spend
     if inherits_parent_budget?
-      # A shared subcategory can use its parent's positive balance, but it does
-      # not own the parent's overspending. Copying a negative balance makes an
-      # inactive $0 child appear over budget by the parent's amount.
       parent = parent_budget_category
       return 0 unless parent
 
-      [ parent.available_to_spend, 0 ].max
+      # Shared children can use only the portion of the parent allocation that
+      # is not reserved for ring-fenced siblings. Their spending is the parent
+      # aggregate less those siblings' spending.
+      ring_fenced_children = parent.subcategories.reject(&:inherits_parent_budget?)
+      shared_budget = (parent[:budgeted_spending] || 0) + parent.rolled_over_amount -
+                      ring_fenced_children.sum { |child| child[:budgeted_spending] || 0 }
+      shared_spending = parent.actual_spending - ring_fenced_children.sum(&:actual_spending)
+
+      [ shared_budget - shared_spending, 0 ].max
     elsif subcategory?
       # Subcategory with individual limit
       (self[:budgeted_spending] || 0) + rolled_over_amount - actual_spending
@@ -288,16 +293,20 @@ class BudgetCategory < ApplicationRecord
   # allocation alone: a category funded only by rollover has money to spend.
   def percent_of_budget_spent
     if inherits_parent_budget?
-      # For subcategories using parent budget, show their spending as percentage of parent's budget
       parent = parent_budget_category
       return 0 unless parent
 
-      parent_budget = (parent[:budgeted_spending] || 0) + parent.rolled_over_amount
-      return 0 if parent_budget == 0 && actual_spending == 0
-      return 100 if parent_budget == 0 && actual_spending > 0
-      (actual_spending.to_f / parent_budget) * 100
+      ring_fenced_children = parent.subcategories.reject(&:inherits_parent_budget?)
+      shared_budget = (parent[:budgeted_spending] || 0) + parent.rolled_over_amount -
+                      ring_fenced_children.sum { |child| child[:budgeted_spending] || 0 }
+      shared_budget = [ shared_budget, 0 ].max
+
+      return 0 if shared_budget == 0 && actual_spending == 0
+      return 100 if shared_budget == 0 && actual_spending > 0
+      (actual_spending.to_f / shared_budget) * 100
     else
-      budget_amount = (self[:budgeted_spending] || 0) + rolled_over_amount
+      child_rollover = subcategory? ? 0 : subcategories.reject(&:inherits_parent_budget?).sum(&:rolled_over_amount)
+      budget_amount = (self[:budgeted_spending] || 0) + rolled_over_amount + child_rollover
       return 0 if budget_amount == 0 && actual_spending == 0
       return 0 if budget_amount > 0 && actual_spending == 0
       return 100 if budget_amount == 0 && actual_spending > 0

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -272,8 +272,11 @@ class BudgetCategory < ApplicationRecord
       # A parent card displays its full allocation and total spending (including
       # all children), so the available amount must reconcile with those same
       # figures. Child allocations are already included in the parent's stored
-      # budget and must not be subtracted a second time here.
-      (self[:budgeted_spending] || 0) + rolled_over_amount - actual_spending
+      # budget, while ring-fenced children carry their rollover separately from
+      # the parent. Include that carry without counting child allocations twice.
+      child_rollover = subcategories.reject(&:inherits_parent_budget?).sum(&:rolled_over_amount)
+
+      (self[:budgeted_spending] || 0) + rolled_over_amount + child_rollover - actual_spending
     end
   end
 

--- a/app/views/api/v1/budget_categories/_budget_category.json.jbuilder
+++ b/app/views/api/v1/budget_categories/_budget_category.json.jbuilder
@@ -23,8 +23,9 @@ if include_derived_amounts
   # Sits with the derived amounts because it is what makes available_to_spend
   # exceed budgeted_spending: without it a client sees the larger number with
   # nothing to account for the difference.
-  json.rolled_over_amount budget_category.rolled_over_amount_money.format
-  json.rolled_over_amount_cents money_to_minor_units.call(budget_category.rolled_over_amount_money)
+  displayed_rollover = Money.new(budget_category.display_rolled_over_amount, budget_category.currency)
+  json.rolled_over_amount displayed_rollover.format
+  json.rolled_over_amount_cents money_to_minor_units.call(displayed_rollover)
   json.available_to_spend budget_category.available_to_spend_money.format
   json.available_to_spend_cents money_to_minor_units.call(budget_category.available_to_spend_money)
 end

--- a/app/views/budget_categories/_budget_category.html.erb
+++ b/app/views/budget_categories/_budget_category.html.erb
@@ -66,7 +66,7 @@
         </div>
         <% if budget_category.rolled_over? %>
           <div class="whitespace-nowrap w-full sm:w-auto text-xs text-secondary privacy-sensitive">
-            <%= t("budget_categories.budget_category.rolled_over", amount: format_money(budget_category.rolled_over_amount_money)) %>
+            <%= t("budget_categories.budget_category.rolled_over", amount: format_money(Money.new(budget_category.display_rolled_over_amount, budget_category.currency))) %>
           </div>
         <% end %>
         <% if budget_category.suggested_daily_spending.present? %>

--- a/app/views/budget_categories/show.html.erb
+++ b/app/views/budget_categories/show.html.erb
@@ -73,7 +73,7 @@
               <div class="flex items-center justify-between text-sm">
                 <dt class="text-secondary"><%= t(".rolled_over") %></dt>
                 <dd class="text-primary font-medium privacy-sensitive">
-                  <%= format_money @budget_category.rolled_over_amount_money %>
+                  <%= format_money Money.new(@budget_category.display_rolled_over_amount, @budget_category.currency) %>
                 </dd>
               </div>
             <% end %>

--- a/test/controllers/api/v1/budget_categories_controller_test.rb
+++ b/test/controllers/api/v1/budget_categories_controller_test.rb
@@ -114,6 +114,38 @@ class Api::V1::BudgetCategoriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 70_000, response_data["available_to_spend_cents"]
   end
 
+  test "show exposes ring-fenced child carry included in parent availability" do
+    parent_category = @family.categories.create!(name: "Parent rollover API", color: "#123456")
+    child_category = @family.categories.create!(name: "Child rollover API", parent: parent_category)
+    previous_budget = @family.budgets.create!(
+      start_date: 6.months.ago.beginning_of_month.to_date,
+      end_date: 6.months.ago.end_of_month.to_date,
+      budgeted_spending: 80,
+      expected_income: 100,
+      currency: "USD"
+    )
+    previous_budget.budget_categories.create!(
+      category: parent_category, budgeted_spending: 80, currency: "USD"
+    )
+    previous_budget.budget_categories.create!(
+      category: child_category, budgeted_spending: 80, currency: "USD", rollover_enabled: true
+    )
+    parent_budget_category = @budget.budget_categories.create!(
+      category: parent_category, budgeted_spending: 100, currency: "USD"
+    )
+    @budget.budget_categories.create!(
+      category: child_category, budgeted_spending: 100, currency: "USD", rollover_enabled: true
+    )
+
+    get api_v1_budget_category_url(parent_budget_category), headers: api_headers(@api_key)
+
+    assert_response :success
+    response_data = JSON.parse(response.body)
+    assert_equal 10_000, response_data["budgeted_spending_cents"]
+    assert_equal 8_000, response_data["rolled_over_amount_cents"]
+    assert_equal 18_000, response_data["available_to_spend_cents"]
+  end
+
   test "returns not found for another family's budget category" do
     get api_v1_budget_category_url(@other_budget_category), headers: api_headers(@api_key)
 

--- a/test/controllers/budgets_controller_test.rb
+++ b/test/controllers/budgets_controller_test.rb
@@ -19,6 +19,67 @@ class BudgetsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show reconciles parent overage without marking shared children over budget" do
+    budget = budgets(:one)
+    parent_category = Category.create!(
+      name: "Vehicle budget presentation",
+      family: budget.family,
+      color: "#4da568",
+      lucide_icon: "car"
+    )
+    limited_category = Category.create!(
+      name: "Vehicle payment presentation",
+      parent: parent_category,
+      family: budget.family
+    )
+    shared_category = Category.create!(
+      name: "Vehicle fuel presentation",
+      parent: parent_category,
+      family: budget.family
+    )
+    parent_budget_category = BudgetCategory.create!(
+      budget: budget,
+      category: parent_category,
+      budgeted_spending: 100,
+      currency: "USD"
+    )
+    BudgetCategory.create!(
+      budget: budget,
+      category: limited_category,
+      budgeted_spending: 80,
+      currency: "USD"
+    )
+    shared_budget_category = BudgetCategory.create!(
+      budget: budget,
+      category: shared_category,
+      budgeted_spending: 0,
+      currency: "USD"
+    )
+
+    Entry.create!(
+      account: accounts(:depository),
+      entryable: Transaction.create!(category: limited_category),
+      date: Date.current,
+      name: "Vehicle payment expense",
+      amount: 1,
+      currency: "USD"
+    )
+    Entry.create!(
+      account: accounts(:depository),
+      entryable: Transaction.create!(category: parent_category),
+      date: Date.current,
+      name: "Vehicle parent expense",
+      amount: 190.90,
+      currency: "USD"
+    )
+
+    get budget_url(Budget.date_to_param(Date.current))
+
+    assert_response :success
+    assert_select "a[href=?]", budget_budget_category_path(budget, parent_budget_category), text: /Over by:\s*\$91\.90/
+    assert_select "a[href=?]", budget_budget_category_path(budget, shared_budget_category), count: 0
+  end
+
   test "breadcrumbs include the Plan hub for preview users" do
     @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => true))
 

--- a/test/controllers/budgets_controller_test.rb
+++ b/test/controllers/budgets_controller_test.rb
@@ -80,6 +80,37 @@ class BudgetsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", budget_budget_category_path(budget, shared_budget_category), count: 0
   end
 
+  test "show displays ring-fenced child carry on the parent card" do
+    budget = budgets(:one)
+    parent_category = budget.family.categories.create!(name: "Parent rollover card", color: "#4da568")
+    child_category = budget.family.categories.create!(name: "Child rollover card", parent: parent_category)
+    previous_budget = budget.family.budgets.create!(
+      start_date: 6.months.ago.beginning_of_month.to_date,
+      end_date: 6.months.ago.end_of_month.to_date,
+      budgeted_spending: 20,
+      expected_income: 100,
+      currency: "USD"
+    )
+    previous_budget.budget_categories.create!(
+      category: parent_category, budgeted_spending: 20, currency: "USD"
+    )
+    previous_budget.budget_categories.create!(
+      category: child_category, budgeted_spending: 20, currency: "USD", rollover_enabled: true
+    )
+    parent_budget_category = budget.budget_categories.create!(
+      category: parent_category, budgeted_spending: 100, currency: "USD"
+    )
+    budget.budget_categories.create!(
+      category: child_category, budgeted_spending: 100, currency: "USD", rollover_enabled: true
+    )
+
+    get budget_url(Budget.date_to_param(Date.current))
+
+    assert_response :success
+    assert_select "a[href=?]", budget_budget_category_path(budget, parent_budget_category),
+                  text: /\+\$20\.00 rolled over/
+  end
+
   test "breadcrumbs include the Plan hub for preview users" do
     @user.update!(preferences: (@user.preferences || {}).merge("preview_features_enabled" => true))
 

--- a/test/models/budget_category_test.rb
+++ b/test/models/budget_category_test.rb
@@ -144,8 +144,9 @@ class BudgetCategoryTest < ActiveSupport::TestCase
     # available amount must reconcile with those figures.
     assert_equal 850, @parent_budget_category.available_to_spend
 
-    # An inheriting subcategory shares the parent's positive balance.
-    assert_equal 850, @subcategory_inheriting_bc.available_to_spend
+    # The inheriting subcategory can use the $700 shared pool after the $300
+    # ring-fenced allocation, less its $50 spending.
+    assert_equal 650, @subcategory_inheriting_bc.available_to_spend
 
     # Subcategory with limit: 300 (its budget) - 100 (its spending) = 200
     assert_equal 200, @subcategory_with_limit_bc.available_to_spend
@@ -153,6 +154,7 @@ class BudgetCategoryTest < ActiveSupport::TestCase
 
   test "inheriting subcategory does not copy parent overspending" do
     @budget.stubs(:budget_category_actual_spending).with(@parent_budget_category).returns(1050)
+    @budget.stubs(:budget_category_actual_spending).with(@subcategory_with_limit_bc).returns(300)
     @budget.stubs(:budget_category_actual_spending).with(@subcategory_inheriting_bc).returns(0)
 
     assert_equal(-50, @parent_budget_category.available_to_spend)
@@ -171,16 +173,31 @@ class BudgetCategoryTest < ActiveSupport::TestCase
 
     assert_equal 30, @parent_budget_category.available_to_spend
     assert_equal 30, @subcategory_with_limit_bc.available_to_spend
-    assert_equal 30, @subcategory_inheriting_bc.available_to_spend
+    assert_equal 0, @subcategory_inheriting_bc.available_to_spend
+    assert_in_delta 83.33, @parent_budget_category.percent_of_budget_spent, 0.01
     assert_not @parent_budget_category.over_budget?
+    assert_not @parent_budget_category.near_limit?
   end
 
-  test "percent_of_budget_spent for inheriting subcategory uses parent budget" do
+  test "inheriting subcategory excludes ring-fenced sibling funds" do
+    @parent_budget_category.update!(budgeted_spending: 100)
+    @subcategory_with_limit_bc.update!(budgeted_spending: 80)
+
+    @budget.stubs(:budget_category_actual_spending).with(@parent_budget_category).returns(10)
+    @budget.stubs(:budget_category_actual_spending).with(@subcategory_with_limit_bc).returns(0)
+    @budget.stubs(:budget_category_actual_spending).with(@subcategory_inheriting_bc).returns(10)
+
+    assert_equal 90, @parent_budget_category.available_to_spend
+    assert_equal 10, @subcategory_inheriting_bc.available_to_spend
+    assert_equal 50.0, @subcategory_inheriting_bc.percent_of_budget_spent
+  end
+
+  test "percent_of_budget_spent for inheriting subcategory uses shared parent budget" do
     # Mock spending
     @budget.stubs(:budget_category_actual_spending).with(@subcategory_inheriting_bc).returns(100)
 
-    # 100 / 1000 (parent budget) = 10%
-    assert_equal 10.0, @subcategory_inheriting_bc.percent_of_budget_spent
+    # 100 / 700 (parent budget less the $300 ring-fenced sibling) = 14.29%
+    assert_in_delta 14.29, @subcategory_inheriting_bc.percent_of_budget_spent, 0.01
   end
 
   test "parent with no subcategories works as before" do

--- a/test/models/budget_category_test.rb
+++ b/test/models/budget_category_test.rb
@@ -161,6 +161,20 @@ class BudgetCategoryTest < ActiveSupport::TestCase
     assert_not @subcategory_inheriting_bc.over_budget?
   end
 
+  test "parent availability includes rollover carried by ring-fenced children" do
+    @parent_budget_category.update!(budgeted_spending: 100)
+    @subcategory_with_limit_bc.update!(budgeted_spending: 100, rollover_enabled: true)
+    @subcategory_with_limit_bc.update_column(:rolled_over_amount, 80)
+
+    @budget.stubs(:budget_category_actual_spending).with(@parent_budget_category).returns(150)
+    @budget.stubs(:budget_category_actual_spending).with(@subcategory_with_limit_bc).returns(150)
+
+    assert_equal 30, @parent_budget_category.available_to_spend
+    assert_equal 30, @subcategory_with_limit_bc.available_to_spend
+    assert_equal 30, @subcategory_inheriting_bc.available_to_spend
+    assert_not @parent_budget_category.over_budget?
+  end
+
   test "percent_of_budget_spent for inheriting subcategory uses parent budget" do
     # Mock spending
     @budget.stubs(:budget_category_actual_spending).with(@subcategory_inheriting_bc).returns(100)

--- a/test/models/budget_category_test.rb
+++ b/test/models/budget_category_test.rb
@@ -174,6 +174,8 @@ class BudgetCategoryTest < ActiveSupport::TestCase
     assert_equal 30, @parent_budget_category.available_to_spend
     assert_equal 30, @subcategory_with_limit_bc.available_to_spend
     assert_equal 0, @subcategory_inheriting_bc.available_to_spend
+    assert_equal 80, @parent_budget_category.display_rolled_over_amount
+    assert @parent_budget_category.rolled_over?
     assert_in_delta 83.33, @parent_budget_category.percent_of_budget_spent, 0.01
     assert_not @parent_budget_category.over_budget?
     assert_not @parent_budget_category.near_limit?

--- a/test/models/budget_category_test.rb
+++ b/test/models/budget_category_test.rb
@@ -133,24 +133,32 @@ class BudgetCategoryTest < ActiveSupport::TestCase
     assert_equal 1000, @parent_budget_category.display_budgeted_spending
   end
 
-  test "inheriting subcategory shares parent available_to_spend" do
+  test "parent available_to_spend reflects its displayed budget and total spending" do
     # Mock the actual spending values
     # Parent's actual_spending from income_statement includes all children
     @budget.stubs(:budget_category_actual_spending).with(@parent_budget_category).returns(150)
     @budget.stubs(:budget_category_actual_spending).with(@subcategory_with_limit_bc).returns(100)
     @budget.stubs(:budget_category_actual_spending).with(@subcategory_inheriting_bc).returns(50)
 
-    # Parent available calculation:
-    # shared_pool = 1000 (parent budget) - 300 (subcategory with limit budget) = 700
-    # shared_pool_spending = 150 (total) - 100 (subcategory with limit spending) = 50
-    # available = 700 - 50 = 650
-    assert_equal 650, @parent_budget_category.available_to_spend
+    # The parent displays the full 1000 budget and 150 total spending, so its
+    # available amount must reconcile with those figures.
+    assert_equal 850, @parent_budget_category.available_to_spend
 
-    # Inheriting subcategory shares parent's available (650)
-    assert_equal 650, @subcategory_inheriting_bc.available_to_spend
+    # An inheriting subcategory shares the parent's positive balance.
+    assert_equal 850, @subcategory_inheriting_bc.available_to_spend
 
     # Subcategory with limit: 300 (its budget) - 100 (its spending) = 200
     assert_equal 200, @subcategory_with_limit_bc.available_to_spend
+  end
+
+  test "inheriting subcategory does not copy parent overspending" do
+    @budget.stubs(:budget_category_actual_spending).with(@parent_budget_category).returns(1050)
+    @budget.stubs(:budget_category_actual_spending).with(@subcategory_inheriting_bc).returns(0)
+
+    assert_equal(-50, @parent_budget_category.available_to_spend)
+    assert_equal 0, @subcategory_inheriting_bc.available_to_spend
+    assert @parent_budget_category.over_budget?
+    assert_not @subcategory_inheriting_bc.over_budget?
   end
 
   test "percent_of_budget_spent for inheriting subcategory uses parent budget" do


### PR DESCRIPTION
## Summary

- reconcile a parent budget category's available amount with the full budget and total spending displayed on its card
- prevent shared zero-budget child categories from inheriting a negative parent balance and appearing over budget
- add model and rendered-controller regressions for both parent and child behavior

Fixes #2074

## Validation

- `bin/rails test test/models/budget_category_test.rb test/controllers/budgets_controller_test.rb` — 70 runs, 192 assertions
- `bin/rails test` — 8,460 runs, 34,057 assertions
- `DISABLE_PARALLELIZATION=true bin/rails test:system` — 115 runs, 507 assertions
- `bin/rubocop -f github -a`
- `bundle exec erb_lint app -a` — 682 ERB files
- `npm run lint` — 123 files
- `bin/brakeman --no-pager` — 0 warnings

All tests completed with zero failures and zero errors. Screenshots are omitted because the reproduction data contains personal financial information; the controller regression verifies the rendered over-budget label and absence of a false child overage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected budget availability and spending-percentage calculations for shared-budget subcategories by excluding ring-fenced sibling funds.
  - Updated parent category balances and rollover displays to include applicable child rollover amounts.
  - Prevented parent overspending from incorrectly displaying negative balances or marking shared child categories as over budget.
  - Improved budget and API responses so rollover and over-budget amounts are shown accurately.

- **Tests**
  - Added coverage for parent overages, rollover balances, shared-budget subcategories, and limited-budget subcategories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->