### PR TITLE
feat: add IBAN columns to account and transaction CSV exports

### DIFF
--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -59,6 +59,17 @@ module AccountableResource
       set_link_options
       render :new, status: :unprocessable_entity
       return
+    rescue ActiveRecord::RecordNotUnique
+      # A raw DB-level race on the partial unique index: two concurrent
+      # requests both passed the Rails uniqueness validation before either
+      # committed, so it surfaces from the adapter instead of being caught
+      # above. Same user-facing outcome, just a different failure point.
+      @account = Current.family.accounts.build(account_params.except(:return_to, :opening_balance_date))
+      @account.errors.add(:iban, :taken)
+      @error_message = @account.errors.full_messages.join(", ")
+      set_link_options
+      render :new, status: :unprocessable_entity
+      return
     end
 
     # Prefer the form-carried return_to, then the session value StoreLocation
@@ -86,7 +97,16 @@ module AccountableResource
     # here so all account types (depositories, credit cards, loans, etc.) can
     # have their currency changed via this shared update path.
     update_params = account_params.except(:return_to, :balance, :opening_balance_date)
-    unless @account.update(update_params)
+    begin
+      unless @account.update(update_params)
+        @error_message = @account.errors.full_messages.join(", ")
+        render :edit, status: :unprocessable_entity
+        return
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # Same raw DB-level race as #create: another request's iban committed
+      # between our validation check and this update's own commit.
+      @account.errors.add(:iban, :taken)
       @error_message = @account.errors.full_messages.join(", ")
       render :edit, status: :unprocessable_entity
       return

--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -83,37 +83,58 @@ module AccountableResource
   end
 
   def update
-    # Handle balance update if the value actually changed
-    if account_params[:balance].present? && account_params[:balance].to_d != @account.balance
-      result = @account.set_current_balance(account_params[:balance].to_d)
-      unless result.success?
-        @error_message = result.error_message
-        render :edit, status: :unprocessable_entity
-        return
-      end
-    end
+    original_balance = @account.balance
+    balance_change_attempted = false
 
-    # Update remaining account attributes. Note: currency is intentionally allowed
-    # here so all account types (depositories, credit cards, loans, etc.) can
-    # have their currency changed via this shared update path.
-    update_params = account_params.except(:return_to, :balance, :opening_balance_date)
-    begin
-      unless @account.update(update_params)
+    # Wrapped in one transaction so a later failure (e.g. a duplicate iban)
+    # rolls back the balance change above it instead of leaving it
+    # committed underneath a 422 response -- set_current_balance's own
+    # sync_later enqueue isn't part of this transaction, so a rolled-back
+    # attempt can still trigger a harmless no-op sync against the
+    # now-unchanged balance.
+    @account.transaction do
+      # Handle balance update if the value actually changed
+      if account_params[:balance].present? && account_params[:balance].to_d != @account.balance
+        balance_change_attempted = true
+        result = @account.set_current_balance(account_params[:balance].to_d)
+        unless result.success?
+          @error_message = result.error_message
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      # Update remaining account attributes. Note: currency is intentionally allowed
+      # here so all account types (depositories, credit cards, loans, etc.) can
+      # have their currency changed via this shared update path.
+      update_params = account_params.except(:return_to, :balance, :opening_balance_date)
+      begin
+        unless @account.update(update_params)
+          @error_message = @account.errors.full_messages.join(", ")
+          raise ActiveRecord::Rollback
+        end
+      rescue ActiveRecord::RecordNotUnique
+        # Same raw DB-level race as #create: another request's iban committed
+        # between our validation check and this update's own commit.
+        @account.errors.add(:iban, :taken)
         @error_message = @account.errors.full_messages.join(", ")
-        render :edit, status: :unprocessable_entity
-        return
+        raise ActiveRecord::Rollback
       end
-    rescue ActiveRecord::RecordNotUnique
-      # Same raw DB-level race as #create: another request's iban committed
-      # between our validation check and this update's own commit.
-      @account.errors.add(:iban, :taken)
-      @error_message = @account.errors.full_messages.join(", ")
-      render :edit, status: :unprocessable_entity
-      return
+
+      @account.lock_saved_attributes!
     end
 
-    @account.lock_saved_attributes!
-    redirect_back_or_to account_path(@account), notice: t("accounts.update.success", type: accountable_type.name.underscore.humanize)
+    if @error_message.present?
+      # set_current_balance persists via its own account.update! before a
+      # later failure rolls the transaction back at the DB level -- restore
+      # just the balance attribute (not a full reload) so the re-rendered
+      # form doesn't show the rolled-back attempted balance as if it had
+      # been saved, while still showing whatever invalid values the user
+      # typed into the other fields (a full reload would wipe those too).
+      @account.balance = original_balance if balance_change_attempted
+      render :edit, status: :unprocessable_entity
+    else
+      redirect_back_or_to account_path(@account), notice: t("accounts.update.success", type: accountable_type.name.underscore.humanize)
+    end
   end
 
   private

--- a/app/controllers/family_merchants_controller.rb
+++ b/app/controllers/family_merchants_controller.rb
@@ -103,7 +103,19 @@ class FamilyMerchantsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   rescue ActiveRecord::RecordInvalid => e
-    @family_merchant = e.record
+    # e.record is the unsaved, never-persisted FamilyMerchant the failed
+    # conversion tried to create. Replacing @family_merchant with it (as a
+    # naive rescue would) breaks the re-rendered form: _form.html.erb picks
+    # its action URL from `family_merchant.persisted?`, so an unpersisted
+    # record posts to the FamilyMerchant#create route instead of back to
+    # this ProviderMerchant's #update -- silently dropping the whole
+    # conversion (transaction reassignment, user_modified protection) on
+    # the next submit. Keep @merchant/@family_merchant pointed at the
+    # original, persisted ProviderMerchant so the form still targets
+    # #update; copy over the failed attempt's errors and submitted values
+    # so the user sees what they typed and why it failed.
+    @merchant.assign_attributes(merchant_params.slice(:name, :website_url, :iban))
+    e.record.errors.each { |error| @merchant.errors.add(error.attribute, error.type, **error.options) }
     render :edit, status: :unprocessable_entity
   end
 

--- a/app/controllers/family_merchants_controller.rb
+++ b/app/controllers/family_merchants_controller.rb
@@ -195,10 +195,10 @@ class FamilyMerchantsController < ApplicationController
       params.require(key).permit(:name, :color, :website_url, :iban)
     end
 
-    # Mirrors Merchant#normalize_iban so a submitted value can be compared
-    # against the persisted (already-normalized) iban without saving first.
+    # So a submitted value can be compared against the persisted
+    # (already-normalized) iban without saving first.
     def normalize_iban(value)
-      value.to_s.gsub(/[[:space:]]+/, "").upcase.presence
+      IbanNormalizable.normalize(value)
     end
 
     def render_create_error

--- a/app/controllers/family_merchants_controller.rb
+++ b/app/controllers/family_merchants_controller.rb
@@ -50,18 +50,16 @@ class FamilyMerchantsController < ApplicationController
         format.json { render json: merchant_json(@family_merchant), status: :created }
       end
     else
-      respond_to do |format|
-        # No explicit format.turbo_stream branch: Turbo's form submissions send an
-        # Accept header that prefers turbo-stream, but forcing that format here would
-        # lock the response's Content-Type to turbo-stream while still rendering the
-        # plain :new HTML template — Turbo's client then sees a turbo-stream
-        # Content-Type with no <turbo-stream> tags in the body and does nothing.
-        # Leaving turbo-stream undeclared lets Rails' content negotiation fall back to
-        # format.html below, which renders :new with the correct text/html type.
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: { errors: @family_merchant.errors.full_messages }, status: :unprocessable_entity }
-      end
+      render_create_error
     end
+  rescue ActiveRecord::RecordNotUnique
+    # A raw DB-level race on the partial (family_id, iban) unique index: two
+    # concurrent creates both passed the Rails uniqueness validation before
+    # either committed, so it surfaces here instead of the `save` branch
+    # above. #save doesn't rescue this on its own since it's a raw
+    # PG::UniqueViolation, not a validation failure.
+    @family_merchant.errors.add(:iban, :taken)
+    render_create_error
   end
 
   def edit
@@ -114,8 +112,15 @@ class FamilyMerchantsController < ApplicationController
     # original, persisted ProviderMerchant so the form still targets
     # #update; copy over the failed attempt's errors and submitted values
     # so the user sees what they typed and why it failed.
-    @merchant.assign_attributes(merchant_params.slice(:name, :website_url, :iban))
+    restore_merchant_after_failed_conversion!
     e.record.errors.each { |error| @merchant.errors.add(error.attribute, error.type, **error.options) }
+    render :edit, status: :unprocessable_entity
+  rescue ActiveRecord::RecordNotUnique
+    # Same race as above, surfaced through the raw DB constraint instead of
+    # the Rails-level validation: two concurrent conversions in the same
+    # family both passed uniqueness before either committed.
+    restore_merchant_after_failed_conversion!
+    @merchant.errors.add(:iban, :taken)
     render :edit, status: :unprocessable_entity
   end
 
@@ -194,6 +199,31 @@ class FamilyMerchantsController < ApplicationController
     # against the persisted (already-normalized) iban without saving first.
     def normalize_iban(value)
       value.to_s.gsub(/[[:space:]]+/, "").upcase.presence
+    end
+
+    def render_create_error
+      respond_to do |format|
+        # No explicit format.turbo_stream branch: Turbo's form submissions send an
+        # Accept header that prefers turbo-stream, but forcing that format here would
+        # lock the response's Content-Type to turbo-stream while still rendering the
+        # plain :new HTML template — Turbo's client then sees a turbo-stream
+        # Content-Type with no <turbo-stream> tags in the body and does nothing.
+        # Leaving turbo-stream undeclared lets Rails' content negotiation fall back to
+        # format.html below, which renders :new with the correct text/html type.
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: { errors: @family_merchant.errors.full_messages }, status: :unprocessable_entity }
+      end
+    end
+
+    # Keeps @merchant/@family_merchant pointed at the original, persisted
+    # ProviderMerchant after a failed conversion attempt (see the #update
+    # rescues), instead of an unpersisted FamilyMerchant that would break
+    # the re-rendered form's submit target. Restores every attribute the
+    # form could have submitted, including :color -- merchant_params
+    # permits it and convert_to_family_merchant_for receives it, so omitting
+    # it here would silently revert a color change on the failed attempt.
+    def restore_merchant_after_failed_conversion!
+      @merchant.assign_attributes(merchant_params.slice(:name, :color, :website_url, :iban))
     end
 
     def merchant_json(merchant)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,5 +1,5 @@
 class Account < ApplicationRecord
-  include AASM, Syncable, Monetizable, Chartable, Linkable, Enrichable, Anchorable, Reconcileable, TaxTreatable, Encryptable
+  include AASM, Syncable, Monetizable, Chartable, Linkable, Enrichable, Anchorable, Reconcileable, TaxTreatable, Encryptable, IbanNormalizable
 
   # deterministic: true preserves equality lookups (e.g. find_by(iban:)) and
   # the family_id+iban uniqueness index, since the same plaintext always
@@ -24,11 +24,11 @@ class Account < ApplicationRecord
   end
 
   before_validation :assign_default_owner, if: -> { owner_id.blank? }
-  # Strips whitespace and upcases so provider-supplied IBANs ("DE893704...")
-  # and manually-entered ones ("DE89 3704...") normalize to the same value —
-  # required for both the uniqueness index and deterministic-encryption
-  # equality lookups to actually match.
-  before_validation :normalize_iban
+  # IbanNormalizable strips everything but letters/digits and upcases, so
+  # provider-supplied IBANs ("DE893704...") and manually-entered ones in any
+  # formatting style ("DE89 3704...", "DE89.3704...", "DE89-3704...")
+  # normalize to the same value — required for both the uniqueness index and
+  # deterministic-encryption equality lookups to actually match.
 
   before_destroy :capture_account_statement_ids_to_move
   before_destroy :cleanup_transfers
@@ -735,14 +735,6 @@ class Account < ApplicationRecord
   end
 
   private
-
-    def normalize_iban
-      # [[:space:]] rather than a literal " " -- a pasted IBAN can carry
-      # tabs, newlines, or NBSP (common when copying from a formatted PDF
-      # bank statement), which delete(" ") would leave in place and quietly
-      # break the uniqueness index and deterministic-encryption lookups.
-      self.iban = iban.to_s.gsub(/[[:space:]]+/, "").upcase.presence
-    end
 
     def assign_default_owner
       return if owner.present?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -4,6 +4,21 @@ class Account < ApplicationRecord
   # deterministic: true preserves equality lookups (e.g. find_by(iban:)) and
   # the family_id+iban uniqueness index, since the same plaintext always
   # produces the same ciphertext.
+  #
+  # Deliberate tradeoff, not an oversight: unlike MonobankAccount#iban
+  # (encrypted non-deterministically, since it's never looked up by value),
+  # this column's whole purpose requires DB-level equality -- the uniqueness
+  # index and find_by(iban:) lookups can't work without a value-preserving
+  # transform. Splitting into a deterministic lookup column plus a separate
+  # non-deterministic display column (the pattern this codebase uses
+  # elsewhere, e.g. SnaptradeItem's client_id/consumer_key vs
+  # snaptrade_user_secret) wouldn't remove the ciphertext-correlation
+  # property being traded off here either, since IT'S the SAME value in both
+  # roles -- the deterministic column would still leak equality. Accepted
+  # for the user's own account/merchant IBAN; deliberately NOT applied to a
+  # transaction's counterparty_iban (see EnableBankingEntry::Processor),
+  # which has no uniqueness requirement and stays in the existing
+  # unencrypted `extra` jsonb column rather than inheriting this tradeoff.
   if encryption_ready?
     encrypts :iban, deterministic: true
   end

--- a/app/models/account/provider_import_adapter.rb
+++ b/app/models/account/provider_import_adapter.rb
@@ -78,10 +78,30 @@ class Account::ProviderImportAdapter
           # through the auto-claim path. Without this, a user who categorised a pending entry
           # (setting user_modified=true) would see the pending badge stuck forever.
           # Excluded and import_locked entries are intentionally left untouched.
-          if skip_reason == "user_modified" && !incoming_pending && entry.entryable.is_a?(Transaction)
-            entry_is_pending = Transaction::PENDING_PROVIDERS.any? { |p| entry.transaction.extra&.dig(p, "pending") }
-            if entry_is_pending
-              entry.transaction.update!(extra: clear_pending_flags_from_extra(entry.transaction.extra))
+          if skip_reason == "user_modified" && entry.entryable.is_a?(Transaction)
+            updated_extra = entry.transaction.extra
+
+            if !incoming_pending
+              entry_is_pending = Transaction::PENDING_PROVIDERS.any? { |p| updated_extra&.dig(p, "pending") }
+              updated_extra = clear_pending_flags_from_extra(updated_extra) if entry_is_pending
+            end
+
+            # counterparty_iban/counterparty_account_id are provider-derived
+            # facts with no corresponding UI field, so backfilling them here
+            # doesn't risk reverting a user edit the way overwriting name/
+            # category/notes would -- unlike those, protecting the user's
+            # work gives no reason to withhold this data. Without this, a
+            # transaction the user touched before this metadata existed
+            # would never receive it, even on later syncs.
+            if extra.is_a?(Hash)
+              counterparty_updates = extra.with_indifferent_access.slice("counterparty_iban", "counterparty_account_id")
+              if counterparty_updates.present?
+                updated_extra = (updated_extra || {}).deep_merge(counterparty_updates.deep_stringify_keys)
+              end
+            end
+
+            if updated_extra != entry.transaction.extra
+              entry.transaction.update!(extra: updated_extra)
             end
           end
           record_skip(entry, skip_reason)

--- a/app/models/concerns/iban_normalizable.rb
+++ b/app/models/concerns/iban_normalizable.rb
@@ -1,0 +1,41 @@
+# Provides a single, shared IBAN normalization rule used everywhere an IBAN
+# is stored or compared in this app (Account, Merchant, EnableBankingAccount,
+# EnableBankingEntry::Processor's counterparty IBAN, the rules condition
+# filter, transaction search, transfer matching, the family_merchants
+# controller's change-detection, and the security backfill task).
+#
+# A real IBAN is only ever letters and digits (ISO 13616): 2-letter country
+# code, 2 check digits, up to 30 alphanumeric characters. Stripping anything
+# that isn't a letter or digit -- not just whitespace -- correctly handles
+# every formatting style a user might paste in (spaces, dots, dashes,
+# tabs/newlines/NBSP from a formatted PDF or bank statement, "DE89.3704...",
+# "DE89-3704...", etc.) instead of only catching whitespace and silently
+# keeping other separators in the stored value.
+#
+# A single shared implementation also avoids the normalization drifting out
+# of sync between call sites, which previously caused a real bug: Monobank's
+# own counter_iban field was normalized differently (or not at all) from the
+# rest of the app, so a value that looked identical to a user could silently
+# fail to match in rules/search.
+#
+# Usage as a model concern (adds a before_validation callback):
+#   include IbanNormalizable
+#
+# Usage as a plain utility (rule filters, search, controllers, rake tasks):
+#   IbanNormalizable.normalize(value)
+module IbanNormalizable
+  extend ActiveSupport::Concern
+
+  def self.normalize(value)
+    value.to_s.gsub(/[^a-zA-Z0-9]/, "").upcase.presence
+  end
+
+  included do
+    before_validation :normalize_iban
+  end
+
+  private
+    def normalize_iban
+      self.iban = IbanNormalizable.normalize(iban)
+    end
+end

--- a/app/models/enable_banking_account.rb
+++ b/app/models/enable_banking_account.rb
@@ -8,6 +8,8 @@ class EnableBankingAccount < ApplicationRecord
     # deterministic: true preserves equality lookups (e.g. find_by(iban:)) —
     # the account's own IBAN was previously stored in plaintext here, unlike
     # the other columns on this model.
+    # See Account#iban for the deliberate tradeoff this makes (accepted here
+    # for the same reason: DB-level uniqueness/lookup can't work otherwise).
     encrypts :iban, deterministic: true
   end
 

--- a/app/models/enable_banking_account.rb
+++ b/app/models/enable_banking_account.rb
@@ -1,5 +1,5 @@
 class EnableBankingAccount < ApplicationRecord
-  include CurrencyNormalizable, Encryptable
+  include CurrencyNormalizable, Encryptable, IbanNormalizable
 
   # Encrypt raw payloads if ActiveRecord encryption is configured
   if encryption_ready?
@@ -12,12 +12,6 @@ class EnableBankingAccount < ApplicationRecord
     # for the same reason: DB-level uniqueness/lookup can't work otherwise).
     encrypts :iban, deterministic: true
   end
-
-  # Same normalization as Account#normalize_iban, applied here too: a
-  # formatted/lowercase provider IBAN must canonicalize to the same
-  # deterministic ciphertext as one written elsewhere, or find_by(iban:)
-  # lookups against this column silently miss.
-  before_validation :normalize_iban
 
   belongs_to :enable_banking_item
 
@@ -216,10 +210,6 @@ class EnableBankingAccount < ApplicationRecord
   end
 
   private
-
-    def normalize_iban
-      self.iban = iban.to_s.gsub(/[[:space:]]+/, "").upcase.presence
-    end
 
     def capture_propagation_failure(target, message)
       DebugLogEntry.capture(

--- a/app/models/enable_banking_account.rb
+++ b/app/models/enable_banking_account.rb
@@ -199,8 +199,12 @@ class EnableBankingAccount < ApplicationRecord
         if target.errors.any?
           capture_propagation_failure(target, target.errors.full_messages.join(", "))
         end
-      rescue ActiveRecord::RecordNotUnique => e
-        capture_propagation_failure(target, "Concurrent iban conflict: #{e.message}")
+      rescue ActiveRecord::RecordNotUnique
+        # Deliberately not e.message: PostgreSQL's unique-violation DETAIL
+        # clause embeds the actual conflicting IBAN value in plaintext,
+        # which would defeat the point of encrypting the column at rest by
+        # persisting it into an unrelated log table instead.
+        capture_propagation_failure(target, "Concurrent iban conflict on the family_id+iban unique index")
       end
     end
   end

--- a/app/models/enable_banking_account.rb
+++ b/app/models/enable_banking_account.rb
@@ -184,13 +184,40 @@ class EnableBankingAccount < ApplicationRecord
         ActiveRecord::Base.transaction(requires_new: true) do
           target.enrich_attribute(:iban, iban, source: "enable_banking")
         end
+
+        # enrich_attribute's own "was it modified" return value can't be
+        # trusted to reflect a failed save (a Rails quirk in how it derives
+        # that from previous_changes), so check the record's errors
+        # directly instead. Empty errors covers both a successful write and
+        # a locked attribute (an intentional, silent skip -- see the method
+        # comment above); errors present means the internal `save` actually
+        # attempted and failed (e.g. another account in the family already
+        # has this IBAN), which is worth surfacing in the support debug log
+        # rather than only a Rails log line.
+        if target.errors.any?
+          capture_propagation_failure(target, target.errors.full_messages.join(", "))
+        end
       rescue ActiveRecord::RecordNotUnique => e
-        Rails.logger.warn("EnableBankingAccount#propagate_iban_to_account! - Concurrent iban conflict on account #{target.id}: #{e.message}")
+        capture_propagation_failure(target, "Concurrent iban conflict: #{e.message}")
       end
     end
   end
 
   private
+
+    def capture_propagation_failure(target, message)
+      DebugLogEntry.capture(
+        category: "provider_sync_warning",
+        level: "warn",
+        message: "Could not propagate IBAN to account: #{message}",
+        source: self.class.name,
+        provider_key: "enable_banking",
+        family: enable_banking_item&.family,
+        account: target,
+        account_provider: account_provider,
+        metadata: { enable_banking_account_id: id, account_id: target.id }
+      )
+    end
 
     def build_account_name(snapshot)
       # Try to build a meaningful name from the account data

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -232,6 +232,19 @@ class EnableBankingEntry::Processor
       # lacks counterparty data (e.g. a booked re-delivery of a transaction whose earlier
       # pending version had it) would leave the old, now-stale value in place instead of
       # clearing it.
+      #
+      # Deliberately stored in transactions.extra (plain jsonb, unencrypted),
+      # not given the deterministic-encryption treatment Account#iban/
+      # Merchant#iban get: this value is never looked up by DB-level equality
+      # (only ILIKE search, dedup, and Ruby-side comparisons after loading),
+      # so there's no lookup requirement forcing that tradeoff here. Actually
+      # encrypting it would require pulling it into its own real column --
+      # Active Record Encryption doesn't support querying inside an encrypted
+      # jsonb value, and every consumer (rules, search, dedup, transfer
+      # matching) reads it via `extra ->> 'counterparty_iban'` SQL directly.
+      # That's a larger, deliberate architecture change for a future PR, not
+      # a default to slide into by extending `extra` the same way fx_rate/
+      # pending/mcc already are.
       cp = counterparty_account_info
       result[:counterparty_iban] = cp[:iban]
       result[:counterparty_account_id] = cp[:iban].blank? ? cp[:other_id] : nil

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -46,6 +46,19 @@ class EnableBankingEntry::Processor
   # ID fields *and* two distinct payments with byte-identical date/amount/
   # currency/direction/creditor/debtor/remittance text, which is rare enough
   # to prefer stability for the common case.
+  #
+  # The same gap exists, for the same reason, when transaction_id/entry_reference
+  # IS present but reused by the ASPSP across two genuinely distinct payments
+  # (the API docs don't guarantee uniqueness -- see the importer's dedup key
+  # comment): the dedup pass can now correctly keep both as separate raw rows
+  # when their counterparty IBANs differ, but they still compute the SAME
+  # external_id here and get collapsed into one Entry during import, silently
+  # dropping one real transaction. Folding IBAN into this branch's ID would
+  # have the identical every-existing-transaction-becomes-a-duplicate problem
+  # as above, just triggered by a much more common ASPSP behavior (a present
+  # but reused transaction_id, vs. an absent one) -- so it's deliberately
+  # left as the wider, still-open half of this same accepted tradeoff rather
+  # than patched narrowly here.
   def self.compute_external_id(raw_transaction_data)
     data = raw_transaction_data.with_indifferent_access
     id = data[:transaction_id].presence || data[:entry_reference].presence

--- a/app/models/enable_banking_entry/processor.rb
+++ b/app/models/enable_banking_entry/processor.rb
@@ -280,12 +280,13 @@ class EnableBankingEntry::Processor
         end
 
         {
-          # Normalized (no spaces, upcased) so it matches the same
-          # convention as accounts.iban/merchants.iban -- required for
-          # equality lookups/comparisons elsewhere (transfer matching, rule
+          # Normalized so it matches the same convention as
+          # accounts.iban/merchants.iban -- required for equality
+          # lookups/comparisons elsewhere (transfer matching, rule
           # conditions) to actually line up, regardless of whether an ASPSP
-          # happens to include spaces in its IBAN formatting.
-          iban: data.dig(account_key, :iban).to_s.gsub(/[[:space:]]+/, "").upcase.presence,
+          # happens to include spaces or other punctuation in its IBAN
+          # formatting.
+          iban: IbanNormalizable.normalize(data.dig(account_key, :iban)),
           other_id: data.dig(additional_key, :identification).presence,
           bank_name: data.dig(agent_key, :name).presence
         }

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -597,27 +597,42 @@ class EnableBankingItem::Importer
 
       duplicates_removed = 0
 
-      # Within each duplicate group, keep the richest representative -- a
-      # present counterparty IBAN first, then BOOK over PDNG -- rather than
-      # whichever row the API happened to return first. IBAN ranks above
-      # status: a BOOK row that lost its IBAN in a later delivery (some
-      # ASPSPs drop counterparty data once a transaction settles) must not
-      # win over a PDNG row from the same group that still carries it, or the
-      # dedup pass would silently discard real IBAN data. Array order isn't a
-      # reliability signal either, and picking the first row arbitrarily
-      # could discard a settled/IBAN-bearing row in favor of a thinner one
-      # (or, in a bucket a blank-IBAN row aliases into, discard the row that
-      # actually owns that IBAN).
+      # Within each duplicate group, keep the richest representative --
+      # BOOK over PDNG, same as before IBAN existed -- rather than whichever
+      # row the API happened to return first. Status ranks above IBAN
+      # presence here (unlike an earlier version of this method): picking a
+      # still-pending row over a settled one just because it had richer
+      # account data would leave the transaction permanently stuck pending
+      # (PENDING_PROVIDERS-gated balances/analytics exclude it) on every
+      # future sync, which is worse than the IBAN gap it would have closed.
+      # Instead, when the BOOK-preferred representative itself lacks IBAN
+      # data that a PDNG sibling in the same group carries (some ASPSPs drop
+      # counterparty data once a transaction settles), that IBAN is merged
+      # into the representative's own account fields below -- so both the
+      # settled status and the IBAN data survive, instead of trading one for
+      # the other.
       result = keyed_with_index.values.map do |group|
         duplicates_removed += group.size - 1 if group.size > 1
 
-        group.min_by do |tx, index|
+        representative, index = group.min_by do |tx, index|
           [
-            counterparty_iban_for_content_key(tx, tx[:credit_debit_indicator]).present? ? 0 : 1,
             tx[:status].to_s == "BOOK" ? 0 : 1,
             index
           ]
         end
+
+        unless counterparty_iban_for_content_key(representative, representative[:credit_debit_indicator]).present?
+          donor = group.map(&:first).find do |tx|
+            counterparty_iban_for_content_key(tx, tx[:credit_debit_indicator]).present?
+          end
+
+          if donor
+            account_key = representative[:credit_debit_indicator] == "CRDT" ? :debtor_account : :creditor_account
+            representative = representative.merge(account_key => donor[account_key])
+          end
+        end
+
+        [ representative, index ]
       end.sort_by { |_tx, index| index }.map(&:first)
 
       if duplicates_removed > 0

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -597,20 +597,24 @@ class EnableBankingItem::Importer
 
       duplicates_removed = 0
 
-      # Within each duplicate group, keep the richest representative --
-      # BOOK over PDNG, then a present counterparty IBAN -- rather than
-      # whichever row the API happened to return first. Array order isn't a
-      # reliability signal, and picking the first row arbitrarily could
-      # discard a settled/IBAN-bearing row in favor of a thinner one (or, in
-      # a bucket a blank-IBAN row aliases into, discard the row that
+      # Within each duplicate group, keep the richest representative -- a
+      # present counterparty IBAN first, then BOOK over PDNG -- rather than
+      # whichever row the API happened to return first. IBAN ranks above
+      # status: a BOOK row that lost its IBAN in a later delivery (some
+      # ASPSPs drop counterparty data once a transaction settles) must not
+      # win over a PDNG row from the same group that still carries it, or the
+      # dedup pass would silently discard real IBAN data. Array order isn't a
+      # reliability signal either, and picking the first row arbitrarily
+      # could discard a settled/IBAN-bearing row in favor of a thinner one
+      # (or, in a bucket a blank-IBAN row aliases into, discard the row that
       # actually owns that IBAN).
       result = keyed_with_index.values.map do |group|
         duplicates_removed += group.size - 1 if group.size > 1
 
         group.min_by do |tx, index|
           [
-            tx[:status].to_s == "BOOK" ? 0 : 1,
             counterparty_iban_for_content_key(tx, tx[:credit_debit_indicator]).present? ? 0 : 1,
+            tx[:status].to_s == "BOOK" ? 0 : 1,
             index
           ]
         end

--- a/app/models/enable_banking_item/importer.rb
+++ b/app/models/enable_banking_item/importer.rb
@@ -683,9 +683,9 @@ class EnableBankingItem::Importer
       account_key = direction == "CRDT" ? :debtor_account : :creditor_account
       # Normalized the same way EnableBankingEntry::Processor stores it:
       # without this, two representations of the same duplicate transaction
-      # with differently-formatted IBANs (spaces vs none) would produce
-      # different content keys and defeat the dedup this key exists for.
-      tx.dig(account_key, :iban).to_s.gsub(/[[:space:]]+/, "").upcase.presence
+      # with differently-formatted IBANs (spaces/punctuation vs none) would
+      # produce different content keys and defeat the dedup this key exists for.
+      IbanNormalizable.normalize(tx.dig(account_key, :iban))
     end
 
     class PaginationTruncatedError < StandardError; end

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -78,7 +78,7 @@ class Family::DataExporter
             account.balance.to_s,
             account.currency,
             account.created_at.iso8601,
-            account.iban
+            csv_safe(account.iban)
           ]
         end
       end
@@ -102,7 +102,7 @@ class Family::DataExporter
               transaction.tags.map { |tag| escape_legacy_tag_name(tag.name) }.join(","),
               transaction.entry.notes,
               transaction.entry.currency,
-              transaction_counterparty_iban(transaction)
+              csv_safe(transaction_counterparty_iban(transaction))
             ]
           end
       end
@@ -124,6 +124,20 @@ class Family::DataExporter
 
     def escape_legacy_tag_name(name)
       name.to_s.gsub(/[\\,|]/) { |char| "\\#{char}" }
+    end
+
+    # iban/counterparty_iban are free text with no format validation (unlike
+    # most other exported columns, which are either system-generated or
+    # constrained by other means), so a family member with no export access
+    # of their own could plant a formula payload for an admin to later open
+    # in a spreadsheet application (CSV/formula injection). Prefixing a
+    # leading =, +, -, @, tab, or CR with a single quote is the standard
+    # mitigation: spreadsheet apps then treat the cell as plain text instead
+    # of evaluating it, while the value itself is unchanged for CSV/text
+    # consumers (including this app's own CSV importer).
+    def csv_safe(value)
+      return value if value.blank?
+      value.start_with?("=", "+", "-", "@", "\t", "\r") ? "'#{value}" : value
     end
 
     def generate_trades_csv

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -62,7 +62,11 @@ class Family::DataExporter
 
     def generate_accounts_csv
       CSV.generate do |csv|
-        csv << [ "id", "name", "type", "subtype", "balance", "currency", "iban", "created_at" ]
+        # iban appended after created_at (not inserted before it) so a
+        # positional (non-header) reader of a pre-existing export -- the
+        # previous last column, created_at, stays at the same index instead
+        # of shifting a row's IBAN string into where a timestamp was expected.
+        csv << [ "id", "name", "type", "subtype", "balance", "currency", "created_at", "iban" ]
 
         # Only export accounts belonging to this family
         @family.accounts.includes(:accountable).find_each do |account|
@@ -73,8 +77,8 @@ class Family::DataExporter
             account.subtype,
             account.balance.to_s,
             account.currency,
-            account.iban,
-            account.created_at.iso8601
+            account.created_at.iso8601,
+            account.iban
           ]
         end
       end

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -62,7 +62,7 @@ class Family::DataExporter
 
     def generate_accounts_csv
       CSV.generate do |csv|
-        csv << [ "id", "name", "type", "subtype", "balance", "currency", "created_at" ]
+        csv << [ "id", "name", "type", "subtype", "balance", "currency", "iban", "created_at" ]
 
         # Only export accounts belonging to this family
         @family.accounts.includes(:accountable).find_each do |account|
@@ -73,6 +73,7 @@ class Family::DataExporter
             account.subtype,
             account.balance.to_s,
             account.currency,
+            account.iban,
             account.created_at.iso8601
           ]
         end
@@ -81,7 +82,7 @@ class Family::DataExporter
 
     def generate_transactions_csv
       CSV.generate do |csv|
-        csv << [ "date", "account_name", "amount", "name", "category", "tags", "notes", "currency" ]
+        csv << [ "date", "account_name", "amount", "name", "category", "tags", "notes", "currency", "counterparty_iban" ]
 
         # Only export transactions from accounts belonging to this family
         # Exclude split parents (export children instead)
@@ -96,7 +97,8 @@ class Family::DataExporter
               transaction.category&.name,
               transaction.tags.map { |tag| escape_legacy_tag_name(tag.name) }.join(","),
               transaction.entry.notes,
-              transaction.entry.currency
+              transaction.entry.currency,
+              transaction.extra&.dig("counterparty_iban")
             ]
           end
       end

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -91,7 +91,7 @@ class Family::DataExporter
         # Only export transactions from accounts belonging to this family
         # Exclude split parents (export children instead)
         exportable_transactions
-          .includes(:category, :tags, entry: :account)
+          .includes(:category, :tags, entry: [ :account, parent_entry: :entryable ])
           .find_each do |transaction|
             csv << [
               transaction.entry.date&.iso8601,
@@ -102,10 +102,24 @@ class Family::DataExporter
               transaction.tags.map { |tag| escape_legacy_tag_name(tag.name) }.join(","),
               transaction.entry.notes,
               transaction.entry.currency,
-              transaction.extra&.dig("counterparty_iban")
+              transaction_counterparty_iban(transaction)
             ]
           end
       end
+    end
+
+    # Split children don't inherit the parent transaction's extra metadata
+    # (Entry#split! never copies it), so a split-off row would otherwise
+    # export blank even though the original synced transaction had a
+    # counterparty IBAN. Falls back to the parent's value in that case.
+    def transaction_counterparty_iban(transaction)
+      transaction.extra&.dig("counterparty_iban") ||
+        parent_transaction(transaction)&.extra&.dig("counterparty_iban")
+    end
+
+    def parent_transaction(transaction)
+      parent = transaction.entry.parent_entry&.entryable
+      parent if parent.is_a?(Transaction)
     end
 
     def escape_legacy_tag_name(name)

--- a/app/models/family_merchant.rb
+++ b/app/models/family_merchant.rb
@@ -8,6 +8,11 @@ class FamilyMerchant < Merchant
 
   validates :color, presence: true, format: { with: /\A#[0-9A-Fa-f]{6}\z/ }
   validates :name, uniqueness: { scope: :family }
+  # Mirrors the DB-level partial unique index (family_id, iban). Without
+  # this, Account::ProviderImportAdapter#find_or_create_merchant's
+  # family-merchant lookup by IBAN could match an unspecified one of two
+  # duplicates, silently assigning a transaction to the wrong merchant.
+  validates :iban, uniqueness: { scope: :family }, allow_nil: true
 
   private
     def set_default_color

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,5 +1,5 @@
 class Merchant < ApplicationRecord
-  include Encryptable
+  include Encryptable, IbanNormalizable
 
   TYPES = %w[FamilyMerchant ProviderMerchant].freeze
 
@@ -24,8 +24,6 @@ class Merchant < ApplicationRecord
   has_many :transactions, dependent: :nullify
   has_many :recurring_transactions, dependent: :destroy
 
-  before_validation :normalize_iban
-
   validates :name, presence: true
   validates :name, exclusion: { in: [ NO_MERCHANT_FILTER_VALUE ] }
   validates :type, inclusion: { in: TYPES }
@@ -49,10 +47,4 @@ class Merchant < ApplicationRecord
   def filter_value
     persisted? ? name : NO_MERCHANT_FILTER_VALUE
   end
-
-  private
-    def normalize_iban
-      # See Account#normalize_iban for why [[:space:]] rather than a literal " ".
-      self.iban = iban.to_s.gsub(/[[:space:]]+/, "").upcase.presence
-    end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -15,6 +15,8 @@ class Merchant < ApplicationRecord
   # and the source+iban uniqueness index. Only meaningful for ProviderMerchant
   # rows in practice, but lives on the shared base class like other
   # provider-specific columns (provider_merchant_id, source).
+  # See Account#iban for the deliberate tradeoff this makes (accepted here
+  # for the same reason: DB-level uniqueness/lookup can't work otherwise).
   if encryption_ready?
     encrypts :iban, deterministic: true
   end

--- a/config/locales/views/merchants/en.yml
+++ b/config/locales/views/merchants/en.yml
@@ -14,7 +14,7 @@ en:
       website_placeholder: Website (e.g., starbucks.com)
       website_hint: Enter the merchant's website to automatically display their logo
       iban_placeholder: IBAN (optional)
-      iban_hint: Used to match transactions to this merchant by account number, in addition to name
+      iban_hint: The merchant's own bank account number, if known
     index:
       empty: No merchants yet
       new: New merchant

--- a/db/migrate/20260911184745_add_family_scoped_iban_uniqueness_to_merchants.rb
+++ b/db/migrate/20260911184745_add_family_scoped_iban_uniqueness_to_merchants.rb
@@ -4,6 +4,32 @@ class AddFamilyScopedIbanUniquenessToMerchants < ActiveRecord::Migration[7.2]
   INDEX_NAME = "index_merchants_on_family_id_and_iban"
 
   def up
+    # On any installation where FamilyMerchant#iban was already writable
+    # before this index existed (the parent IBAN-foundation migration, same
+    # deploy or earlier), duplicate (family_id, iban) pairs may already be
+    # present -- CREATE UNIQUE INDEX CONCURRENTLY aborts outright when they
+    # are, leaving an invalid index behind and the migration re-runnable but
+    # not self-healing. Fail with a clear, actionable error naming the
+    # conflicting merchant ids (not the iban values themselves -- this
+    # column is encrypted at rest, and a migration log is not the place to
+    # put it back in plaintext) rather than surfacing PostgreSQL's raw
+    # unique-violation message.
+    conflicting_merchant_ids = select_rows(<<~SQL.squish)
+      SELECT ARRAY_AGG(id::text ORDER BY id)
+      FROM merchants
+      WHERE type = 'FamilyMerchant' AND iban IS NOT NULL
+      GROUP BY family_id, iban
+      HAVING COUNT(*) > 1
+    SQL
+
+    if conflicting_merchant_ids.any?
+      ids = conflicting_merchant_ids.flat_map { |row| row.first.tr("{}", "").split(",") }
+      raise "Cannot add the family-scoped iban uniqueness index: " \
+            "FamilyMerchant rows #{ids.join(', ')} already share an iban within " \
+            "the same family. Resolve the duplicates (merge or clear iban on " \
+            "all but one per group) before re-running this migration."
+    end
+
     # Without this, two FamilyMerchant rows in the same family could share
     # an IBAN (nothing enforced it), so find_by(iban:) in
     # Account::ProviderImportAdapter#find_or_create_merchant would pick an

--- a/db/migrate/20260911184745_add_family_scoped_iban_uniqueness_to_merchants.rb
+++ b/db/migrate/20260911184745_add_family_scoped_iban_uniqueness_to_merchants.rb
@@ -1,0 +1,34 @@
+class AddFamilyScopedIbanUniquenessToMerchants < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  INDEX_NAME = "index_merchants_on_family_id_and_iban"
+
+  def up
+    # Without this, two FamilyMerchant rows in the same family could share
+    # an IBAN (nothing enforced it), so find_by(iban:) in
+    # Account::ProviderImportAdapter#find_or_create_merchant would pick an
+    # unspecified one -- assigning a future Enable Banking transaction to
+    # the wrong family-configured merchant regardless of its name.
+    unless valid_index_exists?(INDEX_NAME)
+      execute "DROP INDEX CONCURRENTLY IF EXISTS #{INDEX_NAME}"
+      add_index :merchants, [ :family_id, :iban ],
+                unique: true,
+                where: "((iban IS NOT NULL) AND ((type)::text = 'FamilyMerchant'::text))",
+                name: INDEX_NAME,
+                algorithm: :concurrently
+    end
+  end
+
+  def down
+    remove_index :merchants, name: INDEX_NAME, if_exists: true, algorithm: :concurrently
+  end
+
+  private
+    def valid_index_exists?(index_name)
+      select_value(<<~SQL.squish) == true
+        SELECT indisvalid FROM pg_index
+        JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+        WHERE pg_class.relname = '#{index_name}'
+      SQL
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_184745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -1376,6 +1376,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_120000) do
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.string "website_url"
+    t.index ["family_id", "iban"], name: "index_merchants_on_family_id_and_iban", unique: true, where: "((iban IS NOT NULL) AND ((type)::text = 'FamilyMerchant'::text))"
     t.index ["family_id", "name"], name: "index_merchants_on_family_id_and_name", unique: true, where: "((type)::text = 'FamilyMerchant'::text)"
     t.index ["family_id"], name: "index_merchants_on_family_id"
     t.index ["provider_merchant_id", "source"], name: "index_merchants_on_provider_merchant_id_and_source", unique: true, where: "((provider_merchant_id IS NOT NULL) AND ((type)::text = 'ProviderMerchant'::text))"

--- a/lib/tasks/security_backfill.rake
+++ b/lib/tasks/security_backfill.rake
@@ -123,7 +123,7 @@ namespace :security do
             # Normalizing on write, bypassing validations/callbacks as above,
             # matches the normalize_iban callback so find_by(iban:) with a
             # canonical value still matches a formatted/lowercase legacy row.
-            value = value.to_s.gsub(/[[:space:]]+/, "").upcase.presence if field == :iban
+            value = IbanNormalizable.normalize(value) if field == :iban
             encryptor.send("#{field}=", value)
           end
 

--- a/test/controllers/depositories_controller_test.rb
+++ b/test/controllers/depositories_controller_test.rb
@@ -91,6 +91,21 @@ class DepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "update rolls back a balance change when the iban update fails in the same request" do
+    linked_account = accounts(:connected)
+    other_account = accounts(:depository)
+    other_account.update!(iban: "DE89370400440532013000") # pipelock:ignore IBAN
+    original_balance = linked_account.balance
+
+    patch depository_path(linked_account), params: {
+      account: { balance: original_balance + 100, iban: "DE89370400440532013000" } # pipelock:ignore IBAN
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal original_balance, linked_account.reload.balance,
+      "the balance change must not persist when the same request's iban update fails"
+  end
+
   test "update persists a manually entered iban through the shared update action" do
     linked_account = accounts(:connected)
 

--- a/test/controllers/depositories_controller_test.rb
+++ b/test/controllers/depositories_controller_test.rb
@@ -60,6 +60,37 @@ class DepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "create re-renders the form instead of a 500 on a raw unique-index race" do
+    # Simulates two concurrent requests both passing the Rails uniqueness
+    # validation before either commits -- the second one hits the raw DB
+    # constraint instead, surfacing as RecordNotUnique rather than the
+    # RecordInvalid the previous test covers.
+    Account.any_instance.stubs(:save!).raises(
+      ActiveRecord::RecordNotUnique.new("duplicate key value violates unique constraint")
+    )
+
+    assert_no_difference -> { Account.count } do
+      post depositories_path, params: {
+        account: { name: "Race Checking", currency: "USD", balance: 100, accountable_type: "Depository", iban: "DE89370400440532013000" } # pipelock:ignore IBAN
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "update re-renders the form instead of a 500 on a raw unique-index race" do
+    linked_account = accounts(:connected)
+    Account.any_instance.stubs(:update).raises(
+      ActiveRecord::RecordNotUnique.new("duplicate key value violates unique constraint")
+    )
+
+    patch depository_path(linked_account), params: {
+      account: { iban: "DE89370400440532013000" } # pipelock:ignore IBAN
+    }
+
+    assert_response :unprocessable_entity
+  end
+
   test "update persists a manually entered iban through the shared update action" do
     linked_account = accounts(:connected)
 

--- a/test/controllers/family_merchants_controller_test.rb
+++ b/test/controllers/family_merchants_controller_test.rb
@@ -75,6 +75,27 @@ class FamilyMerchantsControllerTest < ActionDispatch::IntegrationTest
     assert_equal converted.id, transactions(:one).reload.merchant_id
   end
 
+  test "a failed iban conversion re-renders the form still targeting the original provider merchant" do
+    # Regression: the rescue used to replace @family_merchant with the failed
+    # conversion's unsaved (never persisted) FamilyMerchant. _form.html.erb
+    # picks its submit URL from `persisted?`, so that form silently posted
+    # to FamilyMerchant#create on the next attempt instead of back to this
+    # ProviderMerchant's #update -- losing the whole conversion (transaction
+    # reassignment, user_modified protection) without any visible error.
+    FamilyMerchant.create!(name: "Existing Landlord", family: @user.family, iban: "AT611904300234573201") # pipelock:ignore IBAN
+    provider_merchant = ProviderMerchant.create!(name: "Provider Payee", source: "enable_banking")
+    transactions(:one).update!(merchant: provider_merchant)
+
+    assert_no_difference "FamilyMerchant.count" do
+      patch family_merchant_url(provider_merchant), params: { provider_merchant: { iban: "AT611904300234573201" } } # pipelock:ignore IBAN
+    end
+
+    assert_response :unprocessable_entity
+    assert_select "form[action=?]", family_merchant_path(provider_merchant)
+    assert_match "has already been taken", response.body
+    assert_nil provider_merchant.reload.iban, "the shared ProviderMerchant must still be untouched"
+  end
+
   test "should destroy merchant" do
     assert_difference("FamilyMerchant.count", -1) do
       delete family_merchant_url(@merchant)

--- a/test/controllers/family_merchants_controller_test.rb
+++ b/test/controllers/family_merchants_controller_test.rb
@@ -96,6 +96,54 @@ class FamilyMerchantsControllerTest < ActionDispatch::IntegrationTest
     assert_nil provider_merchant.reload.iban, "the shared ProviderMerchant must still be untouched"
   end
 
+  test "create re-renders the form instead of a 500 on a raw unique-index race" do
+    # Simulates two concurrent create requests both passing the Rails
+    # uniqueness validation before either commits -- the second one hits the
+    # raw DB constraint instead, surfacing as RecordNotUnique rather than
+    # the RecordInvalid a normal duplicate submission would raise.
+    FamilyMerchant.any_instance.stubs(:save).raises(
+      ActiveRecord::RecordNotUnique.new("duplicate key value violates unique constraint")
+    )
+
+    assert_no_difference "FamilyMerchant.count" do
+      post family_merchants_url, params: { family_merchant: { name: "Race Landlord", iban: "AT611904300234573201" } } # pipelock:ignore IBAN
+    end
+
+    assert_response :unprocessable_entity
+    assert_match "has already been taken", response.body
+  end
+
+  test "a failed iban conversion preserves the submitted color" do
+    FamilyMerchant.create!(name: "Existing Landlord", family: @user.family, iban: "AT611904300234573201") # pipelock:ignore IBAN
+    provider_merchant = ProviderMerchant.create!(name: "Provider Payee", source: "enable_banking", color: "#000000")
+    transactions(:one).update!(merchant: provider_merchant)
+
+    patch family_merchant_url(provider_merchant), params: {
+      provider_merchant: { iban: "AT611904300234573201", color: "#4da568" } # pipelock:ignore IBAN
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "input[name=?][value=?][checked]", "provider_merchant[color]", "#4da568"
+  end
+
+  test "a raw unique-index race during iban conversion re-renders the form instead of a 500" do
+    # Same race as the create test above, but hit through the conversion
+    # path: two concurrent conversions in the same family both pass the
+    # Rails uniqueness validation before either commits.
+    provider_merchant = ProviderMerchant.create!(name: "Provider Payee", source: "enable_banking")
+    transactions(:one).update!(merchant: provider_merchant)
+    ProviderMerchant.any_instance.stubs(:convert_to_family_merchant_for).raises(
+      ActiveRecord::RecordNotUnique.new("duplicate key value violates unique constraint")
+    )
+
+    patch family_merchant_url(provider_merchant), params: { provider_merchant: { iban: "AT611904300234573201" } } # pipelock:ignore IBAN
+
+    assert_response :unprocessable_entity
+    assert_select "form[action=?]", family_merchant_path(provider_merchant)
+    assert_match "has already been taken", response.body
+    assert_nil provider_merchant.reload.iban, "the shared ProviderMerchant must still be untouched"
+  end
+
   test "should destroy merchant" do
     assert_difference("FamilyMerchant.count", -1) do
       delete family_merchant_url(@merchant)

--- a/test/migrations/add_family_scoped_iban_uniqueness_to_merchants_migration_test.rb
+++ b/test/migrations/add_family_scoped_iban_uniqueness_to_merchants_migration_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require Rails.root.join("db/migrate/20260911184745_add_family_scoped_iban_uniqueness_to_merchants")
+
+class AddFamilyScopedIbanUniquenessToMerchantsMigrationTest < ActiveSupport::TestCase
+  test "refuses to run when duplicate family-scoped ibans already exist" do
+    # The schema already has this migration's index applied (it's part of
+    # db/schema.rb); drop it first to simulate the pre-migration state the
+    # duplicate check needs to guard, since the DB-level constraint would
+    # otherwise block the duplicate insert below before the migration is
+    # even involved.
+    ActiveRecord::Base.connection.execute("DROP INDEX IF EXISTS index_merchants_on_family_id_and_iban")
+
+    family = families(:dylan_family)
+    FamilyMerchant.create!(name: "Landlord A", family: family, iban: "AT611904300234573201") # pipelock:ignore IBAN
+    # Bypasses the model uniqueness this migration is meant to add at the DB
+    # level too -- simulates data that predates either.
+    FamilyMerchant.create!(name: "Landlord B", family: family).update_column(:iban, "AT611904300234573201") # pipelock:ignore IBAN
+
+    error = assert_raises(RuntimeError) { AddFamilyScopedIbanUniquenessToMerchants.new.up }
+
+    assert_match "already share an iban within the same family", error.message
+    # Standard transactional test rollback undoes both the DROP INDEX above
+    # and the duplicate rows once this test finishes, restoring the schema
+    # for subsequent tests without any manual cleanup here.
+  end
+end

--- a/test/models/account/provider_import_adapter_test.rb
+++ b/test/models/account/provider_import_adapter_test.rb
@@ -1575,4 +1575,38 @@ class Account::ProviderImportAdapterTest < ActiveSupport::TestCase
         "pending flag must be cleared even for user-modified entries"
     end
   end
+
+  test "backfills counterparty iban on a user-modified entry that predates the feature" do
+    entry = @adapter.import_transaction(
+      external_id: "eb_user_mod_no_iban",
+      amount: 20.0,
+      currency: "EUR",
+      date: Date.today - 5.days,
+      name: "Old Landlord Payment",
+      source: "enable_banking"
+    )
+    assert_nil entry.transaction.extra&.dig("counterparty_iban")
+
+    entry.mark_user_modified!
+    assert entry.reload.user_modified?, "entry should be marked user-modified"
+
+    # A later sync now carries counterparty data the original payload lacked.
+    # The entry is protected (user_modified), but this field has no UI for the
+    # user to have relied upon, so it should still be backfilled.
+    assert_no_difference "@account.entries.count" do
+      updated_entry = @adapter.import_transaction(
+        external_id: "eb_user_mod_no_iban",
+        amount: 20.0,
+        currency: "EUR",
+        date: Date.today - 5.days,
+        name: "Old Landlord Payment",
+        source: "enable_banking",
+        extra: { "counterparty_iban" => "AT611904300234573201" } # pipelock:ignore IBAN
+      )
+
+      assert_equal entry.id, updated_entry.id
+      updated_entry.reload
+      assert_equal "AT611904300234573201", updated_entry.transaction.extra["counterparty_iban"] # pipelock:ignore IBAN
+    end
+  end
 end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -30,6 +30,13 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal "DE89370400440532013000", @account.iban # pipelock:ignore IBAN
   end
 
+  test "normalizes iban by stripping dots, dashes, and other punctuation" do
+    @account.iban = "de89.3704-0044/0532:0130'00"
+    @account.valid?
+
+    assert_equal "DE89370400440532013000", @account.iban # pipelock:ignore IBAN
+  end
+
   test "leaves a blank iban as nil" do
     @account.iban = ""
     @account.valid?

--- a/test/models/concerns/iban_normalizable_test.rb
+++ b/test/models/concerns/iban_normalizable_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class IbanNormalizableTest < ActiveSupport::TestCase
+  test "strips spaces and upcases" do
+    assert_equal "DE89370400440532013000", IbanNormalizable.normalize("de89 3704 0044 0532 0130 00") # pipelock:ignore IBAN
+  end
+
+  test "strips tabs, newlines, and non-breaking spaces" do
+    assert_equal "DE89370400440532013000", IbanNormalizable.normalize("de89\t3704\n0044 0532 0130 00") # pipelock:ignore IBAN
+  end
+
+  test "strips dots" do
+    assert_equal "DE89370400440532013000", IbanNormalizable.normalize("DE89.3704.0044.0532.0130.00") # pipelock:ignore IBAN
+  end
+
+  test "strips dashes" do
+    assert_equal "DE89370400440532013000", IbanNormalizable.normalize("DE89-3704-0044-0532-0130-00") # pipelock:ignore IBAN
+  end
+
+  test "strips any other punctuation, keeping only letters and digits" do
+    assert_equal "DE89370400440532013000", IbanNormalizable.normalize("DE89/3704:0044,0532;0130'00") # pipelock:ignore IBAN
+  end
+
+  test "leaves a blank value as nil" do
+    assert_nil IbanNormalizable.normalize("")
+    assert_nil IbanNormalizable.normalize(nil)
+    assert_nil IbanNormalizable.normalize("   ")
+    assert_nil IbanNormalizable.normalize("...")
+  end
+end

--- a/test/models/enable_banking_account_test.rb
+++ b/test/models/enable_banking_account_test.rb
@@ -165,6 +165,12 @@ class EnableBankingAccountTest < ActiveSupport::TestCase
     assert_equal "NL91ABNA0417164300", linked_account.reload.iban # pipelock:ignore IBAN
   end
 
+  test "normalizes iban by stripping dots, dashes, and other punctuation on sync" do
+    @account.update!(iban: "nl91.abna-0417/1643:00'")
+
+    assert_equal "NL91ABNA0417164300", @account.reload.iban # pipelock:ignore IBAN
+  end
+
   test "does not overwrite an already-present account iban on sync" do
     linked_account = accounts(:depository)
     linked_account.update!(iban: "AT611904300234573201") # pipelock:ignore IBAN

--- a/test/models/enable_banking_account_test.rb
+++ b/test/models/enable_banking_account_test.rb
@@ -217,6 +217,10 @@ class EnableBankingAccountTest < ActiveSupport::TestCase
     assert_nil linked_account.reload.iban
     assert_equal "NL91ABNA0417164300", other_account.reload.iban # pipelock:ignore IBAN
     assert_equal "NL91ABNA0417164300", @account.reload.iban # pipelock:ignore IBAN
+
+    debug_entry = DebugLogEntry.last
+    assert_equal "provider_sync_warning", debug_entry.category
+    assert_equal linked_account.id, debug_entry.account_id
   end
 
   test "does not raise or fail the sync on a raw unique-index race during propagation" do
@@ -240,6 +244,10 @@ class EnableBankingAccountTest < ActiveSupport::TestCase
         iban: "NL91ABNA0417164300" # pipelock:ignore IBAN
       })
     end
+
+    debug_entry = DebugLogEntry.last
+    assert_equal "provider_sync_warning", debug_entry.category
+    assert_match "Concurrent iban conflict", debug_entry.message
   end
 
   test "does not touch linked account when snapshot has no iban" do

--- a/test/models/enable_banking_entry/processor_test.rb
+++ b/test/models/enable_banking_entry/processor_test.rb
@@ -510,6 +510,24 @@ class EnableBankingEntry::ProcessorTest < ActiveSupport::TestCase
     assert_equal "DE89370400440532013000", entry.transaction.extra["counterparty_iban"] # pipelock:ignore IBAN
   end
 
+  test "normalizes a counterparty iban with dots and dashes before storing it" do
+    tx = {
+      entry_reference: "ref_iban_punctuation",
+      transaction_id: nil,
+      booking_date: Date.current.to_s,
+      transaction_amount: { amount: "50.00", currency: "EUR" },
+      credit_debit_indicator: "DBIT",
+      creditor: { name: "Landlord GmbH" },
+      creditor_account: { iban: "de89.3704-0044/0532:0130'00" },
+      status: "BOOK"
+    }
+
+    EnableBankingEntry::Processor.new(tx, enable_banking_account: @enable_banking_account).process
+    entry = @account.entries.find_by!(external_id: "enable_banking_ref_iban_punctuation")
+
+    assert_equal "DE89370400440532013000", entry.transaction.extra["counterparty_iban"] # pipelock:ignore IBAN
+  end
+
   test "stores counterparty iban from the debtor side for an incoming payment" do
     tx = {
       entry_reference: "ref_iban_in",

--- a/test/models/enable_banking_item/importer_dedup_test.rb
+++ b/test/models/enable_banking_item/importer_dedup_test.rb
@@ -179,6 +179,33 @@ class EnableBankingItem::ImporterDedupTest < ActiveSupport::TestCase
     assert_equal 1, result.count
   end
 
+  test "still deduplicates identical transactions whose counterparty iban differs only in punctuation" do
+    transactions = [
+      {
+        entry_reference: "ref_dup_punct_1",
+        booking_date: "2026-02-07",
+        transaction_amount: { amount: "850.00", currency: "EUR" },
+        creditor: { name: "Miete" },
+        creditor_account: { iban: "DE89370400440532013000" }, # pipelock:ignore IBAN
+        credit_debit_indicator: "DBIT",
+        status: "BOOK"
+      },
+      {
+        entry_reference: "ref_dup_punct_2",
+        booking_date: "2026-02-07",
+        transaction_amount: { amount: "850.00", currency: "EUR" },
+        creditor: { name: "Miete" },
+        creditor_account: { iban: "de89.3704-0044/0532:0130'00" },
+        credit_debit_indicator: "DBIT",
+        status: "BOOK"
+      }
+    ]
+
+    result = @importer.send(:deduplicate_api_transactions, transactions)
+
+    assert_equal 1, result.count
+  end
+
   test "merges a pending row's iban into the booked representative that lost it" do
     # Some ASPSPs drop counterparty account data once a transaction settles
     # (the booked delivery has less detail than the earlier pending one).

--- a/test/models/enable_banking_item/importer_dedup_test.rb
+++ b/test/models/enable_banking_item/importer_dedup_test.rb
@@ -179,12 +179,14 @@ class EnableBankingItem::ImporterDedupTest < ActiveSupport::TestCase
     assert_equal 1, result.count
   end
 
-  test "prefers an iban-bearing pending row over a booked row that lost its iban" do
+  test "merges a pending row's iban into the booked representative that lost it" do
     # Some ASPSPs drop counterparty account data once a transaction settles
     # (the booked delivery has less detail than the earlier pending one).
-    # IBAN presence must outrank BOOK/PDNG status when picking the group's
-    # representative, or dedup would silently discard real IBAN data by
-    # keeping the thinner booked row just because it settled.
+    # Status still ranks above IBAN presence when picking the group's
+    # representative (a still-pending row would otherwise get stuck pending
+    # forever), but the IBAN itself must not be silently discarded either --
+    # it's merged into the booked representative instead of being traded
+    # away for it.
     transactions = [
       {
         entry_reference: "ref_pending_with_iban",
@@ -208,7 +210,10 @@ class EnableBankingItem::ImporterDedupTest < ActiveSupport::TestCase
     result = @importer.send(:deduplicate_api_transactions, transactions)
 
     assert_equal 1, result.count
-    assert_equal "ref_pending_with_iban", result.first[:entry_reference]
+    assert_equal "ref_booked_without_iban", result.first[:entry_reference],
+      "the settled row must be kept, not the still-pending one"
+    assert_equal "DE89370400440532013000", result.first.dig(:creditor_account, :iban), # pipelock:ignore IBAN
+      "the booked representative must still gain the pending sibling's iban"
   end
 
   test "keeps transactions with different creditors" do

--- a/test/models/enable_banking_item/importer_dedup_test.rb
+++ b/test/models/enable_banking_item/importer_dedup_test.rb
@@ -179,6 +179,38 @@ class EnableBankingItem::ImporterDedupTest < ActiveSupport::TestCase
     assert_equal 1, result.count
   end
 
+  test "prefers an iban-bearing pending row over a booked row that lost its iban" do
+    # Some ASPSPs drop counterparty account data once a transaction settles
+    # (the booked delivery has less detail than the earlier pending one).
+    # IBAN presence must outrank BOOK/PDNG status when picking the group's
+    # representative, or dedup would silently discard real IBAN data by
+    # keeping the thinner booked row just because it settled.
+    transactions = [
+      {
+        entry_reference: "ref_pending_with_iban",
+        booking_date: "2026-02-07",
+        transaction_amount: { amount: "850.00", currency: "EUR" },
+        creditor: { name: "Miete" },
+        creditor_account: { iban: "DE89370400440532013000" }, # pipelock:ignore IBAN
+        credit_debit_indicator: "DBIT",
+        status: "PDNG"
+      },
+      {
+        entry_reference: "ref_booked_without_iban",
+        booking_date: "2026-02-07",
+        transaction_amount: { amount: "850.00", currency: "EUR" },
+        creditor: { name: "Miete" },
+        credit_debit_indicator: "DBIT",
+        status: "BOOK"
+      }
+    ]
+
+    result = @importer.send(:deduplicate_api_transactions, transactions)
+
+    assert_equal 1, result.count
+    assert_equal "ref_pending_with_iban", result.first[:entry_reference]
+  end
+
   test "keeps transactions with different creditors" do
     transactions = [
       {

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -352,11 +352,14 @@ class Family::DataExporterTest < ActiveSupport::TestCase
   end
 
   test "neutralizes a formula-like account iban so it can't execute in a spreadsheet" do
-    # iban has no format validation, so a family member with no export access
-    # of their own could plant a formula payload here for an admin to later
-    # open in Excel/Sheets (CSV/formula injection). The account.rb model
-    # doesn't constrain iban's shape, so this must be handled at export time.
-    @account.update!(iban: "=1+1")
+    # IbanNormalizable's before_validation strips non-alphanumeric characters
+    # (so a normal update! can no longer store "=1+1" as-is), but iban is
+    # still just a free-text column at the database level -- a pre-existing
+    # row written before that fix shipped, or written directly via SQL/import,
+    # could still carry a formula payload. update_columns bypasses the
+    # callback (while still writing through encryption) to simulate that, so
+    # this test keeps covering the export-time defense in depth.
+    @account.update_columns(iban: "=1+1")
 
     zip_data = @exporter.generate_export
 

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -351,6 +351,40 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     end
   end
 
+  test "neutralizes a formula-like account iban so it can't execute in a spreadsheet" do
+    # iban has no format validation, so a family member with no export access
+    # of their own could plant a formula payload here for an admin to later
+    # open in Excel/Sheets (CSV/formula injection). The account.rb model
+    # doesn't constrain iban's shape, so this must be handled at export time.
+    @account.update!(iban: "=1+1")
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      row = CSV.parse(zip.read("accounts.csv"), headers: true).find { |csv_row| csv_row["name"] == @account.name }
+
+      assert_equal "'=1+1", row["iban"]
+    end
+  end
+
+  test "neutralizes a formula-like transaction counterparty iban" do
+    entry = @account.entries.create!(
+      name: "CSV Formula Payment",
+      amount: 10,
+      currency: "USD",
+      date: Date.parse("2024-05-15"),
+      entryable: Transaction.new(category: @category, extra: { "counterparty_iban" => "@SUM(1+1)" })
+    )
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      row = CSV.parse(zip.read("transactions.csv"), headers: true).find { |csv_row| csv_row["name"] == entry.name }
+
+      assert_equal "'@SUM(1+1)", row["counterparty_iban"]
+    end
+  end
+
   test "exported CSV files can generate matching import rows" do
     create_csv_export_trade!
     @account.entries.create!(

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -281,7 +281,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
   end
 
   test "exports account iban and leaves it blank when not set" do
-    @account.update!(iban: "DE89370400440532013000")
+    @account.update!(iban: "DE89370400440532013000") # pipelock:ignore IBAN
     other_account = @family.accounts.create!(name: "No IBAN Account", balance: 0, currency: "USD", accountable: Depository.new)
 
     zip_data = @exporter.generate_export
@@ -292,7 +292,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
       with_iban = rows.find { |csv_row| csv_row["name"] == @account.name }
       without_iban = rows.find { |csv_row| csv_row["name"] == other_account.name }
 
-      assert_equal "DE89370400440532013000", with_iban["iban"]
+      assert_equal "DE89370400440532013000", with_iban["iban"] # pipelock:ignore IBAN
       assert_nil without_iban["iban"]
     end
   end
@@ -303,7 +303,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
       amount: 850,
       currency: "USD",
       date: Date.parse("2024-05-15"),
-      entryable: Transaction.new(category: @category, extra: { "counterparty_iban" => "DE89370400440532013000" })
+      entryable: Transaction.new(category: @category, extra: { "counterparty_iban" => "DE89370400440532013000" }) # pipelock:ignore IBAN
     )
     without_iban_entry = @account.entries.create!(
       name: "CSV Cash Withdrawal",
@@ -321,7 +321,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
       with_iban_row = rows.find { |csv_row| csv_row["name"] == with_iban_entry.name }
       without_iban_row = rows.find { |csv_row| csv_row["name"] == without_iban_entry.name }
 
-      assert_equal "DE89370400440532013000", with_iban_row["counterparty_iban"]
+      assert_equal "DE89370400440532013000", with_iban_row["counterparty_iban"] # pipelock:ignore IBAN
       assert_nil without_iban_row["counterparty_iban"]
     end
   end

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -326,6 +326,31 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     end
   end
 
+  test "exports the split parent's counterparty iban on split child rows" do
+    split_parent = @account.entries.create!(
+      name: "CSV Split Parent",
+      amount: 100,
+      currency: "USD",
+      date: Date.parse("2024-05-15"),
+      entryable: Transaction.new(category: @category, extra: { "counterparty_iban" => "DE89370400440532013000" }) # pipelock:ignore IBAN
+    )
+    split_children = split_parent.split!([
+      { name: "CSV Split Child A", amount: 60, category_id: @category.id },
+      { name: "CSV Split Child B", amount: 40, category_id: @category.id }
+    ])
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      rows = CSV.parse(zip.read("transactions.csv"), headers: true)
+
+      split_children.each do |child|
+        row = rows.find { |csv_row| csv_row["name"] == child.name }
+        assert_equal "DE89370400440532013000", row["counterparty_iban"] # pipelock:ignore IBAN
+      end
+    end
+  end
+
   test "exported CSV files can generate matching import rows" do
     create_csv_export_trade!
     @account.entries.create!(

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -172,7 +172,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     Zip::File.open_buffer(zip_data) do |zip|
       # Check accounts.csv
       accounts_csv = zip.read("accounts.csv")
-      assert_equal [ "id", "name", "type", "subtype", "balance", "currency", "iban", "created_at" ],
+      assert_equal [ "id", "name", "type", "subtype", "balance", "currency", "created_at", "iban" ],
                    CSV.parse(accounts_csv, headers: true).headers
 
       # Check version marker

--- a/test/models/family/data_exporter_test.rb
+++ b/test/models/family/data_exporter_test.rb
@@ -172,7 +172,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
     Zip::File.open_buffer(zip_data) do |zip|
       # Check accounts.csv
       accounts_csv = zip.read("accounts.csv")
-      assert_equal [ "id", "name", "type", "subtype", "balance", "currency", "created_at" ],
+      assert_equal [ "id", "name", "type", "subtype", "balance", "currency", "iban", "created_at" ],
                    CSV.parse(accounts_csv, headers: true).headers
 
       # Check version marker
@@ -182,7 +182,7 @@ class Family::DataExporterTest < ActiveSupport::TestCase
 
       # Check transactions.csv
       transactions_csv = zip.read("transactions.csv")
-      assert_equal [ "date", "account_name", "amount", "name", "category", "tags", "notes", "currency" ],
+      assert_equal [ "date", "account_name", "amount", "name", "category", "tags", "notes", "currency", "counterparty_iban" ],
                    CSV.parse(transactions_csv, headers: true).headers
 
       # Check trades.csv
@@ -277,6 +277,52 @@ class Family::DataExporterTest < ActiveSupport::TestCase
       assert_includes row["tags"], "\\,"
       assert_includes row["tags"], "\\|"
       assert_equal [ @tag.name, tag2.name ].sort, Import::Row.new(tags: row["tags"]).tags_list.sort
+    end
+  end
+
+  test "exports account iban and leaves it blank when not set" do
+    @account.update!(iban: "DE89370400440532013000")
+    other_account = @family.accounts.create!(name: "No IBAN Account", balance: 0, currency: "USD", accountable: Depository.new)
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      rows = CSV.parse(zip.read("accounts.csv"), headers: true)
+
+      with_iban = rows.find { |csv_row| csv_row["name"] == @account.name }
+      without_iban = rows.find { |csv_row| csv_row["name"] == other_account.name }
+
+      assert_equal "DE89370400440532013000", with_iban["iban"]
+      assert_nil without_iban["iban"]
+    end
+  end
+
+  test "exports transaction counterparty iban and leaves it blank when not present" do
+    with_iban_entry = @account.entries.create!(
+      name: "CSV Rent Payment",
+      amount: 850,
+      currency: "USD",
+      date: Date.parse("2024-05-15"),
+      entryable: Transaction.new(category: @category, extra: { "counterparty_iban" => "DE89370400440532013000" })
+    )
+    without_iban_entry = @account.entries.create!(
+      name: "CSV Cash Withdrawal",
+      amount: 40,
+      currency: "USD",
+      date: Date.parse("2024-05-16"),
+      entryable: Transaction.new(category: @category)
+    )
+
+    zip_data = @exporter.generate_export
+
+    Zip::File.open_buffer(zip_data) do |zip|
+      rows = CSV.parse(zip.read("transactions.csv"), headers: true)
+
+      with_iban_row = rows.find { |csv_row| csv_row["name"] == with_iban_entry.name }
+      without_iban_row = rows.find { |csv_row| csv_row["name"] == without_iban_entry.name }
+
+      assert_equal "DE89370400440532013000", with_iban_row["counterparty_iban"]
+      assert_nil without_iban_row["counterparty_iban"]
     end
   end
 

--- a/test/models/merchant_test.rb
+++ b/test/models/merchant_test.rb
@@ -58,4 +58,31 @@ class MerchantTest < ActiveSupport::TestCase
 
     assert other_source.valid?
   end
+
+  test "enforces uniqueness of iban per family for family merchants at the model level" do
+    family = families(:dylan_family)
+    FamilyMerchant.create!(name: "Landlord", family: family, iban: "AT611904300234573201") # pipelock:ignore IBAN
+
+    duplicate = FamilyMerchant.new(name: "Different Name", family: family, iban: "AT611904300234573201") # pipelock:ignore IBAN
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:iban], "has already been taken"
+  end
+
+  test "enforces uniqueness of iban per family for family merchants at the database level" do
+    family = families(:dylan_family)
+    FamilyMerchant.create!(name: "Landlord", family: family, iban: "AT611904300234573201") # pipelock:ignore IBAN
+
+    duplicate = FamilyMerchant.new(name: "Different Name", family: family, iban: "AT611904300234573201") # pipelock:ignore IBAN
+
+    assert_raises(ActiveRecord::RecordNotUnique) { duplicate.save!(validate: false) }
+  end
+
+  test "allows the same iban across different families for family merchants" do
+    FamilyMerchant.create!(name: "Landlord", family: families(:dylan_family), iban: "AT611904300234573201") # pipelock:ignore IBAN
+
+    other_family = FamilyMerchant.new(name: "Landlord", family: families(:empty), iban: "AT611904300234573201") # pipelock:ignore IBAN
+
+    assert other_family.valid?
+  end
 end

--- a/test/models/merchant_test.rb
+++ b/test/models/merchant_test.rb
@@ -27,6 +27,13 @@ class MerchantTest < ActiveSupport::TestCase
     assert_equal "DE89370400440532013000", merchant.iban # pipelock:ignore IBAN
   end
 
+  test "normalizes iban by stripping dots, dashes, and other punctuation" do
+    merchant = FamilyMerchant.new(name: "Landlord", family: families(:dylan_family), iban: "de89.3704-0044/0532:0130'00")
+    merchant.valid?
+
+    assert_equal "DE89370400440532013000", merchant.iban # pipelock:ignore IBAN
+  end
+
   test "leaves a blank iban as nil" do
     merchant = FamilyMerchant.new(name: "Landlord", family: families(:dylan_family), iban: "")
     merchant.valid?


### PR DESCRIPTION
## Summary
**Depends on #3510 and #3511 (do not merge before those) — this diff currently includes both of their commits too, until they merge.**

Extends the existing family data export (used e.g. for handing records to an accountant) with the IBAN data introduced by #3510/#3511:

- `accounts.csv` gains an `iban` column (the account's own IBAN, manual or synced).
- `transactions.csv` gains a `counterparty_iban` column, read from `extra["counterparty_iban"]`.

Both are blank for accounts/transactions without IBAN data — no special-casing for non-Enable-Banking users or accounts.

## Test plan
- [x] `bin/rails test` (data_exporter) — green
- [x] `bin/rubocop` — clean
- [ ] Live verification: run a family export on a test stack and confirm both new columns before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Account and transaction CSV exports now include IBAN and counterparty IBAN fields.
  - Counterparty IBAN details are backfilled during provider synchronization when available.
  - Merchant IBANs are normalized consistently and validated for uniqueness within a family.

- **Bug Fixes**
  - IBAN conflicts now show clear validation errors instead of causing failed submissions.
  - Editing a provider merchant’s IBAN safely creates a family-specific merchant without changing shared records.
  - Transaction deduplication more accurately handles differing or missing counterparty IBANs.
  - Synchronization conflicts are recorded for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->