### PR TITLE
Improve auto-categorization debug logging

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -368,7 +368,21 @@ class Family < ApplicationRecord
 
     # Bayes handled everything with sufficient confidence — skip the LLM
     # categorizer entirely (including its no-provider error contract).
-    return bayes_result.modified_count if bayes_result.categorized_ids.any? && remaining_ids.empty?
+    if bayes_result.categorized_ids.any? && remaining_ids.empty?
+      DebugLogEntry.capture(
+        category: "auto_categorization",
+        level: "info",
+        message: "Bayesian categorization handled all transactions; skipped LLM categorization",
+        source: self.class.name,
+        family: self,
+        metadata: {
+          requested_transaction_ids: Array(transaction_ids),
+          categorized_transaction_ids: bayes_result.categorized_ids,
+          modified_count: bayes_result.modified_count
+        }
+      )
+      return bayes_result.modified_count
+    end
 
     llm_modified_count = AutoCategorizer.new(self, transaction_ids: remaining_ids).auto_categorize
     bayes_result.modified_count + llm_modified_count

--- a/app/models/family/auto_categorizer.rb
+++ b/app/models/family/auto_categorizer.rb
@@ -33,6 +33,7 @@ class Family::AutoCategorizer
         message: "AI categorization failed: no categories available",
         source: self.class.name,
         family: family,
+        provider: llm_provider,
         metadata: {
           requested_transaction_ids: transaction_ids
         }

--- a/app/models/family/auto_categorizer.rb
+++ b/app/models/family/auto_categorizer.rb
@@ -9,6 +9,12 @@ class Family::AutoCategorizer
   def auto_categorize
     raise Error, "No LLM provider for auto-categorization" unless llm_provider
 
+    protected_ids = protected_transaction_ids
+    cached_ids = cached_transaction_ids
+    blocked_ids = protected_ids - cached_ids
+    log_cache_usage(cached_ids) if cached_ids.any?
+    log_blocked_transactions(blocked_ids) if blocked_ids.any?
+
     if scope.none?
       Rails.logger.info("No transactions to auto-categorize for family #{family.id}")
       return 0
@@ -19,8 +25,19 @@ class Family::AutoCategorizer
     categories_input = user_categories_input
 
     if categories_input.empty?
-      Rails.logger.error("Cannot auto-categorize transactions for family #{family.id}: no categories available")
-      return 0
+      message = "Cannot auto-categorize transactions for family #{family.id}: no categories available"
+      Rails.logger.error(message)
+      DebugLogEntry.capture(
+        category: "auto_categorization",
+        level: "error",
+        message: "AI categorization failed: no categories available",
+        source: self.class.name,
+        family: family,
+        metadata: {
+          requested_transaction_ids: transaction_ids
+        }
+      )
+      raise Error, "No categories available for auto-categorization"
     end
 
     result = llm_provider.auto_categorize(
@@ -34,12 +51,14 @@ class Family::AutoCategorizer
     end
 
     modified_count = 0
+    categorized_transaction_ids = []
     scope.each do |transaction|
       auto_categorization = result.data.find { |c| c.transaction_id == transaction.id }
 
       category_id = categories_input.find { |c| c[:name] == auto_categorization&.category_name }&.dig(:id)
 
       if category_id.present?
+        categorized_transaction_ids << transaction.id
         was_modified = transaction.enrich_attribute(
           :category_id,
           category_id,
@@ -50,6 +69,22 @@ class Family::AutoCategorizer
         modified_count += 1 if was_modified
       end
     end
+
+    DebugLogEntry.capture(
+      category: "auto_categorization",
+      level: "info",
+      message: "AI categorization completed",
+      source: self.class.name,
+      family: family,
+      provider: llm_provider,
+      metadata: {
+        requested_transaction_ids: transaction_ids,
+        categorized_transaction_ids: categorized_transaction_ids,
+        cached_transaction_ids: cached_ids,
+        blocked_transaction_ids: blocked_ids,
+        modified_count: modified_count
+      }
+    )
 
     modified_count
   end
@@ -85,6 +120,51 @@ class Family::AutoCategorizer
           merchant: transaction.merchant&.name
         }
       end
+    end
+
+    def cached_transaction_ids
+      protected_transactions
+            .joins(:data_enrichments)
+            .where(data_enrichments: { attribute_name: "category_id", source: "ai" })
+            .where(Arel.sql("data_enrichments.value = to_jsonb(transactions.category_id::text)"))
+            .distinct
+            .pluck(:id)
+    end
+
+    def protected_transaction_ids
+      protected_transactions.pluck(:id)
+    end
+
+    def protected_transactions
+      family.transactions
+            .where(id: transaction_ids)
+            .where(Arel.sql("transactions.locked_attributes ? :attribute"), attribute: "category_id")
+    end
+
+    def log_cache_usage(cached_transaction_ids)
+      DebugLogEntry.capture(
+        category: "auto_categorization",
+        level: "info",
+        message: "AI categorization cache used",
+        source: self.class.name,
+        family: family,
+        metadata: {
+          cached_transaction_ids: cached_transaction_ids
+        }
+      )
+    end
+
+    def log_blocked_transactions(blocked_transaction_ids)
+      DebugLogEntry.capture(
+        category: "auto_categorization",
+        level: "info",
+        message: "AI categorization blocked by enrichment protection",
+        source: self.class.name,
+        family: family,
+        metadata: {
+          blocked_transaction_ids: blocked_transaction_ids
+        }
+      )
     end
 
     def scope

--- a/app/models/rule/action_executor/auto_categorize.rb
+++ b/app/models/rule/action_executor/auto_categorize.rb
@@ -30,6 +30,11 @@ class Rule::ActionExecutor::AutoCategorize < Rule::ActionExecutor
   end
 
   def execute(transaction_scope, value: nil, ignore_attribute_locks: false, rule_run: nil)
+    blocked_transaction_ids = transaction_scope
+      .where(Arel.sql("transactions.locked_attributes ? :attribute"), attribute: "category_id")
+      .pluck(:id)
+    log_blocked_transactions(blocked_transaction_ids) if blocked_transaction_ids.any?
+
     enrichable_transactions = transaction_scope.enrichable(:category_id)
 
     if enrichable_transactions.empty?
@@ -56,4 +61,19 @@ class Rule::ActionExecutor::AutoCategorize < Rule::ActionExecutor
       jobs_count: jobs_count
     }
   end
+
+  private
+    def log_blocked_transactions(transaction_ids)
+      DebugLogEntry.capture(
+        category: "auto_categorization",
+        level: "info",
+        message: "AI categorization blocked by enrichment protection",
+        source: self.class.name,
+        family: rule.family,
+        metadata: {
+          rule_id: rule.id,
+          blocked_transaction_ids: transaction_ids
+        }
+      )
+    end
 end

--- a/app/models/rule/action_executor/auto_categorize.rb
+++ b/app/models/rule/action_executor/auto_categorize.rb
@@ -30,9 +30,11 @@ class Rule::ActionExecutor::AutoCategorize < Rule::ActionExecutor
   end
 
   def execute(transaction_scope, value: nil, ignore_attribute_locks: false, rule_run: nil)
-    blocked_transaction_ids = transaction_scope
-      .where(Arel.sql("transactions.locked_attributes ? :attribute"), attribute: "category_id")
-      .pluck(:id)
+    protected_scope = protected_transactions(transaction_scope)
+    cached_transaction_ids = cached_transaction_ids(protected_scope)
+    blocked_transaction_ids = protected_scope.pluck(:id) - cached_transaction_ids
+
+    log_cache_usage(cached_transaction_ids) if cached_transaction_ids.any?
     log_blocked_transactions(blocked_transaction_ids) if blocked_transaction_ids.any?
 
     enrichable_transactions = transaction_scope.enrichable(:category_id)
@@ -63,6 +65,33 @@ class Rule::ActionExecutor::AutoCategorize < Rule::ActionExecutor
   end
 
   private
+    def protected_transactions(transaction_scope)
+      transaction_scope.where(Arel.sql("transactions.locked_attributes ? :attribute"), attribute: "category_id")
+    end
+
+    def cached_transaction_ids(protected_scope)
+      protected_scope
+        .joins(:data_enrichments)
+        .where(data_enrichments: { attribute_name: "category_id", source: "ai" })
+        .where(Arel.sql("data_enrichments.value = to_jsonb(transactions.category_id::text)"))
+        .distinct
+        .pluck(:id)
+    end
+
+    def log_cache_usage(transaction_ids)
+      DebugLogEntry.capture(
+        category: "auto_categorization",
+        level: "info",
+        message: "AI categorization cache used",
+        source: self.class.name,
+        family: rule.family,
+        metadata: {
+          rule_id: rule.id,
+          cached_transaction_ids: transaction_ids
+        }
+      )
+    end
+
     def log_blocked_transactions(transaction_ids)
       DebugLogEntry.capture(
         category: "auto_categorization",

--- a/test/jobs/auto_categorize_job_test.rb
+++ b/test/jobs/auto_categorize_job_test.rb
@@ -81,4 +81,31 @@ class AutoCategorizeJobTest < ActiveJob::TestCase
     assert_equal "Failed to auto-categorize transactions: Fixed prompt tokens exceed context budget", entry.metadata["error_message"]
     assert_equal [ transaction.id ], entry.metadata["transaction_ids"]
   end
+
+  test "fails the rule run when no categories are available" do
+    @family.categories.destroy_all
+    transaction = create_transaction(account: @account, name: "Coffee shop").transaction
+    provider = mock
+    Provider::Registry.stubs(:preferred_llm_provider).returns(provider)
+    provider.expects(:auto_categorize).never
+
+    assert_difference "DebugLogEntry.count", 2 do
+      assert_raises(Family::AutoCategorizer::Error) do
+        AutoCategorizeJob.perform_now(@family, transaction_ids: [ transaction.id ], rule_run_id: @rule_run.id)
+      end
+    end
+
+    @rule_run.reload
+    assert_equal "failed", @rule_run.status
+    assert_equal "Family::AutoCategorizer::Error: No categories available for auto-categorization", @rule_run.error_message
+    assert_equal 0, @rule_run.pending_jobs_count
+
+    entries = DebugLogEntry.order(:created_at).last(2)
+    categorization_entry = entries.find { |entry| entry.category == "auto_categorization" }
+    rule_run_entry = entries.find { |entry| entry.category == "rule_run" }
+
+    assert_equal "AI categorization failed: no categories available", categorization_entry.message
+    assert_equal [ transaction.id ], categorization_entry.metadata["requested_transaction_ids"]
+    assert_equal "No categories available for auto-categorization", rule_run_entry.metadata["error_message"]
+  end
 end

--- a/test/models/family/auto_categorize_transactions_test.rb
+++ b/test/models/family/auto_categorize_transactions_test.rb
@@ -26,11 +26,21 @@ class Family::AutoCategorizeTransactionsTest < ActiveSupport::TestCase
 
     txn = create_transaction(account: @account, name: "Starbucks Coffee").transaction
 
-    assert_difference "DataEnrichment.count", 1 do
+    assert_difference [ "DataEnrichment.count", "DebugLogEntry.count" ], 1 do
       assert_equal 1, @family.auto_categorize_transactions([ txn.id ])
     end
     assert_equal @coffee, txn.reload.category
     assert_equal "bayes", txn.data_enrichments.find_by(attribute_name: "category_id").source
+
+    log_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "auto_categorization", log_entry.category
+    assert_equal "info", log_entry.level
+    assert_equal "Bayesian categorization handled all transactions; skipped LLM categorization", log_entry.message
+    assert_equal "Family", log_entry.source
+    assert_equal @family, log_entry.family
+    assert_equal [ txn.id ], log_entry.metadata["requested_transaction_ids"]
+    assert_equal [ txn.id ], log_entry.metadata["categorized_transaction_ids"]
+    assert_equal 1, log_entry.metadata["modified_count"]
   end
 
   test "bayes handles nothing: raises without LLM provider, same contract as today" do
@@ -54,10 +64,12 @@ class Family::AutoCategorizeTransactionsTest < ActiveSupport::TestCase
       AutoCategorization.new(transaction_id: txn.id, category_name: test_category.name)
     ])).once
 
-    assert_difference "DataEnrichment.count", 1 do
+    assert_difference [ "DataEnrichment.count", "DebugLogEntry.count" ], 1 do
       assert_equal 1, @family.auto_categorize_transactions([ txn.id ])
     end
     assert_equal test_category, txn.reload.category
+
+    assert_ai_categorization_log(transaction_ids: [ txn.id ])
   end
 
   test "bayes handles some, LLM handles the rest: modified_count sums" do
@@ -73,12 +85,29 @@ class Family::AutoCategorizeTransactionsTest < ActiveSupport::TestCase
     ])).once
 
     assert_difference "DataEnrichment.count", 2 do
-      assert_equal 2, @family.auto_categorize_transactions([ bayes_txn.id, llm_txn.id ])
+      assert_difference "DebugLogEntry.count", 1 do
+        assert_equal 2, @family.auto_categorize_transactions([ bayes_txn.id, llm_txn.id ])
+      end
     end
     assert_equal @coffee, bayes_txn.reload.category
     assert_equal test_category, llm_txn.reload.category
+
+    assert_ai_categorization_log(transaction_ids: [ llm_txn.id ])
   end
 
   private
+    def assert_ai_categorization_log(transaction_ids:, categorized_transaction_ids: transaction_ids)
+      log_entry = DebugLogEntry.order(:created_at).last
+
+      assert_equal "auto_categorization", log_entry.category
+      assert_equal "info", log_entry.level
+      assert_equal "AI categorization completed", log_entry.message
+      assert_equal "Family::AutoCategorizer", log_entry.source
+      assert_equal @family, log_entry.family
+      assert_equal transaction_ids, log_entry.metadata["requested_transaction_ids"]
+      assert_equal categorized_transaction_ids, log_entry.metadata["categorized_transaction_ids"]
+      assert_equal categorized_transaction_ids.size, log_entry.metadata["modified_count"]
+    end
+
     AutoCategorization = Provider::LlmConcept::AutoCategorization
 end

--- a/test/models/family/auto_categorizer_test.rb
+++ b/test/models/family/auto_categorizer_test.rb
@@ -55,7 +55,9 @@ class Family::AutoCategorizerTest < ActiveSupport::TestCase
   test "logs and raises when no categories are available" do
     @family.categories.destroy_all
     txn = create_transaction(account: @account, name: "Coffee shop").transaction
-    @llm_provider.expects(:auto_categorize).never
+    provider = Provider::Openai.allocate
+    Provider::Registry.stubs(:preferred_llm_provider).returns(provider)
+    provider.expects(:auto_categorize).never
 
     assert_difference "DebugLogEntry.count", 1 do
       error = assert_raises(Family::AutoCategorizer::Error) do
@@ -70,6 +72,7 @@ class Family::AutoCategorizerTest < ActiveSupport::TestCase
     assert_equal "AI categorization failed: no categories available", log_entry.message
     assert_equal "Family::AutoCategorizer", log_entry.source
     assert_equal @family, log_entry.family
+    assert_equal "openai", log_entry.provider_key
     assert_equal [ txn.id ], log_entry.metadata["requested_transaction_ids"]
   end
 

--- a/test/models/family/auto_categorizer_test.rb
+++ b/test/models/family/auto_categorizer_test.rb
@@ -52,6 +52,106 @@ class Family::AutoCategorizerTest < ActiveSupport::TestCase
     assert_equal "Failed to auto-categorize transactions: Fixed prompt tokens exceed context budget", error.message
   end
 
+  test "logs and raises when no categories are available" do
+    @family.categories.destroy_all
+    txn = create_transaction(account: @account, name: "Coffee shop").transaction
+    @llm_provider.expects(:auto_categorize).never
+
+    assert_difference "DebugLogEntry.count", 1 do
+      error = assert_raises(Family::AutoCategorizer::Error) do
+        Family::AutoCategorizer.new(@family, transaction_ids: [ txn.id ]).auto_categorize
+      end
+      assert_equal "No categories available for auto-categorization", error.message
+    end
+
+    log_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "auto_categorization", log_entry.category
+    assert_equal "error", log_entry.level
+    assert_equal "AI categorization failed: no categories available", log_entry.message
+    assert_equal "Family::AutoCategorizer", log_entry.source
+    assert_equal @family, log_entry.family
+    assert_equal [ txn.id ], log_entry.metadata["requested_transaction_ids"]
+  end
+
+  test "logs when AI categorization cache handles the batch" do
+    txn = create_transaction(account: @account, name: "Coffee shop").transaction
+    category = @family.categories.create!(name: "Coffee")
+    txn.enrich_attribute(:category_id, category.id, source: "ai")
+    txn.lock_attr!(:category_id)
+    @llm_provider.expects(:auto_categorize).never
+
+    assert_difference "DebugLogEntry.count", 1 do
+      assert_equal 0, Family::AutoCategorizer.new(@family, transaction_ids: [ txn.id ]).auto_categorize
+    end
+
+    log_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "auto_categorization", log_entry.category
+    assert_equal "AI categorization cache used", log_entry.message
+    assert_equal "Family::AutoCategorizer", log_entry.source
+    assert_equal @family, log_entry.family
+    assert_equal [ txn.id ], log_entry.metadata["cached_transaction_ids"]
+  end
+
+  test "logs when categorization is blocked by enrichment protection" do
+    txn = create_transaction(account: @account, name: "Protected transaction").transaction
+    txn.lock_attr!(:category_id)
+    @llm_provider.expects(:auto_categorize).never
+
+    assert_difference "DebugLogEntry.count", 1 do
+      assert_equal 0, Family::AutoCategorizer.new(@family, transaction_ids: [ txn.id ]).auto_categorize
+    end
+
+    log_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "auto_categorization", log_entry.category
+    assert_equal "AI categorization blocked by enrichment protection", log_entry.message
+    assert_equal "Family::AutoCategorizer", log_entry.source
+    assert_equal @family, log_entry.family
+    assert_equal [ txn.id ], log_entry.metadata["blocked_transaction_ids"]
+  end
+
+  test "does not treat a user-overridden AI category as cached" do
+    txn = create_transaction(account: @account, name: "Coffee shop").transaction
+    ai_category = @family.categories.create!(name: "AI category")
+    user_category = @family.categories.create!(name: "User category")
+    txn.enrich_attribute(:category_id, ai_category.id, source: "ai")
+    txn.lock_attr!(:category_id)
+    txn.update!(category_id: user_category.id)
+    @llm_provider.expects(:auto_categorize).never
+
+    assert_difference "DebugLogEntry.count", 1 do
+      assert_equal 0, Family::AutoCategorizer.new(@family, transaction_ids: [ txn.id ]).auto_categorize
+    end
+
+    log_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "AI categorization blocked by enrichment protection", log_entry.message
+    assert_equal [ txn.id ], log_entry.metadata["blocked_transaction_ids"]
+  end
+
+  test "logs AI cache usage alongside LLM categorization" do
+    cached_txn = create_transaction(account: @account, name: "Coffee shop").transaction
+    llm_txn = create_transaction(account: @account, name: "Bakery").transaction
+    category = @family.categories.create!(name: "Coffee")
+    cached_txn.enrich_attribute(:category_id, category.id, source: "ai")
+    cached_txn.lock_attr!(:category_id)
+
+    @llm_provider.expects(:auto_categorize).returns(provider_success_response([
+      AutoCategorization.new(transaction_id: llm_txn.id, category_name: category.name)
+    ])).once
+
+    assert_difference "DebugLogEntry.count", 2 do
+      assert_equal 1, Family::AutoCategorizer.new(@family, transaction_ids: [ cached_txn.id, llm_txn.id ]).auto_categorize
+    end
+
+    entries = DebugLogEntry.order(:created_at).last(2)
+    cache_entry = entries.find { |entry| entry.message == "AI categorization cache used" }
+    ai_entry = entries.find { |entry| entry.message == "AI categorization completed" }
+
+    assert_equal [ cached_txn.id ], cache_entry.metadata["cached_transaction_ids"]
+    assert_equal [ cached_txn.id, llm_txn.id ], ai_entry.metadata["requested_transaction_ids"]
+    assert_equal [ cached_txn.id ], ai_entry.metadata["cached_transaction_ids"]
+    assert_equal [ llm_txn.id ], ai_entry.metadata["categorized_transaction_ids"]
+  end
+
   private
     AutoCategorization = Provider::LlmConcept::AutoCategorization
 end

--- a/test/models/rule/action_executor/auto_categorize_test.rb
+++ b/test/models/rule/action_executor/auto_categorize_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Rule::ActionExecutor::AutoCategorizeTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  setup do
+    @family = families(:empty)
+    @account = @family.accounts.create!(name: "Rule test", balance: 100, currency: "USD", accountable: Depository.new)
+    @rule = @family.rules.create!(
+      name: "AI category rule",
+      resource_type: "transaction",
+      effective_date: 1.day.ago.to_date,
+      actions: [ Rule::Action.new(action_type: "auto_categorize") ]
+    )
+    @executor = Rule::ActionExecutor::AutoCategorize.new(@rule)
+  end
+
+  test "logs when categorization is blocked by category enrichment protection" do
+    transaction = create_transaction(account: @account, name: "Protected transaction").transaction
+    transaction.lock_attr!(:category_id)
+    @family.expects(:auto_categorize_transactions_later).never
+
+    assert_difference "DebugLogEntry.count", 1 do
+      assert_equal 0, @executor.execute(@account.transactions)
+    end
+
+    log_entry = DebugLogEntry.order(:created_at).last
+    assert_equal "auto_categorization", log_entry.category
+    assert_equal "info", log_entry.level
+    assert_equal "AI categorization blocked by enrichment protection", log_entry.message
+    assert_equal "Rule::ActionExecutor::AutoCategorize", log_entry.source
+    assert_equal @family, log_entry.family
+    assert_equal @rule.id, log_entry.metadata["rule_id"]
+    assert_equal [ transaction.id ], log_entry.metadata["blocked_transaction_ids"]
+  end
+end

--- a/test/models/rule/action_executor/auto_categorize_test.rb
+++ b/test/models/rule/action_executor/auto_categorize_test.rb
@@ -33,4 +33,30 @@ class Rule::ActionExecutor::AutoCategorizeTest < ActiveSupport::TestCase
     assert_equal @rule.id, log_entry.metadata["rule_id"]
     assert_equal [ transaction.id ], log_entry.metadata["blocked_transaction_ids"]
   end
+
+  test "logs cached AI categories separately from blocked transactions" do
+    cached_transaction = create_transaction(account: @account, name: "Cached transaction").transaction
+    blocked_transaction = create_transaction(account: @account, name: "Protected transaction").transaction
+    category = @family.categories.create!(name: "Coffee")
+
+    cached_transaction.enrich_attribute(:category_id, category.id, source: "ai")
+    cached_transaction.lock_attr!(:category_id)
+    blocked_transaction.lock_attr!(:category_id)
+    @family.expects(:auto_categorize_transactions_later).never
+
+    assert_difference "DebugLogEntry.count", 2 do
+      assert_equal 0, @executor.execute(@account.transactions)
+    end
+
+    entries = DebugLogEntry.order(:created_at).last(2)
+    cache_entry = entries.find { |entry| entry.message == "AI categorization cache used" }
+    blocked_entry = entries.find { |entry| entry.message == "AI categorization blocked by enrichment protection" }
+
+    assert_equal "Rule::ActionExecutor::AutoCategorize", cache_entry.source
+    assert_equal @family, cache_entry.family
+    assert_equal @rule.id, cache_entry.metadata["rule_id"]
+    assert_equal [ cached_transaction.id ], cache_entry.metadata["cached_transaction_ids"]
+
+    assert_equal [ blocked_transaction.id ], blocked_entry.metadata["blocked_transaction_ids"]
+  end
 end


### PR DESCRIPTION
## Problem

Auto-categorization outcomes were difficult to diagnose from the support debug log. Bayesian-only batches, AI cache reuse, enrichment protection, successful AI categorization, and missing-category failures did not provide enough structured context.

## Resulting behavior

- Record structured debug entries for Bayesian-only and successful AI categorization runs.
- Distinguish valid AI cache reuse from transactions blocked by category protection.
- Treat an AI enrichment as cached only while its stored value still matches the current category, so user overrides are reported as protected rather than cached.
- Record and raise missing-category failures so associated rule runs fail with useful diagnostics.
- Include family, provider, rule, transaction IDs, and modification counts where available.

## Validation

- Focused auto-categorization tests: 15 runs, 145 assertions, 0 failures, 0 errors.
- Full Rails suite: 8,538 runs, 34,477 assertions, 0 failures, 0 errors, 31 skips.
- RuboCop: passed.
- ERB lint: passed.
- Biome lint: passed.
- Brakeman: 0 errors, 0 security warnings.

No UI changes or migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction auto-categorization handling for cached results and transactions protected from enrichment.
  - Added clearer diagnostic details when transactions are skipped, categorized, or processed through different categorization methods.
  - Auto-categorization now reports an explicit error when no categories are available, allowing affected rule runs to fail clearly instead of completing without results.
  - Preserved existing processing behavior when further categorization is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->