### PR TITLE
fix(l10n): localize German budget rollover labels

### DIFF
--- a/config/locales/views/budgets/de.yml
+++ b/config/locales/views/budgets/de.yml
@@ -69,8 +69,12 @@ de:
       left_to_allocate: noch zu verteilen
       over_set: "> 100 % verplant"
       percent_set: "%{percent} verplant"
+    budget_category:
+      rolled_over: "+%{amount} übertragen"
     budget_category_form:
       monthly_average: "%{amount}/M Ø"
+      rollover_label: Übertrag
+      rollover_title: Nicht ausgegebenes Geld dieser Kategorie in den nächsten Monat übertragen
       shared_placeholder: Geteilt
       shared_title: Leer lassen, um das Budget der Oberkategorie zu teilen
     confirm_button:
@@ -93,6 +97,7 @@ de:
       overspent: überzogen
       overview: Übersicht
       recent_transactions: Letzte Transaktionen
+      rolled_over: Übertragen
       spending: Ausgaben %{date}
       status: Status
       view_all_transactions: Alle Transaktionen der Kategorie

--- a/test/controllers/budget_rollover_localization_test.rb
+++ b/test/controllers/budget_rollover_localization_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class BudgetRolloverLocalizationTest < ActionDispatch::IntegrationTest
+  setup do
+    ensure_tailwind_build
+    sign_in @user = users(:family_admin)
+    @budget = budgets(:one)
+    @category = @budget.family.categories.create!(name: "Synthetic rollover category", color: "#4da568")
+    @budget_category = @budget.budget_categories.create!(
+      category: @category, budgeted_spending: 100, currency: "USD", rollover_enabled: true
+    )
+  end
+
+  test "German rollover translations exist without fallback and preserve the amount" do
+    I18n.with_locale(:de) do
+      {
+        "budget_category.rolled_over" => "+25,00 € übertragen",
+        "budget_category_form.rollover_label" => "Übertrag",
+        "budget_category_form.rollover_title" => "Nicht ausgegebenes Geld dieser Kategorie in den nächsten Monat übertragen",
+        "show.rolled_over" => "Übertragen"
+      }.each do |key, expected|
+        full_key = "budget_categories.#{key}"
+        assert I18n.exists?(full_key, :de, fallback: false)
+        assert_equal expected, I18n.t(full_key, amount: "25,00 €")
+      end
+    end
+  end
+
+  test "German category form renders the rollover label and tooltip" do
+    @user.update!(locale: "de")
+    get budget_budget_categories_path(@budget)
+
+    assert_response :success
+    assert_select "label", text: "Übertrag"
+    assert_select "div[title=?]", "Nicht ausgegebenes Geld dieser Kategorie in den nächsten Monat übertragen"
+  end
+
+  test "German category detail renders the carried amount label" do
+    @user.update!(locale: "de")
+    previous = @budget.family.budgets.create!(
+      start_date: 1.month.ago.beginning_of_month.to_date,
+      end_date: 1.month.ago.end_of_month.to_date,
+      budgeted_spending: 25, expected_income: 100, currency: "USD"
+    )
+    previous.budget_categories.create!(
+      category: @category, budgeted_spending: 25, currency: "USD", rollover_enabled: true
+    )
+    get budget_budget_category_path(@budget, @budget_category)
+
+    assert_response :success
+    assert_select "dt", text: "Übertragen"
+
+    get budget_url(Budget.date_to_param(Date.current))
+
+    assert_response :success
+    assert_select "a[href=?]", budget_budget_category_path(@budget, @budget_category), text: /\+.*25.*übertragen/
+  end
+
+  test "English category form preserves rollover copy" do
+    @user.update!(locale: "en")
+    get budget_budget_categories_path(@budget)
+
+    assert_response :success
+    assert_select "label", text: "Rollover"
+    assert_select "div[title=?]", "Keep this category's unspent money from one month to the next"
+  end
+end


### PR DESCRIPTION
## Summary

German budgets now show translated rollover controls, guidance and carried-amount labels instead of falling back to English. Calculations, currency formatting and English copy are unchanged.

This continues German budget localization with a small, independent rollover slice.

## Validation

- Regression tests reproduce the missing German keys and English form fallback before the change.
- Full Rails suite: 8,553 runs, 34,496 assertions, no failures or errors.
- Focused integration tests cover German controls, tooltip, category detail and carried-amount card, plus English controls.
- RuboCop, ERB lint, Biome and Brakeman pass. Independent code review found no actionable issues.
- Synthetic browser check confirms the German toggle label fits at 1024 and 1440 pixel desktop widths.

## Post-Deploy Monitoring & Validation

On the next deployment, the release owner can check a German category with a positive carry and its rollover toggle. Expect translated labels and an unchanged amount; an English fallback or missing-translation message warrants reverting this locale-only change. No additional operational monitoring is required because calculation and request behavior are unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for budget category rollover labels, amounts, and tooltips.

* **Tests**
  * Added coverage confirming German rollover text displays correctly without fallback.
  * Verified rollover amounts and labels remain accurate across category forms and details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->