### PR TITLE
fix(l10n): localize German Sidekiq health warnings

### DIFF
--- a/config/locales/views/shared/de.yml
+++ b/config/locales/views/shared/de.yml
@@ -39,6 +39,15 @@ de:
       expense: Ausgabe
       income: Einnahme
       transfer: Überweisung
+    sidekiq_health_banner:
+      title: Einige Daten sind möglicherweise nicht aktuell
+      body: "Hintergrundaufgaben werden nicht verarbeitet. Daher sind Kontostände, Nettovermögen und Kontosynchronisierungen möglicherweise nicht aktuell oder fehlen."
+      cta: Systemstatus anzeigen
+      reasons:
+        redis_unreachable: "Die App kann Redis nicht erreichen. Prüfe deine REDIS_URL und ob Redis läuft."
+        no_worker_processes: "Es ist kein Sidekiq-Worker verbunden. Starte den Worker-Container oder die systemd-Unit."
+        stale_heartbeat: "Der Sidekiq-Worker hat seit einiger Zeit kein Lebenszeichen gesendet. Möglicherweise hängt er oder ist abgestürzt."
+        queue_backed_up: "Die älteste Hintergrundaufgabe in der Warteschlange wartet bereits länger als vorgesehen. Der Worker läuft, kommt aber mit der Verarbeitung nicht hinterher."
   concerns:
     self_hostable:
       redis_configured: Redis ist jetzt richtig eingerichtet! Du kannst deine Sure-Installation nun einrichten.

--- a/test/system/sidekiq_health_banner_test.rb
+++ b/test/system/sidekiq_health_banner_test.rb
@@ -16,11 +16,39 @@ class SidekiqHealthBannerTest < ApplicationSystemTestCase
     visit root_path
 
     assert_selector "[data-testid='sidekiq-health-banner']"
+    assert_link "View system health", href: admin_system_health_path
 
     banner_rect = page.evaluate_script("document.querySelector('[data-testid=\"sidekiq-health-banner\"]').getBoundingClientRect()")
     heading_rect = page.evaluate_script("document.querySelector('h1').getBoundingClientRect()")
 
     assert_operator banner_rect["bottom"], :<=, heading_rect["top"],
       "expected the stale-data warning to finish above the dashboard heading"
+  end
+
+  test "German super admin sees localized warning and each failure reason" do
+    users(:sure_support_staff).update!(locale: "de")
+    sign_in users(:sure_support_staff)
+
+    SidekiqHealth::REASONS.each do |reason|
+      @health.stubs(:reason).returns(reason)
+      visit root_path
+      within "[data-testid='sidekiq-health-banner']" do
+        assert_text "Einige Daten sind möglicherweise nicht aktuell"
+        assert_text "Hintergrundaufgaben werden nicht verarbeitet."
+        assert_text I18n.t("shared.sidekiq_health_banner.reasons.#{reason}", locale: :de, fallback: false, raise: true)
+        assert_link "Systemstatus anzeigen", href: admin_system_health_path
+      end
+    end
+    %w[title body cta].each do |key|
+      assert_kind_of String, I18n.t("shared.sidekiq_health_banner.#{key}", locale: :de, fallback: false, raise: true)
+    end
+  end
+
+  test "German family admin does not see the operator warning" do
+    users(:family_admin).update!(locale: "de")
+    sign_in users(:family_admin)
+    visit root_path
+
+    assert_no_selector "[data-testid='sidekiq-health-banner']"
   end
 end


### PR DESCRIPTION
## Summary

German super admins now see the stale-data warning, its four Sidekiq failure explanations, and the system-health link in German instead of English fallback text. Operational behavior, identifiers, and visibility remain unchanged.

Continues the German administration copy work after system-health navigation; job statistics are a separate slice, and AI diagnostics remain follow-up work.

Related: #3477, #3486

## Validation

- The new German rendering test failed on the English fallback before the translation was added.
- Owning system tests and locale integrity: 10 runs, 218 assertions, no failures or errors; four existing skips.
- Full Rails suite: 8,649 runs, 34,960 assertions, no failures or errors; 33 skips.
- RuboCop, ERB lint, Biome, and Brakeman passed. Independent correctness, testing, and project-standards reviews found no issues; German wording received a separate AI language review.
- Synthetic browser checks at 1024px, 1440px, and a 500px narrow viewport confirmed readable text and an accessible link without header overlap. No production data used.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes German display text only, not health detection or job processing. On the next normal verification of an unhealthy Sidekiq state, confirm that a German super admin sees the warning and can open system health.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for the Sidekiq health banner, including status details, guidance, and system health link text.

* **Bug Fixes**
  * Improved validation of the health banner’s layout and navigation link.
  * Confirmed the banner is hidden for German family administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->