### PR TITLE
fix: stop a missing exchange rate from failing a whole account, and make the error legible

### DIFF
--- a/app/models/balance/sync_cache.rb
+++ b/app/models/balance/sync_cache.rb
@@ -1,6 +1,16 @@
 class Balance::SyncCache
   def initialize(account)
     @account = account
+    @unconvertible_entry_count = 0
+    @missing_rate_pairs = []
+  end
+
+  # How many entries were left out of the balance calculation because no exchange rate was
+  # available to convert them into the account's currency. Populated once `converted_entries`
+  # has run; zero on a healthy sync.
+  def unconvertible_entry_count
+    entries_by_date
+    @unconvertible_entry_count
   end
 
   def get_valuation(date)
@@ -34,24 +44,55 @@ class Balance::SyncCache
     end
 
     def converted_entries
-      @converted_entries ||= account.entries.excluding_pending.excluding_split_parents.includes(:entryable).order(:date).to_a.map do |e|
-        custom_rate = e.entryable.exchange_rate if e.entryable.respond_to?(:exchange_rate)
+      @converted_entries ||= begin
+        converted = account.entries.excluding_pending.excluding_split_parents.includes(:entryable).order(:date).to_a.filter_map do |e|
+          custom_rate = e.entryable.exchange_rate if e.entryable.respond_to?(:exchange_rate)
 
-        # Use Money#exchange_to with custom rate if available, standard lookup otherwise.
-        # Mutate the entry in place rather than dup'ing — these instances are scoped to
-        # this sync-cache only and never persisted, so avoiding the dup eliminates a
-        # large amount of ActiveModel::Attribute allocations during sync.
-        # to_a materializes independent instances; no AR identity map is active during sync,
-        # so callers holding a reference to the same association will never see these mutations.
-        new_amount = e.amount_money.exchange_to(
-          account.currency,
-          date: e.date,
-          custom_rate: custom_rate
-        ).amount
+          # Use Money#exchange_to with custom rate if available, standard lookup otherwise.
+          # Mutate the entry in place rather than dup'ing — these instances are scoped to
+          # this sync-cache only and never persisted, so avoiding the dup eliminates a
+          # large amount of ActiveModel::Attribute allocations during sync.
+          # to_a materializes independent instances; no AR identity map is active during sync,
+          # so callers holding a reference to the same association will never see these mutations.
+          begin
+            new_amount = e.amount_money.exchange_to(
+              account.currency,
+              date: e.date,
+              custom_rate: custom_rate
+            ).amount
+          rescue Money::ConversionError => error
+            # Drop the entry instead of converting it at a made-up rate. A 1:1 fallback here
+            # would silently misstate the balance by the size of the FX gap (see #1143), and
+            # raising would abandon the whole account's balances over a single entry.
+            @unconvertible_entry_count += 1
+            @missing_rate_pairs |= [ [ error.from_currency, error.to_currency ] ]
+            next
+          end
 
-        e.amount = new_amount
-        e.currency = account.currency
-        e
+          e.amount = new_amount
+          e.currency = account.currency
+          e
+        end
+
+        report_unconvertible_entries if @unconvertible_entry_count.positive?
+
+        converted
       end
+    end
+
+    def report_unconvertible_entries
+      DebugLogEntry.capture(
+        category: "sync",
+        level: "warn",
+        source: "Balance::SyncCache",
+        message: "Excluded #{@unconvertible_entry_count} #{"entry".pluralize(@unconvertible_entry_count)} from balance calculation: no exchange rate available",
+        account: account,
+        family: account.family,
+        metadata: {
+          account_currency: account.currency,
+          unconvertible_entry_count: @unconvertible_entry_count,
+          missing_rate_pairs: @missing_rate_pairs.map { |from, to| "#{from}->#{to}" }
+        }
+      )
     end
 end

--- a/app/models/balance/sync_cache.rb
+++ b/app/models/balance/sync_cache.rb
@@ -2,7 +2,7 @@ class Balance::SyncCache
   def initialize(account)
     @account = account
     @unconvertible_entry_count = 0
-    @missing_rate_pairs = []
+    @unconvertible_holding_count = 0
   end
 
   # How many entries were left out of the balance calculation because no exchange rate was
@@ -11,6 +11,14 @@ class Balance::SyncCache
   def unconvertible_entry_count
     entries_by_date
     @unconvertible_entry_count
+  end
+
+  # How many holdings were counted at a 1:1 rate for the same reason, overstating or
+  # understating the holdings total by the FX gap. Populated once `holdings_value_by_date`
+  # has run; zero on a healthy sync.
+  def unconvertible_holding_count
+    holdings_value_by_date
+    @unconvertible_holding_count
   end
 
   def get_valuation(date)
@@ -33,18 +41,40 @@ class Balance::SyncCache
     end
 
     def holdings_value_by_date
-      @holdings_value_by_date ||= account.holdings.each_with_object(Hash.new(0)) do |h, totals|
-        begin
-          converted = Money.new(h.amount, h.currency).exchange_to(account.currency, date: h.date).amount
-        rescue Money::ConversionError
-          converted = h.amount # fallback to 1:1 conversion rate if exchange rate unavailable
+      @holdings_value_by_date ||= begin
+        missing_rate_pairs = []
+
+        totals = account.holdings.each_with_object(Hash.new(0)) do |h, acc|
+          begin
+            converted = Money.new(h.amount, h.currency).exchange_to(account.currency, date: h.date).amount
+          rescue Money::ConversionError => error
+            # Fall back to a 1:1 rate, which misstates the holding by the FX gap. Excluding it
+            # instead would be worse here: `BaseCalculator#derive_cash_balance_on_date_from_total`
+            # derives cash as `total_balance - holdings_value`, so a dropped holding reappears
+            # as phantom cash. Report it rather than silently accepting the wrong number.
+            converted = h.amount
+            @unconvertible_holding_count += 1
+            missing_rate_pairs |= [ [ error.from_currency, error.to_currency ] ]
+          end
+          acc[h.date] += converted
         end
-        totals[h.date] += converted
+
+        if @unconvertible_holding_count.positive?
+          report_missing_rates(
+            message: "Valued #{@unconvertible_holding_count} #{"holding".pluralize(@unconvertible_holding_count)} at a 1:1 rate: no exchange rate available",
+            counts: { unconvertible_holding_count: @unconvertible_holding_count },
+            missing_rate_pairs: missing_rate_pairs
+          )
+        end
+
+        totals
       end
     end
 
     def converted_entries
       @converted_entries ||= begin
+        missing_rate_pairs = []
+
         converted = account.entries.excluding_pending.excluding_split_parents.includes(:entryable).order(:date).to_a.filter_map do |e|
           custom_rate = e.entryable.exchange_rate if e.entryable.respond_to?(:exchange_rate)
 
@@ -65,7 +95,7 @@ class Balance::SyncCache
             # would silently misstate the balance by the size of the FX gap (see #1143), and
             # raising would abandon the whole account's balances over a single entry.
             @unconvertible_entry_count += 1
-            @missing_rate_pairs |= [ [ error.from_currency, error.to_currency ] ]
+            missing_rate_pairs |= [ [ error.from_currency, error.to_currency ] ]
             next
           end
 
@@ -74,26 +104,31 @@ class Balance::SyncCache
           e
         end
 
-        report_unconvertible_entries if @unconvertible_entry_count.positive?
+        if @unconvertible_entry_count.positive?
+          report_missing_rates(
+            message: "Excluded #{@unconvertible_entry_count} #{"entry".pluralize(@unconvertible_entry_count)} from balance calculation: no exchange rate available",
+            counts: { unconvertible_entry_count: @unconvertible_entry_count },
+            missing_rate_pairs: missing_rate_pairs
+          )
+        end
 
         converted
       end
     end
 
-    def report_unconvertible_entries
+    def report_missing_rates(message:, counts:, missing_rate_pairs:)
       DebugLogEntry.capture(
         category: "sync",
         level: "warn",
         source: "Balance::SyncCache",
-        message: "Excluded #{@unconvertible_entry_count} #{"entry".pluralize(@unconvertible_entry_count)} from balance calculation: no exchange rate available",
+        message: message,
         account: account,
         family: account.family,
         provider_key: exchange_rate_provider_key,
         metadata: {
           account_currency: account.currency,
-          unconvertible_entry_count: @unconvertible_entry_count,
-          missing_rate_pairs: @missing_rate_pairs.map { |from, to| "#{from}->#{to}" }
-        }
+          missing_rate_pairs: missing_rate_pairs.map { |from, to| "#{from}->#{to}" }
+        }.merge(counts)
       )
     end
 

--- a/app/models/balance/sync_cache.rb
+++ b/app/models/balance/sync_cache.rb
@@ -88,11 +88,21 @@ class Balance::SyncCache
         message: "Excluded #{@unconvertible_entry_count} #{"entry".pluralize(@unconvertible_entry_count)} from balance calculation: no exchange rate available",
         account: account,
         family: account.family,
+        provider_key: exchange_rate_provider_key,
         metadata: {
           account_currency: account.currency,
           unconvertible_entry_count: @unconvertible_entry_count,
           missing_rate_pairs: @missing_rate_pairs.map { |from, to| "#{from}->#{to}" }
         }
       )
+    end
+
+    # Which FX backend was configured when the rate came up missing, so support can filter
+    # these entries by provider. Read from the setting rather than `ExchangeRate.provider`,
+    # which raises on an unrecognized configuration — diagnostics must never fail the sync.
+    def exchange_rate_provider_key
+      ENV["EXCHANGE_RATE_PROVIDER"].presence || Setting.exchange_rate_provider
+    rescue StandardError
+      nil
     end
 end

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -10,9 +10,7 @@ class Money
       @to_currency = to_currency
       @date = date
 
-      error_message = message || "Couldn't find exchange rate from #{from_currency} to #{to_currency} on #{date}"
-
-      super(error_message)
+      super("Couldn't find exchange rate from #{from_currency} to #{to_currency} on #{date}")
     end
   end
 

--- a/test/lib/money_test.rb
+++ b/test/lib/money_test.rb
@@ -202,6 +202,25 @@ class MoneyTest < ActiveSupport::TestCase
     end
   end
 
+  test "conversion error names the currency pair and date it failed on" do
+    error = Money::ConversionError.new(from_currency: "EUR", to_currency: "UAH", date: Date.new(2026, 9, 10))
+
+    assert_equal "Couldn't find exchange rate from EUR to UAH on 2026-09-10", error.message
+    assert_equal "EUR", error.from_currency
+    assert_equal "UAH", error.to_currency
+    assert_equal Date.new(2026, 9, 10), error.date
+  end
+
+  test "conversion error raised by exchange_to carries a descriptive message" do
+    ExchangeRate.expects(:find_or_fetch_rate).returns(nil)
+
+    error = assert_raises(Money::ConversionError) do
+      Money.new(1000, :usd).exchange_to(:jpy, date: Date.new(2026, 9, 10))
+    end
+
+    assert_equal "Couldn't find exchange rate from USD to JPY on 2026-09-10", error.message
+  end
+
   test "uses custom rate when provided" do
     ExchangeRate.expects(:find_or_fetch_rate).never
 

--- a/test/models/balance/sync_cache_test.rb
+++ b/test/models/balance/sync_cache_test.rb
@@ -181,6 +181,74 @@ class Balance::SyncCacheTest < ActiveSupport::TestCase
     assert_in_delta 120.0, amounts[2], 0.01  # 100 EUR * 1.2
   end
 
+  test "excludes an entry with no available exchange rate instead of failing the whole account" do
+    convertible = @account.entries.create!(
+      date: Date.current,
+      name: "USD Transaction",
+      amount: 75,
+      currency: "USD",
+      entryable: Transaction.new(extra: {})
+    )
+    _unconvertible = @account.entries.create!(
+      date: Date.current,
+      name: "EUR Transaction",
+      amount: 100,
+      currency: "EUR",
+      entryable: Transaction.new(extra: {})
+    )
+
+    sync_cache = Balance::SyncCache.new(@account)
+    converted_entries = sync_cache.send(:converted_entries)
+
+    assert_equal [ convertible.name ], converted_entries.map(&:name)
+    assert_equal 1, sync_cache.unconvertible_entry_count
+  end
+
+  test "records a debug log entry naming the missing currency pairs" do
+    @account.entries.create!(
+      date: Date.current,
+      name: "EUR Transaction",
+      amount: 100,
+      currency: "EUR",
+      entryable: Transaction.new(extra: {})
+    )
+    @account.entries.create!(
+      date: Date.current,
+      name: "GBP Transaction",
+      amount: 50,
+      currency: "GBP",
+      entryable: Transaction.new(extra: {})
+    )
+
+    assert_difference "DebugLogEntry.count", 1 do
+      Balance::SyncCache.new(@account).send(:converted_entries)
+    end
+
+    log = DebugLogEntry.order(:created_at).last
+    assert_equal "Balance::SyncCache", log.source
+    assert_equal "warn", log.level
+    assert_equal @account, log.account
+    assert_equal 2, log.metadata["unconvertible_entry_count"]
+    assert_equal [ "EUR->USD", "GBP->USD" ], log.metadata["missing_rate_pairs"].sort
+  end
+
+  test "records no debug log entry when every entry converts" do
+    @account.entries.create!(
+      date: Date.current,
+      name: "USD Transaction",
+      amount: 75,
+      currency: "USD",
+      entryable: Transaction.new(extra: {})
+    )
+
+    assert_no_difference "DebugLogEntry.count" do
+      sync_cache = Balance::SyncCache.new(@account)
+      sync_cache.send(:converted_entries)
+
+      assert_equal 0, sync_cache.unconvertible_entry_count
+    end
+  end
+
   # get_holdings_value
 
   test "returns 0 for date with no holdings" do

--- a/test/models/balance/sync_cache_test.rb
+++ b/test/models/balance/sync_cache_test.rb
@@ -228,6 +228,7 @@ class Balance::SyncCacheTest < ActiveSupport::TestCase
     assert_equal "Balance::SyncCache", log.source
     assert_equal "warn", log.level
     assert_equal @account, log.account
+    assert_equal Setting.exchange_rate_provider, log.provider_key
     assert_equal 2, log.metadata["unconvertible_entry_count"]
     assert_equal [ "EUR->USD", "GBP->USD" ], log.metadata["missing_rate_pairs"].sort
   end

--- a/test/models/balance/sync_cache_test.rb
+++ b/test/models/balance/sync_cache_test.rb
@@ -294,6 +294,41 @@ class Balance::SyncCacheTest < ActiveSupport::TestCase
     assert_equal 100, Balance::SyncCache.new(@account).get_holdings_value(Date.current)
   end
 
+  test "reports a holding valued at 1:1 rather than accepting the wrong number silently" do
+    security = Security.create!(ticker: "TST", name: "Test")
+    @account.holdings.create!(security: security, date: Date.current, qty: 1, price: 100, amount: 100, currency: "EUR")
+
+    sync_cache = Balance::SyncCache.new(@account)
+
+    assert_difference "DebugLogEntry.count", 1 do
+      sync_cache.get_holdings_value(Date.current)
+    end
+
+    assert_equal 1, sync_cache.unconvertible_holding_count
+
+    log = DebugLogEntry.order(:created_at).last
+    assert_equal "Balance::SyncCache", log.source
+    assert_equal "warn", log.level
+    assert_equal @account, log.account
+    assert_equal 1, log.metadata["unconvertible_holding_count"]
+    assert_equal [ "EUR->USD" ], log.metadata["missing_rate_pairs"]
+  end
+
+  test "records no holding diagnostic when every holding converts" do
+    ExchangeRate.create!(from_currency: "EUR", to_currency: "USD", date: Date.current, rate: 1.5)
+
+    security = Security.create!(ticker: "TST", name: "Test")
+    @account.holdings.create!(security: security, date: Date.current, qty: 1, price: 100, amount: 100, currency: "EUR")
+
+    sync_cache = Balance::SyncCache.new(@account)
+
+    assert_no_difference "DebugLogEntry.count" do
+      assert_equal 150.0, sync_cache.get_holdings_value(Date.current)
+    end
+
+    assert_equal 0, sync_cache.unconvertible_holding_count
+  end
+
   test "prioritizes custom rate over fetched rate" do
     # Create fetched rate
     ExchangeRate.create!(


### PR DESCRIPTION
## Problem

Two independent defects that together made a missing exchange rate both fatal and
undiagnosable. I hit them on a UAH account holding one EUR transaction, with an empty
`exchange_rates` table.

**#3492 — one entry takes down the account.** `Balance::SyncCache#converted_entries` called
`Money#exchange_to` with no handling for a missing rate, so the exception escaped through
`Balance::BaseCalculator#flows_for_date` and `Balance::ReverseCalculator#calculate` and
aborted balance calculation for the entire account. 114 UAH transactions plus a single EUR
one produced no balances at all. The transactions themselves imported fine, but the account
was marked as errored, so it read as a total sync failure. `#holdings_value_by_date`, in the
same class, already handled exactly this failure.

**#3491 — the error says nothing.** `Money::ConversionError#initialize` guarded its message
with `message ||`, but `message` runs before `super` and resolves to `Exception#message`'s
default, which returns the class name rather than `nil`. The `||` never reached the
descriptive branch, so that string was unreachable code and every raise in the app surfaced
only `"Money::ConversionError"`. `Sync#error` stores `e.message`, which is why the UI showed
a red "Error" whose sole detail was a class name, with no hint that a currency rate was
missing.

## Resulting behavior

`ConversionError` now always builds its message, so the same failure reports
`"Couldn't find exchange rate from EUR to UAH on 2026-09-10"` — in `Sync#error`, in Sentry,
and everywhere else the app records `e.message`. This is a one-line change with app-wide
reach; nothing depended on the old value.

`converted_entries` now drops an entry it cannot convert instead of raising, so the rest of
the account's balances are calculated. Each excluded entry is counted, the missing currency
pairs are collected, and a single `DebugLogEntry` (category `sync`, level `warn`) records
both, giving support the pair that was absent rather than a bare exception.

## On dropping rather than falling back

The holdings path in the same class falls back to a 1:1 rate. I deliberately did not copy
that: #1143 is a report of exactly that fallback producing wrong numbers (NZD 117 shown as
¥117), and for a UAH/EUR pair a 1:1 rate is off by roughly 48x. Extending it would spread a
known bug into balance calculation.

Dropping the entry is what `IbkrAccount::HistoricalBalancesSync` already does with a row it
cannot convert, so there is precedent. It is not free either — the balance is short by the
excluded amount — but it is bounded, it is recorded, and it beats having no balances at all.
`unconvertible_entry_count` is public so a follow-up can surface a UI warning like the
`unconvertible` counts bills and budgets already display; I left that out to keep this change
to the two defects and avoid new strings across every locale.

The genuinely right answer is for the rate to be there, and `Money#exchange_to` already tries
to fetch one. This is the path when that fails.

## Validation

- `bin/rails test` — 8654 runs, 0 failures. One pre-existing error,
  `RecurringTransaction::PipelineTest#test_run_with_lock!_refuses_to_stack_on_a_held_family_lock`,
  which opens its own `PG.connect` and fails identically on unmodified `main` in my container;
  unrelated to these files.
- `bin/rubocop` — clean on all four files.
- `bin/brakeman --no-pager` — 0 security warnings.
- All five new tests were confirmed to fail against the unfixed code: 3 errors in
  `sync_cache_test` and 2 failures in `money_test` showing `"Money::ConversionError"` in place
  of the message.

No migration, no ERB, no JS, no API surface, so erb_lint, Biome and rswag do not apply.

Fixes #3491
Fixes #3492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Accounts now continue processing when an entry cannot be converted because an exchange rate is unavailable.
  - Entries missing conversion rates are excluded from converted results instead of failing the entire operation.
  - Holdings without available rates are valued using a 1:1 rate so processing can continue.
  - Conversion errors now include the currencies and date involved.
  - Missing rate pairs and the exchange-rate provider are recorded in diagnostic logs.

- **Tests**
  - Added coverage for missing rates, fallback valuations, descriptive errors, diagnostic logging, and successful conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->