### PR TITLE
fix(desktop): add report download & print handling

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -63,14 +63,22 @@ CSV exports are saved in the macOS Downloads folder. Sure sends a native
 notification when a download finishes or fails; allow Sure notifications in
 System Settings to see them. Repeated downloads get a numbered filename.
 
-Print Report opens a separate Sure window using the current signed-in session.
-The native print dialog lets you print or choose PDF → Save as PDF. Close the
-report window to return to the app.
+Print Report opens a separate Sure window using the current signed-in session,
+then the native print dialog once the report has loaded. Print it, or choose
+PDF → Save as PDF. Close the report window to return to the app.
+
+Other links that open a new window follow the same rule: pages of your Sure
+server open in a separate Sure window with your session, and other websites
+open in your default browser. Only the main window has the desktop
+integrations: notifications, SSO in your browser and report CSV exports.
+Downloads are only accepted from pages of your saved servers.
 
 To verify changes to this flow, run `npm test` and `npm run build` in `desktop`,
 then `cargo test --locked` in `desktop/src-tauri`. In the desktop app, export a
 CSV twice, check both files in Downloads, and open Print Report to save a PDF.
-Repeat against a server mounted under a URL prefix, if applicable.
+Open an external link (for example the Discord help icon) and check that it
+opens in your browser. Repeat against a server mounted under a URL prefix, if
+applicable.
 
 ## Deep links
 Registered scheme: `sure://{host}[:port]/{path}` → opens the app to that

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -57,6 +57,21 @@ cd desktop/src-tauri
 cargo test
 ```
 
+## Reports and downloads
+
+CSV exports are saved in the macOS Downloads folder. Sure sends a native
+notification when a download finishes or fails; allow Sure notifications in
+System Settings to see them. Repeated downloads get a numbered filename.
+
+Print Report opens a separate Sure window using the current signed-in session.
+The native print dialog lets you print or choose PDF → Save as PDF. Close the
+report window to return to the app.
+
+To verify changes to this flow, run `npm test` and `npm run build` in `desktop`,
+then `cargo test --locked` in `desktop/src-tauri`. In the desktop app, export a
+CSV twice, check both files in Downloads, and open Print Report to save a PDF.
+Repeat against a server mounted under a URL prefix, if applicable.
+
 ## Deep links
 Registered scheme: `sure://{host}[:port]/{path}` → opens the app to that
 server/page. Example: `open "sure://localhost:3000/accounts"`. (Works from the

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "test": "node --test tests/*.test.mjs",
     "tauri": "tauri"
   },
   "devDependencies": {

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -83,7 +83,7 @@ pub fn grant_server_capability(app: &tauri::AppHandle, origin: &str) {
             .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
             .collect::<String>()
     );
-    let capability = tauri::ipc::CapabilityBuilder::new(id)
+    let capability = tauri::ipc::CapabilityBuilder::new(id.clone())
         .window("main")
         .remote(format!("{canonical}/**"))
         .permission("core:window:allow-start-dragging")
@@ -94,6 +94,16 @@ pub fn grant_server_capability(app: &tauri::AppHandle, origin: &str) {
         .permission("notification:default");
     if let Err(e) = app.add_capability(capability) {
         eprintln!("[sure] failed to grant capability for {canonical}: {e}");
+    }
+    // Tauri implements window.print() through this IPC permission on macOS.
+    // Report windows only need printing, not the main window's bridge access.
+    let print_capability = tauri::ipc::CapabilityBuilder::new(format!("{id}-print"))
+        .window("main")
+        .window("report-*")
+        .remote(format!("{canonical}/**"))
+        .permission("core:webview:allow-print");
+    if let Err(e) = app.add_capability(print_capability) {
+        eprintln!("[sure] failed to grant print capability for {canonical}: {e}");
     }
 }
 

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -83,7 +83,7 @@ pub fn grant_server_capability(app: &tauri::AppHandle, origin: &str) {
             .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
             .collect::<String>()
     );
-    let capability = tauri::ipc::CapabilityBuilder::new(id.clone())
+    let capability = tauri::ipc::CapabilityBuilder::new(id)
         .window("main")
         .remote(format!("{canonical}/**"))
         .permission("core:window:allow-start-dragging")
@@ -94,16 +94,6 @@ pub fn grant_server_capability(app: &tauri::AppHandle, origin: &str) {
         .permission("notification:default");
     if let Err(e) = app.add_capability(capability) {
         eprintln!("[sure] failed to grant capability for {canonical}: {e}");
-    }
-    // Tauri implements window.print() through this IPC permission on macOS.
-    // Report windows only need printing, not the main window's bridge access.
-    let print_capability = tauri::ipc::CapabilityBuilder::new(format!("{id}-print"))
-        .window("main")
-        .window("report-*")
-        .remote(format!("{canonical}/**"))
-        .permission("core:webview:allow-print");
-    if let Err(e) = app.add_capability(print_capability) {
-        eprintln!("[sure] failed to grant print capability for {canonical}: {e}");
     }
 }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -133,7 +133,9 @@ pub fn run() {
             Ok(())
         })
         .on_page_load(|window, payload| {
-            if payload.event() == tauri::webview::PageLoadEvent::Finished {
+            if matches!(window.label(), "main" | "prefs")
+                && payload.event() == tauri::webview::PageLoadEvent::Finished
+            {
                 const BRIDGE: &str = include_str!("../../dist/bridge.js");
                 let _ = window.eval(BRIDGE);
             }

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -1,10 +1,17 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tauri::webview::{DownloadEvent, NewWindowResponse};
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::webview::{DownloadEvent, NewWindowResponse, PageLoadEvent, PageLoadPayload};
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder, Wry};
 use tauri_plugin_decorum::WebviewWindowExt;
 use tauri_plugin_notification::NotificationExt;
+use url::Url;
 
-static REPORT_WINDOW_ID: AtomicUsize = AtomicUsize::new(0);
+static POPUP_WINDOW_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// Wait after a printable report loads before opening the print dialog. This
+/// matches the delay in Sure's print layout, which lets styles settle.
+const PRINT_DELAY: Duration = Duration::from_millis(500);
 
 pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Build the configured window here so native download and popup handlers
@@ -17,43 +24,17 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .find(|window| window.label == "main")
         .expect("main window configuration exists");
     let handle = app.handle().clone();
+    let page = ShownPage::default();
     let window = WebviewWindowBuilder::from_config(app, config)?
-        .on_download(on_download)
-        .on_new_window(move |url, features| {
-            let Some(server) = print_report_server(&url) else {
-                return NewWindowResponse::Deny;
-            };
-            if !crate::servers::is_known_server(&server) {
-                return NewWindowResponse::Deny;
-            }
-
-            let label = format!(
-                "report-{}",
-                REPORT_WINDOW_ID.fetch_add(1, Ordering::Relaxed)
-            );
-            match WebviewWindowBuilder::new(
-                &handle,
-                label,
-                WebviewUrl::External("about:blank".parse().unwrap()),
-            )
-            // WKWebView requires the opener's configuration. This also keeps
-            // the authenticated server session when opening the report.
-            .window_features(features)
-            .title("Sure")
-            .inner_size(1000.0, 800.0)
-            .on_download(on_download)
-            .on_document_title_changed(|window, title| {
-                let _ = window.set_title(&title);
-            })
-            .build()
-            {
-                Ok(window) => NewWindowResponse::Create { window },
-                Err(error) => {
-                    eprintln!("[sure] failed to open report window: {error}");
-                    NewWindowResponse::Deny
-                }
-            }
+        .on_page_load({
+            let page = page.clone();
+            move |_, payload| page.record(&payload)
         })
+        .on_download({
+            let page = page.clone();
+            move |webview, event| on_download(&page, webview, event)
+        })
+        .on_new_window(move |url, _| on_new_window(&handle, &page, url))
         .build()?;
 
     // The window is opaque (the app paints its own solid backgrounds), so we
@@ -67,39 +48,176 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Where a page's request to open a new window (a `target="_blank"` link or
+/// `window.open`) should go.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PopupAction {
+    /// A page of a saved server opens in a Sure window that keeps the session.
+    ServerWindow,
+    /// Any other website opens in the default browser, which has no session.
+    Browser,
+    /// Anything else is ignored.
+    Deny,
+}
+
+/// Decide where a popup goes. Popups are honored only while the opener window
+/// shows a page of a saved server (`opener_trusted`). Frames embedded in that
+/// page count as the page, because the requesting frame is not exposed. Only
+/// plain http(s) addresses without credentials are opened, so no page can hand
+/// other schemes to the system. `is_known_server` is injected so the policy can
+/// be tested without the saved server list.
+pub fn popup_action(
+    url: &Url,
+    opener_trusted: bool,
+    is_known_server: impl Fn(&str) -> bool,
+) -> PopupAction {
+    if !opener_trusted || !is_plain_web_url(url) {
+        return PopupAction::Deny;
+    }
+    if is_known_server(url.as_str()) {
+        PopupAction::ServerWindow
+    } else {
+        PopupAction::Browser
+    }
+}
+
 /// Extract the server mount from a printable-report URL, excluding all other
-/// popup destinations. The caller checks that this server was saved by the user.
-pub fn print_report_server(url: &url::Url) -> Option<String> {
-    if !matches!(url.scheme(), "http" | "https")
-        || !url.username().is_empty()
-        || url.password().is_some()
-    {
+/// pages. The caller checks that this server was saved by the user.
+pub fn print_report_server(url: &Url) -> Option<String> {
+    if !is_plain_web_url(url) {
         return None;
     }
     let mount = url.path().strip_suffix("/reports/print")?;
     Some(format!("{}{mount}", url.origin().ascii_serialization()))
 }
 
-fn on_download(webview: tauri::Webview, event: DownloadEvent<'_>) -> bool {
-    if let DownloadEvent::Finished { success, .. } = event {
-        // macOS does not return a path in Finished. Wry saves downloads to the
-        // Downloads directory and adds a suffix when a filename already exists.
-        let body = if success {
-            "Download complete. The file is in your Downloads folder."
-        } else {
-            eprintln!("[sure] download failed");
-            "Download failed. Please try again."
-        };
-        if let Err(error) = webview
-            .app_handle()
-            .notification()
-            .builder()
-            .title("Sure")
-            .body(body)
-            .show()
-        {
-            eprintln!("[sure] failed to show download notification: {error}");
+fn is_plain_web_url(url: &Url) -> bool {
+    matches!(url.scheme(), "http" | "https")
+        && url.username().is_empty()
+        && url.password().is_none()
+}
+
+/// The page a window shows, recorded each time a navigation commits.
+/// `WebviewWindow::url()` cannot stand in for it: WebKit already reports the
+/// target of a pending navigation there, while the previous page still runs.
+#[derive(Clone, Default)]
+struct ShownPage(Arc<Mutex<Option<Url>>>);
+
+impl ShownPage {
+    fn record(&self, payload: &PageLoadPayload<'_>) {
+        // wry reports Started from didCommitNavigation, when the page changes.
+        if payload.event() == PageLoadEvent::Started {
+            *self.0.lock().unwrap() = Some(payload.url().clone());
         }
     }
-    true
+
+    fn is_saved_server(&self) -> bool {
+        let page = self.0.lock().unwrap().clone();
+        page.is_some_and(|page| crate::servers::is_known_server(page.as_str()))
+    }
+}
+
+fn on_new_window(handle: &AppHandle, opener: &ShownPage, url: Url) -> NewWindowResponse<Wry> {
+    let opener_trusted = opener.is_saved_server();
+    match popup_action(&url, opener_trusted, crate::servers::is_known_server) {
+        PopupAction::ServerWindow => open_server_window(handle, url),
+        PopupAction::Browser => {
+            if let Err(error) = open::that(url.as_str()) {
+                eprintln!("[sure] failed to open link in the browser: {error}");
+            }
+        }
+        PopupAction::Deny => {}
+    }
+    // Allowed popups are opened above, so WebKit never creates its own.
+    NewWindowResponse::Deny
+}
+
+/// Open a page of a saved server in its own Sure window. It is a separate
+/// webview rather than a WebKit popup, which would run on the main window's
+/// configuration and so reach Rust through the main window's IPC handlers. Both
+/// windows use the default website data store, so the session carries over.
+/// Only the main window gets the bridge script and its desktop integrations.
+fn open_server_window(handle: &AppHandle, url: Url) {
+    let label = format!("popup-{}", POPUP_WINDOW_ID.fetch_add(1, Ordering::Relaxed));
+    // Until a page commits, the window stands for the saved-server address it
+    // was opened with, so a file served directly at that address can download.
+    let page = ShownPage(Arc::new(Mutex::new(Some(url.clone()))));
+    let popup_handle = handle.clone();
+    let result = WebviewWindowBuilder::new(handle, label, WebviewUrl::External(url))
+        .title("Sure")
+        .inner_size(1000.0, 800.0)
+        .on_page_load({
+            let page = page.clone();
+            move |window, payload| {
+                page.record(&payload);
+                print_loaded_report(window, payload);
+            }
+        })
+        .on_download({
+            let page = page.clone();
+            move |webview, event| on_download(&page, webview, event)
+        })
+        .on_new_window(move |url, _| on_new_window(&popup_handle, &page, url))
+        .on_document_title_changed(|window, title| {
+            let _ = window.set_title(&title);
+        })
+        .build();
+    if let Err(error) = result {
+        eprintln!("[sure] failed to open window: {error}");
+    }
+}
+
+/// Open the native print dialog once a printable report has loaded. Rust prints
+/// the report's own webview; the page's `window.print()` has no IPC permission,
+/// so it cannot open a second dialog.
+fn print_loaded_report(window: WebviewWindow, payload: PageLoadPayload<'_>) {
+    if payload.event() != PageLoadEvent::Finished
+        || !print_report_server(payload.url())
+            .is_some_and(|server| crate::servers::is_known_server(&server))
+    {
+        return;
+    }
+    std::thread::spawn(move || {
+        std::thread::sleep(PRINT_DELAY);
+        if let Err(error) = window.print() {
+            eprintln!("[sure] failed to print report: {error}");
+        }
+    });
+}
+
+fn on_download(page: &ShownPage, webview: tauri::Webview, event: DownloadEvent<'_>) -> bool {
+    match event {
+        // Only a page of a saved server may save files into Downloads.
+        DownloadEvent::Requested { .. } => {
+            let allowed = page.is_saved_server();
+            if !allowed {
+                eprintln!("[sure] blocked a download from a page outside saved servers");
+            }
+            allowed
+        }
+        // A download refused above also ends here as a failure; stay quiet then.
+        DownloadEvent::Finished { success: false, .. } if !page.is_saved_server() => true,
+        DownloadEvent::Finished { success, .. } => {
+            // macOS does not return a path in Finished. Wry saves downloads to the
+            // Downloads directory and adds a suffix when a filename already exists.
+            let body = if success {
+                "Download complete. The file is in your Downloads folder."
+            } else {
+                eprintln!("[sure] download failed");
+                "Download failed. Please try again."
+            };
+            if let Err(error) = webview
+                .app_handle()
+                .notification()
+                .builder()
+                .title("Sure")
+                .body(body)
+                .show()
+            {
+                eprintln!("[sure] failed to show download notification: {error}");
+            }
+            true
+        }
+        _ => true,
+    }
 }

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -1,8 +1,60 @@
-use tauri::Manager;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tauri::webview::{DownloadEvent, NewWindowResponse};
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_decorum::WebviewWindowExt;
+use tauri_plugin_notification::NotificationExt;
+
+static REPORT_WINDOW_ID: AtomicUsize = AtomicUsize::new(0);
 
 pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
-    let window = app.get_webview_window("main").expect("main window exists");
+    // Build the configured window here so native download and popup handlers
+    // are attached before the webview loads the server.
+    let config = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|window| window.label == "main")
+        .expect("main window configuration exists");
+    let handle = app.handle().clone();
+    let window = WebviewWindowBuilder::from_config(app, config)?
+        .on_download(on_download)
+        .on_new_window(move |url, features| {
+            let Some(server) = print_report_server(&url) else {
+                return NewWindowResponse::Deny;
+            };
+            if !crate::servers::is_known_server(&server) {
+                return NewWindowResponse::Deny;
+            }
+
+            let label = format!(
+                "report-{}",
+                REPORT_WINDOW_ID.fetch_add(1, Ordering::Relaxed)
+            );
+            match WebviewWindowBuilder::new(
+                &handle,
+                label,
+                WebviewUrl::External("about:blank".parse().unwrap()),
+            )
+            // WKWebView requires the opener's configuration. This also keeps
+            // the authenticated server session when opening the report.
+            .window_features(features)
+            .title("Sure")
+            .inner_size(1000.0, 800.0)
+            .on_download(on_download)
+            .on_document_title_changed(|window, title| {
+                let _ = window.set_title(&title);
+            })
+            .build()
+            {
+                Ok(window) => NewWindowResponse::Create { window },
+                Err(error) => {
+                    eprintln!("[sure] failed to open report window: {error}");
+                    NewWindowResponse::Deny
+                }
+            }
+        })
+        .build()?;
 
     // The window is opaque (the app paints its own solid backgrounds), so we
     // skip the transparent-window vibrancy blur — it never showed through and
@@ -13,4 +65,41 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     window.set_traffic_lights_inset(16.0, 20.0)?;
 
     Ok(())
+}
+
+/// Extract the server mount from a printable-report URL, excluding all other
+/// popup destinations. The caller checks that this server was saved by the user.
+pub fn print_report_server(url: &url::Url) -> Option<String> {
+    if !matches!(url.scheme(), "http" | "https")
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    let mount = url.path().strip_suffix("/reports/print")?;
+    Some(format!("{}{mount}", url.origin().ascii_serialization()))
+}
+
+fn on_download(webview: tauri::Webview, event: DownloadEvent<'_>) -> bool {
+    if let DownloadEvent::Finished { success, .. } = event {
+        // macOS does not return a path in Finished. Wry saves downloads to the
+        // Downloads directory and adds a suffix when a filename already exists.
+        let body = if success {
+            "Download complete. The file is in your Downloads folder."
+        } else {
+            eprintln!("[sure] download failed");
+            "Download failed. Please try again."
+        };
+        if let Err(error) = webview
+            .app_handle()
+            .notification()
+            .builder()
+            .title("Sure")
+            .body(body)
+            .show()
+        {
+            eprintln!("[sure] failed to show download notification: {error}");
+        }
+    }
+    true
 }

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -32,7 +32,8 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         })
         .on_download({
             let page = page.clone();
-            move |webview, event| on_download(&page, webview, event)
+            let refused = RefusedDownloads::default();
+            move |webview, event| on_download(&page, &refused, webview, event)
         })
         .on_new_window(move |url, _| on_new_window(&handle, &page, url))
         .build()?;
@@ -155,7 +156,8 @@ fn open_server_window(handle: &AppHandle, url: Url) {
         })
         .on_download({
             let page = page.clone();
-            move |webview, event| on_download(&page, webview, event)
+            let refused = RefusedDownloads::default();
+            move |webview, event| on_download(&page, &refused, webview, event)
         })
         .on_new_window(move |url, _| on_new_window(&popup_handle, &page, url))
         .on_document_title_changed(|window, title| {
@@ -185,19 +187,55 @@ fn print_loaded_report(window: WebviewWindow, payload: PageLoadPayload<'_>) {
     });
 }
 
-fn on_download(page: &ShownPage, webview: tauri::Webview, event: DownloadEvent<'_>) -> bool {
+/// Downloads a window refused. WebKit ends a refused download as a failure for
+/// the same request URL, which must not be reported to the user as one.
+#[derive(Clone, Default)]
+pub struct RefusedDownloads(Arc<Mutex<Vec<Url>>>);
+
+impl RefusedDownloads {
+    /// Remember the decision for a requested download, and return it.
+    pub fn remember(&self, url: &Url, allowed: bool) -> bool {
+        if !allowed {
+            self.0.lock().unwrap().push(url.clone());
+        }
+        allowed
+    }
+
+    /// Whether a finished download is reported: all of them but the refused.
+    pub fn should_report(&self, url: &Url, success: bool) -> bool {
+        if success {
+            return true;
+        }
+        let mut refused = self.0.lock().unwrap();
+        match refused.iter().position(|refused_url| refused_url == url) {
+            Some(index) => {
+                refused.remove(index);
+                false
+            }
+            None => true,
+        }
+    }
+}
+
+fn on_download(
+    page: &ShownPage,
+    refused: &RefusedDownloads,
+    webview: tauri::Webview,
+    event: DownloadEvent<'_>,
+) -> bool {
     match event {
         // Only a page of a saved server may save files into Downloads.
-        DownloadEvent::Requested { .. } => {
+        DownloadEvent::Requested { url, .. } => {
             let allowed = page.is_saved_server();
             if !allowed {
                 eprintln!("[sure] blocked a download from a page outside saved servers");
             }
-            allowed
+            refused.remember(&url, allowed)
         }
-        // A download refused above also ends here as a failure; stay quiet then.
-        DownloadEvent::Finished { success: false, .. } if !page.is_saved_server() => true,
-        DownloadEvent::Finished { success, .. } => {
+        DownloadEvent::Finished { url, success, .. } => {
+            if !refused.should_report(&url, success) {
+                return true;
+            }
             // macOS does not return a path in Finished. Wry saves downloads to the
             // Downloads directory and adds a suffix when a filename already exists.
             let body = if success {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -15,6 +15,7 @@
     "windows": [
       {
         "label": "main",
+        "create": false,
         "title": "Sure",
         "width": 1200,
         "height": 800,

--- a/desktop/src-tauri/tests/window_test.rs
+++ b/desktop/src-tauri/tests/window_test.rs
@@ -1,4 +1,5 @@
-use sure_desktop_lib::window::print_report_server;
+use sure_desktop_lib::servers::{base_covers, normalize_server_url};
+use sure_desktop_lib::window::{popup_action, print_report_server, PopupAction};
 use url::Url;
 
 #[test]
@@ -40,5 +41,72 @@ fn rejects_other_popup_routes_and_non_server_urls() {
             print_report_server(&Url::parse(url).unwrap()).is_none(),
             "accepted {url}"
         );
+    }
+}
+
+// Mirrors servers::is_known_server without reading the saved server list.
+fn saved_server(url: &str) -> bool {
+    normalize_server_url(url).is_ok_and(|url| {
+        ["https://sure.example.com", "https://home.example.com/sure"]
+            .iter()
+            .any(|base| base_covers(base, &url))
+    })
+}
+
+fn action(url: &str, opener_trusted: bool) -> PopupAction {
+    popup_action(&Url::parse(url).unwrap(), opener_trusted, saved_server)
+}
+
+#[test]
+fn opens_saved_server_pages_in_a_sure_window() {
+    for url in [
+        "https://sure.example.com/reports/print?period_type=monthly",
+        "https://sure.example.com/transactions/1/attachments/2?disposition=inline",
+        "https://sure.example.com/privacy",
+        "https://home.example.com/sure/reports/print",
+    ] {
+        assert_eq!(action(url, true), PopupAction::ServerWindow, "{url}");
+    }
+}
+
+#[test]
+fn opens_other_websites_in_the_browser() {
+    for url in [
+        "https://app.snaptrade.com/device?user_code=ABCD-1234",
+        "https://discord.gg/36ZGBsxYEK",
+        "http://example.org/help",
+        "https://sure.example.com.evil.test/reports/print",
+        "http://sure.example.com/reports/print",
+        "https://home.example.com/other",
+        "https://home.example.com/surely",
+    ] {
+        assert_eq!(action(url, true), PopupAction::Browser, "{url}");
+    }
+}
+
+#[test]
+fn ignores_popups_from_pages_outside_saved_servers() {
+    for url in [
+        "https://sure.example.com/reports/print",
+        "https://app.snaptrade.com/device",
+    ] {
+        assert_eq!(action(url, false), PopupAction::Deny, "{url}");
+    }
+}
+
+#[test]
+fn ignores_non_web_schemes_and_credentials() {
+    for url in [
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "about:blank",
+        "data:text/html,hello",
+        "mailto:support@example.com",
+        "sure://sure.example.com/accounts",
+        "x-apple.systempreferences:com.apple.preference.security",
+        "https://user:password@sure.example.com/reports/print",
+        "https://user@example.org/",
+    ] {
+        assert_eq!(action(url, true), PopupAction::Deny, "{url}");
     }
 }

--- a/desktop/src-tauri/tests/window_test.rs
+++ b/desktop/src-tauri/tests/window_test.rs
@@ -1,5 +1,5 @@
 use sure_desktop_lib::servers::{base_covers, normalize_server_url};
-use sure_desktop_lib::window::{popup_action, print_report_server, PopupAction};
+use sure_desktop_lib::window::{popup_action, print_report_server, PopupAction, RefusedDownloads};
 use url::Url;
 
 #[test]
@@ -109,4 +109,30 @@ fn ignores_non_web_schemes_and_credentials() {
     ] {
         assert_eq!(action(url, true), PopupAction::Deny, "{url}");
     }
+}
+
+// The decision made when a download starts holds until it finishes, whatever
+// page the window has navigated to in between.
+#[test]
+fn reports_every_download_outcome_except_refused_downloads() {
+    let downloads = RefusedDownloads::default();
+    let export = Url::parse("https://sure.example.com/reports/export_transactions.csv").unwrap();
+    let tracker = Url::parse("https://tracker.example/file.zip").unwrap();
+
+    assert!(downloads.remember(&export, true));
+    assert!(!downloads.remember(&tracker, false));
+
+    assert!(
+        downloads.should_report(&export, false),
+        "an allowed download that fails is reported"
+    );
+    assert!(downloads.should_report(&export, true));
+    assert!(
+        !downloads.should_report(&tracker, false),
+        "a refused download ends quietly"
+    );
+    assert!(
+        downloads.should_report(&tracker, false),
+        "each refusal silences only its own failure"
+    );
 }

--- a/desktop/src-tauri/tests/window_test.rs
+++ b/desktop/src-tauri/tests/window_test.rs
@@ -1,0 +1,44 @@
+use sure_desktop_lib::window::print_report_server;
+use url::Url;
+
+#[test]
+fn identifies_print_reports_with_filters_and_server_mounts() {
+    for (url, expected) in [
+        (
+            "https://sure.example.com/reports/print?period_type=monthly",
+            "https://sure.example.com",
+        ),
+        (
+            "http://localhost:3000/sure/reports/print?start_date=2026-09-01&end_date=2026-09-09",
+            "http://localhost:3000/sure",
+        ),
+        (
+            "https://sure.example.com/nested/sure/reports/print",
+            "https://sure.example.com/nested/sure",
+        ),
+    ] {
+        assert_eq!(
+            print_report_server(&Url::parse(url).unwrap()).as_deref(),
+            Some(expected)
+        );
+    }
+}
+
+#[test]
+fn rejects_other_popup_routes_and_non_server_urls() {
+    for url in [
+        "https://sure.example.com/reports",
+        "https://sure.example.com/reports/print/other",
+        "https://sure.example.com/reports/printable",
+        "https://sure.example.com/accounts?next=/reports/print",
+        "https://user:password@sure.example.com/reports/print",
+        "file:///reports/print",
+        "javascript:window.print()",
+        "about:blank",
+    ] {
+        assert!(
+            print_report_server(&Url::parse(url).unwrap()).is_none(),
+            "accepted {url}"
+        );
+    }
+}

--- a/desktop/src/bridge.ts
+++ b/desktop/src/bridge.ts
@@ -1,7 +1,7 @@
 // Injected into every page loaded in the main window (local onboarding + the
 // remote Sure site). Adds native-titlebar chrome, drags the window, forwards
-// notifications/badge to Rust, intercepts SSO into the system browser, and
-// navigates on server switches.
+// notifications/badge to Rust, enables report downloads, intercepts SSO into the
+// system browser, and navigates on server switches.
 (() => {
   const tauri = (window as any).__TAURI__;
 
@@ -15,6 +15,36 @@
     hasCore: !!tauri?.core,
     hasWindow: !!tauri?.window,
   });
+
+  // WKWebView needs the download attribute for renderable types such as CSV.
+  // Keep the request in this webview so its authenticated session is retained.
+  // Capture runs before Turbo, while leaving the native click action intact.
+  if (!(window as any).__sureReportDownloadHook) {
+    (window as any).__sureReportDownloadHook = true;
+    document.addEventListener(
+      "click",
+      (ev) => {
+        const link = (ev.target as Element | null)?.closest?.("a[href]") as HTMLAnchorElement | null;
+        if (!link) return;
+        let url: URL;
+        try {
+          url = new URL(link.href, location.href);
+        } catch {
+          return;
+        }
+        if (
+          url.origin !== location.origin ||
+          !url.pathname.endsWith("/reports/export_transactions.csv")
+        ) {
+          return;
+        }
+        if (!link.hasAttribute("download")) link.setAttribute("download", "");
+        link.setAttribute("data-turbo", "false");
+        link.setAttribute("target", "_self");
+      },
+      true
+    );
+  }
 
   // Native titlebar chrome — offset the left icon rail so its logo clears the
   // traffic lights, and make the top ~34px band drag the window. Using a

--- a/desktop/tests/bridge.test.mjs
+++ b/desktop/tests/bridge.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+import ts from "typescript";
+
+const source = readFileSync(new URL("../src/bridge.ts", import.meta.url), "utf8");
+const script = new vm.Script(
+  ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2021 } }).outputText
+);
+
+function loadBridge(pageUrl = "https://sure.example/reports") {
+  const listeners = new Map();
+  const context = vm.createContext({
+    URL,
+    window: {},
+    location: new URL(pageUrl),
+    console: { log() {}, warn() {} },
+    document: {
+      head: { appendChild() {} },
+      createElement: () => ({}),
+      addEventListener(type, listener, capture) {
+        const entries = listeners.get(type) || [];
+        entries.push({ listener, capture });
+        listeners.set(type, entries);
+      },
+    },
+  });
+  script.runInContext(context);
+
+  return {
+    reinject: () => script.runInContext(context),
+    listeners,
+    click(target) {
+      const event = {
+        target,
+        defaultPrevented: false,
+        propagationStopped: false,
+        preventDefault() { this.defaultPrevented = true; },
+        stopImmediatePropagation() { this.propagationStopped = true; },
+      };
+      for (const { listener, capture } of listeners.get("click") || []) {
+        assert.equal(capture, true, "the export link must be prepared before Turbo handles the click");
+        listener(event);
+      }
+      return event;
+    },
+  };
+}
+
+function anchor(href, attributes = {}) {
+  const values = { href, ...attributes };
+  const link = {
+    href,
+    attributes: values,
+    hasAttribute: (name) => Object.hasOwn(values, name),
+    setAttribute: (name, value) => { values[name] = value; },
+    closest: (selector) => {
+      assert.equal(selector, "a[href]");
+      return link;
+    },
+  };
+  return link;
+}
+
+function nestedTarget(link) {
+  return {
+    closest(selector) {
+      assert.equal(selector, "a[href]");
+      return link;
+    },
+  };
+}
+
+test("CSV clicks select native download without cancelling the authenticated request", () => {
+  const bridge = loadBridge();
+  const href = "/reports/export_transactions.csv?period_type=custom&start_date=2026-09-01&end_date=2026-09-09";
+  const link = anchor(href, { target: "_blank" });
+
+  const event = bridge.click(nestedTarget(link));
+
+  assert.deepEqual(link.attributes, {
+    href,
+    target: "_self",
+    download: "",
+    "data-turbo": "false",
+  });
+  assert.equal(link.href, href, "the export URL and date filters must stay unchanged");
+  assert.equal(event.defaultPrevented, false);
+  assert.equal(event.propagationStopped, false);
+});
+
+test("CSV downloads support a server mounted beneath a path prefix", () => {
+  const bridge = loadBridge("https://sure.example/finance/sure/reports");
+  const link = anchor("https://sure.example/finance/sure/reports/export_transactions.csv?period_type=ytd");
+
+  bridge.click(link);
+
+  assert.equal(link.attributes.download, "");
+  assert.equal(link.attributes.target, "_self");
+});
+
+test("an explicit filename is retained when marking a report download", () => {
+  const bridge = loadBridge();
+  const link = anchor("/reports/export_transactions.csv", { download: "report.csv" });
+
+  bridge.click(nestedTarget(link));
+
+  assert.equal(link.attributes.download, "report.csv");
+});
+
+test("other origins, routes and formats are left unchanged", () => {
+  const bridge = loadBridge();
+  for (const href of [
+    "https://other.example/reports/export_transactions.csv",
+    "http://sure.example/reports/export_transactions.csv",
+    "https://sure.example:8443/reports/export_transactions.csv",
+    "/reports/print",
+    "/reports/export_transactions.pdf",
+    "/reports/export_transactions.csv/preview",
+    "/other.csv",
+    "http://[invalid",
+  ]) {
+    const link = anchor(href, { target: "_blank" });
+
+    bridge.click(nestedTarget(link));
+
+    assert.deepEqual(link.attributes, { href, target: "_blank" }, href);
+  }
+});
+
+test("clicks outside links remain unaffected", () => {
+  const bridge = loadBridge();
+  assert.doesNotThrow(() => bridge.click(nestedTarget(null)));
+  assert.doesNotThrow(() => bridge.click({}));
+  assert.doesNotThrow(() => bridge.click(null));
+});
+
+test("reinjection installs only one report download listener, even without Tauri IPC", () => {
+  const bridge = loadBridge();
+  bridge.reinject();
+
+  assert.equal(bridge.listeners.get("click").length, 1);
+  const link = anchor("/reports/export_transactions.csv");
+  bridge.click(nestedTarget(link));
+  assert.equal(link.attributes.download, "");
+});


### PR DESCRIPTION
## Issue
The desktop application did not support opening printable reports and had no native macOS printing for them. CSV downloads also lacked visible feedback, and links that open a new window (`target="_blank"`, `window.open`) did nothing.

## Changes
- Opens Print Report in a separate Sure window that keeps the signed-in session, then opens the native print dialog from Rust once the report has loaded. The window is an independent webview rather than a WebKit popup, which would share the main window's IPC handlers.
- Opens other pages of a saved server that request a new window (attachment and statement previews, footer pages) in the same kind of window. Other websites open in the default browser. Popups are ignored unless the requesting window shows a page of a saved server, and non-web schemes or URLs with credentials are never opened.
- Explicitly triggers the CSV download in the WebView and notifies the user of a successful or failed download. Downloads are only accepted from pages of saved servers.
- Documents the flows and how to verify them in `desktop/README.md`.

## Review feedback
- Codex (print): fixed as described above; the remote `core:webview:allow-print` capability is no longer needed.
- jjmata (popups): fixed as described above.
- CodeRabbit (HTTPS for non-loopback servers): not changed here, see the replies in the threads. Enforcing HTTPS at server registration would break existing LAN self-hosted setups and belongs in a separate PR.

## Validation
- `npm test` (6 tests) and `npm run build` in `desktop`.
- `cargo test --locked` in `desktop/src-tauri` (30 tests); clippy reports only the 2 warnings already on `main`.
- Full `bin/rails test` (8566 runs, 0 failures), RuboCop, ERB lint, Biome and Brakeman pass. No Rails files changed, so system tests are not applicable.
- Manual verification of CSV, PDF and external links in the rebuilt application is still needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Report printing now waits for the report to load before opening the print or PDF-save dialog.
  - Transaction CSV exports download within the current Sure session.
  - Links to saved server pages open in Sure windows, while external websites open in the default browser.
  - Downloads are restricted to saved-server pages for improved security.

- **Documentation**
  - Updated desktop guidance for window, link, download, printing, and browser behavior.

- **Tests**
  - Added coverage for printing, popup routing, downloads, and CSV export handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

