### PR TITLE
fix(providers): honor the category matcher toggle for Up and monobank

### DIFF
--- a/app/models/account/linkable.rb
+++ b/app/models/account/linkable.rb
@@ -75,10 +75,15 @@ module Account::Linkable
   end
 
   # Whether this account's provider applies the category matcher to imported
-  # transactions. Only Plaid honors `enable_category_matcher` today; extend this
-  # when other providers (e.g. SimpleFIN) wire up category matching.
+  # transactions, and therefore honors `enable_category_matcher`. Add a provider
+  # here only once its entry processor checks the toggle; listing one that
+  # ignores it shows the user a switch that does nothing.
+  CATEGORY_MATCHER_PROVIDER_TYPES = %w[PlaidAccount UpAccount MonobankAccount].freeze
+
   def supports_category_matcher?
-    plaid_account.present? || linked_to?("PlaidAccount")
+    return true if plaid_account.present?
+
+    account_providers.exists?(provider_type: CATEGORY_MATCHER_PROVIDER_TYPES)
   end
 
   # Check if holdings can be deleted

--- a/app/models/monobank_entry/processor.rb
+++ b/app/models/monobank_entry/processor.rb
@@ -110,11 +110,13 @@ class MonobankEntry::Processor
     end
 
     # The id of the Sure category the transaction's MCC maps to, or nil when no matcher
-    # was injected, the MCC is missing, or it has no confident equivalent among the
-    # family's categories. The import adapter applies this via enrich_attribute, so it
-    # never overwrites a category the user has set or locked.
+    # was injected, the account has category matching switched off, the MCC is missing,
+    # or it has no confident equivalent among the family's categories. The import
+    # adapter applies this via enrich_attribute, so it never overwrites a category the
+    # user has set or locked.
     def matched_category_id
       return nil unless @category_matcher
+      return nil unless account&.enable_category_matcher?
 
       @category_matcher.match(data[:mcc])&.id
     end

--- a/app/models/up_entry/processor.rb
+++ b/app/models/up_entry/processor.rb
@@ -106,12 +106,13 @@ class UpEntry::Processor
     end
 
     # The id of the Sure category that Up's category slug maps to, or nil when no
-    # matcher was injected, the transaction has no Up category (transfers/income), or
-    # the slug has no confident equivalent among the family's categories. The import
-    # adapter applies this via enrich_attribute, so it never overwrites a category the
-    # user has set or locked.
+    # matcher was injected, the account has category matching switched off, the
+    # transaction has no Up category (transfers/income), or the slug has no confident
+    # equivalent among the family's categories. The import adapter applies this via
+    # enrich_attribute, so it never overwrites a category the user has set or locked.
     def matched_category_id
       return nil unless @category_matcher
+      return nil unless account&.enable_category_matcher?
 
       @category_matcher.match(data[:category_id])&.id
     end

--- a/test/models/account/linkable_test.rb
+++ b/test/models/account/linkable_test.rb
@@ -56,7 +56,21 @@ class Account::LinkableTest < ActiveSupport::TestCase
     assert @account.supports_category_matcher?
   end
 
-  test "supports_category_matcher? returns false for unlinked and non-Plaid accounts" do
+  test "supports_category_matcher? returns true for Up-linked accounts" do
+    up_item = UpItem.create!(family: @family, name: "Test Up", access_token: "up-access-token")
+    up_account = UpAccount.create!(up_item: up_item, name: "Up Spending", account_id: "up_acc_1", currency: "AUD")
+    AccountProvider.create!(account: @account, provider: up_account)
+
+    assert @account.supports_category_matcher?
+  end
+
+  test "supports_category_matcher? returns true for Monobank-linked accounts" do
+    AccountProvider.create!(account: @account, provider: monobank_accounts(:black_card))
+
+    assert @account.supports_category_matcher?
+  end
+
+  test "supports_category_matcher? returns false for unlinked accounts and providers without a matcher" do
     refute @account.supports_category_matcher?
 
     simplefin_item = SimplefinItem.create!(

--- a/test/models/monobank_entry/processor_test.rb
+++ b/test/models/monobank_entry/processor_test.rb
@@ -129,12 +129,58 @@ class MonobankEntry::ProcessorTest < ActiveSupport::TestCase
     assert first.start_with?("monobank_pending_")
   end
 
+  test "applies the matched Sure category when a category_matcher is provided" do
+    @family.categories.bootstrap!
+
+    entry = process(
+      **grocery_transaction,
+      category_matcher: category_matcher
+    )
+
+    assert_equal "Groceries", entry.transaction.category&.name
+    # The raw MCC is still preserved in extra for reference.
+    assert_equal 5411, entry.transaction.extra.dig("monobank", "mcc")
+  end
+
+  test "skips category matching when the account has the matcher switched off" do
+    @family.categories.bootstrap!
+    @account.update!(enable_category_matcher: false)
+
+    entry = process(
+      **grocery_transaction,
+      category_matcher: category_matcher
+    )
+
+    assert_nil entry.transaction.category_id
+    # Still imported, still carries the MCC — only the auto-category is withheld.
+    assert_equal 5411, entry.transaction.extra.dig("monobank", "mcc")
+  end
+
   private
 
-    def process(**transaction_data)
+    def process(category_matcher: nil, **transaction_data)
       MonobankEntry::Processor.new(
         transaction_data.deep_stringify_keys,
-        monobank_account: @monobank_account
+        monobank_account: @monobank_account,
+        category_matcher: category_matcher
       ).process
+    end
+
+    def grocery_transaction
+      {
+        id: "tx_cat_1",
+        time: MIDDAY_UNIX,
+        description: "Silpo",
+        mcc: 5411,
+        originalMcc: 5411,
+        hold: false,
+        amount: -50_000,
+        operationAmount: -50_000,
+        currencyCode: 980
+      }
+    end
+
+    def category_matcher
+      MonobankAccount::Transactions::CategoryMatcher.new(@family.categories.to_a, locale: @family.locale)
     end
 end

--- a/test/models/up_entry/processor_test.rb
+++ b/test/models/up_entry/processor_test.rb
@@ -197,4 +197,29 @@ class UpEntry::ProcessorTest < ActiveSupport::TestCase
 
     assert_nil entry.transaction.category_id
   end
+
+  test "skips category matching when the account has the matcher switched off" do
+    @family.categories.bootstrap!
+    @account.update!(enable_category_matcher: false)
+    matcher = UpAccount::Transactions::CategoryMatcher.new(@family.categories.to_a)
+
+    entry = UpEntry::Processor.new(
+      {
+        id: "tx_cat_3",
+        account_id: "acc_123",
+        status: "SETTLED",
+        description: "Woolworths",
+        amount: { currencyCode: "AUD", value: "-40.00", valueInBaseUnits: -4000 },
+        settledAt: "2026-01-15T00:00:00+11:00",
+        createdAt: "2026-01-15T00:00:00+11:00",
+        category_id: "groceries"
+      },
+      up_account: @up_account,
+      category_matcher: matcher
+    ).process
+
+    assert_nil entry.transaction.category_id
+    # Still imported, still carries the Up slug — only the auto-category is withheld.
+    assert_equal "groceries", entry.transaction.extra.dig("up", "category_id")
+  end
 end


### PR DESCRIPTION
## Problem

`accounts.enable_category_matcher` is meant to let a user switch off provider-suggested categories on a linked account. Only Plaid ever honored it, in both directions:

- `Account::Linkable#supports_category_matcher?` returned true only for Plaid, so the toggle in the account form was never rendered for Up- or monobank-linked accounts.
- `UpEntry::Processor#matched_category_id` and `MonobankEntry::Processor#matched_category_id` never read the flag, so their matchers ran unconditionally.

Both providers ship a real category matcher (`UpAccount::Transactions::CategoryMatcher`, `MonobankAccount::Transactions::CategoryMatcher`), so a user importing from either got auto-categorization with no way to turn it off — and, because the toggle was hidden, no indication that the setting existed. Setting the column `false` by other means had no effect either.

## Resulting behavior

- The account form now shows the existing "Enable category matcher" toggle for Up and monobank accounts, using the provider-neutral copy already in place.
- Both processors return `nil` for the matched category when the account has the toggle off. The transaction still imports and still stores its raw provider metadata (`extra.up.category_id`, `extra.monobank.mcc`) — only the auto-category is withheld, leaving the transaction to the user's rules or the AI categorizer.
- The provider list lives in `Account::Linkable::CATEGORY_MATCHER_PROVIDER_TYPES` rather than a chain of `linked_to?` calls, so wiring up the next provider is one entry plus its processor guard.

No migration and no new strings: the column already exists and defaults to `true`, so nobody's current categorization changes. SimpleFIN is deliberately left out — it has no matcher yet, and its processor already carries a comment asking for exactly this treatment when one lands.

## Validation

- `bin/rails test` — 8654 runs, 0 failures
- `bin/rubocop -f github` — clean
- `bin/brakeman --no-pager` — 0 security warnings
- The four new tests fail against the unfixed code, verified by reverting the three model changes

No ERB, JS or API surface touched, so no erb_lint/Biome/rswag work applies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added category matching support for Up and Monobank accounts, alongside existing Plaid support.

- **Bug Fixes**
  - Category matching is now skipped when disabled for an account.
  - Transactions continue importing with their original category or MCC details preserved, without assigning a matched category when matching is disabled.

- **Tests**
  - Added coverage for category matching and disabled matching across supported account types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->