### PR TITLE
security: consolidate deactivated-user auth enforcement

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -63,7 +63,7 @@ module Api
             device = MobileDevice.upsert_device!(user, device_params)
             token_response = device.issue_token!
           end
-        rescue ActiveRecord::RecordInvalid => e
+        rescue ActiveRecord::RecordInvalid, User::InactiveError => e
           Rails.logger.error("[Auth] Device registration failed: #{e.class} - #{e.message}")
           render json: { error: "Failed to register device" }, status: :unprocessable_entity
           return
@@ -101,8 +101,9 @@ module Api
           # Fast-path re-check to skip a pointless device upsert for a user
           # already known to be inactive — issue_token! re-checks active? under
           # lock immediately before minting (see its comment) and is the actual
-          # authorization boundary, not this check.
-          unless user.reload.active?
+          # authorization boundary, not this check. Treats a concurrently
+          # purged user (reload raises RecordNotFound) the same as inactive.
+          unless user_reloadable_and_active?(user)
             render json: { error: "This account has been deactivated. Please contact an administrator." }, status: :unauthorized
             return
           end
@@ -117,7 +118,7 @@ module Api
 
           begin
             token_response = device.issue_token!
-          rescue ActiveRecord::RecordInvalid
+          rescue User::InactiveError
             render json: { error: "This account has been deactivated. Please contact an administrator." }, status: :unauthorized
             return
           end
@@ -193,15 +194,38 @@ module Api
         # Atomically claim the code before creating the identity
         return render json: { error: "Linking code is invalid or expired" }, status: :unauthorized unless consume_linking_code!(linking_code)
 
-        OidcIdentity.create_from_omniauth(build_omniauth_hash(cached), user)
+        device_info = cached[:device_info]
+        device_info = device_info.symbolize_keys if device_info.respond_to?(:symbolize_keys)
 
-        SsoAuditLog.log_link!(
-          user: user,
-          provider: cached[:provider],
-          request: request
-        )
+        # Identity creation, the audit record, and the actual token mint all
+        # run in one transaction so a rejected request can't leave a linked
+        # identity or a successful-link audit record behind. issue_token!'s
+        # locked active? recheck (the real authorization boundary) is what
+        # decides whether this commits or rolls everything back together.
+        token_response = nil
+        begin
+          ActiveRecord::Base.transaction do
+            OidcIdentity.create_from_omniauth(build_omniauth_hash(cached), user)
 
-        issue_mobile_tokens(user, cached[:device_info])
+            SsoAuditLog.log_link!(
+              user: user,
+              provider: cached[:provider],
+              request: request
+            )
+
+            device = MobileDevice.upsert_device!(user, device_info)
+            token_response = device.issue_token!
+          end
+        rescue User::InactiveError
+          render json: { error: "This account has been deactivated. Please contact an administrator." }, status: :unauthorized
+          return
+        rescue ActiveRecord::RecordInvalid => e
+          Rails.logger.error("[Auth] Device registration failed: #{e.message}")
+          render json: { error: "Failed to register device" }, status: :unprocessable_entity
+          return
+        end
+
+        render json: token_response.merge(user: mobile_user_payload(user))
       end
 
       def sso_create_account
@@ -324,9 +348,7 @@ module Api
 
         user = User.find_by(id: access_token.resource_owner_id)
         new_token = begin
-          user&.with_lock do
-            next false unless user.active?
-
+          user&.with_active_lock! do
             access_token.with_lock do
               next false if access_token.revoked?
 
@@ -345,7 +367,7 @@ module Api
               token
             end
           end
-        rescue ActiveRecord::RecordNotFound
+        rescue ActiveRecord::RecordNotFound, User::InactiveError
           false
         end
 
@@ -425,6 +447,16 @@ module Api
           }
         end
 
+        # A concurrent purge between the initial check and this fast-path
+        # re-check raises RecordNotFound on reload; treat it the same as
+        # inactive instead of letting it fall through to BaseController's
+        # generic record_not_found handler.
+        def user_reloadable_and_active?(user)
+          user.reload.active?
+        rescue ActiveRecord::RecordNotFound
+          false
+        end
+
         def build_omniauth_hash(cached)
           OpenStruct.new(
             provider: cached[:provider],
@@ -467,12 +499,12 @@ module Api
           Rails.cache.delete("mobile_sso_link:#{linking_code}")
         end
 
-        # Shared by sso_link (existing user, needs the active? re-check) and
-        # sso_create_account (brand-new user, always active — the reload is
-        # a harmless no-op there). Reload right before minting, same
-        # reasoning as Authentication#create_session_for.
+        # Used by sso_create_account for its brand-new user (always active —
+        # the reload is a harmless no-op there, but still races a concurrent
+        # purge the same way login's fast path does). Reload right before
+        # minting, same reasoning as Authentication#create_session_for.
         def issue_mobile_tokens(user, device_info)
-          unless user.reload.active?
+          unless user_reloadable_and_active?(user)
             render json: { error: "This account has been deactivated. Please contact an administrator." }, status: :unauthorized
             return
           end
@@ -489,7 +521,7 @@ module Api
 
           begin
             token_response = device.issue_token!
-          rescue ActiveRecord::RecordInvalid
+          rescue User::InactiveError
             render json: { error: "This account has been deactivated. Please contact an administrator." }, status: :unauthorized
             return
           end

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -217,9 +217,11 @@ module Api
             token_response = device.issue_token!
           end
         rescue User::InactiveError
+          restore_linking_code!(linking_code, cached)
           render json: { error: "This account has been deactivated. Please contact an administrator." }, status: :unauthorized
           return
         rescue ActiveRecord::RecordInvalid => e
+          restore_linking_code!(linking_code, cached)
           Rails.logger.error("[Auth] Device registration failed: #{e.message}")
           render json: { error: "Failed to register device" }, status: :unprocessable_entity
           return
@@ -497,6 +499,17 @@ module Api
         # Returns true only for the first caller; subsequent callers get false.
         def consume_linking_code!(linking_code)
           Rails.cache.delete("mobile_sso_link:#{linking_code}")
+        end
+
+        # Best-effort restore so a request rejected *after* consuming the
+        # code (deactivation race or a device-registration failure inside
+        # the transaction) can retry with the same code instead of
+        # restarting the SSO flow from the IdP. Safe to write back verbatim:
+        # a legitimate retry re-authenticates with email/password from
+        # scratch, and OidcIdentity's unique (provider, uid) index is the
+        # backstop if a second request somehow raced onto the restored code.
+        def restore_linking_code!(linking_code, cached)
+          Rails.cache.write("mobile_sso_link:#{linking_code}", cached, expires_in: 10.minutes)
         end
 
         # Used by sso_create_account for its brand-new user (always active —

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -43,14 +43,12 @@ module Authentication
     def create_session_for(user)
       return false unless user&.persisted?
 
-      user.with_lock do
-        next false unless user.active?
-
+      user.with_active_lock! do
         session = user.sessions.create!
         cookies.signed.permanent[:session_token] = { value: session.id, httponly: true }
         session
       end
-    rescue ActiveRecord::RecordNotFound
+    rescue User::InactiveError
       false
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -226,14 +226,6 @@ class SessionsController < ApplicationController
       return
     end
 
-    # Same reasoning as SessionsController#create: check before starting the
-    # MFA challenge, not just after, so a stale in-flight login can't finish
-    # once the user is reactivated.
-    unless user.active?
-      redirect_to new_session_path, alert: t("sessions.create.account_deactivated")
-      return
-    end
-
     if user.otp_required?
       session[:mfa_user_id] = user.id
       redirect_to verify_mfa_path
@@ -420,8 +412,10 @@ class SessionsController < ApplicationController
       # openid_connect already checked user.active? before dispatching here,
       # but record_authentication!/sync_user_attributes!/audit logging run in
       # between — reload right before actually minting a token to narrow that
-      # window, same reasoning as Authentication#create_session_for.
-      unless user.reload.active?
+      # window, same reasoning as Authentication#create_session_for. Treats a
+      # concurrently purged user (reload raises RecordNotFound) the same as
+      # inactive instead of letting it fall through to a generic 404.
+      unless user_reloadable_and_active?(user)
         Rails.logger.warn("[AUTH] Rejected mobile SSO token issuance for deactivated user_id=#{user.id}")
         session.delete(:mobile_sso)
         mobile_sso_redirect(error: "account_deactivated", message: t("sessions.create.account_deactivated"))
@@ -445,7 +439,7 @@ class SessionsController < ApplicationController
 
       begin
         token_response = device.issue_token!
-      rescue ActiveRecord::RecordInvalid
+      rescue User::InactiveError
         Rails.logger.warn("[AUTH] Rejected mobile SSO token issuance for deactivated user_id=#{user.id}")
         mobile_sso_redirect(error: "account_deactivated", message: t("sessions.create.account_deactivated"))
         return
@@ -527,6 +521,16 @@ class SessionsController < ApplicationController
 
     def mobile_sso_redirect(params = {})
       redirect_to "sureapp://oauth/callback?#{params.to_query}", allow_other_host: true
+    end
+
+    # A concurrent purge between the initial check and this fast-path
+    # re-check raises RecordNotFound on reload; treat it the same as
+    # inactive instead of letting it fall through to StoreLocation's
+    # generic not-found handler.
+    def user_reloadable_and_active?(user)
+      user.reload.active?
+    rescue ActiveRecord::RecordNotFound
+      false
     end
 
     def set_session

--- a/app/models/mobile_device.rb
+++ b/app/models/mobile_device.rb
@@ -68,20 +68,17 @@ class MobileDevice < ApplicationRecord
   # response or deep-link callback.
   #
   # This is the single choke point every mobile-token-issuing path funnels
-  # through, so the active? check lives here (under lock, immediately before
-  # minting) rather than at each call site. Callers may *additionally* check
-  # active? earlier for fast, friendly rejection (skip an MFA/device-validation
-  # round trip, avoid a pointless MobileDevice upsert) — but that's a UX
-  # optimization only. This check is the actual authorization boundary and
-  # must never be assumed redundant by a caller, however "obviously"
-  # already-checked the user seems.
+  # through, so User#with_active_lock! (the actual authorization boundary,
+  # locked immediately before minting) lives here rather than at each call
+  # site. Callers may *additionally* check active? earlier for fast, friendly
+  # rejection (skip an MFA/device-validation round trip, avoid a pointless
+  # MobileDevice upsert) — but that's a UX optimization only and must never
+  # be assumed a substitute for this check, however "obviously"
+  # already-checked the user seems. Raises User::InactiveError for a
+  # deactivated/concurrently-purged user, distinct from a genuine
+  # ActiveRecord::RecordInvalid from Doorkeeper::AccessToken.create! itself.
   def issue_token!
-    user.with_lock do
-      unless user.active?
-        errors.add(:base, "User is inactive")
-        raise ActiveRecord::RecordInvalid, self
-      end
-
+    user.with_active_lock! do
       revoke_all_tokens!
 
       access_token = Doorkeeper::AccessToken.create!( # pipelock:ignore Credential in URL
@@ -101,9 +98,6 @@ class MobileDevice < ApplicationRecord
         created_at: access_token.created_at.to_i
       }
     end
-  rescue ActiveRecord::RecordNotFound
-    errors.add(:base, "User is inactive")
-    raise ActiveRecord::RecordInvalid, self
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -324,6 +324,29 @@ class User < ApplicationRecord
     oidc_identities.destroy_all
   end
 
+  # Raised by #with_active_lock! to reject session/token issuance for a
+  # deactivated or concurrently-purged user. The one error contract every
+  # web/JSON/mobile/OAuth-adapter caller rescues, so a deactivation result
+  # can never be confused with an unrelated persistence failure.
+  class InactiveError < StandardError; end
+
+  # The one locked primitive for the actual authorization boundary: asserts
+  # this user is eligible for new session/token issuance *right now*, under
+  # a row lock, immediately before minting. Callers may additionally check
+  # #active? earlier for a fast, friendly rejection (skip an MFA/device
+  # round trip) — that's a UX optimization only, never a substitute for
+  # this check, however "obviously" already-checked the user seems.
+  def with_active_lock!
+    with_lock do
+      raise InactiveError unless active?
+      yield self
+    end
+  rescue ActiveRecord::RecordNotFound
+    # The row was deleted (concurrent purge) between the query that found
+    # this user and the lock attempt — same rejection as "inactive".
+    raise InactiveError
+  end
+
   def can_deactivate
     if admin? && family.users.count > 1
       errors.add(:base, :cannot_deactivate_admin_with_other_users)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -337,13 +337,20 @@ class User < ApplicationRecord
   # round trip) — that's a UX optimization only, never a substitute for
   # this check, however "obviously" already-checked the user seems.
   def with_active_lock!
+    lock_acquired = false
+
     with_lock do
+      lock_acquired = true
       raise InactiveError unless active?
       yield self
     end
   rescue ActiveRecord::RecordNotFound
-    # The row was deleted (concurrent purge) between the query that found
-    # this user and the lock attempt — same rejection as "inactive".
+    # Only translate a RecordNotFound raised by with_lock's own reload (the
+    # row was deleted by a concurrent purge before we could lock it) into
+    # InactiveError. Once the lock is held, re-raise: a RecordNotFound from
+    # inside the caller's block is an unrelated failure and must not be
+    # misreported as "inactive" either.
+    raise if lock_acquired
     raise InactiveError
   end
 

--- a/db/migrate/20260910130000_nullify_sessions_active_impersonator_session_on_delete.rb
+++ b/db/migrate/20260910130000_nullify_sessions_active_impersonator_session_on_delete.rb
@@ -1,0 +1,11 @@
+class NullifySessionsActiveImpersonatorSessionOnDelete < ActiveRecord::Migration[7.2]
+  def up
+    remove_foreign_key :sessions, :impersonation_sessions, column: :active_impersonator_session_id
+    add_foreign_key :sessions, :impersonation_sessions, column: :active_impersonator_session_id, on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key :sessions, :impersonation_sessions, column: :active_impersonator_session_id
+    add_foreign_key :sessions, :impersonation_sessions, column: :active_impersonator_session_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_04_201444) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_10_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -2757,7 +2757,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_201444) do
   add_foreign_key "rule_runs", "rules"
   add_foreign_key "rules", "families"
   add_foreign_key "security_prices", "securities"
-  add_foreign_key "sessions", "impersonation_sessions", column: "active_impersonator_session_id"
+  add_foreign_key "sessions", "impersonation_sessions", column: "active_impersonator_session_id", on_delete: :nullify
   add_foreign_key "sessions", "users"
   add_foreign_key "simplefin_accounts", "simplefin_items"
   add_foreign_key "simplefin_items", "families"

--- a/test/controllers/api/v1/auth_controller_test.rb
+++ b/test/controllers/api/v1/auth_controller_test.rb
@@ -685,14 +685,18 @@ class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
     }, expires_in: 10.minutes)
 
     # Simulate deactivation landing after the initial active? check but
-    # before issue_mobile_tokens actually mints a token — SsoAuditLog.log_link!
+    # before issue_token! actually mints a token — SsoAuditLog.log_link!
     # runs in that window in the real flow, so hook the deactivation there.
     SsoAuditLog.stubs(:log_link!).with do |**kwargs|
       kwargs[:user].update_column(:active, false)
       true
     end
 
-    assert_difference("OidcIdentity.count", 1) do
+    # The identity, the device, and the token mint all run in the same
+    # transaction as the locked active? recheck, so a deactivation landing
+    # in that window must roll all of it back — nothing may survive a
+    # rejected request.
+    assert_no_difference [ "OidcIdentity.count", "MobileDevice.count" ] do
       post "/api/v1/auth/sso_link", params: {
         linking_code: linking_code,
         email: user.email,
@@ -700,6 +704,25 @@ class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
+    assert_response :unauthorized
+    response_data = JSON.parse(response.body)
+    assert_equal "This account has been deactivated. Please contact an administrator.", response_data["error"]
+  end
+
+  test "login rejects a user purged between authentication and the reload fast-path" do
+    user = users(:family_admin)
+    User.stubs(:find_by).with(email: user.email).returns(user)
+    user.stubs(:reload).raises(ActiveRecord::RecordNotFound)
+
+    post "/api/v1/auth/login", params: {
+      email: user.email,
+      password: user_password_test,
+      device: @device_info
+    }
+
+    # Must fall through to the same "deactivated" response every other
+    # rejection on this endpoint uses, not BaseController's generic
+    # record_not_found handler.
     assert_response :unauthorized
     response_data = JSON.parse(response.body)
     assert_equal "This account has been deactivated. Please contact an administrator.", response_data["error"]

--- a/test/controllers/api/v1/auth_controller_test.rb
+++ b/test/controllers/api/v1/auth_controller_test.rb
@@ -696,7 +696,7 @@ class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
     # transaction as the locked active? recheck, so a deactivation landing
     # in that window must roll all of it back — nothing may survive a
     # rejected request.
-    assert_no_difference [ "OidcIdentity.count", "MobileDevice.count" ] do
+    assert_no_difference [ "OidcIdentity.count", "MobileDevice.count", "Doorkeeper::AccessToken.count" ] do
       post "/api/v1/auth/sso_link", params: {
         linking_code: linking_code,
         email: user.email,
@@ -707,6 +707,39 @@ class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
     response_data = JSON.parse(response.body)
     assert_equal "This account has been deactivated. Please contact an administrator.", response_data["error"]
+
+    # The code was already consumed before the rejected transaction; it
+    # must be restored so the user can retry instead of restarting the
+    # whole SSO flow from the IdP.
+    assert Rails.cache.read("mobile_sso_link:#{linking_code}").present?, "Expected linking code to be restored after a rejected request"
+  end
+
+  test "should restore the linking code when device registration fails during sso_link" do
+    user = users(:family_admin)
+
+    linking_code = SecureRandom.urlsafe_base64(32)
+    invalid_device_info = @device_info.merge(device_type: "invalid-type")
+    Rails.cache.write("mobile_sso_link:#{linking_code}", {
+      provider: "google_oauth2",
+      uid: "google-uid-device-failure",
+      email: "google-device-failure@example.com",
+      device_info: invalid_device_info.stringify_keys,
+      allow_account_creation: true
+    }, expires_in: 10.minutes)
+
+    assert_no_difference [ "OidcIdentity.count", "MobileDevice.count" ] do
+      post "/api/v1/auth/sso_link", params: {
+        linking_code: linking_code,
+        email: user.email,
+        password: user_password_test
+      }
+    end
+
+    assert_response :unprocessable_entity
+    response_data = JSON.parse(response.body)
+    assert_equal "Failed to register device", response_data["error"]
+
+    assert Rails.cache.read("mobile_sso_link:#{linking_code}").present?, "Expected linking code to be restored after a rejected request"
   end
 
   test "login rejects a user purged between authentication and the reload fast-path" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -656,6 +656,45 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_nil session[:mobile_sso], "Expected mobile_sso session to be cleared"
   end
 
+  test "mobile SSO rejects a user purged between the initial check and token issuance" do
+    oidc_identity = oidc_identities(:bob_google)
+
+    setup_omniauth_mock(
+      provider: oidc_identity.provider,
+      uid: oidc_identity.uid,
+      email: @user.email,
+      name: "Bob Dylan"
+    )
+
+    Rails.configuration.x.auth.stubs(:sso_providers).returns([
+      { name: "openid_connect", strategy: "openid_connect", label: "Google" }
+    ])
+
+    get "/auth/mobile/openid_connect", params: {
+      device_id: "flutter-device-012",
+      device_name: "Pixel 8",
+      device_type: "android"
+    }
+
+    # Same window as the deactivation race above, but the row disappears
+    # entirely (async purge) instead of merely flipping active: false — the
+    # reload fast-path must treat RecordNotFound the same as inactive rather
+    # than letting it fall through to StoreLocation's generic 404.
+    SsoAuditLog.stubs(:log_login!).with do |**kwargs|
+      kwargs[:user].stubs(:reload).raises(ActiveRecord::RecordNotFound)
+      true
+    end
+
+    assert_no_difference [ "Doorkeeper::AccessToken.count", "MobileDevice.count" ] do
+      get "/auth/openid_connect/callback"
+    end
+
+    redirect_url = @response.redirect_url
+    params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
+    assert_equal "account_deactivated", params["error"]
+    assert_nil session[:mobile_sso], "Expected mobile_sso session to be cleared"
+  end
+
   test "mobile SSO refuses to issue a token for a deactivated user" do
     oidc_identity = oidc_identities(:bob_google)
     @user.update_column(:active, false)

--- a/test/integration/oauth_basic_test.rb
+++ b/test/integration/oauth_basic_test.rb
@@ -36,6 +36,43 @@ class OauthBasicTest < ActionDispatch::IntegrationTest
     assert_not Session.exists?(id: session_record.id), "stale session should be destroyed, not just skipped"
   end
 
+  test "oauth token endpoint refuses a refresh_token exchange after the user is deactivated" do
+    oauth_app = Doorkeeper::Application.create!(
+      name: "Test API Client",
+      redirect_uri: "https://client.example.com/callback",
+      scopes: "read_write"
+    )
+    user = users(:family_admin)
+
+    access_token = Doorkeeper::AccessToken.create!(
+      application: oauth_app,
+      resource_owner_id: user.id,
+      expires_in: 2.hours,
+      scopes: "read_write",
+      use_refresh_token: true
+    )
+    refresh_token = access_token.plaintext_refresh_token
+
+    # update_column bypasses callbacks (same idiom as the test above), then
+    # explicitly exercises User#revoke_all_access_tokens — the mechanism
+    # that actually revokes standard Doorkeeper grants/tokens on
+    # deactivation, since this endpoint never goes through our custom
+    # Authentication concern or MobileDevice#issue_token! at all.
+    user.update_column(:active, false)
+    user.revoke_all_access_tokens
+
+    post "/oauth/token", params: {
+      grant_type: "refresh_token",
+      refresh_token: refresh_token,
+      client_id: oauth_app.uid,
+      client_secret: oauth_app.secret
+    }
+
+    assert_response :bad_request
+    response_body = JSON.parse(response.body)
+    assert_equal "invalid_grant", response_body["error"]
+  end
+
   test "oauth token endpoint exists and handles requests" do
     post "/oauth/token", params: {
       grant_type: "authorization_code",

--- a/test/models/mobile_device_test.rb
+++ b/test/models/mobile_device_test.rb
@@ -31,7 +31,21 @@ class MobileDeviceTest < ActiveSupport::TestCase
     user.update_column(:active, false)
 
     assert_no_difference "Doorkeeper::AccessToken.count" do
-      assert_raises(ActiveRecord::RecordInvalid) { device.issue_token! }
+      assert_raises(User::InactiveError) { device.issue_token! }
     end
+  end
+
+  test "issue_token! does not report a genuine persistence failure as an inactive user" do
+    user = users(:family_member)
+    device = user.mobile_devices.create!(
+      device_id: "persistence-failure-test",
+      device_name: "Persistence failure test device",
+      device_type: "ios"
+    )
+    assert user.active?
+
+    Doorkeeper::AccessToken.stubs(:create!).raises(ActiveRecord::RecordInvalid.new(Doorkeeper::AccessToken.new))
+
+    assert_raises(ActiveRecord::RecordInvalid) { device.issue_token! }
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -962,6 +962,25 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "purging an impersonated user nullifies the admin's active_impersonator_session instead of failing" do
+    admin = users(:sure_support_staff)
+    target = users(:family_member)
+    impersonation = ImpersonationSession.create!(impersonator: admin, impersonated: target, status: :in_progress)
+    admin_session = admin.sessions.create!(active_impersonator_session: impersonation)
+
+    # UserPurgeJob may run before the admin's next request notices the
+    # target is gone — dependent: :destroy on User#impersonated_support_sessions
+    # destroys the ImpersonationSession row underneath the admin's still-live
+    # Session. Without ON DELETE SET NULL on that FK, this raises
+    # ActiveRecord::InvalidForeignKey instead of completing the purge.
+    perform_enqueued_jobs do
+      target.purge
+    end
+
+    assert_not User.exists?(target.id)
+    assert_nil admin_session.reload.active_impersonator_session_id
+  end
+
   test "deactivate refuses the last active super admin" do
     family = Family.create!(name: "Sole admin family", locale: "en", date_format: "%m-%d-%Y", currency: "USD")
     target = User.create!(

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -981,6 +981,34 @@ class UserTest < ActiveSupport::TestCase
     assert_nil admin_session.reload.active_impersonator_session_id
   end
 
+  test "with_active_lock! rejects an inactive user without yielding" do
+    @user.update_column(:active, false)
+    yielded = false
+
+    assert_raises(User::InactiveError) do
+      @user.with_active_lock! { yielded = true }
+    end
+
+    assert_not yielded
+  end
+
+  test "with_active_lock! translates RecordNotFound only when the lock itself can't find the row" do
+    @user.stubs(:with_lock).raises(ActiveRecord::RecordNotFound)
+
+    assert_raises(User::InactiveError) do
+      @user.with_active_lock! { flunk "should not yield when the row can't be locked" }
+    end
+  end
+
+  test "with_active_lock! does not misreport a RecordNotFound raised inside the yielded block" do
+    # A failure unrelated to the user's own activity status (e.g. resolving
+    # some other record inside the caller's block) must propagate as-is,
+    # not get swallowed into "this user is inactive".
+    assert_raises(ActiveRecord::RecordNotFound) do
+      @user.with_active_lock! { raise ActiveRecord::RecordNotFound, "unrelated record missing" }
+    end
+  end
+
   test "deactivate refuses the last active super admin" do
     family = Family.create!(name: "Sole admin family", locale: "en", date_format: "%m-%d-%Y", currency: "USD")
     target = User.create!(


### PR DESCRIPTION
## Summary

Follow-up to #2890 (already the security baseline, not touched/reverted here). Closes the five correctness gaps and most of the architectural-consolidation direction from #3478.

**Correctness gaps closed:**
- `AuthController#sso_link` created the `OidcIdentity` and wrote the `SsoAuditLog` link record *before* the locked `active?` recheck in token issuance. A deactivation landing in that window left an orphaned linked identity/audit record behind even though the request was rejected. Identity creation, the audit record, and the actual token mint now run inside one transaction, so a rejected request rolls all of it back together.
- `sessions.active_impersonator_session_id` had no `ON DELETE` behavior. Purging an impersonated user (`UserPurgeJob`, or `Family#destroy` cascading through users) could raise `ActiveRecord::InvalidForeignKey` if a super-admin session still referenced the impersonation record. The FK now nullifies on delete.
- `user.reload.active?` fast-path checks (`login`, `issue_mobile_tokens`, `handle_mobile_sso_callback`) raised `RecordNotFound` on a concurrent purge, falling through to a generic 404/`head :not_found` instead of each surface's normal "deactivated" response.
- `MobileDevice#issue_token!` raised the same `ActiveRecord::RecordInvalid` for "user inactive" and for a genuine Doorkeeper persistence failure, so real failures were misreported as deactivation and hidden from observability. It now raises a dedicated `User::InactiveError`.
- `SessionsController#desktop_exchange` had two back-to-back, byte-identical `active?` guards; removed the dead second one.

**Architecture:**
- Added `User#with_active_lock!` as the one locked primitive for the actual authorization boundary (used by session creation, mobile token issuance, and the mobile refresh grant), and `User::InactiveError` as the one inactive-user result every web/JSON/mobile/OAuth-adapter caller rescues.
- `Session.find_active_by_cookie` (from #2890) already serves as the one cookie-session resolver shared by `Authentication`, both Doorkeeper authenticators, and `SuperAdminConstraint` — no change needed there.
- Deliberately **not** unifying `User#revoke_all_access_tokens` (called on `deactivate`, revokes tokens/grants/API keys) with `User#revoke_all_credentials!` (called on `permanently_remove!`, additionally destroys sessions/devices/OIDC identities): these intentionally differ in reversibility (soft deactivation vs. immediate hard wipe), and merging them isn't required by any of the issue's correctness gaps.

## Test plan

- [x] New/updated Minitest coverage for every gap above, including two `RecordNotFound`-mid-request races (`User` deleted between auth and reload) and a purge-vs-impersonation-FK test.
- [x] Full backend Minitest suite (isolated local DB): 8449 runs, 34105 assertions, 0 failures (1 unrelated environment-only error in a concurrency test needing a DB role this sandbox doesn't have).
- [x] `rubocop` clean, `brakeman` 0 warnings.
- [x] rswag/OpenAPI shape for `sso_link`/`login`/`refresh` unchanged (status codes/schema unchanged); confirmed pre-existing rswag env failures reproduce identically on unmodified `main`, so no `openapi.yaml` regen needed.

Closes #3478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login, token refresh, and SSO handling when accounts are deactivated or deleted during authentication.
  - Prevented tokens, devices, and linked identities from being created when account status changes mid-process.
  - Restored SSO linking codes when linking fails, allowing the request to be retried.
  - Standardized deactivated-account errors across web and mobile authentication flows.
  - Refresh-token requests for deactivated accounts now return the expected invalid-grant response.
  - Impersonation sessions now cleanly detach when the associated account is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->