### PR TITLE
fix(l10n): localize German system health navigation

### DIFF
--- a/config/locales/views/settings/de.yml
+++ b/config/locales/views/settings/de.yml
@@ -217,6 +217,7 @@ de:
       sso_providers_label: SSO-Anbieter
       statement_vault_label: Auszugsarchiv
       users_label: Benutzer
+      system_health_label: Systemstatus
     settings_nav_link_large:
       next: Weiter
       previous: Zurück

--- a/test/controllers/settings/system_health_navigation_localization_test.rb
+++ b/test/controllers/settings/system_health_navigation_localization_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Settings::SystemHealthNavigationLocalizationTest < ActionDispatch::IntegrationTest
+  setup do
+    ensure_tailwind_build
+  end
+
+  test "German system health navigation has a translation without fallback" do
+    assert_equal "Systemstatus", I18n.t("settings.settings_nav.system_health_label", locale: :de, fallback: false, raise: true)
+  end
+
+  test "super admins see localized system health links in both navigation layouts" do
+    user = users(:sure_support_staff)
+    sign_in user
+
+    { "de" => "Systemstatus", "en" => "System health" }.each do |locale, label|
+      user.update!(locale: locale)
+      get settings_preferences_url
+
+      assert_response :success
+      assert_select "nav a[href='#{admin_system_health_path}']", text: label, count: 2
+    end
+  end
+
+  test "German system health navigation remains hidden from other roles" do
+    %i[family_admin family_member].each do |fixture|
+      user = users(fixture)
+      user.update!(locale: "de")
+      sign_in user
+      get settings_preferences_url
+
+      assert_response :success
+      assert_select "nav a[href='#{admin_system_health_path}']", count: 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary

German super admins now see “Systemstatus” instead of “System health” in settings navigation. English labels and role visibility are unchanged; this navigation-only translation does not change the health page or its checks.

## Validation

- Regression tests first reproduced the missing German key and English fallback; German and English rendering and non-super-admin visibility now pass.
- Full Rails suite: 8,552 runs, 34,487 assertions, no failures or errors, 31 skips.
- RuboCop, ERB lint, Biome and Brakeman passed; code review found no actionable issues.
- Synthetic browser checks at 1024 and 1440 pixels confirmed the translated link fits. German wording received an independent AI language review.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this adds a navigation translation without changing authorization, health probes or stored data. During normal release validation, check that a German super admin sees “Systemstatus” and that other roles still have no link.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added the German “Systemstatus” label for the system health section in settings navigation.

- **Tests**
  - Added coverage for German localization, translation fallback behavior, navigation links across supported layouts, and role-based visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->