### PR TITLE
feat(admin): show profile pictures in user management list

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,6 +9,7 @@ module Admin
       scope = policy_scope(User)
         .left_joins(family: :subscription)
         .includes(:oidc_identities, family: :subscription)
+        .with_attached_profile_image
 
       scope = scope.where(role: params[:role]) if params[:role].present?
       scope = apply_trial_filter(scope) if params[:trial_status].present?

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -103,8 +103,8 @@
                     <tr>
                       <td class="px-4 py-3">
                         <div class="flex items-center gap-3">
-                          <div class="w-8 h-8 rounded-full bg-surface flex items-center justify-center shrink-0">
-                            <span class="text-sm font-medium text-primary"><%= user.initials %></span>
+                          <div class="w-8 h-8 shrink-0">
+                            <%= render "settings/user_avatar", avatar_url: user.profile_image&.variant(:small)&.url, initials: user.initials, lazy: true %>
                           </div>
                           <div>
                             <div class="flex items-center gap-2">

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -94,6 +94,41 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Delete unused family/, response.body)
   end
 
+  test "index renders the profile picture of users who have one" do
+    user = users(:family_admin)
+    user.profile_image.attach(
+      io: File.open(Rails.root.join("test/fixtures/files/profile_image.png")),
+      filename: "profile_image.png",
+      content_type: "image/png"
+    )
+    # The disk service URL embeds a token signed with an expiry, so freeze time
+    # to keep the expected URL identical to the one rendered by the request.
+    travel_to Time.current do
+      variant = user.profile_image.variant(:small).processed
+      ActiveStorage::Current.url_options = { host: "www.example.com", protocol: "http" }
+      expected_src = variant.url
+
+      get admin_users_url
+      assert_response :success
+
+      assert_select "img[src=?]", expected_src, { count: 1 },
+        "User management should render the small profile image variant for users who have one"
+    end
+  end
+
+  test "index falls back to initials for users without a profile picture" do
+    user = users(:family_admin)
+    assert_not user.profile_image.attached?
+
+    get admin_users_url
+    assert_response :success
+
+    assert_match user.initials, response.body,
+      "User management should fall back to initials when there is no profile picture"
+    assert_select "img[src*=?]", "active_storage", { count: 0 },
+      "No avatar image should render for users without a profile picture"
+  end
+
 
 
   test "update can move a user to an existing family" do


### PR DESCRIPTION
## What

Show users' actual profile pictures in the User Management settings list.

The list rendered a hand-rolled initials bubble for every user, so uploaded profile pictures never appeared there. It now renders the shared `settings/user_avatar` partial — the same one used by the nav user menu and the household member list on Profile Info.

**Users without a profile picture continue to see the initials fallback**, which the partial handles natively: initials are the base layer, and the image is overlaid only when one is attached.

Also eager loads the attachments in `Admin::UsersController#index` to avoid an N+1 on attachments/blobs across what can be a long list.

## Testing

Two tests in `Admin::UsersControllerTest`:
1) Attaches a real image, processes the `:small` variant, and asserts the rendered avatar src matches that variant exactly.
2) Asserts users without a profile image still render their initials and no avatar image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Before

<img width="1017" height="362" alt="image" src="https://github.com/user-attachments/assets/a82c0251-6b63-4f21-aeb5-9f478f1257ea" />

## After

<img width="1026" height="367" alt="image" src="https://github.com/user-attachments/assets/e4b96de4-0dc3-4d8e-a9d7-abd9357a998d" />

(John Doe has a profile picture, but Mary Sue does not, so she continues to get the initials fallback.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin user listings now display profile images when available.
  * Users without profile images continue to see avatars generated from their initials.
  * Profile images are loaded efficiently as users view the listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->