### PR TITLE
fix(trade-republic): use canonical activity labels for order executions

### DIFF
--- a/app/models/trade_republic_account/activities_processor.rb
+++ b/app/models/trade_republic_account/activities_processor.rb
@@ -132,7 +132,7 @@ class TradeRepublicAccount::ActivitiesProcessor
         date:           date,
         name:           build_trade_name(security.ticker, signed_quantity),
         source:         "trade_republic",
-        activity_label: is_buy ? t("buy") : t("sell")
+        activity_label: is_buy ? "Buy" : "Sell"
       )
 
       trade_metadata = {

--- a/test/models/trade_republic_account_activities_processor_test.rb
+++ b/test/models/trade_republic_account_activities_processor_test.rb
@@ -120,6 +120,21 @@ class TradeRepublicAccountActivitiesProcessorTest < ActiveSupport::TestCase
     assert_equal "Dividend", entry.transaction.investment_activity_label
   end
 
+  test "order executions carry canonical activity labels under a non-English locale" do
+    I18n.with_locale(:de) do
+      import_event({
+        id: "evt_buy_de",
+        timestamp: "2026-08-01T10:00:00Z",
+        category: "orderExecution",
+        detail: { isin: "US0378331005", name: "Apple", quantity: "2", amount: "300.00", currency: "EUR" }
+      })
+    end
+
+    entry = Entry.find_by(external_id: "trade_republic_event_evt_buy_de")
+    assert_not_nil entry, "Trade::ACTIVITY_LABELS are canonical English, so order executions must import under any locale"
+    assert_equal "Buy", entry.trade.investment_activity_label
+  end
+
   test "card events keep a card-specific activity label" do
     import_event({
       id: "evt_card_payment",


### PR DESCRIPTION
## Problem

`import_order_execution` passed `t("buy")` / `t("sell")` into `activity_label`, which becomes `Trade#investment_activity_label`. `Trade` validates that column against `Trade::ACTIVITY_LABELS` — canonical English strings — so under `:de` the value is `"Kauf"`, validation fails, `entry.save!` raises, and `process_event`'s rescue records a `DebugLogEntry` and moves on. Every order execution in that sync is dropped.

Trade Republic is a German broker, so `:de` is a routine locale here. The locale reaches the worker because ActiveJob serializes `I18n.locale` at enqueue time and wraps `perform` in `I18n.with_locale`. A sync triggered from a request therefore runs the processor in that user's locale, while scheduled syncs enqueue with no request and run at `:en`.

That difference is why this went unnoticed: the failure is self-healing. `merge_timeline_events` accumulates events into `raw_timeline_payload` (capped at 5,000) and the processor reprocesses the entire stored payload on every run, so the next `:en` sync imports the dropped trades correctly. Cash movements were never affected, since `Transaction` has no label validation. The visible symptom is order executions arriving late — after the next scheduled sync — rather than an account that looks empty, plus an error row in `/settings/debug` that nothing correlates to a user report. It only becomes permanent if the events roll past the 5,000-event cap before an `:en` sync runs.

**Canonical English is what this column already holds everywhere else.** Plaid, SnapTrade, IBKR, Questrade, Trading212, Indexa Capital, Kraken, Coinbase, Binance and onchain wallets all use English for `activity_label`, as do manual entry via `Trade::CreateForm` and the CSV and QIF importers. The display-side translation lookup is keyed on those English values (`t("transactions.activity_labels.#{label.parameterize(separator: '_')}")`), so storing `"Kauf"` breaks localization. Trade Republic order executions were the only place a localized string reached this column.

## Change

Pass the canonical `"Buy"` / `"Sell"` instead of `t("buy")` / `t("sell")`. Localization stays on the entry name via `build_trade_name`, which is the part a user actually reads.

Trade Republic's cash path still writes localized labels (`"Einzahlung"`, `"Kartenzahlung"`). Those land on `Transaction`, which has no validation, so they are stored rather than dropped.

## Behavior after

Order executions import under any locale; entry names remain localized. Nothing changes for `:en` users. No migration needed — accounts that dropped trades pick them up on their next sync from the retained timeline payload, as they would have anyway.

## Validation

New regression test wrapping the import in `I18n.with_locale(:de)`, confirmed to fail without the fix (`Expected nil to not be nil`). Full Trade Republic suite green (18 runs, 46 assertions); RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Order execution activity labels now consistently display as “Buy” or “Sell,” regardless of the selected language or locale.
  * Improved order execution imports when using non-English locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->