### PR TITLE
fix(l10n): localize German background job statistics

### DIFF
--- a/config/locales/views/admin/system_health/de.yml
+++ b/config/locales/views/admin/system_health/de.yml
@@ -1,0 +1,36 @@
+---
+de:
+  admin:
+    system_health:
+      show:
+        title: Systemstatus
+        tabs:
+          background_jobs: Hintergrundaufgaben
+          ai: KI-Status
+        alert:
+          title: Hintergrundaufgaben werden nicht ausgeführt
+        status_section_title: Sidekiq-Status
+        status_section_description: Aktueller Status des Hintergrundprozesses, der Synchronisierungen sowie die Berechnung von Kontoständen und Nettovermögen ausführt.
+        counters_section_title: Aufgabenstatistik
+        counters_section_description: Zusammengefasste Sidekiq-Zähler über alle Warteschlangen hinweg.
+        queues_section_title: Warteschlangen
+        queues_section_description: Anzahl der Aufgaben und Wartezeit der ältesten Aufgabe je Warteschlange. Die Wartezeit wird in Sekunden angegeben.
+        labels:
+          status: Status
+          processes: Worker-Prozesse
+          last_heartbeat: Letztes Lebenszeichen
+          max_queue_latency: Längste Wartezeit
+          enqueued: In der Warteschlange
+          retries: Zur Wiederholung vorgemerkt
+          failed: Fehlgeschlagen
+          processed_total: Insgesamt verarbeitet
+          queue: Warteschlange
+          size: Anzahl der Aufgaben
+          latency: Wartezeit
+        values:
+          healthy: Funktionsfähig
+          unhealthy: Beeinträchtigt
+          time_ago: vor %{time_ago}
+          never: Nie
+          seconds: "%{seconds} s"
+          no_queues: Es sind keine Warteschlangen registriert. Möglicherweise läuft der Worker nicht.

--- a/test/controllers/admin/system_health_controller_test.rb
+++ b/test/controllers/admin/system_health_controller_test.rb
@@ -69,7 +69,84 @@ class Admin::SystemHealthControllerTest < ActionDispatch::IntegrationTest
     assert_match(/No Sidekiq worker process is connected/, response.body)
   end
 
+  test "German background job translations are present without fallback" do
+    keys = %w[
+      title tabs.background_jobs tabs.ai alert.title
+      status_section_title status_section_description counters_section_title
+      counters_section_description queues_section_title queues_section_description
+      labels.status labels.processes labels.last_heartbeat labels.max_queue_latency
+      labels.enqueued labels.retries labels.failed labels.processed_total
+      labels.queue labels.size labels.latency values.healthy values.unhealthy
+      values.never values.no_queues
+    ]
+    keys.each do |key|
+      assert_kind_of String, I18n.t("admin.system_health.show.#{key}", locale: :de, fallback: false, raise: true)
+    end
+    assert_equal "vor 2 Minuten", I18n.t("admin.system_health.show.values.time_ago", locale: :de,
+      fallback: false, raise: true, time_ago: "2 Minuten")
+    assert_equal "1,5 s", I18n.t("admin.system_health.show.values.seconds", locale: :de,
+      fallback: false, raise: true, seconds: "1,5")
+  end
+
+  test "German super admin sees localized background job statistics" do
+    users(:sure_support_staff).update!(locale: "de")
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+
+    travel_to Time.current do
+      SidekiqHealth.any_instance.stubs(:last_heartbeat_at).returns(2.minutes.ago)
+      SidekiqHealth.any_instance.stubs(:queue_breakdown).returns([ [ "default", 1234, 1.5 ] ])
+      get admin_system_health_url
+    end
+
+    assert_response :success
+    assert_select "h1", text: "Systemstatus"
+    assert_select "button[role='tab'][aria-selected='true']", text: "Hintergrundaufgaben"
+    assert_select "button[role='tab']", text: "KI-Status"
+    assert_select "h2", text: "Sidekiq-Status"
+    assert_select "h2", text: "Aufgabenstatistik"
+    assert_select "h2", text: "Warteschlangen"
+    assert_select "dd", text: "Funktionsfähig"
+    assert_select "dd", text: "vor 2 Minuten"
+    {
+      "Status" => "Funktionsfähig", "Worker-Prozesse" => "1",
+      "Letztes Lebenszeichen" => "vor 2 Minuten", "Längste Wartezeit" => "0,0 s",
+      "In der Warteschlange" => "0", "Zur Wiederholung vorgemerkt" => "0",
+      "Fehlgeschlagen" => "0", "Insgesamt verarbeitet" => "42"
+    }.each do |label, value|
+      assert_select "dl > div" do |items|
+        item = items.find { |element| element.at_css("dt")&.text == label }
+        assert item, "Missing statistic: #{label}"
+        assert_equal value, item.at_css("dd").text.strip
+      end
+    end
+    assert_select "th", text: "Anzahl der Aufgaben"
+    assert_select "th", text: "Wartezeit"
+    assert_select "td", text: "default"
+    assert_select "td", text: "1.234"
+    assert_select "td", text: "1,5 s"
+  end
+
+  test "German background job statistics show degraded and empty states" do
+    users(:sure_support_staff).update!(locale: "de")
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+    SidekiqHealth.any_instance.stubs(:healthy?).returns(false)
+    SidekiqHealth.any_instance.stubs(:reason).returns(:no_worker_processes)
+    SidekiqHealth.any_instance.stubs(:last_heartbeat_at).returns(nil)
+    SidekiqHealth.any_instance.stubs(:queue_breakdown).returns([])
+
+    get admin_system_health_url
+
+    assert_response :success
+    assert_select "dd", text: "Beeinträchtigt"
+    assert_select "dd", text: "Nie"
+    assert_match "Hintergrundaufgaben werden nicht ausgeführt", response.body
+    assert_select "p", text: "Es sind keine Warteschlangen registriert. Möglicherweise läuft der Worker nicht."
+  end
+
   test "non super admin is redirected away" do
+    users(:family_admin).update!(locale: "de")
     sign_in users(:family_admin)
 
     get admin_system_health_url


### PR DESCRIPTION
## Summary

German administrators now see the system-health title, tabs and Sidekiq statistics in German instead of English fallback text. Queue names and worker behavior are unchanged.

This continues the German localization work after the navigation label landed. Shared warning reasons and AI diagnostic details remain separate follow-ups.

Related: #3477

## Validation

- Regression tests first reproduced the missing German keys and English rendering. Focused controller and locale tests pass: 37 runs, 478 assertions.
- Full Rails suite, RuboCop, ERB-Lint, Biome and Brakeman pass.
- Synthetic browser checks at 1024 and 1440 pixels passed; German labels fit without clipping.
- Independent AI language review and code review completed. No production data was used.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes display text only. After deployment, verify the German background-jobs tab as a super admin; worker and queue diagnostics retain their existing behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added German translations for the system health page, including navigation tabs, alerts, section descriptions, counters, queue labels, and status values.
  - German users can now view health statistics, time and decimal values, and healthy or degraded system states in their selected language.
- **Tests**
  - Added coverage to verify German system health translations and localized page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->