### PR TITLE
Allow API transaction update to opt into sync protection (user_modified)

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -153,6 +153,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
 
         @entry.sync_account_later
         @entry.lock_saved_attributes!
+        @entry.mark_user_modified! if user_modified_requested?
 
         @transaction = @entry.transaction
         render :show
@@ -315,8 +316,8 @@ class Api::V1::TransactionsController < Api::V1::BaseController
       )
     end
 
-    # An API client can opt a transaction it creates into the same
-    # sync-protection a manual edit gets (Entry#protected_from_sync?) -
+    # An API client can opt a transaction it creates or updates into the
+    # same sync-protection a manual edit gets (Entry#protected_from_sync?) -
     # useful for a client that owns its own writes into an account also
     # linked to a bank-sync provider (Plaid/SimpleFin/etc.), so the next
     # sync only links its external_id to the entry instead of overwriting

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7842,6 +7842,10 @@ paths:
                         format: uuid
                       description: Array of tag IDs to assign. Omit to preserve existing
                         tags; use [] to clear all tags.
+                    user_modified:
+                      type: boolean
+                      description: Whether provider syncs should preserve user-supplied
+                        transaction changes
         required: true
     delete:
       summary: Delete a transaction

--- a/spec/requests/api/v1/transactions_spec.rb
+++ b/spec/requests/api/v1/transactions_spec.rb
@@ -321,7 +321,8 @@ RSpec.describe 'API V1 Transactions', type: :request do
                 type: :array,
                 items: { type: :string, format: :uuid },
                 description: 'Array of tag IDs to assign. Omit to preserve existing tags; use [] to clear all tags.'
-              }
+              },
+              user_modified: { type: :boolean, description: 'Whether provider syncs should preserve user-supplied transaction changes' }
             }
           }
         }

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -666,6 +666,38 @@ class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated Transaction Name", response_data["name"]
   end
 
+  test "should protect transaction from provider sync when updated with user_modified true" do
+    update_params = {
+      transaction: {
+        name: "Client-owned Name",
+        user_modified: true
+      }
+    }
+
+    put api_v1_transaction_url(@transaction),
+        params: update_params,
+        headers: api_headers(@api_key)
+    assert_response :success
+
+    response_data = JSON.parse(response.body)
+    assert_equal "Client-owned Name", response_data["name"]
+    assert_equal true, response_data["user_modified"]
+
+    entry = @transaction.entry.reload
+    assert entry.user_modified?
+    assert entry.protected_from_sync?
+  end
+
+  test "should not change user_modified on update by default" do
+    put api_v1_transaction_url(@transaction),
+        params: { transaction: { name: "Updated Name Only" } },
+        headers: api_headers(@api_key)
+    assert_response :success
+
+    assert_equal false, JSON.parse(response.body)["user_modified"]
+    assert_not @transaction.entry.reload.user_modified?
+  end
+
   test "should reject update with read-only API key" do
     update_params = {
       transaction: {


### PR DESCRIPTION
## Summary

Follow-up to #3162, which added an optional `user_modified` param to `POST /api/v1/transactions` but deliberately scoped it to **create** only (offered to extend to update "in a follow-up if that's wanted" — [discussion #3400](https://github.com/we-promise/sure/discussions/3400) asked for it).

`PATCH /api/v1/transactions/:id` has no equivalent today: an API client that edits a transaction's name or category gets a `200`, then watches the edit get silently reverted on the next provider sync (Plaid/SimpleFin/etc.), because the update path never calls `Entry#mark_user_modified!` the way the web UI — and now the create action — does. `Account::ProviderImportAdapter#import_transaction` re-claims the entry and re-enriches its unlocked fields from the sync payload.

This mirrors the create action exactly:
- same permitted param (`:user_modified`)
- same `user_modified_requested?` boolean-cast helper (already present)
- same `@entry.mark_user_modified! if user_modified_requested?`, right after `lock_saved_attributes!`

The transaction JSON view already renders `user_modified`, so there's no view change.

## Changes

- `app/controllers/api/v1/transactions_controller.rb` — one line in `update`; widened the helper comment to "creates or updates"
- `spec/requests/api/v1/transactions_spec.rb` — added `user_modified` to the `patch` request schema
- `docs/api/openapi.yaml` — regenerated block for the update request body
- `test/controllers/api/v1/transactions_controller_test.rb` — two request tests matching the create-side pair:
  - `user_modified: true` on update ⇒ entry is `user_modified?` and `protected_from_sync?`, response echoes it
  - an ordinary update leaves the flag `false`

## Test plan

- [x] `ruby -c` on all changed `.rb` files
- [ ] Full suite via CI (no Rails-compatible toolchain in my environment) — the new tests follow the exact style of the existing `"should update transaction with valid parameters"` and the create-side `user_modified` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction updates now support a `user_modified` option to preserve user-supplied changes during provider syncs.
  * Updated transactions can be marked as protected from synchronization when this option is enabled.

* **Documentation**
  * API documentation now describes the optional `user_modified` field for transaction updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->