### PR TITLE
fix(l10n): localize German AI worker verification

### DIFF
--- a/config/locales/views/admin/system_health/de.yml
+++ b/config/locales/views/admin/system_health/de.yml
@@ -2,6 +2,8 @@
 de:
   admin:
     system_health:
+      verify_worker_ai:
+        queued: Die Worker-Prüfung wurde in die Warteschlange gestellt. Das Ergebnis erscheint unten, sobald ein Worker-Prozess die Prüfung übernimmt – normalerweise innerhalb weniger Sekunden.
       show:
         title: Systemstatus
         tabs:
@@ -34,3 +36,27 @@ de:
           never: Nie
           seconds: "%{seconds} s"
           no_queues: Es sind keine Warteschlangen registriert. Möglicherweise läuft der Worker nicht.
+        ai:
+          worker:
+            title: Worker-Verifikation
+            description: Die obigen Prüfungen wurden in diesem Web-Prozess ausgeführt. Die meisten KI-Aufgaben – Antworten des Assistenten, PDF-Verarbeitung, Embeddings, automatische Kategorisierung und Händlererkennung – laufen jedoch in einem Sidekiq-Worker-Prozess. Dessen Netzwerkzugriff, DNS, Proxy-Regeln oder geladene Zugangsdaten können abweichen. Stelle eine Prüfung in die Warteschlange, um die Konfiguration und Erreichbarkeit aus Sicht eines Workers zu prüfen.
+            verify_button: Worker-Konfiguration prüfen
+            coverage_notice: Jede Prüfung erfasst genau einen Worker-Prozess – denjenigen, der sie aus der Warteschlange übernimmt. Bei mehreren Worker-Replikaten bestätigt ein erfolgreiches Ergebnis nicht, dass alle Worker funktionsfähig sind. Stelle die Prüfung erneut in die Warteschlange, um eine weitere Stichprobe zu erhalten.
+            empty:
+              title: Bisher hat kein Worker ein Prüfergebnis gemeldet
+              description: Klicke auf „Worker-Konfiguration prüfen“, um eine asynchrone Prüfung in die Warteschlange zu stellen. Das Ergebnis erscheint hier, sobald ein Worker-Prozess die Prüfung übernimmt.
+            labels:
+              process: Worker-Prozess
+              checked_at: Geprüft
+              configuration: Konfiguration
+            configuration_statuses:
+              match: Entspricht dem Web-Prozess
+              mismatch: Weicht vom Web-Prozess ab
+            statuses:
+              passing: Erfolgreich
+              failing: Fehlgeschlagen
+              stale: Veraltet
+            settings_origin:
+              title: Welche Einstellungen erfordern einen Neustart?
+              database_backed: Änderungen an Anbieter, Modell und API-Schlüssel unter Einstellungen → Self-Hosting werden in der Datenbank gespeichert. rails-settings-cached verwirft beim Speichern den gemeinsamen Cache. Web- und Worker-Prozess verwenden daher bei der nächsten Anfrage oder Aufgabe den neuen Wert – kein Neustart erforderlich.
+              env_backed: Die Embedding-Konfiguration und alle ausschließlich über Umgebungsvariablen gesetzten Werte werden beim Start des jeweiligen Containers festgelegt. Rails kann die Umgebung eines anderen Containers nicht ändern. Nach solchen Änderungen müssen daher sowohl der Web- als auch der Worker-Dienst neu gestartet oder neu erstellt werden. Wenn die Bereitstellung nur einen der Dienste neu startet oder ein Secret ohne Pod-Neustart aktualisiert, wird die Änderung nicht überall übernommen.

--- a/test/controllers/admin/system_health_controller_test.rb
+++ b/test/controllers/admin/system_health_controller_test.rb
@@ -658,6 +658,83 @@ class Admin::SystemHealthControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
+  test "German worker verification copy is present without fallback" do
+    keys = %w[
+      title description verify_button coverage_notice empty.title empty.description
+      labels.process labels.checked_at labels.configuration
+      configuration_statuses.match configuration_statuses.mismatch
+      statuses.passing statuses.failing statuses.stale
+      settings_origin.title settings_origin.database_backed settings_origin.env_backed
+    ]
+    keys.each do |key|
+      assert_kind_of String, I18n.t("admin.system_health.show.ai.worker.#{key}", locale: :de, fallback: false, raise: true)
+    end
+    assert_kind_of String, I18n.t("admin.system_health.verify_worker_ai.queued", locale: :de, fallback: false, raise: true)
+  end
+
+  test "German super admin sees worker verification guidance and queued notice" do
+    users(:sure_support_staff).update!(locale: "de")
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+
+    with_memory_cache do
+      with_ai_environment do
+        get admin_system_health_url(tab: "ai")
+        assert_response :success
+        assert_select "h2", text: "Worker-Verifikation"
+        assert_select "button", text: "Worker-Konfiguration prüfen"
+        assert_match(/Bisher hat kein Worker ein Prüfergebnis gemeldet/, response.body)
+        assert_match(/Jede Prüfung erfasst genau einen Worker-Prozess/, response.body)
+        assert_match(/Welche Einstellungen erfordern einen Neustart\?/, response.body)
+        assert_match(/kein Neustart erforderlich/, response.body)
+        assert_match(/sowohl der Web- als auch der Worker-Dienst/, response.body)
+
+        assert_enqueued_with(job: WorkerAiHealthCheckJob) do
+          post verify_worker_ai_admin_system_health_url
+        end
+        assert_redirected_to admin_system_health_path(tab: "ai")
+        follow_redirect!
+        assert_match(/Die Worker-Prüfung wurde in die Warteschlange gestellt/, response.body)
+      end
+    end
+  end
+
+  test "German worker results distinguish passing failing stale and differing configurations" do
+    users(:sure_support_staff).update!(locale: "de")
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+
+    with_memory_cache do
+      with_ai_environment("OPENAI_ACCESS_TOKEN" => "synthetic-token") do
+        [
+          [ {}, "Erfolgreich", "Entspricht dem Web-Prozess" ],
+          [ { llm_status: :failing, llm_model: "different-model" }, "Fehlgeschlagen", "Weicht vom Web-Prozess ab" ],
+          [ { checked_at: (WorkerAiHealth::STALE_AFTER + 1.minute).ago }, "Veraltet", "Entspricht dem Web-Prozess" ]
+        ].each do |overrides, status, configuration|
+          WorkerAiHealth.record!(worker_snapshot(**{ vector_store_adapter: :openai, vector_store_status: :passing }.merge(overrides)))
+          get admin_system_health_url(tab: "ai")
+          assert_response :success
+          assert_select "[data-testid='worker-ai-health-result']" do
+            assert_select "[data-testid='worker-process-identity']", text: "worker:1"
+            assert_select "p", text: /Geprüft vor/
+            assert_select "span", text: status
+            assert_select "span", text: configuration
+          end
+          assert_no_match(/synthetic-token/, response.body)
+        end
+      end
+    end
+  end
+
+  test "German family admin cannot queue worker verification" do
+    users(:family_admin).update!(locale: "de")
+    sign_in users(:family_admin)
+    assert_no_enqueued_jobs only: WorkerAiHealthCheckJob do
+      post verify_worker_ai_admin_system_health_url
+    end
+    assert_redirected_to root_path
+  end
+
   private
     # Stubs Rails.cache with an in-process MemoryStore for the duration of
     # the block. Test env normally runs a NullStore (see config/environments/test.rb),


### PR DESCRIPTION
## Summary

German-speaking administrators can read AI worker-verification guidance, result badges and the queued notice in German instead of falling back to English. The copy preserves the distinction between web and worker configuration, single-worker sampling, and settings that require a restart.

Continues the German admin diagnostics work after job statistics and the shared Sidekiq warning. Other AI-health diagnostics remain a separate slice; job behavior and authorization are unchanged.

Related: #3486, #3499

## Validation

- Focused controller and locale tests: 41 runs, 543 assertions, no failures or errors; four existing skips. Covers empty, queued, passing, failing, stale, configuration mismatch and denied-access states.
- Full suite with `TZ=UTC`: 8,718 runs, 35,316 assertions, no failures or errors; 33 skips. An earlier local-time run on the preceding base hit an unrelated date-sensitive holding-import assertion around midnight; no importer code changed here.
- RuboCop, ERB lint, Biome and Brakeman passed.
- Synthetic browser verification at widths 1024, 1440 and 500: 1 run, 15 assertions. Worker instructions and restart guidance were visually inspected; no production data or requests were used.
- Independent AI German-language review and structured code review completed without remaining findings.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: only German copy and regression tests change. During the next routine admin check, confirm the worker section renders in German; no production verification job needs to be triggered for this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German translations for the worker verification panel in the admin system health view.
  * Added localized labels for worker status, configuration, coverage, guidance, and verification actions.

* **Tests**
  * Added coverage ensuring German users see translated worker health information without fallback text.
  * Verified verification actions, status displays, and access restrictions for different administrator roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->